### PR TITLE
[Hotfix][Peek]Consume shortcut only on Desktop and Shell

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -1025,6 +1025,7 @@ ITHUMBNAIL
 IUI
 IUnknown
 IWbem
+IWeb
 IWIC
 iwr
 IYUV
@@ -1528,6 +1529,7 @@ pcs
 PCWSTR
 pdb
 pdbonly
+pdisp
 pdo
 pdto
 pdtobj
@@ -1873,6 +1875,7 @@ setzero
 sfgao
 SFGAOF
 SFP
+SHANDLE
 sharpkeys
 SHCNE
 SHCNF

--- a/src/modules/peek/Peek.UI/Extensions/HWNDExtensions.cs
+++ b/src/modules/peek/Peek.UI/Extensions/HWNDExtensions.cs
@@ -22,6 +22,8 @@ namespace Peek.UI.Extensions
             return activeTab;
         }
 
+        // Keep logic synced with the similar function in the C++ module interface.
+        // TODO: Refactor into same C++ class consumed by both.
         internal static bool IsDesktopWindow(this HWND windowHandle)
         {
             StringBuilder strClassName = new StringBuilder(256);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Ctrl+Space is a shortcut that's used in many different applications.
This PR makes it so we only consume the shortcut in the low level keyboard handler if it's actually the Desktop or a Shell window that's on the foreground.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #26150
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

Uses some of the same logic that is used in Peek UI to detect if it's a Desktop or Shell window but translated to C++

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Verified Ctrl+Space still brings up Peek in the Desktop and File Explorer.
Verified that Ctrl+Space still triggers Intellisense/auto-complete on Visual Studio and VS Code.