### PR TITLE
Added word wrapping for the syntax help window description text

### DIFF
--- a/src/modules/powerrename/PowerRenameUILib/PowerRenameXAML/MainWindow.xaml
+++ b/src/modules/powerrename/PowerRenameUILib/PowerRenameXAML/MainWindow.xaml
@@ -363,7 +363,8 @@
                                                         VerticalAlignment="Center"
                                                         FontSize="12"
                                                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                                        Text="{x:Bind Description}" />
+                                                        Text="{x:Bind Description}" 
+                                                        TextWrapping="Wrap"/>
                                                 </Grid>
                                             </DataTemplate>
                                         </ListView.ItemTemplate>


### PR DESCRIPTION
The syntax help window of powerRename has text cut off issue so i added the text wrap in the textblock.


- [ ] **Closes:** #33906 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo]
