### PR TITLE
[PreviewPane] Use PerMonitorV2 DPI mode

### DIFF
--- a/src/modules/previewpane/GcodePreviewHandler/GcodePreviewHandler.csproj
+++ b/src/modules/previewpane/GcodePreviewHandler/GcodePreviewHandler.csproj
@@ -18,6 +18,7 @@
     <AssemblyName>PowerToys.GcodePreviewHandler</AssemblyName>
     <ProjectGuid>{805306FF-A562-4415-8DEF-E493BDC45918}</ProjectGuid>
     <RootNamespace>Microsoft.PowerToys.PreviewHandler.Gcode</RootNamespace>
+    <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/modules/previewpane/MarkdownPreviewHandler/MarkdownPreviewHandler.csproj
+++ b/src/modules/previewpane/MarkdownPreviewHandler/MarkdownPreviewHandler.csproj
@@ -15,6 +15,7 @@
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <GenerateSatelliteAssembliesForCore>true</GenerateSatelliteAssembliesForCore>
+    <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/modules/previewpane/MonacoPreviewHandler/MonacoPreviewHandler.csproj
+++ b/src/modules/previewpane/MonacoPreviewHandler/MonacoPreviewHandler.csproj
@@ -17,6 +17,7 @@
     <RootNamespace>Microsoft.PowerToys.PreviewHandler.Monaco</RootNamespace>
     <AssemblyName>PowerToys.MonacoPreviewHandler</AssemblyName>
     <OutputType>WinExe</OutputType>
+    <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">

--- a/src/modules/previewpane/PdfPreviewHandler/PdfPreviewHandler.csproj
+++ b/src/modules/previewpane/PdfPreviewHandler/PdfPreviewHandler.csproj
@@ -18,6 +18,7 @@
     <ProjectGuid>{69E1EE8D-143A-4060-9129-4658ACF14AAF}</ProjectGuid>
     <RootNamespace>Microsoft.PowerToys.PreviewHandler.Pdf</RootNamespace>
     <AssemblyName>PowerToys.PdfPreviewHandler</AssemblyName>
+    <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/modules/previewpane/QoiPreviewHandler/QoiPreviewHandler.csproj
+++ b/src/modules/previewpane/QoiPreviewHandler/QoiPreviewHandler.csproj
@@ -18,6 +18,7 @@
     <AssemblyName>PowerToys.QoiPreviewHandler</AssemblyName>
     <ProjectGuid>{6B04803D-B418-4833-A67E-B0FC966636A5}</ProjectGuid>
     <RootNamespace>Microsoft.PowerToys.PreviewHandler.Qoi</RootNamespace>
+    <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/modules/previewpane/SvgPreviewHandler/SvgPreviewHandler.csproj
+++ b/src/modules/previewpane/SvgPreviewHandler/SvgPreviewHandler.csproj
@@ -16,6 +16,7 @@
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <GenerateSatelliteAssembliesForCore>true</GenerateSatelliteAssembliesForCore>
+    <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

On a setup with 2 monitors using different DPI I have been able to reproduce and fix the issue reported from some users.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #30529
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

The introduced property is used by `ApplicationConfiguration.Initialize();` in `Program.cs`.
Seems that pdf, gcode and qoi had no issues but I think it's good to have all the PreviewPane project aligned.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Manually tested preview panes for gcode, qoi, svg, md, pdf and source code files.
Verified that the preview pane is rendered as expected for both monitor.
Verified that no issues occur when the Explorer window is moved between monitors.