### PR TITLE
[Run] Addressed some disposable + VirtualDesktopHelper cleanup

### DIFF
--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -550,6 +550,7 @@ namespace PowerLauncher.ViewModel
                 var queryTimer = new System.Diagnostics.Stopwatch();
                 queryTimer.Start();
                 _updateSource?.Cancel();
+                _updateSource?.Dispose();
                 var currentUpdateSource = new CancellationTokenSource();
                 _updateSource = currentUpdateSource;
                 var currentCancellationToken = _updateSource.Token;

--- a/src/modules/launcher/Wox.Plugin/Common/VirtualDesktop/VirtualDesktopHelper.cs
+++ b/src/modules/launcher/Wox.Plugin/Common/VirtualDesktop/VirtualDesktopHelper.cs
@@ -100,10 +100,10 @@ namespace Wox.Plugin.Common.VirtualDesktop.Helper
             string registryExplorerVirtualDesktops = "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\VirtualDesktops"; // Windows 11
 
             // List of all desktops
-            using RegistryKey virtualDestktopKey = Registry.CurrentUser.OpenSubKey(registryExplorerVirtualDesktops, false);
-            if (virtualDestktopKey != null)
+            using RegistryKey virtualDesktopKey = Registry.CurrentUser.OpenSubKey(registryExplorerVirtualDesktops, false);
+            if (virtualDesktopKey != null)
             {
-                byte[] allDeskValue = (byte[])virtualDestktopKey.GetValue("VirtualDesktopIDs", null);
+                byte[] allDeskValue = (byte[])virtualDesktopKey.GetValue("VirtualDesktopIDs", null);
                 if (allDeskValue != null)
                 {
                     // We clear only, if we can read from registry. Otherwise we keep the existing values.

--- a/src/modules/launcher/Wox.Plugin/Common/VirtualDesktop/VirtualDesktopHelper.cs
+++ b/src/modules/launcher/Wox.Plugin/Common/VirtualDesktop/VirtualDesktopHelper.cs
@@ -33,11 +33,6 @@ namespace Wox.Plugin.Common.VirtualDesktop.Helper
         private readonly bool _isWindowsEleven;
 
         /// <summary>
-        /// Terminal services session id
-        /// </summary>
-        private readonly int _userSessionId;
-
-        /// <summary>
         /// Instance of "Virtual Desktop Manager"
         /// </summary>
         private readonly IVirtualDesktopManager _virtualDesktopManager;
@@ -76,7 +71,6 @@ namespace Wox.Plugin.Common.VirtualDesktop.Helper
             }
 
             _isWindowsEleven = OSVersionHelper.IsWindows11();
-            _userSessionId = Process.GetCurrentProcess().SessionId;
             _desktopListAutoUpdate = desktopListUpdate;
             UpdateDesktopList();
         }
@@ -96,7 +90,8 @@ namespace Wox.Plugin.Common.VirtualDesktop.Helper
         /// <remarks>If we can not read from registry, we set the list/guid to empty values.</remarks>
         public void UpdateDesktopList()
         {
-            string registrySessionVirtualDesktops = $"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\SessionInfo\\{_userSessionId}\\VirtualDesktops"; // Windows 10
+            int userSessionId = Process.GetCurrentProcess().SessionId;
+            string registrySessionVirtualDesktops = $"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\SessionInfo\\{userSessionId}\\VirtualDesktops"; // Windows 10
             string registryExplorerVirtualDesktops = "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\VirtualDesktops"; // Windows 11
 
             // List of all desktops


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

`VirtualDesktopHelper` class is heavy used by WindowWalker plugin at every query.
I have noticed that some `RegistryKey` weren't properly disposed.
I have also cached Terminal Session ID and Windows version since they stay the same during PT execution.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** https://github.com/microsoft/PowerToys/issues/29891
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Tested PT Run and verified that virtual desktop names are properly displayed on WindowWalker results.