### PR TITLE
[Peek] Fix for DateModified tooltip property showing file creation date

### DIFF
--- a/src/modules/peek/Peek.Common/Models/IFileSystemItem.cs
+++ b/src/modules/peek/Peek.Common/Models/IFileSystemItem.cs
@@ -19,7 +19,7 @@ namespace Peek.Common.Models
             {
                 try
                 {
-                    return string.IsNullOrEmpty(Path) ? null : System.IO.File.GetCreationTime(Path);
+                    return string.IsNullOrEmpty(Path) ? null : System.IO.File.GetLastWriteTime(Path);
                 }
                 catch
                 {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
The Peek image preview shows an infotip on hover, including a Date Modified field. This was incorrectly set to the file's creation date.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #34494
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
This was a simple change to return `GetLastWriteTime` for the file.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manual validation by using Peek on an image file where the creation datetime was different to the modified date.
