### PR TITLE
[Peek] Bump SharpCompress and minor ArchivePreviewer changes

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -58,7 +58,7 @@
     <PackageVersion Include="NLog.Extensions.Logging" Version="5.3.8" />
     <PackageVersion Include="NLog.Schema" Version="5.2.8" />
     <PackageVersion Include="ScipBe.Common.Office.OneNote" Version="3.0.1" />
-    <PackageVersion Include="SharpCompress" Version="0.33.0" />
+    <PackageVersion Include="SharpCompress" Version="0.37.2" />
     <PackageVersion Include="StreamJsonRpc" Version="2.14.24" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <!-- Package System.CodeDom added as a hack for being able to exclude the runtime assets so they don't conflict with 8.0.1. This is a dependency of System.Management but the 8.0.1 version wasn't published to nuget. -->

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1343,7 +1343,7 @@ EXHIBIT A -Mozilla Public License.
 - NLog.Extensions.Logging 5.3.8
 - NLog.Schema 5.2.8
 - ScipBe.Common.Office.OneNote 3.0.1
-- SharpCompress 0.33.0
+- SharpCompress 0.37.2
 - StreamJsonRpc 2.14.24
 - StyleCop.Analyzers 1.2.0-beta.556
 - System.CodeDom 8.0.0

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/Archives/ArchivePreviewer.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/Archives/ArchivePreviewer.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Data;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -28,6 +27,8 @@ namespace Peek.FilePreviewer.Previewers.Archives
 {
     public partial class ArchivePreviewer : ObservableObject, IArchivePreviewer
     {
+        private static readonly char[] _keySeparators = { '/', '\\' };
+
         private readonly IconCache _iconCache = new();
         private int _directoryCount;
         private int _fileCount;
@@ -125,10 +126,12 @@ namespace Peek.FilePreviewer.Previewers.Archives
         {
             ArgumentNullException.ThrowIfNull(entry, nameof(entry));
 
-            var levels = entry!.Key
-                .Split('/', '\\')
-                .Where(l => !string.IsNullOrWhiteSpace(l))
-                .ToArray();
+            if (entry.Key == null)
+            {
+                return;
+            }
+
+            var levels = entry.Key.Split(_keySeparators, StringSplitOptions.RemoveEmptyEntries);
 
             ArchiveItem? parent = null;
             for (var i = 0; i < levels.Length; i++)
@@ -209,7 +212,7 @@ namespace Peek.FilePreviewer.Previewers.Archives
 
         private static readonly HashSet<string> _supportedFileTypes = new()
         {
-            ".zip", ".rar", ".7z", ".tar", ".nupkg", ".jar", ".gz", ".tar", ".tar.gz", ".tgz",
+            ".zip", ".rar", ".7z", ".tar", ".nupkg", ".jar", ".gz", ".tar.gz", ".tgz",
         };
     }
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

- Bump SharpCompress to the latest version:
  - .NET8 support
  - Increased compression formats support
  - Fixed an infinite loop when reading corrupted archive
- Minor changes on how archive content is parsed
- Removed duplicate `.tar` in supported file types

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

- Manually tested Peek with every archive format