### PR TITLE
Disable project references so CustomActions doesn't rebuild during MSI

### DIFF
--- a/.pipelines/installer-steps.yml
+++ b/.pipelines/installer-steps.yml
@@ -43,7 +43,7 @@ steps:
     inputs:
       solution: "**/installer/PowerToysSetup.sln"
       vsVersion: 17.0
-      msbuildArgs: /p:CIBuild=true /target:PowerToysInstaller /bl:$(Build.SourcesDirectory)\msbuild.binlog /p:RunBuildEvents=false /p:PerUser=${{parameters.perUserArg}}
+      msbuildArgs: /p:CIBuild=true /p:BuildProjectReferences=false /target:PowerToysInstaller /bl:$(Build.SourcesDirectory)\msbuild.binlog /p:RunBuildEvents=false /p:PerUser=${{parameters.perUserArg}}
       platform: $(BuildPlatform)
       configuration: $(BuildConfiguration)
       clean: false # don't undo our hard work above by deleting the CustomActions dll


### PR DESCRIPTION
Tested and working in PowerToys Signed YAML Release Build_2407.11003