### PR TITLE
[Settings][Find My Mouse] Improve UX for disabled animations

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -407,6 +407,7 @@ dxgi
 dxgidebug
 dxgiformat
 dxguid
+easeofaccess
 ecount
 EData
 Edid
@@ -1712,6 +1713,7 @@ vih
 VIRTUALDESK
 visiblecolorformats
 Visibletrue
+visualeffects
 VKey
 vmovl
 vorrq

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -85,7 +85,7 @@
     <UsePrecompiledHeaders Condition="'$(TF_BUILD)' != ''">false</UsePrecompiledHeaders>
 
     <!-- Change this to bust the cache -->
-    <MSBuildCacheCacheUniverse Condition="'$(MSBuildCacheCacheUniverse)' == ''">202408050737</MSBuildCacheCacheUniverse>
+    <MSBuildCacheCacheUniverse Condition="'$(MSBuildCacheCacheUniverse)' == ''">202408150737</MSBuildCacheCacheUniverse>
 
     <!--
       Visual Studio telemetry reads various ApplicationInsights.config files and other files after the project is finished, likely in a detached process.

--- a/src/settings-ui/Settings.UI/Helpers/StartProcessHelper.cs
+++ b/src/settings-ui/Settings.UI/Helpers/StartProcessHelper.cs
@@ -3,12 +3,17 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using Common.UI;
 
 namespace Microsoft.PowerToys.Settings.UI.Helpers
 {
     public static class StartProcessHelper
     {
         public const string ColorsSettings = "ms-settings:colors";
+
+        public static string AnimationsSettings => OSVersionHelper.IsWindows11()
+            ? "ms-settings:easeofaccess-visualeffects"
+            : "ms-settings:easeofaccess-display";
 
         public static void Start(string process)
         {

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/MouseUtilsPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/MouseUtilsPage.xaml
@@ -148,7 +148,11 @@
                         IsClosable="False"
                         IsOpen="True"
                         Severity="Informational"
-                        Visibility="{x:Bind ViewModel.IsAnimationEnabledBySystem, Mode=OneWay, Converter={StaticResource BoolToInvertedVisibilityConverter}}" />
+                        Visibility="{x:Bind ViewModel.IsAnimationEnabledBySystem, Mode=OneWay, Converter={StaticResource BoolToInvertedVisibilityConverter}}">
+                        <InfoBar.ActionButton>
+                            <HyperlinkButton x:Uid="OpenSettings" Click="OpenAnimationsSettings_Click" />
+                        </InfoBar.ActionButton>
+                    </InfoBar>
                     <tkcontrols:SettingsExpander
                         x:Uid="MouseUtils_FindMyMouse_ExcludedApps"
                         HeaderIcon="{ui:FontIcon Glyph=&#xECE4;}"

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/MouseUtilsPage.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/MouseUtilsPage.xaml.cs
@@ -2,6 +2,8 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using ManagedCommon;
 using Microsoft.PowerToys.Settings.UI.Helpers;
 using Microsoft.PowerToys.Settings.UI.Library;
 using Microsoft.PowerToys.Settings.UI.ViewModels;
@@ -48,6 +50,18 @@ namespace Microsoft.PowerToys.Settings.UI.Views
         public void RefreshEnabledState()
         {
             ViewModel.RefreshEnabledState();
+        }
+
+        private void OpenAnimationsSettings_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+        {
+            try
+            {
+                StartProcessHelper.Start(StartProcessHelper.AnimationsSettings);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError("Error while trying to open the animations settings", ex);
+            }
         }
     }
 }

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -2708,8 +2708,8 @@ Right-click to remove the key combination, thereby deactivating the shortcut.</v
     <value>Time before the spotlight appears (ms)</value>
     <comment>ms = milliseconds</comment>
   </data>
-  <data name="MouseUtils_FindMyMouse_AnimationDurationMs_Disabled.Message" xml:space="preserve">
-    <value>Animations are disabled by OS. See Settings &gt; Accessibility &gt; Visual effects</value>
+  <data name="MouseUtils_FindMyMouse_AnimationDurationMs_Disabled.Title" xml:space="preserve">
+    <value>Animations are disabled in your system settings.</value>
   </data>
   <data name="MouseUtils_FindMyMouse_ShakingMinimumDistance.Header" xml:space="preserve">
     <value>Shake minimum distance</value>
@@ -4204,5 +4204,8 @@ Activate by holding the key for the character you want to add an accent to, then
   </data>
   <data name="MouseWithoutBorders_PolicyIPAddressMappingInfo_TextBoxControl.Description" xml:space="preserve">
     <value>You can not change, remove or disable these enforced rules.</value>
+  </data>
+  <data name="OpenSettings.Content" xml:space="preserve">
+    <value>Open settings</value>
   </data>
 </root>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Like the OP I also hit Find My Mouse having disabled animations but the message didn't provide accurate info to find the option and I ended up using the good old "Advanced System Settings".

Figured out that the option location differ on W10/W11.

This PR aim to tweak a little bit the message and provide a link to open the related Windows setting page based on OS version.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #34224
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

![image](https://github.com/user-attachments/assets/d4796ad8-b868-4707-a7ba-a598422f03f0)

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

- Manually tested the button.
- Verified that the URIs bring to the correct Windows settings page for both W10 and W11.
