### PR TITLE
[PTRun] Replace direct dictionary access with TryGetValue in ImageCache getter for KeyNotFoundException fix.

### DIFF
--- a/src/modules/launcher/Wox.Infrastructure/Image/ImageCache.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Image/ImageCache.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Windows.Media;
 using Wox.Infrastructure.Storage;
 using Wox.Plugin;
+using Wox.Plugin.Logger;
 
 namespace Wox.Infrastructure.Image
 {
@@ -35,6 +36,12 @@ namespace Wox.Infrastructure.Image
             {
                 Usage.AddOrUpdate(path, 1, (k, v) => v + 1);
                 _data.TryGetValue(path, out ImageSource i);
+
+                if (i == null)
+                {
+                    Log.Warn($"ImageSource is null for path: {path}", GetType());
+                }
+
                 return i;
             }
 

--- a/src/modules/launcher/Wox.Infrastructure/Image/ImageCache.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Image/ImageCache.cs
@@ -34,7 +34,7 @@ namespace Wox.Infrastructure.Image
             get
             {
                 Usage.AddOrUpdate(path, 1, (k, v) => v + 1);
-                var i = _data[path];
+                _data.TryGetValue(path, out ImageSource i);
                 return i;
             }
 

--- a/src/modules/launcher/Wox.Plugin/Common/ShellLocalization.cs
+++ b/src/modules/launcher/Wox.Plugin/Common/ShellLocalization.cs
@@ -14,8 +14,6 @@ namespace Wox.Plugin.Common
     /// </summary>
     public class ShellLocalization
     {
-        private readonly object _cacheLock = new object();
-
         // Cache for already localized names. This makes localization of already localized string faster.
         private Dictionary<string, string> _localizationCache = new Dictionary<string, string>();
 
@@ -41,14 +39,11 @@ namespace Wox.Plugin.Common
 
             shellItem.GetDisplayName(SIGDN.NORMALDISPLAY, out string filename);
 
-            lock (_cacheLock)
+            if (!_localizationCache.ContainsKey(path.ToLowerInvariant()))
             {
-                if (!_localizationCache.ContainsKey(path.ToLowerInvariant()))
-                {
-                    // The if condition is required to not get timing problems when called from an parallel execution.
-                    // Without the check we will get "key exists" exceptions.
-                    _localizationCache.Add(path.ToLowerInvariant(), filename);
-                }
+                // The if condition is required to not get timing problems when called from an parallel execution.
+                // Without the check we will get "key exists" exceptions.
+                _localizationCache.Add(path.ToLowerInvariant(), filename);
             }
 
             return filename;

--- a/src/modules/launcher/Wox.Plugin/Common/ShellLocalization.cs
+++ b/src/modules/launcher/Wox.Plugin/Common/ShellLocalization.cs
@@ -14,6 +14,8 @@ namespace Wox.Plugin.Common
     /// </summary>
     public class ShellLocalization
     {
+        private readonly object _cacheLock = new object();
+
         // Cache for already localized names. This makes localization of already localized string faster.
         private Dictionary<string, string> _localizationCache = new Dictionary<string, string>();
 
@@ -39,11 +41,14 @@ namespace Wox.Plugin.Common
 
             shellItem.GetDisplayName(SIGDN.NORMALDISPLAY, out string filename);
 
-            if (!_localizationCache.ContainsKey(path.ToLowerInvariant()))
+            lock (_cacheLock)
             {
-                // The if condition is required to not get timing problems when called from an parallel execution.
-                // Without the check we will get "key exists" exceptions.
-                _localizationCache.Add(path.ToLowerInvariant(), filename);
+                if (!_localizationCache.ContainsKey(path.ToLowerInvariant()))
+                {
+                    // The if condition is required to not get timing problems when called from an parallel execution.
+                    // Without the check we will get "key exists" exceptions.
+                    _localizationCache.Add(path.ToLowerInvariant(), filename);
+                }
             }
 
             return filename;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #25848 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
I tried to reproduce issue. I couldn't get same exception. But similar one is reproduced and fixed. With this fix, it is expected that both the issue and the bug will be resolved. The error I can reproduce is as follows:

-------------------------- Begin exception --------------------------
Message: Failed to get thumbnail for C:\Users\gokce\.vscode\extensions\.58ba1792-1e22-420f-b29f-08d052e2bce7\dist\bundled\stubs\sklearn\kernel_approximation.pyi

Exception full name  : System.Collections.Generic.KeyNotFoundException
Exception message    : The given key 'C:\Users\gokce\source\repos\PowerToys\x64\Debug\modules\launcher\Images\app_error.light.png' was not present in the dictionary.
Exception stack trace:
   at System.Collections.Concurrent.ConcurrentDictionary`2.ThrowKeyNotFoundException(TKey key)
   at System.Collections.Concurrent.ConcurrentDictionary`2.get_Item(TKey key)
   at Wox.Infrastructure.Image.ImageCache.get_Item(String path) in C:\Users\gokce\Source\Repos\PowerToys\src\modules\launcher\Wox.Infrastructure\Image\ImageCache.cs:line 37
   at Wox.Infrastructure.Image.ImageLoader.GetThumbnailResult(String& path, Boolean generateThumbnailsFromFiles, Boolean loadFullImage) in C:\Users\gokce\Source\Repos\PowerToys\src\modules\launcher\Wox.Infrastructure\Image\ImageLoader.cs:line 221
   at Wox.Infrastructure.Image.ImageLoader.<>c__DisplayClass17_0.<LoadInternalAsync>b__0() in C:\Users\gokce\Source\Repos\PowerToys\src\modules\launcher\Wox.Infrastructure\Image\ImageLoader.cs:line 142
   at System.Threading.Tasks.Task`1.InnerInvoke()
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread)
--- End of stack trace from previous location ---
   at Wox.Infrastructure.Image.ImageLoader.LoadInternalAsync(String path, Boolean generateThumbnailsFromFiles, Boolean loadFullImage) in C:\Users\gokce\Source\Repos\PowerToys\src\modules\launcher\Wox.Infrastructure\Image\ImageLoader.cs:line 142
Exception source     : System.Collections.Concurrent
Exception target site: Void ThrowKeyNotFoundException(TKey)
Exception HResult    : -2146232969
-------------------------- End exception --------------------------
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

