### PR TITLE
[CommandNotFound] extending to detect PowerShellPreview installations

### DIFF
--- a/src/settings-ui/Settings.UI/ViewModels/CmdNotFoundViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/CmdNotFoundViewModel.cs
@@ -195,17 +195,19 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 // powerShell Preview might be installed, check it.
                 try
                 {
-                    var environmentPath = Environment.GetEnvironmentVariable("PATH");
-                    IEnumerable<string> pathCandidates = environmentPath.Split(';').Where(x => x.Contains("powershell", StringComparison.InvariantCultureIgnoreCase));
-                    foreach (string path in pathCandidates)
+                    // we have to search for the directory where the PowerShell preview command is located. It is added to the PATH environment variable, so we have to search for it there
+                    foreach (string pathCandidate in Environment.GetEnvironmentVariable("PATH").Split(';'))
                     {
-                        result = RunPowerShellScript(Path.Combine(path, "pwsh-preview.cmd"), arguments, true);
-                        if (result.Contains("PowerShell 7.4 or greater detected."))
+                        if (File.Exists(Path.Combine(pathCandidate, "pwsh-preview.cmd")))
                         {
-                            isPowerShellPreviewDetected = true;
-                            IsPowerShell7Detected = true;
-                            powerShellPreviewPath = path;
-                            break;
+                            result = RunPowerShellScript(Path.Combine(pathCandidate, "pwsh-preview.cmd"), arguments, true);
+                            if (result.Contains("PowerShell 7.4 or greater detected."))
+                            {
+                                isPowerShellPreviewDetected = true;
+                                IsPowerShell7Detected = true;
+                                powerShellPreviewPath = pathCandidate;
+                                break;
+                            }
                         }
                     }
                 }

--- a/src/settings-ui/Settings.UI/ViewModels/CmdNotFoundViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/CmdNotFoundViewModel.cs
@@ -134,14 +134,21 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             get => RuntimeInformation.OSArchitecture == System.Runtime.InteropServices.Architecture.Arm64;
         }
 
+        public string RunPowerShellOrPreviewScript(string powershellExecutable, string powershellArguments, bool hidePowerShellWindow = false)
+        {
+            if (isPowerShellPreviewDetected)
+            {
+                return RunPowerShellScript(Path.Combine(powerShellPreviewPath, "pwsh-preview.cmd"), powershellArguments, hidePowerShellWindow);
+            }
+            else
+            {
+                return RunPowerShellScript(powershellExecutable, powershellArguments, hidePowerShellWindow);
+            }
+        }
+
         public string RunPowerShellScript(string powershellExecutable, string powershellArguments, bool hidePowerShellWindow = false)
         {
             string outputLog = string.Empty;
-            if (isPowerShellPreviewDetected)
-            {
-                powershellExecutable = Path.Combine(powerShellPreviewPath, "pwsh-preview.cmd");
-            }
-
             try
             {
                 var startInfo = new ProcessStartInfo()
@@ -242,7 +249,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         {
             var ps1File = AssemblyDirectory + "\\Assets\\Settings\\Scripts\\InstallPowerShell7.ps1";
             var arguments = $"-NoProfile -ExecutionPolicy Unrestricted -File \"{ps1File}\"";
-            var result = RunPowerShellScript("powershell.exe", arguments);
+            var result = RunPowerShellOrPreviewScript("powershell.exe", arguments);
             if (result.Contains("Powershell 7 successfully installed."))
             {
                 IsPowerShell7Detected = true;
@@ -258,7 +265,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         {
             var ps1File = AssemblyDirectory + "\\Assets\\Settings\\Scripts\\InstallWinGetClientModule.ps1";
             var arguments = $"-NoProfile -ExecutionPolicy Unrestricted -File \"{ps1File}\"";
-            var result = RunPowerShellScript("pwsh.exe", arguments);
+            var result = RunPowerShellOrPreviewScript("pwsh.exe", arguments);
             if (result.Contains("WinGet Client module detected."))
             {
                 IsWinGetClientModuleDetected = true;
@@ -275,7 +282,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         {
             var ps1File = AssemblyDirectory + "\\Assets\\Settings\\Scripts\\EnableModule.ps1";
             var arguments = $"-NoProfile -ExecutionPolicy Unrestricted -File \"{ps1File}\" -scriptPath \"{AssemblyDirectory}\\..\"";
-            var result = RunPowerShellScript("pwsh.exe", arguments);
+            var result = RunPowerShellOrPreviewScript("pwsh.exe", arguments);
 
             if (result.Contains("Module is already registered in the profile file.") || result.Contains("Module was successfully registered in the profile file."))
             {
@@ -290,7 +297,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         {
             var ps1File = AssemblyDirectory + "\\Assets\\Settings\\Scripts\\DisableModule.ps1";
             var arguments = $"-NoProfile -ExecutionPolicy Unrestricted -File \"{ps1File}\"";
-            var result = RunPowerShellScript("pwsh.exe", arguments);
+            var result = RunPowerShellOrPreviewScript("pwsh.exe", arguments);
 
             if (result.Contains("Removed the Command Not Found reference from the profile file.") || result.Contains("No instance of Command Not Found was found in the profile file."))
             {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
extending CommandNotFound to detect PowerShellPreview installations

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [X] **Closes:** #31741
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
if normal PowerShell installation isn't found (7.4 or greater), a check is added to detect PowerShell Preview installations.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
tested locally
