### PR TITLE
[ci]Sign and fix KeyboardManagerEditorLibraryWrapper.dll

### DIFF
--- a/.pipelines/ESRPSigning_core.json
+++ b/.pipelines/ESRPSigning_core.json
@@ -128,6 +128,7 @@
                 "PowerToys.KeyboardManager.dll",
                 "KeyboardManagerEditor\\PowerToys.KeyboardManagerEditor.exe",
                 "KeyboardManagerEngine\\PowerToys.KeyboardManagerEngine.exe",
+                "KeyboardManagerEditorLibraryWrapper.dll",
 
                 "PowerToys.Launcher.dll",
                 "PowerToys.PowerLauncher.dll",

--- a/.pipelines/ESRPSigning_core.json
+++ b/.pipelines/ESRPSigning_core.json
@@ -128,7 +128,7 @@
                 "PowerToys.KeyboardManager.dll",
                 "KeyboardManagerEditor\\PowerToys.KeyboardManagerEditor.exe",
                 "KeyboardManagerEngine\\PowerToys.KeyboardManagerEngine.exe",
-                "KeyboardManagerEditorLibraryWrapper.dll",
+                "PowerToys.KeyboardManagerEditorLibraryWrapper.dll",
 
                 "PowerToys.Launcher.dll",
                 "PowerToys.PowerLauncher.dll",

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibraryWrapper/KeyboardManagerEditorLibraryWrapper.rc
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibraryWrapper/KeyboardManagerEditorLibraryWrapper.rc
@@ -1,0 +1,40 @@
+#include <windows.h>
+#include "resource.h"
+#include "../../../common/version/version.h"
+
+#define APSTUDIO_READONLY_SYMBOLS
+#include "winres.h"
+#undef APSTUDIO_READONLY_SYMBOLS
+
+1 VERSIONINFO
+FILEVERSION FILE_VERSION
+PRODUCTVERSION PRODUCT_VERSION
+FILEFLAGSMASK VS_FFI_FILEFLAGSMASK
+#ifdef _DEBUG
+FILEFLAGS VS_FF_DEBUG
+#else
+FILEFLAGS 0x0L
+#endif
+FILEOS VOS_NT_WINDOWS32
+FILETYPE VFT_DLL
+FILESUBTYPE VFT2_UNKNOWN
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0" // US English (0x0409), Unicode (0x04B0) charset
+        BEGIN
+            VALUE "CompanyName", COMPANY_NAME
+            VALUE "FileDescription", FILE_DESCRIPTION
+            VALUE "FileVersion", FILE_VERSION_STRING
+            VALUE "InternalName", INTERNAL_NAME
+            VALUE "LegalCopyright", COPYRIGHT_NOTE
+            VALUE "OriginalFilename", ORIGINAL_FILENAME
+            VALUE "ProductName", PRODUCT_NAME
+            VALUE "ProductVersion", PRODUCT_VERSION_STRING
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200 // US English (0x0409), Unicode (1200) charset
+    END
+END

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibraryWrapper/KeyboardManagerEditorLibraryWrapper.vcxproj
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibraryWrapper/KeyboardManagerEditorLibraryWrapper.vcxproj
@@ -34,6 +34,9 @@
     <RootNamespace>KeyboardManagerEditorLibraryWrapper</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
+  <PropertyGroup>
+    <TargetName>PowerToys.KeyboardManagerEditorLibraryWrapper</TargetName>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
@@ -218,6 +221,7 @@
     <ClInclude Include="framework.h" />
     <ClInclude Include="KeyboardManagerEditorLibraryWrapper.h" />
     <ClInclude Include="pch.h" />
+    <ClInclude Include="resource.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp" />
@@ -230,6 +234,9 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">Create</PrecompiledHeader>
     </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="KeyboardManagerEditorLibraryWrapper.rc" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\common\logger\logger.vcxproj">

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibraryWrapper/KeyboardManagerEditorLibraryWrapper.vcxproj.filters
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibraryWrapper/KeyboardManagerEditorLibraryWrapper.vcxproj.filters
@@ -24,6 +24,9 @@
     <ClInclude Include="KeyboardManagerEditorLibraryWrapper.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="resource.h">
+      <Filter>Resource Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp">
@@ -38,5 +41,10 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="KeyboardManagerEditorLibraryWrapper.rc">
+      <Filter>Resource Files</Filter>
+    </ResourceCompile>
   </ItemGroup>
 </Project>

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibraryWrapper/resource.h
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibraryWrapper/resource.h
@@ -1,0 +1,13 @@
+//{{NO_DEPENDENCIES}}
+// Microsoft Visual C++ generated include file.
+// Used by AlwaysOnTopModuleInterface.rc
+
+//////////////////////////////
+// Non-localizable
+
+#define FILE_DESCRIPTION "PowerToys Keyboard Manager Editor Library Wrapper"
+#define INTERNAL_NAME "PowerToys.KeyboardManagerEditorLibraryWrapper"
+#define ORIGINAL_FILENAME "PowerToys.KeyboardManagerEditorLibraryWrapper.dll"
+
+// Non-localizable
+//////////////////////////////


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Dart CI is failing after https://github.com/microsoft/PowerToys/commit/68afc6623f2681cb283a3849f3c7fde28bce9a1d because it isn't signing the new DLL or adding proper metadata.

This PR signs KeyboardManagerEditorLibraryWrapper.dll
Adds the usual metadata to the dll
It renames the dll to PowerToys.KeyboardManagerEditorLibraryWrapper.dll


<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Dart CI passes.
Checked properties of PowerToys.KeyboardManagerEditorLibraryWrapper.dll to verify version and metadata is applied.