### PR TITLE
[FancyZones Editor] Duplicating non-selected layout applies duplicated layout fix

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/EditorWindow.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/EditorWindow.cs
@@ -45,6 +45,14 @@ namespace FancyZonesEditor
 
         protected void OnCancel(object sender, RoutedEventArgs e)
         {
+            // restore backup, clean up
+            App.Overlay.EndEditing(true);
+
+            // select and draw applied layout
+            var settings = ((App)Application.Current).MainWindowSettings;
+            settings.SetSelectedModel(settings.AppliedModel);
+            App.Overlay.CurrentDataContext = settings.AppliedModel;
+
             Close();
         }
     }

--- a/src/modules/fancyzones/editor/FancyZonesEditor/GridEditorWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/GridEditorWindow.xaml.cs
@@ -16,15 +16,11 @@ namespace FancyZonesEditor
 
             KeyUp += GridEditorWindow_KeyUp;
             KeyDown += ((App)Application.Current).App_KeyDown;
-
-            _stashedModel = (GridLayoutModel)(App.Overlay.CurrentDataContext as GridLayoutModel).Clone();
         }
 
         protected new void OnCancel(object sender, RoutedEventArgs e)
         {
             base.OnCancel(sender, e);
-            GridLayoutModel model = App.Overlay.CurrentDataContext as GridLayoutModel;
-            _stashedModel.RestoreTo(model);
         }
 
         private void GridEditorWindow_KeyUp(object sender, KeyEventArgs e)
@@ -36,8 +32,6 @@ namespace FancyZonesEditor
 
             ((App)Application.Current).App_KeyUp(sender, e);
         }
-
-        private GridLayoutModel _stashedModel;
 
         // This is required to fix a WPF rendering bug when using custom chrome
         private void EditorWindow_ContentRendered(object sender, System.EventArgs e)

--- a/src/modules/fancyzones/editor/FancyZonesEditor/LayoutBackup.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/LayoutBackup.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Windows;
+using FancyZonesEditor.Models;
+
+namespace FancyZonesEditor
+{
+    public class LayoutBackup
+    {
+        private LayoutModel _backup;
+        private List<LayoutModel> _defaultLayoutsBackup;
+
+        public LayoutBackup()
+        {
+        }
+
+        public void Backup(LayoutModel model)
+        {
+            if (model is GridLayoutModel grid)
+            {
+                _backup = new GridLayoutModel(grid);
+            }
+            else if (model is CanvasLayoutModel canvas)
+            {
+                _backup = new CanvasLayoutModel(canvas);
+            }
+
+            _defaultLayoutsBackup = new List<LayoutModel>(MainWindowSettingsModel.DefaultLayouts.Layouts);
+        }
+
+        public void Restore()
+        {
+            if (_backup != null)
+            {
+                var settings = ((App)Application.Current).MainWindowSettings;
+                var selectedModel = settings.SelectedModel;
+
+                if (selectedModel == null)
+                {
+                    return;
+                }
+
+                if (_backup is GridLayoutModel grid)
+                {
+                    grid.RestoreTo((GridLayoutModel)selectedModel);
+                    grid.InitTemplateZones();
+                }
+                else if (_backup is CanvasLayoutModel canvas)
+                {
+                    canvas.RestoreTo((CanvasLayoutModel)selectedModel);
+                }
+            }
+
+            if (_defaultLayoutsBackup != null)
+            {
+                MainWindowSettingsModel.DefaultLayouts.Restore(_defaultLayoutsBackup);
+            }
+        }
+
+        public void Clear()
+        {
+            _backup = null;
+            _defaultLayoutsBackup = null;
+        }
+    }
+}

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -244,21 +244,15 @@ namespace FancyZonesEditor
             Logger.LogTrace();
 
             var dataContext = ((FrameworkElement)sender).DataContext;
-            Select((LayoutModel)dataContext);
-
             EditLayoutDialog.Hide();
 
-            var mainEditor = App.Overlay;
-            if (mainEditor.CurrentDataContext is not LayoutModel model)
+            if (dataContext is not LayoutModel model)
             {
                 return;
             }
 
-            model.IsSelected = false;
-
             // make a copy
             model = model.Clone();
-            mainEditor.CurrentDataContext = model;
 
             string name = model.Name;
             var index = name.LastIndexOf('(');
@@ -293,11 +287,8 @@ namespace FancyZonesEditor
             }
 
             model.Name = name + " (" + (++maxCustomIndex) + ')';
-
             model.Persist();
 
-            App.Overlay.Monitors[App.Overlay.CurrentDesktop].SetLayoutSettings(model);
-            App.FancyZonesEditorIO.SerializeAppliedLayouts();
             App.FancyZonesEditorIO.SerializeCustomLayouts();
         }
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/MainWindowSettingsModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/MainWindowSettingsModel.cs
@@ -267,27 +267,6 @@ namespace FancyZonesEditor
             return foundModel;
         }
 
-        public void RestoreSelectedModel(LayoutModel model)
-        {
-            if (SelectedModel == null || model == null)
-            {
-                return;
-            }
-
-            SelectedModel.SensitivityRadius = model.SensitivityRadius;
-            SelectedModel.TemplateZoneCount = model.TemplateZoneCount;
-            SelectedModel.IsSelected = model.IsSelected;
-            SelectedModel.IsApplied = model.IsApplied;
-            SelectedModel.Name = model.Name;
-            SelectedModel.QuickKey = model.QuickKey;
-
-            if (model is GridLayoutModel grid)
-            {
-                ((GridLayoutModel)SelectedModel).Spacing = grid.Spacing;
-                ((GridLayoutModel)SelectedModel).ShowSpacing = grid.ShowSpacing;
-            }
-        }
-
         public void SetSelectedModel(LayoutModel model)
         {
             if (_selectedModel != null)

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Overlay.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Overlay.cs
@@ -17,6 +17,7 @@ namespace FancyZonesEditor
         private LayoutPreview _layoutPreview;
         private UserControl _editorLayout;
         private EditorWindow _editorWindow;
+        private LayoutBackup _layoutBackup = new LayoutBackup();
 
         public List<Monitor> Monitors { get; private set; }
 
@@ -259,6 +260,21 @@ namespace FancyZonesEditor
             {
                 _editorWindow.Focus();
             }
+        }
+
+        public void StartEditing(LayoutModel model)
+        {
+            _layoutBackup.Backup(model);
+        }
+
+        public void EndEditing(bool restoreBackup)
+        {
+            if (restoreBackup)
+            {
+                _layoutBackup.Restore();
+            }
+
+            _layoutBackup.Clear();
         }
 
         public void CloseLayoutWindow()


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

The process of duplicating no longer involves simultaneously showing and applying the layout.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #27670 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

* Open FZ Editor
* Select one layout
* Right click different layout and duplicate it
* Close Editor
* Verify that duplicated layout is only duplicated, not applied.
