### PR TITLE
[AdvancedPaste] Hide custom actions on Paste menu when Paste with AI disabled

### DIFF
--- a/src/modules/AdvancedPaste/AdvancedPaste/AdvancedPasteXAML/MainWindow.xaml.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/AdvancedPasteXAML/MainWindow.xaml.cs
@@ -6,6 +6,7 @@ using System;
 
 using AdvancedPaste.Helpers;
 using AdvancedPaste.Settings;
+using AdvancedPaste.ViewModels;
 using ManagedCommon;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
@@ -26,18 +27,26 @@ namespace AdvancedPaste
             this.InitializeComponent();
 
             _userSettings = App.GetService<IUserSettings>();
+            var optionsViewModel = App.GetService<OptionsViewModel>();
 
             var baseHeight = MinHeight;
 
             void UpdateHeight()
             {
-                var trimmedCustomActionCount = Math.Min(_userSettings.CustomActions.Count, 5);
+                var trimmedCustomActionCount = optionsViewModel.IsPasteWithAIEnabled ? Math.Min(_userSettings.CustomActions.Count, 5) : 0;
                 Height = MinHeight = baseHeight + (trimmedCustomActionCount * 40);
             }
 
             UpdateHeight();
 
             _userSettings.CustomActions.CollectionChanged += (_, _) => UpdateHeight();
+            optionsViewModel.PropertyChanged += (_, e) =>
+            {
+                if (e.PropertyName == nameof(optionsViewModel.IsPasteWithAIEnabled))
+                {
+                    UpdateHeight();
+                }
+            };
 
             AppWindow.SetIcon("Assets/AdvancedPaste/AdvancedPaste.ico");
             this.ExtendsContentIntoTitleBar = true;

--- a/src/modules/AdvancedPaste/AdvancedPasteModuleInterface/dllmain.cpp
+++ b/src/modules/AdvancedPaste/AdvancedPasteModuleInterface/dllmain.cpp
@@ -142,13 +142,13 @@ private:
     {
         try
         {
-            winrt::Windows::Security::Credentials::PasswordVault vault;
-            return vault.Retrieve(OPENAI_VAULT_RESOURCE, OPENAI_VAULT_USERNAME) != nullptr;
+            winrt::Windows::Security::Credentials::PasswordVault().Retrieve(OPENAI_VAULT_RESOURCE, OPENAI_VAULT_USERNAME);
+            return true;
         }
         catch (const winrt::hresult_error& ex)
         {
             // Looks like the only way to access the PasswordVault is through the an API that throws an exception in case the resource doesn't exist.
-            // If the compiler breaks here when you're debugging, just continue.
+            // If the debugger breaks here, just continue.
             // If you want to disable breaking here in a more permanent way, just add a condition in Visual Studio's Exception Settings to not break on win::hresult_error, but that might make you not hit other exceptions you might want to catch.
             if (ex.code() == HRESULT_FROM_WIN32(ERROR_NOT_FOUND))
             {


### PR DESCRIPTION
## Summary of the Pull Request
Hides custom actions on Paste menu when "Paste with AI" is disabled, as discussed [here](https://github.com/microsoft/PowerToys/pull/35026#issuecomment-2371820618)

## PR Checklist

- [x] **Closes:** #35025
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed
- Tested fix while transitioning from enabled and disabled "Paste with AI" states.
- Sanity check of Advanced Paste.
