### PR TITLE
[DSC]Improve samples

### DIFF
--- a/src/dsc/Microsoft.PowerToys.Configure/examples/README.md
+++ b/src/dsc/Microsoft.PowerToys.Configure/examples/README.md
@@ -1,0 +1,26 @@
+# PowerToys Desired State Configuration samples
+
+This folder contains samples of DSC files that can be used to configure PowerToys.
+
+> [!NOTE]
+> PowerToys DSC user documentation can be found on [Learn Microsoft PowerToys documentation](https://aka.ms/powertoys-docs-dsc-configure).
+
+### [configuration.dsc.yaml](./configuration.dsc.yaml)
+
+Sample configuration file that changes the enabled state of some modules, changes an integer setting and a hotkey setting.
+
+### [installAndConfiguration.dsc.yaml](./installAndConfiguration.dsc.yaml)
+
+Installs PowerToys and applies configuration.dsc.yaml to it.
+
+### [enableAllModules.dsc.yaml](./enableAllModules.dsc.yaml)
+
+Enables all PowerToys utilities.
+
+### [disableAllModules.dsc.yaml](./disableAllModules.dsc.yaml)
+
+Disables all PowerToys utilities.
+
+### [configureLauncherPlugins.dsc.yaml](./configureLauncherPlugins.dsc.yaml)
+
+Enables PowerToys Run and all its plugins and changes action keyword and global state for the Program plugin.

--- a/src/dsc/Microsoft.PowerToys.Configure/examples/configuration.dsc.yaml
+++ b/src/dsc/Microsoft.PowerToys.Configure/examples/configuration.dsc.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
 properties:
   resources:
     - resource: PowerToysConfigure

--- a/src/dsc/Microsoft.PowerToys.Configure/examples/configuration.dsc.yaml
+++ b/src/dsc/Microsoft.PowerToys.Configure/examples/configuration.dsc.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
 properties:
   resources:
-    - resource: PowerToysConfigure
+    - resource: Microsoft.PowerToys.Configure/PowerToysConfigure
       directives:
         description: Configure PowerToys
       settings:

--- a/src/dsc/Microsoft.PowerToys.Configure/examples/configureLauncherPlugins.dsc.yaml
+++ b/src/dsc/Microsoft.PowerToys.Configure/examples/configureLauncherPlugins.dsc.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
 properties:
   resources:
     - resource: PowerToysConfigure

--- a/src/dsc/Microsoft.PowerToys.Configure/examples/configureLauncherPlugins.dsc.yaml
+++ b/src/dsc/Microsoft.PowerToys.Configure/examples/configureLauncherPlugins.dsc.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
 properties:
   resources:
-    - resource: PowerToysConfigure
+    - resource: Microsoft.PowerToys.Configure/PowerToysConfigure
       directives:
         description: Configure PowerToys
       settings:

--- a/src/dsc/Microsoft.PowerToys.Configure/examples/disableAllModules.dsc.yaml
+++ b/src/dsc/Microsoft.PowerToys.Configure/examples/disableAllModules.dsc.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
 properties:
   resources:
     - resource: PowerToysConfigure

--- a/src/dsc/Microsoft.PowerToys.Configure/examples/disableAllModules.dsc.yaml
+++ b/src/dsc/Microsoft.PowerToys.Configure/examples/disableAllModules.dsc.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
 properties:
   resources:
-    - resource: PowerToysConfigure
+    - resource: Microsoft.PowerToys.Configure/PowerToysConfigure
       directives:
         description: Configure PowerToys
       settings:

--- a/src/dsc/Microsoft.PowerToys.Configure/examples/enableAllModules.dsc.yaml
+++ b/src/dsc/Microsoft.PowerToys.Configure/examples/enableAllModules.dsc.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
 properties:
   resources:
     - resource: PowerToysConfigure

--- a/src/dsc/Microsoft.PowerToys.Configure/examples/enableAllModules.dsc.yaml
+++ b/src/dsc/Microsoft.PowerToys.Configure/examples/enableAllModules.dsc.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
 properties:
   resources:
-    - resource: PowerToysConfigure
+    - resource: Microsoft.PowerToys.Configure/PowerToysConfigure
       directives:
         description: Configure PowerToys
       settings:

--- a/src/dsc/Microsoft.PowerToys.Configure/examples/installAndConfiguration.dsc.yaml
+++ b/src/dsc/Microsoft.PowerToys.Configure/examples/installAndConfiguration.dsc.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
 properties:
   resources:
     - resource: Microsoft.WinGet.DSC/WinGetPackage

--- a/src/dsc/Microsoft.PowerToys.Configure/examples/installAndConfiguration.dsc.yaml
+++ b/src/dsc/Microsoft.PowerToys.Configure/examples/installAndConfiguration.dsc.yaml
@@ -10,7 +10,7 @@ properties:
         id: Microsoft.PowerToys
         source: winget
 
-    - resource: PowerToysConfigure
+    - resource: Microsoft.PowerToys.Configure/PowerToysConfigure
       dependsOn:
         - installPowerToys
       directives:

--- a/src/dsc/Microsoft.PowerToys.Configure/examples/installAndConfiguration.dsc.yaml
+++ b/src/dsc/Microsoft.PowerToys.Configure/examples/installAndConfiguration.dsc.yaml
@@ -1,5 +1,13 @@
 properties:
   resources:
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      directives:
+        description: Install PowerToys
+        allowPrerelease: true
+      settings:
+        id: Microsoft.PowerToys
+        source: winget
+
     - resource: PowerToysConfigure
       directives:
         description: Configure PowerToys

--- a/src/dsc/Microsoft.PowerToys.Configure/examples/installAndConfiguration.dsc.yaml
+++ b/src/dsc/Microsoft.PowerToys.Configure/examples/installAndConfiguration.dsc.yaml
@@ -1,6 +1,7 @@
 properties:
   resources:
     - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: installPowerToys
       directives:
         description: Install PowerToys
         allowPrerelease: true
@@ -9,6 +10,8 @@ properties:
         source: winget
 
     - resource: PowerToysConfigure
+      dependsOn:
+        - installPowerToys
       directives:
         description: Configure PowerToys
       settings:


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Adds an index file for the DSC samples.
Adds a sample that installs and then configures PowerToys.
Improves the samples for DSC, according to best practices from https://github.com/microsoft/devhome/tree/main/docs/sampleConfigurations/DscResources :
- Add the `yaml-language-server` header.
- Use the full resource name to improve time for winget to find the resource.
- Make the configure step depend on the install step.
- Use PowerToys package full name for the install step.
