### PR TITLE
Update Toast Notification Arrow "⇨" was "->"

### DIFF
--- a/src/runner/UpdateUtils.cpp
+++ b/src/runner/UpdateUtils.cpp
@@ -33,7 +33,7 @@ using namespace updating;
 std::wstring CurrentVersionToNextVersion(const new_version_download_info& info)
 {
     auto result = VersionHelper{ VERSION_MAJOR, VERSION_MINOR, VERSION_REVISION }.toWstring();
-    result += L" -> ";
+    result += L" ⇨ ";
     result += info.version.toWstring();
     return result;
 }

--- a/src/runner/UpdateUtils.cpp
+++ b/src/runner/UpdateUtils.cpp
@@ -33,7 +33,7 @@ using namespace updating;
 std::wstring CurrentVersionToNextVersion(const new_version_download_info& info)
 {
     auto result = VersionHelper{ VERSION_MAJOR, VERSION_MINOR, VERSION_REVISION }.toWstring();
-    result += L" ⇨ ";
+    result += L" \u2192 "; // Right arrow
     result += info.version.toWstring();
     return result;
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
When there is a new update for PowerToys a notification occurs. Within the body of the notification there is a "->" which is used to indicate version going to and from. This PR replaces that arrow with an actual arrow character: '⇨'

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #14832
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected

