### PR TITLE
[Settings] Changing UI order for File Explorer Add-ons

### DIFF
--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerPreviewPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerPreviewPage.xaml
@@ -63,16 +63,6 @@
                         </tkcontrols:SettingsExpander.Items>
                     </tkcontrols:SettingsExpander>
 
-                    <tkcontrols:SettingsCard
-                        x:Uid="FileExplorerPreview_ToggleSwitch_Preview_MD"
-                        HeaderIcon="{ui:FontIcon Glyph=&#xE943;}"
-                        IsEnabled="{x:Bind ViewModel.MDRenderIsGpoDisabled, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}">
-                        <ToggleSwitch
-                            x:Uid="ToggleSwitch"
-                            IsEnabled="{x:Bind ViewModel.MDRenderIsGpoEnabled, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}"
-                            IsOn="{x:Bind ViewModel.MDRenderIsEnabled, Mode=TwoWay}" />
-                    </tkcontrols:SettingsCard>
-
                     <tkcontrols:SettingsExpander
                         x:Uid="FileExplorerPreview_ToggleSwitch_Preview_Monaco"
                         HeaderIcon="{ui:FontIcon Glyph=&#xE99A;}"
@@ -101,6 +91,16 @@
                             </tkcontrols:SettingsCard>
                         </tkcontrols:SettingsExpander.Items>
                     </tkcontrols:SettingsExpander>
+
+                    <tkcontrols:SettingsCard
+                        x:Uid="FileExplorerPreview_ToggleSwitch_Preview_MD"
+                        HeaderIcon="{ui:FontIcon Glyph=&#xE943;}"
+                        IsEnabled="{x:Bind ViewModel.MDRenderIsGpoDisabled, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}">
+                        <ToggleSwitch
+                            x:Uid="ToggleSwitch"
+                            IsEnabled="{x:Bind ViewModel.MDRenderIsGpoEnabled, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}"
+                            IsOn="{x:Bind ViewModel.MDRenderIsEnabled, Mode=TwoWay}" />
+                    </tkcontrols:SettingsCard>
 
                     <tkcontrols:SettingsCard
                         x:Uid="FileExplorerPreview_ToggleSwitch_Preview_PDF"
@@ -183,6 +183,16 @@
                             IsOn="{x:Bind ViewModel.GCODEThumbnailIsEnabled, Mode=TwoWay}" />
                     </tkcontrols:SettingsCard>
 
+                    <tkcontrols:SettingsCard
+                        x:Uid="FileExplorerPreview_ToggleSwitch_Thumbnail_QOI"
+                        HeaderIcon="{ui:FontIcon Glyph=&#xE914;}"
+                        IsEnabled="{x:Bind ViewModel.QOIThumbnailIsGpoDisabled, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}">
+                        <ToggleSwitch
+                            x:Uid="ToggleSwitch"
+                            IsEnabled="{x:Bind ViewModel.QOIThumbnailIsGpoEnabled, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}"
+                            IsOn="{x:Bind ViewModel.QOIThumbnailIsEnabled, Mode=TwoWay}" />
+                    </tkcontrols:SettingsCard>
+
                     <tkcontrols:SettingsExpander
                         x:Uid="FileExplorerPreview_ToggleSwitch_Thumbnail_STL"
                         HeaderIcon="{ui:FontIcon Glyph=&#xE914;}"
@@ -197,16 +207,6 @@
                             </tkcontrols:SettingsCard>
                         </tkcontrols:SettingsExpander.Items>
                     </tkcontrols:SettingsExpander>
-
-                    <tkcontrols:SettingsCard
-                        x:Uid="FileExplorerPreview_ToggleSwitch_Thumbnail_QOI"
-                        HeaderIcon="{ui:FontIcon Glyph=&#xE914;}"
-                        IsEnabled="{x:Bind ViewModel.QOIThumbnailIsGpoDisabled, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}">
-                        <ToggleSwitch
-                            x:Uid="ToggleSwitch"
-                            IsEnabled="{x:Bind ViewModel.QOIThumbnailIsGpoEnabled, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}"
-                            IsOn="{x:Bind ViewModel.QOIThumbnailIsEnabled, Mode=TwoWay}" />
-                    </tkcontrols:SettingsCard>
                 </controls:SettingsGroup>
             </StackPanel>
         </controls:SettingsPageControl.ModuleContent>


### PR DESCRIPTION
Changing the order of SettingsCard/SettingsExpander to resolve: #31024

Before:
![image](https://github.com/microsoft/PowerToys/assets/9866362/37d2c9e3-fb47-466d-bda8-fccafb67c41c)

After:
![image](https://github.com/microsoft/PowerToys/assets/9866362/bbc82ff8-a41f-47ca-a3ec-707107c22413)

Before:
![image](https://github.com/microsoft/PowerToys/assets/9866362/fcf3db66-c2db-42e5-8ee6-9b7ffd35ec57)

After: 
![image](https://github.com/microsoft/PowerToys/assets/9866362/29ee4ce5-b153-4dff-b502-111b0a8d98c7)

## PR Checklist

- [x] **Closes:** #31024
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

