### PR TITLE
[PTRun][Calc]Keep leading zeroes on languages where . is not a separator

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator.UnitTest/NumberTranslatorTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator.UnitTest/NumberTranslatorTests.cs
@@ -132,12 +132,26 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
         }
 
         [DataTestMethod]
-        [DataRow("12,0004", "12.0004")]
-        [DataRow("0xF000", "0xF000")]
-        public void Translate_NoRemovalOfLeadingZeroesOnEdgeCases(string input, string expectedResult)
+        [DataRow("de-DE", "12,0004", "12.0004")]
+        [DataRow("de-DE", "0xF000", "0xF000")]
+        [DataRow("de-DE", "0", "0")]
+        [DataRow("de-DE", "00", "0")]
+        [DataRow("de-DE", "12.0004", "120004")] // . is the group separator in de-DE
+        [DataRow("de-DE", "12.04", "1204")]
+        [DataRow("de-DE", "12.4", "124")]
+        [DataRow("de-DE", "123.01 + 52.30", "12301 + 5230")]
+        [DataRow("de-DE", "123.001 + 52.30", "123001 + 5230")]
+        [DataRow("fr-FR", "0", "0")]
+        [DataRow("fr-FR", "00", "0")]
+        [DataRow("fr-FR", "12.0004", "12.0004")] // . is not decimal or group separator in fr-FR
+        [DataRow("fr-FR", "12.04", "12.04")]
+        [DataRow("fr-FR", "12.4", "12.4")]
+        [DataRow("fr-FR", "123.01 + 52.30", "123.01 + 52.30")]
+        [DataRow("fr-FR", "123.001 + 52.30", "123.001 + 52.30")]
+        public void Translate_NoRemovalOfLeadingZeroesOnEdgeCases(string sourceCultureName, string input, string expectedResult)
         {
             // Arrange
-            var translator = NumberTranslator.Create(new CultureInfo("de-de", false), new CultureInfo("en-US", false));
+            var translator = NumberTranslator.Create(new CultureInfo(sourceCultureName, false), new CultureInfo("en-US", false));
 
             // Act
             var result = translator.Translate(input);

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator.UnitTest/NumberTranslatorTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator.UnitTest/NumberTranslatorTests.cs
@@ -136,16 +136,18 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
         [DataRow("de-DE", "0xF000", "0xF000")]
         [DataRow("de-DE", "0", "0")]
         [DataRow("de-DE", "00", "0")]
-        [DataRow("de-DE", "12.0004", "120004")] // . is the group separator in de-DE
+        [DataRow("de-DE", "12.004", "12004")] // . is the group separator in de-DE
         [DataRow("de-DE", "12.04", "1204")]
         [DataRow("de-DE", "12.4", "124")]
+        [DataRow("de-DE", "3.004.044.444,05", "3004044444.05")]
         [DataRow("de-DE", "123.01 + 52.30", "12301 + 5230")]
         [DataRow("de-DE", "123.001 + 52.30", "123001 + 5230")]
         [DataRow("fr-FR", "0", "0")]
         [DataRow("fr-FR", "00", "0")]
-        [DataRow("fr-FR", "12.0004", "12.0004")] // . is not decimal or group separator in fr-FR
+        [DataRow("fr-FR", "12.004", "12.004")] // . is not decimal or group separator in fr-FR
         [DataRow("fr-FR", "12.04", "12.04")]
         [DataRow("fr-FR", "12.4", "12.4")]
+        [DataRow("fr-FR", "12.0004", "12.0004")]
         [DataRow("fr-FR", "123.01 + 52.30", "123.01 + 52.30")]
         [DataRow("fr-FR", "123.001 + 52.30", "123.001 + 52.30")]
         public void Translate_NoRemovalOfLeadingZeroesOnEdgeCases(string sourceCultureName, string input, string expectedResult)

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/CalculateEngine.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/CalculateEngine.cs
@@ -36,8 +36,8 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
             }
 
             // check for division by zero
-            // We check if the string contains a slash followed by space (optional) and zero. Whereas the zero must not followed by dot or comma as this indicates a number with decimal digits.
-            if (new Regex("\\/\\s*0(?![,\\.])").Match(input).Success)
+            // We check if the string contains a slash followed by space (optional) and zero. Whereas the zero must not followed by dot or comma as this indicates a number with decimal digits. The zero must also not be followed by other digits.
+            if (new Regex("\\/\\s*0(?![,\\.0-9])").Match(input).Success)
             {
                 error = Properties.Resources.wox_plugin_calculator_division_by_zero;
                 return default;

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/NumberTranslator.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/NumberTranslator.cs
@@ -76,10 +76,30 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
             string[] tokens = splitRegex.Split(input);
             foreach (string token in tokens)
             {
+                int leadingZeroCount = 0;
+
+                // Count leading zero characters.
+                foreach (char c in token)
+                {
+                    if (c != '0')
+                    {
+                        break;
+                    }
+
+                    leadingZeroCount++;
+                }
+
+                // number is all zero characters. no need to add zero characters at the end.
+                if (token.Length == leadingZeroCount)
+                {
+                    leadingZeroCount = 0;
+                }
+
                 decimal number;
+
                 outputBuilder.Append(
                     decimal.TryParse(token, NumberStyles.Number, cultureFrom, out number)
-                    ? number.ToString(cultureTo)
+                    ? (new string('0', leadingZeroCount) + number.ToString(cultureTo))
                     : token);
             }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

On locales where the dot (.) is not used as a separator for numbers, our number translation was removing leading zeros from what it thinks are simple number tokens.
For example for a user with the number cultures of French(France):
123.01+52.30 gets tokenized as `123` `.` `01` `+` `52` `.` `30`. Then the `01` gets transformed into `1`, meaning we're calculating 123.1+52.30

This PR introduces changes and tests to correct this behavior, by trying to keep leading zeroes when we're parsing numbers.

@Jay-o-Way, Thanks for pushing this forward 😉  Any more tests from issues you think are worth adding?

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #27289 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
- Keep leading zeroes when parsing numbers.
- Add tests for these edge cases.
- Adapt the division by zero detection, since now numbers with leading zeroes will reach that step.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
The tests that were introduced run well.
Set decimal symbol as `,` and digit group symbol as ` ` and verified the calculation in the issue works.
Tested division by zero detection to verify it still works as well as before:
 - 1/0 is detected as division by zero.
 - 1/00 is detected as division by zero.
 - 1/0,4 is not detected as division by zero.
 - 1/04 is not detected as division by zero.
 - 1/0.4 is not detected as division by zero.
 - 1/(1-1) is not detected as division by zero. (even though it is, but the engine returns Infinity)