### PR TITLE
[PreviewHandlers] Check for Disposed state when updating window bounds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -85,7 +85,7 @@
     <UsePrecompiledHeaders Condition="'$(TF_BUILD)' != ''">false</UsePrecompiledHeaders>
 
     <!-- Change this to bust the cache -->
-    <MSBuildCacheCacheUniverse Condition="'$(MSBuildCacheCacheUniverse)' == ''">202310210737</MSBuildCacheCacheUniverse>
+    <MSBuildCacheCacheUniverse Condition="'$(MSBuildCacheCacheUniverse)' == ''">202406130737</MSBuildCacheCacheUniverse>
 
     <!--
       Visual Studio telemetry reads various ApplicationInsights.config files and other files after the project is finished, likely in a detached process.

--- a/src/modules/previewpane/common/controls/FormHandlerControl.cs
+++ b/src/modules/previewpane/common/controls/FormHandlerControl.cs
@@ -120,6 +120,12 @@ namespace Common
         /// </summary>
         public void UpdateWindowBounds(IntPtr hwnd, Rectangle newBounds)
         {
+            if (this.Disposing || this.IsDisposed)
+            {
+                // For unclear reasons, this can be called when handling an error and the form has already been disposed.
+                return;
+            }
+
             // We must set the WS_CHILD style to change the form to a control within the Explorer preview pane
             int windowStyle = NativeMethods.GetWindowLong(Handle, gwlStyle);
             if ((windowStyle & wsChild) == 0)


### PR DESCRIPTION
# Summary of the Pull Request

We've received some `System.ObjectDisposedException` crashes from Watson with stack-traces similar to the below. It appears  that one of our exception-handlers ends up raising a `DEV_FILES_PREVIEW_RESIZE_EVENT` that causes us to try to update window bounds after the associated control has been disposed.

I am unable to repro this despite my best efforts, but this change should still help address the problem.

```
PowerToys.PreviewHandlerCommon.dll!Common.FormHandlerControl.UpdateWindowBounds
PowerToys.PreviewHandlerCommon.dll!Common.FormHandlerControl.SetRect
PowerToys.MonacoPreviewHandler.dll!Microsoft.PowerToys.PreviewHandler.Monaco.Program+_c ._ Main_b_2_0
WindowsBase.dll!System.Windows.Threading.ExceptionWrapper.InternalRealCall
WindowsBase.dll!System.Windows.Threading.ExceptionWrapper.TryCatchWhen
WindowsBase.dll!System.Windows.Threading.DispatcherOperation.Invokelmpl
WindowsBase.dll!MS.Internal.CulturePreservingExecutionContext.CallbackWrapper
System.Private.CoreLib.dll!System.Threading.ExecutionContext.RunInternal
System.Private.CoreLib.dll!System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw
System.Private.CoreLib.dll!System.Threading.ExecutionContext.RunInternal
```