### PR TITLE
Added Arc Browser Support (#32782)

### DIFF
--- a/src/modules/launcher/Wox.Plugin/Common/DefaultBrowserInfo.cs
+++ b/src/modules/launcher/Wox.Plugin/Common/DefaultBrowserInfo.cs
@@ -132,7 +132,7 @@ namespace Wox.Plugin.Common
                     const string ArcExecutableName = "Arc.exe";
                     if (commandPattern.Contains(ArcExecutableName))
                     {
-                        commandPattern = "rundll32 url.dll,FileProtocolHandler"
+                        commandPattern = "rundll32 url.dll,FileProtocolHandler";
                     }
 
                     if (commandPattern.StartsWith('\"'))

--- a/src/modules/launcher/Wox.Plugin/Common/DefaultBrowserInfo.cs
+++ b/src/modules/launcher/Wox.Plugin/Common/DefaultBrowserInfo.cs
@@ -127,6 +127,14 @@ namespace Wox.Plugin.Common
                         commandPattern = commandPattern.Insert(0, "\"");
                     }
 
+                    // Arc.exe takes no parameters.
+                    // Give up and use $"rundll32 url.dll,FileProtocolHandler {URL}" instead.
+                    const string ArcExecutableName = "Arc.exe";
+                    if (commandPattern.Contains(ArcExecutableName))
+                    {
+                        commandPattern = "rundll32 url.dll,FileProtocolHandler"
+                    }
+
                     if (commandPattern.StartsWith('\"'))
                     {
                         var endQuoteIndex = commandPattern.IndexOf('\"', 1);


### PR DESCRIPTION
Arc.exe doesn't take parameters. You have to call url.dll instead.
I was unable to test this code, as I've tried for 4 hours now to get PowerToys Run working at all.
You know something is wrong, when the "stable" branch doesn't even build when following the Dev Documentation.
Eighter it's a "my machine" problem or everything is just broken right now.
Anyway, this small change will eliminate the problem (#32782), if I could even get to it.
Feel free to change whatever, I just want it to work with Arc.