### PR TITLE
[SVGThumbnails]Fix hanging loop and add logs

### DIFF
--- a/src/modules/previewpane/SvgThumbnailProvider/Program.cs
+++ b/src/modules/previewpane/SvgThumbnailProvider/Program.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Globalization;
+using ManagedCommon;
 
 namespace Microsoft.PowerToys.ThumbnailHandler.Svg
 {
@@ -17,6 +18,7 @@ namespace Microsoft.PowerToys.ThumbnailHandler.Svg
         public static void Main(string[] args)
         {
             ApplicationConfiguration.Initialize();
+            Logger.InitializeLogger("\\FileExplorer_localLow\\SvgThumbnails\\logs", true);
             if (args != null)
             {
                 if (args.Length == 2)

--- a/src/modules/previewpane/SvgThumbnailProvider/SvgThumbnailProvider.cs
+++ b/src/modules/previewpane/SvgThumbnailProvider/SvgThumbnailProvider.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using Common.Utilities;
+using ManagedCommon;
 using Microsoft.Web.WebView2.Core;
 using Microsoft.Web.WebView2.WinForms;
 
@@ -197,8 +198,10 @@ namespace Microsoft.PowerToys.ThumbnailHandler.Svg
                         _browser.NavigateToString(SvgContents);
                     }
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
+                    Logger.LogError($"Failed running webView2Environment completed for {FilePath} : ", ex);
+                    thumbnailDone.Set();
                 }
             });
 

--- a/src/modules/previewpane/SvgThumbnailProvider/SvgThumbnailProvider.csproj
+++ b/src/modules/previewpane/SvgThumbnailProvider/SvgThumbnailProvider.csproj
@@ -52,5 +52,6 @@
     <ProjectReference Include="..\..\..\common\GPOWrapper\GPOWrapper.vcxproj" />
     <ProjectReference Include="..\..\..\common\ManagedTelemetry\Telemetry\ManagedTelemetry.csproj" />
     <ProjectReference Include="..\Common\PreviewHandlerCommon.csproj" />
+    <ProjectReference Include="..\..\..\common\Common.UI\Common.UI.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

There is a `ManualResetEventSlim` which was not being set in case of an error in `webView2EnvironmentAwaiter.OnCompleted`. This was causing an infinite wait.
Adds logs to the svg thumbnail handler to log errors when running `webView2EnvironmentAwaiter.OnCompleted`.

Now if generating a thumbnail fails, instead of hanging generation, the file is just skipped and thumbnail generation continues. The failed thumbnails can be regenerated with refreshing the explorer window (F5).

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #31032
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

The SVG Thumbnail Handler uses WebView2 to generate the thumbnail from the svg.
WebView2 requires a local working directory which doesn't seem to be able to be used by two instances at the same time.
I've confirmed this by changing the code so that a different `userDataFolder` was created with a millisecond timestamp for each WebView2 instance and I could no longer reproduce the error. (However this filled up my disk pretty quickly since it created a new WebView2 working directory for each svg generated, so it is not a feasible solutions, as those don't get cleaned up automatically)

If two instances run at the same time with for userDataFolder, it fails with an exception:
```
[22:47:32.8217663] [Error] <<GetThumbnailImpl>b__1>d::MoveNext
    Failed running webView2Environment completed for C:\Users\Jaime\AppData\LocalLow\Microsoft\PowerToys\SvgThumbnailPreview-Temp\081DEDF1-B230-41A0-8299-39683CCB979A.svg :
The group or resource is not in the correct state to perform the requested operation. (0x8007139F)
Inner exception: 

Stack trace: 
   at System.Runtime.InteropServices.Marshal.ThrowExceptionForHR(Int32 errorCode)
   at Microsoft.Web.WebView2.Core.CoreWebView2Environment.CreateCoreWebView2ControllerAsync(IntPtr ParentWindow)
   at Microsoft.Web.WebView2.WinForms.WebView2.InitCoreWebView2Async(CoreWebView2Environment environment, CoreWebView2ControllerOptions controllerOptions)
   at Microsoft.PowerToys.ThumbnailHandler.Svg.SvgThumbnailProvider.<>c__DisplayClass25_0.<<GetThumbnailImpl>b__1>d.MoveNext() in C:\prog\janeasystems\PowerToys\src\modules\previewpane\SvgThumbnailProvider\SvgThumbnailProvider.cs:line 157
```

This was causing a hang when a user has the preview pane open and selecting svg files at the same time as thumbnails are being generated. It really only occurs when the preview pane is showing and generating a preview. I've verified, and selecting a SVG file starts both the SVG Preview Handler and SVG Thumbnail Provider. This was unknown to us, that the generation of a preview would also call the thumbnail provider.
So, when File Explorer is generating svg thumbnails and you try to preview a svg file, you'll get two SVG thumbnail providers running concurrently. Given a lack of support for WebView 2 to run two instances pointing to the same userDataFolder, the best that can be done here at this point seems to be to just fail thumbnail generation for one of the instances.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Tried replicating the error with the zip folder provided in the original issue. Verified that some files don't get their thumbnails generated when the error occurs but thumbnail generation goes forward in the other files. The other files still get their thumbnails generated after refreshing the explorer window (press F5).
