### PR TITLE
[PTRun] ThemeResource of buttons are changed.

### DIFF
--- a/src/modules/launcher/PowerLauncher/Styles/Styles.xaml
+++ b/src/modules/launcher/PowerLauncher/Styles/Styles.xaml
@@ -84,11 +84,11 @@
                             <Setter TargetName="border" Property="Background" Value="Transparent" />
                         </Trigger>
                         <Trigger Property="IsMouseOver" Value="true">
-                            <Setter TargetName="border" Property="Background" Value="{DynamicResource SubtleFillColorSecondaryBrush}" />
+                            <Setter TargetName="border" Property="Background" Value="{DynamicResource ControlStrokeColorSecondaryBrush}" />
                             <Setter TargetName="contentPresenter" Property="TextElement.Foreground" Value="{DynamicResource TextFillColorSecondaryBrush}" />
                         </Trigger>
                         <Trigger Property="IsPressed" Value="true">
-                            <Setter TargetName="border" Property="Background" Value="{DynamicResource SubtleFillColorTertiaryBrush}" />
+                            <Setter TargetName="border" Property="Background" Value="{DynamicResource ControlStrokeColorTertiaryBrush}" />
                             <Setter TargetName="contentPresenter" Property="TextElement.Foreground" Value="{DynamicResource TextFillColorSecondaryBrush}" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="false">
@@ -130,7 +130,7 @@
                             <!--<Setter TargetName="border" Property="BorderBrush" Value="Transparent" />-->
                         </Trigger>
                         <Trigger Property="IsSelected" Value="True">
-                            <Setter TargetName="border" Property="Background" Value="{DynamicResource SubtleFillColorTertiaryBrush}" />
+                            <Setter TargetName="border" Property="Background" Value="{DynamicResource ControlStrokeColorTertiaryBrush  }" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
ThemeResource changed from SubtleFillColorTertiaryBrush to ControlStrokeColorTertiaryBrush
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #32409 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
I followed the steps below when solving this issue.

- I tried all themes from https://wpfui.lepo.co/api/Wpf.Ui.Markup.ThemeResource.html
- Some of them is good at Dark them but not in Light theme (Ex. KeyboardFocusBorderColorBrush )
- "ControlStrokeColorTertiaryBrush" looks good to me. Contrast in Dark 8.6:1 and Light 5.7:1
- I found colors from https://amwx.github.io/FluentAvaloniaDocs/pages/Resources
- I gave Chatgpt the colors of the themes from here and asked it to choose a button background for me with the "ControlAltFillColorQuarternaryBrush" background(selected ListViewItem) and the "TextFillColorPrimaryBrush" button text. Chatgpt chose "ControlStrokeColorTertiaryBrush" too.


<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

![Dark Theme After](https://github.com/microsoft/PowerToys/assets/115616017/29852a37-df27-478d-a51e-c05ad696048c)

![Light Theme After](https://github.com/microsoft/PowerToys/assets/115616017/4f9f5be4-9420-415a-869e-d340959cbf76)