### PR TITLE
[QuickAccent]Fix unstable language loading

### DIFF
--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerAccentPage.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerAccentPage.xaml.cs
@@ -63,8 +63,15 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             this.QuickAccent_Language_Select.DeselectAll();
         }
 
+        private bool loadingLanguageListDontTriggerSelectionChanged;
+
         private void QuickAccent_SelectedLanguage_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
+            if (loadingLanguageListDontTriggerSelectionChanged)
+            {
+                return;
+            }
+
             var listView = sender as ListView;
 
             ViewModel.SelectedLanguageOptions = listView.SelectedItems
@@ -76,10 +83,13 @@ namespace Microsoft.PowerToys.Settings.UI.Views
 
         private void QuickAccent_Language_Select_Loaded(object sender, RoutedEventArgs e)
         {
+            loadingLanguageListDontTriggerSelectionChanged = true;
             foreach (var languageOption in ViewModel.SelectedLanguageOptions)
             {
                 this.QuickAccent_Language_Select.SelectedItems.Add(languageOption);
             }
+
+            loadingLanguageListDontTriggerSelectionChanged = false;
         }
     }
 }

--- a/src/settings-ui/Settings.UI/ViewModels/PowerAccentViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/PowerAccentViewModel.cs
@@ -115,6 +115,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             {
                 SelectedLanguageOptions = _powerAccentSettings.Properties.SelectedLang.Value.Split(',')
                    .Select(l => Languages.Find(lang => lang.LanguageCode == l))
+                   .Where(l => l != null) // Wrongly typed languages will appear as null after find. We want to remove those to avoid crashes.
                    .ToArray();
             }
             else if (_powerAccentSettings.Properties.SelectedLang.Value.Contains("ALL"))


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

When opening the list of language selection of Quick Accent on Settings, the first load selects all the languages one by one, triggering a save everytime, meaning the saved state might get into a state where some of the languages are missing.
This PR guards against triggering the "selctionChanged" event if all we're doing is the first load.

It also adds a check against loading a non existing language and adding a null entry to the loaded array after LINQ.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** https://github.com/microsoft/PowerToys/issues/36370#issuecomment-2552315616
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Selected many languages and opened QuickAccent's settings.json to verify the language list is well saved. After that, unload the QuickAccent page, load it again and open the selected languages expander. Verify the saved file is still good. Do it many times.
