### PR TITLE
[OOBE] Fix msgMonitor to prevent window maximizing

### DIFF
--- a/src/settings-ui/Settings.UI/SettingsXAML/OobeWindow.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/OobeWindow.xaml.cs
@@ -20,7 +20,7 @@ namespace Microsoft.PowerToys.Settings.UI
     /// <summary>
     /// An empty window that can be used on its own or navigated to within a Frame.
     /// </summary>
-    public sealed partial class OobeWindow : WindowEx
+    public sealed partial class OobeWindow : WindowEx, IDisposable
     {
         private PowerToysModules initialModule;
 
@@ -31,6 +31,8 @@ namespace Microsoft.PowerToys.Settings.UI
         private WindowId _windowId;
         private IntPtr _hWnd;
         private AppWindow _appWindow;
+        private WindowMessageMonitor _msgMonitor;
+        private bool disposedValue;
 
         public OobeWindow(PowerToysModules initialModule)
         {
@@ -59,8 +61,8 @@ namespace Microsoft.PowerToys.Settings.UI
 
             this.initialModule = initialModule;
 
-            var msgMonitor = new WindowMessageMonitor(this);
-            msgMonitor.WindowMessageReceived += (_, e) =>
+            _msgMonitor = new WindowMessageMonitor(this);
+            _msgMonitor.WindowMessageReceived += (_, e) =>
             {
                 const int WM_NCLBUTTONDBLCLK = 0x00A3;
                 if (e.Message.MessageId == WM_NCLBUTTONDBLCLK)
@@ -131,6 +133,23 @@ namespace Microsoft.PowerToys.Settings.UI
             {
                 mainWindow.CloseHiddenWindow();
             }
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                _msgMonitor?.Dispose();
+
+                disposedValue = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
         }
     }
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

MsgMonitor was local, therefore as soon as ctor is done, it's gone. So making it a field corrects the behavior.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Related to #28340
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Try double-clicking OOBE title bar and confirm that it's not being maximized.
