### PR TITLE
[Bug fix] Add a format validation step before format conversion.

### DIFF
--- a/src/modules/AdvancedPaste/AdvancedPaste/Helpers/JsonHelper.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/Helpers/JsonHelper.cs
@@ -38,7 +38,7 @@ namespace AdvancedPaste.Helpers
         {
             try
             {
-                using JsonDocument doc = JsonDocument.Parse(text);
+                _ = JsonDocument.Parse(text);
                 return true;
             }
             catch (Exception)

--- a/src/modules/AdvancedPaste/AdvancedPaste/Helpers/JsonHelper.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/Helpers/JsonHelper.cs
@@ -38,7 +38,7 @@ namespace AdvancedPaste.Helpers
         {
             try
             {
-                JsonDocument.Parse(text);
+                using JsonDocument doc = JsonDocument.Parse(text);
                 return true;
             }
             catch (Exception)

--- a/src/modules/AdvancedPaste/AdvancedPaste/Helpers/JsonHelper.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/Helpers/JsonHelper.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Xml;
@@ -33,6 +34,19 @@ namespace AdvancedPaste.Helpers
         private static readonly Regex CsvRemoveStartAndEndQuotationMarksRegex = new Regex(@"^""(?=(""{2})+)|(?<=(""{2})+)""$");
         private static readonly Regex CsvReplaceDoubleQuotationMarksRegex = new Regex(@"""{2}");
 
+        private static bool IsJson(string text)
+        {
+            try
+            {
+                JsonDocument.Parse(text);
+                return true;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
         internal static async Task<string> ToJsonFromXmlOrCsvAsync(DataPackageView clipboardData)
         {
             Logger.LogTrace();
@@ -45,6 +59,12 @@ namespace AdvancedPaste.Helpers
 
             var text = await clipboardData.GetTextAsync();
             string jsonText = string.Empty;
+
+            // If the text is already JSON, return it
+            if (IsJson(text))
+            {
+                return text;
+            }
 
             // Try convert XML
             try


### PR DESCRIPTION

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR aims to fix the bug #35225 by introducing a new method `IsJson` to determine if a given text is in JSON format. 
The `IsJson` method is then utilized in the `ToJsonFromXmlOrCsvAsync` method to optimize the processing logic. 
If the text is already in JSON format, it is returned directly without further conversion from XML or CSV.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #35225 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
### Key Changes:
1. Added `System.Text.Json` namespace.
2. Implemented `IsJson` method to check if the text is in JSON format.
3. Updated `ToJsonFromXmlOrCsvAsync` method to use `IsJson` and return the text directly if it is already JSON.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manually tested
