### PR TITLE
[Peek]Fix foreground window setting

### DIFF
--- a/src/modules/peek/Peek.UI/NativeMethods.txt
+++ b/src/modules/peek/Peek.UI/NativeMethods.txt
@@ -2,6 +2,9 @@
 GetMonitorInfo
 GetDpiForWindow
 GetForegroundWindow
+SetForegroundWindow
+SetActiveWindow
+SendInput
 GetWindowThreadProcessId
 GetCurrentThreadId
 AttachThreadInput


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

After #26364, the way to bring the Peek window to the foreground doesn't seem to be working correctly. It sometimes seems to bring keyboard input in but not mouse input, making the way that we try to detect loss of focus not work when the option to "Automatically close the Peek window after it loses focus" not work.

Changed the way we bring the Peek Window to the foreground mimic what we do on other PowerToys, which is to first send some mouse simulated mouse input and then bring the window to the foreground. This seems to be more stable.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #26366
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Tested switching files multiple times with both the "Automatically close the Peek window after it loses focus" on and off, both on the Desktop and on an Explorer window.
