### PR TITLE
[KBMEditor][Loc]Add comment so translators don't translate "Text" to "SMS"

### DIFF
--- a/src/modules/keyboardmanager/KeyboardManagerEditor/Resources.resx
+++ b/src/modules/keyboardmanager/KeyboardManagerEditor/Resources.resx
@@ -371,6 +371,7 @@
   </data>
   <data name="Mapping_Type_DropDown_Text" xml:space="preserve">
     <value>Send Text</value>
+    <comment>Text as in that the shortcut will be mapped into a sequence of characters. This is not about mobile text messages.</comment>
   </data>
   <data name="Mapping_Type_DropDown_Key_Shortcut" xml:space="preserve">
     <value>Send Key/Shortcut</value>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Some languages have "Send Text" in KBM Editor translated to "Send SMS". This PR adds some comments so that translators have better context.
Doesn't fix but is related to #31742
