### PR TITLE
[DEPS] Update Unitsnet to 5.50.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -85,7 +85,7 @@
     <PackageVersion Include="System.ServiceProcess.ServiceController" Version="8.0.0" />
     <PackageVersion Include="System.Text.Encoding.CodePages" Version="8.0.0" />
     <PackageVersion Include="UnicodeInformation" Version="2.6.0" />
-    <PackageVersion Include="UnitsNet" Version="4.145.0" />
+    <PackageVersion Include="UnitsNet" Version="5.50.0" />
     <PackageVersion Include="UTF.Unknown" Version="2.5.1" />
     <PackageVersion Include="Vanara.PInvoke.User32" Version="3.4.11" />
     <PackageVersion Include="Vanara.PInvoke.Shell32" Version="3.4.11" />

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1365,7 +1365,7 @@ EXHIBIT A -Mozilla Public License.
 - System.ServiceProcess.ServiceController 8.0.0
 - System.Text.Encoding.CodePages 8.0.0
 - UnicodeInformation 2.6.0
-- UnitsNet 4.145.0
+- UnitsNet 5.50.0
 - UTF.Unknown 2.5.1
 - Vanara.PInvoke.Shell32 3.4.11
 - Vanara.PInvoke.User32 3.4.11

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/UnitHandler.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/UnitHandler.cs
@@ -44,13 +44,13 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
                 return first.Value;
             }
 
-            if (UnitParser.Default.TryParse(unit, unitInfo.UnitType, out Enum enum_unit))
+            if (UnitsNetSetup.Default.UnitParser.TryParse(unit, unitInfo.UnitType, out Enum enum_unit))
             {
                 return enum_unit;
             }
 
             var cultureInfoEnglish = new System.Globalization.CultureInfo("en-US");
-            if (UnitParser.Default.TryParse(unit, unitInfo.UnitType, cultureInfoEnglish, out Enum enum_unit_en))
+            if (UnitsNetSetup.Default.UnitParser.TryParse(unit, unitInfo.UnitType, cultureInfoEnglish, out Enum enum_unit_en))
             {
                 return enum_unit_en;
             }


### PR DESCRIPTION
## changes
- Add operators for ReciprocalLength/-Area
- Change nuget license from MIT to MIT-0
- Add operator to convert from TemperatureDelta to TemperatureChangeRate.
- Add MagenticField and Acceleration for .NET nanoFramework
- Change DataMember ordering to 1-indexed
- Add VolumeFlow prefixes Deca
- Add Btu/ft² in irradiation
- Add radiation equivalent dose
- Fix precision of Volume.CubicInch
- Add radiation exposure
- Add radioactivity
- Add units for Molality
- Add Kilo prefix to yards
- Improve precision of PR 1334
- Add density unit PoundsPerCubicYard + Kilo prefix
- Bump nanoFramework refs
- ci: 🔧Update pipelines for v4
- Added some nullability annotations to v4
- Add Femto prefixes to density
- Add micro and nano prefixes
- Added Gigameter (1e+9 meters)
- Fix force conversion rates
- Set neutral language to en-US
- Fix concurrency issue getting abbreviations
- EADME: Update information referring to QuantityType removed in v5 
- Fix unit abbreviation lookup for unit value cast to Enum
- Add Pico and Femto prefixes to meter
- Fix stack overflow deserializing empty JSON
- Add CoefficientOfThermalExpansion units, change base unit
- Add picomoles and femtomoles
- Restrict number extension methods to INumber
- Remove checked-in tools requiring Git LFS
- Add Length.Kilofoot unit
- Add CoefficientOfThermalExpansion operators
- Move unit abbreviation strings into culture-specific resource files
- Fallback to invariant culture if cultures are not found
- Add Speed / Acceleration operator
- Add UnitsNetSetup to hold global static state
- Add units to ElectricCurrentGradient, PressureChangeRate
- Define base units for Pressure, PressureChangeRate
- Add PerfTests for startup and JIT comparing v4 and v5
- Fix whitespace in codegen
- Add Quantity.From/TryFromUnitAbbreviationd
- Added absorbed dose of ionizing radiation units 
- Add ImperialQuart to Volume
- Add Equals() to IQuantity interfaces
- Linear density enhancements
- Add Operators Between Energy, ElectricCharge, and EletricPotential
- Improve precision of ReciprocalLength.InverseMile
- Add picograms and femtograms
- Fix consistent ordering of units
- README: Add link to Python package
- Fix precision of gallon volume units
- Publish test results to ADO pipeline
- Add UsGallonsPerMile, ImperialGallonPerMile, MegaukGallonPerDay, MegausGallonPerDay
- ToUnit for IValueQuantity should return IValueQuantit
- Add MegalitersPerHour, MegalitersPerMinute, MegalitersPerSecond
- Add LeakRate quantity
- Fix quantity name in obsolete attributes
- Add water column pressure units
- Add IValueQuantity interface to expose the value type
- Added Megameter (1e+6 meters)
- Improve precision of Mass, Area units
- Add UnitMath.Clamp(value, min, max)
- Added more units
- Added Femtoampere to ElectricCurrent
- Added support for molar flow units
- Descibe null checks in obsolete message for equality overloads
- 1 mile is 1609.344
- Add unit definition "MegaJoulePerTonne" to SpecificEnergy
- Add Micro and Milli prefixes to Frequency
- Add new Impulse quantity with relevant units
- Update .NET nanoFramework NuGets (v4)
- Improve nullable annotations for net7.0 multi-targeting
-  ci: Split into stages
- Generic math for UnitsNet in .NET 7
- Remove LapseRate quantity
- QuantityValue.ToString(): Specify default culture
- Enable deterministic builds
- Remove obsolete Molarity units
- azure-pipelines: Fix nuget push due to duplicates
- update benchmarks to net6.0
- Bump Newtonsoft.Json from 13.0.1 to 13.0.2 in /UnitsNet.Serialization.JsonNe
- Bump Newtonsoft.Json from 13.0.1 to 13.0.2 in /CodeGen
- Add nanoliter unit to Volume quantity
- Add UnitMath.Clamp(value, min, max) 
- Fix concurrency issue when getting abbreviations
- Add concurrency checks to UnitValueAbbreviationLookup
- Add back IEquatable with strict equality
- Fix path to msbuild components for .NET nanoFramework projects
- Set up Azure Pipelines
- Add EnergyDensity
- Add units PetaJoule, TeraJoule
- Use readonly for structs in QuantityGenerator
- Return non-zero for trigger-js-release action failure
- Bump NuGet.Protocol from 6.2.1 to 6.2.2 in /CodeGen
- Integration with the JS package
- AreaDensity: Add g/m2, mg/m2, add operators
- Fix build hang by upgrading dotcover
- Fix .NET nanoFramework build
- Update .NET nanoFramework NuGets
- 