### PR TITLE
[FancyZones] Change the option description and change the default value

### DIFF
--- a/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
@@ -737,7 +737,7 @@ void FancyZones::OnDisplayChange(DisplayChangeType changeType) noexcept
     {
     case DisplayChangeType::WorkArea: // WorkArea size changed
     case DisplayChangeType::DisplayChange: // Resolution changed or display added
-        updateWindowsPositions = FancyZonesSettings::settings().displayChange_moveWindows;
+        updateWindowsPositions = FancyZonesSettings::settings().displayOrWorkAreaChange_moveWindows;
         break;
     case DisplayChangeType::VirtualDesktop: // Switched virtual desktop
         SyncVirtualDesktops();

--- a/src/modules/fancyzones/FancyZonesLib/Settings.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/Settings.cpp
@@ -22,7 +22,7 @@ namespace NonLocalizable
     const wchar_t MoveWindowAcrossMonitorsID[] = L"fancyzones_moveWindowAcrossMonitors";
     const wchar_t MoveWindowsBasedOnPositionID[] = L"fancyzones_moveWindowsBasedOnPosition";
     const wchar_t OverlappingZonesAlgorithmID[] = L"fancyzones_overlappingZonesAlgorithm";
-    const wchar_t DisplayChangeMoveWindowsID[] = L"fancyzones_displayChange_moveWindows";
+    const wchar_t DisplayOrWorkAreaChangeMoveWindowsID[] = L"fancyzones_displayOrWorkAreaChange_moveWindows";
     const wchar_t ZoneSetChangeMoveWindowsID[] = L"fancyzones_zoneSetChange_moveWindows";
     const wchar_t AppLastZoneMoveWindowsID[] = L"fancyzones_appLastZone_moveWindows";
     const wchar_t OpenWindowOnActiveMonitorID[] = L"fancyzones_openWindowOnActiveMonitor";
@@ -113,7 +113,7 @@ void FancyZonesSettings::LoadSettings()
         SetBoolFlag(values, NonLocalizable::OverrideSnapHotKeysID, SettingId::OverrideSnapHotkeys, m_settings.overrideSnapHotkeys);
         SetBoolFlag(values, NonLocalizable::MoveWindowAcrossMonitorsID, SettingId::MoveWindowAcrossMonitors, m_settings.moveWindowAcrossMonitors);
         SetBoolFlag(values, NonLocalizable::MoveWindowsBasedOnPositionID, SettingId::MoveWindowsBasedOnPosition, m_settings.moveWindowsBasedOnPosition);
-        SetBoolFlag(values, NonLocalizable::DisplayChangeMoveWindowsID, SettingId::DisplayChangeMoveWindows, m_settings.displayChange_moveWindows);
+        SetBoolFlag(values, NonLocalizable::DisplayOrWorkAreaChangeMoveWindowsID, SettingId::DisplayOrWorkAreaChangeMoveWindows, m_settings.displayOrWorkAreaChange_moveWindows);
         SetBoolFlag(values, NonLocalizable::ZoneSetChangeMoveWindowsID, SettingId::ZoneSetChangeMoveWindows, m_settings.zoneSetChange_moveWindows);
         SetBoolFlag(values, NonLocalizable::AppLastZoneMoveWindowsID, SettingId::AppLastZoneMoveWindows, m_settings.appLastZone_moveWindows);
         SetBoolFlag(values, NonLocalizable::OpenWindowOnActiveMonitorID, SettingId::OpenWindowOnActiveMonitor, m_settings.openWindowOnActiveMonitor);

--- a/src/modules/fancyzones/FancyZonesLib/Settings.h
+++ b/src/modules/fancyzones/FancyZonesLib/Settings.h
@@ -27,7 +27,7 @@ struct Settings
     bool shiftDrag = true;
     bool mouseSwitch = false;
     bool mouseMiddleClickSpanningMultipleZones = false;
-    bool displayChange_moveWindows = false;
+    bool displayOrWorkAreaChange_moveWindows = true;
     bool zoneSetChange_flashZones = false;
     bool zoneSetChange_moveWindows = false;
     bool overrideSnapHotkeys = false;

--- a/src/modules/fancyzones/FancyZonesLib/SettingsConstants.h
+++ b/src/modules/fancyzones/FancyZonesLib/SettingsConstants.h
@@ -9,7 +9,7 @@ enum class SettingId
     MoveWindowAcrossMonitors,
     MoveWindowsBasedOnPosition,
     OverlappingZonesAlgorithm,
-    DisplayChangeMoveWindows,
+    DisplayOrWorkAreaChangeMoveWindows,
     ZoneSetChangeMoveWindows,
     AppLastZoneMoveWindows,
     OpenWindowOnActiveMonitor,

--- a/src/modules/fancyzones/FancyZonesLib/trace.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/trace.cpp
@@ -307,7 +307,7 @@ void Trace::SettingsTelemetry(const Settings& settings) noexcept
         TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE),
         TraceLoggingBoolean(settings.shiftDrag, ShiftDragKey),
         TraceLoggingBoolean(settings.mouseSwitch, MouseSwitchKey),
-        TraceLoggingBoolean(settings.displayChange_moveWindows, MoveWindowsOnDisplayChangeKey),
+        TraceLoggingBoolean(settings.displayOrWorkAreaChange_moveWindows, MoveWindowsOnDisplayChangeKey),
         TraceLoggingBoolean(settings.zoneSetChange_flashZones, FlashZonesOnZoneSetChangeKey),
         TraceLoggingBoolean(settings.zoneSetChange_moveWindows, MoveWindowsOnZoneSetChangeKey),
         TraceLoggingBoolean(settings.overrideSnapHotkeys, OverrideSnapHotKeysKey),

--- a/src/modules/fancyzones/FancyZonesTests/UnitTests/FancyZonesSettings.Spec.cpp
+++ b/src/modules/fancyzones/FancyZonesTests/UnitTests/FancyZonesSettings.Spec.cpp
@@ -29,7 +29,7 @@ namespace FancyZonesUnitTests
     {
         Assert::AreEqual(expected.shiftDrag, actual.shiftDrag);
         Assert::AreEqual(expected.mouseSwitch, actual.mouseSwitch);
-        Assert::AreEqual(expected.displayChange_moveWindows, actual.displayChange_moveWindows);
+        Assert::AreEqual(expected.displayOrWorkAreaChange_moveWindows, actual.displayOrWorkAreaChange_moveWindows);
         Assert::AreEqual(expected.zoneSetChange_flashZones, actual.zoneSetChange_flashZones);
         Assert::AreEqual(expected.zoneSetChange_moveWindows, actual.zoneSetChange_moveWindows);
         Assert::AreEqual(expected.overrideSnapHotkeys, actual.overrideSnapHotkeys);
@@ -69,7 +69,7 @@ namespace FancyZonesUnitTests
             PowerToysSettings::PowerToyValues values(NonLocalizable::ModuleKey, NonLocalizable::ModuleKey);
             values.add_property(L"fancyzones_shiftDrag", m_defaultSettings.shiftDrag);
             values.add_property(L"fancyzones_mouseSwitch", m_defaultSettings.mouseSwitch);
-            values.add_property(L"fancyzones_displayChange_moveWindows", m_defaultSettings.displayChange_moveWindows);
+            values.add_property(L"fancyzones_displayOrWorkAreaChange_moveWindows", m_defaultSettings.displayOrWorkAreaChange_moveWindows);
             values.add_property(L"fancyzones_zoneSetChange_flashZones", m_defaultSettings.zoneSetChange_flashZones);
             values.add_property(L"fancyzones_zoneSetChange_moveWindows", m_defaultSettings.zoneSetChange_moveWindows);
             values.add_property(L"fancyzones_overrideSnapHotkeys", m_defaultSettings.overrideSnapHotkeys);
@@ -112,7 +112,7 @@ namespace FancyZonesUnitTests
             PowerToysSettings::PowerToyValues values(NonLocalizable::ModuleKey, NonLocalizable::ModuleKey);
             values.add_property(L"fancyzones_shiftDrag", expected.shiftDrag);
             values.add_property(L"fancyzones_mouseSwitch", expected.mouseSwitch);
-            values.add_property(L"fancyzones_displayChange_moveWindows", expected.displayChange_moveWindows);
+            values.add_property(L"fancyzones_displayOrWorkAreaChange_moveWindows", expected.displayOrWorkAreaChange_moveWindows);
             values.add_property(L"fancyzones_zoneSetChange_flashZones", expected.zoneSetChange_flashZones);
             values.add_property(L"fancyzones_zoneSetChange_moveWindows", expected.zoneSetChange_moveWindows);
             values.add_property(L"fancyzones_overrideSnapHotkeys", expected.overrideSnapHotkeys);

--- a/src/settings-ui/Settings.UI.Library/ConfigDefaults.cs
+++ b/src/settings-ui/Settings.UI.Library/ConfigDefaults.cs
@@ -17,5 +17,6 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         public static readonly bool DefaultUseCursorposEditorStartupscreen = true;
         public static readonly bool DefaultFancyzonesQuickLayoutSwitch = true;
         public static readonly bool DefaultFancyzonesFlashZonesOnQuickSwitch = true;
+        public static readonly bool DefaultFancyzonesDisplayOrWorkAreaChangeMoveWindows = true;
     }
 }

--- a/src/settings-ui/Settings.UI.Library/FZConfigProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/FZConfigProperties.cs
@@ -27,7 +27,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             FancyzonesMoveWindowsAcrossMonitors = new BoolProperty();
             FancyzonesMoveWindowsBasedOnPosition = new BoolProperty();
             FancyzonesOverlappingZonesAlgorithm = new IntProperty();
-            FancyzonesDisplayChangeMoveWindows = new BoolProperty();
+            FancyzonesDisplayOrWorkAreaChangeMoveWindows = new BoolProperty(ConfigDefaults.DefaultFancyzonesDisplayOrWorkAreaChangeMoveWindows);
             FancyzonesZoneSetChangeMoveWindows = new BoolProperty();
             FancyzonesAppLastZoneMoveWindows = new BoolProperty();
             FancyzonesOpenWindowOnActiveMonitor = new BoolProperty();
@@ -76,8 +76,8 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         [JsonPropertyName("fancyzones_overlappingZonesAlgorithm")]
         public IntProperty FancyzonesOverlappingZonesAlgorithm { get; set; }
 
-        [JsonPropertyName("fancyzones_displayChange_moveWindows")]
-        public BoolProperty FancyzonesDisplayChangeMoveWindows { get; set; }
+        [JsonPropertyName("fancyzones_displayOrWorkAreaChange_moveWindows")]
+        public BoolProperty FancyzonesDisplayOrWorkAreaChangeMoveWindows { get; set; }
 
         [JsonPropertyName("fancyzones_zoneSetChange_moveWindows")]
         public BoolProperty FancyzonesZoneSetChangeMoveWindows { get; set; }

--- a/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/FancyZones.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/FancyZones.cs
@@ -49,7 +49,7 @@ namespace ViewModelTests
             Assert.AreEqual(originalGeneralSettings.Enabled.FancyZones, viewModel.IsEnabled);
             Assert.AreEqual(originalSettings.Properties.FancyzonesAppLastZoneMoveWindows.Value, viewModel.AppLastZoneMoveWindows);
             Assert.AreEqual(originalSettings.Properties.FancyzonesBorderColor.Value, viewModel.ZoneBorderColor);
-            Assert.AreEqual(originalSettings.Properties.FancyzonesDisplayChangeMoveWindows.Value, viewModel.DisplayChangeMoveWindows);
+            Assert.AreEqual(originalSettings.Properties.FancyzonesDisplayOrWorkAreaChangeMoveWindows.Value, viewModel.DisplayOrWorkAreaChangeMoveWindows);
             Assert.AreEqual(originalSettings.Properties.FancyzonesEditorHotkey.Value.ToString(), viewModel.EditorHotkey.ToString());
             Assert.AreEqual(originalSettings.Properties.FancyzonesWindowSwitching.Value, viewModel.WindowSwitching);
             Assert.AreEqual(originalSettings.Properties.FancyzonesNextTabHotkey.Value.ToString(), viewModel.NextTabHotkey.ToString());
@@ -270,20 +270,20 @@ namespace ViewModelTests
         }
 
         [TestMethod]
-        public void DisplayChangeMoveWindowsShouldSetValue2TrueWhenSuccessful()
+        public void DisplayOrWorkAreaChangeMoveWindowsShouldSetValue2TrueWhenSuccessful()
         {
             Mock<SettingsUtils> mockSettingsUtils = new Mock<SettingsUtils>();
 
             // arrange
             FancyZonesViewModel viewModel = new FancyZonesViewModel(mockSettingsUtils.Object, SettingsRepository<GeneralSettings>.GetInstance(mockGeneralSettingsUtils.Object), SettingsRepository<FancyZonesSettings>.GetInstance(mockFancyZonesSettingsUtils.Object), sendMockIPCConfigMSG, FancyZonesTestFolderName);
-            Assert.IsFalse(viewModel.DisplayChangeMoveWindows); // check if value was initialized to false.
+            Assert.IsFalse(viewModel.DisplayOrWorkAreaChangeMoveWindows); // check if value was initialized to false.
 
             // act
-            viewModel.DisplayChangeMoveWindows = true;
+            viewModel.DisplayOrWorkAreaChangeMoveWindows = true;
 
             // assert
-            var expected = viewModel.DisplayChangeMoveWindows;
-            var actual = SettingsRepository<FancyZonesSettings>.GetInstance(mockFancyZonesSettingsUtils.Object).SettingsConfig.Properties.FancyzonesDisplayChangeMoveWindows.Value;
+            var expected = viewModel.DisplayOrWorkAreaChangeMoveWindows;
+            var actual = SettingsRepository<FancyZonesSettings>.GetInstance(mockFancyZonesSettingsUtils.Object).SettingsConfig.Properties.FancyzonesDisplayOrWorkAreaChangeMoveWindows.Value;
             Assert.AreEqual(expected, actual);
         }
 

--- a/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/FancyZones.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/FancyZones.cs
@@ -270,16 +270,16 @@ namespace ViewModelTests
         }
 
         [TestMethod]
-        public void DisplayOrWorkAreaChangeMoveWindowsShouldSetValue2TrueWhenSuccessful()
+        public void DisplayOrWorkAreaChangeMoveWindowsShouldSetValue2FalseWhenSuccessful()
         {
             Mock<SettingsUtils> mockSettingsUtils = new Mock<SettingsUtils>();
 
             // arrange
             FancyZonesViewModel viewModel = new FancyZonesViewModel(mockSettingsUtils.Object, SettingsRepository<GeneralSettings>.GetInstance(mockGeneralSettingsUtils.Object), SettingsRepository<FancyZonesSettings>.GetInstance(mockFancyZonesSettingsUtils.Object), sendMockIPCConfigMSG, FancyZonesTestFolderName);
-            Assert.IsFalse(viewModel.DisplayOrWorkAreaChangeMoveWindows); // check if value was initialized to false.
+            Assert.IsTrue(viewModel.DisplayOrWorkAreaChangeMoveWindows); // check if value was initialized to true.
 
             // act
-            viewModel.DisplayOrWorkAreaChangeMoveWindows = true;
+            viewModel.DisplayOrWorkAreaChangeMoveWindows = false;
 
             // assert
             var expected = viewModel.DisplayOrWorkAreaChangeMoveWindows;

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/FancyZonesPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/FancyZonesPage.xaml
@@ -133,7 +133,7 @@
                     <controls:SettingsExpander x:Uid="FancyZones_WindowBehavior_GroupSettings" IsExpanded="True">
                         <controls:SettingsExpander.Items>
                             <controls:SettingsCard ContentAlignment="Left">
-                                <CheckBox x:Uid="FancyZones_DisplayChangeMoveWindowsCheckBoxControl" IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.DisplayChangeMoveWindows}" />
+                                <CheckBox x:Uid="FancyZones_DisplayOrWorkAreaChangeMoveWindowsCheckBoxControl" IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.DisplayOrWorkAreaChangeMoveWindows}" />
                             </controls:SettingsCard>
                             <controls:SettingsCard ContentAlignment="Left">
                                 <CheckBox x:Uid="FancyZones_ZoneSetChangeMoveWindows" IsChecked="{x:Bind Mode=TwoWay, Path=ViewModel.ZoneSetChangeMoveWindows}" />

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -847,8 +847,8 @@
     <value>Create window layouts to help make multi-tasking easy.</value>
     <comment>windows refers to application windows</comment>
   </data>
-  <data name="FancyZones_DisplayChangeMoveWindowsCheckBoxControl.Content" xml:space="preserve">
-    <value>Keep windows in their zones when the screen resolution changes</value>
+  <data name="FancyZones_DisplayOrWorkAreaChangeMoveWindowsCheckBoxControl.Content" xml:space="preserve">
+    <value>Keep windows in their zones when the screen resolution or work area changes</value>
     <comment>windows refers to application windows</comment>
   </data>
   <data name="FancyZones_EnableToggleControl_HeaderText.Header" xml:space="preserve">

--- a/src/settings-ui/Settings.UI/ViewModels/FancyZonesViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/FancyZonesViewModel.cs
@@ -79,7 +79,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             _moveWindowsAcrossMonitors = Settings.Properties.FancyzonesMoveWindowsAcrossMonitors.Value;
             _moveWindowBehaviour = Settings.Properties.FancyzonesMoveWindowsBasedOnPosition.Value ? MoveWindowBehaviour.MoveWindowBasedOnPosition : MoveWindowBehaviour.MoveWindowBasedOnZoneIndex;
             _overlappingZonesAlgorithm = (OverlappingZonesAlgorithm)Settings.Properties.FancyzonesOverlappingZonesAlgorithm.Value;
-            _displayChangemoveWindows = Settings.Properties.FancyzonesDisplayChangeMoveWindows.Value;
+            _displayOrWorkAreaChangeMoveWindows = Settings.Properties.FancyzonesDisplayOrWorkAreaChangeMoveWindows.Value;
             _zoneSetChangeMoveWindows = Settings.Properties.FancyzonesZoneSetChangeMoveWindows.Value;
             _appLastZoneMoveWindows = Settings.Properties.FancyzonesAppLastZoneMoveWindows.Value;
             _openWindowOnActiveMonitor = Settings.Properties.FancyzonesOpenWindowOnActiveMonitor.Value;
@@ -153,7 +153,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         private bool _moveWindowsAcrossMonitors;
         private MoveWindowBehaviour _moveWindowBehaviour;
         private OverlappingZonesAlgorithm _overlappingZonesAlgorithm;
-        private bool _displayChangemoveWindows;
+        private bool _displayOrWorkAreaChangeMoveWindows;
         private bool _zoneSetChangeMoveWindows;
         private bool _appLastZoneMoveWindows;
         private bool _openWindowOnActiveMonitor;
@@ -394,19 +394,19 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             }
         }
 
-        public bool DisplayChangeMoveWindows
+        public bool DisplayOrWorkAreaChangeMoveWindows
         {
             get
             {
-                return _displayChangemoveWindows;
+                return _displayOrWorkAreaChangeMoveWindows;
             }
 
             set
             {
-                if (value != _displayChangemoveWindows)
+                if (value != _displayOrWorkAreaChangeMoveWindows)
                 {
-                    _displayChangemoveWindows = value;
-                    Settings.Properties.FancyzonesDisplayChangeMoveWindows.Value = value;
+                    _displayOrWorkAreaChangeMoveWindows = value;
+                    Settings.Properties.FancyzonesDisplayOrWorkAreaChangeMoveWindows.Value = value;
                     NotifyPropertyChanged();
                 }
             }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

* More clear option description: `Keep windows in their zones when the screen resolution changes` -> `Keep windows in their zones when the screen resolution or work area changes`.
* Set it enabled by default.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

