### PR TITLE
[Run] Improve default browser detection

### DIFF
--- a/src/modules/launcher/Wox.Plugin/Common/DefaultBrowserInfo.cs
+++ b/src/modules/launcher/Wox.Plugin/Common/DefaultBrowserInfo.cs
@@ -17,12 +17,12 @@ namespace Wox.Plugin.Common
         private static readonly object _updateLock = new object();
 
         /// <summary>Gets the path to the MS Edge browser executable.</summary>
-        public static string MSEdgePath =>
-            Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86) +
-            @"\Microsoft\Edge\Application\msedge.exe";
+        public static string MSEdgePath => System.IO.Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
+            @"Microsoft\Edge\Application\msedge.exe");
 
         /// <summary>Gets the command line pattern of the MS Edge.</summary>
-        public static string MSEdgeArgumentsPattern => "--single-argument %1";
+        public const string MSEdgeArgumentsPattern = "--single-argument %1";
 
         public const string MSEdgeName = "Microsoft Edge";
 
@@ -44,7 +44,8 @@ namespace Wox.Plugin.Common
 
         private static long _lastUpdateTickCount = -UpdateTimeout;
 
-        private static bool haveIRanUpdateOnce;
+        private static bool _updatedOnce;
+        private static bool _errorLogged;
 
         /// <summary>
         /// Updates only if at least more than 300ms has passed since the last update, to avoid multiple calls to <see cref="Update"/>.
@@ -68,10 +69,10 @@ namespace Wox.Plugin.Common
         {
             lock (_updateLock)
             {
-                if (!haveIRanUpdateOnce)
+                if (!_updatedOnce)
                 {
-                    Log.Warn("I've tried updating the chosen Web Browser info at least once.", typeof(DefaultBrowserInfo));
-                    haveIRanUpdateOnce = true;
+                    Log.Info("I've tried updating the chosen Web Browser info at least once.", typeof(DefaultBrowserInfo));
+                    _updatedOnce = true;
                 }
 
                 try
@@ -145,6 +146,14 @@ namespace Wox.Plugin.Common
                         }
                     }
 
+                    // Packaged applications could be an URI. Example: shell:AppsFolder\Microsoft.MicrosoftEdge.Stable_8wekyb3d8bbwe!App
+                    if (!System.IO.Path.Exists(Path) && !Uri.TryCreate(Path, UriKind.Absolute, out _))
+                    {
+                        throw new ArgumentException(
+                            $"Command validation failed: {commandPattern}",
+                            nameof(commandPattern));
+                    }
+
                     if (string.IsNullOrEmpty(Path))
                     {
                         throw new ArgumentOutOfRangeException(
@@ -154,11 +163,16 @@ namespace Wox.Plugin.Common
                 }
                 catch (Exception e)
                 {
-                    // fallback to MS Edge
+                    // Fallback to MS Edge
                     Path = MSEdgePath;
                     Name = MSEdgeName;
                     ArgumentsPattern = MSEdgeArgumentsPattern;
-                    Log.Exception("Exception when retrieving browser path/name. Path and Name are set to use Microsoft Edge.", e, typeof(DefaultBrowserInfo));
+
+                    if (!_errorLogged)
+                    {
+                        Log.Exception("Exception when retrieving browser path/name. Path and Name are set to use Microsoft Edge.", e, typeof(DefaultBrowserInfo));
+                        _errorLogged = true;
+                    }
                 }
 
                 string GetRegistryValue(string registryLocation, string valueName)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

- Some users are reporting that the WebSearch plugin is opening Explorer instead of the browser.
- A user reported that the registry value we are using to detect the command pattern to start the browser contains the string `Microsoft Edge HTML Document`: https://github.com/microsoft/PowerToys/issues/21400#issuecomment-2262764771
- Can't find the reason why that string is here but rather than dealing with this string, if the pattern isn't "something valid" to be launched, use Edge. The code is already falling back to Edge in other error cases.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #21400
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

- Small QoL improvements to the code
- Logged the command in case of error
- Fall back to Edge if command isn't a valid path or URI

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

- Tested WebSearch plugin changing the value of `HKEY_CLASSES_ROOT\MSEdgeHTM\shell\open\command`:
  - `"C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe" --single-argument %1`
  - `shell:AppsFolder\Microsoft.MicrosoftEdge.Stable_8wekyb3d8bbwe!App %1`
  - `Microsoft Edge HTML Document`
