### PR TITLE
[ColorPicker][Settings] Cleanup and fix crash

### DIFF
--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/ColorPickerPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/ColorPickerPage.xaml
@@ -162,7 +162,7 @@
                     x:Uid="ColorFormatDialog"
                     IsPrimaryButtonEnabled="{Binding IsValid, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                     PrimaryButtonStyle="{ThemeResource AccentButtonStyle}"
-                    SecondaryButtonClick="ColorFormatDialog_CancelButtonClick">
+                    Closed="ColorFormatDialog_Closed">
                     <ContentDialog.DataContext>
                         <models:ColorFormatModel />
                     </ContentDialog.DataContext>

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/ColorPickerPage.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/ColorPickerPage.xaml.cs
@@ -112,7 +112,6 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             ColorFormatModel colorFormat = ColorFormatDialog.DataContext as ColorFormatModel;
             string oldName = ((KeyValuePair<string, string>)ColorFormatDialog.Tag).Key;
             ViewModel.UpdateColorFormat(oldName, colorFormat);
-            ColorFormatDialog.Hide();
         }
 
         private async void NewFormatClick(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
@@ -125,19 +124,6 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             ColorFormatDialog.PrimaryButtonText = resourceLoader.GetString("ColorFormatSave");
             ColorFormatDialog.PrimaryButtonCommand = AddCommand;
             await ColorFormatDialog.ShowAsync();
-        }
-
-        private void ColorFormatDialog_CancelButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
-        {
-            if (ColorFormatDialog.Tag is KeyValuePair<string, string>)
-            {
-                ColorFormatModel modifiedColorFormat = ColorFormatDialog.DataContext as ColorFormatModel;
-                KeyValuePair<string, string> oldProperties = (KeyValuePair<string, string>)ColorFormatDialog.Tag;
-                modifiedColorFormat.Name = oldProperties.Key;
-                modifiedColorFormat.Format = oldProperties.Value;
-            }
-
-            ColorFormatDialog.Hide();
         }
 
         private async void EditButton_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
@@ -161,6 +147,17 @@ namespace Microsoft.PowerToys.Settings.UI.Views
         public void RefreshEnabledState()
         {
             ViewModel.RefreshEnabledState();
+        }
+
+        private void ColorFormatDialog_Closed(ContentDialog sender, ContentDialogClosedEventArgs args)
+        {
+            if (args.Result != ContentDialogResult.Primary && ColorFormatDialog.Tag is KeyValuePair<string, string>)
+            {
+                ColorFormatModel modifiedColorFormat = ColorFormatDialog.DataContext as ColorFormatModel;
+                KeyValuePair<string, string> oldProperties = (KeyValuePair<string, string>)ColorFormatDialog.Tag;
+                modifiedColorFormat.Name = oldProperties.Key;
+                modifiedColorFormat.Format = oldProperties.Value;
+            }
         }
     }
 }

--- a/src/settings-ui/Settings.UI/ViewModels/ColorPickerViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/ColorPickerViewModel.cs
@@ -300,13 +300,16 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
 
             UpdateColorFormats();
             UpdateColorFormatPreview();
-            ScheduleSavingOfSettings();
         }
 
         private void ColorFormat_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
-            UpdateColorFormats();
-            ScheduleSavingOfSettings();
+            // Remaining properties are handled by the collection and by the dialog
+            if (e.PropertyName == nameof(ColorFormatModel.IsShown))
+            {
+                UpdateColorFormats();
+                ScheduleSavingOfSettings();
+            }
         }
 
         private void ScheduleSavingOfSettings()
@@ -437,6 +440,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 SelectedColorRepresentationValue = colorFormat.Name;    // name might be changed by the user
             }
 
+            UpdateColorFormats();
             UpdateColorFormatPreview();
         }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Settings is crashing if you type in a duplicate name in the color formats dialog: `System.ArgumentException: 'An item with the same key has already been added. Key: RGB'`

This PR fixes:
- Fix the crash described above.
- Saving of `settings.json` is triggered multiple times during typing.
- Rollback color format update if you close the content dialog with ESC key.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #28156
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

- Verified that the file is saved without errors:
  - Toggling color format on/off
  - Moving color format up/down
  - Adding a new color format
  - Editing a color format
  - Deleting a color format
- Verified that the update of a color format rolled-back:
  - Closing the edit dialog with the secondary button
  - Closing the edit dialog with the ESC key