### PR TITLE
[Advanced Paste] Fixed NullReferenceException on Dispose

### DIFF
--- a/src/modules/AdvancedPaste/AdvancedPaste/AdvancedPasteXAML/App.xaml.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/AdvancedPasteXAML/App.xaml.cs
@@ -263,7 +263,7 @@ namespace AdvancedPaste
                 if (disposing)
                 {
                     EtwTrace?.Dispose();
-                    window.Dispose();
+                    window?.Dispose();
                 }
 
                 disposedValue = true;

--- a/src/modules/AdvancedPaste/AdvancedPaste/Helpers/UserSettings.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/Helpers/UserSettings.cs
@@ -154,8 +154,8 @@ namespace AdvancedPaste.Settings
             {
                 if (disposing)
                 {
-                    _cancellationTokenSource.Dispose();
-                    _watcher.Dispose();
+                    _cancellationTokenSource?.Dispose();
+                    _watcher?.Dispose();
                 }
 
                 _disposedValue = true;


### PR DESCRIPTION
## Summary of the Pull Request

Fixed `NullReferenceException` in `App.xaml.cs`.

![image](https://github.com/user-attachments/assets/d41a022e-1058-4f7f-a33e-a7f8aff07f4f)

## PR Checklist

- [ ] **Closes:** #xxx
- [X] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments
Also looked for and fixed a similar issue in another `Dispose` call, which is only theoretical at the moment.

## Validation Steps Performed
- Reproduced crash before fix by disabling Advanced Paste from Settings.
- Tested fix by disabling Advanced Paste from Settings.
- Sanity check of Advanced Paste.
