### PR TITLE
[Run] Improve error MessageBox

### DIFF
--- a/src/modules/launcher/PowerLauncher/Plugin/PluginManager.cs
+++ b/src/modules/launcher/PowerLauncher/Plugin/PluginManager.cs
@@ -183,7 +183,7 @@ namespace PowerLauncher.Plugin
 
             if (!failedPlugins.IsEmpty)
             {
-                var failed = string.Join(",", failedPlugins.Select(x => x.Metadata.Name));
+                var failed = string.Join(", ", failedPlugins.Select(x => x.Metadata.Name));
                 var description = $"{string.Format(CultureInfo.CurrentCulture, FailedToInitializePluginsDescription, failed)}\n\n{Resources.FailedToInitializePluginsDescriptionPartTwo}";
                 Application.Current.Dispatcher.InvokeAsync(() => API.ShowMsg(Resources.FailedToInitializePluginsTitle, description, string.Empty, false));
             }

--- a/src/modules/launcher/PowerLauncher/Plugin/PluginManager.cs
+++ b/src/modules/launcher/PowerLauncher/Plugin/PluginManager.cs
@@ -184,7 +184,7 @@ namespace PowerLauncher.Plugin
             if (!failedPlugins.IsEmpty)
             {
                 var failed = string.Join(",", failedPlugins.Select(x => x.Metadata.Name));
-                var description = string.Format(CultureInfo.CurrentCulture, FailedToInitializePluginsDescription, failed);
+                var description = $"{string.Format(CultureInfo.CurrentCulture, FailedToInitializePluginsDescription, failed)}\n\n{Resources.FailedToInitializePluginsDescriptionPartTwo}";
                 Application.Current.Dispatcher.InvokeAsync(() => API.ShowMsg(Resources.FailedToInitializePluginsTitle, description, string.Empty, false));
             }
         }

--- a/src/modules/launcher/PowerLauncher/Properties/Resources.Designer.cs
+++ b/src/modules/launcher/PowerLauncher/Properties/Resources.Designer.cs
@@ -142,11 +142,20 @@ namespace PowerLauncher.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Plugins: {0} - fail to load and would be disabled, please contact plugins creator for help.
+        ///   Looks up a localized string similar to Fail to initialize plugins: {0}.
         /// </summary>
         public static string FailedToInitializePluginsDescription {
             get {
                 return ResourceManager.GetString("FailedToInitializePluginsDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Please report the bug to https://aka.ms/powerToysReportBug. (For third-party plugins, please contact the plugin author.).
+        /// </summary>
+        public static string FailedToInitializePluginsDescriptionPartTwo {
+            get {
+                return ResourceManager.GetString("FailedToInitializePluginsDescriptionPartTwo", resourceCulture);
             }
         }
         

--- a/src/modules/launcher/PowerLauncher/Properties/Resources.Designer.cs
+++ b/src/modules/launcher/PowerLauncher/Properties/Resources.Designer.cs
@@ -151,7 +151,7 @@ namespace PowerLauncher.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Fail to initialize plugins.
+        ///   Looks up a localized string similar to PowerToys Run - Plugin Initialization Error.
         /// </summary>
         public static string FailedToInitializePluginsTitle {
             get {
@@ -192,6 +192,15 @@ namespace PowerLauncher.Properties {
         public static string registerHotkeyFailed {
             get {
                 return ResourceManager.GetString("registerHotkeyFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to PowerToys Run - Hotkey Error.
+        /// </summary>
+        public static string RegisterHotkeyFailedTitle {
+            get {
+                return ResourceManager.GetString("RegisterHotkeyFailedTitle", resourceCulture);
             }
         }
         

--- a/src/modules/launcher/PowerLauncher/Properties/Resources.resx
+++ b/src/modules/launcher/PowerLauncher/Properties/Resources.resx
@@ -186,7 +186,7 @@
     <value>Settings will be reset to default and program will continue to function.</value>
   </data>
   <data name="FailedToInitializePluginsDescription" xml:space="preserve">
-    <value>Plugins: {0} - fail to load and would be disabled, please contact plugins creator for help</value>
+    <value>Fail to initialize plugins: {0}</value>
   </data>
   <data name="FailedToInitializePluginsTitle" xml:space="preserve">
     <value>PowerToys Run - Plugin Initialization Error</value>
@@ -201,5 +201,9 @@
   <data name="RegisterHotkeyFailedTitle" xml:space="preserve">
     <value>PowerToys Run - Hotkey Error</value>
     <comment>Don't translate "PowerToys Run". This is a product name.</comment>
+  </data>
+  <data name="FailedToInitializePluginsDescriptionPartTwo" xml:space="preserve">
+    <value>Please report the bug to https://aka.ms/powerToysReportBug. (For third-party plugins, please contact the plugin author.)</value>
+    <comment>"https://aka.ms/powerToysReportBug" is a web uri.</comment>
   </data>
 </root>

--- a/src/modules/launcher/PowerLauncher/Properties/Resources.resx
+++ b/src/modules/launcher/PowerLauncher/Properties/Resources.resx
@@ -189,12 +189,17 @@
     <value>Plugins: {0} - fail to load and would be disabled, please contact plugins creator for help</value>
   </data>
   <data name="FailedToInitializePluginsTitle" xml:space="preserve">
-    <value>Fail to initialize plugins</value>
+    <value>PowerToys Run - Plugin Initialization Error</value>
+    <comment>Don't translate "PowerToys Run". This is a product name.</comment>
   </data>
   <data name="ContextMenuItemsAvailable" xml:space="preserve">
     <value>Appended controls available</value>
   </data>
   <data name="PluginKeywords" xml:space="preserve">
     <value>Plugin keywords</value>
+  </data>
+  <data name="RegisterHotkeyFailedTitle" xml:space="preserve">
+    <value>PowerToys Run - Hotkey Error</value>
+    <comment>Don't translate "PowerToys Run". This is a product name.</comment>
   </data>
 </root>

--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -909,7 +909,7 @@ namespace PowerLauncher.ViewModel
             catch (Exception)
             {
                 string errorMsg = string.Format(CultureInfo.InvariantCulture, RegisterHotkeyFailed, hotkeyStr);
-                MessageBox.Show(errorMsg);
+                MessageBox.Show(errorMsg, Properties.Resources.RegisterHotkeyFailedTitle);
             }
         }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This is not a fix to the error, but an improvement to MessageBox error title since it's not clear to the user that the it's related to PT Run.
This was partially addressed by https://github.com/microsoft/PowerToys/pull/25095, but not for all the errors.

![image](https://github.com/user-attachments/assets/cb8fccad-0390-400a-8757-f6e858753abc)

![image](https://github.com/user-attachments/assets/86e6429f-9864-4261-a6b1-aa860d8eb4ab)

![image](https://github.com/user-attachments/assets/af94524f-05a4-413e-8347-1bf20bb78a80)

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #34216
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

- Assessed the `MessageBox.Show(...)` errors that could be triggered on startup, detecting which need to explicit call out "PT Run"
- Aligned loading/initialization error messages.
- Don't think that `IPublicAPI.ShowMsg(...)` dialogs need "PT Run" in title since they are usually showed as a response to a user interaction (example click on a result or action).

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
