### PR TITLE
[KBMEditor]Fix missing dependency at runtime

### DIFF
--- a/installer/PowerToysSetup/KeyboardManager.wxs
+++ b/installer/PowerToysSetup/KeyboardManager.wxs
@@ -25,6 +25,11 @@
         <?if $(sys.BUILDARCH) = x64 ?>
           <File Source="$(var.BinDir)KeyboardManagerEditor\vcruntime140_1_app.dll" />
         <?endif ?>
+        <!-- Latest CppWinRT upgrade made Keyboard Manager Editor depend on additional VC Runtime libraries. -->
+        <!-- These are not in the Keyboard Manager Editor build output. So we copy them from the base build directory. -->
+        <File Source="$(var.BinDir)vcruntime140.dll" />
+        <File Source="$(var.BinDir)vcruntime140_1.dll" />
+        <File Source="$(var.BinDir)msvcp140.dll" />
       </Component>
     </DirectoryRef>
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

After https://github.com/microsoft/PowerToys/commit/5b692438b73e8c10a08c408da6850e51480af6c0 , Keyboard Manager Editor no longer works on machines without the VC++ Runtime Redistributables installed.

This PR adds the dlls that I could see that made Keyboard Manager Editor work again.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #31708
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
On a VM without VC++ Runtime Redistributables installed, KBM is working.
