### PR TITLE
[Hosts] Ignore sample entries

### DIFF
--- a/src/modules/Hosts/Hosts.Tests/EntryTest.cs
+++ b/src/modules/Hosts/Hosts.Tests/EntryTest.cs
@@ -76,6 +76,8 @@ namespace Hosts.Tests
         [DataRow("host 10.1.1.1")]
         [DataRow("# comment 10.1.1.1 host # comment")]
         [DataRow("10.1.1.1 host01 host02 host03 host04 host05 host06 host07 host08 host09 host10")]
+        [DataRow("102.54.94.97 rhino.acme.com # source server")]
+        [DataRow("38.25.63.10 x.acme.com # x client host")]
         public void Not_Valid_Entry(string line)
         {
             var entry = new Entry(0, line);

--- a/src/modules/Hosts/Hosts/HostsXAML/Views/MainPage.xaml
+++ b/src/modules/Hosts/Hosts/HostsXAML/Views/MainPage.xaml
@@ -448,7 +448,7 @@
                         ScrollViewer.IsVerticalRailEnabled="True"
                         ScrollViewer.VerticalScrollBarVisibility="Visible"
                         ScrollViewer.VerticalScrollMode="Enabled"
-                        Text="{Binding Comment, Mode=TwoWay}" />
+                        Text="{Binding Comment, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                     <ToggleSwitch
                         x:Uid="Active"
                         IsOn="{Binding Active, Mode=TwoWay}"

--- a/src/modules/Hosts/Hosts/Models/Entry.cs
+++ b/src/modules/Hosts/Hosts/Models/Entry.cs
@@ -44,6 +44,7 @@ namespace Hosts.Models
         }
 
         [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(Valid))]
         private string _comment;
 
         [ObservableProperty]
@@ -153,7 +154,19 @@ namespace Hosts.Models
 
         public bool Validate(bool validateHostsLength)
         {
+            if (Equals("102.54.94.97", "rhino.acme.com", "source server") || Equals("38.25.63.10", "x.acme.com", "x client host"))
+            {
+                return false;
+            }
+
             return Type != AddressType.Invalid && ValidationHelper.ValidHosts(Hosts, validateHostsLength);
+        }
+
+        private bool Equals(string address, string hosts, string comment)
+        {
+            return string.Equals(Address, address, StringComparison.Ordinal)
+                && string.Equals(Hosts, hosts, StringComparison.Ordinal)
+                && string.Equals(Comment, comment, StringComparison.Ordinal);
         }
     }
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Don't consider valid the following entries:
- `102.54.94.97 rhino.acme.com # source server`
- `38.25.63.10 x.acme.com # x client host`

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #21264
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

- Test are passing
- The sample lines aren't parsed as entries and appears in the additional content textbox
- The sample entries can't be manually inserted in the create/update dialog