### PR TITLE
[PowerRename]Add `$`, `^` and quantifiers to RegEx cheatsheet

### DIFF
--- a/src/modules/powerrename/PowerRenameUILib/PowerRenameXAML/MainWindow.xaml.cpp
+++ b/src/modules/powerrename/PowerRenameUILib/PowerRenameXAML/MainWindow.xaml.cpp
@@ -173,12 +173,12 @@ namespace winrt::PowerRenameUI::implementation
         m_searchRegExShortcuts.Append(winrt::make<PatternSnippet>(L"^", manager.MainResourceMap().GetValue(L"Resources/RegExCheatSheet_StartOfString").ValueAsString()));
         m_searchRegExShortcuts.Append(winrt::make<PatternSnippet>(L"$", manager.MainResourceMap().GetValue(L"Resources/RegExCheatSheet_EndOfString").ValueAsString()));
         m_searchRegExShortcuts.Append(winrt::make<PatternSnippet>(L".", manager.MainResourceMap().GetValue(L"Resources/RegExCheatSheet_MatchAny").ValueAsString()));
-        m_searchRegExShortcuts.Append(winrt::make<PatternSnippet>(L".*", manager.MainResourceMap().GetValue(L"Resources/RegExCheatSheet_MatchAnyOrNone").ValueAsString()));
+        m_searchRegExShortcuts.Append(winrt::make<PatternSnippet>(L"*", manager.MainResourceMap().GetValue(L"Resources/RegExCheatSheet_ZeroOrMore").ValueAsString()));
+        m_searchRegExShortcuts.Append(winrt::make<PatternSnippet>(L"+", manager.MainResourceMap().GetValue(L"Resources/RegExCheatSheet_OneOrMore").ValueAsString()));
         m_searchRegExShortcuts.Append(winrt::make<PatternSnippet>(L"\\d", manager.MainResourceMap().GetValue(L"Resources/RegExCheatSheet_MatchDigit").ValueAsString()));
         m_searchRegExShortcuts.Append(winrt::make<PatternSnippet>(L"\\D", manager.MainResourceMap().GetValue(L"Resources/RegExCheatSheet_MatchNonDigit").ValueAsString()));
         m_searchRegExShortcuts.Append(winrt::make<PatternSnippet>(L"\\w", manager.MainResourceMap().GetValue(L"Resources/RegExCheatSheet_MatchWordChar").ValueAsString()));
         m_searchRegExShortcuts.Append(winrt::make<PatternSnippet>(L"\\S", manager.MainResourceMap().GetValue(L"Resources/RegExCheatSheet_MatchNonWS").ValueAsString()));
-        m_searchRegExShortcuts.Append(winrt::make<PatternSnippet>(L"\\S+", manager.MainResourceMap().GetValue(L"Resources/RegExCheatSheet_MatchOneOrMoreWS").ValueAsString()));
         m_searchRegExShortcuts.Append(winrt::make<PatternSnippet>(L"\\b", manager.MainResourceMap().GetValue(L"Resources/RegExCheatSheet_MatchWordBoundary").ValueAsString()));
 
         m_dateTimeShortcuts = winrt::single_threaded_observable_vector<PowerRenameUI::PatternSnippet>();

--- a/src/modules/powerrename/PowerRenameUILib/PowerRenameXAML/MainWindow.xaml.cpp
+++ b/src/modules/powerrename/PowerRenameUILib/PowerRenameXAML/MainWindow.xaml.cpp
@@ -173,11 +173,13 @@ namespace winrt::PowerRenameUI::implementation
         m_searchRegExShortcuts.Append(winrt::make<PatternSnippet>(L"^", manager.MainResourceMap().GetValue(L"Resources/RegExCheatSheet_StartOfString").ValueAsString()));
         m_searchRegExShortcuts.Append(winrt::make<PatternSnippet>(L"$", manager.MainResourceMap().GetValue(L"Resources/RegExCheatSheet_EndOfString").ValueAsString()));
         m_searchRegExShortcuts.Append(winrt::make<PatternSnippet>(L".", manager.MainResourceMap().GetValue(L"Resources/RegExCheatSheet_MatchAny").ValueAsString()));
-        m_searchRegExShortcuts.Append(winrt::make<PatternSnippet>(L"*", manager.MainResourceMap().GetValue(L"Resources/RegExCheatSheet_ZeroOrMore").ValueAsString()));
         m_searchRegExShortcuts.Append(winrt::make<PatternSnippet>(L"+", manager.MainResourceMap().GetValue(L"Resources/RegExCheatSheet_OneOrMore").ValueAsString()));
+        m_searchRegExShortcuts.Append(winrt::make<PatternSnippet>(L"?", manager.MainResourceMap().GetValue(L"Resources/RegExCheatSheet_ZeroOrOne").ValueAsString()));
+        m_searchRegExShortcuts.Append(winrt::make<PatternSnippet>(L"*", manager.MainResourceMap().GetValue(L"Resources/RegExCheatSheet_ZeroOrMore").ValueAsString()));
         m_searchRegExShortcuts.Append(winrt::make<PatternSnippet>(L"\\d", manager.MainResourceMap().GetValue(L"Resources/RegExCheatSheet_MatchDigit").ValueAsString()));
         m_searchRegExShortcuts.Append(winrt::make<PatternSnippet>(L"\\D", manager.MainResourceMap().GetValue(L"Resources/RegExCheatSheet_MatchNonDigit").ValueAsString()));
         m_searchRegExShortcuts.Append(winrt::make<PatternSnippet>(L"\\w", manager.MainResourceMap().GetValue(L"Resources/RegExCheatSheet_MatchWordChar").ValueAsString()));
+        m_searchRegExShortcuts.Append(winrt::make<PatternSnippet>(L"\\s", manager.MainResourceMap().GetValue(L"Resources/RegExCheatSheet_MatchWS").ValueAsString()));
         m_searchRegExShortcuts.Append(winrt::make<PatternSnippet>(L"\\S", manager.MainResourceMap().GetValue(L"Resources/RegExCheatSheet_MatchNonWS").ValueAsString()));
         m_searchRegExShortcuts.Append(winrt::make<PatternSnippet>(L"\\b", manager.MainResourceMap().GetValue(L"Resources/RegExCheatSheet_MatchWordBoundary").ValueAsString()));
 

--- a/src/modules/powerrename/PowerRenameUILib/PowerRenameXAML/MainWindow.xaml.cpp
+++ b/src/modules/powerrename/PowerRenameUILib/PowerRenameXAML/MainWindow.xaml.cpp
@@ -170,7 +170,10 @@ namespace winrt::PowerRenameUI::implementation
         auto factory = winrt::get_activation_factory<ResourceManager, IResourceManagerFactory>();
         ResourceManager manager = factory.CreateInstance(L"PowerToys.PowerRename.pri");
 
+        m_searchRegExShortcuts.Append(winrt::make<PatternSnippet>(L"^", manager.MainResourceMap().GetValue(L"Resources/RegExCheatSheet_StartOfString").ValueAsString()));
+        m_searchRegExShortcuts.Append(winrt::make<PatternSnippet>(L"$", manager.MainResourceMap().GetValue(L"Resources/RegExCheatSheet_EndOfString").ValueAsString()));
         m_searchRegExShortcuts.Append(winrt::make<PatternSnippet>(L".", manager.MainResourceMap().GetValue(L"Resources/RegExCheatSheet_MatchAny").ValueAsString()));
+        m_searchRegExShortcuts.Append(winrt::make<PatternSnippet>(L".*", manager.MainResourceMap().GetValue(L"Resources/RegExCheatSheet_MatchAnyOrNone").ValueAsString()));
         m_searchRegExShortcuts.Append(winrt::make<PatternSnippet>(L"\\d", manager.MainResourceMap().GetValue(L"Resources/RegExCheatSheet_MatchDigit").ValueAsString()));
         m_searchRegExShortcuts.Append(winrt::make<PatternSnippet>(L"\\D", manager.MainResourceMap().GetValue(L"Resources/RegExCheatSheet_MatchNonDigit").ValueAsString()));
         m_searchRegExShortcuts.Append(winrt::make<PatternSnippet>(L"\\w", manager.MainResourceMap().GetValue(L"Resources/RegExCheatSheet_MatchWordChar").ValueAsString()));

--- a/src/modules/powerrename/PowerRenameUILib/Strings/en-us/Resources.resw
+++ b/src/modules/powerrename/PowerRenameUILib/Strings/en-us/Resources.resw
@@ -133,10 +133,10 @@
     <value>Matches any character</value>
   </data>
   <data name="RegExCheatSheet_ZeroOrMore" xml:space="preserve">
-    <value>Matches zero or more of the preceeding token</value>
+    <value>Matches zero or more of the preceding token</value>
   </data>
   <data name="RegExCheatSheet_OneOrMore" xml:space="preserve">
-    <value>Matches one or more of the preceeding token</value>
+    <value>Matches one or more of the preceding token</value>
   </data>
   <data name="RegExCheatSheet_MatchDigit" xml:space="preserve">
     <value>Any digit, short for [0-9]</value>

--- a/src/modules/powerrename/PowerRenameUILib/Strings/en-us/Resources.resw
+++ b/src/modules/powerrename/PowerRenameUILib/Strings/en-us/Resources.resw
@@ -133,7 +133,7 @@
     <value>Matches any character</value>
   </data>
   <data name="RegExCheatSheet_ZeroOrOne" xml:space="preserve">
-    <value>Macthes zero or one of the preceding token</value>
+    <value>Matches zero or one of the preceding token</value>
   </data>
   <data name="RegExCheatSheet_ZeroOrMore" xml:space="preserve">
     <value>Matches zero or more of the preceding token</value>

--- a/src/modules/powerrename/PowerRenameUILib/Strings/en-us/Resources.resw
+++ b/src/modules/powerrename/PowerRenameUILib/Strings/en-us/Resources.resw
@@ -123,8 +123,17 @@
   <data name="RegExCheatSheet_Title.Text" xml:space="preserve">
     <value>RegEx help</value>
   </data>
+  <data name="RegExCheatSheet_StartOfString" xml:space="preserve">
+    <value>Start of the string</value>
+  </data>
+  <data name="RegExCheatSheet_EndOfString" xml:space="preserve">
+    <value>End of the string</value>
+  </data>
   <data name="RegExCheatSheet_MatchAny" xml:space="preserve">
     <value>Matches any character</value>
+  </data>
+  <data name="RegExCheatSheet_MatchAnyOrNone" xml:space="preserve">
+    <value>Matches zero or more of any character</value>
   </data>
   <data name="RegExCheatSheet_MatchDigit" xml:space="preserve">
     <value>Any digit, short for [0-9]</value>
@@ -133,7 +142,7 @@
     <value>A non-digit, short for [^0-9]</value>
   </data>
   <data name="RegExCheatSheet_MatchNonWS" xml:space="preserve">
-    <value>A non-whitespace character, short for [^\\s]</value>
+    <value>A non-whitespace character, short for [^\s]</value>
   </data>
   <data name="RegExCheatSheet_MatchWordChar" xml:space="preserve">
     <value>A word character, short for [a-zA-Z_0-9]</value>

--- a/src/modules/powerrename/PowerRenameUILib/Strings/en-us/Resources.resw
+++ b/src/modules/powerrename/PowerRenameUILib/Strings/en-us/Resources.resw
@@ -132,8 +132,11 @@
   <data name="RegExCheatSheet_MatchAny" xml:space="preserve">
     <value>Matches any character</value>
   </data>
-  <data name="RegExCheatSheet_MatchAnyOrNone" xml:space="preserve">
-    <value>Matches zero or more of any character</value>
+  <data name="RegExCheatSheet_ZeroOrMore" xml:space="preserve">
+    <value>Matches zero or more of the preceeding token</value>
+  </data>
+  <data name="RegExCheatSheet_OneOrMore" xml:space="preserve">
+    <value>Matches one or more of the preceeding token</value>
   </data>
   <data name="RegExCheatSheet_MatchDigit" xml:space="preserve">
     <value>Any digit, short for [0-9]</value>
@@ -146,9 +149,6 @@
   </data>
   <data name="RegExCheatSheet_MatchWordChar" xml:space="preserve">
     <value>A word character, short for [a-zA-Z_0-9]</value>
-  </data>
-  <data name="RegExCheatSheet_MatchOneOrMoreWS" xml:space="preserve">
-    <value>One or more non-whitespace characters</value>
   </data>
   <data name="RegExCheatSheet_MatchWordBoundary" xml:space="preserve">
     <value>Matches a word boundary where a word character is [a-zA-Z0-9_].</value>

--- a/src/modules/powerrename/PowerRenameUILib/Strings/en-us/Resources.resw
+++ b/src/modules/powerrename/PowerRenameUILib/Strings/en-us/Resources.resw
@@ -132,6 +132,9 @@
   <data name="RegExCheatSheet_MatchAny" xml:space="preserve">
     <value>Matches any character</value>
   </data>
+  <data name="RegExCheatSheet_ZeroOrOne" xml:space="preserve">
+    <value>Macthes zero or one of the preceding token</value>
+  </data>
   <data name="RegExCheatSheet_ZeroOrMore" xml:space="preserve">
     <value>Matches zero or more of the preceding token</value>
   </data>
@@ -143,6 +146,9 @@
   </data>
   <data name="RegExCheatSheet_MatchNonDigit" xml:space="preserve">
     <value>A non-digit, short for [^0-9]</value>
+  </data>
+  <data name="RegExCheatSheet_MatchWS" xml:space="preserve">
+    <value>Any whitespace character</value>
   </data>
   <data name="RegExCheatSheet_MatchNonWS" xml:space="preserve">
     <value>A non-whitespace character, short for [^\s]</value>


### PR DESCRIPTION
## Summary of the Pull Request
Adds these hints to the Regex cheatsheet:
* `^`: Start of the string
* `$`: End of the string
* `+`: Matches one or more of the preceding token
* `?`: Matches zero or one of the preceding token
* `*`: Matches zero or more of the preceding token

Also updates the `\S` description to remove an unnecessary backslash (resw doesn't need escapes)
## PR Checklist
- [x] **Closes:** #35847
- [x] **Communication:** I've discussed this with core contributors already.
- [x] **Tests:** All pass
- [x] **Localization:** All end user facing strings can be localized
- [x] **Dev docs:** No need
- [x] **New binaries:** None
- [x] **Documentation updated:** No need
## Detailed Description of the Pull Request / Additional comments
(The typo is fixed)
![image](https://github.com/user-attachments/assets/bb068cfa-0458-4f92-bf9c-a9485ee2db02)
## Validation Steps Performed
Manually tested