### PR TITLE
[PT Run > Value Generator] Add Base64 Decoding function to the Value Generator

### DIFF
--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.ValueGenerator.UnitTests/InputParserTests.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.ValueGenerator.UnitTests/InputParserTests.cs
@@ -29,6 +29,7 @@ namespace Community.PowerToys.Run.Plugin.ValueGenerator.UnitTests
         [DataRow("base64 abc", typeof(Base64.Base64Request))]
         [DataRow("base99 abc", null)]
         [DataRow("base64s abc", null)]
+        [DataRow("base64d abc=", typeof(Base64.Base64DecodeRequest))]
         public void ParserTest(string input, Type? expectedRequestType)
         {
             var parser = new InputParser();
@@ -77,7 +78,7 @@ namespace Community.PowerToys.Run.Plugin.ValueGenerator.UnitTests
 
         private static bool CommandIsKnown(string command)
         {
-            string[] hashes = new string[] { "md5", "sha1", "sha256", "sha384", "sha512", "base64" };
+            string[] hashes = new string[] { "md5", "sha1", "sha256", "sha384", "sha512", "base64", "base64d" };
 
             if (hashes.Contains(command.ToLowerInvariant()))
             {

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.ValueGenerator/Base64/Base64DecodeRequest.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.ValueGenerator/Base64/Base64DecodeRequest.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.Text;
+using Wox.Plugin.Logger;
+
+namespace Community.PowerToys.Run.Plugin.ValueGenerator.Base64
+{
+    public class Base64DecodeRequest : IComputeRequest
+    {
+        public byte[] Result { get; set; }
+
+        public string Description => "Base64 Decoding";
+
+        public bool IsSuccessful { get; set; }
+
+        public string ErrorMessage { get; set; }
+
+        private string DataToDecode { get; set; }
+
+        public Base64DecodeRequest(string dataToDecode)
+        {
+            DataToDecode = dataToDecode ?? throw new ArgumentNullException(nameof(dataToDecode));
+        }
+
+        public bool Compute()
+        {
+            IsSuccessful = true;
+            try
+            {
+                Result = System.Convert.FromBase64String(DataToDecode);
+            }
+            catch (Exception e)
+            {
+                Log.Exception(e.Message, e, GetType());
+                ErrorMessage = e.Message;
+                IsSuccessful = false;
+            }
+
+            return IsSuccessful;
+        }
+
+        public string ResultToString()
+        {
+            if (Result != null)
+            {
+                return Encoding.UTF8.GetString(Result);
+            }
+            else
+            {
+                return string.Empty;
+            }
+        }
+    }
+}

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.ValueGenerator/InputParser.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.ValueGenerator/InputParser.cs
@@ -121,6 +121,12 @@ namespace Community.PowerToys.Run.Plugin.ValueGenerator
                 string content = query.RawUserQuery.Substring(commandIndex + command.Length).Trim();
                 request = new Base64Request(Encoding.UTF8.GetBytes(content));
             }
+            else if (command.ToLower(null) == "base64d")
+            {
+                int commandIndex = query.RawUserQuery.IndexOf(command, StringComparison.InvariantCultureIgnoreCase);
+                string content = query.RawUserQuery.Substring(commandIndex + command.Length).Trim();
+                request = new Base64DecodeRequest(content);
+            }
             else
             {
                 throw new FormatException($"Invalid Query: {query.RawUserQuery}");


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR adds Base64 Decoding function to complement the existing Encoding. It adds the new keyword `base64d` to Value Generator. It can be tested manually with any Base64 string (``# base64d SGVsbG8gV29ybGQ=``)

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [X] **Closes:** #27847
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated and all pass
- [X] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [X] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: [#4561](https://github.com/MicrosoftDocs/windows-dev-docs/pull/4561)

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manual validation, example: `# base64d SGVsbG8gV29ybGQ=`
Added a unit test
