### PR TITLE
[PT Run] Fix PluginAdditionalOptions value properties defaults.

### DIFF
--- a/src/modules/launcher/PowerLauncher/SettingsReader.cs
+++ b/src/modules/launcher/PowerLauncher/SettingsReader.cs
@@ -281,6 +281,9 @@ namespace PowerLauncher
                 if (option.Key != null && defaultOptions.TryGetValue(option.Key, out PluginAdditionalOption defaultOption))
                 {
                     defaultOption.Value = option.Value;
+                    defaultOption.ComboBoxValue = option.ComboBoxValue;
+                    defaultOption.TextValue = option.TextValue;
+                    defaultOption.NumberValue = option.NumberValue;
                 }
             }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Bug fix for PT Run.

PR https://github.com/microsoft/PowerToys/pull/28601 introduced the TextBox and NumberBox types for additional options.

Their default values are not initiated with `settings.json` like the `Value` property (for CheckBox) is.

This PR fixes it.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** https://github.com/microsoft/PowerToys/issues/29465
- [x] **Communication:** I've discussed with [#28601](https://github.com/microsoft/PowerToys/pull/28601) 's author.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manually tested and everything works fine.

