### PR TITLE
[Settings][KBM]Don't clear data with numpad chord

### DIFF
--- a/src/settings-ui/Settings.UI.Library/KeysDataModel.cs
+++ b/src/settings-ui/Settings.UI.Library/KeysDataModel.cs
@@ -26,7 +26,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         public string OriginalKeys { get; set; }
 
         [JsonPropertyName("secondKeyOfChord")]
-        public int SecondKeyOfChord { get; set; }
+        public uint SecondKeyOfChord { get; set; }
 
         [JsonPropertyName("newRemapKeys")]
         public string NewRemapKeys { get; set; }
@@ -129,7 +129,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             NativeMethods.SetForegroundWindow(handle);
         }
 
-        private static List<string> MapKeysOnlyChord(int secondKeyOfChord)
+        private static List<string> MapKeysOnlyChord(uint secondKeyOfChord)
         {
             var result = new List<string>();
             if (secondKeyOfChord <= 0)
@@ -137,12 +137,12 @@ namespace Microsoft.PowerToys.Settings.UI.Library
                 return result;
             }
 
-            result.Add(Helper.GetKeyName((uint)secondKeyOfChord));
+            result.Add(Helper.GetKeyName(secondKeyOfChord));
 
             return result;
         }
 
-        private static List<string> MapKeys(string stringOfKeys, int secondKeyOfChord, bool splitChordsWithComma = false)
+        private static List<string> MapKeys(string stringOfKeys, uint secondKeyOfChord, bool splitChordsWithComma = false)
         {
             if (stringOfKeys == null)
             {
@@ -192,7 +192,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             }
             else
             {
-                return MapKeys(OriginalKeys, -1, splitChordsWithComma);
+                return MapKeys(OriginalKeys, 0, splitChordsWithComma);
             }
         }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
In the keyboard manager page in Settings, the data for the chord is being read as a signed 32 bit-integer, which causes load errors because some keys (like Numpad Page Up) will overflow a signed 32 bit integer.
This PR corrects this by declaring the chord as an unsigned int instead.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #31713
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Mapped `Ctrl(Left) + Home(Numpad),PgUp(Numpad)` to `Ctrl(Left) + L` like in the issue and verified Settings loads the values correctly in the KBM screen without clearing the data.
