### PR TITLE
[PTRun]Don't try to get an icon with an empty filename

### DIFF
--- a/src/modules/launcher/Wox.Infrastructure/Image/WindowsThumbnailProvider.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Image/WindowsThumbnailProvider.cs
@@ -83,13 +83,17 @@ namespace Wox.Infrastructure.Image
         public static BitmapSource GetThumbnail(string fileName, int width, int height, ThumbnailOptions options)
         {
             IntPtr hBitmap = IntPtr.Zero;
+            string targetLinkedFilePath = string.Empty;
             if (Path.GetExtension(fileName).Equals(".lnk", StringComparison.OrdinalIgnoreCase))
             {
                 // If the file has a '.lnk' extension, it is a shortcut file. Use the shellLinkHelper to retrieve the actual target file path from the shortcut.
                 IShellLinkHelper shellLinkHelper = new ShellLinkHelper();
+                targetLinkedFilePath = shellLinkHelper.RetrieveTargetPath(fileName);
+            }
 
-                string targetFilePath = shellLinkHelper.RetrieveTargetPath(fileName);
-                hBitmap = ExtractIconToHBitmap(targetFilePath);
+            if (!string.IsNullOrEmpty(targetLinkedFilePath))
+            {
+                hBitmap = ExtractIconToHBitmap(targetLinkedFilePath);
             }
             else
             {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

@niels9001  reported having got an exception from System.Drawing.Icon.ExtractAssociatedIcon being called with a null or empty path.
This seems to have been caused by  https://github.com/microsoft/PowerToys/commit/912d7ec060beffa8d9c21ef91928826e0a912541

This PR guards against this scenario.
