### PR TITLE
Trying to correct spelling error around having leading numeric value for user name

### DIFF
--- a/.github/actions/spell-check/allow/names.txt
+++ b/.github/actions/spell-check/allow/names.txt
@@ -28,6 +28,8 @@ videoconference
 
 # USERS
 
+# 8LWXpg is user name but user folder causes a flag
+LWXpg
 Adoumie
 Advaith
 alekhyareddy

--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -2,8 +2,6 @@
 ## "PackagemanagerWrapper.cs" should be "PackageManagerWrapper.cs"
 ## NOTICE.MD > MOZILLA PUBLIC LICENSE v1.1
 
-# user name but user folder causes a flag
-8LWXpg 
 aaaa
 abcdefghjkmnpqrstuvxyz
 abgr


### PR DESCRIPTION
Yet another attempt at trying to get this warning to go away for spelling errors.