### PR TITLE
changed the tool tip of the info button next to the replacement text box in the PowerRename window.

### DIFF
--- a/src/modules/powerrename/PowerRenameUILib/Strings/en-us/Resources.resw
+++ b/src/modules/powerrename/PowerRenameUILib/Strings/en-us/Resources.resw
@@ -343,7 +343,7 @@
     <value>RegEx help</value>
   </data>
   <data name="FileCreationButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Replace syntax help</value>
+    <value>Replace terms help</value>
   </data>
   <data name="FileCreationButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Replace syntax help</value>

--- a/src/modules/powerrename/PowerRenameUILib/Strings/en-us/Resources.resw
+++ b/src/modules/powerrename/PowerRenameUILib/Strings/en-us/Resources.resw
@@ -346,7 +346,7 @@
     <value>Replace terms help</value>
   </data>
   <data name="FileCreationButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Replace syntax help</value>
+    <value>Replace terms help</value>
   </data>
   <data name="ErrorMessage_FileNameTooLong" xml:space="preserve">
     <value>File name is too long</value>

--- a/src/modules/powerrename/PowerRenameUILib/Strings/en-us/Resources.resw
+++ b/src/modules/powerrename/PowerRenameUILib/Strings/en-us/Resources.resw
@@ -343,10 +343,10 @@
     <value>RegEx help</value>
   </data>
   <data name="FileCreationButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Replace Name Syntax Help</value>
+    <value>Replace syntax help</value>
   </data>
   <data name="FileCreationButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Replace Name Syntax Help</value>
+    <value>Replace syntax help</value>
   </data>
   <data name="ErrorMessage_FileNameTooLong" xml:space="preserve">
     <value>File name is too long</value>

--- a/src/modules/powerrename/PowerRenameUILib/Strings/en-us/Resources.resw
+++ b/src/modules/powerrename/PowerRenameUILib/Strings/en-us/Resources.resw
@@ -343,10 +343,10 @@
     <value>RegEx help</value>
   </data>
   <data name="FileCreationButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>File creation date and time help</value>
+    <value>Replace Name Syntax Help</value>
   </data>
   <data name="FileCreationButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>File creation date and time help</value>
+    <value>Replace Name Syntax Help</value>
   </data>
   <data name="ErrorMessage_FileNameTooLong" xml:space="preserve">
     <value>File name is too long</value>


### PR DESCRIPTION
changed the tool tip of the info button next to the replacement text box in the PowerRename window from "Help for Date and Time of the file creation" to "Replace Name Syntax Help" for better understanding of this feature.

- [x] **Closes:** #33907
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

