### PR TITLE
[Settings] General page: setting infobars to NO tab stops

### DIFF
--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/GeneralPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/GeneralPage.xaml
@@ -62,7 +62,7 @@
                                 CornerRadius="0"
                                 IsClosable="False"
                                 IsOpen="{x:Bind ViewModel.SomeUpdateSettingsAreGpoManaged, Mode=OneWay}"
-                                IsTabStop="{x:Bind ViewModel.SomeUpdateSettingsAreGpoManaged, Mode=OneWay}"
+                                IsTabStop="False"
                                 Severity="Informational" />
                         </tkcontrols:SettingsExpander.ItemsHeader>
                         <tkcontrols:SettingsExpander.Items>
@@ -86,7 +86,7 @@
                             x:Uid="General_UpToDate"
                             IsClosable="False"
                             IsOpen="{x:Bind ViewModel.IsNewVersionCheckedAndUpToDate, Mode=OneWay}"
-                            IsTabStop="{x:Bind ViewModel.IsNewVersionCheckedAndUpToDate, Mode=OneWay}"
+                            IsTabStop="False"
                             Severity="Success" />
 
                         <!--  Network error while checking for new version  -->
@@ -94,7 +94,7 @@
                             x:Uid="General_CantCheck"
                             IsClosable="False"
                             IsOpen="{x:Bind ViewModel.IsNoNetwork, Mode=OneWay}"
-                            IsTabStop="{x:Bind ViewModel.IsNoNetwork, Mode=OneWay}"
+                            IsTabStop="False"
                             Severity="Error" />
 
                         <!--  New version available  -->
@@ -102,7 +102,7 @@
                             x:Uid="General_NewVersionAvailable"
                             IsClosable="False"
                             IsOpen="{x:Bind ViewModel.PowerToysUpdatingState, Mode=OneWay, Converter={StaticResource UpdateStateToBoolConverter}, ConverterParameter=ReadyToDownload}"
-                            IsTabStop="{x:Bind ViewModel.PowerToysUpdatingState, Mode=OneWay, Converter={StaticResource UpdateStateToBoolConverter}, ConverterParameter=ReadyToDownload}"
+                            IsTabStop="False"
                             Message="{x:Bind ViewModel.PowerToysNewAvailableVersion, Mode=OneWay}"
                             Severity="Informational">
 
@@ -143,7 +143,7 @@
                             x:Uid="General_NewVersionReadyToInstall"
                             IsClosable="False"
                             IsOpen="{x:Bind ViewModel.PowerToysUpdatingState, Mode=OneWay, Converter={StaticResource UpdateStateToBoolConverter}, ConverterParameter=ReadyToInstall}"
-                            IsTabStop="{x:Bind ViewModel.PowerToysUpdatingState, Mode=OneWay, Converter={StaticResource UpdateStateToBoolConverter}, ConverterParameter=ReadyToInstall}"
+                            IsTabStop="False"
                             Message="{x:Bind ViewModel.PowerToysNewAvailableVersion, Mode=OneWay}"
                             Severity="Success">
                             <InfoBar.Content>
@@ -167,7 +167,7 @@
                             x:Uid="General_FailedToDownloadTheNewVersion"
                             IsClosable="False"
                             IsOpen="{x:Bind ViewModel.PowerToysUpdatingState, Mode=OneWay, Converter={StaticResource UpdateStateToBoolConverter}, ConverterParameter=ErrorDownloading}"
-                            IsTabStop="{x:Bind ViewModel.PowerToysUpdatingState, Mode=OneWay, Converter={StaticResource UpdateStateToBoolConverter}, ConverterParameter=ErrorDownloading}"
+                            IsTabStop="False"
                             Message="{x:Bind ViewModel.PowerToysNewAvailableVersion, Mode=OneWay}"
                             Severity="Error">
                             <InfoBar.Content>
@@ -344,7 +344,7 @@
                     Title="{x:Bind ViewModel.SettingsBackupMessage, Mode=OneWay}"
                     IsClosable="False"
                     IsOpen="{x:Bind ViewModel.SettingsBackupRestoreMessageVisible, Mode=OneWay}"
-                    IsTabStop="{x:Bind ViewModel.SettingsBackupRestoreMessageVisible, Mode=OneWay}"
+                    IsTabStop="False"
                     Severity="{x:Bind ViewModel.BackupRestoreMessageSeverity, Converter={StaticResource StringToInfoBarSeverityConverter}}" />
                 <controls:SettingsGroup x:Uid="General_Experimentation" Visibility="Visible">
                     <tkcontrols:SettingsCard x:Uid="GeneralPage_EnableExperimentation" IsEnabled="{x:Bind ViewModel.IsExperimentationGpoDisallowed, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}">
@@ -357,7 +357,7 @@
                         x:Uid="GPO_SettingIsManaged"
                         IsClosable="False"
                         IsOpen="{x:Bind ViewModel.IsExperimentationGpoDisallowed, Mode=OneWay}"
-                        IsTabStop="{x:Bind ViewModel.IsExperimentationGpoDisallowed, Mode=OneWay}"
+                        IsTabStop="False"
                         Severity="Informational" />
                 </controls:SettingsGroup>
             </StackPanel>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
General page: setting infobars to NO tab stops
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [X] **Closes:** #32222
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

tested locally