### PR TITLE
[ColorPicker] Reset color history to top after choosing new color

### DIFF
--- a/src/modules/colorPicker/ColorPickerUI/Views/ColorEditorView.xaml.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Views/ColorEditorView.xaml.cs
@@ -2,8 +2,11 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.ComponentModel;
+using System.Windows;
 using System.Windows.Controls;
 using ColorPicker.Helpers;
+using ColorPicker.ViewModels;
 
 namespace ColorPicker.Views
 {
@@ -12,8 +15,32 @@ namespace ColorPicker.Views
     /// </summary>
     public partial class ColorEditorView : UserControl
     {
-        public ColorEditorView() =>
+        public ColorEditorView()
+        {
             InitializeComponent();
+            Loaded += OnLoaded;
+        }
+
+        private void OnLoaded(object sender, RoutedEventArgs e)
+        {
+            EnableHistoryColorsScrollIntoView();
+        }
+
+        /// <summary>
+        /// Updating SelectedColorIndex will not refresh ListView viewport.
+        /// We listen for SelectedColorIndex property change and in case of a value <= 0 (new color is added) a call to ScrollIntoView is made so ListView will scroll up.
+        /// </summary>
+        private void EnableHistoryColorsScrollIntoView()
+        {
+            ColorEditorViewModel colorEditorViewModel = (ColorEditorViewModel)this.DataContext;
+            ((INotifyPropertyChanged)colorEditorViewModel).PropertyChanged += (sender, args) =>
+            {
+                if (args.PropertyName == nameof(colorEditorViewModel.SelectedColorIndex) && colorEditorViewModel.SelectedColorIndex <= 0)
+                {
+                    HistoryColors.ScrollIntoView(colorEditorViewModel.SelectedColor);
+                }
+            };
+        }
 
         private void HistoryColors_ItemClick(object sender, ModernWpf.Controls.ItemClickEventArgs e)
         {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
Every time that a new color is added to ListView scroll bar is reset to top, there was an [old attempt](https://github.com/microsoft/PowerToys/pull/15574) but PR was closed.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [X] **Closes:** #15073
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
An event listener to ViewModel.PropertyChanged is added to View, checks if SelectedColorIndex is changed. If it's <= 0 means that a new color is added so a ScrollIntoView is necessary.
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Tested manually to check new behaviour.
