### PR TITLE
[HotFix]Revert "[FancyZones]Filtering popup windows for all operations (#28975)"

### DIFF
--- a/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
@@ -394,6 +394,15 @@ void FancyZones::WindowCreated(HWND window) noexcept
         return;
     }
 
+    // Hotfix
+    // Avoid automatically moving popup windows, as they can be just popup menus.
+    bool isPopup = FancyZonesWindowUtils::IsPopupWindow(window);
+    bool hasThickFrame = FancyZonesWindowUtils::HasThickFrame(window);
+    if (isPopup && !hasThickFrame)
+    {
+        return;
+    }
+
     // Avoid already stamped (zoned) windows
     const bool isZoned = !FancyZonesWindowProperties::RetrieveZoneIndexProperty(window).empty();
     if (isZoned)

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesWindowProcessing.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesWindowProcessing.cpp
@@ -27,9 +27,8 @@ bool FancyZonesWindowProcessing::IsProcessable(HWND window) noexcept
 
     // popup could be the window we don't want to snap: start menu, notification popup, tray window, etc.
     // also, popup could be the windows we want to snap disregarding the "allowSnapPopupWindows" setting, e.g. Telegram
-    bool isPopup = FancyZonesWindowUtils::IsPopupWindow(window);
-    bool hasThickFrame = FancyZonesWindowUtils::HasThickFrame(window);
-    if (isPopup && (!hasThickFrame || !FancyZonesSettings::settings().allowSnapPopupWindows))
+    bool isPopup = FancyZonesWindowUtils::IsPopupWindow(window) && !FancyZonesWindowUtils::HasThickFrameAndMinimizeMaximizeButtons(window);
+    if (isPopup && !FancyZonesSettings::settings().allowSnapPopupWindows)
     {
         return false;
     }


### PR DESCRIPTION
This reverts commit 1b333dfee001b2654a16cc8774f8864e895db067.

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

The generalizing fix for not automatically snapping popups https://github.com/microsoft/PowerToys/commit/1b333dfee001b2654a16cc8774f8864e895db067 broke the snapping for some applications. We can't release a proper fix during the hotfix since that might break other applications, so we're reverting the change for now.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
- [x] **Closes:** #29491

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Calculator snaps again
Godot right menus still don't snap automatically