### PR TITLE
[MWB]Fix crash when trying to read null settings

### DIFF
--- a/src/settings-ui/Settings.UI.Library/MouseWithoutBordersSettings.cs
+++ b/src/settings-ui/Settings.UI.Library/MouseWithoutBordersSettings.cs
@@ -56,13 +56,25 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             {
                 Version = "1.1";
 
-                Properties.ToggleEasyMouseShortcut = ConvertMouseWithoutBordersHotKeyToPowerToys(Properties.HotKeyToggleEasyMouse.Value);
+                if (Properties.HotKeyToggleEasyMouse != null)
+                {
+                    Properties.ToggleEasyMouseShortcut = ConvertMouseWithoutBordersHotKeyToPowerToys(Properties.HotKeyToggleEasyMouse.Value);
+                }
 
-                Properties.LockMachineShortcut = ConvertMouseWithoutBordersHotKeyToPowerToys(Properties.HotKeyLockMachine.Value);
+                if (Properties.HotKeyLockMachine != null)
+                {
+                    Properties.LockMachineShortcut = ConvertMouseWithoutBordersHotKeyToPowerToys(Properties.HotKeyLockMachine.Value);
+                }
 
-                Properties.ReconnectShortcut = ConvertMouseWithoutBordersHotKeyToPowerToys(Properties.HotKeyReconnect.Value);
+                if (Properties.HotKeyReconnect != null)
+                {
+                    Properties.ReconnectShortcut = ConvertMouseWithoutBordersHotKeyToPowerToys(Properties.HotKeyReconnect.Value);
+                }
 
-                Properties.Switch2AllPCShortcut = ConvertMouseWithoutBordersHotKeyToPowerToys(Properties.HotKeySwitch2AllPC.Value);
+                if (Properties.HotKeySwitch2AllPC != null)
+                {
+                    Properties.Switch2AllPCShortcut = ConvertMouseWithoutBordersHotKeyToPowerToys(Properties.HotKeySwitch2AllPC.Value);
+                }
 
                 Properties.HotKeyToggleEasyMouse = null;
                 Properties.HotKeyLockMachine = null;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

After #27442 , there's a bug where both Mouse Without Borders and opening the Mouse Without Borders settings page will crash after the first reload due to trying to read null settings.

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

Add a null check around the Settings, since they might not be there from migration if the user never ran a version before .72.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

1 - Clear %localappdata%\Microsoft\PowerToys
2 - Enable MWB, generate a key
3 - Restart PowerToys as admin
4 - Enable "Service Mode". Verify that MWB is started as a service successfully
5 - Go to another settings page, then try to enter MWB page again. Settings doesn't crash anymore.

