### PR TITLE
[PTRun][Docs] Add WebSearchShortcut to Third-Party plugins

### DIFF
--- a/.github/actions/spell-check/allow/names.txt
+++ b/.github/actions/spell-check/allow/names.txt
@@ -126,6 +126,7 @@ Yuniardi
 yuyoyuppe
 Zoltan
 Zykova
+Riri
 
 
 # OTHERS

--- a/.github/actions/spell-check/allow/names.txt
+++ b/.github/actions/spell-check/allow/names.txt
@@ -126,7 +126,7 @@ Yuniardi
 yuyoyuppe
 Zoltan
 Zykova
-Riri
+riri
 
 
 # OTHERS

--- a/doc/thirdPartyRunPlugins.md
+++ b/doc/thirdPartyRunPlugins.md
@@ -34,6 +34,7 @@ Contact the developers of a plugin directly for assistance with a specific plugi
 | [Clipboard Manager](https://github.com/CoreyHayward/PowerToys-Run-ClipboardManager) | [CoreyHayward](https://github.com/CoreyHayward) | Search and paste text from your clipboard history |
 | [Currency Converter](https://github.com/Advaith3600/PowerToys-Run-Currency-Converter) | [advaith3600](https://github.com/advaith3600) | Convert real and crypto currencies |
 | [FastWeb](https://github.com/CCcat8059/FastWeb) | [CCcat](https://github.com/CCcat8059) | Open website in browser |
+| [WebSearchShortcut](https://github.com/Daydreamer-riri/PowerToys-Run-WebSearchShortcut) | [Riri](https://github.com/Daydreamer-riri) | Select a specific search engine to perform searches. |
 
 ## Extending software plugins
 


### PR DESCRIPTION
## Summary of the Pull Request

Add [WebSearchShortcut](https://github.com/Daydreamer-riri/PowerToys-Run-WebSearchShortcut) to Third-Party plugins for powertoy run

![image](https://github.com/microsoft/PowerToys/assets/70067449/7908a8db-b0c8-49e9-9cc7-286a851574ef)
![image](https://github.com/microsoft/PowerToys/assets/70067449/6277c16d-2bed-42fa-8458-a7528305efb1)

<!-- Please review the items on
This pull request includes a small change to the `thirdPartyRunPlugins.md` file. The change adds a new plugin called `WebSearchShortcut` to the list of third-party plugins for PowerToys Run. The plugin, developed by Riri, allows users to select a specific search engine to perform searches. the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx


