### PR TITLE
Settings   warning elevated apps

### DIFF
--- a/src/modules/fancyzones/FancyZonesLib/NotificationUtil.h
+++ b/src/modules/fancyzones/FancyZonesLib/NotificationUtil.h
@@ -18,8 +18,11 @@ namespace FancyZonesNotifications
         using namespace notifications;
         using namespace NonLocalizable;
 
+        auto settings = PTSettingsHelper::load_general_settings();
+        auto enableWarningsElevatedApps = settings.GetNamedBoolean(L"enable_warnings_elevated_apps", true);
+
         static bool warning_shown = false;
-        if (!warning_shown && !is_toast_disabled(CantDragElevatedDontShowAgainRegistryPath, CantDragElevatedDisableIntervalInDays))
+        if (enableWarningsElevatedApps && !warning_shown && !is_toast_disabled(CantDragElevatedDontShowAgainRegistryPath, 0))
         {
             std::vector<action_t> actions = {
                 link_button{ GET_RESOURCE_STRING(IDS_CANT_DRAG_ELEVATED_LEARN_MORE), FancyZonesRunAsAdminInfoPage },
@@ -29,7 +32,6 @@ namespace FancyZonesNotifications
                                         GET_RESOURCE_STRING(IDS_FANCYZONES),
                                         {},
                                         std::move(actions));
-            warning_shown = true;
         }
     }
 }

--- a/src/runner/general_settings.cpp
+++ b/src/runner/general_settings.cpp
@@ -17,6 +17,7 @@ static std::wstring settings_theme = L"system";
 static bool run_as_elevated = false;
 static bool download_updates_automatically = true;
 static bool enable_experimentation = true;
+static bool enable_warnings_elevated_apps = true;
 
 json::JsonObject GeneralSettings::to_json()
 {
@@ -40,6 +41,7 @@ json::JsonObject GeneralSettings::to_json()
     result.SetNamedValue(L"download_updates_automatically", json::value(downloadUpdatesAutomatically));
     result.SetNamedValue(L"enable_experimentation", json::value(enableExperimentation));
     result.SetNamedValue(L"is_admin", json::value(isAdmin));
+    result.SetNamedValue(L"enable_warnings_elevated_apps", json::value(enableWarningsElevatedApps));
     result.SetNamedValue(L"theme", json::value(theme));
     result.SetNamedValue(L"system_theme", json::value(systemTheme));
     result.SetNamedValue(L"powertoys_version", json::value(powerToysVersion));
@@ -58,6 +60,7 @@ json::JsonObject load_general_settings()
     run_as_elevated = loaded.GetNamedBoolean(L"run_elevated", false);
     download_updates_automatically = loaded.GetNamedBoolean(L"download_updates_automatically", true) && check_user_is_admin();
     enable_experimentation = loaded.GetNamedBoolean(L"enable_experimentation",true);
+    enable_warnings_elevated_apps = loaded.GetNamedBoolean(L"enable_warnings_elevated_apps", true);
 
     return loaded;
 }
@@ -69,6 +72,7 @@ GeneralSettings get_general_settings()
         .isElevated = is_process_elevated(),
         .isRunElevated = run_as_elevated,
         .isAdmin = is_user_admin,
+        .enableWarningsElevatedApps = enable_warnings_elevated_apps,
         .downloadUpdatesAutomatically = download_updates_automatically && is_user_admin,
         .enableExperimentation = enable_experimentation,
         .theme = settings_theme,
@@ -90,6 +94,8 @@ void apply_general_settings(const json::JsonObject& general_configs, bool save)
 {
     Logger::info(L"apply_general_settings: {}", std::wstring{ general_configs.ToString() });
     run_as_elevated = general_configs.GetNamedBoolean(L"run_elevated", false);
+
+    enable_warnings_elevated_apps = general_configs.GetNamedBoolean(L"enable_warnings_elevated_apps", true);
 
     download_updates_automatically = general_configs.GetNamedBoolean(L"download_updates_automatically", true);
 

--- a/src/runner/general_settings.h
+++ b/src/runner/general_settings.h
@@ -10,6 +10,7 @@ struct GeneralSettings
     bool isElevated;
     bool isRunElevated;
     bool isAdmin;
+    bool enableWarningsElevatedApps;
     bool downloadUpdatesAutomatically;
     bool enableExperimentation;
     std::wstring theme;

--- a/src/runner/trace.cpp
+++ b/src/runner/trace.cpp
@@ -52,6 +52,7 @@ void Trace::SettingsChanged(const GeneralSettings& settings)
         g_hProvider,
         "GeneralSettingsChanged",
         TraceLoggingBoolean(settings.isStartupEnabled, "RunAtStartup"),
+        TraceLoggingBoolean(settings.enableWarningsElevatedApps, "EnableWarningsElevatedApps"),
         TraceLoggingWideString(settings.startupDisabledReason.c_str(), "StartupDisabledReason"),
         TraceLoggingWideString(enabledModules.c_str(), "ModulesEnabled"),
         TraceLoggingBoolean(settings.isRunElevated, "AlwaysRunElevated"),

--- a/src/settings-ui/Settings.UI.Library/GeneralSettings.cs
+++ b/src/settings-ui/Settings.UI.Library/GeneralSettings.cs
@@ -29,6 +29,10 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         [JsonPropertyName("is_admin")]
         public bool IsAdmin { get; set; }
 
+        // Gets or sets a value indicating whether is warnings of elevated apps enabled.
+        [JsonPropertyName("enable_warnings_elevated_apps")]
+        public bool EnableWarningsElevatedApps { get; set; }
+
         // Gets or sets theme Name.
         [JsonPropertyName("theme")]
         public string Theme { get; set; }
@@ -57,6 +61,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         {
             Startup = false;
             IsAdmin = false;
+            EnableWarningsElevatedApps = true;
             IsElevated = false;
             AutoDownloadUpdates = false;
             EnableExperimentation = true;

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/GeneralPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/GeneralPage.xaml
@@ -209,6 +209,9 @@
                             </controls:SettingsCard>
                         </controls:SettingsExpander.Items>
                     </controls:SettingsExpander>
+                    <controls:SettingsCard x:Uid="GeneralPage_WarningsElevatedApps">
+                        <ToggleSwitch x:Uid="ToggleSwitch" IsOn="{Binding Mode=TwoWay, Path=EnableWarningsElevatedApps}" />
+                    </controls:SettingsCard>
                 </custom:SettingsGroup>
 
                 <custom:SettingsGroup x:Uid="Appearance_Behavior" IsEnabled="True">

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -1022,6 +1022,12 @@
   <data name="GeneralPage_RunAtStartUp.Description" xml:space="preserve">
     <value>PowerToys will launch automatically</value>
   </data>
+  <data name="GeneralPage_WarningsElevatedApps.Header" xml:space="preserve">
+    <value>Elevated Apps warnings </value>
+  </data>
+	<data name="GeneralPage_WarningsElevatedApps.Description" xml:space="preserve">
+    <value>Toggle this setting to enable or disable notifications about PowerToys module functionality issues when running alongside elevated applications.</value>
+  </data>
   <data name="PowerRename.ModuleDescription" xml:space="preserve">
     <value>A Windows Shell extension for more advanced bulk renaming using search &amp; replace or regular expressions.</value>
   </data>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -1025,7 +1025,7 @@
   <data name="GeneralPage_WarningsElevatedApps.Header" xml:space="preserve">
     <value>Elevated Apps warnings </value>
   </data>
-	<data name="GeneralPage_WarningsElevatedApps.Description" xml:space="preserve">
+  <data name="GeneralPage_WarningsElevatedApps.Description" xml:space="preserve">
     <value>Show notifications about PowerToys functionality issues when running alongside elevated applications.</value>
   </data>
   <data name="PowerRename.ModuleDescription" xml:space="preserve">

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -1026,7 +1026,7 @@
     <value>Elevated Apps warnings </value>
   </data>
 	<data name="GeneralPage_WarningsElevatedApps.Description" xml:space="preserve">
-    <value>Toggle this setting to enable or disable notifications about PowerToys utilities functionality issues when running alongside elevated applications.</value>
+    <value>Show notifications about PowerToys functionality issues when running alongside elevated applications.</value>
   </data>
   <data name="PowerRename.ModuleDescription" xml:space="preserve">
     <value>A Windows Shell extension for more advanced bulk renaming using search &amp; replace or regular expressions.</value>

--- a/src/settings-ui/Settings.UI/ViewModels/GeneralViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/GeneralViewModel.cs
@@ -126,6 +126,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
 
             _isElevated = isElevated;
             _runElevated = GeneralSettingsConfig.RunElevated;
+            _enableWarningsElevatedApps = GeneralSettingsConfig.EnableWarningsElevatedApps;
 
             RunningAsUserDefaultText = runAsUserText;
             RunningAsAdminDefaultText = runAsAdminText;
@@ -150,6 +151,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         private bool _isElevated;
         private bool _runElevated;
         private bool _isAdmin;
+        private bool _enableWarningsElevatedApps;
         private int _themeIndex;
 
         private bool _autoDownloadUpdates;
@@ -267,6 +269,24 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             get
             {
                 return _isAdmin;
+            }
+        }
+
+        public bool EnableWarningsElevatedApps
+        {
+            get
+            {
+                return _enableWarningsElevatedApps;
+            }
+
+            set
+            {
+                if (_enableWarningsElevatedApps != value)
+                {
+                    _enableWarningsElevatedApps = value;
+                    GeneralSettingsConfig.EnableWarningsElevatedApps = value;
+                    NotifyPropertyChanged();
+                }
             }
         }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
https://github.com/microsoft/PowerToys/pull/30607#issuecomment-1869664166

The development mentioned in the comment in the previous PR has been made.

A new setting has been added to General settings. With this setting, elevated apps warnings can be turned on or off.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

- Tested with elevated and non-elevated applications with the setting was off. Warning not seen.
- Tested with elevated and non-elevated applications with the setting was on. Warning was observed only in elevated version.
- Tested separately for Aot and FancyZones.
