### PR TITLE
[PTRun][Calc]Add list separator handling for different cultures

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator.UnitTest/NumberTranslatorTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator.UnitTest/NumberTranslatorTests.cs
@@ -74,6 +74,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
         [DataRow("5,2+6", "5.2+6")]
         [DataRow("round(2,5)", "round(2.5)")]
         [DataRow("3,3333", "3.3333")]
+        [DataRow("max(2;3)", "max(2,3)")]
         public void Translate_NoErrors_WhenCalled(string input, string expectedResult)
         {
             // Arrange

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/NumberTranslator.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/NumberTranslator.cs
@@ -123,7 +123,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
                     outputBuilder.Append(
                         decimal.TryParse(token, NumberStyles.Number, cultureFrom, out number)
                         ? (new string('0', leadingZeroCount) + number.ToString(cultureTo))
-                        : token);
+                        : token.Replace(cultureFrom.TextInfo.ListSeparator, cultureTo.TextInfo.ListSeparator));
                 }
             }
 


### PR DESCRIPTION
## Summary of the Pull Request
Replaces the current culture's list separator with the target culture's list separator in order to allow using functions with multiple arguments in locales where the list separator isn't `,`. For example `pow(2;3)` would be replaced with `pow(2,3)`.
## PR Checklist

- [x] **Closes:** #36732
- [x] **Communication:** I've discussed this with core contributors already.
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [x] **Dev docs:** No need
- [x] **New binaries:** None
- [x] **Documentation updated:** https://github.com/MicrosoftDocs/windows-dev-docs/pull/5259#issue-2773466870
## Detailed Description of the Pull Request / Additional comments
## Validation Steps Performed
Added unit tests, tested manually