### PR TITLE
23723

### DIFF
--- a/src/common/GPOWrapper/GPOWrapper.cpp
+++ b/src/common/GPOWrapper/GPOWrapper.cpp
@@ -176,4 +176,8 @@ namespace winrt::PowerToys::GPOWrapper::implementation
     {
         return static_cast<GpoRuleConfigured>(powertoys_gpo::getAllowedAdvancedPasteOnlineAIModelsValue());
     }
+    GpoRuleConfigured GPOWrapper::GetConfiguredFileExplorerPreviewEnabledValue()
+    {
+        return static_cast<GpoRuleConfigured>(powertoys_gpo::getConfiguredFileExplorerPreviewEnabledValue());
+    }
 }

--- a/src/common/GPOWrapper/GPOWrapper.h
+++ b/src/common/GPOWrapper/GPOWrapper.h
@@ -50,6 +50,7 @@ namespace winrt::PowerToys::GPOWrapper::implementation
         static GpoRuleConfigured GetConfiguredQoiPreviewEnabledValue();
         static GpoRuleConfigured GetConfiguredQoiThumbnailsEnabledValue();
         static GpoRuleConfigured GetAllowedAdvancedPasteOnlineAIModelsValue();
+        static GpoRuleConfigured GetConfiguredFileExplorerPreviewEnabledValue();
     };
 }
 

--- a/src/common/GPOWrapper/GPOWrapper.idl
+++ b/src/common/GPOWrapper/GPOWrapper.idl
@@ -54,6 +54,7 @@ namespace PowerToys
             static GpoRuleConfigured GetConfiguredQoiPreviewEnabledValue();
             static GpoRuleConfigured GetConfiguredQoiThumbnailsEnabledValue();
             static GpoRuleConfigured GetAllowedAdvancedPasteOnlineAIModelsValue();
+            static GpoRuleConfigured GetConfiguredFileExplorerPreviewEnabledValue();
         }
     }
 }

--- a/src/common/ManagedCommon/ModuleType.cs
+++ b/src/common/ManagedCommon/ModuleType.cs
@@ -30,5 +30,6 @@ namespace ManagedCommon
         MeasureTool,
         ShortcutGuide,
         PowerOCR,
+        PowerPreview,
     }
 }

--- a/src/common/ManagedCommon/ModuleType.cs
+++ b/src/common/ManagedCommon/ModuleType.cs
@@ -13,6 +13,7 @@ namespace ManagedCommon
         CropAndLock,
         EnvironmentVariables,
         FancyZones,
+        PowerPreview,
         FileLocksmith,
         FindMyMouse,
         Hosts,
@@ -30,6 +31,5 @@ namespace ManagedCommon
         MeasureTool,
         ShortcutGuide,
         PowerOCR,
-        PowerPreview,
     }
 }

--- a/src/common/utils/gpo.h
+++ b/src/common/utils/gpo.h
@@ -59,6 +59,7 @@ namespace powertoys_gpo {
     const std::wstring POLICY_CONFIGURE_ENABLED_ENVIRONMENT_VARIABLES = L"ConfigureEnabledUtilityEnvironmentVariables";
     const std::wstring POLICY_CONFIGURE_ENABLED_QOI_PREVIEW = L"ConfigureEnabledUtilityFileExplorerQOIPreview";
     const std::wstring POLICY_CONFIGURE_ENABLED_QOI_THUMBNAILS = L"ConfigureEnabledUtilityFileExplorerQOIThumbnails";
+    const std::wstring POLICY_CONFIGURE_ENABLED_FILE_EXPLORER_PREVIEW = L"ConfigureEnabledUtilityFileExplorerPreview";
 
     // The registry value names for PowerToys installer and update policies.
     const std::wstring POLICY_DISABLE_PER_USER_INSTALLATION = L"PerUserInstallationDisabled";
@@ -422,7 +423,7 @@ namespace powertoys_gpo {
     }
 
     inline gpo_rule_configured_t getRunPluginEnabledValue(std::string pluginID)
-    {     
+    {
         if (pluginID == "" || pluginID == " ")
         {
             // this plugin id can't exist in the registry
@@ -431,7 +432,7 @@ namespace powertoys_gpo {
 
         std::wstring plugin_id(pluginID.begin(), pluginID.end());
         auto individual_plugin_setting = getPolicyListValue(POWER_LAUNCHER_INDIVIDUAL_PLUGIN_ENABLED_LIST_PATH, plugin_id);
-        
+
         if (individual_plugin_setting.has_value())
         {
             if (*individual_plugin_setting == L"0")
@@ -458,7 +459,7 @@ namespace powertoys_gpo {
         {
             // If no individual plugin policy exists, we check the policy with the setting for all plugins.
             return getConfiguredValue(POLICY_CONFIGURE_ENABLED_POWER_LAUNCHER_ALL_PLUGINS);
-        }        
+        }
     }
 
     inline gpo_rule_configured_t getConfiguredQoiPreviewEnabledValue()
@@ -474,5 +475,10 @@ namespace powertoys_gpo {
     inline gpo_rule_configured_t getAllowedAdvancedPasteOnlineAIModelsValue()
     {
         return getUtilityEnabledValue(POLICY_ALLOW_ADVANCED_PASTE_ONLINE_AI_MODELS);
+    }
+
+    inline gpo_rule_configured_t getConfiguredFileExplorerPreviewEnabledValue()
+    {
+        return getUtilityEnabledValue(POLICY_CONFIGURE_ENABLED_FILE_EXPLORER_PREVIEW);
     }
 }

--- a/src/gpo/assets/PowerToys.admx
+++ b/src/gpo/assets/PowerToys.admx
@@ -1,507 +1,519 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft Corporation.
      Licensed under the MIT License. -->
-<policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.10" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
-  <policyNamespaces>
-    <target prefix="powertoys" namespace="Microsoft.Policies.PowerToys" />
-  </policyNamespaces>
-  <resources minRequiredRevision="1.10"/><!-- Last changed with PowerToys v0.81.1 -->
-  <supportedOn>
-    <definitions>
-      <definition name="SUPPORTED_POWERTOYS_0_64_0" displayName="$(string.SUPPORTED_POWERTOYS_0_64_0)"/>
-      <definition name="SUPPORTED_POWERTOYS_0_68_0" displayName="$(string.SUPPORTED_POWERTOYS_0_68_0)"/>
-      <definition name="SUPPORTED_POWERTOYS_0_69_0" displayName="$(string.SUPPORTED_POWERTOYS_0_69_0)"/>
-      <definition name="SUPPORTED_POWERTOYS_0_70_0" displayName="$(string.SUPPORTED_POWERTOYS_0_70_0)"/>
-      <definition name="SUPPORTED_POWERTOYS_0_73_0" displayName="$(string.SUPPORTED_POWERTOYS_0_73_0)"/>
-      <definition name="SUPPORTED_POWERTOYS_0_75_0" displayName="$(string.SUPPORTED_POWERTOYS_0_75_0)"/>
-      <definition name="SUPPORTED_POWERTOYS_0_76_0" displayName="$(string.SUPPORTED_POWERTOYS_0_76_0)"/>
-      <definition name="SUPPORTED_POWERTOYS_0_77_0" displayName="$(string.SUPPORTED_POWERTOYS_0_77_0)"/>
-      <definition name="SUPPORTED_POWERTOYS_0_78_0" displayName="$(string.SUPPORTED_POWERTOYS_0_78_0)"/>
-      <definition name="SUPPORTED_POWERTOYS_0_81_0" displayName="$(string.SUPPORTED_POWERTOYS_0_81_0)"/>
-      <definition name="SUPPORTED_POWERTOYS_0_81_1" displayName="$(string.SUPPORTED_POWERTOYS_0_81_1)"/>
-    </definitions>
-  </supportedOn>
-  <categories>
-    <category name="PowerToys" displayName="$(string.PowerToys)" />
-    <category name="InstallerUpdates" displayName="$(string.InstallerUpdates)">
-      <parentCategory ref="PowerToys" />
-    </category>
-    <category name="PowerToysRun" displayName="$(string.PowerToysRun)">
-      <parentCategory ref="PowerToys" />
-    </category>
-    <category name="AdvancedPaste" displayName="$(string.AdvancedPaste)">
-      <parentCategory ref="PowerToys" />
-    </category>
-  </categories>
-  <policies>
+<policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.11" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
+    <policyNamespaces>
+        <target prefix="powertoys" namespace="Microsoft.Policies.PowerToys" />
+    </policyNamespaces>
+    <resources minRequiredRevision="1.11"/>
+    <!-- Last changed with PowerToys v0.82.0 -->
+    <supportedOn>
+        <definitions>
+            <definition name="SUPPORTED_POWERTOYS_0_64_0" displayName="$(string.SUPPORTED_POWERTOYS_0_64_0)"/>
+            <definition name="SUPPORTED_POWERTOYS_0_68_0" displayName="$(string.SUPPORTED_POWERTOYS_0_68_0)"/>
+            <definition name="SUPPORTED_POWERTOYS_0_69_0" displayName="$(string.SUPPORTED_POWERTOYS_0_69_0)"/>
+            <definition name="SUPPORTED_POWERTOYS_0_70_0" displayName="$(string.SUPPORTED_POWERTOYS_0_70_0)"/>
+            <definition name="SUPPORTED_POWERTOYS_0_73_0" displayName="$(string.SUPPORTED_POWERTOYS_0_73_0)"/>
+            <definition name="SUPPORTED_POWERTOYS_0_75_0" displayName="$(string.SUPPORTED_POWERTOYS_0_75_0)"/>
+            <definition name="SUPPORTED_POWERTOYS_0_76_0" displayName="$(string.SUPPORTED_POWERTOYS_0_76_0)"/>
+            <definition name="SUPPORTED_POWERTOYS_0_77_0" displayName="$(string.SUPPORTED_POWERTOYS_0_77_0)"/>
+            <definition name="SUPPORTED_POWERTOYS_0_78_0" displayName="$(string.SUPPORTED_POWERTOYS_0_78_0)"/>
+            <definition name="SUPPORTED_POWERTOYS_0_81_0" displayName="$(string.SUPPORTED_POWERTOYS_0_81_0)"/>
+            <definition name="SUPPORTED_POWERTOYS_0_81_1" displayName="$(string.SUPPORTED_POWERTOYS_0_81_1)"/>
+            <definition name="SUPPORTED_POWERTOYS_0_82_0" displayName="$(string.SUPPORTED_POWERTOYS_0_82_0)"/>
+        </definitions>
+    </supportedOn>
+    <categories>
+        <category name="PowerToys" displayName="$(string.PowerToys)" />
+        <category name="InstallerUpdates" displayName="$(string.InstallerUpdates)">
+            <parentCategory ref="PowerToys" />
+        </category>
+        <category name="PowerToysRun" displayName="$(string.PowerToysRun)">
+            <parentCategory ref="PowerToys" />
+        </category>
+        <category name="AdvancedPaste" displayName="$(string.AdvancedPaste)">
+            <parentCategory ref="PowerToys" />
+        </category>
+    </categories>
+    <policies>
 
-    <policy name="ConfigureGlobalUtilityEnabledState" class="Both" displayName="$(string.ConfigureGlobalUtilityEnabledState)" explainText="$(string.ConfigureGlobalUtilityEnabledStateDescription)" key="Software\Policies\PowerToys" valueName="ConfigureGlobalUtilityEnabledState">
-      <parentCategory ref="PowerToys" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_75_0" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
+        <policy name="ConfigureGlobalUtilityEnabledState" class="Both" displayName="$(string.ConfigureGlobalUtilityEnabledState)" explainText="$(string.ConfigureGlobalUtilityEnabledStateDescription)" key="Software\Policies\PowerToys" valueName="ConfigureGlobalUtilityEnabledState">
+            <parentCategory ref="PowerToys" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_75_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
 
-    <policy name="ConfigureEnabledUtilityAdvancedPaste" class="Both" displayName="$(string.ConfigureEnabledUtilityAdvancedPaste)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityAdvancedPaste">
-      <parentCategory ref="PowerToys" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_81_0" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
-    <policy name="ConfigureEnabledUtilityAlwaysOnTop" class="Both" displayName="$(string.ConfigureEnabledUtilityAlwaysOnTop)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityAlwaysOnTop">
-      <parentCategory ref="PowerToys" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
-    <policy name="ConfigureEnabledUtilityAwake" class="Both" displayName="$(string.ConfigureEnabledUtilityAwake)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityAwake">
-      <parentCategory ref="PowerToys" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
-    <policy name="ConfigureEnabledUtilityCmdNotFound" class="Both" displayName="$(string.ConfigureEnabledUtilityCmdNotFound)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityCmdNotFound">
-      <parentCategory ref="PowerToys" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_77_0" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
-    <policy name="ConfigureEnabledUtilityColorPicker" class="Both" displayName="$(string.ConfigureEnabledUtilityColorPicker)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityColorPicker">
-      <parentCategory ref="PowerToys" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
-    <policy name="ConfigureEnabledUtilityCropAndLock" class="Both" displayName="$(string.ConfigureEnabledUtilityCropAndLock)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityCropAndLock">
-      <parentCategory ref="PowerToys" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_73_0" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
-    <policy name="ConfigureEnabledUtilityEnvironmentVariables" class="Both" displayName="$(string.ConfigureEnabledUtilityEnvironmentVariables)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityEnvironmentVariables">
-      <parentCategory ref="PowerToys" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_75_0" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
-    <policy name="ConfigureEnabledUtilityFancyZones" class="Both" displayName="$(string.ConfigureEnabledUtilityFancyZones)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFancyZones">
-      <parentCategory ref="PowerToys" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
-    <policy name="ConfigureEnabledUtilityFileLocksmith" class="Both" displayName="$(string.ConfigureEnabledUtilityFileLocksmith)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileLocksmith">
-      <parentCategory ref="PowerToys" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
-    <policy name="ConfigureEnabledUtilityFileExplorerSVGPreview" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerSVGPreview)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerSVGPreview">
-      <parentCategory ref="PowerToys" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
-    <policy name="ConfigureEnabledUtilityFileExplorerMarkdownPreview" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerMarkdownPreview)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerMarkdownPreview">
-      <parentCategory ref="PowerToys" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
-    <policy name="ConfigureEnabledUtilityFileExplorerMonacoPreview" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerMonacoPreview)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerMonacoPreview">
-      <parentCategory ref="PowerToys" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
-    <policy name="ConfigureEnabledUtilityFileExplorerPDFPreview" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerPDFPreview)" explainText="$(string.ConfigureEnabledUtilityDescriptionPDFPreviewHandler)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerPDFPreview">
-      <parentCategory ref="PowerToys" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
-    <policy name="ConfigureEnabledUtilityFileExplorerGcodePreview" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerGcodePreview)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerGcodePreview">
-      <parentCategory ref="PowerToys" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
-    <policy name="ConfigureEnabledUtilityFileExplorerSVGThumbnails" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerSVGThumbnails)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerSVGThumbnails">
-      <parentCategory ref="PowerToys" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
-    <policy name="ConfigureEnabledUtilityFileExplorerPDFThumbnails" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerPDFThumbnails)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerPDFThumbnails">
-      <parentCategory ref="PowerToys" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
-    <policy name="ConfigureEnabledUtilityFileExplorerGcodeThumbnails" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerGcodeThumbnails)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerGcodeThumbnails">
-      <parentCategory ref="PowerToys" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
-    <policy name="ConfigureEnabledUtilityFileExplorerQOIPreview" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerQOIPreview)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerQOIPreview">
-      <parentCategory ref="PowerToys" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_76_0" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
-    <policy name="ConfigureEnabledUtilityFileExplorerQOIThumbnails" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerQOIThumbnails)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerQOIThumbnails">
-      <parentCategory ref="PowerToys" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_76_0" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
-    <policy name="ConfigureEnabledUtilityFileExplorerSTLThumbnails" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerSTLThumbnails)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerSTLThumbnails">
-      <parentCategory ref="PowerToys" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
-    <policy name="ConfigureEnabledUtilityHostsFileEditor" class="Both" displayName="$(string.ConfigureEnabledUtilityHostsFileEditor)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityHostsFileEditor">
-      <parentCategory ref="PowerToys" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
-    <policy name="ConfigureEnabledUtilityImageResizer" class="Both" displayName="$(string.ConfigureEnabledUtilityImageResizer)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityImageResizer">
-      <parentCategory ref="PowerToys" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
-    <policy name="ConfigureEnabledUtilityKeyboardManager" class="Both" displayName="$(string.ConfigureEnabledUtilityKeyboardManager)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityKeyboardManager">
-      <parentCategory ref="PowerToys" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
-    <policy name="ConfigureEnabledUtilityFindMyMouse" class="Both" displayName="$(string.ConfigureEnabledUtilityFindMyMouse)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFindMyMouse">
-      <parentCategory ref="PowerToys" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
-    <policy name="ConfigureEnabledUtilityMouseHighlighter" class="Both" displayName="$(string.ConfigureEnabledUtilityMouseHighlighter)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityMouseHighlighter">
-      <parentCategory ref="PowerToys" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
-    <policy name="ConfigureEnabledUtilityMousePointerCrosshairs" class="Both" displayName="$(string.ConfigureEnabledUtilityMousePointerCrosshairs)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityMousePointerCrosshairs">
-      <parentCategory ref="PowerToys" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
-    <policy name="ConfigureEnabledUtilityMouseJump" class="Both" displayName="$(string.ConfigureEnabledUtilityMouseJump)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityMouseJump">
-      <parentCategory ref="PowerToys" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_68_0" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
-    <policy name="ConfigureEnabledUtilityMouseWithoutBorders" class="Both" displayName="$(string.ConfigureEnabledUtilityMouseWithoutBorders)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityMouseWithoutBorders">
-      <parentCategory ref="PowerToys" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_70_0" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
-    <policy name="ConfigureEnabledUtilityPeek" class="Both" displayName="$(string.ConfigureEnabledUtilityPeek)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityPeek">
-      <parentCategory ref="PowerToys" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_70_0" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
-    <policy name="ConfigureEnabledUtilityPowerRename" class="Both" displayName="$(string.ConfigureEnabledUtilityPowerRename)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityPowerRename">
-      <parentCategory ref="PowerToys" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
-    <policy name="ConfigureEnabledUtilityPowerLauncher" class="Both" displayName="$(string.ConfigureEnabledUtilityPowerLauncher)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityPowerLauncher">
-      <parentCategory ref="PowerToys" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
-    <policy name="ConfigureEnabledUtilityQuickAccent" class="Both" displayName="$(string.ConfigureEnabledUtilityQuickAccent)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityQuickAccent">
-      <parentCategory ref="PowerToys" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
-    <policy name="ConfigureEnabledUtilityRegistryPreview" class="Both" displayName="$(string.ConfigureEnabledUtilityRegistryPreview)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityRegistryPreview">
-      <parentCategory ref="PowerToys" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_69_0" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
-    <policy name="ConfigureEnabledUtilityScreenRuler" class="Both" displayName="$(string.ConfigureEnabledUtilityScreenRuler)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityScreenRuler">
-      <parentCategory ref="PowerToys" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
-    <policy name="ConfigureEnabledUtilityShortcutGuide" class="Both" displayName="$(string.ConfigureEnabledUtilityShortcutGuide)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityShortcutGuide">
-      <parentCategory ref="PowerToys" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
-    <policy name="ConfigureEnabledUtilityTextExtractor" class="Both" displayName="$(string.ConfigureEnabledUtilityTextExtractor)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityTextExtractor">
-      <parentCategory ref="PowerToys" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
-    <policy name="ConfigureEnabledUtilityVideoConferenceMute" class="Both" displayName="$(string.ConfigureEnabledUtilityVideoConferenceMute)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityVideoConferenceMute">
-      <parentCategory ref="PowerToys" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
-    <policy name="DisablePerUserInstallation" class="Machine" displayName="$(string.DisablePerUserInstallation)" explainText="$(string.DisablePerUserInstallationDescription)" key="Software\Policies\PowerToys" valueName="PerUserInstallationDisabled">
-      <parentCategory ref="InstallerUpdates" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_69_0" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
-    <policy name="DisableAutomaticUpdateDownload" class="Both" displayName="$(string.DisableAutomaticUpdateDownload)" explainText="$(string.DisableAutomaticUpdateDownloadDescription)" key="Software\Policies\PowerToys" valueName="AutomaticUpdateDownloadDisabled">
-      <parentCategory ref="InstallerUpdates" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_68_0" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
-    <policy name="SuspendNewUpdateToast" class="Both" displayName="$(string.SuspendNewUpdateToast)" explainText="$(string.SuspendNewUpdateToastDescription)" key="Software\Policies\PowerToys" valueName="SuspendNewUpdateAvailableToast">
-      <parentCategory ref="InstallerUpdates" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_68_0" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
-    <policy name="DisableNewUpdateToast" class="Both" displayName="$(string.DisableNewUpdateToast)" explainText="$(string.DisableNewUpdateToastDescription)" key="Software\Policies\PowerToys" valueName="DisableNewUpdateAvailableToast">
-      <parentCategory ref="InstallerUpdates" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_78_0" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
-    <policy name="DoNotShowWhatsNewAfterUpdates" class="Both" displayName="$(string.DoNotShowWhatsNewAfterUpdates)" explainText="$(string.DoNotShowWhatsNewAfterUpdatesDescription)" key="Software\Policies\PowerToys" valueName="DoNotShowWhatsNewAfterUpdates">
-      <parentCategory ref="InstallerUpdates" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_78_0" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
-    <policy name="AllowExperimentation" class="Both" displayName="$(string.AllowExperimentation)" explainText="$(string.AllowExperimentationDescription)" key="Software\Policies\PowerToys" valueName="AllowExperimentation">
-      <parentCategory ref="PowerToys" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_68_0" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
-    <policy name="PowerToysRunAllPluginsEnabledState" class="Both" displayName="$(string.PowerToysRunAllPluginsEnabledState)" explainText="$(string.PowerToysRunAllPluginsEnabledStateDescription)" key="Software\Policies\PowerToys" valueName="PowerLauncherAllPluginsEnabledState">
-      <parentCategory ref="PowerToysRun" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_75_0" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
-    <policy name="PowerToysRunIndividualPluginEnabledState" class="Both" displayName="$(string.PowerToysRunIndividualPluginEnabledState)" explainText="$(string.PowerToysRunIndividualPluginEnabledStateDescription)" presentation="$(presentation.PowerToysRunIndividualPluginEnabledState)" key="Software\Policies\PowerToys\PowerLauncherIndividualPluginEnabledList">
-      <parentCategory ref="PowerToysRun" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_75_0"/>
-      <elements>
-        <list id="PowerToysRunIndividualPluginEnabledList" explicitValue="true" />
-      </elements>
-    </policy>
-    <policy name="AllowPowerToysAdvancedPasteOnlineAIModels" class="Both" displayName="$(string.AllowPowerToysAdvancedPasteOnlineAIModels)" explainText="$(string.AllowPowerToysAdvancedPasteOnlineAIModelsDescription)" key="Software\Policies\PowerToys" valueName="AllowPowerToysAdvancedPasteOnlineAIModels">
-      <parentCategory ref="AdvancedPaste" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_81_1" />
-      <enabledValue>
-        <decimal value="1" />
-      </enabledValue>
-      <disabledValue>
-        <decimal value="0" />
-      </disabledValue>
-    </policy>
-  </policies>
+        <policy name="ConfigureEnabledUtilityAdvancedPaste" class="Both" displayName="$(string.ConfigureEnabledUtilityAdvancedPaste)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityAdvancedPaste">
+            <parentCategory ref="PowerToys" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_81_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy name="ConfigureEnabledUtilityAlwaysOnTop" class="Both" displayName="$(string.ConfigureEnabledUtilityAlwaysOnTop)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityAlwaysOnTop">
+            <parentCategory ref="PowerToys" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy name="ConfigureEnabledUtilityAwake" class="Both" displayName="$(string.ConfigureEnabledUtilityAwake)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityAwake">
+            <parentCategory ref="PowerToys" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy name="ConfigureEnabledUtilityCmdNotFound" class="Both" displayName="$(string.ConfigureEnabledUtilityCmdNotFound)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityCmdNotFound">
+            <parentCategory ref="PowerToys" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_77_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy name="ConfigureEnabledUtilityColorPicker" class="Both" displayName="$(string.ConfigureEnabledUtilityColorPicker)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityColorPicker">
+            <parentCategory ref="PowerToys" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy name="ConfigureEnabledUtilityCropAndLock" class="Both" displayName="$(string.ConfigureEnabledUtilityCropAndLock)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityCropAndLock">
+            <parentCategory ref="PowerToys" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_73_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy name="ConfigureEnabledUtilityEnvironmentVariables" class="Both" displayName="$(string.ConfigureEnabledUtilityEnvironmentVariables)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityEnvironmentVariables">
+            <parentCategory ref="PowerToys" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_75_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy name="ConfigureEnabledUtilityFancyZones" class="Both" displayName="$(string.ConfigureEnabledUtilityFancyZones)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFancyZones">
+            <parentCategory ref="PowerToys" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy name="ConfigureEnabledUtilityFileLocksmith" class="Both" displayName="$(string.ConfigureEnabledUtilityFileLocksmith)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileLocksmith">
+            <parentCategory ref="PowerToys" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy name="ConfigureEnabledUtilityFileExplorerPreview" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerPreview)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerPreview">
+            <parentCategory ref="PowerToys" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_82_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy name="ConfigureEnabledUtilityFileExplorerSVGPreview" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerSVGPreview)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerSVGPreview">
+            <parentCategory ref="PowerToys" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy name="ConfigureEnabledUtilityFileExplorerMarkdownPreview" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerMarkdownPreview)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerMarkdownPreview">
+            <parentCategory ref="PowerToys" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy name="ConfigureEnabledUtilityFileExplorerMonacoPreview" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerMonacoPreview)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerMonacoPreview">
+            <parentCategory ref="PowerToys" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy name="ConfigureEnabledUtilityFileExplorerPDFPreview" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerPDFPreview)" explainText="$(string.ConfigureEnabledUtilityDescriptionPDFPreviewHandler)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerPDFPreview">
+            <parentCategory ref="PowerToys" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy name="ConfigureEnabledUtilityFileExplorerGcodePreview" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerGcodePreview)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerGcodePreview">
+            <parentCategory ref="PowerToys" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy name="ConfigureEnabledUtilityFileExplorerSVGThumbnails" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerSVGThumbnails)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerSVGThumbnails">
+            <parentCategory ref="PowerToys" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy name="ConfigureEnabledUtilityFileExplorerPDFThumbnails" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerPDFThumbnails)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerPDFThumbnails">
+            <parentCategory ref="PowerToys" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy name="ConfigureEnabledUtilityFileExplorerGcodeThumbnails" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerGcodeThumbnails)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerGcodeThumbnails">
+            <parentCategory ref="PowerToys" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy name="ConfigureEnabledUtilityFileExplorerQOIPreview" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerQOIPreview)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerQOIPreview">
+            <parentCategory ref="PowerToys" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_76_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy name="ConfigureEnabledUtilityFileExplorerQOIThumbnails" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerQOIThumbnails)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerQOIThumbnails">
+            <parentCategory ref="PowerToys" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_76_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy name="ConfigureEnabledUtilityFileExplorerSTLThumbnails" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerSTLThumbnails)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerSTLThumbnails">
+            <parentCategory ref="PowerToys" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy name="ConfigureEnabledUtilityHostsFileEditor" class="Both" displayName="$(string.ConfigureEnabledUtilityHostsFileEditor)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityHostsFileEditor">
+            <parentCategory ref="PowerToys" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy name="ConfigureEnabledUtilityImageResizer" class="Both" displayName="$(string.ConfigureEnabledUtilityImageResizer)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityImageResizer">
+            <parentCategory ref="PowerToys" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy name="ConfigureEnabledUtilityKeyboardManager" class="Both" displayName="$(string.ConfigureEnabledUtilityKeyboardManager)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityKeyboardManager">
+            <parentCategory ref="PowerToys" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy name="ConfigureEnabledUtilityFindMyMouse" class="Both" displayName="$(string.ConfigureEnabledUtilityFindMyMouse)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFindMyMouse">
+            <parentCategory ref="PowerToys" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy name="ConfigureEnabledUtilityMouseHighlighter" class="Both" displayName="$(string.ConfigureEnabledUtilityMouseHighlighter)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityMouseHighlighter">
+            <parentCategory ref="PowerToys" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy name="ConfigureEnabledUtilityMousePointerCrosshairs" class="Both" displayName="$(string.ConfigureEnabledUtilityMousePointerCrosshairs)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityMousePointerCrosshairs">
+            <parentCategory ref="PowerToys" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy name="ConfigureEnabledUtilityMouseJump" class="Both" displayName="$(string.ConfigureEnabledUtilityMouseJump)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityMouseJump">
+            <parentCategory ref="PowerToys" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_68_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy name="ConfigureEnabledUtilityMouseWithoutBorders" class="Both" displayName="$(string.ConfigureEnabledUtilityMouseWithoutBorders)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityMouseWithoutBorders">
+            <parentCategory ref="PowerToys" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_70_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy name="ConfigureEnabledUtilityPeek" class="Both" displayName="$(string.ConfigureEnabledUtilityPeek)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityPeek">
+            <parentCategory ref="PowerToys" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_70_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy name="ConfigureEnabledUtilityPowerRename" class="Both" displayName="$(string.ConfigureEnabledUtilityPowerRename)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityPowerRename">
+            <parentCategory ref="PowerToys" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy name="ConfigureEnabledUtilityPowerLauncher" class="Both" displayName="$(string.ConfigureEnabledUtilityPowerLauncher)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityPowerLauncher">
+            <parentCategory ref="PowerToys" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy name="ConfigureEnabledUtilityQuickAccent" class="Both" displayName="$(string.ConfigureEnabledUtilityQuickAccent)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityQuickAccent">
+            <parentCategory ref="PowerToys" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy name="ConfigureEnabledUtilityRegistryPreview" class="Both" displayName="$(string.ConfigureEnabledUtilityRegistryPreview)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityRegistryPreview">
+            <parentCategory ref="PowerToys" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_69_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy name="ConfigureEnabledUtilityScreenRuler" class="Both" displayName="$(string.ConfigureEnabledUtilityScreenRuler)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityScreenRuler">
+            <parentCategory ref="PowerToys" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy name="ConfigureEnabledUtilityShortcutGuide" class="Both" displayName="$(string.ConfigureEnabledUtilityShortcutGuide)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityShortcutGuide">
+            <parentCategory ref="PowerToys" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy name="ConfigureEnabledUtilityTextExtractor" class="Both" displayName="$(string.ConfigureEnabledUtilityTextExtractor)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityTextExtractor">
+            <parentCategory ref="PowerToys" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy name="ConfigureEnabledUtilityVideoConferenceMute" class="Both" displayName="$(string.ConfigureEnabledUtilityVideoConferenceMute)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityVideoConferenceMute">
+            <parentCategory ref="PowerToys" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy name="DisablePerUserInstallation" class="Machine" displayName="$(string.DisablePerUserInstallation)" explainText="$(string.DisablePerUserInstallationDescription)" key="Software\Policies\PowerToys" valueName="PerUserInstallationDisabled">
+            <parentCategory ref="InstallerUpdates" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_69_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy name="DisableAutomaticUpdateDownload" class="Both" displayName="$(string.DisableAutomaticUpdateDownload)" explainText="$(string.DisableAutomaticUpdateDownloadDescription)" key="Software\Policies\PowerToys" valueName="AutomaticUpdateDownloadDisabled">
+            <parentCategory ref="InstallerUpdates" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_68_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy name="SuspendNewUpdateToast" class="Both" displayName="$(string.SuspendNewUpdateToast)" explainText="$(string.SuspendNewUpdateToastDescription)" key="Software\Policies\PowerToys" valueName="SuspendNewUpdateAvailableToast">
+            <parentCategory ref="InstallerUpdates" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_68_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy name="DisableNewUpdateToast" class="Both" displayName="$(string.DisableNewUpdateToast)" explainText="$(string.DisableNewUpdateToastDescription)" key="Software\Policies\PowerToys" valueName="DisableNewUpdateAvailableToast">
+            <parentCategory ref="InstallerUpdates" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_78_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy name="DoNotShowWhatsNewAfterUpdates" class="Both" displayName="$(string.DoNotShowWhatsNewAfterUpdates)" explainText="$(string.DoNotShowWhatsNewAfterUpdatesDescription)" key="Software\Policies\PowerToys" valueName="DoNotShowWhatsNewAfterUpdates">
+            <parentCategory ref="InstallerUpdates" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_78_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy name="AllowExperimentation" class="Both" displayName="$(string.AllowExperimentation)" explainText="$(string.AllowExperimentationDescription)" key="Software\Policies\PowerToys" valueName="AllowExperimentation">
+            <parentCategory ref="PowerToys" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_68_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy name="PowerToysRunAllPluginsEnabledState" class="Both" displayName="$(string.PowerToysRunAllPluginsEnabledState)" explainText="$(string.PowerToysRunAllPluginsEnabledStateDescription)" key="Software\Policies\PowerToys" valueName="PowerLauncherAllPluginsEnabledState">
+            <parentCategory ref="PowerToysRun" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_75_0" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+        <policy name="PowerToysRunIndividualPluginEnabledState" class="Both" displayName="$(string.PowerToysRunIndividualPluginEnabledState)" explainText="$(string.PowerToysRunIndividualPluginEnabledStateDescription)" presentation="$(presentation.PowerToysRunIndividualPluginEnabledState)" key="Software\Policies\PowerToys\PowerLauncherIndividualPluginEnabledList">
+            <parentCategory ref="PowerToysRun" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_75_0"/>
+            <elements>
+                <list id="PowerToysRunIndividualPluginEnabledList" explicitValue="true" />
+            </elements>
+        </policy>
+        <policy name="AllowPowerToysAdvancedPasteOnlineAIModels" class="Both" displayName="$(string.AllowPowerToysAdvancedPasteOnlineAIModels)" explainText="$(string.AllowPowerToysAdvancedPasteOnlineAIModelsDescription)" key="Software\Policies\PowerToys" valueName="AllowPowerToysAdvancedPasteOnlineAIModels">
+            <parentCategory ref="AdvancedPaste" />
+            <supportedOn ref="SUPPORTED_POWERTOYS_0_81_1" />
+            <enabledValue>
+                <decimal value="1" />
+            </enabledValue>
+            <disabledValue>
+                <decimal value="0" />
+            </disabledValue>
+        </policy>
+    </policies>
 </policyDefinitions>

--- a/src/gpo/assets/PowerToys.admx
+++ b/src/gpo/assets/PowerToys.admx
@@ -2,518 +2,517 @@
 <!-- Copyright (c) Microsoft Corporation.
      Licensed under the MIT License. -->
 <policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.11" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
-    <policyNamespaces>
-        <target prefix="powertoys" namespace="Microsoft.Policies.PowerToys" />
-    </policyNamespaces>
-    <resources minRequiredRevision="1.11"/>
-    <!-- Last changed with PowerToys v0.82.0 -->
-    <supportedOn>
-        <definitions>
-            <definition name="SUPPORTED_POWERTOYS_0_64_0" displayName="$(string.SUPPORTED_POWERTOYS_0_64_0)"/>
-            <definition name="SUPPORTED_POWERTOYS_0_68_0" displayName="$(string.SUPPORTED_POWERTOYS_0_68_0)"/>
-            <definition name="SUPPORTED_POWERTOYS_0_69_0" displayName="$(string.SUPPORTED_POWERTOYS_0_69_0)"/>
-            <definition name="SUPPORTED_POWERTOYS_0_70_0" displayName="$(string.SUPPORTED_POWERTOYS_0_70_0)"/>
-            <definition name="SUPPORTED_POWERTOYS_0_73_0" displayName="$(string.SUPPORTED_POWERTOYS_0_73_0)"/>
-            <definition name="SUPPORTED_POWERTOYS_0_75_0" displayName="$(string.SUPPORTED_POWERTOYS_0_75_0)"/>
-            <definition name="SUPPORTED_POWERTOYS_0_76_0" displayName="$(string.SUPPORTED_POWERTOYS_0_76_0)"/>
-            <definition name="SUPPORTED_POWERTOYS_0_77_0" displayName="$(string.SUPPORTED_POWERTOYS_0_77_0)"/>
-            <definition name="SUPPORTED_POWERTOYS_0_78_0" displayName="$(string.SUPPORTED_POWERTOYS_0_78_0)"/>
-            <definition name="SUPPORTED_POWERTOYS_0_81_0" displayName="$(string.SUPPORTED_POWERTOYS_0_81_0)"/>
-            <definition name="SUPPORTED_POWERTOYS_0_81_1" displayName="$(string.SUPPORTED_POWERTOYS_0_81_1)"/>
-            <definition name="SUPPORTED_POWERTOYS_0_82_0" displayName="$(string.SUPPORTED_POWERTOYS_0_82_0)"/>
-        </definitions>
-    </supportedOn>
-    <categories>
-        <category name="PowerToys" displayName="$(string.PowerToys)" />
-        <category name="InstallerUpdates" displayName="$(string.InstallerUpdates)">
-            <parentCategory ref="PowerToys" />
-        </category>
-        <category name="PowerToysRun" displayName="$(string.PowerToysRun)">
-            <parentCategory ref="PowerToys" />
-        </category>
-        <category name="AdvancedPaste" displayName="$(string.AdvancedPaste)">
-            <parentCategory ref="PowerToys" />
-        </category>
-    </categories>
-    <policies>
+  <policyNamespaces>
+    <target prefix="powertoys" namespace="Microsoft.Policies.PowerToys" />
+  </policyNamespaces>
+  <resources minRequiredRevision="1.11"/><!-- Last changed with PowerToys v0.82.0 -->
+  <supportedOn>
+    <definitions>
+      <definition name="SUPPORTED_POWERTOYS_0_64_0" displayName="$(string.SUPPORTED_POWERTOYS_0_64_0)"/>
+      <definition name="SUPPORTED_POWERTOYS_0_68_0" displayName="$(string.SUPPORTED_POWERTOYS_0_68_0)"/>
+      <definition name="SUPPORTED_POWERTOYS_0_69_0" displayName="$(string.SUPPORTED_POWERTOYS_0_69_0)"/>
+      <definition name="SUPPORTED_POWERTOYS_0_70_0" displayName="$(string.SUPPORTED_POWERTOYS_0_70_0)"/>
+      <definition name="SUPPORTED_POWERTOYS_0_73_0" displayName="$(string.SUPPORTED_POWERTOYS_0_73_0)"/>
+      <definition name="SUPPORTED_POWERTOYS_0_75_0" displayName="$(string.SUPPORTED_POWERTOYS_0_75_0)"/>
+      <definition name="SUPPORTED_POWERTOYS_0_76_0" displayName="$(string.SUPPORTED_POWERTOYS_0_76_0)"/>
+      <definition name="SUPPORTED_POWERTOYS_0_77_0" displayName="$(string.SUPPORTED_POWERTOYS_0_77_0)"/>
+      <definition name="SUPPORTED_POWERTOYS_0_78_0" displayName="$(string.SUPPORTED_POWERTOYS_0_78_0)"/>
+      <definition name="SUPPORTED_POWERTOYS_0_81_0" displayName="$(string.SUPPORTED_POWERTOYS_0_81_0)"/>
+      <definition name="SUPPORTED_POWERTOYS_0_81_1" displayName="$(string.SUPPORTED_POWERTOYS_0_81_1)"/>
+      <definition name="SUPPORTED_POWERTOYS_0_82_0" displayName="$(string.SUPPORTED_POWERTOYS_0_82_0)"/>
+    </definitions>
+  </supportedOn>
+  <categories>
+    <category name="PowerToys" displayName="$(string.PowerToys)" />
+    <category name="InstallerUpdates" displayName="$(string.InstallerUpdates)">
+      <parentCategory ref="PowerToys" />
+    </category>
+    <category name="PowerToysRun" displayName="$(string.PowerToysRun)">
+      <parentCategory ref="PowerToys" />
+    </category>
+    <category name="AdvancedPaste" displayName="$(string.AdvancedPaste)">
+      <parentCategory ref="PowerToys" />
+    </category>
+  </categories>
+  <policies>
 
-        <policy name="ConfigureGlobalUtilityEnabledState" class="Both" displayName="$(string.ConfigureGlobalUtilityEnabledState)" explainText="$(string.ConfigureGlobalUtilityEnabledStateDescription)" key="Software\Policies\PowerToys" valueName="ConfigureGlobalUtilityEnabledState">
-            <parentCategory ref="PowerToys" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_75_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
+    <policy name="ConfigureGlobalUtilityEnabledState" class="Both" displayName="$(string.ConfigureGlobalUtilityEnabledState)" explainText="$(string.ConfigureGlobalUtilityEnabledStateDescription)" key="Software\Policies\PowerToys" valueName="ConfigureGlobalUtilityEnabledState">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_75_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
 
-        <policy name="ConfigureEnabledUtilityAdvancedPaste" class="Both" displayName="$(string.ConfigureEnabledUtilityAdvancedPaste)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityAdvancedPaste">
-            <parentCategory ref="PowerToys" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_81_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-        <policy name="ConfigureEnabledUtilityAlwaysOnTop" class="Both" displayName="$(string.ConfigureEnabledUtilityAlwaysOnTop)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityAlwaysOnTop">
-            <parentCategory ref="PowerToys" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-        <policy name="ConfigureEnabledUtilityAwake" class="Both" displayName="$(string.ConfigureEnabledUtilityAwake)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityAwake">
-            <parentCategory ref="PowerToys" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-        <policy name="ConfigureEnabledUtilityCmdNotFound" class="Both" displayName="$(string.ConfigureEnabledUtilityCmdNotFound)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityCmdNotFound">
-            <parentCategory ref="PowerToys" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_77_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-        <policy name="ConfigureEnabledUtilityColorPicker" class="Both" displayName="$(string.ConfigureEnabledUtilityColorPicker)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityColorPicker">
-            <parentCategory ref="PowerToys" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-        <policy name="ConfigureEnabledUtilityCropAndLock" class="Both" displayName="$(string.ConfigureEnabledUtilityCropAndLock)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityCropAndLock">
-            <parentCategory ref="PowerToys" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_73_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-        <policy name="ConfigureEnabledUtilityEnvironmentVariables" class="Both" displayName="$(string.ConfigureEnabledUtilityEnvironmentVariables)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityEnvironmentVariables">
-            <parentCategory ref="PowerToys" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_75_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-        <policy name="ConfigureEnabledUtilityFancyZones" class="Both" displayName="$(string.ConfigureEnabledUtilityFancyZones)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFancyZones">
-            <parentCategory ref="PowerToys" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-        <policy name="ConfigureEnabledUtilityFileLocksmith" class="Both" displayName="$(string.ConfigureEnabledUtilityFileLocksmith)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileLocksmith">
-            <parentCategory ref="PowerToys" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-        <policy name="ConfigureEnabledUtilityFileExplorerPreview" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerPreview)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerPreview">
-            <parentCategory ref="PowerToys" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_82_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-        <policy name="ConfigureEnabledUtilityFileExplorerSVGPreview" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerSVGPreview)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerSVGPreview">
-            <parentCategory ref="PowerToys" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-        <policy name="ConfigureEnabledUtilityFileExplorerMarkdownPreview" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerMarkdownPreview)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerMarkdownPreview">
-            <parentCategory ref="PowerToys" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-        <policy name="ConfigureEnabledUtilityFileExplorerMonacoPreview" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerMonacoPreview)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerMonacoPreview">
-            <parentCategory ref="PowerToys" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-        <policy name="ConfigureEnabledUtilityFileExplorerPDFPreview" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerPDFPreview)" explainText="$(string.ConfigureEnabledUtilityDescriptionPDFPreviewHandler)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerPDFPreview">
-            <parentCategory ref="PowerToys" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-        <policy name="ConfigureEnabledUtilityFileExplorerGcodePreview" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerGcodePreview)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerGcodePreview">
-            <parentCategory ref="PowerToys" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-        <policy name="ConfigureEnabledUtilityFileExplorerSVGThumbnails" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerSVGThumbnails)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerSVGThumbnails">
-            <parentCategory ref="PowerToys" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-        <policy name="ConfigureEnabledUtilityFileExplorerPDFThumbnails" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerPDFThumbnails)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerPDFThumbnails">
-            <parentCategory ref="PowerToys" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-        <policy name="ConfigureEnabledUtilityFileExplorerGcodeThumbnails" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerGcodeThumbnails)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerGcodeThumbnails">
-            <parentCategory ref="PowerToys" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-        <policy name="ConfigureEnabledUtilityFileExplorerQOIPreview" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerQOIPreview)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerQOIPreview">
-            <parentCategory ref="PowerToys" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_76_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-        <policy name="ConfigureEnabledUtilityFileExplorerQOIThumbnails" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerQOIThumbnails)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerQOIThumbnails">
-            <parentCategory ref="PowerToys" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_76_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-        <policy name="ConfigureEnabledUtilityFileExplorerSTLThumbnails" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerSTLThumbnails)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerSTLThumbnails">
-            <parentCategory ref="PowerToys" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-        <policy name="ConfigureEnabledUtilityHostsFileEditor" class="Both" displayName="$(string.ConfigureEnabledUtilityHostsFileEditor)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityHostsFileEditor">
-            <parentCategory ref="PowerToys" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-        <policy name="ConfigureEnabledUtilityImageResizer" class="Both" displayName="$(string.ConfigureEnabledUtilityImageResizer)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityImageResizer">
-            <parentCategory ref="PowerToys" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-        <policy name="ConfigureEnabledUtilityKeyboardManager" class="Both" displayName="$(string.ConfigureEnabledUtilityKeyboardManager)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityKeyboardManager">
-            <parentCategory ref="PowerToys" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-        <policy name="ConfigureEnabledUtilityFindMyMouse" class="Both" displayName="$(string.ConfigureEnabledUtilityFindMyMouse)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFindMyMouse">
-            <parentCategory ref="PowerToys" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-        <policy name="ConfigureEnabledUtilityMouseHighlighter" class="Both" displayName="$(string.ConfigureEnabledUtilityMouseHighlighter)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityMouseHighlighter">
-            <parentCategory ref="PowerToys" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-        <policy name="ConfigureEnabledUtilityMousePointerCrosshairs" class="Both" displayName="$(string.ConfigureEnabledUtilityMousePointerCrosshairs)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityMousePointerCrosshairs">
-            <parentCategory ref="PowerToys" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-        <policy name="ConfigureEnabledUtilityMouseJump" class="Both" displayName="$(string.ConfigureEnabledUtilityMouseJump)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityMouseJump">
-            <parentCategory ref="PowerToys" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_68_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-        <policy name="ConfigureEnabledUtilityMouseWithoutBorders" class="Both" displayName="$(string.ConfigureEnabledUtilityMouseWithoutBorders)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityMouseWithoutBorders">
-            <parentCategory ref="PowerToys" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_70_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-        <policy name="ConfigureEnabledUtilityPeek" class="Both" displayName="$(string.ConfigureEnabledUtilityPeek)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityPeek">
-            <parentCategory ref="PowerToys" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_70_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-        <policy name="ConfigureEnabledUtilityPowerRename" class="Both" displayName="$(string.ConfigureEnabledUtilityPowerRename)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityPowerRename">
-            <parentCategory ref="PowerToys" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-        <policy name="ConfigureEnabledUtilityPowerLauncher" class="Both" displayName="$(string.ConfigureEnabledUtilityPowerLauncher)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityPowerLauncher">
-            <parentCategory ref="PowerToys" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-        <policy name="ConfigureEnabledUtilityQuickAccent" class="Both" displayName="$(string.ConfigureEnabledUtilityQuickAccent)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityQuickAccent">
-            <parentCategory ref="PowerToys" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-        <policy name="ConfigureEnabledUtilityRegistryPreview" class="Both" displayName="$(string.ConfigureEnabledUtilityRegistryPreview)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityRegistryPreview">
-            <parentCategory ref="PowerToys" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_69_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-        <policy name="ConfigureEnabledUtilityScreenRuler" class="Both" displayName="$(string.ConfigureEnabledUtilityScreenRuler)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityScreenRuler">
-            <parentCategory ref="PowerToys" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-        <policy name="ConfigureEnabledUtilityShortcutGuide" class="Both" displayName="$(string.ConfigureEnabledUtilityShortcutGuide)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityShortcutGuide">
-            <parentCategory ref="PowerToys" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-        <policy name="ConfigureEnabledUtilityTextExtractor" class="Both" displayName="$(string.ConfigureEnabledUtilityTextExtractor)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityTextExtractor">
-            <parentCategory ref="PowerToys" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-        <policy name="ConfigureEnabledUtilityVideoConferenceMute" class="Both" displayName="$(string.ConfigureEnabledUtilityVideoConferenceMute)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityVideoConferenceMute">
-            <parentCategory ref="PowerToys" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-        <policy name="DisablePerUserInstallation" class="Machine" displayName="$(string.DisablePerUserInstallation)" explainText="$(string.DisablePerUserInstallationDescription)" key="Software\Policies\PowerToys" valueName="PerUserInstallationDisabled">
-            <parentCategory ref="InstallerUpdates" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_69_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-        <policy name="DisableAutomaticUpdateDownload" class="Both" displayName="$(string.DisableAutomaticUpdateDownload)" explainText="$(string.DisableAutomaticUpdateDownloadDescription)" key="Software\Policies\PowerToys" valueName="AutomaticUpdateDownloadDisabled">
-            <parentCategory ref="InstallerUpdates" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_68_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-        <policy name="SuspendNewUpdateToast" class="Both" displayName="$(string.SuspendNewUpdateToast)" explainText="$(string.SuspendNewUpdateToastDescription)" key="Software\Policies\PowerToys" valueName="SuspendNewUpdateAvailableToast">
-            <parentCategory ref="InstallerUpdates" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_68_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-        <policy name="DisableNewUpdateToast" class="Both" displayName="$(string.DisableNewUpdateToast)" explainText="$(string.DisableNewUpdateToastDescription)" key="Software\Policies\PowerToys" valueName="DisableNewUpdateAvailableToast">
-            <parentCategory ref="InstallerUpdates" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_78_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-        <policy name="DoNotShowWhatsNewAfterUpdates" class="Both" displayName="$(string.DoNotShowWhatsNewAfterUpdates)" explainText="$(string.DoNotShowWhatsNewAfterUpdatesDescription)" key="Software\Policies\PowerToys" valueName="DoNotShowWhatsNewAfterUpdates">
-            <parentCategory ref="InstallerUpdates" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_78_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-        <policy name="AllowExperimentation" class="Both" displayName="$(string.AllowExperimentation)" explainText="$(string.AllowExperimentationDescription)" key="Software\Policies\PowerToys" valueName="AllowExperimentation">
-            <parentCategory ref="PowerToys" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_68_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-        <policy name="PowerToysRunAllPluginsEnabledState" class="Both" displayName="$(string.PowerToysRunAllPluginsEnabledState)" explainText="$(string.PowerToysRunAllPluginsEnabledStateDescription)" key="Software\Policies\PowerToys" valueName="PowerLauncherAllPluginsEnabledState">
-            <parentCategory ref="PowerToysRun" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_75_0" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-        <policy name="PowerToysRunIndividualPluginEnabledState" class="Both" displayName="$(string.PowerToysRunIndividualPluginEnabledState)" explainText="$(string.PowerToysRunIndividualPluginEnabledStateDescription)" presentation="$(presentation.PowerToysRunIndividualPluginEnabledState)" key="Software\Policies\PowerToys\PowerLauncherIndividualPluginEnabledList">
-            <parentCategory ref="PowerToysRun" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_75_0"/>
-            <elements>
-                <list id="PowerToysRunIndividualPluginEnabledList" explicitValue="true" />
-            </elements>
-        </policy>
-        <policy name="AllowPowerToysAdvancedPasteOnlineAIModels" class="Both" displayName="$(string.AllowPowerToysAdvancedPasteOnlineAIModels)" explainText="$(string.AllowPowerToysAdvancedPasteOnlineAIModelsDescription)" key="Software\Policies\PowerToys" valueName="AllowPowerToysAdvancedPasteOnlineAIModels">
-            <parentCategory ref="AdvancedPaste" />
-            <supportedOn ref="SUPPORTED_POWERTOYS_0_81_1" />
-            <enabledValue>
-                <decimal value="1" />
-            </enabledValue>
-            <disabledValue>
-                <decimal value="0" />
-            </disabledValue>
-        </policy>
-    </policies>
+    <policy name="ConfigureEnabledUtilityAdvancedPaste" class="Both" displayName="$(string.ConfigureEnabledUtilityAdvancedPaste)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityAdvancedPaste">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_81_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityAlwaysOnTop" class="Both" displayName="$(string.ConfigureEnabledUtilityAlwaysOnTop)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityAlwaysOnTop">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityAwake" class="Both" displayName="$(string.ConfigureEnabledUtilityAwake)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityAwake">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityCmdNotFound" class="Both" displayName="$(string.ConfigureEnabledUtilityCmdNotFound)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityCmdNotFound">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_77_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityColorPicker" class="Both" displayName="$(string.ConfigureEnabledUtilityColorPicker)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityColorPicker">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityCropAndLock" class="Both" displayName="$(string.ConfigureEnabledUtilityCropAndLock)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityCropAndLock">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_73_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityEnvironmentVariables" class="Both" displayName="$(string.ConfigureEnabledUtilityEnvironmentVariables)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityEnvironmentVariables">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_75_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityFancyZones" class="Both" displayName="$(string.ConfigureEnabledUtilityFancyZones)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFancyZones">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityFileLocksmith" class="Both" displayName="$(string.ConfigureEnabledUtilityFileLocksmith)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileLocksmith">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityFileExplorerPreview" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerPreview)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerPreview">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_82_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityFileExplorerSVGPreview" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerSVGPreview)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerSVGPreview">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityFileExplorerMarkdownPreview" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerMarkdownPreview)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerMarkdownPreview">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityFileExplorerMonacoPreview" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerMonacoPreview)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerMonacoPreview">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityFileExplorerPDFPreview" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerPDFPreview)" explainText="$(string.ConfigureEnabledUtilityDescriptionPDFPreviewHandler)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerPDFPreview">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityFileExplorerGcodePreview" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerGcodePreview)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerGcodePreview">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityFileExplorerSVGThumbnails" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerSVGThumbnails)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerSVGThumbnails">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityFileExplorerPDFThumbnails" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerPDFThumbnails)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerPDFThumbnails">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityFileExplorerGcodeThumbnails" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerGcodeThumbnails)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerGcodeThumbnails">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityFileExplorerQOIPreview" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerQOIPreview)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerQOIPreview">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_76_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityFileExplorerQOIThumbnails" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerQOIThumbnails)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerQOIThumbnails">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_76_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityFileExplorerSTLThumbnails" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerSTLThumbnails)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerSTLThumbnails">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityHostsFileEditor" class="Both" displayName="$(string.ConfigureEnabledUtilityHostsFileEditor)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityHostsFileEditor">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityImageResizer" class="Both" displayName="$(string.ConfigureEnabledUtilityImageResizer)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityImageResizer">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityKeyboardManager" class="Both" displayName="$(string.ConfigureEnabledUtilityKeyboardManager)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityKeyboardManager">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityFindMyMouse" class="Both" displayName="$(string.ConfigureEnabledUtilityFindMyMouse)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFindMyMouse">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityMouseHighlighter" class="Both" displayName="$(string.ConfigureEnabledUtilityMouseHighlighter)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityMouseHighlighter">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityMousePointerCrosshairs" class="Both" displayName="$(string.ConfigureEnabledUtilityMousePointerCrosshairs)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityMousePointerCrosshairs">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityMouseJump" class="Both" displayName="$(string.ConfigureEnabledUtilityMouseJump)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityMouseJump">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_68_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityMouseWithoutBorders" class="Both" displayName="$(string.ConfigureEnabledUtilityMouseWithoutBorders)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityMouseWithoutBorders">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_70_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityPeek" class="Both" displayName="$(string.ConfigureEnabledUtilityPeek)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityPeek">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_70_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityPowerRename" class="Both" displayName="$(string.ConfigureEnabledUtilityPowerRename)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityPowerRename">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityPowerLauncher" class="Both" displayName="$(string.ConfigureEnabledUtilityPowerLauncher)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityPowerLauncher">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityQuickAccent" class="Both" displayName="$(string.ConfigureEnabledUtilityQuickAccent)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityQuickAccent">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityRegistryPreview" class="Both" displayName="$(string.ConfigureEnabledUtilityRegistryPreview)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityRegistryPreview">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_69_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityScreenRuler" class="Both" displayName="$(string.ConfigureEnabledUtilityScreenRuler)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityScreenRuler">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityShortcutGuide" class="Both" displayName="$(string.ConfigureEnabledUtilityShortcutGuide)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityShortcutGuide">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityTextExtractor" class="Both" displayName="$(string.ConfigureEnabledUtilityTextExtractor)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityTextExtractor">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityVideoConferenceMute" class="Both" displayName="$(string.ConfigureEnabledUtilityVideoConferenceMute)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityVideoConferenceMute">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="DisablePerUserInstallation" class="Machine" displayName="$(string.DisablePerUserInstallation)" explainText="$(string.DisablePerUserInstallationDescription)" key="Software\Policies\PowerToys" valueName="PerUserInstallationDisabled">
+      <parentCategory ref="InstallerUpdates" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_69_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="DisableAutomaticUpdateDownload" class="Both" displayName="$(string.DisableAutomaticUpdateDownload)" explainText="$(string.DisableAutomaticUpdateDownloadDescription)" key="Software\Policies\PowerToys" valueName="AutomaticUpdateDownloadDisabled">
+      <parentCategory ref="InstallerUpdates" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_68_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="SuspendNewUpdateToast" class="Both" displayName="$(string.SuspendNewUpdateToast)" explainText="$(string.SuspendNewUpdateToastDescription)" key="Software\Policies\PowerToys" valueName="SuspendNewUpdateAvailableToast">
+      <parentCategory ref="InstallerUpdates" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_68_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="DisableNewUpdateToast" class="Both" displayName="$(string.DisableNewUpdateToast)" explainText="$(string.DisableNewUpdateToastDescription)" key="Software\Policies\PowerToys" valueName="DisableNewUpdateAvailableToast">
+      <parentCategory ref="InstallerUpdates" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_78_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="DoNotShowWhatsNewAfterUpdates" class="Both" displayName="$(string.DoNotShowWhatsNewAfterUpdates)" explainText="$(string.DoNotShowWhatsNewAfterUpdatesDescription)" key="Software\Policies\PowerToys" valueName="DoNotShowWhatsNewAfterUpdates">
+      <parentCategory ref="InstallerUpdates" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_78_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="AllowExperimentation" class="Both" displayName="$(string.AllowExperimentation)" explainText="$(string.AllowExperimentationDescription)" key="Software\Policies\PowerToys" valueName="AllowExperimentation">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_68_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="PowerToysRunAllPluginsEnabledState" class="Both" displayName="$(string.PowerToysRunAllPluginsEnabledState)" explainText="$(string.PowerToysRunAllPluginsEnabledStateDescription)" key="Software\Policies\PowerToys" valueName="PowerLauncherAllPluginsEnabledState">
+      <parentCategory ref="PowerToysRun" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_75_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="PowerToysRunIndividualPluginEnabledState" class="Both" displayName="$(string.PowerToysRunIndividualPluginEnabledState)" explainText="$(string.PowerToysRunIndividualPluginEnabledStateDescription)" presentation="$(presentation.PowerToysRunIndividualPluginEnabledState)" key="Software\Policies\PowerToys\PowerLauncherIndividualPluginEnabledList">
+      <parentCategory ref="PowerToysRun" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_75_0"/>
+      <elements>
+        <list id="PowerToysRunIndividualPluginEnabledList" explicitValue="true" />
+      </elements>
+    </policy>
+    <policy name="AllowPowerToysAdvancedPasteOnlineAIModels" class="Both" displayName="$(string.AllowPowerToysAdvancedPasteOnlineAIModels)" explainText="$(string.AllowPowerToysAdvancedPasteOnlineAIModelsDescription)" key="Software\Policies\PowerToys" valueName="AllowPowerToysAdvancedPasteOnlineAIModels">
+      <parentCategory ref="AdvancedPaste" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_81_1" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+  </policies>
 </policyDefinitions>

--- a/src/gpo/assets/en-US/PowerToys.adml
+++ b/src/gpo/assets/en-US/PowerToys.adml
@@ -1,187 +1,189 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft Corporation.
      Licensed under the MIT License. -->
-<policyDefinitionResources xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.10" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
-  <displayName>PowerToys</displayName>
-  <description>PowerToys</description>
-  <resources>
-    <stringTable>
-      <string id="PowerToys">Microsoft PowerToys</string>
-      <string id="InstallerUpdates">Installer and Updates</string>
-      <string id="PowerToysRun">PowerToys Run</string>
-      <string id="AdvancedPaste">Advanced Paste</string>
+<policyDefinitionResources xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.11" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
+    <displayName>PowerToys</displayName>
+    <description>PowerToys</description>
+    <resources>
+        <stringTable>
+            <string id="PowerToys">Microsoft PowerToys</string>
+            <string id="InstallerUpdates">Installer and Updates</string>
+            <string id="PowerToysRun">PowerToys Run</string>
+            <string id="AdvancedPaste">Advanced Paste</string>
 
-      <string id="SUPPORTED_POWERTOYS_0_64_0">PowerToys version 0.64.0 or later</string>
-      <string id="SUPPORTED_POWERTOYS_0_68_0">PowerToys version 0.68.0 or later</string>
-      <string id="SUPPORTED_POWERTOYS_0_69_0">PowerToys version 0.69.0 or later</string>
-      <string id="SUPPORTED_POWERTOYS_0_70_0">PowerToys version 0.70.0 or later</string>
-      <string id="SUPPORTED_POWERTOYS_0_73_0">PowerToys version 0.73.0 or later</string>
-      <string id="SUPPORTED_POWERTOYS_0_75_0">PowerToys version 0.75.0 or later</string>
-      <string id="SUPPORTED_POWERTOYS_0_76_0">PowerToys version 0.76.0 or later</string>
-      <string id="SUPPORTED_POWERTOYS_0_77_0">PowerToys version 0.77.0 or later</string>
-      <string id="SUPPORTED_POWERTOYS_0_78_0">PowerToys version 0.78.0 or later</string>
-      <string id="SUPPORTED_POWERTOYS_0_81_0">PowerToys version 0.81.0 or later</string>
-      <string id="SUPPORTED_POWERTOYS_0_81_1">PowerToys version 0.81.1 or later</string>
+            <string id="SUPPORTED_POWERTOYS_0_64_0">PowerToys version 0.64.0 or later</string>
+            <string id="SUPPORTED_POWERTOYS_0_68_0">PowerToys version 0.68.0 or later</string>
+            <string id="SUPPORTED_POWERTOYS_0_69_0">PowerToys version 0.69.0 or later</string>
+            <string id="SUPPORTED_POWERTOYS_0_70_0">PowerToys version 0.70.0 or later</string>
+            <string id="SUPPORTED_POWERTOYS_0_73_0">PowerToys version 0.73.0 or later</string>
+            <string id="SUPPORTED_POWERTOYS_0_75_0">PowerToys version 0.75.0 or later</string>
+            <string id="SUPPORTED_POWERTOYS_0_76_0">PowerToys version 0.76.0 or later</string>
+            <string id="SUPPORTED_POWERTOYS_0_77_0">PowerToys version 0.77.0 or later</string>
+            <string id="SUPPORTED_POWERTOYS_0_78_0">PowerToys version 0.78.0 or later</string>
+            <string id="SUPPORTED_POWERTOYS_0_81_0">PowerToys version 0.81.0 or later</string>
+            <string id="SUPPORTED_POWERTOYS_0_81_1">PowerToys version 0.81.1 or later</string>
+            <string id="SUPPORTED_POWERTOYS_0_82_0">PowerToys version 0.82.0 or later</string>
 
       <string id="ConfigureGlobalUtilityEnabledStateDescription">This policy configures the enabled state for all PowerToys utilities.
 
-If you enable this setting, all utilities will be always enabled and the user won't be able to disable it.
+                If you enable this setting, all utilities will be always enabled and the user won't be able to disable it.
 
-If you disable this setting, all utilities will be always disabled and the user won't be able to enable it.
+                If you disable this setting, all utilities will be always disabled and the user won't be able to enable it.
 
-If you don't configure this setting, users are able to enable or disable the utilities.
+                If you don't configure this setting, users are able to enable or disable the utilities.
 
-The individual enabled state policies for the utilities will override this policy.
-</string>
+                The individual enabled state policies for the utilities will override this policy.
+            </string>
 
       <string id="ConfigureEnabledUtilityDescription">This policy configures the enabled state for a PowerToys utility.
 
-If you enable this setting, the utility will be always enabled and the user won't be able to disable it.
+                If you enable this setting, the utility will be always enabled and the user won't be able to disable it.
 
-If you disable this setting, the utility will be always disabled and the user won't be able to enable it.
+                If you disable this setting, the utility will be always disabled and the user won't be able to enable it.
 
-If you don't configure this setting, users are able to enable or disable the utility.
+                If you don't configure this setting, users are able to enable or disable the utility.
 
-This policy has a higher priority than the policy "Configure global utility enabled state" and overrides it.
-</string>
+                This policy has a higher priority than the policy "Configure global utility enabled state" and overrides it.
+            </string>
       <string id="ConfigureEnabledUtilityDescriptionPDFPreviewHandler">(Note: There have been reports of incompatibility between the PDF Preview Handler and Outlook)
 
-This policy configures the enabled state for a PowerToys utility.
+                This policy configures the enabled state for a PowerToys utility.
 
-If you enable this setting, the utility will be always enabled and the user won't be able to disable it.
+                If you enable this setting, the utility will be always enabled and the user won't be able to disable it.
 
-If you disable this setting, the utility will be always disabled and the user won't be able to enable it.
+                If you disable this setting, the utility will be always disabled and the user won't be able to enable it.
 
-If you don't configure this setting, users are able to enable or disable the utility.
+                If you don't configure this setting, users are able to enable or disable the utility.
 
-This policy has a higher priority than the policy "Configure global utility enabled state" and overrides it.
-</string>
+                This policy has a higher priority than the policy "Configure global utility enabled state" and overrides it.
+            </string>
       <string id="DisablePerUserInstallationDescription">This policy configures whether per-user PowerToys installation is allowed or not.
 
-If enabled, per-user installation is not allowed.
+                If enabled, per-user installation is not allowed.
 
-If disabled or not configured, per-user installation is allowed.
-</string>
+                If disabled or not configured, per-user installation is allowed.
+            </string>
       <string id="DisableAutomaticUpdateDownloadDescription">This policy configures whether the automatic download and installation of available updates is disabled or not. (On metered connections updates are never downloaded.)
 
-If enabled, automatic download and installation is disabled.
+                If enabled, automatic download and installation is disabled.
 
-If disabled or not configured, the user can control this in the settings.
-</string>
+                If disabled or not configured, the user can control this in the settings.
+            </string>
       <string id="SuspendNewUpdateToastDescription">This policy configures whether the action center notification for new updates is suspended for 2 minor releases. (Example: if the installed version is v0.60.0, then the next notification is shown for the v0.63.* release.)
 
-If enabled, the notification is suspended.
+                If enabled, the notification is suspended.
 
-If disabled or not configured, the notification is shown.
+                If disabled or not configured, the notification is shown.
 
-Note: The notification about new major versions is always displayed.
+                Note: The notification about new major versions is always displayed.
 
-This policy has no effect if the update notification is disabled by the policy "Disable Action Center notification for new updates" or the user setting.
-</string>
+                This policy has no effect if the update notification is disabled by the policy "Disable Action Center notification for new updates" or the user setting.
+            </string>
       <string id="DisableNewUpdateToastDescription">This policy configures whether the action center notification for new updates is shown or not.
 
-If enabled, the notification is disabled.
+                If enabled, the notification is disabled.
 
-If disabled or not configured, the user can control if the notification is shown or not.
-</string>
+                If disabled or not configured, the user can control if the notification is shown or not.
+            </string>
       <string id="DoNotShowWhatsNewAfterUpdatesDescription">This policy allows you to configure if the window with the release notes is shown after updates.
 
-If enabled, the window with the release notes is not shown automatically.
+                If enabled, the window with the release notes is not shown automatically.
 
-If disabled or not configured, the user can control this in the settings of PowerToys.
-</string>
+                If disabled or not configured, the user can control this in the settings of PowerToys.
+            </string>
       <string id="AllowExperimentationDescription">This policy configures whether PowerToys experimentation is allowed. With experimentation allowed the user sees the new features being experimented if it gets selected as part of the test group. (Experimentation will only happen on Windows Insider builds.)
 
-If this setting is enabled or not configured, the user can control experimentation in the PowerToys settings menu.
+                If this setting is enabled or not configured, the user can control experimentation in the PowerToys settings menu.
 
-If this setting is disabled, experimentation is not allowed.
-</string>
+                If this setting is disabled, experimentation is not allowed.
+            </string>
       <string id="PowerToysRunAllPluginsEnabledStateDescription">This policy configures the enabled state for all PowerToys Run plugins. All plugins will have the same state.
 
-If you enable this setting, the plugins will be always enabled and the user won't be able to disable it.
+                If you enable this setting, the plugins will be always enabled and the user won't be able to disable it.
 
-If you disable this setting, the plugins will be always disabled and the user won't be able to enable it.
+                If you disable this setting, the plugins will be always disabled and the user won't be able to enable it.
 
-If you don't configure this setting, users are able to enable or disable the plugins.
+                If you don't configure this setting, users are able to enable or disable the plugins.
 
-You can override this policy for individual plugins using the policy "Configure enabled state for individual plugins".
+                You can override this policy for individual plugins using the policy "Configure enabled state for individual plugins".
 
-Note: Changes require a restart of PowerToys Run.
-</string>
+                Note: Changes require a restart of PowerToys Run.
+            </string>
       <string id="PowerToysRunIndividualPluginEnabledStateDescription">With this policy you can configure an individual enabled state for each PowerToys Run plugin that you add to the list.
 
-If you enable this setting, you can define the list of plugins and their enabled states:
-  - The value name (first column) is the plugin ID. You will find it in the plugin.json file which is located in the plugin folder.
-  - The value (second column) is a numeric value: 0 for disabled, 1 for enabled and 2 for user takes control.
-  - Example to disable the Program plugin: 791FC278BA414111B8D1886DFE447410 | 0
+                If you enable this setting, you can define the list of plugins and their enabled states:
+                - The value name (first column) is the plugin ID. You will find it in the plugin.json file which is located in the plugin folder.
+                - The value (second column) is a numeric value: 0 for disabled, 1 for enabled and 2 for user takes control.
+                - Example to disable the Program plugin: 791FC278BA414111B8D1886DFE447410 | 0
 
-If you disable or don't configure this policy, either the user or the policy "Configure enabled state for all plugins" takes control over the enabled state of the plugins.
+                If you disable or don't configure this policy, either the user or the policy "Configure enabled state for all plugins" takes control over the enabled state of the plugins.
 
-You can set the enabled state for all plugins not configured by this policy using the policy "Configure enabled state for all plugins".
+                You can set the enabled state for all plugins not configured by this policy using the policy "Configure enabled state for all plugins".
 
-Note: Changes require a restart of PowerToys Run.
-</string>
+                Note: Changes require a restart of PowerToys Run.
+            </string>
       <string id="AllowPowerToysAdvancedPasteOnlineAIModelsDescription">This policy configures the enabled disable state for using Advanced Paste online AI models.
 
-If you enable or don't configure this policy, the user takes control over the enabled state of the Enable paste with AI Advanced Paste setting.
+                If you enable or don't configure this policy, the user takes control over the enabled state of the Enable paste with AI Advanced Paste setting.
 
-If you disable this policy, the user won't be able to enable Enable paste with AI Advanced Paste setting and use Advanced Paste AI prompt nor set up the Open AI key in PowerToys Settings.
-</string>
-      <string id="ConfigureGlobalUtilityEnabledState">Configure global utility enabled state</string>
-      <string id="ConfigureEnabledUtilityAdvancedPaste">Advanced Paste: Configure enabled state</string>
-      <string id="ConfigureEnabledUtilityAlwaysOnTop">Always On Top: Configure enabled state</string>
-      <string id="ConfigureEnabledUtilityAwake">Awake: Configure enabled state</string>
-      <string id="ConfigureEnabledUtilityColorPicker">Color Picker: Configure enabled state</string>
-      <string id="ConfigureEnabledUtilityCmdNotFound">Command Not Found: Configure enabled state</string>
-      <string id="ConfigureEnabledUtilityCropAndLock">Crop And Lock: Configure enabled state</string>
-      <string id="ConfigureEnabledUtilityEnvironmentVariables">Environment Variables: Configure enabled state</string>
-      <string id="ConfigureEnabledUtilityFancyZones">FancyZones: Configure enabled state</string>
-      <string id="ConfigureEnabledUtilityFileLocksmith">File Locksmith: Configure enabled state</string>
-      <string id="ConfigureEnabledUtilityFileExplorerSVGPreview">SVG file preview: Configure enabled state</string>
-      <string id="ConfigureEnabledUtilityFileExplorerMarkdownPreview">Markdown file preview: Configure enabled state</string>
-      <string id="ConfigureEnabledUtilityFileExplorerMonacoPreview">Source code file preview: Configure enabled state</string>
-      <string id="ConfigureEnabledUtilityFileExplorerPDFPreview">PDF file preview: Configure enabled state</string>
-      <string id="ConfigureEnabledUtilityFileExplorerGcodePreview">Gcode file preview: Configure enabled state</string>
-      <string id="ConfigureEnabledUtilityFileExplorerSVGThumbnails">SVG file thumbnail: Configure enabled state</string>
-      <string id="ConfigureEnabledUtilityFileExplorerPDFThumbnails">PDF file thumbnail: Configure enabled state</string>
-      <string id="ConfigureEnabledUtilityFileExplorerGcodeThumbnails">Gcode file thumbnail: Configure enabled state</string>
-      <string id="ConfigureEnabledUtilityFileExplorerSTLThumbnails">STL file thumbnail: Configure enabled state</string>
-      <string id="ConfigureEnabledUtilityHostsFileEditor">Hosts file editor: Configure enabled state</string>
-      <string id="ConfigureEnabledUtilityImageResizer">Image Resizer: Configure enabled state</string>
-      <string id="ConfigureEnabledUtilityKeyboardManager">Keyboard Manager: Configure enabled state</string>
-      <string id="ConfigureEnabledUtilityFindMyMouse">Find My Mouse: Configure enabled state</string>
-      <string id="ConfigureEnabledUtilityMouseHighlighter">Mouse Highlighter: Configure enabled state</string>
-      <string id="ConfigureEnabledUtilityMouseJump">Mouse Jump: Configure enabled state</string>
-      <string id="ConfigureEnabledUtilityMousePointerCrosshairs">Mouse Pointer Crosshairs: Configure enabled state</string>
-      <string id="ConfigureEnabledUtilityMouseWithoutBorders">Mouse Without Borders: Configure enabled state</string>
-      <string id="ConfigureEnabledUtilityPeek">Peek: Configure enabled state</string>
-      <string id="ConfigureEnabledUtilityPowerRename">Power Rename: Configure enabled state</string>
-      <string id="ConfigureEnabledUtilityPowerLauncher">PowerToys Run: Configure enabled state</string>
-      <string id="ConfigureEnabledUtilityQuickAccent">Quick Accent: Configure enabled state</string>
-      <string id="ConfigureEnabledUtilityRegistryPreview">Registry Preview: Configure enabled state</string>
-      <string id="ConfigureEnabledUtilityScreenRuler">Screen Ruler: Configure enabled state</string>
-      <string id="ConfigureEnabledUtilityShortcutGuide">Shortcut Guide: Configure enabled state</string>
-      <string id="ConfigureEnabledUtilityTextExtractor">Text Extractor: Configure enabled state</string>
-      <string id="ConfigureEnabledUtilityVideoConferenceMute">Video Conference Mute: Configure enabled state</string>
-      <string id="DisablePerUserInstallation">Disable per-user installation</string>
-      <string id="DisableAutomaticUpdateDownload">Disable automatic downloads</string>
-      <string id="DoNotShowWhatsNewAfterUpdates">Do not show the release notes after updates</string>
-      <string id="SuspendNewUpdateToast">Suspend Action Center notification for new updates</string>
-      <string id="DisableNewUpdateToast">Disable Action Center notification for new updates</string>
-      <string id="AllowExperimentation">Allow Experimentation</string>
-      <string id="PowerToysRunAllPluginsEnabledState">Configure enabled state for all plugins</string>
-      <string id="PowerToysRunIndividualPluginEnabledState">Configure enabled state for individual plugins</string>
-      <string id="ConfigureEnabledUtilityFileExplorerQOIPreview">QOI file preview: Configure enabled state</string>
-      <string id="ConfigureEnabledUtilityFileExplorerQOIThumbnails">QOI file thumbnail: Configure enabled state</string>
-      <string id="AllowPowerToysAdvancedPasteOnlineAIModels">Advanced Paste: Allow using online AI models</string>
-    </stringTable>
+                If you disable this policy, the user won't be able to enable Enable paste with AI Advanced Paste setting and use Advanced Paste AI prompt nor set up the Open AI key in PowerToys Settings.
+            </string>
+            <string id="ConfigureGlobalUtilityEnabledState">Configure global utility enabled state</string>
+            <string id="ConfigureEnabledUtilityAdvancedPaste">Advanced Paste: Configure enabled state</string>
+            <string id="ConfigureEnabledUtilityAlwaysOnTop">Always On Top: Configure enabled state</string>
+            <string id="ConfigureEnabledUtilityAwake">Awake: Configure enabled state</string>
+            <string id="ConfigureEnabledUtilityColorPicker">Color Picker: Configure enabled state</string>
+            <string id="ConfigureEnabledUtilityCmdNotFound">Command Not Found: Configure enabled state</string>
+            <string id="ConfigureEnabledUtilityCropAndLock">Crop And Lock: Configure enabled state</string>
+            <string id="ConfigureEnabledUtilityEnvironmentVariables">Environment Variables: Configure enabled state</string>
+            <string id="ConfigureEnabledUtilityFancyZones">FancyZones: Configure enabled state</string>
+            <string id="ConfigureEnabledUtilityFileLocksmith">File Locksmith: Configure enabled state</string>
+            <string id="ConfigureEnabledUtilityFileLocksmith">File Explorer add-ons: Configure enabled state</string>
+            <string id="ConfigureEnabledUtilityFileExplorerSVGPreview">SVG file preview: Configure enabled state</string>
+            <string id="ConfigureEnabledUtilityFileExplorerMarkdownPreview">Markdown file preview: Configure enabled state</string>
+            <string id="ConfigureEnabledUtilityFileExplorerMonacoPreview">Source code file preview: Configure enabled state</string>
+            <string id="ConfigureEnabledUtilityFileExplorerPDFPreview">PDF file preview: Configure enabled state</string>
+            <string id="ConfigureEnabledUtilityFileExplorerGcodePreview">Gcode file preview: Configure enabled state</string>
+            <string id="ConfigureEnabledUtilityFileExplorerSVGThumbnails">SVG file thumbnail: Configure enabled state</string>
+            <string id="ConfigureEnabledUtilityFileExplorerPDFThumbnails">PDF file thumbnail: Configure enabled state</string>
+            <string id="ConfigureEnabledUtilityFileExplorerGcodeThumbnails">Gcode file thumbnail: Configure enabled state</string>
+            <string id="ConfigureEnabledUtilityFileExplorerSTLThumbnails">STL file thumbnail: Configure enabled state</string>
+            <string id="ConfigureEnabledUtilityHostsFileEditor">Hosts file editor: Configure enabled state</string>
+            <string id="ConfigureEnabledUtilityImageResizer">Image Resizer: Configure enabled state</string>
+            <string id="ConfigureEnabledUtilityKeyboardManager">Keyboard Manager: Configure enabled state</string>
+            <string id="ConfigureEnabledUtilityFindMyMouse">Find My Mouse: Configure enabled state</string>
+            <string id="ConfigureEnabledUtilityMouseHighlighter">Mouse Highlighter: Configure enabled state</string>
+            <string id="ConfigureEnabledUtilityMouseJump">Mouse Jump: Configure enabled state</string>
+            <string id="ConfigureEnabledUtilityMousePointerCrosshairs">Mouse Pointer Crosshairs: Configure enabled state</string>
+            <string id="ConfigureEnabledUtilityMouseWithoutBorders">Mouse Without Borders: Configure enabled state</string>
+            <string id="ConfigureEnabledUtilityPeek">Peek: Configure enabled state</string>
+            <string id="ConfigureEnabledUtilityPowerRename">Power Rename: Configure enabled state</string>
+            <string id="ConfigureEnabledUtilityPowerLauncher">PowerToys Run: Configure enabled state</string>
+            <string id="ConfigureEnabledUtilityQuickAccent">Quick Accent: Configure enabled state</string>
+            <string id="ConfigureEnabledUtilityRegistryPreview">Registry Preview: Configure enabled state</string>
+            <string id="ConfigureEnabledUtilityScreenRuler">Screen Ruler: Configure enabled state</string>
+            <string id="ConfigureEnabledUtilityShortcutGuide">Shortcut Guide: Configure enabled state</string>
+            <string id="ConfigureEnabledUtilityTextExtractor">Text Extractor: Configure enabled state</string>
+            <string id="ConfigureEnabledUtilityVideoConferenceMute">Video Conference Mute: Configure enabled state</string>
+            <string id="DisablePerUserInstallation">Disable per-user installation</string>
+            <string id="DisableAutomaticUpdateDownload">Disable automatic downloads</string>
+            <string id="DoNotShowWhatsNewAfterUpdates">Do not show the release notes after updates</string>
+            <string id="SuspendNewUpdateToast">Suspend Action Center notification for new updates</string>
+            <string id="DisableNewUpdateToast">Disable Action Center notification for new updates</string>
+            <string id="AllowExperimentation">Allow Experimentation</string>
+            <string id="PowerToysRunAllPluginsEnabledState">Configure enabled state for all plugins</string>
+            <string id="PowerToysRunIndividualPluginEnabledState">Configure enabled state for individual plugins</string>
+            <string id="ConfigureEnabledUtilityFileExplorerQOIPreview">QOI file preview: Configure enabled state</string>
+            <string id="ConfigureEnabledUtilityFileExplorerQOIThumbnails">QOI file thumbnail: Configure enabled state</string>
+            <string id="AllowPowerToysAdvancedPasteOnlineAIModels">Advanced Paste: Allow using online AI models</string>
+        </stringTable>
 
-    <presentationTable>
-      <presentation id="PowerToysRunIndividualPluginEnabledState">
-        <listBox refId="PowerToysRunIndividualPluginEnabledList">List of managed plugins:</listBox>
-      </presentation>
-    </presentationTable>
+        <presentationTable>
+            <presentation id="PowerToysRunIndividualPluginEnabledState">
+                <listBox refId="PowerToysRunIndividualPluginEnabledList">List of managed plugins:</listBox>
+            </presentation>
+        </presentationTable>
 
-  </resources>
+    </resources>
 </policyDefinitionResources>
 

--- a/src/gpo/assets/en-US/PowerToys.adml
+++ b/src/gpo/assets/en-US/PowerToys.adml
@@ -138,7 +138,7 @@
             <string id="ConfigureEnabledUtilityEnvironmentVariables">Environment Variables: Configure enabled state</string>
             <string id="ConfigureEnabledUtilityFancyZones">FancyZones: Configure enabled state</string>
             <string id="ConfigureEnabledUtilityFileLocksmith">File Locksmith: Configure enabled state</string>
-            <string id="ConfigureEnabledUtilityFileLocksmith">File Explorer add-ons: Configure enabled state</string>
+            <string id="ConfigureEnabledUtilityFileExplorerPreview">File Explorer add-ons: Configure enabled state</string>
             <string id="ConfigureEnabledUtilityFileExplorerSVGPreview">SVG file preview: Configure enabled state</string>
             <string id="ConfigureEnabledUtilityFileExplorerMarkdownPreview">Markdown file preview: Configure enabled state</string>
             <string id="ConfigureEnabledUtilityFileExplorerMonacoPreview">Source code file preview: Configure enabled state</string>

--- a/src/gpo/assets/en-US/PowerToys.adml
+++ b/src/gpo/assets/en-US/PowerToys.adml
@@ -2,188 +2,188 @@
 <!-- Copyright (c) Microsoft Corporation.
      Licensed under the MIT License. -->
 <policyDefinitionResources xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.11" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
-    <displayName>PowerToys</displayName>
-    <description>PowerToys</description>
-    <resources>
-        <stringTable>
-            <string id="PowerToys">Microsoft PowerToys</string>
-            <string id="InstallerUpdates">Installer and Updates</string>
-            <string id="PowerToysRun">PowerToys Run</string>
-            <string id="AdvancedPaste">Advanced Paste</string>
+  <displayName>PowerToys</displayName>
+  <description>PowerToys</description>
+  <resources>
+    <stringTable>
+      <string id="PowerToys">Microsoft PowerToys</string>
+      <string id="InstallerUpdates">Installer and Updates</string>
+      <string id="PowerToysRun">PowerToys Run</string>
+      <string id="AdvancedPaste">Advanced Paste</string>
 
-            <string id="SUPPORTED_POWERTOYS_0_64_0">PowerToys version 0.64.0 or later</string>
-            <string id="SUPPORTED_POWERTOYS_0_68_0">PowerToys version 0.68.0 or later</string>
-            <string id="SUPPORTED_POWERTOYS_0_69_0">PowerToys version 0.69.0 or later</string>
-            <string id="SUPPORTED_POWERTOYS_0_70_0">PowerToys version 0.70.0 or later</string>
-            <string id="SUPPORTED_POWERTOYS_0_73_0">PowerToys version 0.73.0 or later</string>
-            <string id="SUPPORTED_POWERTOYS_0_75_0">PowerToys version 0.75.0 or later</string>
-            <string id="SUPPORTED_POWERTOYS_0_76_0">PowerToys version 0.76.0 or later</string>
-            <string id="SUPPORTED_POWERTOYS_0_77_0">PowerToys version 0.77.0 or later</string>
-            <string id="SUPPORTED_POWERTOYS_0_78_0">PowerToys version 0.78.0 or later</string>
-            <string id="SUPPORTED_POWERTOYS_0_81_0">PowerToys version 0.81.0 or later</string>
-            <string id="SUPPORTED_POWERTOYS_0_81_1">PowerToys version 0.81.1 or later</string>
-            <string id="SUPPORTED_POWERTOYS_0_82_0">PowerToys version 0.82.0 or later</string>
+      <string id="SUPPORTED_POWERTOYS_0_64_0">PowerToys version 0.64.0 or later</string>
+      <string id="SUPPORTED_POWERTOYS_0_68_0">PowerToys version 0.68.0 or later</string>
+      <string id="SUPPORTED_POWERTOYS_0_69_0">PowerToys version 0.69.0 or later</string>
+      <string id="SUPPORTED_POWERTOYS_0_70_0">PowerToys version 0.70.0 or later</string>
+      <string id="SUPPORTED_POWERTOYS_0_73_0">PowerToys version 0.73.0 or later</string>
+      <string id="SUPPORTED_POWERTOYS_0_75_0">PowerToys version 0.75.0 or later</string>
+      <string id="SUPPORTED_POWERTOYS_0_76_0">PowerToys version 0.76.0 or later</string>
+      <string id="SUPPORTED_POWERTOYS_0_77_0">PowerToys version 0.77.0 or later</string>
+      <string id="SUPPORTED_POWERTOYS_0_78_0">PowerToys version 0.78.0 or later</string>
+      <string id="SUPPORTED_POWERTOYS_0_81_0">PowerToys version 0.81.0 or later</string>
+      <string id="SUPPORTED_POWERTOYS_0_81_1">PowerToys version 0.81.1 or later</string>
+      <string id="SUPPORTED_POWERTOYS_0_82_0">PowerToys version 0.82.0 or later</string>
 
       <string id="ConfigureGlobalUtilityEnabledStateDescription">This policy configures the enabled state for all PowerToys utilities.
 
-                If you enable this setting, all utilities will be always enabled and the user won't be able to disable it.
+If you enable this setting, all utilities will be always enabled and the user won't be able to disable it.
 
-                If you disable this setting, all utilities will be always disabled and the user won't be able to enable it.
+If you disable this setting, all utilities will be always disabled and the user won't be able to enable it.
 
-                If you don't configure this setting, users are able to enable or disable the utilities.
+If you don't configure this setting, users are able to enable or disable the utilities.
 
-                The individual enabled state policies for the utilities will override this policy.
-            </string>
+The individual enabled state policies for the utilities will override this policy.
+</string>
 
       <string id="ConfigureEnabledUtilityDescription">This policy configures the enabled state for a PowerToys utility.
 
-                If you enable this setting, the utility will be always enabled and the user won't be able to disable it.
+If you enable this setting, the utility will be always enabled and the user won't be able to disable it.
 
-                If you disable this setting, the utility will be always disabled and the user won't be able to enable it.
+If you disable this setting, the utility will be always disabled and the user won't be able to enable it.
 
-                If you don't configure this setting, users are able to enable or disable the utility.
+If you don't configure this setting, users are able to enable or disable the utility.
 
-                This policy has a higher priority than the policy "Configure global utility enabled state" and overrides it.
-            </string>
+This policy has a higher priority than the policy "Configure global utility enabled state" and overrides it.
+</string>
       <string id="ConfigureEnabledUtilityDescriptionPDFPreviewHandler">(Note: There have been reports of incompatibility between the PDF Preview Handler and Outlook)
 
-                This policy configures the enabled state for a PowerToys utility.
+This policy configures the enabled state for a PowerToys utility.
 
-                If you enable this setting, the utility will be always enabled and the user won't be able to disable it.
+If you enable this setting, the utility will be always enabled and the user won't be able to disable it.
 
-                If you disable this setting, the utility will be always disabled and the user won't be able to enable it.
+If you disable this setting, the utility will be always disabled and the user won't be able to enable it.
 
-                If you don't configure this setting, users are able to enable or disable the utility.
+If you don't configure this setting, users are able to enable or disable the utility.
 
-                This policy has a higher priority than the policy "Configure global utility enabled state" and overrides it.
-            </string>
+This policy has a higher priority than the policy "Configure global utility enabled state" and overrides it.
+</string>
       <string id="DisablePerUserInstallationDescription">This policy configures whether per-user PowerToys installation is allowed or not.
 
-                If enabled, per-user installation is not allowed.
+If enabled, per-user installation is not allowed.
 
-                If disabled or not configured, per-user installation is allowed.
-            </string>
+If disabled or not configured, per-user installation is allowed.
+</string>
       <string id="DisableAutomaticUpdateDownloadDescription">This policy configures whether the automatic download and installation of available updates is disabled or not. (On metered connections updates are never downloaded.)
 
-                If enabled, automatic download and installation is disabled.
+If enabled, automatic download and installation is disabled.
 
-                If disabled or not configured, the user can control this in the settings.
-            </string>
+If disabled or not configured, the user can control this in the settings.
+</string>
       <string id="SuspendNewUpdateToastDescription">This policy configures whether the action center notification for new updates is suspended for 2 minor releases. (Example: if the installed version is v0.60.0, then the next notification is shown for the v0.63.* release.)
 
-                If enabled, the notification is suspended.
+If enabled, the notification is suspended.
 
-                If disabled or not configured, the notification is shown.
+If disabled or not configured, the notification is shown.
 
-                Note: The notification about new major versions is always displayed.
+Note: The notification about new major versions is always displayed.
 
-                This policy has no effect if the update notification is disabled by the policy "Disable Action Center notification for new updates" or the user setting.
-            </string>
+This policy has no effect if the update notification is disabled by the policy "Disable Action Center notification for new updates" or the user setting.
+</string>
       <string id="DisableNewUpdateToastDescription">This policy configures whether the action center notification for new updates is shown or not.
 
-                If enabled, the notification is disabled.
+If enabled, the notification is disabled.
 
-                If disabled or not configured, the user can control if the notification is shown or not.
-            </string>
+If disabled or not configured, the user can control if the notification is shown or not.
+</string>
       <string id="DoNotShowWhatsNewAfterUpdatesDescription">This policy allows you to configure if the window with the release notes is shown after updates.
 
-                If enabled, the window with the release notes is not shown automatically.
+If enabled, the window with the release notes is not shown automatically.
 
-                If disabled or not configured, the user can control this in the settings of PowerToys.
-            </string>
+If disabled or not configured, the user can control this in the settings of PowerToys.
+</string>
       <string id="AllowExperimentationDescription">This policy configures whether PowerToys experimentation is allowed. With experimentation allowed the user sees the new features being experimented if it gets selected as part of the test group. (Experimentation will only happen on Windows Insider builds.)
 
-                If this setting is enabled or not configured, the user can control experimentation in the PowerToys settings menu.
+If this setting is enabled or not configured, the user can control experimentation in the PowerToys settings menu.
 
-                If this setting is disabled, experimentation is not allowed.
-            </string>
+If this setting is disabled, experimentation is not allowed.
+</string>
       <string id="PowerToysRunAllPluginsEnabledStateDescription">This policy configures the enabled state for all PowerToys Run plugins. All plugins will have the same state.
 
-                If you enable this setting, the plugins will be always enabled and the user won't be able to disable it.
+If you enable this setting, the plugins will be always enabled and the user won't be able to disable it.
 
-                If you disable this setting, the plugins will be always disabled and the user won't be able to enable it.
+If you disable this setting, the plugins will be always disabled and the user won't be able to enable it.
 
-                If you don't configure this setting, users are able to enable or disable the plugins.
+If you don't configure this setting, users are able to enable or disable the plugins.
 
-                You can override this policy for individual plugins using the policy "Configure enabled state for individual plugins".
+You can override this policy for individual plugins using the policy "Configure enabled state for individual plugins".
 
-                Note: Changes require a restart of PowerToys Run.
-            </string>
+Note: Changes require a restart of PowerToys Run.
+</string>
       <string id="PowerToysRunIndividualPluginEnabledStateDescription">With this policy you can configure an individual enabled state for each PowerToys Run plugin that you add to the list.
 
-                If you enable this setting, you can define the list of plugins and their enabled states:
-                - The value name (first column) is the plugin ID. You will find it in the plugin.json file which is located in the plugin folder.
-                - The value (second column) is a numeric value: 0 for disabled, 1 for enabled and 2 for user takes control.
-                - Example to disable the Program plugin: 791FC278BA414111B8D1886DFE447410 | 0
+If you enable this setting, you can define the list of plugins and their enabled states:
+  - The value name (first column) is the plugin ID. You will find it in the plugin.json file which is located in the plugin folder.
+  - The value (second column) is a numeric value: 0 for disabled, 1 for enabled and 2 for user takes control.
+  - Example to disable the Program plugin: 791FC278BA414111B8D1886DFE447410 | 0
 
-                If you disable or don't configure this policy, either the user or the policy "Configure enabled state for all plugins" takes control over the enabled state of the plugins.
+If you disable or don't configure this policy, either the user or the policy "Configure enabled state for all plugins" takes control over the enabled state of the plugins.
 
-                You can set the enabled state for all plugins not configured by this policy using the policy "Configure enabled state for all plugins".
+You can set the enabled state for all plugins not configured by this policy using the policy "Configure enabled state for all plugins".
 
-                Note: Changes require a restart of PowerToys Run.
-            </string>
+Note: Changes require a restart of PowerToys Run.
+</string>
       <string id="AllowPowerToysAdvancedPasteOnlineAIModelsDescription">This policy configures the enabled disable state for using Advanced Paste online AI models.
 
-                If you enable or don't configure this policy, the user takes control over the enabled state of the Enable paste with AI Advanced Paste setting.
+If you enable or don't configure this policy, the user takes control over the enabled state of the Enable paste with AI Advanced Paste setting.
 
-                If you disable this policy, the user won't be able to enable Enable paste with AI Advanced Paste setting and use Advanced Paste AI prompt nor set up the Open AI key in PowerToys Settings.
-            </string>
-            <string id="ConfigureGlobalUtilityEnabledState">Configure global utility enabled state</string>
-            <string id="ConfigureEnabledUtilityAdvancedPaste">Advanced Paste: Configure enabled state</string>
-            <string id="ConfigureEnabledUtilityAlwaysOnTop">Always On Top: Configure enabled state</string>
-            <string id="ConfigureEnabledUtilityAwake">Awake: Configure enabled state</string>
-            <string id="ConfigureEnabledUtilityColorPicker">Color Picker: Configure enabled state</string>
-            <string id="ConfigureEnabledUtilityCmdNotFound">Command Not Found: Configure enabled state</string>
-            <string id="ConfigureEnabledUtilityCropAndLock">Crop And Lock: Configure enabled state</string>
-            <string id="ConfigureEnabledUtilityEnvironmentVariables">Environment Variables: Configure enabled state</string>
-            <string id="ConfigureEnabledUtilityFancyZones">FancyZones: Configure enabled state</string>
-            <string id="ConfigureEnabledUtilityFileLocksmith">File Locksmith: Configure enabled state</string>
-            <string id="ConfigureEnabledUtilityFileExplorerPreview">File Explorer add-ons: Configure enabled state</string>
-            <string id="ConfigureEnabledUtilityFileExplorerSVGPreview">SVG file preview: Configure enabled state</string>
-            <string id="ConfigureEnabledUtilityFileExplorerMarkdownPreview">Markdown file preview: Configure enabled state</string>
-            <string id="ConfigureEnabledUtilityFileExplorerMonacoPreview">Source code file preview: Configure enabled state</string>
-            <string id="ConfigureEnabledUtilityFileExplorerPDFPreview">PDF file preview: Configure enabled state</string>
-            <string id="ConfigureEnabledUtilityFileExplorerGcodePreview">Gcode file preview: Configure enabled state</string>
-            <string id="ConfigureEnabledUtilityFileExplorerSVGThumbnails">SVG file thumbnail: Configure enabled state</string>
-            <string id="ConfigureEnabledUtilityFileExplorerPDFThumbnails">PDF file thumbnail: Configure enabled state</string>
-            <string id="ConfigureEnabledUtilityFileExplorerGcodeThumbnails">Gcode file thumbnail: Configure enabled state</string>
-            <string id="ConfigureEnabledUtilityFileExplorerSTLThumbnails">STL file thumbnail: Configure enabled state</string>
-            <string id="ConfigureEnabledUtilityHostsFileEditor">Hosts file editor: Configure enabled state</string>
-            <string id="ConfigureEnabledUtilityImageResizer">Image Resizer: Configure enabled state</string>
-            <string id="ConfigureEnabledUtilityKeyboardManager">Keyboard Manager: Configure enabled state</string>
-            <string id="ConfigureEnabledUtilityFindMyMouse">Find My Mouse: Configure enabled state</string>
-            <string id="ConfigureEnabledUtilityMouseHighlighter">Mouse Highlighter: Configure enabled state</string>
-            <string id="ConfigureEnabledUtilityMouseJump">Mouse Jump: Configure enabled state</string>
-            <string id="ConfigureEnabledUtilityMousePointerCrosshairs">Mouse Pointer Crosshairs: Configure enabled state</string>
-            <string id="ConfigureEnabledUtilityMouseWithoutBorders">Mouse Without Borders: Configure enabled state</string>
-            <string id="ConfigureEnabledUtilityPeek">Peek: Configure enabled state</string>
-            <string id="ConfigureEnabledUtilityPowerRename">Power Rename: Configure enabled state</string>
-            <string id="ConfigureEnabledUtilityPowerLauncher">PowerToys Run: Configure enabled state</string>
-            <string id="ConfigureEnabledUtilityQuickAccent">Quick Accent: Configure enabled state</string>
-            <string id="ConfigureEnabledUtilityRegistryPreview">Registry Preview: Configure enabled state</string>
-            <string id="ConfigureEnabledUtilityScreenRuler">Screen Ruler: Configure enabled state</string>
-            <string id="ConfigureEnabledUtilityShortcutGuide">Shortcut Guide: Configure enabled state</string>
-            <string id="ConfigureEnabledUtilityTextExtractor">Text Extractor: Configure enabled state</string>
-            <string id="ConfigureEnabledUtilityVideoConferenceMute">Video Conference Mute: Configure enabled state</string>
-            <string id="DisablePerUserInstallation">Disable per-user installation</string>
-            <string id="DisableAutomaticUpdateDownload">Disable automatic downloads</string>
-            <string id="DoNotShowWhatsNewAfterUpdates">Do not show the release notes after updates</string>
-            <string id="SuspendNewUpdateToast">Suspend Action Center notification for new updates</string>
-            <string id="DisableNewUpdateToast">Disable Action Center notification for new updates</string>
-            <string id="AllowExperimentation">Allow Experimentation</string>
-            <string id="PowerToysRunAllPluginsEnabledState">Configure enabled state for all plugins</string>
-            <string id="PowerToysRunIndividualPluginEnabledState">Configure enabled state for individual plugins</string>
-            <string id="ConfigureEnabledUtilityFileExplorerQOIPreview">QOI file preview: Configure enabled state</string>
-            <string id="ConfigureEnabledUtilityFileExplorerQOIThumbnails">QOI file thumbnail: Configure enabled state</string>
-            <string id="AllowPowerToysAdvancedPasteOnlineAIModels">Advanced Paste: Allow using online AI models</string>
-        </stringTable>
+If you disable this policy, the user won't be able to enable Enable paste with AI Advanced Paste setting and use Advanced Paste AI prompt nor set up the Open AI key in PowerToys Settings.
+</string>
+      <string id="ConfigureGlobalUtilityEnabledState">Configure global utility enabled state</string>
+      <string id="ConfigureEnabledUtilityAdvancedPaste">Advanced Paste: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityAlwaysOnTop">Always On Top: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityAwake">Awake: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityColorPicker">Color Picker: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityCmdNotFound">Command Not Found: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityCropAndLock">Crop And Lock: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityEnvironmentVariables">Environment Variables: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityFancyZones">FancyZones: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityFileLocksmith">File Locksmith: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityFileExplorerPreview">File Explorer add-ons: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityFileExplorerSVGPreview">SVG file preview: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityFileExplorerMarkdownPreview">Markdown file preview: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityFileExplorerMonacoPreview">Source code file preview: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityFileExplorerPDFPreview">PDF file preview: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityFileExplorerGcodePreview">Gcode file preview: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityFileExplorerSVGThumbnails">SVG file thumbnail: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityFileExplorerPDFThumbnails">PDF file thumbnail: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityFileExplorerGcodeThumbnails">Gcode file thumbnail: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityFileExplorerSTLThumbnails">STL file thumbnail: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityHostsFileEditor">Hosts file editor: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityImageResizer">Image Resizer: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityKeyboardManager">Keyboard Manager: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityFindMyMouse">Find My Mouse: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityMouseHighlighter">Mouse Highlighter: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityMouseJump">Mouse Jump: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityMousePointerCrosshairs">Mouse Pointer Crosshairs: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityMouseWithoutBorders">Mouse Without Borders: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityPeek">Peek: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityPowerRename">Power Rename: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityPowerLauncher">PowerToys Run: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityQuickAccent">Quick Accent: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityRegistryPreview">Registry Preview: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityScreenRuler">Screen Ruler: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityShortcutGuide">Shortcut Guide: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityTextExtractor">Text Extractor: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityVideoConferenceMute">Video Conference Mute: Configure enabled state</string>
+      <string id="DisablePerUserInstallation">Disable per-user installation</string>
+      <string id="DisableAutomaticUpdateDownload">Disable automatic downloads</string>
+      <string id="DoNotShowWhatsNewAfterUpdates">Do not show the release notes after updates</string>
+      <string id="SuspendNewUpdateToast">Suspend Action Center notification for new updates</string>
+      <string id="DisableNewUpdateToast">Disable Action Center notification for new updates</string>
+      <string id="AllowExperimentation">Allow Experimentation</string>
+      <string id="PowerToysRunAllPluginsEnabledState">Configure enabled state for all plugins</string>
+      <string id="PowerToysRunIndividualPluginEnabledState">Configure enabled state for individual plugins</string>
+      <string id="ConfigureEnabledUtilityFileExplorerQOIPreview">QOI file preview: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityFileExplorerQOIThumbnails">QOI file thumbnail: Configure enabled state</string>
+      <string id="AllowPowerToysAdvancedPasteOnlineAIModels">Advanced Paste: Allow using online AI models</string>
+    </stringTable>
 
-        <presentationTable>
-            <presentation id="PowerToysRunIndividualPluginEnabledState">
-                <listBox refId="PowerToysRunIndividualPluginEnabledList">List of managed plugins:</listBox>
-            </presentation>
-        </presentationTable>
+    <presentationTable>
+      <presentation id="PowerToysRunIndividualPluginEnabledState">
+        <listBox refId="PowerToysRunIndividualPluginEnabledList">List of managed plugins:</listBox>
+      </presentation>
+    </presentationTable>
 
-    </resources>
+  </resources>
 </policyDefinitionResources>
 

--- a/src/modules/previewpane/powerpreview/powerpreview.cpp
+++ b/src/modules/previewpane/powerpreview/powerpreview.cpp
@@ -166,6 +166,18 @@ void PowerPreviewModule::enable()
     }
 
     m_enabled = true;
+
+    try
+    {
+        PowerToysSettings::PowerToyValues settings =
+            PowerToysSettings::PowerToyValues::load_from_settings_file(PowerPreviewModule::get_key());
+
+        apply_settings(settings);
+    }
+    catch (std::exception const& e)
+    {
+        Trace::InitSetErrorLoadingFile(e.what());
+    }
 }
 
 // Disable active preview handlers.

--- a/src/settings-ui/Settings.UI.Library/EnabledModules.cs
+++ b/src/settings-ui/Settings.UI.Library/EnabledModules.cs
@@ -56,7 +56,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 
         private bool fileExplorerPreview = true;
 
-        [JsonPropertyName("File Explorer Preview")]
+        [JsonPropertyName("File Explorer")]
         public bool PowerPreview
         {
             get => fileExplorerPreview;

--- a/src/settings-ui/Settings.UI/Helpers/ModuleHelper.cs
+++ b/src/settings-ui/Settings.UI/Helpers/ModuleHelper.cs
@@ -150,6 +150,7 @@ namespace Microsoft.PowerToys.Settings.UI.Helpers
                 ModuleType.CropAndLock => typeof(CropAndLockPage),
                 ModuleType.EnvironmentVariables => typeof(EnvironmentVariablesPage),
                 ModuleType.FancyZones => typeof(FancyZonesPage),
+                ModuleType.PowerPreview => typeof(PowerPreviewPage),
                 ModuleType.FileLocksmith => typeof(FileLocksmithPage),
                 ModuleType.FindMyMouse => typeof(MouseUtilsPage),
                 ModuleType.Hosts => typeof(HostsPage),

--- a/src/settings-ui/Settings.UI/Helpers/ModuleHelper.cs
+++ b/src/settings-ui/Settings.UI/Helpers/ModuleHelper.cs
@@ -68,6 +68,7 @@ namespace Microsoft.PowerToys.Settings.UI.Helpers
                 case ModuleType.MeasureTool: return generalSettingsConfig.Enabled.MeasureTool;
                 case ModuleType.ShortcutGuide: return generalSettingsConfig.Enabled.ShortcutGuide;
                 case ModuleType.PowerOCR: return generalSettingsConfig.Enabled.PowerOcr;
+                case ModuleType.PowerPreview: return generalSettingsConfig.Enabled.PowerPreview;
                 default: return false;
             }
         }
@@ -100,6 +101,7 @@ namespace Microsoft.PowerToys.Settings.UI.Helpers
                 case ModuleType.MeasureTool: generalSettingsConfig.Enabled.MeasureTool = isEnabled; break;
                 case ModuleType.ShortcutGuide: generalSettingsConfig.Enabled.ShortcutGuide = isEnabled; break;
                 case ModuleType.PowerOCR: generalSettingsConfig.Enabled.PowerOcr = isEnabled; break;
+                case ModuleType.PowerPreview: generalSettingsConfig.Enabled.PowerPreview = isEnabled; break;
             }
         }
 
@@ -131,6 +133,7 @@ namespace Microsoft.PowerToys.Settings.UI.Helpers
                 case ModuleType.MeasureTool: return GPOWrapper.GetConfiguredScreenRulerEnabledValue();
                 case ModuleType.ShortcutGuide: return GPOWrapper.GetConfiguredShortcutGuideEnabledValue();
                 case ModuleType.PowerOCR: return GPOWrapper.GetConfiguredTextExtractorEnabledValue();
+                case ModuleType.PowerPreview: return GPOWrapper.GetConfiguredFileExplorerPreviewEnabledValue();
                 default: return GpoRuleConfigured.Unavailable;
             }
         }

--- a/src/settings-ui/Settings.UI/Helpers/ModuleHelper.cs
+++ b/src/settings-ui/Settings.UI/Helpers/ModuleHelper.cs
@@ -52,6 +52,7 @@ namespace Microsoft.PowerToys.Settings.UI.Helpers
                 case ModuleType.CropAndLock: return generalSettingsConfig.Enabled.CropAndLock;
                 case ModuleType.EnvironmentVariables: return generalSettingsConfig.Enabled.EnvironmentVariables;
                 case ModuleType.FancyZones: return generalSettingsConfig.Enabled.FancyZones;
+                case ModuleType.PowerPreview: return generalSettingsConfig.Enabled.PowerPreview;
                 case ModuleType.FileLocksmith: return generalSettingsConfig.Enabled.FileLocksmith;
                 case ModuleType.FindMyMouse: return generalSettingsConfig.Enabled.FindMyMouse;
                 case ModuleType.Hosts: return generalSettingsConfig.Enabled.Hosts;
@@ -69,7 +70,6 @@ namespace Microsoft.PowerToys.Settings.UI.Helpers
                 case ModuleType.MeasureTool: return generalSettingsConfig.Enabled.MeasureTool;
                 case ModuleType.ShortcutGuide: return generalSettingsConfig.Enabled.ShortcutGuide;
                 case ModuleType.PowerOCR: return generalSettingsConfig.Enabled.PowerOcr;
-                case ModuleType.PowerPreview: return generalSettingsConfig.Enabled.PowerPreview;
                 default: return false;
             }
         }
@@ -85,6 +85,7 @@ namespace Microsoft.PowerToys.Settings.UI.Helpers
                 case ModuleType.CropAndLock: generalSettingsConfig.Enabled.CropAndLock = isEnabled; break;
                 case ModuleType.EnvironmentVariables: generalSettingsConfig.Enabled.EnvironmentVariables = isEnabled; break;
                 case ModuleType.FancyZones: generalSettingsConfig.Enabled.FancyZones = isEnabled; break;
+                case ModuleType.PowerPreview: generalSettingsConfig.Enabled.PowerPreview = isEnabled; break;
                 case ModuleType.FileLocksmith: generalSettingsConfig.Enabled.FileLocksmith = isEnabled; break;
                 case ModuleType.FindMyMouse: generalSettingsConfig.Enabled.FindMyMouse = isEnabled; break;
                 case ModuleType.Hosts: generalSettingsConfig.Enabled.Hosts = isEnabled; break;
@@ -102,7 +103,6 @@ namespace Microsoft.PowerToys.Settings.UI.Helpers
                 case ModuleType.MeasureTool: generalSettingsConfig.Enabled.MeasureTool = isEnabled; break;
                 case ModuleType.ShortcutGuide: generalSettingsConfig.Enabled.ShortcutGuide = isEnabled; break;
                 case ModuleType.PowerOCR: generalSettingsConfig.Enabled.PowerOcr = isEnabled; break;
-                case ModuleType.PowerPreview: generalSettingsConfig.Enabled.PowerPreview = isEnabled; break;
             }
         }
 
@@ -117,6 +117,7 @@ namespace Microsoft.PowerToys.Settings.UI.Helpers
                 case ModuleType.CropAndLock: return GPOWrapper.GetConfiguredCropAndLockEnabledValue();
                 case ModuleType.EnvironmentVariables: return GPOWrapper.GetConfiguredEnvironmentVariablesEnabledValue();
                 case ModuleType.FancyZones: return GPOWrapper.GetConfiguredFancyZonesEnabledValue();
+                case ModuleType.PowerPreview: return GPOWrapper.GetConfiguredFileExplorerPreviewEnabledValue();
                 case ModuleType.FileLocksmith: return GPOWrapper.GetConfiguredFileLocksmithEnabledValue();
                 case ModuleType.FindMyMouse: return GPOWrapper.GetConfiguredFindMyMouseEnabledValue();
                 case ModuleType.Hosts: return GPOWrapper.GetConfiguredHostsFileEditorEnabledValue();
@@ -134,7 +135,6 @@ namespace Microsoft.PowerToys.Settings.UI.Helpers
                 case ModuleType.MeasureTool: return GPOWrapper.GetConfiguredScreenRulerEnabledValue();
                 case ModuleType.ShortcutGuide: return GPOWrapper.GetConfiguredShortcutGuideEnabledValue();
                 case ModuleType.PowerOCR: return GPOWrapper.GetConfiguredTextExtractorEnabledValue();
-                case ModuleType.PowerPreview: return GPOWrapper.GetConfiguredFileExplorerPreviewEnabledValue();
                 default: return GpoRuleConfigured.Unavailable;
             }
         }

--- a/src/settings-ui/Settings.UI/Helpers/ModuleHelper.cs
+++ b/src/settings-ui/Settings.UI/Helpers/ModuleHelper.cs
@@ -6,7 +6,6 @@ using global::PowerToys.GPOWrapper;
 using ManagedCommon;
 using Microsoft.PowerToys.Settings.UI.Library;
 using Microsoft.PowerToys.Settings.UI.Views;
-using Windows.UI;
 
 namespace Microsoft.PowerToys.Settings.UI.Helpers
 {
@@ -22,6 +21,7 @@ namespace Microsoft.PowerToys.Settings.UI.Helpers
                 case ModuleType.MouseHighlighter:
                 case ModuleType.MouseJump:
                 case ModuleType.MousePointerCrosshairs: return $"MouseUtils_{moduleType}/Header";
+                case ModuleType.PowerPreview: return "FileExplorerPreview/ModuleTitle";
                 default: return $"{moduleType}/ModuleTitle";
             }
         }
@@ -36,6 +36,7 @@ namespace Microsoft.PowerToys.Settings.UI.Helpers
                 case ModuleType.MousePointerCrosshairs: return "ms-appx:///Assets/Settings/Icons/MouseCrosshairs.png";
                 case ModuleType.MeasureTool: return "ms-appx:///Assets/Settings/Icons/ScreenRuler.png";
                 case ModuleType.PowerLauncher: return $"ms-appx:///Assets/Settings/Icons/PowerToysRun.png";
+                case ModuleType.PowerPreview: return $"ms-appx:///Assets/Settings/Icons/FileExplorerPreview.png";
                 default: return $"ms-appx:///Assets/Settings/Icons/{moduleType}.png";
             }
         }

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerPreviewPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerPreviewPage.xaml
@@ -13,6 +13,11 @@
     <controls:SettingsPageControl x:Uid="FileExplorerPreview" ModuleImageSource="ms-appx:///Assets/Settings/Modules/FileExplorerPreview.png">
         <controls:SettingsPageControl.ModuleContent>
             <StackPanel ChildrenTransitions="{StaticResource SettingsCardsAnimations}" Orientation="Vertical">
+                <tkcontrols:SettingsCard x:Uid="FileExplorerPreview_EnableToggleControl_HeaderText" HeaderIcon="{ui:BitmapIcon Source=/Assets/Settings/Icons/FileExplorerPreview.png}">
+                    <!--  IsEnabled="{x:Bind ViewModel.IsEnabledGpoConfigured, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}"  -->
+                    <ToggleSwitch x:Uid="ToggleSwitch" IsOn="{x:Bind ViewModel.IsEnabled, Mode=TwoWay}" />
+                </tkcontrols:SettingsCard>
+
                 <controls:SettingsGroup x:Uid="FileExplorerPreview_PreviewPane">
                     <InfoBar
                         x:Uid="FileExplorerPreview_PreviewHandlerOutlookIncompatibility"

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerPreviewPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerPreviewPage.xaml
@@ -13,10 +13,18 @@
     <controls:SettingsPageControl x:Uid="FileExplorerPreview" ModuleImageSource="ms-appx:///Assets/Settings/Modules/FileExplorerPreview.png">
         <controls:SettingsPageControl.ModuleContent>
             <StackPanel ChildrenTransitions="{StaticResource SettingsCardsAnimations}" Orientation="Vertical">
-                <tkcontrols:SettingsCard x:Uid="FileExplorerPreview_EnableToggleControl_HeaderText" HeaderIcon="{ui:BitmapIcon Source=/Assets/Settings/Icons/FileExplorerPreview.png}">
-                    <!--  IsEnabled="{x:Bind ViewModel.IsEnabledGpoConfigured, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}"  -->
+                <tkcontrols:SettingsCard
+                    x:Uid="FileExplorerPreview_EnableToggleControl_HeaderText"
+                    HeaderIcon="{ui:BitmapIcon Source=/Assets/Settings/Icons/FileExplorerPreview.png}"
+                    IsEnabled="{x:Bind ViewModel.IsEnabledGpoConfigured, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}">
                     <ToggleSwitch x:Uid="ToggleSwitch" IsOn="{x:Bind ViewModel.IsEnabled, Mode=TwoWay}" />
                 </tkcontrols:SettingsCard>
+                <InfoBar
+                    x:Uid="GPO_SettingIsManaged"
+                    IsClosable="False"
+                    IsOpen="{x:Bind ViewModel.IsEnabledGpoConfigured, Mode=OneWay}"
+                    IsTabStop="{x:Bind ViewModel.IsEnabledGpoConfigured, Mode=OneWay}"
+                    Severity="Informational" />
 
                 <controls:SettingsGroup x:Uid="FileExplorerPreview_PreviewPane">
                     <InfoBar

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerPreviewPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerPreviewPage.xaml
@@ -26,7 +26,7 @@
                     IsTabStop="{x:Bind ViewModel.IsEnabledGpoConfigured, Mode=OneWay}"
                     Severity="Informational" />
 
-                <controls:SettingsGroup x:Uid="FileExplorerPreview_PreviewPane">
+                <controls:SettingsGroup x:Uid="FileExplorerPreview_PreviewPane" IsEnabled="{x:Bind ViewModel.IsEnabled, Mode=OneWay}">
                     <InfoBar
                         x:Uid="FileExplorerPreview_PreviewHandlerOutlookIncompatibility"
                         IsClosable="False"
@@ -160,7 +160,7 @@
                     </tkcontrols:SettingsCard>
                 </controls:SettingsGroup>
 
-                <controls:SettingsGroup x:Uid="FileExplorerPreview_IconThumbnail_GroupSettings">
+                <controls:SettingsGroup x:Uid="FileExplorerPreview_IconThumbnail_GroupSettings" IsEnabled="{x:Bind ViewModel.IsEnabled, Mode=OneWay}">
                     <InfoBar
                         x:Uid="FileExplorerPreview_RebootRequired"
                         IsClosable="False"

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerPreviewPage.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerPreviewPage.xaml.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.PowerToys.Settings.UI.Helpers;
 using Microsoft.PowerToys.Settings.UI.Library;
 using Microsoft.PowerToys.Settings.UI.ViewModels;
 using Microsoft.UI.Xaml.Controls;
@@ -11,7 +12,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
     /// <summary>
     /// An empty page that can be used on its own or navigated to within a Frame.
     /// </summary>
-    public sealed partial class PowerPreviewPage : Page
+    public sealed partial class PowerPreviewPage : Page, IRefreshablePage
     {
         public PowerPreviewViewModel ViewModel { get; set; }
 
@@ -21,6 +22,11 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             var settingsUtils = new SettingsUtils();
             ViewModel = new PowerPreviewViewModel(SettingsRepository<PowerPreviewSettings>.GetInstance(settingsUtils), SettingsRepository<GeneralSettings>.GetInstance(settingsUtils), ShellPage.SendDefaultIPCMessage);
             DataContext = ViewModel;
+        }
+
+        public void RefreshEnabledState()
+        {
+            ViewModel.RefreshEnabledState();
         }
     }
 }

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerPreviewPage.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerPreviewPage.xaml.cs
@@ -9,9 +9,6 @@ using Microsoft.UI.Xaml.Controls;
 
 namespace Microsoft.PowerToys.Settings.UI.Views
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
     public sealed partial class PowerPreviewPage : Page, IRefreshablePage
     {
         public PowerPreviewViewModel ViewModel { get; set; }

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -4195,4 +4195,7 @@ Activate by holding the key for the character you want to add an accent to, then
   <data name="FileExplorerPreview_EnableToggleControl_HeaderText.Header" xml:space="preserve">
     <value>Enable File Explorer add-ons</value>
   </data>
+  <data name="FileExplorerPreview_ShortDescription" xml:space="preserve">
+    <value>Custom preview handlers for Windows File Explorer</value>
+  </data>
 </root>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -4192,4 +4192,7 @@ Activate by holding the key for the character you want to add an accent to, then
   <data name="AdvancedPaste_EnableAIDialog_NoteAICreditsErrorText.Text" xml:space="preserve">
     <value>If you do not have credits you will see an 'API key quota exceeded' error</value>
   </data>
+  <data name="FileExplorerPreview_EnableToggleControl_HeaderText.Header" xml:space="preserve">
+    <value>Enable File Explorer add-ons</value>
+  </data>
 </root>

--- a/src/settings-ui/Settings.UI/ViewModels/DashboardViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/DashboardViewModel.cs
@@ -153,6 +153,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 ModuleType.CropAndLock => GetModuleItemsCropAndLock(),
                 ModuleType.EnvironmentVariables => GetModuleItemsEnvironmentVariables(),
                 ModuleType.FancyZones => GetModuleItemsFancyZones(),
+                ModuleType.PowerPreview => GetModuleItemsPowerPreview(),
                 ModuleType.FileLocksmith => GetModuleItemsFileLocksmith(),
                 ModuleType.FindMyMouse => GetModuleItemsFindMyMouse(),
                 ModuleType.Hosts => GetModuleItemsHosts(),
@@ -170,7 +171,6 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 ModuleType.MeasureTool => GetModuleItemsMeasureTool(),
                 ModuleType.ShortcutGuide => GetModuleItemsShortcutGuide(),
                 ModuleType.PowerOCR => GetModuleItemsPowerOCR(),
-                ModuleType.PowerPreview => GetModuleItemsPowerPreview(),
                 _ => new ObservableCollection<DashboardModuleItem>(), // never called, all values listed above
             };
         }

--- a/src/settings-ui/Settings.UI/ViewModels/DashboardViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/DashboardViewModel.cs
@@ -170,6 +170,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 ModuleType.MeasureTool => GetModuleItemsMeasureTool(),
                 ModuleType.ShortcutGuide => GetModuleItemsShortcutGuide(),
                 ModuleType.PowerOCR => GetModuleItemsPowerOCR(),
+                ModuleType.PowerPreview => GetModuleItemsPowerPreview(),
                 _ => new ObservableCollection<DashboardModuleItem>(), // never called, all values listed above
             };
         }
@@ -470,6 +471,15 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             var list = new List<DashboardModuleItem>
             {
                 new DashboardModuleShortcutItem() { Label = resourceLoader.GetString("PowerOcr_ShortDescription"), Shortcut = moduleSettingsRepository.SettingsConfig.Properties.ActivationShortcut.GetKeysList() },
+            };
+            return new ObservableCollection<DashboardModuleItem>(list);
+        }
+
+        private ObservableCollection<DashboardModuleItem> GetModuleItemsPowerPreview()
+        {
+            var list = new List<DashboardModuleItem>
+            {
+                new DashboardModuleTextItem() { Label = resourceLoader.GetString("FileExplorerPreview_ShortDescription") },
             };
             return new ObservableCollection<DashboardModuleItem>(list);
         }

--- a/src/settings-ui/Settings.UI/ViewModels/PowerPreviewViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/PowerPreviewViewModel.cs
@@ -214,7 +214,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
 
         private void InitializeEnabledValue()
         {
-            _enabledGpoRuleConfiguration = GPOWrapper.GetConfiguredFancyZonesEnabledValue();
+            _enabledGpoRuleConfiguration = GPOWrapper.GetConfiguredFileExplorerPreviewEnabledValue();
             if (_enabledGpoRuleConfiguration == GpoRuleConfigured.Disabled || _enabledGpoRuleConfiguration == GpoRuleConfigured.Enabled)
             {
                 // Get the enabled state from GPO.

--- a/src/settings-ui/Settings.UI/ViewModels/PowerPreviewViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/PowerPreviewViewModel.cs
@@ -214,7 +214,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
 
         private void InitializeEnabledValue()
         {
-            /*_enabledGpoRuleConfiguration = GPOWrapper.GetConfiguredFancyZonesEnabledValue();
+            _enabledGpoRuleConfiguration = GPOWrapper.GetConfiguredFancyZonesEnabledValue();
             if (_enabledGpoRuleConfiguration == GpoRuleConfigured.Disabled || _enabledGpoRuleConfiguration == GpoRuleConfigured.Enabled)
             {
                 // Get the enabled state from GPO.
@@ -222,9 +222,9 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 _isEnabled = _enabledGpoRuleConfiguration == GpoRuleConfigured.Enabled;
             }
             else
-            {*/
-            _isEnabled = GeneralSettingsConfig.Enabled.PowerPreview;
-            /*}*/
+            {
+                _isEnabled = GeneralSettingsConfig.Enabled.PowerPreview;
+            }
         }
 
         public void RefreshEnabledState()
@@ -233,6 +233,8 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             OnPropertyChanged(nameof(IsEnabled));
         }
 
+        private GpoRuleConfigured _enabledGpoRuleConfiguration;
+        private bool _enabledStateIsGPOConfigured;
         private bool _isEnabled;
 
         private GpoRuleConfigured _svgRenderEnabledGpoRuleConfiguration;
@@ -315,11 +317,11 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             get => _isEnabled;
             set
             {
-                /*if (_enabledStateIsGPOConfigured)
+                if (_enabledStateIsGPOConfigured)
                 {
                     // If it's GPO configured, shouldn't be able to change this state.
                     return;
-                }*/
+                }
 
                 if (_isEnabled != value)
                 {
@@ -333,6 +335,11 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                     SendConfigMSG(outgoing.ToString());
                 }
             }
+        }
+
+        public bool IsEnabledGpoConfigured
+        {
+            get => _enabledStateIsGPOConfigured;
         }
 
         public bool SomePreviewPaneEnabledGposConfigured

--- a/src/settings-ui/Settings.UI/ViewModels/PowerPreviewViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/PowerPreviewViewModel.cs
@@ -208,7 +208,32 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             {
                 _qoiThumbnailIsEnabled = Settings.Properties.EnableQoiThumbnail;
             }
+
+            InitializeEnabledValue();
         }
+
+        private void InitializeEnabledValue()
+        {
+            /*_enabledGpoRuleConfiguration = GPOWrapper.GetConfiguredFancyZonesEnabledValue();
+            if (_enabledGpoRuleConfiguration == GpoRuleConfigured.Disabled || _enabledGpoRuleConfiguration == GpoRuleConfigured.Enabled)
+            {
+                // Get the enabled state from GPO.
+                _enabledStateIsGPOConfigured = true;
+                _isEnabled = _enabledGpoRuleConfiguration == GpoRuleConfigured.Enabled;
+            }
+            else
+            {*/
+            _isEnabled = GeneralSettingsConfig.Enabled.PowerPreview;
+            /*}*/
+        }
+
+        public void RefreshEnabledState()
+        {
+            InitializeEnabledValue();
+            OnPropertyChanged(nameof(IsEnabled));
+        }
+
+        private bool _isEnabled;
 
         private GpoRuleConfigured _svgRenderEnabledGpoRuleConfiguration;
         private bool _svgRenderEnabledStateIsGPOConfigured;
@@ -284,6 +309,31 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         private bool _qoiThumbnailIsGpoEnabled;
         private bool _qoiThumbnailIsGpoDisabled;
         private bool _qoiThumbnailIsEnabled;
+
+        public bool IsEnabled
+        {
+            get => _isEnabled;
+            set
+            {
+                /*if (_enabledStateIsGPOConfigured)
+                {
+                    // If it's GPO configured, shouldn't be able to change this state.
+                    return;
+                }*/
+
+                if (_isEnabled != value)
+                {
+                    _isEnabled = value;
+                    OnPropertyChanged(nameof(IsEnabled));
+
+                    // Set the status in the general settings
+                    GeneralSettingsConfig.Enabled.PowerPreview = value;
+                    var outgoing = new OutGoingGeneralSettings(GeneralSettingsConfig);
+
+                    SendConfigMSG(outgoing.ToString());
+                }
+            }
+        }
 
         public bool SomePreviewPaneEnabledGposConfigured
         {

--- a/tools/BugReportTool/BugReportTool/ReportGPOValues.cpp
+++ b/tools/BugReportTool/BugReportTool/ReportGPOValues.cpp
@@ -68,4 +68,5 @@ void ReportGPOValues(const std::filesystem::path& tmpDir)
     report << "getConfiguredQoiPreviewEnabledValue: " << gpo_rule_configured_to_string(powertoys_gpo::getConfiguredQoiPreviewEnabledValue()) << std::endl;
     report << "getConfiguredQoiThumbnailsEnabledValue: " << gpo_rule_configured_to_string(powertoys_gpo::getConfiguredQoiThumbnailsEnabledValue()) << std::endl;
     report << "getAllowedAdvancedPasteOnlineAIModelsValue: " << gpo_rule_configured_to_string(powertoys_gpo::getAllowedAdvancedPasteOnlineAIModelsValue()) << std::endl;
+    report << "getConfiguredFileExplorerPreviewEnabledValue: " << gpo_rule_configured_to_string(powertoys_gpo::getConfiguredFileExplorerPreviewEnabledValue()) << std::endl;
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Added an enable toggle switch for File Explorer.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #23723
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [x] **Dev docs:** Not necessary
- [x] **New binaries:** None necessary
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

- Added an overall GPO for File Explorer.
- Added it as a module to the dashboard and all apps popup.
- Stopped File Explorer Preview from running if it isn't enabled in the settings.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

### Setting saved to JSON
- Opened Settings
- Flipped the switch
- Exited the runner
- Opened Settings
- The setting had been saved correctly

### Previews were not run if disabled
- Built and ran installer
- Had previews and thumbnails ON
- Previews and thumbnails ran and were visible
- Turned the switch OFF
- Previews and thumbnails no longer showed up
- Turned the switch ON
- Previews and thumbnails appeared again

### GPO
- Logged in as an admin
- Set the group policy for File Explorer add-ons to disabled
- The card was disabled and showed a lock icon, the switch was disabled and had a notification saying the setting was controlled, and the previews did not appear
- Set the group policy to enabled
- Restarted PowerToys
- Everything was still locked, but the previews showed up and the switch was on