### PR TITLE
[Settings]Fix links to the Text Extractor page

### DIFF
--- a/src/common/Common.UI/SettingsDeepLink.cs
+++ b/src/common/Common.UI/SettingsDeepLink.cs
@@ -65,7 +65,7 @@ namespace Common.UI
                 case SettingsWindow.MeasureTool:
                     return "MeasureTool";
                 case SettingsWindow.PowerOCR:
-                    return "PowerOCR";
+                    return "PowerOcr";
                 case SettingsWindow.RegistryPreview:
                     return "RegistryPreview";
                 case SettingsWindow.CropAndLock:

--- a/src/runner/settings_window.cpp
+++ b/src/runner/settings_window.cpp
@@ -671,7 +671,7 @@ std::string ESettingsWindowNames_to_string(ESettingsWindowNames value)
     case ESettingsWindowNames::MeasureTool:
         return "MeasureTool";
     case ESettingsWindowNames::PowerOCR:
-        return "PowerOCR";
+        return "PowerOcr";
     case ESettingsWindowNames::RegistryPreview:
         return "RegistryPreview";
     case ESettingsWindowNames::CropAndLock:
@@ -747,7 +747,7 @@ ESettingsWindowNames ESettingsWindowNames_from_string(std::string value)
     {
         return ESettingsWindowNames::MeasureTool;
     }
-    else if (value == "PowerOCR")
+    else if (value == "PowerOcr")
     {
         return ESettingsWindowNames::PowerOCR;
     }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

On 0.80.0, links from Text extractor util to its Settings page or from PowerToys plugin of PT Run were broken.
This seems to have been caused by the change from "PowerOCR" to "PowerOcr" to help in the DSC PR.
This PR converts the other strings that stayed as "PowerOCR" to "PowerOcr".

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #32352
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

From Text Extractor util, press the settings button and verify it opens Settings in the Text Extractor page.
From PT Run PowerToys plugin, search for Text Extractor and press the Settings button.
From Dashboard, press the Text Extractor entry and verify it opens the Text Extractor Settings page.
From OOBE, press the button that opens the Text Extractor settings page.