### PR TITLE
[QuickAccent]Cache computed all language characters

### DIFF
--- a/src/modules/poweraccent/PowerAccent.Core/Languages.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/Languages.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Concurrent;
 using PowerToys.PowerAccentKeyboardService;
 
 namespace PowerAccent.Core
@@ -80,11 +81,15 @@ namespace PowerAccent.Core
             };
         }
 
+        // Store the computed letters for each key, so that subsequent calls don't take as long.
+        private static ConcurrentDictionary<LetterKey, string[]> _allLanguagesCache = new ConcurrentDictionary<LetterKey, string[]>();
+
         // All
         private static string[] GetDefaultLetterKeyALL(LetterKey letter)
         {
-            // would be even better to loop through Languages and call these functions dynamically, but I don't know how to do that!
-            return GetDefaultLetterKeyCA(letter)
+            if (!_allLanguagesCache.ContainsKey(letter))
+            {
+                _allLanguagesCache[letter] = GetDefaultLetterKeyCA(letter)
                 .Union(GetDefaultLetterKeyCUR(letter))
                 .Union(GetDefaultLetterKeyCY(letter))
                 .Union(GetDefaultLetterKeyCZ(letter))
@@ -113,7 +118,10 @@ namespace PowerAccent.Core
                 .Union(GetDefaultLetterKeySR(letter))
                 .Union(GetDefaultLetterKeySV(letter))
                 .Union(GetDefaultLetterKeyTK(letter))
-            .ToArray();
+                .ToArray();
+            }
+
+            return _allLanguagesCache[letter];
         }
 
         // Currencies (source: https://www.eurochange.co.uk/travel-money/world-currency-abbreviations-symbols-and-codes-travel-money)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

After https://github.com/microsoft/PowerToys/pull/28164, were adding computation effort for each character when "All languages" is selected, since we now combine all languages at runtime. This PR adds a runtime cache so that this computation happens only once per key.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Related:** #28164
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Verified Quick Accent still works correctly when "All Languages" is selected.
