### PR TITLE
Switch away from the WinDev agent pools

### DIFF
--- a/.pipelines/ci/templates/build-powertoys-ci.yml
+++ b/.pipelines/ci/templates/build-powertoys-ci.yml
@@ -12,11 +12,11 @@ jobs:
     NUGET_RESTORE_MSBUILD_ARGS: /p:Platform=${{ parameters.platform }} # Required for nuget to work due to self contained
     NODE_OPTIONS: --max_old_space_size=16384
   pool:
-    demands: ImageOverride -equals WinDevVS17-latest
+    demands: ImageOverride -equals SHINE-VS17-Latest
     ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
-      name: WinDevPoolOSS-L
+      name: SHINE-OSS-L
     ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
-      name: WinDevPool-L
+      name: SHINE-INT-L
   timeoutInMinutes: 120
   strategy:
     maxParallel: 10

--- a/.pipelines/ci/templates/build-powertoys-installer.yml
+++ b/.pipelines/ci/templates/build-powertoys-installer.yml
@@ -10,7 +10,7 @@ jobs:
     BuildConfiguration: ${{ parameters.configuration }}
     BuildPlatform: ${{ parameters.platform }}
   pool:
-      name: WinDevPool-L
+      name: SHINE-INT-L
   timeoutInMinutes: 120
   strategy:
     maxParallel: 10

--- a/.pipelines/release.yml
+++ b/.pipelines/release.yml
@@ -3,8 +3,8 @@ trigger: none
 pr: none
 
 pool: 
-  name: WinDevPool-L
-  demands: ImageOverride -equals WinDevVS17-latest
+  name: SHINE-INT-L
+  demands: ImageOverride -equals SHINE-VS17-Latest
 
 parameters:
   - name: buildConfigurations


### PR DESCRIPTION
Using our own pools like this gives us a lot of freedom in the tooling that's installed, the OS versions it targets, and when we take on Visual Studio updates.

As part of this effort, I've also stood up a "small" agent pool. At the time of this PR, that pool is using D2ads-v5 SKU VMs (2 vcore 8 GiB) versus the "large" agent pool's D8as-v5 (8 vcore 32 GiB). Smaller build tasks can in the future be moved over to the small pool. Compilation's the hard part, so it gets to stay on the large pool.