### PR TITLE
[PTRun]Bring back acrylic and proper fix to title bar accent showing

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.WindowWalker/Components/LivePreview.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.WindowWalker/Components/LivePreview.cs
@@ -19,13 +19,13 @@ namespace Microsoft.Plugin.WindowWalker.Components
         /// <param name="hwnd">handle to the window to exclude</param>
         public static void SetWindowExclusionFromLivePreview(IntPtr hwnd)
         {
-            int renderPolicy = (int)DwmNCRenderingPolicies.Enabled;
+            uint renderPolicy = (uint)DwmNCRenderingPolicies.Enabled;
 
             _ = NativeMethods.DwmSetWindowAttribute(
                 hwnd,
                 12,
                 ref renderPolicy,
-                sizeof(int));
+                sizeof(uint));
         }
 
         /// <summary>

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml
@@ -32,9 +32,9 @@
 
     <Grid x:Name="RootGrid" MouseDown="OnMouseDown">
         <!--  We set the background here because the Acrylic can be too translucent / background too bright on Light theme  -->
-        <!--<Grid.Background>
+        <Grid.Background>
             <SolidColorBrush Opacity="0.8" Color="{DynamicResource ApplicationBackgroundColor}" />
-        </Grid.Background>-->
+        </Grid.Background>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml
@@ -45,11 +45,6 @@
             Grid.Row="0"
             Padding="12,4,12,3">
             <local:LauncherControl x:Name="SearchBox" />
-            <Border.Background>
-                <!--  Setting the background of the search bar to fix https://github.com/microsoft/PowerToys/issues/30206  -->
-                <!--  The title bar accent would bleed if the option to "Show accent color on title bars and windows borders" is enabled on Windows  -->
-                <SolidColorBrush Opacity="1" Color="{DynamicResource ApplicationBackgroundColor}" />
-            </Border.Background>
         </Border>
 
         <!--  Have to use a Grid instead of a StackPanel for scrolling to work?  -->

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -63,7 +63,7 @@ namespace PowerLauncher
 
             if (OSVersionHelper.IsWindows11())
             {
-                WindowBackdropType = Wpf.Ui.Controls.WindowBackdropType.Mica;
+                WindowBackdropType = Wpf.Ui.Controls.WindowBackdropType.Acrylic;
             }
             else
             {

--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -8,11 +8,13 @@ using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
+using System.Windows.Interop;
 using System.Windows.Threading;
 using Common.UI;
 using interop;
@@ -1006,6 +1008,36 @@ namespace PowerLauncher.ViewModel
             if (MainWindowVisibility != Visibility.Visible)
             {
                 MainWindowVisibility = Visibility.Visible;
+
+                // HACK: The following code in this if is a fix for https://github.com/microsoft/PowerToys/issues/30206 and https://github.com/microsoft/PowerToys/issues/33135
+                // WPF UI theme watcher removes the composition target background color, among other weird stuff.
+                // https://github.com/lepoco/wpfui/blob/303f0aefcd59a142bc681415dc4360a34a15f33d/src/Wpf.Ui/Controls/Window/WindowBackdrop.cs#L280
+                // So we set it back with https://github.com/lepoco/wpfui/blob/303f0aefcd59a142bc681415dc4360a34a15f33d/src/Wpf.Ui/Controls/Window/WindowBackdrop.cs#L191
+                var window = Application.Current.MainWindow;
+                Wpf.Ui.Controls.WindowBackdrop.RemoveBackground(window);
+
+                // Taken from WPFUI's fix for the title bar issue. We should be able to remove this fix when WPF UI 4 is integrated.
+                // https://github.com/lepoco/wpfui/pull/1122/files#diff-196b404f4db09632665ef546da6c8e57302b2f3e3d082eb4b5c295ae3482d94a
+                IntPtr windowHandle = new WindowInteropHelper(window).Handle;
+                if (windowHandle == IntPtr.Zero)
+                {
+                    return;
+                }
+
+                HwndSource windowSource = HwndSource.FromHwnd(windowHandle);
+
+                // Remove background from client area
+                if (windowSource != null && windowSource.Handle != IntPtr.Zero && windowSource?.CompositionTarget != null)
+                {
+                    // NOTE: https://learn.microsoft.com/en-us/windows/win32/api/dwmapi/ne-dwmapi-dwmwindowattribute
+                    // Specifying DWMWA_COLOR_DEFAULT (value 0xFFFFFFFF) for the color will reset the window back to using the system's default behavior for the caption color.
+                    uint titlebarPvAttribute = 0xFFFFFFFE;
+                    _ = Wox.Plugin.Common.Win32.NativeMethods.DwmSetWindowAttribute(
+                        windowSource.Handle,
+                        (int)Wox.Plugin.Common.Win32.DwmWindowAttributes.CaptionColor,
+                        ref titlebarPvAttribute,
+                        Marshal.SizeOf(typeof(uint)));
+                }
             }
             else
             {

--- a/src/modules/launcher/Wox.Plugin/Common/Win32/NativeMethods.cs
+++ b/src/modules/launcher/Wox.Plugin/Common/Win32/NativeMethods.cs
@@ -66,7 +66,7 @@ namespace Wox.Plugin.Common.Win32
         public static extern int DwmpActivateLivePreview([MarshalAs(UnmanagedType.Bool)] bool fActivate, IntPtr hWndExclude, IntPtr hWndInsertBefore, LivePreviewTrigger lpt, IntPtr prcFinalRect);
 
         [DllImport("dwmapi.dll", PreserveSig = false)]
-        public static extern int DwmSetWindowAttribute(IntPtr hwnd, int attr, ref int attrValue, int attrSize);
+        public static extern int DwmSetWindowAttribute(IntPtr hwnd, int attr, ref uint attrValue, int attrSize);
 
         [DllImport("dwmapi.dll", PreserveSig = false)]
         public static extern int DwmGetWindowAttribute(IntPtr hwnd, int dwAttribute, out int pvAttribute, int cbAttribute);
@@ -493,29 +493,29 @@ namespace Wox.Plugin.Common.Win32
     public enum DwmWindowAttributes
     {
         NCRenderingEnabled = 1,
-        NCRenderingPolicy,
-        TransitionsForceDisabled,
-        AllowNCPaint,
-        CaptionButtonBounds,
-        NonClientRtlLayout,
-        ForceIconicRepresentation,
-        Flip3DPolicy,
-        ExtendedFrameBounds,
-        HasIconicBitmap,
-        DisallowPeek,
-        ExcludedFromPeek,
-        Cloak,
-        Cloaked,
-        FreezeRepresentation,
-        PassiveUpdateMode,
-        UseHostbackdropbrush,
-        UseImmersiveDarkMode,
-        WindowCornerPreference,
-        BorderColor,
-        CaptionColor,
-        TextColor,
+        NCRenderingPolicy = 2,
+        TransitionsForceDisabled = 3,
+        AllowNCPaint = 4,
+        CaptionButtonBounds = 5,
+        NonClientRtlLayout = 6,
+        ForceIconicRepresentation = 7,
+        Flip3DPolicy = 8,
+        ExtendedFrameBounds = 9,
+        HasIconicBitmap = 10,
+        DisallowPeek = 11,
+        ExcludedFromPeek = 12,
+        Cloak = 13,
+        Cloaked = 14,
+        FreezeRepresentation = 15,
+        PassiveUpdateMode = 16,
+        UseHostbackdropbrush = 17,
+        UseImmersiveDarkMode = 20,
+        WindowCornerPreference = 33,
+        BorderColor = 34,
+        CaptionColor = 35,
+        TextColor = 36,
         VisibleFrameBorderThickness,
-        Last,
+        Last = 37,
     }
 
     /// <summary>

--- a/src/modules/launcher/Wox.Plugin/Common/Win32/NativeMethods.cs
+++ b/src/modules/launcher/Wox.Plugin/Common/Win32/NativeMethods.cs
@@ -514,8 +514,8 @@ namespace Wox.Plugin.Common.Win32
         BorderColor = 34,
         CaptionColor = 35,
         TextColor = 36,
-        VisibleFrameBorderThickness,
-        Last = 37,
+        VisibleFrameBorderThickness = 37,
+        Last,
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Recent UI changes in PowerToys Run made users unhappy with the looks of PowerToys Run. And those changes didn't properly fix the issues they were trying to solve.

This reverts https://github.com/microsoft/PowerToys/pull/33046 and https://github.com/microsoft/PowerToys/pull/32118
It brings back Acrylic backdrop.
It removes the opaque search bar background that was disliked by users.
It includes the fix in wpf ui for the title bar accent showing through: https://github.com/lepoco/wpfui/pull/1122/files#diff-196b404f4db09632665ef546da6c8e57302b2f3e3d082eb4b5c295ae3482d94a
If fixes PowerToys Run becoming opaque after a theme change too.

It also fixes the Wox Plugin DWM Attributes enum, since the values were wrong. Used this as a base to update the values: https://groups.google.com/g/golang-codereviews/c/C06XsvvpNPo?pli=1

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #33135
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Set up the accent color to show in windows title bar:
![image](https://github.com/microsoft/PowerToys/assets/26118718/57c04875-8fd0-46fa-b0a7-53e5247485e2)

After that, verified the tile bar didn't appear in PowerToys Run, as specified in https://github.com/microsoft/PowerToys/issues/30206

Also changed theme a couple of times to verify it still looked good with some transparency.
