### PR TITLE
[ContextMenus]Update win11 msix menus if wrong version

### DIFF
--- a/src/common/utils/package.h
+++ b/src/common/utils/package.h
@@ -10,6 +10,7 @@
 #include <winrt/Windows.Management.Deployment.h>
 
 #include "../logger/logger.h"
+#include "../version/version.h"
 
 namespace package {
     inline BOOL IsWin11OrGreater()
@@ -47,10 +48,14 @@ namespace package {
         for (auto const& package : packageManager.FindPackagesForUser({}))
         {
             const auto& packageFullName = std::wstring{ package.Id().FullName() };
+            const auto& packageVersion = package.Id().Version();
 
             if (packageFullName.contains(packageDisplayName))
             {
-                return true;
+                if (packageVersion.Major == VERSION_MAJOR && packageVersion.Minor == VERSION_MINOR && packageVersion.Revision == VERSION_REVISION)
+                {
+                    return true;
+                }
             }
         }
 
@@ -72,6 +77,7 @@ namespace package {
             // Declare use of an external location
             AddPackageOptions options;
             options.ExternalLocationUri(externalUri);
+            options.ForceUpdateFromAnyVersion(true);
 
             IAsyncOperationWithProgress<DeploymentResult, DeploymentProgress> deploymentOperation = packageManager.AddPackageByUriAsync(packageUri, options);
             deploymentOperation.get();
@@ -82,6 +88,7 @@ namespace package {
                 auto deploymentResult{ deploymentOperation.GetResults() };
                 auto errorCode = deploymentOperation.ErrorCode();
                 auto errorText = deploymentResult.ErrorText();
+
 
                 Logger::error(L"Register {} package failed. ErrorCode: {}, ErrorText: {}", sparsePkgPath, std::to_wstring(errorCode), errorText);
                 return false;

--- a/src/common/utils/package.h
+++ b/src/common/utils/package.h
@@ -89,7 +89,6 @@ namespace package {
                 auto errorCode = deploymentOperation.ErrorCode();
                 auto errorText = deploymentResult.ErrorText();
 
-
                 Logger::error(L"Register {} package failed. ErrorCode: {}, ErrorText: {}", sparsePkgPath, std::to_wstring(errorCode), errorText);
                 return false;
             }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

When installing as user and then updating, the Win11 context menus msix entries aren't properly updated, meaning the context menu entries won't appear.
This PR checks if the package is at the right version or it will still run the msix install logic.
It also allows updating to older versions in the case of downgrades, just in case.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #37178 and #35210
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Install 0.87.1 user installation.
- Verify the context menu entries are working.
- Run `Get-AppxPackage -Name *powertoys*` in Powershell, to make sure the context menu entries are installed.
- Install user installation from Dart with the updated code.
- Verify the context menu entries are still working.
- Run `Get-AppxPackage -Name *powertoys*` in Powershell, to make sure the context menu entries are installed and at the updated version.
