### PR TITLE
[MWB]Work without service if service doesn't start

### DIFF
--- a/src/modules/MouseWithoutBorders/App/Class/Program.cs
+++ b/src/modules/MouseWithoutBorders/App/Class/Program.cs
@@ -86,15 +86,25 @@ namespace MouseWithoutBorders.Class
 
                 // If we're started from the .dll module or from the service process, we should
                 // assume the service mode.
-                if (serviceMode || runningAsSystem)
+                if (serviceMode && !runningAsSystem)
                 {
-                    if (!runningAsSystem)
+                    try
                     {
                         var sc = new ServiceController(ServiceName);
                         sc.Start();
                         return;
                     }
+                    catch (Exception ex)
+                    {
+                        Common.Log("Couldn't start the service. Will try to continue as not a service.");
+                        Common.Log(ex);
+                        serviceMode = false;
+                        Setting.Values.UseService = false;
+                    }
+                }
 
+                if (serviceMode || runningAsSystem)
+                {
                     if (args.Length > 2)
                     {
                         Helper.UserLocalAppDataPath = args[2].Trim();

--- a/src/modules/MouseWithoutBorders/App/Class/Setting.cs
+++ b/src/modules/MouseWithoutBorders/App/Class/Setting.cs
@@ -979,6 +979,30 @@ namespace MouseWithoutBorders.Class
             }
         }
 
+        // If starting the service fails, work in not service mode.
+        internal bool UseService
+        {
+            get
+            {
+                lock (_loadingSettingsLock)
+                {
+                    return _properties.UseService;
+                }
+            }
+
+            set
+            {
+                lock (_loadingSettingsLock)
+                {
+                    _properties.UseService = value;
+                    if (!PauseInstantSaving)
+                    {
+                        SaveSettings();
+                    }
+                }
+            }
+        }
+
         internal bool SendErrorLogV2
         {
             get


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Currently, Mouse Without Borders won't work correctly if the service is deleted but the user has the Use Service option turned on.
This PR adds some code to make MouseWithoutBorders start without the service and disable the Setting if it can't start the service.
It also disables the Use Service option if that's the case.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Set PowerToys Mouse Without Borders to use the service.
Exit PowerToys.
delete the service.
Start PowerToys without admin permissions.
Mouse Without Borders will still start correctly and disable the service mode.

