### PR TITLE
[PTRun]Add hotkey to the show telemetry event

### DIFF
--- a/src/modules/launcher/PowerLauncher.Telemetry/Events/LauncherShowEvent.cs
+++ b/src/modules/launcher/PowerLauncher.Telemetry/Events/LauncherShowEvent.cs
@@ -12,6 +12,13 @@ namespace Microsoft.PowerLauncher.Telemetry
     [EventData]
     public class LauncherShowEvent : EventBase, IEvent
     {
+        public LauncherShowEvent(string hotkey)
+        {
+            Hotkey = hotkey;
+        }
+
+        public string Hotkey { get; private set; }
+
         public PartA_PrivTags PartA_PrivTags => PartA_PrivTags.ProductAndServiceUsage;
     }
 }

--- a/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/MainViewModel.cs
@@ -466,7 +466,7 @@ namespace PowerLauncher.ViewModel
                         // Don't trigger telemetry on cold boot. Must have been loaded at least once.
                         if (value == Visibility.Visible)
                         {
-                            PowerToysTelemetry.Log.WriteEvent(new LauncherShowEvent());
+                            PowerToysTelemetry.Log.WriteEvent(new LauncherShowEvent(_settings.Hotkey));
                         }
                         else
                         {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Adds the hotkey for PowerToys Run to the LauncherShowEvent so we can get frequency data for which hotkeys are used to activate PowerToys Run.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Verified the Hotkey was added to the telemetry events with the "View Diagnostic Data" option turned on.