### PR TITLE
[PTRun] Implement thread-safety in query results task with lock

### DIFF
--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/Main.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/Main.cs
@@ -18,8 +18,6 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
 {
     public class Main : IPlugin, IPluginI18n, IContextMenu, IDisposable
     {
-        private static readonly object _convertLock = new object();
-
         public string Name => Properties.Resources.plugin_name;
 
         public string Description => Properties.Resources.plugin_description;
@@ -52,16 +50,9 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
                 return new List<Result>();
             }
 
-            List<Result> result = null;
-            lock (_convertLock)
-            {
-                // Convert
-                result = UnitHandler.Convert(convertModel)
+            return UnitHandler.Convert(convertModel)
                 .Select(x => GetResult(x))
                 .ToList();
-            }
-
-            return result;
         }
 
         private Result GetResult(UnitConversionResult result)

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/Main.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/Main.cs
@@ -18,6 +18,8 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
 {
     public class Main : IPlugin, IPluginI18n, IContextMenu, IDisposable
     {
+        private static readonly object _convertLock = new object();
+
         public string Name => Properties.Resources.plugin_name;
 
         public string Description => Properties.Resources.plugin_description;
@@ -50,10 +52,16 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
                 return new List<Result>();
             }
 
-            // Convert
-            return UnitHandler.Convert(convertModel)
+            List<Result> result = null;
+            lock (_convertLock)
+            {
+                // Convert
+                result = UnitHandler.Convert(convertModel)
                 .Select(x => GetResult(x))
                 .ToList();
+            }
+
+            return result;
         }
 
         private Result GetResult(UnitConversionResult result)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
When PTRun first opened, it throws an exception in QueryResults function at first query. This error is solved by using _updateSource.Token instead of local currentCancellationToken to avoid dangling reference.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #30848 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

- Disable PTRun and enable it again
- Copy "%% 10 ft in m"
- Run PTRun with hotkey and paste "%% 10 ft in m"
- Observe the result is shown or not
