### PR TITLE
build: reintroduce variables.EnablePipelineCache

### DIFF
--- a/.pipelines/v2/ci.yml
+++ b/.pipelines/v2/ci.yml
@@ -32,7 +32,7 @@ parameters:
   - name: enableMsBuildCaching
     type: boolean
     displayName: "Enable MSBuild Caching"
-    default: false
+    default: true
   - name: runTests
     type: boolean
     displayName: "Run Tests"

--- a/.pipelines/v2/templates/pipeline-ci-build.yml
+++ b/.pipelines/v2/templates/pipeline-ci-build.yml
@@ -17,6 +17,10 @@ parameters:
     type: boolean
     default: true
 
+variables:
+  ${{ if eq(parameters.enableMsBuildCaching, true) }}:
+    EnablePipelineCache: true
+
 stages:
   # Allow manual builds to skip pre-check
   - ${{ if ne(variables['Build.Reason'], 'Manual') }}:

--- a/.pipelines/v2/templates/pipeline-ci-build.yml
+++ b/.pipelines/v2/templates/pipeline-ci-build.yml
@@ -3,6 +3,9 @@ variables:
     value: false
   - name: EnablePipelineCache
     value: true
+  - ${{ if eq(parameters.enableMsBuildCaching, true) }}:
+    - name: EnablePipelineCache
+      value: true
 
 parameters:
   - name: buildPlatforms
@@ -16,10 +19,6 @@ parameters:
   - name: runTests
     type: boolean
     default: true
-
-variables:
-  ${{ if eq(parameters.enableMsBuildCaching, true) }}:
-    EnablePipelineCache: true
 
 stages:
   # Allow manual builds to skip pre-check


### PR DESCRIPTION
This may have been able to be imputed by the presence of `Cache@1`, but we might as well make it explicit.