### PR TITLE
[ci]Proper workaround for the vc tools version check

### DIFF
--- a/.pipelines/v2/templates/job-build-project.yml
+++ b/.pipelines/v2/templates/job-build-project.yml
@@ -205,6 +205,13 @@ jobs:
     - template: .\steps-restore-nuget.yml
 
   - pwsh: |-
+      & "$(build.sourcesdirectory)\.pipelines\verifyAndSetLatestVCToolsVersion.ps1"
+    displayName: Work around DD-1541167 (VCToolsVersion)
+    ${{ if eq(parameters.useVSPreview, true) }}:
+      env:
+        VCWhereExtraVersionTarget: '-prerelease'
+
+  - pwsh: |-
       & "$(build.sourcesdirectory)\.pipelines\installWiX.ps1"
     displayName: Download and install WiX 3.14 development build
 

--- a/.pipelines/verifyAndSetLatestVCToolsVersion.ps1
+++ b/.pipelines/verifyAndSetLatestVCToolsVersion.ps1
@@ -1,0 +1,5 @@
+$LatestVCToolsVersion = (([xml](& 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe' -latest $env:VCWhereExtraVersionTarget -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -include packages -format xml)).instances.instance.packages.package | ? { $_.id -eq "Microsoft.VisualCpp.CRT.Source" }).version;
+
+Write-Output "Latest VCToolsVersion: $LatestVCToolsVersion"
+Write-Output "Updating VCToolsVersion environment variable for job"
+Write-Output "##vso[task.setvariable variable=VCToolsVersion]$LatestVCToolsVersion"

--- a/.pipelines/verifyAndSetLatestVCToolsVersion.ps1
+++ b/.pipelines/verifyAndSetLatestVCToolsVersion.ps1
@@ -1,5 +1,7 @@
-$LatestVCToolsVersion = (([xml](& 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe' -latest $env:VCWhereExtraVersionTarget -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -include packages -format xml)).instances.instance.packages.package | ? { $_.id -eq "Microsoft.VisualCpp.CRT.Source" }).version;
-
+$VSInstances = ([xml](& 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe' -latest -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -include packages -format xml))
+$VSPackages = $VSInstances.instances.instance.packages.package
+$LatestVCPackage = ($VSInstances.instances.instance.packages.package | ? { $_.id -eq "Microsoft.VisualCpp.Tools.Core" })
+$LatestVCToolsVersion = $LatestVCPackage.version;
 Write-Output "Latest VCToolsVersion: $LatestVCToolsVersion"
 Write-Output "Updating VCToolsVersion environment variable for job"
 Write-Output "##vso[task.setvariable variable=VCToolsVersion]$LatestVCToolsVersion"


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Re-adds the workaround to get the current VC tools version, that was removed on: https://github.com/microsoft/PowerToys/commit/2c069ce708fcec23f3012c6434003908bead332c

Adopts the same changes to the workaround as happened on the Terminal project: https://github.com/microsoft/terminal/pull/18468

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Dart CI passes.
