### PR TITLE
Fix for 35956 new+prompt rename when creating file

### DIFF
--- a/src/modules/NewPlus/NewShellExtensionContextMenu.win10/shell_context_menu_win10.cpp
+++ b/src/modules/NewPlus/NewShellExtensionContextMenu.win10/shell_context_menu_win10.cpp
@@ -32,7 +32,7 @@ IFACEMETHODIMP shell_context_menu_win10::Initialize(PCIDLIST_ABSOLUTE, IDataObje
 IFACEMETHODIMP shell_context_menu_win10::QueryContextMenu(HMENU menu_handle, UINT menu_index, UINT menu_first_cmd_id, UINT, UINT menu_flags)
 {
     if (!NewSettingsInstance().GetEnabled() 
-            || package::IsWin11OrGreater()
+//            || package::IsWin11OrGreater()
         )
     {
         return E_FAIL;

--- a/src/modules/NewPlus/NewShellExtensionContextMenu.win10/shell_context_menu_win10.cpp
+++ b/src/modules/NewPlus/NewShellExtensionContextMenu.win10/shell_context_menu_win10.cpp
@@ -32,7 +32,7 @@ IFACEMETHODIMP shell_context_menu_win10::Initialize(PCIDLIST_ABSOLUTE, IDataObje
 IFACEMETHODIMP shell_context_menu_win10::QueryContextMenu(HMENU menu_handle, UINT menu_index, UINT menu_first_cmd_id, UINT, UINT menu_flags)
 {
     if (!NewSettingsInstance().GetEnabled() 
-//            || package::IsWin11OrGreater()
+            || package::IsWin11OrGreater()
         )
     {
         return E_FAIL;

--- a/src/modules/NewPlus/NewShellExtensionContextMenu/new_utilities.h
+++ b/src/modules/NewPlus/NewShellExtensionContextMenu/new_utilities.h
@@ -376,8 +376,10 @@ namespace newplus::utilities
             // Copy file and determine final filename
             std::filesystem::path target_final_fullpath = template_entry->copy_object_to(GetActiveWindow(), target_fullpath);
 
+            // Consider copy completed. If we do tracing after enter_rename_mode, then rename mode won't consistently work
             trace.UpdateState(true);
             Trace::EventCopyTemplate(target_final_fullpath.extension().c_str());
+            Trace::EventCopyTemplateResult(hr);
             trace.Flush();
             trace.UpdateState(false);
 
@@ -385,19 +387,19 @@ namespace newplus::utilities
             template_entry->refresh_target(target_final_fullpath);
 
             // Enter rename mode
-            explorer_enter_rename_mode(target_final_fullpath);
+            template_entry->enter_rename_mode(target_final_fullpath);
         }
         catch (const std::exception& ex)
         {
+            hr = S_FALSE;
+
             Logger::error(ex.what());
 
-            hr = S_FALSE;
+            trace.UpdateState(true);
+            Trace::EventCopyTemplateResult(hr);
+            trace.Flush();
+            trace.UpdateState(false);
         }
-
-        trace.UpdateState(true);
-        Trace::EventCopyTemplateResult(hr);
-        trace.Flush();
-        trace.UpdateState(false);
 
         return hr;
     }

--- a/src/modules/NewPlus/NewShellExtensionContextMenu/new_utilities.h
+++ b/src/modules/NewPlus/NewShellExtensionContextMenu/new_utilities.h
@@ -391,10 +391,9 @@ namespace newplus::utilities
         }
         catch (const std::exception& ex)
         {
-            hr = S_FALSE;
-
             Logger::error(ex.what());
 
+            hr = S_FALSE;
             trace.UpdateState(true);
             Trace::EventCopyTemplateResult(hr);
             trace.Flush();

--- a/src/modules/NewPlus/NewShellExtensionContextMenu/new_utilities.h
+++ b/src/modules/NewPlus/NewShellExtensionContextMenu/new_utilities.h
@@ -215,10 +215,10 @@ namespace newplus::utilities
 
     inline bool is_desktop_folder(const std::filesystem::path target_fullpath)
     {
-        TCHAR desktopPath[MAX_PATH];
-        if (SUCCEEDED(SHGetFolderPath(NULL, CSIDL_DESKTOP, NULL, 0, desktopPath)))
+        TCHAR desktop_path[MAX_PATH];
+        if (SUCCEEDED(SHGetFolderPath(NULL, CSIDL_DESKTOP, NULL, 0, desktop_path)))
         {
-            return StrCmpIW(target_fullpath.c_str(), desktopPath) == 0;
+            return StrCmpIW(target_fullpath.c_str(), desktop_path) == 0;
         }
         return false;
     }
@@ -385,7 +385,7 @@ namespace newplus::utilities
             template_entry->refresh_target(target_final_fullpath);
 
             // Enter rename mode
-            template_entry->enter_rename_mode(target_final_fullpath);
+            explorer_enter_rename_mode(target_final_fullpath);
         }
         catch (const std::exception& ex)
         {


### PR DESCRIPTION
## Summary of the Pull Request
Fix for enter rename mode after copy not always working.
Also small nit rename of variable.

## PR Checklist
- [x] **Closes:** #35956 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [n/a] **Tests:** Added/updated and all pass
- [n/a] **Localization:** All end user facing strings can be localized
- [n/a] **Dev docs:** Added/updated
- [n/a] **New binaries:** Added on the required places
   - [n/a] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [n/a] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [n/a] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [n/a] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [n/a] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments
Fix for enter rename mode after copy.
Also small nit rename of variable.

## Validation Steps Performed
Tested Windows 10 and Windows 11 versions
Instantiated several template files and large folders
Checked tracing of copy
