### PR TITLE
Remove "prerelease: true"

### DIFF
--- a/.configurations/configuration.dsc.yaml
+++ b/.configurations/configuration.dsc.yaml
@@ -12,7 +12,6 @@ properties:
       id: vsPackage
       directives:
         description: Install Visual Studio 2022 Community (Any edition will work)
-        allowPrerelease: true
       settings:
         id: Microsoft.VisualStudio.2022.Community
         source: winget

--- a/.configurations/configuration.vsEnterprise.dsc.yaml
+++ b/.configurations/configuration.vsEnterprise.dsc.yaml
@@ -12,7 +12,6 @@ properties:
       id: vsPackage
       directives:
         description: Install Visual Studio 2022 Enterprise (Any edition will work)
-        allowPrerelease: true
       settings:
         id: Microsoft.VisualStudio.2022.Enterprise
         source: winget

--- a/.configurations/configuration.vsProfessional.dsc.yaml
+++ b/.configurations/configuration.vsProfessional.dsc.yaml
@@ -12,7 +12,6 @@ properties:
       id: vsPackage
       directives:
         description: Install Visual Studio 2022 Professional (Any edition will work)
-        allowPrerelease: true
       settings:
         id: Microsoft.VisualStudio.2022.Professional
         source: winget

--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -754,7 +754,7 @@ lnks
 LOADFROMFILE
 LOBYTE
 LOCALDISPLAY
-LOCALPACKAGE
+localpackage
 LOCALSYSTEM
 LOCATIONCHANGE
 LOGFONT
@@ -1722,6 +1722,7 @@ WIC
 wifi
 wil
 winapi
+winappsdk
 wincodec
 Wincodecsdk
 wincolor
@@ -1846,5 +1847,3 @@ zonable
 zoneset
 Zoneszonabletester
 zzz
-localpackage
-winappsdk


### PR DESCRIPTION
The Microsoft.WinGet.DSC module is GA so prerelease: true is no longer needed.

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #36483
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Removes prerelease directive for WinGet DSC resources in WinGet Configuration files

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Cloned repository and ran `winget configure validate <configuration file>`

![image](https://github.com/user-attachments/assets/7d3e6f8f-23ba-4f51-9c84-75fb3bcbd9a7)




