### PR TITLE
New+ bug fix for 35179 where if target folder with same name already exists New+ creates folder instance within the existing one

### DIFF
--- a/src/modules/NewPlus/NewShellExtensionContextMenu/new_utilities.h
+++ b/src/modules/NewPlus/NewShellExtensionContextMenu/new_utilities.h
@@ -50,6 +50,12 @@ namespace newplus::utilities
         return false;
     }
 
+    inline bool is_directory(const std::filesystem::path path)
+    {
+        const auto entry = std::filesystem::directory_entry(path);
+        return entry.is_directory();
+    }
+
     inline bool wstring_same_when_comparing_ignore_case(std::wstring stringA, std::wstring stringB)
     {
         transform(stringA.begin(), stringA.end(), stringA.begin(), towupper);

--- a/src/modules/NewPlus/NewShellExtensionContextMenu/shell_context_sub_menu_item.cpp
+++ b/src/modules/NewPlus/NewShellExtensionContextMenu/shell_context_sub_menu_item.cpp
@@ -81,11 +81,6 @@ IFACEMETHODIMP shell_context_sub_menu_item::Invoke(_In_opt_ IShellItemArray*, _I
         // Copy file and determine final filename
         std::filesystem::path target_final_fullpath = this->template_entry->copy_object_to(GetActiveWindow(), target_fullpath);
 
-        // Set Last Modified Date to current on all files
-        target_final_fullpath.
-
-
-
         Trace::EventCopyTemplate(target_final_fullpath.extension().c_str());
 
         // Refresh folder items

--- a/src/modules/NewPlus/NewShellExtensionContextMenu/shell_context_sub_menu_item.cpp
+++ b/src/modules/NewPlus/NewShellExtensionContextMenu/shell_context_sub_menu_item.cpp
@@ -70,12 +70,21 @@ IFACEMETHODIMP shell_context_sub_menu_item::Invoke(_In_opt_ IShellItemArray*, _I
 
         // Determine initial filename
         std::filesystem::path source_fullpath = template_entry->path;
-        std::filesystem::path target_fullpath = std::wstring(target_path_name) 
-            + L"\\" 
-            + this->template_entry->get_target_filename(!utilities::get_newplus_setting_hide_starting_digits());
+        std::filesystem::path target_fullpath = std::wstring(target_path_name);
+
+        // Only append name to target if source is not a directory
+        if (!utilities::is_directory(target_fullpath))
+        {
+            target_fullpath.append(this->template_entry->get_target_filename(!utilities::get_newplus_setting_hide_starting_digits()));
+        }
 
         // Copy file and determine final filename
         std::filesystem::path target_final_fullpath = this->template_entry->copy_object_to(GetActiveWindow(), target_fullpath);
+
+        // Set Last Modified Date to current on all files
+        target_final_fullpath.
+
+
 
         Trace::EventCopyTemplate(target_final_fullpath.extension().c_str());
 


### PR DESCRIPTION
## Summary of the Pull Request
Fix for if target folder with same name already exists New+ creates folder instance within the existing one

## PR Checklist

- [x] **Closes:** #35179 
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [not included] **Tests:** Added/updated and all pass
- [n/a] **Localization:** All end user facing strings can be localized
- [n/a] **Dev docs:** Added/updated
- [n/a] **New binaries:** Added on the required places
   - [n/a] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [n/a] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [n/a] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [n/a] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [n/a] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments
This PR only fixes the case where if a folder with the name already exist then a new folder would be created within the existing one
Code added a check to see if target is a directory don't append source filename

## Validation Steps Performed
Manually tested locally created 5 folders
Manually tested locally created 5 files
