### PR TITLE
[Settings] Fix crash on dashboard when KBM settings update

### DIFF
--- a/src/settings-ui/Settings.UI/ViewModels/DashboardViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/DashboardViewModel.cs
@@ -88,10 +88,17 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
 
         private void LoadKBMSettingsFromJson()
         {
-            KeyboardManagerProfile kbmProfile = GetKBMProfile();
-            _kbmItem.RemapKeys = kbmProfile?.RemapKeys.InProcessRemapKeys;
-            _kbmItem.RemapShortcuts = KeyboardManagerViewModel.CombineShortcutLists(kbmProfile?.RemapShortcuts.GlobalRemapShortcuts, kbmProfile?.RemapShortcuts.AppSpecificRemapShortcuts);
-            dispatcher.Invoke(new Action(() => UpdateKBMItems()));
+            try
+            {
+                KeyboardManagerProfile kbmProfile = GetKBMProfile();
+                _kbmItem.RemapKeys = kbmProfile?.RemapKeys.InProcessRemapKeys;
+                _kbmItem.RemapShortcuts = KeyboardManagerViewModel.CombineShortcutLists(kbmProfile?.RemapShortcuts.GlobalRemapShortcuts, kbmProfile?.RemapShortcuts.AppSpecificRemapShortcuts);
+                dispatcher.Invoke(new Action(() => UpdateKBMItems()));
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError($"Failed to load KBM settings: {ex.Message}");
+            }
         }
 
         private void UpdateKBMItems()


### PR DESCRIPTION
## Summary of the Pull Request
Fixed crash of Settings when KBM settings update by any mechanism.

## PR Checklist

- [X] **Closes:** #33074
- [X] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments
To show updated KBM remappings on the dashboard,  the Settings app watches for changes to the KBM settings file and reloads the file on change. Reloading the file can fail (most likely because the writing process takes an exclusive lock and isn't yet done writing) and the process crashes when this happens. This change guards against this.

## Validation Steps Performed
With Settings open, made several changes to KBM remappings:
- Via the KBM settings editor
- Via a PowerShell script that updates the backing settings file.

![after_fix](https://github.com/user-attachments/assets/c5355a9e-b763-4c04-bb3d-edaf56b8a588)
