### PR TITLE
[Peek] Update FilePreviewer to prevent tooltips from obscuring title bar controls

### DIFF
--- a/src/modules/peek/Peek.FilePreviewer/FilePreview.xaml
+++ b/src/modules/peek/Peek.FilePreviewer/FilePreview.xaml
@@ -30,8 +30,12 @@
             MaxWidth="{x:Bind ImagePreviewer.MaxImageSize.Width, Mode=OneWay}"
             MaxHeight="{x:Bind ImagePreviewer.MaxImageSize.Height, Mode=OneWay}"
             Source="{x:Bind ImagePreviewer.Preview, Mode=OneWay}"
-            ToolTipService.ToolTip="{x:Bind InfoTooltip, Mode=OneWay}"
-            Visibility="{x:Bind IsPreviewVisible(ImagePreviewer, Previewer.State), Mode=OneWay}" />
+            Visibility="{x:Bind IsPreviewVisible(ImagePreviewer, Previewer.State), Mode=OneWay}"
+            PointerMoved="ToolTipParentControl_PointerMoved">
+            <ToolTipService.ToolTip>
+                <ToolTip Content="{x:Bind InfoTooltip, Mode=OneWay}" />
+            </ToolTipService.ToolTip>
+        </Image>
 
         <MediaPlayerElement
             x:Name="VideoPreview"
@@ -39,8 +43,11 @@
             AutoPlay="True"
             FlowDirection="LeftToRight"
             Source="{x:Bind VideoPreviewer.Preview, Mode=OneWay}"
-            ToolTipService.ToolTip="{x:Bind InfoTooltip, Mode=OneWay}"
-            Visibility="{x:Bind IsPreviewVisible(VideoPreviewer, Previewer.State), Mode=OneWay}">
+            Visibility="{x:Bind IsPreviewVisible(VideoPreviewer, Previewer.State), Mode=OneWay}"
+            PointerMoved="ToolTipParentControl_PointerMoved">
+            <ToolTipService.ToolTip>
+                <ToolTip Content="{x:Bind InfoTooltip, Mode=OneWay}" />
+            </ToolTipService.ToolTip>
             <MediaPlayerElement.KeyboardAccelerators>
                 <KeyboardAccelerator Key="Space" Invoked="KeyboardAccelerator_Space_Invoked" />
             </MediaPlayerElement.KeyboardAccelerators>

--- a/src/modules/peek/Peek.FilePreviewer/FilePreview.xaml.cs
+++ b/src/modules/peek/Peek.FilePreviewer/FilePreview.xaml.cs
@@ -12,6 +12,7 @@ using ManagedCommon;
 using Microsoft.PowerToys.Telemetry;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.Web.WebView2.Core;
 using Peek.Common.Extensions;
@@ -336,7 +337,7 @@ namespace Peek.FilePreviewer
             }
 
             // Fetch and format available file properties
-            var sb = new StringBuilder();
+            var sb = new StringBuilder(256);
 
             string fileNameFormatted = ReadableStringHelper.FormatResourceString("PreviewTooltip_FileName", Item.Name);
             sb.Append(fileNameFormatted);
@@ -355,6 +356,25 @@ namespace Peek.FilePreviewer
             sb.Append(fileSizeFormatted);
 
             InfoTooltip = sb.ToString();
+        }
+
+        /// <summary>
+        /// Set the placement of the tooltip for those previewers supporting the feature, ensuring it does not obscure the Main Window's title bar.
+        /// </summary>
+        private void ToolTipParentControl_PointerMoved(object sender, PointerRoutedEventArgs e)
+        {
+            var previewControl = sender as FrameworkElement;
+            if (previewControl != null)
+            {
+                var placement = (e.GetCurrentPoint(previewControl).Position.Y < previewControl.ActualHeight / 2) ?
+                    PlacementMode.Bottom : PlacementMode.Top;
+
+                var toolTip = ToolTipService.GetToolTip(previewControl) as ToolTip;
+                if (toolTip != null)
+                {
+                    toolTip.Placement = placement;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Update to prevent ImagePreview and VideoPreview controls' tooltips from obscuring the Main Window's title bar.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #34496
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

When the user hovers over the top-right portion of an `ImagePreview` or `VideoPreview`, the associated tooltip is opened, with the text bound to `InfoToolTip`. This worked, but unfortunately the tooltip could obscure the Windows controls such as the close icon, which was an accessibility problem. This PR dynamically sets the `Placement` of the tooltip so it opens below the mouse pointer in the top portion of the previewers. The `PointerMoved` handler is generic, so will work with any future previewer which needs a tooltip.

The tooltips are proper child elements of the previewer controls now, as they need to be instantiated.

I updated the StringBuilder which appends the tooltip contents to have an initial capacity of 256 characters. This prevents the builder from resizing itself multiple times. This is a tiny perf/allocation improvement.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Manual tests only:
- Tested with a mix of image and movie files.
- Tested starting with a different previewer which doesn't use tooltips then navigating to an image or movie file which does need a tooltip.
- Tested starting with an image or movie file then navigating to a different file type then opening another image or movie file.