### PR TITLE
[Launcher] Reverted start-position to slightly off-center while still addressing multi-monitor/multi-DPI scenarios

### DIFF
--- a/src/modules/launcher/PowerLauncher/Helper/WindowsInteropHelper.cs
+++ b/src/modules/launcher/PowerLauncher/Helper/WindowsInteropHelper.cs
@@ -10,6 +10,7 @@ using System.Windows;
 using System.Windows.Forms;
 using System.Windows.Interop;
 using System.Windows.Media;
+using Point = System.Windows.Point;
 
 namespace PowerLauncher.Helper
 {
@@ -187,15 +188,18 @@ namespace PowerLauncher.Helper
             _ = NativeMethods.SetWindowLong(hwnd, GWL_EX_STYLE, NativeMethods.GetWindowLong(hwnd, GWL_EX_STYLE) | WS_EX_TOOLWINDOW);
         }
 
-        public static void MoveToScreenCenter(Window window, Screen screen)
+        /// <summary>
+        /// Transforms pixels to Device Independent Pixels used by WPF
+        /// </summary>
+        /// <param name="visual">current window, required to get presentation source</param>
+        /// <param name="unitX">horizontal position in pixels</param>
+        /// <param name="unitY">vertical position in pixels</param>
+        /// <returns>point containing device independent pixels</returns>
+        public static Point TransformPixelsToDIP(Visual visual, double unitX, double unitY)
         {
-            var workingArea = screen.WorkingArea;
-            var matrix = GetCompositionTarget(window).TransformFromDevice;
-            var dpiX = matrix.M11;
-            var dpiY = matrix.M22;
+            var matrix = GetCompositionTarget(visual).TransformFromDevice;
 
-            window.Left = (dpiX * workingArea.Left) + (((dpiX * workingArea.Width) - window.Width) / 2);
-            window.Top = (dpiY * workingArea.Top) + (((dpiY * workingArea.Height) - window.Height) / 2);
+            return new Point((int)(matrix.M11 * unitX), (int)(matrix.M22 * unitY));
         }
 
         private static CompositionTarget GetCompositionTarget(Visual visual)

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -449,14 +449,22 @@ namespace PowerLauncher
             // In terms of the hack itself, removing any of these three steps seems to fail in certain scenarios only,
             // so be careful with testing!
             var desiredScreen = GetScreen();
+            var workingArea = desiredScreen.WorkingArea;
+            Point ToDIP(double unitX, double unitY) => WindowsInteropHelper.TransformPixelsToDIP(this, unitX, unitY);
 
             // Move to top-left of desired screen.
-            Top = desiredScreen.WorkingArea.Top;
-            Left = desiredScreen.WorkingArea.Left;
+            Top = workingArea.Top;
+            Left = workingArea.Left;
 
             // Centralize twice.
-            WindowsInteropHelper.MoveToScreenCenter(this, desiredScreen);
-            WindowsInteropHelper.MoveToScreenCenter(this, desiredScreen);
+            void MoveToScreenTopCenter()
+            {
+                Left = ((ToDIP(workingArea.Width, 0).X - ActualWidth) / 2) + ToDIP(workingArea.X, 0).X;
+                Top = ((ToDIP(0, workingArea.Height).Y - SearchBox.ActualHeight) / 4) + ToDIP(0, workingArea.Y).Y;
+            }
+
+            MoveToScreenTopCenter();
+            MoveToScreenTopCenter();
         }
 
         private void OnLocationChanged(object sender, EventArgs e)


### PR DESCRIPTION
## Summary of the Pull Request
Reverted start-position to slightly off-center while still addressing multi-monitor/multi-DPI scenarios.

## PR Checklist

- [X] **Closes:** #34072
- [X] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments
Please see code.

## Validation Steps Performed
Tested change in regular scenarios and also in the following 2-monitor setups (2 x 4 cases)
- Primary 100% scale, secondary 175% scale and vice-versa
- Primary above, below, to the left and right of secondary

...in the following ways:
- Bring up launcher on primary multiple times.
- Now bring up launcher on secondary multiple times.
- Now bring up launcher on primary multiple times.

Also tested that the startup position is the same as v0.81 with the following single-monitor (1920 x 1080) scaling factors:
- 100%
- 150%
- 175%