### PR TITLE
Revert "[Deps]Bump check-spelling/check-spelling from 0.0.21 to 0.0.22 (#28953)"

### DIFF
--- a/.github/workflows/spelling2.yml
+++ b/.github/workflows/spelling2.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
     - name: check-spelling
       id: spelling
-      uses: check-spelling/check-spelling@v0.0.22
+      uses: check-spelling/check-spelling@v0.0.21
       with:
         config: .github/actions/spell-check
         suppress_push_for_open_pull_request: 1
@@ -97,7 +97,7 @@ jobs:
     if: (success() || failure()) && needs.spelling.outputs.followup && github.event_name == 'push'
     steps:
     - name: comment
-      uses: check-spelling/check-spelling@v0.0.22
+      uses: check-spelling/check-spelling@v0.0.21
       with:
         config: .github/actions/spell-check
         checkout: true
@@ -114,7 +114,7 @@ jobs:
     if: (success() || failure()) && needs.spelling.outputs.followup && contains(github.event_name, 'pull_request')
     steps:
     - name: comment
-      uses: check-spelling/check-spelling@v0.0.22
+      uses: check-spelling/check-spelling@v0.0.21
       with:
         config: .github/actions/spell-check
         checkout: true


### PR DESCRIPTION
This reverts commit d3edd6acc2ac6cef8630d089980b493713bd47ff.

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Spell check is failing on main. Let's revert this recent upgrade from the bot.