### PR TITLE
build: make the agent pool selection more robust

### DIFF
--- a/.pipelines/ci/templates/build-powertoys-ci.yml
+++ b/.pipelines/ci/templates/build-powertoys-ci.yml
@@ -24,10 +24,10 @@ jobs:
     NODE_OPTIONS: --max_old_space_size=16384
   pool:
     demands: ImageOverride -equals SHINE-VS17-Latest
-    ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
-      name: SHINE-OSS-L
-    ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
+    ${{ if eq(variables['System.CollectionId'], 'cb55739e-4afe-46a3-970f-1b49d8ee7564') }}:
       name: SHINE-INT-L
+    ${{ else }}:
+      name: SHINE-OSS-L
   timeoutInMinutes: 120
   strategy:
     maxParallel: 10

--- a/.pipelines/ci/templates/build-powertoys-precheck.yml
+++ b/.pipelines/ci/templates/build-powertoys-precheck.yml
@@ -3,10 +3,10 @@ jobs:
 - job: Precheck
   pool:
     demands: ImageOverride -equals SHINE-VS17-Latest
-    ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
-      name: SHINE-OSS-L
-    ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
+    ${{ if eq(variables['System.CollectionId'], 'cb55739e-4afe-46a3-970f-1b49d8ee7564') }}:
       name: SHINE-INT-L
+    ${{ else }}:
+      name: SHINE-OSS-L
   steps:
   - checkout: none
 

--- a/.pipelines/ci/templates/run-ui-tests-ci.yml
+++ b/.pipelines/ci/templates/run-ui-tests-ci.yml
@@ -9,10 +9,10 @@ jobs:
   variables:
     SrcPath: $(Build.Repository.LocalPath)
   pool:
-    ${{ if eq(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
-      name: SHINE-OSS-Testing-x64
-    ${{ if ne(variables['System.CollectionUri'], 'https://dev.azure.com/ms/') }}:
+    ${{ if eq(variables['System.CollectionId'], 'cb55739e-4afe-46a3-970f-1b49d8ee7564') }}:
       name: SHINE-INT-Testing-x64
+    ${{ else }}:
+      name: SHINE-OSS-Testing-x64
   steps:
   - checkout: self
     fetchDepth: 1


### PR DESCRIPTION
We are no longer exclusively using one organization named "ms" and one organization not named "ms".

This change flips the sense of the organization comparison so the `OSS` agents can be used for every collection except very specifically the Microsoft one. I also switched to using its ID.