### PR TITLE
[MWB]Hide cursor when setting to the top of screen

### DIFF
--- a/src/modules/MouseWithoutBorders/App/Class/Setting.cs
+++ b/src/modules/MouseWithoutBorders/App/Class/Setting.cs
@@ -923,7 +923,9 @@ namespace MouseWithoutBorders.Class
             }
         }
 
-        internal bool StealFocusWhenSwitchingMachine => _properties.StealFocusWhenSwitchingMachine;
+        // Was a value read from registry on original Mouse Without Border, but default should be true. We wrongly released it as false, so we're forcing true here.
+        // This value wasn't changeable from UI, anyway.
+        internal bool StealFocusWhenSwitchingMachine => true;
 
         private string deviceId;
 

--- a/src/settings-ui/Settings.UI.Library/MouseWithoutBordersProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/MouseWithoutBordersProperties.cs
@@ -107,9 +107,6 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         [JsonConverter(typeof(BoolPropertyJsonConverter))]
         public bool FirstCtrlShiftS { get; set; }
 
-        [JsonConverter(typeof(BoolPropertyJsonConverter))]
-        public bool StealFocusWhenSwitchingMachine { get; set; }
-
         public StringProperty DeviceID { get; set; }
 
         public MouseWithoutBordersProperties()
@@ -151,7 +148,6 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             Name2IP = new StringProperty(string.Empty);
             UseVKMap = false;
             FirstCtrlShiftS = false;
-            StealFocusWhenSwitchingMachine = false;
         }
 
         public object Clone()


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Currently, when "Hide mouse at the screen edge" is turned on, it keeps showing the mouse cursor at the top of the screen and things that are beneath still get activated, like showing tooltips under the mouse.
This PR fixes this.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #26338
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

This error comes from misevaluating the value of a non-editable Setting when porting the code originally. We set it to false when the correct default should be true.
Also removes the Setting that we misread from the Settings file.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Testing Mouse Without Borders with the Hide mouse at the screen edge option turned on hides the cursor. (It does create some weird pixels at the screen top, like original MWB did)