### PR TITLE
Implemented basic functionality for being able to jump between zones with keyboard shortcuts

### DIFF
--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesWinHookEventIDs.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesWinHookEventIDs.cpp
@@ -17,6 +17,7 @@ UINT WM_PRIV_APPLIED_LAYOUTS_FILE_UPDATE;
 UINT WM_PRIV_DEFAULT_LAYOUTS_FILE_UPDATE;
 UINT WM_PRIV_SNAP_HOTKEY;
 UINT WM_PRIV_QUICK_LAYOUT_KEY;
+UINT WM_PRIV_FOCUS_ZONE_KEY;
 UINT WM_PRIV_SETTINGS_CHANGED;
 
 std::once_flag init_flag;
@@ -39,6 +40,7 @@ void InitializeWinhookEventIds()
         WM_PRIV_DEFAULT_LAYOUTS_FILE_UPDATE = RegisterWindowMessage(L"{61fd2afb-e909-41b2-b6f3-b9f546f2ae3f}");
         WM_PRIV_SNAP_HOTKEY = RegisterWindowMessage(L"{72f4fd8e-23f1-43ab-bbbc-029363df9a84}");
         WM_PRIV_QUICK_LAYOUT_KEY = RegisterWindowMessage(L"{15baab3d-c67b-4a15-aFF0-13610e05e947}");
+        WM_PRIV_FOCUS_ZONE_KEY = RegisterWindowMessage(L"{3ac7fa7b-6d34-4904-be8c-cec99b0f39c6}");
         WM_PRIV_SETTINGS_CHANGED = RegisterWindowMessage(L"{89ca3Daa-bf2d-4e73-9f3f-c60716364e27}");
     });
 }

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesWinHookEventIDs.h
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesWinHookEventIDs.h
@@ -15,6 +15,7 @@ extern UINT WM_PRIV_APPLIED_LAYOUTS_FILE_UPDATE; // Scheduled when the watched a
 extern UINT WM_PRIV_DEFAULT_LAYOUTS_FILE_UPDATE; // Scheduled when the watched default-layouts.json file is updated
 extern UINT WM_PRIV_SNAP_HOTKEY; // Scheduled when we receive a snap hotkey key down press
 extern UINT WM_PRIV_QUICK_LAYOUT_KEY; // Scheduled when we receive a key down press to quickly apply a layout
+extern UINT WM_PRIV_FOCUS_ZONE_KEY; // Scheduled when we receive a key down press to focus a work area zone
 extern UINT WM_PRIV_SETTINGS_CHANGED; // Scheduled when the a watched settings file is updated
 
 void InitializeWinhookEventIds();

--- a/src/modules/fancyzones/FancyZonesLib/LayoutAssignedWindows.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/LayoutAssignedWindows.cpp
@@ -106,6 +106,40 @@ void LayoutAssignedWindows::CycleWindows(HWND window, bool reverse)
     }
 }
 
+HWND GetLowestZOrderWindow(const std::vector<HWND>& windows)
+{
+    // Find which window in windows is at the top of the z-order
+    HWND window = GetTopWindow(GetDesktopWindow());
+    while (window)
+    {
+        if (find(begin(windows), end(windows), window) != end(windows))
+        {
+            return window;
+        }
+
+        window = GetWindow(window, GW_HWNDNEXT);
+    }
+
+    // TODO: Log not found error
+    return nullptr;
+}
+
+HWND LayoutAssignedWindows::GetCurrentWindowFromZoneIndexSet(ZoneIndexSet indexSet) noexcept
+{
+    if (!m_windowsByIndexSets.contains(indexSet))
+    {
+        return nullptr;
+    }
+
+    const auto& assignedWindows = m_windowsByIndexSets[indexSet];
+    if (assignedWindows.empty())
+    {
+        return nullptr;
+    }
+
+    return GetLowestZOrderWindow(assignedWindows);
+}
+
 void LayoutAssignedWindows::InsertWindowIntoZone(HWND window, std::optional<size_t> tabSortKeyWithinZone, const ZoneIndexSet& indexSet)
 {
     if (tabSortKeyWithinZone.has_value())

--- a/src/modules/fancyzones/FancyZonesLib/LayoutAssignedWindows.h
+++ b/src/modules/fancyzones/FancyZonesLib/LayoutAssignedWindows.h
@@ -17,6 +17,8 @@ public :
     
     void CycleWindows(HWND window, bool reverse);
 
+    HWND GetCurrentWindowFromZoneIndexSet(ZoneIndexSet indexSet) noexcept;
+
 private:
     std::map<HWND, ZoneIndexSet> m_windowIndexSet{};
     std::map<ZoneIndexSet, std::vector<HWND>> m_windowsByIndexSets{};

--- a/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
@@ -160,6 +160,31 @@ bool WorkArea::Unsnap(HWND window)
     return true;
 }
 
+bool WorkArea::Focus(const ZoneIndexSet& zones)
+{
+    if (!m_layout || zones.empty())
+    {
+        return false;
+    }
+
+    for (ZoneIndex zone : zones)
+    {
+        if (static_cast<size_t>(zone) >= m_layout->Zones().size())
+        {
+            return false;
+        }
+    }
+
+    HWND windowToFocus = m_layoutWindows.GetCurrentWindowFromZoneIndexSet(zones);
+    if (!windowToFocus)
+    {
+        return false;
+    }
+    FancyZonesWindowUtils::SwitchToWindow(windowToFocus);
+
+    return true;
+}
+
 const GUID WorkArea::GetLayoutId() const noexcept
 {
     if (m_layout)

--- a/src/modules/fancyzones/FancyZonesLib/WorkArea.h
+++ b/src/modules/fancyzones/FancyZonesLib/WorkArea.h
@@ -50,6 +50,8 @@ public:
     bool Snap(HWND window, const ZoneIndexSet& zones, bool updatePosition = true);
     bool Unsnap(HWND window);
 
+    bool Focus(const ZoneIndexSet& zones);
+
     void ShowZones(const ZoneIndexSet& highlight, HWND draggedWindow = nullptr);
     void HideZones();
     void FlashZones();


### PR DESCRIPTION
Added TODOs for things needed before ready for a PR contribution.

## Summary of the Pull Request
This is just basic functionality. It allow you to use key combinations (e.g. win-alt-<arrow keys> or win-alt-<h,j,k,l>) to move keyboard focus to a different zone.

## Detailed Description of the Pull Request / Additional comments

Not yet implemented (but should be straightforward to add based on the existing Snap() code):

- Cycle - doesn't currently wrap focus when at the last zone
- Multi-mon - doesn't jump focus between monitors
- UI to enable/disable or ability to change keyboard shortcuts used (I used ctrl-alt-shift-<h,j,k,l> and then use Keyboard Manager to remap win-alt combinations to these)
-  Currently only supports relative position mode. Zone index mode should be easy to add based on existing Snap() code
- Logging
- Unit tests
- Doc updates
- Refactoring - there's some code duplication between Snap* and Focus* methods. Would be good to factor out commonality where it makes sense