### PR TITLE
[Settings] Theme override fix and cleanup

### DIFF
--- a/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/General.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/General.cs
@@ -53,7 +53,6 @@ namespace ViewModelTests
                 runAsUserText: "GeneralSettings_RunningAsUserText",
                 isElevated: false,
                 isAdmin: false,
-                updateTheme: UpdateUIThemeMethod,
                 ipcMSGCallBackFunc: sendMockIPCConfigMSG,
                 ipcMSGRestartAsAdminMSGCallBackFunc: sendRestartAdminIPCMessage,
                 ipcMSGCheckForUpdatesCallBackFunc: sendCheckForUpdatesIPCMessage,
@@ -83,7 +82,6 @@ namespace ViewModelTests
                 "GeneralSettings_RunningAsUserText",
                 false,
                 false,
-                UpdateUIThemeMethod,
                 sendMockIPCConfigMSG,
                 sendRestartAdminIPCMessage,
                 sendCheckForUpdatesIPCMessage,
@@ -120,7 +118,6 @@ namespace ViewModelTests
                 "GeneralSettings_RunningAsUserText",
                 false,
                 false,
-                UpdateUIThemeMethod,
                 sendMockIPCConfigMSG,
                 sendRestartAdminIPCMessage,
                 sendCheckForUpdatesIPCMessage,
@@ -152,7 +149,6 @@ namespace ViewModelTests
                 "GeneralSettings_RunningAsUserText",
                 false,
                 false,
-                UpdateUIThemeMethod,
                 sendMockIPCConfigMSG,
                 sendRestartAdminIPCMessage,
                 sendCheckForUpdatesIPCMessage,
@@ -186,7 +182,6 @@ namespace ViewModelTests
                 "GeneralSettings_RunningAsUserText",
                 false,
                 false,
-                UpdateUIThemeMethod,
                 sendMockIPCConfigMSG,
                 sendRestartAdminIPCMessage,
                 sendCheckForUpdatesIPCMessage,
@@ -217,7 +212,6 @@ namespace ViewModelTests
                 "GeneralSettings_RunningAsUserText",
                 false,
                 false,
-                UpdateUIThemeMethod,
                 sendMockIPCConfigMSG,
                 sendRestartAdminIPCMessage,
                 sendCheckForUpdatesIPCMessage,
@@ -242,11 +236,6 @@ namespace ViewModelTests
             Assert.IsTrue(modules.PowerRename);
             Assert.IsTrue(modules.PowerLauncher);
             Assert.IsTrue(modules.ColorPicker);
-        }
-
-        public static int UpdateUIThemeMethod(string themeName)
-        {
-            return 0;
         }
     }
 }

--- a/src/settings-ui/Settings.UI/Helpers/WindowHelper.cs
+++ b/src/settings-ui/Settings.UI/Helpers/WindowHelper.cs
@@ -6,10 +6,11 @@ using System;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text.Json;
+using Microsoft.UI.Xaml;
 
 namespace Microsoft.PowerToys.Settings.UI.Helpers
 {
-    internal sealed class Utils
+    internal sealed class WindowHelper
     {
         private static string _placementPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), @"Microsoft\PowerToys\settings-placement.json");
 
@@ -43,6 +44,14 @@ namespace Microsoft.PowerToys.Settings.UI.Helpers
             }
             catch (Exception)
             {
+            }
+        }
+
+        public static void SetTheme(Window window, ElementTheme theme)
+        {
+            if (window.Content is FrameworkElement rootElement)
+            {
+                rootElement.RequestedTheme = theme;
             }
         }
     }

--- a/src/settings-ui/Settings.UI/Services/ThemeService.cs
+++ b/src/settings-ui/Settings.UI/Services/ThemeService.cs
@@ -26,7 +26,7 @@ namespace Microsoft.PowerToys.Settings.UI.Services
         public void ApplyTheme()
         {
             Theme = GetTheme();
-            ThemeChanged(null, Theme);
+            ThemeChanged?.Invoke(null, Theme);
         }
 
         private ElementTheme GetTheme()

--- a/src/settings-ui/Settings.UI/Services/ThemeService.cs
+++ b/src/settings-ui/Settings.UI/Services/ThemeService.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.PowerToys.Settings.UI.Library;
+using Microsoft.PowerToys.Settings.UI.Library.Interfaces;
+using Microsoft.UI.Xaml;
+
+namespace Microsoft.PowerToys.Settings.UI.Services
+{
+    public class ThemeService
+    {
+        private readonly ISettingsRepository<GeneralSettings> _generalSettingsRepository;
+
+        public event EventHandler<ElementTheme> ThemeChanged;
+
+        public ElementTheme Theme { get; private set; } = ElementTheme.Default;
+
+        public ThemeService(ISettingsRepository<GeneralSettings> generalSettingsRepository)
+        {
+            _generalSettingsRepository = generalSettingsRepository;
+            Theme = GetTheme();
+        }
+
+        public void ApplyTheme()
+        {
+            Theme = GetTheme();
+            ThemeChanged(null, Theme);
+        }
+
+        private ElementTheme GetTheme()
+        {
+            switch (_generalSettingsRepository.SettingsConfig.Theme.ToUpperInvariant())
+            {
+                case "LIGHT":
+                    return ElementTheme.Light;
+                case "DARK":
+                    return ElementTheme.Dark;
+                case "SYSTEM":
+                    return ElementTheme.Default;
+                default:
+                    ManagedCommon.Logger.LogError($"Unexpected theme name: {_generalSettingsRepository.SettingsConfig.Theme}");
+                    return ElementTheme.Default;
+            }
+        }
+    }
+}

--- a/src/settings-ui/Settings.UI/SettingsXAML/App.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/App.xaml.cs
@@ -5,20 +5,16 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Net.Http.Json;
-using System.Runtime.InteropServices;
 using System.Text.Json;
-using System.Threading;
 using System.Threading.Tasks;
-using Common.UI;
 using interop;
 using ManagedCommon;
 using Microsoft.PowerToys.Settings.UI.Helpers;
 using Microsoft.PowerToys.Settings.UI.Library;
 using Microsoft.PowerToys.Settings.UI.Library.Telemetry.Events;
+using Microsoft.PowerToys.Settings.UI.Services;
 using Microsoft.PowerToys.Settings.UI.Views;
 using Microsoft.PowerToys.Telemetry;
 using Microsoft.UI.Xaml;
@@ -72,8 +68,6 @@ namespace Microsoft.PowerToys.Settings.UI
         public Type StartupPage { get; set; } = typeof(Views.DashboardPage);
 
         public static Action<string> IPCMessageReceivedCallback { get; set; }
-
-        private static bool loggedImmersiveDarkException;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="App"/> class.
@@ -259,19 +253,6 @@ namespace Microsoft.PowerToys.Settings.UI
                     ShellPage.OpenFlyoutCallback(p);
                 }
             }
-
-            if (SelectedTheme() == ElementTheme.Default)
-            {
-                try
-                {
-                    themeListener = new ThemeListener();
-                    themeListener.ThemeChanged += (_) => HandleThemeChange();
-                }
-                catch (Exception ex)
-                {
-                    Logger.LogError($"HandleThemeChange exception. Please install .NET 4.", ex);
-                }
-            }
         }
 
         /// <summary>
@@ -311,7 +292,7 @@ namespace Microsoft.PowerToys.Settings.UI
                 ShowMessageDialog("The application is running in Debug mode.", "DEBUG");
 #else
                 /* If we try to run Settings as a standalone app, it will start PowerToys.exe if not running and open Settings again through it in the Dashboard page. */
-                SettingsDeepLink.OpenSettings(SettingsDeepLink.SettingsWindow.Dashboard, true);
+                Common.UI.SettingsDeepLink.OpenSettings(Common.UI.SettingsDeepLink.SettingsWindow.Dashboard, true);
                 Exit();
 #endif
             }
@@ -347,92 +328,24 @@ namespace Microsoft.PowerToys.Settings.UI
             return ipcmanager;
         }
 
-        public static ElementTheme SelectedTheme()
-        {
-            switch (SettingsRepository<GeneralSettings>.GetInstance(settingsUtils).SettingsConfig.Theme.ToUpper(CultureInfo.InvariantCulture))
-            {
-                case "DARK": return ElementTheme.Dark;
-                case "LIGHT": return ElementTheme.Light;
-                default: return ElementTheme.Default;
-            }
-        }
-
         public static bool IsDarkTheme()
         {
-            var selectedTheme = SelectedTheme();
-            return selectedTheme == ElementTheme.Dark || (selectedTheme == ElementTheme.Default && ThemeHelpers.GetAppTheme() == AppTheme.Dark);
-        }
-
-        public static void HandleThemeChange()
-        {
-            try
-            {
-                bool isDark = IsDarkTheme();
-
-                if (settingsWindow != null)
-                {
-                    var hWnd = WinRT.Interop.WindowNative.GetWindowHandle(settingsWindow);
-                    ThemeHelpers.SetImmersiveDarkMode(hWnd, isDark);
-                }
-
-                if (oobeWindow != null)
-                {
-                    var hWnd = WinRT.Interop.WindowNative.GetWindowHandle(oobeWindow);
-                    ThemeHelpers.SetImmersiveDarkMode(hWnd, isDark);
-                }
-
-                if (SelectedTheme() == ElementTheme.Default)
-                {
-                    themeListener = new ThemeListener();
-                    themeListener.ThemeChanged += (_) => HandleThemeChange();
-                }
-                else if (themeListener != null)
-                {
-                    themeListener.Dispose();
-                    themeListener = null;
-                }
-            }
-            catch (Exception e)
-            {
-                if (!loggedImmersiveDarkException)
-                {
-                    Logger.LogError($"HandleThemeChange exception. Please install .NET 4.", e);
-                    loggedImmersiveDarkException = true;
-                }
-            }
+            return ThemeService.Theme == ElementTheme.Dark || (ThemeService.Theme == ElementTheme.Default && ThemeHelpers.GetAppTheme() == AppTheme.Dark);
         }
 
         public static int UpdateUIThemeMethod(string themeName)
         {
-            switch (themeName?.ToUpperInvariant())
-            {
-                case "LIGHT":
-                    // OobeShellPage.OobeShellHandler.RequestedTheme = ElementTheme.Light;
-                    ShellPage.ShellHandler.RequestedTheme = ElementTheme.Light;
-                    break;
-                case "DARK":
-                    // OobeShellPage.OobeShellHandler.RequestedTheme = ElementTheme.Dark;
-                    ShellPage.ShellHandler.RequestedTheme = ElementTheme.Dark;
-                    break;
-                case "SYSTEM":
-                    // OobeShellPage.OobeShellHandler.RequestedTheme = ElementTheme.Default;
-                    ShellPage.ShellHandler.RequestedTheme = ElementTheme.Default;
-                    break;
-                default:
-                    Logger.LogError($"Unexpected theme name: {themeName}");
-                    break;
-            }
-
-            HandleThemeChange();
             return 0;
         }
 
         private static ISettingsUtils settingsUtils = new SettingsUtils();
+        private static ThemeService themeService = new ThemeService(SettingsRepository<GeneralSettings>.GetInstance(settingsUtils));
+
+        public static ThemeService ThemeService => themeService;
 
         private static MainWindow settingsWindow;
         private static OobeWindow oobeWindow;
         private static FlyoutWindow flyoutWindow;
-        private static ThemeListener themeListener;
 
         public static void ClearSettingsWindow()
         {

--- a/src/settings-ui/Settings.UI/SettingsXAML/MainWindow.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/MainWindow.xaml.cs
@@ -27,6 +27,9 @@ namespace Microsoft.PowerToys.Settings.UI
             var bootTime = new System.Diagnostics.Stopwatch();
             bootTime.Start();
 
+            App.ThemeService.ThemeChanged += OnThemeChanged;
+            App.ThemeService.ApplyTheme();
+
             ShellPage.SetElevationStatus(App.IsElevated);
             ShellPage.SetIsUserAnAdmin(App.IsUserAnAdmin);
 
@@ -36,7 +39,7 @@ namespace Microsoft.PowerToys.Settings.UI
             AppWindow appWindow = AppWindow.GetFromWindowId(windowId);
             appWindow.SetIcon("Assets\\Settings\\icon.ico");
 
-            var placement = Utils.DeserializePlacementOrDefault(hWnd);
+            var placement = WindowHelper.DeserializePlacementOrDefault(hWnd);
             if (createHidden)
             {
                 placement.ShowCmd = NativeMethods.SW_HIDE;
@@ -202,7 +205,7 @@ namespace Microsoft.PowerToys.Settings.UI
         private void Window_Closed(object sender, WindowEventArgs args)
         {
             var hWnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
-            Utils.SerializePlacement(hWnd);
+            WindowHelper.SerializePlacement(hWnd);
 
             if (App.GetOobeWindow() == null)
             {
@@ -213,6 +216,8 @@ namespace Microsoft.PowerToys.Settings.UI
                 args.Handled = true;
                 NativeMethods.ShowWindow(hWnd, NativeMethods.SW_HIDE);
             }
+
+            App.ThemeService.ThemeChanged -= OnThemeChanged;
         }
 
         private void Window_Activated(object sender, WindowActivatedEventArgs args)
@@ -221,9 +226,14 @@ namespace Microsoft.PowerToys.Settings.UI
             {
                 this.Activated -= Window_Activated;
                 var hWnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
-                var placement = Utils.DeserializePlacementOrDefault(hWnd);
+                var placement = WindowHelper.DeserializePlacementOrDefault(hWnd);
                 NativeMethods.SetWindowPlacement(hWnd, ref placement);
             }
+        }
+
+        private void OnThemeChanged(object sender, ElementTheme theme)
+        {
+            WindowHelper.SetTheme(this, theme);
         }
 
         internal void EnsurePageIsSelected()

--- a/src/settings-ui/Settings.UI/SettingsXAML/OobeWindow.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/OobeWindow.xaml.cs
@@ -4,7 +4,6 @@
 
 using System;
 using interop;
-using ManagedCommon;
 using Microsoft.PowerToys.Settings.UI.Helpers;
 using Microsoft.PowerToys.Settings.UI.OOBE.Enums;
 using Microsoft.PowerToys.Settings.UI.OOBE.Views;
@@ -36,6 +35,9 @@ namespace Microsoft.PowerToys.Settings.UI
 
         public OobeWindow(PowerToysModules initialModule)
         {
+            App.ThemeService.ThemeChanged += OnThemeChanged;
+            App.ThemeService.ApplyTheme();
+
             this.InitializeComponent();
 
             // Set window icon
@@ -133,6 +135,13 @@ namespace Microsoft.PowerToys.Settings.UI
             {
                 mainWindow.CloseHiddenWindow();
             }
+
+            App.ThemeService.ThemeChanged -= OnThemeChanged;
+        }
+
+        private void OnThemeChanged(object sender, ElementTheme theme)
+        {
+            WindowHelper.SetTheme(this, theme);
         }
 
         private void Dispose(bool disposing)

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/GeneralPage.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/GeneralPage.xaml.cs
@@ -8,11 +8,9 @@ using System.Threading.Tasks;
 using ManagedCommon;
 using Microsoft.PowerToys.Settings.UI.Helpers;
 using Microsoft.PowerToys.Settings.UI.Library;
-using Microsoft.PowerToys.Settings.UI.OOBE.Views;
 using Microsoft.PowerToys.Settings.UI.ViewModels;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Windows.Storage.Pickers;
 
 namespace Microsoft.PowerToys.Settings.UI.Views
 {
@@ -73,7 +71,6 @@ namespace Microsoft.PowerToys.Settings.UI.Views
                 loader.GetString("GeneralSettings_RunningAsUserText"),
                 ShellPage.IsElevated,
                 ShellPage.IsUserAnAdmin,
-                App.UpdateUIThemeMethod,
                 ShellPage.SendDefaultIPCMessage,
                 ShellPage.SendRestartAdminIPCMessage,
                 ShellPage.SendCheckForUpdatesIPCMessage,

--- a/src/settings-ui/Settings.UI/ViewModels/DashboardViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/DashboardViewModel.cs
@@ -64,8 +64,6 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
 
             UpdatingSettings updatingSettingsConfig = UpdatingSettings.LoadSettings();
             UpdateAvailable = updatingSettingsConfig != null && (updatingSettingsConfig.State == UpdatingSettings.UpdatingState.ReadyToInstall || updatingSettingsConfig.State == UpdatingSettings.UpdatingState.ReadyToDownload);
-
-            App.UpdateUIThemeMethod(generalSettingsConfig.Theme);
         }
 
         private void AddDashboardListItem(ModuleType moduleType)

--- a/src/settings-ui/Settings.UI/ViewModels/GeneralViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/GeneralViewModel.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.IO.Abstractions;
-using System.Net.NetworkInformation;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
@@ -48,8 +47,6 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
 
         public ButtonClickCommand UpdateNowButtonEventHandler { get; set; }
 
-        public Func<string, int> UpdateUIThemeCallBack { get; }
-
         public Func<string, int> SendConfigMSG { get; }
 
         public Func<string, int> SendRestartAsAdminConfigMSG { get; }
@@ -68,7 +65,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
 
         private SettingsBackupAndRestoreUtils settingsBackupAndRestoreUtils = SettingsBackupAndRestoreUtils.Instance;
 
-        public GeneralViewModel(ISettingsRepository<GeneralSettings> settingsRepository, string runAsAdminText, string runAsUserText, bool isElevated, bool isAdmin, Func<string, int> updateTheme, Func<string, int> ipcMSGCallBackFunc, Func<string, int> ipcMSGRestartAsAdminMSGCallBackFunc, Func<string, int> ipcMSGCheckForUpdatesCallBackFunc, string configFileSubfolder = "", Action dispatcherAction = null, Action hideBackupAndRestoreMessageAreaAction = null, Action<int> doBackupAndRestoreDryRun = null, Func<Task<string>> pickSingleFolderDialog = null, object resourceLoader = null)
+        public GeneralViewModel(ISettingsRepository<GeneralSettings> settingsRepository, string runAsAdminText, string runAsUserText, bool isElevated, bool isAdmin, Func<string, int> ipcMSGCallBackFunc, Func<string, int> ipcMSGRestartAsAdminMSGCallBackFunc, Func<string, int> ipcMSGCheckForUpdatesCallBackFunc, string configFileSubfolder = "", Action dispatcherAction = null, Action hideBackupAndRestoreMessageAreaAction = null, Action<int> doBackupAndRestoreDryRun = null, Func<Task<string>> pickSingleFolderDialog = null, object resourceLoader = null)
         {
             CheckForUpdatesEventHandler = new ButtonClickCommand(CheckForUpdatesClick);
             RestartElevatedButtonEventHandler = new ButtonClickCommand(RestartElevated);
@@ -96,9 +93,6 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             SendConfigMSG = ipcMSGCallBackFunc;
             SendCheckForUpdatesConfigMSG = ipcMSGCheckForUpdatesCallBackFunc;
             SendRestartAsAdminConfigMSG = ipcMSGRestartAsAdminMSGCallBackFunc;
-
-            // set the callback function value to update the UI theme.
-            UpdateUIThemeCallBack = updateTheme;
 
             // Update Settings file folder:
             _settingsConfigFileFolder = configFileSubfolder;
@@ -440,14 +434,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
 
                     _themeIndex = value;
 
-                    try
-                    {
-                        UpdateUIThemeCallBack(GeneralSettingsConfig.Theme);
-                    }
-                    catch (Exception e)
-                    {
-                        Logger.LogError("Exception encountered when changing Settings theme", e);
-                    }
+                    App.ThemeService.ApplyTheme();
 
                     NotifyPropertyChanged();
                 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Fix settings app theme override:
- Apply theme override to OOBE window
- Make theme override even if settings window isn't opened in the Dashboard page (e.g. opened from another utility)
- Decouple from the listener based on `System.Management` that fail in case of missing .NET 4

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #32280
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

TODO
- [x] Clarify if immersive dark mode is still needed
  Verified that setting the immersive dark mode apply only on classic title bar and doesn't have any effect on modern title bar
- [x] Flyout window?
  Not changing flyout behavior in this PR: this have been discussed on #23831 and in the relative PR

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Theme override is applied when app is opened
- Theme override is applied to both main and OOBE window
- Theme override is applied even if settings app isn't opened on Dashboard page but on the settings page of an utility
- When theme is overwritten (dark or light), app theme doesn't change if Windows theme is changed
- When theme isn't overwritten (windows default), app theme change if Windows theme is changed
