### PR TITLE
PowerToys Run Calculator: Add trigonometric angle unit conversion functions

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator.UnitTest/ExtendedCalculatorParserTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator.UnitTest/ExtendedCalculatorParserTests.cs
@@ -341,5 +341,92 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
             Assert.IsNotNull(result);
             Assert.AreEqual(expectedResult, result);
         }
+
+        [DataTestMethod]
+        [DataRow("rad(30)", "(180 / pi) * (30)")]
+        [DataRow("rad( 30 )", "(180 / pi) * ( 30 )")]
+        [DataRow("deg(30)", "(30)")]
+        [DataRow("grad(30)", "(9 / 10) * (30)")]
+        [DataRow("rad(  30)", "(180 / pi) * (  30)")]
+        [DataRow("rad(30  )", "(180 / pi) * (30  )")]
+        [DataRow("rad(  30  )", "(180 / pi) * (  30  )")]
+        [DataRow("rad(deg(30))", "(180 / pi) * ((30))")]
+        [DataRow("deg(rad(30))", "((180 / pi) * (30))")]
+        [DataRow("grad(rad(30))", "(9 / 10) * ((180 / pi) * (30))")]
+        [DataRow("rad(grad(30))", "(180 / pi) * ((9 / 10) * (30))")]
+        [DataRow("rad(30) + deg(45)", "(180 / pi) * (30) + (45)")]
+        [DataRow("sin(rad(30))", "sin((180 / pi) * (30))")]
+        [DataRow("cos( rad( 45 ) )", "cos( (180 / pi) * ( 45 ) )")]
+        [DataRow("tan(rad(grad(90)))", "tan((180 / pi) * ((9 / 10) * (90)))")]
+        [DataRow("rad(30) + rad(45)", "(180 / pi) * (30) + (180 / pi) * (45)")]
+        [DataRow("rad(30) * grad(90)", "(180 / pi) * (30) * (9 / 10) * (90)")]
+        [DataRow("rad(30)/rad(45)", "(180 / pi) * (30)/(180 / pi) * (45)")]
+        public void ExpandTrigConversions_Degrees(string input, string expectedResult)
+        {
+            // Call ExpandTrigConversions in degrees mode
+            string result = CalculateHelper.ExpandTrigConversions(input, CalculateEngine.TrigMode.Degrees);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(expectedResult, result);
+        }
+
+        [DataTestMethod]
+        [DataRow("rad(30)", "(30)")]
+        [DataRow("rad( 30 )", "( 30 )")]
+        [DataRow("deg(30)", "(pi / 180) * (30)")]
+        [DataRow("grad(30)", "(pi / 200) * (30)")]
+        [DataRow("rad(  30)", "(  30)")]
+        [DataRow("rad(30  )", "(30  )")]
+        [DataRow("rad(  30  )", "(  30  )")]
+        [DataRow("rad(deg(30))", "((pi / 180) * (30))")]
+        [DataRow("deg(rad(30))", "(pi / 180) * ((30))")]
+        [DataRow("grad(rad(30))", "(pi / 200) * ((30))")]
+        [DataRow("rad(grad(30))", "((pi / 200) * (30))")]
+        [DataRow("rad(30) + deg(45)", "(30) + (pi / 180) * (45)")]
+        [DataRow("sin(rad(30))", "sin((30))")]
+        [DataRow("cos( rad( 45 ) )", "cos( ( 45 ) )")]
+        [DataRow("tan(rad(grad(90)))", "tan(((pi / 200) * (90)))")]
+        [DataRow("rad(30) + rad(45)", "(30) + (45)")]
+        [DataRow("rad(30) * grad(90)", "(30) * (pi / 200) * (90)")]
+        [DataRow("rad(30)/rad(45)", "(30)/(45)")]
+        public void ExpandTrigConversions_Radians(string input, string expectedResult)
+        {
+            // Call ExpandTrigConversions in radians mode
+            string result = CalculateHelper.ExpandTrigConversions(input, CalculateEngine.TrigMode.Radians);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(expectedResult, result);
+        }
+
+        [DataTestMethod]
+        [DataRow("rad(30)", "(200 / pi) * (30)")]
+        [DataRow("rad( 30 )", "(200 / pi) * ( 30 )")]
+        [DataRow("deg(30)", "(10 / 9) * (30)")]
+        [DataRow("grad(30)", "(30)")]
+        [DataRow("rad(  30)", "(200 / pi) * (  30)")]
+        [DataRow("rad(30  )", "(200 / pi) * (30  )")]
+        [DataRow("rad(  30  )", "(200 / pi) * (  30  )")]
+        [DataRow("rad(deg(30))", "(200 / pi) * ((10 / 9) * (30))")]
+        [DataRow("deg(rad(30))", "(10 / 9) * ((200 / pi) * (30))")]
+        [DataRow("grad(rad(30))", "((200 / pi) * (30))")]
+        [DataRow("rad(grad(30))", "(200 / pi) * ((30))")]
+        [DataRow("rad(30) + deg(45)", "(200 / pi) * (30) + (10 / 9) * (45)")]
+        [DataRow("sin(rad(30))", "sin((200 / pi) * (30))")]
+        [DataRow("cos( rad( 45 ) )", "cos( (200 / pi) * ( 45 ) )")]
+        [DataRow("tan(rad(grad(90)))", "tan((200 / pi) * ((90)))")]
+        [DataRow("rad(30) + rad(45)", "(200 / pi) * (30) + (200 / pi) * (45)")]
+        [DataRow("rad(30) * grad(90)", "(200 / pi) * (30) * (90)")]
+        [DataRow("rad(30)/rad(45)", "(200 / pi) * (30)/(200 / pi) * (45)")]
+        public void ExpandTrigConversions_Gradians(string input, string expectedResult)
+        {
+            // Call ExpandTrigConversions in gradians mode
+            string result = CalculateHelper.ExpandTrigConversions(input, CalculateEngine.TrigMode.Gradians);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(expectedResult, result);
+        }
     }
 }

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/CalculateEngine.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/CalculateEngine.cs
@@ -59,8 +59,14 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
 
             input = CalculateHelper.FixHumanMultiplicationExpressions(input);
 
+            // Get the user selected trigonometry unit
+            TrigMode trigMode = Main.GetTrigMode();
+
             // Modify trig functions depending on angle unit setting
-            input = CalculateHelper.UpdateTrigFunctions(input, Main.GetTrigMode());
+            input = CalculateHelper.UpdateTrigFunctions(input, trigMode);
+
+            // Expand conversions between trig units
+            input = CalculateHelper.ExpandTrigConversions(input, trigMode);
 
             var result = _magesEngine.Interpret(input);
 

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/CalculateHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/CalculateHelper.cs
@@ -326,7 +326,6 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
                 modifiedInput = ModifyMathFunction(modifiedInput, "rad", RadToGrad);
             }
 
-            System.Diagnostics.Debug.WriteLine($"ExpandTrigConversions: \"{input}\" -> \"{modifiedInput}\"");
             return modifiedInput;
         }
     }

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/CalculateHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/CalculateHelper.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text.RegularExpressions;
+using static Microsoft.PowerToys.Run.Plugin.Calculator.CalculateEngine;
 
 namespace Microsoft.PowerToys.Run.Plugin.Calculator
 {
@@ -18,6 +19,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
             @"factorial\s*\(|sign\s*\(|round\s*\(|rand\s*\(\)|randi\s*\([^\)]|" +
             @"sin\s*\(|cos\s*\(|tan\s*\(|arcsin\s*\(|arccos\s*\(|arctan\s*\(|" +
             @"sinh\s*\(|cosh\s*\(|tanh\s*\(|arsinh\s*\(|arcosh\s*\(|artanh\s*\(|" +
+            @"rad\s*\(|deg\s*\(|grad\s*\(|" + /* trigonometry unit conversion macros */
             @"pi|" +
             @"==|~=|&&|\|\||" +
             @"((-?(\d+(\.\d*)?)|-?(\.\d+))[Ee](-?\d+))|" + /* expression from CheckScientificNotation between parenthesis */
@@ -26,7 +28,9 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
             RegexOptions.Compiled);
 
         private const string DegToRad = "(pi / 180) * ";
+        private const string DegToGrad = "(10 / 9) * ";
         private const string GradToRad = "(pi / 200) * ";
+        private const string GradToDeg = "(9 / 10) * ";
         private const string RadToDeg = "(180 / pi) * ";
         private const string RadToGrad = "(200 / pi) * ";
 
@@ -266,10 +270,10 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
             return input;
         }
 
-        public static string UpdateTrigFunctions(string input, CalculateEngine.TrigMode mode)
+        public static string UpdateTrigFunctions(string input, TrigMode mode)
         {
             string modifiedInput = input;
-            if (mode == CalculateEngine.TrigMode.Degrees)
+            if (mode == TrigMode.Degrees)
             {
                 modifiedInput = ModifyTrigFunction(modifiedInput, "sin", DegToRad);
                 modifiedInput = ModifyTrigFunction(modifiedInput, "cos", DegToRad);
@@ -278,7 +282,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
                 modifiedInput = ModifyTrigFunction(modifiedInput, "arccos", RadToDeg);
                 modifiedInput = ModifyTrigFunction(modifiedInput, "arctan", RadToDeg);
             }
-            else if (mode == CalculateEngine.TrigMode.Gradians)
+            else if (mode == TrigMode.Gradians)
             {
                 modifiedInput = ModifyTrigFunction(modifiedInput, "sin", GradToRad);
                 modifiedInput = ModifyTrigFunction(modifiedInput, "cos", GradToRad);
@@ -288,6 +292,41 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
                 modifiedInput = ModifyTrigFunction(modifiedInput, "arctan", RadToGrad);
             }
 
+            return modifiedInput;
+        }
+
+        private static string ModifyMathFunction(string input, string function, string modification)
+        {
+            // Create the pattern to match the function, opening bracket, and any spaces in between
+            string pattern = $@"{function}\s*\(";
+            return Regex.Replace(input, pattern, modification + "(");
+        }
+
+        public static string ExpandTrigConversions(string input, TrigMode mode)
+        {
+            string modifiedInput = input;
+
+            // Expand "rad", "deg" and "grad" to their respective conversions for the current trig unit
+            if (mode == TrigMode.Radians)
+            {
+                modifiedInput = ModifyMathFunction(modifiedInput, "deg", DegToRad);
+                modifiedInput = ModifyMathFunction(modifiedInput, "grad", GradToRad);
+                modifiedInput = ModifyMathFunction(modifiedInput, "rad", string.Empty);
+            }
+            else if (mode == TrigMode.Degrees)
+            {
+                modifiedInput = ModifyMathFunction(modifiedInput, "deg", string.Empty);
+                modifiedInput = ModifyMathFunction(modifiedInput, "grad", GradToDeg);
+                modifiedInput = ModifyMathFunction(modifiedInput, "rad", RadToDeg);
+            }
+            else if (mode == TrigMode.Gradians)
+            {
+                modifiedInput = ModifyMathFunction(modifiedInput, "deg", DegToGrad);
+                modifiedInput = ModifyMathFunction(modifiedInput, "grad", string.Empty);
+                modifiedInput = ModifyMathFunction(modifiedInput, "rad", RadToGrad);
+            }
+
+            System.Diagnostics.Debug.WriteLine($"ExpandTrigConversions: \"{input}\" -> \"{modifiedInput}\"");
             return modifiedInput;
         }
     }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Added a function to the PowerToys Run calculator plugin to allow for a value to be treated as a certain angle unit. For example,  in `rad(pi / 2)`, `pi / 2` is treated as being in radians, which need converting to the user selected unit.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #37434 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Added conversion functions for the PowerToys Run Calculator plugin. This allows the use of `rad`, `deg`, and `grad` to specify how to interpret a value. For example, `rad(pi / 2)` would treat the value `pi / 2` as being in radians, and convert it to the angle unit currently selected as default in the settings, by prepending the mathematical conversion (e.g. `(180 / pi) *`). This allows for quick conversions between the different angle units.

**Demonstration**:
When degrees is selected as the user specified unit:

![image](https://github.com/user-attachments/assets/d2b23818-9146-4f56-815a-a211a0e613a9)

This would convert the radians value `pi / 2` into degrees. Internally, this would be converted to `(180 / pi) * (pi / 2)`, via Regex replacement, before being passed to the Mages evaluator, adding the correct conversion from radians to degrees.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Tests have been written, and all pass.
