### PR TITLE
[Peek] UserSettings load logging fix and refactor

### DIFF
--- a/src/modules/peek/Peek.UI/Services/UserSettings.cs
+++ b/src/modules/peek/Peek.UI/Services/UserSettings.cs
@@ -3,10 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.IO;
 using System.IO.Abstractions;
 using System.Threading;
-
 using ManagedCommon;
 using Microsoft.PowerToys.Settings.UI.Library;
 using Microsoft.PowerToys.Settings.UI.Library.Utilities;
@@ -16,71 +14,72 @@ namespace Peek.UI
     public class UserSettings : IUserSettings
     {
         private const string PeekModuleName = "Peek";
-        private const int MaxNumberOfRetry = 5;
+        private const int MaxAttempts = 4;
 
         private readonly SettingsUtils _settingsUtils;
-        private readonly IFileSystemWatcher _watcher;
-        private readonly Lock _loadingSettingsLock = new();
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "IDE0052:Remove unread private members", Justification = "Defined in helper called in constructor.")]
+        private readonly IFileSystemWatcher _watcher;
+
+        /// <summary>
+        /// Gets a value indicating whether Peek closes automatically when the window loses focus.
+        /// </summary>
         public bool CloseAfterLosingFocus { get; private set; }
 
         public UserSettings()
         {
             _settingsUtils = new SettingsUtils();
-            CloseAfterLosingFocus = false;
 
             LoadSettingsFromJson();
 
-            _watcher = Helper.GetFileWatcher(PeekModuleName, "settings.json", () => LoadSettingsFromJson());
+            _watcher = Helper.GetFileWatcher(PeekModuleName, SettingsUtils.DefaultFileName, LoadSettingsFromJson);
+        }
+
+        private void ApplySettings(PeekSettings settings)
+        {
+            CloseAfterLosingFocus = settings.Properties.CloseAfterLosingFocus.Value;
+        }
+
+        private void ApplyDefaults()
+        {
+            ApplySettings(new PeekSettings());
         }
 
         private void LoadSettingsFromJson()
         {
-            lock (_loadingSettingsLock)
+            for (int attempt = 1; attempt <= MaxAttempts; attempt++)
             {
-                var retry = true;
-                var retryCount = 0;
-
-                while (retry)
+                try
                 {
-                    try
+                    ApplySettings(_settingsUtils.GetSettingsOrDefault<PeekSettings>(PeekModuleName));
+                    return;
+                }
+                catch (System.IO.IOException ex)
+                {
+                    Logger.LogError($"Peek settings load attempt {attempt} failed: {ex.Message}", ex);
+                    if (attempt == MaxAttempts)
                     {
-                        retryCount++;
-
-                        if (!_settingsUtils.SettingsExists(PeekModuleName))
-                        {
-                            Logger.LogInfo("Peek settings.json was missing, creating a new one");
-                            var defaultSettings = new PeekSettings();
-                            defaultSettings.Save(_settingsUtils);
-                        }
-
-                        var settings = _settingsUtils.GetSettingsOrDefault<PeekSettings>(PeekModuleName);
-                        if (settings != null)
-                        {
-                            CloseAfterLosingFocus = settings.Properties.CloseAfterLosingFocus.Value;
-                        }
-
-                        retry = false;
+                        Logger.LogError($"Failed to load Peek settings after {MaxAttempts} attempts. Continuing with default settings.");
+                        ApplyDefaults();
+                        return;
                     }
-                    catch (IOException e)
-                    {
-                        if (retryCount > MaxNumberOfRetry)
-                        {
-                            retry = false;
-                            Logger.LogError($"Failed to Deserialize PowerToys settings, Retrying {e.Message}", e);
-                        }
-                        else
-                        {
-                            Thread.Sleep(500);
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        retry = false;
-                        Logger.LogError("Failed to read changed settings", ex);
-                    }
+
+                    // Exponential back-off then retry.
+                    Thread.Sleep(CalculateRetryDelay(attempt));
+                }
+                catch (Exception ex)
+                {
+                    // Anything other than an IO exception is an immediate failure.
+                    Logger.LogError($"Peek settings load failed, continuing with defaults: {ex.Message}", ex);
+                    ApplyDefaults();
+                    return;
                 }
             }
+        }
+
+        private static int CalculateRetryDelay(int attempt)
+        {
+            return (int)Math.Pow(2, attempt) * 100;
         }
     }
 }

--- a/src/settings-ui/Settings.UI.Library/SettingsUtils.cs
+++ b/src/settings-ui/Settings.UI.Library/SettingsUtils.cs
@@ -14,7 +14,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 {
     public class SettingsUtils : ISettingsUtils
     {
-        private const string DefaultFileName = "settings.json";
+        public const string DefaultFileName = "settings.json";
         private const string DefaultModuleName = "";
         private readonly IFile _file;
         private readonly ISettingsPath _settingsPath;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #34791
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
This PR corrects the following issues with Peek's UserSettings class:

- A default value was manually set for `CloseAfterLosingFocus` in the constructor. This should be set by instantiating the `PeekProperties` class instead, which should be the single source for settings defaults.
- The exception logging was in the wrong if block, meaning an error was only logged if all 6 failed attempts had been made to load the settings file.
- `retryCount` was misnamed, as it represented the current _attempt_ number, not the number of retries. This made the loop exit check difficult to understand. I'm unsure, but I think the intention was to try the load 5 times, but it ended up being 6 because of this.
- A check was made for whether the settings file exists, and a new settings file created if it was absent. However, this is already handled by `GetSettingsOrDefault`.
- (This is a bit pedantic, I admit.) The filename “settings.json” was hard-coded when setting up the FileSystemWatcher. I’ve made the `SettingsUtils.DefaultFileName` string public and used this instead, guaranteeing they'll always be consistent. It’s very unlikely "settings.json" would ever be changed, but you never know...

Updates were also made to the following:

- Added a smaller number of retries with an exponential back-off delay instead of always waiting 500ms between retry attempts. This means temporary file lock issues won’t hold the application up for as long. There are now 4 attempts instead of 6 in the previous code.
- Set the failsafe defaults using `PeekProperties` defaults if the settings file could not be read.
- Moved the lock to only cover the critical section which applies the settings.
- Added warning suppression for `_watcher` declaration. This is required because the `FileSystemWatcher` is set up in another class.
- Simplified flow and separated out some functionality into separate methods.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

The application was tested before and after the change, confirming that:

- A new settings file is still created if one doesn't exist.
- Defaults are used if the file could not be read after all retries have been exhausted or if a non-IOException happened.
- Logging failed attempts is fixed and now correctly happens regardless of the number of attempts made to load the file.