### PR TITLE
Process Restart Management with Error Handling

### DIFF
--- a/src/runner/RestartManagement.cpp
+++ b/src/runner/RestartManagement.cpp
@@ -12,6 +12,8 @@ void RestartProcess(const std::wstring& processName)
     WCHAR sessionKey[CCH_RM_SESSION_KEY + 1];
     if (RmStartSession(&sessionHandle, 0, sessionKey) != ERROR_SUCCESS)
     {
+        DWORD ErrorCode = GetLastError();
+        printf("RmStartSession failed with an error code: %d\n", ErrorCode);
         return;
     }
     auto processHandles = getProcessHandlesByName(processName, PROCESS_QUERY_INFORMATION);
@@ -29,6 +31,8 @@ void RestartProcess(const std::wstring& processName)
     if (pInfo.empty() ||
         RmRegisterResources(sessionHandle, 0, nullptr, sizeof(pInfo), pInfo.data(), 0, nullptr) != ERROR_SUCCESS)
     {
+        DWORD second_ErrorCode = GetLastError();
+        printf("RmRegisterResources failed with an error code: %d\n", second_ErrorCode);
         return;
     }
     RmShutdown(sessionHandle, RmForceShutdown, nullptr);


### PR DESCRIPTION
The edited code shows error message.

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
         Added error handling and error code display to `RmStartSession` and `RmRegisterResources` functions.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [n/a] **Closes:** #xxx
- [n/a] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [n/a] **Tests:** Added/updated and all pass
- [n/a] **Localization:** All end user facing strings can be localized
- [n/a] **Dev docs:** Added/updated
- [n/a] **New binaries:** Added on the required places
   - [n/a] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [n/a] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [n/a] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [n/a] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [n/a] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
            I didn't add any new functions, but this change makes displaying error messages possible.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
              Not tested yet.