### PR TITLE
[Flyout] Fix icon alignment bug

### DIFF
--- a/src/settings-ui/Settings.UI/SettingsXAML/Flyout/LaunchPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Flyout/LaunchPage.xaml
@@ -5,9 +5,8 @@
     xmlns:animatedVisuals="using:Microsoft.UI.Xaml.Controls.AnimatedVisuals"
     xmlns:controls="using:Microsoft.PowerToys.Settings.UI.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:local="using:Microsoft.PowerToys.Settings.UI.Flyout"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:tk7controls="using:CommunityToolkit.WinUI.UI.Controls"
+    xmlns:tkcontrols="using:CommunityToolkit.WinUI.Controls"
     xmlns:ui="using:CommunityToolkit.WinUI"
     xmlns:viewModels="using:Microsoft.PowerToys.Settings.UI.ViewModels"
     mc:Ignorable="d">
@@ -65,13 +64,13 @@
             <Grid Grid.Row="1">
                 <ItemsControl
                     Margin="12,26,12,24"
-                    HorizontalAlignment="Center"
+                    HorizontalAlignment="Stretch"
                     VerticalAlignment="Top"
                     ItemsSource="{x:Bind ViewModel.FlyoutMenuItems}"
                     TabNavigation="Local">
                     <ItemsControl.ItemsPanel>
                         <ItemsPanelTemplate>
-                            <tk7controls:WrapPanel VerticalSpacing="12" />
+                            <tkcontrols:WrapPanel HorizontalAlignment="Stretch" VerticalSpacing="12" />
                         </ItemsPanelTemplate>
                     </ItemsControl.ItemsPanel>
                     <ItemsControl.ItemTemplate>


### PR DESCRIPTION
## Summary of the Pull Request
This PR:
- Fixes: #30355
- Uses the Toolkit 8.x version of the `WrapPanel`

**Steps to validate:**
- Turn on 4 modules that have their icons in the flyout view to check if alignment is correct.
- Now turn 3 off so that only one is enabled, it should be left aligned now instead of centered.


@stefansjfw @jaimecbernardo I wasn't able to test this myself, but it should be a straightforward fix. This can get in after 0.78 so I'll keep it as a draft for now.


## PR Checklist

- [x] **Closes:** #30355
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

