### PR TITLE
[ci]Fix signing new Workspaces dll in Dart

### DIFF
--- a/.pipelines/ESRPSigning_core.json
+++ b/.pipelines/ESRPSigning_core.json
@@ -201,6 +201,7 @@
                 "PowerToys.WorkspacesLauncherUI.exe",
                 "PowerToys.WorkspacesLauncherUI.dll",
                 "PowerToys.WorkspacesModuleInterface.dll",
+                "PowerToys.WorkspacesCsharpLibrary.dll",
 
                 "WinUI3Apps\\PowerToys.RegistryPreviewExt.dll",
                 "WinUI3Apps\\PowerToys.RegistryPreviewUILib.dll",


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
After https://github.com/microsoft/PowerToys/commit/6b3bbf7e8f94f47d9881e32a1b8ed6f11920db41 was merged, the new "PowerToys.WorkspacesCsharpLibrary.dll" dll isn't being signed.
This PR signs it.