### PR TITLE
[Quick Accent] Add ₸ (Kazakhstani Tenge) to Currencies

### DIFF
--- a/src/modules/poweraccent/PowerAccent.Core/Languages.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/Languages.cs
@@ -198,7 +198,7 @@ namespace PowerAccent.Core
                 LetterKey.VK_P => new[] { "£", "₽" },
                 LetterKey.VK_R => new[] { "₹", "៛", "﷼" },
                 LetterKey.VK_S => new[] { "$", "₪" },
-                LetterKey.VK_T => new[] { "₮", "₺" },
+                LetterKey.VK_T => new[] { "₮", "₺", "₸" },
                 LetterKey.VK_W => new[] { "₩" },
                 LetterKey.VK_Y => new[] { "¥" },
                 LetterKey.VK_Z => new[] { "z" },


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Adds the Kazakhstani Tenge (₸) to Currencies in Quick Accent
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #26481
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** No need
- [x] **Localization:** Localization is not affected
- [x] **Dev docs:** No need
- [x] **New binaries:** None
- [x] **Documentation updated:** No need

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Adds ₸ to <kbd>T</kbd>. I know that [the source](https://www.eurochange.co.uk/travel-money/world-currency-abbreviations-symbols-and-codes-travel-money) for currency symbols that's mentioned in Languages.cs doesn't contain ₸, so here's a [Wikipedia article](https://en.wikipedia.org/wiki/Kazakhstani_tenge) as proof.
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Tested locally