### PR TITLE
[Peek] Fix leak in unmanaged memory

### DIFF
--- a/src/modules/peek/Peek.Common/Models/FileItem.cs
+++ b/src/modules/peek/Peek.Common/Models/FileItem.cs
@@ -10,47 +10,31 @@ using Windows.Storage;
 
 #nullable enable
 
-namespace Peek.Common.Models
+namespace Peek.Common.Models;
+
+public class FileItem(string path, string name) : IFileSystemItem
 {
-    public class FileItem : IFileSystemItem
+    public string Name { get; init; } = name;
+
+    public string ParsingName => string.Empty;
+
+    public string Path { get; init; } = path;
+
+    public string Extension => System.IO.Path.GetExtension(Path).ToLower(CultureInfo.InvariantCulture);
+
+    public async Task<IStorageItem?> GetStorageItemAsync() => await GetStorageFileAsync();
+
+    public async Task<StorageFile?> GetStorageFileAsync()
     {
-        private StorageFile? storageFile;
-
-        public FileItem(string path, string name)
+        try
         {
-            Path = path;
-            Name = name;
+            // Don't cache these objects; they are cheap to create but seem to have a large (unmanaged) memory footprint.
+            return await StorageFile.GetFileFromPathAsync(Path);
         }
-
-        public string Name { get; init; }
-
-        public string ParsingName => string.Empty;
-
-        public string Path { get; init; }
-
-        public string Extension => System.IO.Path.GetExtension(Path).ToLower(CultureInfo.InvariantCulture);
-
-        public async Task<IStorageItem?> GetStorageItemAsync()
+        catch (Exception ex)
         {
-            return await GetStorageFileAsync();
-        }
-
-        public async Task<StorageFile?> GetStorageFileAsync()
-        {
-            if (storageFile == null)
-            {
-                try
-                {
-                    storageFile = await StorageFile.GetFileFromPathAsync(Path);
-                }
-                catch (Exception ex)
-                {
-                    Logger.LogError("Error getting file from path. " + ex.Message);
-                    storageFile = null;
-                }
-            }
-
-            return storageFile;
+            Logger.LogError("Error getting file from path. " + ex.Message);
+            return null;
         }
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request
Fixes an issue where Peek leaks a small amount of memory for each image (or likely for each file) viewed in the context of a folder operation.

## PR Checklist

- [x] **Closes:** #33593
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments
For unclear reasons, a non-trivial amount of unmanaged memory (between a few hundred KB and 1 MB) is held for each `Windows.Storage.StorageFile` instance kept in an internal cache (which is created for each previewed file and not released until the Peek context is changed). This type is intended to only hold a small amount of file-metadata, but in practice seems to have a bigger footprint.

## Validation Steps Performed
Created a test bench as follows:
- Created a folder with 2000 images (all duplicates of a single 300 KB image).
- Created a script to preview all files in the folder by activating the Peek window and repeatedly injecting the right cursor key.
- Tracked process private bytes and broke this down into managed and unmanaged memory using a memory profiler.

Before this change, the overall memory usage goes up from ~100 MB to ~2GB. Almost all of this delta is attributable to an increase in unmanaged memory. After my change, the overall memory usage is more or less stable.

I did not observe any loss in functionality (although I only did a sanity check) or any visible increase in preview loading time as a result of this change.

