### PR TITLE
[Runner] Unnecessary RegisterWindowMessage

### DIFF
--- a/src/runner/tray_icon.cpp
+++ b/src/runner/tray_icon.cpp
@@ -17,7 +17,7 @@ namespace
     HWND tray_icon_hwnd = NULL;
 
     // Message code that Windows will use for tray icon notifications.
-    UINT wm_icon_notify = 0;
+    enum { wm_icon_notify = WM_APP };
 
     // Contains the Windows Message for taskbar creation.
     UINT wm_taskbar_restart = 0;
@@ -274,7 +274,7 @@ void start_tray_icon()
     auto icon = LoadIcon(h_instance, MAKEINTRESOURCE(APPICON));
     if (icon)
     {
-        UINT id_tray_icon = wm_icon_notify = RegisterWindowMessageW(L"WM_PowerToysIconNotify");
+        UINT id_tray_icon = 1;
 
         WNDCLASS wc = {};
         wc.hCursor = LoadCursor(nullptr, IDC_ARROW);

--- a/src/runner/tray_icon.cpp
+++ b/src/runner/tray_icon.cpp
@@ -16,12 +16,13 @@ namespace
 {
     HWND tray_icon_hwnd = NULL;
 
-    // Message code that Windows will use for tray icon notifications.
-    enum { wm_icon_notify = WM_APP };
+    enum { 
+        wm_icon_notify = WM_APP,
+        wm_run_on_main_ui_thread,
+    };
 
     // Contains the Windows Message for taskbar creation.
     UINT wm_taskbar_restart = 0;
-    UINT wm_run_on_main_ui_thread = 0;
 
     NOTIFYICONDATAW tray_icon_data;
     bool tray_icon_created = false;
@@ -157,7 +158,6 @@ LRESULT __stdcall tray_icon_window_proc(HWND window, UINT message, WPARAM wparam
         {
             tray_icon_hwnd = window;
             wm_taskbar_restart = RegisterWindowMessageW(L"TaskbarCreated");
-            wm_run_on_main_ui_thread = RegisterWindowMessage(L"RunOnMainThreadCallback");
         }
         break;
     case WM_DESTROY:


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

`RegisterWindowMessage` is a shared global resource that cannot be released back to the system until the session is logged off. A session unique message is not required for tray icons, Explorer does not care what its value is, it just needs to be unique in the WNDPROC of the HWND that registered the icon. The tray icon id is also internal to the HWND and can be any value when the HWND just registers a single tray icon.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx


<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

