### PR TITLE
[Peek]Fix IsDevFilePreview and white flash

### DIFF
--- a/src/modules/peek/Peek.FilePreviewer/Controls/BrowserControl.xaml.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Controls/BrowserControl.xaml.cs
@@ -24,7 +24,7 @@ namespace Peek.FilePreviewer.Controls
         /// </summary>
         private Uri? _navigatedUri;
 
-        private Color originalBackgroundColor;
+        private Color? _originalBackgroundColor;
 
         public delegate void NavigationCompletedHandler(WebView2? sender, CoreWebView2NavigationCompletedEventArgs? args);
 
@@ -52,6 +52,7 @@ namespace Peek.FilePreviewer.Controls
             typeof(BrowserControl),
             new PropertyMetadata(null, new PropertyChangedCallback((d, e) => ((BrowserControl)d).OnIsDevFilePreviewChanged())));
 
+        // Will actually be true for Markdown files as well.
         public bool IsDevFilePreview
         {
             get
@@ -101,6 +102,11 @@ namespace Peek.FilePreviewer.Controls
         private void SourcePropertyChanged()
         {
             OpenUriDialog.Hide();
+
+            // Setting the background color to transparent.
+            // This ensures that non-HTML files are displayed with a transparent background.
+            PreviewBrowser.DefaultBackgroundColor = Color.FromArgb(0, 0, 0, 0);
+
             Navigate();
         }
 
@@ -113,6 +119,10 @@ namespace Peek.FilePreviewer.Controls
                 {
                     PreviewBrowser.CoreWebView2.SetVirtualHostNameToFolderMapping(Microsoft.PowerToys.FilePreviewCommon.MonacoHelper.VirtualHostName, Microsoft.PowerToys.FilePreviewCommon.MonacoHelper.MonacoDirectory, CoreWebView2HostResourceAccessKind.Allow);
                 }
+                else
+                {
+                    PreviewBrowser.CoreWebView2.ClearVirtualHostNameToFolderMapping(Microsoft.PowerToys.FilePreviewCommon.MonacoHelper.VirtualHostName);
+                }
             }
         }
 
@@ -123,7 +133,10 @@ namespace Peek.FilePreviewer.Controls
                 await PreviewBrowser.EnsureCoreWebView2Async();
 
                 // Storing the original background color so it can be reset later for specific file types like HTML.
-                originalBackgroundColor = PreviewBrowser.DefaultBackgroundColor;
+                if (!_originalBackgroundColor.HasValue)
+                {
+                    _originalBackgroundColor = PreviewBrowser.DefaultBackgroundColor;
+                }
 
                 // Setting the background color to transparent when initially loading the WebView2 component.
                 // This ensures that non-HTML files are displayed with a transparent background.
@@ -142,6 +155,10 @@ namespace Peek.FilePreviewer.Controls
                 {
                     PreviewBrowser.CoreWebView2.SetVirtualHostNameToFolderMapping(Microsoft.PowerToys.FilePreviewCommon.MonacoHelper.VirtualHostName, Microsoft.PowerToys.FilePreviewCommon.MonacoHelper.MonacoDirectory, CoreWebView2HostResourceAccessKind.Allow);
                 }
+                else
+                {
+                    PreviewBrowser.CoreWebView2.ClearVirtualHostNameToFolderMapping(Microsoft.PowerToys.FilePreviewCommon.MonacoHelper.VirtualHostName);
+                }
 
                 PreviewBrowser.CoreWebView2.DOMContentLoaded += CoreWebView2_DOMContentLoaded;
                 PreviewBrowser.CoreWebView2.NewWindowRequested += CoreWebView2_NewWindowRequested;
@@ -158,11 +175,16 @@ namespace Peek.FilePreviewer.Controls
         {
             // If the file being previewed is HTML or HTM, reset the background color to its original state.
             // This is done to ensure that HTML and HTM files are displayed as intended, with their own background settings.
-            if (Source?.ToString().EndsWith(".html", StringComparison.OrdinalIgnoreCase) == true ||
-                Source?.ToString().EndsWith(".htm", StringComparison.OrdinalIgnoreCase) == true)
+            // This shouldn't be done for dev file previewer.
+            if (!IsDevFilePreview &&
+                (Source?.ToString().EndsWith(".html", StringComparison.OrdinalIgnoreCase) == true ||
+                Source?.ToString().EndsWith(".htm", StringComparison.OrdinalIgnoreCase) == true))
             {
                 // Reset to default behavior for HTML files
-                PreviewBrowser.DefaultBackgroundColor = originalBackgroundColor;
+                if (_originalBackgroundColor.HasValue)
+                {
+                    PreviewBrowser.DefaultBackgroundColor = _originalBackgroundColor.Value;
+                }
             }
 
             DOMContentLoaded?.Invoke(sender, args);

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/WebBrowserPreviewer/WebBrowserPreviewer.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/WebBrowserPreviewer/WebBrowserPreviewer.cs
@@ -118,6 +118,8 @@ namespace Peek.FilePreviewer.Previewers
                     }
                     else
                     {
+                        // Simple html file to preview. Shouldn't do things like enabling scripts or using a virtual mapped directory.
+                        IsDevFilePreview = false;
                         Preview = new Uri(File.Path);
                     }
                 });


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

After #28557 , which fixed #27747 , a white flash now appears every time we navigate with Peek to a dev file opened with Monaco.

This PR makes the IsDevFilePreview detection work better and improves what's applied when that's not a case. For example, now we won't change the background back to white if it's a dev file or Markdown and we won't enable scripts or make a virtual folder mapping if it's a simple html file.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Related:** #28557
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Tested html files and verified those look good in Peek. I used the html file described in the original issue.
Tested dev file preview and markdown files after having tested the html file and verified the white flash no longer appears.
