### PR TITLE
Image resizer: UI tweaks

### DIFF
--- a/src/modules/imageresizer/ui/Properties/Resources.Designer.cs
+++ b/src/modules/imageresizer/ui/Properties/Resources.Designer.cs
@@ -142,7 +142,7 @@ namespace ImageResizer.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Ign_ore the orientation of pictures.
+        ///   Looks up a localized string similar to Ignore the orientation of pictures.
         /// </summary>
         public static string Input_IgnoreOrientation {
             get {
@@ -160,7 +160,7 @@ namespace ImageResizer.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to R_esize the original pictures (don&apos;t create copies).
+        ///   Looks up a localized string similar to Resize the original pictures (don&apos;t create copies).
         /// </summary>
         public static string Input_Replace {
             get {
@@ -178,7 +178,7 @@ namespace ImageResizer.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to _Make pictures smaller but not larger.
+        ///   Looks up a localized string similar to Make pictures smaller but not larger.
         /// </summary>
         public static string Input_ShrinkOnly {
             get {

--- a/src/modules/imageresizer/ui/Properties/Resources.resx
+++ b/src/modules/imageresizer/ui/Properties/Resources.resx
@@ -140,19 +140,19 @@
     <value>Custom</value>
   </data>
   <data name="Input_IgnoreOrientation" xml:space="preserve">
-    <value>Ign_ore the orientation of pictures</value>
+    <value>Ignore the orientation of pictures</value>
   </data>
   <data name="Input_GifWarning" xml:space="preserve">
     <value>Gif files with animations may not be correctly resized.</value>
   </data>
   <data name="Input_Replace" xml:space="preserve">
-    <value>R_esize the original pictures (don't create copies)</value>
+    <value>Resize the original pictures (don't create copies)</value>
   </data>
   <data name="Input_Resize" xml:space="preserve">
     <value>Resize</value>
   </data>
   <data name="Input_ShrinkOnly" xml:space="preserve">
-    <value>_Make pictures smaller but not larger</value>
+    <value>Make pictures smaller but not larger</value>
   </data>
   <data name="Large" xml:space="preserve">
     <value>Large</value>

--- a/src/modules/imageresizer/ui/Views/InputPage.xaml
+++ b/src/modules/imageresizer/ui/Views/InputPage.xaml
@@ -70,7 +70,7 @@
         <Grid Grid.Row="1">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
-                <RowDefinition Height="*" MinHeight="160" />
+                <RowDefinition Height="*" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
@@ -182,31 +182,35 @@
             <!--  CheckBoxes  -->
             <StackPanel
                 Grid.Row="1"
-                VerticalAlignment="Top"
-                Orientation="Vertical">
+                Margin="16,12,16,0"
+                VerticalAlignment="Top">
+                <!--  Note: TextBlock because text wrapping is not supported by CheckBox  -->
+                <CheckBox IsChecked="{Binding Settings.ShrinkOnly}">
+                    <CheckBox.Content>
+                        <TextBlock Text="{x:Static p:Resources.Input_ShrinkOnly}" TextWrapping="Wrap" />
+                    </CheckBox.Content>
+                </CheckBox>
 
-                <CheckBox
-                    Margin="16,12,16,0"
-                    Content="{x:Static p:Resources.Input_ShrinkOnly}"
-                    IsChecked="{Binding Settings.ShrinkOnly}" />
-
-                <CheckBox
-                    Margin="16,2,16,0"
-                    Content="{x:Static p:Resources.Input_IgnoreOrientation}"
-                    IsChecked="{Binding Settings.IgnoreOrientation}" />
+                <CheckBox IsChecked="{Binding Settings.IgnoreOrientation}">
+                    <CheckBox.Content>
+                        <TextBlock Text="{x:Static p:Resources.Input_IgnoreOrientation}" TextWrapping="Wrap" />
+                    </CheckBox.Content>
+                </CheckBox>
                 <!--
                     TODO: This option doesn't make much sense when resizing into a directory. We should swap it for an option
                     to overwrite any files in the directory instead (issue #88)
                 -->
-                <CheckBox
-                    Margin="16,2,16,0"
-                    Content="{x:Static p:Resources.Input_Replace}"
-                    IsChecked="{Binding Settings.Replace}" />
+                <CheckBox IsChecked="{Binding Settings.Replace}">
+                    <CheckBox.Content>
+                        <TextBlock Text="{x:Static p:Resources.Input_Replace}" TextWrapping="Wrap" />
+                    </CheckBox.Content>
+                </CheckBox>
 
-                <CheckBox
-                    Margin="16,2,16,0"
-                    Content="{x:Static p:Resources.Input_RemoveMetadata}"
-                    IsChecked="{Binding Settings.RemoveMetadata}" />
+                <CheckBox IsChecked="{Binding Settings.RemoveMetadata}">
+                    <CheckBox.Content>
+                        <TextBlock Text="{x:Static p:Resources.Input_RemoveMetadata}" TextWrapping="Wrap" />
+                    </CheckBox.Content>
+                </CheckBox>
             </StackPanel>
 
             <!--  Separator line  -->

--- a/src/modules/imageresizer/ui/Views/InputPage.xaml
+++ b/src/modules/imageresizer/ui/Views/InputPage.xaml
@@ -9,15 +9,16 @@
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
+            <!--  ComboBox  -->
             <RowDefinition Height="*" />
+            <!--  other controls  -->
         </Grid.RowDefinitions>
 
         <ComboBox
             x:Name="SizeComboBox"
-            Grid.Row="1"
+            Grid.Row="0"
             Height="64"
-            Margin="16,16,16,24"
+            Margin="16"
             HorizontalAlignment="Stretch"
             VerticalAlignment="Stretch"
             VerticalContentAlignment="Stretch"
@@ -25,43 +26,33 @@
             SelectedIndex="{Binding Settings.SelectedSizeIndex}">
             <ComboBox.Resources>
                 <DataTemplate DataType="{x:Type m:ResizeSize}">
-                    <Grid
-                        Margin="2,0,0,0"
-                        VerticalAlignment="Center"
-                        AutomationProperties.Name="{Binding Name}">
+                    <Grid AutomationProperties.Name="{Binding Name}">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
                         </Grid.RowDefinitions>
-                        <TextBlock FontWeight="SemiBold" Text="{Binding Name}" />
+                        <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{Binding Name}" />
                         <StackPanel
                             Grid.Row="1"
                             VerticalAlignment="Top"
                             Orientation="Horizontal">
-                            <TextBlock
-                                FontSize="12"
-                                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                                Text="{Binding Fit, Converter={StaticResource EnumValueConverter}, ConverterParameter=ThirdPersonSingular}" />
+                            <TextBlock Foreground="{DynamicResource TextFillColorSecondaryBrush}" Text="{Binding Fit, Converter={StaticResource EnumValueConverter}, ConverterParameter=ThirdPersonSingular}" />
                             <TextBlock
                                 Margin="4,0,0,0"
-                                FontSize="12"
-                                FontWeight="SemiBold"
+                                Style="{StaticResource BodyStrongTextBlockStyle}"
                                 Text="{Binding Width, Converter={StaticResource AutoDoubleConverter}, ConverterParameter=Auto}" />
                             <TextBlock
                                 Margin="4,0,0,0"
-                                FontSize="12"
                                 Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                                 Text="×"
                                 Visibility="{Binding ShowHeight, Converter={StaticResource BoolValueConverter}}" />
                             <TextBlock
                                 Margin="4,0,0,0"
-                                FontSize="12"
-                                FontWeight="SemiBold"
+                                Style="{StaticResource BodyStrongTextBlockStyle}"
                                 Text="{Binding Height, Converter={StaticResource AutoDoubleConverter}, ConverterParameter=Auto}"
                                 Visibility="{Binding ShowHeight, Converter={StaticResource BoolValueConverter}}" />
                             <TextBlock
                                 Margin="4,0,0,0"
-                                FontSize="12"
                                 Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                                 Text="{Binding Unit, Converter={StaticResource EnumValueConverter}, ConverterParameter=ToLower}" />
                         </StackPanel>
@@ -76,7 +67,7 @@
             </ComboBox.Resources>
         </ComboBox>
 
-        <Grid Grid.Row="2">
+        <Grid Grid.Row="1">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />
@@ -90,10 +81,8 @@
                 BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
                 BorderThickness="0,1,0,0" />
 
-            <Grid
-                Height="86"
-                Margin="18,16,16,16"
-                Visibility="{Binding ElementName=SizeComboBox, Path=SelectedValue, Converter={StaticResource SizeTypeToVisibilityConverter}}">
+            <!--  input matrix  -->
+            <Grid Margin="16" Visibility="{Binding ElementName=SizeComboBox, Path=SelectedValue, Converter={StaticResource SizeTypeToVisibilityConverter}}">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="20" />
                     <ColumnDefinition Width="*" />
@@ -107,14 +96,11 @@
                     <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
 
-
                 <TextBlock
-                    HorizontalAlignment="Left"
                     VerticalAlignment="Center"
                     AutomationProperties.Name="{x:Static p:Resources.Width}"
-                    FontSize="12"
-                    FontWeight="SemiBold"
                     Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                    Style="{StaticResource BodyStrongTextBlockStyle}"
                     Text="{x:Static p:Resources.WidthChar}"
                     ToolTipService.ToolTip="{x:Static p:Resources.Width}" />
                 <ui:NumberBox
@@ -133,14 +119,13 @@
                             UpdateSourceTrigger="PropertyChanged" />
                     </ui:NumberBox.Value>
                 </ui:NumberBox>
+
                 <TextBlock
                     Grid.Column="3"
-                    HorizontalAlignment="Left"
                     VerticalAlignment="Center"
                     AutomationProperties.Name="{x:Static p:Resources.Height}"
-                    FontSize="12"
-                    FontWeight="SemiBold"
                     Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                    Style="{StaticResource BodyStrongTextBlockStyle}"
                     Text="{x:Static p:Resources.HeightChar}"
                     ToolTipService.ToolTip="{x:Static p:Resources.Height}"
                     Visibility="{Binding ElementName=SizeComboBox, Path=SelectedValue.ShowHeight, Converter={StaticResource BoolValueConverter}}" />
@@ -166,13 +151,10 @@
 
                 <ui:SymbolIcon
                     Grid.Row="2"
-                    Margin="-2,0,0,0"
-                    HorizontalAlignment="Left"
                     VerticalAlignment="Center"
                     Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                     Symbol="ArrowMaximize16"
                     ToolTipService.ToolTip="{x:Static p:Resources.Resize_Type}" />
-
                 <ComboBox
                     Grid.Row="2"
                     Grid.Column="1"
@@ -184,23 +166,20 @@
                 <ui:SymbolIcon
                     Grid.Row="2"
                     Grid.Column="3"
-                    Margin="-2,0,0,0"
-                    HorizontalAlignment="Left"
                     VerticalAlignment="Center"
-                    FontSize="18"
+                    FontSize="16"
                     Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                     Symbol="Ruler16"
                     ToolTipService.ToolTip="{x:Static p:Resources.Unit}" />
-
                 <ComboBox
                     Grid.Row="2"
                     Grid.Column="4"
                     AutomationProperties.Name="{x:Static p:Resources.Unit}"
                     ItemsSource="{Binding Source={StaticResource ResizeUnitValues}}"
                     Text="{Binding ElementName=SizeComboBox, Path=SelectedValue.Unit, Mode=TwoWay}" />
-
             </Grid>
 
+            <!--  CheckBoxes  -->
             <StackPanel
                 Grid.Row="1"
                 VerticalAlignment="Top"
@@ -230,21 +209,24 @@
                     IsChecked="{Binding Settings.RemoveMetadata}" />
             </StackPanel>
 
+            <!--  Separator line  -->
             <Border
                 Grid.Row="2"
                 Height="1"
-                Margin="0,12,0,8"
+                Margin="0,8"
                 HorizontalAlignment="Stretch"
                 VerticalAlignment="Top"
                 Background="{DynamicResource DividerStrokeColorDefaultBrush}" />
+
             <ui:InfoBar
                 Grid.Row="3"
-                Margin="16,0,16,0"
-                Padding="12,8,8,8"
+                Margin="16,0"
                 IsClosable="False"
                 IsOpen="{Binding TryingToResizeGifFiles}"
                 Message="{x:Static p:Resources.Input_GifWarning}"
                 Severity="Warning" />
+
+            <!--  Buttons  -->
             <Grid Grid.Row="4" Margin="16,8,16,16">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition />
@@ -252,26 +234,23 @@
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
 
-                <ui:Button
-                    Width="36"
+                <Button
                     Height="36"
-                    Margin="-6,0,0,0"
-                    Padding="0"
                     HorizontalAlignment="Left"
                     AutomationProperties.Name="{x:Static p:Resources.Open_settings}"
                     Background="Transparent"
                     BorderBrush="Transparent"
                     Command="{Binding OpenSettingsCommand}"
                     ToolTipService.ToolTip="{x:Static p:Resources.Open_settings}">
-                    <ui:Button.Content>
-                        <ui:SymbolIcon FontSize="18" Symbol="Settings20" />
-                    </ui:Button.Content>
-                </ui:Button>
-                <ui:Button
+                    <Button.Content>
+                        <ui:SymbolIcon Symbol="Settings20" />
+                    </Button.Content>
+                </Button>
+
+                <Button
                     Grid.Column="1"
                     MinWidth="76"
                     Margin="8,0,0,0"
-                    Appearance="Primary"
                     AutomationProperties.Name="{x:Static p:Resources.Resize_Tooltip}"
                     Command="{Binding ResizeCommand}"
                     IsDefault="True">
@@ -279,9 +258,9 @@
                         <ui:SymbolIcon FontSize="18" Symbol="ResizeImage20" />
                         <TextBlock Margin="8,0,0,0" Text="{x:Static p:Resources.Input_Resize}" />
                     </StackPanel>
-                </ui:Button>
+                </Button>
 
-                <ui:Button
+                <Button
                     Grid.Column="2"
                     MinWidth="76"
                     Margin="8,0,0,0"
@@ -289,8 +268,6 @@
                     Content="{x:Static p:Resources.Cancel}"
                     IsCancel="True" />
             </Grid>
-
-
         </Grid>
     </Grid>
 </UserControl>

--- a/src/modules/imageresizer/ui/Views/InputPage.xaml
+++ b/src/modules/imageresizer/ui/Views/InputPage.xaml
@@ -70,7 +70,7 @@
         <Grid Grid.Row="1">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
-                <RowDefinition Height="*" />
+                <RowDefinition Height="*" MinHeight="160" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
@@ -215,7 +215,6 @@
                 Height="1"
                 Margin="0,8"
                 HorizontalAlignment="Stretch"
-                VerticalAlignment="Top"
                 Background="{DynamicResource DividerStrokeColorDefaultBrush}" />
 
             <ui:InfoBar
@@ -252,7 +251,9 @@
                     MinWidth="76"
                     Margin="8,0,0,0"
                     AutomationProperties.Name="{x:Static p:Resources.Resize_Tooltip}"
+                    Background="{DynamicResource AccentFillColorDefaultBrush}"
                     Command="{Binding ResizeCommand}"
+                    Foreground="{DynamicResource TextOnAccentFillColorPrimaryBrush}"
                     IsDefault="True">
                     <StackPanel Orientation="Horizontal">
                         <ui:SymbolIcon FontSize="18" Symbol="ResizeImage20" />

--- a/src/modules/imageresizer/ui/Views/MainWindow.xaml
+++ b/src/modules/imageresizer/ui/Views/MainWindow.xaml
@@ -1,4 +1,4 @@
-﻿<ui:FluentWindow
+<ui:FluentWindow
     x:Class="ImageResizer.Views.MainWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -9,9 +9,6 @@
     xmlns:vm="clr-namespace:ImageResizer.ViewModels"
     Name="_this"
     Width="360"
-    Height="506"
-    ui:Design.Background="{DynamicResource ApplicationBackgroundBrush}"
-    ui:Design.Foreground="{DynamicResource TextFillColorPrimaryBrush}"
     AutomationProperties.Name="{x:Static p:Resources.ImageResizer}"
     ExtendsContentIntoTitleBar="True"
     Icon="/PowerToys.ImageResizer;component/Resources/ImageResizer.ico"

--- a/src/modules/imageresizer/ui/Views/MainWindow.xaml
+++ b/src/modules/imageresizer/ui/Views/MainWindow.xaml
@@ -58,6 +58,7 @@
                 <ui:ImageIcon Source="/PowerToys.ImageResizer;component/Resources/ImageResizer.ico" />
             </ui:TitleBar.Icon>
         </ui:TitleBar>
+
         <ContentPresenter Grid.Row="1" Content="{Binding CurrentPage}" />
     </Grid>
 </ui:FluentWindow>

--- a/src/modules/imageresizer/ui/Views/ProgressPage.xaml
+++ b/src/modules/imageresizer/ui/Views/ProgressPage.xaml
@@ -34,13 +34,12 @@
             Margin="0,12,0,0"
             Padding="12,12"
             BorderThickness="0,1,0,0">
-            <StackPanel HorizontalAlignment="Right" Orientation="Horizontal">
-                <Button
-                    MinWidth="76"
-                    Command="{Binding StopCommand}"
-                    Content="{x:Static p:Resources.Progress_Stop}"
-                    IsCancel="True" />
-            </StackPanel>
+            <Button
+                MinWidth="76"
+                HorizontalAlignment="Right"
+                Command="{Binding StopCommand}"
+                Content="{x:Static p:Resources.Progress_Stop}"
+                IsCancel="True" />
         </Border>
     </StackPanel>
 </UserControl>

--- a/src/modules/imageresizer/ui/Views/ResultsPage.xaml
+++ b/src/modules/imageresizer/ui/Views/ResultsPage.xaml
@@ -10,8 +10,7 @@
             FontSize="16"
             Text="{x:Static p:Resources.Results_MainInstruction}" />
         <ScrollViewer
-            MaxWidth="363"
-            MaxHeight="350"
+            MaxHeight="360"
             HorizontalAlignment="Stretch"
             VerticalScrollBarVisibility="Auto">
             <ItemsControl Margin="12,4,12,0" ItemsSource="{Binding Errors}">
@@ -28,20 +27,20 @@
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
         </ScrollViewer>
+
         <Border
             Margin="0,12,0,0"
             Padding="12,12"
             Background="{DynamicResource LayerFillColorDefaultBrush}"
             BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
             BorderThickness="0,1,0,0">
-            <StackPanel HorizontalAlignment="Right" Orientation="Horizontal">
-                <Button
-                    MinWidth="76"
-                    Command="{Binding CloseCommand}"
-                    Content="{x:Static p:Resources.Results_Close}"
-                    IsCancel="True"
-                    IsDefault="True" />
-            </StackPanel>
+            <Button
+                MinWidth="76"
+                HorizontalAlignment="Right"
+                Command="{Binding CloseCommand}"
+                Content="{x:Static p:Resources.Results_Close}"
+                IsCancel="True"
+                IsDefault="True" />
         </Border>
     </StackPanel>
 </UserControl>

--- a/src/modules/imageresizer/ui/Views/ResultsPage.xaml
+++ b/src/modules/imageresizer/ui/Views/ResultsPage.xaml
@@ -32,7 +32,7 @@
             Margin="0,12,0,0"
             Padding="12,12"
             Background="{DynamicResource LayerFillColorDefaultBrush}"
-            BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
+            BorderBrush="{DynamicResource DividerStrokeColorDefaultBrush}"
             BorderThickness="0,1,0,0">
             <Button
                 MinWidth="76"


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

- Placed text in a TextBlock inside the CheckBoxes, to apply TextWrapping
  -  had to remove the _underscores, because they would be printed otherwise
- tweaked a few sizes with a few pixels

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** none
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

> [!NOTE]
> I _wanted_ to start fixing #29098, but when debugging, the (minimum) Height of the window is always too large to test. Even when `ResizeMode="CanResize"`. How do I solve this?

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Before
![image](https://github.com/microsoft/PowerToys/assets/65828559/52983276-354c-45d7-ac5b-a68c5460128e)
After
![image](https://github.com/microsoft/PowerToys/assets/65828559/ad1bd626-f9c6-45a2-a336-d59c72a1d46a)
