### PR TITLE
[Registry Preview] Better preview in data grid like in Regedit

### DIFF
--- a/src/modules/registrypreview/RegistryPreviewUI/MainWindow.Utilities.cs
+++ b/src/modules/registrypreview/RegistryPreviewUI/MainWindow.Utilities.cs
@@ -415,14 +415,53 @@ namespace RegistryPreview
                         value += registryLine;
                     }
 
-                    // Clean out any escaped characters in the value, only for the preview
-                    value = StripEscapedCharacters(value);
-
                     // update the ListViewItem with the loaded value, based off REG value type
                     switch (registryValue.Type)
                     {
                         case "ERROR":
                             // do nothing
+                            break;
+                        case "REG_SZ":
+                            if (value == "\"")
+                            {
+                                // Value is most likely missing an end quote
+                                registryValue.Type = "ERROR";
+                                value = resourceLoader.GetString("InvalidString");
+                            }
+                            else
+                            {
+                                for (int i = 1; i < value.Length; i++)
+                                {
+                                    if (value[i - 1] == '\\')
+                                    {
+                                        // Only allow these escape characters
+                                        if (value[i] != '"' && value[i] != '\\')
+                                        {
+                                            registryValue.Type = "ERROR";
+                                            value = resourceLoader.GetString("InvalidString");
+                                            break;
+                                        }
+
+                                        i++;
+                                    }
+
+                                    if (value[i - 1] != '\\' && value[i] == '"')
+                                    {
+                                        // Don't allow non-escaped quotes
+                                        registryValue.Type = "ERROR";
+                                        value = resourceLoader.GetString("InvalidString");
+                                        break;
+                                    }
+                                }
+
+                                if (registryValue.Type != "ERROR")
+                                {
+                                    // Clean out any escaped characters in the value, only for the preview
+                                    value = StripEscapedCharacters(value);
+                                }
+                            }
+
+                            registryValue.Value = value;
                             break;
                         case "REG_BINARY":
                         case "REG_NONE":

--- a/src/modules/registrypreview/RegistryPreviewUI/MainWindow.Utilities.cs
+++ b/src/modules/registrypreview/RegistryPreviewUI/MainWindow.Utilities.cs
@@ -1113,7 +1113,7 @@ namespace RegistryPreview
                 value = value.Remove(indexOf, value.Length - indexOf);
             }
 
-            return value;
+            return value.TrimEnd();
         }
 
         /// <summary>

--- a/src/modules/registrypreview/RegistryPreviewUI/MainWindow.Utilities.cs
+++ b/src/modules/registrypreview/RegistryPreviewUI/MainWindow.Utilities.cs
@@ -441,6 +441,7 @@ namespace RegistryPreview
                                 }
                                 catch
                                 {
+                                    registryValue.Type = "ERROR";
                                     value = resourceLoader.GetString("InvalidBinary");
                                 }
                             }
@@ -451,6 +452,7 @@ namespace RegistryPreview
                         case "REG_DWORD":
                             if (value.Length <= 0)
                             {
+                                registryValue.Type = "ERROR";
                                 value = resourceLoader.GetString("InvalidDword");
                             }
                             else
@@ -461,6 +463,7 @@ namespace RegistryPreview
                                 }
                                 else
                                 {
+                                    registryValue.Type = "ERROR";
                                     value = resourceLoader.GetString("InvalidDword");
                                 }
                             }
@@ -471,6 +474,7 @@ namespace RegistryPreview
                         case "REG_QWORD":
                             if (value.Length <= 0)
                             {
+                                registryValue.Type = "ERROR";
                                 value = resourceLoader.GetString("InvalidQword");
                             }
                             else
@@ -485,6 +489,7 @@ namespace RegistryPreview
                                 }
                                 catch
                                 {
+                                    registryValue.Type = "ERROR";
                                     value = resourceLoader.GetString("InvalidQword");
                                 }
                             }
@@ -515,6 +520,7 @@ namespace RegistryPreview
                             }
                             catch
                             {
+                                registryValue.Type = "ERROR";
                                 value = resourceLoader.GetString("InvalidString");
                             }
 

--- a/src/modules/registrypreview/RegistryPreviewUI/RegistryValue.xaml.cs
+++ b/src/modules/registrypreview/RegistryPreviewUI/RegistryValue.xaml.cs
@@ -33,7 +33,7 @@ namespace RegistryPreview
                 switch (Type)
                 {
                     case "REG_SZ":
-                    case "REG_EXAND_SZ":
+                    case "REG_EXPAND_SZ":
                     case "REG_MULTI_SZ":
                         return uriStringValue;
                     case "ERROR":

--- a/src/modules/registrypreview/RegistryPreviewUI/Strings/en-US/Resources.resw
+++ b/src/modules/registrypreview/RegistryPreviewUI/Strings/en-US/Resources.resw
@@ -228,7 +228,7 @@
     <value>User Account Control</value>
   </data>
   <data name="ValueColumn.Header" xml:space="preserve">
-    <value>Value</value>
+    <value>Data</value>
   </data>
   <data name="WriteButton.Label" xml:space="preserve">
     <value>Write to Registry</value>
@@ -250,5 +250,14 @@
   </data>
   <data name="ZeroLength" xml:space="preserve">
     <value>(zero-length binary value)</value>
+  </data>
+  <data name="InvalidBinary" xml:space="preserve">
+    <value>(Invalid binary value)</value>
+  </data>
+  <data name="InvalidDword" xml:space="preserve">
+    <value>(Invalid DWORD (32-bit) value)</value>
+  </data>
+  <data name="InvalidString" xml:space="preserve">
+    <value>(Invalid string value)</value>
   </data>
 </root>

--- a/src/modules/registrypreview/RegistryPreviewUI/Strings/en-US/Resources.resw
+++ b/src/modules/registrypreview/RegistryPreviewUI/Strings/en-US/Resources.resw
@@ -138,6 +138,12 @@
   <data name="FilterRegistryName" xml:space="preserve">
     <value>Registry files (*.reg)</value>
   </data>
+  <data name="InvalidBinary" xml:space="preserve">
+    <value>(Invalid binary value)</value>
+  </data>
+  <data name="InvalidDword" xml:space="preserve">
+    <value>(Invalid DWORD (32-bit) value)</value>
+  </data>
   <data name="InvalidQword" xml:space="preserve">
     <value>(Invalid QWORD (64-bit) value)</value>
   </data>
@@ -146,6 +152,9 @@
   </data>
   <data name="InvalidRegistryFileTitle" xml:space="preserve">
     <value>File was not a Registry file</value>
+  </data>
+  <data name="InvalidString" xml:space="preserve">
+    <value>(Invalid string value)</value>
   </data>
   <data name="LargeRegistryFile" xml:space="preserve">
     <value> is larger than 10MB which is too large for this application.</value>
@@ -250,14 +259,5 @@
   </data>
   <data name="ZeroLength" xml:space="preserve">
     <value>(zero-length binary value)</value>
-  </data>
-  <data name="InvalidBinary" xml:space="preserve">
-    <value>(Invalid binary value)</value>
-  </data>
-  <data name="InvalidDword" xml:space="preserve">
-    <value>(Invalid DWORD (32-bit) value)</value>
-  </data>
-  <data name="InvalidString" xml:space="preserve">
-    <value>(Invalid string value)</value>
   </data>
 </root>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR updates the data grid in Registry Preview to properly show the data values shown in Registry Editor.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [X] **Closes:** https://github.com/microsoft/PowerToys/issues/25118
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [X] **Localization:** All end user facing strings can be localized
- [X] **Dev docs:** No changes needed
- [X] **New binaries:** No changes made
- [X] **Documentation updated:** No changes needed

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

### Left: Registry Preview | Right: Registry Editor
![image](https://github.com/microsoft/PowerToys/assets/3975545/32656809-5b5c-4407-a14f-b528c66690f3)