### PR TITLE
Detect full-screen games in Powertoys Run launcher more thoroughly

### DIFF
--- a/src/modules/launcher/PowerLauncher/Helper/NativeMethods.cs
+++ b/src/modules/launcher/PowerLauncher/Helper/NativeMethods.cs
@@ -69,6 +69,9 @@ namespace PowerLauncher.Helper
         [DllImport("user32.DLL", CharSet = CharSet.Unicode)]
         internal static extern IntPtr FindWindowEx(IntPtr hwndParent, IntPtr hwndChildAfter, string lpszClass, string lpszWindow);
 
+        [DllImport("shell32.dll")]
+        public static extern int SHQueryUserNotificationState(out UserNotificationState pquns);
+
         public static string[] CommandLineToArgvW(string cmdLine)
         {
             IntPtr argv = IntPtr.Zero;
@@ -241,5 +244,16 @@ namespace PowerLauncher.Helper
         // It's relatively safe to reuse.
         TRAYMOUSEMESSAGE = 0x800, // WM_USER + 1024
         APP = 0x8000,
+    }
+
+    internal enum UserNotificationState : int
+    {
+        QUNS_NOT_PRESENT = 1,
+        QUNS_BUSY,
+        QUNS_RUNNING_D3D_FULL_SCREEN,
+        QUNS_PRESENTATION_MODE,
+        QUNS_ACCEPTS_NOTIFICATIONS,
+        QUNS_QUIET_TIME,
+        QUNS_APP,
     }
 }

--- a/src/modules/launcher/PowerLauncher/Helper/NativeMethods.cs
+++ b/src/modules/launcher/PowerLauncher/Helper/NativeMethods.cs
@@ -70,7 +70,7 @@ namespace PowerLauncher.Helper
         internal static extern IntPtr FindWindowEx(IntPtr hwndParent, IntPtr hwndChildAfter, string lpszClass, string lpszWindow);
 
         [DllImport("shell32.dll")]
-        public static extern int SHQueryUserNotificationState(out UserNotificationState pquns);
+        public static extern int SHQueryUserNotificationState(out UserNotificationState state);
 
         public static string[] CommandLineToArgvW(string cmdLine)
         {

--- a/src/modules/launcher/PowerLauncher/Helper/WindowsInteropHelper.cs
+++ b/src/modules/launcher/PowerLauncher/Helper/WindowsInteropHelper.cs
@@ -114,9 +114,9 @@ namespace PowerLauncher.Helper
         {
             // First, check to see if a game is fullscreen, if so, we definitely have
             // a full-screen window
-            UserNotificationState pquns;
-            if (Marshal.GetExceptionForHR(NativeMethods.SHQueryUserNotificationState(out pquns)) == null &&
-                pquns == UserNotificationState.QUNS_RUNNING_D3D_FULL_SCREEN)
+            UserNotificationState state;
+            if (Marshal.GetExceptionForHR(NativeMethods.SHQueryUserNotificationState(out state)) == null &&
+                state == UserNotificationState.QUNS_RUNNING_D3D_FULL_SCREEN)
             {
                 return true;
             }

--- a/src/modules/launcher/PowerLauncher/Helper/WindowsInteropHelper.cs
+++ b/src/modules/launcher/PowerLauncher/Helper/WindowsInteropHelper.cs
@@ -112,6 +112,15 @@ namespace PowerLauncher.Helper
 
         public static bool IsWindowFullscreen()
         {
+            // First, check to see if a game is fullscreen, if so, we definitely have
+            // a full-screen window
+            UserNotificationState pquns;
+            if (Marshal.GetExceptionForHR(NativeMethods.SHQueryUserNotificationState(out pquns)) == null &&
+                pquns == UserNotificationState.QUNS_RUNNING_D3D_FULL_SCREEN)
+            {
+                return true;
+            }
+
             // get current active window
             IntPtr hWnd = NativeMethods.GetForegroundWindow();
 


### PR DESCRIPTION
## Summary of the Pull Request

Powertoys Run does not always correctly detect whether a game is full-screen, leading to Heated Gamer Moments™️ when Powertoys Run opens in the middle of your game. This PR tries to catch these cases more thoroughly

## Detailed Description of the Pull Request / Additional comments

The current test for whether a window is full-screen (i.e. a movie or a game) is a bit of a heuristic. In certain cases however, we can *know* that a window is full-screen. Check that case first, then proceed with the existing logic