### PR TITLE
[Peek] Delayed activation

### DIFF
--- a/src/modules/peek/Peek.UI/App.xaml.cs
+++ b/src/modules/peek/Peek.UI/App.xaml.cs
@@ -11,7 +11,6 @@ using Microsoft.UI.Xaml;
 using Peek.FilePreviewer;
 using Peek.UI.Telemetry.Events;
 using Peek.UI.Views;
-using WinUIEx;
 
 namespace Peek.UI
 {
@@ -95,9 +94,6 @@ namespace Peek.UI
             }
 
             Window = new MainWindow();
-
-            Window.Activate();
-            Window.Hide();
         }
 
         private void App_UnhandledException(object sender, Microsoft.UI.Xaml.UnhandledExceptionEventArgs e)

--- a/src/modules/peek/Peek.UI/MainWindow.xaml.cs
+++ b/src/modules/peek/Peek.UI/MainWindow.xaml.cs
@@ -28,6 +28,7 @@ namespace Peek.UI
         public MainWindowViewModel ViewModel { get; }
 
         private ThemeListener? themeListener;
+        private bool activated;
 
         public MainWindow()
         {
@@ -84,6 +85,15 @@ namespace Peek.UI
         /// </summary>
         private void OnPeekHotkey()
         {
+            // First Peek activation
+            if (!activated)
+            {
+                Activate();
+                Initialize();
+                activated = true;
+                return;
+            }
+
             if (AppWindow.IsVisible)
             {
                 if (IsNewSingleSelectedItem())


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

I have been able to repro the issue only a few times on Windows startup.
Enable Peek module with high CPU usage on machine sometimes made the window flashing.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #26401 #26925
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

- Remove window activation on startup (not needed and causing issues)
- Delay the window activation the first Peek is invoked

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

- Tested first and subsequent Peek activation successfully