### PR TITLE
Enable caching in CI pipeline

### DIFF
--- a/.pipelines/ci/ci.yml
+++ b/.pipelines/ci/ci.yml
@@ -26,14 +26,19 @@ pr:
 #     0.0.1904.0900
 name: 0.0.$(Date:yyMM).$(Date:dd)$(Rev:rr)
 
+variables:
+  EnablePipelineCache: true
+
 jobs:
   - template: ./templates/build-powertoys-precheck.yml
   - template: ./templates/build-powertoys-ci.yml
     parameters:
-      platform: x64    
+      platform: x64
+      enableCaching: true
   - template: ./templates/build-powertoys-ci.yml
     parameters:
       platform: arm64
+      enableCaching: true
   - template: ./templates/run-ui-tests-ci.yml
     parameters:
       platform: x64 


### PR DESCRIPTION
Enable caching in CI pipeline

Some rough numbers suggest that on average this can save ~10 mins of the build.