### PR TITLE
[Run][Folder] Allow UNC starting with //

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder.UnitTests/DriveOrSharedFolderTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder.UnitTests/DriveOrSharedFolderTests.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Plugin.Folder.UnitTests
 
         [DataTestMethod]
         [DataRow(@"\\test-server\testdir", true)]
+        [DataRow(@"//test-server/testdir", true)]
         [DataRow(@"c:", true)]
         [DataRow(@"c:\", true)]
         [DataRow(@"C:\", true)]

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Path/FolderHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Folder/Sources/Path/FolderHelper.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Plugin.Folder.Sources
             ArgumentNullException.ThrowIfNull(search);
 
             // Using Ordinal this is internal and we're comparing symbols
-            if (search.StartsWith(@"\\", StringComparison.Ordinal))
+            if (search.StartsWith(@"\\", StringComparison.Ordinal) || search.StartsWith(@"//", StringComparison.Ordinal))
             { // share folder
                 return true;
             }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Allow to query UNC paths that starts with `//`.

Note that `//` is the default activation keyword for the URI plugin.
I don't think we should change it since it's been like this for years but `//` should work if the activation keyword is changed or the plugin is disabled.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #32307
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Manually tested.

![image](https://github.com/microsoft/PowerToys/assets/25966642/55b34d5f-a11e-45c8-a5be-be2c26fb6624)
