### PR TITLE
Opt-into MSBuild -graph param for pipelines

### DIFF
--- a/.pipelines/ci/templates/build-powertoys-steps.yml
+++ b/.pipelines/ci/templates/build-powertoys-steps.yml
@@ -100,7 +100,7 @@ steps:
     ${{ if eq(parameters.enableCaching, true) }}:
       msbuildArgs: -restore ${{ parameters.additionalBuildArguments }} -graph -reportfileaccesses -p:MSBuildCacheEnabled=true -p:MSBuildCacheLogDirectory=$(Build.ArtifactStagingDirectory)\logs\MSBuildCache -bl:$(Build.ArtifactStagingDirectory)\logs\PowerToys.binlog -ds:false
     ${{ else }}:
-      msbuildArgs: -restore ${{ parameters.additionalBuildArguments }} -bl:$(Build.ArtifactStagingDirectory)\logs\PowerToys.binlog -ds:false
+      msbuildArgs: -restore ${{ parameters.additionalBuildArguments }} -graph -bl:$(Build.ArtifactStagingDirectory)\logs\PowerToys.binlog -ds:false
     msbuildArchitecture: x64
     maximumCpuCount: true
   ${{ if eq(parameters.enableCaching, true) }}:
@@ -114,7 +114,7 @@ steps:
     vsVersion: 17.0
     platform: '$(BuildPlatform)'
     configuration: '$(BuildConfiguration)'
-    msbuildArgs: -restore ${{ parameters.additionalBuildArguments }} -bl:$(Build.ArtifactStagingDirectory)\logs\BugReportTool.binlog -ds:false
+    msbuildArgs: -restore ${{ parameters.additionalBuildArguments }} -graph -bl:$(Build.ArtifactStagingDirectory)\logs\BugReportTool.binlog -ds:false
     msbuildArchitecture: x64
     maximumCpuCount: true
 
@@ -125,7 +125,7 @@ steps:
     vsVersion: 17.0
     platform: '$(BuildPlatform)'
     configuration: '$(BuildConfiguration)'
-    msbuildArgs: -restore ${{ parameters.additionalBuildArguments }} -bl:$(Build.ArtifactStagingDirectory)\logs\WebcamReportTool.binlog -ds:false
+    msbuildArgs: -restore ${{ parameters.additionalBuildArguments }} -graph -bl:$(Build.ArtifactStagingDirectory)\logs\WebcamReportTool.binlog -ds:false
     msbuildArchitecture: x64
     maximumCpuCount: true
 
@@ -136,7 +136,7 @@ steps:
     vsVersion: 17.0
     platform: '$(BuildPlatform)'
     configuration: '$(BuildConfiguration)'
-    msbuildArgs: -restore ${{ parameters.additionalBuildArguments }} -bl:$(Build.ArtifactStagingDirectory)\logs\StylesReportTool.binlog -ds:false
+    msbuildArgs: -restore ${{ parameters.additionalBuildArguments }} -graph -bl:$(Build.ArtifactStagingDirectory)\logs\StylesReportTool.binlog -ds:false
     msbuildArchitecture: x64
     maximumCpuCount: true
 

--- a/.pipelines/release.yml
+++ b/.pipelines/release.yml
@@ -156,7 +156,7 @@ extends:
           inputs:
             solution: '**\PowerToys.sln'
             vsVersion: 17.0
-            msbuildArgs: -restore /p:RestorePackagesConfig=true /p:RestoreConfigFile="$(Build.SourcesDirectory)\.pipelines\release-nuget.config" /p:CIBuild=true /bl:$(Build.SourcesDirectory)\msbuild.binlog
+            msbuildArgs: -restore -graph /p:RestorePackagesConfig=true /p:RestoreConfigFile="$(Build.SourcesDirectory)\.pipelines\release-nuget.config" /p:CIBuild=true /bl:$(Build.SourcesDirectory)\msbuild.binlog
             platform: $(BuildPlatform)
             configuration: $(BuildConfiguration)
             clean: true
@@ -167,7 +167,7 @@ extends:
           inputs:
             solution: '**/tools/BugReportTool/BugReportTool.sln'
             vsVersion: 17.0
-            msbuildArgs: -restore /p:RestorePackagesConfig=true /p:RestoreConfigFile="$(Build.SourcesDirectory)\.pipelines\release-nuget.config" /p:CIBuild=true /bl:$(Build.SourcesDirectory)\msbuild.binlog
+            msbuildArgs: -restore -graph /p:RestorePackagesConfig=true /p:RestoreConfigFile="$(Build.SourcesDirectory)\.pipelines\release-nuget.config" /p:CIBuild=true /bl:$(Build.SourcesDirectory)\msbuild.binlog
             platform: $(BuildPlatform)
             configuration: $(BuildConfiguration)
             clean: true
@@ -178,7 +178,7 @@ extends:
           inputs:
             solution: '**/tools/WebcamReportTool/WebcamReportTool.sln'
             vsVersion: 17.0
-            msbuildArgs: -restore /p:RestorePackagesConfig=true /p:RestoreConfigFile="$(Build.SourcesDirectory)\.pipelines\release-nuget.config" /p:CIBuild=true /bl:$(Build.SourcesDirectory)\msbuild.binlog
+            msbuildArgs: -restore -graph /p:RestorePackagesConfig=true /p:RestoreConfigFile="$(Build.SourcesDirectory)\.pipelines\release-nuget.config" /p:CIBuild=true /bl:$(Build.SourcesDirectory)\msbuild.binlog
             platform: $(BuildPlatform)
             configuration: $(BuildConfiguration)
             clean: true
@@ -189,7 +189,7 @@ extends:
           inputs:
             solution: '**/tools/StylesReportTool/StylesReportTool.sln'
             vsVersion: 17.0
-            msbuildArgs: -restore /p:RestorePackagesConfig=true /p:RestoreConfigFile="$(Build.SourcesDirectory)\.pipelines\release-nuget.config" /p:CIBuild=true /bl:$(Build.SourcesDirectory)\msbuild.binlog
+            msbuildArgs: -restore -graph /p:RestorePackagesConfig=true /p:RestoreConfigFile="$(Build.SourcesDirectory)\.pipelines\release-nuget.config" /p:CIBuild=true /bl:$(Build.SourcesDirectory)\msbuild.binlog
             platform: $(BuildPlatform)
             configuration: $(BuildConfiguration)
             clean: true
@@ -202,6 +202,7 @@ extends:
             vsVersion: 17.0
             msbuildArgs: >-
               /target:Publish
+              /graph
               /p:Configuration=$(BuildConfiguration);Platform=$(BuildPlatform);AppxBundle=Never
               /p:VCRTForwarders-IncludeDebugCRT=false
               /p:PowerToysRoot=$(Build.SourcesDirectory)
@@ -218,6 +219,7 @@ extends:
             # The arguments should be the same as the ones for Settings; make sure they are.
             msbuildArgs: >-
               /target:Publish
+              /graph
               /p:Configuration=$(BuildConfiguration);Platform=$(BuildPlatform);AppxBundle=Never
               /p:VCRTForwarders-IncludeDebugCRT=false
               /p:PowerToysRoot=$(Build.SourcesDirectory)
@@ -234,6 +236,7 @@ extends:
             # The arguments should be the same as the ones for Settings; make sure they are.
             msbuildArgs: >-
               /target:Publish
+              /graph
               /p:Configuration=$(BuildConfiguration);Platform=$(BuildPlatform);AppxBundle=Never
               /p:VCRTForwarders-IncludeDebugCRT=false
               /p:PowerToysRoot=$(Build.SourcesDirectory)
@@ -250,6 +253,7 @@ extends:
             # The arguments should be the same as the ones for Settings; make sure they are.
             msbuildArgs: >-
               /target:Publish
+              /graph
               /p:Configuration=$(BuildConfiguration);Platform=$(BuildPlatform);AppxBundle=Never
               /p:VCRTForwarders-IncludeDebugCRT=false
               /p:PowerToysRoot=$(Build.SourcesDirectory)
@@ -266,6 +270,7 @@ extends:
             # The arguments should be the same as the ones for Settings; make sure they are.
             msbuildArgs: >-
               /target:Publish
+              /graph
               /p:Configuration=$(BuildConfiguration);Platform=$(BuildPlatform);AppxBundle=Never
               /p:VCRTForwarders-IncludeDebugCRT=false
               /p:PowerToysRoot=$(Build.SourcesDirectory)
@@ -282,6 +287,7 @@ extends:
             # The arguments should be the same as the ones for Settings; make sure they are.
             msbuildArgs: >-
               /target:Publish
+              /graph
               /p:Configuration=$(BuildConfiguration);Platform=$(BuildPlatform);AppxBundle=Never
               /p:VCRTForwarders-IncludeDebugCRT=false
               /p:PowerToysRoot=$(Build.SourcesDirectory)
@@ -298,6 +304,7 @@ extends:
             # The arguments should be the same as the ones for Settings; make sure they are.
             msbuildArgs: >-
               /target:Publish
+              /graph
               /p:Configuration=$(BuildConfiguration);Platform=$(BuildPlatform);AppxBundle=Never
               /p:VCRTForwarders-IncludeDebugCRT=false
               /p:PowerToysRoot=$(Build.SourcesDirectory)


### PR DESCRIPTION
This adds the `-graph` MSBuld parameter in the pipelines. This parameter causes MSBuild to evaluate the dependency graph and build "bottom up" instead of "top down". This can lead to better machine utilization since all dependencies are known up front and can start immediately, as opposed to being discovered just-in-time as a project needs them.

In practice for this repo I did not see a huge impact, but it may be helping a little so why not.