### PR TITLE
[ci][Arm64]Manually copy WebView2 core dll after building and publishing

### DIFF
--- a/.pipelines/v2/templates/job-build-project.yml
+++ b/.pipelines/v2/templates/job-build-project.yml
@@ -379,6 +379,7 @@ jobs:
   ### HACK: On ARM64 builds, building an app with Windows App SDK copies the x64 WebView2 dll instead of the ARM64 one. This command makes sure the right dll is used.
   - script: |
       COPY /Y "packages\Microsoft.Web.WebView2.1.0.2739.15\runtimes\win-ARM64\native_uap\Microsoft.Web.WebView2.Core.dll" "ARM64\Release\WinUI3Apps\Microsoft.Web.WebView2.Core.dll" || exit /b 1
+    displayName: HACK Copy core WebView2 ARM64 dll to output directory
     condition: eq(variables['BuildPlatform'],'arm64')
 
   # Check if deps.json files don't reference different dll versions.

--- a/.pipelines/v2/templates/job-build-project.yml
+++ b/.pipelines/v2/templates/job-build-project.yml
@@ -377,14 +377,14 @@ jobs:
         maximumCpuCount: true
 
   ### HACK: On ARM64 builds, building an app with Windows App SDK copies the x64 WebView2 dll instead of the ARM64 one. This task makes sure the right dll is used.
-  - ${{ if eq(variables['BuildPlatform'], 'arm64') }}:
-    - task: CopyFiles@2
-      displayName: HACK Copy core WebView2 ARM64 dll to output directory
-      inputs:
-        contents: packages/Microsoft.Web.WebView2.1.0.2739.15/runtimes/win-ARM64/native_uap/Microsoft.Web.WebView2.Core.dll
-        targetFolder: $(Build.SourcesDirectory)/ARM64/Release/WinUI3Apps/
-        flattenFolders: True
-        OverWrite: True
+  - task: CopyFiles@2
+    displayName: HACK Copy core WebView2 ARM64 dll to output directory
+    condition: eq(variables['BuildPlatform'],'arm64')
+    inputs:
+      contents: packages/Microsoft.Web.WebView2.1.0.2739.15/runtimes/win-ARM64/native_uap/Microsoft.Web.WebView2.Core.dll
+      targetFolder: $(Build.SourcesDirectory)/ARM64/Release/WinUI3Apps/
+      flattenFolders: True
+      OverWrite: True
 
   # Check if deps.json files don't reference different dll versions.
   - pwsh: |-

--- a/.pipelines/v2/templates/job-build-project.yml
+++ b/.pipelines/v2/templates/job-build-project.yml
@@ -376,6 +376,11 @@ jobs:
         msbuildArchitecture: x64
         maximumCpuCount: true
 
+  ### HACK: On ARM64 builds, building an app with Windows App SDK copies the x64 WebView2 dll instead of the ARM64 one. This command makes sure the right dll is used.
+  - pwsh: |
+      copy /Y "packages\Microsoft.Web.WebView2.1.0.2739.15\runtimes\win-ARM64\native_uap\Microsoft.Web.WebView2.Core.dll" "ARM64\Release\WinUI3Apps\Microsoft.Web.WebView2.Core.dll"
+    condition: eq(variables['BuildPlatform'],'arm64')
+
   # Check if deps.json files don't reference different dll versions.
   - pwsh: |-
       & '.pipelines/verifyDepsJsonLibraryVersions.ps1' -targetDir '$(build.sourcesdirectory)\$(BuildPlatform)\$(BuildConfiguration)'

--- a/.pipelines/v2/templates/job-build-project.yml
+++ b/.pipelines/v2/templates/job-build-project.yml
@@ -377,8 +377,8 @@ jobs:
         maximumCpuCount: true
 
   ### HACK: On ARM64 builds, building an app with Windows App SDK copies the x64 WebView2 dll instead of the ARM64 one. This command makes sure the right dll is used.
-  - pwsh: |
-      copy /Y "packages\Microsoft.Web.WebView2.1.0.2739.15\runtimes\win-ARM64\native_uap\Microsoft.Web.WebView2.Core.dll" "ARM64\Release\WinUI3Apps\Microsoft.Web.WebView2.Core.dll"
+  - script: |
+      COPY /Y "packages\Microsoft.Web.WebView2.1.0.2739.15\runtimes\win-ARM64\native_uap\Microsoft.Web.WebView2.Core.dll" "ARM64\Release\WinUI3Apps\Microsoft.Web.WebView2.Core.dll" || exit /b 1
     condition: eq(variables['BuildPlatform'],'arm64')
 
   # Check if deps.json files don't reference different dll versions.

--- a/.pipelines/v2/templates/job-build-project.yml
+++ b/.pipelines/v2/templates/job-build-project.yml
@@ -386,9 +386,6 @@ jobs:
       flattenFolders: True
       OverWrite: True
 
-  - script: |
-      COPY /Y "packages\Microsoft.Web.WebView2.1.0.2739.15\runtimes\win-ARM64\native_uap\Microsoft.Web.WebView2.Core.dll" "ARM64\Release\WinUI3Apps\Microsoft.Web.WebView2.Core.dll" || exit /b 1
-
   # Check if deps.json files don't reference different dll versions.
   - pwsh: |-
       & '.pipelines/verifyDepsJsonLibraryVersions.ps1' -targetDir '$(build.sourcesdirectory)\$(BuildPlatform)\$(BuildConfiguration)'

--- a/.pipelines/v2/templates/job-build-project.yml
+++ b/.pipelines/v2/templates/job-build-project.yml
@@ -377,14 +377,14 @@ jobs:
         maximumCpuCount: true
 
   ### HACK: On ARM64 builds, building an app with Windows App SDK copies the x64 WebView2 dll instead of the ARM64 one. This task makes sure the right dll is used.
-  - task: CopyFiles@2
-    displayName: HACK Copy core WebView2 ARM64 dll to output directory
-    condition: eq(variables['BuildPlatform'],'arm64')
-    inputs:
-      contents: packages/Microsoft.Web.WebView2.1.0.2739.15/runtimes/win-ARM64/native_uap/Microsoft.Web.WebView2.Core.dll
-      targetFolder: $(Build.SourcesDirectory)/ARM64/Release/WinUI3Apps/
-      flattenFolders: True
-      OverWrite: True
+  - ${{ if eq(variables['BuildPlatform'], 'arm64') }}:
+    - task: CopyFiles@2
+      displayName: HACK Copy core WebView2 ARM64 dll to output directory
+      inputs:
+        contents: packages/Microsoft.Web.WebView2.1.0.2739.15/runtimes/win-ARM64/native_uap/Microsoft.Web.WebView2.Core.dll
+        targetFolder: $(Build.SourcesDirectory)/ARM64/Release/WinUI3Apps/
+        flattenFolders: True
+        OverWrite: True
 
   # Check if deps.json files don't reference different dll versions.
   - pwsh: |-

--- a/.pipelines/v2/templates/job-build-project.yml
+++ b/.pipelines/v2/templates/job-build-project.yml
@@ -376,11 +376,18 @@ jobs:
         msbuildArchitecture: x64
         maximumCpuCount: true
 
-  ### HACK: On ARM64 builds, building an app with Windows App SDK copies the x64 WebView2 dll instead of the ARM64 one. This command makes sure the right dll is used.
-  - script: |
-      COPY /Y "packages\Microsoft.Web.WebView2.1.0.2739.15\runtimes\win-ARM64\native_uap\Microsoft.Web.WebView2.Core.dll" "ARM64\Release\WinUI3Apps\Microsoft.Web.WebView2.Core.dll" || exit /b 1
+  ### HACK: On ARM64 builds, building an app with Windows App SDK copies the x64 WebView2 dll instead of the ARM64 one. This task makes sure the right dll is used.
+  - task: CopyFiles@2
     displayName: HACK Copy core WebView2 ARM64 dll to output directory
     condition: eq(variables['BuildPlatform'],'arm64')
+    inputs:
+      contents: packages/Microsoft.Web.WebView2.1.0.2739.15/runtimes/win-ARM64/native_uap/Microsoft.Web.WebView2.Core.dll
+      targetFolder: $(Build.SourcesDirectory)/ARM64/Release/WinUI3Apps/
+      flattenFolders: True
+      OverWrite: True
+
+  - script: |
+      COPY /Y "packages\Microsoft.Web.WebView2.1.0.2739.15\runtimes\win-ARM64\native_uap\Microsoft.Web.WebView2.Core.dll" "ARM64\Release\WinUI3Apps\Microsoft.Web.WebView2.Core.dll" || exit /b 1
 
   # Check if deps.json files don't reference different dll versions.
   - pwsh: |-


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

After we've upgraded Windows App SDK to 1.6, Dev Files Preview on Peek has been broken on ARM64.
For .86, we've added WebView2 to Registry Preview in order to have Monaco Editor as the text editor, which is also broken on ARM64.
After a lengthy investigation, it seems we've found the core issue, PowerToys has been shipping with a x64 Microsoft.Web.WebView2.Core.dll in the ARM64 installer, which fails at runtime.
We seem to have hit a version of https://github.com/microsoft/WindowsAppSDK/issues/4826

When we build PowerToys in Dart for release, we publish some of the C# WinUI3Apps after building PowerToys and before signing / building the install. This means that the WindowsAppSDK build will recopy its WebView2 dependency, which for some reason is ARM64. On local builds of PowerToys, PowerRename, a C++ WinAppSDK application finished last, which copies the right dll and it's the reason we weren't being able to repro the issue on local builds of ARM64 PowerToys.

This PR solves the issue by including a short time hack in the CI to copy the right dll after publishing the C# WinUI3Apps when building for ARM64.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Waiting for 4 concurrent builds of ARM64 from Dart to test whether the problem is solved.
