### PR TITLE
[Run][VS Code] Cleanup and NullReferenceException fix

### DIFF
--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/VSCodeHelper/VSCodeInstances.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/VSCodeHelper/VSCodeInstances.cs
@@ -15,9 +15,7 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.VSCodeHelper
 {
     public static class VSCodeInstances
     {
-        private static List<string> _paths = new List<string>();
-
-        private static string _userAppDataPath = Environment.GetEnvironmentVariable("AppData");
+        private static readonly string _userAppDataPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
 
         public static List<VSCodeInstance> Instances { get; set; } = new List<VSCodeInstance>();
 
@@ -44,7 +42,7 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.VSCodeHelper
             int bitmap1Width = bitmap1.Width;
             int bitmap1Height = bitmap1.Height;
 
-            Bitmap overlayBitmapResized = new Bitmap(overlayBitmap, new System.Drawing.Size(bitmap1Width / 2, bitmap1Height / 2));
+            using Bitmap overlayBitmapResized = new Bitmap(overlayBitmap, new System.Drawing.Size(bitmap1Width / 2, bitmap1Height / 2));
 
             float marginLeft = (float)((bitmap1Width * 0.7) - (overlayBitmapResized.Width * 0.5));
             float marginTop = (float)((bitmap1Height * 0.7) - (overlayBitmapResized.Height * 0.5));
@@ -62,84 +60,80 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.VSCodeHelper
         // Gets the executablePath and AppData foreach instance of VSCode
         public static void LoadVSCodeInstances()
         {
-            var environmentPath = Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.User);
-            environmentPath += (environmentPath.Length > 0 && environmentPath.EndsWith(';') ? ";" : string.Empty) + Environment.GetEnvironmentVariable("PATH");
-            var paths = environmentPath.Split(";").ToList();
-            paths = paths.Distinct().ToList();
+            var environmentPath = Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.User) ?? string.Empty;
+            environmentPath += (environmentPath.Length > 0 && environmentPath.EndsWith(';') ? string.Empty : ";") + Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+            var paths = environmentPath
+                .Split(';')
+                .Distinct()
+                .Where(x => x.Contains("VS Code", StringComparison.OrdinalIgnoreCase)
+                    || x.Contains("VSCodium", StringComparison.OrdinalIgnoreCase)
+                    || x.Contains("vscode", StringComparison.OrdinalIgnoreCase)).ToArray();
 
-            var deletedItems = paths.Except(_paths).Any();
-            var newItems = _paths.Except(paths).Any();
-
-            if (newItems || deletedItems)
+            foreach (var path in paths)
             {
-                Instances = new List<VSCodeInstance>();
-
-                paths = paths.Where(x =>
-                                    x.Contains("VS Code", StringComparison.OrdinalIgnoreCase) ||
-                                    x.Contains("VSCodium", StringComparison.OrdinalIgnoreCase) ||
-                                    x.Contains("vscode", StringComparison.OrdinalIgnoreCase)).ToList();
-                foreach (var path in paths)
+                if (Directory.Exists(path))
                 {
-                    if (Directory.Exists(path))
+                    var files = Directory.GetFiles(path)
+                        .Where(x => (x.Contains("code", StringComparison.OrdinalIgnoreCase) || x.Contains("VSCodium", StringComparison.OrdinalIgnoreCase))
+                            && !x.EndsWith(".cmd", StringComparison.OrdinalIgnoreCase)).ToArray();
+
+                    var iconPath = Path.GetDirectoryName(path);
+
+                    if (files.Length > 0)
                     {
-                        var files = Directory.GetFiles(path);
-                        var iconPath = Path.GetDirectoryName(path);
-                        files = files.Where(x =>
-                                            (x.Contains("code", StringComparison.OrdinalIgnoreCase) ||
-                                            x.Contains("VSCodium", StringComparison.OrdinalIgnoreCase))
-                                            && !x.EndsWith(".cmd", StringComparison.OrdinalIgnoreCase)).ToArray();
+                        var file = files[0];
+                        var version = string.Empty;
 
-                        if (files.Length > 0)
+                        var instance = new VSCodeInstance
                         {
-                            var file = files[0];
-                            var version = string.Empty;
+                            ExecutablePath = file,
+                        };
 
-                            var instance = new VSCodeInstance
-                            {
-                                ExecutablePath = file,
-                            };
+                        if (file.EndsWith("code", StringComparison.OrdinalIgnoreCase))
+                        {
+                            version = "Code";
+                            instance.VSCodeVersion = VSCodeVersion.Stable;
+                        }
+                        else if (file.EndsWith("code-insiders", StringComparison.OrdinalIgnoreCase))
+                        {
+                            version = "Code - Insiders";
+                            instance.VSCodeVersion = VSCodeVersion.Insiders;
+                        }
+                        else if (file.EndsWith("code-exploration", StringComparison.OrdinalIgnoreCase))
+                        {
+                            version = "Code - Exploration";
+                            instance.VSCodeVersion = VSCodeVersion.Exploration;
+                        }
+                        else if (file.EndsWith("VSCodium", StringComparison.OrdinalIgnoreCase))
+                        {
+                            version = "VSCodium";
+                            instance.VSCodeVersion = VSCodeVersion.Stable; // ?
+                        }
 
-                            if (file.EndsWith("code", StringComparison.OrdinalIgnoreCase))
-                            {
-                                version = "Code";
-                                instance.VSCodeVersion = VSCodeVersion.Stable;
-                            }
-                            else if (file.EndsWith("code-insiders", StringComparison.OrdinalIgnoreCase))
-                            {
-                                version = "Code - Insiders";
-                                instance.VSCodeVersion = VSCodeVersion.Insiders;
-                            }
-                            else if (file.EndsWith("code-exploration", StringComparison.OrdinalIgnoreCase))
-                            {
-                                version = "Code - Exploration";
-                                instance.VSCodeVersion = VSCodeVersion.Exploration;
-                            }
-                            else if (file.EndsWith("VSCodium", StringComparison.OrdinalIgnoreCase))
-                            {
-                                version = "VSCodium";
-                                instance.VSCodeVersion = VSCodeVersion.Stable; // ?
-                            }
+                        if (version != string.Empty)
+                        {
+                            var portableData = Path.Join(iconPath, "data");
+                            instance.AppData = Directory.Exists(portableData) ? Path.Join(portableData, "user-data") : Path.Combine(_userAppDataPath, version);
 
-                            if (version != string.Empty)
+                            var vsCodeIconPath = Path.Join(iconPath, $"{version}.exe");
+                            var vsCodeIcon = Icon.ExtractAssociatedIcon(vsCodeIconPath);
+
+                            if (vsCodeIcon != null)
                             {
-                                var portableData = Path.Join(iconPath, "data");
-                                instance.AppData = Directory.Exists(portableData) ? Path.Join(portableData, "user-data") : Path.Combine(_userAppDataPath, version);
-
-                                var iconVSCode = Path.Join(iconPath, $"{version}.exe");
-
-                                var bitmapIconVscode = Icon.ExtractAssociatedIcon(iconVSCode).ToBitmap();
+                                using var vsCodeIconBitmap = vsCodeIcon.ToBitmap();
 
                                 // workspace
-                                var folderIcon = (Bitmap)System.Drawing.Image.FromFile(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + "//Images//folder.png");
-                                instance.WorkspaceIconBitMap = Bitmap2BitmapImage(BitmapOverlayToCenter(folderIcon, bitmapIconVscode));
+                                using var folderIcon = (Bitmap)Image.FromFile(Path.Join(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "Images//folder.png"));
+                                using var bitmapFolderIcon = BitmapOverlayToCenter(folderIcon, vsCodeIconBitmap);
+                                instance.WorkspaceIconBitMap = Bitmap2BitmapImage(bitmapFolderIcon);
 
                                 // remote
-                                var monitorIcon = (Bitmap)System.Drawing.Image.FromFile(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + "//Images//monitor.png");
-
-                                instance.RemoteIconBitMap = Bitmap2BitmapImage(BitmapOverlayToCenter(monitorIcon, bitmapIconVscode));
-
-                                Instances.Add(instance);
+                                using var monitorIcon = (Bitmap)Image.FromFile(Path.Join(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "Images//monitor.png"));
+                                using var bitmapMonitorIcon = BitmapOverlayToCenter(monitorIcon, vsCodeIconBitmap);
+                                instance.RemoteIconBitMap = Bitmap2BitmapImage(bitmapMonitorIcon);
                             }
+
+                            Instances.Add(instance);
                         }
                     }
                 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Cleanup and possible `NullReferenceException` fix in the logic that read VS Code instances:
- Edge case but `Environment.GetEnvironmentVariable(...)` and `Icon.ExtractAssociatedIcon(...)` may return `null`
- Added missing `using`

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #26633
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

VS Code plugin provides results for VS Code workspaces in PT Run
