### PR TITLE
[MWB]Simulate input to gain focus when hiding mouse

### DIFF
--- a/src/modules/MouseWithoutBorders/App/Helper/FormHelper.cs
+++ b/src/modules/MouseWithoutBorders/App/Helper/FormHelper.cs
@@ -433,6 +433,11 @@ namespace MouseWithoutBorders
                     Program.DotForm.TopMost = true;
                     Program.DotForm.Show();
                     Application.DoEvents();
+
+                    // Simulate input to help bring to the foreground, as it doesn't seem to work in every case otherwise.
+                    NativeMethods.INPUT input = new NativeMethods.INPUT { type = (int)NativeMethods.InputType.INPUT_MOUSE, mi = { } };
+                    NativeMethods.INPUT[] inputs = new NativeMethods.INPUT[] { input };
+                    _ = NativeMethods.SendInput(1, inputs, Marshal.SizeOf(typeof(NativeMethods.INPUT)));
                     m.Result = SetForeGround() ? new IntPtr(1) : IntPtr.Zero;
                     break;
 

--- a/src/modules/MouseWithoutBorders/App/Helper/NativeMethods.cs
+++ b/src/modules/MouseWithoutBorders/App/Helper/NativeMethods.cs
@@ -405,7 +405,7 @@ namespace MouseWithoutBorders
             CallingConvention = CallingConvention.StdCall)]
         internal static extern int CallNextHookEx(int idHook, int nCode, int wParam, IntPtr lParam);
 
-        private enum InputType
+        internal enum InputType
         {
             INPUT_MOUSE = 0,
             INPUT_KEYBOARD = 1,

--- a/src/settings-ui/Settings.UI/Views/MouseWithoutBordersPage.xaml
+++ b/src/settings-ui/Settings.UI/Views/MouseWithoutBordersPage.xaml
@@ -92,7 +92,7 @@
                                 Content="&#xE8C8;"
                                 FontFamily="{StaticResource SymbolThemeFontFamily}">
                                 <ToolTipService.ToolTip>
-                                    <TextBlock x:Uid="MouseWithoutBorders_CopyMachineName" />
+                                    <TextBlock x:Uid="MouseWithoutBorders_CopyMachineName" TextWrapping="Wrap" />
                                 </ToolTipService.ToolTip>
                             </Button>
                         </StackPanel>
@@ -161,7 +161,7 @@
                             </ItemsControl>
                             <Button HorizontalAlignment="Right" Command="{x:Bind Mode=OneTime, Path=ReconnectCommand}">
                                 <ToolTipService.ToolTip>
-                                    <TextBlock x:Uid="MouseWithoutBorders_ReconnectTooltip" />
+                                    <TextBlock x:Uid="MouseWithoutBorders_ReconnectTooltip" TextWrapping="Wrap"/>
                                 </ToolTipService.ToolTip>
                                 <TextBlock x:Uid="MouseWithoutBorders_ReconnectButton" />
                             </Button>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Sometimes it seems that the "Hide mouse at the screen edge" option doesn't work alright, because the helper form used to steal focus is not able to get focus correctly.
Harden it by simulating some mouse input first, similar to what we do on other utilities.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Built PowerToys and started it outside Visual Studio. (Debugger attached makes gaining focus easier according to Windows rules)
After that, tried going to another computer and verified the focus is indeed stolen and that the Window at the top of the screen doesn't get focused instead.
Disable/Enable Mouse Without Borders in the Settings.
Again, tried going to another computer and verified the focus is indeed stolen and that the Window at the top of the screen doesn't get focused instead.