### PR TITLE
ci: run all native tests on arm64 runners too!

### DIFF
--- a/.pipelines/v2/templates/job-test-project.yml
+++ b/.pipelines/v2/templates/job-test-project.yml
@@ -59,6 +59,30 @@ jobs:
       inputs:
         displaySettings: 'optimal'
 
+  # The arm64 builder cannot run arm64 tests, so we have to run them here
+  - ${{ if ne(parameters.platform, 'arm64') }}:
+    - task: VSTest@3
+      displayName: Run Tests
+      inputs:
+        platform: '$(BuildPlatform)'
+        configuration: '$(BuildConfiguration)'
+        testSelector: 'testAssemblies'
+        searchFolder: '$(Pipeline.Workspace)\build-${{ parameters.platform }}-${{ parameters.configuration }}${{ parameters.inputArtifactStem }}'
+        vsTestVersion: 'toolsInstaller'
+        rerunFailedTests: true
+        # Look at all those naming schemes!
+        testAssemblyVer2: |
+          **\UnitTests-*.dll
+          **\UnitTest-*.dll
+          **\*UnitTests.dll
+          **\*.UnitTest.dll
+          **\*.Tests.dll
+          **\*.Test.dll
+          **\KeyboardManager*Test.dll
+          !**\UITests-*.dll
+          !**\obj\**
+          !**\ref\**
+
   - task: VSTest@3
     displayName: Run UI Tests
     inputs:


### PR DESCRIPTION
The build pipeline rewrite in #34984 afforded us a better understanding of the build phases.

This pull request adds a test step to ARM64 that runs the test binaries which _couldn't_ be run during compilation.

It might be slower due to lack of caching, but it sure beats not having ARM64 tests.