### PR TITLE
[ZoomIt]Fix transparent draw after changing another setting

### DIFF
--- a/src/modules/ZoomIt/ZoomIt/Zoomit.cpp
+++ b/src/modules/ZoomIt/ZoomIt/Zoomit.cpp
@@ -6023,6 +6023,12 @@ LRESULT APIENTRY MainWndProc(
         // Apply tray icon setting
         EnableDisableTrayIcon(hWnd, g_ShowTrayIcon);
 
+        // This is also called by ZoomIt when it starts and loads the Settings. Opacity is added after loading from registry, so we use the same pattern.
+        if ((g_PenColor >> 24) == 0)
+        {
+            g_PenColor |= 0xFF << 24;
+        }
+
         // Apply hotkey settings
         UnregisterAllHotkeys(hWnd);
         g_ToggleMod = GetKeyMod(g_ToggleKey);

--- a/src/modules/ZoomIt/ZoomItSettingsInterop/ZoomItSettings.cpp
+++ b/src/modules/ZoomIt/ZoomItSettingsInterop/ZoomItSettings.cpp
@@ -105,9 +105,12 @@ namespace winrt::PowerToys::ZoomItSettingsInterop::implementation
                     }
                     else if (special_semantics->second == SPECIAL_SEMANTICS_COLOR)
                     {
-                        // PowerToys settings likes colors as #FFFFFF strings.
+                        /* PowerToys settings likes colors as #FFFFFF strings.
+                        But currently these Settings are internal state for ZoomIt, not something that we really need to send Settings.
+                        Code is kept here as a reference if a future color Setting ends up being configured.
                         hstring s = winrt::to_hstring(std::format("#{:02x}{:02x}{:02x}", value & 0xFF, (value >> 8) & 0xFF, (value >> 16) & 0xFF));
                         _settings.add_property(curSetting->ValueName, s);
+                        */
                     }
                 }
                 break;
@@ -211,6 +214,9 @@ namespace winrt::PowerToys::ZoomItSettingsInterop::implementation
                     }
                     else if (special_semantics->second == SPECIAL_SEMANTICS_COLOR)
                     {
+                        /* PowerToys settings likes colors as #FFFFFF strings.
+                        But currently these Settings are internal state for ZoomIt, not something that we really need to save from Settings.
+                        Code is kept here as a reference if a future color Setting ends up being configured.
                         auto possibleValue = valuesFromSettings.get_string_value(curSetting->ValueName);
                         if (possibleValue.has_value())
                         {
@@ -219,8 +225,8 @@ namespace winrt::PowerToys::ZoomItSettingsInterop::implementation
                             {
                                 *static_cast<PDWORD>(curSetting->Setting) = RGB(r, g, b);
                             }
-
                         }
+                        */
                     }
                 }
                 break;

--- a/src/settings-ui/Settings.UI.Library/ZoomItProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/ZoomItProperties.cs
@@ -44,12 +44,6 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 
         public KeyboardKeysProperty SnipToggleKey { get; set; }
 
-        public StringProperty PenColor { get; set; }
-
-        public IntProperty PenWidth { get; set; }
-
-        public StringProperty BreakPenColor { get; set; }
-
         public KeyboardKeysProperty BreakTimerKey { get; set; }
 
         public StringProperty Font { get; set; }
@@ -80,23 +74,13 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 
         public BoolProperty BreakShowDesktop { get; set; }
 
-        public BoolProperty BreakOnSecondary { get; set; }
-
-        public IntProperty FontScale { get; set; }
-
         public BoolProperty ShowExpiredTime { get; set; }
 
         public BoolProperty ShowTrayIcon { get; set; }
 
         public BoolProperty AnimnateZoom { get; set; }
 
-        public BoolProperty TelescopeZoomOut { get; set; }
-
-        public BoolProperty SnapToGrid { get; set; }
-
         public IntProperty ZoominSliderLevel { get; set; }
-
-        public IntProperty RecordFrameRate { get; set; }
 
         public IntProperty RecordScaling { get; set; }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

While testing the release candidate with ZoomIt, we found an error that caused the draw mode to not work after changing a Setting.
It turns out we were missing the code that sets opacity after loading the settings from PowerToys.
This PR adds that code.

This PR also identifies some other settings that are used internally by ZoomIt as state only and removes them from the settings the Settings application knows, so that we don't keep status for those while manipulating other settings and end up overwriting the changes the running ZoomIt has done to that internal state.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
1 - Start ZoomIt.
2 - Verify Draw works.
3 - Change any Setting.
4 - Verify Draw still works. (Before this fix it would try to draw with transparent ink)
5 - Change pen color (Press G or B in draw mode for Green or Blue, for example)
6 - Try to change any Setting.
7 - Enter draw mode and verify your color change is still remembered.
