### PR TITLE
Removed extra space from welcome page

### DIFF
--- a/src/settings-ui/Settings.UI/SettingsXAML/OOBE/Views/OobeWhatsNew.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/OOBE/Views/OobeWhatsNew.xaml
@@ -66,7 +66,7 @@
 
         <StackPanel
             Grid.Row="1"
-            Margin="32,0,0,16"
+            Margin="32,16,0,16"
             VerticalAlignment="Top"
             Orientation="Vertical">
             <TextBlock

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -2174,7 +2174,7 @@ Take a moment to preview the various utilities listed or view our comprehensive 
     <value>Preference updated.</value>
   </data>
   <data name="Oobe_WhatsNew_DataDiagnostics_Yes_Click_InfoBar_Desc.Text" xml:space="preserve">
-    <value>You can change this at any time from </value>
+    <value>You can change this at any time from</value>
   </data>
   <data name="Oobe_WhatsNew_DataDiagnostics_Yes_Click_OpenSettings_Text.Text" xml:space="preserve">
     <value>settings.</value>


### PR DESCRIPTION
Issue : #35753

Description : Extra space found in the welcome page text "You can change this at any time **from  settings**"

Fix: Removed extra space