### PR TITLE
[Run] Switch to WPF UI theme manager

### DIFF
--- a/src/modules/PowerOCR/PowerOCR/OCROverlay.xaml.cs
+++ b/src/modules/PowerOCR/PowerOCR/OCROverlay.xaml.cs
@@ -50,15 +50,7 @@ public partial class OCROverlay : Window
 
         InitializeComponent();
 
-        // workaround for #30177
-        try
-        {
-            Wpf.Ui.Appearance.SystemThemeWatcher.Watch(this, Wpf.Ui.Controls.WindowBackdropType.None);
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError($"Exception in SystemThemeWatcher.Watch, issue 30177. {ex.Message}");
-        }
+        Wpf.Ui.Appearance.SystemThemeWatcher.Watch(this, Wpf.Ui.Controls.WindowBackdropType.None);
 
         PopulateLanguageMenu();
     }

--- a/src/modules/imageresizer/ui/Views/MainWindow.xaml.cs
+++ b/src/modules/imageresizer/ui/Views/MainWindow.xaml.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Common.UI;
 using ImageResizer.ViewModels;
-using ManagedCommon;
 using Microsoft.Win32;
 using Wpf.Ui.Controls;
 using AppResources = ImageResizer.Properties.Resources;
@@ -31,15 +30,7 @@ namespace ImageResizer.Views
                 WindowBackdropType = WindowBackdropType.None;
             }
 
-            // workaround for #30177
-            try
-            {
-                Wpf.Ui.Appearance.SystemThemeWatcher.Watch(this, WindowBackdropType);
-            }
-            catch (Exception ex)
-            {
-                Logger.LogError($"Exception in SystemThemeWatcher.Watch, issue 30177. {ex.Message}");
-            }
+            Wpf.Ui.Appearance.SystemThemeWatcher.Watch(this, WindowBackdropType);
         }
 
         public IEnumerable<string> OpenPictureFiles()

--- a/src/modules/launcher/PowerLauncher/App.xaml
+++ b/src/modules/launcher/PowerLauncher/App.xaml
@@ -2,13 +2,11 @@
     x:Class="PowerLauncher.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:theming="clr-namespace:Common.UI;assembly=PowerToys.Common.UI"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
     ShutdownMode="OnMainWindowClose"
     Startup="OnStartup">
     <Application.Resources>
         <ResourceDictionary>
-            <theming:CustomLibraryThemeProvider x:Key="{x:Static theming:CustomLibraryThemeProvider.DefaultInstance}" />
             <ResourceDictionary.MergedDictionaries>
                 <ui:ThemesDictionary Theme="Dark" />
                 <ui:ControlsDictionary />

--- a/src/modules/launcher/PowerLauncher/App.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/App.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation
+﻿// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -41,7 +41,6 @@ namespace PowerLauncher
         private PowerToysRunSettings _settings;
         private MainViewModel _mainVM;
         private MainWindow _mainWindow;
-        private ThemeManager _themeManager;
         private SettingWindowViewModel _settingsVM;
         private StringMatcher _stringMatcher;
         private SettingsReader _settingsReader;
@@ -122,8 +121,7 @@ namespace PowerLauncher
                 RegisterAppDomainExceptions();
                 RegisterDispatcherUnhandledException();
 
-                _themeManager = new ThemeManager(this);
-                ImageLoader.Initialize(_themeManager.GetCurrentTheme());
+                ImageLoader.Initialize(ApplicationThemeManager.GetAppTheme().ToTheme());
 
                 _settingsVM = new SettingWindowViewModel();
                 _settings = _settingsVM.Settings;
@@ -136,8 +134,8 @@ namespace PowerLauncher
 
                 _mainVM = new MainViewModel(_settings, NativeThreadCTS.Token);
                 _mainWindow = new MainWindow(_settings, _mainVM, NativeThreadCTS.Token);
-                API = new PublicAPIInstance(_settingsVM, _mainVM, _alphabet, _themeManager);
-                _settingsReader = new SettingsReader(_settings, _themeManager);
+                API = new PublicAPIInstance(_settingsVM, _mainVM, _alphabet);
+                _settingsReader = new SettingsReader(_settings, _mainWindow);
                 _settingsReader.ReadSettings();
 
                 PluginManager.InitializePlugins(API);
@@ -151,10 +149,6 @@ namespace PowerLauncher
                 RegisterExitEvents();
 
                 _settingsReader.ReadSettingsOnChange();
-
-                _themeManager.ThemeChanged += OnThemeChanged;
-
-                OnThemeChanged(_settings.Theme, _settings.Theme);
 
                 textToLog.AppendLine("End PowerToys Run startup ----------------------------------------------------  ");
 
@@ -215,48 +209,6 @@ namespace PowerLauncher
         }
 
         /// <summary>
-        /// Callback when windows theme is changed.
-        /// </summary>
-        /// <param name="oldTheme">Previous Theme</param>
-        /// <param name="newTheme">Current Theme</param>
-        private void OnThemeChanged(Theme oldTheme, Theme newTheme)
-        {
-            // If OS theme is high contrast, don't change theme.
-            if (SystemParameters.HighContrast)
-            {
-                return;
-            }
-
-            ApplicationTheme theme = ApplicationTheme.Unknown;
-
-            switch (newTheme)
-            {
-                case Theme.Dark:
-                    theme = ApplicationTheme.Dark; break;
-                case Theme.Light:
-                    theme = ApplicationTheme.Light; break;
-                case Theme.HighContrastWhite:
-                case Theme.HighContrastBlack:
-                case Theme.HighContrastOne:
-                case Theme.HighContrastTwo:
-                    theme = ApplicationTheme.HighContrast; break;
-                default:
-                    break;
-            }
-
-            _mainWindow?.Dispatcher.Invoke(() =>
-            {
-                if (theme != ApplicationTheme.Unknown)
-                {
-                    ApplicationThemeManager.Apply(theme);
-                }
-            });
-
-            ImageLoader.UpdateIconPath(newTheme);
-            _mainVM.Query();
-        }
-
-        /// <summary>
         /// let exception throw as normal is better for Debug
         /// </summary>
         [Conditional("RELEASE")]
@@ -302,11 +254,6 @@ namespace PowerLauncher
                 Log.Info("Start PowerToys Run Exit----------------------------------------------------  ", GetType());
                 if (disposing)
                 {
-                    if (_themeManager != null)
-                    {
-                        _themeManager.ThemeChanged -= OnThemeChanged;
-                    }
-
                     API?.SaveAppAllSettings();
                     PluginManager.Dispose();
 
@@ -314,7 +261,6 @@ namespace PowerLauncher
                     _mainWindow?.Dispatcher.Invoke(Dispose);
                     API?.Dispose();
                     _mainVM?.Dispose();
-                    _themeManager?.Dispose();
                 }
 
                 Log.Info("End PowerToys Run Exit ----------------------------------------------------  ", GetType());

--- a/src/modules/launcher/PowerLauncher/App.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/App.xaml.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Windows;
-using Common.UI;
 using interop;
 using ManagedCommon;
 using Microsoft.PowerLauncher.Telemetry;
@@ -40,10 +39,10 @@ namespace PowerLauncher
         private PowerToysRunSettings _settings;
         private MainViewModel _mainVM;
         private MainWindow _mainWindow;
+        private ThemeManager _themeManager;
         private SettingWindowViewModel _settingsVM;
         private StringMatcher _stringMatcher;
         private SettingsReader _settingsReader;
-        private ThemeManager _themeManager;
 
         // To prevent two disposals running at the same time.
         private static readonly object _disposingLock = new object();
@@ -81,7 +80,7 @@ namespace PowerLauncher
             {
                 application.InitializeComponent();
 
-                NativeEventWaiter.WaitForEventLoop(
+                Common.UI.NativeEventWaiter.WaitForEventLoop(
                     Constants.RunExitEvent(),
                     () =>
                     {

--- a/src/modules/launcher/PowerLauncher/App.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/App.xaml.cs
@@ -120,6 +120,8 @@ namespace PowerLauncher
                 RegisterAppDomainExceptions();
                 RegisterDispatcherUnhandledException();
 
+                ImageLoader.Initialize();
+
                 _settingsVM = new SettingWindowViewModel();
                 _settings = _settingsVM.Settings;
                 _settings.StartedFromPowerToysRunner = e.Args.Contains("--started-from-runner");
@@ -132,7 +134,6 @@ namespace PowerLauncher
                 _mainVM = new MainViewModel(_settings, NativeThreadCTS.Token);
                 _mainWindow = new MainWindow(_settings, _mainVM, NativeThreadCTS.Token);
                 _themeManager = new ThemeManager(_settings, _mainWindow);
-                ImageLoader.Initialize(_themeManager.CurrentTheme);
                 API = new PublicAPIInstance(_settingsVM, _mainVM, _alphabet, _themeManager);
                 _settingsReader = new SettingsReader(_settings, _themeManager);
                 _settingsReader.ReadSettings();

--- a/src/modules/launcher/PowerLauncher/Helper/ThemeExtensions.cs
+++ b/src/modules/launcher/PowerLauncher/Helper/ThemeExtensions.cs
@@ -22,20 +22,6 @@ namespace PowerLauncher.Helper
             };
         }
 
-        public static ApplicationTheme ToApplicationTheme(this Theme theme)
-        {
-            return theme switch
-            {
-                Theme.Dark => ApplicationTheme.Dark,
-                Theme.Light => ApplicationTheme.Light,
-                Theme.HighContrastWhite => ApplicationTheme.HighContrast,
-                Theme.HighContrastBlack => ApplicationTheme.HighContrast,
-                Theme.HighContrastOne => ApplicationTheme.HighContrast,
-                Theme.HighContrastTwo => ApplicationTheme.HighContrast,
-                _ => ApplicationTheme.Unknown,
-            };
-        }
-
         private static Theme GetHighContrastBaseType()
         {
             string registryKey = @"HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Themes";

--- a/src/modules/launcher/PowerLauncher/Helper/ThemeExtensions.cs
+++ b/src/modules/launcher/PowerLauncher/Helper/ThemeExtensions.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using ManagedCommon;
+using Microsoft.Win32;
+using Wpf.Ui.Appearance;
+
+namespace PowerLauncher.Helper
+{
+    public static class ThemeExtensions
+    {
+        public static Theme ToTheme(this ApplicationTheme applicationTheme)
+        {
+            return applicationTheme switch
+            {
+                ApplicationTheme.Dark => Theme.Dark,
+                ApplicationTheme.Light => Theme.Light,
+                ApplicationTheme.HighContrast => GetHighContrastBaseType(),
+                _ => Theme.Light,
+            };
+        }
+
+        public static ApplicationTheme ToApplicationTheme(this Theme theme)
+        {
+            return theme switch
+            {
+                Theme.Dark => ApplicationTheme.Dark,
+                Theme.Light => ApplicationTheme.Light,
+                Theme.HighContrastWhite => ApplicationTheme.HighContrast,
+                Theme.HighContrastBlack => ApplicationTheme.HighContrast,
+                Theme.HighContrastOne => ApplicationTheme.HighContrast,
+                Theme.HighContrastTwo => ApplicationTheme.HighContrast,
+                _ => ApplicationTheme.Unknown,
+            };
+        }
+
+        private static Theme GetHighContrastBaseType()
+        {
+            string registryKey = @"HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Themes";
+            string theme = (string)Registry.GetValue(registryKey, "CurrentTheme", string.Empty);
+            theme = theme.Split('\\').Last().Split('.').First().ToString();
+
+            switch (theme)
+            {
+                case "hc1":
+                    return Theme.HighContrastOne;
+                case "hc2":
+                    return Theme.HighContrastTwo;
+                case "hcwhite":
+                    return Theme.HighContrastWhite;
+                case "hcblack":
+                    return Theme.HighContrastBlack;
+                default:
+                    return Theme.HighContrastOne;
+            }
+        }
+    }
+}

--- a/src/modules/launcher/PowerLauncher/Helper/ThemeManager.cs
+++ b/src/modules/launcher/PowerLauncher/Helper/ThemeManager.cs
@@ -45,7 +45,6 @@ namespace PowerLauncher.Helper
             }
             else if (fromSettings)
             {
-                _currentTheme = ApplicationThemeManager.GetAppTheme().ToTheme();
                 _mainWindow?.Dispatcher.Invoke(ApplicationThemeManager.ApplySystemTheme);
             }
 

--- a/src/modules/launcher/PowerLauncher/Helper/ThemeManager.cs
+++ b/src/modules/launcher/PowerLauncher/Helper/ThemeManager.cs
@@ -4,6 +4,7 @@
 
 using System;
 using ManagedCommon;
+using Wox.Infrastructure.Image;
 using Wox.Infrastructure.UserSettings;
 using Wpf.Ui.Appearance;
 
@@ -48,6 +49,7 @@ namespace PowerLauncher.Helper
                 _mainWindow?.Dispatcher.Invoke(ApplicationThemeManager.ApplySystemTheme);
             }
 
+            ImageLoader.UpdateIconPath(_currentTheme);
             ThemeChanged?.Invoke(_currentTheme, _currentTheme);
         }
 

--- a/src/modules/launcher/PowerLauncher/Helper/ThemeManager.cs
+++ b/src/modules/launcher/PowerLauncher/Helper/ThemeManager.cs
@@ -50,6 +50,8 @@ namespace PowerLauncher.Helper
             }
 
             ImageLoader.UpdateIconPath(_currentTheme);
+
+            // oldTheme isn't used
             ThemeChanged?.Invoke(_currentTheme, _currentTheme);
         }
 

--- a/src/modules/launcher/PowerLauncher/Helper/ThemeManager.cs
+++ b/src/modules/launcher/PowerLauncher/Helper/ThemeManager.cs
@@ -4,11 +4,10 @@
 
 using System;
 using ManagedCommon;
-using PowerLauncher.Helper;
 using Wox.Infrastructure.UserSettings;
 using Wpf.Ui.Appearance;
 
-namespace PowerLauncher
+namespace PowerLauncher.Helper
 {
     public class ThemeManager : IDisposable
     {

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -15,7 +15,6 @@ using System.Windows.Interop;
 using System.Windows.Media.Imaging;
 using Common.UI;
 using interop;
-using ManagedCommon;
 using Microsoft.PowerLauncher.Telemetry;
 using Microsoft.PowerToys.Telemetry;
 using PowerLauncher.Helper;
@@ -58,12 +57,16 @@ namespace PowerLauncher
             _settings = settings;
             InitializeComponent();
 
-            WindowBackdropType = OSVersionHelper.IsWindows11()
-                ? Wpf.Ui.Controls.WindowBackdropType.Acrylic
-                : Wpf.Ui.Controls.WindowBackdropType.None;
+            if (OSVersionHelper.IsWindows11())
+            {
+                WindowBackdropType = Wpf.Ui.Controls.WindowBackdropType.Acrylic;
+            }
+            else
+            {
+                WindowBackdropType = Wpf.Ui.Controls.WindowBackdropType.None;
+            }
 
             SystemThemeWatcher.Watch(this, WindowBackdropType);
-            ApplicationThemeManager.Changed += ApplicationThemeManager_Changed;
 
             _firstDeleteTimer.Elapsed += CheckForFirstDelete;
             _firstDeleteTimer.Interval = 1000;
@@ -72,35 +75,6 @@ namespace PowerLauncher
                 SendSettingsTelemetry,
                 Application.Current.Dispatcher,
                 _nativeWaiterCancelToken);
-        }
-
-        public void SetTheme(bool fromSettings)
-        {
-            if (_settings.Theme == Theme.Light)
-            {
-                ApplicationThemeManager.Apply(ApplicationTheme.Light, WindowBackdropType);
-            }
-            else if (_settings.Theme == Theme.Dark)
-            {
-                ApplicationThemeManager.Apply(ApplicationTheme.Dark, WindowBackdropType);
-            }
-            else if (fromSettings)
-            {
-                ApplicationThemeManager.ApplySystemTheme();
-            }
-        }
-
-        private void ApplicationThemeManager_Changed(ApplicationTheme currentApplicationTheme, System.Windows.Media.Color systemAccent)
-        {
-            try
-            {
-                ApplicationThemeManager.Changed -= ApplicationThemeManager_Changed;
-                SetTheme(false);
-            }
-            finally
-            {
-                ApplicationThemeManager.Changed += ApplicationThemeManager_Changed;
-            }
         }
 
         private void SendSettingsTelemetry()
@@ -203,8 +177,6 @@ namespace PowerLauncher
 
         private void OnLoaded(object sender, RoutedEventArgs e)
         {
-            SetTheme(false);
-
             WindowsInteropHelper.DisableControlBox(this);
             InitializePosition();
 
@@ -826,7 +798,6 @@ namespace PowerLauncher
                 {
                     _firstDeleteTimer?.Dispose();
                     _hwndSource?.Dispose();
-                    ApplicationThemeManager.Changed -= ApplicationThemeManager_Changed;
                 }
 
                 _firstDeleteTimer = null;

--- a/src/modules/launcher/PowerLauncher/PowerLauncher.csproj
+++ b/src/modules/launcher/PowerLauncher/PowerLauncher.csproj
@@ -80,7 +80,6 @@
     <PackageReference Include="Microsoft.Data.Sqlite" />
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" />
-    <PackageReference Include="ModernWpfUI" />
     <PackageReference Include="ScipBe.Common.Office.OneNote" />
     <PackageReference Include="System.Reactive" />
     <PackageReference Include="System.Data.OleDb" />

--- a/src/modules/launcher/PowerLauncher/PublicAPIInstance.cs
+++ b/src/modules/launcher/PowerLauncher/PublicAPIInstance.cs
@@ -6,18 +6,15 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
-using System.Windows.Media;
-using Common.UI;
 using ManagedCommon;
 using Microsoft.Toolkit.Uwp.Notifications;
-using PowerLauncher.Helper;
+using PowerLauncher;
 using PowerLauncher.Plugin;
 using PowerLauncher.ViewModel;
 using Windows.UI.Notifications;
 using Wox.Infrastructure;
 using Wox.Infrastructure.Image;
 using Wox.Plugin;
-using Wpf.Ui.Appearance;
 
 namespace Wox
 {
@@ -26,26 +23,27 @@ namespace Wox
         private readonly SettingWindowViewModel _settingsVM;
         private readonly MainViewModel _mainVM;
         private readonly Alphabet _alphabet;
+        private readonly ThemeManager _themeManager;
         private bool _disposed;
 
-        public event ThemeChangedHandler ThemeChanged;
+        public event Common.UI.ThemeChangedHandler ThemeChanged;
 
-        public PublicAPIInstance(SettingWindowViewModel settingsVM, MainViewModel mainVM, Alphabet alphabet)
+        public PublicAPIInstance(SettingWindowViewModel settingsVM, MainViewModel mainVM, Alphabet alphabet, ThemeManager themeManager)
         {
             _settingsVM = settingsVM ?? throw new ArgumentNullException(nameof(settingsVM));
             _mainVM = mainVM ?? throw new ArgumentNullException(nameof(mainVM));
             _alphabet = alphabet ?? throw new ArgumentNullException(nameof(alphabet));
-            ApplicationThemeManager.Changed += OnThemeChanged;
+            _themeManager = themeManager ?? throw new ArgumentNullException(nameof(themeManager));
+            _themeManager.ThemeChanged += OnThemeChanged;
 
             ToastNotificationManagerCompat.OnActivated += args =>
             {
             };
         }
 
-        private void OnThemeChanged(ApplicationTheme currentApplicationTheme, Color systemAccent)
+        private void OnThemeChanged(Theme oldTheme, Theme newTheme)
         {
-            // oldTheme isn't used
-            ThemeChanged?.Invoke(currentApplicationTheme.ToTheme(), currentApplicationTheme.ToTheme());
+            ThemeChanged?.Invoke(oldTheme, newTheme);
         }
 
         public void RemoveUserSelectedItem(Result result)
@@ -109,7 +107,7 @@ namespace Wox
 
         public Theme GetCurrentTheme()
         {
-            return ApplicationThemeManager.GetAppTheme().ToTheme();
+            return _themeManager.CurrentTheme;
         }
 
         public void Dispose()
@@ -118,18 +116,13 @@ namespace Wox
             GC.SuppressFinalize(this);
         }
 
-        protected void OnThemeChanged(Theme oldTheme, Theme newTheme)
-        {
-            ThemeChanged?.Invoke(oldTheme, newTheme);
-        }
-
         protected virtual void Dispose(bool disposing)
         {
             if (!_disposed)
             {
                 if (disposing)
                 {
-                    ApplicationThemeManager.Changed -= OnThemeChanged;
+                    _themeManager.ThemeChanged -= OnThemeChanged;
                     _disposed = true;
                 }
             }

--- a/src/modules/launcher/PowerLauncher/PublicAPIInstance.cs
+++ b/src/modules/launcher/PowerLauncher/PublicAPIInstance.cs
@@ -8,7 +8,7 @@ using System.Linq;
 using System.Windows;
 using ManagedCommon;
 using Microsoft.Toolkit.Uwp.Notifications;
-using PowerLauncher;
+using PowerLauncher.Helper;
 using PowerLauncher.Plugin;
 using PowerLauncher.ViewModel;
 using Windows.UI.Notifications;
@@ -39,11 +39,6 @@ namespace Wox
             ToastNotificationManagerCompat.OnActivated += args =>
             {
             };
-        }
-
-        private void OnThemeChanged(Theme oldTheme, Theme newTheme)
-        {
-            ThemeChanged?.Invoke(oldTheme, newTheme);
         }
 
         public void RemoveUserSelectedItem(Result result)
@@ -114,6 +109,11 @@ namespace Wox
         {
             Dispose(disposing: true);
             GC.SuppressFinalize(this);
+        }
+
+        protected void OnThemeChanged(Theme oldTheme, Theme newTheme)
+        {
+            ThemeChanged?.Invoke(oldTheme, newTheme);
         }
 
         protected virtual void Dispose(bool disposing)

--- a/src/modules/launcher/PowerLauncher/PublicAPIInstance.cs
+++ b/src/modules/launcher/PowerLauncher/PublicAPIInstance.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation
+﻿// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -6,21 +6,18 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
-
+using System.Windows.Media;
 using Common.UI;
-
 using ManagedCommon;
-
 using Microsoft.Toolkit.Uwp.Notifications;
-
+using PowerLauncher.Helper;
 using PowerLauncher.Plugin;
 using PowerLauncher.ViewModel;
-
 using Windows.UI.Notifications;
-
 using Wox.Infrastructure;
 using Wox.Infrastructure.Image;
 using Wox.Plugin;
+using Wpf.Ui.Appearance;
 
 namespace Wox
 {
@@ -29,22 +26,26 @@ namespace Wox
         private readonly SettingWindowViewModel _settingsVM;
         private readonly MainViewModel _mainVM;
         private readonly Alphabet _alphabet;
-        private readonly ThemeManager _themeManager;
         private bool _disposed;
 
         public event ThemeChangedHandler ThemeChanged;
 
-        public PublicAPIInstance(SettingWindowViewModel settingsVM, MainViewModel mainVM, Alphabet alphabet, ThemeManager themeManager)
+        public PublicAPIInstance(SettingWindowViewModel settingsVM, MainViewModel mainVM, Alphabet alphabet)
         {
             _settingsVM = settingsVM ?? throw new ArgumentNullException(nameof(settingsVM));
             _mainVM = mainVM ?? throw new ArgumentNullException(nameof(mainVM));
             _alphabet = alphabet ?? throw new ArgumentNullException(nameof(alphabet));
-            _themeManager = themeManager ?? throw new ArgumentNullException(nameof(themeManager));
-            _themeManager.ThemeChanged += OnThemeChanged;
+            ApplicationThemeManager.Changed += OnThemeChanged;
 
             ToastNotificationManagerCompat.OnActivated += args =>
             {
             };
+        }
+
+        private void OnThemeChanged(ApplicationTheme currentApplicationTheme, Color systemAccent)
+        {
+            // oldTheme isn't used
+            ThemeChanged?.Invoke(currentApplicationTheme.ToTheme(), currentApplicationTheme.ToTheme());
         }
 
         public void RemoveUserSelectedItem(Result result)
@@ -108,7 +109,7 @@ namespace Wox
 
         public Theme GetCurrentTheme()
         {
-            return _themeManager.GetCurrentTheme();
+            return ApplicationThemeManager.GetAppTheme().ToTheme();
         }
 
         public void Dispose()
@@ -128,7 +129,7 @@ namespace Wox
             {
                 if (disposing)
                 {
-                    _themeManager.ThemeChanged -= OnThemeChanged;
+                    ApplicationThemeManager.Changed -= OnThemeChanged;
                     _disposed = true;
                 }
             }

--- a/src/modules/launcher/PowerLauncher/SettingsReader.cs
+++ b/src/modules/launcher/PowerLauncher/SettingsReader.cs
@@ -162,7 +162,7 @@ namespace PowerLauncher
                         {
                             if (_mainWindow.IsLoaded)
                             {
-                                _mainWindow.SetTheme();
+                                _mainWindow.SetTheme(true);
                             }
                         });
                     }

--- a/src/modules/launcher/PowerLauncher/SettingsReader.cs
+++ b/src/modules/launcher/PowerLauncher/SettingsReader.cs
@@ -29,8 +29,8 @@ namespace PowerLauncher
         private const int MaxRetries = 10;
         private static readonly object _readSyncObject = new object();
         private readonly PowerToysRunSettings _settings;
+        private readonly ThemeManager _themeManager;
         private Action _refreshPluginsOverviewCallback;
-        private ThemeManager _themeManager;
 
         private IFileSystemWatcher _watcher;
 

--- a/src/modules/launcher/PowerLauncher/SettingsReader.cs
+++ b/src/modules/launcher/PowerLauncher/SettingsReader.cs
@@ -30,15 +30,15 @@ namespace PowerLauncher
         private static readonly object _readSyncObject = new object();
         private readonly PowerToysRunSettings _settings;
         private Action _refreshPluginsOverviewCallback;
-        private MainWindow _mainWindow;
+        private ThemeManager _themeManager;
 
         private IFileSystemWatcher _watcher;
 
-        public SettingsReader(PowerToysRunSettings settings, MainWindow mainWindow)
+        public SettingsReader(PowerToysRunSettings settings, ThemeManager themeManager)
         {
             _settingsUtils = new SettingsUtils();
             _settings = settings;
-            _mainWindow = mainWindow;
+            _themeManager = themeManager;
 
             var overloadSettings = _settingsUtils.GetSettingsOrDefault<PowerLauncherSettings>(PowerLauncherSettings.ModuleName);
             UpdateSettings(overloadSettings);
@@ -157,14 +157,7 @@ namespace PowerLauncher
                     if (_settings.Theme != overloadSettings.Properties.Theme)
                     {
                         _settings.Theme = overloadSettings.Properties.Theme;
-
-                        _mainWindow?.Dispatcher.Invoke(() =>
-                        {
-                            if (_mainWindow.IsLoaded)
-                            {
-                                _mainWindow.SetTheme(true);
-                            }
-                        });
+                        _themeManager.SetTheme(true);
                     }
 
                     if (_settings.StartupPosition != overloadSettings.Properties.Position)

--- a/src/modules/launcher/PowerLauncher/ThemeManager.cs
+++ b/src/modules/launcher/PowerLauncher/ThemeManager.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using ManagedCommon;
+using PowerLauncher.Helper;
+using Wox.Infrastructure.UserSettings;
+using Wpf.Ui.Appearance;
+
+namespace PowerLauncher
+{
+    public class ThemeManager : IDisposable
+    {
+        private readonly PowerToysRunSettings _settings;
+        private readonly MainWindow _mainWindow;
+        private Theme _currentTheme;
+        private bool _disposed;
+
+        public Theme CurrentTheme => _currentTheme;
+
+        public event Common.UI.ThemeChangedHandler ThemeChanged;
+
+        public ThemeManager(PowerToysRunSettings settings, MainWindow mainWindow)
+        {
+            _settings = settings;
+            _mainWindow = mainWindow;
+            _currentTheme = ApplicationThemeManager.GetAppTheme().ToTheme();
+            SetTheme(false);
+
+            ApplicationThemeManager.Changed += ApplicationThemeManager_Changed;
+        }
+
+        public void SetTheme(bool fromSettings)
+        {
+            if (_settings.Theme == Theme.Light)
+            {
+                _currentTheme = Theme.Light;
+                _mainWindow?.Dispatcher.Invoke(() => ApplicationThemeManager.Apply(ApplicationTheme.Light, _mainWindow.WindowBackdropType));
+            }
+            else if (_settings.Theme == Theme.Dark)
+            {
+                _currentTheme = Theme.Dark;
+                _mainWindow?.Dispatcher.Invoke(() => ApplicationThemeManager.Apply(ApplicationTheme.Dark, _mainWindow.WindowBackdropType));
+            }
+            else if (fromSettings)
+            {
+                _currentTheme = ApplicationThemeManager.GetAppTheme().ToTheme();
+                _mainWindow?.Dispatcher.Invoke(ApplicationThemeManager.ApplySystemTheme);
+            }
+
+            ThemeChanged?.Invoke(_currentTheme, _currentTheme);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        private void ApplicationThemeManager_Changed(ApplicationTheme currentApplicationTheme, System.Windows.Media.Color systemAccent)
+        {
+            var newTheme = currentApplicationTheme.ToTheme();
+            if (_currentTheme == newTheme)
+            {
+                return;
+            }
+
+            _currentTheme = newTheme;
+            SetTheme(false);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                ApplicationThemeManager.Changed -= ApplicationThemeManager_Changed;
+            }
+
+            _disposed = true;
+        }
+    }
+}

--- a/src/modules/launcher/Wox.Infrastructure/Image/ImageLoader.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Image/ImageLoader.cs
@@ -31,7 +31,7 @@ namespace Wox.Infrastructure.Image
 
         private static IImageHashGenerator _hashGenerator;
 
-        public static string ErrorIconPath { get; set; }
+        public static string ErrorIconPath { get; set; } = Constant.LightThemedErrorIcon;
 
         private static readonly string[] ImageExtensions =
         {
@@ -54,7 +54,7 @@ namespace Wox.Infrastructure.Image
             return fs.Read(buffer, 0, buffer.Length) == buffer.Length && pngSignature.SequenceEqual(buffer);
         }
 
-        public static void Initialize(Theme theme)
+        public static void Initialize()
         {
             _hashGenerator = new ImageHashGenerator();
 
@@ -86,7 +86,6 @@ namespace Wox.Infrastructure.Image
                 }
             }
 
-            UpdateIconPath(theme);
             Task.Run(() =>
             {
                 Stopwatch.Normal("ImageLoader.Initialize - Preload images cost", async () =>

--- a/src/modules/poweraccent/PowerAccent.UI/Selector.xaml.cs
+++ b/src/modules/poweraccent/PowerAccent.UI/Selector.xaml.cs
@@ -5,7 +5,6 @@
 using System;
 using System.ComponentModel;
 using System.Windows;
-using ManagedCommon;
 using Wpf.Ui.Controls;
 using Point = PowerAccent.Core.Point;
 using Size = PowerAccent.Core.Size;
@@ -40,15 +39,7 @@ public partial class Selector : FluentWindow, IDisposable, INotifyPropertyChange
     {
         InitializeComponent();
 
-        // workaround for #30177
-        try
-        {
-            Wpf.Ui.Appearance.SystemThemeWatcher.Watch(this);
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError($"Exception in SystemThemeWatcher.Watch, issue 30177. {ex.Message}");
-        }
+        Wpf.Ui.Appearance.SystemThemeWatcher.Watch(this);
 
         Application.Current.MainWindow.ShowActivated = false;
         Application.Current.MainWindow.Topmost = true;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Switch to WPF UI theme manager.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #29992 #30429
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description on the Pull Request / Additional comments

- Reverted theme manager work-around in ImageResizer / Run / QuickAccent / TextExtractor. The issue has been fully fixed in 0.76.2 by upgrading WPF UI.
- Removed dependencies of Modern WPF and ControlzEx (the theme manager in Common.UI namespace) in favor of WPF UI theme manager.
- Simplified theme changing and theme override logic.
- Fixed an issue where theme override is lost on Windows startup.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

- Tested theme settings override at Windows startup.
- Tested theme settings override over HC mode.
- Tested system theme change.
- Tested multiple theme modes switching.
- Verified that plugins icons are correctly applied with system/dark/light theme settings.
- Verified that plugins icons are correctly applied with HC 1/2/black/white.
