### PR TITLE
[PTRun][Docs] Updated Third party plugins to include UnicodeInput

### DIFF
--- a/.github/actions/spell-check/allow/names.txt
+++ b/.github/actions/spell-check/allow/names.txt
@@ -94,6 +94,7 @@ Melman
 Mikhayelyan
 msft
 Myrvold
+nathancartlidge
 Nemeth
 nielslaute
 oldnewthing

--- a/doc/thirdPartyRunPlugins.md
+++ b/doc/thirdPartyRunPlugins.md
@@ -35,6 +35,7 @@ Contact the developers of a plugin directly for assistance with a specific plugi
 | [Currency Converter](https://github.com/Advaith3600/PowerToys-Run-Currency-Converter) | [advaith3600](https://github.com/advaith3600) | Convert real and crypto currencies |
 | [FastWeb](https://github.com/CCcat8059/FastWeb) | [CCcat](https://github.com/CCcat8059) | Open website in browser |
 | [WebSearchShortcut](https://github.com/Daydreamer-riri/PowerToys-Run-WebSearchShortcut) | [Riri](https://github.com/Daydreamer-riri) | Select a specific search engine to perform searches. |
+| [UnicodeInput](https://github.com/nathancartlidge/powertoys-run-unicode) | [nathancartlidge](https://github.com/nathancartlidge) | Copy Unicode characters to the clipboard |
 
 ## Extending software plugins
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Adds a new plugin, [UnicodeInput](https://github.com/nathancartlidge/powertoys-run-unicode), (developed by myself) to the third-party plugins list for PowerToys Run.

## Detailed Description of the Pull Request / Additional comments
This plugin allows for the rapid input of some unicode characters and symbols

![image](https://github.com/microsoft/PowerToys/assets/11426516/3eb5b98f-1ad0-49f7-9913-0e47f55cea8b)