### PR TITLE
[Zoomit]Fix warning C4706 and related error C2220

### DIFF
--- a/src/modules/ZoomIt/ZoomIt/Zoomit.cpp
+++ b/src/modules/ZoomIt/ZoomIt/Zoomit.cpp
@@ -1820,7 +1820,7 @@ INT_PTR CALLBACK OptionsTabProc( HWND hDlg, UINT message,
         break;
 
     case WM_PAINT:
-        if( (hTextPreview = GetDlgItem( hDlg, IDC_TEXT_FONT ))) {
+        if( (hTextPreview = GetDlgItem( hDlg, IDC_TEXT_FONT )) != 0 ) {
 
             // 16-pt preview
             LOGFONT _lf = g_LogFont;


### PR DESCRIPTION
There is an assignment inside an if condition. This generates a warning C4706 on my Visual Studio 2022 17.12.4 . The warning is then considered as an error C2220. Added an explicit comparison != 0.