### PR TITLE
[Quick Accent] Add fractions

### DIFF
--- a/src/modules/poweraccent/PowerAccent.Core/Languages.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/Languages.cs
@@ -134,6 +134,13 @@ namespace PowerAccent.Core
         {
             return letter switch
             {
+                LetterKey.VK_0 => new[] { "↉" },
+                LetterKey.VK_1 => new[] { "½", "⅓", "¼", "⅕", "⅙", "⅐", "⅛", "⅑", "⅒" },
+                LetterKey.VK_2 => new[] { "⅔", "⅖" },
+                LetterKey.VK_3 => new[] { "¾", "⅗", "⅜" },
+                LetterKey.VK_4 => new[] { "⅘" },
+                LetterKey.VK_5 => new[] { "⅚", "⅝" },
+                LetterKey.VK_7 => new[] { "⅞" },
                 LetterKey.VK_A => new[] { "α", "ά", "ȧ" },
                 LetterKey.VK_B => new[] { "ḃ", "β" },
                 LetterKey.VK_C => new[] { "ċ", "χ", "°C", "©", "ℂ" },


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Adds fractions to Quick Accent
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #28719 and #28005
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [x] **Documentation updated:** No need

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Adds these fractions to Quick Accent: ↉, ⅙, ⅐, ⅛, ⅑, ⅒, ½, ⅓, ¼, ⅕, ⅔, ⅖, ⅗, ¾, ⅜, ⅘, ⅝, ⅚, ⅞
They are mapped to keys based on their numerator (as suggested in #28005)
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Observing Quick Accent
