### PR TITLE
Disable project caching

### DIFF
--- a/.pipelines/ci/ci.yml
+++ b/.pipelines/ci/ci.yml
@@ -34,11 +34,9 @@ jobs:
   - template: ./templates/build-powertoys-ci.yml
     parameters:
       platform: x64
-      enableCaching: true
   - template: ./templates/build-powertoys-ci.yml
     parameters:
       platform: arm64
-      enableCaching: true
   - template: ./templates/run-ui-tests-ci.yml
     parameters:
       platform: x64 


### PR DESCRIPTION
There appears to be some bugs in this feature for pipeline runs triggered from forks.