### PR TITLE
[Settings] Ensure PTRun plugin icon paths are well formed

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -85,7 +85,7 @@
     <UsePrecompiledHeaders Condition="'$(TF_BUILD)' != ''">false</UsePrecompiledHeaders>
 
     <!-- Change this to bust the cache -->
-    <MSBuildCacheCacheUniverse Condition="'$(MSBuildCacheCacheUniverse)' == ''">202310210737</MSBuildCacheCacheUniverse>
+    <MSBuildCacheCacheUniverse Condition="'$(MSBuildCacheCacheUniverse)' == ''">202406130737</MSBuildCacheCacheUniverse>
 
     <!--
       Visual Studio telemetry reads various ApplicationInsights.config files and other files after the project is finished, likely in a detached process.

--- a/src/settings-ui/Settings.UI/SettingsXAML/App.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/App.xaml.cs
@@ -76,9 +76,16 @@ namespace Microsoft.PowerToys.Settings.UI
         /// </summary>
         public App()
         {
-            Logger.InitializeLogger("\\Settings\\Logs");
+            Logger.InitializeLogger(@"\Settings\Logs");
 
-            this.InitializeComponent();
+            InitializeComponent();
+
+            UnhandledException += App_UnhandledException;
+        }
+
+        private void App_UnhandledException(object sender, Microsoft.UI.Xaml.UnhandledExceptionEventArgs e)
+        {
+            Logger.LogError("Unhandled exception", e.Exception);
         }
 
         public static void OpenSettingsWindow(Type type = null, bool ensurePageIsSelected = false)

--- a/src/settings-ui/Settings.UI/ViewModels/PowerLauncherPluginViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/PowerLauncherPluginViewModel.cs
@@ -179,10 +179,9 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             return $"{Name}. {Description}";
         }
 
-        public string IconPath
-        {
-            get => isDark() ? settings.IconPathDark : settings.IconPathLight;
-        }
+#nullable enable
+        public Uri? IconPath => Uri.TryCreate(isDark() ? settings.IconPathDark : settings.IconPathLight, UriKind.Absolute, out var uri) ? uri : null;
+#nullable restore
 
         public event PropertyChangedEventHandler PropertyChanged;
 


### PR DESCRIPTION
# Summary of the Pull Request

We've received some crashes from Watson with a stack-trace similar to the below. The issue appears to be caused by an icon path that cannot be parsed by `System.Uri` in the binding `<BitmapIcon UriSource="{x:Bind IconPath}" />`. The fix is to check for this beforehand and bind to `null` instead - this will result in an empty icon against the plugin on the settings page.

```
Microsoft.WinUI.dlIIABI.Microsoft.UI.Xaml.Markup.IXamlBindingHelperStaticsMethods.ConvertValue
Microsoft.WinUI.dll!Microsoft.UI.Xaml.Markup.XamlBindingHelper.ConvertValue
PowerToys.Settings.dll!Microsoft.PowerToys.Settings.UI.Views.PowerLauncherPage+PowerLauncherPage_obj55_Bindings.Update_IconPath
PowerToys.Settings.dll!Unknown
(Plugin-specific frames redacted)
```