### PR TITLE
[Run] Fix operation was canceled on startup

### DIFF
--- a/src/modules/launcher/PowerLauncher/App.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/App.xaml.cs
@@ -9,27 +9,20 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Windows;
-
 using Common.UI;
-
 using interop;
-
 using ManagedCommon;
-
 using Microsoft.PowerLauncher.Telemetry;
 using Microsoft.PowerToys.Telemetry;
-
 using PowerLauncher.Helper;
 using PowerLauncher.Plugin;
 using PowerLauncher.ViewModel;
-
 using Wox;
 using Wox.Infrastructure;
 using Wox.Infrastructure.Image;
 using Wox.Infrastructure.UserSettings;
 using Wox.Plugin;
 using Wox.Plugin.Logger;
-
 using Stopwatch = Wox.Infrastructure.Stopwatch;
 
 namespace PowerLauncher
@@ -155,8 +148,6 @@ namespace PowerLauncher
 
                 _settingsReader.ReadSettingsOnChange();
 
-                _mainVM.MainWindowVisibility = Visibility.Visible;
-                _mainVM.ColdStartFix();
                 _themeManager.ThemeChanged += OnThemeChanged;
                 textToLog.AppendLine("End PowerToys Run startup ----------------------------------------------------  ");
 
@@ -164,11 +155,6 @@ namespace PowerLauncher
 
                 Log.Info(textToLog.ToString(), GetType());
                 PowerToysTelemetry.Log.WriteEvent(new LauncherBootEvent() { BootTimeMs = bootTime.ElapsedMilliseconds });
-
-                // [Conditional("RELEASE")]
-                // check update every 5 hours
-
-                // check updates on startup
             });
         }
 

--- a/src/modules/launcher/PowerLauncher/Plugin/PluginManager.cs
+++ b/src/modules/launcher/PowerLauncher/Plugin/PluginManager.cs
@@ -11,6 +11,7 @@ using System.IO.Abstractions;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
+using System.Windows;
 using global::PowerToys.GPOWrapper;
 using ManagedCommon;
 using PowerLauncher.Properties;
@@ -180,7 +181,7 @@ namespace PowerLauncher.Plugin
             {
                 var failed = string.Join(",", failedPlugins.Select(x => x.Metadata.Name));
                 var description = string.Format(CultureInfo.CurrentCulture, Resources.FailedToInitializePluginsDescription, failed);
-                API.ShowMsg(Resources.FailedToInitializePluginsTitle, description, string.Empty, false);
+                Application.Current.Dispatcher.InvokeAsync(() => API.ShowMsg(Resources.FailedToInitializePluginsTitle, description, string.Empty, false));
             }
         }
 

--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -1028,34 +1028,6 @@ namespace PowerLauncher.ViewModel
             }
         }
 
-        public void ColdStartFix()
-        {
-            // Fix Cold start for List view xaml island
-            List<Result> list = new List<Result>();
-            Result r = new Result
-            {
-                Title = "hello",
-            };
-            list.Add(r);
-            Results.AddResults(list, _updateToken);
-            Results.Clear();
-
-            // Fix Cold start for plugins, "m" is just a random string needed to query results
-            var pluginQueryPairs = QueryBuilder.Build("m");
-
-            // To execute a query corresponding to each plugin
-            foreach (KeyValuePair<PluginPair, Query> pluginQueryItem in pluginQueryPairs)
-            {
-                var plugin = pluginQueryItem.Key;
-                var query = pluginQueryItem.Value;
-
-                if (!plugin.Metadata.Disabled && plugin.Metadata.Name != "Window Walker")
-                {
-                    _ = PluginManager.QueryForPlugin(plugin, query);
-                }
-            }
-        }
-
         public void HandleContextMenu(Key acceleratorKey, ModifierKeys acceleratorModifiers)
         {
             var results = SelectedResults;

--- a/src/modules/launcher/Wox.Plugin/PluginPair.cs
+++ b/src/modules/launcher/Wox.Plugin/PluginPair.cs
@@ -4,10 +4,10 @@
 
 using System;
 using System.Diagnostics;
-using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Loader;
+using System.Windows;
 using Microsoft.PowerToys.Settings.UI.Library;
 using Wox.Plugin.Logger;
 using Wox.Plugin.Properties;
@@ -74,7 +74,7 @@ namespace Wox.Plugin
                     if (!IsPluginInitialized)
                     {
                         string description = $"{Resources.FailedToLoadPluginDescription} {Metadata.Name}\n\n{Resources.FailedToLoadPluginDescriptionPartTwo}";
-                        api.ShowMsg(Resources.FailedToLoadPluginTitle, description, string.Empty, false);
+                        Application.Current.Dispatcher.InvokeAsync(() => api.ShowMsg(Resources.FailedToLoadPluginTitle, description, string.Empty, false));
                     }
                 }
                 else


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

I am not able to reproduce the original issue even if I remember I hit this once during 3rd party plugins development.
My analysis:
- User mention having 3rd party plugins installed
- If some plugins fail to load the message box that is opened blocks the startup method
- `ColdStartFix()` execution is delayed after dismissing the message box
- `ColdStartFix()` uses the same cancellation token used to cancel results update

It seems to be a sort of race condition when `ColdStartFix()` is delayed by the message box and user start a new search.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #29741
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

- Make message box not block the startup using dispatcher
- Remove cold start warmup
- Removed main window set to visible on startup. It's actually set to collapsed.
https://github.com/microsoft/PowerToys/blob/bb10ef5ef5491c5f9d7b588b68e48be872c49155/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs#L203

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

- Tested PT Run
- Verified that main window is created collapsed
- Verified that the message box that is showed if a plugins fail to load doesn't block the startup method
- Verified that removing the startup doesn't have impact on first query.
  Average query times collected on 10 first query after Run startup.

| Plugin | With Cold Start (ms) | Without Cold Start (ms) |
| ------- | ----------------- | -------------------- |
|Calculator|36|29|
|Folder|4|5|
|PowerToys|6|5|
|Program|101|97|
|System Commands|2|7|
|Windows Uri Handler|3|5|
|Windows Terminal|57|52
|Window Walker|95|68
|Windows Indexer|75|49|
