### PR TITLE
ctrl + w to close peek implemented

### DIFF
--- a/src/modules/peek/Peek.UI/PeekXAML/MainWindow.xaml
+++ b/src/modules/peek/Peek.UI/PeekXAML/MainWindow.xaml
@@ -23,6 +23,7 @@
             <KeyboardAccelerator Key="Right" Invoked="NextNavigationInvoked" />
             <KeyboardAccelerator Key="Down" Invoked="NextNavigationInvoked" />
             <KeyboardAccelerator Key="Escape" Invoked="EscKeyInvoked" />
+            <KeyboardAccelerator Key="W" Modifiers="Control,Shift" Invoked="CtrlWInvoked" />
         </Grid.KeyboardAccelerators>
 
         <Grid.RowDefinitions>

--- a/src/modules/peek/Peek.UI/PeekXAML/MainWindow.xaml
+++ b/src/modules/peek/Peek.UI/PeekXAML/MainWindow.xaml
@@ -23,7 +23,7 @@
             <KeyboardAccelerator Key="Right" Invoked="NextNavigationInvoked" />
             <KeyboardAccelerator Key="Down" Invoked="NextNavigationInvoked" />
             <KeyboardAccelerator Key="Escape" Invoked="EscKeyInvoked" />
-            <KeyboardAccelerator Key="W" Modifiers="Control,Shift" Invoked="CtrlWInvoked" />
+            <KeyboardAccelerator Key="W" Modifiers="Control" Invoked="CtrlWInvoked" />
         </Grid.KeyboardAccelerators>
 
         <Grid.RowDefinitions>

--- a/src/modules/peek/Peek.UI/PeekXAML/MainWindow.xaml.cs
+++ b/src/modules/peek/Peek.UI/PeekXAML/MainWindow.xaml.cs
@@ -121,6 +121,11 @@ namespace Peek.UI
             Uninitialize();
         }
 
+        private void CtrlWInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
+        {
+            Uninitialize();
+        }
+
         private void Initialize(Windows.Win32.Foundation.HWND foregroundWindowHandle)
         {
             var bootTime = new System.Diagnostics.Stopwatch();


### PR DESCRIPTION
## Summary of the Pull Request
implemented ctrl + w to close peek.

## PR Checklist

- [x] **Closes:** #29867
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed
crtl + w should close peek.
