### PR TITLE
[KeyboardManager] editors: change focus after adding a new key/shortcut row in the editor

### DIFF
--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/EditKeyboardWindow.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/EditKeyboardWindow.cpp
@@ -339,8 +339,8 @@ inline void CreateEditKeyboardWindowImpl(HINSTANCE hInst, KBMEditor::KeyboardMan
         // Whenever a remap is added move to the bottom of the screen
         scrollViewer.ChangeView(nullptr, scrollViewer.ScrollableHeight(), nullptr);
 
-        // Set focus to the first Type Button in the newly added row
-        UIHelpers::SetFocusOnTypeButtonInLastRow(keyRemapTable, EditorConstants::RemapTableColCount);
+        // Set focus to the first "Select" Button in the newly added row
+        UIHelpers::SetFocusOnFirstSelectButtonInLastRowOfEditKeyboardWindow(keyRemapTable, EditorConstants::RemapTableColCount);
     });
 
     // Remap key button content

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/EditShortcutsWindow.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/EditShortcutsWindow.cpp
@@ -335,8 +335,8 @@ inline void CreateEditShortcutsWindowImpl(HINSTANCE hInst, KBMEditor::KeyboardMa
         // Whenever a remap is added move to the bottom of the screen
         scrollViewer.ChangeView(nullptr, scrollViewer.ScrollableHeight(), nullptr);
 
-        // Set focus to the first Type Button in the newly added row
-        UIHelpers::SetFocusOnTypeButtonInLastRow(shortcutTable, EditorConstants::ShortcutTableColCount);
+        // Set focus to the first "Select" Button in the newly added row
+        UIHelpers::SetFocusOnFirstSelectButtonInLastRowOfEditShortcutsWindow(shortcutTable, EditorConstants::ShortcutTableColCount);
 
         //newShortcut.OpenNewShortcutControlRow(shortcutTable, shortcutTable.Children().GetAt(shortcutTable.Children().Size() - 1).as<StackPanel>());
     });

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/UIHelpers.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/UIHelpers.cpp
@@ -8,24 +8,39 @@ using namespace Windows::UI::Xaml::Automation::Peers;
 
 namespace UIHelpers
 {
-    // This method sets focus to the first Type button on the last row of the Grid
-    void SetFocusOnTypeButtonInLastRow(StackPanel& parent, long colCount)
+    // This method sets focus to the first "Select" button on the last row of the Grid of EditKeyboardWindow
+    void SetFocusOnFirstSelectButtonInLastRowOfEditKeyboardWindow(StackPanel& parent, long colCount)
     {
         // First element in the last row (StackPanel)
         auto lastHotKeyLine = parent.Children().GetAt(parent.Children().Size() - 1).as<StackPanel>();
 
-        // Get "To" Column
-        auto toColumn = lastHotKeyLine.Children().GetAt(2).as<StackPanel>();
+        // Get "From" Column
+        auto fromColumn = lastHotKeyLine.Children().GetAt(0).as<StackPanel>();
 
-        // Get first line in "To" Column
-        auto firstLineIntoColumn = toColumn.Children().GetAt(0).as<StackPanel>();
-
-        // Get Type Button from the first line
-        Button typeButton = firstLineIntoColumn.Children().GetAt(1).as<Button>();
-        if (typeButton != nullptr)
+        // Get "Select" Button from the "From" Column
+        Button selectButton = fromColumn.Children().GetAt(0).as<Button>();
+        if (selectButton != nullptr)
         {
             // Set programmatic focus on the button
-            typeButton.Focus(FocusState::Programmatic);
+            selectButton.Focus(FocusState::Programmatic);
+        }
+    }
+
+    // This method sets focus to the first "Select" button on the last row of the Grid of EditShortcutsWindow
+    void SetFocusOnFirstSelectButtonInLastRowOfEditShortcutsWindow(StackPanel& parent, long colCount)
+    {
+        // First element in the last row (StackPanel)
+        auto lastHotKeyLine = parent.Children().GetAt(parent.Children().Size() - 1).as<StackPanel>();
+
+        // Get "From" Column
+        auto fromColumn = lastHotKeyLine.Children().GetAt(0).as<StackPanel>();
+
+        StackPanel selectButtonTry = fromColumn.Children().GetAt(1).as<StackPanel>();
+        Button selectButtonTry2 = selectButtonTry.Children().GetAt(1).as<Button>();
+        if (selectButtonTry2 != nullptr)
+        {
+            // Set programmatic focus on the button
+            selectButtonTry2.Focus(FocusState::Programmatic);
         }
     }
 

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/UIHelpers.h
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/UIHelpers.h
@@ -17,8 +17,11 @@ namespace winrt
 // This namespace contains UI methods that are to be used for both KBM windows
 namespace UIHelpers
 {
-    // This method sets focus to the first Type button on the last row of the Grid
-    void SetFocusOnTypeButtonInLastRow(StackPanel& parent, long colCount);
+    // This method sets focus to the first "Select" button on the last row of the Grid of EditKeyboardWindow
+    void SetFocusOnFirstSelectButtonInLastRowOfEditKeyboardWindow(StackPanel& parent, long colCount);
+
+    // This method sets focus to the first "Select" button on the last row of the Grid of EditShortcutsWindow
+    void SetFocusOnFirstSelectButtonInLastRowOfEditShortcutsWindow(StackPanel& parent, long colCount);
 
     RECT GetForegroundWindowDesktopRect();
 


### PR DESCRIPTION

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Modifying focus after creating a new row in the editor windows. Setting it to the first interactive element.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [X] **Closes:** #32267
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
tested locally
