### PR TITLE
Cache nuget packages using pipeline caching

### DIFF
--- a/.pipelines/ci/templates/build-powertoys-steps.yml
+++ b/.pipelines/ci/templates/build-powertoys-steps.yml
@@ -83,6 +83,24 @@ steps:
 - task: VisualStudioTestPlatformInstaller@1
   displayName: Ensure VSTest Platform
 
+- task: Cache@2
+  displayName: 'Cache nuget packages (PackageReference)'
+  inputs:
+    key: '"PackageReference" | "$(Agent.OS)" | Directory.Packages.props'
+    restoreKeys: |
+       "PackageReference" | "$(Agent.OS)"
+       "PackageReference"
+    path: $(NUGET_PACKAGES)
+
+- task: Cache@2
+  displayName: 'Cache nuget packages (packages.config)'
+  inputs:
+    key: '"packages.config" | "$(Agent.OS)" | **/packages.config'
+    restoreKeys: |
+       "packages.config" | "$(Agent.OS)"
+       "packages.config"
+    path: packages
+
 - ${{ if eq(parameters.enableCaching, true) }}:
   - task: NuGetToolInstaller@1
     displayName: Install NuGet


### PR DESCRIPTION
This change uses [Pipeline Caching](https://learn.microsoft.com/en-us/azure/devops/pipelines/artifacts/caching-nuget?view=azure-devops) to cache NuGet packages.

This should improve pipeline performance. It adds ~2 mins to pull the packages from the cache, but save ~3 mins from the restore, netting about 1 min of savings.

Before:
![image](https://github.com/microsoft/PowerToys/assets/6445614/9597e988-ca93-4ef1-8e06-7c732ca9a221)

After:
![image](https://github.com/microsoft/PowerToys/assets/6445614/8368b0eb-b08c-4c6e-9aa6-189e54627106)
