### PR TITLE
[AdvancedPaste] Clear image sources to fix memory leak

### DIFF
--- a/src/modules/AdvancedPaste/AdvancedPaste/AdvancedPasteXAML/Pages/MainPage.xaml.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/AdvancedPasteXAML/Pages/MainPage.xaml.cs
@@ -87,6 +87,7 @@ namespace AdvancedPaste.Pages
 
                 _dispatcherQueue.TryEnqueue(async () =>
                 {
+                    // Clear to avoid leaks due to Garbage Collection not clearing the bitmap from memory. Fix for https://github.com/microsoft/PowerToys/issues/33423
                     clipboardHistory.Where(x => x.Image is not null)
                                     .ToList()
                                     .ForEach(x => x.Image.ClearValue(BitmapImage.UriSourceProperty));

--- a/src/modules/AdvancedPaste/AdvancedPaste/AdvancedPasteXAML/Pages/MainPage.xaml.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/AdvancedPasteXAML/Pages/MainPage.xaml.cs
@@ -86,6 +86,10 @@ namespace AdvancedPaste.Pages
 
                 _dispatcherQueue.TryEnqueue(async () =>
                 {
+                    clipboardHistory.Where(x => x.Image is not null)
+                                    .ToList()
+                                    .ForEach(x => x.Image.ClearValue(BitmapImage.UriSourceProperty));
+
                     clipboardHistory.Clear();
 
                     foreach (var item in items)

--- a/src/modules/AdvancedPaste/AdvancedPaste/AdvancedPasteXAML/Pages/MainPage.xaml.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/AdvancedPasteXAML/Pages/MainPage.xaml.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using AdvancedPaste.Helpers;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Clear source of clipboard history images to force the garbage collector to clean up the memory. Another way to confirm this fix is to call GB.Collect() manually.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #33423
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

- Run Advanced paste and show UI
- while UI is shown, copy image multiple times to get it to clipboard
- observe that Advanced Paste does not consume additional memory every time image is coppied
