### PR TITLE
[FancyZones Editor] Fix layout selection after deleting custom

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
@@ -1019,23 +1019,43 @@ namespace FancyZonesEditor.Utils
                     continue;
                 }
 
-                // check if the custom layout wasn't deleted
-                if (JsonTagToLayoutType(layout.AppliedLayout.Type) == LayoutType.Custom)
+                LayoutType layoutType = JsonTagToLayoutType(layout.AppliedLayout.Type);
+                LayoutSettings settings = new LayoutSettings
                 {
-                    bool layoutExists = false;
+                    ZonesetUuid = layout.AppliedLayout.Uuid,
+                    ShowSpacing = layout.AppliedLayout.ShowSpacing,
+                    Spacing = layout.AppliedLayout.Spacing,
+                    Type = layoutType,
+                    ZoneCount = layout.AppliedLayout.ZoneCount,
+                    SensitivityRadius = layout.AppliedLayout.SensitivityRadius,
+                };
+
+                // check if the custom layout exists
+                bool existingLayout = layoutType != LayoutType.Custom;
+                if (layoutType == LayoutType.Custom)
+                {
                     foreach (LayoutModel custom in MainWindowSettingsModel.CustomModels)
                     {
                         if (custom.Uuid == layout.AppliedLayout.Uuid)
                         {
-                            layoutExists = true;
+                            existingLayout = true;
                             break;
                         }
                     }
+                }
 
-                    if (!layoutExists)
-                    {
-                        continue;
-                    }
+                // replace deleted layout with the Blank layout
+                if (!existingLayout)
+                {
+                    LayoutModel blankLayout = MainWindowSettingsModel.TemplateModels[(int)LayoutType.Blank];
+                    settings.ZonesetUuid = blankLayout.Uuid;
+                    settings.Type = blankLayout.Type;
+                    settings.ZoneCount = blankLayout.TemplateZoneCount;
+                    settings.SensitivityRadius = blankLayout.SensitivityRadius;
+
+                    // grid layout settings, just resetting them
+                    settings.ShowSpacing = false;
+                    settings.Spacing = 0;
                 }
 
                 bool unused = true;
@@ -1047,16 +1067,6 @@ namespace FancyZonesEditor.Utils
                         (monitor.Device.VirtualDesktopId == layout.Device.VirtualDesktop ||
                         layout.Device.VirtualDesktop == DefaultVirtualDesktopGuid))
                     {
-                        var settings = new LayoutSettings
-                        {
-                            ZonesetUuid = layout.AppliedLayout.Uuid,
-                            ShowSpacing = layout.AppliedLayout.ShowSpacing,
-                            Spacing = layout.AppliedLayout.Spacing,
-                            Type = JsonTagToLayoutType(layout.AppliedLayout.Type),
-                            ZoneCount = layout.AppliedLayout.ZoneCount,
-                            SensitivityRadius = layout.AppliedLayout.SensitivityRadius,
-                        };
-
                         monitor.Settings = settings;
                         unused = false;
                         break;

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Utils/FancyZonesEditorIO.cs
@@ -1019,6 +1019,25 @@ namespace FancyZonesEditor.Utils
                     continue;
                 }
 
+                // check if the custom layout wasn't deleted
+                if (JsonTagToLayoutType(layout.AppliedLayout.Type) == LayoutType.Custom)
+                {
+                    bool layoutExists = false;
+                    foreach (LayoutModel custom in MainWindowSettingsModel.CustomModels)
+                    {
+                        if (custom.Uuid == layout.AppliedLayout.Uuid)
+                        {
+                            layoutExists = true;
+                            break;
+                        }
+                    }
+
+                    if (!layoutExists)
+                    {
+                        continue;
+                    }
+                }
+
                 bool unused = true;
                 foreach (Monitor monitor in monitors)
                 {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Check if the layout exists on reading.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

* Apply the same layout on 2 virtual desktops
* Delete the layout, close the editor
* Switch to another VD and open the editor
* Verify the empty layout is selected