### PR TITLE
[Peek]Force white background on html after WebView2 update

### DIFF
--- a/src/modules/peek/Peek.FilePreviewer/Controls/BrowserControl.xaml.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Controls/BrowserControl.xaml.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.UI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.Web.WebView2.Core;
@@ -135,7 +136,8 @@ namespace Peek.FilePreviewer.Controls
                 // Storing the original background color so it can be reset later for specific file types like HTML.
                 if (!_originalBackgroundColor.HasValue)
                 {
-                    _originalBackgroundColor = PreviewBrowser.DefaultBackgroundColor;
+                    // HACK: We used to store PreviewBrowser.DefaultBackgroundColor here, but WebView started returning transparent when running without a debugger attached. We want html files to be seen as in the browser, which has white as a default background color.
+                    _originalBackgroundColor = Colors.White;
                 }
 
                 // Setting the background color to transparent when initially loading the WebView2 component.


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

After the recent WebView2 version bump, DefaultBackgroundColor for WebView2 started being initialized with transparent instead of white, unless you put some break points before getting this property. So the _Loaded event of the controller and EnsureCoreWebView2Async are no longer good garantees that this code is working.

This PR forces the white background color.

## Validation Steps Performed
Tested with this html file, which looks good on 0.75.1 and looked badly on main.
[testhtml2.zip](https://github.com/microsoft/PowerToys/files/13451875/testhtml2.zip)

