### PR TITLE
[PowerRename] Suppress redundant midl warning

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -1081,6 +1081,7 @@ microsoft
 MIDDLEDOWN
 MIDDLEUP
 Midl
+midl
 mii
 MIIM
 millis

--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -1080,7 +1080,6 @@ microsoft
 MIDDLEDOWN
 MIDDLEUP
 midl
-midl
 mii
 MIIM
 millis

--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -136,7 +136,6 @@ BITMAPFILEHEADER
 bitmapimage
 BITMAPINFO
 BITMAPINFOHEADER
-Bitmaps
 bitmask
 BITSPIXEL
 bla
@@ -1080,7 +1079,7 @@ mic
 microsoft
 MIDDLEDOWN
 MIDDLEUP
-Midl
+midl
 midl
 mii
 MIIM
@@ -1678,7 +1677,6 @@ Sekan
 SENDCHANGE
 sendinput
 sendvirtualinput
-Seperate
 Seraphima
 serverside
 SETCONTEXT
@@ -1783,7 +1781,6 @@ spam
 spdisp
 spdlog
 spdo
-spec'ing
 spesi
 splitwstring
 spsi
@@ -1837,7 +1834,6 @@ stringtable
 stringval
 Strm
 Strmiids
-Stroe
 Strret
 strsafe
 strutil

--- a/src/modules/powerrename/PowerRenameUILib/ExplorerItemsSource.idl
+++ b/src/modules/powerrename/PowerRenameUILib/ExplorerItemsSource.idl
@@ -1,4 +1,4 @@
-// IVectorView and IObservableVector define memebers with the same name, and we must support both interfaces
+// IVectorView and IObservableVector define members with the same name, and we must support both interfaces
 midl_pragma warning(disable : 4066)
 
 namespace PowerRenameUI

--- a/src/modules/powerrename/PowerRenameUILib/ExplorerItemsSource.idl
+++ b/src/modules/powerrename/PowerRenameUILib/ExplorerItemsSource.idl
@@ -1,3 +1,6 @@
+// IVectorView and IObservableVector define memebers with the same name, and we must support both interfaces
+midl_pragma warning(disable : 4066)
+
 namespace PowerRenameUI
 {
     [default_interface] runtimeclass ExplorerItemsSource : 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Removes these warnings:
```
1>Processing WinMD c:\program files (x86)\windows kits\10\references\10.0.20348.0\windows.ui.xaml.core.direct.xamldirectcontract\3.0.0.0\windows.ui.xaml.core.direct.xamldirectcontract.winmd
1>..\PowerToys\src\modules\powerrename\PowerRenameUILib\ExplorerItemsSource.idl(9): warning MIDL4066: [msg]A member name has been qualified with an interface name because name collisions occurred across interface members on a runtime class. [context]"GetAt" has been renamed as "Windows.Foundation.Collections.IVector`1<Object>.GetAt" on runtime class "PowerRenameUI.ExplorerItemsSource"
1>..\PowerToys\src\modules\powerrename\PowerRenameUILib\ExplorerItemsSource.idl(9): warning MIDL4066: [msg]A member name has been qualified with an interface name because name collisions occurred across interface members on a runtime class. [context]"GetAt" has been renamed as "Windows.Foundation.Collections.IVectorView`1<Object>.GetAt" on runtime class "PowerRenameUI.ExplorerItemsSource"
1>..\PowerToys\src\modules\powerrename\PowerRenameUILib\ExplorerItemsSource.idl(9): warning MIDL4066: [msg]A member name has been qualified with an interface name because name collisions occurred across interface members on a runtime class. [context]"get_Size" has been renamed as "Windows.Foundation.Collections.IVectorView`1<Object>.get_Size" on runtime class "PowerRenameUI.ExplorerItemsSource"
1>..\PowerToys\src\modules\powerrename\PowerRenameUILib\ExplorerItemsSource.idl(9): warning MIDL4066: [msg]A member name has been qualified with an interface name because name collisions occurred across interface members on a runtime class. [context]"Size" has been renamed as "Windows.Foundation.Collections.IVectorView`1<Object>.Size" on runtime class "PowerRenameUI.ExplorerItemsSource"
1>..\PowerToys\src\modules\powerrename\PowerRenameUILib\ExplorerItemsSource.idl(9): warning MIDL4066: [msg]A member name has been qualified with an interface name because name collisions occurred across interface members on a runtime class. [context]"get_Size" has been renamed as "Windows.Foundation.Collections.IVector`1<Object>.get_Size" on runtime class "PowerRenameUI.ExplorerItemsSource"
1>..\PowerToys\src\modules\powerrename\PowerRenameUILib\ExplorerItemsSource.idl(9): warning MIDL4066: [msg]A member name has been qualified with an interface name because name collisions occurred across interface members on a runtime class. [context]"Size" has been renamed as "Windows.Foundation.Collections.IVector`1<Object>.Size" on runtime class "PowerRenameUI.ExplorerItemsSource"
1>..\PowerToys\src\modules\powerrename\PowerRenameUILib\ExplorerItemsSource.idl(9): warning MIDL4066: [msg]A member name has been qualified with an interface name because name collisions occurred across interface members on a runtime class. [context]"IndexOf" has been renamed as "Windows.Foundation.Collections.IVector`1<Object>.IndexOf" on runtime class "PowerRenameUI.ExplorerItemsSource"
1>..\PowerToys\src\modules\powerrename\PowerRenameUILib\ExplorerItemsSource.idl(9): warning MIDL4066: [msg]A member name has been qualified with an interface name because name collisions occurred across interface members on a runtime class. [context]"IndexOf" has been renamed as "Windows.Foundation.Collections.IVectorView`1<Object>.IndexOf" on runtime class "PowerRenameUI.ExplorerItemsSource"
1>..\PowerToys\src\modules\powerrename\PowerRenameUILib\ExplorerItemsSource.idl(9): warning MIDL4066: [msg]A member name has been qualified with an interface name because name collisions occurred across interface members on a runtime class. [context]"GetMany" has been renamed as "Windows.Foundation.Collections.IVector`1<Object>.GetMany" on runtime class "PowerRenameUI.ExplorerItemsSource"
1>..\PowerToys\src\modules\powerrename\PowerRenameUILib\ExplorerItemsSource.idl(9): warning MIDL4066: [msg]A member name has been qualified with an interface name because name collisions occurred across interface members on a runtime class. [context]"GetMany" has been renamed as "Windows.Foundation.Collections.IVectorView`1<Object>.GetMany" on runtime class "PowerRenameUI.ExplorerItemsSource"
1>Done building project "PowerRenameUI.vcxproj".
```

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #xxx
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

