### PR TITLE
[Run][Calculator] Replace input with result

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator.UnitTest/QueryTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator.UnitTest/QueryTests.cs
@@ -13,6 +13,19 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
     [TestClass]
     public class QueryTests
     {
+        private static Mock<Main> _main;
+        private static Mock<IPublicAPI> _api;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            _api = new Mock<IPublicAPI>();
+            _api.Setup(api => api.ChangeQuery(It.IsAny<string>(), It.IsAny<bool>())).Verifiable();
+
+            _main = new Mock<Main>();
+            _main.Object.Init(new PluginInitContext() { API = _api.Object });
+        }
+
         [DataTestMethod]
         [DataRow("=pi(9+)", "Expression wrong or incomplete (Did you forget some parentheses?)")]
         [DataRow("=pi,", "Expression wrong or incomplete (Did you forget some parentheses?)")]
@@ -28,12 +41,10 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
         [DataRow("10+(8*9)/0*7", "Expression contains division by zero")]
         public void ErrorResultOnInvalidKeywordQuery(string typedString, string expectedResult)
         {
-            // Setup
-            Mock<Main> main = new();
             Query expectedQuery = new(typedString, "=");
 
             // Act
-            var result = main.Object.Query(expectedQuery).FirstOrDefault().SubTitle;
+            var result = _main.Object.Query(expectedQuery).FirstOrDefault().SubTitle;
 
             // Assert
             Assert.AreEqual(expectedResult, result);
@@ -55,11 +66,10 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
         public void NoResultOnInvalidGlobalQuery(string typedString)
         {
             // Setup
-            Mock<Main> main = new();
             Query expectedQuery = new(typedString);
 
             // Act
-            var result = main.Object.Query(expectedQuery).Count;
+            var result = _main.Object.Query(expectedQuery).Count;
 
             // Assert
             Assert.AreEqual(result, 0);
@@ -79,13 +89,12 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
         public void NoResultIfQueryEndsWithBinaryOperator(string typedString)
         {
             // Setup
-            Mock<Main> main = new();
             Query expectedQuery = new(typedString);
             Query expectedQueryWithKeyword = new("=" + typedString, "=");
 
             // Act
-            var result = main.Object.Query(expectedQuery).Count;
-            var resultWithKeyword = main.Object.Query(expectedQueryWithKeyword).Count;
+            var result = _main.Object.Query(expectedQuery).Count;
+            var resultWithKeyword = _main.Object.Query(expectedQueryWithKeyword).Count;
 
             // Assert
             Assert.AreEqual(result, 0);
@@ -100,13 +109,12 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
         public void NoErrorForDivisionByNumberWithDecimalDigits(string typedString)
         {
             // Setup
-            Mock<Main> main = new();
             Query expectedQuery = new(typedString);
             Query expectedQueryWithKeyword = new("=" + typedString, "=");
 
             // Act
-            var result = main.Object.Query(expectedQuery).FirstOrDefault().SubTitle;
-            var resultWithKeyword = main.Object.Query(expectedQueryWithKeyword).FirstOrDefault().SubTitle;
+            var result = _main.Object.Query(expectedQuery).FirstOrDefault().SubTitle;
+            var resultWithKeyword = _main.Object.Query(expectedQueryWithKeyword).FirstOrDefault().SubTitle;
 
             // Assert
             Assert.AreEqual(result, "Copy this number to the clipboard");
@@ -190,13 +198,12 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
         public void NoErrorForHumanMultiplicationExpressions(string typedString)
         {
             // Setup
-            Mock<Main> main = new();
             Query expectedQuery = new(typedString);
             Query expectedQueryWithKeyword = new("=" + typedString, "=");
 
             // Act
-            var result = main.Object.Query(expectedQuery).FirstOrDefault()?.SubTitle;
-            var resultWithKeyword = main.Object.Query(expectedQueryWithKeyword).FirstOrDefault()?.SubTitle;
+            var result = _main.Object.Query(expectedQuery).FirstOrDefault()?.SubTitle;
+            var resultWithKeyword = _main.Object.Query(expectedQueryWithKeyword).FirstOrDefault()?.SubTitle;
 
             // Assert
             Assert.AreEqual("Copy this number to the clipboard", result);
@@ -221,13 +228,12 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
         public void RightAnswerForHumanMultiplicationExpressions(string typedString, double answer)
         {
             // Setup
-            Mock<Main> main = new();
             Query expectedQuery = new(typedString);
             Query expectedQueryWithKeyword = new("=" + typedString, "=");
 
             // Act
-            var result = main.Object.Query(expectedQuery).FirstOrDefault()?.Title;
-            var resultWithKeyword = main.Object.Query(expectedQueryWithKeyword).FirstOrDefault()?.Title;
+            var result = _main.Object.Query(expectedQuery).FirstOrDefault()?.Title;
+            var resultWithKeyword = _main.Object.Query(expectedQueryWithKeyword).FirstOrDefault()?.Title;
 
             // Assert
             Assert.AreEqual(answer.ToString(CultureInfo.CurrentCulture), result);
@@ -242,17 +248,32 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
         public void RightAnswerForLargeHexadecimalNumbers(string typedString, double answer)
         {
             // Setup
-            Mock<Main> main = new();
             Query expectedQuery = new(typedString);
             Query expectedQueryWithKeyword = new("=" + typedString, "=");
 
             // Act
-            var result = main.Object.Query(expectedQuery).FirstOrDefault()?.Title;
-            var resultWithKeyword = main.Object.Query(expectedQueryWithKeyword).FirstOrDefault()?.Title;
+            var result = _main.Object.Query(expectedQuery).FirstOrDefault()?.Title;
+            var resultWithKeyword = _main.Object.Query(expectedQueryWithKeyword).FirstOrDefault()?.Title;
 
             // Assert
             Assert.AreEqual(answer.ToString(CultureInfo.CurrentCulture), result);
             Assert.AreEqual(answer.ToString(CultureInfo.CurrentCulture), resultWithKeyword);
+        }
+
+        [DataTestMethod]
+        [DataRow("=", "=1+1=", true)]
+        [DataRow("=", "=1+1", false)]
+        [DataRow("", "1+1=", false)]
+        public void HandleQueryEndsWithActionKeyword(string actionKeyword, string query, bool shouldChangeQuery)
+        {
+            // Setup
+            Query expectedQuery = new(query, actionKeyword);
+
+            // Act
+            _main.Object.Query(expectedQuery);
+
+            // Assert
+            _api.Verify(api => api.ChangeQuery(It.IsAny<string>(), It.IsAny<bool>()), shouldChangeQuery ? Times.Once : Times.Never);
         }
     }
 }

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator.UnitTest/QueryTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator.UnitTest/QueryTests.cs
@@ -4,6 +4,7 @@
 
 using System.Globalization;
 using System.Linq;
+using Microsoft.PowerToys.Settings.UI.Library;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Wox.Plugin;
@@ -261,13 +262,15 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
         }
 
         [DataTestMethod]
-        [DataRow("=", "=1+1=", true)]
-        [DataRow("=", "=1+1", false)]
+        [DataRow("#", "#1+1=", true)]
+        [DataRow("#", "#1+1", false)]
+        [DataRow("#", "#1/0=", false)]
         [DataRow("", "1+1=", false)]
-        public void HandleQueryEndsWithActionKeyword(string actionKeyword, string query, bool shouldChangeQuery)
+        public void HandleInputReplace(string actionKeyword, string query, bool shouldChangeQuery)
         {
             // Setup
             Query expectedQuery = new(query, actionKeyword);
+            _main.Object.UpdateSettings(new PowerLauncherPluginSettings()); // Default settings
 
             // Act
             _main.Object.Query(expectedQuery);

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/Main.cs
@@ -17,6 +17,10 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
 {
     public class Main : IPlugin, IPluginI18n, IDisposable, ISettingProvider
     {
+        private const string InputUseEnglishFormat = nameof(InputUseEnglishFormat);
+        private const string OutputUseEnglishFormat = nameof(OutputUseEnglishFormat);
+        private const string ReplaceInput = nameof(ReplaceInput);
+
         private static readonly CalculateEngine CalculateEngine = new CalculateEngine();
 
         private PluginInitContext Context { get; set; }
@@ -25,6 +29,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
 
         private bool _inputUseEnglishFormat;
         private bool _outputUseEnglishFormat;
+        private bool _replaceInput;
 
         public string Name => Resources.wox_plugin_calculator_plugin_name;
 
@@ -40,19 +45,26 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
         public IEnumerable<PluginAdditionalOption> AdditionalOptions => new List<PluginAdditionalOption>()
         {
             // The number examples has to be created at runtime to prevent translation.
-            new PluginAdditionalOption()
+            new PluginAdditionalOption
             {
-                Key = "InputUseEnglishFormat",
+                Key = InputUseEnglishFormat,
                 DisplayLabel = Resources.wox_plugin_calculator_in_en_format,
                 DisplayDescription = string.Format(CultureInfo.CurrentCulture, WoxPluginCalculatorInEnFormatDescription, 1000.55.ToString("N2", new CultureInfo("en-us"))),
                 Value = false,
             },
-            new PluginAdditionalOption()
+            new PluginAdditionalOption
             {
-                Key = "OutputUseEnglishFormat",
+                Key = OutputUseEnglishFormat,
                 DisplayLabel = Resources.wox_plugin_calculator_out_en_format,
                 DisplayDescription = string.Format(CultureInfo.CurrentCulture, WoxPluginCalculatorOutEnFormatDescription, 1000.55.ToString("G", new CultureInfo("en-us"))),
                 Value = false,
+            },
+            new PluginAdditionalOption
+            {
+                Key = ReplaceInput,
+                DisplayLabel = Resources.wox_plugin_calculator_replace_input,
+                DisplayDescription = Resources.wox_plugin_calculator_replace_input_description,
+                Value = true,
             },
         };
 
@@ -61,7 +73,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
             ArgumentNullException.ThrowIfNull(query);
 
             bool isGlobalQuery = string.IsNullOrEmpty(query.ActionKeyword);
-            bool keywordAppended = query.Search.EndsWith(query.ActionKeyword, StringComparison.OrdinalIgnoreCase);
+            bool replaceInput = _replaceInput && !isGlobalQuery && query.Search.EndsWith('=');
             CultureInfo inputCulture = _inputUseEnglishFormat ? new CultureInfo("en-us") : CultureInfo.CurrentCulture;
             CultureInfo outputCulture = _outputUseEnglishFormat ? new CultureInfo("en-us") : CultureInfo.CurrentCulture;
 
@@ -74,9 +86,9 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
             NumberTranslator translator = NumberTranslator.Create(inputCulture, new CultureInfo("en-US"));
             var input = translator.Translate(query.Search.Normalize(NormalizationForm.FormKC));
 
-            if (!isGlobalQuery && keywordAppended)
+            if (replaceInput)
             {
-                input = input[..^query.ActionKeyword.Length];
+                input = input[..^1];
             }
 
             if (!CalculateHelper.InputValid(input))
@@ -95,15 +107,16 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
                     // If errorMessage is not default then do error handling
                     return errorMessage == default ? new List<Result>() : ErrorHandler.OnError(IconPath, isGlobalQuery, query.RawQuery, errorMessage);
                 }
-                else if (!isGlobalQuery && keywordAppended && result.RoundedResult.HasValue)
+                else if (replaceInput)
                 {
-                    Context.API.ChangeQuery($"{query.ActionKeyword}{result.RoundedResult.Value.ToString(inputCulture)}");
+                    var pluginResult = ResultHelper.CreateResult(result.RoundedResult, IconPath, inputCulture, outputCulture);
+                    Context.API.ChangeQuery($"{query.ActionKeyword} {pluginResult.QueryTextDisplay}");
                     return new List<Result>();
                 }
 
                 return new List<Result>
                 {
-                    ResultHelper.CreateResult(result.RoundedResult, IconPath, outputCulture),
+                    ResultHelper.CreateResult(result.RoundedResult, IconPath, inputCulture, outputCulture),
                 };
             }
             catch (Mages.Core.ParseException)
@@ -168,18 +181,23 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
         {
             var inputUseEnglishFormat = false;
             var outputUseEnglishFormat = false;
+            var replaceInput = true;
 
             if (settings != null && settings.AdditionalOptions != null)
             {
-                var optionInputEn = settings.AdditionalOptions.FirstOrDefault(x => x.Key == "InputUseEnglishFormat");
+                var optionInputEn = settings.AdditionalOptions.FirstOrDefault(x => x.Key == InputUseEnglishFormat);
                 inputUseEnglishFormat = optionInputEn?.Value ?? inputUseEnglishFormat;
 
-                var optionOutputEn = settings.AdditionalOptions.FirstOrDefault(x => x.Key == "OutputUseEnglishFormat");
+                var optionOutputEn = settings.AdditionalOptions.FirstOrDefault(x => x.Key == OutputUseEnglishFormat);
                 outputUseEnglishFormat = optionOutputEn?.Value ?? outputUseEnglishFormat;
+
+                var optionReplaceInput = settings.AdditionalOptions.FirstOrDefault(x => x.Key == ReplaceInput);
+                replaceInput = optionReplaceInput?.Value ?? replaceInput;
             }
 
             _inputUseEnglishFormat = inputUseEnglishFormat;
             _outputUseEnglishFormat = outputUseEnglishFormat;
+            _replaceInput = replaceInput;
         }
 
         public void Dispose()

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/Properties/Resources.Designer.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/Properties/Resources.Designer.cs
@@ -185,5 +185,23 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.Properties {
                 return ResourceManager.GetString("wox_plugin_calculator_plugin_name", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Replace input appending &apos;=&apos;.
+        /// </summary>
+        public static string wox_plugin_calculator_replace_input {
+            get {
+                return ResourceManager.GetString("wox_plugin_calculator_replace_input", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to When using direct activation, appending &apos;=&apos; to the expression will replace the input with the calculated result (e.g. =5*3-2=)..
+        /// </summary>
+        public static string wox_plugin_calculator_replace_input_description {
+            get {
+                return ResourceManager.GetString("wox_plugin_calculator_replace_input_description", resourceCulture);
+            }
+        }
     }
 }

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/Properties/Resources.resx
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/Properties/Resources.resx
@@ -165,6 +165,6 @@
     <value>Replace input by appending '='</value>
   </data>
   <data name="wox_plugin_calculator_replace_input_description" xml:space="preserve">
-    <value>When using direct activation, appending '=' to the expression will replace the input with the calculated result (e.g. =5*3-2=).</value>
+    <value>When using direct activation, appending '=' to the expression will replace the input with the calculated result (e.g. '=5*3-2=' will change the query to '=13').</value>
   </data>
 </root>

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/Properties/Resources.resx
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/Properties/Resources.resx
@@ -162,7 +162,7 @@
     <value>Expression contains division by zero</value>
   </data>
   <data name="wox_plugin_calculator_replace_input" xml:space="preserve">
-    <value>Replace input by appending '='</value>
+    <value>Replace input if query ends with '='</value>
   </data>
   <data name="wox_plugin_calculator_replace_input_description" xml:space="preserve">
     <value>When using direct activation, appending '=' to the expression will replace the input with the calculated result (e.g. '=5*3-2=' will change the query to '=13').</value>

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/Properties/Resources.resx
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/Properties/Resources.resx
@@ -161,4 +161,10 @@
   <data name="wox_plugin_calculator_division_by_zero" xml:space="preserve">
     <value>Expression contains division by zero</value>
   </data>
+  <data name="wox_plugin_calculator_replace_input" xml:space="preserve">
+    <value>Replace input appending '='</value>
+  </data>
+  <data name="wox_plugin_calculator_replace_input_description" xml:space="preserve">
+    <value>When using direct activation, appending '=' to the expression will replace the input with the calculated result (e.g. =5*3-2=).</value>
+  </data>
 </root>

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/Properties/Resources.resx
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/Properties/Resources.resx
@@ -162,7 +162,7 @@
     <value>Expression contains division by zero</value>
   </data>
   <data name="wox_plugin_calculator_replace_input" xml:space="preserve">
-    <value>Replace input appending '='</value>
+    <value>Replace input by appending '='</value>
   </data>
   <data name="wox_plugin_calculator_replace_input_description" xml:space="preserve">
     <value>When using direct activation, appending '=' to the expression will replace the input with the calculated result (e.g. =5*3-2=).</value>

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/ResultHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/ResultHelper.cs
@@ -12,12 +12,12 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
 {
     public static class ResultHelper
     {
-        public static Result CreateResult(CalculateResult result, string iconPath, CultureInfo culture)
+        public static Result CreateResult(CalculateResult result, string iconPath, CultureInfo inputCulture, CultureInfo outputCulture)
         {
-            return CreateResult(result.RoundedResult, iconPath, culture);
+            return CreateResult(result.RoundedResult, iconPath, inputCulture, outputCulture);
         }
 
-        public static Result CreateResult(decimal? roundedResult, string iconPath, CultureInfo culture)
+        public static Result CreateResult(decimal? roundedResult, string iconPath, CultureInfo inputCulture, CultureInfo outputCulture)
         {
             // Return null when the expression is not a valid calculator query.
             if (roundedResult == null)
@@ -28,11 +28,12 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
             return new Result
             {
                 // Using CurrentCulture since this is user facing
-                Title = roundedResult?.ToString(culture),
+                Title = roundedResult?.ToString(outputCulture),
                 IcoPath = iconPath,
                 Score = 300,
                 SubTitle = Properties.Resources.wox_plugin_calculator_copy_number_to_clipboard,
-                Action = c => Action(roundedResult, culture),
+                Action = c => Action(roundedResult, outputCulture),
+                QueryTextDisplay = roundedResult?.ToString(inputCulture),
             };
         }
 

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -842,9 +842,6 @@ namespace PowerLauncher
         {
             if (_viewModel.Plugins.Count > 0 && _viewModel.SelectedPlugin != null)
             {
-                // Needed to update UI in case the user choose the same plugin multiple times
-                _viewModel.ChangeQueryText(string.Empty);
-
                 _viewModel.ChangeQueryText(_viewModel.SelectedPlugin.Metadata.ActionKeyword, true);
                 SearchBox.QueryTextBox.Focus();
 

--- a/src/modules/launcher/PowerLauncher/PublicAPIInstance.cs
+++ b/src/modules/launcher/PowerLauncher/PublicAPIInstance.cs
@@ -49,7 +49,10 @@ namespace Wox
 
         public void ChangeQuery(string query, bool requery = false)
         {
-            _mainVM.ChangeQueryText(query, requery);
+            Application.Current.Dispatcher.Invoke(() =>
+            {
+                _mainVM.ChangeQueryText(query, requery);
+            });
         }
 
         public void CheckForNewUpdate()

--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -9,7 +9,6 @@ using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Text;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
@@ -380,7 +379,14 @@ namespace PowerLauncher.ViewModel
         /// <param name="requery">Optional Parameter that if true, will automatically execute a query against the updated text</param>
         public void ChangeQueryText(string queryText, bool requery = false)
         {
+            var sameQueryText = SystemQueryText == queryText;
+
             SystemQueryText = queryText;
+
+            if (sameQueryText)
+            {
+                OnPropertyChanged(nameof(SystemQueryText));
+            }
 
             if (requery)
             {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This is super useful! Wondering why this is not implemented yet! 😄 
Replace query text with the current result appending `=` to the search.

![Calculator](https://github.com/microsoft/PowerToys/assets/25966642/42dd9609-92ff-43c1-a833-af6a0e168859)

![image](https://github.com/microsoft/PowerToys/assets/25966642/b2f4f3d3-1ca5-4f74-bd5e-b62848baf439)

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #4087
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

- Changed API to allow changing query text using the dispatcher.
- Fixed a bug when the same query text couldn't be programmatically set more than one time in a row.
- Removed empty query work-around for plugins overview.
- Added options for the new feature enabled by default).

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

- Verified that the same plugin can be selected 2 times in a row from the plugins overview.
- Verified that input is replaced only when the Calculator plugin is invoked with the action keyword.
- Verified that input is replaced with the correct number format.

![image](https://github.com/microsoft/PowerToys/assets/25966642/a69940c5-ea00-4661-86d2-74d9a1f61509)