### PR TITLE
[New+]Don't override New actions from Explorer on Windows 10

### DIFF
--- a/.github/actions/spell-check/patterns.txt
+++ b/.github/actions/spell-check/patterns.txt
@@ -131,7 +131,7 @@ _mm_(?!dd)\w+
 
 # hit-count: 4 file-count: 4
 # microsoft
-\b(?:https?://|)(?:(?:(?:blogs|download\.visualstudio|developer|docs|msdn2?|research)\.|)microsoft|blogs\.msdn)\.co(?:m|\.\w\w)/[-_a-zA-Z0-9()=./%]*
+\b(?:https?://|)(?:(?:(?:blogs|download\.visualstudio|developer|docs|learn|msdn2?|research)\.|)microsoft|blogs\.msdn)\.co(?:m|\.\w\w)/[-_a-zA-Z0-9()=./%#]*
 
 aka\.ms/[a-zA-Z0-9]+
 

--- a/src/modules/NewPlus/NewShellExtensionContextMenu.win10/shell_context_menu_win10.cpp
+++ b/src/modules/NewPlus/NewShellExtensionContextMenu.win10/shell_context_menu_win10.cpp
@@ -220,7 +220,7 @@ IFACEMETHODIMP shell_context_menu_win10::InvokeCommand(CMINVOKECOMMANDINFO* para
     if (HIWORD(params->lpVerb)!=0)
     {
         // Not a menu command. It's likely a string verb command from another menu.
-        // The logic to interpret lpVerb is explained here: https://learn.microsoft.com/en-us/previous-versions//bb776881(v=vs.85)?redirectedfrom=MSDN#invokecommand-method
+        // The logic to interpret lpVerb is explained here: https://learn.microsoft.com/en-us/previous-versions//bb776881(v=vs.85)#invokecommand-method
         return E_FAIL;
     }
 

--- a/src/modules/NewPlus/NewShellExtensionContextMenu.win10/shell_context_menu_win10.cpp
+++ b/src/modules/NewPlus/NewShellExtensionContextMenu.win10/shell_context_menu_win10.cpp
@@ -217,6 +217,12 @@ IFACEMETHODIMP shell_context_menu_win10::InvokeCommand(CMINVOKECOMMANDINFO* para
         return E_FAIL;
     }
 
+    if (HIWORD(params->lpVerb)!=0)
+    {
+        // Not a menu command. It's likely a string verb command from another menu.
+        return E_FAIL;
+    }
+
     // Get selected menu item (a template or the "Open templates" item)
     const auto selected_menu_item_index = LOWORD(params->lpVerb) - 1;
     if (selected_menu_item_index < 0)

--- a/src/modules/NewPlus/NewShellExtensionContextMenu.win10/shell_context_menu_win10.cpp
+++ b/src/modules/NewPlus/NewShellExtensionContextMenu.win10/shell_context_menu_win10.cpp
@@ -220,6 +220,7 @@ IFACEMETHODIMP shell_context_menu_win10::InvokeCommand(CMINVOKECOMMANDINFO* para
     if (HIWORD(params->lpVerb)!=0)
     {
         // Not a menu command. It's likely a string verb command from another menu.
+        // The logic to interpret lpVerb is explained here: https://learn.microsoft.com/en-us/previous-versions//bb776881(v=vs.85)?redirectedfrom=MSDN#invokecommand-method
         return E_FAIL;
     }
 

--- a/src/modules/NewPlus/NewShellExtensionContextMenu.win10/shell_context_menu_win10.cpp
+++ b/src/modules/NewPlus/NewShellExtensionContextMenu.win10/shell_context_menu_win10.cpp
@@ -38,9 +38,9 @@ IFACEMETHODIMP shell_context_menu_win10::QueryContextMenu(HMENU menu_handle, UIN
         return E_FAIL;
     }
 
-    if (menu_flags & CMF_DEFAULTONLY)
+    if (menu_flags & (CMF_DEFAULTONLY | CMF_VERBSONLY | CMF_OPTIMIZEFORINVOKE))
     {
-        return MAKE_HRESULT(SEVERITY_SUCCESS, FACILITY_NULL, 0);
+        return E_UNEXPECTED;
     }
 
     try


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

New+ is currently trying to respond to verbs that don't correspond to the submenu item call in InvokeCommand. Checking old documentation for InvokeCommand, we can see that we're missing a check in there.

https://learn.microsoft.com/en-us/previous-versions//bb776881(v=vs.85)?redirectedfrom=MSDN#invokecommand-method

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #36387
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

Just adds the check we require to make sure we're not responding to "string"-based verbs, according to the documentation.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Verified that on Windows 10 with this build it's possible to now call New Folder from the WIndows Explorer Ribbon and also through the Ctrl+Shift+N shortcut. Now a new folder gets created instead of the old one. Also tried to create a New text file from the ribbon and it worked. Also tried New+ features to make sure they were still working.
