### PR TITLE
[PTRun][System] Sort NetworkInterfaces by IPv4, then IPv6

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.System/Components/NetworkConnectionProperties.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.System/Components/NetworkConnectionProperties.cs
@@ -143,15 +143,13 @@ namespace Microsoft.PowerToys.Run.Plugin.System.Components
         /// <returns>List containing all network adapters</returns>
         internal static List<NetworkConnectionProperties> GetList()
         {
-            List<NetworkConnectionProperties> list = new List<NetworkConnectionProperties>();
-
-            var interfaces = NetworkInterface.GetAllNetworkInterfaces().Where(x => x.NetworkInterfaceType != NetworkInterfaceType.Loopback && x.GetPhysicalAddress() != null);
-            foreach (NetworkInterface i in interfaces)
-            {
-                list.Add(new NetworkConnectionProperties(i));
-            }
-
-            return list;
+            var interfaces = NetworkInterface.GetAllNetworkInterfaces()
+                                             .Where(x => x.NetworkInterfaceType != NetworkInterfaceType.Loopback && x.GetPhysicalAddress() != null)
+                                             .Select(i => new NetworkConnectionProperties(i))
+                                             .OrderByDescending(i => i.IPv4) // list IPv4 first
+                                             .ThenBy(i => i.IPv6Primary) // then IPv6
+                                             .ToList();
+            return interfaces;
         }
 
         /// <summary>


### PR DESCRIPTION

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Updated NetworkInterfaces to first sort by IPv4, then IPv6 to match the logic from the DelayedQuery test.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
On devices with multiple NICs / those connected primarily to WiFi, the DelayedQuery test fails, as it expects to find ipv4 interfaces first. On some of my devices, mainly Windows Dev Kit 2023, the MAC addresses return first and somehow matches. This PR sorts the resolves of the network interfaces list to match the logic of the test.

![image](https://github.com/microsoft/PowerToys/assets/4016293/a0d09fca-536a-4c76-8530-d4c7b6f46a91)
![image](https://github.com/microsoft/PowerToys/assets/4016293/b390f64d-8aaf-4eb5-a12b-60f7b39f5883)
![image](https://github.com/microsoft/PowerToys/assets/4016293/ea5e05cb-c903-4714-a24a-a700ef4f06f6)
![image](https://github.com/microsoft/PowerToys/assets/4016293/b2bd60ce-76cc-46fa-aeb1-8afde9a0c39c)

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
After sorting the Network Interfaces, the tests properly succeed. 

![image](https://github.com/microsoft/PowerToys/assets/4016293/393f2764-0946-49dc-9a33-08764836362f)
![image](https://github.com/microsoft/PowerToys/assets/4016293/205897c1-143a-4f58-a8b4-fef1c1250d14)
![image](https://github.com/microsoft/PowerToys/assets/4016293/b41e84aa-7307-4ff0-ad14-67d4ae29f6bd)


