### PR TITLE
[Fix] Fix preview for folders with dot

### DIFF
--- a/src/modules/peek/Peek.Common/Models/FileItem.cs
+++ b/src/modules/peek/Peek.Common/Models/FileItem.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Globalization;
 using System.Threading.Tasks;
 using ManagedCommon;
 using Windows.Storage;
@@ -24,6 +25,8 @@ namespace Peek.Common.Models
         public string Name { get; init; }
 
         public string Path { get; init; }
+
+        public string Extension => System.IO.Path.GetExtension(Path).ToLower(CultureInfo.InvariantCulture);
 
         public async Task<IStorageItem?> GetStorageItemAsync()
         {

--- a/src/modules/peek/Peek.Common/Models/FolderItem.cs
+++ b/src/modules/peek/Peek.Common/Models/FolderItem.cs
@@ -25,6 +25,8 @@ namespace Peek.Common.Models
 
         public string Path { get; init; }
 
+        public string Extension => string.Empty;
+
         public async Task<IStorageItem?> GetStorageItemAsync()
         {
             return await GetStorageFolderAsync();

--- a/src/modules/peek/Peek.Common/Models/IFileSystemItem.cs
+++ b/src/modules/peek/Peek.Common/Models/IFileSystemItem.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Globalization;
 using System.Threading.Tasks;
 using Peek.Common.Helpers;
 using Windows.Storage;
@@ -32,7 +31,7 @@ namespace Peek.Common.Models
             }
         }
 
-        public string Extension => System.IO.Path.GetExtension(Path).ToLower(CultureInfo.InvariantCulture);
+        public string Extension { get; }
 
         public string Name { get; init; }
 

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/Archives/ArchivePreviewer.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/Archives/ArchivePreviewer.cs
@@ -111,9 +111,9 @@ namespace Peek.FilePreviewer.Previewers.Archives
             State = PreviewState.Loaded;
         }
 
-        public static bool IsFileTypeSupported(string fileExt)
+        public static bool IsItemSupported(IFileSystemItem item)
         {
-            return _supportedFileTypes.Contains(fileExt);
+            return _supportedFileTypes.Contains(item.Extension);
         }
 
         public void Dispose()

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/Drive/DrivePreviewer.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/Drive/DrivePreviewer.cs
@@ -89,9 +89,9 @@ namespace Peek.FilePreviewer.Previewers.Drive
             State = PreviewState.Loaded;
         }
 
-        public static bool IsPathSupported(string path)
+        public static bool IsItemSupported(IFileSystemItem item)
         {
-            return DriveInfo.GetDrives().Any(d => d.Name == path);
+            return DriveInfo.GetDrives().Any(d => d.Name == item.Path);
         }
 
         private string GetDriveTypeDescription(DriveType driveType) => driveType switch

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/Interfaces/IArchivePreviewer.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/Interfaces/IArchivePreviewer.cs
@@ -8,7 +8,7 @@ using Peek.FilePreviewer.Previewers.Archives.Models;
 
 namespace Peek.FilePreviewer.Previewers.Interfaces
 {
-    public interface IArchivePreviewer : IPreviewer, IDisposable
+    public interface IArchivePreviewer : IPreviewer, IPreviewTarget, IDisposable
     {
         ObservableCollection<ArchiveItem> Tree { get; }
 

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/Interfaces/IAudioPreviewer.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/Interfaces/IAudioPreviewer.cs
@@ -6,7 +6,7 @@ using Peek.FilePreviewer.Previewers.MediaPreviewer.Models;
 
 namespace Peek.FilePreviewer.Previewers.Interfaces
 {
-    public interface IAudioPreviewer : IPreviewer
+    public interface IAudioPreviewer : IPreviewer, IPreviewTarget
     {
         public AudioPreviewData? Preview { get; }
     }

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/Interfaces/IBrowserPreviewer.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/Interfaces/IBrowserPreviewer.cs
@@ -4,9 +4,9 @@
 
 using System;
 
-namespace Peek.FilePreviewer.Previewers
+namespace Peek.FilePreviewer.Previewers.Interfaces
 {
-    public interface IBrowserPreviewer : IPreviewer
+    public interface IBrowserPreviewer : IPreviewer, IPreviewTarget
     {
         public Uri? Preview { get; }
 

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/Interfaces/IDrivePreviewer.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/Interfaces/IDrivePreviewer.cs
@@ -6,7 +6,7 @@ using Peek.FilePreviewer.Previewers.Drive.Models;
 
 namespace Peek.FilePreviewer.Previewers.Interfaces
 {
-    public interface IDrivePreviewer : IPreviewer
+    public interface IDrivePreviewer : IPreviewer, IPreviewTarget
     {
         public DrivePreviewData? Preview { get; }
     }

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/Interfaces/IImagePreviewer.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/Interfaces/IImagePreviewer.cs
@@ -7,7 +7,7 @@ using Windows.Foundation;
 
 namespace Peek.FilePreviewer.Previewers.Interfaces
 {
-    public interface IImagePreviewer : IPreviewer
+    public interface IImagePreviewer : IPreviewer, IPreviewTarget
     {
         public ImageSource? Preview { get; }
 

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/Interfaces/IPreviewTarget.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/Interfaces/IPreviewTarget.cs
@@ -2,12 +2,12 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Windows.Media.Core;
+using Peek.Common.Models;
 
 namespace Peek.FilePreviewer.Previewers.Interfaces
 {
-    public interface IVideoPreviewer : IPreviewer, IPreviewTarget
+    public interface IPreviewTarget
     {
-        public MediaSource? Preview { get; }
+        static abstract bool IsItemSupported(IFileSystemItem item);
     }
 }

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/Interfaces/IPreviewer.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/Interfaces/IPreviewer.cs
@@ -2,20 +2,16 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.ComponentModel;
 using System.Threading;
 using System.Threading.Tasks;
 using Peek.FilePreviewer.Models;
-using Windows.Foundation;
 
 namespace Peek.FilePreviewer.Previewers
 {
     public interface IPreviewer : INotifyPropertyChanged
     {
         PreviewState State { get; set; }
-
-        public static bool IsFileTypeSupported(string fileExt) => throw new NotImplementedException();
 
         public Task<PreviewSize> GetPreviewSizeAsync(CancellationToken cancellationToken);
 

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/Interfaces/IShellPreviewHandlerPreviewer.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/Interfaces/IShellPreviewHandlerPreviewer.cs
@@ -4,9 +4,9 @@
 
 using Windows.Win32.UI.Shell;
 
-namespace Peek.FilePreviewer.Previewers
+namespace Peek.FilePreviewer.Previewers.Interfaces
 {
-    public interface IShellPreviewHandlerPreviewer : IPreviewer
+    public interface IShellPreviewHandlerPreviewer : IPreviewer, IPreviewTarget
     {
         public IPreviewHandler? Preview { get; }
 

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/MediaPreviewer/AudioPreviewer.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/MediaPreviewer/AudioPreviewer.cs
@@ -154,9 +154,9 @@ namespace Peek.FilePreviewer.Previewers.MediaPreviewer
             });
         }
 
-        public static bool IsFileTypeSupported(string fileExt)
+        public static bool IsItemSupported(IFileSystemItem item)
         {
-            return _supportedFileTypes.Contains(fileExt);
+            return _supportedFileTypes.Contains(item.Extension);
         }
 
         private static readonly HashSet<string> _supportedFileTypes = new()

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/MediaPreviewer/ImagePreviewer.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/MediaPreviewer/ImagePreviewer.cs
@@ -70,9 +70,9 @@ namespace Peek.FilePreviewer.Previewers
 
         private ImageSource? highQualityThumbnailPreview;
 
-        public static bool IsFileTypeSupported(string fileExt)
+        public static bool IsItemSupported(IFileSystemItem item)
         {
-            return _supportedFileTypes.Contains(fileExt);
+            return _supportedFileTypes.Contains(item.Extension);
         }
 
         public void Dispose()

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/MediaPreviewer/VideoPreviewer.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/MediaPreviewer/VideoPreviewer.cs
@@ -42,9 +42,9 @@ namespace Peek.FilePreviewer.Previewers
 
         private Task<bool>? VideoTask { get; set; }
 
-        public static bool IsFileTypeSupported(string fileExt)
+        public static bool IsItemSupported(IFileSystemItem item)
         {
-            return _supportedFileTypes.Contains(fileExt);
+            return _supportedFileTypes.Contains(item.Extension);
         }
 
         public void Dispose()

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/PreviewerFactory.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/PreviewerFactory.cs
@@ -23,39 +23,39 @@ namespace Peek.FilePreviewer.Previewers
             _previewSettings = Application.Current.GetService<IPreviewSettings>();
         }
 
-        public IPreviewer Create(IFileSystemItem file)
+        public IPreviewer Create(IFileSystemItem item)
         {
-            if (ImagePreviewer.IsFileTypeSupported(file.Extension))
+            if (ImagePreviewer.IsItemSupported(item))
             {
-                return new ImagePreviewer(file);
+                return new ImagePreviewer(item);
             }
-            else if (VideoPreviewer.IsFileTypeSupported(file.Extension))
+            else if (VideoPreviewer.IsItemSupported(item))
             {
-                return new VideoPreviewer(file);
+                return new VideoPreviewer(item);
             }
-            else if (AudioPreviewer.IsFileTypeSupported(file.Extension))
+            else if (AudioPreviewer.IsItemSupported(item))
             {
-                return new AudioPreviewer(file);
+                return new AudioPreviewer(item);
             }
-            else if (WebBrowserPreviewer.IsFileTypeSupported(file.Extension))
+            else if (WebBrowserPreviewer.IsItemSupported(item))
             {
-                return new WebBrowserPreviewer(file, _previewSettings);
+                return new WebBrowserPreviewer(item, _previewSettings);
             }
-            else if (ArchivePreviewer.IsFileTypeSupported(file.Extension))
+            else if (ArchivePreviewer.IsItemSupported(item))
             {
-                return new ArchivePreviewer(file);
+                return new ArchivePreviewer(item);
             }
-            else if (ShellPreviewHandlerPreviewer.IsFileTypeSupported(file.Extension))
+            else if (ShellPreviewHandlerPreviewer.IsItemSupported(item))
             {
-                return new ShellPreviewHandlerPreviewer(file);
+                return new ShellPreviewHandlerPreviewer(item);
             }
-            else if (DrivePreviewer.IsPathSupported(file.Path))
+            else if (DrivePreviewer.IsItemSupported(item))
             {
-                return new DrivePreviewer(file);
+                return new DrivePreviewer(item);
             }
 
             // Other previewer types check their supported file types here
-            return CreateDefaultPreviewer(file);
+            return CreateDefaultPreviewer(item);
         }
 
         public IPreviewer CreateDefaultPreviewer(IFileSystemItem file)

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/ShellPreviewHandlerPreviewer/ShellPreviewHandlerPreviewer.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/ShellPreviewHandlerPreviewer/ShellPreviewHandlerPreviewer.cs
@@ -16,6 +16,7 @@ using Peek.Common.Helpers;
 using Peek.Common.Models;
 using Peek.FilePreviewer.Models;
 using Peek.FilePreviewer.Previewers.Helpers;
+using Peek.FilePreviewer.Previewers.Interfaces;
 using Windows.Win32;
 using Windows.Win32.System.Com;
 using Windows.Win32.UI.Shell;
@@ -205,9 +206,9 @@ namespace Peek.FilePreviewer.Previewers
             }
         }
 
-        public static bool IsFileTypeSupported(string fileExt)
+        public static bool IsItemSupported(IFileSystemItem item)
         {
-            return !string.IsNullOrEmpty(GetPreviewHandlerGuid(fileExt));
+            return !string.IsNullOrEmpty(GetPreviewHandlerGuid(item.Extension));
         }
 
         private static string? GetPreviewHandlerGuid(string fileExt)

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/WebBrowserPreviewer/WebBrowserPreviewer.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/WebBrowserPreviewer/WebBrowserPreviewer.cs
@@ -13,6 +13,7 @@ using Peek.Common.Extensions;
 using Peek.Common.Helpers;
 using Peek.Common.Models;
 using Peek.FilePreviewer.Models;
+using Peek.FilePreviewer.Previewers.Interfaces;
 
 namespace Peek.FilePreviewer.Previewers
 {
@@ -137,9 +138,9 @@ namespace Peek.FilePreviewer.Previewers
             });
         }
 
-        public static bool IsFileTypeSupported(string fileExt)
+        public static bool IsItemSupported(IFileSystemItem item)
         {
-            return _supportedFileTypes.Contains(fileExt) || MonacoHelper.SupportedMonacoFileTypes.Contains(fileExt);
+            return _supportedFileTypes.Contains(item.Extension) || MonacoHelper.SupportedMonacoFileTypes.Contains(item.Extension);
         }
 
         private bool HasFailedLoadingPreview()


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Fix extension being returned for folders that contains `.` in their name.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #32060
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

- Always return empty extensions for folder items
- Small refactoring on how is checked if an item is supported by the previewer and added an interface

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

- Verified that every previewer is invoked as expected.
- Verified that the default previewer is always invoked for folders ending with `.extension`