### PR TITLE
[Settings]Flyout disables Awake if settings page is opened

### DIFF
--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/AwakePage.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/AwakePage.xaml.cs
@@ -182,6 +182,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
 
         public void RefreshEnabledState()
         {
+            UpdateEnabledState(_generalSettingsRepository.SettingsConfig.Enabled.Awake);
             ViewModel.RefreshEnabledState();
         }
     }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
While testing a build version, we noticed that Awake didn't disable through the flyout if the Settings page was opened in the Awake page.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Open Settings in the Awake page and use the flyout to enable/disable Awake. Verify the change propagates.
