### PR TITLE
[Laucher] Added border on W10

### DIFF
--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml
@@ -27,109 +27,111 @@
     WindowStartupLocation="Manual"
     WindowStyle="None"
     mc:Ignorable="d">
-    <Grid x:Name="RootGrid" MouseDown="OnMouseDown">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" MaxHeight="{Binding Results.MaxHeight}" />
-        </Grid.RowDefinitions>
-        <Border
-            x:Name="SearchBoxBorder"
-            Grid.Row="0"
-            Padding="12,4,12,3">
-            <local:LauncherControl x:Name="SearchBox" />
-        </Border>
-
-        <!--  Have to use a Grid instead of a StackPanel for scrolling to work?  -->
-        <Grid
-            x:Name="KeywordsOverviewGrid"
-            Grid.Row="1"
-            MaxHeight="{Binding Results.MaxHeight}"
-            Visibility="{Binding PluginsOverviewVisibility}">
+    <Border x:Name="MainBorder">
+        <Grid x:Name="RootGrid" MouseDown="OnMouseDown">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
-                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" MaxHeight="{Binding Results.MaxHeight}" />
             </Grid.RowDefinitions>
-            <Rectangle
-                Height="1"
-                VerticalAlignment="Top"
-                Fill="{DynamicResource DividerStrokeColorDefaultBrush}" />
-            <TextBlock
-                Margin="22,12,0,4"
-                FontWeight="SemiBold"
-                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                Style="{StaticResource CaptionTextBlockStyle}"
-                Text="{x:Static p:Resources.PluginKeywords}" />
+            <Border
+                x:Name="SearchBoxBorder"
+                Grid.Row="0"
+                Padding="12,4,12,3">
+                <local:LauncherControl x:Name="SearchBox" />
+            </Border>
 
-            <ListView
-                x:Name="pluginsHintsList"
+            <!--  Have to use a Grid instead of a StackPanel for scrolling to work?  -->
+            <Grid
+                x:Name="KeywordsOverviewGrid"
                 Grid.Row="1"
-                Background="Transparent"
-                BorderBrush="Transparent"
-                ItemContainerStyle="{StaticResource PluginsListViewItemStyle}"
-                ItemsSource="{Binding Plugins}"
-                PreviewMouseLeftButtonUp="PluginsHintsList_PreviewMouseLeftButtonUp"
-                ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                ScrollViewer.VerticalScrollBarVisibility="Auto"
-                SelectedItem="{Binding SelectedPlugin, Mode=TwoWay}"
-                SelectionMode="Single">
-                <ListView.ItemsPanel>
-                    <ItemsPanelTemplate>
-                        <VirtualizingStackPanel
-                            Margin="16,0"
-                            IsVirtualizing="{TemplateBinding VirtualizingPanel.IsVirtualizing}"
-                            VirtualizationMode="{TemplateBinding VirtualizingPanel.VirtualizationMode}" />
-                    </ItemsPanelTemplate>
-                </ListView.ItemsPanel>
-                <ListView.ItemTemplate>
-                    <DataTemplate>
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" />
-                                <ColumnDefinition Width="*" />
-                            </Grid.ColumnDefinitions>
-                            <Border
-                                Width="32"
-                                Height="32"
-                                Padding="2,0,2,0"
-                                Background="{DynamicResource ControlFillColorDefaultBrush}"
-                                BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
-                                BorderThickness="1"
-                                CornerRadius="4"
-                                ToolTipService.ToolTip="{Binding Metadata.ActionKeyword}">
+                MaxHeight="{Binding Results.MaxHeight}"
+                Visibility="{Binding PluginsOverviewVisibility}">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+                <Rectangle
+                    Height="1"
+                    VerticalAlignment="Top"
+                    Fill="{DynamicResource DividerStrokeColorDefaultBrush}" />
+                <TextBlock
+                    Margin="22,12,0,4"
+                    FontWeight="SemiBold"
+                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                    Style="{StaticResource CaptionTextBlockStyle}"
+                    Text="{x:Static p:Resources.PluginKeywords}" />
+
+                <ListView
+                    x:Name="pluginsHintsList"
+                    Grid.Row="1"
+                    Background="Transparent"
+                    BorderBrush="Transparent"
+                    ItemContainerStyle="{StaticResource PluginsListViewItemStyle}"
+                    ItemsSource="{Binding Plugins}"
+                    PreviewMouseLeftButtonUp="PluginsHintsList_PreviewMouseLeftButtonUp"
+                    ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                    ScrollViewer.VerticalScrollBarVisibility="Auto"
+                    SelectedItem="{Binding SelectedPlugin, Mode=TwoWay}"
+                    SelectionMode="Single">
+                    <ListView.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <VirtualizingStackPanel
+                                Margin="16,0"
+                                IsVirtualizing="{TemplateBinding VirtualizingPanel.IsVirtualizing}"
+                                VirtualizationMode="{TemplateBinding VirtualizingPanel.VirtualizationMode}" />
+                        </ItemsPanelTemplate>
+                    </ListView.ItemsPanel>
+                    <ListView.ItemTemplate>
+                        <DataTemplate>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
+                                <Border
+                                    Width="32"
+                                    Height="32"
+                                    Padding="2,0,2,0"
+                                    Background="{DynamicResource ControlFillColorDefaultBrush}"
+                                    BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
+                                    BorderThickness="1"
+                                    CornerRadius="4"
+                                    ToolTipService.ToolTip="{Binding Metadata.ActionKeyword}">
+                                    <TextBlock
+                                        HorizontalAlignment="Center"
+                                        VerticalAlignment="Center"
+                                        FontWeight="SemiBold"
+                                        Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                                        Text="{Binding Metadata.ActionKeyword}"
+                                        TextAlignment="Left"
+                                        TextTrimming="WordEllipsis" />
+                                </Border>
                                 <TextBlock
-                                    HorizontalAlignment="Center"
+                                    Grid.Column="1"
+                                    Margin="12,0,0,0"
                                     VerticalAlignment="Center"
-                                    FontWeight="SemiBold"
                                     Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-                                    Text="{Binding Metadata.ActionKeyword}"
-                                    TextAlignment="Left"
-                                    TextTrimming="WordEllipsis" />
-                            </Border>
-                            <TextBlock
-                                Grid.Column="1"
-                                Margin="12,0,0,0"
-                                VerticalAlignment="Center"
-                                Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-                                Text="{Binding Plugin.Description}"
-                                TextTrimming="CharacterEllipsis"
-                                TextWrapping="Wrap" />
-                        </Grid>
-                    </DataTemplate>
-                </ListView.ItemTemplate>
-            </ListView>
+                                    Text="{Binding Plugin.Description}"
+                                    TextTrimming="CharacterEllipsis"
+                                    TextWrapping="Wrap" />
+                            </Grid>
+                        </DataTemplate>
+                    </ListView.ItemTemplate>
+                </ListView>
+            </Grid>
+
+            <local:ResultList
+                x:Name="ListBox"
+                Grid.Row="2"
+                VerticalAlignment="Stretch"
+                BorderBrush="{DynamicResource DividerStrokeColorDefaultBrush}"
+                BorderThickness="0,1,0,0"
+                PreviewMouseDown="ListBox_PreviewMouseDown"
+                Visibility="{Binding Results.Visibility}" />
+
         </Grid>
-
-        <local:ResultList
-            x:Name="ListBox"
-            Grid.Row="2"
-            VerticalAlignment="Stretch"
-            BorderBrush="{DynamicResource DividerStrokeColorDefaultBrush}"
-            BorderThickness="0,1,0,0"
-            PreviewMouseDown="ListBox_PreviewMouseDown"
-            Visibility="{Binding Results.Visibility}" />
-
-    </Grid>
+    </Border>
     <Window.InputBindings>
         <KeyBinding Key="Escape" Command="{Binding EscCommand}" />
         <KeyBinding Key="Enter" Command="{Binding OpenResultWithKeyboardCommand}" />

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml
@@ -27,7 +27,7 @@
     WindowStartupLocation="Manual"
     WindowStyle="None"
     mc:Ignorable="d">
-    <Border x:Name="MainBorder">
+    <Border x:Name="MainBorder" BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}">
         <Grid x:Name="RootGrid" MouseDown="OnMouseDown">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml
@@ -28,109 +28,109 @@
     WindowStyle="None"
     mc:Ignorable="d">
     <Border x:Name="MainBorder">
-    <Grid x:Name="RootGrid" MouseDown="OnMouseDown">
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" MaxHeight="{Binding Results.MaxHeight}" />
-        </Grid.RowDefinitions>
-        <Border
-            x:Name="SearchBoxBorder"
-            Grid.Row="0"
-            Padding="12,4,12,3">
-            <local:LauncherControl x:Name="SearchBox" />
-        </Border>
-
-        <!--  Have to use a Grid instead of a StackPanel for scrolling to work?  -->
-        <Grid
-            x:Name="KeywordsOverviewGrid"
-            Grid.Row="1"
-            MaxHeight="{Binding Results.MaxHeight}"
-            Visibility="{Binding PluginsOverviewVisibility}">
+        <Grid x:Name="RootGrid" MouseDown="OnMouseDown">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
-                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" MaxHeight="{Binding Results.MaxHeight}" />
             </Grid.RowDefinitions>
-            <Rectangle
-                Height="1"
-                VerticalAlignment="Top"
-                Fill="{DynamicResource DividerStrokeColorDefaultBrush}" />
-            <TextBlock
-                Margin="22,12,0,4"
-                FontWeight="SemiBold"
-                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                Style="{StaticResource CaptionTextBlockStyle}"
-                Text="{x:Static p:Resources.PluginKeywords}" />
+            <Border
+                x:Name="SearchBoxBorder"
+                Grid.Row="0"
+                Padding="12,4,12,3">
+                <local:LauncherControl x:Name="SearchBox" />
+            </Border>
 
-            <ListView
-                x:Name="pluginsHintsList"
+            <!--  Have to use a Grid instead of a StackPanel for scrolling to work?  -->
+            <Grid
+                x:Name="KeywordsOverviewGrid"
                 Grid.Row="1"
-                Background="Transparent"
-                BorderBrush="Transparent"
-                ItemContainerStyle="{StaticResource PluginsListViewItemStyle}"
-                ItemsSource="{Binding Plugins}"
-                PreviewMouseLeftButtonUp="PluginsHintsList_PreviewMouseLeftButtonUp"
-                ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                ScrollViewer.VerticalScrollBarVisibility="Auto"
-                SelectedItem="{Binding SelectedPlugin, Mode=TwoWay}"
-                SelectionMode="Single">
-                <ListView.ItemsPanel>
-                    <ItemsPanelTemplate>
-                        <VirtualizingStackPanel
-                            Margin="16,0"
-                            IsVirtualizing="{TemplateBinding VirtualizingPanel.IsVirtualizing}"
-                            VirtualizationMode="{TemplateBinding VirtualizingPanel.VirtualizationMode}" />
-                    </ItemsPanelTemplate>
-                </ListView.ItemsPanel>
-                <ListView.ItemTemplate>
-                    <DataTemplate>
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="Auto" />
-                                <ColumnDefinition Width="*" />
-                            </Grid.ColumnDefinitions>
-                            <Border
-                                Width="32"
-                                Height="32"
-                                Padding="2,0,2,0"
-                                Background="{DynamicResource ControlFillColorDefaultBrush}"
-                                BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
-                                BorderThickness="1"
-                                CornerRadius="4"
-                                ToolTipService.ToolTip="{Binding Metadata.ActionKeyword}">
+                MaxHeight="{Binding Results.MaxHeight}"
+                Visibility="{Binding PluginsOverviewVisibility}">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
+                <Rectangle
+                    Height="1"
+                    VerticalAlignment="Top"
+                    Fill="{DynamicResource DividerStrokeColorDefaultBrush}" />
+                <TextBlock
+                    Margin="22,12,0,4"
+                    FontWeight="SemiBold"
+                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                    Style="{StaticResource CaptionTextBlockStyle}"
+                    Text="{x:Static p:Resources.PluginKeywords}" />
+
+                <ListView
+                    x:Name="pluginsHintsList"
+                    Grid.Row="1"
+                    Background="Transparent"
+                    BorderBrush="Transparent"
+                    ItemContainerStyle="{StaticResource PluginsListViewItemStyle}"
+                    ItemsSource="{Binding Plugins}"
+                    PreviewMouseLeftButtonUp="PluginsHintsList_PreviewMouseLeftButtonUp"
+                    ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                    ScrollViewer.VerticalScrollBarVisibility="Auto"
+                    SelectedItem="{Binding SelectedPlugin, Mode=TwoWay}"
+                    SelectionMode="Single">
+                    <ListView.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <VirtualizingStackPanel
+                                Margin="16,0"
+                                IsVirtualizing="{TemplateBinding VirtualizingPanel.IsVirtualizing}"
+                                VirtualizationMode="{TemplateBinding VirtualizingPanel.VirtualizationMode}" />
+                        </ItemsPanelTemplate>
+                    </ListView.ItemsPanel>
+                    <ListView.ItemTemplate>
+                        <DataTemplate>
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
+                                <Border
+                                    Width="32"
+                                    Height="32"
+                                    Padding="2,0,2,0"
+                                    Background="{DynamicResource ControlFillColorDefaultBrush}"
+                                    BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
+                                    BorderThickness="1"
+                                    CornerRadius="4"
+                                    ToolTipService.ToolTip="{Binding Metadata.ActionKeyword}">
+                                    <TextBlock
+                                        HorizontalAlignment="Center"
+                                        VerticalAlignment="Center"
+                                        FontWeight="SemiBold"
+                                        Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                                        Text="{Binding Metadata.ActionKeyword}"
+                                        TextAlignment="Left"
+                                        TextTrimming="WordEllipsis" />
+                                </Border>
                                 <TextBlock
-                                    HorizontalAlignment="Center"
+                                    Grid.Column="1"
+                                    Margin="12,0,0,0"
                                     VerticalAlignment="Center"
-                                    FontWeight="SemiBold"
                                     Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-                                    Text="{Binding Metadata.ActionKeyword}"
-                                    TextAlignment="Left"
-                                    TextTrimming="WordEllipsis" />
-                            </Border>
-                            <TextBlock
-                                Grid.Column="1"
-                                Margin="12,0,0,0"
-                                VerticalAlignment="Center"
-                                Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-                                Text="{Binding Plugin.Description}"
-                                TextTrimming="CharacterEllipsis"
-                                TextWrapping="Wrap" />
-                        </Grid>
-                    </DataTemplate>
-                </ListView.ItemTemplate>
-            </ListView>
+                                    Text="{Binding Plugin.Description}"
+                                    TextTrimming="CharacterEllipsis"
+                                    TextWrapping="Wrap" />
+                            </Grid>
+                        </DataTemplate>
+                    </ListView.ItemTemplate>
+                </ListView>
+            </Grid>
+
+            <local:ResultList
+                x:Name="ListBox"
+                Grid.Row="2"
+                VerticalAlignment="Stretch"
+                BorderBrush="{DynamicResource DividerStrokeColorDefaultBrush}"
+                BorderThickness="0,1,0,0"
+                PreviewMouseDown="ListBox_PreviewMouseDown"
+                Visibility="{Binding Results.Visibility}" />
+
         </Grid>
-
-        <local:ResultList
-            x:Name="ListBox"
-            Grid.Row="2"
-            VerticalAlignment="Stretch"
-            BorderBrush="{DynamicResource DividerStrokeColorDefaultBrush}"
-            BorderThickness="0,1,0,0"
-            PreviewMouseDown="ListBox_PreviewMouseDown"
-            Visibility="{Binding Results.Visibility}" />
-
-    </Grid>
     </Border>
     <Window.InputBindings>
         <KeyBinding Key="Escape" Command="{Binding EscCommand}" />

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml
@@ -28,109 +28,109 @@
     WindowStyle="None"
     mc:Ignorable="d">
     <Border x:Name="MainBorder">
-        <Grid x:Name="RootGrid" MouseDown="OnMouseDown">
+    <Grid x:Name="RootGrid" MouseDown="OnMouseDown">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" MaxHeight="{Binding Results.MaxHeight}" />
+        </Grid.RowDefinitions>
+        <Border
+            x:Name="SearchBoxBorder"
+            Grid.Row="0"
+            Padding="12,4,12,3">
+            <local:LauncherControl x:Name="SearchBox" />
+        </Border>
+
+        <!--  Have to use a Grid instead of a StackPanel for scrolling to work?  -->
+        <Grid
+            x:Name="KeywordsOverviewGrid"
+            Grid.Row="1"
+            MaxHeight="{Binding Results.MaxHeight}"
+            Visibility="{Binding PluginsOverviewVisibility}">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="*" MaxHeight="{Binding Results.MaxHeight}" />
+                <RowDefinition Height="*" />
             </Grid.RowDefinitions>
-            <Border
-                x:Name="SearchBoxBorder"
-                Grid.Row="0"
-                Padding="12,4,12,3">
-                <local:LauncherControl x:Name="SearchBox" />
-            </Border>
+            <Rectangle
+                Height="1"
+                VerticalAlignment="Top"
+                Fill="{DynamicResource DividerStrokeColorDefaultBrush}" />
+            <TextBlock
+                Margin="22,12,0,4"
+                FontWeight="SemiBold"
+                Foreground="{DynamicResource TextFillColorSecondaryBrush}"
+                Style="{StaticResource CaptionTextBlockStyle}"
+                Text="{x:Static p:Resources.PluginKeywords}" />
 
-            <!--  Have to use a Grid instead of a StackPanel for scrolling to work?  -->
-            <Grid
-                x:Name="KeywordsOverviewGrid"
+            <ListView
+                x:Name="pluginsHintsList"
                 Grid.Row="1"
-                MaxHeight="{Binding Results.MaxHeight}"
-                Visibility="{Binding PluginsOverviewVisibility}">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="*" />
-                </Grid.RowDefinitions>
-                <Rectangle
-                    Height="1"
-                    VerticalAlignment="Top"
-                    Fill="{DynamicResource DividerStrokeColorDefaultBrush}" />
-                <TextBlock
-                    Margin="22,12,0,4"
-                    FontWeight="SemiBold"
-                    Foreground="{DynamicResource TextFillColorSecondaryBrush}"
-                    Style="{StaticResource CaptionTextBlockStyle}"
-                    Text="{x:Static p:Resources.PluginKeywords}" />
-
-                <ListView
-                    x:Name="pluginsHintsList"
-                    Grid.Row="1"
-                    Background="Transparent"
-                    BorderBrush="Transparent"
-                    ItemContainerStyle="{StaticResource PluginsListViewItemStyle}"
-                    ItemsSource="{Binding Plugins}"
-                    PreviewMouseLeftButtonUp="PluginsHintsList_PreviewMouseLeftButtonUp"
-                    ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                    ScrollViewer.VerticalScrollBarVisibility="Auto"
-                    SelectedItem="{Binding SelectedPlugin, Mode=TwoWay}"
-                    SelectionMode="Single">
-                    <ListView.ItemsPanel>
-                        <ItemsPanelTemplate>
-                            <VirtualizingStackPanel
-                                Margin="16,0"
-                                IsVirtualizing="{TemplateBinding VirtualizingPanel.IsVirtualizing}"
-                                VirtualizationMode="{TemplateBinding VirtualizingPanel.VirtualizationMode}" />
-                        </ItemsPanelTemplate>
-                    </ListView.ItemsPanel>
-                    <ListView.ItemTemplate>
-                        <DataTemplate>
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="*" />
-                                </Grid.ColumnDefinitions>
-                                <Border
-                                    Width="32"
-                                    Height="32"
-                                    Padding="2,0,2,0"
-                                    Background="{DynamicResource ControlFillColorDefaultBrush}"
-                                    BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
-                                    BorderThickness="1"
-                                    CornerRadius="4"
-                                    ToolTipService.ToolTip="{Binding Metadata.ActionKeyword}">
-                                    <TextBlock
-                                        HorizontalAlignment="Center"
-                                        VerticalAlignment="Center"
-                                        FontWeight="SemiBold"
-                                        Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-                                        Text="{Binding Metadata.ActionKeyword}"
-                                        TextAlignment="Left"
-                                        TextTrimming="WordEllipsis" />
-                                </Border>
+                Background="Transparent"
+                BorderBrush="Transparent"
+                ItemContainerStyle="{StaticResource PluginsListViewItemStyle}"
+                ItemsSource="{Binding Plugins}"
+                PreviewMouseLeftButtonUp="PluginsHintsList_PreviewMouseLeftButtonUp"
+                ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                ScrollViewer.VerticalScrollBarVisibility="Auto"
+                SelectedItem="{Binding SelectedPlugin, Mode=TwoWay}"
+                SelectionMode="Single">
+                <ListView.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <VirtualizingStackPanel
+                            Margin="16,0"
+                            IsVirtualizing="{TemplateBinding VirtualizingPanel.IsVirtualizing}"
+                            VirtualizationMode="{TemplateBinding VirtualizingPanel.VirtualizationMode}" />
+                    </ItemsPanelTemplate>
+                </ListView.ItemsPanel>
+                <ListView.ItemTemplate>
+                    <DataTemplate>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <Border
+                                Width="32"
+                                Height="32"
+                                Padding="2,0,2,0"
+                                Background="{DynamicResource ControlFillColorDefaultBrush}"
+                                BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
+                                BorderThickness="1"
+                                CornerRadius="4"
+                                ToolTipService.ToolTip="{Binding Metadata.ActionKeyword}">
                                 <TextBlock
-                                    Grid.Column="1"
-                                    Margin="12,0,0,0"
+                                    HorizontalAlignment="Center"
                                     VerticalAlignment="Center"
+                                    FontWeight="SemiBold"
                                     Foreground="{DynamicResource TextFillColorPrimaryBrush}"
-                                    Text="{Binding Plugin.Description}"
-                                    TextTrimming="CharacterEllipsis"
-                                    TextWrapping="Wrap" />
-                            </Grid>
-                        </DataTemplate>
-                    </ListView.ItemTemplate>
-                </ListView>
-            </Grid>
-
-            <local:ResultList
-                x:Name="ListBox"
-                Grid.Row="2"
-                VerticalAlignment="Stretch"
-                BorderBrush="{DynamicResource DividerStrokeColorDefaultBrush}"
-                BorderThickness="0,1,0,0"
-                PreviewMouseDown="ListBox_PreviewMouseDown"
-                Visibility="{Binding Results.Visibility}" />
-
+                                    Text="{Binding Metadata.ActionKeyword}"
+                                    TextAlignment="Left"
+                                    TextTrimming="WordEllipsis" />
+                            </Border>
+                            <TextBlock
+                                Grid.Column="1"
+                                Margin="12,0,0,0"
+                                VerticalAlignment="Center"
+                                Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                                Text="{Binding Plugin.Description}"
+                                TextTrimming="CharacterEllipsis"
+                                TextWrapping="Wrap" />
+                        </Grid>
+                    </DataTemplate>
+                </ListView.ItemTemplate>
+            </ListView>
         </Grid>
+
+        <local:ResultList
+            x:Name="ListBox"
+            Grid.Row="2"
+            VerticalAlignment="Stretch"
+            BorderBrush="{DynamicResource DividerStrokeColorDefaultBrush}"
+            BorderThickness="0,1,0,0"
+            PreviewMouseDown="ListBox_PreviewMouseDown"
+            Visibility="{Binding Results.Visibility}" />
+
+    </Grid>
     </Border>
     <Window.InputBindings>
         <KeyBinding Key="Escape" Command="{Binding EscCommand}" />

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -194,11 +194,19 @@ namespace PowerLauncher
             _viewModel.RegisterHotkey(_hwndSource.Handle);
             if (OSVersionHelper.IsWindows11())
             {
+                MainBorder.BorderBrush = null;
+                MainBorder.BorderThickness = new System.Windows.Thickness(0);
+
                 // ResizeMode="NoResize" removes rounded corners. So force them to rounded.
                 IntPtr hWnd = new WindowInteropHelper(GetWindow(this)).EnsureHandle();
                 DWMWINDOWATTRIBUTE attribute = DWMWINDOWATTRIBUTE.DWMWA_WINDOW_CORNER_PREFERENCE;
                 DWM_WINDOW_CORNER_PREFERENCE preference = DWM_WINDOW_CORNER_PREFERENCE.DWMWCP_ROUND;
                 DwmSetWindowAttribute(hWnd, attribute, ref preference, sizeof(uint));
+            }
+            else
+            {
+                MainBorder.BorderBrush = System.Windows.Media.Brushes.Gray;
+                MainBorder.BorderThickness = new System.Windows.Thickness(0.5);
             }
         }
 

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -203,7 +203,6 @@ namespace PowerLauncher
             else
             {
                 // On Windows10 ResizeMode="NoResize" removes the border so we add a new one.
-                MainBorder.BorderBrush = System.Windows.Media.Brushes.Gray;
                 MainBorder.BorderThickness = new System.Windows.Thickness(0.5);
             }
         }

--- a/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
+++ b/src/modules/launcher/PowerLauncher/MainWindow.xaml.cs
@@ -194,9 +194,6 @@ namespace PowerLauncher
             _viewModel.RegisterHotkey(_hwndSource.Handle);
             if (OSVersionHelper.IsWindows11())
             {
-                MainBorder.BorderBrush = null;
-                MainBorder.BorderThickness = new System.Windows.Thickness(0);
-
                 // ResizeMode="NoResize" removes rounded corners. So force them to rounded.
                 IntPtr hWnd = new WindowInteropHelper(GetWindow(this)).EnsureHandle();
                 DWMWINDOWATTRIBUTE attribute = DWMWINDOWATTRIBUTE.DWMWA_WINDOW_CORNER_PREFERENCE;
@@ -205,6 +202,7 @@ namespace PowerLauncher
             }
             else
             {
+                // On Windows10 ResizeMode="NoResize" removes the border so we add a new one.
                 MainBorder.BorderBrush = System.Windows.Media.Brushes.Gray;
                 MainBorder.BorderThickness = new System.Windows.Thickness(0.5);
             }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Added a border on W10 since only W11 had it.
Screenshots of the new  look in W10.
<!-- Please review the items on the PR checklist before submitting-->
<img width="972" alt="dark" src="https://github.com/user-attachments/assets/7756fdc6-61de-4f26-b14a-39b7e434b3cd" />
<img width="1020" alt="light" src="https://github.com/user-attachments/assets/88e0f298-b40b-4141-a8d3-a4d168f8582e" />

## PR Checklist

- [x] **Closes:** #36391
- [X] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
ResizeMode="NoResize" removes the border which on W11 was added back by enabling round corners 
<pre> 
if (OSVersionHelper.IsWindows11())
{
   WindowInteropHelper(GetWindow(this)).EnsureHandle(); 
   DWMWINDOWATTRIBUTE attribute = DWMWINDOWATTRIBUTE.DWMWA_WINDOW_CORNER_PREFERENCE; 
   DWM_WINDOW_CORNER_PREFERENCE preference = DWM_WINDOW_CORNER_PREFERENCE.DWMWCP_ROUND;  
   DwmSetWindowAttribute(hWnd, attribute, ref preference, sizeof(uint)); 
}  </pre>
Added a gray border on W10.
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Tested On W10 and W11 on dark,light and all high contrast modes.
