### PR TITLE
[Build]Fix uninitialized variable error on VS 17.8

### DIFF
--- a/src/modules/EnvironmentVariables/EnvironmentVariablesModuleInterface/dllmain.cpp
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesModuleInterface/dllmain.cpp
@@ -53,7 +53,7 @@ private:
     //contains the non localized key of the powertoy
     std::wstring app_key;
 
-    HANDLE m_hProcess;
+    HANDLE m_hProcess = nullptr;
 
     HANDLE m_hShowEvent;
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
My latest local build with the latest VS 17.8 throws a build error because of an uninitialized variable. Initializing implicitly removes the error.