### PR TITLE
[QuickAccent]Added ` (backtick) and ~ (tilde) to VK_OEM_5 (#20333)

### DIFF
--- a/src/modules/poweraccent/PowerAccent.Core/Languages.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/Languages.cs
@@ -225,6 +225,7 @@ namespace PowerAccent.Core
                 LetterKey.VK_DIVIDE_ => new[] { "÷", "√" },
                 LetterKey.VK_MULTIPLY_ => new[] { "×", "⋅" },
                 LetterKey.VK_PLUS => new[] { "≤", "≥", "≠", "≈", "≙", "⊕", "⊗", "∓", "≅", "≡" },
+                LetterKey.VK_BACKSLASH => new[] { "`", "~" },
                 _ => Array.Empty<string>(),
             };
         }

--- a/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.h
+++ b/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.h
@@ -109,7 +109,8 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
                                                                LetterKey::VK_MINUS,
                                                                LetterKey::VK_SLASH_,
                                                                LetterKey::VK_DIVIDE_,
-                                                               LetterKey::VK_MULTIPLY_, };
+                                                               LetterKey::VK_MULTIPLY_,
+                                                               LetterKey::VK_BACKSLASH, };
         LetterKey letterPressed{};
 
         static inline const std::vector<TriggerKey> triggers = { TriggerKey::Right, TriggerKey::Left, TriggerKey::Space };

--- a/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.idl
+++ b/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.idl
@@ -47,7 +47,8 @@ namespace PowerToys
             VK_MINUS = 0xBD,
             VK_MULTIPLY_ = 0x6A,
             VK_SLASH_ = 0xBF,
-            VK_DIVIDE_ = 0x6F
+            VK_DIVIDE_ = 0x6F,
+            VK_BACKSLASH = 0xDC
         };
 
         enum TriggerKey


### PR DESCRIPTION
Added  ` (backtick) and ~ (tilde) to VK_OEM_5 key (#20333). Note that as with many VK_OEM_* keys, the location of the key changes based on the keyboard. On ITA keyboards it is on the left of the 1 key. I've added the tilde character (already present in the VK_MINUS key) because as a programmer I think having both (relatively rarely used) characters together is easier to remember than having them hidden under two different keys. I think a better solution would be to have a Custom set of mappings that persons can configure through a json file. I don't like the idea of mixing QuickAccent together with Keyboard Manager because they are "different". 