### PR TITLE
[Build]Don't add source hash to product version of binaries

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,6 +12,7 @@
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisMode>Recommended</AnalysisMode>
     <_SkipUpgradeNetAnalyzersNuGetWarning>true</_SkipUpgradeNetAnalyzersNuGetWarning>
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion> <!-- Don't add source revision hash to the product version of binaries. -->
     <PlatformTarget>$(Platform)</PlatformTarget>
   </PropertyGroup>
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Visual Studio 17.8 is automatically adding the source control hash to the Product versions of C# binaries. Example:
![image](https://github.com/microsoft/PowerToys/assets/26118718/5a802242-3e1d-40a2-a629-119efa54a2b8)

This PR opts out of that new feature to avoid side effects.

One side effects discovered by @davidegiacometti is that this is added to the log folder as well. Example : `%LOCALAPPDATA%\Microsoft\PowerToys\Peek\Logs\0.0.1.0+7d9681ecd2533e63a13ac3a88257e698b9c7b5a9`