### PR TITLE
[MWB] fix machine connection status highlighting

### DIFF
--- a/src/settings-ui/Settings.UI/ViewModels/MouseWithoutBordersViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/MouseWithoutBordersViewModel.cs
@@ -42,7 +42,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
 
         private static readonly Dictionary<SocketStatus, Brush> StatusColors = new Dictionary<SocketStatus, Brush>()
 {
-    { SocketStatus.NA, new SolidColorBrush(ColorHelper.FromArgb(0x71, 0x71, 0x71, 0x71)) },
+    { SocketStatus.NA, new SolidColorBrush(ColorHelper.FromArgb(0, 0x71, 0x71, 0x71)) },
     { SocketStatus.Resolving, new SolidColorBrush(Colors.Yellow) },
     { SocketStatus.Connecting, new SolidColorBrush(Colors.Orange) },
     { SocketStatus.Handshaking, new SolidColorBrush(Colors.Blue) },

--- a/src/settings-ui/Settings.UI/Views/MouseWithoutBordersPage.xaml
+++ b/src/settings-ui/Settings.UI/Views/MouseWithoutBordersPage.xaml
@@ -125,6 +125,7 @@
                                             Width="136"
                                             Height="90"
                                             Margin="4"
+                                            BorderThickness="2" 
                                             AllowDrop="{Binding Mode=OneWay, Path=Item.CanDragDrop}"
                                             Background="{ThemeResource SolidBackgroundFillColorBaseAltBrush}"
                                             BorderBrush="{Binding Item.StatusBrush}"


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Fix issues introduced by 667aad247ada979423ff41cc4c5dd5583eef85f8

- reintroduced border thickness
- made default status transparent in accordance w/ the improved design

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- connect 2 machines
- status is highlighted
