### PR TITLE
[Settings] Remember maximized state

### DIFF
--- a/src/settings-ui/Settings.UI/SettingsXAML/App.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/App.xaml.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
+using Common.UI;
 using interop;
 using ManagedCommon;
 using Microsoft.PowerToys.Settings.UI.Helpers;

--- a/src/settings-ui/Settings.UI/SettingsXAML/App.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/App.xaml.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
-using Common.UI;
 using interop;
 using ManagedCommon;
 using Microsoft.PowerToys.Settings.UI.Helpers;
@@ -82,7 +81,7 @@ namespace Microsoft.PowerToys.Settings.UI
         {
             if (settingsWindow == null)
             {
-                settingsWindow = new MainWindow(IsDarkTheme());
+                settingsWindow = new MainWindow();
             }
 
             settingsWindow.Activate();
@@ -92,7 +91,7 @@ namespace Microsoft.PowerToys.Settings.UI
                 settingsWindow.NavigateToSection(type);
 
                 WindowHelpers.BringToForeground(settingsWindow.GetWindowHandle());
-             }
+            }
 
             if (ensurePageIsSelected)
             {

--- a/src/settings-ui/Settings.UI/SettingsXAML/MainWindow.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/MainWindow.xaml.cs
@@ -7,7 +7,6 @@ using ManagedCommon;
 using Microsoft.PowerLauncher.Telemetry;
 using Microsoft.PowerToys.Settings.UI.Helpers;
 using Microsoft.PowerToys.Settings.UI.Library;
-using Microsoft.PowerToys.Settings.UI.OOBE.Views;
 using Microsoft.PowerToys.Settings.UI.Views;
 using Microsoft.PowerToys.Telemetry;
 using Microsoft.UI;
@@ -41,6 +40,9 @@ namespace Microsoft.PowerToys.Settings.UI
             if (createHidden)
             {
                 placement.ShowCmd = NativeMethods.SW_HIDE;
+
+                // Restore the last known placement on the first activation
+                this.Activated += Window_Activated;
             }
 
             NativeMethods.SetWindowPlacement(hWnd, ref placement);
@@ -210,6 +212,17 @@ namespace Microsoft.PowerToys.Settings.UI
             {
                 args.Handled = true;
                 NativeMethods.ShowWindow(hWnd, NativeMethods.SW_HIDE);
+            }
+        }
+
+        private void Window_Activated(object sender, WindowActivatedEventArgs args)
+        {
+            if (args.WindowActivationState != WindowActivationState.Deactivated)
+            {
+                this.Activated -= Window_Activated;
+                var hWnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
+                var placement = Utils.DeserializePlacementOrDefault(hWnd);
+                NativeMethods.SetWindowPlacement(hWnd, ref placement);
             }
         }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

- Fix a bug that hit dark mode when after opening the flyout, the settings window don't preserve the maximized state.
- Also restore the last known placement when the settings window is created hidden: happens when OOBE or flyout are opened before settings after PT startup.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #31423
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

- Verified that the settings window remember position and size after opening the flyout: tested with tray double click, tray menu entry and flyout button.
- Verified that the settings window remember the maximized state after opening the flyout: tested with tray double click, tray menu entry and flyout button.
- Verified that the event handler is invoked as expected and unsubscribed when the window is create hidden.