### PR TITLE
[MWB] Remove Thread.Suspend API usage, because it always results in P…

### DIFF
--- a/src/modules/MouseWithoutBorders/App/Class/Common.Log.cs
+++ b/src/modules/MouseWithoutBorders/App/Class/Common.Log.cs
@@ -85,28 +85,6 @@ namespace MouseWithoutBorders
             return stack;
         }
 
-        internal static void SuspendAllThreadsBut(int threadId)
-        {
-            lock (ThreadsLock)
-            {
-#pragma warning disable 618 // Temporary
-                threads.Where(t => t.IsAlive && t.ManagedThreadId != threadId).ToList().ForEach(
-                    t =>
-                    {
-                        try
-                        {
-                            t.Suspend();
-                        }
-                        catch (Exception)
-                        {
-                            // This method is suspending every thread so that it can kill the process right after restarting.
-                            // Makes no sense to crash on a thread suspension fail, since we're killing the process afterwards, anyway.
-                        }
-                    });
-#pragma warning restore 618
-            }
-        }
-
         internal void SetApartmentState(ApartmentState apartmentState)
         {
             thread.SetApartmentState(apartmentState);

--- a/src/modules/MouseWithoutBorders/App/Class/Common.cs
+++ b/src/modules/MouseWithoutBorders/App/Class/Common.cs
@@ -349,8 +349,6 @@ namespace MouseWithoutBorders
                     _ = Process.Start(Application.ExecutablePath, desktop);
                     LogDebug($"Started on desktop {desktop}");
 
-                    Thread.SuspendAllThreadsBut(Thread.CurrentThread.ManagedThreadId);
-
                     Process.GetCurrentProcess().KillProcess(true);
                 },
                     $"{actionName} watchdog").Start();


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
According to [the docs](https://learn.microsoft.com/en-us/dotnet/api/system.threading.thread.suspend?view=net-7.0#exceptions), we shouldn't use this method at all. Since it was called right before killing the process, it's safe to remove this logic altogether.


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #xxx
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

