### PR TITLE
[Settings][AdvPaste]Check clibboard history gpo

### DIFF
--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/AdvancedPaste.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/AdvancedPaste.xaml
@@ -76,18 +76,18 @@
                     </controls:SettingsGroup>
 
                     <controls:SettingsGroup x:Uid="AdvancedPaste_ClipboardHistorySettingsGroup" IsEnabled="{x:Bind ViewModel.IsEnabled, Mode=OneWay}">
-                        <InfoBar
-                            x:Uid="GPO_SettingIsManaged"
-                            IsClosable="False"
-                            IsOpen="{x:Bind ViewModel.ClipboardHistoryDisabledByGPO, Mode=OneWay}"
-                            IsTabStop="{x:Bind ViewModel.ClipboardHistoryDisabledByGPO, Mode=OneWay}"
-                            Severity="Informational" />
                         <tkcontrols:SettingsCard
                             x:Uid="AdvancedPaste_Clipboard_History_Enabled_SettingsCard"
                             HeaderIcon="{ui:FontIcon Glyph=&#xF0E3;}"
                             IsEnabled="{x:Bind ViewModel.ClipboardHistoryDisabledByGPO, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}">
                             <ToggleSwitch IsOn="{x:Bind ViewModel.ClipboardHistoryEnabled, Mode=TwoWay}" />
                         </tkcontrols:SettingsCard>
+                        <InfoBar
+                            x:Uid="GPO_SettingIsManaged"
+                            IsClosable="False"
+                            IsOpen="{x:Bind ViewModel.ClipboardHistoryDisabledByGPO, Mode=OneWay}"
+                            IsTabStop="{x:Bind ViewModel.ClipboardHistoryDisabledByGPO, Mode=OneWay}"
+                            Severity="Informational" />
                     </controls:SettingsGroup>
 
                     <controls:SettingsGroup x:Uid="AdvancedPaste_Direct_Access_Hotkeys_GroupSettings" IsEnabled="{x:Bind ViewModel.IsEnabled, Mode=OneWay}">

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/AdvancedPaste.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/AdvancedPaste.xaml
@@ -76,7 +76,13 @@
                     </controls:SettingsGroup>
 
                     <controls:SettingsGroup x:Uid="AdvancedPaste_ClipboardHistorySettingsGroup" IsEnabled="{x:Bind ViewModel.IsEnabled, Mode=OneWay}">
-                        <tkcontrols:SettingsCard x:Uid="AdvancedPaste_Clipboard_History_Enabled_SettingsCard" HeaderIcon="{ui:FontIcon Glyph=&#xF0E3;}">
+                        <InfoBar
+                            x:Uid="GPO_SettingIsManaged"
+                            IsClosable="False"
+                            IsOpen="{x:Bind ViewModel.ClipboardHistoryDisabledByGPO, Mode=OneWay}"
+                            IsTabStop="{x:Bind ViewModel.ClipboardHistoryDisabledByGPO, Mode=OneWay}"
+                            Severity="Informational" />
+                        <tkcontrols:SettingsCard x:Uid="AdvancedPaste_Clipboard_History_Enabled_SettingsCard" HeaderIcon="{ui:FontIcon Glyph=&#xF0E3;}" IsEnabled="{x:Bind ViewModel.ClipboardHistoryDisabledByGPO, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}">
                             <ToggleSwitch IsOn="{x:Bind ViewModel.ClipboardHistoryEnabled, Mode=TwoWay}" />
                         </tkcontrols:SettingsCard>
                     </controls:SettingsGroup>

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/AdvancedPaste.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/AdvancedPaste.xaml
@@ -82,7 +82,10 @@
                             IsOpen="{x:Bind ViewModel.ClipboardHistoryDisabledByGPO, Mode=OneWay}"
                             IsTabStop="{x:Bind ViewModel.ClipboardHistoryDisabledByGPO, Mode=OneWay}"
                             Severity="Informational" />
-                        <tkcontrols:SettingsCard x:Uid="AdvancedPaste_Clipboard_History_Enabled_SettingsCard" HeaderIcon="{ui:FontIcon Glyph=&#xF0E3;}" IsEnabled="{x:Bind ViewModel.ClipboardHistoryDisabledByGPO, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}">
+                        <tkcontrols:SettingsCard
+                            x:Uid="AdvancedPaste_Clipboard_History_Enabled_SettingsCard"
+                            HeaderIcon="{ui:FontIcon Glyph=&#xF0E3;}"
+                            IsEnabled="{x:Bind ViewModel.ClipboardHistoryDisabledByGPO, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}">
                             <ToggleSwitch IsOn="{x:Bind ViewModel.ClipboardHistoryEnabled, Mode=TwoWay}" />
                         </tkcontrols:SettingsCard>
                     </controls:SettingsGroup>

--- a/src/settings-ui/Settings.UI/ViewModels/AdvancedPasteViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/AdvancedPasteViewModel.cs
@@ -145,6 +145,27 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             }
         }
 
+        private bool IsClipboardHistoryDisabledByGPO()
+        {
+            string registryKey = @"HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\System\";
+            try
+            {
+                object allowClipboardHistory = Registry.GetValue(registryKey, "AllowClipboardHistory", null);
+                if (allowClipboardHistory != null)
+                {
+                    return (int)allowClipboardHistory == 0;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
         private void SetClipboardHistoryEnabled(bool value)
         {
             string registryKey = @"HKEY_CURRENT_USER\Software\Microsoft\Clipboard\";
@@ -167,6 +188,11 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                     SetClipboardHistoryEnabled(value);
                 }
             }
+        }
+
+        public bool ClipboardHistoryDisabledByGPO
+        {
+            get => IsClipboardHistoryDisabledByGPO();
         }
 
         public HotkeySettings AdvancedPasteUIShortcut


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
(Note: This PR was originally https://github.com/microsoft/PowerToys/pull/32977 but I've tried opening the PR from a different repo to avoid caching errors)
Don't allow enabling/disabling the Clipboard History in Settings if the user has it disabled by GPO.

![image](https://github.com/microsoft/PowerToys/assets/26118718/efde2c4b-808f-4aa9-a62c-520b52382f7b)

![image](https://github.com/microsoft/PowerToys/assets/26118718/04847030-a1f2-4db6-bd87-27de7e331715)


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #32945
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Tested the behavior with the GPO enabled/disabled/not configured.
Message only shows on disabled, as expected.
