### PR TITLE
[PTRun][Calc]Improve handling of non-base 10 numbers

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator.UnitTest/ExtendedCalculatorParserTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator.UnitTest/ExtendedCalculatorParserTests.cs
@@ -197,6 +197,8 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
         [DataRow("randi(0.5)", true)]
         [DataRow("rand()", true)]
         [DataRow("rand(0.5)", false)]
+        [DataRow("0X78AD+0o123", true)]
+        [DataRow("0o9", false)]
         public void InputValid_TestValid_WhenCalled(string input, bool valid)
         {
             // Act
@@ -233,7 +235,8 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
                new object[] { "abs(-2)", 2M },
                new object[] { "abs(2)", 2M },
                new object[] { "0+(1*2)/(0+1)", 2M }, // Validate that division by "(0+1)" is not interpret as division by zero.
-               new object[] { "0+(1*2)/0.5", 4M }, // Validate that division by  number with decimal digits is not interpret as division by zero.
+               new object[] { "0+(1*2)/0.5", 4M }, // Validate that division by number with decimal digits is not interpret as division by zero.
+               new object[] { "0+(1*2)/0o004", 0.5M }, // Validate that division by an octal number with zeroes is not treated as division by zero.
            };
 
         [DataTestMethod]

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator.UnitTest/QueryTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator.UnitTest/QueryTests.cs
@@ -41,6 +41,8 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
         [DataRow("=5 / 0", "Expression contains division by zero")]
         [DataRow("10+(8*9)/0+7", "Expression contains division by zero")]
         [DataRow("10+(8*9)/0*7", "Expression contains division by zero")]
+        [DataRow("10+(8*9)/0x00", "Expression contains division by zero")]
+        [DataRow("10+(8*9)/0b0", "Expression contains division by zero")]
         public void ErrorResultOnInvalidKeywordQuery(string typedString, string expectedResult)
         {
             Query expectedQuery = new(typedString, "=");

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/CalculateEngine.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/CalculateEngine.cs
@@ -37,8 +37,8 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
             }
 
             // check for division by zero
-            // We check if the string contains a slash followed by space (optional) and zero. Whereas the zero must not be followed by a dot, comma, or 'x'/'X' as these indicate a number with decimal digits or a hexadecimal value respectively. The zero must also not be followed by other digits.
-            if (new Regex("\\/\\s*0(?![,\\.0-9xX])").Match(input).Success)
+            // We check if the string contains a slash followed by space (optional) and zero. Whereas the zero must not be followed by a dot, comma, 'b', 'o' or 'x' as these indicate a number with decimal digits or a binary/octal/hexadecimal value respectively. The zero must also not be followed by other digits.
+            if (new Regex("\\/\\s*0(?!(?:[,\\.0-9]|[box]0*[1-9a-f]))", RegexOptions.IgnoreCase).Match(input).Success)
             {
                 error = Properties.Resources.wox_plugin_calculator_division_by_zero;
                 return default;

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/CalculateHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/CalculateHelper.cs
@@ -21,7 +21,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
             @"pi|" +
             @"==|~=|&&|\|\||" +
             @"((-?(\d+(\.\d*)?)|-?(\.\d+))[Ee](-?\d+))|" + /* expression from CheckScientificNotation between parenthesis */
-            @"e|[0-9]|0x[0-9a-fA-F]+|0b[01]+|[\+\-\*\/\^\., ""]|[\(\)\|\!\[\]]" +
+            @"e|[0-9]|0[xX][0-9a-fA-F]+|0[bB][01]+|0[oO][0-7]+|[\+\-\*\/\^\., ""]|[\(\)\|\!\[\]]" +
             @")+$",
             RegexOptions.Compiled);
 


### PR DESCRIPTION
## Summary of the Pull Request
* Make the division by zero check aware of binary and octal numbers (see #36390)
* Allow octal numbers in `CalculateHelper.InputValid()`
* Allow uppercase base notation (as in `0X`) in `CalculateHelper.InputValid()`
* Make division by zero in another base trigger the division by zero check (solves https://github.com/microsoft/PowerToys/pull/36390#issuecomment-2568085139)
## PR Checklist

- [x] **Closes:** #36699
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [x] **Dev docs:** No need
- [x] **New binaries:** None
- [x] **Documentation updated:** No need
## Detailed Description of the Pull Request / Additional comments
The Mages dep has been recently upgraded to v3.0.0, introducing support for octal numbers and hence requiring this PR. Therefore it would be great if it got merged in this release cycle, so that there wouldn't be a release with v3.0.0 that doesn't properly support it.
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manually tested in PTRun + added tests