### PR TITLE
[Runner] Don't accumulate installers

### DIFF
--- a/src/Update/PowerToys.Update.cpp
+++ b/src/Update/PowerToys.Update.cpp
@@ -73,6 +73,9 @@ std::optional<fs::path> ObtainInstaller(bool& isUpToDate)
             return std::nullopt;
         }
 
+        // Cleanup old updates before downloading the latest
+        updating::cleanup_updates();
+
         auto downloaded_installer = download_new_version(std::get<new_version_download_info>(*new_version_info)).get();
         if (!downloaded_installer)
         {

--- a/src/common/updating/updating.h
+++ b/src/common/updating/updating.h
@@ -28,6 +28,7 @@ namespace updating
     std::future<std::optional<std::filesystem::path>> download_new_version(const new_version_download_info& new_version);
     std::filesystem::path get_pending_updates_path();
     std::future<nonstd::expected<github_version_info, std::wstring>> get_github_version_info_async(const bool prerelease = false);
+    void cleanup_updates();
 
     // non-localized
     constexpr inline std::wstring_view INSTALLER_FILENAME_PATTERN = L"powertoyssetup";

--- a/src/runner/UpdateUtils.cpp
+++ b/src/runner/UpdateUtils.cpp
@@ -159,6 +159,10 @@ void ProcessNewVersionInfo(const github_version_info& version_info,
     if (download_update)
     {
         Logger::trace(L"Downloading installer for a new version");
+
+        // Cleanup old updates before downloading the latest
+        updating::cleanup_updates();
+
         if (download_new_version(new_version_info).get())
         {
             state.state = UpdateState::readyToInstall;

--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -295,57 +295,6 @@ toast_notification_handler_result toast_notification_handler(const std::wstring_
     }
 }
 
-void cleanup_updates()
-{
-    auto state = UpdateState::read();
-    if (state.state != UpdateState::upToDate)
-    {
-        return;
-    }
-
-    auto update_dir = updating::get_pending_updates_path();
-    if (std::filesystem::exists(update_dir))
-    {
-        // Msi and exe files
-        for (const auto& entry : std::filesystem::directory_iterator(update_dir))
-        {
-            auto entryPath = entry.path().wstring();
-            std::transform(entryPath.begin(), entryPath.end(), entryPath.begin(), ::towlower);
-
-            if (entryPath.ends_with(L".msi") || entryPath.ends_with(L".exe"))
-            {
-                std::error_code err;
-                std::filesystem::remove(entry, err);
-                if (err.value())
-                {
-                    Logger::warn("Failed to delete installer file {}. {}", entry.path().string(), err.message());
-                }
-            }
-        }
-    }
-
-    // Log files
-    auto rootPath{ PTSettingsHelper::get_root_save_folder_location() };
-    auto currentVersion = left_trim<wchar_t>(get_product_version(), L"v");
-    if (std::filesystem::exists(rootPath))
-    {
-        for (const auto& entry : std::filesystem::directory_iterator(rootPath))
-        {
-            auto entryPath = entry.path().wstring();
-            std::transform(entryPath.begin(), entryPath.end(), entryPath.begin(), ::towlower);
-            if (entry.is_regular_file() && entryPath.ends_with(L".log") && entryPath.find(currentVersion) == std::string::npos)
-            {
-                std::error_code err;
-                std::filesystem::remove(entry, err);
-                if (err.value())
-                {
-                    Logger::warn("Failed to delete log file {}. {}", entry.path().string(), err.message());
-                }
-            }
-        }
-    }
-}
-
 int WINAPI WinMain(HINSTANCE /*hInstance*/, HINSTANCE /*hPrevInstance*/, LPSTR lpCmdLine, int /*nCmdShow*/)
 {
     Gdiplus::GdiplusStartupInput gpStartupInput;
@@ -454,7 +403,11 @@ int WINAPI WinMain(HINSTANCE /*hInstance*/, HINSTANCE /*hPrevInstance*/, LPSTR l
         modules();
 
         std::thread{ [] {
-            cleanup_updates();
+            auto state = UpdateState::read();
+            if (state.state == UpdateState::upToDate)
+            {
+                updating::cleanup_updates();
+            }
         } }.detach();
 
         auto general_settings = load_general_settings();


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Installers and logs are currently cleaned on PT startup only if it's up to date.
If the users skips some updates, the installers are accumulated wasting disk space.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #27811
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

- Moved the method that cleanup installers and logs in the common updating library
- Cleanup before downloading a new version

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

- Build PT with an old version
- Put some logs in `%LOCALAPPDATA%\Microsoft\PowerToys` and some installers in `%LOCALAPPDATA%\Microsoft\PowerToys\Updates`
- Verified that when the new version is downloaded installers and logs are cleaned up (tested from runner and from updater)
- Verified that when PT is started up to date installers and logs are cleaned up
