### PR TITLE
[KBM]Send remappings configuration telemetry

### DIFF
--- a/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardManager.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardManager.cpp
@@ -85,6 +85,24 @@ void KeyboardManager::LoadSettings()
         // retry once
         state.LoadSettings();
     }
+    try
+    {
+        // Send telemetry about configured key/shortcut to key/shortcut mappings, OS an app specific level.
+        Trace::SendKeyAndShortcutRemapLoadedConfiguration(state);
+    }
+    catch (...)
+    {
+        try
+        {
+            Logger::error("Failed to send telemetry for the configured remappings.");
+            // Try not to crash the app sending telemetry. Everything inside a try.
+            Trace::ErrorSendingKeyAndShortcutRemapLoadedConfiguration();
+        }
+        catch (...)
+        {
+
+        }
+    }
 }
 
 LRESULT CALLBACK KeyboardManager::HookProc(int nCode, const WPARAM wParam, const LPARAM lParam)

--- a/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/trace.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/trace.cpp
@@ -117,7 +117,7 @@ void Trace::SendKeyAndShortcutRemapLoadedConfiguration(State& remappings) noexce
     LayoutMap keyboardMap;
     for (auto const& keyRemap : remappings.singleKeyReMap)
     {
-        if (keyRemap.second.index() == 0)
+        if (keyRemap.second.index() == 0) // 0 - Remapping to key
         {
             DWORD keyRemappedTo = std::get<DWORD>(keyRemap.second);
             TraceLoggingWrite(
@@ -131,7 +131,7 @@ void Trace::SendKeyAndShortcutRemapLoadedConfiguration(State& remappings) noexce
                 TraceLoggingWideString(keyboardMap.GetKeyName(keyRemappedTo).c_str(), "HumanRemapTo")
             );
         }
-        else if (keyRemap.second.index() == 1)
+        else if (keyRemap.second.index() == 1) // 1 - Remapping to shortcut
         {
             Shortcut shortcutRemappedTo = std::get<Shortcut>(keyRemap.second);
             TraceLoggingWrite(
@@ -154,7 +154,7 @@ void Trace::SendKeyAndShortcutRemapLoadedConfiguration(State& remappings) noexce
     for (auto const& shortcutRemap : remappings.osLevelShortcutReMap)
     {
         Shortcut shortcutRemappedFrom = shortcutRemap.first;
-        if (shortcutRemap.second.targetShortcut.index() == 0)
+        if (shortcutRemap.second.targetShortcut.index() == 0) // 0 - Remapping to key
         {
             DWORD keyRemappedTo = std::get<DWORD>(shortcutRemap.second.targetShortcut);
             TraceLoggingWrite(
@@ -171,7 +171,7 @@ void Trace::SendKeyAndShortcutRemapLoadedConfiguration(State& remappings) noexce
                 TraceLoggingWideString(GetShortcutHumanReadableString(shortcutRemappedFrom, keyboardMap).c_str(), "HumanRemapFrom"),
                 TraceLoggingWideString(keyboardMap.GetKeyName(keyRemappedTo).c_str(), "HumanRemapTo"));
         }
-        else if (shortcutRemap.second.targetShortcut.index() == 1)
+        else if (shortcutRemap.second.targetShortcut.index() == 1) // 1 - Remapping to shortcut
         {
             Shortcut shortcutRemappedTo = std::get<Shortcut>(shortcutRemap.second.targetShortcut);
             TraceLoggingWrite(
@@ -201,7 +201,7 @@ void Trace::SendKeyAndShortcutRemapLoadedConfiguration(State& remappings) noexce
         for (auto const& shortcutRemap : appShortcutRemap.second)
         {
             Shortcut shortcutRemappedFrom = shortcutRemap.first;
-            if (shortcutRemap.second.targetShortcut.index() == 0)
+            if (shortcutRemap.second.targetShortcut.index() == 0) // 0 - Remapping to key
             {
                 DWORD keyRemappedTo = std::get<DWORD>(shortcutRemap.second.targetShortcut);
                 TraceLoggingWrite(
@@ -220,7 +220,7 @@ void Trace::SendKeyAndShortcutRemapLoadedConfiguration(State& remappings) noexce
                     TraceLoggingWideString(appName.c_str(), "TargetApp")
                 );
             }
-            else if (shortcutRemap.second.targetShortcut.index() == 1)
+            else if (shortcutRemap.second.targetShortcut.index() == 1) // 1 - Remapping to shortcut
             {
                 Shortcut shortcutRemappedTo = std::get<Shortcut>(shortcutRemap.second.targetShortcut);
                 TraceLoggingWrite(

--- a/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/trace.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/trace.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "trace.h"
+#include <common/interop/keyboard_layout.h>
 
 TRACELOGGING_DEFINE_PROVIDER(
     g_hProvider,
@@ -81,6 +82,181 @@ void Trace::ShortcutRemapInvoked(bool isShortcutToShortcut, bool isAppSpecific) 
         }
     }
 }
+
+// Function to return a human readable string for the shortcut
+std::wstring GetShortcutHumanReadableString(Shortcut const & shortcut, LayoutMap& keyboardMap)
+{
+    std::wstring humanReadableShortcut = L"";
+    if (shortcut.winKey != ModifierKey::Disabled)
+    {
+        humanReadableShortcut += keyboardMap.GetKeyName(shortcut.GetWinKey(ModifierKey::Both)) + L" + ";
+    }
+    if (shortcut.ctrlKey != ModifierKey::Disabled)
+    {
+        humanReadableShortcut += keyboardMap.GetKeyName(shortcut.GetCtrlKey()) + L" + ";
+    }
+    if (shortcut.altKey != ModifierKey::Disabled)
+    {
+        humanReadableShortcut += keyboardMap.GetKeyName(shortcut.GetAltKey()) + L" + ";
+    }
+    if (shortcut.shiftKey != ModifierKey::Disabled)
+    {
+        humanReadableShortcut += keyboardMap.GetKeyName(shortcut.GetShiftKey()) + L" + ";
+    }
+    if (shortcut.actionKey != NULL)
+    {
+        humanReadableShortcut += keyboardMap.GetKeyName(shortcut.actionKey);
+    }
+    return humanReadableShortcut;
+}
+
+
+// Log the current remappings of key and shortcuts when keyboard manager engine loads the settings.
+void Trace::SendKeyAndShortcutRemapLoadedConfiguration(State& remappings) noexcept
+{
+    LayoutMap keyboardMap;
+    for (auto const& keyRemap : remappings.singleKeyReMap)
+    {
+        if (keyRemap.second.index() == 0)
+        {
+            DWORD keyRemappedTo = std::get<DWORD>(keyRemap.second);
+            TraceLoggingWrite(
+                g_hProvider,
+                "KeyboardManager_KeyRemapConfigurationLoaded",
+                ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
+                TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE),
+                TraceLoggingInt64(keyRemap.first, "KeyRemapFrom"),
+                TraceLoggingInt64(keyRemappedTo, "KeyRemapTo"),
+                TraceLoggingWideString(keyboardMap.GetKeyName(keyRemap.first).c_str(), "HumanRemapFrom"),
+                TraceLoggingWideString(keyboardMap.GetKeyName(keyRemappedTo).c_str(), "HumanRemapTo")
+            );
+        }
+        else if (keyRemap.second.index() == 1)
+        {
+            Shortcut shortcutRemappedTo = std::get<Shortcut>(keyRemap.second);
+            TraceLoggingWrite(
+                g_hProvider,
+                "KeyboardManager_KeyRemapConfigurationLoaded",
+                ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
+                TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE),
+                TraceLoggingInt64(keyRemap.first, "KeyRemapFrom"),
+                TraceLoggingInt64(shortcutRemappedTo.actionKey, "KeyRemapTo"),
+                TraceLoggingInt8(static_cast<INT8>(shortcutRemappedTo.winKey), "ModifierRemapToWin"),
+                TraceLoggingInt8(static_cast<INT8>(shortcutRemappedTo.ctrlKey), "ModifierRemapToCtrl"),
+                TraceLoggingInt8(static_cast<INT8>(shortcutRemappedTo.altKey), "ModifierRemapToAlt"),
+                TraceLoggingInt8(static_cast<INT8>(shortcutRemappedTo.shiftKey), "ModifierRemapToShift"),
+                TraceLoggingWideString(keyboardMap.GetKeyName(keyRemap.first).c_str(), "HumanRemapFrom"),
+                TraceLoggingWideString(GetShortcutHumanReadableString(shortcutRemappedTo, keyboardMap).c_str(), "HumanRemapTo")
+            );
+        }
+    }
+
+    for (auto const& shortcutRemap : remappings.osLevelShortcutReMap)
+    {
+        Shortcut shortcutRemappedFrom = shortcutRemap.first;
+        if (shortcutRemap.second.targetShortcut.index() == 0)
+        {
+            DWORD keyRemappedTo = std::get<DWORD>(shortcutRemap.second.targetShortcut);
+            TraceLoggingWrite(
+                g_hProvider,
+                "KeyboardManager_ShortcutRemapConfigurationLoaded",
+                ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
+                TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE),
+                TraceLoggingInt64(shortcutRemappedFrom.actionKey, "KeyRemapFrom"),
+                TraceLoggingInt8(static_cast<INT8>(shortcutRemappedFrom.winKey), "ModifierRemapFromWin"),
+                TraceLoggingInt8(static_cast<INT8>(shortcutRemappedFrom.ctrlKey), "ModifierRemapFromCtrl"),
+                TraceLoggingInt8(static_cast<INT8>(shortcutRemappedFrom.altKey), "ModifierRemapFromAlt"),
+                TraceLoggingInt8(static_cast<INT8>(shortcutRemappedFrom.shiftKey), "ModifierRemapFromShift"),
+                TraceLoggingInt64(keyRemappedTo, "KeyRemapTo"),
+                TraceLoggingWideString(GetShortcutHumanReadableString(shortcutRemappedFrom, keyboardMap).c_str(), "HumanRemapFrom"),
+                TraceLoggingWideString(keyboardMap.GetKeyName(keyRemappedTo).c_str(), "HumanRemapTo"));
+        }
+        else if (shortcutRemap.second.targetShortcut.index() == 1)
+        {
+            Shortcut shortcutRemappedTo = std::get<Shortcut>(shortcutRemap.second.targetShortcut);
+            TraceLoggingWrite(
+                g_hProvider,
+                "KeyboardManager_ShortcutRemapConfigurationLoaded",
+                ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
+                TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE),
+                TraceLoggingInt64(shortcutRemappedFrom.actionKey, "KeyRemapFrom"),
+                TraceLoggingInt8(static_cast<INT8>(shortcutRemappedFrom.winKey), "ModifierRemapFromWin"),
+                TraceLoggingInt8(static_cast<INT8>(shortcutRemappedFrom.ctrlKey), "ModifierRemapFromCtrl"),
+                TraceLoggingInt8(static_cast<INT8>(shortcutRemappedFrom.altKey), "ModifierRemapFromAlt"),
+                TraceLoggingInt8(static_cast<INT8>(shortcutRemappedFrom.shiftKey), "ModifierRemapFromShift"),
+                TraceLoggingInt64(shortcutRemappedTo.actionKey, "KeyRemapTo"),
+                TraceLoggingInt8(static_cast<INT8>(shortcutRemappedTo.winKey), "ModifierRemapToWin"),
+                TraceLoggingInt8(static_cast<INT8>(shortcutRemappedTo.ctrlKey), "ModifierRemapToCtrl"),
+                TraceLoggingInt8(static_cast<INT8>(shortcutRemappedTo.altKey), "ModifierRemapToAlt"),
+                TraceLoggingInt8(static_cast<INT8>(shortcutRemappedTo.shiftKey), "ModifierRemapToShift"),
+                TraceLoggingWideString(GetShortcutHumanReadableString(shortcutRemappedFrom, keyboardMap).c_str(), "HumanRemapFrom"),
+                TraceLoggingWideString(GetShortcutHumanReadableString(shortcutRemappedTo, keyboardMap).c_str(), "HumanRemapTo")
+            );
+        }
+    }
+
+    for (auto const& appShortcutRemap : remappings.appSpecificShortcutReMap)
+    {
+        std::wstring appName = appShortcutRemap.first;
+        for (auto const& shortcutRemap : appShortcutRemap.second)
+        {
+            Shortcut shortcutRemappedFrom = shortcutRemap.first;
+            if (shortcutRemap.second.targetShortcut.index() == 0)
+            {
+                DWORD keyRemappedTo = std::get<DWORD>(shortcutRemap.second.targetShortcut);
+                TraceLoggingWrite(
+                    g_hProvider,
+                    "KeyboardManager_AppSpecificShortcutRemapConfigurationLoaded",
+                    ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
+                    TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE),
+                    TraceLoggingInt64(shortcutRemappedFrom.actionKey, "KeyRemapFrom"),
+                    TraceLoggingInt8(static_cast<INT8>(shortcutRemappedFrom.winKey), "ModifierRemapFromWin"),
+                    TraceLoggingInt8(static_cast<INT8>(shortcutRemappedFrom.ctrlKey), "ModifierRemapFromCtrl"),
+                    TraceLoggingInt8(static_cast<INT8>(shortcutRemappedFrom.altKey), "ModifierRemapFromAlt"),
+                    TraceLoggingInt8(static_cast<INT8>(shortcutRemappedFrom.shiftKey), "ModifierRemapFromShift"),
+                    TraceLoggingInt64(keyRemappedTo, "KeyRemapTo"),
+                    TraceLoggingWideString(GetShortcutHumanReadableString(shortcutRemappedFrom, keyboardMap).c_str(), "HumanRemapFrom"),
+                    TraceLoggingWideString(keyboardMap.GetKeyName(keyRemappedTo).c_str(), "HumanRemapTo"),
+                    TraceLoggingWideString(appName.c_str(), "TargetApp")
+                );
+            }
+            else if (shortcutRemap.second.targetShortcut.index() == 1)
+            {
+                Shortcut shortcutRemappedTo = std::get<Shortcut>(shortcutRemap.second.targetShortcut);
+                TraceLoggingWrite(
+                    g_hProvider,
+                    "KeyboardManager_AppSpecificShortcutRemapConfigurationLoaded",
+                    ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
+                    TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE),
+                    TraceLoggingInt64(shortcutRemappedFrom.actionKey, "KeyRemapFrom"),
+                    TraceLoggingInt8(static_cast<INT8>(shortcutRemappedFrom.winKey), "ModifierRemapFromWin"),
+                    TraceLoggingInt8(static_cast<INT8>(shortcutRemappedFrom.ctrlKey), "ModifierRemapFromCtrl"),
+                    TraceLoggingInt8(static_cast<INT8>(shortcutRemappedFrom.altKey), "ModifierRemapFromAlt"),
+                    TraceLoggingInt8(static_cast<INT8>(shortcutRemappedFrom.shiftKey), "ModifierRemapFromShift"),
+                    TraceLoggingInt64(shortcutRemappedTo.actionKey, "KeyRemapTo"),
+                    TraceLoggingInt8(static_cast<INT8>(shortcutRemappedTo.winKey), "ModifierRemapToWin"),
+                    TraceLoggingInt8(static_cast<INT8>(shortcutRemappedTo.ctrlKey), "ModifierRemapToCtrl"),
+                    TraceLoggingInt8(static_cast<INT8>(shortcutRemappedTo.altKey), "ModifierRemapToAlt"),
+                    TraceLoggingInt8(static_cast<INT8>(shortcutRemappedTo.shiftKey), "ModifierRemapToShift"),
+                    TraceLoggingWideString(GetShortcutHumanReadableString(shortcutRemappedFrom, keyboardMap).c_str(), "HumanRemapFrom"),
+                    TraceLoggingWideString(GetShortcutHumanReadableString(shortcutRemappedTo, keyboardMap).c_str(), "HumanRemapTo"),
+                    TraceLoggingWideString(appName.c_str(), "TargetApp")
+                );
+            }
+        }
+    }
+}
+
+// Log an error while trying to send remappings telemetry.
+void Trace::ErrorSendingKeyAndShortcutRemapLoadedConfiguration() noexcept
+{
+    TraceLoggingWrite(
+        g_hProvider,
+        "KeyboardManager_ErrorSendingKeyAndShortcutRemapLoadedConfiguration",
+        ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
+        TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));
+}
+
 
 // Log if an error occurs in KBM
 void Trace::Error(const DWORD errorCode, std::wstring errorMessage, std::wstring methodName) noexcept

--- a/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/trace.h
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/trace.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "State.h"
+
 class Trace
 {
 public:
@@ -11,7 +13,13 @@ public:
 
     // Log if a shortcut remap has been invoked (not being used currently, due to being garrulous)
     static void ShortcutRemapInvoked(bool isShortcutToShortcut, bool isAppSpecific) noexcept;
-    
+
+    // Log the current remappings of key and shortcuts when keyboard manager engine loads the settings.
+    static void SendKeyAndShortcutRemapLoadedConfiguration(State& remappings) noexcept;
+
+    // Log an error while trying to send remappings telemetry.
+    static void ErrorSendingKeyAndShortcutRemapLoadedConfiguration() noexcept;
+
     // Log if an error occurs in KBM
     static void Error(const DWORD errorCode, std::wstring errorMessage, std::wstring methodName) noexcept;
 };


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

On Keyboard manager settings load (on startup or when a mapping gets changed), telemetry will be sent about which key->key, key->shortcut, shortcut->key or shortcut->shortcut mappings are configured. App specific shortcut remaps are sent as well.
Human readable strings are sent as well.

`KeyboardManager_KeyRemapConfigurationLoaded` -> event sent for each remapping that maps a key to a key or shortcut.
`KeyboardManager_ShortcutRemapConfigurationLoaded` -> event sent for each remapping that maps a shortcut to a key or shortcut.
`KeyboardManager_AppSpecificShortcutRemapConfigurationLoaded` -> event sent for each app specific remapping that maps a shortcut to a key or shortcut.

Also adds a `KeyboardManager_ErrorSendingKeyAndShortcutRemapLoadedConfiguration` event to log when sending the remappings configuration fails.
