### PR TITLE
[ColorPicker]Fix picker opaque corners

### DIFF
--- a/src/modules/colorPicker/ColorPickerUI/Helpers/AppStateHandler.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/AppStateHandler.cs
@@ -135,6 +135,14 @@ namespace ColorPicker.Helpers
                 Application.Current.MainWindow.Opacity = 0;
                 Application.Current.MainWindow.Visibility = Visibility.Visible;
                 _colorPickerShown = true;
+
+                // HACK: WPF UI theme watcher removes the composition target background color, among other weird stuff.
+                // https://github.com/lepoco/wpfui/blob/303f0aefcd59a142bc681415dc4360a34a15f33d/src/Wpf.Ui/Controls/Window/WindowBackdrop.cs#L280
+                // So we set it back with https://github.com/lepoco/wpfui/blob/303f0aefcd59a142bc681415dc4360a34a15f33d/src/Wpf.Ui/Controls/Window/WindowBackdrop.cs#L191
+                // And also reapply the intended backdrop.
+                // This hack fixes: https://github.com/microsoft/PowerToys/issues/31725
+                Wpf.Ui.Controls.WindowBackdrop.RemoveBackground(Application.Current.MainWindow);
+                Wpf.Ui.Controls.WindowBackdrop.ApplyBackdrop(Application.Current.MainWindow, Wpf.Ui.Controls.WindowBackdropType.None);
             }
         }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

After we've applied WPF UI to Color Picker, the picker's corners started becoming visible instead of transparent to account for the border radius, as explained in #31725 .

After deeply investigating this issue, I've figured out it seems to be caused by the Theme Watcher from WPFUI removing the transparent color from both the composition target and the window control. My current workaround is setting those and the backdrop correctly when showing the window.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #31725
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Run ColorPicker and verify corners look correctly.
Change theme a couple of times and verify picker stills shows up correctly.
