### PR TITLE
[Launcher][Calculator]Allow scientific notation with lowercase 'e'

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/CalculateHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/CalculateHelper.cs
@@ -20,7 +20,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
             @"sinh\s*\(|cosh\s*\(|tanh\s*\(|arsinh\s*\(|arcosh\s*\(|artanh\s*\(|" +
             @"pi|" +
             @"==|~=|&&|\|\||" +
-            @"((-?(\d+(\.\d*)?)|-?(\.\d+))[E](-?\d+))|" + /* expression from CheckScientificNotation between parenthesis */
+            @"((-?(\d+(\.\d*)?)|-?(\.\d+))[Ee](-?\d+))|" + /* expression from CheckScientificNotation between parenthesis */
             @"e|[0-9]|0x[0-9a-fA-F]+|0b[01]+|[\+\-\*\/\^\., ""]|[\(\)\|\!\[\]]" +
             @")+$",
             RegexOptions.Compiled);
@@ -73,11 +73,11 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
              * (-?(\d+({0}\d*)?)|-?({0}\d+)): Used to capture one of two types:
              * -?(\d+({0}\d*)?): Captures a decimal number starting with a number (e.g. "-1.23")
              * -?({0}\d+): Captures a decimal number without leading number (e.g. ".23")
-             * E: Captures capital 'E'
+             * e: Captures 'e' or 'E'
              * (-?\d+): Captures an integer number (e.g. "-1" or "23")
              */
-            var p = @"(-?(\d+(\.\d*)?)|-?(\.\d+))E(-?\d+)";
-            return Regex.Replace(input, p, "($1 * 10^($5))");
+            var p = @"(-?(\d+(\.\d*)?)|-?(\.\d+))e(-?\d+)";
+            return Regex.Replace(input, p, "($1 * 10^($5))", RegexOptions.IgnoreCase);
         }
 
         /*


### PR DESCRIPTION
## Summary of the Pull Request
Allows scientific notation to be written with a lowercase 'e' (both `1e9` and `1E9`) in the Calculator plugin. Previously, only capital 'E' was allowed.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #36045
- [x] **Communication:** I've discussed this with core contributors already.
- [x] **Tests:** None added, all pass
- [x] **Localization:** All end user facing strings can be localized
- [x] **Dev docs:** No need
- [x] **New binaries:** None
- [x] **Documentation updated:** No need

## Validation Steps Performed
Both 1e9 and 1E9 produce the expected results, doesn't affect using e as Euler's number in any way.