### PR TITLE
[Registry Preview] Fix the issue of saving files without truncation

### DIFF
--- a/src/modules/registrypreview/RegistryPreviewUI/MainWindow.Utilities.cs
+++ b/src/modules/registrypreview/RegistryPreviewUI/MainWindow.Utilities.cs
@@ -800,7 +800,7 @@ namespace RegistryPreview
                 FileStreamOptions fileStreamOptions = new FileStreamOptions();
                 fileStreamOptions.Access = FileAccess.Write;
                 fileStreamOptions.Share = FileShare.Write;
-                fileStreamOptions.Mode = FileMode.OpenOrCreate;
+                fileStreamOptions.Mode = FileMode.Create;
 
                 fileStream = new FileStream(App.AppFilename, fileStreamOptions);
                 StreamWriter streamWriter = new StreamWriter(fileStream, System.Text.Encoding.Unicode);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Fix the issue of saving files without truncation, according to <https://learn.microsoft.com/en-us/dotnet/api/system.io.filemode?view=net-7.0>, it should be `FileMode.Create`, not `FileMode.OpenOrCreate`, which will truncate the file if it exists.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #27049 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

