### PR TITLE
[ci]Fix precheck getting commit id in the fallback

### DIFF
--- a/.pipelines/ci/templates/build-powertoys-precheck.yml
+++ b/.pipelines/ci/templates/build-powertoys-precheck.yml
@@ -27,7 +27,7 @@ jobs:
         }
         catch {
           # Fall back to the latest commit otherwise.
-          $commit = "$(system.pullRequest.sourceCommitId)";
+          $commit = "$(build.sourceVersion)";
           $gitHubCommit = Invoke-RestMethod -Method Get "https://api.github.com/repos/microsoft/PowerToys/commits/$commit"
           if(([array]($githubCommit.files.filename) -notmatch ".md|.txt").Length -eq 0) {
             Write-Host '##vso[task.setvariable variable=skipBuild;isOutput=true]Yes'


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

CI is currently failing the precheck on main:
![image](https://github.com/microsoft/PowerToys/assets/26118718/ea16dc90-397a-48f2-a794-d0f62303ea18)

This is because on push, there's no `system.pullRequest`.

Use Build.SourceVersion from https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#build-variables-devops-services , since there's no PR.