### PR TITLE
[Peek]Fix crash while loading thumbnails for small pngs

### DIFF
--- a/src/modules/peek/Peek.FilePreviewer/Previewers/Helpers/BitmapHelper.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/Helpers/BitmapHelper.cs
@@ -18,6 +18,7 @@ namespace Peek.FilePreviewer.Previewers.Helpers
         public static async Task<BitmapSource> GetBitmapFromHBitmapAsync(IntPtr hbitmap, bool isSupportingTransparency, CancellationToken cancellationToken)
         {
             Bitmap? bitmap = null;
+            Bitmap? tempBitmapForDeletion = null;
 
             try
             {
@@ -32,7 +33,8 @@ namespace Peek.FilePreviewer.Previewers.Helpers
 
                     var transparentBitmap = new Bitmap(bitmapData.Width, bitmapData.Height, bitmapData.Stride, PixelFormat.Format32bppArgb, bitmapData.Scan0);
 
-                    bitmap.Dispose();
+                    // Can't dispose of original bitmap yet as that causes crashes on png files. Saving it for later disposal after saving to stream.
+                    tempBitmapForDeletion = bitmap;
                     bitmap = transparentBitmap;
                 }
 
@@ -53,6 +55,7 @@ namespace Peek.FilePreviewer.Previewers.Helpers
             finally
             {
                 bitmap?.Dispose();
+                tempBitmapForDeletion?.Dispose();
 
                 // delete HBitmap to avoid memory leaks
                 NativeMethods.DeleteObject(hbitmap);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

After #27979 was merged some small png files started crashing peek. This seems to be caused by a early disposal of the Bitmap. Waiting before disposing made the crash go away for me.
@pedrolamas , FYI ;) 

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Before this fix, using Peek right after startup on this image crashed Peek. With this fix it doesn't crash anymore.
[26118718.zip](https://github.com/microsoft/PowerToys/files/12456869/26118718.zip)