### PR TITLE
[MWB] prevent spurious wakeups

### DIFF
--- a/src/modules/MouseWithoutBorders/App/Class/Common.cs
+++ b/src/modules/MouseWithoutBorders/App/Class/Common.cs
@@ -540,11 +540,6 @@ namespace MouseWithoutBorders
             else
             {
                 SendHeartBeat();
-
-                if (Setting.Values.BlockScreenSaverEx && lastInputEventCount == Common.InputEventCount && Common.DesMachineID == Common.MachineID)
-                {
-                    PokeMyself();
-                }
             }
 
             lastInputEventCount = Common.InputEventCount;

--- a/src/modules/MouseWithoutBorders/App/Class/Setting.cs
+++ b/src/modules/MouseWithoutBorders/App/Class/Setting.cs
@@ -501,25 +501,6 @@ namespace MouseWithoutBorders.Class
             }
         }
 
-        internal bool BlockScreenSaverEx
-        {
-            get
-            {
-                lock (_loadingSettingsLock)
-                {
-                    return _properties.BlockScreenSaverOnOtherMachines;
-                }
-            }
-
-            set
-            {
-                lock (_loadingSettingsLock)
-                {
-                    _properties.BlockScreenSaverOnOtherMachines = value;
-                }
-            }
-        }
-
         internal bool MoveMouseRelatively
         {
             get


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Essentially, the original MWB doesn't equate `BlockScreenSaverEx` with `BlockScreenSaver` as we did before this change, and the former one is a deprecated option, `false` by default, and with no way to be changed from the old UI. Thus, I've removed that property altogether + removed the check as well. 

Note: `PokeMyself` is still a valid function that's used when `BlockScreenSaver` is true and a "client" machine receives a TCP/IP package that makes it move a mouse a bit effectively preventing it from going to sleep.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #26339
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
You don't need to run as a service or even run MWB on multiple machines to reproduce the issue. You can just:

- press Start -> "edit power plan"
- set "turn off the display" to 1 min
- Win+L
- observe that the display sleep breaks every minute

This PR removes that behavior.
