### PR TITLE
[PT Run][Calculator] Ignore regional formatting

### DIFF
--- a/doc/devdocs/modules/launcher/plugins/calculator.md
+++ b/doc/devdocs/modules/launcher/plugins/calculator.md
@@ -11,7 +11,7 @@ The Calculator plugin as the name suggests is used to perform calculations on th
 	|--------------|-----------|------------|------------|
 	| `InputUseEnglishFormat` | `false` | Use English (United States) number format for input | Ignores your system setting and expects numbers in the format '1,000.50' |
 	| `OutputUseEnglishFormat` | `false` | Use English (United States) number format for output | Ignores your system setting and returns numbers in the format '1000.50' |
-	| `IgnoreRegionalFormatting` | `false` | Ignore delimiters from non-native formatting in input | Changes input to match your regional setting, treating the last non-digit symbol as decimal separator |
+	| `IgnoreRegionalFormatting` | `false` | Ignore difference between decimal and group separators | Ignores difference between '.' and ',', treating the last of them as the decimal separator |
 
 * The optional plugin settings are implemented via the [`ISettingProvider`](/src/modules/launcher/Wox.Plugin/ISettingProvider.cs) interface from `Wox.Plugin` project. All available settings for the plugin are defined in the [`Main`](/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/Main.cs) class of the plugin.
 

--- a/doc/devdocs/modules/launcher/plugins/calculator.md
+++ b/doc/devdocs/modules/launcher/plugins/calculator.md
@@ -11,7 +11,7 @@ The Calculator plugin as the name suggests is used to perform calculations on th
 	|--------------|-----------|------------|------------|
 	| `InputUseEnglishFormat` | `false` | Use English (United States) number format for input | Ignores your system setting and expects numbers in the format '1,000.50' |
 	| `OutputUseEnglishFormat` | `false` | Use English (United States) number format for output | Ignores your system setting and returns numbers in the format '1000.50' |
-	| `IgnoreRegionalInput` | `false` | Ignore delimiters from non-native formatting in input | Changes input to match your regional setting, treating the last non-digit symbol as decimal separator |
+	| `IgnoreRegionalFormatting` | `false` | Ignore delimiters from non-native formatting in input | Changes input to match your regional setting, treating the last non-digit symbol as decimal separator |
 
 * The optional plugin settings are implemented via the [`ISettingProvider`](/src/modules/launcher/Wox.Plugin/ISettingProvider.cs) interface from `Wox.Plugin` project. All available settings for the plugin are defined in the [`Main`](/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/Main.cs) class of the plugin.
 

--- a/doc/devdocs/modules/launcher/plugins/calculator.md
+++ b/doc/devdocs/modules/launcher/plugins/calculator.md
@@ -11,6 +11,7 @@ The Calculator plugin as the name suggests is used to perform calculations on th
 	|--------------|-----------|------------|------------|
 	| `InputUseEnglishFormat` | `false` | Use English (United States) number format for input | Ignores your system setting and expects numbers in the format '1,000.50' |
 	| `OutputUseEnglishFormat` | `false` | Use English (United States) number format for output | Ignores your system setting and returns numbers in the format '1000.50' |
+	| `IgnoreRegionalInput` | `false` | Ignore delimiters from non-native formatting in input | Changes input to match your regional setting, treating the last non-digit symbol as decimal separator |
 
 * The optional plugin settings are implemented via the [`ISettingProvider`](/src/modules/launcher/Wox.Plugin/ISettingProvider.cs) interface from `Wox.Plugin` project. All available settings for the plugin are defined in the [`Main`](/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/Main.cs) class of the plugin.
 

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator.UnitTest/NumberTranslatorTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator.UnitTest/NumberTranslatorTests.cs
@@ -179,5 +179,23 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
             Assert.IsNotNull(result);
             Assert.AreEqual(expectedResult, result);
         }
+
+        [DataTestMethod]
+        [DataRow("2,5", "2.5", true)]
+        [DataRow("2,5*10", "2.5*10", true)]
+        [DataRow("2,5", "25", false)]
+        [DataRow("2,5*10", "25*10", false)]
+        public void Translate_Ignoring_Regional_Formatting(string input, string expectedResult, bool ignoreRegionalFormatting)
+        {
+            // Arrange
+            var translator = NumberTranslator.Create(new CultureInfo("en-US", false), new CultureInfo("en-US", false));
+
+            // Act
+            var result = translator.Translate(input, ignoreRegionalFormatting);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(expectedResult, result);
+        }
     }
 }

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/Main.cs
@@ -20,6 +20,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
         private const string InputUseEnglishFormat = nameof(InputUseEnglishFormat);
         private const string OutputUseEnglishFormat = nameof(OutputUseEnglishFormat);
         private const string ReplaceInput = nameof(ReplaceInput);
+        private const string IgnoreRegionalInput = nameof(IgnoreRegionalInput);
 
         private static readonly CalculateEngine CalculateEngine = new CalculateEngine();
 
@@ -30,6 +31,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
         private bool _inputUseEnglishFormat;
         private bool _outputUseEnglishFormat;
         private bool _replaceInput;
+        private bool _ignoreRegionalInput;
 
         public string Name => Resources.wox_plugin_calculator_plugin_name;
 
@@ -66,6 +68,13 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
                 DisplayDescription = Resources.wox_plugin_calculator_replace_input_description,
                 Value = true,
             },
+            new PluginAdditionalOption
+            {
+                Key = IgnoreRegionalInput,
+                DisplayLabel = Resources.wox_plugin_calculator_ignore_regional_input,
+                DisplayDescription = Resources.wox_plugin_calculator_ignore_regional_input_description,
+                Value = false,
+            },
         };
 
         public List<Result> Query(Query query)
@@ -84,7 +93,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
             }
 
             NumberTranslator translator = NumberTranslator.Create(inputCulture, new CultureInfo("en-US"));
-            var input = translator.Translate(query.Search.Normalize(NormalizationForm.FormKC));
+            var input = translator.Translate(query.Search.Normalize(NormalizationForm.FormKC), _ignoreRegionalInput);
 
             if (replaceInput)
             {
@@ -182,6 +191,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
             var inputUseEnglishFormat = false;
             var outputUseEnglishFormat = false;
             var replaceInput = true;
+            var ignoreRegionalInput = false;
 
             if (settings != null && settings.AdditionalOptions != null)
             {
@@ -193,11 +203,15 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
 
                 var optionReplaceInput = settings.AdditionalOptions.FirstOrDefault(x => x.Key == ReplaceInput);
                 replaceInput = optionReplaceInput?.Value ?? replaceInput;
+
+                var optionIgnoreRegionalInput = settings.AdditionalOptions.FirstOrDefault(x => x.Key == IgnoreRegionalInput);
+                ignoreRegionalInput = optionIgnoreRegionalInput?.Value ?? ignoreRegionalInput;
             }
 
             _inputUseEnglishFormat = inputUseEnglishFormat;
             _outputUseEnglishFormat = outputUseEnglishFormat;
             _replaceInput = replaceInput;
+            _ignoreRegionalInput = ignoreRegionalInput;
         }
 
         public void Dispose()

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/Main.cs
@@ -20,7 +20,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
         private const string InputUseEnglishFormat = nameof(InputUseEnglishFormat);
         private const string OutputUseEnglishFormat = nameof(OutputUseEnglishFormat);
         private const string ReplaceInput = nameof(ReplaceInput);
-        private const string IgnoreRegionalInput = nameof(IgnoreRegionalInput);
+        private const string IgnoreRegionalFormatting = nameof(IgnoreRegionalFormatting);
 
         private static readonly CalculateEngine CalculateEngine = new CalculateEngine();
 
@@ -31,7 +31,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
         private bool _inputUseEnglishFormat;
         private bool _outputUseEnglishFormat;
         private bool _replaceInput;
-        private bool _ignoreRegionalInput;
+        private bool _ignoreRegionalFormatting;
 
         public string Name => Resources.wox_plugin_calculator_plugin_name;
 
@@ -70,9 +70,9 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
             },
             new PluginAdditionalOption
             {
-                Key = IgnoreRegionalInput,
-                DisplayLabel = Resources.wox_plugin_calculator_ignore_regional_input,
-                DisplayDescription = Resources.wox_plugin_calculator_ignore_regional_input_description,
+                Key = IgnoreRegionalFormatting,
+                DisplayLabel = Resources.wox_plugin_calculator_ignore_regional_formatting,
+                DisplayDescription = Resources.wox_plugin_calculator_ignore_regional_formatting_description,
                 Value = false,
             },
         };
@@ -93,7 +93,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
             }
 
             NumberTranslator translator = NumberTranslator.Create(inputCulture, new CultureInfo("en-US"));
-            var input = translator.Translate(query.Search.Normalize(NormalizationForm.FormKC), _ignoreRegionalInput);
+            var input = translator.Translate(query.Search.Normalize(NormalizationForm.FormKC), _ignoreRegionalFormatting);
 
             if (replaceInput)
             {
@@ -191,7 +191,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
             var inputUseEnglishFormat = false;
             var outputUseEnglishFormat = false;
             var replaceInput = true;
-            var ignoreRegionalInput = false;
+            var ignoreRegionalFormatting = false;
 
             if (settings != null && settings.AdditionalOptions != null)
             {
@@ -204,14 +204,14 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
                 var optionReplaceInput = settings.AdditionalOptions.FirstOrDefault(x => x.Key == ReplaceInput);
                 replaceInput = optionReplaceInput?.Value ?? replaceInput;
 
-                var optionIgnoreRegionalInput = settings.AdditionalOptions.FirstOrDefault(x => x.Key == IgnoreRegionalInput);
-                ignoreRegionalInput = optionIgnoreRegionalInput?.Value ?? ignoreRegionalInput;
+                var optionIgnoreRegionalInput = settings.AdditionalOptions.FirstOrDefault(x => x.Key == IgnoreRegionalFormatting);
+                ignoreRegionalFormatting = optionIgnoreRegionalInput?.Value ?? ignoreRegionalFormatting;
             }
 
             _inputUseEnglishFormat = inputUseEnglishFormat;
             _outputUseEnglishFormat = outputUseEnglishFormat;
             _replaceInput = replaceInput;
-            _ignoreRegionalInput = ignoreRegionalInput;
+            _ignoreRegionalFormatting = ignoreRegionalFormatting;
         }
 
         public void Dispose()

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/Main.cs
@@ -43,6 +43,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
 
         private static readonly CompositeFormat WoxPluginCalculatorInEnFormatDescription = System.Text.CompositeFormat.Parse(Properties.Resources.wox_plugin_calculator_in_en_format_description);
         private static readonly CompositeFormat WoxPluginCalculatorOutEnFormatDescription = System.Text.CompositeFormat.Parse(Properties.Resources.wox_plugin_calculator_out_en_format_description);
+        private static readonly CompositeFormat WoxPluginCalculatorIgnoreRegionalDescription = System.Text.CompositeFormat.Parse(Properties.Resources.wox_plugin_calculator_ignore_regional_formatting_description);
 
         public IEnumerable<PluginAdditionalOption> AdditionalOptions => new List<PluginAdditionalOption>()
         {
@@ -72,7 +73,11 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
             {
                 Key = IgnoreRegionalFormatting,
                 DisplayLabel = Resources.wox_plugin_calculator_ignore_regional_formatting,
-                DisplayDescription = Resources.wox_plugin_calculator_ignore_regional_formatting_description,
+                DisplayDescription = string.Format(
+                    CultureInfo.CurrentCulture,
+                    WoxPluginCalculatorIgnoreRegionalDescription,
+                    CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator,
+                    CultureInfo.CurrentCulture.NumberFormat.NumberGroupSeparator),
                 Value = false,
             },
         };

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/NumberTranslator.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/NumberTranslator.cs
@@ -128,6 +128,8 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
                         {
                             var separatorRegex = new Regex(@"[^\d](?=.*[^\d])");
                             token_bis = separatorRegex.Replace(token, string.Empty);
+                            var separatorRegex2 = new Regex(@"[^\d]");
+                            token_bis = separatorRegex2.Replace(token_bis, cultureFrom.NumberFormat.NumberDecimalSeparator);
                         }
                     }
 

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/NumberTranslator.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/NumberTranslator.cs
@@ -135,13 +135,10 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
                     {
                         if (!string.IsNullOrEmpty(token))
                         {
-                            if (char.IsDigit(token[0]))
-                            {
-                                var separatorRegex = new Regex(@"[^\d](?=.*[^\d])");
-                                token_bis = separatorRegex.Replace(token, string.Empty);
-                                var separatorRegex2 = new Regex(@"[^\d]");
-                                token_bis = separatorRegex2.Replace(token_bis, cultureFrom.NumberFormat.NumberDecimalSeparator);
-                            }
+                            var separatorRegex = new Regex(@"[^\d](?=.*[^\d])");
+                            token_bis = separatorRegex.Replace(token, string.Empty);
+                            var separatorRegex2 = new Regex(@"[^\d]");
+                            token_bis = separatorRegex2.Replace(token_bis, cultureFrom.NumberFormat.NumberDecimalSeparator);
                         }
                     }
 

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/NumberTranslator.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/NumberTranslator.cs
@@ -119,9 +119,20 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
                     }
 
                     decimal number;
+                    var token_bis = token;
+
+                    // if (RegionalInput flag)
+                    if (!string.IsNullOrEmpty(token))
+                    {
+                        if (char.IsDigit(token[0]))
+                        {
+                            var separatorRegex = new Regex(@"[^\d](?=.*[^\d])");
+                            token_bis = separatorRegex.Replace(token, string.Empty);
+                        }
+                    }
 
                     outputBuilder.Append(
-                        decimal.TryParse(token, NumberStyles.Number, cultureFrom, out number)
+                        decimal.TryParse(token_bis, NumberStyles.Number, cultureFrom, out number)
                         ? (new string('0', leadingZeroCount) + number.ToString(cultureTo))
                         : token);
                 }

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/NumberTranslator.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/NumberTranslator.cs
@@ -58,9 +58,9 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
         /// </summary>
         /// <param name="input">input string to translate</param>
         /// <returns>translated string</returns>
-        public string Translate(string input, bool ignoreRegionalInput)
+        public string Translate(string input, bool ignoreRegionalFormatting)
         {
-            return Translate(input, sourceCulture, targetCulture, splitRegexForSource, ignoreRegionalInput);
+            return Translate(input, sourceCulture, targetCulture, splitRegexForSource, ignoreRegionalFormatting);
         }
 
         /// <summary>
@@ -73,7 +73,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
             return Translate(input, targetCulture, sourceCulture, splitRegexForTarget, false);
         }
 
-        private static string Translate(string input, CultureInfo cultureFrom, CultureInfo cultureTo, Regex splitRegex, bool ignoreRegionalInput)
+        private static string Translate(string input, CultureInfo cultureFrom, CultureInfo cultureTo, Regex splitRegex, bool ignoreRegionalFormatting)
         {
             var outputBuilder = new StringBuilder();
             var hexRegex = new Regex(@"(?:(0x[\da-fA-F]+))");
@@ -131,7 +131,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
                     decimal number;
                     var token_bis = token;
 
-                    if (ignoreRegionalInput)
+                    if (ignoreRegionalFormatting)
                     {
                         if (!string.IsNullOrEmpty(token))
                         {

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/NumberTranslator.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/NumberTranslator.cs
@@ -50,7 +50,17 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
         /// <returns>translated string</returns>
         public string Translate(string input)
         {
-            return Translate(input, sourceCulture, targetCulture, splitRegexForSource);
+            return Translate(input, sourceCulture, targetCulture, splitRegexForSource, false);
+        }
+
+        /// <summary>
+        /// Translate from source to target culture.
+        /// </summary>
+        /// <param name="input">input string to translate</param>
+        /// <returns>translated string</returns>
+        public string Translate(string input, bool ignoreRegionalInput)
+        {
+            return Translate(input, sourceCulture, targetCulture, splitRegexForSource, ignoreRegionalInput);
         }
 
         /// <summary>
@@ -60,10 +70,10 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
         /// <returns>source culture string</returns>
         public string TranslateBack(string input)
         {
-            return Translate(input, targetCulture, sourceCulture, splitRegexForTarget);
+            return Translate(input, targetCulture, sourceCulture, splitRegexForTarget, false);
         }
 
-        private static string Translate(string input, CultureInfo cultureFrom, CultureInfo cultureTo, Regex splitRegex)
+        private static string Translate(string input, CultureInfo cultureFrom, CultureInfo cultureTo, Regex splitRegex, bool ignoreRegionalInput)
         {
             var outputBuilder = new StringBuilder();
             var hexRegex = new Regex(@"(?:(0x[\da-fA-F]+))");
@@ -121,15 +131,17 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
                     decimal number;
                     var token_bis = token;
 
-                    // if (RegionalInput flag)
-                    if (!string.IsNullOrEmpty(token))
+                    if (ignoreRegionalInput)
                     {
-                        if (char.IsDigit(token[0]))
+                        if (!string.IsNullOrEmpty(token))
                         {
-                            var separatorRegex = new Regex(@"[^\d](?=.*[^\d])");
-                            token_bis = separatorRegex.Replace(token, string.Empty);
-                            var separatorRegex2 = new Regex(@"[^\d]");
-                            token_bis = separatorRegex2.Replace(token_bis, cultureFrom.NumberFormat.NumberDecimalSeparator);
+                            if (char.IsDigit(token[0]))
+                            {
+                                var separatorRegex = new Regex(@"[^\d](?=.*[^\d])");
+                                token_bis = separatorRegex.Replace(token, string.Empty);
+                                var separatorRegex2 = new Regex(@"[^\d]");
+                                token_bis = separatorRegex2.Replace(token_bis, cultureFrom.NumberFormat.NumberDecimalSeparator);
+                            }
                         }
                     }
 

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/Properties/Resources.Designer.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/Properties/Resources.Designer.cs
@@ -115,6 +115,24 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Ignore regional formatting, using the last delimiter symbol to separate whole and decimal parts.
+        /// </summary>
+        public static string wox_plugin_calculator_ignore_regional_input {
+            get {
+                return ResourceManager.GetString("wox_plugin_calculator_ignore_regional_input", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Only uses the last delimiter symbol, treating &apos;1 234.567,89&apos; as &apos;{0}&apos;..
+        /// </summary>
+        public static string wox_plugin_calculator_ignore_regional_input_description {
+            get {
+                return ResourceManager.GetString("wox_plugin_calculator_ignore_regional_input_description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Use English (United States) number format for input.
         /// </summary>
         public static string wox_plugin_calculator_in_en_format {

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/Properties/Resources.Designer.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/Properties/Resources.Designer.cs
@@ -124,7 +124,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Only uses the last delimiter symbol, treating &apos;1 234.567,89&apos; as &apos;{0}&apos;..
+        ///   Looks up a localized string similar to Changes input to match your regional setting, treating the last non-digit symbol as decimal separator.
         /// </summary>
         public static string wox_plugin_calculator_ignore_regional_input_description {
             get {

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/Properties/Resources.Designer.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/Properties/Resources.Designer.cs
@@ -117,18 +117,18 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Ignore regional formatting, using the last delimiter symbol to separate whole and decimal parts.
         /// </summary>
-        public static string wox_plugin_calculator_ignore_regional_input {
+        public static string wox_plugin_calculator_ignore_regional_formatting {
             get {
-                return ResourceManager.GetString("wox_plugin_calculator_ignore_regional_input", resourceCulture);
+                return ResourceManager.GetString("wox_plugin_calculator_ignore_regional_formatting", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to Changes input to match your regional setting, treating the last non-digit symbol as decimal separator.
         /// </summary>
-        public static string wox_plugin_calculator_ignore_regional_input_description {
+        public static string wox_plugin_calculator_ignore_regional_formatting_description {
             get {
-                return ResourceManager.GetString("wox_plugin_calculator_ignore_regional_input_description", resourceCulture);
+                return ResourceManager.GetString("wox_plugin_calculator_ignore_regional_formatting_description", resourceCulture);
             }
         }
         

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/Properties/Resources.Designer.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/Properties/Resources.Designer.cs
@@ -115,7 +115,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Ignore regional formatting, using the last delimiter symbol to separate whole and decimal parts.
+        ///   Looks up a localized string similar to Ignore difference between decimal and group separators.
         /// </summary>
         public static string wox_plugin_calculator_ignore_regional_formatting {
             get {
@@ -124,7 +124,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Changes input to match your regional setting, treating the last non-digit symbol as decimal separator.
+        ///   Looks up a localized string similar to Ignores difference between &apos;{0}&apos; and &apos;{1}&apos;, treating the last of them as the decimal separator.
         /// </summary>
         public static string wox_plugin_calculator_ignore_regional_formatting_description {
             get {

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/Properties/Resources.resx
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/Properties/Resources.resx
@@ -171,7 +171,6 @@
     <value>Ignore regional formatting, using the last delimiter symbol to separate whole and decimal parts</value>
   </data>
   <data name="wox_plugin_calculator_ignore_regional_input_description" xml:space="preserve">
-    <value>Only uses the last delimiter symbol, treating '1 234.567,89' as '{0}'.</value>
-    <comment>{0} is a placeholder and will be replaced in code.</comment>
+    <value>Changes input to match your regional setting, treating the last non-digit symbol as decimal separator</value>
   </data>
 </root>

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/Properties/Resources.resx
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/Properties/Resources.resx
@@ -168,9 +168,10 @@
     <value>When using direct activation, appending '=' to the expression will replace the input with the calculated result (e.g. '=5*3-2=' will change the query to '=13').</value>
   </data>
   <data name="wox_plugin_calculator_ignore_regional_formatting" xml:space="preserve">
-    <value>Ignore regional formatting, using the last delimiter symbol to separate whole and decimal parts</value>
+    <value>Ignore difference between decimal and group separators</value>
   </data>
   <data name="wox_plugin_calculator_ignore_regional_formatting_description" xml:space="preserve">
-    <value>Changes input to match your regional setting, treating the last non-digit symbol as decimal separator</value>
+    <value>Ignores difference between '{0}' and '{1}', treating the last of them as the decimal separator</value>
+    <comment>{0} and {1} are placeholders and will be replaced in code</comment>
   </data>
 </root>

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/Properties/Resources.resx
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/Properties/Resources.resx
@@ -167,4 +167,11 @@
   <data name="wox_plugin_calculator_replace_input_description" xml:space="preserve">
     <value>When using direct activation, appending '=' to the expression will replace the input with the calculated result (e.g. '=5*3-2=' will change the query to '=13').</value>
   </data>
+  <data name="wox_plugin_calculator_ignore_regional_input" xml:space="preserve">
+    <value>Ignore regional formatting, using the last delimiter symbol to separate whole and decimal parts</value>
+  </data>
+  <data name="wox_plugin_calculator_ignore_regional_input_description" xml:space="preserve">
+    <value>Only uses the last delimiter symbol, treating '1 234.567,89' as '{0}'.</value>
+    <comment>{0} is a placeholder and will be replaced in code.</comment>
+  </data>
 </root>

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/Properties/Resources.resx
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/Properties/Resources.resx
@@ -167,10 +167,10 @@
   <data name="wox_plugin_calculator_replace_input_description" xml:space="preserve">
     <value>When using direct activation, appending '=' to the expression will replace the input with the calculated result (e.g. '=5*3-2=' will change the query to '=13').</value>
   </data>
-  <data name="wox_plugin_calculator_ignore_regional_input" xml:space="preserve">
+  <data name="wox_plugin_calculator_ignore_regional_formatting" xml:space="preserve">
     <value>Ignore regional formatting, using the last delimiter symbol to separate whole and decimal parts</value>
   </data>
-  <data name="wox_plugin_calculator_ignore_regional_input_description" xml:space="preserve">
+  <data name="wox_plugin_calculator_ignore_regional_formatting_description" xml:space="preserve">
     <value>Changes input to match your regional setting, treating the last non-digit symbol as decimal separator</value>
   </data>
 </root>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #32739 
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [x] **Dev docs:** Added/updated
- [x] **New binaries:** Not needed
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Initial issue has been inconsistency when pressing `.` on numpad in Russian, which would produce non-English decimal separators (namely, for my locale, `,` instead of `.`). This PR aims to fix that by introducing a new optional flag `IgnoreRegionalFormatting` and editing the input in NumberTranslator.cs to remove all but last separators and replace the last with the locale-appropriate one.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Open PT Run and enter same mixed decimal number with different decimal separators, and see that if the flag is turned on, the exact symbol for the decimal separator doesn't matter. Couple tests were created to check it.