### PR TITLE
[Peek][PreviewPane] Fix missing Copy menu-item

### DIFF
--- a/src/common/FilePreviewCommon/Assets/Monaco/index.html
+++ b/src/common/FilePreviewCommon/Assets/Monaco/index.html
@@ -9,7 +9,7 @@
         // `theme` can be "vs" for light theme or "vs-dark" for dark theme
         // `lang` is the language of the file
         // `wrap` if the editor is wrapping or not
-        
+
         var theme = ("[[PT_THEME]]" == "dark") ? "vs-dark" : "vs";
         var lang = "[[PT_LANG]]";
         var wrap = ([[PT_WRAP]] == 1) ? true : false;
@@ -19,11 +19,29 @@
         var stickyScroll = ([[PT_STICKY_SCROLL]] == 1) ? true : false;
 
         var fontSize = [[PT_FONT_SIZE]];
-        
+        var contextMenu = ([[PT_CONTEXTMENU]] == 1) ? true : false;
+
+        var editor;
+
         // Code taken from https://stackoverflow.com/a/30106551/14774889
-        var code = decodeURIComponent(atob(base64code).split('').map(function(c) {
+        var code = decodeURIComponent(atob(base64code).split('').map(function (c) {
             return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
         }).join(''));
+
+        function runToggleTextWrapCommand() {
+            if (wrap) {
+                editor.updateOptions({ wordWrap: 'off' })
+            } else {
+                editor.updateOptions({ wordWrap: 'on' })
+            }
+            wrap = !wrap;
+        }
+
+        function runCopyCommand() {
+            editor.focus();
+            document.execCommand('copy');
+        }
+
     </script>
     <!-- Set browser to Edge-->
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
@@ -33,32 +51,33 @@
     <title>Previewer for developer Files</title>
     <style>
         /* Fits content to window size */
-        html, body{
-            padding:0;
+        html, body {
+            padding: 0;
         }
-        #container,.monaco-editor {
-            position:fixed;
-            height:100%;
-            left:0;
-            top:0;
-            right:0;
-            bottom:0;
+
+        #container, .monaco-editor {
+            position: fixed;
+            height: 100%;
+            left: 0;
+            top: 0;
+            right: 0;
+            bottom: 0;
         }
-        .overflowingContentWidgets{
+
+        .overflowingContentWidgets {
             /*Hides alert box */
-            display:none!important
-        } 
+            display: none !important
+        }
     </style>
 </head>
 
-<body oncontextmenu="onContextMenu()">
+<body>
     <!-- Container for the editor -->
     <div id="container"></div>
     <!-- Script -->
     <script src="http://[[PT_URL]]/monacoSRC/min/vs/loader.js"></script>
     <script src="http://[[PT_URL]]/monacoSpecialLanguages.js" type="module"></script>
-<script type="module">
-        var editor;
+    <script type="module">
         import { registerAdditionalLanguages } from 'http://[[PT_URL]]/monacoSpecialLanguages.js';
         import { customTokenColors } from 'http://[[PT_URL]]/customTokenColors.js';
         require.config({ paths: { vs: 'http://[[PT_URL]]/monacoSRC/min/vs' } });
@@ -80,8 +99,9 @@
                 language: lang, // Sets language of the code
                 readOnly: true, // Sets to readonly
                 theme: 'theme', // Sets editor theme
-                minimap: {enabled: false}, // Disables minimap
+                minimap: { enabled: false }, // Disables minimap
                 lineNumbersMinChars: '3', // Width of the line numbers
+                contextmenu: contextMenu,
                 scrollbar: {
                     // Deactivate shadows
                     shadows: false,
@@ -90,7 +110,7 @@
                     vertical: 'auto',
                     horizontal: 'auto',
                 },
-                stickyScroll: {enabled: stickyScroll},
+                stickyScroll: { enabled: stickyScroll },
                 fontSize: fontSize,
                 wordWrap: (wrap ? 'on' : 'off') // Word wraps
             });
@@ -117,12 +137,7 @@
                 // Method that will be executed when the action is triggered.
                 // @param editor The editor instance is passed in as a convenience
                 run: function (ed) {
-                    if (wrap) {
-                        editor.updateOptions({ wordWrap: 'off' })
-                    } else {
-                        editor.updateOptions({ wordWrap: 'on' })
-                    }
-                    wrap = !wrap;
+                    runToggleTextWrapCommand();
                 }
             });
 

--- a/src/modules/peek/Peek.FilePreviewer/Controls/BrowserControl.xaml.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Controls/BrowserControl.xaml.cs
@@ -224,6 +224,7 @@ namespace Peek.FilePreviewer.Controls
                 CustomContextMenu
                     ? [
                         CreateCommandMenuItem("ContextMenu_Copy", "runCopyCommand"),
+                        sender.Environment.CreateContextMenuItem(string.Empty, null, CoreWebView2ContextMenuItemKind.Separator),
                         CreateCommandMenuItem("ContextMenu_ToggleTextWrapping", "runToggleTextWrapCommand"),
                     ]
                     : menuItems.Where(menuItem => menuItem.Name == "copy").ToList();

--- a/src/modules/peek/Peek.FilePreviewer/Controls/BrowserControl.xaml.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Controls/BrowserControl.xaml.cs
@@ -145,7 +145,7 @@ namespace Peek.FilePreviewer.Controls
                 PreviewBrowser.DefaultBackgroundColor = Color.FromArgb(0, 0, 0, 0);
 
                 PreviewBrowser.CoreWebView2.Settings.AreDefaultScriptDialogsEnabled = false;
-                PreviewBrowser.CoreWebView2.Settings.AreDefaultContextMenusEnabled = false;
+                PreviewBrowser.CoreWebView2.Settings.AreDefaultContextMenusEnabled = true;
                 PreviewBrowser.CoreWebView2.Settings.AreDevToolsEnabled = false;
                 PreviewBrowser.CoreWebView2.Settings.AreHostObjectsAllowed = false;
                 PreviewBrowser.CoreWebView2.Settings.IsGeneralAutofillEnabled = false;

--- a/src/modules/peek/Peek.FilePreviewer/FilePreview.xaml
+++ b/src/modules/peek/Peek.FilePreviewer/FilePreview.xaml
@@ -62,6 +62,7 @@
         <controls:BrowserControl
             x:Name="BrowserPreview"
             x:Load="True"
+            CustomContextMenu="{x:Bind BrowserPreviewer.CustomContextMenu, Mode=OneWay}"
             DOMContentLoaded="BrowserPreview_DOMContentLoaded"
             FlowDirection="LeftToRight"
             IsDevFilePreview="{x:Bind BrowserPreviewer.IsDevFilePreview, Mode=OneWay}"

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/Interfaces/IBrowserPreviewer.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/Interfaces/IBrowserPreviewer.cs
@@ -11,5 +11,7 @@ namespace Peek.FilePreviewer.Previewers.Interfaces
         public Uri? Preview { get; }
 
         public bool IsDevFilePreview { get; }
+
+        public bool CustomContextMenu { get; }
     }
 }

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/WebBrowserPreviewer/Helpers/MonacoHelper.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/WebBrowserPreviewer/Helpers/MonacoHelper.cs
@@ -80,6 +80,7 @@ namespace Peek.FilePreviewer.Previewers
 
             html = html.Replace("[[PT_LANG]]", vsCodeLangSet, StringComparison.InvariantCulture);
             html = html.Replace("[[PT_WRAP]]", wrapText ? "1" : "0", StringComparison.InvariantCulture);
+            html = html.Replace("[[PT_CONTEXTMENU]]", "0", StringComparison.InvariantCulture);
             html = html.Replace("[[PT_STICKY_SCROLL]]", stickyScroll ? "1" : "0", StringComparison.InvariantCulture);
             html = html.Replace("[[PT_THEME]]", theme, StringComparison.InvariantCulture);
             html = html.Replace("[[PT_FONT_SIZE]]", fontSize.ToString(CultureInfo.InvariantCulture), StringComparison.InvariantCulture);

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/WebBrowserPreviewer/WebBrowserPreviewer.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/WebBrowserPreviewer/WebBrowserPreviewer.cs
@@ -43,6 +43,9 @@ namespace Peek.FilePreviewer.Previewers
         [ObservableProperty]
         private bool isDevFilePreview;
 
+        [ObservableProperty]
+        private bool customContextMenu;
+
         private bool disposed;
 
         public WebBrowserPreviewer(IFileSystemItem file, IPreviewSettings previewSettings)
@@ -107,9 +110,14 @@ namespace Peek.FilePreviewer.Previewers
                 {
                     bool isHtml = File.Extension == ".html" || File.Extension == ".htm";
                     bool isMarkdown = File.Extension == ".md";
-                    IsDevFilePreview = MonacoHelper.SupportedMonacoFileTypes.Contains(File.Extension);
 
-                    if (IsDevFilePreview && !isHtml && !isMarkdown)
+                    bool supportedByMonaco = MonacoHelper.SupportedMonacoFileTypes.Contains(File.Extension);
+                    bool useMonaco = supportedByMonaco && !isHtml && !isMarkdown;
+
+                    IsDevFilePreview = supportedByMonaco;
+                    CustomContextMenu = useMonaco;
+
+                    if (useMonaco)
                     {
                         var raw = await ReadHelper.Read(File.Path.ToString());
                         Preview = new Uri(MonacoHelper.PreviewTempFile(raw, File.Extension, TempFolderPath.Path, _previewSettings.SourceCodeTryFormat, _previewSettings.SourceCodeWrapText, _previewSettings.SourceCodeStickyScroll, _previewSettings.SourceCodeFontSize));

--- a/src/modules/peek/Peek.UI/Strings/en-us/Resources.resw
+++ b/src/modules/peek/Peek.UI/Strings/en-us/Resources.resw
@@ -318,4 +318,12 @@
     <value>Length: {0}</value>
     <comment>{0} is the duration of the audio read from file metadata</comment>
   </data>
+  <data name="ContextMenu_Copy" xml:space="preserve">
+    <value>Copy</value>
+    <comment>Copy selected text to clipboard</comment>
+  </data>
+  <data name="ContextMenu_ToggleTextWrapping" xml:space="preserve">
+    <value>Toggle text wrapping</value>
+    <comment>Toggle whether text in pane is word-wrapped</comment>
+  </data>
 </root>

--- a/src/modules/previewpane/MarkdownPreviewHandler/MarkdownPreviewHandlerControl.cs
+++ b/src/modules/previewpane/MarkdownPreviewHandler/MarkdownPreviewHandlerControl.cs
@@ -143,7 +143,7 @@ namespace Microsoft.PowerToys.PreviewHandler.Markdown
                         await _browser.EnsureCoreWebView2Async(_webView2Environment).ConfigureAwait(true);
                         _browser.CoreWebView2.SetVirtualHostNameToFolderMapping(VirtualHostName, AssemblyDirectory, CoreWebView2HostResourceAccessKind.Deny);
                         _browser.CoreWebView2.Settings.AreDefaultScriptDialogsEnabled = false;
-                        _browser.CoreWebView2.Settings.AreDefaultContextMenusEnabled = false;
+                        _browser.CoreWebView2.Settings.AreDefaultContextMenusEnabled = true;
                         _browser.CoreWebView2.Settings.AreDevToolsEnabled = false;
                         _browser.CoreWebView2.Settings.AreHostObjectsAllowed = false;
                         _browser.CoreWebView2.Settings.IsGeneralAutofillEnabled = false;
@@ -159,6 +159,23 @@ namespace Microsoft.PowerToys.PreviewHandler.Markdown
                             if (new Uri(e.Request.Uri) != _localFileURI)
                             {
                                 e.Response = _browser.CoreWebView2.Environment.CreateWebResourceResponse(null, 403, "Forbidden", null);
+                            }
+                        };
+
+                        _browser.CoreWebView2.ContextMenuRequested += (object sender, CoreWebView2ContextMenuRequestedEventArgs args) =>
+                        {
+                            var menuItems = args.MenuItems;
+
+                            if (!menuItems.IsReadOnly)
+                            {
+                                var copyMenuItem = menuItems.FirstOrDefault(menuItem => menuItem.Name == "copy");
+
+                                menuItems.Clear();
+
+                                if (copyMenuItem != null)
+                                {
+                                    menuItems.Add(copyMenuItem);
+                                }
                             }
                         };
 

--- a/src/modules/previewpane/MonacoPreviewHandler/MonacoPreviewHandlerControl.cs
+++ b/src/modules/previewpane/MonacoPreviewHandler/MonacoPreviewHandlerControl.cs
@@ -396,6 +396,7 @@ namespace Microsoft.PowerToys.PreviewHandler.Monaco
             _html = FilePreviewCommon.MonacoHelper.ReadIndexHtml();
             _html = _html.Replace("[[PT_LANG]]", _vsCodeLangSet, StringComparison.InvariantCulture);
             _html = _html.Replace("[[PT_WRAP]]", _settings.Wrap ? "1" : "0", StringComparison.InvariantCulture);
+            _html = _html.Replace("[[PT_CONTEXTMENU]]", "1", StringComparison.InvariantCulture);
             _html = _html.Replace("[[PT_THEME]]", Settings.GetTheme(), StringComparison.InvariantCulture);
             _html = _html.Replace("[[PT_STICKY_SCROLL]]", _settings.StickyScroll ? "1" : "0", StringComparison.InvariantCulture);
             _html = _html.Replace("[[PT_FONT_SIZE]]", _settings.FontSize.ToString(CultureInfo.InvariantCulture), StringComparison.InvariantCulture);


### PR DESCRIPTION
## Summary of the Pull Request
Fixes two bugs:
- Peek: Missing "Copy" menu-item for all WebView2 previewers.
- PreviewPane: Missing "Copy" menu-item for markdown files only.

## PR Checklist

- [X] **Closes:** #32449
- [X] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [X] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments
The issues are:
- Peek: 
  - When not using Monaco (markdown, html) - the default WebView2 context menu has been disabled. I have enabled it and then disabled ALL menu-items other than "Copy" (such as "Back").
  - When using Monaco + Release (other code files) - current code tries to use the Monaco context menu, but it is somehow disabled at runtime. I spent MANY hours trying to find out why but without success. It works fine when I view the generated html + js files in a browser or in a Debug build or in PreviewPane. But I couldn't find the root cause. Trying to fix it by enabling the WebView2 context menu instead doesn't work as for whatever reason, WebView2 doesn't generate a "Copy" menu-item (it thinks there's no selected text when there is). So in this case, the only thing I could get to work was generating context menu-items via WebView2 callbacks that call JS functions. As a bonus, this way of doing it also allows "Toggle text wrapping" to work.
- PreviewPane:
  - Markdown - the default WebView2 context menu has been disabled. Like for Peek, I have enabled it and then disabled ALL menu-items other than "Copy" (such as "Back").
  - Monaco (other code files) - this already just works fine, so I've left it as is. I *could* make it work the same way as I've done for Peek for consistency, but I've chosen to leave it as is since it works.
  
![image](https://github.com/user-attachments/assets/d758ada7-bb62-4f40-bef7-ad08ffb83786)
![image](https://github.com/user-attachments/assets/4e0baa7e-632f-412a-b2b1-b9f666277ca7)

## Validation Steps Performed
- Tested copy (via menu-item and CTRL+C) for text formats on Peek/PreviewPane. Also tested "Toggle text wrapping" where appropriate.
- Sanity check of Peek and PreviewPane.