### PR TITLE
[Peek] Asynchronously display correct folder size

### DIFF
--- a/src/modules/peek/Peek.Common/Extensions/IFileSystemItemExtensions.cs
+++ b/src/modules/peek/Peek.Common/Extensions/IFileSystemItemExtensions.cs
@@ -102,32 +102,6 @@ namespace Peek.Common.Extensions
             return size;
         }
 
-        public static ulong GetSizeInBytes(this IFileSystemItem item)
-        {
-            ulong sizeInBytes = 0;
-
-            try
-            {
-                switch (item)
-                {
-                    case FolderItem _:
-                        FileSystemObject fileSystemObject = new FileSystemObject();
-                        Folder folder = fileSystemObject.GetFolder(item.Path);
-                        sizeInBytes = (ulong)folder.Size;
-                        break;
-                    case FileItem _:
-                        sizeInBytes = item.FileSizeBytes;
-                        break;
-                }
-            }
-            catch
-            {
-                sizeInBytes = 0;
-            }
-
-            return sizeInBytes;
-        }
-
         public static async Task<string> GetContentTypeAsync(this IFileSystemItem item)
         {
             string contentType = string.Empty;

--- a/src/modules/peek/Peek.FilePreviewer/FilePreview.xaml.cs
+++ b/src/modules/peek/Peek.FilePreviewer/FilePreview.xaml.cs
@@ -349,9 +349,7 @@ namespace Peek.FilePreviewer
             string dateModifiedFormatted = string.IsNullOrEmpty(dateModified) ? string.Empty : "\n" + ReadableStringHelper.FormatResourceString("PreviewTooltip_DateModified", dateModified);
             sb.Append(dateModifiedFormatted);
 
-            cancellationToken.ThrowIfCancellationRequested();
-            ulong bytes = await Task.Run(Item.GetSizeInBytes);
-            string fileSize = ReadableStringHelper.BytesToReadableString(bytes);
+            string fileSize = ReadableStringHelper.BytesToReadableString(Item.FileSizeBytes);
             string fileSizeFormatted = string.IsNullOrEmpty(fileSize) ? string.Empty : "\n" + ReadableStringHelper.FormatResourceString("PreviewTooltip_FileSize", fileSize);
             sb.Append(fileSizeFormatted);
 

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/UnsupportedFilePreviewer/UnsupportedFilePreviewer.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/UnsupportedFilePreviewer/UnsupportedFilePreviewer.cs
@@ -4,10 +4,13 @@
 
 using System;
 using System.Globalization;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
+using ManagedCommon;
 using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Peek.Common.Extensions;
 using Peek.Common.Helpers;
@@ -20,6 +23,11 @@ namespace Peek.FilePreviewer.Previewers
 {
     public partial class UnsupportedFilePreviewer : ObservableObject, IUnsupportedFilePreviewer, IDisposable
     {
+        private static readonly EnumerationOptions _fileEnumOptions = new() { MatchType = MatchType.Win32, AttributesToSkip = 0, IgnoreInaccessible = true };
+        private static readonly EnumerationOptions _directoryEnumOptions = new() { MatchType = MatchType.Win32, AttributesToSkip = FileAttributes.ReparsePoint, IgnoreInaccessible = true };
+        private readonly DispatcherTimer _folderSizeDispatcherTimer = new();
+        private ulong _folderSize;
+
         [ObservableProperty]
         private UnsupportedFilePreviewData preview = new UnsupportedFilePreviewData();
 
@@ -28,6 +36,9 @@ namespace Peek.FilePreviewer.Previewers
 
         public UnsupportedFilePreviewer(IFileSystemItem file)
         {
+            _folderSizeDispatcherTimer.Interval = TimeSpan.FromMilliseconds(500);
+            _folderSizeDispatcherTimer.Tick += FolderSizeDispatcherTimer_Tick;
+
             Item = file;
             Preview.FileName = file.Name;
             Preview.DateModified = file.DateModified?.ToString(CultureInfo.CurrentCulture);
@@ -46,6 +57,7 @@ namespace Peek.FilePreviewer.Previewers
 
         public void Dispose()
         {
+            _folderSizeDispatcherTimer.Tick -= FolderSizeDispatcherTimer_Tick;
             GC.SuppressFinalize(this);
         }
 
@@ -117,20 +129,24 @@ namespace Peek.FilePreviewer.Previewers
 
             var isTaskSuccessful = await TaskExtension.RunSafe(async () =>
             {
-                // File Properties
-                cancellationToken.ThrowIfCancellationRequested();
-
-                var bytes = await Task.Run(Item.GetSizeInBytes);
-
                 cancellationToken.ThrowIfCancellationRequested();
 
                 var type = await Task.Run(Item.GetContentTypeAsync);
 
                 cancellationToken.ThrowIfCancellationRequested();
 
-                var readableFileSize = ReadableStringHelper.BytesToReadableString(bytes);
-
                 isDisplayValid = type != null;
+
+                var readableFileSize = string.Empty;
+
+                if (Item is FileItem)
+                {
+                    readableFileSize = ReadableStringHelper.BytesToReadableString(Item.FileSizeBytes);
+                }
+                else if (Item is FolderItem)
+                {
+                    ComputeFolderSize(cancellationToken);
+                }
 
                 await Dispatcher.RunOnUiThread(() =>
                 {
@@ -149,6 +165,72 @@ namespace Peek.FilePreviewer.Previewers
             var isLoadingDisplayInfoSuccessful = DisplayInfoTask?.Result ?? false;
 
             return !isLoadingIconPreviewSuccessful || !isLoadingDisplayInfoSuccessful;
+        }
+
+        private void ComputeFolderSize(CancellationToken cancellationToken)
+        {
+            Task.Run(
+            () =>
+            {
+                try
+                {
+                    // Special folders like recycle bin don't have a path
+                    if (string.IsNullOrWhiteSpace(Item.Path))
+                    {
+                        return;
+                    }
+
+                    Dispatcher.RunOnUiThread(_folderSizeDispatcherTimer.Start);
+                    GetDirectorySize(new DirectoryInfo(Item.Path), cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogError("Failed to calculate folder size", ex);
+                }
+                finally
+                {
+                    Dispatcher.RunOnUiThread(_folderSizeDispatcherTimer.Stop);
+                }
+
+                // If everything went well, ensure the UI is updated
+                Dispatcher.RunOnUiThread(UpdateFolderSize);
+            },
+            cancellationToken);
+        }
+
+        private void GetDirectorySize(DirectoryInfo directory, CancellationToken cancellationToken)
+        {
+            var files = directory.GetFiles("*", _fileEnumOptions);
+            for (var i = 0; i < files.Length; i++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var f = files[i];
+                if (f.Length > 0)
+                {
+                    _folderSize += Convert.ToUInt64(f.Length);
+                }
+            }
+
+            var directories = directory.GetDirectories("*", _directoryEnumOptions);
+            for (var i = 0; i < directories.Length; i++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                GetDirectorySize(directories[i], cancellationToken);
+            }
+        }
+
+        private void UpdateFolderSize()
+        {
+            Preview.FileSize = ReadableStringHelper.BytesToReadableString(_folderSize);
+        }
+
+        private void FolderSizeDispatcherTimer_Tick(object? sender, object e)
+        {
+            UpdateFolderSize();
         }
     }
 }

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/UnsupportedFilePreviewer/UnsupportedFilePreviewer.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/UnsupportedFilePreviewer/UnsupportedFilePreviewer.cs
@@ -170,7 +170,7 @@ namespace Peek.FilePreviewer.Previewers
         private void ComputeFolderSize(CancellationToken cancellationToken)
         {
             Task.Run(
-            () =>
+            async () =>
             {
                 try
                 {
@@ -180,7 +180,7 @@ namespace Peek.FilePreviewer.Previewers
                         return;
                     }
 
-                    Dispatcher.RunOnUiThread(_folderSizeDispatcherTimer.Start);
+                    await Dispatcher.RunOnUiThread(_folderSizeDispatcherTimer.Start);
                     GetDirectorySize(new DirectoryInfo(Item.Path), cancellationToken);
                 }
                 catch (OperationCanceledException)
@@ -192,11 +192,11 @@ namespace Peek.FilePreviewer.Previewers
                 }
                 finally
                 {
-                    Dispatcher.RunOnUiThread(_folderSizeDispatcherTimer.Stop);
+                    await Dispatcher.RunOnUiThread(_folderSizeDispatcherTimer.Stop);
                 }
 
                 // If everything went well, ensure the UI is updated
-                Dispatcher.RunOnUiThread(UpdateFolderSize);
+                await Dispatcher.RunOnUiThread(UpdateFolderSize);
             },
             cancellationToken);
         }

--- a/src/modules/peek/Peek.UI/PeekXAML/Views/TitleBar.xaml.cs
+++ b/src/modules/peek/Peek.UI/PeekXAML/Views/TitleBar.xaml.cs
@@ -339,14 +339,23 @@ namespace Peek.UI.Views
 
         private void UpdateDefaultAppToLaunch()
         {
-            // Update the name of default app to launch
-            DefaultAppName = DefaultAppHelper.TryGetDefaultAppName(Item.Extension);
+            if (Item is FileItem)
+            {
+                // Update the name of default app to launch
+                DefaultAppName = DefaultAppHelper.TryGetDefaultAppName(Item.Extension);
 
-            string openWithAppTextFormat = ResourceLoaderInstance.ResourceLoader.GetString("LaunchAppButton_OpenWithApp_Text");
-            OpenWithAppText = string.Format(CultureInfo.InvariantCulture, openWithAppTextFormat, DefaultAppName);
+                string openWithAppTextFormat = ResourceLoaderInstance.ResourceLoader.GetString("LaunchAppButton_OpenWithApp_Text");
+                OpenWithAppText = string.Format(CultureInfo.InvariantCulture, openWithAppTextFormat, DefaultAppName);
 
-            string openWithAppToolTipFormat = ResourceLoaderInstance.ResourceLoader.GetString("LaunchAppButton_OpenWithApp_ToolTip");
-            OpenWithAppToolTip = string.Format(CultureInfo.InvariantCulture, openWithAppToolTipFormat, DefaultAppName);
+                string openWithAppToolTipFormat = ResourceLoaderInstance.ResourceLoader.GetString("LaunchAppButton_OpenWithApp_ToolTip");
+                OpenWithAppToolTip = string.Format(CultureInfo.InvariantCulture, openWithAppToolTipFormat, DefaultAppName);
+            }
+            else
+            {
+                DefaultAppName = string.Empty;
+                OpenWithAppText = string.Empty;
+                OpenWithAppToolTip = string.Empty;
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Replace the current implementation of the method that retrieve folder size.
The current method is slow and doesn't provide the current implementation if the user don't have full access to the folder (e.g. 0 bytes on `C:\Windows`).

_PR_
![PR](https://github.com/microsoft/PowerToys/assets/25966642/0f459f6c-7ba9-426e-9289-63b6064ae415)

_0.78_
![main](https://github.com/microsoft/PowerToys/assets/25966642/7390448a-42ba-419d-939d-9f8c18c90107)

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

This should fully fix #27226 along with drives previews and this old PR https://github.com/microsoft/PowerToys/pull/27709

- [x] **Closes:** #22655 #27226
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

- Asynchronously computing size for folders and dispatch the info to the UI every 0.5s
- Fixed an issue when Peek was trying to get the default app associated to folders
   Peek log contains this repeated error:
  ```
  [15:09:56.6479301] [Error] DefaultAppHelper::TryGetDefaultAppName
    Error when getting accessString for  file: Value does not fall within the expected range.
  ```

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Tested performance on large folders like `C:\Windows` and `C:\Program Files`
- Verified that the computed size match what's is displayed in Explorer properties (note that may be incorrect due to temp files being written during computation)
- Tested the cancellation of computing size
- Verified the memory usage when computing size
