### PR TITLE
Avoid using the Test SDK for Arm64 builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -45,7 +45,19 @@
   </ItemGroup>
 
   <!-- Add ability to run tests via "msbuild /t:Test" -->
-  <Sdk Name="Microsoft.Build.RunVSTest" Version="1.0.319" />
+  <!--
+    Workaround an MSBuild bug where Microsoft.Common.Test.targets is missing from the Arm64 installation.
+    See: https://github.com/dotnet/msbuild/pull/9984
+    NB 1: This means that using "/t:Test" is not supported for Arm64 builds and tests will need to be run in an alternate way,
+          eg running tests in VS or invoking vstest.console directly.
+    NB 2: <Sdk> elements do not support conditions, so this is also being worked around.
+          Once the change referenced above is fixed, the ImportGroup below can be replaced with:
+            <Sdk Name="Microsoft.Build.RunVSTest" Version="1.0.319" />
+  -->
+  <ImportGroup Condition="'$(PROCESSOR_ARCHITECTURE)' != 'ARM64'">
+    <Import Project="Sdk.props" Sdk="Microsoft.Build.RunVSTest" Version="1.0.319" />
+    <Import Project="Sdk.targets" Sdk="Microsoft.Build.RunVSTest" Version="1.0.319" />
+  </ImportGroup>
   <PropertyGroup>
     <VSTestLogger>trx</VSTestLogger>
     <!--


### PR DESCRIPTION
Avoid using the Test SDK for Arm64 builds

This is a workaround until https://github.com/dotnet/msbuild/pull/9984 ships to unblock people developing on Arm64 machines.