### PR TITLE
Fixed crash from COM object double release in PowerToys.exe

### DIFF
--- a/src/modules/peek/peek/dllmain.cpp
+++ b/src/modules/peek/peek/dllmain.cpp
@@ -187,7 +187,7 @@ private:
         }
 
         // Enumerate all Shell Windows to compare the window handle against.
-        IUnknownPtr spEnum{};
+        IUnknownPtr spEnum{}; // _com_ptr_t; no Release required.
         result = spShellWindows->_NewEnum(&spEnum);
         if (result != S_OK || spEnum == nullptr)
         {
@@ -195,7 +195,7 @@ private:
             return true; // Might as well assume it's possible it's an explorer window.
         }
 
-        IEnumVARIANTPtr spEnumVariant{};
+        IEnumVARIANTPtr spEnumVariant{}; // _com_ptr_t; no Release required.
         result = spEnum.QueryInterface(__uuidof(spEnumVariant), &spEnumVariant);
         if (result != S_OK || spEnumVariant == nullptr)
         {
@@ -219,8 +219,6 @@ private:
                     {
                         VariantClear(&variantElement);
                         spWebBrowserApp->Release();
-                        spEnumVariant->Release();
-                        spEnum->Release();
                         return true;
                     }
                 }
@@ -229,8 +227,6 @@ private:
             VariantClear(&variantElement);
         }
 
-        spEnumVariant->Release();
-        spEnum->Release();
         return false;
     }
 


### PR DESCRIPTION
# Summary of the Pull Request

We've received a crash-report with the following stack-trace:

```
Unhandled exception at 0x00007FFA04B61F24 (PowerToys.Peek.dll) in PowerToys.exe_240605_164917.dmp: 0xC0000005: Access violation reading location 0x00007FFA41D729A8.
```

```
[Inline Frame] PowerToys.Peek.dll!_com_ptr_t<_com_IIID<IEnumVARIANT,&_GUID_00020404_0000_0000_c000_000000000046>>::_Release() Line 977	C++
[Inline Frame] PowerToys.Peek.dll!_com_ptr_t<_com_IIID<IEnumVARIANT,&_GUID_00020404_0000_0000_c000_000000000046>>::{dtor}() Line 232	C++
[Inline Frame] PowerToys.Peek.dll!Peek::is_explorer_window(HWND__ *) Line 234	C++
[Inline Frame] PowerToys.Peek.dll!Peek::is_peek_or_explorer_or_desktop_window_focused() Line 260	C++
PowerToys.Peek.dll!Peek::on_hotkey(unsigned __int64 __formal) Line 454	C++
[Inline Frame] PowerToys.exe!PowertoyModule::update_hotkeys::__l4::<lambda_1>::operator()() Line 68	C++
[Inline Frame] PowerToys.exe!std::invoke(PowertoyModule::update_hotkeys::__l4::<lambda_1> &) Line 1729	C++
PowerToys.exe!std::_Func_impl_no_alloc<`PowertoyModule::update_hotkeys'::`4'::<lambda_1>,bool>::_Do_call() Line 907	C++
[Inline Frame] PowerToys.exe!std::_Func_class<bool>::operator()() Line 951	C++
PowerToys.exe!CentralizedKeyboardHook::KeyboardHookProc(int nCode=0, unsigned __int64 wParam=1, __int64 lParam=330946) Line 173	C++
user32.dll!00007ffa4c36a3f8()	Unknown
```

The trace makes it clear that:
- The issue is a double release of a COM object (the first frame is `::_Release()`).
- The double release occurs in the destructor of the [`_com_ptr_t`](https://learn.microsoft.com/en-us/cpp/cpp/com-ptr-t-class?view=msvc-170) smart COM pointer  (the second frame is `_com_ptr_t::{dtor}()`)
- The issue is triggered by RAII - (the third frame is `Peek::is_explorer_window(HWND__ *) Line 234`, which is the end of that function).

Inspecting the code, we see that the function in question contains two smart pointers whose contained COM objects are manually released.

```
// typedef _com_ptr_t<_com_IIID<IUnknown, &_uuidof(IUnknown)>> IUnknownPtr
IUnknownPtr spEnum{};

...
// typedef _com_ptr_t<_com_IIID<IEnumVARIANT, &_uuidof(IEnumVARIANT)>> IEnumVARIANTPtr
IEnumVARIANTPtr spEnumVariant{};

...
spEnumVariant->Release();
spEnum->Release();
return false;
```

The implementation of _com_ptr_t's destructor and `Release` functions below should make it clear why its ok to call `Release` on the pointer (like `ptr.Release()`) but *not* on the contained COM object (`ptr->Release()`) . In the latter case, there is no book-keeping on the smart pointer to prevent the double release. 

```
~_com_ptr_t() noexcept
{
    if (m_pInterface) {
        m_pInterface->Release();
    }
}    

void Release()
{
    if (m_pInterface)
    {
        m_pInterface->Release();
        m_pInterface = nullptr;
    }
    else
    {
        _com_issue_error(E_POINTER);
    }
}
```
But of course, it's preferable to simply not call `Release` at all and let the smart pointer do all the work.