### PR TITLE
[Build]Clean the WPARAM warning on IDL

### DIFF
--- a/src/common/interop/KeyboardHook.idl
+++ b/src/common/interop/KeyboardHook.idl
@@ -1,12 +1,10 @@
-typedef UInt64 WPARAM;
-
 namespace PowerToys
 {
     namespace Interop
     {
         struct KeyboardEvent
         {
-            WPARAM message;
+            UInt64 message;
             Int32 key;
             UInt64 dwExtraInfo;
         };


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Cleans a build warning about WPARAM when building the idl file. Seems like typedef is not liked too much when compiling for winrt/Cpp.
