### PR TITLE
[Settings > New+] Fixed crash when cancel template folder selection

### DIFF
--- a/src/settings-ui/Settings.UI/ViewModels/NewPlusViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/NewPlusViewModel.cs
@@ -261,7 +261,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         private async void PickNewTemplateFolder()
         {
             var newPath = await PickFolderDialog();
-            if (newPath.Length > 1)
+            if (!string.IsNullOrEmpty(newPath))
             {
                 TemplateLocation = newPath;
             }
@@ -270,8 +270,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         private async Task<string> PickFolderDialog()
         {
             var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(App.GetSettingsWindow());
-            string pathFolder = await Task.FromResult<string>(ShellGetFolder.GetFolderDialogWithFlags(hwnd, ShellGetFolder.FolderDialogFlags._BIF_NEWDIALOGSTYLE));
-            return pathFolder;
+            return await Task.FromResult(GetFolderDialogWithFlags(hwnd, FolderDialogFlags._BIF_NEWDIALOGSTYLE));
         }
 
         private void SaveSettingsToJson()


### PR DESCRIPTION
## Summary of the Pull Request
Fixed crash when cancelling template folder selection from settings.

## PR Checklist

- [x] **Closes:** #35038
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments
See linked issue.

## Validation Steps Performed
- Reproduced crash before fix.
- Tested fix does not crash.
- Tested hitting cancel does not alter template folder.
- Tested choosing folder does alter template folder.
