### PR TITLE
[CmdNotFound]Add telemetry for instance created and failure

### DIFF
--- a/src/modules/cmdNotFound/CmdNotFound/Telemetry/CmdNotFoundFeedbackProvidedFailureEvent.cs
+++ b/src/modules/cmdNotFound/CmdNotFound/Telemetry/CmdNotFoundFeedbackProvidedFailureEvent.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics.Tracing;
+using Microsoft.PowerToys.Telemetry;
+using Microsoft.PowerToys.Telemetry.Events;
+
+namespace WinGetCommandNotFound.Telemetry
+{
+    [EventData]
+    public class CmdNotFoundFeedbackProvidedFailureEvent : EventBase, IEvent
+    {
+        public string Message { get; set; } = string.Empty;
+
+        public PartA_PrivTags PartA_PrivTags => PartA_PrivTags.ProductAndServiceUsage;
+    }
+}

--- a/src/modules/cmdNotFound/CmdNotFound/Telemetry/CmdNotFoundInstanceCreatedEvent.cs
+++ b/src/modules/cmdNotFound/CmdNotFound/Telemetry/CmdNotFoundInstanceCreatedEvent.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics.Tracing;
+using Microsoft.PowerToys.Telemetry;
+using Microsoft.PowerToys.Telemetry.Events;
+
+namespace WinGetCommandNotFound.Telemetry
+{
+    [EventData]
+    public class CmdNotFoundInstanceCreatedEvent : EventBase, IEvent
+    {
+        public PartA_PrivTags PartA_PrivTags => PartA_PrivTags.ProductAndServiceUsage;
+    }
+}

--- a/src/modules/cmdNotFound/CmdNotFound/WinGetCommandNotFoundFeedbackPredictor.cs
+++ b/src/modules/cmdNotFound/CmdNotFound/WinGetCommandNotFoundFeedbackPredictor.cs
@@ -38,6 +38,9 @@ namespace WinGetCommandNotFound
             _pool = provider.Create(new PooledPowerShellObjectPolicy());
             _pool.Return(_pool.Get());
             Task.Run(() => WarmUp());
+
+            // Telemetry that a shell is creating an instance of CommandNotFound.
+            PowerToysTelemetry.Log.WriteEvent(new Telemetry.CmdNotFoundInstanceCreatedEvent());
         }
 
         public Guid Id => _guid;
@@ -105,6 +108,7 @@ namespace WinGetCommandNotFound
                 catch (Exception ex)
                 {
                     Logger.LogError("GetFeedback failed to execute", ex);
+                    PowerToysTelemetry.Log.WriteEvent(new Telemetry.CmdNotFoundFeedbackProvidedFailureEvent { Message = ex.Message });
                     return new FeedbackItem($"Failed to execute PowerToys Command Not Found.{Environment.NewLine}This is a known issue if PowerShell 7 is installed from the Store or MSIX. If that isn't your case, please report an issue.", new List<string>(), FeedbackDisplayLayout.Portrait);
                 }
             }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Add telemetry events for when Command Not Found had an instance created in a shell.
Also add telemetry for when a failure is detected on generating feedback for packages to install.