### PR TITLE
[Settings] Sort Languages ComboBox

### DIFF
--- a/src/settings-ui/Settings.UI/ViewModels/GeneralViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/GeneralViewModel.cs
@@ -9,7 +9,6 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.IO.Abstractions;
-using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
@@ -1082,25 +1081,50 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         private void InitializeLanguages()
         {
             var lang = LanguageModel.LoadSetting();
-            int i = 0;
+            var selectedLanguageIndex = 0;
 
             foreach (var item in langTagsAndIds)
             {
-                Languages.Add(new LanguageModel { Tag = item.Key, ResourceID = item.Value, Language = GetResourceString(item.Value) });
+                var language = new LanguageModel { Tag = item.Key, ResourceID = item.Value, Language = GetResourceString(item.Value) };
+                var index = GetLanguageIndex(language.Language, item.Key == string.Empty);
+                Languages.Insert(index, language);
 
                 if (item.Key.Equals(lang, StringComparison.Ordinal))
                 {
-                    _initLanguagesIndex = i;
-                    LanguagesIndex = i;
+                    selectedLanguageIndex = index;
                 }
-
-                i++;
+                else if (index <= selectedLanguageIndex)
+                {
+                    selectedLanguageIndex++;
+                }
             }
+
+            _initLanguagesIndex = selectedLanguageIndex;
+            LanguagesIndex = selectedLanguageIndex;
+        }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Globalization", "CA1309:Use ordinal string comparison", Justification = "Building a user facing list")]
+        private int GetLanguageIndex(string language, bool isDefault)
+        {
+            if (Languages.Count == 0 || isDefault)
+            {
+                return 0;
+            }
+
+            for (var i = 1; i < Languages.Count; i++)
+            {
+                if (string.Compare(Languages[i].Language, language, StringComparison.CurrentCultureIgnoreCase) > 0)
+                {
+                    return i;
+                }
+            }
+
+            return Languages.Count;
         }
 
         private void NotifyLanguageChanged()
         {
-            OutGoingLanguageSettings outsettings = new OutGoingLanguageSettings(langTagsAndIds.ElementAt(LanguagesIndex).Key);
+            OutGoingLanguageSettings outsettings = new OutGoingLanguageSettings(Languages[_languagesIndex].Tag);
 
             SendConfigMSG(outsettings.ToString());
         }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Sort the languages ComboBox keeping the default on top.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #35268
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

The importance of using `StringComparison.CurrentCultureIgnoreCase` can be noted using Portuguese.

![image](https://github.com/user-attachments/assets/a3297724-bffb-442a-8747-1d10e9e6350a)

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Tested using `PowerToys.Settings.pri` from the latest stable build.
- Verified that the languages in the ComboBox are sorted with the default on top
- Switched multiple languages
- Verified that the UI and `language.json` are in sync
