### PR TITLE
Fix for bug when creating folders or files using New+ within folders that contain Unicode character (wstring all the way)

### DIFF
--- a/src/modules/NewPlus/NewShellExtensionContextMenu/template_item.cpp
+++ b/src/modules/NewPlus/NewShellExtensionContextMenu/template_item.cpp
@@ -67,12 +67,12 @@ std::filesystem::path template_item::copy_object_to(const HWND window_handle, co
 {
     // SHFILEOPSTRUCT wants the from and to paths to be terminated with two NULLs,
     wchar_t double_terminated_path_from[MAX_PATH + 1] = { 0 };
-    wcsncpy_s(double_terminated_path_from, this->path.c_str(), this->path.string().length());
-    double_terminated_path_from[this->path.string().length() + 1] = 0;
+    wcsncpy_s(double_terminated_path_from, this->path.c_str(), this->path.wstring().length());
+    double_terminated_path_from[this->path.wstring().length() + 1] = 0;
 
     wchar_t double_terminated_path_to[MAX_PATH + 1] = { 0 };
-    wcsncpy_s(double_terminated_path_to, destination.c_str(), destination.string().length());
-    double_terminated_path_to[destination.string().length() + 1] = 0;
+    wcsncpy_s(double_terminated_path_to, destination.c_str(), destination.wstring().length());
+    double_terminated_path_to[destination.wstring().length() + 1] = 0;
 
     SHFILEOPSTRUCT file_operation_params = { 0 };
     file_operation_params.wFunc = FO_COPY;


### PR DESCRIPTION
## Summary of the Pull Request
Fixed mistaken usage of std::string with std::wstring

## PR Checklist
- [x] **Closes:** #35357
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [n/a] **Tests:** Added/updated and all pass
- [n/a] **Localization:** All end user facing strings can be localized
- [n/a] **Dev docs:** Added/updated
- [n/a] **New binaries:** Added on the required places
   - [n/a] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [n/a] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [n/a] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [n/a] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [n/a] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments
Fixed mistaken usage of std::string with std::wstring

## Validation Steps Performed
1. Created folders and files using New+ in non-Unicode named folders
2. Created folders and files using New+ in Unicode named folder ("Hebrew alphabet אָלֶף־בֵּית עִבְרִ")
