### PR TITLE
[runner]Fix triggering non-set hotkeys

### DIFF
--- a/src/runner/centralized_kb_hook.cpp
+++ b/src/runner/centralized_kb_hook.cpp
@@ -151,6 +151,11 @@ namespace CentralizedKeyboardHook
             .key = static_cast<unsigned char>(keyPressInfo.vkCode)
         };
 
+        if (hotkey == Hotkey{})
+        {
+            return CallNextHookEx(hHook, nCode, wParam, lParam);
+        }
+
         std::function<bool()> action;
         {
             // Hold the lock for the shortest possible duration


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Apparently, left-clicking Slack systray icon sends None (vkCode = 0) keyboard input. As all of the modifier keys are false (if not pressed) this is the same as key combination as default non-set Hotkey{}. therefore, whatever non-set hotkey was not set - was triggered. 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #32971 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Without this fix:
- Copy some text
- Left click slack systray icon and observe that text is pasted into slack input text box

With the fix:
- Follow the same steps and observe that nothing is pasted into slack
