### PR TITLE
[PTRun][Docs] Update new plugin checklist

### DIFF
--- a/doc/devdocs/modules/launcher/new-plugin-checklist.md
+++ b/doc/devdocs/modules/launcher/new-plugin-checklist.md
@@ -3,8 +3,9 @@
 - [ ] The plugin is a project under `modules\launcher\Plugins`
 - [ ] Microsoft plugin project name pattern: `Microsoft.PowerToys.Run.Plugin.{PluginName}`
 - [ ] Community plugin project name pattern: `Community.PowerToys.Run.Plugin.{PluginName}`
-- [ ] The plugin target framework should be `net8.0-windows`
+- [ ] The plugin target framework should be `net9.0-windows10.0.22621.0`
 - [ ] If the plugin uses any 3rd party dependencies the project file should import `DynamicPlugin.props`
+- [ ] 3rd party dependencies must be compatible with .NET 9
 - [ ] The plugin has to contain a `plugin.json` file of the following format in its root folder:
 
 ```json
@@ -35,7 +36,6 @@ public static string PluginID => "xxxxxxx"; // The part xxxxxxx stands for the p
 - [ ] Plugin's output code and assets have to be included in the installer [`Product.wxs`](/installer/PowerToysSetup/Product.wxs)
 - [ ] Test the plugin with a local build. Build the installer, install, check that the plugin works as expected
 - [ ] All plugin's binaries have to be included in the signed build [`pipeline.user.windows.yml`](/.pipelines/pipeline.user.windows.yml)
-- [ ] The plugin target framework has to be net8.0-windows. All dependencies should be compatible with .NET 8.
 
 Some localization steps can only be done after the first pass by the localization team to provide the localized resources.
 In the PR that adds a new plugin, reference a new issue to track the work for fully enabling localization for the new plugin.


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

- Change target framework
- Remove duplicate statement
- Move statement closer to something similar

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [x] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

- The target framework for plugins should be `net9.0-windows10.0.22621.0`.
  - Should we link here? https://github.com/microsoft/PowerToys/blob/5ef918750d384b76d4db3b82fde8942396c6f3d5/src/Common.Dotnet.CsWinRT.props#L6

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

