### PR TITLE
[FZ Editor][Accessibility] Make sure ToggleSwitch do not react on Enter

### DIFF
--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml
@@ -664,7 +664,8 @@
                                 AutomationProperties.Name="{x:Static props:Resources.Show_Space_Zones}"
                                 IsOn="{Binding ShowSpacing}"
                                 OffContent=""
-                                OnContent="">
+                                OnContent=""
+                                KeyDown="SpaceAroundSetting_KeyDown">
                                 <ui:ToggleSwitch.Resources>
                                     <sys:Double x:Key="ToggleSwitchThemeMinWidth">0</sys:Double>
                                 </ui:ToggleSwitch.Resources>

--- a/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
+++ b/src/modules/fancyzones/editor/FancyZonesEditor/MainWindow.xaml.cs
@@ -662,5 +662,14 @@ namespace FancyZonesEditor
                 MainWindowSettingsModel.DefaultLayouts.Reset(MonitorConfigurationType.Vertical);
             }
         }
+
+        private void SpaceAroundSetting_KeyDown(object sender, KeyEventArgs e)
+        {
+            // Making sure that pressing Enter while SpaceAroundSetting ToggleSwitch is focused will not close the edit dialog.
+            if (e.Key == Key.Enter)
+            {
+                e.Handled = true;
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Pressing Enter while ToggliSwitch was focused used to close Edit dialog as Enter is wired to Save button. ToggleSwitch should not react on Enter, only Space. This change ensures that behavior.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #32246
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

