### PR TITLE
[Settings > MWB] Fix infobars to hide when moduls is disabled and beeing not closable

### DIFF
--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/MouseWithoutBordersPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/MouseWithoutBordersPage.xaml
@@ -170,9 +170,9 @@
 
                     <InfoBar
                         x:Uid="MouseWithoutBorders_CannotDragDropAsAdmin"
-                        IsClosable="True"
-                        IsOpen="{x:Bind ViewModel.IsElevated, Mode=OneWay}"
-                        IsTabStop="True"
+                        IsClosable="False"
+                        IsOpen="{x:Bind ViewModel.ShowInfobarCannotDragDropAsAdmin, Mode=OneWay}"
+                        IsTabStop="{x:Bind ViewModel.ShowInfobarCannotDragDropAsAdmin, Mode=OneWay}"
                         Severity="Informational" />
 
 
@@ -191,14 +191,14 @@
                     <InfoBar
                         x:Uid="MouseWithoutBorders_RunAsAdminText"
                         IsClosable="False"
-                        IsOpen="{x:Bind ViewModel.CanToggleUseService, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}"
-                        IsTabStop="True"
+                        IsOpen="{x:Bind ViewModel.ShowInfobarRunAsAdminText, Mode=OneWay}"
+                        IsTabStop="{x:Bind ViewModel.ShowInfobarRunAsAdminText, Mode=OneWay}"
                         Severity="Informational" />
                     <InfoBar
                         x:Uid="MouseWithoutBorders_ServiceUserUninstallWarning"
-                        IsClosable="True"
-                        IsOpen="True"
-                        IsTabStop="True"
+                        IsClosable="False"
+                        IsOpen="{x:Bind ViewModel.IsEnabled, Mode=OneWay}"
+                        IsTabStop="{x:Bind ViewModel.IsEnabled, Mode=OneWay}"
                         Severity="Warning" />
                     <tkcontrols:SettingsCard
                         x:Uid="MouseWithoutBorders_UninstallService"

--- a/src/settings-ui/Settings.UI/ViewModels/MouseWithoutBordersViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/MouseWithoutBordersViewModel.cs
@@ -92,6 +92,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                     Settings.Properties.UseService = value;
                     OnPropertyChanged(nameof(UseService));
                     OnPropertyChanged(nameof(CanUninstallService));
+                    OnPropertyChanged(nameof(ShowInfobarRunAsAdminText));
 
                     // Must block here until the process exits
                     Task.Run(async () =>
@@ -566,6 +567,8 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                     _isEnabled = value;
                     GeneralSettingsConfig.Enabled.MouseWithoutBorders = value;
                     OnPropertyChanged(nameof(IsEnabled));
+                    OnPropertyChanged(nameof(ShowInfobarRunAsAdminText));
+                    OnPropertyChanged(nameof(ShowInfobarCannotDragDropAsAdmin));
 
                     Task.Run(async () =>
                     {

--- a/src/settings-ui/Settings.UI/ViewModels/MouseWithoutBordersViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/MouseWithoutBordersViewModel.cs
@@ -1045,6 +1045,14 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         public void NotifyPropertyChanged([CallerMemberName] string propertyName = null)
         {
             OnPropertyChanged(propertyName);
+
+            // Skip saving settings for UI properties
+            if (propertyName == nameof(ShowInfobarCannotDragDropAsAdmin) ||
+                propertyName == nameof(ShowInfobarRunAsAdminText))
+            {
+                return;
+            }
+
             SettingsUtils.SaveSettings(Settings.ToJsonString(), MouseWithoutBordersSettings.ModuleName);
 
             if (propertyName == nameof(UseService))
@@ -1070,6 +1078,16 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         internal void UninstallService()
         {
             SendCustomAction("uninstall_service");
+        }
+
+        public bool ShowInfobarCannotDragDropAsAdmin
+        {
+            get { return IsElevated && IsEnabled; }
+        }
+
+        public bool ShowInfobarRunAsAdminText
+        {
+            get { return !CanToggleUseService && IsEnabled; }
         }
     }
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This PR fixes two bugs for the info bars on the MWB settings page:
- The bars are shown if module is disabled.
- Some bars can be closed.
- Some bars are reacting to tab stop on closed state.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #33560
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Manual build of PowerToys settings and tested behavior.
