### PR TITLE
[Peek] Add support for previewing AutoHotKey files, CSV, and other plaintext files

### DIFF
--- a/src/common/FilePreviewCommon/Assets/Monaco/monacoExtraExtensions.txt
+++ b/src/common/FilePreviewCommon/Assets/Monaco/monacoExtraExtensions.txt
@@ -1,0 +1,5 @@
+# Extra file extensions to preview with Monaco.
+
+.ahk	# AutoHotKey scripts
+.csv	# comma-separated values
+.tsv	# tab-separated values

--- a/src/common/FilePreviewCommon/FilePreviewCommon.csproj
+++ b/src/common/FilePreviewCommon/FilePreviewCommon.csproj
@@ -26,6 +26,9 @@
     <None Update="Assets\Monaco\index.html">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="Assets\Monaco\monacoExtraExtensions.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="Assets\Monaco\monacoSpecialLanguages.js">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/ShellPreviewHandlerPreviewer/ShellPreviewHandlerPreviewer.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/ShellPreviewHandlerPreviewer/ShellPreviewHandlerPreviewer.cs
@@ -206,9 +206,14 @@ namespace Peek.FilePreviewer.Previewers
             }
         }
 
+        public static bool IsExtensionSupported(string extension)
+        {
+            return !string.IsNullOrEmpty(GetPreviewHandlerGuid(extension));
+        }
+
         public static bool IsItemSupported(IFileSystemItem item)
         {
-            return !string.IsNullOrEmpty(GetPreviewHandlerGuid(item.Extension));
+            return IsExtensionSupported(item.Extension);
         }
 
         private static string? GetPreviewHandlerGuid(string fileExt)

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/WebBrowserPreviewer/Helpers/MonacoHelper.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/WebBrowserPreviewer/Helpers/MonacoHelper.cs
@@ -54,6 +54,8 @@ namespace Peek.FilePreviewer.Previewers
         /// Get the file extensions which are not present in the JSON languages document but which
         /// may still be previewed by Monaco.
         /// </summary>
+        /// <remarks>Filters out extensions handled by Shell preview handlers, so Office will still
+        /// handle rendering .csv and others if it is installed.</remarks>
         private static IEnumerable<string> GetExtraSupportedExtensions()
         {
             try
@@ -65,7 +67,8 @@ namespace Peek.FilePreviewer.Previewers
                 return File.Exists(path) ?
                     File.ReadAllLines(path)
                         .Select(line => ExtensionsFileRegex().Match(line))
-                        .Where(match => match.Success)
+                        .Where(match => match.Success &&
+                            !ShellPreviewHandlerPreviewer.IsExtensionSupported(match.Groups[1].Value))
                         .Select(match => match.Groups[1].Value) : [];
             }
             catch


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
This allows for the previewing of AutoHotKey .ahk script files, .csv and .tsv files with the Monaco renderer in Peek (via the WebBrowserPreviewer).

It also introduces an extensible way to add further file extensions for plaintext previews in the future via a simple settings file.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #34483 and #33811
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

This uses Monaco to preview plaintext files even if they are not contained within the Monaco supported languages JSON file.

.ahk, .csv, and .tsv extensions have been added for now. Others may be added (possibly by end-users) by editing the new 'Assets\Monaco\monacoExtraExtensions.txt' file.

A small additional fix was made to MonacoHelper.cs by placing a `using` for the JsonDocument instantiation there, as it was not Disposed properly previously.

Care has been taken to not override any Shell preview handlers which could render these new file types. (This was necessary because `ShellPreviewHandlerPreviewer` is later than `WebBrowserPreviewer` in the `IsItemSupported()` checks in PreviewerFactory.cs)

It may be worthwhile enhancing this in the future. For example, by:

- Allowing end users to edit the list of plaintext file extensions via Settings; or
- Using file introspection to determine whether a file is plaintext, instead of rejecting it because its extension is unknown and then opening the generic unsupported file previewer.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

- I used the current version of PowerToys to attempt to open .ahk, .csv and .tsv files on my machine, which does not have Microsoft Office installed (so no preview handler for .csv files). I confirmed that the contents were not rendered and the UnsupportedFilePreview was used to show summary information only.
- I confirmed each of the file types could be opened as plaintext with the updated build.
- I ran through my test folder, which contains a mix of image files, documents, text files and so on, confirming there were no issues created for other file types.

Please note: I don't own Microsoft Office / Office 365, so could not confirm that the Excel previewer handler for CSV files still works correctly with this update. Could this please be tested by one of the devs with that software installed? Many thanks.