### PR TITLE
[PTRun][UnitConverter]Add usage prompt

### DIFF
--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/Main.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/Main.cs
@@ -30,6 +30,8 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
         private bool _disposed;
 
         private static readonly CompositeFormat CopyToClipboard = System.Text.CompositeFormat.Parse(Properties.Resources.copy_to_clipboard);
+        private static readonly CompositeFormat UsagePromptTitle = System.Text.CompositeFormat.Parse(Properties.Resources.usage_prompt_title);
+        private static readonly CompositeFormat UsagePromptSubtitle = System.Text.CompositeFormat.Parse(Properties.Resources.usage_prompt_subtitle);
 
         public void Init(PluginInitContext context)
         {
@@ -44,6 +46,14 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
         {
             ArgumentNullException.ThrowIfNull(query);
 
+            bool isKeywordSearch = !string.IsNullOrEmpty(query.ActionKeyword);
+            bool isEmptySearch = string.IsNullOrEmpty(query.Search);
+
+            if (isEmptySearch && isKeywordSearch)
+            {
+                return GetSuggestionResults(query);
+            }
+
             // Parse
             ConvertModel convertModel = InputInterpreter.Parse(query);
             if (convertModel == null)
@@ -54,6 +64,24 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
             return UnitHandler.Convert(convertModel)
                 .Select(x => GetResult(x))
                 .ToList();
+        }
+
+        private List<Result> GetSuggestionResults(Query query)
+        {
+            var title = string.Format(CultureInfo.CurrentCulture, UsagePromptTitle, query.ActionKeyword);
+            var subTitle = string.Format(CultureInfo.CurrentCulture, UsagePromptSubtitle);
+            List<Result> ret =
+            [
+                new Result
+                {
+                    Title = title,
+                    SubTitle = subTitle,
+                    IcoPath = _icon_path,
+                    Action = c => true,
+                }
+            ];
+
+            return ret;
         }
 
         private Result GetResult(UnitConversionResult result)

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/Properties/Resources.Designer.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/Properties/Resources.Designer.cs
@@ -104,5 +104,23 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter.Properties {
                 return ResourceManager.GetString("plugin_name", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to e.g. 10 ft to m.
+        /// </summary>
+        public static string usage_prompt_subtitle {
+            get {
+                return ResourceManager.GetString("usage_prompt_subtitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Usage: {0} [value] [fromUnit] to [toUnit].
+        /// </summary>
+        public static string usage_prompt_title {
+            get {
+                return ResourceManager.GetString("usage_prompt_title", resourceCulture);
+            }
+        }
     }
 }

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/Properties/Resources.resx
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/Properties/Resources.resx
@@ -132,4 +132,10 @@
   <data name="plugin_name" xml:space="preserve">
     <value>Unit Converter</value>
   </data>
+  <data name="usage_prompt_subtitle" xml:space="preserve">
+    <value>e.g. 10 ft to m</value>
+  </data>
+  <data name="usage_prompt_title" xml:space="preserve">
+    <value>Usage: {0} [value] [fromUnit] to [toUnit]</value>
+  </data>
 </root>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Added usage prompt when a keyword is typed

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #34575
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

Added usage prompt when a keyword is typed

![image](https://github.com/user-attachments/assets/d3c2b699-8808-4d59-a40c-ef21a513c489)

I'm not sure whether this usage prompt is enough. I tried adding the supported units, but the input box is too narrow to display them all. Any feedback welcomes

