### PR TITLE
[KBM]Send daily activation telemetry

### DIFF
--- a/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardEventHandlers.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardEventHandlers.cpp
@@ -136,7 +136,7 @@ namespace KeyboardEventHandlers
                         auto currentDay = std::chrono::duration_cast<std::chrono::days>(std::chrono::system_clock::now().time_since_epoch()).count();
                         if (dayWeLastSentKeyToShortcutTelemetryOn != currentDay)
                         {
-                            Trace::DailyKeyToKeyRemapInvoked();
+                            Trace::DailyKeyToShortcutRemapInvoked();
                             dayWeLastSentKeyToShortcutTelemetryOn = currentDay;
                         }
                     }

--- a/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardEventHandlers.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardEventHandlers.cpp
@@ -118,6 +118,28 @@ namespace KeyboardEventHandlers
                             ResetIfModifierKeyForLowerLevelKeyHandlers(ii, itSk, it->first);
                         }
                     }
+
+                    // Send daily telemetry event for Keyboard Manager key activation.
+                    if (remapToKey)
+                    {
+                        static int dayWeLastSentKeyToKeyTelemetryOn = -1;
+                        auto currentDay = std::chrono::duration_cast<std::chrono::days>(std::chrono::system_clock::now().time_since_epoch()).count();
+                        if (dayWeLastSentKeyToKeyTelemetryOn != currentDay)
+                        {
+                            Trace::DailyKeyToKeyRemapInvoked();
+                            dayWeLastSentKeyToKeyTelemetryOn = currentDay;
+                        }
+                    }
+                    else
+                    {
+                        static int dayWeLastSentKeyToShortcutTelemetryOn = -1;
+                        auto currentDay = std::chrono::duration_cast<std::chrono::days>(std::chrono::system_clock::now().time_since_epoch()).count();
+                        if (dayWeLastSentKeyToShortcutTelemetryOn != currentDay)
+                        {
+                            Trace::DailyKeyToKeyRemapInvoked();
+                            dayWeLastSentKeyToShortcutTelemetryOn = currentDay;
+                        }
+                    }
                 }
 
                 return 1;
@@ -347,6 +369,54 @@ namespace KeyboardEventHandlers
 
                     UINT res = ii.SendVirtualInput(static_cast<UINT>(key_count), keyEventList, sizeof(INPUT));
                     delete[] keyEventList;
+
+                    // Send daily telemetry event for Keyboard Manager key activation.
+                    if (activatedApp.has_value())
+                    {
+                        if (remapToKey)
+                        {
+                            static int dayWeLastSentAppSpecificShortcutToKeyTelemetryOn = -1;
+                            auto currentDay = std::chrono::duration_cast<std::chrono::days>(std::chrono::system_clock::now().time_since_epoch()).count();
+                            if (dayWeLastSentAppSpecificShortcutToKeyTelemetryOn != currentDay)
+                            {
+                                Trace::DailyAppSpecificShortcutToKeyRemapInvoked();
+                                dayWeLastSentAppSpecificShortcutToKeyTelemetryOn = currentDay;
+                            }
+                        }
+                        else if (remapToShortcut)
+                        {
+                            static int dayWeLastSentAppSpecificShortcutToShortcutTelemetryOn = -1;
+                            auto currentDay = std::chrono::duration_cast<std::chrono::days>(std::chrono::system_clock::now().time_since_epoch()).count();
+                            if (dayWeLastSentAppSpecificShortcutToShortcutTelemetryOn != currentDay)
+                            {
+                                Trace::DailyAppSpecificShortcutToShortcutRemapInvoked();
+                                dayWeLastSentAppSpecificShortcutToShortcutTelemetryOn = currentDay;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        if (remapToKey)
+                        {
+                            static int dayWeLastSentShortcutToKeyTelemetryOn = -1;
+                            auto currentDay = std::chrono::duration_cast<std::chrono::days>(std::chrono::system_clock::now().time_since_epoch()).count();
+                            if (dayWeLastSentShortcutToKeyTelemetryOn != currentDay)
+                            {
+                                Trace::DailyShortcutToKeyRemapInvoked();
+                                dayWeLastSentShortcutToKeyTelemetryOn = currentDay;
+                            }
+                        }
+                        else if (remapToShortcut)
+                        {
+                            static int dayWeLastSentShortcutToShortcutTelemetryOn = -1;
+                            auto currentDay = std::chrono::duration_cast<std::chrono::days>(std::chrono::system_clock::now().time_since_epoch()).count();
+                            if (dayWeLastSentShortcutToShortcutTelemetryOn != currentDay)
+                            {
+                                Trace::DailyShortcutToShortcutRemapInvoked();
+                                dayWeLastSentShortcutToShortcutTelemetryOn = currentDay;
+                            }
+                        }
+                    }
 
                     return 1;
                 }

--- a/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/trace.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/trace.cpp
@@ -18,6 +18,66 @@ void Trace::UnregisterProvider() noexcept
     TraceLoggingUnregister(g_hProvider);
 }
 
+// Log if a key to key remap has been invoked today.
+void Trace::DailyKeyToKeyRemapInvoked() noexcept
+{
+        TraceLoggingWrite(
+            g_hProvider,
+            "KeyboardManager_DailyKeyToKeyRemapInvoked",
+            ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
+            TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));
+}
+
+// Log if a key to shortcut remap has been invoked today.
+void Trace::DailyKeyToShortcutRemapInvoked() noexcept
+{
+        TraceLoggingWrite(
+            g_hProvider,
+            "KeyboardManager_DailyKeyToShortcutRemapInvoked",
+            ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
+            TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));
+}
+
+// Log if a shortcut to key remap has been invoked today.
+void Trace::DailyShortcutToKeyRemapInvoked() noexcept
+{
+        TraceLoggingWrite(
+            g_hProvider,
+            "KeyboardManager_DailyShortcutToKeyRemapInvoked",
+            ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
+            TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));
+}
+
+// Log if a shortcut to shortcut remap has been invoked today.
+void Trace::DailyShortcutToShortcutRemapInvoked() noexcept
+{
+        TraceLoggingWrite(
+            g_hProvider,
+            "KeyboardManager_DailyShortcutToShortcutRemapInvoked",
+            ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
+            TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));
+}
+
+// Log if an app specific shortcut to key remap has been invoked today.
+void Trace::DailyAppSpecificShortcutToKeyRemapInvoked() noexcept
+{
+        TraceLoggingWrite(
+            g_hProvider,
+            "KeyboardManager_DailyAppSpecificShortcutToKeyRemapInvoked",
+            ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
+            TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));
+}
+
+// Log if an app specific shortcut to shortcut remap has been invoked today.
+void Trace::DailyAppSpecificShortcutToShortcutRemapInvoked() noexcept
+{
+        TraceLoggingWrite(
+            g_hProvider,
+            "KeyboardManager_DailyAppSpecificShortcutToShortcutRemapInvoked",
+            ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
+            TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));
+}
+
 // Log if a key remap has been invoked (not being used currently, due to being garrulous)
 void Trace::KeyRemapInvoked(bool isKeyToKey) noexcept
 {

--- a/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/trace.h
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/trace.h
@@ -6,6 +6,24 @@ public:
     static void RegisterProvider() noexcept;
     static void UnregisterProvider() noexcept;
 
+    // Log if a key to key remap has been invoked today.
+    static void DailyKeyToKeyRemapInvoked() noexcept;
+
+    // Log if a key to shortcut remap has been invoked today.
+    static void DailyKeyToShortcutRemapInvoked() noexcept;
+
+    // Log if a shortcut to key remap has been invoked today.
+    static void DailyShortcutToKeyRemapInvoked() noexcept;
+
+    // Log if a shortcut to shortcut remap has been invoked today.
+    static void DailyShortcutToShortcutRemapInvoked() noexcept;
+
+    // Log if an app specific shortcut to key remap has been invoked today.
+    static void DailyAppSpecificShortcutToKeyRemapInvoked() noexcept;
+
+    // Log if an app specific shortcut to shortcut remap has been invoked today.
+    static void DailyAppSpecificShortcutToShortcutRemapInvoked() noexcept;
+
     // Log if a key remap has been invoked (not being used currently, due to being garrulous)
     static void KeyRemapInvoked(bool isKeyToKey) noexcept;
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR adds telemetry events that we try to send daily (or per process instance) to know # of users that actually use KBM daily at least once.
This adds the following events:

```
DailyKeyToKeyRemapInvoked
DailyKeyToShortcutRemapInvoked
DailyShortcutToKeyRemapInvoked
DailyShortcutToShortcutRemapInvoked
DailyAppSpecificShortcutToKeyRemapInvoked
DailyAppSpecificShortcutToShortcutRemapInvoked
```