### PR TITLE
Opt into Microsoft.Build.RunVSTest to run tests within MSBuild

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -1612,6 +1612,7 @@ TRAYMOUSEMESSAGE
 triaging
 TRK
 trl
+trx
 Tsd
 TServer
 TStr
@@ -1713,6 +1714,7 @@ vscdb
 vsconfig
 VSCROLL
 vsetq
+VSINSTALLDIR
 VSM
 vso
 vsonline

--- a/.pipelines/ci/templates/build-powertoys-steps.yml
+++ b/.pipelines/ci/templates/build-powertoys-steps.yml
@@ -91,21 +91,21 @@ steps:
     displayName: 'nuget restore packages.config'
 
 - task: VSBuild@1
-  displayName: 'Build PowerToys.sln'
+  displayName: 'Build and Test PowerToys.sln'
   inputs:
     solution: '**\PowerToys.sln'
     vsVersion: 17.0
     platform: '$(BuildPlatform)'
     configuration: '$(BuildConfiguration)'
     ${{ if eq(parameters.enableCaching, true) }}:
-      msbuildArgs: -restore ${{ parameters.additionalBuildArguments }} -graph -reportfileaccesses -p:MSBuildCacheEnabled=true -p:MSBuildCacheLogDirectory=$(Build.ArtifactStagingDirectory)\logs\MSBuildCache -bl:$(Build.ArtifactStagingDirectory)\logs\PowerToys.binlog -ds:false
+      msbuildArgs: -restore ${{ parameters.additionalBuildArguments }} -t:Build;Test -graph -reportfileaccesses -p:MSBuildCacheEnabled=true -p:MSBuildCacheLogDirectory=$(Build.ArtifactStagingDirectory)\logs\MSBuildCache -bl:$(Build.ArtifactStagingDirectory)\logs\PowerToys.binlog -ds:false
     ${{ else }}:
-      msbuildArgs: -restore ${{ parameters.additionalBuildArguments }} -graph -bl:$(Build.ArtifactStagingDirectory)\logs\PowerToys.binlog -ds:false
+      msbuildArgs: -restore ${{ parameters.additionalBuildArguments }} -t:Build;Test -graph -bl:$(Build.ArtifactStagingDirectory)\logs\PowerToys.binlog -ds:false
     msbuildArchitecture: x64
     maximumCpuCount: true
   ${{ if eq(parameters.enableCaching, true) }}:
     env:
-      SYSTEM_ACCESSTOKEN: $(System.AccessToken)        
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
 - task: VSBuild@1
   displayName: 'Build BugReportTool.sln'
@@ -222,47 +222,13 @@ steps:
     arguments: -targetDir '$(build.sourcesdirectory)\$(BuildPlatform)\$(BuildConfiguration)\WinUI3Apps'
     pwsh: true
 
-# directly not doing WinAppDriver testing
-- task: VSTest@2
-  displayName: 'MS Tests'
-  condition: ne(variables['BuildPlatform'], 'arm64') # No arm64 agents to run the tests.
+# Publish test results which ran in MSBuild
+- task: PublishTestResults@2
+  displayName: 'Publish Test Results'
   inputs:
-    platform: '$(BuildPlatform)'
-    configuration: '$(BuildConfiguration)'
-    testSelector: 'testAssemblies'
-    testAssemblyVer2: |
-      **\UnitTests-GcodeThumbnailProvider.dll
-      **\UnitTests-StlThumbnailProvider.dll
-      **\UnitTests-PdfThumbnailProvider.dll
-      **\UnitTests-QoiThumbnailProvider.dll
-      **\Settings.UI.UnitTests.dll
-      **\UnitTests-GcodePreviewHandler.dll
-      **\UnitTests-QoiPreviewHandler.dll
-      **\UnitTests-FancyZonesEditor.dll
-      **\UnitTests-PdfPreviewHandler.dll
-      **\UnitTests-PreviewHandlerCommon.dll
-      **\Microsoft.PowerToys.Run.Plugin.Registry.UnitTests.dll
-      **\UnitTest-ColorPickerUI.dll
-      **\Microsoft.Interop.Tests.dll
-      **\ImageResizer.Test.dll
-      **\Community.PowerToys.Run.Plugin.UnitConverter.UnitTest.dll
-      **\Community.PowerToys.Run.Plugin.ValueGenerator.UnitTests.dll
-      **\Microsoft.Plugin.Folder.UnitTests.dll
-      **\Microsoft.Plugin.Program.UnitTests.dll
-      **\Microsoft.PowerToys.Run.Plugin.Calculator.UnitTest.dll
-      **\Microsoft.Plugin.Uri.UnitTests.dll
-      **\Wox.Test.dll
-      **\Microsoft.PowerToys.Run.Plugin.System.UnitTests.dll
-      **\Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests.dll
-      **\Microsoft.Plugin.WindowsTerminal.UnitTests.dll
-      **\Microsoft.Plugin.WindowWalker.UnitTests.dll
-      **\PreviewPaneUnitTests.dll
-      **\UnitTests-SvgThumbnailProvider.dll
-      **\UnitTests-SvgPreviewHandler.dll
-      **\PowerToys.Hosts.Tests.dll
-      **\MouseJumpUI.UnitTests.dll
-      !**\obj\**
-      !**\ref\**
+    testResultsFormat: VSTest
+    testResultsFiles: '**/*.trx'
+  condition: always()
 
 # Native dlls
 - task: VSTest@2
@@ -277,7 +243,6 @@ steps:
       **\KeyboardManagerEditorTest.dll
       **\UnitTests-CommonLib.dll
       **\PowerRenameUnitTests.dll
-      **\powerpreviewTest.dll
       **\UnitTests-FancyZones.dll
       !**\obj\**
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -44,6 +44,20 @@
     </PackageReference>
   </ItemGroup>
 
+  <!-- Add ability to run tests via "msbuild /t:Test" -->
+  <Sdk Name="Microsoft.Build.RunVSTest" Version="1.0.319" />
+  <PropertyGroup>
+    <VSTestLogger>trx</VSTestLogger>
+    <!--
+      RunVSTest by default uses %VSINSTALLDIR%\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe,
+      but some of the CI scenarios don't define %VSINSTALLDIR%, so be explicit about where to look for vstest.
+      Note: $(VsInstallRoot) is a built-in MSBuild property, so should always be defined.
+    -->
+    <VSTestToolPath>$(VsInstallRoot)\Common7\IDE\CommonExtensions\Microsoft\TestWindow</VSTestToolPath>
+    <!-- No arm64 agents to run the tests. -->
+    <RunVSTest Condition="'$(Platform)' == 'ARM64'">false</RunVSTest>
+  </PropertyGroup>
+
   <!-- MSBuildCache -->
   <PropertyGroup>
     <!-- Off by default -->
@@ -72,6 +86,12 @@
       $(LocalAppData)\Microsoft\Windows\INetCache\**;
       A:\;
       E:\;
+    </MSBuildCacheAllowFileAccessAfterProjectFinishFilePatterns>
+
+    <!-- Unit tests of low-priv processes, eg the preview handler tests, may log to this location. -->
+    <MSBuildCacheAllowFileAccessAfterProjectFinishFilePatterns>
+      $(MSBuildCacheAllowFileAccessAfterProjectFinishFilePatterns);
+      $(USERPROFILE)\AppData\LocalLow\Microsoft\PowerToys\**;
     </MSBuildCacheAllowFileAccessAfterProjectFinishFilePatterns>
 
     <!-- 

--- a/packages.config
+++ b/packages.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.MSBuildCache.AzurePipelines" version="0.1.258-preview" />
-  <package id="Microsoft.MSBuildCache.Local" version="0.1.258-preview" />
-  <package id="Microsoft.MSBuildCache.SharedCompilation" version="0.1.258-preview" />
+  <package id="Microsoft.MSBuildCache.AzurePipelines" version="0.1.271-preview" />
+  <package id="Microsoft.MSBuildCache.Local" version="0.1.271-preview" />
+  <package id="Microsoft.MSBuildCache.SharedCompilation" version="0.1.271-preview" />
 </packages>

--- a/src/modules/fancyzones/UITests-FancyZones/UITests-FancyZones.csproj
+++ b/src/modules/fancyzones/UITests-FancyZones/UITests-FancyZones.csproj
@@ -11,6 +11,8 @@
     <Nullable>enable</Nullable>
     <OutputType>Library</OutputType>
     <Version>$(Version).0</Version>
+    <!-- This is a UI test, so don't run as part of MSBuild -->
+    <RunVSTest>false</RunVSTest>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/modules/fancyzones/UITests-FancyZonesEditor/UITests-FancyZonesEditor.csproj
+++ b/src/modules/fancyzones/UITests-FancyZonesEditor/UITests-FancyZonesEditor.csproj
@@ -11,6 +11,8 @@
     <Nullable>enable</Nullable>
     <OutputType>Library</OutputType>
     <Version>$(Version).0</Version>
+    <!-- This is a UI test, so don't run as part of MSBuild -->
+    <RunVSTest>false</RunVSTest>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
This change runs tests as part of MSBuild so that tests can be run as soon as their associated project is built, potentially concurrently with other projects' builds, as opposed to running all tests sequentially after running all builds.

This adds a minute or less to the "build" steps since it's not building and testing, and cutting out the explicit test step in favor of simply uploading the test results. The net impact is ~5 mins of savings.

I confirmed that the total number of tests is identical before and after, so there should be no loss of test coverage.

[Before](https://dev.azure.com/ms/PowerToys/_build/results?buildId=559047&view=logs&j=0f660c0a-4423-5c5d-276b-f98b39c69e13&t=ecf341a7-dafd-5ce6-eabd-86286d881b78):
![image](https://github.com/microsoft/PowerToys/assets/6445614/62574b5e-98ac-4ea3-a5aa-5e099817c80e)

[After](https://dev.azure.com/ms/PowerToys/_build/results?buildId=559452&view=logs&j=0f660c0a-4423-5c5d-276b-f98b39c69e13&t=0b176b82-c97a-5033-1567-981690da77e3):
![image](https://github.com/microsoft/PowerToys/assets/6445614/d3f21a64-eab0-4f9b-892a-3fad051cc57b)

