### PR TITLE
[ci]Sign FancyZonesEditorCommon.dll

### DIFF
--- a/.pipelines/ESRPSigning_core.json
+++ b/.pipelines/ESRPSigning_core.json
@@ -54,6 +54,7 @@
                 "fancyzones.dll",
                 "PowerToys.FancyZonesEditor.exe",
                 "PowerToys.FancyZonesEditor.dll",
+                "PowerToys.FancyZonesEditorCommon.dll",
                 "PowerToys.FancyZonesModuleInterface.dll",
                 "PowerToys.FancyZones.exe",
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

The new dll "PowerToys.FancyZonesEditorCommon.dll" added in https://github.com/microsoft/PowerToys/commit/f6e7635a4e143def0a6bb2ada4d562c0de318059 is currently not being sign in CI. Add it to the list of binaries to sign.
