### PR TITLE
[ImageResizer]Fix use without initializing warning

### DIFF
--- a/src/modules/imageresizer/ImageResizerContextMenu/dllmain.cpp
+++ b/src/modules/imageresizer/ImageResizerContextMenu/dllmain.cpp
@@ -255,14 +255,20 @@ private:
             for (DWORD i = 0; i < fileCount; i++)
             {
                 IShellItem* shellItem;
-                psiItemArray->GetItemAt(i, &shellItem);
-                LPWSTR itemName;
-                // Retrieves the entire file system path of the file from its shell item
-                shellItem->GetDisplayName(SIGDN_FILESYSPATH, &itemName);
-                CString fileName(itemName);
-                fileName.Append(_T("\r\n"));
-                // Write the file path into the input stream for image resizer
-                writePipe.Write(fileName, fileName.GetLength() * sizeof(TCHAR));
+                HRESULT getItemAtResult = psiItemArray->GetItemAt(i, &shellItem);
+                if (SUCCEEDED(getItemAtResult))
+                {
+                    LPWSTR itemName;
+                    // Retrieves the entire file system path of the file from its shell item
+                    HRESULT getDisplayResult = shellItem->GetDisplayName(SIGDN_FILESYSPATH, &itemName);
+                    if (SUCCEEDED(getDisplayResult))
+                    {
+                        CString fileName(itemName);
+                        fileName.Append(_T("\r\n"));
+                        // Write the file path into the input stream for image resizer
+                        writePipe.Write(fileName, fileName.GetLength() * sizeof(TCHAR));
+                    }
+                }
             }
             writePipe.Close();
         }

--- a/src/modules/imageresizer/dll/ContextMenuHandler.cpp
+++ b/src/modules/imageresizer/dll/ContextMenuHandler.cpp
@@ -386,8 +386,14 @@ HRESULT __stdcall CContextMenuHandler::GetState(IShellItemArray* psiItemArray, B
     PERCEIVED type;
     PERCEIVEDFLAG flag;
     IShellItem* shellItem;
+
     //Check extension of first item in the list (the item which is right-clicked on)
-    psiItemArray->GetItemAt(0, &shellItem);
+    HRESULT getItemAtResult = psiItemArray->GetItemAt(0, &shellItem);
+    if(!SUCCEEDED(getItemAtResult)) {
+        // Avoid crashes in the following code.
+        return E_FAIL;
+    }
+
     LPTSTR pszPath;
     // Retrieves the entire file system path of the file from its shell item
     HRESULT getDisplayResult = shellItem->GetDisplayName(SIGDN_FILESYSPATH, &pszPath);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

We've received some warning regarding use of the variables "shellItem" and "itemName" in ImageResizer, saying that they could be used without being initialized. This PR tries to fix those warnings.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Building CI release and testing the context menus.
