### PR TITLE
[Dev]Add missing ATL lib to .vsconfig

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -14,6 +14,7 @@
     "Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre",
     "Microsoft.VisualStudio.Component.VC.ATL.ARM64",
     "Microsoft.VisualStudio.Component.VC.ATL.ARM64.Spectre",
+    "Microsoft.VisualStudio.Component.VC.ATL",
     "Microsoft.VisualStudio.Component.VC.ATL.Spectre",
     "Microsoft.VisualStudio.ComponentGroup.WindowsAppSDK.Cs"
   ]


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

The current .vsconfig file works when we go through Visual Studio and click the warning to install missing requirements. However, it doesn't seem to work when you install Visual Studio from scratch by selecting "Import configuration" from the Visual Studio Installer app.
For some reason, the warning on Visual Studio will install the "Microsoft.VisualStudio.Component.VC.ATL" component, while Visual Studio Installer Import Configuration won't, unless it's specifically in the .vsconfig file.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #19851 (missing this edge case for this issue)

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Installed Visual Studio from Scratch through the import configuration method.
