### PR TITLE
Making the powertoys-code-owners team code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,16 +1,16 @@
 # Protect `.github` folder except the spell-check rules inside it. (The exception happens by not defining any owner user or group for the path.)
 # Protection of the spell-check rules makes no sense as it needs to be changed in nearly every PR.
-/.github/ @crutkas @DHowett @ethanfangg
+/.github/ @crutkas @DHowett @ethanfangg @cinnamon-msft @yeelam-gordon @jamrobot
 /.github/actions/spell-check/
 
 # locking down pipeline folder
-/.pipelines/ @crutkas @DHowett @ethanfangg
+/.pipelines/ @crutkas @DHowett @ethanfangg @cinnamon-msft @yeelam-gordon @jamrobot
 
 # locking down nuget config
-nuget.config  @crutkas @DHowett @ethanfangg
-packages.config  @crutkas @DHowett @ethanfangg
+nuget.config  @crutkas @DHowett @ethanfangg @cinnamon-msft @yeelam-gordon @jamrobot
+packages.config  @crutkas @DHowett @ethanfangg @cinnamon-msft @yeelam-gordon @jamrobot
 
 # locking down files that should not change
-LICENSE @crutkas @DHowett @ethanfangg
-SECURITY.md @crutkas @DHowett @ethanfangg
-CODE_OF_CONDUCT.md @crutkas @DHowett @ethanfangg
+LICENSE @crutkas @DHowett @ethanfangg @cinnamon-msft @yeelam-gordon @jamrobot
+SECURITY.md @crutkas @DHowett @ethanfangg @cinnamon-msft @yeelam-gordon @jamrobot
+CODE_OF_CONDUCT.md @crutkas @DHowett @ethanfangg @cinnamon-msft @yeelam-gordon @jamrobot

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,16 +1,16 @@
 # Protect `.github` folder except the spell-check rules inside it. (The exception happens by not defining any owner user or group for the path.)
 # Protection of the spell-check rules makes no sense as it needs to be changed in nearly every PR.
-/.github/ @crutkas @DHowett @ethanfangg @cinnamon-msft @yeelam-gordon @jamrobot
+/.github/ @microsoft/powertoys-code-owners
 /.github/actions/spell-check/
 
 # locking down pipeline folder
-/.pipelines/ @crutkas @DHowett @ethanfangg @cinnamon-msft @yeelam-gordon @jamrobot
+/.pipelines/ @microsoft/powertoys-code-owners
 
 # locking down nuget config
-nuget.config  @crutkas @DHowett @ethanfangg @cinnamon-msft @yeelam-gordon @jamrobot
-packages.config  @crutkas @DHowett @ethanfangg @cinnamon-msft @yeelam-gordon @jamrobot
+nuget.config  @microsoft/powertoys-code-owners
+packages.config  @microsoft/powertoys-code-owners
 
 # locking down files that should not change
-LICENSE @crutkas @DHowett @ethanfangg @cinnamon-msft @yeelam-gordon @jamrobot
-SECURITY.md @crutkas @DHowett @ethanfangg @cinnamon-msft @yeelam-gordon @jamrobot
-CODE_OF_CONDUCT.md @crutkas @DHowett @ethanfangg @cinnamon-msft @yeelam-gordon @jamrobot
+LICENSE @microsoft/powertoys-code-owners
+SECURITY.md @microsoft/powertoys-code-owners
+CODE_OF_CONDUCT.md @microsoft/powertoys-code-owners

--- a/.github/actions/spell-check/allow/names.txt
+++ b/.github/actions/spell-check/allow/names.txt
@@ -87,6 +87,7 @@ Howett
 htcfreek
 Huynh
 Ionut
+jamrobot
 Jaswal
 jefflord
 Jordi


### PR DESCRIPTION
1. Migrated the users below to the powertoys-code-owners team
2. Migrated the list of users to team in code owner file
3. Gave team write access

![image](https://github.com/user-attachments/assets/9d799312-2d5d-439d-9257-bbafbe2c6cb0)
