### PR TITLE
[Quick Accent] Add IPA

### DIFF
--- a/src/modules/poweraccent/PowerAccent.Core/Languages.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/Languages.cs
@@ -795,6 +795,7 @@ namespace PowerAccent.Core
                 LetterKey.VK_W => new[] { "ɰ", "ɯ" },
                 LetterKey.VK_Y => new[] { "ʏ" },
                 LetterKey.VK_Z => new[] { "ʒ", "ʐ", "ʑ" },
+                LetterKey.VK_COMMA => new[] { "ʡ", "ʔ", "ʕ", "ʢ" },
                 _ => Array.Empty<string>(),
             };
         }

--- a/src/modules/poweraccent/PowerAccent.Core/Languages.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/Languages.cs
@@ -27,6 +27,7 @@ namespace PowerAccent.Core
         HE,
         HU,
         IS,
+        IPA,
         IT,
         KU,
         LT,
@@ -70,6 +71,7 @@ namespace PowerAccent.Core
                 Language.HE => GetDefaultLetterKeyHE(letter), // Hebrew
                 Language.HU => GetDefaultLetterKeyHU(letter), // Hungarian
                 Language.IS => GetDefaultLetterKeyIS(letter), // Iceland
+                Language.IPA => GetDefaultLetterKeyIPA(letter), // IPA (International phonetic alphabet)
                 Language.IT => GetDefaultLetterKeyIT(letter), // Italian
                 Language.KU => GetDefaultLetterKeyKU(letter), // Kurdish
                 Language.LT => GetDefaultLetterKeyLT(letter), // Lithuanian
@@ -116,6 +118,7 @@ namespace PowerAccent.Core
                 .Union(GetDefaultLetterKeyHE(letter))
                 .Union(GetDefaultLetterKeyHU(letter))
                 .Union(GetDefaultLetterKeyIS(letter))
+                .Union(GetDefaultLetterKeyIPA(letter))
                 .Union(GetDefaultLetterKeyIT(letter))
                 .Union(GetDefaultLetterKeyKU(letter))
                 .Union(GetDefaultLetterKeyLT(letter))
@@ -766,6 +769,32 @@ namespace PowerAccent.Core
                 LetterKey.VK_E => new[] { "€" },
                 LetterKey.VK_S => new[] { "š" },
                 LetterKey.VK_Z => new[] { "ž" },
+                _ => Array.Empty<string>(),
+            };
+        }
+
+        private static string[] GetDefaultLetterKeyIPA(LetterKey letter)
+        {
+            return letter switch
+            {
+                LetterKey.VK_A => new[] { "ɐ", "ɑ", "ɒ" },
+                LetterKey.VK_B => new[] { "ʙ" },
+                LetterKey.VK_E => new[] { "ɘ", "ɵ", "ə", "ɛ", "ɜ", "ɞ" },
+                LetterKey.VK_F => new[] { "ɟ", "ɸ" },
+                LetterKey.VK_G => new[] { "ɢ", "ɣ" },
+                LetterKey.VK_H => new[] { "ɦ", "ʜ" },
+                LetterKey.VK_I => new[] { "ɨ", "ɪ" },
+                LetterKey.VK_J => new[] { "ʝ" },
+                LetterKey.VK_L => new[] { "ɬ", "ɮ", "ꞎ", "ɭ", "ʎ", "ʟ", "ɺ" },
+                LetterKey.VK_N => new[] { "ɳ", "ɲ", "ŋ", "ɴ" },
+                LetterKey.VK_O => new[] { "ɤ", "ɔ", "ɶ" },
+                LetterKey.VK_R => new[] { "ʁ", "ɹ", "ɻ", "ɾ", "ɽ", "ʀ" },
+                LetterKey.VK_S => new[] { "ʃ", "ʂ", "ɕ" },
+                LetterKey.VK_U => new[] { "ʉ", "ʊ" },
+                LetterKey.VK_V => new[] { "ʋ", "ⱱ", "ʌ" },
+                LetterKey.VK_W => new[] { "ɰ", "ɯ" },
+                LetterKey.VK_Y => new[] { "ʏ" },
+                LetterKey.VK_Z => new[] { "ʒ", "ʐ", "ʑ" },
                 _ => Array.Empty<string>(),
             };
         }

--- a/src/modules/poweraccent/PowerAccent.Core/Languages.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/Languages.cs
@@ -773,6 +773,7 @@ namespace PowerAccent.Core
             };
         }
 
+        // IPA (International Phonetic Alphabet)
         private static string[] GetDefaultLetterKeyIPA(LetterKey letter)
         {
             return letter switch

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerAccentPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerAccentPage.xaml
@@ -70,6 +70,7 @@
                             <ComboBoxItem x:Uid="QuickAccent_SelectedLanguage_Hebrew" />
                             <ComboBoxItem x:Uid="QuickAccent_SelectedLanguage_Hungarian" />
                             <ComboBoxItem x:Uid="QuickAccent_SelectedLanguage_Icelandic" />
+                            <ComboBoxItem x:Uid="QuickAccent_SelectedLanguage_IPA" />
                             <ComboBoxItem x:Uid="QuickAccent_SelectedLanguage_Italian" />
                             <ComboBoxItem x:Uid="QuickAccent_SelectedLanguage_Kurdish" />
                             <ComboBoxItem x:Uid="QuickAccent_SelectedLanguage_Lithuanian" />

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -3486,6 +3486,7 @@ Activate by holding the key for the character you want to add an accent to, then
   </data>
   <data name="QuickAccent_SelectedLanguage_IPA.Content" xml:space="preserve">
     <value>IPA</value>
+    <comment>International Phonetic Alphabet</comment>
   </data>
   <data name="QuickAccent_SelectedLanguage_Lithuanian.Content" xml:space="preserve">
     <value>Lithuanian</value>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -3484,6 +3484,9 @@ Activate by holding the key for the character you want to add an accent to, then
   <data name="QuickAccent_SelectedLanguage_Esperanto.Content" xml:space="preserve">
     <value>Esperanto</value>
   </data>
+  <data name="QuickAccent_SelectedLanguage_IPA.Content" xml:space="preserve">
+    <value>IPA</value>
+  </data>
   <data name="QuickAccent_SelectedLanguage_Lithuanian.Content" xml:space="preserve">
     <value>Lithuanian</value>
   </data>

--- a/src/settings-ui/Settings.UI/ViewModels/PowerAccentViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/PowerAccentViewModel.cs
@@ -41,6 +41,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             "HE",
             "HU",
             "IS",
+            "IPA",
             "IT",
             "KU",
             "LT",


### PR DESCRIPTION
## Summary of the Pull Request
Adds characters for the International Phonetic Alphabet

## PR Checklist

- [x] **Closes:** #25860, #27627
- [x] **Communication:** I've discussed this with core contributors already.
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [x] **Dev docs:** No need
- [x] **New binaries:** None
- [x] **Documentation updated:** No need

## Detailed Description of the Pull Request / Additional comments
Adds IPA to Quick Accent as a separate language. The table with all the characters is in #25860

## Validation Steps Performed
Observing