### PR TITLE
[Peek] show thumbnail and fallback to icon on unsupported files

### DIFF
--- a/src/modules/peek/Peek.FilePreviewer/Previewers/UnsupportedFilePreviewer/UnsupportedFilePreviewer.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/UnsupportedFilePreviewer/UnsupportedFilePreviewer.cs
@@ -4,11 +4,9 @@
 
 using System;
 using System.Globalization;
-using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
-using Microsoft.PowerToys.Settings.UI.Library;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Peek.Common.Extensions;
@@ -76,7 +74,7 @@ namespace Peek.FilePreviewer.Previewers
             else
             {
                 State = PreviewState.Loaded;
-        }
+            }
         }
 
         public async Task CopyAsync()
@@ -99,7 +97,8 @@ namespace Peek.FilePreviewer.Previewers
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 
-                    var iconBitmap = await IconHelper.GetIconAsync(Item.Path, cancellationToken);
+                    var iconBitmap = await IconHelper.GetThumbnailAsync(Item.Path, cancellationToken)
+                        ?? await IconHelper.GetIconAsync(Item.Path, cancellationToken);
 
                     cancellationToken.ThrowIfCancellationRequested();
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Allow Peek to retrieve the thumbnail of unsupported files and use that as icon; if a thumbnail is not available, fallback to the file icon (as it currently does).

![image](https://github.com/microsoft/PowerToys/assets/85504/6f9bda22-9e8d-45a4-b70e-c6e430b8c645)

![image](https://github.com/microsoft/PowerToys/assets/85504/c4f4c904-84b9-4b18-9954-c3e4871cfbb3)

![image](https://github.com/microsoft/PowerToys/assets/85504/a392b328-76c2-4f4d-95e4-8be8543eb66b)

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

While looking through this code, I've found a couple of places where some potential memory leaks could be occurring, and I have tried to fix those as I found them.

(Specifically, when `((IShellItemImageFactory)nativeShellItem).GetImage` method was called, we immediately followed it by `cancellationToken.ThrowIfCancellationRequested()` but never destroyed the `hbitmap` instance from the previous!)

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Manual validation against a couple of .gcode, .3mf, and .unknown files