### PR TITLE
[Peek] Fix TitleBar Drag Region

### DIFF
--- a/src/modules/peek/Peek.UI/PeekXAML/Views/TitleBar.xaml.cs
+++ b/src/modules/peek/Peek.UI/PeekXAML/Views/TitleBar.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation
+﻿// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -82,6 +82,8 @@ namespace Peek.UI.Views
         {
             InitializeComponent();
             TitleBarRootContainer.SizeChanged += TitleBarRootContainer_SizeChanged;
+
+            LaunchAppButton.RegisterPropertyChangedCallback(VisibilityProperty, LaunchAppButtonVisibilityChangedCallback);
         }
 
         public IFileSystemItem Item
@@ -117,6 +119,9 @@ namespace Peek.UI.Views
             if (AppWindowTitleBar.IsCustomizationSupported())
             {
                 UpdateTitleBarCustomization(mainWindow);
+
+                // Ensure the drag region of the title bar is updated on first Peek activation
+                UpdateDragRegion();
             }
             else
             {
@@ -356,6 +361,17 @@ namespace Peek.UI.Views
                 OpenWithAppText = string.Empty;
                 OpenWithAppToolTip = string.Empty;
             }
+        }
+
+        /// <summary>
+        /// Ensure the drag region of the title bar is updated when the visibility of the launch app button changes.
+        /// </summary>
+        private async void LaunchAppButtonVisibilityChangedCallback(DependencyObject sender, DependencyProperty dp)
+        {
+            // Ensure the ActualWidth is updated
+            await Task.Delay(100);
+
+            UpdateDragRegion();
         }
     }
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

There are some edge cases when the TitleBar draggable region become outdated:

1. On Peek first activation sometimes the "open with default app button" isn't clickable
2. While navigating from a folder to a file with pinned window "open with default app button" isn't clickable
3. While navigating from a file to a folder with pinned window "open with default app button" isn't visible but the area dosen't allow to drag the window

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #26572
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

Don't really a fan of the delay here... Open to ideas!
The event that invalidates the drag region is the visibility of the button and I have verified that width or actual width property changed callback aren't fired.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Manually tested scenario 1, 2 and 3.