### PR TITLE
Fixing keyboard hook eagerness. 

### DIFF
--- a/src/modules/MouseWithoutBorders/App/Class/InputHook.cs
+++ b/src/modules/MouseWithoutBorders/App/Class/InputHook.cs
@@ -563,8 +563,8 @@ namespace MouseWithoutBorders.Class
                 }
                 else if (shiftDown || winDown)
                 {
-                    // the following else cases should work if control and alt is pressed, the hotkeys should be captured.
-                    // But if the other 2 modifiers (shift or win) are pressed, they hotkeys should not be activated
+                    // The following else cases should work if control and alt modifiers are pressed. The hotkeys should still be captured.
+                    // But if any of the other 2 modifiers (shift or win) are pressed, they hotkeys should not be activated.
                     // Issue #26597
                     return true;
                 }

--- a/src/modules/MouseWithoutBorders/App/Class/InputHook.cs
+++ b/src/modules/MouseWithoutBorders/App/Class/InputHook.cs
@@ -561,6 +561,13 @@ namespace MouseWithoutBorders.Class
                         Common.MainForm.Quit(false, false);
                     });
                 }
+                else if (shiftDown || winDown)
+                {
+                    // the following else cases should work if control and alt is pressed, the hotkeys should be captured.
+                    // But if the other 2 modifiers (shift or win) are pressed, they hotkeys should not be activated
+                    // Issue #26597
+                    return true;
+                }
                 else if (vkCode == Setting.Values.HotKeySwitchMachine ||
                      vkCode == Setting.Values.HotKeySwitchMachine + 1 ||
                      vkCode == Setting.Values.HotKeySwitchMachine + 2 ||


### PR DESCRIPTION
capture ctrl+alt keys only if shift and win are NOT pressed.

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #26597 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
checking shift and alt key state before capturing a key press

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
tested locally
