### PR TITLE
[MWB]Fix thread suspend crash on process restart

### DIFF
--- a/src/modules/MouseWithoutBorders/App/Class/Common.Log.cs
+++ b/src/modules/MouseWithoutBorders/App/Class/Common.Log.cs
@@ -90,7 +90,19 @@ namespace MouseWithoutBorders
             lock (ThreadsLock)
             {
 #pragma warning disable 618 // Temporary
-                threads.Where(t => t.IsAlive && t.ManagedThreadId != threadId).ToList().ForEach(t => t.Suspend());
+                threads.Where(t => t.IsAlive && t.ManagedThreadId != threadId).ToList().ForEach(
+                    t =>
+                    {
+                        try
+                        {
+                            t.Suspend();
+                        }
+                        catch (Exception)
+                        {
+                            // This method is suspending every thread so that it can kill the process right after restarting.
+                            // Makes no sense to crash on a thread suspension fail, since we're killing the process afterwards, anyway.
+                        }
+                    });
 #pragma warning restore 618
             }
         }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

A big number of Watson crashes are reported when trying to restart the MWB process. This is due to thread suspension failing. It makes little sense to crash since we're killing the process afterwards anyway.
This adds an exception handler so that we don't crash.