### PR TITLE
[Peek][Monaco Preview] Open Monaco URI in default browser

### DIFF
--- a/src/modules/peek/Peek.FilePreviewer/Controls/BrowserControl.xaml
+++ b/src/modules/peek/Peek.FilePreviewer/Controls/BrowserControl.xaml
@@ -12,9 +12,15 @@
     mc:Ignorable="d">
 
     <Grid>
-        <controls:WebView2 x:Name="PreviewBrowser"
-                           Loaded="PreviewWV2_Loaded"
-                           NavigationStarting="PreviewBrowser_NavigationStarting"
-                           NavigationCompleted="PreviewWV2_NavigationCompleted"/>
+        <controls:WebView2
+            x:Name="PreviewBrowser"
+            Loaded="PreviewWV2_Loaded"
+            NavigationStarting="PreviewBrowser_NavigationStarting"
+            NavigationCompleted="PreviewWV2_NavigationCompleted" />
+        <ContentDialog
+            x:Name="OpenUriDialog"
+            x:Uid="OpenUriDialog"
+            PrimaryButtonStyle="{ThemeResource AccentButtonStyle}"
+            SecondaryButtonClick="OpenUriDialog_SecondaryButtonClick" />
     </Grid>
 </UserControl>

--- a/src/modules/peek/Peek.FilePreviewer/Controls/BrowserControl.xaml.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Controls/BrowserControl.xaml.cs
@@ -135,6 +135,7 @@ namespace Peek.FilePreviewer.Controls
                 }
 
                 PreviewBrowser.CoreWebView2.DOMContentLoaded += CoreWebView2_DOMContentLoaded;
+                PreviewBrowser.CoreWebView2.NewWindowRequested += CoreWebView2_NewWindowRequested;
             }
             catch (Exception ex)
             {
@@ -147,6 +148,16 @@ namespace Peek.FilePreviewer.Controls
         private void CoreWebView2_DOMContentLoaded(CoreWebView2 sender, CoreWebView2DOMContentLoadedEventArgs args)
         {
             DOMContentLoaded?.Invoke(sender, args);
+        }
+
+        private async void CoreWebView2_NewWindowRequested(CoreWebView2 sender, CoreWebView2NewWindowRequestedEventArgs args)
+        {
+            // Monaco opens URI in a new window. We open the URI in the default web browser.
+            if (args.Uri != null && args.IsUserInitiated)
+            {
+                args.Handled = true;
+                await Launcher.LaunchUriAsync(new Uri(args.Uri));
+            }
         }
 
         private async void PreviewBrowser_NavigationStarting(WebView2 sender, Microsoft.Web.WebView2.Core.CoreWebView2NavigationStartingEventArgs args)

--- a/src/modules/peek/Peek.FilePreviewer/Controls/BrowserControl.xaml.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Controls/BrowserControl.xaml.cs
@@ -3,11 +3,13 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.Web.WebView2.Core;
 using Peek.Common.Constants;
 using Peek.Common.Helpers;
+using Windows.ApplicationModel.DataTransfer;
 using Windows.System;
 using Windows.UI;
 
@@ -96,6 +98,7 @@ namespace Peek.FilePreviewer.Controls
 
         private void SourcePropertyChanged()
         {
+            OpenUriDialog.Hide();
             Navigate();
         }
 
@@ -156,7 +159,7 @@ namespace Peek.FilePreviewer.Controls
             if (args.Uri != null && args.IsUserInitiated)
             {
                 args.Handled = true;
-                await Launcher.LaunchUriAsync(new Uri(args.Uri));
+                await ShowOpenUriDialogAsync(new Uri(args.Uri));
             }
         }
 
@@ -168,10 +171,11 @@ namespace Peek.FilePreviewer.Controls
             }
 
             // In case user starts or tries to navigate from within the HTML file we launch default web browser for navigation.
-            if (args.Uri != null && args.Uri != _navigatedUri?.ToString() && args.IsUserInitiated)
+            // TODO: && args.IsUserInitiated - always false for PDF files, revert the workaround when fixed in WebView2: https://github.com/microsoft/PowerToys/issues/27403
+            if (args.Uri != null && args.Uri != _navigatedUri?.ToString())
             {
                 args.Cancel = true;
-                await Launcher.LaunchUriAsync(new Uri(args.Uri));
+                await ShowOpenUriDialogAsync(new Uri(args.Uri));
             }
         }
 
@@ -182,7 +186,29 @@ namespace Peek.FilePreviewer.Controls
                 _navigatedUri = Source;
             }
 
-            NavigationCompleted?.Invoke(sender, args);
+            // Don't raise NavigationCompleted event if NavigationStarting has been cancelled
+            if (args.WebErrorStatus != CoreWebView2WebErrorStatus.OperationCanceled)
+            {
+                NavigationCompleted?.Invoke(sender, args);
+            }
+        }
+
+        private async Task ShowOpenUriDialogAsync(Uri uri)
+        {
+            OpenUriDialog.Content = uri.ToString();
+            var result = await OpenUriDialog.ShowAsync();
+
+            if (result == ContentDialogResult.Primary)
+            {
+                await Launcher.LaunchUriAsync(uri);
+            }
+        }
+
+        private void OpenUriDialog_SecondaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
+        {
+            var dataPackage = new DataPackage();
+            dataPackage.SetText(sender.Content.ToString());
+            Clipboard.SetContent(dataPackage);
         }
     }
 }

--- a/src/modules/peek/Peek.UI/Strings/en-us/Resources.resw
+++ b/src/modules/peek/Peek.UI/Strings/en-us/Resources.resw
@@ -237,4 +237,20 @@
     <value>{0} bytes</value>
     <comment>Abbreviation for the size bytes</comment>
   </data>
+  <data name="OpenUriDialog.CloseButtonText" xml:space="preserve">
+    <value>Cancel</value>
+    <comment>Dialog showed when an URI is clicked. Button to close the dialog.</comment>
+  </data>
+  <data name="OpenUriDialog.PrimaryButtonText" xml:space="preserve">
+    <value>Open</value>
+    <comment>Dialog showed when an URI is clicked. Button to open the URI.</comment>
+  </data>
+  <data name="OpenUriDialog.SecondaryButtonText" xml:space="preserve">
+    <value>Copy</value>
+    <comment>Dialog showed when an URI is clicked. Button to copy the URI.</comment>
+  </data>
+  <data name="OpenUriDialog.Title" xml:space="preserve">
+    <value>Do you want Peek to open the external application?</value>
+    <comment>Title of the dialog showed when an URI is clicked,"Peek" is the name of the utility. </comment>
+  </data>
 </root>

--- a/src/modules/previewpane/MonacoPreviewHandler/MonacoPreviewHandlerControl.cs
+++ b/src/modules/previewpane/MonacoPreviewHandler/MonacoPreviewHandlerControl.cs
@@ -157,6 +157,7 @@ namespace Microsoft.PowerToys.PreviewHandler.Monaco
                                 _webView.NavigationCompleted += WebView2Init;
                                 _webView.Height = this.Height;
                                 _webView.Width = this.Width;
+                                _webView.CoreWebView2.NewWindowRequested += CoreWebView2_NewWindowRequested;
                                 Controls.Add(_webView);
                                 _webView.SendToBack();
                                 _loadingBar.Value = 100;
@@ -215,6 +216,16 @@ namespace Microsoft.PowerToys.PreviewHandler.Monaco
             {
                 Logger.LogInfo("File is too big to display. Showing error message");
                 AddTextBoxControl(Resources.Max_File_Size_Error.Replace("%1", (_settings.MaxFileSize / 1000).ToString(CultureInfo.CurrentCulture), StringComparison.InvariantCulture));
+            }
+        }
+
+        private async void CoreWebView2_NewWindowRequested(object sender, CoreWebView2NewWindowRequestedEventArgs e)
+        {
+            // Monaco opens URI in a new window. We open the URI in the default web browser.
+            if (e.Uri != null && e.IsUserInitiated)
+            {
+                e.Handled = true;
+                await Launcher.LaunchUriAsync(new Uri(e.Uri));
             }
         }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

- Open Monaco URI in default browser
- Aligned behavior in Monaco Preview Pane
- Added dialog to open URI in Peek: PDF, MD and Monaco.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #27649
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

 Tested on Peek and PreviewPane:
- CTRL+Click on a URI in a file previewed in Monaco
- Link is opened in the default browser