### PR TITLE
[Run-UnitConverter] Use capital letters in DegreePrefixer

### DIFF
--- a/doc/devdocs/modules/launcher/plugins/community.unitconverter.md
+++ b/doc/devdocs/modules/launcher/plugins/community.unitconverter.md
@@ -19,13 +19,13 @@ This plugin uses a package called [UnitsNet](https://github.com/angularsen/Units
  - [Temperature](https://github.com/angularsen/UnitsNet/blob/master/UnitsNet/GeneratedCode/Units/TemperatureUnit.g.cs)
  - [Volume](https://github.com/angularsen/UnitsNet/blob/master/UnitsNet/GeneratedCode/Units/VolumeUnit.g.cs)
 
- These are the ones that are currently enabled (though UnitsNet supports many more). They are defined in [`Main.cs`](/src/modules/launcher/Plugins/Community.PowerToys.Run.UnitConverter/Main.cs).
+ These are the ones that are currently enabled (though UnitsNet supports many more). They are defined in [`UnitHandler.cs`](/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/UnitHandler.cs).
 
 
-### [`InputInterpreter`](/src/modules/launcher/Plugins/Community.PowerToys.Run.UnitConverter/InputInterpreter.cs)
+### [`InputInterpreter`](/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/InputInterpreter.cs)
  - Class which manipulates user input such that it may be interpreted correctly and thus converted.
  - Uses a regex amongst other things to do this.
 
-### [`UnitHandler`](/src/modules/launcher/Plugins/Community.PowerToys.Run.UnitConverter/UnitHandler.cs)
+### [`UnitHandler`](/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/UnitHandler.cs)
  - Class that does the actual conversion.
  - Supports abbreviations in user input (single, double, or none).

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter.UnitTest/InputInterpreterTests.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter.UnitTest/InputInterpreterTests.cs
@@ -67,9 +67,9 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter.UnitTest
 
         [DataTestMethod]
         [DataRow(new string[] { "5", "CeLsIuS", "in", "faHrenheiT" }, new string[] { "5", "DegreeCelsius", "in", "DegreeFahrenheit" })]
-        [DataRow(new string[] { "5", "f", "in", "celsius" }, new string[] { "5", "°f", "in", "DegreeCelsius" })]
-        [DataRow(new string[] { "5", "c", "in", "f" }, new string[] { "5", "°c", "in", "°f" })]
-        [DataRow(new string[] { "5", "f", "in", "c" }, new string[] { "5", "°f", "in", "°c" })]
+        [DataRow(new string[] { "5", "f", "in", "celsius" }, new string[] { "5", "°F", "in", "DegreeCelsius" })]
+        [DataRow(new string[] { "5", "c", "in", "f" }, new string[] { "5", "°C", "in", "°F" })]
+        [DataRow(new string[] { "5", "f", "in", "c" }, new string[] { "5", "°F", "in", "°C" })]
 #pragma warning restore CA1861 // Avoid constant arrays as arguments
         public void PrefixesDegrees(string[] input, string[] expectedResult)
         {

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/InputInterpreter.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/InputInterpreter.cs
@@ -91,7 +91,7 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
 
                             if (!isFeet || !isInches)
                             {
-                                // atleast one could not be parsed correctly
+                                // at least one could not be parsed correctly
                                 break;
                             }
 
@@ -114,7 +114,7 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
         }
 
         /// <summary>
-        /// Adds degree prefixes to degree units for shorthand notation. E.g. '10 c in fahrenheit' becomes '10 °c in DegreeFahrenheit'.
+        /// Adds degree prefixes to degree units for shorthand notation. E.g. '10 c in fahrenheit' becomes '10 °C in DegreeFahrenheit'.
         /// </summary>
         public static void DegreePrefixer(ref string[] split)
         {
@@ -129,11 +129,11 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
                     break;
 
                 case "c":
-                    split[1] = "°c";
+                    split[1] = "°C";
                     break;
 
                 case "f":
-                    split[1] = "°f";
+                    split[1] = "°F";
                     break;
 
                 default:
@@ -151,11 +151,11 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
                     break;
 
                 case "c":
-                    split[3] = "°c";
+                    split[3] = "°C";
                     break;
 
                 case "f":
-                    split[3] = "°f";
+                    split[3] = "°F";
                     break;
 
                 default:

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/InputInterpreter.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/InputInterpreter.cs
@@ -164,22 +164,6 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
         }
 
         /// <summary>
-        /// The plural form "feet" is not recognized by UniteNets. Replace it with "ft".
-        /// </summary>
-        public static void FeetToFt(ref string[] split)
-        {
-            if (string.Equals(split[1], "feet", StringComparison.OrdinalIgnoreCase))
-            {
-                split[1] = "ft";
-            }
-
-            if (string.Equals(split[3], "feet", StringComparison.OrdinalIgnoreCase))
-            {
-                split[3] = "ft";
-            }
-        }
-
-        /// <summary>
         /// Converts spelling "kph" to "km/h"
         /// </summary>
         public static void KPHHandler(ref string[] split)
@@ -291,7 +275,6 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
 
             InputInterpreter.DegreePrefixer(ref split);
             InputInterpreter.MetreToMeter(ref split);
-            InputInterpreter.FeetToFt(ref split);
             InputInterpreter.KPHHandler(ref split);
             InputInterpreter.GallonHandler(ref split, CultureInfo.CurrentCulture);
             InputInterpreter.OunceHandler(ref split, CultureInfo.CurrentCulture);

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/UnitHandler.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/UnitHandler.cs
@@ -10,7 +10,7 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
 {
     public static class UnitHandler
     {
-        private static readonly int _roundingFractionalDigits = 4;
+        private static readonly int _roundingSignificantDigits = 4;
 
         private static readonly QuantityInfo[] _included = new QuantityInfo[]
         {
@@ -71,7 +71,7 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
 
             var power = Math.Floor(Math.Log10(Math.Abs(value)));
             var exponent = Math.Pow(10, power);
-            var rounded = Math.Round(value / exponent, _roundingFractionalDigits) * exponent;
+            var rounded = Math.Round(value / exponent, _roundingSignificantDigits) * exponent;
             return rounded;
         }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
`f` and `c` would previously get converted to `°f` and `°c`, now they get converted to `°F` and `°C`.
Also removes the `FeetToFt()` function, as it's not needed anymore
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #34842
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [x] **Dev docs:** No need
- [x] **New binaries:** None
- [x] **Documentation updated:** No need

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
**Before**:
![image](https://github.com/user-attachments/assets/ba6ef358-4739-4008-86fa-2f7e25e8bd21)
**After**:
![image](https://github.com/user-attachments/assets/6a068e42-93d1-493d-873e-91af648bf4d4)

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manually trying it in PTRun.
