### PR TITLE
[Launcher] extending TextChangedEventArgs with Initiator

### DIFF
--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -358,10 +358,18 @@ namespace PowerLauncher
                 _isTextSetProgrammatically = true;
                 if (_viewModel.Results != null)
                 {
-                    SearchBox.QueryTextBox.Text = MainViewModel.GetSearchText(
+                    string newText = MainViewModel.GetSearchText(
                         _viewModel.Results.SelectedIndex,
                         _viewModel.SystemQueryText,
                         _viewModel.QueryText);
+                    if (SearchBox.QueryTextBox.Text != newText)
+                    {
+                        SearchBox.QueryTextBox.Text = newText;
+                    }
+                    else
+                    {
+                        _isTextSetProgrammatically = false;
+                    }
                 }
             }
         }
@@ -455,6 +463,12 @@ namespace PowerLauncher
 
         private void Launcher_KeyDown(object sender, KeyEventArgs e)
         {
+            // ignoring key presses while the previous key press processing is ongoing (affects only the down, up keys)
+            if (_isTextSetProgrammatically)
+            {
+                return;
+            }
+
             if (e.Key == Key.Tab && Keyboard.IsKeyDown(Key.LeftShift))
             {
                 _viewModel.SelectPrevTabItemCommand.Execute(null);

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -578,7 +578,12 @@ namespace PowerLauncher
 
         private void ClearAutoCompleteText(TextBox textBox, System.Reactive.EventPattern<TextChangedEventWithInitiatorArgs> @event)
         {
-            @event.EventArgs.IsTextSetProgrammatically = _isTextSetProgrammatically;
+            bool isTextSetProgrammaticallyAtStart = _isTextSetProgrammatically;
+            if (@event != null)
+            {
+                @event.EventArgs.IsTextSetProgrammatically = isTextSetProgrammaticallyAtStart;
+            }
+
             var text = textBox.Text;
             var autoCompleteText = SearchBox.AutoCompleteTextBlock.Text;
 
@@ -598,7 +603,7 @@ namespace PowerLauncher
                 if (pTRunStartNewSearchAction == "DeSelect")
                 {
                     // leave the results, be deselect anything to it will not be activated by <enter> key, can still be arrow-key or clicked though
-                    if (!@event.EventArgs.IsTextSetProgrammatically)
+                    if (!isTextSetProgrammaticallyAtStart)
                     {
                         DeselectAllResults();
                     }
@@ -606,7 +611,7 @@ namespace PowerLauncher
                 else if (pTRunStartNewSearchAction == "Clear")
                 {
                     // remove all results to prepare for new results, this causes flashing usually and is not cool
-                    if (!@event.EventArgs.IsTextSetProgrammatically)
+                    if (!isTextSetProgrammaticallyAtStart)
                     {
                         ClearResults();
                     }

--- a/src/modules/launcher/PowerLauncher/TextChangedEventWithInitiatorArgs.cs
+++ b/src/modules/launcher/PowerLauncher/TextChangedEventWithInitiatorArgs.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace PowerLauncher
+{
+    internal sealed class TextChangedEventWithInitiatorArgs : TextChangedEventArgs
+    {
+        public TextChangedEventWithInitiatorArgs(RoutedEvent id, UndoAction action)
+            : base(id, action)
+        {
+        }
+
+        public bool IsTextSetProgrammatically { get; set; }
+    }
+}


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
[Launcher] extending TextChangedEventArgs with Initiator

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [X] **Closes:** #18693 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
The issue was caused by paralel processing of (quick) key presses. The initiator (human/program) was overwritten which caused that the original search was replaced (as for human initiator). 
In the modifications, the initiator is stored in the extended TextEventChangedArgs object which is distinct for every text modification so paralelism does not affect it.
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
tested locally
