### PR TITLE
Changed Unit Converter description (#17612)

### DIFF
--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/Properties/Resources.Designer.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/Properties/Resources.Designer.cs
@@ -88,7 +88,7 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Provides unit conversion (e.g. 10 ft in m).
+        ///   Looks up a localized string similar to Provides unit conversion (e.g. 10 ft to m).
         /// </summary>
         public static string plugin_description {
             get {

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/Properties/Resources.resx
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/Properties/Resources.resx
@@ -127,7 +127,7 @@
     <value>Copy {0} to clipboard</value>
   </data>
   <data name="plugin_description" xml:space="preserve">
-    <value>Provides unit conversion (e.g. 10 ft in m)</value>
+    <value>Provides unit conversion (e.g. 10 ft to m)</value>
   </data>
   <data name="plugin_name" xml:space="preserve">
     <value>Unit Converter</value>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Changed the description of the Unit Converter plugin for PowerToys Run to use "to" instead of "in".
The word "in" can be confused for the abbreviation "in" as in "inches". Using "to" means the same thing, but it isn't a unit abbreviation.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #17612
- [x] **Communication:** Discussed on issue
- [x] **Tests:** None relevant
- [x] **Localization:** All end user facing strings can be localized
- [x] **Dev docs:** No necessary changes
- [x] **New binaries:** None required
- [x] **Documentation updated:** Not necessary
