### PR TITLE
[Quick Accent] Fix character description not being visually centered

### DIFF
--- a/src/modules/poweraccent/PowerAccent.Core/PowerAccent.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/PowerAccent.cs
@@ -150,7 +150,7 @@ public class PowerAccent : IDisposable
         {
             var unicode = unicodeList.First();
             var charUnicodeNumber = unicode.CodePoint.ToString("X4", CultureInfo.InvariantCulture);
-            description.AppendFormat(CultureInfo.InvariantCulture, "(U+{0}) {1} ", charUnicodeNumber, unicode.Name);
+            description.AppendFormat(CultureInfo.InvariantCulture, "(U+{0}) {1}", charUnicodeNumber, unicode.Name);
 
             return description.ToString();
         }


### PR DESCRIPTION
## Summary of the Pull Request
The description string has an unnecessary space at the end, causing it to appear off center. This PR fixes that by removing that space.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #30474
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [x] **Dev docs:** No need
- [x] **New binaries:** None
- [x] **Documentation updated:** No need

## Validation Steps Performed
Triggering Quick Accent and measuring if the description is centered using Screen Ruler.