### PR TITLE
Retrieve handles by SystemExtendedHandleInformation (64) instead of SystemHandleInformation (16)

### DIFF
--- a/src/modules/FileLocksmith/FileLocksmithLibInterop/FileLocksmith.cpp
+++ b/src/modules/FileLocksmith/FileLocksmithLibInterop/FileLocksmith.cpp
@@ -36,7 +36,7 @@ std::vector<ProcessResult> find_processes_recursive(const std::vector<std::wstri
         }
     }
 
-    std::map<DWORD, std::set<std::wstring>> pid_files;
+    std::map<ULONG_PTR, std::set<std::wstring>> pid_files;
 
     // Returns a normal path of the file specified by kernel_name, if it matches
     // the search criteria. Otherwise, return an empty string.

--- a/src/modules/FileLocksmith/FileLocksmithLibInterop/NtdllBase.h
+++ b/src/modules/FileLocksmith/FileLocksmithLibInterop/NtdllBase.h
@@ -16,20 +16,23 @@ class Ntdll
 private:
     HMODULE m_module;
 public:
-    struct SYSTEM_HANDLE
+    struct SYSTEM_HANDLE_TABLE_ENTRY_INFO_EX
     {
-        ULONG ProcessId;
-        BYTE ObjectTypeNumber;
-        BYTE Flags;
-        USHORT Handle;
         PVOID Object;
-        ACCESS_MASK GrantedAccess;
+        ULONG_PTR UniqueProcessId;
+        ULONG_PTR HandleValue;
+        ULONG GrantedAccess;
+        USHORT CreatorBackTraceIndex;
+        USHORT ObjectTypeIndex;
+        ULONG HandleAttributes;
+        ULONG Reserved;
     };
 
-    struct SYSTEM_HANDLE_INFORMATION
+    struct SYSTEM_HANDLE_INFORMATION_EX
     {
-        ULONG HandleCount;
-        SYSTEM_HANDLE Handles[1];
+        ULONG_PTR NumberOfHandles;
+        ULONG_PTR Reserved;
+        SYSTEM_HANDLE_TABLE_ENTRY_INFO_EX Handles[1];
     };
 
     enum POOL_TYPE

--- a/src/modules/FileLocksmith/FileLocksmithLibInterop/NtdllExtensions.cpp
+++ b/src/modules/FileLocksmith/FileLocksmithLibInterop/NtdllExtensions.cpp
@@ -154,21 +154,21 @@ std::wstring NtdllExtensions::path_to_kernel_name(LPCWSTR path)
 
 std::vector<NtdllExtensions::HandleInfo> NtdllExtensions::handles() noexcept
 {
-    auto get_info_result = NtQuerySystemInformationMemoryLoop(SystemHandleInformation);
+    auto get_info_result = NtQuerySystemInformationMemoryLoop(SystemExtendedHandleInformation);
     if (NT_ERROR(get_info_result.status))
     {
         return {};
     }
 
-    auto info_ptr = (SYSTEM_HANDLE_INFORMATION*)get_info_result.memory.data();
+    auto info_ptr = (SYSTEM_HANDLE_INFORMATION_EX*)get_info_result.memory.data();
 
-    std::map<DWORD, HANDLE> pid_to_handle;
+    std::map<ULONG_PTR, HANDLE> pid_to_handle;
     std::vector<HandleInfo> result;
 
     std::vector<BYTE> object_info_buffer(DefaultResultBufferSize);
 
     std::atomic<ULONG> i = 0;
-    std::atomic<ULONG> handle_count = info_ptr->HandleCount;
+    std::atomic<ULONG_PTR> handle_count = info_ptr->NumberOfHandles;
     std::atomic<HANDLE> process_handle = NULL;
     std::atomic<HANDLE> handle_copy = NULL;
     ULONG previous_i;
@@ -188,7 +188,7 @@ std::vector<NtdllExtensions::HandleInfo> NtdllExtensions::handles() noexcept
                 handle_copy = NULL;
 
                 auto handle_info = info_ptr->Handles + i;
-                DWORD pid = handle_info->ProcessId;
+                auto pid = handle_info->UniqueProcessId;
 
                 auto iter = pid_to_handle.find(pid);
                 if (iter != pid_to_handle.end())
@@ -197,7 +197,7 @@ std::vector<NtdllExtensions::HandleInfo> NtdllExtensions::handles() noexcept
                 }
                 else
                 {
-                    process_handle = OpenProcess(PROCESS_DUP_HANDLE, FALSE, pid);
+                    process_handle = OpenProcess(PROCESS_DUP_HANDLE, FALSE, (DWORD)pid);
                     if (!process_handle)
                     {
                         continue;
@@ -215,7 +215,7 @@ std::vector<NtdllExtensions::HandleInfo> NtdllExtensions::handles() noexcept
                 // }
 
                 HANDLE local_handle_copy;
-                auto dh_result = DuplicateHandle(process_handle, (HANDLE)handle_info->Handle, GetCurrentProcess(), &local_handle_copy, 0, 0, DUPLICATE_SAME_ACCESS);
+                auto dh_result = DuplicateHandle(process_handle, (HANDLE)handle_info->HandleValue, GetCurrentProcess(), &local_handle_copy, 0, 0, DUPLICATE_SAME_ACCESS);
                 if (dh_result == 0)
                 {
                     // Ignore this handle.
@@ -241,7 +241,7 @@ std::vector<NtdllExtensions::HandleInfo> NtdllExtensions::handles() noexcept
                 if (type_name == L"File")
                 {
                     file_name = file_handle_to_kernel_name(handle_copy, object_info_buffer);
-                    result.push_back(HandleInfo{ pid, handle_info->Handle, type_name, file_name });
+                    result.push_back(HandleInfo{ pid, handle_info->HandleValue, type_name, file_name });
                 }
 
                 CloseHandle(handle_copy);

--- a/src/modules/FileLocksmith/FileLocksmithLibInterop/NtdllExtensions.h
+++ b/src/modules/FileLocksmith/FileLocksmithLibInterop/NtdllExtensions.h
@@ -11,7 +11,7 @@ private:
     constexpr static size_t MaxResultBufferSize = 1024 * 1024 * 1024;
 
     constexpr static int ObjectNameInformation = 1;
-    constexpr static int SystemHandleInformation = 16;
+    constexpr static int SystemExtendedHandleInformation = 64;
 
     struct MemoryLoopResult
     {
@@ -35,8 +35,8 @@ public:
 
     struct HandleInfo
     {
-        DWORD pid;
-        USHORT handle;
+        ULONG_PTR pid;
+        ULONG_PTR handle;
         std::wstring type_name;
         std::wstring kernel_file_name;
     };


### PR DESCRIPTION
## Issue
File Locksmith cannot detect processes with PIDs greater than 65535: https://github.com/microsoft/PowerToys/issues/28293

## Summary of the Pull Request
It is to fix the issue(https://github.com/microsoft/PowerToys/issues/28293) that FileLocksmith cannot detect a process with a PID greater than 65535.

## Detailed Description of the Pull Request / Additional comments
struct Ntdll.SYSTEM_HANDLE is defined incorrectly. Here is the right definition in WRK: https://github.com/HighSchoolSoftwareClub/Windows-Research-Kernel-WRK-/blob/26b524b2d0f18de703018e16ec5377889afcf4ab/WRK-v1.2/public/sdk/inc/ntexapi.h#L1540
typedef struct _SYSTEM_HANDLE_TABLE_ENTRY_INFO {
    USHORT UniqueProcessId;
    USHORT CreatorBackTraceIndex;
    UCHAR ObjectTypeIndex;
    UCHAR HandleAttributes;
    USHORT HandleValue;
    PVOID Object;
    ULONG GrantedAccess;
} SYSTEM_HANDLE_TABLE_ENTRY_INFO, *PSYSTEM_HANDLE_TABLE_ENTRY_INFO;

Because UniqueProcessId is in USHORT, it cannot represent PIDs greater than 65535.

To retrieve handles with PIDs greater than 65535, we need to use SystemExtendedHandleInformation with SYSTEM_HANDLE_TABLE_ENTRY_INFO_EX. Here is the definition: https://github.com/HighSchoolSoftwareClub/Windows-Research-Kernel-WRK-/blob/26b524b2d0f18de703018e16ec5377889afcf4ab/WRK-v1.2/public/sdk/inc/ntexapi.h#L1555
typedef struct _SYSTEM_HANDLE_TABLE_ENTRY_INFO_EX {
    PVOID Object;
    ULONG_PTR UniqueProcessId;
    ULONG_PTR HandleValue;
    ULONG GrantedAccess;
    USHORT CreatorBackTraceIndex;
    USHORT ObjectTypeIndex;
    ULONG  HandleAttributes;
    ULONG  Reserved;
} SYSTEM_HANDLE_TABLE_ENTRY_INFO_EX, *PSYSTEM_HANDLE_TABLE_ENTRY_INFO_EX;

## Validation Steps Performed
On a Windows 10/11 machine which has been running for days, there're many processes with PIDs greater than 65535. Existing FileLockSmith cannot find them.

With this PR, FileLockSmith is able to find all processes.

