### PR TITLE
[AdvancedPaste] Custom Actions follow-up fixes #1

### DIFF
--- a/src/modules/AdvancedPaste/AdvancedPaste/AdvancedPasteXAML/Pages/MainPage.xaml.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/AdvancedPasteXAML/Pages/MainPage.xaml.cs
@@ -25,6 +25,7 @@ namespace AdvancedPaste.Pages
     {
         private readonly ObservableCollection<ClipboardItem> clipboardHistory;
         private readonly Microsoft.UI.Dispatching.DispatcherQueue _dispatcherQueue = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
+        private (VirtualKey Key, DateTime Timestamp) _lastKeyEvent = (VirtualKey.None, DateTime.MinValue);
 
         public OptionsViewModel ViewModel { get; private set; }
 
@@ -144,6 +145,15 @@ namespace AdvancedPaste.Pages
             }
 
             Logger.LogTrace();
+
+            var thisKeyEvent = (sender.Key, Timestamp: DateTime.Now);
+            if (thisKeyEvent.Key == _lastKeyEvent.Key && (thisKeyEvent.Timestamp - _lastKeyEvent.Timestamp) < TimeSpan.FromMilliseconds(200))
+            {
+                // Sometimes, multiple keyboard accelerator events are raised for a single Ctrl + VirtualKey press.
+                return;
+            }
+
+            _lastKeyEvent = thisKeyEvent;
 
             switch (sender.Key)
             {

--- a/src/modules/AdvancedPaste/AdvancedPaste/ViewModels/OptionsViewModel.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/ViewModels/OptionsViewModel.cs
@@ -61,17 +61,11 @@ namespace AdvancedPaste.ViewModels
 
         private bool _pasteFormatsDirty;
 
-        [ObservableProperty]
-        [NotifyPropertyChangedFor(nameof(IsCustomAIEnabled))]
-        private bool _isCustomAIEnabledOverride = false;
-
         public ObservableCollection<PasteFormat> StandardPasteFormats { get; } = [];
 
         public ObservableCollection<PasteFormat> CustomActionPasteFormats { get; } = [];
 
-        public bool IsCustomAIEnabled => IsCustomAIEnabledOverride || IsCustomAIEnabledCore;
-
-        private bool IsCustomAIEnabledCore => IsAllowedByGPO && IsClipboardDataText && aiHelper.IsAIEnabled;
+        public bool IsCustomAIEnabled => IsAllowedByGPO && IsClipboardDataText && aiHelper.IsAIEnabled;
 
         public event EventHandler<CustomActionActivatedEventArgs> CustomActionActivated;
 
@@ -218,20 +212,6 @@ namespace AdvancedPaste.ViewModels
 
             ClipboardHistoryEnabled = IsClipboardHistoryEnabled();
             GeneratedResponses.Clear();
-
-            _dispatcherQueue.TryEnqueue(async () =>
-            {
-                // Work-around for ListViews being disabled but sometimes not appearing grayed out.
-                // It appears that this is sometimes only triggered by a change event. This
-                // work-around sometimes still doesn't work, but it's better than not having it.
-                await Task.Delay(5);
-                IsClipboardDataText = true;
-                IsCustomAIEnabledOverride = true;
-
-                await Task.Delay(150);
-                ReadClipboard();
-                IsCustomAIEnabledOverride = false;
-            });
         }
 
         // List to store generated responses
@@ -437,7 +417,7 @@ namespace AdvancedPaste.ViewModels
 
         internal void ExecutePasteFormat(PasteFormat pasteFormat)
         {
-            if (!IsClipboardDataText || (pasteFormat.Format == PasteFormats.Custom && !IsCustomAIEnabledCore))
+            if (!IsClipboardDataText || (pasteFormat.Format == PasteFormats.Custom && !IsCustomAIEnabled))
             {
                 return;
             }

--- a/src/modules/AdvancedPaste/AdvancedPasteModuleInterface/dllmain.cpp
+++ b/src/modules/AdvancedPaste/AdvancedPasteModuleInterface/dllmain.cpp
@@ -41,6 +41,7 @@ namespace
     const wchar_t JSON_KEY_PROPERTIES[] = L"properties";
     const wchar_t JSON_KEY_CUSTOM_ACTIONS[] = L"custom-actions";
     const wchar_t JSON_KEY_SHORTCUT[] = L"shortcut";
+    const wchar_t JSON_KEY_IS_SHOWN[] = L"isShown";
     const wchar_t JSON_KEY_ID[] = L"id";
     const wchar_t JSON_KEY_WIN[] = L"win";
     const wchar_t JSON_KEY_ALT[] = L"alt";
@@ -220,8 +221,11 @@ private:
                         {
                             const auto object = customAction.GetObjectW();
 
-                            m_custom_action_hotkeys.push_back(parse_single_hotkey(object.GetNamedObject(JSON_KEY_SHORTCUT)));
-                            m_custom_action_ids.push_back(static_cast<int>(object.GetNamedNumber(JSON_KEY_ID)));
+                            if (object.GetNamedBoolean(JSON_KEY_IS_SHOWN, false))
+                            {
+                                m_custom_action_hotkeys.push_back(parse_single_hotkey(object.GetNamedObject(JSON_KEY_SHORTCUT)));
+                                m_custom_action_ids.push_back(static_cast<int>(object.GetNamedNumber(JSON_KEY_ID)));
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary of the Pull Request
Fixes the following issues with [this PR](https://github.com/microsoft/PowerToys/pull/34395):
- Removes a workaround to enable and disable custom actions when Advanced Paste window is shown. Note that the issue addressed by the workaround (that the custom actions list-view is sometimes not properly grayed out visually when disabled) is not addressed.
- Fixes an issue where using an in-app shortcut - ctrl+<num> - results in multiple preview items on the flyout.
- Fixes an issue where using a keyboard shortcut for a disabled custom action still brings up the Advanced Paste window.

## PR Checklist

- [ ] **Closes:** #xxx
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Tested fixes
- Sanity check of Advanced Paste
