### PR TITLE
[Peek] Expand image format support for Image Previewer

### DIFF
--- a/src/modules/peek/Peek.FilePreviewer/Previewers/MediaPreviewer/ImagePreviewer.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/MediaPreviewer/ImagePreviewer.cs
@@ -3,8 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -22,6 +25,7 @@ using Peek.FilePreviewer.Models;
 using Peek.FilePreviewer.Previewers.Helpers;
 using Peek.FilePreviewer.Previewers.Interfaces;
 using Windows.Foundation;
+using Windows.Graphics.Imaging;
 
 namespace Peek.FilePreviewer.Previewers
 {
@@ -57,6 +61,12 @@ namespace Peek.FilePreviewer.Previewers
         private bool IsQoi() => Item.Extension == ".qoi";
 
         private DispatcherQueue Dispatcher { get; }
+
+        private static readonly HashSet<string> _supportedFileTypes =
+            BitmapDecoder.GetDecoderInformationEnumerator()
+                .SelectMany(di => di.FileExtensions)
+                .Union([".svg", ".qoi"])
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
         public static bool IsItemSupported(IFileSystemItem item)
         {
@@ -199,74 +209,5 @@ namespace Peek.FilePreviewer.Previewers
                 });
             });
         }
-
-        private static readonly HashSet<string> _supportedFileTypes = new HashSet<string>
-        {
-                // Image types
-                ".bmp",
-                ".gif",
-                ".jpg",
-                ".jfif",
-                ".jfi",
-                ".jif",
-                ".jpeg",
-                ".jpe",
-                ".png",
-                ".tif",  // very slow for large files: no thumbnail?
-                ".tiff", // NEED TO TEST
-                ".dib",  // NEED TO TEST
-                ".heic",
-                ".heif",
-                ".hif",  // NEED TO TEST
-                ".avif", // NEED TO TEST
-                ".jxr",
-                ".wdp",
-                ".ico",  // NEED TO TEST
-                ".thumb", // NEED TO TEST
-                ".webp",
-
-                // Raw types
-                ".arw",
-                ".cr2",
-                ".crw",
-                ".erf",
-                ".kdc", // NEED TO TEST
-                ".mrw",
-                ".nef",
-                ".nrw",
-                ".orf",
-                ".pef",
-                ".raf",
-                ".raw",
-                ".rw2",
-                ".rwl",
-                ".sr2",
-                ".srw",
-                ".srf",
-                ".dcs", // NEED TO TEST
-                ".dcr",
-                ".drf", // NEED TO TEST
-                ".k25",
-                ".3fr",
-                ".ari", // NEED TO TEST
-                ".bay", // NEED TO TEST
-                ".cap", // NEED TO TEST
-                ".iiq",
-                ".eip", // NEED TO TEST
-                ".fff",
-                ".mef",
-
-                // ".mdc", // Crashes in GetFullBitmapFromPathAsync
-                ".mos",
-                ".R3D",
-                ".rwz", // NEED TO TEST
-                ".x3f",
-                ".ori",
-                ".cr3",
-
-                ".svg",
-
-                ".qoi",
-        };
     }
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This removes the hardcoded list of file extensions from Peek's Image Previewer code, and instead relies upon the list returned from `BitmapDecoder` directly, which represents the formats the end user's system is capable of decoding.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
The use of `GetDecoderInformationEnumerator()` to get all WIC-supported formats:

- Automatically picks up new codec support if installed on a user's system
- Is more accurate, directly reflecting what the system can handle
- Future-proofs the code against new image formats, i.e. we don't have to add to the list of supported extensions if Windows adds more (like HEIC etc.)


<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
This was tested manually with a test folder of images in a variety of different formats, from popular filetypes like JPEG and GIF, to AVIF, cursor files, JPEGXL, and several example RAW files. I also tested with other non-image files, such as PDF, text file, MP3 and videos, to ensure the other previewers were unaffected.

Note: I don't have an example file for every supported image format.

## Additions and Removals
On my Windows 11 machine, this PR adds Peek support for the following types:

```
.rle
.icon
.cur
.exif
.dng
.dds
.avci
.heics
.heifs
.avcs
.avifs
.PTX
.PXN
.DNG
.JXL
```

These were previously in the hardcoded list, but are not marked as compatible on my machine:

```
.jfi
.jif
.thumb
.r3d
.rwz
```

These may have been present on the original developer's machine when the list was curated. They should be picked up with this new code if a WIC decoder exists on the target machine for them.

## Examples

**Cursor**:
![image](https://github.com/user-attachments/assets/e8f47f5a-d0e8-4d2c-a143-2f8630feaaf8)


**JPEGXL** (after adding system support via [JXL WinThumb](https://github.com/saschanaz/jxl-winthumb)):
![image](https://github.com/user-attachments/assets/c3ce9a75-c35b-4e9a-ae13-466b105b5254)

(Example JPEGXL images can be created by converting existing image files with https://squoosh.app/)


**DNG** (drone footage still):
![image](https://github.com/user-attachments/assets/dcc84cb2-c4bb-4b50-9875-52f898e3060c)


## Important Note
HEIC and JPEGXL are marked in Windows as compatible, but require separate installation. For HEIC this means paying a licence, as it is patent-encumbered. For JPEGXL, Windows support is not yet built-in, but can be added via a third party extension. If the user does not have a WIC-compatible codec installed, there will be no change from the previous version of Peek, i.e. the UnsupportedFilePreviewer will be used to show overview information of the file:

![image](https://github.com/user-attachments/assets/36666487-b8d5-43af-8878-42bdbe2cce7d)
