### PR TITLE
[Quick Accent] Move number super and subscripts from Portuguese to All Languages

### DIFF
--- a/src/modules/poweraccent/PowerAccent.Core/Languages.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/Languages.cs
@@ -157,14 +157,16 @@ namespace PowerAccent.Core
         {
             return letter switch
             {
-                LetterKey.VK_0 => new[] { "↉" },
-                LetterKey.VK_1 => new[] { "½", "⅓", "¼", "⅕", "⅙", "⅐", "⅛", "⅑", "⅒" },
-                LetterKey.VK_2 => new[] { "⅔", "⅖" },
-                LetterKey.VK_3 => new[] { "¾", "⅗", "⅜" },
-                LetterKey.VK_4 => new[] { "⅘" },
-                LetterKey.VK_5 => new[] { "⅚", "⅝" },
-                LetterKey.VK_7 => new[] { "⅞" },
-                LetterKey.VK_8 => new[] { "∞" },
+                LetterKey.VK_0 => new[] { "₀", "⁰", "↉" },
+                LetterKey.VK_1 => new[] { "₁", "¹", "½", "⅓", "¼", "⅕", "⅙", "⅐", "⅛", "⅑", "⅒" },
+                LetterKey.VK_2 => new[] { "₂", "²", "⅔", "⅖" },
+                LetterKey.VK_3 => new[] { "₃", "³", "¾", "⅗", "⅜" },
+                LetterKey.VK_4 => new[] { "₄", "⁴", "⅘" },
+                LetterKey.VK_5 => new[] { "₅", "⁵", "⅚", "⅝" },
+                LetterKey.VK_6 => new[] { "₆", "⁶" },
+                LetterKey.VK_7 => new[] { "₇", "⁷", "⅞" },
+                LetterKey.VK_8 => new[] { "₈", "⁸", "∞" },
+                LetterKey.VK_9 => new[] { "₉", "⁹" },
                 LetterKey.VK_A => new[] { "ȧ", "ǽ", "∀" },
                 LetterKey.VK_B => new[] { "ḃ" },
                 LetterKey.VK_C => new[] { "ċ", "°C", "©", "ℂ", "∁" },
@@ -478,16 +480,6 @@ namespace PowerAccent.Core
         {
             return letter switch
             {
-                LetterKey.VK_0 => new[] { "₀", "⁰" },
-                LetterKey.VK_1 => new[] { "₁", "¹" },
-                LetterKey.VK_2 => new[] { "₂", "²" },
-                LetterKey.VK_3 => new[] { "₃", "³" },
-                LetterKey.VK_4 => new[] { "₄", "⁴" },
-                LetterKey.VK_5 => new[] { "₅", "⁵" },
-                LetterKey.VK_6 => new[] { "₆", "⁶" },
-                LetterKey.VK_7 => new[] { "₇", "⁷" },
-                LetterKey.VK_8 => new[] { "₈", "⁸" },
-                LetterKey.VK_9 => new[] { "₉", "⁹" },
                 LetterKey.VK_A => new[] { "á", "à", "â", "ã", "ª" },
                 LetterKey.VK_C => new[] { "ç" },
                 LetterKey.VK_E => new[] { "é", "ê", "€" },


### PR DESCRIPTION
[Quick Accent] Move number super and subscripts from Portuguese to All Languages
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Moves number super and subscripts from Portuguese to All Languages
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #34366
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [x] **Dev docs:** No need
- [x] **New binaries:** None
- [x] **Documentation updated:** No need

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here --> 
## Detailed Description of the Pull Request / Additional comments
Moves number super and subscripts from Portuguese to All Languages, because other languages use it as much as Portuguese
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manually tested Quick Accent
