### PR TITLE
Add support for new issue types of Microsoft Organisation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,6 @@
 name: "🕷️ Bug report"
 description: Report errors or unexpected behavior
+type: Bug
 labels:
 - Issue-Bug
 - Needs-Triage

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,6 @@
 name: "⭐ Feature or enhancement request"
 description: Propose something new.
+type: Feature
 labels:
 - Needs-Triage
 body:

--- a/.github/ISSUE_TEMPLATE/translation_issue.yml
+++ b/.github/ISSUE_TEMPLATE/translation_issue.yml
@@ -1,5 +1,6 @@
 name: "🌐 Localization/Translation issue"
 description: Report incorrect translations.
+type: Bug
 labels:
 - Issue-Bug
 - Area-Localization


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Microsoft added issue types to their GitHub org. This PR adds those to the corresponding issue templates.

![image](https://github.com/user-attachments/assets/ed072f78-0529-49f3-acf2-19728d26d849)

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #35351
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

