### PR TITLE
[Peek] Fix PreviewHandler previewer not visible on first activation

### DIFF
--- a/src/modules/peek/Peek.FilePreviewer/Controls/ShellPreviewHandlerControl.xaml
+++ b/src/modules/peek/Peek.FilePreviewer/Controls/ShellPreviewHandlerControl.xaml
@@ -13,5 +13,4 @@
     GotFocus="UserControl_GotFocus"
     IsEnabled="False"
     IsTabStop="True"
-    Loaded="UserControl_Loaded"
     mc:Ignorable="d" />

--- a/src/modules/peek/Peek.FilePreviewer/Controls/ShellPreviewHandlerControl.xaml.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Controls/ShellPreviewHandlerControl.xaml.cs
@@ -61,6 +61,8 @@ namespace Peek.FilePreviewer.Controls
 
         partial void OnSourceChanged(IPreviewHandler? value)
         {
+            EnsureContainerHwndCreated();
+
             if (Source != null)
             {
                 UpdatePreviewerTheme();
@@ -82,6 +84,8 @@ namespace Peek.FilePreviewer.Controls
 
         private void OnHandlerVisibilityChanged()
         {
+            EnsureContainerHwndCreated();
+
             if (HandlerVisibility == Visibility.Visible)
             {
                 PInvoke.ShowWindow(containerHwnd, SHOW_WINDOW_CMD.SW_SHOW);
@@ -138,8 +142,19 @@ namespace Peek.FilePreviewer.Controls
             return PInvoke.DefWindowProc(hWnd, msg, wParam, lParam);
         }
 
-        private void UserControl_Loaded(object sender, RoutedEventArgs e)
+        private void EnsureContainerHwndCreated()
         {
+            if (!containerHwnd.IsNull)
+            {
+                return;
+            }
+
+            var peekWindow = new HWND(Win32Interop.GetWindowFromWindowId(XamlRoot?.ContentIslandEnvironment?.AppWindowId ?? default));
+            if (peekWindow.IsNull)
+            {
+                return;
+            }
+
             fixed (char* pContainerClassName = "PeekShellPreviewHandlerContainer")
             {
                 PInvoke.RegisterClass(new WNDCLASSW()
@@ -158,7 +173,7 @@ namespace Peek.FilePreviewer.Controls
                     0, // Y
                     0, // Width
                     0, // Height
-                    (HWND)Win32Interop.GetWindowFromWindowId(XamlRoot.ContentIslandEnvironment.AppWindowId), // Peek UI window
+                    peekWindow,
                     HMENU.Null,
                     HINSTANCE.Null);
 
@@ -169,6 +184,8 @@ namespace Peek.FilePreviewer.Controls
 
         private void UserControl_EffectiveViewportChanged(FrameworkElement sender, EffectiveViewportChangedEventArgs args)
         {
+            EnsureContainerHwndCreated();
+
             var dpi = (float)PInvoke.GetDpiForWindow(containerHwnd) / 96;
 
             // Resize the container window


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Issue is 100% reproducible on latest stable PT release: when the first previewed file uses the PreviewHandler (e.g. Office) the preview doesn't work, requiring a window resize or a second activation to be displayed.

This happen because for some weird reason the `EffectiveViewportChanged` event is fired before the loading of the user control: at that point the `containerHwnd` isn't created yet.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #34462
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

- Moved the creation of `containerHwnd` outside the `Loaded` event handler.
- Ensure the `containerHwnd` has been created before using it.
- Added an extra check to ensure the parent window (Peek) is valid.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Manually tested.
Verified that the PreviewHandler is displayed at the first preview after Peek activation.