### PR TITLE
[FileLocksmith] Fix issue causing explorer to crash

### DIFF
--- a/installer/PowerToysSetup/FileLocksmith.wxs
+++ b/installer/PowerToysSetup/FileLocksmith.wxs
@@ -27,9 +27,6 @@
         <RegistryKey Root="$(var.RegistryScope)" Key="Software\Classes\Drive\ShellEx\ContextMenuHandlers\FileLocksmithExt">
           <RegistryValue Type="string" Value="{84D68575-E186-46AD-B0CB-BAEB45EE29C0}"/>
         </RegistryKey>
-		<RegistryKey Root="$(var.RegistryScope)" Key="SOFTWARE\Classes\Directory\background\ShellEx\ContextMenuHandlers\FileLocksmithExt">
-          <RegistryValue Type="string" Value="{84D68575-E186-46AD-B0CB-BAEB45EE29C0}"/>
-        </RegistryKey>
       </Component>
     </DirectoryRef>
 

--- a/src/modules/FileLocksmith/FileLocksmithExt/ExplorerCommand.cpp
+++ b/src/modules/FileLocksmith/FileLocksmithExt/ExplorerCommand.cpp
@@ -69,25 +69,7 @@ IFACEMETHODIMP ExplorerCommand::GetCanonicalName(GUID* pguidCommandName)
 
 IFACEMETHODIMP ExplorerCommand::GetState(IShellItemArray* psiItemArray, BOOL fOkToBeSlow, EXPCMDSTATE* pCmdState)
 {
-    if (!globals::enabled)
-    {
-        *pCmdState = ECS_HIDDEN;
-    }
-
-    if (FileLocksmithSettingsInstance().GetShowInExtendedContextMenu())
-    {
-        *pCmdState = ECS_HIDDEN;
-        return S_OK;
-    }
-
-    // When right clicking directory background, selection is empty.
-    if (nullptr == psiItemArray)
-    {
-        *pCmdState = ECS_HIDDEN;
-        return S_OK;
-    }
-
-    *pCmdState = ECS_ENABLED;
+    *pCmdState = FileLocksmithSettingsInstance().GetEnabled() ? ECS_ENABLED : ECS_HIDDEN;
     return S_OK;
 }
 
@@ -112,9 +94,11 @@ IFACEMETHODIMP ExplorerCommand::EnumSubCommands(IEnumExplorerCommand** ppEnum)
 
 IFACEMETHODIMP ExplorerCommand::Initialize(PCIDLIST_ABSOLUTE pidlFolder, IDataObject* pdtobj, HKEY hkeyProgID)
 {
+    m_data_obj = NULL;
+
     if (!FileLocksmithSettingsInstance().GetEnabled())
     {
-        return S_OK;
+        return E_FAIL;
     }
 
     if (pdtobj)
@@ -132,12 +116,12 @@ IFACEMETHODIMP ExplorerCommand::QueryContextMenu(HMENU hmenu, UINT indexMenu, UI
     // Skip if disabled
     if (!FileLocksmithSettingsInstance().GetEnabled())
     {
-        return S_OK;
+        return E_FAIL;
     }
 
     if (FileLocksmithSettingsInstance().GetShowInExtendedContextMenu() && !(uFlags & CMF_EXTENDEDVERBS))
     {
-        return S_OK;
+        return E_FAIL;
     }
 
     HRESULT hr = E_UNEXPECTED;

--- a/src/modules/FileLocksmith/FileLocksmithExt/dllmain.cpp
+++ b/src/modules/FileLocksmith/FileLocksmithExt/dllmain.cpp
@@ -11,7 +11,6 @@ namespace globals
 {
     HMODULE instance;
     std::atomic<ULONG> ref_count;
-    std::atomic<bool> enabled;
 }
 
 BOOL APIENTRY DllMain( HMODULE hModule,


### PR DESCRIPTION
Remove unneeded registry key
Align context menu handler logic with other modules

Newly introduced registry key (to support having FileLocksmith context menu entry when opening context menu from directory background) was causing explorer to crash. After updating PT to new version, explorer still has old version context menu handler dll loaded which does not support the directory background trigger. Therefore, triggering context menu from dir background was causing explorer to crash in some cases. Explorer restart would mitigate this because it would load new dll after restart.

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #27230 #27241
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Scenario 1
 - Install older PT version (e.g. v70.1
 - Take some file (any), right-click it to trigger context menu handler
 - Delete the file
 - Install this PT version
 - Right click desktop
 - Ensure explorer does not crash

Scenario 2
 - Install PT v71
 - Update using this version
 - Ensure that FileLocksmith still works as expected.
 - Change Show in extended context menu setting and ensure it works as expected.
