### PR TITLE
[Image Resizer] Added AutomationProperties.HelpText to dimensions combo-box

### DIFF
--- a/src/modules/imageresizer/ui/App.xaml
+++ b/src/modules/imageresizer/ui/App.xaml
@@ -14,6 +14,7 @@
             </ResourceDictionary.MergedDictionaries>
 
             <v:SizeTypeToVisibilityConverter x:Key="SizeTypeToVisibilityConverter" />
+            <v:SizeTypeToHelpTextConverter x:Key="SizeTypeToHelpTextConverter" />
             <v:EnumValueConverter x:Key="EnumValueConverter" />
             <v:AutoDoubleConverter x:Key="AutoDoubleConverter" />
             <v:BoolValueConverter x:Key="BoolValueConverter" />

--- a/src/modules/imageresizer/ui/Properties/Settings.cs
+++ b/src/modules/imageresizer/ui/Properties/Settings.cs
@@ -254,6 +254,7 @@ namespace ImageResizer.Properties
             {
                 _selectedSizeIndex = value;
                 NotifyPropertyChanged();
+                NotifyPropertyChanged(nameof(SelectedSize));
             }
         }
 

--- a/src/modules/imageresizer/ui/Views/InputPage.xaml
+++ b/src/modules/imageresizer/ui/Views/InputPage.xaml
@@ -22,12 +22,19 @@
             HorizontalAlignment="Stretch"
             VerticalAlignment="Stretch"
             VerticalContentAlignment="Stretch"
+            AutomationProperties.HelpText="{Binding Settings.SelectedSize, Converter={StaticResource SizeTypeToHelpTextConverter}}"
             AutomationProperties.Name="{x:Static p:Resources.Image_Sizes}"
             ItemsSource="{Binding Settings.AllSizes}"
             SelectedIndex="{Binding Settings.SelectedSizeIndex}">
+            <ComboBox.ItemContainerStyle>
+                <Style BasedOn="{StaticResource {x:Type ComboBoxItem}}" TargetType="ComboBoxItem">
+                    <Setter Property="AutomationProperties.Name" Value="{Binding Name}" />
+                    <Setter Property="AutomationProperties.HelpText" Value="{Binding ., Converter={StaticResource SizeTypeToHelpTextConverter}}" />
+                </Style>
+            </ComboBox.ItemContainerStyle>
             <ComboBox.Resources>
                 <DataTemplate DataType="{x:Type m:ResizeSize}">
-                    <Grid VerticalAlignment="Center" AutomationProperties.Name="{Binding Name}">
+                    <Grid VerticalAlignment="Center">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
@@ -55,7 +62,7 @@
                 </DataTemplate>
 
                 <DataTemplate DataType="{x:Type m:CustomSize}">
-                    <Grid VerticalAlignment="Center" AutomationProperties.Name="{Binding Name}">
+                    <Grid VerticalAlignment="Center">
                         <TextBlock FontWeight="SemiBold" Text="{Binding Name}" />
                     </Grid>
                 </DataTemplate>

--- a/src/modules/imageresizer/ui/Views/SizeTypeToHelpTextConverter.cs
+++ b/src/modules/imageresizer/ui/Views/SizeTypeToHelpTextConverter.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+using ImageResizer.Models;
+
+namespace ImageResizer.Views;
+
+[ValueConversion(typeof(ResizeSize), typeof(string))]
+public sealed partial class SizeTypeToHelpTextConverter : IValueConverter
+{
+    private const char MultiplicationSign = '\u00D7';
+
+    private readonly EnumValueConverter _enumConverter = new();
+    private readonly AutoDoubleConverter _autoDoubleConverter = new();
+
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is not ResizeSize size)
+        {
+            return DependencyProperty.UnsetValue;
+        }
+
+        string EnumToString(Enum value, string parameter = null) =>
+            _enumConverter.Convert(value, typeof(string), parameter, culture) as string;
+
+        string DoubleToString(double value) =>
+            _autoDoubleConverter.Convert(value, typeof(string), null, culture) as string;
+
+        var fit = EnumToString(size.Fit, "ThirdPersonSingular");
+        var width = DoubleToString(size.Width);
+        var unit = EnumToString(size.Unit);
+
+        return size.ShowHeight ?
+            $"{fit} {width} {MultiplicationSign} {DoubleToString(size.Height)} {unit}" :
+            $"{fit} {width} {unit}";
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => throw new NotImplementedException();
+}


### PR DESCRIPTION
## Summary of the Pull Request
To assist screen readers, adds an accessibility-related property to the combo-box that allows for the image dimensions to be chosen.

## PR Checklist
- [x] **Closes:** #32260
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments
Note that Narrator now always reads the selected dimensions when the combo-box has focus. But when choosing an option, the dimensions are only read when the "read item advanced" (Narrator + 0) shortcut is hit.

## Validation Steps Performed
- Tested fix
- Sanity check of Image resizer
