### PR TITLE
[PTRun][VSCodeWorkspaces]Fix wrong installation directory

### DIFF
--- a/installer/PowerToysSetup/Run.wxs
+++ b/installer/PowerToysSetup/Run.wxs
@@ -142,7 +142,7 @@
         <Directory Id="UnitConverterPluginFolder" Name="UnitConverter">
           <Directory Id="UnitConverterImagesFolder" Name="Images" />
         </Directory>
-        <Directory Id="VSCodeWorkspacesPluginFolder" Name="VSCodeWorkspace">
+        <Directory Id="VSCodeWorkspacesPluginFolder" Name="VSCodeWorkspaces">
           <Directory Id="VSCodeWorkspaceImagesFolder" Name="Images" />
         </Directory>
         <Directory Id="WindowWalkerPluginFolder" Name="WindowWalker">


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Fixed the mismatched installation folder name for VSCodeWorkspaces.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #27775
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** Not applicable
- [ ] **Dev docs:** Not applicable
- [ ] **New binaries:** Not applicable
- [ ] **Documentation updated:** Not applicable

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

```wxs
- <Directory Id="VSCodeWorkspacesPluginFolder" Name="VSCodeWorkspace">
+ <Directory Id="VSCodeWorkspacesPluginFolder" Name="VSCodeWorkspaces">
```

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

![image](https://github.com/microsoft/PowerToys/assets/36418285/a0169e66-f24b-49a4-85c1-7a8b3de04f49)
![image](https://github.com/microsoft/PowerToys/assets/36418285/72d0b0db-3f96-47bb-a693-ea5e2dacfd12)
And it worked.