### PR TITLE
[NewPlus]Normalize settings infrastructure

### DIFF
--- a/src/settings-ui/Settings.UI.Library/NewPlusProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/NewPlusProperties.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.PowerToys.Settings.UI.Library
+{
+    public class NewPlusProperties
+    {
+        public const string ModuleName = "NewPlus";
+
+        public NewPlusProperties()
+        {
+            HideFileExtension = new BoolProperty(true);
+            HideStartingDigits = new BoolProperty(true);
+            TemplateLocation = new StringProperty(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Microsoft", "PowerToys", "NewPlus", "Templates"));
+        }
+
+        [JsonPropertyName("HideFileExtension")]
+        public BoolProperty HideFileExtension { get; set; }
+
+        [JsonPropertyName("HideStartingDigits")]
+        public BoolProperty HideStartingDigits { get; set; }
+
+        [JsonPropertyName("TemplateLocation")]
+        public StringProperty TemplateLocation { get; set; }
+
+        public override string ToString() => JsonSerializer.Serialize(this);
+    }
+}

--- a/src/settings-ui/Settings.UI.Library/NewPlusSettings.cs
+++ b/src/settings-ui/Settings.UI.Library/NewPlusSettings.cs
@@ -12,34 +12,27 @@ using Settings.UI.Library.Resources;
 
 namespace Microsoft.PowerToys.Settings.UI.Library
 {
-    public class NewPlusSettings : ISettingsConfig
+    public class NewPlusSettings : BasePTModuleSettings, ISettingsConfig
     {
         public const string ModuleName = "NewPlus";
+        public const string ModuleVersion = "1.0";
 
-        public void InitializeWithDefaultSettings()
+        [JsonPropertyName("properties")]
+        public NewPlusProperties Properties { get; set; }
+
+        public NewPlusSettings()
         {
-            // This code path should never happen
+            Name = ModuleName;
+            Version = ModuleVersion;
+            Properties = new NewPlusProperties();
         }
-
-        public string ToJsonString()
-        {
-            return JsonSerializer.Serialize(this);
-        }
-
-        [JsonPropertyName("HideFileExtension")]
-        public bool HideFileExtension { get; set; }
-
-        [JsonPropertyName("HideStartingDigits")]
-        public bool HideStartingDigits { get; set; }
-
-        [JsonPropertyName("TemplateLocation")]
-        public string TemplateLocation { get; set; }
 
         public string GetModuleName()
         {
-            return ModuleName;
+            return Name;
         }
 
+        // This can be utilized in the future if the settings.json file is to be modified/deleted.
         public bool UpgradeSettingsConfiguration()
         {
             return false;

--- a/src/settings-ui/Settings.UI/ViewModels/DashboardViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/DashboardViewModel.cs
@@ -130,7 +130,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             {
                 var settingsUtils = new SettingsUtils();
                 var settings = NewPlusViewModel.LoadSettings(settingsUtils);
-                NewPlusViewModel.CopyTemplateExamples(settings.TemplateLocation);
+                NewPlusViewModel.CopyTemplateExamples(settings.Properties.TemplateLocation.Value);
             }
         }
 

--- a/src/settings-ui/Settings.UI/ViewModels/NewPlusViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/NewPlusViewModel.cs
@@ -47,9 +47,9 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             Settings = LoadSettings(settingsUtils);
 
             // Initialize properties
-            _hideFileExtension = Settings.HideFileExtension;
-            _hideStartingDigits = Settings.HideStartingDigits;
-            _templateLocation = Settings.TemplateLocation;
+            _hideFileExtension = Settings.Properties.HideFileExtension.Value;
+            _hideStartingDigits = Settings.Properties.HideStartingDigits.Value;
+            _templateLocation = Settings.Properties.TemplateLocation.Value;
             InitializeEnabledValue();
             InitializeGpoValues();
 
@@ -119,12 +119,10 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 if (_templateLocation != value)
                 {
                     _templateLocation = value;
-                    Settings.TemplateLocation = value;
+                    Settings.Properties.TemplateLocation.Value = value;
                     OnPropertyChanged(nameof(TemplateLocation));
 
                     NotifySettingsChanged();
-
-                    SaveSettingsToJson();
                 }
             }
         }
@@ -146,12 +144,10 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 if (_hideFileExtension != value && !_hideFileExtensionIsGPOConfigured)
                 {
                     _hideFileExtension = value;
-                    Settings.HideFileExtension = value;
+                    Settings.Properties.HideFileExtension.Value = value;
                     OnPropertyChanged(nameof(HideFileExtension));
 
                     NotifySettingsChanged();
-
-                    SaveSettingsToJson();
                 }
             }
         }
@@ -168,12 +164,10 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 if (_hideStartingDigits != value)
                 {
                     _hideStartingDigits = value;
-                    Settings.HideStartingDigits = value;
+                    Settings.Properties.HideStartingDigits.Value = value;
                     OnPropertyChanged(nameof(HideStartingDigits));
 
                     NotifySettingsChanged();
-
-                    SaveSettingsToJson();
                 }
             }
         }
@@ -208,10 +202,10 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             {
                 settings = settingsUtils.GetSettingsOrDefault<NewPlusSettings>(NewPlusSettings.ModuleName);
 
-                if (string.IsNullOrEmpty(settings.TemplateLocation))
+                if (string.IsNullOrEmpty(settings.Properties.TemplateLocation.Value))
                 {
                     // This can happen when running the DEBUG Settings application without first letting the runner create the default settings file.
-                    settings.TemplateLocation = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Microsoft", "PowerToys", "NewPlus", "Templates");
+                    settings.Properties.TemplateLocation.Value = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Microsoft", "PowerToys", "NewPlus", "Templates");
                 }
             }
             catch (Exception e)
@@ -277,11 +271,6 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         {
             var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(App.GetSettingsWindow());
             return await Task.FromResult(GetFolderDialogWithFlags(hwnd, FolderDialogFlags._BIF_NEWDIALOGSTYLE));
-        }
-
-        private void SaveSettingsToJson()
-        {
-            _settingsUtils.SaveSettings(Settings.ToJsonString(), ModuleName);
         }
     }
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Settings for NewPlus were not behaving well with DSC. The main reason seemed to be that they were not following convention and dividing into a Settings object that implemented `BasePTModuleSettings` with a Properties field, like the other Settings classes.

This PR aims to make New Plus settings conform to standards in PowerToys.