### PR TITLE
[CI] Fix prebuild check to use commit when no pull request number exists

### DIFF
--- a/.pipelines/ci/templates/build-powertoys-precheck.yml
+++ b/.pipelines/ci/templates/build-powertoys-precheck.yml
@@ -15,13 +15,24 @@ jobs:
     inputs:
       targetType: 'inline'
       script: |
-        $pullRequestNumber = "$(system.pullRequest.pullRequestNumber)";
-        $gitHubPullRequest = Invoke-RestMethod -Method Get "https://api.github.com/repos/microsoft/PowerToys/pulls/$pullRequestNumber/files"
-        # If there are no files updated in the commit that are .md, set skipBuild variable
-        if(([array]($gitHubPullRequest.filename) -notmatch ".md|.txt").Length -eq 0)
-        {
+        try {
+          # Try based on pull request first
+          $pullRequestNumber = "$(system.pullRequest.pullRequestNumber)";
+          $gitHubPullRequest = Invoke-RestMethod -Method Get "https://api.github.com/repos/microsoft/PowerToys/pulls/$pullRequestNumber/files"
+          # If there are no files updated in the commit that are .md, set skipBuild variable
+          if(([array]($gitHubPullRequest.filename) -notmatch ".md|.txt").Length -eq 0) {
+              Write-Host '##vso[task.setvariable variable=skipBuild;isOutput=true]Yes'
+              Write-Host 'Skipping Build'
+          }
+        }
+        catch {
+          # Fall back to the latest commit otherwise.
+          $commit = "$(system.pullRequest.sourceCommitId)";
+          $gitHubCommit = Invoke-RestMethod -Method Get "https://api.github.com/repos/microsoft/PowerToys/commits/$commit"
+          if(([array]($githubCommit.files.filename) -notmatch ".md|.txt").Length -eq 0) {
             Write-Host '##vso[task.setvariable variable=skipBuild;isOutput=true]Yes'
             Write-Host 'Skipping Build'
+          }
         }
       pwsh: true
     name: verifyBuildRequest


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Resolve issue caused by no pull request number being logged to a system variable when CI runs after PR is merged

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [X] **Closes:** #24417 
- [X] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

