### PR TITLE
[MeasureTool] Update default activation shortcut to resolve conflict with Windows Explorer built-in shortcut

### DIFF
--- a/src/modules/MeasureTool/MeasureToolModuleInterface/dllmain.cpp
+++ b/src/modules/MeasureTool/MeasureToolModuleInterface/dllmain.cpp
@@ -82,9 +82,9 @@ private:
         {
             Logger::info("MeasureTool is going to use default shortcut");
             m_hotkey.win = true;
+            m_hotkey.ctrl = true;
             m_hotkey.alt = false;
             m_hotkey.shift = true;
-            m_hotkey.ctrl = false;
             m_hotkey.key = 'M';
         }
     }

--- a/src/settings-ui/Settings.UI.Library/MeasureToolProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/MeasureToolProperties.cs
@@ -12,7 +12,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
     public class MeasureToolProperties
     {
         [CmdConfigureIgnore]
-        public HotkeySettings DefaultActivationShortcut => new HotkeySettings(true, false, false, true, 0x4D);
+        public HotkeySettings DefaultActivationShortcut => new HotkeySettings(true, true, false, true, 0x4D);
 
         public MeasureToolProperties()
         {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Update default activation shortcut and resolve #32623 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #32623
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: MicrosoftDocs/windows-dev-docs#4977

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
The default activation shortcut for the Screen Ruler (MeasureTool) has been updated so as to no longer conflict with the built-in Windows Explorer shortcut used to restore windows minimized with `⊞ Win`-`M`:
* Old shortcut: `⊞ Win`-`Shift`-`M`
* New shortcut: `⊞ Win`-`Ctrl`-`Shift`-`M`

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
* Installed the package on a fresh virtual machine
* Launched PowerToys
* Pressed `⊞ Win`-`Ctrl`-`Shift`-`M` 
* Observed that this caused the MeasureTool UI to appear and function normally