### PR TITLE
[Tests]Fix flaky interop tests

### DIFF
--- a/src/common/interop/interop-tests/InteropTests.cs
+++ b/src/common/interop/interop-tests/InteropTests.cs
@@ -49,6 +49,9 @@ namespace Microsoft.Interop.Tests
                     serverPipe.Start();
                     ClientPipe.Start();
 
+                    // Test can be flaky as the pipes are still being set up and we end up receiving no message. Wait for a bit to avoid that.
+                    Thread.Sleep(100);
+
                     ClientPipe.Send(testString);
                     reset.WaitOne();
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Sometimes the Interop Tests hung in CI. This seems to be caused by the sending of a message before the OS has set up the pipes correctly. We add a little wait to the test to reduce flakiness.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
![image](https://github.com/microsoft/PowerToys/assets/26118718/fa326de5-89fa-411a-b678-e36878c6cbb6)
Ran the "TestSend" with "Run Until Failure" and it ran 1000 times without hanging.
