### PR TITLE
[QuickAccent]Add degree sign, integral, and vertical ellipsis

### DIFF
--- a/src/modules/poweraccent/PowerAccent.Core/Languages.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/Languages.cs
@@ -157,7 +157,7 @@ namespace PowerAccent.Core
         {
             return letter switch
             {
-                LetterKey.VK_0 => new[] { "₀", "⁰", "↉" },
+                LetterKey.VK_0 => new[] { "₀", "⁰", "°", "↉" },
                 LetterKey.VK_1 => new[] { "₁", "¹", "½", "⅓", "¼", "⅕", "⅙", "⅐", "⅛", "⅑", "⅒" },
                 LetterKey.VK_2 => new[] { "₂", "²", "⅔", "⅖" },
                 LetterKey.VK_3 => new[] { "₃", "³", "¾", "⅗", "⅜" },
@@ -184,7 +184,7 @@ namespace PowerAccent.Core
                 LetterKey.VK_P => new[] { "ṗ", "℗", "∏", "¶" },
                 LetterKey.VK_Q => new[] { "ℚ" },
                 LetterKey.VK_R => new[] { "ṙ", "®", "ℝ" },
-                LetterKey.VK_S => new[] { "ṡ", "§", "∑" },
+                LetterKey.VK_S => new[] { "ṡ", "§", "∑", "∫" },
                 LetterKey.VK_T => new[] { "ţ", "ṫ", "ŧ", "™" },
                 LetterKey.VK_U => new[] { "ŭ" },
                 LetterKey.VK_V => new[] { "V̇" },
@@ -193,7 +193,7 @@ namespace PowerAccent.Core
                 LetterKey.VK_Y => new[] { "ẏ", "ꝡ" },
                 LetterKey.VK_Z => new[] { "ʒ", "ǯ", "ℤ" },
                 LetterKey.VK_COMMA => new[] { "∙", "₋", "⁻", "–", "√" }, // – is in VK_MINUS for other languages, but not VK_COMMA, so we add it here.
-                LetterKey.VK_PERIOD => new[] { "…", "\u0300", "\u0301", "\u0302", "\u0303", "\u0304", "\u0308", "\u030B", "\u030C" },
+                LetterKey.VK_PERIOD => new[] { "…", "⁝", "\u0300", "\u0301", "\u0302", "\u0303", "\u0304", "\u0308", "\u030B", "\u030C" },
                 LetterKey.VK_MINUS => new[] { "~", "‐", "‑", "‒", "—", "―", "⁓", "−", "⸺", "⸻", "∓" },
                 LetterKey.VK_SLASH_ => new[] { "÷", "√" },
                 LetterKey.VK_DIVIDE_ => new[] { "÷", "√" },


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Add degree sign, integral, and vertical ellipsis to QuickAccent

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:**  #23237 
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [x] **Dev docs:** None
- [x] **New binaries:** None
- [x] **Documentation updated:** None

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

The following symbols are added, as discussed in #23237 :

- ° (degree sign, U+00B0): added to `0`
- ∫ (integral, U+222B): added to `s`
- ⁝ (vertical ellipsis, U+205D): added to `.`

![Screenshot 2024-09-09 222719](https://github.com/user-attachments/assets/357dcc23-4a90-4e72-b8ad-f83f49c02d1c)

The following symbols mentioned in the issue are not added, as they were already present:

- π (pi, U+03C0): already under `p`
- μ (mu/micro, U+03BC): already under `m`
- … (horizontal ellipsis, U+2026): already under `.`
- ≤ (less than or equal, U+2264): already under `=` and `,`
- ≥ (greater than or equal, U+2265): already under `=` and `,`


<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Manually tested on Win11.
