### PR TITLE
[Settings > New+] Crash when running Dev build of settings

### DIFF
--- a/src/settings-ui/Settings.UI/ViewModels/NewPlusViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/NewPlusViewModel.cs
@@ -207,6 +207,12 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             try
             {
                 settings = settingsUtils.GetSettingsOrDefault<NewPlusSettings>(NewPlusSettings.ModuleName);
+
+                if (string.IsNullOrEmpty(settings.TemplateLocation))
+                {
+                    // This can happen when running the DEBUG Settings application without first letting the runner create the default settings file.
+                    settings.TemplateLocation = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Microsoft", "PowerToys", "NewPlus", "Templates");
+                }
             }
             catch (Exception e)
             {


### PR DESCRIPTION
## Summary of the Pull Request
Prevents a crash when running a Dev build of Settings.exe by removing an assumption of a initially valid template location created by the Runner.

## PR Checklist

- [x] **Closes:** #35037
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed
- Reproduced issue by running Dev build of Settings.
- Fixed issue and then:
    - Ran Dev build of Settings, ensured it did not crash and settings on NewPlus were correctly populated. Toggled enabled state a few times. Made Settings changes.
    - Then ran Runner, ensured it did not crash.
    - Toggled enabled state again a few times.
    - Reran the above steps while first running Runner (which makes it create a default settings file).