### PR TITLE
[AdvancedPaste] Check "Paste with AI" enabled state for custom actions

### DIFF
--- a/src/modules/AdvancedPaste/AdvancedPaste/ViewModels/OptionsViewModel.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/ViewModels/OptionsViewModel.cs
@@ -94,6 +94,7 @@ namespace AdvancedPaste.ViewModels
 
             ClipboardHistoryEnabled = IsClipboardHistoryEnabled();
             ReadClipboard();
+            UpdateAllowedByGPO();
             _clipboardTimer = new() { Interval = TimeSpan.FromSeconds(1) };
             _clipboardTimer.Tick += ClipboardTimer_Tick;
             _clipboardTimer.Start();
@@ -462,7 +463,7 @@ namespace AdvancedPaste.ViewModels
         {
             Logger.LogTrace();
 
-            if (string.IsNullOrWhiteSpace(inputInstructions))
+            if (string.IsNullOrWhiteSpace(inputInstructions) || !IsCustomAIEnabled)
             {
                 return string.Empty;
             }

--- a/src/modules/AdvancedPaste/AdvancedPasteModuleInterface/dllmain.cpp
+++ b/src/modules/AdvancedPaste/AdvancedPasteModuleInterface/dllmain.cpp
@@ -145,9 +145,16 @@ private:
             winrt::Windows::Security::Credentials::PasswordVault vault;
             return vault.Retrieve(OPENAI_VAULT_RESOURCE, OPENAI_VAULT_USERNAME) != nullptr;
         }
-        catch (...)
+        catch (const winrt::hresult_error& ex)
         {
-            Logger::warn("Unable to retrieve OpenAI key from vault; assuming there isn't one.");
+            // Looks like the only way to access the PasswordVault is through the an API that throws an exception in case the resource doesn't exist.
+            // If the compiler breaks here when you're debugging, just continue.
+            // If you want to disable breaking here in a more permanent way, just add a condition in Visual Studio's Exception Settings to not break on win::hresult_error, but that might make you not hit other exceptions you might want to catch.
+            if (ex.code() == HRESULT_FROM_WIN32(ERROR_NOT_FOUND))
+            {
+                return false; // Credential doesn't exist.
+            }
+            Logger::error("Unexpected error while retrieving OpenAI key from vault: {}", winrt::to_string(ex.message()));
             return false;
         }
     }

--- a/src/modules/AdvancedPaste/AdvancedPasteModuleInterface/dllmain.cpp
+++ b/src/modules/AdvancedPaste/AdvancedPasteModuleInterface/dllmain.cpp
@@ -242,22 +242,24 @@ private:
                 m_custom_action_hotkeys.clear();
                 m_custom_action_ids.clear();
 
-                if (settingsObject.HasKey(JSON_KEY_PROPERTIES) && is_open_ai_enabled())
+                if (settingsObject.HasKey(JSON_KEY_PROPERTIES))
                 {
                     const auto propertiesObject = settingsObject.GetNamedObject(JSON_KEY_PROPERTIES);
 
                     if (propertiesObject.HasKey(JSON_KEY_CUSTOM_ACTIONS))
                     {
                         const auto customActions = propertiesObject.GetNamedObject(JSON_KEY_CUSTOM_ACTIONS).GetNamedArray(JSON_KEY_VALUE);
-
-                        for (const auto& customAction : customActions)
+                        if (customActions.Size() > 0 && is_open_ai_enabled())
                         {
-                            const auto object = customAction.GetObjectW();
-
-                            if (object.GetNamedBoolean(JSON_KEY_IS_SHOWN, false))
+                            for (const auto& customAction : customActions)
                             {
-                                m_custom_action_hotkeys.push_back(parse_single_hotkey(object.GetNamedObject(JSON_KEY_SHORTCUT)));
-                                m_custom_action_ids.push_back(static_cast<int>(object.GetNamedNumber(JSON_KEY_ID)));
+                                const auto object = customAction.GetObjectW();
+
+                                if (object.GetNamedBoolean(JSON_KEY_IS_SHOWN, false))
+                                {
+                                    m_custom_action_hotkeys.push_back(parse_single_hotkey(object.GetNamedObject(JSON_KEY_SHORTCUT)));
+                                    m_custom_action_ids.push_back(static_cast<int>(object.GetNamedNumber(JSON_KEY_ID)));
+                                }
                             }
                         }
                     }

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/AdvancedPaste.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/AdvancedPaste.xaml
@@ -102,7 +102,10 @@
                     </controls:SettingsGroup>
 
                     <controls:SettingsGroup x:Uid="AdvancedPaste_Direct_Access_Hotkeys_GroupSettings" IsEnabled="{x:Bind ViewModel.IsEnabled, Mode=OneWay}">
-                        <tkcontrols:SettingsCard x:Uid="AdvancedPasteUI_Actions" HeaderIcon="{ui:FontIcon Glyph=&#xE792;}">
+                        <tkcontrols:SettingsCard
+                            x:Uid="AdvancedPasteUI_Actions"
+                            HeaderIcon="{ui:FontIcon Glyph=&#xE792;}"
+                            IsEnabled="{x:Bind ViewModel.IsOpenAIEnabled, Mode=OneWay}">
                             <Button
                                 x:Uid="AdvancedPasteUI_AddCustomActionButton"
                                 Click="AddCustomActionButton_Click"
@@ -130,6 +133,7 @@
                             x:Name="CustomActions"
                             x:Uid="CustomActions"
                             HorizontalAlignment="Stretch"
+                            IsEnabled="{x:Bind ViewModel.IsOpenAIEnabled, Mode=OneWay}"
                             IsTabStop="False"
                             ItemsSource="{x:Bind ViewModel.CustomActions, Mode=OneWay}">
                             <ItemsControl.ItemTemplate>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -2000,7 +2000,8 @@ Made with 💗 by Microsoft and the PowerToys community.</value>
     <value>Actions</value>
   </data>
   <data name="AdvancedPasteUI_Actions.Description" xml:space="preserve">
-    <value>Create and manage advanced paste custom actions</value>
+    <value>Create and manage advanced paste custom actions.
+(Requires Paste with AI to be enabled)</value>
   </data>
   <data name="AdvancedPasteUI_AddCustomActionButton.Content" xml:space="preserve">
     <value>Add custom action</value>

--- a/src/settings-ui/Settings.UI/ViewModels/AdvancedPasteViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/AdvancedPasteViewModel.cs
@@ -397,6 +397,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 PasswordCredential cred = vault.Retrieve("https://platform.openai.com/api-keys", "PowerToys_AdvancedPaste_OpenAIKey");
                 vault.Remove(cred);
                 OnPropertyChanged(nameof(IsOpenAIEnabled));
+                NotifySettingsChanged();
             }
             catch (Exception)
             {
@@ -411,6 +412,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 PasswordCredential cred = new PasswordCredential("https://platform.openai.com/api-keys", "PowerToys_AdvancedPaste_OpenAIKey", password);
                 vault.Add(cred);
                 OnPropertyChanged(nameof(IsOpenAIEnabled));
+                NotifySettingsChanged();
             }
             catch (Exception)
             {


### PR DESCRIPTION
## Summary of the Pull Request
Fixes issues with custom actions not being fully disabled when "Paste with AI" is disabled.

## PR Checklist

- [x] **Closes:** #35025
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
- Disabled "Add custom action" button and list of custom actions when Paste with AI is disabled.
- Prevented registering keyboard shortcuts in module interface or propagating them to Paste window when Paste with AI is disabled.
- Added further redundant checks in Paste window.

## Validation Steps Performed
- Tested fix while transitioning from enabled and disabled "Paste with AI" states.
- Sanity check of Advanced Paste.
