### PR TITLE
[PTRun]Fix Access crash when saving settings version

### DIFF
--- a/src/modules/launcher/Wox.Infrastructure/Storage/StoragePowerToysVersionInfo.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Storage/StoragePowerToysVersionInfo.cs
@@ -3,7 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.IO;
 using System.IO.Abstractions;
+using Wox.Plugin.Logger;
 
 namespace Wox.Infrastructure.Storage
 {
@@ -123,8 +125,15 @@ namespace Wox.Infrastructure.Storage
 
         public void Close()
         {
-            // Update the Version file to the current version of powertoys
-            File.WriteAllText(FilePath, currentPowerToysVersion);
+            try
+            {
+                // Update the Version file to the current version of powertoys
+                File.WriteAllText(FilePath, currentPowerToysVersion);
+            }
+            catch (System.Exception e)
+            {
+                Log.Exception($"Error in saving version at <{FilePath}>", e, GetType());
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

We're getting reported crashes of unauthorized access exceptions when saving the version files.
Catching and logging this exception will reduce the number of reported issues without much issues. If a version file doesn't get saved, only issue that might occur is that the corresponding settings file might get recreated next run in the same way as when we're doing a PowerToys version upgrade. Still better than crashing, though.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #14840
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manually put an exception throw in the code to verify PowerToys Run didn't crash and we had the exception saved to the logs.
