### PR TITLE
[Installer]Create DSC module in right path for user installs

### DIFF
--- a/installer/PowerToysSetupCustomActions/CustomAction.cpp
+++ b/installer/PowerToysSetupCustomActions/CustomAction.cpp
@@ -357,7 +357,7 @@ UINT __stdcall InstallDSCModuleCA(MSIHANDLE hInstall)
             ExitOnFailure(hr, "Unable to determine Powershell modules path");
         }
 
-        const auto modulesPath = baseModulesPath / L"Microsoft.PowerToys.Configure" / get_product_version();
+        const auto modulesPath = baseModulesPath / L"Microsoft.PowerToys.Configure" / get_product_version(false);
 
         std::error_code errorCode;
         fs::create_directories(modulesPath, errorCode);
@@ -411,7 +411,7 @@ UINT __stdcall UninstallDSCModuleCA(MSIHANDLE hInstall)
         }
 
         const auto powerToysModulePath = baseModulesPath / L"Microsoft.PowerToys.Configure";
-        const auto versionedModulePath = powerToysModulePath / get_product_version();
+        const auto versionedModulePath = powerToysModulePath / get_product_version(false);
 
         std::error_code errorCode;
 

--- a/src/common/version/version.h
+++ b/src/common/version/version.h
@@ -27,18 +27,18 @@ enum class version_architecture
 version_architecture get_current_architecture();
 const wchar_t* get_architecture_string(const version_architecture);
 
-inline std::wstring get_product_version()
+inline std::wstring get_product_version(bool includeV = true)
 {
-    static std::wstring version = L"v" + std::to_wstring(VERSION_MAJOR) +
+    static std::wstring version = (includeV ? L"v" : L"") + std::to_wstring(VERSION_MAJOR) +
                                   L"." + std::to_wstring(VERSION_MINOR) +
                                   L"." + std::to_wstring(VERSION_REVISION);
 
     return version;
 }
 
-inline std::wstring get_std_product_version()
+inline std::wstring get_std_product_version(bool includeV = true)
 {
-    static std::wstring version = L"v" + std::to_wstring(VERSION_MAJOR) +
+    static std::wstring version = (includeV ? L"v" : L"") + std::to_wstring(VERSION_MAJOR) +
                                   L"." + std::to_wstring(VERSION_MINOR) +
                                   L"." + std::to_wstring(VERSION_REVISION) + L".0";
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
User-scope installer is putting the module in "Modules\Microsoft.PowerToys.Configure\v0.0.1" instead of "Modules\Microsoft.PowerToys.Configure\0.0.1".
This PR fixes that use of the PowerToys version to not include the "v".

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #33744
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Build the user install, installed it and tested to see if DSC ran correctly.
