### PR TITLE
[ColorPicker]Revert turning the main window into a FluentWindow

### DIFF
--- a/src/modules/colorPicker/ColorPickerUI/MainWindow.xaml
+++ b/src/modules/colorPicker/ColorPickerUI/MainWindow.xaml
@@ -1,4 +1,4 @@
-﻿<ui:FluentWindow
+﻿<Window
     x:Class="ColorPicker.MainWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -6,21 +6,19 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:e="http://schemas.microsoft.com/xaml/behaviors"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
     Width="120"
     Height="64"
     MinWidth="0"
     MinHeight="0"
+    AllowsTransparency="True"
     AutomationProperties.Name="Color Picker"
     Background="Transparent"
-    ExtendsContentIntoTitleBar="True"
     Opacity="0.1"
     ResizeMode="NoResize"
     ShowInTaskbar="False"
     SizeToContent="WidthAndHeight"
     SourceInitialized="MainWindowSourceInitialized"
     Topmost="True"
-    WindowCornerPreference="Default"
     WindowStyle="None"
     mc:Ignorable="d">
     <e:Interaction.Behaviors>
@@ -28,4 +26,4 @@
         <behaviors:AppearAnimationBehavior />
     </e:Interaction.Behaviors>
     <ContentControl x:Name="MainView" Content="{Binding MainViewModel}" />
-</ui:FluentWindow>
+</Window>

--- a/src/modules/colorPicker/ColorPickerUI/MainWindow.xaml.cs
+++ b/src/modules/colorPicker/ColorPickerUI/MainWindow.xaml.cs
@@ -13,7 +13,7 @@ namespace ColorPicker
     /// <summary>
     /// Interaction logic for MainWindow.xaml
     /// </summary>
-    public partial class MainWindow : FluentWindow
+    public partial class MainWindow : Window
     {
         public MainWindow()
         {


### PR DESCRIPTION

This reverts commit 62d278b23e95a8264e24bdd10eaaddfcc21570a3.

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Making the Color Picker windows be a Fluent Windows is making it not be drawn on very specific configuration. Yanking it out for release until we can figure it out.
