### PR TITLE
[FancyZones] Fix moved to the current active monitor when maximized

### DIFF
--- a/src/modules/fancyzones/FancyZonesLib/MonitorUtils.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/MonitorUtils.cpp
@@ -360,7 +360,7 @@ namespace MonitorUtils
                 if (GetMonitorInfo(monitor, &destMi))
                 {
                     RECT newPosition = FitOnScreen(placement.rcNormalPosition, originMi.rcWork, destMi.rcWork);
-                    FancyZonesWindowUtils::SizeWindowToRect(window, newPosition);
+                    FancyZonesWindowUtils::SizeWindowToRect(window, newPosition, false);
                 }
             }
         }

--- a/src/modules/fancyzones/FancyZonesLib/WindowUtils.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WindowUtils.cpp
@@ -253,7 +253,7 @@ void FancyZonesWindowUtils::SwitchToWindow(HWND window) noexcept
     }
 }
 
-void FancyZonesWindowUtils::SizeWindowToRect(HWND window, RECT rect) noexcept
+void FancyZonesWindowUtils::SizeWindowToRect(HWND window, RECT rect, BOOL snapZone) noexcept
 {
     WINDOWPLACEMENT placement{};
     ::GetWindowPlacement(window, &placement);
@@ -265,8 +265,15 @@ void FancyZonesWindowUtils::SizeWindowToRect(HWND window, RECT rect) noexcept
         ::GetWindowPlacement(window, &placement);
     }
 
+    BOOL maximizeLater = false;
     if (IsWindowVisible(window))
     {
+        // If is not snap zone then need keep maximize state (move to active monitor)
+        if (!snapZone && placement.showCmd == SW_SHOWMAXIMIZED)
+        {
+            maximizeLater = true;
+        }
+
         // Do not restore minimized windows. We change their placement though so they restore to the correct zone.
         if ((placement.showCmd != SW_SHOWMINIMIZED) &&
             (placement.showCmd != SW_MINIMIZE))
@@ -292,6 +299,12 @@ void FancyZonesWindowUtils::SizeWindowToRect(HWND window, RECT rect) noexcept
     if (!result)
     {
         Logger::error(L"SetWindowPlacement failed, {}", get_last_error_or_default(GetLastError()));
+    }
+
+    // make sure window is moved to the correct monitor before maximize.
+    if (maximizeLater)
+    {
+        placement.showCmd = SW_SHOWMAXIMIZED;
     }
 
     // Do it again, allowing Windows to resize the window and set correct scaling

--- a/src/modules/fancyzones/FancyZonesLib/WindowUtils.h
+++ b/src/modules/fancyzones/FancyZonesLib/WindowUtils.h
@@ -31,7 +31,7 @@ namespace FancyZonesWindowUtils
     bool IsExcludedByDefault(const HWND& hwnd, const std::wstring& processPath) noexcept;
 
     void SwitchToWindow(HWND window) noexcept;
-    void SizeWindowToRect(HWND window, RECT rect) noexcept; // Parameter rect must be in screen coordinates (e.g. obtained from GetWindowRect)
+    void SizeWindowToRect(HWND window, RECT rect, BOOL snapZone = true) noexcept; // Parameter rect must be in screen coordinates (e.g. obtained from GetWindowRect)
     void SaveWindowSizeAndOrigin(HWND window) noexcept;
     void RestoreWindowSize(HWND window) noexcept;
     void RestoreWindowOrigin(HWND window) noexcept;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #29209
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
- Fix moved to the current active monitor when maximized not keep maximized

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Enable `Move newly created windows to the current active monitor` > Maximized window > Create new window on other monitor > New window should maximized
