### PR TITLE
[Settings] WinAppSDK 1.6 Flyout Fix

### DIFF
--- a/src/settings-ui/Settings.UI/Helpers/NativeMethods.cs
+++ b/src/settings-ui/Settings.UI/Helpers/NativeMethods.cs
@@ -10,8 +10,9 @@ namespace Microsoft.PowerToys.Settings.UI.Helpers
 {
     public static class NativeMethods
     {
-        private const int GWL_STYLE = -16;
         private const int WS_POPUP = 1 << 31; // 0x80000000
+        internal const int GWL_STYLE = -16;
+        internal const int WS_CAPTION = 0x00C00000;
         internal const int SPI_GETDESKWALLPAPER = 0x0073;
         internal const int SW_SHOWNORMAL = 1;
         internal const int SW_SHOWMAXIMIZED = 3;

--- a/src/settings-ui/Settings.UI/SettingsXAML/FlyoutWindow.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/FlyoutWindow.xaml
@@ -4,8 +4,6 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:flyout="using:Microsoft.PowerToys.Settings.UI.Flyout"
-    xmlns:i="using:Microsoft.Xaml.Interactivity"
-    xmlns:ic="using:Microsoft.Xaml.Interactions.Core"
     xmlns:local="using:Microsoft.PowerToys.Settings.UI"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:winuiex="using:WinUIEx"
@@ -29,17 +27,6 @@
             LightTintOpacity="0" />
     </winuiex:WindowEx.Backdrop>
     <Grid>
-        <!--  HACK: https://github.com/microsoft/microsoft-ui-xaml/issues/7629  -->
-        <!--  W11 grey border, W10: no border  -->
-        <i:Interaction.Behaviors>
-            <ic:DataTriggerBehavior
-                Binding="{x:Bind ViewModel.Windows10}"
-                ComparisonCondition="Equal"
-                Value="True">
-                <ic:ChangePropertyAction PropertyName="BorderThickness" Value="1" />
-                <ic:ChangePropertyAction PropertyName="BorderBrush" Value="{ThemeResource SurfaceStrokeColorDefaultBrush}" />
-            </ic:DataTriggerBehavior>
-        </i:Interaction.Behaviors>
         <flyout:ShellPage x:Name="FlyoutShellPage" />
     </Grid>
 </winuiex:WindowEx>

--- a/src/settings-ui/Settings.UI/SettingsXAML/FlyoutWindow.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/FlyoutWindow.xaml.cs
@@ -28,6 +28,13 @@ namespace Microsoft.PowerToys.Settings.UI
         public FlyoutWindow(POINT? initialPosition)
         {
             this.InitializeComponent();
+
+            // Remove the caption style from the window style. Windows App SDK 1.6 added it, which made the title bar and borders appear for the Flyout. This code removes it.
+            var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
+            var windowStyle = NativeMethods.GetWindowLong(hwnd, NativeMethods.GWL_STYLE);
+            windowStyle &= ~NativeMethods.WS_CAPTION;
+            _ = NativeMethods.SetWindowLong(hwnd, NativeMethods.GWL_STYLE, windowStyle);
+
             this.Activated += FlyoutWindow_Activated;
             FlyoutAppearPosition = initialPosition;
             ViewModel = new FlyoutViewModel();

--- a/src/settings-ui/Settings.UI/ViewModels/Flyout/FlyoutViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/Flyout/FlyoutViewModel.cs
@@ -3,11 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.ComponentModel;
-using System.Runtime.CompilerServices;
 using System.Timers;
-using Common.UI;
-using Microsoft.PowerToys.Settings.UI.Library.Utilities;
 
 namespace Microsoft.PowerToys.Settings.UI.ViewModels.Flyout
 {
@@ -18,21 +14,6 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels.Flyout
 
         public bool CanHide { get; set; }
 
-        private bool _windows10;
-
-        public bool Windows10
-        {
-            get => _windows10;
-            set
-            {
-                if (_windows10 != value)
-                {
-                    _windows10 = value;
-                    OnPropertyChanged();
-                }
-            }
-        }
-
         public FlyoutViewModel()
         {
             CanHide = true;
@@ -40,7 +21,6 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels.Flyout
             _hideTimer.Elapsed += HideTimer_Elapsed;
             _hideTimer.Interval = 1000;
             _hideTimer.Enabled = false;
-            _windows10 = !OSVersionHelper.IsWindows11();
         }
 
         private void HideTimer_Elapsed(object sender, ElapsedEventArgs e)
@@ -54,13 +34,6 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels.Flyout
             CanHide = false;
             _hideTimer.Stop();
             _hideTimer.Start();
-        }
-
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        private void OnPropertyChanged([CallerMemberName] string propertyName = null)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
 
         public void Dispose()


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

- This PR aim to fix a flyout issue caused by the WinAppSDK 1.6 https://github.com/microsoft/PowerToys/pull/34622#pullrequestreview-2287475001
- This will also revert #24907 since the workaround isn't needed anymore

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #24907
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

- Applied the same fix used for Screen Ruler https://github.com/microsoft/PowerToys/pull/34622#pullrequestreview-2285814240
- Reverted the W10 workaround

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Tested the flyout with light/dark theme.

_0.84.1 (left) - PR (right)_
![image](https://github.com/user-attachments/assets/d8090b1a-830d-4a90-bee5-1b2e6f5f76d3)
![Untitled](https://github.com/user-attachments/assets/132c9431-cc27-4ecd-8959-2953846ded6b)
