### PR TITLE
Display in titlebar/tray if running as admin

### DIFF
--- a/src/modules/FileLocksmith/FileLocksmithUI/FileLocksmithXAML/MainWindow.xaml
+++ b/src/modules/FileLocksmith/FileLocksmithUI/FileLocksmithXAML/MainWindow.xaml
@@ -6,7 +6,6 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:views="using:PowerToys.FileLocksmithUI.Views"
     xmlns:winuiex="using:WinUIEx"
-    x:Uid="AppTitle"
     Width="680"
     MinWidth="480"
     MinHeight="320"
@@ -39,7 +38,6 @@
                 Height="16"/>
             <TextBlock
                 x:Name="AppTitleTextBlock"
-                x:Uid="AppTitleText"
                 Grid.Column="2"
                 VerticalAlignment="Center"
                 Style="{StaticResource CaptionTextBlockStyle}" />

--- a/src/modules/FileLocksmith/FileLocksmithUI/FileLocksmithXAML/MainWindow.xaml.cs
+++ b/src/modules/FileLocksmith/FileLocksmithUI/FileLocksmithXAML/MainWindow.xaml.cs
@@ -5,8 +5,8 @@
 using System;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
+using PowerToys.FileLocksmithUI.Helpers;
 using WinUIEx;
 
 namespace FileLocksmithUI
@@ -21,6 +21,11 @@ namespace FileLocksmithUI
             SetTitleBar(AppTitleBar);
             Activated += MainWindow_Activated;
             AppWindow.SetIcon("Assets/FileLocksmith/Icon.ico");
+
+            var loader = ResourceLoaderInstance.ResourceLoader;
+            var title = isElevated ? loader.GetString("AppAdminTitle") : loader.GetString("AppTitle");
+            Title = title;
+            AppTitleTextBlock.Text = title;
         }
 
         private void MainWindow_Activated(object sender, WindowActivatedEventArgs args)

--- a/src/modules/FileLocksmith/FileLocksmithUI/Helpers/ResourceLoaderInstance.cs
+++ b/src/modules/FileLocksmith/FileLocksmithUI/Helpers/ResourceLoaderInstance.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Windows.ApplicationModel.Resources;
+
+namespace PowerToys.FileLocksmithUI.Helpers
+{
+    internal static class ResourceLoaderInstance
+    {
+        internal static ResourceLoader ResourceLoader { get; private set; }
+
+        static ResourceLoaderInstance()
+        {
+            ResourceLoader = new Microsoft.Windows.ApplicationModel.Resources.ResourceLoader("PowerToys.FileLocksmithUI.pri");
+        }
+    }
+}

--- a/src/modules/FileLocksmith/FileLocksmithUI/Strings/en-us/Resources.resw
+++ b/src/modules/FileLocksmith/FileLocksmithUI/Strings/en-us/Resources.resw
@@ -117,11 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="AppTitle.Title" xml:space="preserve">
+  <data name="AppTitle" xml:space="preserve">
     <value>File Locksmith</value>
-  </data>
-  <data name="AppTitleText.Text" xml:space="preserve">
-    <value>File Locksmith</value>
+    <comment>Title of the window when running as user.</comment>
   </data>
   <data name="EmptyListDescription.Text" xml:space="preserve">
     <value>No results</value>
@@ -161,5 +159,9 @@
   </data>
   <data name="User.Header" xml:space="preserve">
     <value>User</value>
+  </data>
+  <data name="AppAdminTitle" xml:space="preserve">
+    <value>Administrator: File Locksmith</value>
+    <comment>Title of the window when running as administrator.</comment>
   </data>
 </root>

--- a/src/modules/Hosts/Hosts/HostsXAML/MainWindow.xaml
+++ b/src/modules/Hosts/Hosts/HostsXAML/MainWindow.xaml
@@ -37,8 +37,7 @@
                 x:Name="AppTitleTextBlock"
                 Grid.Column="2"
                 Style="{StaticResource CaptionTextBlockStyle}"
-                VerticalAlignment="Center"
-                Text="Hosts File Editor" />
+                VerticalAlignment="Center" />
         </Grid>
         
         <views:MainPage Grid.Row="1" />

--- a/src/modules/Hosts/Hosts/HostsXAML/MainWindow.xaml.cs
+++ b/src/modules/Hosts/Hosts/HostsXAML/MainWindow.xaml.cs
@@ -2,7 +2,6 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Hosts.Helpers;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media;
@@ -19,7 +18,11 @@ namespace Hosts
             ExtendsContentIntoTitleBar = true;
             SetTitleBar(titleBar);
             AppWindow.SetIcon("Assets/Hosts/Hosts.ico");
-            Title = ResourceLoaderInstance.ResourceLoader.GetString("WindowTitle");
+
+            var loader = ResourceLoaderInstance.ResourceLoader;
+            var title = App.GetService<IElevationHelper>().IsElevated ? loader.GetString("WindowAdminTitle") : loader.GetString("WindowTitle");
+            Title = title;
+            AppTitleTextBlock.Text = title;
 
             BringToForeground();
 

--- a/src/modules/Hosts/Hosts/Strings/en-us/Resources.resw
+++ b/src/modules/Hosts/Hosts/Strings/en-us/Resources.resw
@@ -299,8 +299,12 @@
   <data name="WarningDialog_Title" xml:space="preserve">
     <value>Warning</value>
   </data>
+  <data name="WindowAdminTitle" xml:space="preserve">
+    <value>Administrator: Hosts File Editor</value>
+    <comment>Title of the window when running as administrator. "Hosts File Editor" is the name of the utility. "Hosts" refers to the system hosts file, do not loc</comment>
+  </data>
   <data name="WindowTitle" xml:space="preserve">
     <value>Hosts File Editor</value>
-    <comment>"Hosts File Editor" is the name of the utility. "Hosts" refers to the system hosts file, do not loc</comment>
+    <comment>Title of the window when running as user. "Hosts File Editor" is the name of the utility. "Hosts" refers to the system hosts file, do not loc</comment>
   </data>
 </root>

--- a/src/runner/Resources.resx
+++ b/src/runner/Resources.resx
@@ -126,4 +126,7 @@
     <value>A new PowerToys version has been installed. Please restart the computer when possible, to fully reload File Explorer extensions.</value>
     <comment>File Explorer refers to the Windows File Explorer application.</comment>
   </data>
+  <data name="TRAY_ICON_ADMIN_TOOLTIP" xml:space="preserve">
+    <value>Administrator</value>
+  </data>
 </root>

--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -100,7 +100,7 @@ int runner(bool isProcessElevated, bool openSettings, std::string settingsWindow
 //init_global_error_handlers();
 #endif
     Trace::RegisterProvider();
-    start_tray_icon();
+    start_tray_icon(isProcessElevated);
     CentralizedKeyboardHook::Start();
 
     int result = -1;

--- a/src/runner/runner.vcxproj
+++ b/src/runner/runner.vcxproj
@@ -118,6 +118,9 @@
   <ItemGroup>
     <Manifest Include="PowerToys.exe.manifest" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Resources.resx" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Import Project="..\..\deps\spdlog.props" />
   <ImportGroup Label="ExtensionTargets">

--- a/src/runner/runner.vcxproj.filters
+++ b/src/runner/runner.vcxproj.filters
@@ -112,4 +112,9 @@
   <ItemGroup>
     <ResourceCompile Include="Generated Files/runner.rc" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Resources.resx">
+      <Filter>Resource Files</Filter>
+    </EmbeddedResource>
+  </ItemGroup>
 </Project>

--- a/src/runner/tray_icon.cpp
+++ b/src/runner/tray_icon.cpp
@@ -268,7 +268,7 @@ LRESULT __stdcall tray_icon_window_proc(HWND window, UINT message, WPARAM wparam
     return DefWindowProc(window, message, wparam, lparam);
 }
 
-void start_tray_icon()
+void start_tray_icon(bool isProcessElevated)
 {
     auto h_instance = reinterpret_cast<HINSTANCE>(&__ImageBase);
     auto icon = LoadIcon(h_instance, MAKEINTRESOURCE(APPICON));
@@ -304,8 +304,16 @@ void start_tray_icon()
         tray_icon_data.hWnd = hwnd;
         tray_icon_data.uID = id_tray_icon;
         tray_icon_data.uCallbackMessage = wm_icon_notify;
-        std::wstring about_msg_pt_version = L"PowerToys " + get_product_version();
-        wcscpy_s(tray_icon_data.szTip, sizeof(tray_icon_data.szTip) / sizeof(WCHAR), about_msg_pt_version.c_str());
+
+        std::wstringstream pt_version_tooltip_stream;
+        if (isProcessElevated)
+        {
+            pt_version_tooltip_stream << GET_RESOURCE_STRING(IDS_TRAY_ICON_ADMIN_TOOLTIP) << L": ";
+        }
+
+        pt_version_tooltip_stream << L"PowerToys " << get_product_version() << '\0';
+        std::wstring pt_version_tooltip = pt_version_tooltip_stream.str();
+        wcscpy_s(tray_icon_data.szTip, sizeof(tray_icon_data.szTip) / sizeof(WCHAR), pt_version_tooltip.c_str());
         tray_icon_data.uFlags = NIF_ICON | NIF_TIP | NIF_MESSAGE;
         ChangeWindowMessageFilterEx(hwnd, WM_COMMAND, MSGFLT_ALLOW, nullptr);
 

--- a/src/runner/tray_icon.h
+++ b/src/runner/tray_icon.h
@@ -3,7 +3,7 @@
 #include <string>
 
 // Start the Tray Icon
-void start_tray_icon();
+void start_tray_icon(bool isProcessElevated);
 // Stop the Tray Icon
 void stop_tray_icon();
 // Open the Settings Window

--- a/src/settings-ui/Settings.UI/SettingsXAML/MainWindow.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/MainWindow.xaml.cs
@@ -50,8 +50,8 @@ namespace Microsoft.PowerToys.Settings.UI
 
             NativeMethods.SetWindowPlacement(hWnd, ref placement);
 
-            var loader = Helpers.ResourceLoaderInstance.ResourceLoader;
-            Title = loader.GetString("SettingsWindow_Title");
+            var loader = ResourceLoaderInstance.ResourceLoader;
+            Title = App.IsElevated ? loader.GetString("SettingsWindow_AdminTitle") : loader.GetString("SettingsWindow_Title");
 
             // send IPC Message
             ShellPage.SetDefaultSndMessageCallback(msg =>

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/ShellPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/ShellPage.xaml
@@ -49,7 +49,6 @@
                     Source="/Assets/Settings/icon.ico" />
                 <TextBlock
                     x:Name="AppTitleBarText"
-                    x:Uid="SettingsWindow_TitleTxt"
                     Margin="12,0,0,0"
                     VerticalAlignment="Center"
                     Style="{StaticResource CaptionTextBlockStyle}"

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/ShellPage.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/ShellPage.xaml.cs
@@ -373,6 +373,8 @@ namespace Microsoft.PowerToys.Settings.UI.Views
                 // https://docs.microsoft.com/windows/apps/develop/title-bar?tabs=winui3#full-customization
                 u.ExtendsContentIntoTitleBar = true;
                 u.SetTitleBar(AppTitleBar);
+                var loader = ResourceLoaderInstance.ResourceLoader;
+                AppTitleBarText.Text = App.IsElevated ? loader.GetString("SettingsWindow_AdminTitle") : loader.GetString("SettingsWindow_Title");
 #if DEBUG
                 DebugMessage.Visibility = Visibility.Visible;
 #endif

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -2152,6 +2152,7 @@ From there, simply click on one of the supported files in the File Explorer and 
   </data>
   <data name="SettingsWindow_Title" xml:space="preserve">
     <value>PowerToys Settings</value>
+    <comment>Title of the settings window when running as user</comment>
   </data>
   <data name="Awake.ModuleTitle" xml:space="preserve">
     <value>Awake</value>
@@ -3612,9 +3613,6 @@ Activate by holding the key for the character you want to add an accent to, then
     <value>Maximum width (px)</value>
     <comment>px = pixels</comment>
   </data>
-  <data name="SettingsWindow_TitleTxt.Text" xml:space="preserve">
-    <value>PowerToys Settings</value>
-  </data>
   <data name="Oobe_Peek.Description" xml:space="preserve">
     <value>A lightning fast file preview feature for Windows.</value>
   </data>
@@ -3673,5 +3671,9 @@ Activate by holding the key for the character you want to add an accent to, then
   </data>
   <data name="MouseUtils_FindMyMouse_ActivationShortcut.Header" xml:space="preserve">
     <value>Activation shortcut</value>
+  </data>
+  <data name="SettingsWindow_AdminTitle" xml:space="preserve">
+    <value>Administrator: PowerToys Settings</value>
+    <comment>Title of the settings window when running as administrator</comment>
   </data>
 </root>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

- Added "Administrator" to titlebar text when app is running as admin.
  - Settings
  - File Locksmith
  - Hosts File Editor
- Added "Administrator" to tray icon tooltip.

Does it make sense to have this behavior on other utilities?

Added on Hosts File Editor due to the impact of the utility running as user/admin and the presence of an option that change how is launched.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #28424
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

![1](https://github.com/microsoft/PowerToys/assets/25966642/b5709cea-9811-48d5-983a-4389d39ac73b)
_Titlebar_

![2](https://github.com/microsoft/PowerToys/assets/25966642/b97ce646-6b39-4f23-8633-14bbededaeed) ![3](https://github.com/microsoft/PowerToys/assets/25966642/b67e1ab6-b6c0-4510-9cd1-626443d554cf)
_Taskbar thumbnail_

![4](https://github.com/microsoft/PowerToys/assets/25966642/3b61f445-f0d2-4316-9eff-ceadc9d8127d)
_Task manager_

![image](https://github.com/microsoft/PowerToys/assets/25966642/9a4d68b4-bd14-4455-9428-57cd9e595081)
_Tray icon tooltip_

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Validated window title displayed on titlebar, taskbar thumbnail and task manager when running as user and elevated.