### PR TITLE
[Settings] Solving Hook-related problems with modifier keys appearing at ShortcutControl

### DIFF
--- a/src/settings-ui/Settings.UI/SettingsXAML/Controls/ShortcutControl/ShortcutControl.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Controls/ShortcutControl/ShortcutControl.xaml.cs
@@ -185,7 +185,7 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
                     if (!matchValue && _modifierKeysOnEntering.Contains(VirtualKey.Control))
                     {
                         SendSingleKeyboardInput((short)virtualKey, (uint)NativeKeyboardHelper.KeyEventF.KeyUp);
-                        _ = _modifierKeysOnEntering.Remove(virtualKey);
+                        _ = _modifierKeysOnEntering.Remove(VirtualKey.Control);
                     }
 
                     internalSettings.Ctrl = matchValue;
@@ -196,7 +196,7 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
                     if (!matchValue && _modifierKeysOnEntering.Contains(VirtualKey.Menu))
                     {
                         SendSingleKeyboardInput((short)virtualKey, (uint)NativeKeyboardHelper.KeyEventF.KeyUp);
-                        _ = _modifierKeysOnEntering.Remove(virtualKey);
+                        _ = _modifierKeysOnEntering.Remove(VirtualKey.Menu);
                     }
 
                     internalSettings.Alt = matchValue;
@@ -207,7 +207,7 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
                     if (!matchValue && _modifierKeysOnEntering.Contains(VirtualKey.Shift))
                     {
                         SendSingleKeyboardInput((short)virtualKey, (uint)NativeKeyboardHelper.KeyEventF.KeyUp);
-                        _ = _modifierKeysOnEntering.Remove(virtualKey);
+                        _ = _modifierKeysOnEntering.Remove(VirtualKey.Shift);
                     }
 
                     internalSettings.Shift = matchValue;

--- a/src/settings-ui/Settings.UI/SettingsXAML/Controls/ShortcutControl/ShortcutControl.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Controls/ShortcutControl/ShortcutControl.xaml.cs
@@ -17,8 +17,7 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
     public sealed partial class ShortcutControl : UserControl, IDisposable
     {
         private readonly UIntPtr ignoreKeyEventFlag = (UIntPtr)0x5555;
-        private bool _shiftKeyDownOnEntering;
-        private bool _shiftToggled;
+        private System.Collections.Generic.Dictionary<VirtualKey, bool> _modifierKeysOnEntering = new System.Collections.Generic.Dictionary<VirtualKey, bool>();
         private bool _enabled;
         private HotkeySettings hotkeySettings;
         private HotkeySettings internalSettings;
@@ -167,26 +166,50 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
 
         private void KeyEventHandler(int key, bool matchValue, int matchValueCode)
         {
-            switch ((VirtualKey)key)
+            VirtualKey virtualKey = (VirtualKey)key;
+            switch (virtualKey)
             {
                 case VirtualKey.LeftWindows:
                 case VirtualKey.RightWindows:
+                    if (!matchValue && _modifierKeysOnEntering.ContainsKey(virtualKey))
+                    {
+                        SendSingleKeyboardInput((short)virtualKey, (uint)NativeKeyboardHelper.KeyEventF.KeyUp);
+                        _modifierKeysOnEntering.Remove(virtualKey);
+                    }
+
                     internalSettings.Win = matchValue;
                     break;
                 case VirtualKey.Control:
                 case VirtualKey.LeftControl:
                 case VirtualKey.RightControl:
+                    if (!matchValue && _modifierKeysOnEntering.ContainsKey(VirtualKey.Control))
+                    {
+                        SendSingleKeyboardInput((short)VirtualKey.Control, (uint)NativeKeyboardHelper.KeyEventF.KeyUp);
+                        _modifierKeysOnEntering.Remove(VirtualKey.Control);
+                    }
+
                     internalSettings.Ctrl = matchValue;
                     break;
                 case VirtualKey.Menu:
                 case VirtualKey.LeftMenu:
                 case VirtualKey.RightMenu:
+                    if (!matchValue && _modifierKeysOnEntering.ContainsKey(VirtualKey.Menu))
+                    {
+                        SendSingleKeyboardInput((short)VirtualKey.Menu, (uint)NativeKeyboardHelper.KeyEventF.KeyUp);
+                        _modifierKeysOnEntering.Remove(VirtualKey.Menu);
+                    }
+
                     internalSettings.Alt = matchValue;
                     break;
                 case VirtualKey.Shift:
                 case VirtualKey.LeftShift:
                 case VirtualKey.RightShift:
-                    _shiftToggled = true;
+                    if (!matchValue && _modifierKeysOnEntering.ContainsKey(VirtualKey.Shift))
+                    {
+                        SendSingleKeyboardInput((short)VirtualKey.Shift, (uint)NativeKeyboardHelper.KeyEventF.KeyUp);
+                        _modifierKeysOnEntering.Remove(VirtualKey.Shift);
+                    }
+
                     internalSettings.Shift = matchValue;
                     break;
                 case VirtualKey.Escape:
@@ -235,13 +258,13 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
             if ((VirtualKey)key == VirtualKey.Tab)
             {
                 // Shift was not pressed while entering and Shift is not pressed while leaving the hotkey control, treat it as a normal tab key press.
-                if (!internalSettings.Shift && !_shiftKeyDownOnEntering && !internalSettings.Win && !internalSettings.Alt && !internalSettings.Ctrl)
+                if (!internalSettings.Shift && !_modifierKeysOnEntering.ContainsKey(VirtualKey.Shift) && !internalSettings.Win && !internalSettings.Alt && !internalSettings.Ctrl)
                 {
                     return false;
                 }
 
                 // Shift was not pressed while entering but it was pressed while leaving the hotkey, therefore simulate a shift key press as the system does not know about shift being pressed in the hotkey.
-                else if (internalSettings.Shift && !_shiftKeyDownOnEntering && !internalSettings.Win && !internalSettings.Alt && !internalSettings.Ctrl)
+                else if (internalSettings.Shift && !_modifierKeysOnEntering.ContainsKey(VirtualKey.Shift) && !internalSettings.Win && !internalSettings.Alt && !internalSettings.Ctrl)
                 {
                     // This is to reset the shift key press within the control as it was not used within the control but rather was used to leave the hotkey.
                     internalSettings.Shift = false;
@@ -253,27 +276,8 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
 
                 // Shift was pressed on entering and remained pressed, therefore only ignore the tab key so that it can be passed to the system.
                 // As the shift key is already assumed to be pressed by the system while it entered the hotkey control, shift would still remain pressed, hence ignoring the tab input would simulate a Shift+Tab key press.
-                else if (!internalSettings.Shift && _shiftKeyDownOnEntering && !_shiftToggled && !internalSettings.Win && !internalSettings.Alt && !internalSettings.Ctrl)
+                else if (!internalSettings.Shift && _modifierKeysOnEntering.ContainsKey(VirtualKey.Shift) && !internalSettings.Win && !internalSettings.Alt && !internalSettings.Ctrl)
                 {
-                    return false;
-                }
-
-                // Shift was pressed on entering but it was released and later pressed again.
-                // Ignore the tab key and the system already has the shift key pressed, therefore this would simulate Shift+Tab.
-                // However, since the last shift key was only used to move out of the control, reset the status of shift within the control.
-                else if (internalSettings.Shift && _shiftKeyDownOnEntering && _shiftToggled && !internalSettings.Win && !internalSettings.Alt && !internalSettings.Ctrl)
-                {
-                    internalSettings.Shift = false;
-
-                    return false;
-                }
-
-                // Shift was pressed on entering and was later released.
-                // The system still has shift in the key pressed status, therefore pass a Shift KeyUp message to the system, to release the shift key, therefore simulating only the Tab key press.
-                else if (!internalSettings.Shift && _shiftKeyDownOnEntering && _shiftToggled && !internalSettings.Win && !internalSettings.Alt && !internalSettings.Ctrl)
-                {
-                    SendSingleKeyboardInput((short)VirtualKey.Shift, (uint)NativeKeyboardHelper.KeyEventF.KeyUp);
-
                     return false;
                 }
             }
@@ -368,13 +372,32 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
             }
 
             // Reset the status on entering the hotkey each time.
-            _shiftKeyDownOnEntering = false;
-            _shiftToggled = false;
+            _modifierKeysOnEntering.Clear();
 
-            // To keep track of the shift key, whether it was pressed on entering.
+            // To keep track of the modifier keys, whether it was pressed on entering.
             if ((NativeMethods.GetAsyncKeyState((int)VirtualKey.Shift) & 0x8000) != 0)
             {
-                _shiftKeyDownOnEntering = true;
+                _modifierKeysOnEntering.Add(VirtualKey.Shift, true);
+            }
+
+            if ((NativeMethods.GetAsyncKeyState((int)VirtualKey.Control) & 0x8000) != 0)
+            {
+                _modifierKeysOnEntering.Add(VirtualKey.Control, true);
+            }
+
+            if ((NativeMethods.GetAsyncKeyState((int)VirtualKey.Menu) & 0x8000) != 0)
+            {
+                _modifierKeysOnEntering.Add(VirtualKey.Menu, true);
+            }
+
+            if ((NativeMethods.GetAsyncKeyState((int)VirtualKey.LeftWindows) & 0x8000) != 0)
+            {
+                _modifierKeysOnEntering.Add(VirtualKey.LeftWindows, true);
+            }
+
+            if ((NativeMethods.GetAsyncKeyState((int)VirtualKey.RightWindows) & 0x8000) != 0)
+            {
+                _modifierKeysOnEntering.Add(VirtualKey.RightWindows, true);
             }
 
             _isActive = true;
@@ -461,6 +484,31 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
         private void ShortcutDialog_Closing(ContentDialog sender, ContentDialogClosingEventArgs args)
         {
             _isActive = false;
+
+            // Modifier keys remains pressed on dialog closing, system will receive a KeyUp message at some time in the future, therefore pass a KeyDown message to the system.
+            if (internalSettings.Win)
+            {
+                SendSingleKeyboardInput((short)VirtualKey.LeftWindows, (uint)NativeKeyboardHelper.KeyEventF.KeyDown);
+                internalSettings.Win = false;
+            }
+
+            if (internalSettings.Ctrl)
+            {
+                SendSingleKeyboardInput((short)VirtualKey.Control, (uint)NativeKeyboardHelper.KeyEventF.KeyDown);
+                internalSettings.Ctrl = false;
+            }
+
+            if (internalSettings.Alt)
+            {
+                SendSingleKeyboardInput((short)VirtualKey.Menu, (uint)NativeKeyboardHelper.KeyEventF.KeyDown);
+                internalSettings.Alt = false;
+            }
+
+            if (internalSettings.Shift)
+            {
+                SendSingleKeyboardInput((short)VirtualKey.Shift, (uint)NativeKeyboardHelper.KeyEventF.KeyDown);
+                internalSettings.Shift = false;
+            }
         }
 
         private void Dispose(bool disposing)

--- a/src/settings-ui/Settings.UI/SettingsXAML/Controls/ShortcutControl/ShortcutControl.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Controls/ShortcutControl/ShortcutControl.xaml.cs
@@ -17,7 +17,7 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
     public sealed partial class ShortcutControl : UserControl, IDisposable
     {
         private readonly UIntPtr ignoreKeyEventFlag = (UIntPtr)0x5555;
-        private System.Collections.Generic.Dictionary<VirtualKey, bool> _modifierKeysOnEntering = new System.Collections.Generic.Dictionary<VirtualKey, bool>();
+        private System.Collections.Generic.HashSet<VirtualKey> _modifierKeysOnEntering = new System.Collections.Generic.HashSet<VirtualKey>();
         private bool _enabled;
         private HotkeySettings hotkeySettings;
         private HotkeySettings internalSettings;
@@ -171,10 +171,10 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
             {
                 case VirtualKey.LeftWindows:
                 case VirtualKey.RightWindows:
-                    if (!matchValue && _modifierKeysOnEntering.ContainsKey(virtualKey))
+                    if (!matchValue && _modifierKeysOnEntering.Contains(virtualKey))
                     {
                         SendSingleKeyboardInput((short)virtualKey, (uint)NativeKeyboardHelper.KeyEventF.KeyUp);
-                        _modifierKeysOnEntering.Remove(virtualKey);
+                        _ = _modifierKeysOnEntering.Remove(virtualKey);
                     }
 
                     internalSettings.Win = matchValue;
@@ -182,10 +182,10 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
                 case VirtualKey.Control:
                 case VirtualKey.LeftControl:
                 case VirtualKey.RightControl:
-                    if (!matchValue && _modifierKeysOnEntering.ContainsKey(VirtualKey.Control))
+                    if (!matchValue && _modifierKeysOnEntering.Contains(VirtualKey.Control))
                     {
-                        SendSingleKeyboardInput((short)VirtualKey.Control, (uint)NativeKeyboardHelper.KeyEventF.KeyUp);
-                        _modifierKeysOnEntering.Remove(VirtualKey.Control);
+                        SendSingleKeyboardInput((short)virtualKey, (uint)NativeKeyboardHelper.KeyEventF.KeyUp);
+                        _ = _modifierKeysOnEntering.Remove(virtualKey);
                     }
 
                     internalSettings.Ctrl = matchValue;
@@ -193,10 +193,10 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
                 case VirtualKey.Menu:
                 case VirtualKey.LeftMenu:
                 case VirtualKey.RightMenu:
-                    if (!matchValue && _modifierKeysOnEntering.ContainsKey(VirtualKey.Menu))
+                    if (!matchValue && _modifierKeysOnEntering.Contains(VirtualKey.Menu))
                     {
-                        SendSingleKeyboardInput((short)VirtualKey.Menu, (uint)NativeKeyboardHelper.KeyEventF.KeyUp);
-                        _modifierKeysOnEntering.Remove(VirtualKey.Menu);
+                        SendSingleKeyboardInput((short)virtualKey, (uint)NativeKeyboardHelper.KeyEventF.KeyUp);
+                        _ = _modifierKeysOnEntering.Remove(virtualKey);
                     }
 
                     internalSettings.Alt = matchValue;
@@ -204,10 +204,10 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
                 case VirtualKey.Shift:
                 case VirtualKey.LeftShift:
                 case VirtualKey.RightShift:
-                    if (!matchValue && _modifierKeysOnEntering.ContainsKey(VirtualKey.Shift))
+                    if (!matchValue && _modifierKeysOnEntering.Contains(VirtualKey.Shift))
                     {
-                        SendSingleKeyboardInput((short)VirtualKey.Shift, (uint)NativeKeyboardHelper.KeyEventF.KeyUp);
-                        _modifierKeysOnEntering.Remove(VirtualKey.Shift);
+                        SendSingleKeyboardInput((short)virtualKey, (uint)NativeKeyboardHelper.KeyEventF.KeyUp);
+                        _ = _modifierKeysOnEntering.Remove(virtualKey);
                     }
 
                     internalSettings.Shift = matchValue;
@@ -258,13 +258,13 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
             if ((VirtualKey)key == VirtualKey.Tab)
             {
                 // Shift was not pressed while entering and Shift is not pressed while leaving the hotkey control, treat it as a normal tab key press.
-                if (!internalSettings.Shift && !_modifierKeysOnEntering.ContainsKey(VirtualKey.Shift) && !internalSettings.Win && !internalSettings.Alt && !internalSettings.Ctrl)
+                if (!internalSettings.Shift && !_modifierKeysOnEntering.Contains(VirtualKey.Shift) && !internalSettings.Win && !internalSettings.Alt && !internalSettings.Ctrl)
                 {
                     return false;
                 }
 
                 // Shift was not pressed while entering but it was pressed while leaving the hotkey, therefore simulate a shift key press as the system does not know about shift being pressed in the hotkey.
-                else if (internalSettings.Shift && !_modifierKeysOnEntering.ContainsKey(VirtualKey.Shift) && !internalSettings.Win && !internalSettings.Alt && !internalSettings.Ctrl)
+                else if (internalSettings.Shift && !_modifierKeysOnEntering.Contains(VirtualKey.Shift) && !internalSettings.Win && !internalSettings.Alt && !internalSettings.Ctrl)
                 {
                     // This is to reset the shift key press within the control as it was not used within the control but rather was used to leave the hotkey.
                     internalSettings.Shift = false;
@@ -276,7 +276,7 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
 
                 // Shift was pressed on entering and remained pressed, therefore only ignore the tab key so that it can be passed to the system.
                 // As the shift key is already assumed to be pressed by the system while it entered the hotkey control, shift would still remain pressed, hence ignoring the tab input would simulate a Shift+Tab key press.
-                else if (!internalSettings.Shift && _modifierKeysOnEntering.ContainsKey(VirtualKey.Shift) && !internalSettings.Win && !internalSettings.Alt && !internalSettings.Ctrl)
+                else if (!internalSettings.Shift && _modifierKeysOnEntering.Contains(VirtualKey.Shift) && !internalSettings.Win && !internalSettings.Alt && !internalSettings.Ctrl)
                 {
                     return false;
                 }
@@ -377,27 +377,27 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
             // To keep track of the modifier keys, whether it was pressed on entering.
             if ((NativeMethods.GetAsyncKeyState((int)VirtualKey.Shift) & 0x8000) != 0)
             {
-                _modifierKeysOnEntering.Add(VirtualKey.Shift, true);
+                _modifierKeysOnEntering.Add(VirtualKey.Shift);
             }
 
             if ((NativeMethods.GetAsyncKeyState((int)VirtualKey.Control) & 0x8000) != 0)
             {
-                _modifierKeysOnEntering.Add(VirtualKey.Control, true);
+                _modifierKeysOnEntering.Add(VirtualKey.Control);
             }
 
             if ((NativeMethods.GetAsyncKeyState((int)VirtualKey.Menu) & 0x8000) != 0)
             {
-                _modifierKeysOnEntering.Add(VirtualKey.Menu, true);
+                _modifierKeysOnEntering.Add(VirtualKey.Menu);
             }
 
             if ((NativeMethods.GetAsyncKeyState((int)VirtualKey.LeftWindows) & 0x8000) != 0)
             {
-                _modifierKeysOnEntering.Add(VirtualKey.LeftWindows, true);
+                _modifierKeysOnEntering.Add(VirtualKey.LeftWindows);
             }
 
             if ((NativeMethods.GetAsyncKeyState((int)VirtualKey.RightWindows) & 0x8000) != 0)
             {
-                _modifierKeysOnEntering.Add(VirtualKey.RightWindows, true);
+                _modifierKeysOnEntering.Add(VirtualKey.RightWindows);
             }
 
             _isActive = true;
@@ -484,31 +484,6 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
         private void ShortcutDialog_Closing(ContentDialog sender, ContentDialogClosingEventArgs args)
         {
             _isActive = false;
-
-            // Modifier keys remains pressed on dialog closing, system will receive a KeyUp message at some time in the future, therefore pass a KeyDown message to the system.
-            if (internalSettings.Win)
-            {
-                SendSingleKeyboardInput((short)VirtualKey.LeftWindows, (uint)NativeKeyboardHelper.KeyEventF.KeyDown);
-                internalSettings.Win = false;
-            }
-
-            if (internalSettings.Ctrl)
-            {
-                SendSingleKeyboardInput((short)VirtualKey.Control, (uint)NativeKeyboardHelper.KeyEventF.KeyDown);
-                internalSettings.Ctrl = false;
-            }
-
-            if (internalSettings.Alt)
-            {
-                SendSingleKeyboardInput((short)VirtualKey.Menu, (uint)NativeKeyboardHelper.KeyEventF.KeyDown);
-                internalSettings.Alt = false;
-            }
-
-            if (internalSettings.Shift)
-            {
-                SendSingleKeyboardInput((short)VirtualKey.Shift, (uint)NativeKeyboardHelper.KeyEventF.KeyDown);
-                internalSettings.Shift = false;
-            }
         }
 
         private void Dispose(bool disposing)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Solve the problem that the system receives incomplete KeyDown&KeyUp messages when pressing and holding the modifier keys to enter or close the ShortcutDialog of ShortcutControl.
Currently at the ShortcutControl, when you hold down the modifier key and then open or close the ShortcutDialog, KeyDown/KeyUp will be intercepted by the hook, causing the system not to receive the full KeyDown&KeyUp message.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #27514 
- [ ] **Tests:** Added/updated and all pass
<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

