### PR TITLE
[FancyZones] Fix #25353 setting page bouncing

### DIFF
--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/FancyZonesPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/FancyZonesPage.xaml
@@ -189,24 +189,9 @@
                             <controls:SettingsCard x:Uid="FancyZones_MoveWindow" IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.SnapHotkeysCategoryEnabled}">
                                 <ComboBox
                                     MinWidth="{StaticResource SettingActionControlMinWidth}"
-                                    MinHeight="56"
                                     SelectedIndex="{x:Bind Mode=TwoWay, Path=ViewModel.MoveWindowsBasedOnPosition, Converter={StaticResource BoolToComboBoxIndexConverter}}">
-                                    <ComboBoxItem x:Uid="FancyZones_MoveWindowLeftRightBasedOnZoneIndex_Accessible">
-                                        <StackPanel Orientation="Vertical" Spacing="4">
-                                            <custom:IsEnabledTextBlock x:Uid="FancyZones_MoveWindowLeftRightBasedOnZoneIndex" />
-                                            <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}" Style="{StaticResource SecondaryTextStyle}">
-                                                <Run x:Uid="FancyZones_MoveWindowLeftRightBasedOnZoneIndex_Description" />
-                                            </TextBlock>
-                                        </StackPanel>
-                                    </ComboBoxItem>
-                                    <ComboBoxItem x:Uid="FancyZones_MoveWindowBasedOnRelativePosition_Accessible">
-                                        <StackPanel Orientation="Vertical" Spacing="4">
-                                            <custom:IsEnabledTextBlock x:Uid="FancyZones_MoveWindowBasedOnRelativePosition" />
-                                            <TextBlock FontFamily="{ThemeResource SymbolThemeFontFamily}" Style="{StaticResource SecondaryTextStyle}">
-                                                <Run x:Uid="FancyZones_MoveWindowBasedOnRelativePosition_Description" />
-                                            </TextBlock>
-                                        </StackPanel>
-                                    </ComboBoxItem>
+                                    <ComboBoxItem x:Uid="FancyZones_MoveWindowLeftRightBasedOnZoneIndex_Accessible" />
+                                    <ComboBoxItem x:Uid="FancyZones_MoveWindowBasedOnRelativePosition_Accessible" />
                                 </ComboBox>
                             </controls:SettingsCard>
                             <controls:SettingsCard ContentAlignment="Left" IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.SnapHotkeysCategoryEnabled}">

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -1781,28 +1781,14 @@ Made with 💗 by Microsoft and the PowerToys community.</value>
     <value>Small</value>
     <comment>The size of the image</comment>
   </data>
-  <data name="FancyZones_MoveWindowBasedOnRelativePosition_Accessible.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Windows key + Up, down, left or right arrow key to move windows based on relative position</value>
+  <data name="FancyZones_MoveWindowBasedOnRelativePosition_Accessible.Content" xml:space="preserve">
+    <value>Windows key + Up, down, left or right based on relative position</value>
   </data>
-  <data name="FancyZones_MoveWindowLeftRightBasedOnZoneIndex_Accessible.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Windows key + Left or right arrow keys to move windows based on zone index</value>
-  </data>
-  <data name="FancyZones_MoveWindowBasedOnRelativePosition_Description.Text" xml:space="preserve">
-    <value>Windows key +    or </value>
-    <comment>Do not loc the icons (hex numbers)</comment>
-  </data>
-  <data name="FancyZones_MoveWindowLeftRightBasedOnZoneIndex_Description.Text" xml:space="preserve">
-    <value>Windows key +  or </value>
-    <comment>Do not loc the icons (hex numbers)</comment>
-  </data>
-  <data name="FancyZones_MoveWindowBasedOnRelativePosition.Text" xml:space="preserve">
-    <value>Relative position</value>
+  <data name="FancyZones_MoveWindowLeftRightBasedOnZoneIndex_Accessible.Content" xml:space="preserve">
+    <value>Windows key + Left or right based on zone index</value>
   </data>
   <data name="FancyZones_MoveWindow.Header" xml:space="preserve">
     <value>Move windows based on</value>
-  </data>
-  <data name="FancyZones_MoveWindowLeftRightBasedOnZoneIndex.Text" xml:space="preserve">
-    <value>Zone index</value>
   </data>
   <data name="ColorPicker_Editor.Header" xml:space="preserve">
     <value>Color formats</value>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #25353
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
- Fix FancyZones setting page bouncing when scroll to bottom (issue because combobox in this page use StackPanel make it bouncing when scroll to bottom > Use normal combobox)
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Open FancyZones setting page > Scroll to bottom > Verify no bouncing anymore
