### PR TITLE
[runner] Use guid to identify tray icon

### DIFF
--- a/src/runner/tray_icon.cpp
+++ b/src/runner/tray_icon.cpp
@@ -274,7 +274,7 @@ void start_tray_icon()
     auto icon = LoadIcon(h_instance, MAKEINTRESOURCE(APPICON));
     if (icon)
     {
-        UINT id_tray_icon = wm_icon_notify = RegisterWindowMessageW(L"WM_PowerToysIconNotify");
+        wm_icon_notify = RegisterWindowMessageW(L"WM_PowerToysIconNotify");
 
         WNDCLASS wc = {};
         wc.hCursor = LoadCursor(nullptr, IDC_ARROW);
@@ -302,11 +302,13 @@ void start_tray_icon()
         tray_icon_data.cbSize = sizeof(tray_icon_data);
         tray_icon_data.hIcon = icon;
         tray_icon_data.hWnd = hwnd;
-        tray_icon_data.uID = id_tray_icon;
+        GUID guid;
+        CLSIDFromString(tray_icon_guid, &guid);
+        tray_icon_data.guidItem = guid;
         tray_icon_data.uCallbackMessage = wm_icon_notify;
         std::wstring about_msg_pt_version = L"PowerToys " + get_product_version();
         wcscpy_s(tray_icon_data.szTip, sizeof(tray_icon_data.szTip) / sizeof(WCHAR), about_msg_pt_version.c_str());
-        tray_icon_data.uFlags = NIF_ICON | NIF_TIP | NIF_MESSAGE;
+        tray_icon_data.uFlags = NIF_ICON | NIF_TIP | NIF_MESSAGE | NIF_GUID;
         ChangeWindowMessageFilterEx(hwnd, WM_COMMAND, MSGFLT_ALLOW, nullptr);
 
         tray_icon_created = Shell_NotifyIcon(NIM_ADD, &tray_icon_data) == TRUE;

--- a/src/runner/tray_icon.h
+++ b/src/runner/tray_icon.h
@@ -14,3 +14,5 @@ typedef void (*main_loop_callback_function)(PVOID);
 bool dispatch_run_on_main_ui_thread(main_loop_callback_function _callback, PVOID data);
 
 const inline wchar_t* pt_tray_icon_window_class = L"PToyTrayIconWindow";
+
+const inline wchar_t* tray_icon_guid = L"{F933F1D8-B8AE-41A4-A134-FB36323E0095}";


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
**Steps to reproduce the issue:**
 - Install PT v0.70.0
 - Reboot
 - Install PT v0.70.1
 - Reboot
 - Install PT v0.71.0
 - Right-click task bar -> Taskbar Settings -> Other system tray icons - observe that there are 3 PowerToys.Runner entries in the list

** Workaround to remove multiple entries **
1) Manually remove registry entries from `Computer\HKEY_CURRENT_USER\Control Panel\NotifyIconSettings` related to old versions of PowerToys
or
2)
 - Uninstall PowerToys
 - Reboot (or restart explorer.exe)
 - Install PowerToys again

Not sure what is the exact reason behind this issues. It happens only on PT update. Registry entries in `Computer\HKEY_CURRENT_USER\Control Panel\NotifyIconSettings` are not being removed properly for some reason. On uninstall every single entry (even the old-version ones) are being removed properly, but only after explorer.exe restart. Because of this my best guess is that explorer has something cached for tray icons between uninstall and install in update scenario and because of that reg entry is not removed (maybe because the exe file it points to still exists - new version installed it again).

Using guid to identify tray icon instead of old logic (uID + hwnd) makes update work properly when PT is installed first time. Mentioned workaround is still needed to remove old entries.

I tried removing the icon explicitly by calling NotifyShellIcon with NIM_DELETE arg, but didn't help neither.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #24502
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
 - Build 3 different versions of this PR
 - Install and update twice as explained in steps to reproduce at the top
 - Observe that there is only one PowerToys.runner taskbar entry in Personalization -> Taksbar -> Other system tray icons
