### PR TITLE
[FZ Editor]Dictionary Implementation to fix temporal coupling

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/LayoutBackup.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/LayoutBackup.cs
@@ -12,7 +12,7 @@ namespace FancyZonesEditor
     {
         private LayoutModel _backup;
         private string _hotkeyBackup;
-        private List<LayoutModel> _defaultLayoutsBackup;
+        private Dictionary<MonitorConfigurationType, LayoutModel> _defaultLayoutsBackup;
 
         public LayoutBackup()
         {
@@ -30,7 +30,7 @@ namespace FancyZonesEditor
             }
 
             _hotkeyBackup = MainWindowSettingsModel.LayoutHotkeys.Key(model.Uuid);
-            _defaultLayoutsBackup = new List<LayoutModel>(MainWindowSettingsModel.DefaultLayouts.Layouts);
+            _defaultLayoutsBackup = new Dictionary<MonitorConfigurationType, LayoutModel>(MainWindowSettingsModel.DefaultLayouts.Layouts);
         }
 
         public void Restore(LayoutModel layoutToRestore)

--- a/src/modules/fancyzones/editor/FancyZonesEditor/LayoutBackup.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/LayoutBackup.cs
@@ -12,7 +12,7 @@ namespace FancyZonesEditor
     {
         private LayoutModel _backup;
         private string _hotkeyBackup;
-        private List<LayoutModel> _defaultLayoutsBackup;
+        private Dictionary<int, LayoutModel> _defaultLayoutsBackup;
 
         public LayoutBackup()
         {
@@ -30,7 +30,7 @@ namespace FancyZonesEditor
             }
 
             _hotkeyBackup = MainWindowSettingsModel.LayoutHotkeys.Key(model.Uuid);
-            _defaultLayoutsBackup = new List<LayoutModel>(MainWindowSettingsModel.DefaultLayouts.Layouts);
+            _defaultLayoutsBackup = new Dictionary<int, LayoutModel>(MainWindowSettingsModel.DefaultLayouts.Layouts);
         }
 
         public void Restore(LayoutModel layoutToRestore)

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/DefaultLayoutsModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/DefaultLayoutsModel.cs
@@ -13,7 +13,7 @@ namespace FancyZonesEditor.Models
     {
         private static int Count { get; } = Enum.GetValues(typeof(MonitorConfigurationType)).Length;
 
-        public List<LayoutModel> Layouts { get; } = new List<LayoutModel>(Count);
+        public Dictionary<MonitorConfigurationType,  LayoutModel> Layouts { get; } = new Dictionary<MonitorConfigurationType, LayoutModel>(Count);
 
         public DefaultLayoutsModel()
         {
@@ -36,12 +36,12 @@ namespace FancyZonesEditor.Models
 
         public void Reset(string uuid)
         {
-            if (Layouts[(int)MonitorConfigurationType.Horizontal].Uuid == uuid)
+            if (Layouts[MonitorConfigurationType.Horizontal].Uuid == uuid)
             {
                 Set(MainWindowSettingsModel.TemplateModels[(int)LayoutType.PriorityGrid], MonitorConfigurationType.Horizontal);
             }
 
-            if (Layouts[(int)MonitorConfigurationType.Vertical].Uuid == uuid)
+            if (Layouts[MonitorConfigurationType.Vertical].Uuid == uuid)
             {
                 Set(MainWindowSettingsModel.TemplateModels[(int)LayoutType.Rows], MonitorConfigurationType.Vertical);
             }
@@ -49,23 +49,16 @@ namespace FancyZonesEditor.Models
 
         public void Set(LayoutModel layout, MonitorConfigurationType type)
         {
-            if (Layouts.Count <= (int)type)
-            {
-                Layouts.Insert((int)type, layout);
-            }
-            else
-            {
-                Layouts[(int)type] = layout;
-            }
+            Layouts[type] = layout;
 
             FirePropertyChanged();
         }
 
-        public void Restore(List<LayoutModel> layouts)
+        public void Restore(Dictionary<MonitorConfigurationType, LayoutModel> layouts)
         {
-            for (int i = 0; i < Count; i++)
+            foreach (var monitorConfigurationType in layouts.Keys)
             {
-                Set(layouts[i], (MonitorConfigurationType)i);
+                Set(layouts[monitorConfigurationType], monitorConfigurationType);
             }
         }
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/DefaultLayoutsModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/DefaultLayoutsModel.cs
@@ -13,7 +13,7 @@ namespace FancyZonesEditor.Models
     {
         private static int Count { get; } = Enum.GetValues(typeof(MonitorConfigurationType)).Length;
 
-        public List<LayoutModel> Layouts { get; } = new List<LayoutModel>(Count);
+        public Dictionary<int,  LayoutModel> Layouts { get; } = new Dictionary<int, LayoutModel>(Count);
 
         public DefaultLayoutsModel()
         {
@@ -51,7 +51,7 @@ namespace FancyZonesEditor.Models
         {
             if (Layouts.Count <= (int)type)
             {
-                Layouts.Insert((int)type, layout);
+                Layouts[(int)type] = layout;
             }
             else
             {
@@ -61,7 +61,7 @@ namespace FancyZonesEditor.Models
             FirePropertyChanged();
         }
 
-        public void Restore(List<LayoutModel> layouts)
+        public void Restore(Dictionary<int, LayoutModel> layouts)
         {
             for (int i = 0; i < Count; i++)
             {

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/LayoutModel.cs
@@ -166,7 +166,7 @@ namespace FancyZonesEditor.Models
         {
             get
             {
-                return MainWindowSettingsModel.DefaultLayouts.Layouts[(int)MonitorConfigurationType.Vertical].Uuid == this.Uuid;
+                return MainWindowSettingsModel.DefaultLayouts.Layouts[MonitorConfigurationType.Vertical].Uuid == this.Uuid;
             }
         }
 
@@ -174,7 +174,7 @@ namespace FancyZonesEditor.Models
         {
             get
             {
-                return MainWindowSettingsModel.DefaultLayouts.Layouts[(int)MonitorConfigurationType.Vertical].Uuid != this.Uuid;
+                return MainWindowSettingsModel.DefaultLayouts.Layouts[MonitorConfigurationType.Vertical].Uuid != this.Uuid;
             }
         }
 

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/MainWindowSettingsModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/MainWindowSettingsModel.cs
@@ -80,8 +80,8 @@ namespace FancyZonesEditor
             TemplateModels.Insert((int)LayoutType.PriorityGrid, priorityGridModel);
 
             // set default layouts
-            DefaultLayouts.Set(priorityGridModel, MonitorConfigurationType.Horizontal);
             DefaultLayouts.Set(rowsModel, MonitorConfigurationType.Vertical);
+            DefaultLayouts.Set(priorityGridModel, MonitorConfigurationType.Horizontal);
         }
 
         // IsShiftKeyPressed - is the shift key currently being held down


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
While working on tests for the fancy zone editor we noticed a temporal coupling and raised and issue [here](https://github.com/microsoft/PowerToys/issues/29050) #29050 . This is one way we propose to fix the issue. We have proposed another way to fix this issues [here](https://github.com/microsoft/PowerToys/pull/29136) as well
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #29050
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [x] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
We changed the layouts in the defaultLayoutsModel from a list to a Dictionary of set size. That way the default layouts can be set in any order. Before you had to make sure you set the horizontal layout before the vertical. We also updated all the supporting calls and code to make sure it works. 
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->

## Validation Steps Performed
We swapped the order of the layouts being set in mainWindowSettingsModel to prove the dictionary approach works. Before if you swapped them the project would hit an index out of range error. 

