### PR TITLE
Removing Markdown exclude

### DIFF
--- a/.pipelines/v2/ci.yml
+++ b/.pipelines/v2/ci.yml
@@ -4,22 +4,22 @@ trigger:
     include:
       - main
       - stable
-  paths:
-    exclude:
-      - doc/*
-      - temp/*
-      - tools/*
-      - '**.md'
+#  paths:
+#    exclude:
+#      - doc/*
+#      - temp/*
+#      - tools/*
+#      - '**.md'
 
 pr:
   branches:
     include:
       - main
       - stable
-  paths:
-    exclude:
-      - '**.md'
-      - doc
+#  paths:
+#    exclude:
+#      - '**.md'
+#      - doc
 
 name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
 


### PR DESCRIPTION
Currently, we enabled a check that all CI steps must pass.  The CI system actively ignores certain file changes to enable a faster cycle for certain files.  These two rules conflict with one another and requires an admin override.  With new pipelines and build caching now, we feel this is a happy middle ground for speed as well.

This change removed the exclusion of the `doc/*`, `temp/*`, `tools/*`, and `**.md` paths from the CI pipeline.

