### PR TITLE
[MWB]Update the service's path on a new install

### DIFF
--- a/src/modules/MouseWithoutBorders/App/Class/Common.cs
+++ b/src/modules/MouseWithoutBorders/App/Class/Common.cs
@@ -735,7 +735,7 @@ namespace MouseWithoutBorders
             SendPackage(src, PackageType.ClipboardCapture);
         }
 
-        internal static void ShowToolTip(string tip, int timeOutInMilliseconds = 5000, ToolTipIcon icon = ToolTipIcon.Info, bool showBalloonTip = true)
+        internal static void ShowToolTip(string tip, int timeOutInMilliseconds = 5000, ToolTipIcon icon = ToolTipIcon.Info, bool showBalloonTip = true, bool forceEvenIfHidingOldUI = false)
         {
             if (!Common.RunOnLogonDesktop && !Common.RunOnScrSaverDesktop)
             {
@@ -752,7 +752,7 @@ namespace MouseWithoutBorders
                     {
                         if (MainForm != null)
                         {
-                            MainForm.ShowToolTip(tip, timeOutInMilliseconds);
+                            MainForm.ShowToolTip(tip, timeOutInMilliseconds, forceEvenIfHidingOldUI: forceEvenIfHidingOldUI);
                         }
                         else
                         {

--- a/src/modules/MouseWithoutBorders/App/Class/Program.cs
+++ b/src/modules/MouseWithoutBorders/App/Class/Program.cs
@@ -46,6 +46,8 @@ namespace MouseWithoutBorders.Class
 
         private static readonly string ServiceModeArg = "UseService";
 
+        public static bool ShowServiceModeErrorTooltip;
+
         [STAThread]
         private static void Main()
         {
@@ -98,6 +100,7 @@ namespace MouseWithoutBorders.Class
                     {
                         Common.Log("Couldn't start the service. Will try to continue as not a service.");
                         Common.Log(ex);
+                        ShowServiceModeErrorTooltip = true;
                         serviceMode = false;
                         Setting.Values.UseService = false;
                     }

--- a/src/modules/MouseWithoutBorders/App/Form/frmScreen.cs
+++ b/src/modules/MouseWithoutBorders/App/Form/frmScreen.cs
@@ -897,7 +897,10 @@ namespace MouseWithoutBorders
         {
             if (!Common.RunOnLogonDesktop && !Common.RunOnScrSaverDesktop)
             {
+                // In order to show tooltips, the icon needs to be shown.
+                NotifyIcon.Visible = true;
                 NotifyIcon.ShowBalloonTip(timeOutInMilliseconds, Application.ProductName, txt, icon);
+                NotifyIcon.Visible = Setting.Values.ShowOriginalUI;
             }
         }
 
@@ -938,6 +941,11 @@ namespace MouseWithoutBorders
             {
                 NotifyIcon.Visible = false;
                 NotifyIcon.Visible = Setting.Values.ShowOriginalUI;
+            }
+
+            if (Program.ShowServiceModeErrorTooltip)
+            {
+                Common.ShowToolTip("Couldn't start the service. Will continue as not a service. Service mode must be enabled in the Settings again.", 10000);
             }
         }
 

--- a/src/modules/MouseWithoutBorders/App/Form/frmScreen.cs
+++ b/src/modules/MouseWithoutBorders/App/Form/frmScreen.cs
@@ -893,14 +893,23 @@ namespace MouseWithoutBorders
             }
         }
 
-        internal void ShowToolTip(string txt, int timeOutInMilliseconds, ToolTipIcon icon = ToolTipIcon.Info)
+        internal void ShowToolTip(string txt, int timeOutInMilliseconds, ToolTipIcon icon = ToolTipIcon.Info, bool forceEvenIfHidingOldUI = false)
         {
             if (!Common.RunOnLogonDesktop && !Common.RunOnScrSaverDesktop)
             {
+                var oldNotifyVisibility = NotifyIcon.Visible;
+
                 // In order to show tooltips, the icon needs to be shown.
-                NotifyIcon.Visible = true;
+                if (forceEvenIfHidingOldUI)
+                {
+                    NotifyIcon.Visible = true;
+                }
+
                 NotifyIcon.ShowBalloonTip(timeOutInMilliseconds, Application.ProductName, txt, icon);
-                NotifyIcon.Visible = Setting.Values.ShowOriginalUI;
+                if (forceEvenIfHidingOldUI)
+                {
+                    NotifyIcon.Visible = oldNotifyVisibility;
+                }
             }
         }
 
@@ -945,7 +954,7 @@ namespace MouseWithoutBorders
 
             if (Program.ShowServiceModeErrorTooltip)
             {
-                Common.ShowToolTip("Couldn't start the service. Will continue as not a service. Service mode must be enabled in the Settings again.", 10000);
+                Common.ShowToolTip("Couldn't start the service. Will continue as not a service. Service mode must be enabled in the Settings again.", 10000, forceEvenIfHidingOldUI: true);
             }
         }
 

--- a/src/modules/MouseWithoutBorders/ModuleInterface/dllmain.cpp
+++ b/src/modules/MouseWithoutBorders/ModuleInterface/dllmain.cpp
@@ -243,13 +243,27 @@ private:
             }
         }
 
+        // Pass local app data of the current user to the service
+        PWSTR cLocalAppPath;
+        winrt::check_hresult(SHGetKnownFolderPath(FOLDERID_LocalAppData, 0, nullptr, &cLocalAppPath));
+        CoTaskMemFree(cLocalAppPath);
+
+        std::wstring localAppPath{ cLocalAppPath };
+        std::wstring binaryWithArgsPath = L"\"";
+        binaryWithArgsPath += servicePath;
+        binaryWithArgsPath += L"\" ";
+        binaryWithArgsPath += escapeDoubleQuotes(localAppPath);
+
         bool alreadyRegistered = false;
+        bool isServicePathCorrect = true;
         if (pServiceConfig)
         {
             std::wstring_view existingServicePath{ pServiceConfig->lpBinaryPathName };
-            existingServicePath = existingServicePath.substr(1, existingServicePath.find(L'"', 1) - 1);
-            alreadyRegistered = std::filesystem::path{ existingServicePath } == servicePath;
-            LocalFree(pServiceConfig);
+            alreadyRegistered = true;
+            isServicePathCorrect = (existingServicePath == binaryWithArgsPath);
+            if (isServicePathCorrect) {
+                Logger::warn(L"The service path is not correct. Current: {} Expected: {}", existingServicePath, binaryWithArgsPath);
+            }
 
             if (alreadyRegistered && pServiceConfig->dwStartType == SERVICE_DISABLED)
             {
@@ -274,46 +288,33 @@ private:
                     }
                 }
             }
-
-            if (alreadyRegistered)
-            {
-                SERVICE_DELAYED_AUTO_START_INFO delayedAutoStartInfo;
-                if (!QueryServiceConfig2W(schService, SERVICE_CONFIG_DELAYED_AUTO_START_INFO, reinterpret_cast<LPBYTE>(&delayedAutoStartInfo), sizeof(delayedAutoStartInfo), &bytesNeeded) || delayedAutoStartInfo.fDelayedAutostart)
-                {
-                    alreadyRegistered = false;
-                    // Wait until the service has been actually deleted so we can recreate it again
-                    for (int i = 0; i < 10; ++i)
-                    {
-                        schService = OpenServiceW(schSCManager, SERVICE_NAME, SERVICE_QUERY_STATUS | SERVICE_QUERY_CONFIG | SERVICE_CHANGE_CONFIG);
-                        if (schService)
-                        {
-                            CloseServiceHandle(schService);
-                            Sleep(1000);
-                        }
-                        else
-                        {
-                            break;
-                        }
-                    }
-                }
-            }
+            LocalFree(pServiceConfig);
         }
 
         if (alreadyRegistered)
         {
+            if (!isServicePathCorrect) {
+                if (!ChangeServiceConfigW(schService,
+                    SERVICE_NO_CHANGE,
+                    SERVICE_NO_CHANGE,
+                    SERVICE_NO_CHANGE,
+                    binaryWithArgsPath.c_str(),
+                    nullptr,
+                    nullptr,
+                    nullptr,
+                    nullptr,
+                    nullptr,
+                    nullptr))
+                {
+                    Logger::error(L"Failed to update the service's path. ERROR: {}", GetLastError());
+                }
+                else
+                {
+                    Logger::info(L"Updated the service's path.");
+                }
+            }
             return;
         }
-
-        // Pass local app data of the current user to the service
-        PWSTR cLocalAppPath;
-        winrt::check_hresult(SHGetKnownFolderPath(FOLDERID_LocalAppData, 0, nullptr, &cLocalAppPath));
-        CoTaskMemFree(cLocalAppPath);
-
-        std::wstring localAppPath{ cLocalAppPath };
-        std::wstring binaryWithArgsPath = L"\"";
-        binaryWithArgsPath += servicePath;
-        binaryWithArgsPath += L"\" ";
-        binaryWithArgsPath += escapeDoubleQuotes(localAppPath);
 
         schService = CreateServiceW(
             schSCManager,


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
When the service path updates between installations, it's impossible to set the service correctly again without deleting the service manually.
This PR makes changes so that the service path gets updated.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #27357
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Also deletes some unused code that waits on service deletion, but actually wasn't doing anything and wasn't even called.
Adds a tooltip message to show when the service couldn't start correctly.
Adds code to show tooltips correctly even when ShowOriginalUI is off, since no tooltips were being shown in that case.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
1 - Install 0.71.0 user install and set up mwb with service mode on, then uninstall.
2 - Install a machine version based on this PR and verify it shows the MWB tooltip saying it couldn't start as a service.
3 - Try to enable the service and verify it works.

I've also tested with "PowerToys always running as admin" on and that is able to register the new path correctly right after install.