### PR TITLE
[Caching] Allow file accesses under windir

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -86,6 +86,7 @@
       $(LocalAppData)\Microsoft\Windows\INetCache\**;
       A:\;
       E:\;
+      $(windir)\**;
     </MSBuildCacheAllowFileAccessAfterProjectFinishFilePatterns>
 
     <!-- Unit tests of low-priv processes, eg the preview handler tests, may log to this location. -->


### PR DESCRIPTION
[Caching] Allow file accesses under windir

See: https://dev.azure.com/ms/PowerToys/_build/results?buildId=560673&view=logs&j=b6b44f60-477e-5b36-eeeb-589df0c177de&t=f5043f15-036d-5d3b-8695-92dff4115778

> File access reported from process `ProcessId: 1844` after the project finished. This may lead to incorrect caching. Node Id: SRC_DSC_POWERTOYS.SETTINGS.DSC.SCHEMA.GENERATOR_POWERTOYS.SETTINGS.DSC.SCHEMA.GENERATOR.CSPROJ_BUODDESOY_YECINYO98HZQ, Path: C:\Windows\System32\ci.dll

This file access is happening from MSBuild.exe itself and appears benign for cacheability.