### PR TITLE
[QuickAccent] Fix minimum width being too large

### DIFF
--- a/src/modules/poweraccent/PowerAccent.UI/Selector.xaml
+++ b/src/modules/poweraccent/PowerAccent.UI/Selector.xaml
@@ -6,7 +6,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
     Title="MainWindow"
-    MinWidth="600"
+    MinWidth="0"
     MinHeight="0"
     ui:Design.Background="{DynamicResource ApplicationBackgroundBrush}"
     DataContext="{Binding RelativeSource={RelativeSource Self}}"

--- a/src/modules/poweraccent/PowerAccent.UI/Selector.xaml
+++ b/src/modules/poweraccent/PowerAccent.UI/Selector.xaml
@@ -102,6 +102,7 @@
 
         <Grid
             Grid.Row="1"
+            MinWidth="600"
             Background="{DynamicResource LayerOnAcrylicFillColorDefaultBrush}"
             Visibility="{Binding CharacterNameVisibility, UpdateSourceTrigger=PropertyChanged}">
             <TextBlock


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
After the recent move to WPFUI, Quick Accent started respecting its minimum width, but it doesn't look great when we have small characters.
![image](https://github.com/microsoft/PowerToys/assets/26118718/e31f0604-e8df-4281-939a-da4a57a21020)

This PR removes this minimum width.
