### PR TITLE
[Hosts] Consolidate launch

### DIFF
--- a/src/modules/Hosts/HostsModuleInterface/dllmain.cpp
+++ b/src/modules/Hosts/HostsModuleInterface/dllmain.cpp
@@ -147,7 +147,17 @@ public:
             if (m_enabled && err == ERROR_SUCCESS)
             {
                 Logger::trace(L"{} event was signaled", CommonSharedConstants::SHOW_HOSTS_EVENT);
-                launch_process(false);
+
+                if (is_process_running())
+                {
+                    bring_process_to_front();
+                }
+                else
+                {
+                    launch_process(false);
+                }
+
+                Trace::ActivateEditor();
             }
         });
 
@@ -156,7 +166,17 @@ public:
             if (m_enabled && err == ERROR_SUCCESS)
             {
                 Logger::trace(L"{} event was signaled", CommonSharedConstants::SHOW_HOSTS_ADMIN_EVENT);
-                launch_process(true);
+                
+                if (is_process_running())
+                {
+                    bring_process_to_front();
+                }
+                else
+                {
+                    launch_process(true);
+                }
+
+                Trace::ActivateEditor();
             }
         });
     }
@@ -209,31 +229,8 @@ public:
         return false;
     }
 
-    virtual void call_custom_action(const wchar_t* action) override
+    virtual void call_custom_action(const wchar_t* /*action*/) override
     {
-        try
-        {
-            PowerToysSettings::CustomActionObject action_object =
-                PowerToysSettings::CustomActionObject::from_json_string(action);
-
-            if (is_process_running())
-            {
-                bring_process_to_front();
-            }
-            else if (action_object.get_name() == L"Launch")
-            {
-                launch_process(false);
-            }
-            else if (action_object.get_name() == L"LaunchAdministrator")
-            {
-                launch_process(true);
-            }
-            Trace::ActivateEditor();
-        }
-        catch (std::exception&)
-        {
-            Logger::error(L"Failed to parse action. {}", action);
-        }
     }
 
     virtual void set_config(const wchar_t* /*config*/) override

--- a/src/settings-ui/Settings.UI/Flyout/LaunchPage.xaml.cs
+++ b/src/settings-ui/Settings.UI/Flyout/LaunchPage.xaml.cs
@@ -2,7 +2,6 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 using System;
-using System.Collections.ObjectModel;
 using System.Threading;
 using global::Windows.System;
 using interop;
@@ -10,7 +9,6 @@ using Microsoft.PowerToys.Settings.UI.Controls;
 using Microsoft.PowerToys.Settings.UI.Library;
 using Microsoft.PowerToys.Settings.UI.Library.Telemetry.Events;
 using Microsoft.PowerToys.Settings.UI.ViewModels;
-using Microsoft.PowerToys.Settings.UI.Views;
 using Microsoft.PowerToys.Telemetry;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -54,13 +52,11 @@ namespace Microsoft.PowerToys.Settings.UI.Flyout
                 case "Hosts": // Launch Hosts
                     {
                         bool launchAdmin = SettingsRepository<HostsSettings>.GetInstance(new SettingsUtils()).SettingsConfig.Properties.LaunchAdministrator;
-                        var actionName = "Launch";
-                        if (!App.IsElevated && launchAdmin)
+                        string eventName = App.IsElevated || !launchAdmin ? Constants.ShowHostsSharedEvent() : Constants.ShowHostsAdminSharedEvent();
+                        using (var eventHandle = new EventWaitHandle(false, EventResetMode.AutoReset, eventName))
                         {
-                            actionName = "LaunchAdministrator";
+                            eventHandle.Set();
                         }
-
-                        Views.ShellPage.SendDefaultIPCMessage("{\"action\":{\"Hosts\":{\"action_name\":\"" + actionName + "\", \"value\":\"\"}}}");
                     }
 
                     break;

--- a/src/settings-ui/Settings.UI/Flyout/LaunchPage.xaml.cs
+++ b/src/settings-ui/Settings.UI/Flyout/LaunchPage.xaml.cs
@@ -52,7 +52,10 @@ namespace Microsoft.PowerToys.Settings.UI.Flyout
                 case "Hosts": // Launch Hosts
                     {
                         bool launchAdmin = SettingsRepository<HostsSettings>.GetInstance(new SettingsUtils()).SettingsConfig.Properties.LaunchAdministrator;
-                        string eventName = App.IsElevated || !launchAdmin ? Constants.ShowHostsSharedEvent() : Constants.ShowHostsAdminSharedEvent();
+                        string eventName = !App.IsElevated && launchAdmin
+                            ? Constants.ShowHostsAdminSharedEvent()
+                            : Constants.ShowHostsSharedEvent();
+
                         using (var eventHandle = new EventWaitHandle(false, EventResetMode.AutoReset, eventName))
                         {
                             eventHandle.Set();

--- a/src/settings-ui/Settings.UI/OOBE/Views/OobeHosts.xaml.cs
+++ b/src/settings-ui/Settings.UI/OOBE/Views/OobeHosts.xaml.cs
@@ -37,7 +37,10 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
         private void Launch_Hosts_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
         {
             bool launchAdmin = SettingsRepository<HostsSettings>.GetInstance(new SettingsUtils()).SettingsConfig.Properties.LaunchAdministrator;
-            string eventName = App.IsElevated || !launchAdmin ? Constants.ShowHostsSharedEvent() : Constants.ShowHostsAdminSharedEvent();
+            string eventName = !App.IsElevated && launchAdmin
+                ? Constants.ShowHostsAdminSharedEvent()
+                : Constants.ShowHostsSharedEvent();
+
             using (var eventHandle = new EventWaitHandle(false, EventResetMode.AutoReset, eventName))
             {
                 eventHandle.Set();

--- a/src/settings-ui/Settings.UI/OOBE/Views/OobeHosts.xaml.cs
+++ b/src/settings-ui/Settings.UI/OOBE/Views/OobeHosts.xaml.cs
@@ -2,6 +2,8 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading;
+using interop;
 using Microsoft.PowerToys.Settings.UI.Library;
 using Microsoft.PowerToys.Settings.UI.OOBE.Enums;
 using Microsoft.PowerToys.Settings.UI.OOBE.ViewModel;
@@ -35,14 +37,11 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
         private void Launch_Hosts_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
         {
             bool launchAdmin = SettingsRepository<HostsSettings>.GetInstance(new SettingsUtils()).SettingsConfig.Properties.LaunchAdministrator;
-            var actionName = "Launch";
-
-            if (!App.IsElevated && launchAdmin)
+            string eventName = App.IsElevated || !launchAdmin ? Constants.ShowHostsSharedEvent() : Constants.ShowHostsAdminSharedEvent();
+            using (var eventHandle = new EventWaitHandle(false, EventResetMode.AutoReset, eventName))
             {
-                actionName = "LaunchAdministrator";
+                eventHandle.Set();
             }
-
-            ShellPage.SendDefaultIPCMessage("{\"action\":{\"Hosts\":{\"action_name\":\"" + actionName + "\", \"value\":\"\"}}}");
         }
 
         private void Launch_Settings_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)

--- a/src/settings-ui/Settings.UI/ViewModels/HostsViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/HostsViewModel.cs
@@ -157,7 +157,10 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
 
         public void Launch()
         {
-            string eventName = _isElevated || !LaunchAdministrator ? Constants.ShowHostsSharedEvent() : Constants.ShowHostsAdminSharedEvent();
+            string eventName = !_isElevated && LaunchAdministrator
+                ? Constants.ShowHostsAdminSharedEvent()
+                : Constants.ShowHostsSharedEvent();
+
             using (var eventHandle = new EventWaitHandle(false, EventResetMode.AutoReset, eventName))
             {
                 eventHandle.Set();

--- a/src/settings-ui/Settings.UI/ViewModels/HostsViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/HostsViewModel.cs
@@ -4,7 +4,9 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using global::PowerToys.GPOWrapper;
+using interop;
 using Microsoft.PowerToys.Settings.UI.Library;
 using Microsoft.PowerToys.Settings.UI.Library.Helpers;
 using Microsoft.PowerToys.Settings.UI.Library.Interfaces;
@@ -155,14 +157,11 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
 
         public void Launch()
         {
-            var actionName = "Launch";
-
-            if (!_isElevated && LaunchAdministrator)
+            string eventName = _isElevated || !LaunchAdministrator ? Constants.ShowHostsSharedEvent() : Constants.ShowHostsAdminSharedEvent();
+            using (var eventHandle = new EventWaitHandle(false, EventResetMode.AutoReset, eventName))
             {
-                actionName = "LaunchAdministrator";
+                eventHandle.Set();
             }
-
-            SendConfigMSG("{\"action\":{\"Hosts\":{\"action_name\":\"" + actionName + "\", \"value\":\"\"}}}");
         }
 
         public void NotifyPropertyChanged([CallerMemberName] string propertyName = null)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Consolidate how Hosts Editor is launched using events.
Fix 2 small issues when launched through events (PT Run):
- ActivateEditor telemetry event was missing
- Another process was always started

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #26490
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Tested launch from:
  - Settings page
  - OOBE
  - Flyout
  - PT Run
- Tested with:
  - PT admin
  - PT user
  - PT user and Hosts **launch as administrator** setting enabled
