### PR TITLE
[Runner]ask to restart the computer after update

### DIFF
--- a/src/runner/Resources.resx
+++ b/src/runner/Resources.resx
@@ -123,6 +123,7 @@
     <value>Bug report .zip file has been created on your Desktop.</value>
   </data>
   <data name="PT_VERSION_CHANGE_ASK_FOR_COMPUTER_RESTART" xml:space="preserve">
-    <value>A new PowerToys version has been installed. Please restart the computer when possible.</value>
+    <value>A new PowerToys version has been installed. Please restart the computer when possible, to fully reload File Explorer extensions.</value>
+    <comment>File Explorer refers to the Windows File Explorer application.</comment>
   </data>
 </root>

--- a/src/runner/Resources.resx
+++ b/src/runner/Resources.resx
@@ -122,4 +122,7 @@
   <data name="BUGREPORT_SUCCESS" xml:space="preserve">
     <value>Bug report .zip file has been created on your Desktop.</value>
   </data>
+  <data name="PT_VERSION_CHANGE_ASK_FOR_COMPUTER_RESTART" xml:space="preserve">
+    <value>A new PowerToys version has been installed. Please restart the computer when possible.</value>
+  </data>
 </root>

--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -106,6 +106,11 @@ int runner(bool isProcessElevated, bool openSettings, std::string settingsWindow
     int result = -1;
     try
     {
+        if (!openOobe && openScoobe)
+        {
+            notifications::show_toast(GET_RESOURCE_STRING(IDS_PT_VERSION_CHANGE_ASK_FOR_COMPUTER_RESTART).c_str(), L"PowerToys");
+        }
+
         std::thread{ [] {
             PeriodicUpdateWorker();
         } }.detach();


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

When moving across versions, modules like the file preview/thumbnail handlers or the context menu extensions might keep their old versions loaded in explorer.exe or a preview handler process.
Before, the installer just restarted after an update when needed, but now we've turned that off.
This PR adds a toast notification to show a message so that users know they should restart their computer when possible.

![image](https://github.com/microsoft/PowerToys/assets/26118718/b01e690e-1d42-401c-b28f-2bfdfae6de30)

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Deleted or changed version in "%localappdata%\Microsoft\PowerToys\last_version_run.json" to simulate a new version and start PowerToys. The toast notification should be shown.

**Attention:** To test this running from Visual Studio, you need to have a PowerToys version installed so that the toast notification registry entries for PowerToys are in place, otherwise no notification will be shown.
