### PR TITLE
[ci]Fix 1ES Pipeline to stable release

### DIFF
--- a/.pipelines/release.yml
+++ b/.pipelines/release.yml
@@ -8,7 +8,7 @@ resources:
   - repository: 1ESPipelineTemplates
     type: git
     name: 1ESPipelineTemplates/1ESPipelineTemplates
-    ref: refs/tags/release
+    ref: refs/tags/release-2023-11-13-4
 
 parameters:
   - name: buildConfigurations


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

With the release of the latest 1ES Enterprise template on CI, our builds started failing the Guardian Post-Analysis checks.
Reverting to the release of the 1ES Enterprise template prior to the latest one fixes this to enable release until we figure out a better long term solution.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Dart CI successfully builds again.
