### PR TITLE
Adjusting 8LWXpg user name in so it doesn't throw a spell check

### DIFF
--- a/.github/actions/spell-check/allow/names.txt
+++ b/.github/actions/spell-check/allow/names.txt
@@ -28,7 +28,6 @@ videoconference
 
 # USERS
 
-LWXpg  # (number eight)LWXpg is actual user name but spell checker throws error with a numeric leading value ... which is kinda odd
 Adoumie
 Advaith
 alekhyareddy

--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -2,7 +2,8 @@
 ## "PackagemanagerWrapper.cs" should be "PackageManagerWrapper.cs"
 ## NOTICE.MD > MOZILLA PUBLIC LICENSE v1.1
 
-8LWXpg # user name but user folder causes a flag
+# user name but user folder causes a flag
+8LWXpg 
 aaaa
 abcdefghjkmnpqrstuvxyz
 abgr

--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -1,6 +1,8 @@
 # FALSE POSITIVES
 ## "PackagemanagerWrapper.cs" should be "PackageManagerWrapper.cs"
 ## NOTICE.MD > MOZILLA PUBLIC LICENSE v1.1
+
+8LWXpg # user name but user folder causes a flag
 aaaa
 abcdefghjkmnpqrstuvxyz
 abgr


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Trying to resolve the warning for 8LWXpg user name
![image](https://github.com/user-attachments/assets/fabb48b0-590f-4bd4-8180-7b55922c7028)

