### PR TITLE
[Settings][ImageResizer] Add fallback encoder description

### DIFF
--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -1488,6 +1488,9 @@
   <data name="ImageResizer_FallBackEncoderText.Header" xml:space="preserve">
     <value>Fallback encoder</value>
   </data>
+  <data name="ImageResizer_FallBackEncoderText.Description" xml:space="preserve">
+    <value>Used when missing encoder for original format (read supported, write not supported)</value>
+  </data>
   <data name="ImageResizer_FileFormatDescription.Text" xml:space="preserve">
     <value>The following parameters can be used:</value>
   </data>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -1489,7 +1489,7 @@
     <value>Fallback encoder</value>
   </data>
   <data name="ImageResizer_FallBackEncoderText.Description" xml:space="preserve">
-    <value>Used when missing encoder for original format (read supported, write not supported)</value>
+    <value>Used when missing encoder for original format</value>
   </data>
   <data name="ImageResizer_FileFormatDescription.Text" xml:space="preserve">
     <value>The following parameters can be used:</value>


### PR DESCRIPTION
The ImageResizer provides the *Fallback encoder* setting. It is not obvious what it is a fallback for.

[The documentation on *Fallback encoding*](https://learn.microsoft.com/en-us/windows/powertoys/image-resizer#fallback-encoding) describes it.

Add a description to the setting to make it obvious and descriptive from the settings dialog setting alone.

---

Before:

![image](https://github.com/microsoft/PowerToys/assets/93181/903656e0-c5a6-450f-82d2-d377f07d360c)

After:

![image](https://github.com/microsoft/PowerToys/assets/93181/df3eb087-090e-4fc3-a887-f9e6a42042e5)

---

## PR Checklist

* [x] Closes: #32564
* [x] Localization: All end user facing strings can be localized