### PR TITLE
[Monaco]Fix Json format preview setting

### DIFF
--- a/src/common/FilePreviewCommon/Formatters/FilePreviewJsonSerializerContext.cs
+++ b/src/common/FilePreviewCommon/Formatters/FilePreviewJsonSerializerContext.cs
@@ -7,7 +7,6 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.PowerToys.FilePreviewCommon.Monaco.Formatters;
 
-[JsonSourceGenerationOptions(WriteIndented = true)]
 [JsonSerializable(typeof(JsonDocument))]
 internal sealed partial class FilePreviewJsonSerializerContext : JsonSerializerContext
 {

--- a/src/common/FilePreviewCommon/Formatters/JsonFormatter.cs
+++ b/src/common/FilePreviewCommon/Formatters/JsonFormatter.cs
@@ -14,8 +14,11 @@ namespace Microsoft.PowerToys.FilePreviewCommon.Monaco.Formatters
 
         private static readonly JsonSerializerOptions _serializerOptions = new JsonSerializerOptions
         {
+            WriteIndented = true,
             Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
         };
+
+        private static readonly FilePreviewJsonSerializerContext _filePreviewJsonSerializerContext = new(_serializerOptions);
 
         /// <inheritdoc/>
         public string Format(string value)
@@ -27,8 +30,7 @@ namespace Microsoft.PowerToys.FilePreviewCommon.Monaco.Formatters
 
             using (var jDocument = JsonDocument.Parse(value, new JsonDocumentOptions { CommentHandling = JsonCommentHandling.Skip }))
             {
-                FilePreviewJsonSerializerContext context = new(_serializerOptions);
-                return JsonSerializer.Serialize(jDocument, context.JsonDocument);
+                return JsonSerializer.Serialize(jDocument, _filePreviewJsonSerializerContext.JsonDocument);
             }
         }
     }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

After https://github.com/microsoft/PowerToys/commit/20a5f67222f74c687a08aa4d3bf1ba8c978faf86 , the option to "Try to format the source for preview" started failing for json files in both the dev file preview handler and when previewing json files in Peek.

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
This fixes two issues:
1 - `[JsonSourceGenerationOptions(WriteIndented = true)]` was not applied, so used `WriteIndented = true,` in the `JsonSerializerOptions` like it was before the AOT changes to make it work.
2 - After the first fix, the Json formatting was being applied only once, creating an error in the logs:
```
[Error] MonacoHelper::InitializeIndexFileAndSelectedFile
    Failed to apply formatting
System.InvalidOperationException: JsonSerializerOptions instances cannot be modified once encapsulated by a JsonSerializerContext. Such encapsulation can happen either when calling 'JsonSerializerOptions.AddContext' or when passing the options instance to a JsonSerializerContext constructor.
Stack trace: 
   at System.Text.Json.ThrowHelper.ThrowInvalidOperationException_SerializerOptionsReadOnly(JsonSerializerContext context)
   at System.Text.Json.Serialization.JsonSerializerContext..ctor(JsonSerializerOptions options)
   at Microsoft.PowerToys.FilePreviewCommon.Monaco.Formatters.FilePreviewJsonSerializerContext..ctor(JsonSerializerOptions options) in D:\janeasystems\PowerToys\src\common\FilePreviewCommon\obj\x64\Debug\net9.0-windows10.0.22621.0\System.Text.Json.SourceGeneration\System.Text.Json.SourceGeneration.JsonSourceGenerator\FilePreviewJsonSerializerContext.g.cs:line 40
   at Microsoft.PowerToys.FilePreviewCommon.Monaco.Formatters.JsonFormatter.Format(String value) in D:\janeasystems\PowerToys\src\common\FilePreviewCommon\Formatters\JsonFormatter.cs:line 31
   at Peek.FilePreviewer.Previewers.MonacoHelper.InitializeIndexFileAndSelectedFile(String fileContent, String extension, String tempFolder, Boolean tryFormat, Boolean wrapText, Boolean stickyScroll, Int32 fontSize, Boolean minimap) in D:\janeasystems\PowerToys\src\modules\peek\Peek.FilePreviewer\Previewers\WebBrowserPreviewer\Helpers\MonacoHelper.cs:line 68
```
So, I've created a singleton `FilePreviewJsonSerializerContext` as well, since it seems the static `JsonSerializerOptions` can only be used once to create the `FilePreviewJsonSerializerContext`.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
For both the Source file preview and Peek when previewing a json file, disabled and enabled the "Try to format the source for preview" in Settings and verified the Setting applied correctly.

