### PR TITLE
[Workspaces] Add encoder parameter to bitmap.save()

### DIFF
--- a/src/modules/Workspaces/WorkspacesCsharpLibrary/DrawHelper.cs
+++ b/src/modules/Workspaces/WorkspacesCsharpLibrary/DrawHelper.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Linq;
+
+namespace WorkspacesCsharpLibrary
+{
+    public class DrawHelper
+    {
+        public static void SaveBitmap(Bitmap bitmap, MemoryStream memory)
+        {
+            ImageCodecInfo imageCodecInfo = ImageCodecInfo.GetImageEncoders().FirstOrDefault(codec => codec.FormatID == ImageFormat.Png.Guid);
+            EncoderParameters encoderParameters = new(1);
+            encoderParameters.Param[0] = new EncoderParameter(Encoder.Quality, 50);
+
+            bitmap.Save(memory, imageCodecInfo, encoderParameters);
+        }
+    }
+}

--- a/src/modules/Workspaces/WorkspacesCsharpLibrary/Models/BaseApplication.cs
+++ b/src/modules/Workspaces/WorkspacesCsharpLibrary/Models/BaseApplication.cs
@@ -132,7 +132,11 @@ namespace WorkspacesCsharpLibrary.Models
 
                         using (var memory = new MemoryStream())
                         {
-                            previewBitmap.Save(memory, ImageFormat.Png);
+                            ImageCodecInfo imageCodecInfo = ImageCodecInfo.GetImageEncoders().FirstOrDefault(codec => codec.FormatID == ImageFormat.Png.Guid);
+                            EncoderParameters encoderParameters = new(1);
+                            encoderParameters.Param[0] = new EncoderParameter(Encoder.Quality, 50);
+
+                            previewBitmap.Save(memory, imageCodecInfo, encoderParameters);
                             memory.Position = 0;
 
                             BitmapImage bitmapImage = new BitmapImage();

--- a/src/modules/Workspaces/WorkspacesCsharpLibrary/Models/BaseApplication.cs
+++ b/src/modules/Workspaces/WorkspacesCsharpLibrary/Models/BaseApplication.cs
@@ -132,11 +132,7 @@ namespace WorkspacesCsharpLibrary.Models
 
                         using (var memory = new MemoryStream())
                         {
-                            ImageCodecInfo imageCodecInfo = ImageCodecInfo.GetImageEncoders().FirstOrDefault(codec => codec.FormatID == ImageFormat.Png.Guid);
-                            EncoderParameters encoderParameters = new(1);
-                            encoderParameters.Param[0] = new EncoderParameter(Encoder.Quality, 50);
-
-                            previewBitmap.Save(memory, imageCodecInfo, encoderParameters);
+                            DrawHelper.SaveBitmap(previewBitmap, memory);
                             memory.Position = 0;
 
                             BitmapImage bitmapImage = new BitmapImage();

--- a/src/modules/Workspaces/WorkspacesEditor/Utils/DrawHelper.cs
+++ b/src/modules/Workspaces/WorkspacesEditor/Utils/DrawHelper.cs
@@ -153,11 +153,7 @@ namespace WorkspacesEditor.Utils
             }
 
             using MemoryStream memory = new();
-            ImageCodecInfo imageCodecInfo = ImageCodecInfo.GetImageEncoders().FirstOrDefault(codec => codec.FormatID == ImageFormat.Png.Guid);
-            EncoderParameters encoderParameters = new(1);
-            encoderParameters.Param[0] = new EncoderParameter(Encoder.Quality, 50);
-
-            previewBitmap.Save(memory, imageCodecInfo, encoderParameters);
+            WorkspacesCsharpLibrary.DrawHelper.SaveBitmap(previewBitmap, memory);
 
             memory.Position = 0;
 
@@ -317,11 +313,8 @@ namespace WorkspacesEditor.Utils
 
             using MemoryStream memory = new();
 
-            ImageCodecInfo imageCodecInfo = ImageCodecInfo.GetImageEncoders().FirstOrDefault(codec => codec.FormatID == ImageFormat.Png.Guid);
-            EncoderParameters encoderParameters = new(1);
-            encoderParameters.Param[0] = new EncoderParameter(Encoder.Quality, 50);
+            WorkspacesCsharpLibrary.DrawHelper.SaveBitmap(previewBitmap, memory);
 
-            previewBitmap.Save(memory, imageCodecInfo, encoderParameters);
             memory.Position = 0;
 
             BitmapImage bitmapImage = new();

--- a/src/modules/Workspaces/WorkspacesEditor/Utils/DrawHelper.cs
+++ b/src/modules/Workspaces/WorkspacesEditor/Utils/DrawHelper.cs
@@ -153,7 +153,12 @@ namespace WorkspacesEditor.Utils
             }
 
             using MemoryStream memory = new();
-            previewBitmap.Save(memory, ImageFormat.Png);
+            ImageCodecInfo imageCodecInfo = ImageCodecInfo.GetImageEncoders().FirstOrDefault(codec => codec.FormatID == ImageFormat.Png.Guid);
+            EncoderParameters encoderParameters = new(1);
+            encoderParameters.Param[0] = new EncoderParameter(Encoder.Quality, 50);
+
+            previewBitmap.Save(memory, imageCodecInfo, encoderParameters);
+
             memory.Position = 0;
 
             BitmapImage bitmapImage = new();
@@ -311,7 +316,12 @@ namespace WorkspacesEditor.Utils
             }
 
             using MemoryStream memory = new();
-            previewBitmap.Save(memory, ImageFormat.Png);
+
+            ImageCodecInfo imageCodecInfo = ImageCodecInfo.GetImageEncoders().FirstOrDefault(codec => codec.FormatID == ImageFormat.Png.Guid);
+            EncoderParameters encoderParameters = new(1);
+            encoderParameters.Param[0] = new EncoderParameter(Encoder.Quality, 50);
+
+            previewBitmap.Save(memory, imageCodecInfo, encoderParameters);
             memory.Position = 0;
 
             BitmapImage bitmapImage = new();

--- a/src/modules/Workspaces/WorkspacesEditor/Utils/WorkspacesIcon.cs
+++ b/src/modules/Workspaces/WorkspacesEditor/Utils/WorkspacesIcon.cs
@@ -94,7 +94,11 @@ namespace WorkspacesEditor.Utils
             FileStream fileStream = new FileStream(path, FileMode.CreateNew);
             using (var memoryStream = new MemoryStream())
             {
-                icon.Save(memoryStream, ImageFormat.Png);
+                ImageCodecInfo imageCodecInfo = ImageCodecInfo.GetImageEncoders().FirstOrDefault(codec => codec.FormatID == ImageFormat.Png.Guid);
+                EncoderParameters encoderParameters = new(1);
+                encoderParameters.Param[0] = new EncoderParameter(Encoder.Quality, 50);
+
+                icon.Save(memoryStream, imageCodecInfo, encoderParameters);
 
                 BinaryWriter iconWriter = new BinaryWriter(fileStream);
                 if (fileStream != null && iconWriter != null)

--- a/src/modules/Workspaces/WorkspacesEditor/Utils/WorkspacesIcon.cs
+++ b/src/modules/Workspaces/WorkspacesEditor/Utils/WorkspacesIcon.cs
@@ -94,11 +94,7 @@ namespace WorkspacesEditor.Utils
             FileStream fileStream = new FileStream(path, FileMode.CreateNew);
             using (var memoryStream = new MemoryStream())
             {
-                ImageCodecInfo imageCodecInfo = ImageCodecInfo.GetImageEncoders().FirstOrDefault(codec => codec.FormatID == ImageFormat.Png.Guid);
-                EncoderParameters encoderParameters = new(1);
-                encoderParameters.Param[0] = new EncoderParameter(Encoder.Quality, 50);
-
-                icon.Save(memoryStream, imageCodecInfo, encoderParameters);
+                WorkspacesCsharpLibrary.DrawHelper.SaveBitmap(icon, memoryStream);
 
                 BinaryWriter iconWriter = new BinaryWriter(fileStream);
                 if (fileStream != null && iconWriter != null)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

The previously used Bitmap.Save() method caused sporadically exceptions, crashes with the message encoder cannot be null.
The calls have been replaced by an overload call which contains the encoder as a parameter.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

tested locally