### PR TITLE
[Build] Remove wildcards items in vcxproj

### DIFF
--- a/Cpp.Build.props
+++ b/Cpp.Build.props
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0"
   xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 

--- a/Cpp.Build.props
+++ b/Cpp.Build.props
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0"
   xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
@@ -33,6 +33,7 @@
     <PreferredToolArchitecture>x64</PreferredToolArchitecture>
     <PreferredToolArchitecture Condition="'$(PROCESSOR_ARCHITECTURE)' == 'ARM64' or '$(PROCESSOR_ARCHITEW6432)' == 'ARM64'">arm64</PreferredToolArchitecture>
     <VcpkgEnabled>false</VcpkgEnabled>
+    <ReplaceWildcardsInProjectItems>true</ReplaceWildcardsInProjectItems>
     <ExternalIncludePath>$(MSBuildThisFileFullPath)\..\deps\;$(MSBuildThisFileFullPath)\..\packages\;$(ExternalIncludePath)</ExternalIncludePath>
     <!-- Enable control flow guard for C++ projects that don't consume any C++ files -->
     <!-- This covers the case where a .dll exports a .lib, but doesn't have any ClCompile entries. -->

--- a/PowerToys.sln
+++ b/PowerToys.sln
@@ -171,6 +171,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		src\.editorconfig = src\.editorconfig
 		.vsconfig = .vsconfig
+		Cpp.Build.props = Cpp.Build.props
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
 		Directory.Packages.props = Directory.Packages.props

--- a/src/modules/FileLocksmith/FileLocksmithContextMenu/FileLocksmithContextMenu.vcxproj
+++ b/src/modules/FileLocksmith/FileLocksmithContextMenu/FileLocksmithContextMenu.vcxproj
@@ -98,7 +98,30 @@ MakeAppx.exe pack /d . /p $(OutDir)FileLocksmithContextMenuPackage.msix /nv</Com
     <None Include="Resources.resx" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="Assets\FileLocksmith\**" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="Assets\FileLocksmith\FileLocksmith.ico">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Assets\FileLocksmith\LargeTile.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Assets\FileLocksmith\SmallTile.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Assets\FileLocksmith\SplashScreen.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Assets\FileLocksmith\Square150x150Logo.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Assets\FileLocksmith\Square44x44Logo.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Assets\FileLocksmith\storelogo.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Assets\FileLocksmith\Wide310x150Logo.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\common\SettingsAPI\SettingsAPI.vcxproj">

--- a/src/modules/FileLocksmith/FileLocksmithContextMenu/FileLocksmithContextMenu.vcxproj.filters
+++ b/src/modules/FileLocksmith/FileLocksmithContextMenu/FileLocksmithContextMenu.vcxproj.filters
@@ -37,6 +37,30 @@
     <None Include="Resources.resx">
       <Filter>Resource Files</Filter>
     </None>
+    <None Include="Assets\FileLocksmith\FileLocksmith.ico">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="Assets\FileLocksmith\LargeTile.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="Assets\FileLocksmith\SmallTile.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="Assets\FileLocksmith\SplashScreen.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="Assets\FileLocksmith\Square44x44Logo.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="Assets\FileLocksmith\Square150x150Logo.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="Assets\FileLocksmith\storelogo.png">
+      <Filter>Resource Files</Filter>
+    </None>
+    <None Include="Assets\FileLocksmith\Wide310x150Logo.png">
+      <Filter>Resource Files</Filter>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="FileLocksmithContextMenu.base.rc">

--- a/src/modules/ShortcutGuide/ShortcutGuide/ShortcutGuide.vcxproj
+++ b/src/modules/ShortcutGuide/ShortcutGuide/ShortcutGuide.vcxproj
@@ -95,7 +95,55 @@
   <ItemGroup>
     <None Include="packages.config" />
     <None Include="PropertySheet.props" />
-    <CopyFileToFolders Include="Assets\ShortcutGuide\**">
+    <CopyFileToFolders Include="Assets\ShortcutGuide\0.svg">
+      <FileType>Document</FileType>
+      <DestinationFolders>$(OutDir)\Assets\ShortcutGuide</DestinationFolders>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="Assets\ShortcutGuide\1.svg">
+      <FileType>Document</FileType>
+      <DestinationFolders>$(OutDir)\Assets\ShortcutGuide</DestinationFolders>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="Assets\ShortcutGuide\2.svg">
+      <FileType>Document</FileType>
+      <DestinationFolders>$(OutDir)\Assets\ShortcutGuide</DestinationFolders>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="Assets\ShortcutGuide\3.svg">
+      <FileType>Document</FileType>
+      <DestinationFolders>$(OutDir)\Assets\ShortcutGuide</DestinationFolders>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="Assets\ShortcutGuide\4.svg">
+      <FileType>Document</FileType>
+      <DestinationFolders>$(OutDir)\Assets\ShortcutGuide</DestinationFolders>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="Assets\ShortcutGuide\5.svg">
+      <FileType>Document</FileType>
+      <DestinationFolders>$(OutDir)\Assets\ShortcutGuide</DestinationFolders>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="Assets\ShortcutGuide\6.svg">
+      <FileType>Document</FileType>
+      <DestinationFolders>$(OutDir)\Assets\ShortcutGuide</DestinationFolders>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="Assets\ShortcutGuide\7.svg">
+      <FileType>Document</FileType>
+      <DestinationFolders>$(OutDir)\Assets\ShortcutGuide</DestinationFolders>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="Assets\ShortcutGuide\8.svg">
+      <FileType>Document</FileType>
+      <DestinationFolders>$(OutDir)\Assets\ShortcutGuide</DestinationFolders>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="Assets\ShortcutGuide\9.svg">
+      <FileType>Document</FileType>
+      <DestinationFolders>$(OutDir)\Assets\ShortcutGuide</DestinationFolders>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="Assets\ShortcutGuide\no_active_window.svg">
+      <FileType>Document</FileType>
+      <DestinationFolders>$(OutDir)\Assets\ShortcutGuide</DestinationFolders>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="Assets\ShortcutGuide\overlay.svg">
+      <FileType>Document</FileType>
+      <DestinationFolders>$(OutDir)\Assets\ShortcutGuide</DestinationFolders>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="Assets\ShortcutGuide\overlay_portrait.svg">
       <FileType>Document</FileType>
       <DestinationFolders>$(OutDir)\Assets\ShortcutGuide</DestinationFolders>
     </CopyFileToFolders>

--- a/src/modules/imageresizer/ImageResizerContextMenu/ImageResizerContextMenu.vcxproj
+++ b/src/modules/imageresizer/ImageResizerContextMenu/ImageResizerContextMenu.vcxproj
@@ -99,7 +99,30 @@ MakeAppx.exe pack /d . /p $(OutDir)ImageResizerContextMenuPackage.msix /nv</Comm
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="Assets\ImageResizer\**" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="Assets\ImageResizer\ImageResizer.ico">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Assets\ImageResizer\LargeTile.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Assets\ImageResizer\SmallTile.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Assets\ImageResizer\SplashScreen.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Assets\ImageResizer\Square150x150Logo.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Assets\ImageResizer\Square44x44Logo.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Assets\ImageResizer\storelogo.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Assets\ImageResizer\Wide310x150Logo.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\common\logger\logger.vcxproj">

--- a/src/modules/powerrename/PowerRenameContextMenu/PowerRenameContextMenu.vcxproj
+++ b/src/modules/powerrename/PowerRenameContextMenu/PowerRenameContextMenu.vcxproj
@@ -103,7 +103,30 @@ MakeAppx.exe pack /d . /p $(OutDir)PowerRenameContextMenuPackage.msix /nv</Comma
     <None Include="PowerRenameContextMenu.base.rc" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="Assets\PowerRename\**" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="Assets\PowerRename\LargeTile.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Assets\PowerRename\PowerRenameUI.ico">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Assets\PowerRename\SmallTile.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Assets\PowerRename\SplashScreen.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Assets\PowerRename\Square150x150Logo.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Assets\PowerRename\Square44x44Logo.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Assets\PowerRename\storelogo.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Assets\PowerRename\Wide310x150Logo.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\common\logger\logger.vcxproj">


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Fix the solution warning related to wildcards items in vcxproj.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #33853 #23459
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

https://learn.microsoft.com/cpp/build/reference/vcxproj-files-and-wildcards#list-all-items-explicitly
Since wildcards where used for assets that doesn't change frequently I have added `ReplaceWildcardsInProjectItems` for CPP projects. This will make VS automatically expand wildcards.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

- Verified that the warning is fixed
- Tested with a local build
- Verified that all the expanded assets are present as expected in the output dir (compared with 0.82.1 installation dir).