### PR TITLE
[PT-Run] Unit converter - Can´t use abbreviations

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -200,6 +200,7 @@ CMINVOKECOMMANDINFO
 CMINVOKECOMMANDINFOEX
 CMock
 CMONITORS
+cmph
 cmpgt
 cne
 CNF
@@ -244,6 +245,7 @@ copiedcolorrepresentation
 cotaskmem
 COULDNOT
 countof
+cph
 CPower
 cppblog
 cppruntime
@@ -760,6 +762,7 @@ keyremaps
 keyvault
 KILLFOCUS
 killrunner
+kmph
 Knownfolders
 ksh
 KSPROPERTY

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/InputInterpreter.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/InputInterpreter.cs
@@ -180,6 +180,22 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
         }
 
         /// <summary>
+        /// Converts spelling "kph" to "km/h"
+        /// </summary>
+        public static void KPHHandler(ref string[] split)
+        {
+            split[1] = split[1].Replace("cph", "cm/h", System.StringComparison.CurrentCultureIgnoreCase);
+            split[1] = split[1].Replace("kph", "km/h", System.StringComparison.CurrentCultureIgnoreCase);
+            split[1] = split[1].Replace("kmph", "km/h", System.StringComparison.CurrentCultureIgnoreCase);
+            split[1] = split[1].Replace("cmph", "cm/h", System.StringComparison.CurrentCultureIgnoreCase);
+
+            split[3] = split[3].Replace("cph", "cm/h", System.StringComparison.CurrentCultureIgnoreCase);
+            split[3] = split[3].Replace("kph", "km/h", System.StringComparison.CurrentCultureIgnoreCase);
+            split[3] = split[3].Replace("kmph", "km/h", System.StringComparison.CurrentCultureIgnoreCase);
+            split[3] = split[3].Replace("cmph", "cm/h", System.StringComparison.CurrentCultureIgnoreCase);
+        }
+
+        /// <summary>
         /// Converts spelling "metre" to "meter", also for centimetre and other variants
         /// </summary>
         public static void MetreToMeter(ref string[] split)
@@ -239,6 +255,7 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
             InputInterpreter.DegreePrefixer(ref split);
             InputInterpreter.MetreToMeter(ref split);
             InputInterpreter.FeetToFt(ref split);
+            InputInterpreter.KPHHandler(ref split);
             InputInterpreter.GallonHandler(ref split, CultureInfo.CurrentCulture);
             if (!double.TryParse(split[0], out double value))
             {


### PR DESCRIPTION
## Summary of the Pull Request
This PR introduces abbreviations for the units - `kph` that gets converted to `km/h` and `cph` that gets converted to `cm/h`.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #21472 
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** All end user-facing strings can be localized
- [x] **Dev docs:** Added/updated
- [x] **New binaries:** Added on the required places
   - [x] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [x] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [x] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [x] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [x] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
- Added abbreviations for `kph` to `km/h`
- Added abbreviations for `cph` to `cm/h`

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Ran and tested myself locally
