### PR TITLE
shifting Store to user based vs machine

### DIFF
--- a/.github/workflows/msstore-submissions.yml
+++ b/.github/workflows/msstore-submissions.yml
@@ -16,7 +16,7 @@ jobs:
         run: |
           release=$(curl https://api.github.com/repos/Microsoft/PowerToys/releases | jq '[.[]|select(.name | contains("Release"))][0]')
           assets=$(jq -n "$release" | jq '.assets')
-          powerToysSetup=$(jq -n "$assets" | jq '[.[]|select(.name | contains("PowerToysSetup"))]')
+          powerToysSetup=$(jq -n "$assets" | jq '[.[]|select(.name | contains("PowerToysUserSetup"))]')
           echo ::set-output name=powerToysInstallerX64Url::$(jq -n "$powerToysSetup" | jq -r '[.[]|select(.name | contains("x64"))][0].browser_download_url')
           echo ::set-output name=powerToysInstallerArm64Url::$(jq -n "$powerToysSetup" | jq -r '[.[]|select(.name | contains("arm64"))][0].browser_download_url')
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Looks like we've been sending the default to store to be machine wide, this will shift to PowerToysUserSetup based installer instead.  The machine wide does a UAC dialog which is not ideal.

PowerToysUserSetup-0.81.1-arm64.exe vs PowerToysSetup-0.81.1-arm64.exe

As store does not actively update Win32 apps, this should be a 'foward moving' update