### PR TITLE
Getting latest sqlite

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,7 +28,7 @@
     <PackageVersion Include="Mages" Version="2.0.2" />
     <PackageVersion Include="Markdig.Signed" Version="0.34.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="8.0.7" />
     <PackageVersion Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.4.336902" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="8.0.0" />

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1318,7 +1318,7 @@ EXHIBIT A -Mozilla Public License.
 - Mages 2.0.2
 - Markdig.Signed 0.34.0
 - Microsoft.CodeAnalysis.NetAnalyzers 8.0.0
-- Microsoft.Data.Sqlite 8.0.0
+- Microsoft.Data.Sqlite 8.0.7
 - Microsoft.Extensions.DependencyInjection 8.0.0
 - Microsoft.Extensions.Hosting 8.0.0
 - Microsoft.Extensions.Hosting.WindowsServices 8.0.0


### PR DESCRIPTION
Updating to latest sqlite, can hold until .84

VS Code workspaces is the only item that uses this.
![image](https://github.com/user-attachments/assets/d6b501a6-6f43-4e7b-a188-8fbd10cacc56)
