### PR TITLE
[ci]Remove vc tools version workaround

### DIFF
--- a/.pipelines/v2/templates/job-build-project.yml
+++ b/.pipelines/v2/templates/job-build-project.yml
@@ -205,13 +205,6 @@ jobs:
     - template: .\steps-restore-nuget.yml
 
   - pwsh: |-
-      & "$(build.sourcesdirectory)\.pipelines\verifyAndSetLatestVCToolsVersion.ps1"
-    displayName: Work around DD-1541167 (VCToolsVersion)
-    ${{ if eq(parameters.useVSPreview, true) }}:
-      env:
-        VCWhereExtraVersionTarget: '-prerelease'
-
-  - pwsh: |-
       & "$(build.sourcesdirectory)\.pipelines\installWiX.ps1"
     displayName: Download and install WiX 3.14 development build
 

--- a/.pipelines/verifyAndSetLatestVCToolsVersion.ps1
+++ b/.pipelines/verifyAndSetLatestVCToolsVersion.ps1
@@ -1,5 +1,0 @@
-$LatestVCToolsVersion = (([xml](& 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe' -latest $env:VCWhereExtraVersionTarget -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -include packages -format xml)).instances.instance.packages.package | ? { $_.id -eq "Microsoft.VisualCpp.CRT.Source" }).version;
-
-Write-Output "Latest VCToolsVersion: $LatestVCToolsVersion"
-Write-Output "Updating VCToolsVersion environment variable for job"
-Write-Output "##vso[task.setvariable variable=VCToolsVersion]$LatestVCToolsVersion"


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Dart CI builds started failing after a new version of build agents.
Turns out the workaround we had to get the correct version for the VC tools is no longer needed on Dart.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Dart build passes.
