### PR TITLE
[PTRun] Allow preventing usage based ordering results

### DIFF
--- a/src/modules/launcher/PowerLauncher/ViewModel/ResultsViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/ResultsViewModel.cs
@@ -282,11 +282,11 @@ namespace PowerLauncher.ViewModel
 
             if (options.SearchQueryTuningEnabled)
             {
-                sorted = Results.OrderByDescending(x => (x.Result.Metadata.WeightBoost + x.Result.Score + (x.Result.SelectedCount * options.SearchClickedItemWeight))).ToList();
+                sorted = Results.OrderByDescending(x => x.Result.GetSortOrder(options.SearchClickedItemWeight)).ToList();
             }
             else
             {
-                sorted = Results.OrderByDescending(x => (x.Result.Metadata.WeightBoost + x.Result.Score + (x.Result.SelectedCount * 5))).ToList();
+                sorted = Results.OrderByDescending(x => x.Result.GetSortOrder(5)).ToList();
             }
 
             // remove history items in they are in the list as non-history items

--- a/src/modules/launcher/PowerLauncher/ViewModel/ResultsViewModel.cs
+++ b/src/modules/launcher/PowerLauncher/ViewModel/ResultsViewModel.cs
@@ -282,11 +282,11 @@ namespace PowerLauncher.ViewModel
 
             if (options.SearchQueryTuningEnabled)
             {
-                sorted = Results.OrderByDescending(x => x.Result.GetSortOrder(options.SearchClickedItemWeight)).ToList();
+                sorted = Results.OrderByDescending(x => x.Result.GetSortOrderScore(options.SearchClickedItemWeight)).ToList();
             }
             else
             {
-                sorted = Results.OrderByDescending(x => x.Result.GetSortOrder(5)).ToList();
+                sorted = Results.OrderByDescending(x => x.Result.GetSortOrderScore(5)).ToList();
             }
 
             // remove history items in they are in the list as non-history items

--- a/src/modules/launcher/Wox.Plugin/Result.cs
+++ b/src/modules/launcher/Wox.Plugin/Result.cs
@@ -187,5 +187,11 @@ namespace Wox.Plugin
         /// Gets plugin ID that generated this result
         /// </summary>
         public string PluginID { get; internal set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the selected data should be applied to this result.
+        /// </summary>
+        /// <remarks>Enabling this option will affect the sort ordering of this result</remarks>
+        public bool DisableSelectedDataRetrieval { get; set; }
     }
 }

--- a/src/modules/launcher/Wox.Plugin/Result.cs
+++ b/src/modules/launcher/Wox.Plugin/Result.cs
@@ -189,9 +189,18 @@ namespace Wox.Plugin
         public string PluginID { get; internal set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether the selected data should be applied to this result.
+        /// Gets or sets a value indicating whether usage based sorting should be applied to this result.
         /// </summary>
-        /// <remarks>Enabling this option will affect the sort ordering of this result</remarks>
-        public bool DisableSelectedDataRetrieval { get; set; }
+        public bool DisableUsageBasedScoring { get; set; }
+
+        public int GetSortOrder(int selectedItemMultiplier)
+        {
+            if (DisableUsageBasedScoring)
+            {
+                return Metadata.WeightBoost + Score;
+            }
+
+            return Metadata.WeightBoost + Score + (SelectedCount * selectedItemMultiplier);
+        }
     }
 }

--- a/src/modules/launcher/Wox.Plugin/Result.cs
+++ b/src/modules/launcher/Wox.Plugin/Result.cs
@@ -193,7 +193,7 @@ namespace Wox.Plugin
         /// </summary>
         public bool DisableUsageBasedScoring { get; set; }
 
-        public int GetSortOrder(int selectedItemMultiplier)
+        public int GetSortOrderScore(int selectedItemMultiplier)
         {
             if (DisableUsageBasedScoring)
             {

--- a/src/modules/launcher/Wox.Plugin/UserSelectedRecord.cs
+++ b/src/modules/launcher/Wox.Plugin/UserSelectedRecord.cs
@@ -106,7 +106,7 @@ namespace Wox.Plugin
         {
             ArgumentNullException.ThrowIfNull(result);
 
-            if (result != null && Records.TryGetValue(result.ToString(), out var value))
+            if (result != null && !result.DisableSelectedDataRetrieval && Records.TryGetValue(result.ToString(), out var value))
             {
                 return value;
             }

--- a/src/modules/launcher/Wox.Plugin/UserSelectedRecord.cs
+++ b/src/modules/launcher/Wox.Plugin/UserSelectedRecord.cs
@@ -106,7 +106,7 @@ namespace Wox.Plugin
         {
             ArgumentNullException.ThrowIfNull(result);
 
-            if (result != null && !result.DisableSelectedDataRetrieval && Records.TryGetValue(result.ToString(), out var value))
+            if (result != null && Records.TryGetValue(result.ToString(), out var value))
             {
                 return value;
             }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Implement an additional functionality on the Result model allowing the prevention of selected count retrieval.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #36519 
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
This PR adds an additional property to the `Result.cs` model which allows for disabling the functionality which fetches the `SelectedCount` data from PowerToys. This enables the ability for plugins to prevent the `SelectedCount` property from being populated for individual results meaning that the sort order can be manipulated as desired by the Plugin giving more control back to the plugin developers.
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

