### PR TITLE
Enable anti-aliasing for AlwaysOnTop frame rendering

### DIFF
--- a/src/modules/alwaysontop/AlwaysOnTop/FrameDrawer.cpp
+++ b/src/modules/alwaysontop/AlwaysOnTop/FrameDrawer.cpp
@@ -62,7 +62,7 @@ bool FrameDrawer::CreateRenderTargets(const RECT& clientRect)
         return false;
     }
 
-    m_renderTarget->SetAntialiasMode(D2D1_ANTIALIAS_MODE_ALIASED);
+    m_renderTarget->SetAntialiasMode(D2D1_ANTIALIAS_MODE_PER_PRIMITIVE);
     m_renderTargetSizeHash = rectHash;
 
     return true;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This pull request enables anti-aliasing for the rounded edges on the frames rendered by AlwaysOnTop. This addresses an issue where accessory frames used to indicate that AOT was activated would have somewhat nasty-looking corners (this would be pronounced on lower-resolution/DPI displays). Here are some screenshots:

![image](https://github.com/microsoft/PowerToys/assets/36348486/d2994110-b1b0-4ddd-9557-00ca978de4cc)

![image](https://github.com/microsoft/PowerToys/assets/36348486/df5da7f2-8845-4341-9bcb-0ff0fb3b0cca)

I am curious why it wasn't already behaving like this, since the aliasing behavior is explicitly specified.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

Use `D2D1_ANTIALIAS_MODE_PER_PRIMITIVE` instead of `D2D1_ANTIALIAS_MODE_ALIASED` in `FrameDrawer::CreateRenderTargets()`

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

