### PR TITLE
[FancyZones] FZEditor not excluded fix

### DIFF
--- a/src/common/utils/excluded_apps.h
+++ b/src/common/utils/excluded_apps.h
@@ -32,7 +32,7 @@ inline bool find_folder_in_path(const std::wstring& where, const std::vector<std
 }
 
 #define MAX_TITLE_LENGTH 255
-inline bool check_excluded_app_with_title(const HWND& hwnd, std::wstring& processPath, const std::vector<std::wstring>& excludedApps)
+inline bool check_excluded_app_with_title(const HWND& hwnd, const std::vector<std::wstring>& excludedApps)
 {
     WCHAR title[MAX_TITLE_LENGTH];
     int len = GetWindowTextW(hwnd, title, MAX_TITLE_LENGTH);
@@ -42,23 +42,25 @@ inline bool check_excluded_app_with_title(const HWND& hwnd, std::wstring& proces
     }
 
     std::wstring titleStr(title);
-    auto lastBackslashPos = processPath.find_last_of(L'\\');
-    if (lastBackslashPos != std::wstring::npos)
+    CharUpperBuffW(titleStr.data(), static_cast<DWORD>(titleStr.length()));
+
+    for (const auto& app : excludedApps)
     {
-        processPath = processPath.substr(0, lastBackslashPos + 1); // retain up to the last backslash
-        processPath.append(titleStr); // append the title
+        if (titleStr.contains(app))
+        {
+            return true;
+        }
     }
-    CharUpperBuffW(processPath.data(), static_cast<DWORD>(processPath.length()));
-    return find_app_name_in_path(processPath, excludedApps);
+    return false;
 }
 
-inline bool check_excluded_app(const HWND& hwnd, std::wstring& processPath, const std::vector<std::wstring>& excludedApps)
+inline bool check_excluded_app(const HWND& hwnd, const std::wstring& processPath, const std::vector<std::wstring>& excludedApps)
 {
     bool res = find_app_name_in_path(processPath, excludedApps);
 
     if (!res)
     {
-        res = check_excluded_app_with_title(hwnd, processPath, excludedApps);
+        res = check_excluded_app_with_title(hwnd, excludedApps);
     }
 
     return res;

--- a/src/modules/fancyzones/FancyZonesLib/WindowUtils.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WindowUtils.cpp
@@ -202,12 +202,12 @@ bool FancyZonesWindowUtils::IsExcluded(HWND window)
     return false;
 }
 
-bool FancyZonesWindowUtils::IsExcludedByUser(const HWND& hwnd, std::wstring& processPath) noexcept
+bool FancyZonesWindowUtils::IsExcludedByUser(const HWND& hwnd, const std::wstring& processPath) noexcept
 {
     return (check_excluded_app(hwnd, processPath, FancyZonesSettings::settings().excludedAppsArray));
 }
 
-bool FancyZonesWindowUtils::IsExcludedByDefault(const HWND& hwnd, std::wstring& processPath) noexcept
+bool FancyZonesWindowUtils::IsExcludedByDefault(const HWND& hwnd, const std::wstring& processPath) noexcept
 {
     static std::vector<std::wstring> defaultExcludedFolders = { NonLocalizable::SystemAppsFolder };
     if (find_folder_in_path(processPath, defaultExcludedFolders))

--- a/src/modules/fancyzones/FancyZonesLib/WindowUtils.h
+++ b/src/modules/fancyzones/FancyZonesLib/WindowUtils.h
@@ -27,8 +27,8 @@ namespace FancyZonesWindowUtils
     bool IsProcessOfWindowElevated(HWND window); // If HWND is already dead, we assume it wasn't elevated
     
     bool IsExcluded(HWND window);
-    bool IsExcludedByUser(const HWND& hwnd, std::wstring& processPath) noexcept;
-    bool IsExcludedByDefault(const HWND& hwnd, std::wstring& processPath) noexcept;
+    bool IsExcludedByUser(const HWND& hwnd, const std::wstring& processPath) noexcept;
+    bool IsExcludedByDefault(const HWND& hwnd, const std::wstring& processPath) noexcept;
 
     void SwitchToWindow(HWND window) noexcept;
     void SizeWindowToRect(HWND window, RECT rect) noexcept; // Parameter rect must be in screen coordinates (e.g. obtained from GetWindowRect)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Updated `check_excluded_app_with_title` so it doesn't change the process path string.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #30136 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

* Turn on `Move newly created windows to the current active monitor.`
* Open editor
* Verify the editor's layout windows are not moved to the active monitor.