### PR TITLE
[FileLocksmith]Avoid GDI object leak on context menu

### DIFF
--- a/src/modules/FileLocksmith/FileLocksmithExt/ExplorerCommand.cpp
+++ b/src/modules/FileLocksmith/FileLocksmithExt/ExplorerCommand.cpp
@@ -104,7 +104,6 @@ IFACEMETHODIMP ExplorerCommand::Initialize(PCIDLIST_ABSOLUTE pidlFolder, IDataOb
     if (pdtobj)
     {
         m_data_obj = pdtobj;
-        m_data_obj->AddRef();
     }
     return S_OK;
 }
@@ -242,10 +241,6 @@ ExplorerCommand::ExplorerCommand()
 
 ExplorerCommand::~ExplorerCommand()
 {
-    if (m_data_obj)
-    {
-        m_data_obj->Release();
-    }
     --globals::ref_count;
 }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

We're receiving exceptions for crashes due to leaks for this context menu entry on Watson. This is our only context menu code that is adding references to the object we receive on QueryContext, so I'm removing that code. File Explorer likely handles that through the context menu calls.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Built installer and tested File Locksmith, on files, folders and drives from the context menu. Everything still works.
