### PR TITLE
[ARM][Settings][CmdNotFound] Fix CmdNotFound page init

### DIFF
--- a/src/settings-ui/Settings.UI/ViewModels/CmdNotFoundViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/CmdNotFoundViewModel.cs
@@ -58,6 +58,9 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 _enabledStateIsGPOConfigured = true;
             }
 
+            // Update PATH environment variable to get pwsh.exe on further calls.
+            Environment.SetEnvironmentVariable("PATH", (Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.Machine) ?? string.Empty) + ";" + (Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.User) ?? string.Empty), EnvironmentVariableTarget.Process);
+
             CheckCommandNotFoundRequirements();
         }
 


### PR DESCRIPTION
On ARM, process does not inherit environment, so PATH variable only contains SYSTEM values. As pwsh.exe path is in USER PATH, check requirements script on CmdNotFound page load will fail and as a result all requirements will be shown as missing.

Therefore, on loading, we manually set PATH variable, same as we do after installing pwsh7.

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Before:
 - Open Settings app and navigate to CmdNotFound page
 - Install all requirements
 - Enable CmdNotFound
 - Stop PowerToys
 - Start PowerToys, Open Settings app and navigate to CmdNotFound page
 - See that everything is shown as missing and module disabled
 
Now:
 Scenario works as expected
