### PR TITLE
[VCM] do not trigger cascade of un/mute changes

### DIFF
--- a/src/modules/videoconference/VideoConferenceModule/VideoConferenceModule.cpp
+++ b/src/modules/videoconference/VideoConferenceModule/VideoConferenceModule.cpp
@@ -342,7 +342,6 @@ void VideoConferenceModule::onMicrophoneConfigurationChanged()
             toolbar.setMicrophoneMute(muted);
         });
     }
-    setMuteChangedCallback();
 }
 
 VideoConferenceModule::VideoConferenceModule()
@@ -403,25 +402,6 @@ void VideoConferenceModule::set_config(const wchar_t* config)
     catch (...)
     {
         LOG("VideoConferenceModule::set_config: exception during saving new settings values");
-    }
-}
-
-void VideoConferenceModule::setMuteChangedCallback()
-{
-    // Keep all controlledMic mute state same _microphoneTrackedInUI
-    // Should not change manually in Control Panel
-    for (const auto& controlledMic : _controlledMicrophones)
-    {
-        if (controlledMic->id() != _microphoneTrackedInUI->id())
-        {
-            controlledMic->set_mute_changed_callback([&](const bool muted) {
-                auto muteState = getMicrophoneMuteState();
-                if (muted != muteState)
-                {
-                    controlledMic->set_muted(muteState);
-                }
-            });
-        }
     }
 }
 
@@ -552,7 +532,6 @@ void VideoConferenceModule::updateControlledMicrophones(const std::wstring_view 
             controlledMic->set_muted(true);
         }
     }
-    setMuteChangedCallback();
 }
 
 MicrophoneDevice* VideoConferenceModule::controlledDefaultMic()

--- a/src/modules/videoconference/VideoConferenceModule/VideoConferenceModule.h
+++ b/src/modules/videoconference/VideoConferenceModule/VideoConferenceModule.h
@@ -73,7 +73,6 @@ public:
 
 private:
 
-    void setMuteChangedCallback();
     void init_settings();
     void updateControlledMicrophones(const std::wstring_view new_mic);
     MicrophoneDevice* controlledDefaultMic();


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
After https://github.com/microsoft/PowerToys/pull/28658, I've started experiencing issues when using "Startup action: Mute". Specifically, I have 2 physical mic devices and NVIDIA Broadcast device, and NVIDIA device wasn't unmuting in 90% cases after initial mute.

After debugging, it turns out that the callbacks for `VolumeNotifier::OnNotify` are in a race with `setMuteChangedCallback` to make the NVIDIA device muted, since `getMicrophoneMuteState` was returing false for it, because we haven't unumted the tracked physical device.

This PR removes the new callback logic.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- use "Mute" startup action and toggle mute all mics back and forth, verify that all mics stay in the same state.
- use "Unmute" startup action and verify it works as wellA