### PR TITLE
[Common] NotificationUtil helper class with FileWatcher

### DIFF
--- a/src/common/SettingsAPI/FileWatcher.h
+++ b/src/common/SettingsAPI/FileWatcher.h
@@ -9,6 +9,9 @@
 #include <string>
 #include <functional>
 
+#include <wil/resource.h>
+#include <wil/filesystem.h>
+
 class FileWatcher
 {
     std::wstring m_path;

--- a/src/common/SettingsAPI/pch.h
+++ b/src/common/SettingsAPI/pch.h
@@ -10,4 +10,3 @@
 #include <fstream>
 
 #include <common/logger/logger.h>
-#include <wil/filesystem.h>

--- a/src/common/notifications/NotificationUtil.cpp
+++ b/src/common/notifications/NotificationUtil.cpp
@@ -18,9 +18,9 @@ namespace notifications
     NotificationUtil::NotificationUtil()
     {
         ReadSettings();
-        auto settingsfileName = PTSettingsHelper::get_powertoys_general_save_file_location();
+        auto settingsFileName = PTSettingsHelper::get_powertoys_general_save_file_location();
 
-        m_settingsFileWatcher = std::make_unique<FileWatcher>(settingsfileName, [this]() {
+        m_settingsFileWatcher = std::make_unique<FileWatcher>(settingsFileName, [this]() {
             ReadSettings();
         });
     }

--- a/src/common/notifications/NotificationUtil.cpp
+++ b/src/common/notifications/NotificationUtil.cpp
@@ -1,0 +1,56 @@
+#include "pch.h"
+#include "NotificationUtil.h"
+
+#include <common/notifications/notifications.h>
+#include <common/notifications/dont_show_again.h>
+#include <common/utils/resources.h>
+#include <common/SettingsAPI/settings_helpers.h>
+
+// Non-Localizable strings
+namespace NonLocalizable
+{
+    const wchar_t RunAsAdminInfoPage[] = L"https://aka.ms/powertoysDetectedElevatedHelp";
+    const wchar_t ToastNotificationButtonUrl[] = L"powertoys://cant_drag_elevated_disable/";
+}
+
+namespace notifications
+{
+    NotificationUtil::NotificationUtil()
+    {
+        ReadSettings();
+        auto settingsfileName = PTSettingsHelper::get_powertoys_general_save_file_location();
+
+        m_settingsFileWatcher = std::make_unique<FileWatcher>(settingsfileName, [this]() {
+            ReadSettings();
+        });
+    }
+
+    NotificationUtil::~NotificationUtil()
+    {
+        m_settingsFileWatcher.reset();
+    }
+
+    void NotificationUtil::WarnIfElevationIsRequired(std::wstring title, std::wstring message, std::wstring button1, std::wstring button2)
+    {
+        if (m_warningsElevatedApps && !m_warningShown && !is_toast_disabled(ElevatedDontShowAgainRegistryPath, ElevatedDisableIntervalInDays))
+        {
+            std::vector<action_t> actions = {
+                link_button{ button1, NonLocalizable::RunAsAdminInfoPage },
+                link_button{ button2, NonLocalizable::ToastNotificationButtonUrl }
+            };
+
+            show_toast_with_activations(message,
+                                        title,
+                                        {},
+                                        std::move(actions));
+
+            m_warningShown = true;
+        }
+    }
+
+    void NotificationUtil::ReadSettings()
+    {
+        auto settings = PTSettingsHelper::load_general_settings();
+        m_warningsElevatedApps = settings.GetNamedBoolean(L"enable_warnings_elevated_apps", true);
+    }
+}

--- a/src/common/notifications/NotificationUtil.h
+++ b/src/common/notifications/NotificationUtil.h
@@ -1,40 +1,22 @@
 #pragma once
 
-#include <common/notifications/notifications.h>
-#include <common/notifications/dont_show_again.h>
-#include <common/utils/resources.h>
-#include <common/SettingsAPI/settings_helpers.h>
-
-#include "Generated Files/resource.h"
+#include <common/SettingsAPI/FileWatcher.h>
 
 namespace notifications
 {
-    // Non-Localizable strings
-    namespace NonLocalizable
+    class NotificationUtil
     {
-        const wchar_t RunAsAdminInfoPage[] = L"https://aka.ms/powertoysDetectedElevatedHelp";
-        const wchar_t ToastNotificationButtonUrl[] = L"powertoys://cant_drag_elevated_disable/";
-    }
+    public:
+        NotificationUtil();
+        ~NotificationUtil();
 
-    inline void WarnIfElevationIsRequired(std::wstring title, std::wstring message, std::wstring button1, std::wstring button2)
-    {
-        using namespace NonLocalizable;
+        void WarnIfElevationIsRequired(std::wstring title, std::wstring message, std::wstring button1, std::wstring button2);
 
-        auto settings = PTSettingsHelper::load_general_settings();
-        auto enableWarningsElevatedApps = settings.GetNamedBoolean(L"enable_warnings_elevated_apps", true);
+    private:
+        std::unique_ptr<FileWatcher> m_settingsFileWatcher;
+        bool m_warningsElevatedApps;
+        bool m_warningShown = false;
 
-        static bool warning_shown = false;
-        if (enableWarningsElevatedApps && !warning_shown && !is_toast_disabled(ElevatedDontShowAgainRegistryPath, ElevatedDisableIntervalInDays))
-        {
-            std::vector<action_t> actions = {
-                link_button{ button1, RunAsAdminInfoPage },
-                link_button{ button2, ToastNotificationButtonUrl }
-            };
-            show_toast_with_activations(message,
-                                        title,
-                                        {},
-                                        std::move(actions));
-            warning_shown = true;
-        }
-    }
+        void ReadSettings();
+    };
 }

--- a/src/common/notifications/notifications.vcxproj
+++ b/src/common/notifications/notifications.vcxproj
@@ -27,13 +27,14 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="notifications.h" />
-    <ClInclude Include="NotificationUtil.h" />
     <ClInclude Include="dont_show_again.h" />
+    <ClInclude Include="NotificationUtil.h" />
     <ClInclude Include="pch.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dont_show_again.cpp" />
     <ClCompile Include="notifications.cpp" />
+    <ClCompile Include="NotificationUtil.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(UsePrecompiledHeaders)' != 'false'">Create</PrecompiledHeader>
     </ClCompile>

--- a/src/modules/Workspaces/WorkspacesSnapshotTool/SnapshotUtils.cpp
+++ b/src/modules/Workspaces/WorkspacesSnapshotTool/SnapshotUtils.cpp
@@ -3,6 +3,7 @@
 
 #include <common/utils/elevation.h>
 #include <common/utils/process_path.h>
+#include <common/utils/resources.h>
 #include <common/notifications/NotificationUtil.h>
 
 #include <workspaces-common/WindowEnumerator.h>
@@ -10,6 +11,8 @@
 
 #include <WorkspacesLib/AppUtils.h>
 #include <WorkspacesLib/PwaHelper.h>
+
+#include "Generated Files/resource.h"
 
 #pragma comment(lib, "ntdll.lib")
 
@@ -73,7 +76,9 @@ namespace SnapshotUtils
                 // Notify the user that running as admin is required to process elevated windows.
                 if (!is_process_elevated() && IsProcessElevated(pid))
                 {
-                    notifications::WarnIfElevationIsRequired(GET_RESOURCE_STRING(IDS_PROJECTS),
+                    auto notificationUtil = std::make_unique<notifications::NotificationUtil>();
+
+                    notificationUtil->WarnIfElevationIsRequired(GET_RESOURCE_STRING(IDS_PROJECTS),
                                                              GET_RESOURCE_STRING(IDS_SYSTEM_FOREGROUND_ELEVATED),
                                                              GET_RESOURCE_STRING(IDS_SYSTEM_FOREGROUND_ELEVATED_LEARN_MORE),
                                                              GET_RESOURCE_STRING(IDS_SYSTEM_FOREGROUND_ELEVATED_DIALOG_DONT_SHOW_AGAIN));

--- a/src/modules/Workspaces/WorkspacesSnapshotTool/SnapshotUtils.cpp
+++ b/src/modules/Workspaces/WorkspacesSnapshotTool/SnapshotUtils.cpp
@@ -79,9 +79,9 @@ namespace SnapshotUtils
                     auto notificationUtil = std::make_unique<notifications::NotificationUtil>();
 
                     notificationUtil->WarnIfElevationIsRequired(GET_RESOURCE_STRING(IDS_PROJECTS),
-                                                             GET_RESOURCE_STRING(IDS_SYSTEM_FOREGROUND_ELEVATED),
-                                                             GET_RESOURCE_STRING(IDS_SYSTEM_FOREGROUND_ELEVATED_LEARN_MORE),
-                                                             GET_RESOURCE_STRING(IDS_SYSTEM_FOREGROUND_ELEVATED_DIALOG_DONT_SHOW_AGAIN));
+                                                                GET_RESOURCE_STRING(IDS_SYSTEM_FOREGROUND_ELEVATED),
+                                                                GET_RESOURCE_STRING(IDS_SYSTEM_FOREGROUND_ELEVATED_LEARN_MORE),
+                                                                GET_RESOURCE_STRING(IDS_SYSTEM_FOREGROUND_ELEVATED_DIALOG_DONT_SHOW_AGAIN));
                 }
 
                 continue;

--- a/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.cpp
+++ b/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.cpp
@@ -510,7 +510,10 @@ void AlwaysOnTop::HandleWinHookEvent(WinHookEvent* data) noexcept
     {
         if (!is_process_elevated() && IsProcessOfWindowElevated(data->hwnd))
         {
-            m_notificationUtil->WarnIfElevationIsRequired(GET_RESOURCE_STRING(IDS_ALWAYSONTOP), GET_RESOURCE_STRING(IDS_SYSTEM_FOREGROUND_ELEVATED), GET_RESOURCE_STRING(IDS_SYSTEM_FOREGROUND_ELEVATED_LEARN_MORE), GET_RESOURCE_STRING(IDS_SYSTEM_FOREGROUND_ELEVATED_DIALOG_DONT_SHOW_AGAIN));
+            m_notificationUtil->WarnIfElevationIsRequired(GET_RESOURCE_STRING(IDS_ALWAYSONTOP),
+                                                          GET_RESOURCE_STRING(IDS_SYSTEM_FOREGROUND_ELEVATED),
+                                                          GET_RESOURCE_STRING(IDS_SYSTEM_FOREGROUND_ELEVATED_LEARN_MORE),
+                                                          GET_RESOURCE_STRING(IDS_SYSTEM_FOREGROUND_ELEVATED_DIALOG_DONT_SHOW_AGAIN));
         }
         RefreshBorders();
     }

--- a/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.cpp
+++ b/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.cpp
@@ -9,7 +9,6 @@
 #include <common/utils/process_path.h>
 
 #include <common/utils/elevation.h>
-#include <common/notifications/NotificationUtil.h>
 #include <Generated Files/resource.h>
 
 #include <interop/shared_constants.h>
@@ -36,7 +35,8 @@ AlwaysOnTop::AlwaysOnTop(bool useLLKH, DWORD mainThreadId) :
     SettingsObserver({SettingId::FrameEnabled, SettingId::Hotkey, SettingId::ExcludeApps}),
     m_hinstance(reinterpret_cast<HINSTANCE>(&__ImageBase)),
     m_useCentralizedLLKH(useLLKH),
-    m_mainThreadId(mainThreadId)
+    m_mainThreadId(mainThreadId),
+    m_notificationUtil(std::make_unique<notifications::NotificationUtil>())
 {
     s_instance = this;
     DPIAware::EnableDPIAwarenessForThisProcess();
@@ -64,6 +64,7 @@ AlwaysOnTop::AlwaysOnTop(bool useLLKH, DWORD mainThreadId) :
 AlwaysOnTop::~AlwaysOnTop()
 {
     m_running = false;
+    m_notificationUtil.reset();
 
     if (m_hPinEvent)
     {
@@ -509,7 +510,7 @@ void AlwaysOnTop::HandleWinHookEvent(WinHookEvent* data) noexcept
     {
         if (!is_process_elevated() && IsProcessOfWindowElevated(data->hwnd))
         {
-            notifications::WarnIfElevationIsRequired(GET_RESOURCE_STRING(IDS_ALWAYSONTOP), GET_RESOURCE_STRING(IDS_SYSTEM_FOREGROUND_ELEVATED), GET_RESOURCE_STRING(IDS_SYSTEM_FOREGROUND_ELEVATED_LEARN_MORE), GET_RESOURCE_STRING(IDS_SYSTEM_FOREGROUND_ELEVATED_DIALOG_DONT_SHOW_AGAIN));
+            m_notificationUtil->WarnIfElevationIsRequired(GET_RESOURCE_STRING(IDS_ALWAYSONTOP), GET_RESOURCE_STRING(IDS_SYSTEM_FOREGROUND_ELEVATED), GET_RESOURCE_STRING(IDS_SYSTEM_FOREGROUND_ELEVATED_LEARN_MORE), GET_RESOURCE_STRING(IDS_SYSTEM_FOREGROUND_ELEVATED_DIALOG_DONT_SHOW_AGAIN));
         }
         RefreshBorders();
     }

--- a/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.h
+++ b/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.h
@@ -9,6 +9,7 @@
 #include <WindowBorder.h>
 
 #include <common/hooks/WinHookEvent.h>
+#include <common/notifications/NotificationUtil.h>
 
 class AlwaysOnTop : public SettingsObserver
 {
@@ -53,6 +54,7 @@ private:
     std::thread m_thread;
     const bool m_useCentralizedLLKH;
     bool m_running = true;
+    std::unique_ptr<notifications::NotificationUtil> m_notificationUtil;
 
     LRESULT WndProc(HWND, UINT, WPARAM, LPARAM) noexcept;
     void HandleWinHookEvent(WinHookEvent* data) noexcept;

--- a/src/modules/fancyzones/FancyZonesLib/WindowMouseSnap.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WindowMouseSnap.cpp
@@ -11,7 +11,7 @@
 #include <FancyZonesLib/trace.h>
 
 #include <common/utils/elevation.h>
-#include <common/notifications/NotificationUtil.h>
+#include <common/utils/resources.h>
 
 WindowMouseSnap::WindowMouseSnap(HWND window, const std::unordered_map<HMONITOR, std::unique_ptr<WorkArea>>& activeWorkAreas) :
     m_window(window),
@@ -27,7 +27,7 @@ WindowMouseSnap::~WindowMouseSnap()
     ResetWindowTransparency();
 }
 
-std::unique_ptr<WindowMouseSnap> WindowMouseSnap::Create(HWND window, const std::unordered_map<HMONITOR, std::unique_ptr<WorkArea>>& activeWorkAreas)
+std::unique_ptr<WindowMouseSnap> WindowMouseSnap::Create(HWND window, const std::unordered_map<HMONITOR, std::unique_ptr<WorkArea>>& activeWorkAreas, notifications::NotificationUtil* notificationUtil)
 {
     if (FancyZonesWindowUtils::IsCursorTypeIndicatingSizeEvent() || !FancyZonesWindowProcessing::IsProcessableManually(window))
     {
@@ -36,8 +36,12 @@ std::unique_ptr<WindowMouseSnap> WindowMouseSnap::Create(HWND window, const std:
 
     if (!is_process_elevated() && IsProcessOfWindowElevated(window))
     {
-        // Notifies user if unable to drag elevated window
-        notifications::WarnIfElevationIsRequired(GET_RESOURCE_STRING(IDS_FANCYZONES), GET_RESOURCE_STRING(IDS_CANT_DRAG_ELEVATED), GET_RESOURCE_STRING(IDS_CANT_DRAG_ELEVATED_LEARN_MORE), GET_RESOURCE_STRING(IDS_CANT_DRAG_ELEVATED_DIALOG_DONT_SHOW_AGAIN));
+        if (notificationUtil != nullptr)
+        {
+            // Notifies user if unable to drag elevated window
+            notificationUtil->WarnIfElevationIsRequired(GET_RESOURCE_STRING(IDS_FANCYZONES), GET_RESOURCE_STRING(IDS_CANT_DRAG_ELEVATED), GET_RESOURCE_STRING(IDS_CANT_DRAG_ELEVATED_LEARN_MORE), GET_RESOURCE_STRING(IDS_CANT_DRAG_ELEVATED_DIALOG_DONT_SHOW_AGAIN));
+        }
+
         return nullptr;
     }
 

--- a/src/modules/fancyzones/FancyZonesLib/WindowMouseSnap.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WindowMouseSnap.cpp
@@ -39,7 +39,10 @@ std::unique_ptr<WindowMouseSnap> WindowMouseSnap::Create(HWND window, const std:
         if (notificationUtil != nullptr)
         {
             // Notifies user if unable to drag elevated window
-            notificationUtil->WarnIfElevationIsRequired(GET_RESOURCE_STRING(IDS_FANCYZONES), GET_RESOURCE_STRING(IDS_CANT_DRAG_ELEVATED), GET_RESOURCE_STRING(IDS_CANT_DRAG_ELEVATED_LEARN_MORE), GET_RESOURCE_STRING(IDS_CANT_DRAG_ELEVATED_DIALOG_DONT_SHOW_AGAIN));
+            notificationUtil->WarnIfElevationIsRequired(GET_RESOURCE_STRING(IDS_FANCYZONES),
+                                                        GET_RESOURCE_STRING(IDS_CANT_DRAG_ELEVATED),
+                                                        GET_RESOURCE_STRING(IDS_CANT_DRAG_ELEVATED_LEARN_MORE),
+                                                        GET_RESOURCE_STRING(IDS_CANT_DRAG_ELEVATED_DIALOG_DONT_SHOW_AGAIN));
         }
 
         return nullptr;

--- a/src/modules/fancyzones/FancyZonesLib/WindowMouseSnap.h
+++ b/src/modules/fancyzones/FancyZonesLib/WindowMouseSnap.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <FancyZonesLib/HighlightedZones.h>
+#include <common/notifications/NotificationUtil.h>
 
 class WorkArea;
 
@@ -9,7 +10,7 @@ class WindowMouseSnap
     WindowMouseSnap(HWND window, const std::unordered_map<HMONITOR, std::unique_ptr<WorkArea>>& activeWorkAreas);
 
 public:
-    static std::unique_ptr<WindowMouseSnap> Create(HWND window, const std::unordered_map<HMONITOR, std::unique_ptr<WorkArea>>& activeWorkAreas);
+    static std::unique_ptr<WindowMouseSnap> Create(HWND window, const std::unordered_map<HMONITOR, std::unique_ptr<WorkArea>>& activeWorkAreas, notifications::NotificationUtil* notificationUtil);
     ~WindowMouseSnap();
 
     bool MoveSizeStart(HMONITOR monitor, bool isSnapping);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Replace the current `WarnIfElevationIsRequired` inline function  with a proper helper class that uses `FileWatcher`.
The new helper allows to cache the option and uses the `FileWatcher` to listen for changes in the general settings JSON.
It will prevent AOT and FZ to constantly read the general settings JSON.

Note that `WarnIfElevationIsRequired` is also used by the Workspaces snapshot tool but only once.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #36586
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Tested manually:

- General > Show a warning for functionality issues when running alongside elevated applications > Off
  - Verified that AOT, FZ and Workspaces snapshot tool don't show the notification
- General > Show a warning for functionality issues when running alongside elevated applications > On
  - Verified that AOT, FZ and Workspaces snapshot tool show the notification
  - Verified that AOT and FZ don't show the notification a second time
- Verified that AOT and FZ read the general settings JSON when the option is changed
- Verified using Process Monitor that AOT and FZ don't constantly read the general settings JSON