### PR TITLE
[Settings]Fix IsEnabledTextBlock secondary style

### DIFF
--- a/src/settings-ui/Settings.UI/SettingsXAML/App.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/App.xaml
@@ -11,7 +11,6 @@
             <ResourceDictionary.MergedDictionaries>
                 <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
                 <ResourceDictionary Source="/SettingsXAML/Controls/KeyVisual/KeyVisual.xaml" />
-                <ResourceDictionary Source="/SettingsXAML/Controls/IsEnabledTextBlock/IsEnabledTextBlock.xaml" />
                 <ResourceDictionary Source="/SettingsXAML/Styles/TextBlock.xaml" />
                 <ResourceDictionary Source="/SettingsXAML/Styles/Button.xaml" />
                 <ResourceDictionary Source="/SettingsXAML/Themes/Colors.xaml" />

--- a/src/settings-ui/Settings.UI/SettingsXAML/Controls/IsEnabledTextBlock/IsEnabledTextBlock.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Controls/IsEnabledTextBlock/IsEnabledTextBlock.cs
@@ -14,7 +14,7 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
     {
         public IsEnabledTextBlock()
         {
-            this.DefaultStyleKey = typeof(IsEnabledTextBlock);
+            this.Style = (Style)App.Current.Resources["DefaultIsEnabledTextBlockStyle"];
         }
 
         protected override void OnApplyTemplate()

--- a/src/settings-ui/Settings.UI/SettingsXAML/Controls/IsEnabledTextBlock/IsEnabledTextBlock.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Controls/IsEnabledTextBlock/IsEnabledTextBlock.xaml
@@ -3,7 +3,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Microsoft.PowerToys.Settings.UI.Controls">
 
-    <Style TargetType="local:IsEnabledTextBlock">
+    <Style x:Key="DefaultIsEnabledTextBlockStyle" TargetType="local:IsEnabledTextBlock">
         <Setter Property="Foreground" Value="{ThemeResource DefaultTextForegroundThemeBrush}" />
         <Setter Property="IsTabStop" Value="False" />
         <Setter Property="Template">
@@ -35,7 +35,9 @@
     </Style>
     <Style
         x:Key="SecondaryIsEnabledTextBlockStyle"
-        TargetType="local:IsEnabledTextBlock">
+        TargetType="local:IsEnabledTextBlock"
+        BasedOn="{StaticResource DefaultIsEnabledTextBlockStyle}"
+        >
         <Setter Property="Foreground" Value="{ThemeResource TextFillColorSecondaryBrush}" />
         <Setter Property="FontSize" Value="{StaticResource SecondaryTextFontSize}" />
     </Style>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

After https://github.com/microsoft/PowerToys/pull/27451 flattening work, the description on CheckBoxWithDescriptionControl instances or the word "To" that indicates KBM mappings in Settings can no longer be seen. This seems to be caused by the fact that those entries depend on the "SecondaryIsEnabledTextBlockStyle", which seems to no longer be based on the decault "IsEnabledTextBlock" control style after we moved Themes/General.xaml to another directory ("Themes/General.xaml" is magic).

To solve this, we set specific style names to the IsEnabledTextBlock control instead of relying on defaults.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #27905
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

This PR also removes an entry in a merged dictionary that is duplicated, since Generic.xaml already points to IsEnabledTextBlock,xaml.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Checked the checkbox descriptions are present again in PowerToys Run page:
![image](https://github.com/microsoft/PowerToys/assets/26118718/1df7f4a0-3bfc-4630-b348-63fa2c664d2f)

Checked the KBM "to" word appears again
![image](https://github.com/microsoft/PowerToys/assets/26118718/88acc8bc-cafe-4ac9-af82-b9f170f6eef8)

Checked the FancyZones "Zone index" label is still there (instance of IsEnabledTextBox with the default style):
![image](https://github.com/microsoft/PowerToys/assets/26118718/fc0eb49e-4adb-4a41-a205-f2b4fd1fe357)
