### PR TITLE
Improved advanced paste telemetry

### DIFF
--- a/src/modules/AdvancedPaste/AdvancedPaste/AdvancedPasteXAML/App.xaml.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/AdvancedPasteXAML/App.xaml.cs
@@ -91,6 +91,7 @@ namespace AdvancedPaste
             NativeEventWaiter.WaitForEventLoop(interop.Constants.ShowAdvancedPasteSharedEvent(), OnAdvancedPasteHotkey);
             NativeEventWaiter.WaitForEventLoop(interop.Constants.AdvancedPasteMarkdownEvent(), OnAdvancedPasteMarkdownHotkey);
             NativeEventWaiter.WaitForEventLoop(interop.Constants.AdvancedPasteJsonEvent(), OnAdvancedPasteJsonHotkey);
+            OnAdvancedPasteHotkey();
         }
 
         private void App_UnhandledException(object sender, Microsoft.UI.Xaml.UnhandledExceptionEventArgs e)

--- a/src/modules/AdvancedPaste/AdvancedPaste/AdvancedPasteXAML/App.xaml.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/AdvancedPasteXAML/App.xaml.cs
@@ -91,7 +91,6 @@ namespace AdvancedPaste
             NativeEventWaiter.WaitForEventLoop(interop.Constants.ShowAdvancedPasteSharedEvent(), OnAdvancedPasteHotkey);
             NativeEventWaiter.WaitForEventLoop(interop.Constants.AdvancedPasteMarkdownEvent(), OnAdvancedPasteMarkdownHotkey);
             NativeEventWaiter.WaitForEventLoop(interop.Constants.AdvancedPasteJsonEvent(), OnAdvancedPasteJsonHotkey);
-            OnAdvancedPasteHotkey();
         }
 
         private void App_UnhandledException(object sender, Microsoft.UI.Xaml.UnhandledExceptionEventArgs e)

--- a/src/modules/AdvancedPaste/AdvancedPaste/AdvancedPasteXAML/Controls/PromptBox.xaml.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/AdvancedPasteXAML/Controls/PromptBox.xaml.cs
@@ -78,8 +78,6 @@ namespace AdvancedPaste.Controls
         {
             Logger.LogTrace();
 
-            PowerToysTelemetry.Log.WriteEvent(new Telemetry.AdvancedPasteGenerateCustomFormatEvent());
-
             VisualStateManager.GoToState(this, "LoadingState", true);
             string inputInstructions = InputTxtBox.Text;
             ViewModel.SaveQuery(inputInstructions);

--- a/src/modules/AdvancedPaste/AdvancedPaste/AdvancedPasteXAML/Pages/MainPage.xaml.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/AdvancedPasteXAML/Pages/MainPage.xaml.cs
@@ -231,6 +231,7 @@ namespace AdvancedPaste.Pages
             var item = e.ClickedItem as ClipboardItem;
             if (item is not null)
             {
+                PowerToysTelemetry.Log.WriteEvent(new Telemetry.AdvancedPasteClipboardItemClicked());
                 if (!string.IsNullOrEmpty(item.Content))
                 {
                     ClipboardHelper.SetClipboardTextContent(item.Content);

--- a/src/modules/AdvancedPaste/AdvancedPaste/Telemetry/AdvancedPasteClipboardItemClicked.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/Telemetry/AdvancedPasteClipboardItemClicked.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics.Tracing;
+using Microsoft.PowerToys.Telemetry;
+using Microsoft.PowerToys.Telemetry.Events;
+
+namespace AdvancedPaste.Telemetry
+{
+    [EventData]
+    public class AdvancedPasteClipboardItemClicked : EventBase, IEvent
+    {
+        public PartA_PrivTags PartA_PrivTags => PartA_PrivTags.ProductAndServiceUsage;
+    }
+}

--- a/src/modules/AdvancedPaste/AdvancedPaste/Telemetry/AdvancedPasteGenerateCustomFormatEvent.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/Telemetry/AdvancedPasteGenerateCustomFormatEvent.cs
@@ -11,6 +11,19 @@ namespace AdvancedPaste.Telemetry
     [EventData]
     public class AdvancedPasteGenerateCustomFormatEvent : EventBase, IEvent
     {
+        public int PromptTokens { get; set; }
+
+        public int CompletionTokens { get; set; }
+
+        public string ModelName { get; set; }
+
+        public AdvancedPasteGenerateCustomFormatEvent(int promptTokens, int completionTokens, string modelName)
+        {
+            this.PromptTokens = promptTokens;
+            this.CompletionTokens = completionTokens;
+            ModelName = modelName;
+        }
+
         public PartA_PrivTags PartA_PrivTags => PartA_PrivTags.ProductAndServiceUsage;
     }
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This PR improves advanced paste telemetry. Here's what's changed

- Added `AdvancedPasteClipboardItemClicked` event
- Changed `CustomFormatEvent` to only fire on successful completion and include the number of tokens used, and the model name

Here are the goals of adding this telemtry:

- `AdvancedPasteClipboardItemClicked` helps us estimate the total number of user who are using the clipboard history feature, which helps us prioritize future investments and improvements in PowerToys. (This is just regular feature usage data).
- `CustomFormatEvent` now includes number of tokens used, and the model name. We are considering using alternative models to power Advanced Paste (as we've heard feedback about this), and these different models could have different token lengths. Understanding the average usage will help us make good decisions that will benefit the most users. As well, the model name is hard coded right now, but in the future if we do add different AI models for completion then this will help us compare their performance.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [X] Communication: I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected


<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

The details above are detailed enough since this change is super small. 

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Ensured that PowerToys successfully built (Need help verifying the events fire off correctly).
