### PR TITLE
[PowerRename] Do not crash with big counter values and bound max padd…

### DIFF
--- a/src/modules/powerrename/lib/Enumerating.h
+++ b/src/modules/powerrename/lib/Enumerating.h
@@ -44,6 +44,7 @@ struct Enumerator
         wchar_t format[32];
         swprintf_s(format, sizeof(format) / sizeof(wchar_t), L"%%0%ud", padding);
 
+        //swprintf __fastfails when the buffer is too small, so we're checking the required buffer size ahead of printing to it and falling back to 0 padding in case it cannot fit. Note that we must use swprintf with nullptr buf, because the _s version panicks on it as well.
         const size_t requiredBufSize = swprintf(nullptr, 0, format, enumeratedIndex) + 1ull;
         const bool fitsBuf = requiredBufSize < bufSize;
         if (!fitsBuf)

--- a/src/modules/powerrename/lib/Enumerating.h
+++ b/src/modules/powerrename/lib/Enumerating.h
@@ -32,7 +32,7 @@ std::vector<EnumOptions> parseEnumOptions(const std::wstring& replaceWith);
 struct Enumerator
 {
     inline Enumerator(EnumOptions options) :
-        start{ options.start.value_or(0) }, increment{ options.increment.value_or(1) }, padding{ options.padding.value_or(0) }, replaceStrSpan{ options.replaceStrSpan }
+        start{ options.start.value_or(0) }, increment{ options.increment.value_or(1) }, padding{ options.padding.value_or(0) % MAX_PATH }, replaceStrSpan{ options.replaceStrSpan }
     {
     }
 
@@ -43,6 +43,14 @@ struct Enumerator
         const int32_t enumeratedIndex = enumerate(index);
         wchar_t format[32];
         swprintf_s(format, sizeof(format) / sizeof(wchar_t), L"%%0%ud", padding);
+
+        const size_t requiredBufSize = swprintf(nullptr, 0, format, enumeratedIndex) + 1ull;
+        const bool fitsBuf = requiredBufSize < bufSize;
+        if (!fitsBuf)
+        {
+            swprintf_s(format, sizeof(format) / sizeof(wchar_t), L"%%%ud", 0);
+        }
+
         return swprintf_s(buf, bufSize, format, enumeratedIndex);
     }
 

--- a/src/modules/powerrename/lib/Enumerating.h
+++ b/src/modules/powerrename/lib/Enumerating.h
@@ -44,7 +44,7 @@ struct Enumerator
         wchar_t format[32];
         swprintf_s(format, sizeof(format) / sizeof(wchar_t), L"%%0%ud", padding);
 
-        //swprintf __fastfails when the buffer is too small, so we're checking the required buffer size ahead of printing to it and falling back to 0 padding in case it cannot fit. Note that we must use swprintf with nullptr buf, because the _s version panicks on it as well.
+        //swprintf panics when the buffer is too small, so we're checking the required buffer size ahead of printing to it and falling back to 0 padding in case it cannot fit. Note that we must use swprintf with nullptr buf, because the _s version panics on it as well.
         const size_t requiredBufSize = swprintf(nullptr, 0, format, enumeratedIndex) + 1ull;
         const bool fitsBuf = requiredBufSize < bufSize;
         if (!fitsBuf)


### PR DESCRIPTION
…ing value

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
`swprintf_s` `__fastfail`s when the buffer is too small, so we're checking the required buffer size ahead of printing to it and falling back to 0 padding in case it cannot fit. Note that we must use `swprintf` with `nullptr` buf, because the `_s` version panicks on it as well.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #28247
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- verified that PowerRename now falls back to zero padding with a value of

```
${padding=999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999}
```
