### PR TITLE
[Settings]Fix crash opening system color settings

### DIFF
--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/GeneralPage.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/GeneralPage.xaml.cs
@@ -122,7 +122,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             }
             catch (Exception ex)
             {
-                Logger.LogError($"Error while trying to open the system color settings: {ex.Message}");
+                Logger.LogError("Error while trying to open the system color settings", ex);
             }
         }
 

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/GeneralPage.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/GeneralPage.xaml.cs
@@ -116,7 +116,14 @@ namespace Microsoft.PowerToys.Settings.UI.Views
 
         private void OpenColorsSettings_Click(object sender, RoutedEventArgs e)
         {
-            Helpers.StartProcessHelper.Start(Helpers.StartProcessHelper.ColorsSettings);
+            try
+            {
+                Helpers.StartProcessHelper.Start(Helpers.StartProcessHelper.ColorsSettings);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError($"Error while trying to open the system color settings: {ex.Message}");
+            }
         }
 
         private void RefreshBackupRestoreStatus(int delayMs = 0)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

A user reported Settings crashes when trying to press the "Windows color settings" link.
![image](https://github.com/microsoft/PowerToys/assets/26118718/1363c6d9-33ee-46f7-b634-a3717f1d8cf3)

This PR catches exceptions and logs them instead.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #27781
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Couldn't repro the original issue, so verified:
- Clicking still opens the settings in the page where you can switch theme.
- Replaced inner code of "StartProcessHelper.Start" with an exception and verified clicking the link creates a log entry instead of crashing.

