### PR TITLE
[CropAndLock]Fix crash on reparent SetPosition fail

### DIFF
--- a/src/modules/CropAndLock/CropAndLock/ReparentCropAndLockWindow.cpp
+++ b/src/modules/CropAndLock/CropAndLock/ReparentCropAndLockWindow.cpp
@@ -131,7 +131,10 @@ void ReparentCropAndLockWindow::CropAndLock(HWND windowToCrop, RECT cropRect)
     SetWindowLongPtrW(m_currentTarget, GWL_STYLE, targetStyle);
     auto x = -cropRect.left;
     auto y = -cropRect.top;
-    winrt::check_bool(SetWindowPos(m_currentTarget, nullptr, x, y, 0, 0, SWP_NOSIZE | SWP_FRAMECHANGED | SWP_NOZORDER));
+    if (0 == SetWindowPos(m_currentTarget, nullptr, x, y, 0, 0, SWP_NOSIZE | SWP_FRAMECHANGED | SWP_NOZORDER))
+    {
+        MessageBoxW(nullptr, L"CropAndLock couldn't properly reparent the target window. It might not handle reparenting well.", L"CropAndLock", MB_ICONERROR);
+    }
 }
 
 void ReparentCropAndLockWindow::Hide()


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
While testing the release candidate, we've caught Crop And Lock crashing when trying to reparent some issues.
This seems to happen with Windows App SDK applications that are updated to 1.4.1. Those applications crash when the SetParent call is made.
While nothing can be done about apps crashing when we try to SetParent, we can avoid CropAndLock crashing on the subsequent SetPosition call and show an error message instead.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Try to call reparent on the PowerToys Settings or Registry Preview. While the apps crash (WASDK 1.4.1 upgrade), Crop and Lock shows a message instead of crashing.
