### PR TITLE
Fix for incorrect title bar reset value

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -85,7 +85,7 @@
     <UsePrecompiledHeaders Condition="'$(TF_BUILD)' != ''">false</UsePrecompiledHeaders>
 
     <!-- Change this to bust the cache -->
-    <MSBuildCacheCacheUniverse Condition="'$(MSBuildCacheCacheUniverse)' == ''">202406130737</MSBuildCacheCacheUniverse>
+    <MSBuildCacheCacheUniverse Condition="'$(MSBuildCacheCacheUniverse)' == ''">202407100737</MSBuildCacheCacheUniverse>
 
     <!--
       Visual Studio telemetry reads various ApplicationInsights.config files and other files after the project is finished, likely in a detached process.

--- a/src/common/Common.UI/OSVersionHelper.cs
+++ b/src/common/Common.UI/OSVersionHelper.cs
@@ -12,5 +12,10 @@ namespace Common.UI
         {
             return Environment.OSVersion.Version.Major >= 10 && Environment.OSVersion.Version.Build >= 22000;
         }
+
+        public static bool IsGreaterThanWindows11_21H2()
+        {
+            return Environment.OSVersion.Version.Major >= 10 && Environment.OSVersion.Version.Build > 22000;
+        }
     }
 }

--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -1016,7 +1016,8 @@ namespace PowerLauncher.ViewModel
                 var window = Application.Current.MainWindow;
                 Wpf.Ui.Controls.WindowBackdrop.RemoveBackground(window);
 
-                if (OSVersionHelper.IsWindows11())
+                // Setting uint titlebarPvAttribute = 0xFFFFFFFE; works on 22H2 or higher, 21H2 (aka SV1) this value causes a crash
+                if (OSVersionHelper.IsGreaterThanWindows11_21H2())
                 {
                     // Taken from WPFUI's fix for the title bar issue. We should be able to remove this fix when WPF UI 4 is integrated.
                     // https://github.com/lepoco/wpfui/pull/1122/files#diff-196b404f4db09632665ef546da6c8e57302b2f3e3d082eb4b5c295ae3482d94a
@@ -1033,7 +1034,8 @@ namespace PowerLauncher.ViewModel
                     {
                         // NOTE: https://learn.microsoft.com/en-us/windows/win32/api/dwmapi/ne-dwmapi-dwmwindowattribute
                         // Specifying DWMWA_COLOR_DEFAULT (value 0xFFFFFFFF) for the color will reset the window back to using the system's default behavior for the caption color.
-                        uint titlebarPvAttribute = 0xFFFFFFFF;
+                        uint titlebarPvAttribute = 0xFFFFFFFE;
+
                         _ = Wox.Plugin.Common.Win32.NativeMethods.DwmSetWindowAttribute(
                             windowSource.Handle,
                             (int)Wox.Plugin.Common.Win32.DwmWindowAttributes.CaptionColor, // CaptionColor attribute is only available on Windows 11.

--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -1033,7 +1033,7 @@ namespace PowerLauncher.ViewModel
                     {
                         // NOTE: https://learn.microsoft.com/en-us/windows/win32/api/dwmapi/ne-dwmapi-dwmwindowattribute
                         // Specifying DWMWA_COLOR_DEFAULT (value 0xFFFFFFFF) for the color will reset the window back to using the system's default behavior for the caption color.
-                        uint titlebarPvAttribute = 0xFFFFFFFE;
+                        uint titlebarPvAttribute = 0xFFFFFFFF;
                         _ = Wox.Plugin.Common.Win32.NativeMethods.DwmSetWindowAttribute(
                             windowSource.Handle,
                             (int)Wox.Plugin.Common.Win32.DwmWindowAttributes.CaptionColor, // CaptionColor attribute is only available on Windows 11.


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Looks like Win11 21h2 (22000) doesn't like it if the value for resetting the titlebar.

`uint titlebarPvAttribute = 0xFFFFFFFE;`

fix is to catch SV1 currently

Comment had it right but code was incorrect.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #https://github.com/microsoft/PowerToys/issues/33504
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Created azure SV1 and SV2 VM.  installed PowerToys.  SV1 crashed, SV2 worked on 0.82.

I created fix and tested on SV1 machine and PT Run worked again.
![image](https://github.com/microsoft/PowerToys/assets/1462282/8bd7a18f-5156-4963-b2c6-dfeff9a1790d)

