### PR TITLE
[Registry Preview] Update all AppBarButtons to use an explicit AppBarButton.Icon (Fix for 27766)

### DIFF
--- a/src/modules/registrypreview/RegistryPreviewUI/RegistryPreviewXAML/MainWindow.xaml
+++ b/src/modules/registrypreview/RegistryPreviewUI/RegistryPreviewXAML/MainWindow.xaml
@@ -95,7 +95,7 @@
                     x:Uid="OpenButton"
                     Click="OpenButton_Click">
                         <AppBarButton.Icon>
-                            <FontIcon Glyph="&#xe8e5;"/>
+                            <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xe8e5;"/>
                         </AppBarButton.Icon>
                         <AppBarButton.KeyboardAccelerators>
                             <KeyboardAccelerator Key="O" Modifiers="Control" />
@@ -104,8 +104,10 @@
                     <AppBarButton
                     x:Name="refreshButton"
                     x:Uid="RefreshButton"
-                    Icon="Refresh"
                     Click="RefreshButton_Click">
+                        <AppBarButton.Icon>
+                            <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xe72c;"/>
+                        </AppBarButton.Icon>
                         <AppBarButton.KeyboardAccelerators>
                             <KeyboardAccelerator Key="F5" />
                         </AppBarButton.KeyboardAccelerators>
@@ -114,9 +116,11 @@
                     <AppBarButton
                     x:Name="saveButton"
                     x:Uid="SaveButton"
-                    Icon="Save"
                     Click="SaveButton_Click"
                     IsEnabled="False">
+                        <AppBarButton.Icon>
+                            <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xe74e;"/>
+                        </AppBarButton.Icon>
                         <AppBarButton.KeyboardAccelerators>
                             <KeyboardAccelerator Key="S" Modifiers="Control" />
                         </AppBarButton.KeyboardAccelerators>
@@ -127,7 +131,7 @@
                     Click="SaveAsButton_Click"
                     IsEnabled="True">
                         <AppBarButton.Icon>
-                            <FontIcon Glyph="&#xe792;"/>
+                            <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xe792;"/>
                         </AppBarButton.Icon>
                         <AppBarButton.KeyboardAccelerators>
                             <KeyboardAccelerator Key="S" Modifiers="Control,Shift" />
@@ -137,8 +141,10 @@
                     <AppBarButton
                     x:Name="editButton"
                     x:Uid="EditButton"
-                    Icon="Edit"
                     Click="EditButton_Click">
+                        <AppBarButton.Icon>
+                            <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xe8a7;"/>
+                        </AppBarButton.Icon>
                         <AppBarButton.KeyboardAccelerators>
                             <KeyboardAccelerator Key="E" Modifiers="Control" />
                         </AppBarButton.KeyboardAccelerators>
@@ -147,6 +153,9 @@
                         x:Name="writeButton"
                         x:Uid="WriteButton"
                         Click="WriteButton_Click">
+                        <AppBarButton.Icon>
+                            <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xe72d;"/>
+                        </AppBarButton.Icon>
                         <AppBarButton.KeyboardAccelerators>
                             <KeyboardAccelerator Key="W" Modifiers="Control" />
                         </AppBarButton.KeyboardAccelerators>
@@ -155,6 +164,9 @@
                         x:Name="registryButton"
                         x:Uid="RegistryButton"
                         Click="RegistryButton_Click">
+                        <AppBarButton.Icon>
+                            <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xe8ad;"/>
+                        </AppBarButton.Icon>
                         <AppBarButton.KeyboardAccelerators>
                             <KeyboardAccelerator Key="R" Modifiers="Control" />
                         </AppBarButton.KeyboardAccelerators>
@@ -164,6 +176,9 @@
                         x:Uid="RegistryJumpToKeyButton"
                         Click="RegistryJumpToKeyButton_Click"
                         IsEnabled="True">
+                        <AppBarButton.Icon>
+                            <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xee49;"/>
+                        </AppBarButton.Icon>
                         <AppBarButton.KeyboardAccelerators>
                             <KeyboardAccelerator Key="R" Modifiers="Control,Shift" />
                         </AppBarButton.KeyboardAccelerators>

--- a/src/modules/registrypreview/RegistryPreviewUI/RegistryPreviewXAML/MainWindow.xaml
+++ b/src/modules/registrypreview/RegistryPreviewUI/RegistryPreviewXAML/MainWindow.xaml
@@ -176,9 +176,6 @@
                         x:Uid="RegistryJumpToKeyButton"
                         Click="RegistryJumpToKeyButton_Click"
                         IsEnabled="True">
-                        <AppBarButton.Icon>
-                            <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xee49;"/>
-                        </AppBarButton.Icon>
                         <AppBarButton.KeyboardAccelerators>
                             <KeyboardAccelerator Key="R" Modifiers="Control,Shift" />
                         </AppBarButton.KeyboardAccelerators>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
A recent update of awesomeness came through this app, cleaning up the UI in various ways, which is amazing.  However, a bug may have snuck back into the code around the icons used in the commandbar in various languages; this brings the fix back into the code.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [X] **Closes:** #27766 (regression of #25284)
- [X] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Localization:** All end user facing strings can be localized

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
In the XAML file, I've removed all references to Icon="Name" and replaced it with a corresponding FontIcon; I also added an explicit FontFamily to the FontIcon to avoid issues across Windows versions and languages, per the "best practices" called out in the WinUI 3 documentation.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Visually verified the UI:
![image](https://github.com/microsoft/PowerToys/assets/18704482/3593c65c-55ce-49b0-a2f0-04460be58501)

