### PR TITLE
[Text Extractor] Restructuring Screen scale handling

### DIFF
--- a/src/modules/PowerOCR/PowerOCR/Helpers/ImageMethods.cs
+++ b/src/modules/PowerOCR/PowerOCR/Helpers/ImageMethods.cs
@@ -47,8 +47,9 @@ internal sealed class ImageMethods
         return destination;
     }
 
-    internal static ImageSource GetWindowBoundsImage(Window passedWindow, System.Drawing.Rectangle screenRectangle)
+    internal static ImageSource GetWindowBoundsImage(OCROverlay passedWindow)
     {
+        Rectangle screenRectangle = passedWindow.GetScreenRectangle();
         using Bitmap bmp = new(screenRectangle.Width, screenRectangle.Height, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
         using Graphics g = Graphics.FromImage(bmp);
 
@@ -56,34 +57,7 @@ internal sealed class ImageMethods
         return BitmapToImageSource(bmp);
     }
 
-    internal static Bitmap GetWindowBoundsBitmap(Window passedWindow)
-    {
-        DpiScale dpi = VisualTreeHelper.GetDpi(passedWindow);
-        int windowWidth = (int)(passedWindow.ActualWidth * dpi.DpiScaleX);
-        int windowHeight = (int)(passedWindow.ActualHeight * dpi.DpiScaleY);
-
-        System.Windows.Point absPosPoint = passedWindow.GetAbsolutePosition();
-        int thisCorrectedLeft = (int)absPosPoint.X;
-        int thisCorrectedTop = (int)absPosPoint.Y;
-
-        Bitmap bmp = new(
-            windowWidth,
-            windowHeight,
-            System.Drawing.Imaging.PixelFormat.Format32bppArgb);
-        using Graphics g = Graphics.FromImage(bmp);
-
-        g.CopyFromScreen(
-            thisCorrectedLeft,
-            thisCorrectedTop,
-            0,
-            0,
-            bmp.Size,
-            CopyPixelOperation.SourceCopy);
-
-        return bmp;
-    }
-
-    internal static Bitmap GetRegionAsBitmap(Window passedWindow, Rectangle selectedRegion)
+    internal static Bitmap GetRegionAsBitmap(OCROverlay passedWindow, Rectangle selectedRegion)
     {
         Bitmap bmp = new(
             selectedRegion.Width,
@@ -91,15 +65,11 @@ internal sealed class ImageMethods
             System.Drawing.Imaging.PixelFormat.Format32bppArgb);
 
         using Graphics g = Graphics.FromImage(bmp);
-
-        System.Windows.Point absPosPoint = passedWindow.GetAbsolutePosition();
-
-        int thisCorrectedLeft = (int)absPosPoint.X + selectedRegion.Left;
-        int thisCorrectedTop = (int)absPosPoint.Y + selectedRegion.Top;
+        Rectangle screenRectangle = passedWindow.GetScreenRectangle();
 
         g.CopyFromScreen(
-            thisCorrectedLeft,
-            thisCorrectedTop,
+            screenRectangle.Left + selectedRegion.Left,
+            screenRectangle.Top + selectedRegion.Top,
             0,
             0,
             bmp.Size,
@@ -109,7 +79,7 @@ internal sealed class ImageMethods
         return bmp;
     }
 
-    internal static async Task<string> GetRegionsText(Window? passedWindow, Rectangle selectedRegion, Language? preferredLanguage)
+    internal static async Task<string> GetRegionsText(OCROverlay? passedWindow, Rectangle selectedRegion, Language? preferredLanguage)
     {
         if (passedWindow is null)
         {
@@ -122,17 +92,15 @@ internal sealed class ImageMethods
         return resultText != null ? resultText.Trim() : string.Empty;
     }
 
-    internal static async Task<string> GetClickedWord(Window passedWindow, System.Windows.Point clickedPoint, Language? preferredLanguage)
+    internal static async Task<string> GetClickedWord(OCROverlay passedWindow, System.Windows.Point clickedPoint, Language? preferredLanguage)
     {
-        DpiScale dpi = VisualTreeHelper.GetDpi(passedWindow);
-        Bitmap bmp = new((int)(passedWindow.ActualWidth * dpi.DpiScaleX), (int)(passedWindow.ActualHeight * dpi.DpiScaleY), System.Drawing.Imaging.PixelFormat.Format32bppArgb);
+        Rectangle screenRectangle = passedWindow.GetScreenRectangle();
+        Bitmap bmp = new((int)screenRectangle.Width, (int)passedWindow.Height, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
         Graphics g = Graphics.FromImage(bmp);
 
         System.Windows.Point absPosPoint = passedWindow.GetAbsolutePosition();
-        int thisCorrectedLeft = (int)absPosPoint.X;
-        int thisCorrectedTop = (int)absPosPoint.Y;
 
-        g.CopyFromScreen(thisCorrectedLeft, thisCorrectedTop, 0, 0, bmp.Size, CopyPixelOperation.SourceCopy);
+        g.CopyFromScreen((int)absPosPoint.X, (int)absPosPoint.Y, 0, 0, bmp.Size, CopyPixelOperation.SourceCopy);
 
         System.Windows.Point adjustedPoint = new(clickedPoint.X, clickedPoint.Y);
 

--- a/src/modules/PowerOCR/PowerOCR/Helpers/ImageMethods.cs
+++ b/src/modules/PowerOCR/PowerOCR/Helpers/ImageMethods.cs
@@ -47,20 +47,12 @@ internal sealed class ImageMethods
         return destination;
     }
 
-    internal static ImageSource GetWindowBoundsImage(Window passedWindow)
+    internal static ImageSource GetWindowBoundsImage(Window passedWindow, System.Drawing.Rectangle screenRectangle)
     {
-        DpiScale dpi = VisualTreeHelper.GetDpi(passedWindow);
-        int windowWidth = (int)(passedWindow.ActualWidth * dpi.DpiScaleX);
-        int windowHeight = (int)(passedWindow.ActualHeight * dpi.DpiScaleY);
-
-        System.Windows.Point absPosPoint = passedWindow.GetAbsolutePosition();
-        int thisCorrectedLeft = (int)absPosPoint.X;
-        int thisCorrectedTop = (int)absPosPoint.Y;
-
-        using Bitmap bmp = new(windowWidth, windowHeight, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
+        using Bitmap bmp = new(screenRectangle.Width, screenRectangle.Height, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
         using Graphics g = Graphics.FromImage(bmp);
 
-        g.CopyFromScreen(thisCorrectedLeft, thisCorrectedTop, 0, 0, bmp.Size, CopyPixelOperation.SourceCopy);
+        g.CopyFromScreen(screenRectangle.Left, screenRectangle.Top, 0, 0, bmp.Size, CopyPixelOperation.SourceCopy);
         return BitmapToImageSource(bmp);
     }
 

--- a/src/modules/PowerOCR/PowerOCR/Helpers/OcrExtensions.cs
+++ b/src/modules/PowerOCR/PowerOCR/Helpers/OcrExtensions.cs
@@ -62,7 +62,7 @@ namespace PowerOCR.Helpers
             }
         }
 
-        public static async Task<string> GetRegionsTextAsTableAsync(Window passedWindow, Rectangle regionScaled, Language? language)
+        public static async Task<string> GetRegionsTextAsTableAsync(OCROverlay passedWindow, Rectangle regionScaled, Language? language)
         {
             if (language is null)
             {

--- a/src/modules/PowerOCR/PowerOCR/Helpers/WPFExtensionMethods.cs
+++ b/src/modules/PowerOCR/PowerOCR/Helpers/WPFExtensionMethods.cs
@@ -46,11 +46,11 @@ public static class WPFExtensionMethods
         return new DpiScale(dpiX / 96.0, dpiY / 96.0);
     }
 
-    // https://msdn.microsoft.com/en-us/library/windows/desktop/dd145062(v=vs.85).aspx
+    // https://msdn.microsoft.com/library/windows/desktop/dd145062(v=vs.85).aspx
     [DllImport("User32.dll")]
     private static extern IntPtr MonitorFromPoint([In] System.Drawing.Point pt, [In] uint dwFlags);
 
-    // https://msdn.microsoft.com/en-us/library/windows/desktop/dn280510(v=vs.85).aspx
+    // https://msdn.microsoft.com/library/windows/desktop/dn280510(v=vs.85).aspx
     [DllImport("Shcore.dll")]
     private static extern IntPtr GetDpiForMonitor([In] IntPtr hmonitor, [In] DpiType dpiType, [Out] out uint dpiX, [Out] out uint dpiY);
 

--- a/src/modules/PowerOCR/PowerOCR/Helpers/WPFExtensionMethods.cs
+++ b/src/modules/PowerOCR/PowerOCR/Helpers/WPFExtensionMethods.cs
@@ -37,4 +37,28 @@ public static class WPFExtensionMethods
 
         return new Point(r.X, r.Y);
     }
+
+    public static DpiScale GetDpi(this System.Windows.Forms.Screen screen)
+    {
+        var pnt = new System.Drawing.Point(screen.Bounds.Left + 1, screen.Bounds.Top + 1);
+        var mon = MonitorFromPoint(pnt, 2/*MONITOR_DEFAULTTONEAREST*/);
+        GetDpiForMonitor(mon, DpiType.Effective, out uint dpiX, out uint dpiY);
+        return new DpiScale(dpiX / 96.0, dpiY / 96.0);
+    }
+
+    // https://msdn.microsoft.com/en-us/library/windows/desktop/dd145062(v=vs.85).aspx
+    [DllImport("User32.dll")]
+    private static extern IntPtr MonitorFromPoint([In] System.Drawing.Point pt, [In] uint dwFlags);
+
+    // https://msdn.microsoft.com/en-us/library/windows/desktop/dn280510(v=vs.85).aspx
+    [DllImport("Shcore.dll")]
+    private static extern IntPtr GetDpiForMonitor([In] IntPtr hmonitor, [In] DpiType dpiType, [Out] out uint dpiX, [Out] out uint dpiY);
+
+    // https://msdn.microsoft.com/en-us/library/windows/desktop/dn280511(v=vs.85).aspx
+    public enum DpiType
+    {
+        Effective = 0,
+        Angular = 1,
+        Raw = 2,
+    }
 }

--- a/src/modules/PowerOCR/PowerOCR/Helpers/WPFExtensionMethods.cs
+++ b/src/modules/PowerOCR/PowerOCR/Helpers/WPFExtensionMethods.cs
@@ -40,8 +40,8 @@ public static class WPFExtensionMethods
 
     public static DpiScale GetDpi(this System.Windows.Forms.Screen screen)
     {
-        var pnt = new System.Drawing.Point(screen.Bounds.Left + 1, screen.Bounds.Top + 1);
-        var mon = MonitorFromPoint(pnt, 2/*MONITOR_DEFAULTTONEAREST*/);
+        var point = new System.Drawing.Point(screen.Bounds.Left + 1, screen.Bounds.Top + 1);
+        var mon = MonitorFromPoint(point, 2/*MONITOR_DEFAULTTONEAREST*/);
         GetDpiForMonitor(mon, DpiType.Effective, out uint dpiX, out uint dpiY);
         return new DpiScale(dpiX / 96.0, dpiY / 96.0);
     }

--- a/src/modules/PowerOCR/PowerOCR/Helpers/WPFExtensionMethods.cs
+++ b/src/modules/PowerOCR/PowerOCR/Helpers/WPFExtensionMethods.cs
@@ -54,7 +54,7 @@ public static class WPFExtensionMethods
     [DllImport("Shcore.dll")]
     private static extern IntPtr GetDpiForMonitor([In] IntPtr hmonitor, [In] DpiType dpiType, [Out] out uint dpiX, [Out] out uint dpiY);
 
-    // https://msdn.microsoft.com/en-us/library/windows/desktop/dn280511(v=vs.85).aspx
+    // https://msdn.microsoft.com/library/windows/desktop/dn280511(v=vs.85).aspx
     public enum DpiType
     {
         Effective = 0,

--- a/src/modules/PowerOCR/PowerOCR/Helpers/WindowUtilities.cs
+++ b/src/modules/PowerOCR/PowerOCR/Helpers/WindowUtilities.cs
@@ -24,8 +24,9 @@ public static class WindowUtilities
         Logger.LogInfo($"Adding Overlays for each screen");
         foreach (Screen screen in Screen.AllScreens)
         {
-            Logger.LogInfo($"screen {screen}");
-            OCROverlay overlay = new(screen.Bounds);
+            DpiScale dpiScale = screen.GetDpi();
+            Logger.LogInfo($"screen {screen}, dpiScale {dpiScale.DpiScaleX}, {dpiScale.DpiScaleY}");
+            OCROverlay overlay = new(screen.Bounds, dpiScale);
 
             overlay.Show();
             ActivateWindow(overlay);

--- a/src/modules/PowerOCR/PowerOCR/OCROverlay.xaml
+++ b/src/modules/PowerOCR/PowerOCR/OCROverlay.xaml
@@ -7,8 +7,6 @@
     xmlns:p="clr-namespace:PowerOCR.Properties"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
     Title="TextExtractor"
-    Width="200"
-    Height="200"
     ui:Design.Background="Transparent"
     AllowsTransparency="True"
     Background="Transparent"

--- a/src/modules/PowerOCR/PowerOCR/OCROverlay.xaml.cs
+++ b/src/modules/PowerOCR/PowerOCR/OCROverlay.xaml.cs
@@ -42,11 +42,16 @@ public partial class OCROverlay : Window
     private bool isComboBoxReady;
     private const double ActiveOpacity = 0.4;
     private readonly UserSettings userSettings = new(new ThrottledActionInvoker());
+    private System.Drawing.Rectangle screenRectangle;
 
-    public OCROverlay(System.Drawing.Rectangle screenRectangle)
+    public OCROverlay(System.Drawing.Rectangle screenRectangleParam, DpiScale dpiScale)
     {
-        Left = screenRectangle.Left >= 0 ? screenRectangle.Left : screenRectangle.Left + (screenRectangle.Width / 2);
-        Top = screenRectangle.Top >= 0 ? screenRectangle.Top : screenRectangle.Top + (screenRectangle.Height / 2);
+        screenRectangle = screenRectangleParam;
+
+        Left = screenRectangle.Left;
+        Top = screenRectangle.Top;
+        Width = screenRectangle.Width / dpiScale.DpiScaleX;
+        Height = screenRectangle.Height / dpiScale.DpiScaleY;
 
         InitializeComponent();
 
@@ -106,12 +111,11 @@ public partial class OCROverlay : Window
 
     private void Window_Loaded(object sender, RoutedEventArgs e)
     {
-        WindowState = WindowState.Maximized;
         FullWindow.Rect = new Rect(0, 0, Width, Height);
         KeyDown += MainWindow_KeyDown;
         KeyUp += MainWindow_KeyUp;
 
-        BackgroundImage.Source = ImageMethods.GetWindowBoundsImage(this);
+        BackgroundImage.Source = ImageMethods.GetWindowBoundsImage(this, this.screenRectangle);
         BackgroundBrush.Opacity = ActiveOpacity;
 
         TopButtonsStackPanel.Visibility = Visibility.Visible;

--- a/src/modules/PowerOCR/PowerOCR/OCROverlay.xaml.cs
+++ b/src/modules/PowerOCR/PowerOCR/OCROverlay.xaml.cs
@@ -5,10 +5,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
+using System.Windows.Interop;
 using System.Windows.Media;
 using Common.UI;
 using ManagedCommon;
@@ -43,10 +45,15 @@ public partial class OCROverlay : Window
     private const double ActiveOpacity = 0.4;
     private readonly UserSettings userSettings = new(new ThrottledActionInvoker());
     private System.Drawing.Rectangle screenRectangle;
+    private DpiScale dpiScale;
 
-    public OCROverlay(System.Drawing.Rectangle screenRectangleParam, DpiScale dpiScale)
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern bool MoveWindow(IntPtr hWnd, int x, int y, int nWidth, int nHeight, bool bRepaint);
+
+    public OCROverlay(System.Drawing.Rectangle screenRectangleParam, DpiScale dpiScaleParam)
     {
         screenRectangle = screenRectangleParam;
+        dpiScale = dpiScaleParam;
 
         Left = screenRectangle.Left;
         Top = screenRectangle.Top;
@@ -123,6 +130,12 @@ public partial class OCROverlay : Window
 #if DEBUG
         Topmost = false;
 #endif
+        IntPtr hwnd = new WindowInteropHelper(this).Handle;
+
+        // The first move puts it on the correct monitor, which triggers WM_DPICHANGED
+        // The +1/-1 coerces WPF to update Window.Top/Left/Width/Height in the second move
+        MoveWindow(hwnd, (int)(screenRectangle.Left + 1), (int)screenRectangle.Top, (int)(screenRectangle.Width - 1), (int)screenRectangle.Height, false);
+        MoveWindow(hwnd, (int)screenRectangle.Left, (int)screenRectangle.Top, (int)screenRectangle.Width, (int)screenRectangle.Height, true);
     }
 
     private void Window_Unloaded(object sender, RoutedEventArgs e)

--- a/src/modules/PowerOCR/PowerOCR/OCROverlay.xaml.cs
+++ b/src/modules/PowerOCR/PowerOCR/OCROverlay.xaml.cs
@@ -122,7 +122,7 @@ public partial class OCROverlay : Window
         KeyDown += MainWindow_KeyDown;
         KeyUp += MainWindow_KeyUp;
 
-        BackgroundImage.Source = ImageMethods.GetWindowBoundsImage(this, this.screenRectangle);
+        BackgroundImage.Source = ImageMethods.GetWindowBoundsImage(this);
         BackgroundBrush.Opacity = ActiveOpacity;
 
         TopButtonsStackPanel.Visibility = Visibility.Visible;
@@ -492,5 +492,10 @@ public partial class OCROverlay : Window
             default:
                 break;
         }
+    }
+
+    public System.Drawing.Rectangle GetScreenRectangle()
+    {
+        return screenRectangle;
     }
 }

--- a/src/modules/PowerOCR/PowerOCR/app.manifest
+++ b/src/modules/PowerOCR/PowerOCR/app.manifest
@@ -47,6 +47,12 @@
       <!-- Windows 10 -->
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
 
+        <windowsSettings>
+            <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+            <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+                PerMonitor
+            </dpiAwareness>
+        </windowsSettings>
     </application>
   </compatibility>
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Restructuring Screen scale handling

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Aimed to fix #31243
The original issue is probably caused by a Framwork bug. This PR does not solve it, but makes DPI handling more apparent.
If the (possibly framework) bug is not present, for the most usual monitor setups, both solution, old and restructured work well. 
If the bug is present, the original solution draws an extra overlay to the main monitor (from point 0,0 with a reduced width, height), the restructured version draws the overlay to the correct position, which due to the framework bug is shown in a faulty location. That way visually there is a mess on the screen (the overlay is shown shifted, usually to the right where it supposted to be). Therefore this "corrected" version result a visually worse outcome, yet it is closer to the correct behaviour.

The original solution was briefly:
- for each screen create a 200x200 overlay window 
- maximize it (width, height correct at this point)
- when getting the snapshot from the screen, calculate the dpi (this goes wrong)

The restructured solution:
- for each screen get the dpi 
- calculate the position and size of the overlay window
- when getting the snapshot from the screen, use the calculated/stored values. 

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
tested locally
