### PR TITLE
[Tests]Disallow user override of culture options while running tests

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator.UnitTest/ExtendedCalculatorParserTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator.UnitTest/ExtendedCalculatorParserTests.cs
@@ -239,7 +239,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
 
             // Act
             // Using en-us culture to have a fixed number style
-            var result = engine.Interpret(input, new CultureInfo("en-us"), out _);
+            var result = engine.Interpret(input, new CultureInfo("en-us", false), out _);
 
             // Assert
             Assert.IsNotNull(result);

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator.UnitTest/NumberTranslatorTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator.UnitTest/NumberTranslatorTests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
         public void Translate_ThrowError_WhenCalledNull(string input)
         {
             // Arrange
-            var translator = NumberTranslator.Create(new CultureInfo("de-DE"), new CultureInfo("en-US"));
+            var translator = NumberTranslator.Create(new CultureInfo("de-DE", false), new CultureInfo("en-US", false));
 
             // Act
             Assert.ThrowsException<ArgumentNullException>(() => translator.Translate(input));
@@ -58,7 +58,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
         public void Translate_WhenCalledEmpty(string input)
         {
             // Arrange
-            var translator = NumberTranslator.Create(new CultureInfo("de-DE"), new CultureInfo("en-US"));
+            var translator = NumberTranslator.Create(new CultureInfo("de-DE", false), new CultureInfo("en-US", false));
 
             // Act
             var result = translator.Translate(input);
@@ -76,7 +76,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
         public void Translate_NoErrors_WhenCalled(string input, string expectedResult)
         {
             // Arrange
-            var translator = NumberTranslator.Create(new CultureInfo("de-DE"), new CultureInfo("en-US"));
+            var translator = NumberTranslator.Create(new CultureInfo("de-DE", false), new CultureInfo("en-US", false));
 
             // Act
             var result = translator.Translate(input);
@@ -95,7 +95,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
         public void TranslateBack_NoErrors_WhenCalled(string input, string expectedResult)
         {
             // Arrange
-            var translator = NumberTranslator.Create(new CultureInfo("de-DE"), new CultureInfo("en-US"));
+            var translator = NumberTranslator.Create(new CultureInfo("de-DE", false), new CultureInfo("en-US", false));
 
             // Act
             var result = translator.TranslateBack(input);
@@ -113,7 +113,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
         public void Translate_RemoveNumberGroupSeparator_WhenCalled(string decimalSeparator, string groupSeparator, string input, string expectedResult)
         {
             // Arrange
-            var sourceCulture = new CultureInfo("en-US")
+            var sourceCulture = new CultureInfo("en-US", false)
             {
                 NumberFormat =
                 {
@@ -121,7 +121,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
                     NumberGroupSeparator = groupSeparator,
                 },
             };
-            var translator = NumberTranslator.Create(sourceCulture, new CultureInfo("en-US"));
+            var translator = NumberTranslator.Create(sourceCulture, new CultureInfo("en-US", false));
 
             // Act
             var result = translator.Translate(input);
@@ -137,7 +137,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
         public void Translate_NoRemovalOfLeadingZeroesOnEdgeCases(string input, string expectedResult)
         {
             // Arrange
-            var translator = NumberTranslator.Create(new CultureInfo("de-de"), new CultureInfo("en-US"));
+            var translator = NumberTranslator.Create(new CultureInfo("de-de", false), new CultureInfo("en-US", false));
 
             // Act
             var result = translator.Translate(input);

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.System/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.System/Main.cs
@@ -88,7 +88,7 @@ namespace Microsoft.PowerToys.Run.Plugin.System
         public List<Result> Query(Query query)
         {
             List<Result> results = new List<Result>();
-            CultureInfo culture = _localizeSystemCommands ? CultureInfo.CurrentUICulture : new CultureInfo("en-US", false);
+            CultureInfo culture = _localizeSystemCommands ? CultureInfo.CurrentUICulture : new CultureInfo("en-US");
 
             if (query == null)
             {
@@ -135,7 +135,7 @@ namespace Microsoft.PowerToys.Run.Plugin.System
         public List<Result> Query(Query query, bool delayedExecution)
         {
             List<Result> results = new List<Result>();
-            CultureInfo culture = _localizeSystemCommands ? CultureInfo.CurrentUICulture : new CultureInfo("en-US", false);
+            CultureInfo culture = _localizeSystemCommands ? CultureInfo.CurrentUICulture : new CultureInfo("en-US");
 
             if (query == null)
             {

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.System/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.System/Main.cs
@@ -88,7 +88,7 @@ namespace Microsoft.PowerToys.Run.Plugin.System
         public List<Result> Query(Query query)
         {
             List<Result> results = new List<Result>();
-            CultureInfo culture = _localizeSystemCommands ? CultureInfo.CurrentUICulture : new CultureInfo("en-US");
+            CultureInfo culture = _localizeSystemCommands ? CultureInfo.CurrentUICulture : new CultureInfo("en-US", false);
 
             if (query == null)
             {
@@ -135,7 +135,7 @@ namespace Microsoft.PowerToys.Run.Plugin.System
         public List<Result> Query(Query query, bool delayedExecution)
         {
             List<Result> results = new List<Result>();
-            CultureInfo culture = _localizeSystemCommands ? CultureInfo.CurrentUICulture : new CultureInfo("en-US");
+            CultureInfo culture = _localizeSystemCommands ? CultureInfo.CurrentUICulture : new CultureInfo("en-US", false);
 
             if (query == null)
             {

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests/ImageTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests/ImageTests.cs
@@ -24,9 +24,9 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests
 
             // Set culture to 'en-us'
             originalCulture = CultureInfo.CurrentCulture;
-            CultureInfo.CurrentCulture = new CultureInfo("en-us");
+            CultureInfo.CurrentCulture = new CultureInfo("en-us", false);
             originalUiCulture = CultureInfo.CurrentUICulture;
-            CultureInfo.CurrentUICulture = new CultureInfo("en-us");
+            CultureInfo.CurrentUICulture = new CultureInfo("en-us", false);
         }
 
         [DataTestMethod]

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests/QueryTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests/QueryTests.cs
@@ -25,9 +25,9 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests
 
             // Set culture to 'en-us'
             originalCulture = CultureInfo.CurrentCulture;
-            CultureInfo.CurrentCulture = new CultureInfo("en-us");
+            CultureInfo.CurrentCulture = new CultureInfo("en-us", false);
             originalUiCulture = CultureInfo.CurrentUICulture;
-            CultureInfo.CurrentUICulture = new CultureInfo("en-us");
+            CultureInfo.CurrentUICulture = new CultureInfo("en-us", false);
         }
 
         [DataTestMethod]

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests/StringParserTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests/StringParserTests.cs
@@ -20,9 +20,9 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests
         {
             // Set culture to 'en-us'
             originalCulture = CultureInfo.CurrentCulture;
-            CultureInfo.CurrentCulture = new CultureInfo("en-us");
+            CultureInfo.CurrentCulture = new CultureInfo("en-us", false);
             originalUiCulture = CultureInfo.CurrentUICulture;
-            CultureInfo.CurrentUICulture = new CultureInfo("en-us");
+            CultureInfo.CurrentUICulture = new CultureInfo("en-us", false);
         }
 
         [DataTestMethod]

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests/TimeDateResultTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests/TimeDateResultTests.cs
@@ -26,9 +26,17 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests
             CultureInfo.CurrentUICulture = new CultureInfo("en-us", false);
         }
 
-        private DateTime GetDateTimeForTest()
+        private DateTime GetDateTimeForTest(bool embedUtc = false)
         {
-            return new DateTime(2022, 03, 02, 22, 30, 45);
+            var dateTime = new DateTime(2022, 03, 02, 22, 30, 45);
+            if (embedUtc)
+            {
+                return DateTime.SpecifyKind(dateTime, DateTimeKind.Utc);
+            }
+            else
+            {
+                return dateTime;
+            }
         }
 
         [DataTestMethod]
@@ -181,8 +189,8 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests
         public void UtcFormatsWithShortTimeAndShortDate(string formatLabel, string expectedFormat)
         {
             // Setup
-            var helperResults = AvailableResultsList.GetList(true, false, false, GetDateTimeForTest());
-            var expectedResult = GetDateTimeForTest().ToUniversalTime().ToString(expectedFormat, CultureInfo.CurrentCulture);
+            var helperResults = AvailableResultsList.GetList(true, false, false, GetDateTimeForTest(true));
+            var expectedResult = GetDateTimeForTest().ToString(expectedFormat, CultureInfo.CurrentCulture);
 
             // Act
             var result = helperResults.FirstOrDefault(x => x.Label.Equals(formatLabel, StringComparison.OrdinalIgnoreCase));
@@ -201,8 +209,8 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests
         public void UtcFormatsWithShortTimeAndLongDate(string formatLabel, string expectedFormat)
         {
             // Setup
-            var helperResults = AvailableResultsList.GetList(true, false, true, GetDateTimeForTest());
-            var expectedResult = GetDateTimeForTest().ToUniversalTime().ToString(expectedFormat, CultureInfo.CurrentCulture);
+            var helperResults = AvailableResultsList.GetList(true, false, true, GetDateTimeForTest(true));
+            var expectedResult = GetDateTimeForTest().ToString(expectedFormat, CultureInfo.CurrentCulture);
 
             // Act
             var result = helperResults.FirstOrDefault(x => x.Label.Equals(formatLabel, StringComparison.OrdinalIgnoreCase));
@@ -221,8 +229,8 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests
         public void UtcFormatsWithLongTimeAndShortDate(string formatLabel, string expectedFormat)
         {
             // Setup
-            var helperResults = AvailableResultsList.GetList(true, true, false, GetDateTimeForTest());
-            var expectedResult = GetDateTimeForTest().ToUniversalTime().ToString(expectedFormat, CultureInfo.CurrentCulture);
+            var helperResults = AvailableResultsList.GetList(true, true, false, GetDateTimeForTest(true));
+            var expectedResult = GetDateTimeForTest().ToString(expectedFormat, CultureInfo.CurrentCulture);
 
             // Act
             var result = helperResults.FirstOrDefault(x => x.Label.Equals(formatLabel, StringComparison.OrdinalIgnoreCase));
@@ -241,8 +249,8 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests
         public void UtcFormatsWithLongTimeAndLongDate(string formatLabel, string expectedFormat)
         {
             // Setup
-            var helperResults = AvailableResultsList.GetList(true, true, true, GetDateTimeForTest());
-            var expectedResult = GetDateTimeForTest().ToUniversalTime().ToString(expectedFormat, CultureInfo.CurrentCulture);
+            var helperResults = AvailableResultsList.GetList(true, true, true, GetDateTimeForTest(true));
+            var expectedResult = GetDateTimeForTest().ToString(expectedFormat, CultureInfo.CurrentCulture);
 
             // Act
             var result = helperResults.FirstOrDefault(x => x.Label.Equals(formatLabel, StringComparison.OrdinalIgnoreCase));

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests/TimeDateResultTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests/TimeDateResultTests.cs
@@ -21,9 +21,9 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests
         {
             // Set culture to 'en-us'
             originalCulture = CultureInfo.CurrentCulture;
-            CultureInfo.CurrentCulture = new CultureInfo("en-us");
+            CultureInfo.CurrentCulture = new CultureInfo("en-us", false);
             originalUiCulture = CultureInfo.CurrentUICulture;
-            CultureInfo.CurrentUICulture = new CultureInfo("en-us");
+            CultureInfo.CurrentUICulture = new CultureInfo("en-us", false);
         }
 
         private DateTime GetDateTimeForTest()


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
On some tests, we set a culture to try and compare date in numbers to the expected value in a specific culture. However, this might still be overridden by some user options, causing tests to fail in local dev machines.

This PR disables user overrides when creating the culture info we use for the tests.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
DateTime tests still pass after changing time format to 24 hours.

