### PR TITLE
[Peek] Handle crash when opening app for Internet shortcuts

### DIFF
--- a/src/modules/peek/Peek.UI/Views/TitleBar.xaml.cs
+++ b/src/modules/peek/Peek.UI/Views/TitleBar.xaml.cs
@@ -138,6 +138,11 @@ namespace Peek.UI.Views
             }
 
             StorageFile? storageFile = await fileItem.GetStorageFileAsync();
+            if (storageFile == null)
+            {
+                return;
+            }
+
             LauncherOptions options = new();
 
             PowerToysTelemetry.Log.WriteEvent(new OpenWithEvent() { App = DefaultAppName ?? string.Empty });

--- a/src/modules/peek/Peek.UI/Views/TitleBar.xaml.cs
+++ b/src/modules/peek/Peek.UI/Views/TitleBar.xaml.cs
@@ -138,16 +138,18 @@ namespace Peek.UI.Views
             }
 
             StorageFile? storageFile = await fileItem.GetStorageFileAsync();
-            if (storageFile == null)
-            {
-                return;
-            }
-
             LauncherOptions options = new();
 
             PowerToysTelemetry.Log.WriteEvent(new OpenWithEvent() { App = DefaultAppName ?? string.Empty });
 
-            if (string.IsNullOrEmpty(DefaultAppName))
+            // StorageFile objects can't represent files that are ".lnk", ".url", or ".wsh" file types.
+            // https://learn.microsoft.com/en-us/uwp/api/windows.storage.storagefile?view=winrt-22621
+            if (storageFile == null)
+            {
+                options.DisplayApplicationPicker = true;
+                await Launcher.LaunchUriAsync(new Uri(Item.Path), options);
+            }
+            else if (string.IsNullOrEmpty(DefaultAppName))
             {
                 // If there's no default app found, open the App picker
                 options.DisplayApplicationPicker = true;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

~~I've added a null check to fix crashing which seems important, but there is still an underlying problem with opening the internet shortcut.~~
~~With the fix, it's not crashing, but clicking the button won't do anything. I'll set this PR as a draft for further investigation, but if I won't finish until the release, we can merge the crash fix at least.~~

StorageFile objects can't represent files that are ".lnk", ".url", or ".wsh" file types and `GetFileFromPathAsync` throws an AccessDenied exception when trying to open such file. 
But it's possible to open those files calling `Launcher.LaunchUriAsync` with the application picker instead of `Launcher.LaunchFileAsync` as for all other file types. 
It won't work without a picker even if you set the app as a default.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #26573
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

* Drag an internet shortcut from the browser to the desktop.
* Preview the shortcut in Peek.
* Click the "Open in Internet Browser".