### PR TITLE
[PTRun][WindowWalker Plugin] Display the application icon for a runni… (#7770)

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.WindowWalker.UnitTests/PluginSettingsTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.WindowWalker.UnitTests/PluginSettingsTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Plugin.WindowWalker.UnitTests
             var result = settings?.Length;
 
             // Assert
-            Assert.AreEqual(8, result);
+            Assert.AreEqual(9, result);
         }
 
         [DataTestMethod]
@@ -34,6 +34,7 @@ namespace Microsoft.Plugin.WindowWalker.UnitTests
         [DataRow("OpenAfterKillAndClose")]
         [DataRow("HideKillProcessOnElevatedProcesses")]
         [DataRow("HideExplorerSettingInfo")]
+        [DataRow("UseWindowIconInResults")]
         public void DoesSettingExist(string name)
         {
             // Setup
@@ -55,6 +56,7 @@ namespace Microsoft.Plugin.WindowWalker.UnitTests
         [DataRow("OpenAfterKillAndClose", false)]
         [DataRow("HideKillProcessOnElevatedProcesses", false)]
         [DataRow("HideExplorerSettingInfo", false)]
+        [DataRow("UseWindowIconInResults", true)]
         public void DefaultValues(string name, bool valueExpected)
         {
             // Setup

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.WindowWalker/Components/ResultHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.WindowWalker/Components/ResultHelper.cs
@@ -34,7 +34,12 @@ namespace Microsoft.Plugin.WindowWalker.Components
                 resultsList.Add(new Result()
                 {
                     Title = x.Result.Title,
-                    IcoPath = icon,
+                    IcoPath = WindowWalkerSettings.Instance.UseWindowIconInResults ? string.Empty : icon,
+                    Icon = WindowWalkerSettings.Instance.UseWindowIconInResults ? () =>
+                    {
+                        return x.Result.WindowIcon ?? x.Result.Process.ProcessIcon;
+                    }
+                    : null,
                     SubTitle = GetSubtitle(x.Result),
                     ContextData = x.Result,
                     Action = c =>

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.WindowWalker/Components/WindowWalkerSettings.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.WindowWalker/Components/WindowWalkerSettings.cs
@@ -70,6 +70,11 @@ namespace Microsoft.Plugin.WindowWalker.Components
         internal bool HideExplorerSettingInfo { get; private set; }
 
         /// <summary>
+        /// Gets a value indicating whether we show the window icon in the search results or not.
+        /// </summary>
+        internal bool UseWindowIconInResults { get; private set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="WindowWalkerSettings"/> class.
         /// Private constructor to make sure there is never more than one instance of this class
         /// </summary>
@@ -160,6 +165,12 @@ namespace Microsoft.Plugin.WindowWalker.Components
                     DisplayDescription = Resources.wox_plugin_windowwalker_SettingExplorerSettingInfo_Description,
                     Value = false,
                 },
+                new PluginAdditionalOption
+                {
+                    Key = nameof(UseWindowIconInResults),
+                    DisplayLabel = Resources.wox_plugin_windowwalker_SettingUseWindowIconInResults,
+                    Value = true,
+                },
             };
 
             return optionList;
@@ -184,6 +195,7 @@ namespace Microsoft.Plugin.WindowWalker.Components
             OpenAfterKillAndClose = GetSettingOrDefault(settings, nameof(OpenAfterKillAndClose));
             HideKillProcessOnElevatedProcesses = GetSettingOrDefault(settings, nameof(HideKillProcessOnElevatedProcesses));
             HideExplorerSettingInfo = GetSettingOrDefault(settings, nameof(HideExplorerSettingInfo));
+            UseWindowIconInResults = GetSettingOrDefault(settings, nameof(UseWindowIconInResults));
         }
 
         /// <summary>

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.WindowWalker/Properties/Resources.Designer.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.WindowWalker/Properties/Resources.Designer.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Plugin.WindowWalker.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Folder windows doesn&apos;t run in separate processes. (Klick to open Explorer properties.).
+        ///   Looks up a localized string similar to Folder windows do not run in separate processes. (Click to open Explorer properties.).
         /// </summary>
         public static string wox_plugin_windowwalker_ExplorerInfoSubTitle {
             get {
@@ -300,6 +300,15 @@ namespace Microsoft.Plugin.WindowWalker.Properties {
         public static string wox_plugin_windowwalker_SettingSubtitlePid {
             get {
                 return ResourceManager.GetString("wox_plugin_windowwalker_SettingSubtitlePid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Show window icon in results.
+        /// </summary>
+        public static string wox_plugin_windowwalker_SettingUseWindowIconInResults {
+            get {
+                return ResourceManager.GetString("wox_plugin_windowwalker_SettingUseWindowIconInResults", resourceCulture);
             }
         }
     }

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.WindowWalker/Properties/Resources.resx
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.WindowWalker/Properties/Resources.resx
@@ -202,4 +202,7 @@
   <data name="wox_plugin_windowwalker_SettingSubtitleDesktopName_Description" xml:space="preserve">
     <value>This information is only shown in subtitle and tool tip, if you have at least two desktops.</value>
   </data>
+  <data name="wox_plugin_windowwalker_SettingUseWindowIconInResults" xml:space="preserve">
+    <value>Show window icon in results</value>
+  </data>
 </root>

--- a/src/modules/launcher/Wox.Plugin/Common/Win32/NativeMethods.cs
+++ b/src/modules/launcher/Wox.Plugin/Common/Win32/NativeMethods.cs
@@ -62,6 +62,9 @@ namespace Wox.Plugin.Common.Win32
         [DllImport("kernel32.dll", SetLastError = true)]
         public static extern IntPtr OpenProcess(ProcessAccessFlags dwDesiredAccess, [MarshalAs(UnmanagedType.Bool)] bool bInheritHandle, int dwProcessId);
 
+        [DllImport("kernel32.dll", SetLastError = true, BestFitMapping = false, CharSet = CharSet.Unicode)]
+        public static extern bool QueryFullProcessImageName([In] IntPtr hProcess, [In] int dwFlags, [Out] StringBuilder lpExeName, ref uint lpdwSize);
+
         [DllImport("dwmapi.dll", EntryPoint = "#113", CallingConvention = CallingConvention.StdCall)]
         public static extern int DwmpActivateLivePreview([MarshalAs(UnmanagedType.Bool)] bool fActivate, IntPtr hWndExclude, IntPtr hWndInsertBefore, LivePreviewTrigger lpt, IntPtr prcFinalRect);
 
@@ -74,12 +77,18 @@ namespace Wox.Plugin.Common.Win32
         [DllImport("user32.dll", BestFitMapping = false, CharSet = CharSet.Unicode)]
         public static extern int GetClassName(IntPtr hWnd, StringBuilder lpClassName, int nMaxCount);
 
+        [DllImport("user32.dll", EntryPoint = "GetClassLongPtr")]
+        public static extern IntPtr GetClassLongPtr(IntPtr hWnd, int nIndex);
+
         [DllImport("user32.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool GetWindowPlacement(IntPtr hWnd, out WINDOWPLACEMENT lpwndpl);
 
         [DllImport("user32.dll")]
         public static extern int SendMessage(IntPtr hWnd, int msg, int wParam);
+
+        [DllImport("user32.dll")]
+        public static extern int SendMessage(IntPtr hWnd, int msg, int wParam, int lParam);
 
         [DllImport("kernel32.dll")]
         [return: MarshalAs(UnmanagedType.Bool)]
@@ -156,6 +165,37 @@ namespace Wox.Plugin.Common.Win32
         /// The UUID is guaranteed to be unique to this computer only.
         /// </summary>
         public const int RPC_S_UUID_LOCAL_ONLY = 0x720;
+
+        /// <summary>
+        /// Retrieves a handle to the small icon associated with the class.
+        /// </summary>
+        public const int GCL_HICONSM = -34;
+
+        /// <summary>
+        /// Retrieves a handle to the icon associated with the class.
+        /// </summary>
+        public const int GCL_HICON = -14;
+
+        /// <summary>
+        /// Sent to a window to retrieve a handle to the large or small icon associated with a window.
+        /// </summary>
+        public const int WM_GETICON = 0x7f;
+
+        /// <summary>
+        /// Retrieve the small icon for the window.
+        /// </summary>
+        public const int ICON_SMALL = 0;
+
+        /// <summary>
+        /// Retrieve the large icon for the window.
+        /// </summary>
+        public const int ICON_BIG = 1;
+
+        /// <summary>
+        /// Retrieves the small icon provided by the application. If the application does not provide one,
+        /// the system uses the system-generated icon for that window.
+        /// </summary>
+        public const int ICON_SMALL2 = 2;
     }
 
     public static class ShellItemTypeConstants


### PR DESCRIPTION
* Display the application icon for a running process in the search results (#7770)

* Add a setting to opt-out of showing icon

* Adapt tests

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Attempts to retrieve and show the window icon (through `SendMessage`), if it fails attempts to retrieve an icon by querying the process file name and using `Icon.ExtractAssociatedIcon` and if that fails uses `SystemIcons.Application`. The icons are cached in static dictionaries.

Added a setting to opt-out of showing the icons (reverting to previous default icon) and updated the test for the settings.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #7770 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manually tested the functions for retrieving the icons (both window and process). In practice haven't observed a situation where all of the first `SendMessage(WM_ICON,  ...)` attempts have failed.

One thing that bugs me is that if attempts to get the window icon fails and the process file path has a length greater than 1000, it will always show the `SystemIcons.Application` fallback because the buffer used for `QueryFullProcessImageName` is capped at 1000 characters. Might want to retry the query with an increased buffer size if it fails instead.