### PR TITLE
Quick Accent: Add currencies to VK_3 and VK_4 (most commonly used keys for currencies) 

### DIFF
--- a/enc_temp_folder/658a7cb89a1691d4fe7681d552883ca/Languages.cs
+++ b/enc_temp_folder/658a7cb89a1691d4fe7681d552883ca/Languages.cs
@@ -267,9 +267,8 @@ namespace PowerAccent.Core
             LetterKey.VK_H => new[] { "₴" },
             LetterKey.VK_K => new[] { "₭" },
             LetterKey.VK_L => new[] { "ł", "£" },
-            LetterKey.VK_M => new[] { "₼" },
             LetterKey.VK_N => new[] { "л" },
-            LetterKey.VK_O => new[] { "¤" },
+            LetterKey.VK_M => new[] { "₼" },
             LetterKey.VK_P => new[] { "£", "₽" },
             LetterKey.VK_R => new[] { "₹", "៛", "﷼" },
             LetterKey.VK_S => new[] { "$", "₪" },
@@ -280,14 +279,14 @@ namespace PowerAccent.Core
             LetterKey.VK_3 => new[]
             {
                     "฿", "в", "₿", "¢", "₡", "č", "₫", "€", "£", "ƒ",
-                    "₴", "₭", "ł", "₼", "л", "¤", "₽", "₹", "៛", "﷼",
-                    "$","₪", "₮", "₺", "₸", "₩", "¥", "z",
+                    "₴", "₭", "ł", "л", "₼", "₽", "₹", "៛", "﷼", "$",
+                    "₪", "₮", "₺", "₸", "₩", "¥", "z",
             }, // VK_3  is commonly used for the locale currency symbol
             LetterKey.VK_4 => new[]
             {
                     "฿", "в", "₿", "¢", "₡", "č", "₫", "€", "£", "ƒ",
-                    "₴", "₭", "ł", "₼", "л", "¤", "₽", "₹", "៛", "﷼",
-                    "$","₪", "₮", "₺", "₸", "₩", "¥", "z",
+                    "₴", "₭", "ł", "л", "₼", "₽", "₹", "៛", "﷼", "$",
+                    "₪", "₮", "₺", "₸", "₩", "¥", "z",
             }, // VK_4  is commonly used for the locale currency symbol
             _ => Array.Empty<string>(),
         };

--- a/src/modules/poweraccent/PowerAccent.Core/Languages.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/Languages.cs
@@ -257,30 +257,39 @@ namespace PowerAccent.Core
         }
 
         // Currencies (source: https://www.eurochange.co.uk/travel-money/world-currency-abbreviations-symbols-and-codes-travel-money)
-        private static string[] GetDefaultLetterKeyCUR(LetterKey letter)
+        private static string[] GetDefaultLetterKeyCUR(LetterKey letter) => letter switch
         {
-            return letter switch
+            LetterKey.VK_B => new[] { "฿", "в", "₿" },
+            LetterKey.VK_C => new[] { "¢", "₡", "č" },
+            LetterKey.VK_D => new[] { "₫" },
+            LetterKey.VK_E => new[] { "€", "£" },
+            LetterKey.VK_F => new[] { "ƒ" },
+            LetterKey.VK_H => new[] { "₴" },
+            LetterKey.VK_K => new[] { "₭" },
+            LetterKey.VK_L => new[] { "ł", "£" },
+            LetterKey.VK_N => new[] { "л" },
+            LetterKey.VK_M => new[] { "₼" },
+            LetterKey.VK_P => new[] { "£", "₽" },
+            LetterKey.VK_R => new[] { "₹", "៛", "﷼" },
+            LetterKey.VK_S => new[] { "$", "₪" },
+            LetterKey.VK_T => new[] { "₮", "₺", "₸" },
+            LetterKey.VK_W => new[] { "₩" },
+            LetterKey.VK_Y => new[] { "¥" },
+            LetterKey.VK_Z => new[] { "z" },
+            LetterKey.VK_3 => new[]
             {
-                LetterKey.VK_B => new[] { "฿", "в" },
-                LetterKey.VK_C => new[] { "¢", "₡", "č" },
-                LetterKey.VK_D => new[] { "₫" },
-                LetterKey.VK_E => new[] { "€" },
-                LetterKey.VK_F => new[] { "ƒ" },
-                LetterKey.VK_H => new[] { "₴" },
-                LetterKey.VK_K => new[] { "₭" },
-                LetterKey.VK_L => new[] { "ł" },
-                LetterKey.VK_N => new[] { "л" },
-                LetterKey.VK_M => new[] { "₼" },
-                LetterKey.VK_P => new[] { "£", "₽" },
-                LetterKey.VK_R => new[] { "₹", "៛", "﷼" },
-                LetterKey.VK_S => new[] { "$", "₪" },
-                LetterKey.VK_T => new[] { "₮", "₺", "₸" },
-                LetterKey.VK_W => new[] { "₩" },
-                LetterKey.VK_Y => new[] { "¥" },
-                LetterKey.VK_Z => new[] { "z" },
-                _ => Array.Empty<string>(),
-            };
-        }
+                    "฿", "в", "₿", "¢", "₡", "č", "₫", "€", "£", "ƒ",
+                    "₴", "₭", "ł", "л", "₼", "₽", "₹", "៛", "﷼", "$",
+                    "₪", "₮", "₺", "₸", "₩", "¥", "z",
+            }, // VK_3  is commonly used for the locale currency symbol
+            LetterKey.VK_4 => new[]
+            {
+                    "฿", "в", "₿", "¢", "₡", "č", "₫", "€", "£", "ƒ",
+                    "₴", "₭", "ł", "л", "₼", "₽", "₹", "៛", "﷼", "$",
+                    "₪", "₮", "₺", "₸", "₩", "¥", "z",
+            }, // VK_4  is commonly used for the locale currency symbol
+            _ => Array.Empty<string>(),
+        };
 
         // Croatian
         private static string[] GetDefaultLetterKeyHR(LetterKey letter)


### PR DESCRIPTION
## Summary of the Pull Request
Added currencies to VK_3 and VK_4 (the most commonly used keys for currencies) and a couple of other minor currency updates - added £ to VK_L (base character) and VK_E (similar-presenting character), ¤ (generic currency symbol) to VK_O, and ₿ (bitcoin symbol) to VK_B. Few things were mapped to 3 and 4, so the lists aren't long even with the whole set of currency characters added. 

Built and verified updates worked as expected. 

## PR Checklist
- [X] **Closes:** #20339 
- [X] **Communication:** I've discussed this with core contributors in the noted issue.
- [X] **Tests:** NA - Quick Accent doesn't have tests.
- [X] **Localization:** NA - QA uses virtual keys which are locale agnostic. 
- [X] **Dev docs:** NA - minor change
- [NA] **New binaries:** Added on the required places
   - [NA] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [NA] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [NA] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [NA] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [NA] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments

Note: I'd investigated attempting to determine whether a virtual key represented a currency symbol to dynamically show the additional currency symbols only in that event. However, there wasn't a straightforward way to accomplish that and it would require significant changes to the application's structure to implement. 

## Validation Steps Performed
Built and manually verified that the additional characters appeared and were output following the update.
