### PR TITLE
[Run] Fix clear query on launch for action invoked from keyboard

### DIFF
--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -1065,7 +1065,6 @@ namespace PowerLauncher.ViewModel
                 {
                     if (contextMenuItems.AcceleratorKey == acceleratorKey && contextMenuItems.AcceleratorModifiers == acceleratorModifiers)
                     {
-                        MainWindowVisibility = Visibility.Collapsed;
                         contextMenuItems.Command.Execute(null);
                     }
                 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This PR fixes the following bug:

- Enable option **Clear the previous query on launch**
- Invoke a context action with the keyboard shortcut
- Press PT Run shortcut
- Query isn't cleared

This PR change a behavior (that was already broken) where the PT Run was always hidden even if the action returned `false`.

https://github.com/microsoft/PowerToys/blob/59fb08cdd8a42967bd547ae3288054e6df20472e/src/modules/launcher/Wox.Plugin/ContextMenuResult.cs#L24-L28

Built-in plugins are returning `false` only in case of error and in many cases we open a MessageBox that will hide the PT Run window anyway.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #22392
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

- The current code force the window to collapse before executing the action
- This is properly handled by the command honoring the involved option

https://github.com/microsoft/PowerToys/blob/59fb08cdd8a42967bd547ae3288054e6df20472e/src/modules/launcher/PowerLauncher/ViewModel/ResultViewModel.cs#L161-L174

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

- Tested the invocation of context action with mouse/keyboard with **Clear the previous query on launch** enabled/disabled
- Verified that the action is launched and the query cleared based on the option
