### PR TITLE
[PTRun]Don't apply transparency fix after theme change on Windows 10

### DIFF
--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -1014,7 +1014,12 @@ namespace PowerLauncher.ViewModel
                 // https://github.com/lepoco/wpfui/blob/303f0aefcd59a142bc681415dc4360a34a15f33d/src/Wpf.Ui/Controls/Window/WindowBackdrop.cs#L280
                 // So we set it back with https://github.com/lepoco/wpfui/blob/303f0aefcd59a142bc681415dc4360a34a15f33d/src/Wpf.Ui/Controls/Window/WindowBackdrop.cs#L191
                 var window = Application.Current.MainWindow;
-                Wpf.Ui.Controls.WindowBackdrop.RemoveBackground(window);
+
+                // Only makes sense for Windows 11 or greater, since Windows 10 doesn't have Mica.
+                if (OSVersionHelper.IsWindows11())
+                {
+                    Wpf.Ui.Controls.WindowBackdrop.RemoveBackground(window);
+                }
 
                 // Setting uint titlebarPvAttribute = 0xFFFFFFFE; works on 22H2 or higher, 21H2 (aka SV1) this value causes a crash
                 if (OSVersionHelper.IsGreaterThanWindows11_21H2())


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

The fix we did for fixing the loss of transparency after a theme change on Windows 11 is causing issues on Windows 10, making PowerToys Run appear too gray.
This PR changes so that the fix will only apply on Windows 11.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #33622 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Verified PTRun on Windows 10 no longer appears "gray" when on dark theme.
