### PR TITLE
[ci][Tests]Fix vstest location for VS 17.10 release

### DIFF
--- a/.pipelines/ci/templates/run-ui-tests-ci.yml
+++ b/.pipelines/ci/templates/run-ui-tests-ci.yml
@@ -60,7 +60,7 @@ jobs:
       searchFolder: '$(Pipeline.Workspace)\build-${{ parameters.platform }}-${{ parameters.configuration }}'
       vstestLocationMethod: 'location' # otherwise fails to find vstest.console.exe 
       #vstestLocation: '$(Agent.ToolsDirectory)\VsTest\**\${{ parameters.platform }}\tools\net462\Common7\IDE\Extensions\TestPlatform'
-      vstestLocation: '$(Agent.ToolsDirectory)\VsTest\17.10.0-release-24177-07\x64\tools\net462\Common7\IDE\Extensions\TestPlatform'
+      vstestLocation: '$(Agent.ToolsDirectory)\VsTest\17.10.0\x64\tools\net462\Common7\IDE\Extensions\TestPlatform'
       uiTests: true
       rerunFailedTests: true
       testAssemblyVer2: |


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Updates the VsTest folder for the 17.10 release of Visual Studio, in order to properly run the UI tests in CI.