### PR TITLE
[PTRun]Fix accent on title bar bleed into UI

### DIFF
--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml
@@ -45,6 +45,11 @@
             Grid.Row="0"
             Padding="12,4,12,3">
             <local:LauncherControl x:Name="SearchBox" />
+            <Border.Background>
+                <!-- Setting the background of the search bar to fix https://github.com/microsoft/PowerToys/issues/30206 -->
+                <!-- The title bar accent would bleed if the option to "Show accent color on title bars and windows borders" is enabled on Windows -->
+                <SolidColorBrush Opacity="1" Color="{DynamicResource ApplicationBackgroundColor}" />
+            </Border.Background>
         </Border>
 
         <!--  Have to use a Grid instead of a StackPanel for scrolling to work?  -->

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml
@@ -46,8 +46,8 @@
             Padding="12,4,12,3">
             <local:LauncherControl x:Name="SearchBox" />
             <Border.Background>
-                <!-- Setting the background of the search bar to fix https://github.com/microsoft/PowerToys/issues/30206 -->
-                <!-- The title bar accent would bleed if the option to "Show accent color on title bars and windows borders" is enabled on Windows -->
+                <!--  Setting the background of the search bar to fix https://github.com/microsoft/PowerToys/issues/30206  -->
+                <!--  The title bar accent would bleed if the option to "Show accent color on title bars and windows borders" is enabled on Windows  -->
                 <SolidColorBrush Opacity="1" Color="{DynamicResource ApplicationBackgroundColor}" />
             </Border.Background>
         </Border>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

There's this option on Windows, called "Show accent color on title bars and windows borders":

![image](https://github.com/microsoft/PowerToys/assets/26118718/505e7826-cda1-47c7-9226-101305ea8db4)


It makes PowerToys Run look like this:
![image](https://github.com/microsoft/PowerToys/assets/26118718/0311943f-c5f6-4c98-9d36-7356fe132898)

WPF UI doesn't seem to give much tools in terms of overriding that, so we make the search box opaque instead:

![image](https://github.com/microsoft/PowerToys/assets/26118718/43dabe1d-85d3-43bf-a012-d507b012e639)


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #30206 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx
