### PR TITLE
[Workspaces] fixing bug: editor starts outside of visible desktop area

### DIFF
--- a/src/modules/Workspaces/WorkspacesEditor/MainWindow.xaml.cs
+++ b/src/modules/Workspaces/WorkspacesEditor/MainWindow.xaml.cs
@@ -91,7 +91,7 @@ namespace WorkspacesEditor
 
         private bool IsEditorInsideVisibleArea()
         {
-            System.Windows.Forms.Screen[] allScreens = System.Windows.Forms.Screen.AllScreens;
+            System.Windows.Forms.Screen[] allScreens = MonitorHelper.GetDpiUnawareScreens();
             Rectangle commonBounds = allScreens[0].Bounds;
             for (int screenIndex = 1; screenIndex < allScreens.Length; screenIndex++)
             {

--- a/src/modules/Workspaces/WorkspacesEditor/MainWindow.xaml.cs
+++ b/src/modules/Workspaces/WorkspacesEditor/MainWindow.xaml.cs
@@ -3,10 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Drawing;
+using System.Linq;
 using System.Threading;
 using System.Windows;
 using System.Windows.Interop;
-
 using ManagedCommon;
 using Microsoft.PowerToys.Telemetry;
 using WorkspacesEditor.Utils;
@@ -30,9 +31,9 @@ namespace WorkspacesEditor
             MainViewModel = mainViewModel;
             mainViewModel.SetMainWindow(this);
 
-            if (Properties.Settings.Default.Height == -1)
+            if (Properties.Settings.Default.Height == -1 || !IsEditorInsideVisibleArea())
             {
-                // This is the very first time the window is created. Place it on the screen center
+                // This is the very first time the window is created or it would be placed outside the visible area (monitor rearrangement). Place it on the screen center
                 WindowInteropHelper windowInteropHelper = new WindowInteropHelper(this);
                 System.Windows.Forms.Screen screen = System.Windows.Forms.Screen.FromHandle(windowInteropHelper.Handle);
                 double dpi = MonitorHelper.GetScreenDpiFromScreen(screen);
@@ -86,6 +87,20 @@ namespace WorkspacesEditor
                 },
                 Application.Current.Dispatcher,
                 cancellationToken.Token);
+        }
+
+        private bool IsEditorInsideVisibleArea()
+        {
+            System.Windows.Forms.Screen[] allScreens = System.Windows.Forms.Screen.AllScreens;
+            Rectangle commonBounds = allScreens[0].Bounds;
+            for (int screenIndex = 1; screenIndex < allScreens.Length; screenIndex++)
+            {
+                Rectangle rectangle = allScreens[screenIndex].Bounds;
+                commonBounds = Rectangle.Union(rectangle, commonBounds);
+            }
+
+            Rectangle editorBounds = new Rectangle((int)Properties.Settings.Default.Left, (int)Properties.Settings.Default.Top, (int)Properties.Settings.Default.Width, (int)Properties.Settings.Default.Height);
+            return editorBounds.IntersectsWith(commonBounds);
         }
 
         private void SavePosition()


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

On startup check if the editor is within the visible desktop area. If not, reset its position to default values

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #36749
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
tested locally
