### PR TITLE
[Deps]Update Microsoft.Windows.CsWinRT to 2.0.4

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,7 +38,7 @@
     <PackageVersion Include="Microsoft.Windows.Compatibility" Version="7.0.3" />
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.2.46-beta" />
     <!-- CsWinRT version needs to be set to have a WinRT.Runtime.dll at the same version contained inside the NET SDK we're currently building on CI. -->
-    <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="2.0.3" />
+    <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="2.0.4" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
     <PackageVersion Include="Microsoft.Windows.SDK.Contracts" Version="10.0.19041.1" />
     <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.4.230913002" />


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
A recent update in the CI machines updated the .NET SDK that's currently building on CI. This caused a conflict on the dependencies used by CsWinRT, so we're updating it to 2.0.4.