### PR TITLE
[Hosts]Indicate when an entry input field is invalid

### DIFF
--- a/src/modules/Hosts/Hosts/HostsXAML/Views/MainPage.xaml
+++ b/src/modules/Hosts/Hosts/HostsXAML/Views/MainPage.xaml
@@ -439,11 +439,14 @@
                         Text="{Binding Address, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
                         <TextBox.Description>
                             <StackPanel
-                                Margin="0,6,0,0"
+                                Margin="0,4"
                                 Orientation="Horizontal"
+                                Spacing="4"
                                 Visibility="{Binding IsAddressValid, Converter={StaticResource BoolToInvertedVisibilityConverter}}">
                                 <FontIcon
-                                    Margin="0,0,6,0"
+                                    Margin="0,0,0,0"
+                                    AutomationProperties.AccessibilityView="Raw"
+                                    FontSize="14"
                                     Foreground="{ThemeResource SystemFillColorCautionBrush}"
                                     Glyph="&#xE7BA;" />
                                 <TextBlock x:Uid="EntryAddressIsInvalidWarning" />
@@ -461,11 +464,13 @@
                         TextWrapping="Wrap">
                         <TextBox.Description>
                             <StackPanel
-                                Margin="0,6,0,0"
+                                Margin="0,4"
                                 Orientation="Horizontal"
+                                Spacing="4"
                                 Visibility="{Binding IsHostsValid, Converter={StaticResource BoolToInvertedVisibilityConverter}}">
                                 <FontIcon
-                                    Margin="0,0,6,0"
+                                    AutomationProperties.AccessibilityView="Raw"
+                                    FontSize="14"
                                     Foreground="{ThemeResource SystemFillColorCautionBrush}"
                                     Glyph="&#xE7BA;" />
                                 <TextBlock x:Uid="EntryHostsIsInvalidWarning" />

--- a/src/modules/Hosts/Hosts/HostsXAML/Views/MainPage.xaml
+++ b/src/modules/Hosts/Hosts/HostsXAML/Views/MainPage.xaml
@@ -436,7 +436,20 @@
                     <TextBox
                         x:Uid="Address"
                         IsSpellCheckEnabled="False"
-                        Text="{Binding Address, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                        Text="{Binding Address, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                        <TextBox.Description>
+                            <StackPanel
+                                Margin="0,6,0,0"
+                                Orientation="Horizontal"
+                                Visibility="{Binding IsAddressValid, Converter={StaticResource BoolToInvertedVisibilityConverter}}">
+                                <FontIcon
+                                    Margin="0,0,6,0"
+                                    Foreground="{ThemeResource SystemFillColorCautionBrush}"
+                                    Glyph="&#xE7BA;" />
+                                <TextBlock x:Uid="EntryAddressIsInvalidWarning" />
+                            </StackPanel>
+                        </TextBox.Description>
+                    </TextBox>
                     <TextBox
                         x:Uid="Hosts"
                         AcceptsReturn="False"
@@ -445,7 +458,20 @@
                         ScrollViewer.VerticalScrollBarVisibility="Visible"
                         ScrollViewer.VerticalScrollMode="Enabled"
                         Text="{Binding Hosts, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                        TextWrapping="Wrap" />
+                        TextWrapping="Wrap">
+                        <TextBox.Description>
+                            <StackPanel
+                                Margin="0,6,0,0"
+                                Orientation="Horizontal"
+                                Visibility="{Binding IsHostsValid, Converter={StaticResource BoolToInvertedVisibilityConverter}}">
+                                <FontIcon
+                                    Margin="0,0,6,0"
+                                    Foreground="{ThemeResource SystemFillColorCautionBrush}"
+                                    Glyph="&#xE7BA;" />
+                                <TextBlock x:Uid="EntryHostsIsInvalidWarning" />
+                            </StackPanel>
+                        </TextBox.Description>
+                    </TextBox>
                     <TextBox
                         x:Uid="Comment"
                         AcceptsReturn="False"

--- a/src/modules/Hosts/Hosts/Models/Entry.cs
+++ b/src/modules/Hosts/Hosts/Models/Entry.cs
@@ -16,6 +16,7 @@ namespace Hosts.Models
 
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(Valid))]
+        [NotifyPropertyChangedFor(nameof(IsAddressValid))]
         private string _address;
 
         partial void OnAddressChanged(string value)
@@ -36,6 +37,7 @@ namespace Hosts.Models
 
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(Valid))]
+        [NotifyPropertyChangedFor(nameof(IsHostsValid))]
         private string _hosts;
 
         partial void OnHostsChanged(string value)
@@ -60,6 +62,10 @@ namespace Hosts.Models
         private bool _duplicate;
 
         public bool Valid => Validate(true);
+
+        public bool IsAddressValid => ValidateAddressField();
+
+        public bool IsHostsValid => ValidateHostsField(true);
 
         public string Line { get; private set; }
 
@@ -152,6 +158,16 @@ namespace Hosts.Models
             };
         }
 
+        private bool ValidateAddressField()
+        {
+            return Type != AddressType.Invalid;
+        }
+
+        private bool ValidateHostsField(bool validateHostsLength)
+        {
+            return ValidationHelper.ValidHosts(Hosts, validateHostsLength);
+        }
+
         public bool Validate(bool validateHostsLength)
         {
             if (Equals("102.54.94.97", "rhino.acme.com", "source server") || Equals("38.25.63.10", "x.acme.com", "x client host"))
@@ -159,7 +175,7 @@ namespace Hosts.Models
                 return false;
             }
 
-            return Type != AddressType.Invalid && ValidationHelper.ValidHosts(Hosts, validateHostsLength);
+            return ValidateAddressField() && ValidateHostsField(validateHostsLength);
         }
 
         private bool Equals(string address, string hosts, string comment)

--- a/src/modules/Hosts/Hosts/Strings/en-us/Resources.resw
+++ b/src/modules/Hosts/Hosts/Strings/en-us/Resources.resw
@@ -300,10 +300,10 @@
     <comment>"Hosts" refers to the system hosts file, do not loc</comment>
   </data>
   <data name="EntryAddressIsInvalidWarning.Text" xml:space="preserve">
-    <value>Address not recognized as IPv4 or IPv6.</value>
+    <value>Address not recognized as IPv4 or IPv6</value>
   </data>
   <data name="EntryHostsIsInvalidWarning.Text" xml:space="preserve">
-    <value>The host name entry is invalid.</value>
+    <value>Invalid host name</value>
   </data>
   <data name="UpdateBtn" xml:space="preserve">
     <value>Update</value>

--- a/src/modules/Hosts/Hosts/Strings/en-us/Resources.resw
+++ b/src/modules/Hosts/Hosts/Strings/en-us/Resources.resw
@@ -303,7 +303,7 @@
     <value>Must be a valid IPv4 or IPv6 address</value>
   </data>
   <data name="EntryHostsIsInvalidWarning.Text" xml:space="preserve">
-    <value>Invalid host name</value>
+    <value>Must be one or more valid host names separated by spaces</value>
   </data>
   <data name="UpdateBtn" xml:space="preserve">
     <value>Update</value>

--- a/src/modules/Hosts/Hosts/Strings/en-us/Resources.resw
+++ b/src/modules/Hosts/Hosts/Strings/en-us/Resources.resw
@@ -300,10 +300,10 @@
     <comment>"Hosts" refers to the system hosts file, do not loc</comment>
   </data>
   <data name="EntryAddressIsInvalidWarning.Text" xml:space="preserve">
-    <value>Must be a valid IPv4 or IPv6 address</value>
+    <value>Has to be a valid IPv4 or IPv6 address</value>
   </data>
   <data name="EntryHostsIsInvalidWarning.Text" xml:space="preserve">
-    <value>Must be one or more valid host names separated by spaces</value>
+    <value>Has to be one or more valid host names separated by spaces</value>
   </data>
   <data name="UpdateBtn" xml:space="preserve">
     <value>Update</value>

--- a/src/modules/Hosts/Hosts/Strings/en-us/Resources.resw
+++ b/src/modules/Hosts/Hosts/Strings/en-us/Resources.resw
@@ -299,6 +299,12 @@
     <value>Entries contain too many hosts</value>
     <comment>"Hosts" refers to the system hosts file, do not loc</comment>
   </data>
+  <data name="EntryAddressIsInvalidWarning.Text" xml:space="preserve">
+    <value>Address not recognized as IPv4 or IPv6.</value>
+  </data>
+  <data name="EntryHostsIsInvalidWarning.Text" xml:space="preserve">
+    <value>The host name entry is invalid.</value>
+  </data>
   <data name="UpdateBtn" xml:space="preserve">
     <value>Update</value>
   </data>

--- a/src/modules/Hosts/Hosts/Strings/en-us/Resources.resw
+++ b/src/modules/Hosts/Hosts/Strings/en-us/Resources.resw
@@ -300,7 +300,7 @@
     <comment>"Hosts" refers to the system hosts file, do not loc</comment>
   </data>
   <data name="EntryAddressIsInvalidWarning.Text" xml:space="preserve">
-    <value>Address not recognized as IPv4 or IPv6</value>
+    <value>Must be a valid IPv4 or IPv6 address</value>
   </data>
   <data name="EntryHostsIsInvalidWarning.Text" xml:space="preserve">
     <value>Invalid host name</value>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Windows App SDK 1.5 is expected to bring data validation for input fields. In the meanwhile, we're doing something a bit more manual.

![image](https://github.com/microsoft/PowerToys/assets/9866362/0c8c3b57-6a47-446d-bd9e-779cf23bbbbe)


Show a warning message when the input fields are invalid to improve accessibility.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #21287
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Checked behavior with valid and invalid entries for both fields.