### PR TITLE
[ci]Fix the call to generateMonacoWxs.ps1 - move to main installer project

### DIFF
--- a/installer/PowerToysSetup/PowerToysInstaller.wixproj
+++ b/installer/PowerToysSetup/PowerToysInstaller.wixproj
@@ -13,7 +13,9 @@
 call "$([MSBuild]::GetVsInstallRoot())\Common7\Tools\VsDevCmd.bat" -arch=amd64 -host_arch=amd64 -winsdk=10.0.19041.0
 SET PTRoot=..\..\..\..\..
 call "..\..\..\publish.cmd" x64
-)</PreBuildEvent>
+)
+call powershell.exe -NonInteractive -executionpolicy Unrestricted -File $(MSBuildThisFileDirectory)\generateMonacoWxs.ps1 -monacoWxsFile "$(MSBuildThisFileDirectory)\MonacoSRC.wxs"
+</PreBuildEvent>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Platform)' != 'x64'">
@@ -22,7 +24,9 @@ call "..\..\..\publish.cmd" x64
 call "$([MSBuild]::GetVsInstallRoot())\Common7\Tools\VsDevCmd.bat" -arch=arm64 -host_arch=amd64 -winsdk=10.0.19041.0
 SET PTRoot=..\..\..\..\..
 call "..\..\..\publish.cmd" arm64
-)</PreBuildEvent>
+)
+call powershell.exe -NonInteractive -executionpolicy Unrestricted -File $(MSBuildThisFileDirectory)\generateMonacoWxs.ps1 -monacoWxsFile "$(MSBuildThisFileDirectory)\MonacoSRC.wxs"
+</PreBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
     <RunPostBuildEvent>Always</RunPostBuildEvent>

--- a/installer/PowerToysSetupCustomActions/PowerToysSetupCustomActions.vcxproj
+++ b/installer/PowerToysSetupCustomActions/PowerToysSetupCustomActions.vcxproj
@@ -75,7 +75,6 @@
       call cmd /C "copy ""$(ProjectDir)..\PowerToysSetup\Tools.wxs"" ""$(ProjectDir)..\PowerToysSetup\Tools.wxs.bk""""
       call cmd /C "copy ""$(ProjectDir)..\PowerToysSetup\VideoConference.wxs"" ""$(ProjectDir)..\PowerToysSetup\VideoConference.wxs.bk""""
       call cmd /C "copy ""$(ProjectDir)..\PowerToysSetup\WinAppSDK.wxs"" ""$(ProjectDir)..\PowerToysSetup\WinAppSDK.wxs.bk""""
-      call powershell.exe -NonInteractive -executionpolicy Unrestricted -File ..\PowerToysSetup\generateMonacoWxs.ps1 -monacoWxsFile "$(ProjectDir)..\PowerToysSetup\MonacoSRC.wxs"
       call powershell.exe -NonInteractive -executionpolicy Unrestricted -File parseRuntimes.ps1 -runtimedepsjsonpath "$(ProjectDir)..\..\$(Platform)\$(Configuration)\Settings\PowerToys.Settings.deps.json" -wpfdepsjsonpath "$(ProjectDir)..\..\$(Platform)\$(Configuration)\modules\ColorPicker\PowerToys.ColorPickerUI.deps.json" -depsfileslistspath "$(ProjectDir)DepsFilesLists.h" -productwxspath "$(ProjectDir)..\PowerToysSetup\Core.wxs"
       if not "$(PerUser)" == "true" call powershell.exe -NonInteractive -executionpolicy Unrestricted -File ..\PowerToysSetup\generateAllFileComponents.ps1 -platform $(Platform)
       if "$(PerUser)" == "true" call powershell.exe -NonInteractive -executionpolicy Unrestricted -File ..\PowerToysSetup\generateAllFileComponents.ps1 -platform $(Platform) -installscopeperuser $(PerUser)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Opening this PR as a draft at first while we're waiting for the scheduled release CI build to run.

I suspect that after https://github.com/microsoft/PowerToys/pull/26375, the main branch won't pass release CI correctly, either because per-user installer build will fail or because the Installer CustomActions.dll won't be signed.

This PR calls generateMonacoWxs.ps1 in PrebuildEvents of PowerInstaller.wixproj to try and guarantee it runs after the HeatDirectory task that creates the initial MonacoSRC.wxs file.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Related to:** #26375 

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

Right now, the call to generateMonacoWxs.ps1 in in the PowerToysSetupCustomActions.vcxproj.
This works on PR CI and building locally because the workflow there is:
1. Start build PowerToysInstaller.wixproj
2. PowerToysInstaller.wixproj calls the HeatDirectory action to create MonacoSRC.wxs file
3. Build the PowerToysSetupCustomActions.vcxproj dependency
4. PowerToysSetupCustomActions.vcxproj calls generateMonacoWxs.ps1 to edit MonacoSRC.wxs for user installer.
5. Build of PowerToysSetupCustomActions.vcxproj ends
6. Build of PowerToysInstaller.wixproj continues and then finishes.

However, in release CI, we run the PowerToysSetupCustomActions build before the installer so that we can sign the custom action dll.
So the workflow runs like this instead:
1. Start build PowerToysSetupCustomActions.vcxproj
2. PowerToysSetupCustomActions.vcxproj calls generateMonacoWxs.ps1 to edit MonacoSRC.wxs for user installer.
3. Build of PowerToysSetupCustomActions.vcxproj ends
4. Sign PowerToysSetupCustomActions.dll
5. Start build PowerToysInstaller.wixproj
6. PowerToysInstaller.wixproj calls the HeatDirectory action to create MonacoSRC.wxs file
7. Build of PowerToysInstaller.wixproj continues and then finishes.

As we can the, the order in release CI will result in a undesirable state.

In order to have this run properly, we move the call of generateMonacoWxs.ps1 to PowerToysInstaller.wixproj so that's independent of PowerToysSetupCustomActions.vcxproj.

This is the desired workflow this PR tries to achieve on all build scenarios:
1. Start build PowerToysInstaller.wixproj
2. PowerToysInstaller.wixproj calls the HeatDirectory action to create MonacoSRC.wxs file
3. PowerToysInstaller.wixproj calls generateMonacoWxs.ps1 to edit MonacoSRC.wxs for user installer.
4. Build of PowerToysInstaller.wixproj continues and then finishes.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Built and tested user installer locally.
Fired up a release CI run for this branch as well. Still waiting for the results.
