### PR TITLE
[FZ Editor] List initialized in constructor to fix temporal coupling

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/DefaultLayoutsModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/DefaultLayoutsModel.cs
@@ -17,6 +17,10 @@ namespace FancyZonesEditor.Models
 
         public DefaultLayoutsModel()
         {
+            for (int i = 0; i < Count; i++)
+            {
+                Layouts.Add(null);
+            }
         }
 
         public event PropertyChangedEventHandler PropertyChanged;

--- a/src/modules/fancyzones/editor/FancyZonesEditor/Models/MainWindowSettingsModel.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/Models/MainWindowSettingsModel.cs
@@ -80,8 +80,8 @@ namespace FancyZonesEditor
             TemplateModels.Insert((int)LayoutType.PriorityGrid, priorityGridModel);
 
             // set default layouts
-            DefaultLayouts.Set(priorityGridModel, MonitorConfigurationType.Horizontal);
             DefaultLayouts.Set(rowsModel, MonitorConfigurationType.Vertical);
+            DefaultLayouts.Set(priorityGridModel, MonitorConfigurationType.Horizontal);
         }
 
         // IsShiftKeyPressed - is the shift key currently being held down


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
While working on tests for the fancy zone editor we noticed a temporal coupling and raised and issue [here](https://github.com/microsoft/PowerToys/issues/29050) #29050 . This is one way we propose to fix the issue. There is another proposed fix we made in [This PR](https://github.com/microsoft/PowerToys/pull/29135) 
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #29050 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [x] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
We initialized the layout list with nulls. That way the default layouts can be set in any order. Before you had to make sure you set the horizontal layout before the vertical. For this fix there was no additional updates to calls or other classes needed. 
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->

## Validation Steps Performed
We swapped the order of the layouts being set in mainWindowSettingsModel to prove the new initialized list approach works. Before if you swapped them the project would hit an index out of range error. 

