### PR TITLE
[spellcheck]Fix MPL 1.1 license "declatory" typo

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -388,7 +388,6 @@ Deact
 debian
 debugbreak
 DECLAR
-declatory
 declspec
 decryptor
 Dedup

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -432,7 +432,7 @@ We use the UTF.Unknown NuGet package for detecting encoding in text/code files.
      shall survive.
 
      8.2.  If You initiate litigation by asserting a patent infringement
-     claim (excluding declatory judgment actions) against Initial Developer
+     claim (excluding declaratory judgment actions) against Initial Developer
      or a Contributor (the Initial Developer or Contributor against whom
      You file such action is referred to as "Participant")  alleging that:
 
@@ -1124,7 +1124,7 @@ We use the UTF.Unknown NuGet package for detecting encoding in text/code files.
      shall survive.
 
      8.2.  If You initiate litigation by asserting a patent infringement
-     claim (excluding declatory judgment actions) against Initial Developer
+     claim (excluding declaratory judgment actions) against Initial Developer
      or a Contributor (the Initial Developer or Contributor against whom
      You file such action is referred to as "Participant")  alleging that:
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

The MPL license in NOTICE.md contains a typo. It mentions "declatory judgement actions" instead of "declaratory judgement actions.

This PR corrects the typo and removes "declatory" from the spell check exceptions.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
spellcheck runs successfully after the removal of the "declatory" typo.
