### PR TITLE
implemented ctrl + w to close peek.

### DIFF
--- a/src/modules/peek/Peek.UI/PeekXAML/MainWindow.xaml
+++ b/src/modules/peek/Peek.UI/PeekXAML/MainWindow.xaml
@@ -23,6 +23,7 @@
             <KeyboardAccelerator Key="Right" Invoked="NextNavigationInvoked" />
             <KeyboardAccelerator Key="Down" Invoked="NextNavigationInvoked" />
             <KeyboardAccelerator Key="Escape" Invoked="EscKeyInvoked" />
+            <KeyboardAccelerator Key="W" Modifiers="Control,Shift" Invoked="CtrlWInvoked" />
         </Grid.KeyboardAccelerators>
 
         <Grid.RowDefinitions>

--- a/src/modules/peek/Peek.UI/PeekXAML/MainWindow.xaml
+++ b/src/modules/peek/Peek.UI/PeekXAML/MainWindow.xaml
@@ -22,8 +22,8 @@
             <KeyboardAccelerator Key="Up" Invoked="PreviousNavigationInvoked" />
             <KeyboardAccelerator Key="Right" Invoked="NextNavigationInvoked" />
             <KeyboardAccelerator Key="Down" Invoked="NextNavigationInvoked" />
-            <KeyboardAccelerator Key="Escape" Invoked="EscKeyInvoked" />
-            <KeyboardAccelerator Key="W" Modifiers="Control" Invoked="EscKeyInvoked" />
+            <KeyboardAccelerator Key="Escape" Invoked="CloseInvoked" />
+            <KeyboardAccelerator Key="W" Modifiers="Control" Invoked="CloseInvoked" />
         </Grid.KeyboardAccelerators>
 
         <Grid.RowDefinitions>

--- a/src/modules/peek/Peek.UI/PeekXAML/MainWindow.xaml
+++ b/src/modules/peek/Peek.UI/PeekXAML/MainWindow.xaml
@@ -23,7 +23,10 @@
             <KeyboardAccelerator Key="Right" Invoked="NextNavigationInvoked" />
             <KeyboardAccelerator Key="Down" Invoked="NextNavigationInvoked" />
             <KeyboardAccelerator Key="Escape" Invoked="CloseInvoked" />
-            <KeyboardAccelerator Key="W" Modifiers="Control" Invoked="CloseInvoked" />
+            <KeyboardAccelerator
+                Key="W"
+                Invoked="CloseInvoked"
+                Modifiers="Control" />
         </Grid.KeyboardAccelerators>
 
         <Grid.RowDefinitions>

--- a/src/modules/peek/Peek.UI/PeekXAML/MainWindow.xaml
+++ b/src/modules/peek/Peek.UI/PeekXAML/MainWindow.xaml
@@ -23,7 +23,7 @@
             <KeyboardAccelerator Key="Right" Invoked="NextNavigationInvoked" />
             <KeyboardAccelerator Key="Down" Invoked="NextNavigationInvoked" />
             <KeyboardAccelerator Key="Escape" Invoked="EscKeyInvoked" />
-            <KeyboardAccelerator Key="W" Modifiers="Control" Invoked="CtrlWInvoked" />
+            <KeyboardAccelerator Key="W" Modifiers="Control" Invoked="EscKeyInvoked" />
         </Grid.KeyboardAccelerators>
 
         <Grid.RowDefinitions>

--- a/src/modules/peek/Peek.UI/PeekXAML/MainWindow.xaml
+++ b/src/modules/peek/Peek.UI/PeekXAML/MainWindow.xaml
@@ -23,7 +23,7 @@
             <KeyboardAccelerator Key="Right" Invoked="NextNavigationInvoked" />
             <KeyboardAccelerator Key="Down" Invoked="NextNavigationInvoked" />
             <KeyboardAccelerator Key="Escape" Invoked="EscKeyInvoked" />
-            <KeyboardAccelerator Key="W" Modifiers="Control,Shift" Invoked="CtrlWInvoked" />
+            <KeyboardAccelerator Key="W" Modifiers="Control" Invoked="CtrlWInvoked" />
         </Grid.KeyboardAccelerators>
 
         <Grid.RowDefinitions>

--- a/src/modules/peek/Peek.UI/PeekXAML/MainWindow.xaml.cs
+++ b/src/modules/peek/Peek.UI/PeekXAML/MainWindow.xaml.cs
@@ -116,7 +116,7 @@ namespace Peek.UI
             ViewModel.AttemptNextNavigation();
         }
 
-        private void EscKeyInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
+        private void CloseInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
         {
             Uninitialize();
         }

--- a/src/modules/peek/Peek.UI/PeekXAML/MainWindow.xaml.cs
+++ b/src/modules/peek/Peek.UI/PeekXAML/MainWindow.xaml.cs
@@ -121,11 +121,6 @@ namespace Peek.UI
             Uninitialize();
         }
 
-        private void CtrlWInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
-        {
-            Uninitialize();
-        }
-
         private void Initialize(Windows.Win32.Foundation.HWND foregroundWindowHandle)
         {
             var bootTime = new System.Diagnostics.Stopwatch();

--- a/src/modules/peek/Peek.UI/PeekXAML/MainWindow.xaml.cs
+++ b/src/modules/peek/Peek.UI/PeekXAML/MainWindow.xaml.cs
@@ -121,6 +121,11 @@ namespace Peek.UI
             Uninitialize();
         }
 
+        private void CtrlWInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
+        {
+            Uninitialize();
+        }
+
         private void Initialize(Windows.Win32.Foundation.HWND foregroundWindowHandle)
         {
             var bootTime = new System.Diagnostics.Stopwatch();


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
implemented ctrl + w to close peek.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #29867
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Implemented CrtlWInvoked() with the method Uninitialize() in it. liked to the Ctrl + W shortcut
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
crtl + w should close peek.
