### PR TITLE
[HotFix][RegistryPreview]Fix out of bonds array access error

### DIFF
--- a/src/modules/registrypreview/RegistryPreviewUI/MainWindow.Utilities.cs
+++ b/src/modules/registrypreview/RegistryPreviewUI/MainWindow.Utilities.cs
@@ -445,7 +445,7 @@ namespace RegistryPreview
                                         i++;
                                     }
 
-                                    if (value[i - 1] != '\\' && value[i] == '"')
+                                    if (i < value.Length && value[i - 1] != '\\' && value[i] == '"')
                                     {
                                         // Don't allow non-escaped quotes
                                         registryValue.Type = "ERROR";


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

After https://github.com/microsoft/PowerToys/pull/28488, Registry preview does some escape character checks. On this code there's an iterator increment that doesn't recheck for bounds, so this was causing a out of bonds exception for some files, like the one presented in the issue.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #28798
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Opened the file indicated as crashing in the issue and verified it no longer crashes Registry Preview.
