### PR TITLE
Unit converter supports negative values

### DIFF
--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter.UnitTest/InputInterpreterTests.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter.UnitTest/InputInterpreterTests.cs
@@ -19,6 +19,12 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter.UnitTest
         [DataRow(new string[] { "1'5\"" }, new string[] { "1", "'", "5", "\"" })]
         [DataRow(new string[] { "5\"" }, new string[] { "5", "\"" })]
         [DataRow(new string[] { "1'5" }, new string[] { "1", "'", "5" })]
+        [DataRow(new string[] { "-1,5'" }, new string[] { "-1,5", "'" })]
+        [DataRow(new string[] { "-1.5'" }, new string[] { "-1.5", "'" })]
+        [DataRow(new string[] { "-1'" }, new string[] { "-1", "'" })]
+        [DataRow(new string[] { "-1'5\"" }, new string[] { "-1", "'", "5", "\"" })]
+        [DataRow(new string[] { "-5\"" }, new string[] { "-5", "\"" })]
+        [DataRow(new string[] { "-1'5" }, new string[] { "-1", "'", "5" })]
         public void RegexSplitsInput(string[] input, string[] expectedResult)
         {
             string[] shortsplit = InputInterpreter.RegexSplitter(input);
@@ -27,6 +33,7 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter.UnitTest
 
         [DataTestMethod]
         [DataRow(new string[] { "1cm", "to", "mm" }, new string[] { "1", "cm", "to", "mm" })]
+        [DataRow(new string[] { "-1cm", "to", "mm" }, new string[] { "-1", "cm", "to", "mm" })]
         public void InsertsSpaces(string[] input, string[] expectedResult)
         {
             InputInterpreter.InputSpaceInserter(ref input);
@@ -38,6 +45,10 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter.UnitTest
         [DataRow(new string[] { "1\"", "in", "cm" }, new string[] { "1", "inch", "in", "cm" })]
         [DataRow(new string[] { "1'6", "in", "cm" }, new string[] { "1.5", "foot", "in", "cm" })]
         [DataRow(new string[] { "1'6\"", "in", "cm" }, new string[] { "1.5", "foot", "in", "cm" })]
+        [DataRow(new string[] { "-1'", "in", "cm" }, new string[] { "-1", "foot", "in", "cm" })]
+        [DataRow(new string[] { "-1\"", "in", "cm" }, new string[] { "-1", "inch", "in", "cm" })]
+        [DataRow(new string[] { "-1'6", "in", "cm" }, new string[] { "-1.5", "foot", "in", "cm" })]
+        [DataRow(new string[] { "-1'6\"", "in", "cm" }, new string[] { "-1.5", "foot", "in", "cm" })]
         public void HandlesShorthandFeetInchNotation(string[] input, string[] expectedResult)
         {
             InputInterpreter.ShorthandFeetInchHandler(ref input, CultureInfo.InvariantCulture);
@@ -69,6 +80,8 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter.UnitTest
         [DataTestMethod]
         [DataRow("a f in c")]
         [DataRow("12 f in")]
+        [DataRow("1-2 f in c")]
+        [DataRow("12- f in c")]
         public void ParseInvalidQueries(string queryString)
         {
             Query query = new Query(queryString);
@@ -79,6 +92,8 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter.UnitTest
         [DataTestMethod]
         [DataRow("12 f in c", 12)]
         [DataRow("10m to cm", 10)]
+        [DataRow("-12 f in c", -12)]
+        [DataRow("-10m to cm", -10)]
         public void ParseValidQueries(string queryString, double result)
         {
             Query query = new Query(queryString);

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/InputInterpreter.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/InputInterpreter.cs
@@ -14,11 +14,11 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
 {
     public static class InputInterpreter
     {
-        private static string pattern = @"(?<=\d)(?![,.])(?=\D)|(?<=\D)(?<![,.])(?=\d)";
+        private static readonly string Pattern = @"(?<=\d)(?![,.\-])(?=[\D])|(?<=[\D])(?<![,.\-])(?=\d)";
 
         public static string[] RegexSplitter(string[] split)
         {
-            return Regex.Split(split[0], pattern);
+            return Regex.Split(split[0], Pattern);
         }
 
         /// <summary>
@@ -31,7 +31,7 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
                 return;
             }
 
-            string[] parseInputWithoutSpace = Regex.Split(split[0], pattern);
+            string[] parseInputWithoutSpace = Regex.Split(split[0], Pattern);
 
             if (parseInputWithoutSpace.Length > 1)
             {
@@ -80,6 +80,12 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
                         // ex: 1'2 and 1'2"
                         if (shortsplit[1] == "\'")
                         {
+                            bool isNegative = shortsplit[0].StartsWith('-');
+                            if (isNegative)
+                            {
+                                shortsplit[0] = shortsplit[0].Remove(0, 1);
+                            }
+
                             bool isFeet = double.TryParse(shortsplit[0], NumberStyles.AllowDecimalPoint, culture, out double feet);
                             bool isInches = double.TryParse(shortsplit[2], NumberStyles.AllowDecimalPoint, culture, out double inches);
 
@@ -89,9 +95,13 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
                                 break;
                             }
 
-                            string convertedTotalInFeet = Length.FromFeetInches(feet, inches).Feet.ToString(culture);
+                            double convertedTotalInFeet = Length.FromFeetInches(feet, inches).Feet;
+                            if (isNegative)
+                            {
+                                convertedTotalInFeet *= -1;
+                            }
 
-                            string[] newInput = new string[] { convertedTotalInFeet, "foot", split[1], split[2] };
+                            string[] newInput = new string[] { convertedTotalInFeet.ToString(culture), "foot", split[1], split[2] };
                             split = newInput;
                         }
 


### PR DESCRIPTION
## Summary of the Pull Request
Fixes #30678
Allow unit converter to convert negative values.
For example, -10℃ is converted to 14℉.

## PR Checklist

- [x] **Closes:** #30678
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments
Previous Unit Converter was not designed to accept negative values.
In the regular expression used to distinguish between numbers and non-numbers, the minus sign was treated as a non-number character. Modify to treat the minus sign as part of the number.

## Validation Steps Performed
When you launch PowerToys Run and enter `%%-10C to F`, it displays 14℉

![image](https://github.com/microsoft/PowerToys/assets/81973731/596551f5-3672-42d8-a873-c1733338809c)
