### PR TITLE
[PowerRename] Remember last window size and optimize sorting

### DIFF
--- a/src/modules/powerrename/PowerRenameContextMenu/pch.h
+++ b/src/modules/powerrename/PowerRenameContextMenu/pch.h
@@ -7,6 +7,7 @@
 #ifndef PCH_H
 #define PCH_H
 
+#define NOMINMAX
 // add headers that you want to pre-compile here
 #include "framework.h"
 

--- a/src/modules/powerrename/PowerRenameUILib/PowerRenameXAML/MainWindow.xaml.cpp
+++ b/src/modules/powerrename/PowerRenameUILib/PowerRenameXAML/MainWindow.xaml.cpp
@@ -21,6 +21,7 @@
 
 #include "microsoft.ui.xaml.window.h"
 #include <winrt/Microsoft.UI.Interop.h>
+#include <winrt/Windows.UI.ViewManagement.h>
 #include <winrt/Microsoft.UI.Windowing.h>
 #include <common/Themes/theme_helpers.h>
 #include <common/Themes/theme_listener.h>
@@ -133,8 +134,7 @@ namespace winrt::PowerRenameUI::implementation
             GetDpiForMonitor(hMonitor, MONITOR_DPI_TYPE::MDT_EFFECTIVE_DPI, &x_dpi, &x_dpi);
             UINT window_dpi = GetDpiForWindow(m_window);
 
-            int width = 1400;
-            int height = 800;
+            const auto [width, height] = CSettingsInstance().GetLastWindowSize();
 
             winrt::Windows::Graphics::RectInt32 rect;
             // Scale window size
@@ -285,6 +285,23 @@ namespace winrt::PowerRenameUI::implementation
         InitAutoComplete();
         SearchReplaceChanged();
         InvalidateItemListViewState();
+
+        SizeChanged({ this, &MainWindow::OnSizeChanged });
+        Closed({ this, &MainWindow::OnClosed });
+    }
+
+    void MainWindow::OnSizeChanged(winrt::Windows::Foundation::IInspectable const&, winrt::Microsoft::UI::Xaml::WindowSizeChangedEventArgs const& /*args*/)
+    {
+        const auto appWindow =
+            Microsoft::UI::Windowing::AppWindow::GetFromWindowId(Microsoft::UI::GetWindowIdFromWindow(m_window));
+        const auto [width, height] = appWindow.Size();
+
+        CSettingsInstance().UpdateLastWindowSize(static_cast<int>(width), static_cast<int>(height));
+    }
+
+    void MainWindow::OnClosed(winrt::Windows::Foundation::IInspectable const&, winrt::Microsoft::UI::Xaml::WindowEventArgs const&)
+    {
+        CSettingsInstance().Save();
     }
 
     void MainWindow::InvalidateItemListViewState()

--- a/src/modules/powerrename/PowerRenameUILib/PowerRenameXAML/MainWindow.xaml.cpp
+++ b/src/modules/powerrename/PowerRenameUILib/PowerRenameXAML/MainWindow.xaml.cpp
@@ -134,7 +134,7 @@ namespace winrt::PowerRenameUI::implementation
             GetDpiForMonitor(hMonitor, MONITOR_DPI_TYPE::MDT_EFFECTIVE_DPI, &x_dpi, &x_dpi);
             UINT window_dpi = GetDpiForWindow(m_window);
 
-            const auto [width, height] = CSettingsInstance().GetLastWindowSize();
+            const auto& [width, height] = CSettingsInstance().GetLastWindowSize();
 
             winrt::Windows::Graphics::RectInt32 rect;
             // Scale window size

--- a/src/modules/powerrename/PowerRenameUILib/PowerRenameXAML/MainWindow.xaml.h
+++ b/src/modules/powerrename/PowerRenameUILib/PowerRenameXAML/MainWindow.xaml.h
@@ -74,6 +74,9 @@ namespace winrt::PowerRenameUI::implementation
 
         MainWindow();
 
+        void OnSizeChanged(winrt::Windows::Foundation::IInspectable const&, winrt::Microsoft::UI::Xaml::WindowSizeChangedEventArgs const&);
+        void OnClosed(winrt::Windows::Foundation::IInspectable const&, winrt::Microsoft::UI::Xaml::WindowEventArgs const&);
+
         void InvalidateItemListViewState();
 
         Windows::Foundation::Collections::IObservableVector<hstring> SearchMRU() { return m_searchMRUList; }
@@ -95,6 +98,7 @@ namespace winrt::PowerRenameUI::implementation
         void ShowRenamed(winrt::Windows::Foundation::IInspectable const& sender, winrt::Microsoft::UI::Xaml::RoutedEventArgs const& e);
 
     private:
+        winrt::Windows::Foundation::Size m_lastWindowSize;
         bool m_allSelected;
 
         winrt::Windows::Foundation::Collections::IObservableVector<hstring> m_searchMRUList;

--- a/src/modules/powerrename/dll/pch.h
+++ b/src/modules/powerrename/dll/pch.h
@@ -3,6 +3,7 @@
 #include "targetver.h"
 
 #define WIN32_LEAN_AND_MEAN // Exclude rarely-used stuff from Windows headers
+#define NOMINMAX
 // Windows Header Files:
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Foundation.Collections.h>

--- a/src/modules/powerrename/lib/PowerRenameEnum.cpp
+++ b/src/modules/powerrename/lib/PowerRenameEnum.cpp
@@ -102,7 +102,10 @@ HRESULT CPowerRenameEnum::_ParseEnumItems(_In_ IEnumShellItems* pesi, _In_ int d
             l->Compare(r, SICHINT_DISPLAY, &res);
             return res < 0;
         };
-        std::sort(begin(items), end(items), cmpShellItems);
+
+        // We need to sort only the first layer, because later ones are enumerated correctly
+        if (depth == 0)
+            std::sort(begin(items), end(items), cmpShellItems);
 
         for (const auto& item : items)
         {

--- a/src/modules/powerrename/lib/Settings.cpp
+++ b/src/modules/powerrename/lib/Settings.cpp
@@ -25,6 +25,8 @@ namespace
     const wchar_t c_replaceText[] = L"ReplaceText";
     const wchar_t c_mruEnabled[] = L"MRUEnabled";
     const wchar_t c_useBoostLib[] = L"UseBoostLib";
+    const wchar_t c_lastWindowWidth[] = L"LastWindowWidth";
+    const wchar_t c_lastWindowHeight[] = L"LastWindowHeight";
 
 }
 
@@ -49,6 +51,8 @@ void CSettings::Save()
     jsonData.SetNamedValue(c_searchText, json::value(settings.searchText));
     jsonData.SetNamedValue(c_replaceText, json::value(settings.replaceText));
     jsonData.SetNamedValue(c_useBoostLib, json::value(settings.useBoostLib));
+    jsonData.SetNamedValue(c_lastWindowWidth, json::value(settings.lastWindowWidth));
+    jsonData.SetNamedValue(c_lastWindowHeight, json::value(settings.lastWindowHeight));
 
     json::to_file(jsonFilePath, jsonData);
     GetSystemTimeAsFileTime(&lastLoadedTime);
@@ -139,6 +143,9 @@ void CSettings::ParseJson()
             {
                 settings.useBoostLib = jsonSettings.GetNamedBoolean(c_useBoostLib);
             }
+
+            settings.lastWindowWidth = static_cast<int>(jsonSettings.GetNamedNumber(c_lastWindowWidth, DEFAULT_WINDOW_WIDTH));
+            settings.lastWindowHeight = static_cast<int>(jsonSettings.GetNamedNumber(c_lastWindowHeight, DEFAULT_WINDOW_HEIGHT));
         }
         catch (const winrt::hresult_error&)
         {

--- a/src/modules/powerrename/lib/Settings.h
+++ b/src/modules/powerrename/lib/Settings.h
@@ -6,6 +6,9 @@
 class CSettings
 {
 public:
+    static constexpr inline int DEFAULT_WINDOW_WIDTH = 1400;
+    static constexpr inline int DEFAULT_WINDOW_HEIGHT = 800;
+
     CSettings();
 
     inline bool GetEnabled()
@@ -23,6 +26,17 @@ public:
     {
         settings.enabled = enabled;
         Save();
+    }
+
+    inline std::tuple<int, int> GetLastWindowSize() const
+    {
+        return std::make_tuple(settings.lastWindowWidth, settings.lastWindowHeight);
+    }
+
+    inline void UpdateLastWindowSize(const int width, const int height)
+    {
+        settings.lastWindowWidth = std::max(width, DEFAULT_WINDOW_WIDTH);
+        settings.lastWindowHeight = std::max(height, DEFAULT_WINDOW_HEIGHT);
     }
 
     inline bool GetShowIconOnMenu() const
@@ -134,6 +148,8 @@ private:
         unsigned int flags{ 0 };
         std::wstring searchText{};
         std::wstring replaceText{};
+        int lastWindowWidth{ DEFAULT_WINDOW_WIDTH };
+        int lastWindowHeight{ DEFAULT_WINDOW_HEIGHT };
     };
 
     void Reload();

--- a/src/modules/powerrename/unittests/pch.h
+++ b/src/modules/powerrename/unittests/pch.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#define NOMINMAX
 #include "targetver.h"
 
 #include <atlbase.h>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
- Persist last window size if it's bigger than the default
- only sort top-level items, because the rest are enumerated correctly using WinAPI

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #2152
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

