### PR TITLE
[PreviewHandlers]Ignore telemetry exceptions

### DIFF
--- a/src/modules/previewpane/GcodePreviewHandler/GcodePreviewHandlerControl.cs
+++ b/src/modules/previewpane/GcodePreviewHandler/GcodePreviewHandlerControl.cs
@@ -84,7 +84,13 @@ namespace Microsoft.PowerToys.PreviewHandler.Gcode
 
                 Resize += FormResized;
                 base.DoPreview(fs);
-                PowerToysTelemetry.Log.WriteEvent(new GcodeFilePreviewed());
+                try
+                {
+                    PowerToysTelemetry.Log.WriteEvent(new GcodeFilePreviewed());
+                }
+                catch
+                { // Should not crash if sending telemetry is failing. Ignore the exception.
+                }
             }
             catch (Exception ex)
             {
@@ -214,7 +220,14 @@ namespace Microsoft.PowerToys.PreviewHandler.Gcode
         /// <param name="dataSource">Stream reference to access source file.</param>
         private void PreviewError<T>(Exception exception, T dataSource)
         {
-            PowerToysTelemetry.Log.WriteEvent(new GcodeFilePreviewError { Message = exception.Message });
+            try
+            {
+                PowerToysTelemetry.Log.WriteEvent(new GcodeFilePreviewError { Message = exception.Message });
+            }
+            catch
+            { // Should not crash if sending telemetry is failing. Ignore the exception.
+            }
+
             Controls.Clear();
             _infoBarAdded = true;
             AddTextBoxControl(Properties.Resource.GcodeNotPreviewedError);

--- a/src/modules/previewpane/MarkdownPreviewHandler/MarkdownPreviewHandlerControl.cs
+++ b/src/modules/previewpane/MarkdownPreviewHandler/MarkdownPreviewHandlerControl.cs
@@ -200,11 +200,23 @@ namespace Microsoft.PowerToys.PreviewHandler.Markdown
                     }
                 });
 
-                PowerToysTelemetry.Log.WriteEvent(new MarkdownFilePreviewed());
+                try
+                {
+                    PowerToysTelemetry.Log.WriteEvent(new MarkdownFilePreviewed());
+                }
+                catch
+                { // Should not crash if sending telemetry is failing. Ignore the exception.
+                }
             }
             catch (Exception ex)
             {
-                PowerToysTelemetry.Log.WriteEvent(new MarkdownFilePreviewError { Message = ex.Message });
+                try
+                {
+                    PowerToysTelemetry.Log.WriteEvent(new MarkdownFilePreviewError { Message = ex.Message });
+                }
+                catch
+                { // Should not crash if sending telemetry is failing. Ignore the exception.
+                }
 
                 Controls.Clear();
                 _infoBarDisplayed = true;

--- a/src/modules/previewpane/PdfPreviewHandler/PdfPreviewHandlerControl.cs
+++ b/src/modules/previewpane/PdfPreviewHandler/PdfPreviewHandlerControl.cs
@@ -161,11 +161,23 @@ namespace Microsoft.PowerToys.PreviewHandler.Pdf
                     }
                 }
 
-                PowerToysTelemetry.Log.WriteEvent(new PdfFilePreviewed());
+                try
+                {
+                    PowerToysTelemetry.Log.WriteEvent(new PdfFilePreviewed());
+                }
+                catch
+                { // Should not crash if sending telemetry is failing. Ignore the exception.
+                }
             }
             catch (Exception ex)
             {
-                PowerToysTelemetry.Log.WriteEvent(new PdfFilePreviewError { Message = ex.Message });
+                try
+                {
+                    PowerToysTelemetry.Log.WriteEvent(new PdfFilePreviewError { Message = ex.Message });
+                }
+                catch
+                { // Should not crash if sending telemetry is failing. Ignore the exception.
+                }
 
                 Controls.Clear();
                 _infoBar = GetTextBoxControl(Resources.PdfNotPreviewedError);

--- a/src/modules/previewpane/SvgPreviewHandler/SvgPreviewControl.cs
+++ b/src/modules/previewpane/SvgPreviewHandler/SvgPreviewControl.cs
@@ -143,7 +143,13 @@ namespace Microsoft.PowerToys.PreviewHandler.Svg
             }
             catch (Exception ex)
             {
-                PowerToysTelemetry.Log.WriteEvent(new SvgFilePreviewError { Message = ex.Message });
+                try
+                {
+                    PowerToysTelemetry.Log.WriteEvent(new SvgFilePreviewError { Message = ex.Message });
+                }
+                catch
+                { // Should not crash if sending telemetry is failing. Ignore the exception.
+                }
             }
 
             try
@@ -160,7 +166,13 @@ namespace Microsoft.PowerToys.PreviewHandler.Svg
                 AddWebViewControl(svgData);
                 Resize += FormResized;
                 base.DoPreview(dataSource);
-                PowerToysTelemetry.Log.WriteEvent(new SvgFilePreviewed());
+                try
+                {
+                    PowerToysTelemetry.Log.WriteEvent(new SvgFilePreviewed());
+                }
+                catch
+                { // Should not crash if sending telemetry is failing. Ignore the exception.
+                }
             }
             catch (Exception ex)
             {
@@ -288,7 +300,14 @@ namespace Microsoft.PowerToys.PreviewHandler.Svg
         /// <param name="dataSource">Stream reference to access source file.</param>
         private void PreviewError<T>(Exception exception, T dataSource)
         {
-            PowerToysTelemetry.Log.WriteEvent(new SvgFilePreviewError { Message = exception.Message });
+            try
+            {
+                PowerToysTelemetry.Log.WriteEvent(new SvgFilePreviewError { Message = exception.Message });
+            }
+            catch
+            { // Should not crash if sending telemetry is failing. Ignore the exception.
+            }
+
             Controls.Clear();
             _infoBarAdded = true;
             AddTextBoxControl(Properties.Resource.SvgNotPreviewedError);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
We receive quite a big number of exceptions on Watson when sending Telemetry for preview handlers. We should ignore those, since not being able to send telemetry shouldn't crash the handler.