### PR TITLE
[Registry Preview] Ended up with four unrelated fixes in one PR - not a role model, sorry

### DIFF
--- a/src/modules/registrypreview/RegistryPreviewUI/MainWindow.Events.cs
+++ b/src/modules/registrypreview/RegistryPreviewUI/MainWindow.Events.cs
@@ -55,6 +55,12 @@ namespace RegistryPreview
                     resourceLoader.GetString("YesNoCancelDialogCloseButtonText"));
             }
 
+            // Check to see if the textbox's context menu is open
+            if (textBox.ContextFlyout != null && textBox.ContextFlyout.IsOpen)
+            {
+                textBox.ContextFlyout.Hide();
+            }
+
             // Save window placement
             SaveWindowPlacementFile(settingsFolder, windowPlacementFile);
         }

--- a/src/modules/registrypreview/RegistryPreviewUI/MainWindow.Utilities.cs
+++ b/src/modules/registrypreview/RegistryPreviewUI/MainWindow.Utilities.cs
@@ -292,12 +292,19 @@ namespace RegistryPreview
 
                     // set the name and the value
                     string name = registryLine.Substring(0, equal);
+
+                    // trim the whitespace and quotes from the name
+                    name = name.Trim();
                     name = StripFirstAndLast(name);
 
                     // Clean out any escaped characters in the value, only for the preview
                     name = StripEscapedCharacters(name);
 
+                    // set the value
                     string value = registryLine.Substring(equal + 1);
+
+                    // trim the whitespace from the value
+                    value = value.Trim();
 
                     // Create a new listview item that will be used to display the value
                     registryValue = new RegistryValue(name, "REG_SZ", string.Empty);
@@ -1028,8 +1035,11 @@ namespace RegistryPreview
 
             try
             {
-                fileContents = jsonWindowPlacement.Stringify();
-                await Windows.Storage.FileIO.WriteTextAsync(storageFile, fileContents);
+                if (jsonWindowPlacement != null)
+                {
+                    fileContents = jsonWindowPlacement.Stringify();
+                    await Windows.Storage.FileIO.WriteTextAsync(storageFile, fileContents);
+                }
             }
             catch (Exception ex)
             {

--- a/src/modules/registrypreview/RegistryPreviewUI/RegistryPreviewXAML/App.xaml.cs
+++ b/src/modules/registrypreview/RegistryPreviewUI/RegistryPreviewXAML/App.xaml.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Web;
 using Microsoft.UI.Xaml;
 using Microsoft.Windows.AppLifecycle;
 using Windows.ApplicationModel.Activation;
@@ -49,6 +50,20 @@ namespace RegistryPreview
                     if (eventArgs.Files.Count > 0)
                     {
                         AppFilename = eventArgs.Files[0].Path;
+                    }
+                }
+            }
+            else if (activatedArgs.Kind == ExtendedActivationKind.Protocol)
+            {
+                // When the app is the default handler for REG files and the filename has non-ASCII characters, the app gets activated by Protocol
+                AppFilename = string.Empty;
+                if (activatedArgs.Data != null)
+                {
+                    IProtocolActivatedEventArgs eventArgs = (IProtocolActivatedEventArgs)activatedArgs.Data;
+                    if (eventArgs.Uri.AbsoluteUri.Length > 0)
+                    {
+                        AppFilename = eventArgs.Uri.Query.Replace("?ContractId=Windows.File&Verb=open&File=", string.Empty);
+                        AppFilename = HttpUtility.UrlDecode(AppFilename);
                     }
                 }
             }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Was reviewing someone else's PR and decided to take look at two issues and ended up fixing a third and fourth.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [X] **Closes:** 
- #26029
- #28147 
- No number: exception being thrown on first run, when size/position JSON file is missing.
- [X] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
- Found an exception that was being thrown on first run, when the app tries to load a json file that hasn't been created yet.  The code always caught the exception, but if a simple if statement can prevent it, yay.
- Adds support for files that may have whitespace around the = of a value line; a past fix enabled whitespace elsewhere.
- Fixes issue for non-ASCII filenames, when app is registered as the default handler. (This was neat: if the filename is only ASCII then the app gets activated as "File" activation but if there are non-ASCII characters, then it activates as "Protocol" but you'd only ever know this if you are under a debugger.)
- Adds a workaround that makes sure that we close the TextBox's context menu is closed when closing the app, to prevent a crash.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Ran a number of different test files through its paces, including past files that were known to fail on older code.  Didn't see any regressions or impact to the rest of the product.
