### PR TITLE
[PTRun] Fix description in popup when plugins failed to load

### DIFF
--- a/src/modules/launcher/PowerLauncher/Plugin/PluginManager.cs
+++ b/src/modules/launcher/PowerLauncher/Plugin/PluginManager.cs
@@ -30,7 +30,7 @@ namespace PowerLauncher.Plugin
         private static readonly IDirectory Directory = FileSystem.Directory;
         private static readonly object AllPluginsLock = new object();
 
-        private static readonly CompositeFormat FailedToInitializePluginsTitle = System.Text.CompositeFormat.Parse(Properties.Resources.FailedToInitializePluginsTitle);
+        private static readonly CompositeFormat FailedToInitializePluginsDescription = System.Text.CompositeFormat.Parse(Properties.Resources.FailedToInitializePluginsDescription);
 
         private static IEnumerable<PluginPair> _contextMenuPlugins = new List<PluginPair>();
 
@@ -184,7 +184,7 @@ namespace PowerLauncher.Plugin
             if (!failedPlugins.IsEmpty)
             {
                 var failed = string.Join(",", failedPlugins.Select(x => x.Metadata.Name));
-                var description = string.Format(CultureInfo.CurrentCulture, FailedToInitializePluginsTitle, failed);
+                var description = string.Format(CultureInfo.CurrentCulture, FailedToInitializePluginsDescription, failed);
                 Application.Current.Dispatcher.InvokeAsync(() => API.ShowMsg(Resources.FailedToInitializePluginsTitle, description, string.Empty, false));
             }
         }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

When PTRun fails to load some plugin, a popup is displayed which is supposed to list the failed plugins.
The format string to use for the description was the wrong one, title instead of description, so the content of the popup was the same as its title.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Tested by having my custom plugin fail to load :)

