### PR TITLE
[Settings]Fix crash showing non-existent New+ template folder

### DIFF
--- a/src/settings-ui/Settings.UI/ViewModels/NewPlusViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/NewPlusViewModel.cs
@@ -250,12 +250,21 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
 
         private void OpenNewTemplateFolder()
         {
-            var process = new ProcessStartInfo()
+            try
             {
-                FileName = _templateLocation,
-                UseShellExecute = true,
-            };
-            Process.Start(process);
+                CopyTemplateExamples(_templateLocation);
+
+                var process = new ProcessStartInfo()
+                {
+                    FileName = _templateLocation,
+                    UseShellExecute = true,
+                };
+                Process.Start(process);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError("Failed to show NewPlus template folder.", ex);
+            }
         }
 
         private async void PickNewTemplateFolder()


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

When you click to show the New+ template folder and it doesn't exist, Settings crash.
This PR adds an exception handler and tries to create the template folder if it doesn't exist for some reason.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #35228
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Delete templates folder and try to open it from Settings.
