### PR TITLE
[ImageResizer] Fix issues with blank Width and Height controls

### DIFF
--- a/src/modules/imageresizer/ui/App.xaml
+++ b/src/modules/imageresizer/ui/App.xaml
@@ -20,6 +20,8 @@
             <v:VisibilityBoolConverter x:Key="VisibilityBoolConverter" />
             <v:EnumToIntConverter x:Key="EnumToIntConverter" />
             <v:AccessTextToTextConverter x:Key="AccessTextToTextConverter" />
+            <v:NumberBoxValueConverter x:Key="NumberBoxValueConverter" />
+            <v:ZeroToEmptyStringNumberFormatter x:Key="ZeroToEmptyStringNumberFormatter" />
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/src/modules/imageresizer/ui/Views/AutoDoubleConverter.cs
+++ b/src/modules/imageresizer/ui/Views/AutoDoubleConverter.cs
@@ -10,29 +10,55 @@ using System.Windows.Data;
 
 using ImageResizer.Properties;
 
-namespace ImageResizer.Views
+namespace ImageResizer.Views;
+
+/// <summary>
+/// Converts between double and string for text-based controls bound to Width or Height fields.
+/// Optionally returns localized "Auto" text when the underlying value is 0, letting the UI show,
+/// for example "(auto) x 1024 pixels".
+/// </summary>
+[ValueConversion(typeof(double), typeof(string))]
+internal class AutoDoubleConverter : IValueConverter
 {
-    [ValueConversion(typeof(double), typeof(string))]
-    internal class AutoDoubleConverter : IValueConverter
-    {
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    /// <summary>
+    /// Converts a double to a string, optionally showing "Auto" for 0 values. NaN values are
+    /// converted to empty strings.
+    /// </summary>
+    /// <param name="value">The value to convert from <see cref="double"/> to
+    /// <see cref="string"/>.</param>
+    /// <param name="targetType">The conversion target type. <see cref="string"/> here.</param>
+    /// <param name="parameter">Set to "Auto" to return the localized "Auto" string if the
+    /// value is 0.</param>
+    /// <param name="culture">The <see cref="CultureInfo"/> to use for the number formatting.
+    /// </param>
+    /// <returns>The string representation of the passed-in value.</returns>
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture) =>
+        value switch
         {
-            var d = (double)value;
+            double d => d switch
+            {
+                double.NaN => "0",
+                0 => (string)parameter == "Auto" ? Resources.Input_Auto : "0",
+                _ => d.ToString(culture),
+            },
 
-            return d != 0
-                ? d.ToString(culture)
-                : (string)parameter == "Auto"
-                    ? Resources.Input_Auto
-                    : string.Empty;
-        }
+            _ => "0",
+        };
 
-        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    /// <summary>
+    /// Converts the string representation back to a double, returning 0 if the string is empty,
+    /// null or not a valid number in the specified culture.
+    /// </summary>
+    /// <param name="value">The string value to convert.</param>
+    /// <param name="targetType">The conversion target type. <see cref="double"/> here.</param>
+    /// <param name="parameter">Converter parameter. Unused.</param>
+    /// <param name="culture">The <see cref="CultureInfo"/> to use for the text parsing.</param>
+    /// <returns>The corresponding double value.</returns>
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) =>
+        value switch
         {
-            var text = (string)value;
-
-            return !string.IsNullOrEmpty(text)
-                ? double.Parse(text, culture)
-                : 0;
-        }
-    }
+            null or "" => 0,
+            string text when double.TryParse(text, NumberStyles.Any, culture, out double result) => result,
+            _ => 0,
+        };
 }

--- a/src/modules/imageresizer/ui/Views/InputPage.xaml
+++ b/src/modules/imageresizer/ui/Views/InputPage.xaml
@@ -4,8 +4,8 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:m="clr-namespace:ImageResizer.Models"
     xmlns:p="clr-namespace:ImageResizer.Properties"
-    xmlns:v="clr-namespace:ImageResizer.Views"
-    xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml">
+    xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+    xmlns:v="clr-namespace:ImageResizer.Views">
 
     <Grid>
         <Grid.RowDefinitions>
@@ -113,11 +113,11 @@
                     </ui:NumberBox.NumberFormatter>
                     <ui:NumberBox.Value>
                         <Binding
+                            Converter="{StaticResource NumberBoxValueConverter}"
                             ElementName="SizeComboBox"
                             Mode="TwoWay"
                             Path="SelectedValue.Width"
-                            UpdateSourceTrigger="PropertyChanged"
-                            Converter="{StaticResource NumberBoxValueConverter}" />
+                            UpdateSourceTrigger="PropertyChanged" />
                     </ui:NumberBox.Value>
                 </ui:NumberBox>
 
@@ -146,11 +146,11 @@
                     </ui:NumberBox.NumberFormatter>
                     <ui:NumberBox.Value>
                         <Binding
+                            Converter="{StaticResource NumberBoxValueConverter}"
                             ElementName="SizeComboBox"
                             Mode="TwoWay"
                             Path="SelectedValue.Height"
-                            UpdateSourceTrigger="PropertyChanged"
-                            Converter="{StaticResource NumberBoxValueConverter}" />
+                            UpdateSourceTrigger="PropertyChanged" />
                     </ui:NumberBox.Value>
                 </ui:NumberBox>
 

--- a/src/modules/imageresizer/ui/Views/InputPage.xaml
+++ b/src/modules/imageresizer/ui/Views/InputPage.xaml
@@ -4,6 +4,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:m="clr-namespace:ImageResizer.Models"
     xmlns:p="clr-namespace:ImageResizer.Properties"
+    xmlns:v="clr-namespace:ImageResizer.Views"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml">
 
     <Grid>
@@ -107,12 +108,16 @@
                     KeyDown="Button_KeyDown"
                     Minimum="0"
                     SpinButtonPlacementMode="Inline">
+                    <ui:NumberBox.NumberFormatter>
+                        <v:ZeroToEmptyStringNumberFormatter />
+                    </ui:NumberBox.NumberFormatter>
                     <ui:NumberBox.Value>
                         <Binding
                             ElementName="SizeComboBox"
                             Mode="TwoWay"
                             Path="SelectedValue.Width"
-                            UpdateSourceTrigger="PropertyChanged" />
+                            UpdateSourceTrigger="PropertyChanged"
+                            Converter="{StaticResource NumberBoxValueConverter}" />
                     </ui:NumberBox.Value>
                 </ui:NumberBox>
 
@@ -136,12 +141,16 @@
                     Minimum="0"
                     SpinButtonPlacementMode="Inline"
                     Visibility="{Binding ElementName=SizeComboBox, Path=SelectedValue.ShowHeight, Converter={StaticResource BoolValueConverter}}">
+                    <ui:NumberBox.NumberFormatter>
+                        <v:ZeroToEmptyStringNumberFormatter />
+                    </ui:NumberBox.NumberFormatter>
                     <ui:NumberBox.Value>
                         <Binding
                             ElementName="SizeComboBox"
                             Mode="TwoWay"
                             Path="SelectedValue.Height"
-                            UpdateSourceTrigger="PropertyChanged" />
+                            UpdateSourceTrigger="PropertyChanged"
+                            Converter="{StaticResource NumberBoxValueConverter}" />
                     </ui:NumberBox.Value>
                 </ui:NumberBox>
 

--- a/src/modules/imageresizer/ui/Views/NumberBoxValueConverter.cs
+++ b/src/modules/imageresizer/ui/Views/NumberBoxValueConverter.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace ImageResizer.Views;
+
+public class NumberBoxValueConverter : IValueConverter
+{
+    /// <summary>
+    /// Converts the underlying double value to a display-friendly format. Ensures that NaN values
+    /// are not propagated to the UI.
+    /// </summary>
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture) =>
+        value is double d && double.IsNaN(d) ? 0 : value;
+
+    /// <summary>
+    /// Converts the user input back to the underlying double value. If the input is not a valid
+    /// number, 0 is returned.
+    /// </summary>
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) =>
+        value switch
+        {
+            null => 0,
+            double d when double.IsNaN(d) => 0,
+            string str when !double.TryParse(str, out _) => 0,
+            _ => value,
+        };
+}

--- a/src/modules/imageresizer/ui/Views/ZeroToEmptyStringNumberFormatter.cs
+++ b/src/modules/imageresizer/ui/Views/ZeroToEmptyStringNumberFormatter.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Globalization;
+using Wpf.Ui.Controls;
+
+namespace ImageResizer.Views;
+
+public class ZeroToEmptyStringNumberFormatter : INumberFormatter, INumberParser
+{
+    public string FormatDouble(double? value) => value switch
+    {
+        null => string.Empty,
+        0 => string.Empty,
+        _ => value.Value.ToString(CultureInfo.CurrentCulture),
+    };
+
+    public double? ParseDouble(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return 0;
+        }
+
+        return double.TryParse(value, NumberStyles.Any, CultureInfo.CurrentCulture, out double result) ? result : 0;
+    }
+
+    public string FormatInt(int? value) => throw new NotImplementedException();
+
+    public string FormatUInt(uint? value) => throw new NotImplementedException();
+
+    public int? ParseInt(string value) => throw new NotImplementedException();
+
+    public uint? ParseUInt(string value) => throw new NotImplementedException();
+}

--- a/src/settings-ui/Settings.UI/Converters/ImageResizerDoubleToAutoConverter.cs
+++ b/src/settings-ui/Settings.UI/Converters/ImageResizerDoubleToAutoConverter.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Globalization;
+using Microsoft.UI.Xaml.Data;
+
+namespace Microsoft.PowerToys.Settings.UI.Converters;
+
+/// <summary>
+/// Converts between double and string for text-based controls bound to Width or Height fields.
+/// Optionally returns localized "Auto" text when the underlying value is 0, letting the UI show,
+/// for example "(auto) x 1024 pixels".
+/// </summary>
+public sealed partial class ImageResizerDoubleToAutoConverter : IValueConverter
+{
+    private static readonly string AutoText =
+        Helpers.ResourceLoaderInstance.ResourceLoader.GetString("ImageResizer_AutoText");
+
+    /// <summary>
+    /// Converts a double to a string, optionally showing "Auto" for 0 values. NaN values are
+    /// converted to empty strings.
+    /// </summary>
+    /// <param name="value">The value to convert from <see cref="double"/> to
+    /// <see cref="string"/>.</param>
+    /// <param name="targetType">The conversion target type. <see cref="string"/> here.</param>
+    /// <param name="parameter">Set to "Auto" to return the localized "Auto" string if the
+    /// value is 0.</param>
+    /// <param name="language">Ignored.</param>
+    /// <returns>The string representation of the passed-in value.</returns>
+    public object Convert(object value, Type targetType, object parameter, string language) =>
+        value switch
+        {
+            double d => d switch
+            {
+                double.NaN => "0",
+                0 => (string)parameter == "Auto" ? AutoText : "0",
+                _ => d.ToString(CultureInfo.CurrentCulture),
+            },
+
+            _ => "0",
+        };
+
+    /// <summary>
+    /// Converts the string representation back to a double, returning 0 if the string is empty,
+    /// null or not a valid number in the specified culture.
+    /// </summary>
+    /// <param name="value">The string value to convert.</param>
+    /// <param name="targetType">The conversion target type. <see cref="double"/> here.</param>
+    /// <param name="parameter">Converter parameter. Unused.</param>
+    /// <param name="language">Ignored.</param>
+    /// <returns>The corresponding double value.</returns>
+    public object ConvertBack(object value, Type targetType, object parameter, string language) =>
+        value switch
+        {
+            null or "" => 0.0,
+            string text when double.TryParse(text, NumberStyles.Any, CultureInfo.CurrentCulture, out double result) => result,
+            _ => 0.0,
+        };
+}

--- a/src/settings-ui/Settings.UI/Converters/ImageResizerNumberBoxValueConverter.cs
+++ b/src/settings-ui/Settings.UI/Converters/ImageResizerNumberBoxValueConverter.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.UI.Xaml.Data;
+
+namespace Microsoft.PowerToys.Settings.UI.Converters;
+
+public partial class ImageResizerNumberBoxValueConverter : IValueConverter
+{
+    /// <summary>
+    /// Converts the underlying double value to a display-friendly format. Ensures that NaN values
+    /// are not propagated to the UI.
+    /// </summary>
+    public object Convert(object value, Type targetType, object parameter, string language) =>
+        value is double d && double.IsNaN(d) ? 0.0 : value;
+
+    /// <summary>
+    /// Converts the user input back to the underlying double value. If the input is not a valid
+    /// number, a double with value 0 is returned.
+    /// </summary>
+    public object ConvertBack(object value, Type targetType, object parameter, string language) =>
+        value switch
+        {
+            null => 0.0,
+            double d when double.IsNaN(d) => 0.0,
+            string str when !double.TryParse(str, out _) => 0.0,
+            _ => value,
+        };
+}

--- a/src/settings-ui/Settings.UI/Converters/ImageResizerZeroToEmptyStringNumberFormatter.cs
+++ b/src/settings-ui/Settings.UI/Converters/ImageResizerZeroToEmptyStringNumberFormatter.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Globalization;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Microsoft.PowerToys.Settings.UI.Converters;
+
+public partial class ImageResizerZeroToEmptyStringNumberFormatter
+{
+    public string Format(long value) => throw new NotImplementedException();
+
+    public string Format(ulong value) => throw new NotImplementedException();
+
+    public string Format(double value) => throw new NotImplementedException();
+
+    public string FormatDouble(double? value) => value switch
+    {
+        null => string.Empty,
+        0 => string.Empty,
+        _ => value.Value.ToString(CultureInfo.CurrentCulture),
+    };
+
+    public double? ParseDouble(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return 0.0;
+        }
+
+        return double.TryParse(text, NumberStyles.Any, CultureInfo.CurrentCulture, out double result) ? result : 0.0;
+    }
+
+    public long? ParseInt(string text) => throw new NotImplementedException();
+
+    public ulong? ParseUInt(string text) => throw new NotImplementedException();
+}

--- a/src/settings-ui/Settings.UI/SettingsXAML/Controls/ImageResizerDimensionsNumberBox.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Controls/ImageResizerDimensionsNumberBox.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Microsoft.PowerToys.Settings.UI.Controls;
+
+public partial class ImageResizerDimensionsNumberBox : NumberBox
+{
+    public ImageResizerDimensionsNumberBox()
+    {
+        this.Loaded += (_, _) => UpdateDisplayText();
+
+        this.ValueChanged += (_, _) => UpdateDisplayText();
+
+        this.GotFocus += (s, e) =>
+        {
+            // Show "0" in the UI when focused on the empty value. This ensures that the spinbutton
+            // controls are usable.
+            if (Value is double.NaN)
+            {
+                Value = 0.0;
+            }
+        };
+
+        this.LostFocus += (_, _) => UpdateDisplayText();
+    }
+
+    private void UpdateDisplayText()
+    {
+        if (FocusState == FocusState.Unfocused && Value == 0)
+        {
+            Text = string.Empty;
+        }
+    }
+}

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/ImageResizerPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/ImageResizerPage.xaml
@@ -19,6 +19,9 @@
         <converters:ImageResizerUnitToStringConverter x:Key="ImageResizerUnitToStringConverter" />
         <converters:ImageResizerUnitToIntConverter x:Key="ImageResizerUnitToIntConverter" />
         <converters:ImageResizerSizeToAccessibleTextConverter x:Key="ImageResizerSizeToAccessibleTextConverter" />
+        <converters:ImageResizerDoubleToAutoConverter x:Key="ImageResizerDoubleToAutoConverter" />
+        <converters:ImageResizerNumberBoxValueConverter x:Key="ImageResizerNumberBoxValueConverter" />
+        <converters:ImageResizerZeroToEmptyStringNumberFormatter x:Key="ImageResizerZeroToEmptyStringNumberFormatter" />
         <toolkitconverters:BoolToObjectConverter
             x:Key="BoolToComboBoxIndexConverter"
             FalseValue="1"
@@ -78,7 +81,7 @@
                                                 Margin="0,0,4,0"
                                                 FontWeight="SemiBold"
                                                 Style="{ThemeResource SecondaryTextStyle}"
-                                                Text="{x:Bind Width, Mode=OneWay}" />
+                                                Text="{x:Bind Width, Mode=OneWay, Converter={StaticResource ImageResizerDoubleToAutoConverter}, ConverterParameter=Auto}" />
                                             <TextBlock
                                                 Margin="0,5,4,0"
                                                 AutomationProperties.AccessibilityView="Raw"
@@ -91,7 +94,7 @@
                                                 Margin="0,0,4,0"
                                                 FontWeight="SemiBold"
                                                 Style="{ThemeResource SecondaryTextStyle}"
-                                                Text="{x:Bind Height, Mode=OneWay}"
+                                                Text="{x:Bind Height, Mode=OneWay, Converter={StaticResource ImageResizerDoubleToAutoConverter}, ConverterParameter=Auto}"
                                                 Visibility="{x:Bind IsHeightUsed, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
                                             <TextBlock
                                                 Margin="0,0,4,0"
@@ -136,20 +139,20 @@
                                                         </ComboBox>
 
                                                         <StackPanel Orientation="Horizontal" Spacing="8">
-                                                            <NumberBox
+                                                            <controls:ImageResizerDimensionsNumberBox
                                                                 x:Uid="ImageResizer_Width"
                                                                 Width="116"
                                                                 Minimum="0"
                                                                 SpinButtonPlacementMode="Compact"
-                                                                Value="{x:Bind Width, Mode=TwoWay}" />
+                                                                Value="{x:Bind Width, Mode=TwoWay, Converter={StaticResource ImageResizerNumberBoxValueConverter}}" />
 
-                                                            <NumberBox
+                                                            <controls:ImageResizerDimensionsNumberBox
                                                                 x:Uid="ImageResizer_Height"
                                                                 Width="116"
                                                                 Minimum="0"
                                                                 SpinButtonPlacementMode="Compact"
                                                                 Visibility="{x:Bind IsHeightUsed, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"
-                                                                Value="{x:Bind Height, Mode=TwoWay}" />
+                                                                Value="{x:Bind Height, Mode=TwoWay, Converter={StaticResource ImageResizerNumberBoxValueConverter}}" />
                                                         </StackPanel>
 
                                                         <ComboBox

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -1193,6 +1193,10 @@
     <value>TIFF compression</value>
     <comment>{Locked="TIFF"}</comment>
   </data>
+  <data name="ImageResizer_AutoText" xml:space="preserve">
+    <value>(auto)</value>
+    <comment>Displayed on the preset card when the Width or Height property is zero. The same as "Input_Auto" in the ImageResizerUI project's resources.</comment>
+  </data>
   <data name="File.Header" xml:space="preserve">
     <value>File</value>
     <comment>as in a computer file</comment>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This fixes some related issues with the Width and Height NumberBox controls for the Custom preset. The issues were:
1. Users could not clear existing numbers from the field and move away from the field without a databinding error being displayed. (Red border.)
2. Settings were not saved if Width or Height were blank, leading to the _previous_ value for that dimension being used in the resize operation. This would result in incorrect sizes for the resulting image, and the UI not showing the actual value used.
3. Empty/auto values were not saved to the settings file, meaning the previous value of Width or Height was loaded in again when Image Resizer was re-launched.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #37311, #29556
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

The issue centred around the fact that emptying a NumberBox bound to a non-nullable double value will result in a data binding error because the empty control now has a null `Value`.

Inputting 0 into the fields instead of clearing them completely is fine and would be reasonable as a workaround, but this does not reflect the description of the feature on the Image Resizer help page, which specifically mentions that one or the other dimension field may be left blank to take advantage of the auto-scaling functionality.

The solution is to translate empty strings to 0, _but not to display 0 in the UI_. This is achieved through combining a NumberFormatter and a ValueConverter:
- The NumberFormatter ensures that if the control has a value of 0, it will display an empty string.
- The ValueConverter ensures that when the user clears the NumberBox or inputs an expression that evaluates to an invalid input, that 0 is always set as the result.

Without the ValueConverter, the data binding step would fail because `null` is the value of a cleared NumberBox and we would be attempting to bind to `ResizeSize.Width` or `ResizeSize.Height`, which are non-nullable.

There are likely some alternative methods to get around this, perhaps by using `double.NaN` instead of 0, or changing Width and Height to nullable. However, relying on the ValueConverter and NumberFormatter means that we do not need to change the underlying types, and this was seen as lower risk.

I made a few changes and added comments to AutoDoubleConverter.cs. This was because I initially thought I could use it on the custom preset's Width and Height fields, before deciding to create a new Converter made specifically to resolve the issue at hand. Also, I took the opportunity to make it more defensive in terms of type handling by using pattern matching. The functionality is identical.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

The application was manually tested both via the command line and by running directly from Visual Studio (which opens up the file picker because there is no file pre-selected).

Tested that:
- Width and Height NumberBoxes may now be empty, and no error is reported when they are in this state.
- When Width or Height is set to (auto) by blanking it out, the other dimension is used correctly to resize the image. The previous value of the now-blank field is not used.
- If "0" is input manually into either field, it is updated to be an empty string when focus moves from the control, keeping the UI consistent.
- The empty value is persisted to the settings file and is reloaded correctly when the application is re-launched. (An empty value is saved as "0".)
- A variety of file types are supported (sanity check - I did not test all supported types).
- **(auto)** text appears in the list of presets where one dimension has not been provided.
- The specific steps detailed in the original Issues no longer appear.
- All unit tests still pass.
- The Settings page for Image Resizer is still correct.

## Screenshots

Dimensions may be blank without validation errors:
![image](https://github.com/user-attachments/assets/c353e654-b4ab-4aca-9009-42927f15d43b)

Empty dimensions are correctly marked as auto in the presets drop-down:
![image](https://github.com/user-attachments/assets/f9dcacb0-d980-4f89-bdaf-ef88fc94b53c)

