### PR TITLE
[Settings]Remove unused expander in File Locksmith page

### DIFF
--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/FileLocksmithPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/FileLocksmithPage.xaml
@@ -33,16 +33,15 @@
                 <controls:SettingsGroup
                     x:Uid="FileLocksmith_ShellIntegration"
                     IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsFileLocksmithEnabled}">
-                    <labs:SettingsExpander
-                        x:Uid="FileLocksmith_Toggle_ContextMenu"
-                        IsExpanded="True">
+                    <labs:SettingsCard
+                        x:Uid="FileLocksmith_Toggle_ContextMenu">
                         <ComboBox
                             MinWidth="{StaticResource SettingActionControlMinWidth}"
                             SelectedIndex="{x:Bind Mode=TwoWay, Path=ViewModel.EnabledOnContextExtendedMenu, Converter={StaticResource BoolToComboBoxIndexConverter}}">
                             <ComboBoxItem x:Uid="FileLocksmith_Toggle_StandardContextMenu" />
                             <ComboBoxItem x:Uid="FileLocksmith_Toggle_ExtendedContextMenu" />
                         </ComboBox>                        
-                    </labs:SettingsExpander>
+                    </labs:SettingsCard>
                 </controls:SettingsGroup>
             </StackPanel>
         </controls:SettingsPageControl.ModuleContent>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This is a nit. There's an empty expander in the File Locksmith's page in Settings, so this PR converts it to a simple card.

Before:
![image](https://github.com/microsoft/PowerToys/assets/26118718/5ed7c564-91d7-43ae-9125-ef19df7af866)

After:
![image](https://github.com/microsoft/PowerToys/assets/26118718/c41f3587-b98e-430f-a758-3079b94fa3de)


