### PR TITLE
[Peek]Fix using the correct Monaco assets at runtime

### DIFF
--- a/src/common/FilePreviewCommon/MonacoHelper.cs
+++ b/src/common/FilePreviewCommon/MonacoHelper.cs
@@ -38,7 +38,11 @@ namespace Microsoft.PowerToys.FilePreviewCommon
         {
             string baseDirectory = AppContext.BaseDirectory ?? string.Empty;
 
+            // AppContext.BaseDirectory returns a stray \\ so we want to remove that.
+            baseDirectory = Path.TrimEndingDirectorySeparator(baseDirectory);
+
             // If the executable is within "WinUI3Apps", correct the path first.
+            // The idea of GetFileName here is getting the last directory in the path.
             if (Path.GetFileName(baseDirectory) == "WinUI3Apps")
             {
                 baseDirectory = Path.Combine(baseDirectory, "..");


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

After https://github.com/microsoft/PowerToys/commit/20a5f67222f74c687a08aa4d3bf1ba8c978faf86, when trying to run Peek Monaco preview on a release installer, there's a crash on WebView 2.
This seems to be caused by the MonacoHelper not recognizing it's on the WinUI3Apps directory.
`Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)` was replaced by `AppContext.BaseDirectory` on https://github.com/microsoft/PowerToys/commit/20a5f67222f74c687a08aa4d3bf1ba8c978faf86 , but the latter includes a stray directory separator at the end that must be removed for the remaining logic to make sense.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Built a release installer and tested Monaco on both Peek and the file preview handler.
