### PR TITLE
Fix for bug 31820: Force file pickers to open modal

### DIFF
--- a/src/modules/registrypreview/RegistryPreviewUI/MainWindow.Events.cs
+++ b/src/modules/registrypreview/RegistryPreviewUI/MainWindow.Events.cs
@@ -155,7 +155,9 @@ namespace RegistryPreview
 
             // Pull in a new REG file - we have to use the direct Win32 method because FileOpenPicker crashes when it's
             // called while running as admin
+            IntPtr windowHandle = WinRT.Interop.WindowNative.GetWindowHandle(this);
             string filename = OpenFilePicker.ShowDialog(
+                windowHandle,
                 resourceLoader.GetString("FilterRegistryName") + '\0' + "*.reg" + '\0' + resourceLoader.GetString("FilterAllFiles") + '\0' + "*.*" + '\0' + '\0',
                 resourceLoader.GetString("OpenDialogTitle"));
 
@@ -197,7 +199,9 @@ namespace RegistryPreview
         {
             // Save out a new REG file and then open it - we have to use the direct Win32 method because FileOpenPicker crashes when it's
             // called while running as admin
+            IntPtr windowHandle = WinRT.Interop.WindowNative.GetWindowHandle(this);
             string filename = SaveFilePicker.ShowDialog(
+                windowHandle,
                 resourceLoader.GetString("SuggestFileName"),
                 resourceLoader.GetString("FilterRegistryName") + '\0' + "*.reg" + '\0' + resourceLoader.GetString("FilterAllFiles") + '\0' + "*.*" + '\0' + '\0',
                 resourceLoader.GetString("SaveDialogTitle"));

--- a/src/modules/registrypreview/RegistryPreviewUI/OpenFileName.cs
+++ b/src/modules/registrypreview/RegistryPreviewUI/OpenFileName.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Runtime.InteropServices;
 
 namespace RegistryPreview
@@ -13,11 +14,12 @@ namespace RegistryPreview
         [DllImport("comdlg32.dll", SetLastError = true, CharSet = CharSet.Auto)]
         private static extern bool GetOpenFileName(ref FileName openFileName);
 
-        public static string ShowDialog(string filter, string dialogTitle)
+        public static string ShowDialog(IntPtr windowHandle, string filter, string dialogTitle)
         {
             FileName openFileName = default(FileName);
             openFileName.StructSize = Marshal.SizeOf(openFileName);
 
+            openFileName.HwndOwner = windowHandle;
             openFileName.Filter = filter;
             openFileName.File = new string(new char[256]);
             openFileName.MaxFile = openFileName.File.Length;

--- a/src/modules/registrypreview/RegistryPreviewUI/SaveFileName.cs
+++ b/src/modules/registrypreview/RegistryPreviewUI/SaveFileName.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Runtime.InteropServices;
 
 namespace RegistryPreview
@@ -13,11 +14,12 @@ namespace RegistryPreview
         [DllImport("comdlg32.dll", SetLastError = true, CharSet = CharSet.Auto)]
         private static extern bool GetSaveFileName(ref FileName saveFileName);
 
-        public static string ShowDialog(string suggestedFilename, string filter, string dialogTitle)
+        public static string ShowDialog(IntPtr windowHandle, string suggestedFilename, string filter, string dialogTitle)
         {
             FileName saveFileName = default(FileName);
             saveFileName.StructSize = Marshal.SizeOf(saveFileName);
 
+            saveFileName.HwndOwner = windowHandle;
             saveFileName.Filter = filter;
             saveFileName.File = new string(new char[256]);
             saveFileName.MaxFile = saveFileName.File.Length;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Updated the file pickers so that they do not open modeless.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #31820
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Win32-based file pickers will always open modal, if you pass in a parent hWnd to become modal for.  If you don't pass in an hWnd value, the dialog will open modeless, which resulted in bug #31820.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Confirmed that if I click Open or Save As within the Registry Previewer that I cannot click anything else on the app until the dialog is closed.  Also confirmed that it is modal to the launching app window (so if you have more than one Previewer open, the modal dialog only blocks the app that opened it.)