### PR TITLE
Use pipeline artifacts instead of build artifacts

### DIFF
--- a/.pipelines/ci/templates/build-powertoys-steps.yml
+++ b/.pipelines/ci/templates/build-powertoys-steps.yml
@@ -308,9 +308,7 @@ steps:
     contents: '$(BuildPlatform)/$(BuildConfiguration)/**/*'
     targetFolder: '$(Build.ArtifactStagingDirectory)\$(BuildPlatform)\$(BuildConfiguration)'
 
-- task: PublishBuildArtifacts@1
+- publish: $(Build.ArtifactStagingDirectory)\$(BuildPlatform)\$(BuildConfiguration)
   displayName: Publish Build Artifacts
+  artifact: build-$(BuildPlatform)-$(BuildConfiguration)
   condition: and(succeeded(), ne(variables['BuildPlatform'],'arm64')) 
-  inputs:
-    pathToPublish: '$(Build.ArtifactStagingDirectory)\$(BuildPlatform)\$(BuildConfiguration)'
-    artifactName: build-$(BuildPlatform)-$(BuildConfiguration)

--- a/.pipelines/ci/templates/run-ui-tests-ci.yml
+++ b/.pipelines/ci/templates/run-ui-tests-ci.yml
@@ -20,11 +20,9 @@ jobs:
     clean: true
     fetchTags: false
 
-  - task: DownloadPipelineArtifact@2
+  - download: current
     displayName: Download artifacts
-    inputs:
-      artifact: build-${{ parameters.platform }}-${{ parameters.configuration }}
-      path: $(Build.ArtifactStagingDirectory)
+    artifact: build-${{ parameters.platform }}-${{ parameters.configuration }}
 
   - task: UseDotNet@2
     displayName: 'Use .NET 6 SDK'
@@ -59,7 +57,7 @@ jobs:
       platform: '$(BuildPlatform)'
       configuration: '$(BuildConfiguration)'
       testSelector: 'testAssemblies'
-      searchFolder: '$(Build.ArtifactStagingDirectory)'
+      searchFolder: '$(Pipeline.Workspace)\build-${{ parameters.platform }}-${{ parameters.configuration }}'
       vstestLocationMethod: 'location' # otherwise fails to find vstest.console.exe 
       #vstestLocation: '$(Agent.ToolsDirectory)\VsTest\**\${{ parameters.platform }}\tools\net462\Common7\IDE\Extensions\TestPlatform'
       vstestLocation: '$(Agent.ToolsDirectory)\VsTest\17.10.0-preview-24080-01\x64\tools\net462\Common7\IDE\Extensions\TestPlatform'

--- a/.pipelines/loc/loc.yml
+++ b/.pipelines/loc/loc.yml
@@ -43,10 +43,6 @@ steps:
 - powershell: 'tar czf LocOutput.tar.gz LocOutput'
   displayName: 'PowerShell Script'
 
-- task: PublishBuildArtifacts@1
+- publish: LocOutput.tar.gz
   displayName: 'Publish Artifact: LocOutput'
-  inputs:
-    PathtoPublish: LocOutput.tar.gz
-    ArtifactName: LocOutput
-
-
+  artifact: LocOutput


### PR DESCRIPTION
This simply changes the pipelines to use "Pipeline Artifacts" instead of "Build Artifacts". Basically two different implementations of the same general concept.

This brings the "Publish Build Artifacts" step of the pipeline from ~9 mins to ~20 secs. This also brings the "Download artifacts" step of the UI tests job from ~3 mins to ~1:20. So total this change speeds up the overall pipeline execution by ~15%.

Compare the existing: https://dev.azure.com/ms/PowerToys/_build/results?buildId=559316&view=logs&j=0f660c0a-4423-5c5d-276b-f98b39c69e13&t=be2e0fe3-12af-5e69-3062-a884288b2c3e

![image](https://github.com/microsoft/PowerToys/assets/6445614/0fd04f74-0de4-4da3-9ed3-4706975fb6f9)
![image](https://github.com/microsoft/PowerToys/assets/6445614/e0e61f87-a4f0-4f10-8425-54133be431eb)

With the new: https://dev.azure.com/ms/PowerToys/_build/results?buildId=559377&view=logs&j=8051a522-456e-5530-e7a5-d1cd88f6bb77&t=0f481525-d1c6-4f2f-81b2-c139993c688c

![image](https://github.com/microsoft/PowerToys/assets/6445614/421ca3af-4692-4401-8a5d-d6bfac9bbab8)
![image](https://github.com/microsoft/PowerToys/assets/6445614/31e2ebbe-b835-4537-a107-5359a31f0d6e)
