### PR TITLE
[PtRun] Hash Collision Image Cache

### DIFF
--- a/src/modules/launcher/Wox.Infrastructure/Image/IImageHashGenerator.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Image/IImageHashGenerator.cs
@@ -8,6 +8,6 @@ namespace Wox.Infrastructure.Image
 {
     public interface IImageHashGenerator
     {
-        string GetHashFromImage(ImageSource image);
+        string GetHashFromImage(ImageSource image, string filePath);
     }
 }

--- a/src/modules/launcher/Wox.Infrastructure/Image/ImageHashGenerator.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Image/ImageHashGenerator.cs
@@ -15,7 +15,7 @@ namespace Wox.Infrastructure.Image
     public class ImageHashGenerator : IImageHashGenerator
     {
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Security", "CA5350:Do Not Use Weak Cryptographic Algorithms", Justification = "Level of protection needed for the image data does not require a security guarantee")]
-        public string GetHashFromImage(ImageSource image)
+        public string GetHashFromImage(ImageSource image, string filePath)
         {
             if (!(image is BitmapSource bitmapSource))
             {
@@ -26,13 +26,11 @@ namespace Wox.Infrastructure.Image
             {
                 using (var outStream = new MemoryStream())
                 {
-                    // PngBitmapEncoder enc2 = new PngBitmapEncoder();
-                    // enc2.Frames.Add(BitmapFrame.Create(tt));
-                    var enc = new JpegBitmapEncoder();
+                    BitmapEncoder encoder = GetEncoderByFileExtension(filePath);
                     var bitmapFrame = BitmapFrame.Create(bitmapSource);
                     bitmapFrame.Freeze();
-                    enc.Frames.Add(bitmapFrame);
-                    enc.Save(outStream);
+                    encoder.Frames.Add(bitmapFrame);
+                    encoder.Save(outStream);
                     var byteArray = outStream.GetBuffer();
                     return Convert.ToBase64String(SHA1.HashData(byteArray));
                 }
@@ -41,6 +39,25 @@ namespace Wox.Infrastructure.Image
             {
                 Log.Exception($"Failed to get hash from image", e, MethodBase.GetCurrentMethod().DeclaringType);
                 return null;
+            }
+        }
+
+        public static BitmapEncoder GetEncoderByFileExtension(string filePath)
+        {
+            string fileExtension = Path.GetExtension(filePath).ToLowerInvariant();
+
+            switch (fileExtension)
+            {
+                case ".png":
+                    return new PngBitmapEncoder();
+                case ".jpg":
+                case ".jpeg":
+                    return new JpegBitmapEncoder();
+                case ".bmp":
+                    return new BmpBitmapEncoder();
+                default:
+                    // Default to PNG if the format is unknown or unsupported because PNG is a lossless compression format
+                    return new PngBitmapEncoder();
             }
         }
     }

--- a/src/modules/launcher/Wox.Infrastructure/Image/ImageHashGenerator.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Image/ImageHashGenerator.cs
@@ -26,6 +26,7 @@ namespace Wox.Infrastructure.Image
             {
                 using (var outStream = new MemoryStream())
                 {
+                    // Dynamically selecting the encoder based on the file extension to preserve the original image format characteristics as much as possible.
                     BitmapEncoder encoder = GetEncoderByFileExtension(filePath);
                     var bitmapFrame = BitmapFrame.Create(bitmapSource);
                     bitmapFrame.Freeze();

--- a/src/modules/launcher/Wox.Infrastructure/Image/ImageLoader.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Image/ImageLoader.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Concurrent;
-using System.Drawing;
 using System.Globalization;
 using System.IO;
 using System.IO.Abstractions;

--- a/src/modules/launcher/Wox.Infrastructure/Image/ImageLoader.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Image/ImageLoader.cs
@@ -267,14 +267,14 @@ namespace Wox.Infrastructure.Image
             if (imageResult.ImageType != ImageType.Error && imageResult.ImageType != ImageType.Cache)
             {
                 // we need to get image hash
-                string hash = _enableImageHash ? _hashGenerator.GetHashFromImage(img) : null;
+                string hash = _enableImageHash ? _hashGenerator.GetHashFromImage(img, path) : null;
 
                 if (hash != null)
                 {
                     if (GuidToKey.TryGetValue(hash, out string key))
                     {
                         // image already exists
-                        if (ImageCache.Usage.TryGetValue(path, out _) && Path.GetFileName(path).Equals(Path.GetFileName(key), StringComparison.Ordinal))
+                        if (ImageCache.Usage.TryGetValue(path, out _))
                         {
                             img = ImageCache[key];
                         }

--- a/src/modules/launcher/Wox.Infrastructure/Image/ImageLoader.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Image/ImageLoader.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Drawing;
 using System.Globalization;
 using System.IO;
 using System.IO.Abstractions;
@@ -273,7 +274,7 @@ namespace Wox.Infrastructure.Image
                     if (GuidToKey.TryGetValue(hash, out string key))
                     {
                         // image already exists
-                        if (ImageCache.Usage.TryGetValue(path, out _) && CompareImages((BitmapSource)ImageCache[key], (BitmapSource)img))
+                        if (ImageCache.Usage.TryGetValue(path, out _) && Path.GetFileName(path).Equals(Path.GetFileName(key), StringComparison.Ordinal))
                         {
                             img = ImageCache[key];
                         }
@@ -300,52 +301,6 @@ namespace Wox.Infrastructure.Image
             image.UriSource = new Uri(path);
             image.EndInit();
             return image;
-        }
-
-        private static bool CompareImages(BitmapSource img1, BitmapSource img2)
-        {
-            // First, check if we are comparing the same instance.
-            if (ReferenceEquals(img1, img2))
-            {
-                return true;
-            }
-
-            if (img1 == null || img2 == null)
-            {
-                return false;
-            }
-
-            // Check if dimensions match.
-            if (img1.PixelWidth != img2.PixelWidth || img1.PixelHeight != img2.PixelHeight)
-            {
-                return false;
-            }
-
-            // Check dpi settings
-            if (img1.DpiX != img2.DpiX || img1.DpiY != img2.DpiY)
-            {
-                return false;
-            }
-
-            // Compare pixel formats
-            if (img1.Format != img2.Format)
-            {
-                return false;
-            }
-
-            byte[] img1Bytes = GetPixels(img1);
-            byte[] img2Bytes = GetPixels(img2);
-
-            // Use sequence equal to compare byte arrays
-            return img1Bytes.SequenceEqual(img2Bytes);
-        }
-
-        private static byte[] GetPixels(BitmapSource image)
-        {
-            int stride = ((image.PixelWidth * image.Format.BitsPerPixel) + 7) / 8;
-            byte[] pixels = new byte[image.PixelHeight * stride];
-            image.CopyPixels(pixels, stride, 0);
-            return pixels;
         }
     }
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

- Hash collision is observed.
- Implemented "CompareImages" method to perform a pixel-by-pixel comparison between two images.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #31449 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Icons are in PNG format. PNG uses lossless compression, ensuring that all original image details are preserved. This is crucial for hashing because even small changes in image data can lead to different hashing outputs.

JPEG uses lossy compression, and when images are compressed using JPEG, visually different images, especially with aggressive compression settings or default quality levels, can produce similar or identical byte sequences upon compression.

Unlike JPEG, PNG supports transparency and allows for more complex images with transparent backgrounds.
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

- Tested with "Icon.dark" and "Icon2.dark" icons to ensure correct behavior.
- "Icon.dark" icon duplicated and named "Icon3.dark" and added to "ImageCache.JSON" manually. Comparison returned false after start and image is not overwritten as expected.
- "Icon.dark" is changed with another dark image and there was no collision and icons are shown correctly.
- "Icon.dark" is added to another folder and added to "ImageCache.JSON" manually. Comparison returned true after start and image is overwritten as expected.
