### PR TITLE
[Registry Preview] Fix for bug 27234 that doesn't display DWORD values.

### DIFF
--- a/src/modules/registrypreview/RegistryPreviewUI/MainWindow.Utilities.cs
+++ b/src/modules/registrypreview/RegistryPreviewUI/MainWindow.Utilities.cs
@@ -438,6 +438,8 @@ namespace RegistryPreview
                                 registryValue.Type = "ERROR";
                             }
 
+                            registryValue.Value = value;
+
                             break;
                         case "REG_QWORD":
                             if (value.Length <= 0)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
A line of code got removed at some point, causing DWORD Values to not show its value in the previewers.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [X] **Closes:** #27234
- [X] **Tests:** Added/updated and all pass

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Add back a line that should have been there on the last check-in for this file.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Tested with my usual collection of REG files and actually looked for the value on in the grid.