### PR TITLE
Forcing window back on double click / right click

### DIFF
--- a/src/settings-ui/Settings.UI/SettingsXAML/App.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/App.xaml.cs
@@ -90,7 +90,9 @@ namespace Microsoft.PowerToys.Settings.UI
             if (type != null)
             {
                 settingsWindow.NavigateToSection(type);
-            }
+
+                WindowHelpers.BringToForeground(settingsWindow.GetWindowHandle());
+             }
 
             if (ensurePageIsSelected)
             {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

via system tray, PowerToys Settings is open but not in focus, double clicking / right click ->Settings will not force the focus back in.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** https://github.com/microsoft/PowerToys/issues/31035  (may be other issues but for life of me, i can't find one)
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

1. Launch powertoys
2. Double click in systray to force settings app to launch
3. Launch Edge
4. Place edge on top of powertoys settings
5. Expected result is Settings goes into focus and visually on top of Edge.
