### PR TITLE
Drop outdated sln win-app-driver README.md file reference

### DIFF
--- a/PowerToys.sln
+++ b/PowerToys.sln
@@ -146,11 +146,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PowerLauncher", "src\module
 		{FDB3555B-58EF-4AE6-B5F1-904719637AB4} = {FDB3555B-58EF-4AE6-B5F1-904719637AB4}
 	EndProjectSection
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{E775CC2C-24CB-48D6-9C3A-BE4CCE0DB17A}"
-	ProjectSection(SolutionItems) = preProject
-		src\tests\win-app-driver\README.md = src\tests\win-app-driver\README.md
-	EndProjectSection
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "previewpane", "previewpane", "{2F305555-C296-497E-AC20-5FA1B237996A}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PreviewHandlerCommon", "src\modules\previewpane\Common\PreviewHandlerCommon.csproj", "{AF2349B8-E5B6-4004-9502-687C1C7730B1}"


### PR DESCRIPTION
## Summary of the Pull Request

PR #29453 removed the `src/tests/win-app-driver` folder, but missed removing the sln file reference to the folders `README.md` file.

Remove the outdated file reference.

## PR Checklist

- [ ] **Closes:** #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] ~**Tests:** Added/updated and all pass~
- [ ] ~**Localization:** All end user facing strings can be localized~
- [ ] ~**Dev docs:** Added/updated~
- [ ] ~**New binaries:** Added on the required places~
   - [ ] ~[JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries~
   - [ ] ~[WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder~
   - [ ] ~[YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects~
   - [ ] ~[YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)~
- [ ] ~**Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx~

## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

* Manually: Opened Solution in VS. Trying to open README.md fails with missing file. After this change, the file is no longer listed.