### PR TITLE
[Run] Tooltips fix and improvement

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Registry/Helper/ResultHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Registry/Helper/ResultHelper.cs
@@ -58,7 +58,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Registry.Helper
 
                 result.Action = (_) => ContextMenuHelper.TryToOpenInRegistryEditor(entry);
                 result.ContextData = entry;
-                result.ToolTipData = new ToolTipData(Resources.RegistryKey, $"{Resources.KeyName}\t{result.Title}");
+                result.ToolTipData = new ToolTipData(Resources.RegistryKey, $"{Resources.KeyName} {result.Title}");
 
                 resultList.Add(result);
             }
@@ -198,10 +198,10 @@ namespace Microsoft.PowerToys.Run.Plugin.Registry.Helper
         /// <returns>A tool-tip text</returns>
         private static string GetToolTipTextForRegistryValue(RegistryKey key, KeyValuePair<string, object> valueEntry)
         {
-            return $"{Resources.KeyName}\t{key.Name}{Environment.NewLine}"
-                 + $"{Resources.Name}\t{valueEntry.Key}{Environment.NewLine}"
-                 + $"{Resources.Type}\t{ValueHelper.GetType(key, valueEntry.Key)}{Environment.NewLine}"
-                 + $"{Resources.Value}\t{ValueHelper.GetValue(key, valueEntry.Key)}";
+            return $"{Resources.KeyName} {key.Name}{Environment.NewLine}"
+                 + $"{Resources.Name} {valueEntry.Key}{Environment.NewLine}"
+                 + $"{Resources.Type} {ValueHelper.GetType(key, valueEntry.Key)}{Environment.NewLine}"
+                 + $"{Resources.Value} {ValueHelper.GetValue(key, valueEntry.Key)}";
         }
 
         /// <summary>

--- a/src/modules/launcher/PowerLauncher/ResultList.xaml
+++ b/src/modules/launcher/PowerLauncher/ResultList.xaml
@@ -85,12 +85,14 @@
                                     FontWeight="SemiBold"
                                     Style="{DynamicResource CollapsableTextblock}"
                                     Text="{Binding Result.ToolTipData.Title}"
+                                    TextAlignment="Left"
                                     TextWrapping="Wrap" />
                                 <TextBlock
                                     Margin="0,4,0,0"
                                     Foreground="{DynamicResource TextFillColorSecondaryBrush}"
                                     Style="{DynamicResource CollapsableTextblock}"
                                     Text="{Binding Result.ToolTipData.Text}"
+                                    TextAlignment="Left"
                                     TextWrapping="Wrap" />
                             </StackPanel>
                         </ToolTip>

--- a/src/modules/launcher/PowerLauncher/ResultList.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/ResultList.xaml.cs
@@ -22,7 +22,7 @@ namespace PowerLauncher
 
         // From https://learn.microsoft.com/dotnet/desktop/wpf/data/how-to-find-datatemplate-generated-elements
         private TypeChildItem FindVisualChild<TypeChildItem>(DependencyObject obj)
-    where TypeChildItem : DependencyObject
+            where TypeChildItem : DependencyObject
         {
             for (int i = 0; i < VisualTreeHelper.GetChildrenCount(obj); i++)
             {
@@ -80,20 +80,22 @@ namespace PowerLauncher
             }
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1309:Use ordinal string comparison", Justification = "Using StringComparison.InvariantCulture since this is user facing")]
         private void ToolTip_Opened(object sender, RoutedEventArgs e)
         {
-            if (string.Equals(sender.GetType().FullName, "System.Windows.Controls.ToolTip", System.StringComparison.InvariantCulture))
+            if (string.Equals(sender.GetType().FullName, "System.Windows.Controls.ToolTip", System.StringComparison.Ordinal))
             {
-                HideCurrentToolTip();
-                _previouslyOpenedToolTip = (ToolTip)sender;
+                var openedToolTip = (ToolTip)sender;
+                if (_previouslyOpenedToolTip != openedToolTip)
+                {
+                    HideCurrentToolTip();
+                    _previouslyOpenedToolTip = openedToolTip;
+                }
             }
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1309:Use ordinal string comparison", Justification = "Using StringComparison.InvariantCulture since this is user facing")]
         private void SuggestionsListView_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            if (string.Equals(((ListView)e.OriginalSource).Name, "SuggestionsList", System.StringComparison.InvariantCulture))
+            if (string.Equals(((ListView)e.OriginalSource).Name, "SuggestionsList", System.StringComparison.Ordinal))
             {
                 HideCurrentToolTip();
             }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

- Fix tooltip closed automatically when opened with mouse more than 1 time
- Improve spacing when tooltip text is wrapped
- Don't use tab in tooltip for Registry plugin results (aligned to other plugins like WindowWalker)

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #9451 #13883
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

0.78.0 and PR comparison

![2](https://github.com/microsoft/PowerToys/assets/25966642/4409395e-ef08-4183-a469-3e831b2c9234)
![2b](https://github.com/microsoft/PowerToys/assets/25966642/0928e0e0-38c6-447b-80cb-ad81ac845e02)

![1](https://github.com/microsoft/PowerToys/assets/25966642/f67662c3-0c55-45cb-b9b1-c469a9880f8f)
![1b](https://github.com/microsoft/PowerToys/assets/25966642/e1d00b11-34fb-4cb0-a6dd-de0b608e5513)

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

- Tested tooltips for Registry plugin results
- Tested tooltips with long trimmed text (frequently happens with MSIX packages paths)
- Tested tooltip opening more than 1 time for results
- Tested tooltip opening more than 1 time for context actions
- Tested context action tooltips with keyboard navigation