### PR TITLE
[MWB] Fix use after free in service registration

### DIFF
--- a/src/modules/MouseWithoutBorders/ModuleInterface/dllmain.cpp
+++ b/src/modules/MouseWithoutBorders/ModuleInterface/dllmain.cpp
@@ -198,7 +198,7 @@ private:
             Logger::error("Failed to delete MWB service");
             return;
         }
-    
+
         Trace::MouseWithoutBorders::ToggleServiceRegistration(false);
     }
 
@@ -242,11 +242,11 @@ private:
         }
 
         // Pass local app data of the current user to the service
-        PWSTR cLocalAppPath;
-        winrt::check_hresult(SHGetKnownFolderPath(FOLDERID_LocalAppData, 0, nullptr, &cLocalAppPath));
-        CoTaskMemFree(cLocalAppPath);
 
-        std::wstring localAppPath{ cLocalAppPath };
+        wil::unique_cotaskmem_string cLocalAppPath;
+        winrt::check_hresult(SHGetKnownFolderPath(FOLDERID_LocalAppData, 0, nullptr, &cLocalAppPath));
+
+        std::wstring localAppPath{ cLocalAppPath.get() };
         std::wstring binaryWithArgsPath = L"\"";
         binaryWithArgsPath += servicePath;
         binaryWithArgsPath += L"\" ";
@@ -259,7 +259,8 @@ private:
             std::wstring_view existingServicePath{ pServiceConfig->lpBinaryPathName };
             alreadyRegistered = true;
             isServicePathCorrect = (existingServicePath == binaryWithArgsPath);
-            if (isServicePathCorrect) {
+            if (isServicePathCorrect)
+            {
                 Logger::warn(L"The service path is not correct. Current: {} Expected: {}", existingServicePath, binaryWithArgsPath);
             }
 
@@ -291,18 +292,19 @@ private:
 
         if (alreadyRegistered)
         {
-            if (!isServicePathCorrect) {
+            if (!isServicePathCorrect)
+            {
                 if (!ChangeServiceConfigW(schService,
-                    SERVICE_NO_CHANGE,
-                    SERVICE_NO_CHANGE,
-                    SERVICE_NO_CHANGE,
-                    binaryWithArgsPath.c_str(),
-                    nullptr,
-                    nullptr,
-                    nullptr,
-                    nullptr,
-                    nullptr,
-                    nullptr))
+                                          SERVICE_NO_CHANGE,
+                                          SERVICE_NO_CHANGE,
+                                          SERVICE_NO_CHANGE,
+                                          binaryWithArgsPath.c_str(),
+                                          nullptr,
+                                          nullptr,
+                                          nullptr,
+                                          nullptr,
+                                          nullptr,
+                                          nullptr))
                 {
                     Logger::error(L"Failed to update the service's path. ERROR: {}", GetLastError());
                 }

--- a/src/modules/MouseWithoutBorders/ModuleInterface/dllmain.cpp
+++ b/src/modules/MouseWithoutBorders/ModuleInterface/dllmain.cpp
@@ -242,7 +242,6 @@ private:
         }
 
         // Pass local app data of the current user to the service
-
         wil::unique_cotaskmem_string cLocalAppPath;
         winrt::check_hresult(SHGetKnownFolderPath(FOLDERID_LocalAppData, 0, nullptr, &cLocalAppPath));
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
- `cLocalAppPath` was used in `localAppPath` ctor after the former was freed with `CoTaskMemFree`. Hard to repro, because zero-page thread is not so fast to reclaim the memory. 
- Also applied our std clang-format style guide.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #xxx
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- registered MWB service w/o issues
