### PR TITLE
[Peek] Add check to ensure window class name matches File Explorer

### DIFF
--- a/src/modules/peek/Peek.UI/Helpers/FileExplorerHelper.cs
+++ b/src/modules/peek/Peek.UI/Helpers/FileExplorerHelper.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Text;
 using Peek.Common.Models;
 using Peek.UI.Extensions;
 using SHDocVw;
@@ -11,7 +10,6 @@ using Windows.Win32;
 using Windows.Win32.Foundation;
 using Windows.Win32.UI.Shell;
 using IServiceProvider = Peek.Common.Models.IServiceProvider;
-using NativeMethods = Peek.UI.Native.NativeMethods;
 
 namespace Peek.UI.Helpers
 {
@@ -67,16 +65,8 @@ namespace Peek.UI.Helpers
             ShellWindows shellWindows = shell.Windows();
             foreach (IWebBrowserApp webBrowserApp in shellWindows)
             {
-                StringBuilder className = new StringBuilder(256);
-                if (NativeMethods.GetClassName(new IntPtr(webBrowserApp.HWND), className, className.Capacity) == 0)
+                if (webBrowserApp.Document is Shell32.IShellFolderViewDual2 shellFolderView)
                 {
-                    continue;
-                }
-
-                // This is the class name for File Explorer
-                if (className.ToString() == "CabinetWClass")
-                {
-                    var shellFolderView = (Shell32.IShellFolderViewDual2)webBrowserApp.Document;
                     var folderTitle = shellFolderView.Folder.Title;
 
                     if (webBrowserApp.HWND == foregroundWindowHandle)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
The casting error that occurred when there was an active window other than File Explorer was fixed.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #27745 #27692 #26256 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

- Open a directory with Directory Opus.
- Open a directory with File Explorer.
- Preview a file with Peek in File Explorer.
