### PR TITLE
[Peek] Fix memory leak caused by unmanaged bitmaps not being freed

### DIFF
--- a/src/modules/peek/Peek.FilePreviewer/FilePreview.xaml.cs
+++ b/src/modules/peek/Peek.FilePreviewer/FilePreview.xaml.cs
@@ -153,6 +153,9 @@ namespace Peek.FilePreviewer
             _cancellationTokenSource.Cancel();
             _cancellationTokenSource = new();
 
+            // Clear up any unmanaged resources before creating a new previewer instance.
+            (Previewer as IDisposable)?.Dispose();
+
             if (Item == null)
             {
                 Previewer = null;

--- a/src/modules/peek/Peek.FilePreviewer/Peek.FilePreviewer.csproj
+++ b/src/modules/peek/Peek.FilePreviewer/Peek.FilePreviewer.csproj
@@ -104,12 +104,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Page Update="Controls\UnsupportedFilePreview\FailedFallbackPreviewControl.xaml">
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-  </ItemGroup>
-
-  <ItemGroup>
     <Page Update="FilePreview.xaml">
       <Generator>MSBuild:Compile</Generator>
     </Page>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Fixes the Peek PowerToy leaking unmanaged resources associated with bitmaps when using the `ImagePreviewer`. Also ensures any Previewer implementing `IDisposable` will be correctly disposed.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #33593
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
The Peek PowerToy creates a Previewer for each item as the user navigates a folder. For the ImagePreviewer, a `Clear` method is provided which cleans up unmanaged resources, including bitmaps created for preview thumbnails. Unfortunately, `Clear` is not called on the old Previewer before a new instance is created, leading to unreachable resources which are never freed. This PR ensures `Dispose` is called on a Previewer if it implements `IDisposable`. ImagePreviewer calls `Clear` within its `Dispose`, which fixes the leak.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Manual validation:

1. Attached to the `PowerToys.Peek.UI` exe in VS, where the memory leak manifests.
2. Created a Heap Snapshot.
3. Manually navigated through a test folder, which contains 90% image files, and also zip files for several minutes.
4. Created another Heap Snapshot.
5. Confirmed that the Process Memory used was stable.
6. Confirmed that only a small number of pinned `Byte[]` instances were present in the heap snapshot.
7. Left the program running for more than an hour as I did other work. Confirmed that it still ran without issue and memory issues had not resurfaced.

### Before Fix
Despite garbage collection, unmanaged resources are not freed, leading to an ever-increasing amount of memory used - nearly 2GB in this example.

![Screenshot 2024-08-28 172800](https://github.com/user-attachments/assets/c27d61b1-5296-45de-b44e-cbe39ffdecbf)

### After Fix
![image](https://github.com/user-attachments/assets/14b45357-fa26-4d97-b09d-2c8bb61af383)
