### PR TITLE
[PTRun]Disable titlebar accent workaround on Windows 10

### DIFF
--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -1016,27 +1016,30 @@ namespace PowerLauncher.ViewModel
                 var window = Application.Current.MainWindow;
                 Wpf.Ui.Controls.WindowBackdrop.RemoveBackground(window);
 
-                // Taken from WPFUI's fix for the title bar issue. We should be able to remove this fix when WPF UI 4 is integrated.
-                // https://github.com/lepoco/wpfui/pull/1122/files#diff-196b404f4db09632665ef546da6c8e57302b2f3e3d082eb4b5c295ae3482d94a
-                IntPtr windowHandle = new WindowInteropHelper(window).Handle;
-                if (windowHandle == IntPtr.Zero)
+                if (OSVersionHelper.IsWindows11())
                 {
-                    return;
-                }
+                    // Taken from WPFUI's fix for the title bar issue. We should be able to remove this fix when WPF UI 4 is integrated.
+                    // https://github.com/lepoco/wpfui/pull/1122/files#diff-196b404f4db09632665ef546da6c8e57302b2f3e3d082eb4b5c295ae3482d94a
+                    IntPtr windowHandle = new WindowInteropHelper(window).Handle;
+                    if (windowHandle == IntPtr.Zero)
+                    {
+                        return;
+                    }
 
-                HwndSource windowSource = HwndSource.FromHwnd(windowHandle);
+                    HwndSource windowSource = HwndSource.FromHwnd(windowHandle);
 
-                // Remove background from client area
-                if (windowSource != null && windowSource.Handle != IntPtr.Zero && windowSource?.CompositionTarget != null)
-                {
-                    // NOTE: https://learn.microsoft.com/en-us/windows/win32/api/dwmapi/ne-dwmapi-dwmwindowattribute
-                    // Specifying DWMWA_COLOR_DEFAULT (value 0xFFFFFFFF) for the color will reset the window back to using the system's default behavior for the caption color.
-                    uint titlebarPvAttribute = 0xFFFFFFFE;
-                    _ = Wox.Plugin.Common.Win32.NativeMethods.DwmSetWindowAttribute(
-                        windowSource.Handle,
-                        (int)Wox.Plugin.Common.Win32.DwmWindowAttributes.CaptionColor,
-                        ref titlebarPvAttribute,
-                        Marshal.SizeOf(typeof(uint)));
+                    // Remove background from client area
+                    if (windowSource != null && windowSource.Handle != IntPtr.Zero && windowSource?.CompositionTarget != null)
+                    {
+                        // NOTE: https://learn.microsoft.com/en-us/windows/win32/api/dwmapi/ne-dwmapi-dwmwindowattribute
+                        // Specifying DWMWA_COLOR_DEFAULT (value 0xFFFFFFFF) for the color will reset the window back to using the system's default behavior for the caption color.
+                        uint titlebarPvAttribute = 0xFFFFFFFE;
+                        _ = Wox.Plugin.Common.Win32.NativeMethods.DwmSetWindowAttribute(
+                            windowSource.Handle,
+                            (int)Wox.Plugin.Common.Win32.DwmWindowAttributes.CaptionColor,
+                            ref titlebarPvAttribute,
+                            Marshal.SizeOf(typeof(uint)));
+                    }
                 }
             }
             else

--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -1036,7 +1036,7 @@ namespace PowerLauncher.ViewModel
                         uint titlebarPvAttribute = 0xFFFFFFFE;
                         _ = Wox.Plugin.Common.Win32.NativeMethods.DwmSetWindowAttribute(
                             windowSource.Handle,
-                            (int)Wox.Plugin.Common.Win32.DwmWindowAttributes.CaptionColor,
+                            (int)Wox.Plugin.Common.Win32.DwmWindowAttributes.CaptionColor, // CaptionColor attribute is only available on Windows 11.
                             ref titlebarPvAttribute,
                             Marshal.SizeOf(typeof(uint)));
                     }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

After https://github.com/microsoft/PowerToys/pull/33458 , that fix crashes on Windows 10, where the caption color attribute is not supported.

This PR disables the fix on Windows 10, since it's not even needed there actually.

Fixes: #33504