### PR TITLE
[Peek] Fix title bar with maximized window

### DIFF
--- a/src/modules/peek/Peek.UI/Extensions/WindowExtensions.cs
+++ b/src/modules/peek/Peek.UI/Extensions/WindowExtensions.cs
@@ -2,7 +2,6 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Runtime.InteropServices;
 using ManagedCommon;
 using Microsoft.UI.Xaml;
@@ -25,12 +24,31 @@ namespace Peek.UI.Extensions
         internal static void CenterOnMonitor(this Window window, HWND hwndDesktop, double? width = null, double? height = null)
         {
             var hwndToCenter = new HWND(window.GetWindowHandle());
+
+            // If the window is maximized, restore to normal state before change its size
+            var placement = default(WINDOWPLACEMENT);
+            if (PInvoke.GetWindowPlacement(hwndToCenter, ref placement))
+            {
+                if (placement.showCmd == SHOW_WINDOW_CMD.SW_MAXIMIZE)
+                {
+                    placement.showCmd = SHOW_WINDOW_CMD.SW_SHOWNORMAL;
+                    if (!PInvoke.SetWindowPlacement(hwndToCenter, in placement))
+                    {
+                        Logger.LogError($"SetWindowPlacement failed with error {Marshal.GetLastWin32Error()}");
+                    }
+                }
+            }
+            else
+            {
+                Logger.LogError($"GetWindowPlacement failed with error {Marshal.GetLastWin32Error()}");
+            }
+
             var monitor = PInvoke.MonitorFromWindow(hwndDesktop, MONITOR_FROM_FLAGS.MONITOR_DEFAULTTONEAREST);
             MONITORINFO info = default(MONITORINFO);
             info.cbSize = 40;
             PInvoke.GetMonitorInfo(monitor, ref info);
             var dpi = PInvoke.GetDpiForWindow(new HWND(hwndDesktop));
-            PInvoke.GetWindowRect(new HWND(hwndToCenter), out RECT windowRect);
+            PInvoke.GetWindowRect(hwndToCenter, out RECT windowRect);
             var scalingFactor = dpi / 96d;
             var w = width.HasValue ? (int)(width * scalingFactor) : windowRect.right - windowRect.left;
             var h = height.HasValue ? (int)(height * scalingFactor) : windowRect.bottom - windowRect.top;
@@ -38,7 +56,8 @@ namespace Peek.UI.Extensions
             var cy = (info.rcMonitor.bottom + info.rcMonitor.top) / 2;
             var left = cx - (w / 2);
             var top = cy - (h / 2);
-            SetWindowPosOrThrow(new HWND(hwndToCenter), default(HWND), left, top, w, h, SET_WINDOW_POS_FLAGS.SWP_SHOWWINDOW);
+
+            SetWindowPosOrThrow(hwndToCenter, default(HWND), left, top, w, h, SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE);
         }
 
         private static void SetWindowPosOrThrow(HWND hWnd, HWND hWndInsertAfter, int x, int y, int cx, int cy, SET_WINDOW_POS_FLAGS uFlags)

--- a/src/modules/peek/Peek.UI/NativeMethods.txt
+++ b/src/modules/peek/Peek.UI/NativeMethods.txt
@@ -18,3 +18,5 @@ MONITORINFO
 GetWindowRect
 SET_WINDOW_POS_FLAGS
 SetWindowPos
+GetWindowPlacement
+SetWindowPlacement


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Fix title bar state when Peek window is resized.

Pass `SWP_NOACTIVATE` instead of `SWP_SHOWWINDOW` to `SetWindowPos` since the method is just adjusting window size and there is no need to activate it.
Reference: https://learn.microsoft.com/windows/win32/api/winuser/nf-winuser-setwindowpos

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #31171
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

- Preview a file
- Maximize window
- Navigate to next file using arrow
- Window is resized and title bar is not messed up
- With pinned button active the window stay maximized