### PR TITLE
[PTRun] Add border brush color changes to button on mouse over and selection

### DIFF
--- a/src/modules/launcher/PowerLauncher/Styles/Styles.xaml
+++ b/src/modules/launcher/PowerLauncher/Styles/Styles.xaml
@@ -127,10 +127,11 @@
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="true">
                             <Setter TargetName="border" Property="Background" Value="Transparent" />
-                            <!--<Setter TargetName="border" Property="BorderBrush" Value="Transparent" />-->
+                            <Setter TargetName="border" Property="BorderBrush" Value="{DynamicResource KeyboardFocusBorderColorBrush}" />
                         </Trigger>
                         <Trigger Property="IsSelected" Value="True">
                             <Setter TargetName="border" Property="Background" Value="{DynamicResource SubtleFillColorTertiaryBrush}" />
+                            <Setter TargetName="border" Property="BorderBrush" Value="{DynamicResource KeyboardFocusBorderColorBrush}" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Added border brush color to mouse-over and keyboard selection events to enhance visibility and user experience.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #32409 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Left-> Keyboard selected
Right-> Mouse over
Dark theme : border-out background: 4.9:1   border-button background: 4.1:1   out background-button background: 1.2:1
Light theme : border-out background: 5.9:1  border-button background: 5.7:1  out background-button background: 1:1

![Dark KB and Mouseover](https://github.com/microsoft/PowerToys/assets/115616017/16121342-ea97-408a-bb6b-7d986069f3c2)
![Light KB and Mouseover](https://github.com/microsoft/PowerToys/assets/115616017/659d8911-b7ae-4b88-8b6a-b8755fb9457c)


<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
https://www.tpgi.com/color-contrast-checker/ is used for checking contrast ratio.

- Open PowerToys Run and search for anything.
- Navigate to buttons with tab and arrow keys.
- Hover the mouse over another button.
- Check contrast ratio with CCA.
