### PR TITLE
[KBM]Change UI strings to mention remap to text

### DIFF
--- a/src/modules/keyboardmanager/KeyboardManagerEditor/Resources.resx
+++ b/src/modules/keyboardmanager/KeyboardManagerEditor/Resources.resx
@@ -184,7 +184,7 @@
     <comment>Key on a keyboard</comment>
   </data>
   <data name="EditShortcuts_Info" xml:space="preserve">
-    <value>Select the shortcut you want to change ("Select") and then the key, shortcut or text you want it to invoke ("To send").</value>
+    <value>Select the shortcut you want to change ("Select") and then configure the key, shortcut or text you want it to send ("To send").</value>
     <comment>Key on a keyboard</comment>
   </data>
   <data name="EditShortcuts_InfoExample" xml:space="preserve">

--- a/src/modules/keyboardmanager/KeyboardManagerEditor/Resources.resx
+++ b/src/modules/keyboardmanager/KeyboardManagerEditor/Resources.resx
@@ -177,7 +177,7 @@
     <value>Some of the shortcuts could not be remapped. Continue anyway?</value>
   </data>
   <data name="EditKeyboard_Info" xml:space="preserve">
-    <value>Select the key you want to change ("Select") and then the key, shortcut or text you want it to send ("To send").</value>
+    <value>Select the key you want to change ("Select") and then configure the key, shortcut or text you want it to send ("To send").</value>
   </data>
   <data name="EditKeyboard_InfoExample" xml:space="preserve">
     <value>Example of a remapping: Select A and send "Ctrl+C", "A" would be your "Select" and "Ctrl+C" would be your "To send" command.</value>

--- a/src/modules/keyboardmanager/KeyboardManagerEditor/Resources.resx
+++ b/src/modules/keyboardmanager/KeyboardManagerEditor/Resources.resx
@@ -177,14 +177,14 @@
     <value>Some of the shortcuts could not be remapped. Continue anyway?</value>
   </data>
   <data name="EditKeyboard_Info" xml:space="preserve">
-    <value>Select the key you want to change ("Select") and then the key or shortcut you want it to send ("To send").</value>
+    <value>Select the key you want to change ("Select") and then the key, shortcut or text you want it to send ("To send").</value>
   </data>
   <data name="EditKeyboard_InfoExample" xml:space="preserve">
     <value>Example of a remapping: Select A and send "Ctrl+C", "A" would be your "Select" and "Ctrl+C" would be your "To send" command.</value>
     <comment>Key on a keyboard</comment>
   </data>
   <data name="EditShortcuts_Info" xml:space="preserve">
-    <value>Select the shortcut you want to change ("Select") and then the key or shortcut you want it to invoke ("To send").</value>
+    <value>Select the shortcut you want to change ("Select") and then the key, shortcut or text you want it to invoke ("To send").</value>
     <comment>Key on a keyboard</comment>
   </data>
   <data name="EditShortcuts_InfoExample" xml:space="preserve">
@@ -290,11 +290,8 @@
   <data name="Mapping_Type_DropDown_Text" xml:space="preserve">
     <value>Text</value>
   </data>
-  <data name="Mapping_Type_DropDown_Shortcut" xml:space="preserve">
-    <value>Shortcut</value>
-  </data>
-  <data name="Mapping_Type_DropDown_Key" xml:space="preserve">
-    <value>Key</value>
+  <data name="Mapping_Type_DropDown_Key_Shortcut" xml:space="preserve">
+    <value>Key/Shortcut</value>
     <comment>Key on a keyboard</comment>
   </data>
   <data name="Add_Key_Remap_Button" xml:space="preserve">

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/KeyboardManagerEditorStrings.h
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/KeyboardManagerEditorStrings.h
@@ -17,14 +17,9 @@ namespace KeyboardManagerEditorStrings
         return GET_RESOURCE_STRING(IDS_MAPPING_TYPE_DROPDOWN_TEXT);
     }
 
-    inline std::wstring MappingTypeShortcut()
+    inline std::wstring MappingTypeKeyShortcut()
     {
-        return GET_RESOURCE_STRING(IDS_MAPPING_TYPE_DROPDOWN_SHORTCUT);
-    }
-
-    inline std::wstring MappingTypeKey()
-    {
-        return GET_RESOURCE_STRING(IDS_MAPPING_TYPE_DROPDOWN_KEY);
+        return GET_RESOURCE_STRING(IDS_MAPPING_TYPE_DROPDOWN_KEY_SHORTCUT);
     }
 
     // Function to return the error message

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/ShortcutControl.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/ShortcutControl.cpp
@@ -124,7 +124,7 @@ void ShortcutControl::AddNewShortcutControlRow(StackPanel& parent, std::vector<s
 
     auto typeCombo = ComboBox();
     typeCombo.Width(EditorConstants::RemapTableDropDownWidth);
-    typeCombo.Items().Append(winrt::box_value(KeyboardManagerEditorStrings::MappingTypeShortcut()));
+    typeCombo.Items().Append(winrt::box_value(KeyboardManagerEditorStrings::MappingTypeKeyShortcut()));
     typeCombo.Items().Append(winrt::box_value(KeyboardManagerEditorStrings::MappingTypeText()));
     auto controlStackPanel = keyboardRemapControlObjects.back()[1]->shortcutControlLayout.as<StackPanel>();
     auto firstLineStackPanel = keyboardRemapControlObjects.back()[1]->keyComboAndSelectStackPanel.as<StackPanel>();

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/SingleKeyRemapControl.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/SingleKeyRemapControl.cpp
@@ -77,7 +77,7 @@ SingleKeyRemapControl::SingleKeyRemapControl(StackPanel table, StackPanel row, c
 
         auto typeCombo = ComboBox();
         typeCombo.Width(EditorConstants::RemapTableDropDownWidth);
-        typeCombo.Items().Append(winrt::box_value(KeyboardManagerEditorStrings::MappingTypeKey()));
+        typeCombo.Items().Append(winrt::box_value(KeyboardManagerEditorStrings::MappingTypeKeyShortcut()));
         typeCombo.Items().Append(winrt::box_value(KeyboardManagerEditorStrings::MappingTypeText()));
         keyComboAndSelectStackPanel.Children().Append(typeCombo);
         keyComboAndSelectStackPanel.Children().Append(typeKey.as<Button>());

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -1495,10 +1495,10 @@
     <value>Encoding</value>
   </data>
   <data name="KeyboardManager_RemapKeyboardButton.Description" xml:space="preserve">
-    <value>Remap keys to other keys or shortcuts</value>
+    <value>Remap keys to other keys, shortcuts or text snippets</value>
   </data>
   <data name="KeyboardManager_RemapShortcutsButton.Description" xml:space="preserve">
-    <value>Remap shortcuts to other shortcuts or keys for all or specific applications</value>
+    <value>Remap shortcuts to other shortcuts, keys or text snippets for all or specific applications</value>
   </data>
   <data name="General.ModuleDescription" xml:space="preserve">
     <value>Microsoft PowerToys is a set of utilities for power users to tune and streamline their Windows experience for greater productivity.


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Keyboard Manager will now allow remapping to text as well. This PR tweaks the strings in the UI to mention the remap to text as well.

![image](https://github.com/microsoft/PowerToys/assets/26118718/1ca0ab3e-acce-404b-8884-83e02986905b)

![image](https://github.com/microsoft/PowerToys/assets/26118718/34658139-5137-40a2-acca-5118ef0a4401)

![image](https://github.com/microsoft/PowerToys/assets/26118718/9453b7ea-fd04-4978-9dd7-4d74157adfb5)


<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Ran Settings and KBM Editor and verified the strings were changed.
