### PR TITLE
[Peek] Fix Monaco assets folder discovery

### DIFF
--- a/src/common/FilePreviewCommon/MonacoHelper.cs
+++ b/src/common/FilePreviewCommon/MonacoHelper.cs
@@ -29,34 +29,28 @@ namespace Microsoft.PowerToys.FilePreviewCommon
             new XmlFormatter(),
         }.AsReadOnly();
 
-        private static string? _monacoDirectory;
+        private static readonly Lazy<string> _monacoDirectory = new(GetRuntimeMonacoDirectory);
 
-        public static string GetRuntimeMonacoDirectory()
+        /// <summary>
+        /// Gets the path of the Monaco assets folder.
+        /// </summary>
+        public static string MonacoDirectory => _monacoDirectory.Value;
+
+        private static string GetRuntimeMonacoDirectory()
         {
-            string codeBase = Assembly.GetExecutingAssembly().Location;
-            string path = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(codeBase) ?? string.Empty, "Assets", "Monaco"));
-            if (Path.Exists(path))
-            {
-                return path;
-            }
-            else
-            {
-                // We're likely in WinUI3Apps directory and need to go back to the base directory.
-                return Path.GetFullPath(Path.Combine(Path.GetDirectoryName(codeBase) ?? string.Empty, "..", "Assets", "Monaco"));
-            }
-        }
+            string exePath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? string.Empty;
 
-        public static string MonacoDirectory
-        {
-            get
+            // If the executable is within "WinUI3Apps", correct the path first.
+            if (Path.GetFileName(exePath) == "WinUI3Apps")
             {
-                if (string.IsNullOrEmpty(_monacoDirectory))
-                {
-                    _monacoDirectory = GetRuntimeMonacoDirectory();
-                }
-
-                return _monacoDirectory;
+                exePath = Path.Combine(exePath, "..");
             }
+
+            string monacoPath = Path.Combine(exePath, "Assets", "Monaco");
+
+            return Directory.Exists(monacoPath) ?
+                monacoPath :
+                throw new DirectoryNotFoundException($"Monaco assets directory not found at {monacoPath}");
         }
 
         public static JsonDocument GetLanguages()


### PR DESCRIPTION
## Summary of the Pull Request
The `MonacoHelper` class in `FilePreviewCommon` handles locating the Monaco assets directory so the Monaco language file and template HTML file may be loaded. This PR corrects an issue whereby `GetRuntimeMonacoDirectory()` would return an incorrect folder location if an empty `INSTALLDIR\WinUI3Apps\Assets\Monaco` existed in addition to the correct `INSTALLDIR\Assets\Monaco` location.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #35728
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
The function now does an explicit check to see if the calling assembly lies within the WinUI3Apps folder, and if so it navigates to the parent directory before continuing resolution of the assets path.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
I reproduced the failure case by creating an empty `\AppData\Local\PowerToys\WinUI3Apps\Assets\Monaco` folder and then using Peek to preview files supported by Monaco, such as source code files. This confirmed the original report. After applying the fix and retesting, the same Peek previews correctly rendered the files.

I also confirmed that the Explorer Preview Pane was unaffected, and also used Peek to view several non-Monaco files, such as images and PDFs, to confirm that other file types were still rendering without issue.

## Before and After
![image](https://github.com/user-attachments/assets/fff5bff4-0aeb-4719-9d95-289c1143d416)

![image](https://github.com/user-attachments/assets/b599660c-d997-4660-8410-24505540e0b7)

## Additional Info
A `WinUI3Apps\Assets\Monaco` folder is created when compiling the solution from source, and its contents look identical to the folder a level up in the hierarchy. I don't know if this is related to the original issue, but thought it was worth a mention.