### PR TITLE
Fix for bug 29152, where Key names were being mishandled and returned as "invalid" in the UX

### DIFF
--- a/src/modules/registrypreview/RegistryPreviewUI/MainWindow.Utilities.cs
+++ b/src/modules/registrypreview/RegistryPreviewUI/MainWindow.Utilities.cs
@@ -774,7 +774,19 @@ namespace RegistryPreview
 
                 // before moving onto the next node, tag the previous node and update the path
                 previousNode = newNode;
-                fullPath = fullPath.Replace(string.Format(CultureInfo.InvariantCulture, @"\{0}", individualKeys[i]), string.Empty);
+
+                // this used to use Replace but that would replace all instances of the same key name, which causes bugs.
+                try
+                {
+                    int removeAt = fullPath.LastIndexOf(string.Format(CultureInfo.InvariantCulture, @"\{0}", individualKeys[i]), StringComparison.InvariantCulture);
+                    if (removeAt > -1)
+                    {
+                        fullPath = fullPath.Substring(0, removeAt);
+                    }
+                }
+                catch
+                {
+                }
 
                 // One last check: if we get here, the parent of this node is not yet in the tree, so we need to add it as a RootNode
                 if (i == 0)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Updated the string functions called when processing Key values to be better about repeating key names.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [X] **Closes:** #29152
- [X] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Replaced String.Replace with String.Substring to avoid the removal of multiple instances of a string, rather than just the last one.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
If a Key had multiple instances of the exact same string, when the Key was parsed when populating the UI, all instances of the string were replaced instead of the just the last one.  If a Key had the text "\Control1234\Control" when the right most leaf was processed, the Key became "1234" because all instances of "\Control" were removed.

Tested with the sample included in #29152 as well as my usual collection of files.  Also confirmed that "deleted Keys" would still work as there was some concern from the OP of the bug.
