### PR TITLE
[Peek] Use space to play/resume video

### DIFF
--- a/src/modules/peek/Peek.FilePreviewer/FilePreview.xaml
+++ b/src/modules/peek/Peek.FilePreviewer/FilePreview.xaml
@@ -40,6 +40,9 @@
             Source="{x:Bind VideoPreviewer.Preview, Mode=OneWay}"
             ToolTipService.ToolTip="{x:Bind ImageInfoTooltip, Mode=OneWay}"
             Visibility="{x:Bind IsPreviewVisible(VideoPreviewer, Previewer.State), Mode=OneWay}">
+            <MediaPlayerElement.KeyboardAccelerators>
+                <KeyboardAccelerator Key="Space" Invoked="KeyboardAccelerator_Space_Invoked" />
+            </MediaPlayerElement.KeyboardAccelerators>
             <MediaPlayerElement.TransportControls>
                 <MediaTransportControls
                     x:Name="mediaTransport"

--- a/src/modules/peek/Peek.FilePreviewer/FilePreview.xaml.cs
+++ b/src/modules/peek/Peek.FilePreviewer/FilePreview.xaml.cs
@@ -299,6 +299,28 @@ namespace Peek.FilePreviewer
             }
         }
 
+        private void KeyboardAccelerator_Space_Invoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
+        {
+            var mediaPlayer = VideoPreview.MediaPlayer;
+
+            if (mediaPlayer.Source == null || !mediaPlayer.CanPause)
+            {
+                return;
+            }
+
+            if (mediaPlayer.CurrentState == Windows.Media.Playback.MediaPlayerState.Playing)
+            {
+                mediaPlayer.Pause();
+            }
+            else
+            {
+                mediaPlayer.Play();
+            }
+
+            // Prevent the keyboard accelerator to be called twice
+            args.Handled = true;
+        }
+
         private async Task UpdateImageTooltipAsync(CancellationToken cancellationToken)
         {
             if (Item == null)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Added a keyboard accelerator to play/resume video.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #26986
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

- Spacebar is play/resume the currently playing video
- Spacebar is doing nothing when another previewer is currently used in the Peek window
