### PR TITLE
Cache nuget packages using pipeline caching

### DIFF
--- a/.pipelines/ci/templates/build-powertoys-steps.yml
+++ b/.pipelines/ci/templates/build-powertoys-steps.yml
@@ -83,6 +83,15 @@ steps:
 - task: VisualStudioTestPlatformInstaller@1
   displayName: Ensure VSTest Platform
 
+- task: Cache@2
+  displayName: 'Cache nuget packages'
+  inputs:
+    key: 'nuget | "$(Agent.OS)" | **/packages.config'
+    restoreKeys: |
+       nuget | "$(Agent.OS)"
+       nuget
+    path: packages
+
 - ${{ if eq(parameters.enableCaching, true) }}:
   - task: NuGetToolInstaller@1
     displayName: Install NuGet


### PR DESCRIPTION
This change uses [Pipeline Caching](https://learn.microsoft.com/en-us/azure/devops/pipelines/artifacts/caching-nuget?view=azure-devops) to cache the `/packages` directory.

This should improve pipeline performance. (Will update the description with numbers once I have them)