### PR TITLE
Fix crash caused by dangling thread

### DIFF
--- a/src/runner/settings_window.cpp
+++ b/src/runner/settings_window.cpp
@@ -625,7 +625,7 @@ void close_settings_window()
     if (g_settings_process_id != 0)
     {
         SetEvent(g_terminateSettingsEvent);
-        wil::unique_handle proc{ OpenProcess(PROCESS_TERMINATE, false, g_settings_process_id) };
+        wil::unique_handle proc{ OpenProcess(PROCESS_ALL_ACCESS, false, g_settings_process_id) };
         if (proc)
         {
             WaitForSingleObject(proc.get(), 1500);

--- a/src/settings-ui/Settings.UI/Helpers/NativeEventWaiter.cs
+++ b/src/settings-ui/Settings.UI/Helpers/NativeEventWaiter.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.Threading;
-
+using System.Threading.Tasks;
 using Microsoft.UI.Dispatching;
 
 namespace Microsoft.PowerToys.Settings.UI.Helpers
@@ -14,7 +14,7 @@ namespace Microsoft.PowerToys.Settings.UI.Helpers
         public static void WaitForEventLoop(string eventName, Action callback)
         {
             var dispatcherQueue = DispatcherQueue.GetForCurrentThread();
-            new Thread(() =>
+            new Task(() =>
             {
                 var eventHandle = new EventWaitHandle(false, EventResetMode.AutoReset, eventName);
                 while (true)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Background running thread was preventing Settings app to close properly causing crash on next launch. Task is killed on app close.

Additionally, PROCESS_ALL_ACCESS is needed from runner to be able to WaitForSingleObject on settings process.

Repro steps:
- run PT
- double click tray icon to run settings app
- close settings app (X button)
- double click tray icon again
- crash

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

