### PR TITLE
[MouseJump]Bring back telemetry events

### DIFF
--- a/src/common/interop/Constants.cpp
+++ b/src/common/interop/Constants.cpp
@@ -91,6 +91,10 @@ namespace winrt::PowerToys::Interop::implementation
     {
         return CommonSharedConstants::MOUSE_JUMP_SHOW_PREVIEW_EVENT;
     }
+    hstring Constants::TerminateMouseJumpSharedEvent()
+    {
+        return CommonSharedConstants::TERMINATE_MOUSE_JUMP_SHARED_EVENT;
+    }
     hstring Constants::AwakeExitEvent()
     {
         return CommonSharedConstants::AWAKE_EXIT_EVENT;

--- a/src/common/interop/Constants.h
+++ b/src/common/interop/Constants.h
@@ -26,6 +26,7 @@ namespace winrt::PowerToys::Interop::implementation
         static hstring ShowPowerOCRSharedEvent();
         static hstring TerminatePowerOCRSharedEvent();
         static hstring MouseJumpShowPreviewEvent();
+        static hstring TerminateMouseJumpSharedEvent();
         static hstring AwakeExitEvent();
         static hstring ShowPeekEvent();
         static hstring TerminatePeekEvent();

--- a/src/common/interop/Constants.idl
+++ b/src/common/interop/Constants.idl
@@ -23,6 +23,7 @@ namespace PowerToys
             static String ShowPowerOCRSharedEvent();
             static String TerminatePowerOCRSharedEvent();
             static String MouseJumpShowPreviewEvent();
+            static String TerminateMouseJumpSharedEvent();
             static String AwakeExitEvent();
             static String ShowPeekEvent();
             static String TerminatePeekEvent();

--- a/src/common/interop/shared_constants.h
+++ b/src/common/interop/shared_constants.h
@@ -81,6 +81,8 @@ namespace CommonSharedConstants
     // Path to the events used by Mouse Jump
     const wchar_t MOUSE_JUMP_SHOW_PREVIEW_EVENT[] = L"Local\\MouseJumpEvent-aa0be051-3396-4976-b7ba-1a9cc7d236a5";
 
+    const wchar_t TERMINATE_MOUSE_JUMP_SHARED_EVENT[] = L"Local\\TerminateMouseJumpEvent-252fa337-317f-4c37-a61f-99464c3f9728";
+
     // Path to the event used by RegistryPreview
     const wchar_t REGISTRY_PREVIEW_TRIGGER_EVENT[] = L"Local\\RegistryPreviewEvent-4C559468-F75A-4E7F-BC4F-9C9688316687";
 

--- a/src/modules/MouseUtils/MouseJump/dllmain.cpp
+++ b/src/modules/MouseUtils/MouseJump/dllmain.cpp
@@ -62,8 +62,11 @@ private:
 
     Hotkey m_hotkey;
 
-    // Handle to event used to invoke PowerOCR
+    // Handle to event used to invoke MouseJump
     HANDLE m_hInvokeEvent;
+
+    // Handle to event used to terminate MouseJump
+    HANDLE m_hTerminateEvent;
 
     void parse_hotkey(PowerToysSettings::PowerToyValues& settings)
     {
@@ -154,6 +157,7 @@ public:
     {
         LoggerHelpers::init_logger(MODULE_NAME, L"ModuleInterface", LogSettings::mouseJumpLoggerName);
         m_hInvokeEvent = CreateDefaultEvent(CommonSharedConstants::MOUSE_JUMP_SHOW_PREVIEW_EVENT);
+        m_hTerminateEvent = CreateDefaultEvent(CommonSharedConstants::TERMINATE_MOUSE_JUMP_SHARED_EVENT);
         init_settings();
     };
 
@@ -245,6 +249,8 @@ public:
         if (m_enabled)
         {
             ResetEvent(m_hInvokeEvent);
+            SetEvent(m_hTerminateEvent);
+            WaitForSingleObject(m_hProcess, 1500);
             TerminateProcess(m_hProcess, 1);
         }
 

--- a/src/modules/MouseUtils/MouseJumpUI/MainForm.cs
+++ b/src/modules/MouseUtils/MouseJumpUI/MainForm.cs
@@ -166,6 +166,7 @@ internal sealed partial class MainForm : Form
 
             // move mouse pointer
             Logger.LogInfo($"clicked location = {clickedLocation}");
+            Microsoft.PowerToys.Telemetry.PowerToysTelemetry.Log.WriteEvent(new Telemetry.MouseJumpTeleportCursorEvent());
             MouseHelper.SetCursorPosition(clickedLocation);
         }
 
@@ -201,6 +202,8 @@ internal sealed partial class MainForm : Form
             this.OnPreviewImageUpdated);
 
         stopwatch.Stop();
+
+        Microsoft.PowerToys.Telemetry.PowerToysTelemetry.Log.WriteEvent(new Telemetry.MouseJumpShowEvent());
 
         // we have to activate the form to make sure the deactivate event fires
         this.Activate();

--- a/src/modules/MouseUtils/MouseJumpUI/Program.cs
+++ b/src/modules/MouseUtils/MouseJumpUI/Program.cs
@@ -13,6 +13,7 @@ using System.Windows.Threading;
 using Common.UI;
 using ManagedCommon;
 using Microsoft.PowerToys.Settings.UI.Library;
+using Microsoft.PowerToys.Telemetry;
 using MouseJumpUI.Helpers;
 using PowerToys.Interop;
 
@@ -20,6 +21,8 @@ namespace MouseJumpUI;
 
 internal static class Program
 {
+    private static CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+
     /// <summary>
     /// The main entry point for the application.
     /// </summary>
@@ -27,6 +30,7 @@ internal static class Program
     private static void Main(string[] args)
     {
         Logger.InitializeLogger("\\MouseJump\\Logs");
+        ETWTrace etwTrace = new ETWTrace();
 
         // To customize application configuration such as set high DPI settings or default font,
         // see https://aka.ms/applicationconfiguration.
@@ -62,13 +66,10 @@ internal static class Program
 
         Logger.LogInfo($"Mouse Jump started from the PowerToys Runner. Runner pid={runnerPid}");
 
-        var cancellationTokenSource = new CancellationTokenSource();
-
         RunnerHelper.WaitForPowerToysRunner(runnerPid, () =>
         {
-            Logger.LogInfo("PowerToys Runner exited. Exiting Mouse Jump");
-            cancellationTokenSource.Cancel();
-            Application.Exit();
+            Logger.LogInfo("PowerToys Runner exited.");
+            TerminateApp();
         });
 
         var settingsHelper = new SettingsHelper();
@@ -80,7 +81,21 @@ internal static class Program
             Dispatcher.CurrentDispatcher,
             cancellationTokenSource.Token);
 
+        NativeEventWaiter.WaitForEventLoop(
+            Constants.TerminateMouseJumpSharedEvent(),
+            TerminateApp,
+            Dispatcher.CurrentDispatcher,
+            cancellationTokenSource.Token);
+
         Application.Run();
+        etwTrace?.Dispose();
+    }
+
+    private static void TerminateApp()
+    {
+        Logger.LogInfo("Exiting Mouse Jump.");
+        cancellationTokenSource.Cancel();
+        Application.Exit();
     }
 
     private static MouseJumpSettings ReadSettings()


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

With the MouseJump refactors, we ended up removing some telemetry events from being called in code. This PR brings those events back.
This PR also makes sure MouseJump conforms to the new opt-in telemetry changes.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Verified the etl events were written some time after using MouseJump features.
