### PR TITLE
[runner] Fix crashes caused by wrong setting AllowDataDiagnostics registry value

### DIFF
--- a/src/common/ManagedTelemetry/Telemetry/DataDiagnosticsSettings.cs
+++ b/src/common/ManagedTelemetry/Telemetry/DataDiagnosticsSettings.cs
@@ -20,14 +20,14 @@ namespace Microsoft.PowerToys.Telemetry
             try
             {
                 registryValue = Registry.GetValue(DataDiagnosticsRegistryKey, DataDiagnosticsRegistryValueName, 0);
+
+                if (registryValue is not null)
+                {
+                    return (int)registryValue == 1 ? true : false;
+                }
             }
             catch
             {
-            }
-
-            if (registryValue is not null)
-            {
-                return (int)registryValue == 1 ? true : false;
             }
 
             return false;

--- a/src/common/SettingsAPI/settings_helpers.cpp
+++ b/src/common/SettingsAPI/settings_helpers.cpp
@@ -174,9 +174,8 @@ namespace PTSettingsHelper
             return;
         }
 
-        const bool value = enabled;
-        const size_t buf_size = sizeof(bool);
-        if (RegSetValueExW(key, DataDiagnosticsRegValueName, 0, REG_QWORD, reinterpret_cast<const BYTE*>(&value), buf_size) != ERROR_SUCCESS)
+        const DWORD value = enabled ? 1 : 0;
+        if (RegSetValueExW(key, DataDiagnosticsRegValueName, 0, REG_DWORD, reinterpret_cast<const BYTE*>(&value), sizeof(value)) != ERROR_SUCCESS)
         {
             RegCloseKey(key);
             return;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Registry value was not being set properly ending with invalid registry value. When other apps try to read the value, crash was occurring.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #36028
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Close PT
- Disable data diagnostic in gpo
- Start PT
- Make sure all modules work
