### PR TITLE
[PTRun][Calculator]Error check when loading trigonometry mode

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/Main.cs
@@ -13,6 +13,7 @@ using ManagedCommon;
 using Microsoft.PowerToys.Run.Plugin.Calculator.Properties;
 using Microsoft.PowerToys.Settings.UI.Library;
 using Wox.Plugin;
+using Wox.Plugin.Logger;
 
 namespace Microsoft.PowerToys.Run.Plugin.Calculator
 {
@@ -212,8 +213,18 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
                 var optionReplaceInput = settings.AdditionalOptions.FirstOrDefault(x => x.Key == ReplaceInput);
                 replaceInput = optionReplaceInput?.Value ?? replaceInput;
 
-                var optionTrigMode = settings.AdditionalOptions.FirstOrDefault(x => x.Key == TrigMode);
-                trigMode = (CalculateEngine.TrigMode)int.Parse(optionTrigMode.ComboBoxValue.ToString(CultureInfo.InvariantCulture), CultureInfo.InvariantCulture);
+                try
+                {
+                    var optionTrigMode = settings.AdditionalOptions.FirstOrDefault(x => x.Key == TrigMode);
+                    if (optionTrigMode != null)
+                    {
+                        trigMode = (CalculateEngine.TrigMode)int.Parse(optionTrigMode.ComboBoxValue.ToString(CultureInfo.InvariantCulture), CultureInfo.InvariantCulture);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Log.Exception("Error while trying to load Trigonometry Mode setting: {ex.Message}", ex, GetType());
+                }
             }
 
             _inputUseEnglishFormat = inputUseEnglishFormat;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

While testing the release candidate, one of the team hit an exception on the calculator UpdateSettings function.
Added better error checking to the function.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Switched trigonometry mode and verified the setting still applied correctly, by test `=sin(pi/2)` on Radians and `=sin(90)` on Degrees.
