### PR TITLE
[PTRun][Docs] Add EdgeWorkspaces to Third-Party plugins

### DIFF
--- a/.github/actions/spell-check/allow/names.txt
+++ b/.github/actions/spell-check/allow/names.txt
@@ -136,6 +136,7 @@ Zykova
 Kairu
 Deibisu
 riri
+quachpas
 
 # OTHERS
 

--- a/doc/thirdPartyRunPlugins.md
+++ b/doc/thirdPartyRunPlugins.md
@@ -44,6 +44,7 @@ Below are community created plugins that target a website or software.  They are
 | Plugin | Author | Description |
 | ------ | ------ | ----------- |
 | [Edge Favorite](https://github.com/davidegiacometti/PowerToys-Run-EdgeFavorite) | [davidegiacometti](https://github.com/davidegiacometti) | Open Microsoft Edge favorites |
+| [Edge Workspaces](https://github.com/quachpas/PowerToys-Run-EdgeWorkspaces) | [quachpas](https://github.com/quachpas) | Open Microsoft Edge workspaces|
 | [Everything](https://github.com/lin-ycv/EverythingPowerToys) | [Yu Chieh (Victor) Lin](https://github.com/Lin-ycv) | Get search results from Everything |
 | [GitKraken](https://github.com/davidegiacometti/PowerToys-Run-GitKraken) | [davidegiacometti](https://github.com/davidegiacometti) | Open GitKraken repositories |
 | [Visual Studio Recents](https://github.com/davidegiacometti/PowerToys-Run-VisualStudio) | [davidegiacometti](https://github.com/davidegiacometti) | Open Visual Studio recents |


### PR DESCRIPTION
## Summary of the Pull Request

Add a new PTRun third-party plugin to open Microsoft Edge workspaces: https://github.com/quachpas/PowerToys-Run-EdgeWorkspaces/

## Detailed Description of the Pull Request / Additional comments

The plugin adds support for [Microsoft Edge workspaces](https://www.microsoft.com/en-us/edge/features/workspaces).

<img width="481" alt="PTRun-EdgeWorkspaces" src="https://github.com/microsoft/PowerToys/assets/20374810/46861a02-7075-47bc-b3bf-ef9eaf3f7ca5">
