### PR TITLE
[KBM] Simultaneous shortcut invocation in Keyboard Manager

### DIFF
--- a/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardEventHandlers.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardEventHandlers.cpp
@@ -625,8 +625,15 @@ namespace KeyboardEventHandlers
 
                         Helpers::SetModifierKeyEvents(std::get<Shortcut>(it->second.targetShortcut), it->second.winKeyInvoked, keyEventList, i, false, KeyboardManagerConstants::KEYBOARDMANAGER_SHORTCUT_FLAG, it->first, data->lParam->vkCode);
 
-                        // Set original shortcut key down state except the action key and the released modifier since the original action key may or may not be held down. If it is held down it will generate it's own key message
-                        Helpers::SetModifierKeyEvents(it->first, it->second.winKeyInvoked, keyEventList, i, true, KeyboardManagerConstants::KEYBOARDMANAGER_SHORTCUT_FLAG, std::get<Shortcut>(it->second.targetShortcut), data->lParam->vkCode);
+                        if (!isAltRightKeyInvoked)
+                        {
+                            // Set original shortcut key down state except the action key and the released modifier since the original action key may or may not be held down. If it is held down it will generate it's own key message
+                            Helpers::SetModifierKeyEvents(it->first, it->second.winKeyInvoked, keyEventList, i, true, KeyboardManagerConstants::KEYBOARDMANAGER_SHORTCUT_FLAG, std::get<Shortcut>(it->second.targetShortcut), data->lParam->vkCode);
+                        }
+                        else
+                        {
+                            isAltRightKeyInvoked = false;
+                        }
 
                         // Send a dummy key event to prevent modifier press+release from being triggered. Example: Win+Ctrl+A->Ctrl+V, press Win+Ctrl+A and release A then Ctrl, since Win will be pressed here we need to send a dummy event after it
                         Helpers::SetDummyKeyEvent(keyEventList, i, KeyboardManagerConstants::KEYBOARDMANAGER_SHORTCUT_FLAG);

--- a/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/State.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/State.cpp
@@ -73,3 +73,15 @@ std::wstring State::GetActivatedApp()
 {
     return activatedAppSpecificShortcutTarget;
 }
+
+// Sets the previous action key to use in another shortcut
+void State::SetPreviousActionKey(const DWORD prevKey)
+{
+    previousActionKey = prevKey;
+}
+
+// Gets the previous action key
+DWORD State::GetPreviousActionKey()
+{
+    return previousActionKey;
+}

--- a/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/State.h
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/State.h
@@ -6,6 +6,8 @@ class State : public MappingConfiguration
 private:
     // Stores the activated target application in app-specific shortcut
     std::wstring activatedAppSpecificShortcutTarget;
+    // Stores the previous action key
+    DWORD previousActionKey = {};
 
 public:
     // Function to get the iterator of a single key remap given the source key. Returns nullopt if it isn't remapped
@@ -26,4 +28,10 @@ public:
 
     // Gets the activated target application in app-specific shortcut
     std::wstring GetActivatedApp();
+
+    // Sets the previous action key to use in another shortcut
+    void SetPreviousActionKey(const DWORD prevKey); 
+    
+    // Gets the previous action key
+    DWORD GetPreviousActionKey();
 };

--- a/src/modules/keyboardmanager/common/Shortcut.cpp
+++ b/src/modules/keyboardmanager/common/Shortcut.cpp
@@ -746,7 +746,7 @@ bool IgnoreKeyCode(DWORD key)
 }
 
 // Function to check if any keys are pressed down except those in the shortcut
-bool Shortcut::IsKeyboardStateClearExceptShortcut(KeyboardManagerInput::InputInterface& ii) const
+bool Shortcut::IsKeyboardStateClearExceptShortcut(KeyboardManagerInput::InputInterface& ii, int prevKey) const
 {
     // Iterate through all the virtual key codes - 0xFF is set to key down because of the Num Lock
     for (int keyVal = 1; keyVal < 0xFF; keyVal++)
@@ -884,8 +884,8 @@ bool Shortcut::IsKeyboardStateClearExceptShortcut(KeyboardManagerInput::InputInt
                     continue;
                 }
             }
-            // If any other key is pressed check if it is the action key
-            else if (keyVal != static_cast<int>(actionKey))
+            // If any other key is pressed check if it is the action key or check if it is previous action key
+            else if (keyVal != static_cast<int>(actionKey) && (prevKey != 0 && keyVal != prevKey))
             {
                 return false;
             }

--- a/src/modules/keyboardmanager/common/Shortcut.h
+++ b/src/modules/keyboardmanager/common/Shortcut.h
@@ -181,7 +181,7 @@ public:
     bool CheckModifiersKeyboardState(KeyboardManagerInput::InputInterface& ii) const;
 
     // Function to check if any keys are pressed down except those in the shortcut
-    bool IsKeyboardStateClearExceptShortcut(KeyboardManagerInput::InputInterface& ii) const;
+    bool IsKeyboardStateClearExceptShortcut(KeyboardManagerInput::InputInterface& ii, int prevKey) const;
 
     // Function to get the number of modifiers that are common between the current shortcut and the shortcut in the argument
     int GetCommonModifiersCount(const Shortcut& input) const;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Simultaneous shortcut invoke operations are allowed.

Note: This branch opened from #31923 to avoid code conflicts.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #18459 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

The following 3 shortcuts were used while testing:

- Win (Left) + E
- Win (Left) + S
- Win (Left) + V

While testing, all combinations of these shortcuts were tried:

- Win (Left) + E + S
- Win (Left) + E + V
- Win (Left) + S + V
- Win (Left) + S + E
- Win (Left) + V + E
- Win (Left) + V + S
- Win (Left) + E + S + V, V + S + E, S + V + E ...

It was also tested with remap a key and remap a shortcut above together :

- R -> E
- T -> S
- Y -> V

While testing, the keys were tested with different press, keep pressed and release states:

- Win (Left) + E + Hold V pressed
- Win (Left) + E, release and press V consecutive
- Win (Left) + E, release E, press E, press V
- Win (Left) + E, release E, release Win (Left), press Win (Left) + E + V
- Win (Left) + E + Hold V pressed, release V and E, press V + Hold E pressed
- Win (Left) + release and press(hold or consecutive) different combinations of E + S + V

It was tested by making the following assignments to the shortcuts:

- Win (Left) + E -> Disable
- Win (Left) + S -> Disable
- Win (Left) + V -> Disable

- Win (Left) + E -> A
- Win (Left) + S -> B
- Win (Left) + V -> C

- Win (Left) + E -> Ctrl (Left) + A
- Win (Left) + S -> Ctrl (Left) + V
- Win (Left) + V -> Ctrl (Left) + C

- Win (Left) + E -> Send Text (qwe)
- Win (Left) + S -> Send Text (asd)
- Win (Left) + V -> Send Text (zxc)

- Win (Left) + E -> Run Program (calculator.exe)
- Win (Left) + S -> Run Program (notepad++.exe)
- Win (Left) + V -> Run Program (chrome.exe)

- Win (Left) + E -> Open URI (https://www.google.com/)
- Win (Left) + S -> Open URI (https://github.com/microsoft/PowerToys)
- Win (Left) + V -> Open URI (https://learn.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes)