### PR TITLE
[RegPreview] Various improvements on how files are saved

### DIFF
--- a/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Events.cs
+++ b/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Events.cs
@@ -22,7 +22,7 @@ namespace RegistryPreviewUILib
     {
         private readonly DispatcherQueue _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
 
-        // Indicator if we loaded/reloaded/saved a file and need to skip TextChangedEevent one time.
+        // Indicator if we loaded/reloaded/saved a file and need to skip TextChanged event one time.
         private static bool newFileLoaded;
 
         /// <summary>

--- a/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Events.cs
+++ b/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Events.cs
@@ -81,7 +81,7 @@ namespace RegistryPreviewUILib
         }
 
         /// <summary>
-        /// Resets the editor content
+        /// New button action: Ask to save last changes and reset editor content to reg header only
         /// </summary>
         private async void NewButton_Click(object sender, RoutedEventArgs e)
         {
@@ -109,7 +109,7 @@ namespace RegistryPreviewUILib
                 switch (contentDialogResult)
                 {
                     case ContentDialogResult.Primary:
-                        // Save, then continue the file open
+                        // Save, then continue the new action
                         if (!AskFileName(string.Empty) ||
                             !SaveFile())
                         {
@@ -118,10 +118,10 @@ namespace RegistryPreviewUILib
 
                         break;
                     case ContentDialogResult.Secondary:
-                        // Don't save and continue the file open!
+                        // Don't save and continue the new action!
                         break;
                     default:
-                        // Don't open the new file!
+                        // Don't open the new action!
                         return;
                 }
             }
@@ -281,10 +281,10 @@ namespace RegistryPreviewUILib
                 switch (contentDialogResult)
                 {
                     case ContentDialogResult.Primary:
-                        // Don't save and continue the file open!
+                        // Don't save and continue the reload action!
                         break;
                     default:
-                        // Don't open the new file!
+                        // Don't continue the reload action!
                         return;
                 }
             }
@@ -360,7 +360,7 @@ namespace RegistryPreviewUILib
                 switch (contentDialogResult)
                 {
                     case ContentDialogResult.Primary:
-                        // Save, then continue the file open
+                        // Save, then continue the merge action
                         if (!AskFileName(string.Empty) ||
                             !SaveFile())
                         {
@@ -369,11 +369,11 @@ namespace RegistryPreviewUILib
 
                         break;
                     case ContentDialogResult.Secondary:
-                        // Don't save and continue the file open!
+                        // Don't save and continue the merge action!
                         UpdateUnsavedFileState(false);
                         break;
                     default:
-                        // Don't open the new file!
+                        // Don't merge the file!
                         return;
                 }
             }

--- a/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Events.cs
+++ b/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Events.cs
@@ -119,8 +119,7 @@ namespace RegistryPreviewUILib
                         break;
                     case ContentDialogResult.Secondary:
                         // Don't save and continue the file open!
-                        saveButton.IsEnabled = false;
-                        UpdateUnsavedFileIndicator(false);
+                        UpdateUnsavedFileState(false);
                         break;
                     default:
                         // Don't open the new file!
@@ -154,8 +153,7 @@ namespace RegistryPreviewUILib
                 UpdateToolBarAndUI(await OpenRegistryFile(_appFileName));
 
                 // disable the Save button as it's a new file
-                saveButton.IsEnabled = false;
-                UpdateUnsavedFileIndicator(false);
+                UpdateUnsavedFileState(false);
 
                 // Restore the event handler as we're loaded
                 MonacoEditor.TextChanged += MonacoEditor_TextChanged;
@@ -208,9 +206,7 @@ namespace RegistryPreviewUILib
             // reload the current Registry file and update the toolbar accordingly.
             UpdateToolBarAndUI(await OpenRegistryFile(_appFileName), true, true);
 
-            // disable the Save button as it's a new file
-            saveButton.IsEnabled = false;
-            UpdateUnsavedFileIndicator(false);
+            UpdateUnsavedFileState(false);
 
             // restore the TextChanged handler
             MonacoEditor.TextChanged += MonacoEditor_TextChanged;
@@ -341,7 +337,7 @@ namespace RegistryPreviewUILib
                         break;
                     case ContentDialogResult.Secondary:
                         // Don't save and continue the file open!
-                        saveButton.IsEnabled = false;
+                        UpdateUnsavedFileState(false);
                         break;
                     default:
                         // Don't open the new file!
@@ -436,8 +432,7 @@ namespace RegistryPreviewUILib
                 RefreshRegistryFile();
                 if (!editorContentChangedScripted)
                 {
-                    saveButton.IsEnabled = true;
-                    UpdateUnsavedFileIndicator(true);
+                    UpdateUnsavedFileState(true);
                 }
 
                 editorContentChangedScripted = false;

--- a/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Events.cs
+++ b/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Events.cs
@@ -111,6 +111,7 @@ namespace RegistryPreviewUILib
                     case ContentDialogResult.Secondary:
                         // Don't save and continue the file open!
                         saveButton.IsEnabled = false;
+                        UpdateUnsavedFileIndicator(false);
                         break;
                     default:
                         // Don't open the new file!
@@ -142,6 +143,7 @@ namespace RegistryPreviewUILib
 
                 // disable the Save button as it's a new file
                 saveButton.IsEnabled = false;
+                UpdateUnsavedFileIndicator(false);
 
                 // Restore the event handler as we're loaded
                 MonacoEditor.TextChanged += MonacoEditor_TextChanged;
@@ -193,6 +195,7 @@ namespace RegistryPreviewUILib
 
             // disable the Save button as it's a new file
             saveButton.IsEnabled = false;
+            UpdateUnsavedFileIndicator(false);
 
             // restore the TextChanged handler
             MonacoEditor.TextChanged += MonacoEditor_TextChanged;
@@ -412,6 +415,7 @@ namespace RegistryPreviewUILib
             {
                 RefreshRegistryFile();
                 saveButton.IsEnabled = true;
+                UpdateUnsavedFileIndicator(true);
             });
         }
 

--- a/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Events.cs
+++ b/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Events.cs
@@ -440,7 +440,7 @@ namespace RegistryPreviewUILib
         /// Sets indicator for programatic text change and adds text changed handler
         /// </summary>
         /// <remarks>
-        /// Use this always, if buttton actions temporary disable the text changed event
+        /// Use this always, if button actions temporary disable the text changed event
         /// </remarks>
         private void ButtonAction_RestoreTextChangedEvent()
         {

--- a/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Events.cs
+++ b/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Events.cs
@@ -146,7 +146,6 @@ namespace RegistryPreviewUILib
             {
                 // mute the TextChanged handler to make for clean UI
                 MonacoEditor.TextChanged -= MonacoEditor_TextChanged;
-                editorContentChangedScripted = true;
 
                 // update file name
                 _appFileName = storageFile.Path;
@@ -156,7 +155,7 @@ namespace RegistryPreviewUILib
                 UpdateUnsavedFileState(false);
 
                 // Restore the event handler as we're loaded
-                MonacoEditor.TextChanged += MonacoEditor_TextChanged;
+                ButtonAction_RestoreTextChangedEvent();
             }
         }
 
@@ -180,7 +179,6 @@ namespace RegistryPreviewUILib
         private async void SaveAsButton_Click(object sender, RoutedEventArgs e)
         {
             // mute the TextChanged handler to make for clean UI
-            editorContentChangedScripted = true;
             MonacoEditor.TextChanged -= MonacoEditor_TextChanged;
 
             if (!AskFileName(_appFileName) || !SaveFile())
@@ -191,7 +189,7 @@ namespace RegistryPreviewUILib
             UpdateToolBarAndUI(await OpenRegistryFile(_appFileName));
 
             // restore the TextChanged handler
-            MonacoEditor.TextChanged += MonacoEditor_TextChanged;
+            ButtonAction_RestoreTextChangedEvent();
         }
 
         /// <summary>
@@ -200,7 +198,6 @@ namespace RegistryPreviewUILib
         private async void RefreshButton_Click(object sender, RoutedEventArgs e)
         {
             // mute the TextChanged handler to make for clean UI
-            editorContentChangedScripted = true;
             MonacoEditor.TextChanged -= MonacoEditor_TextChanged;
 
             // reload the current Registry file and update the toolbar accordingly.
@@ -209,7 +206,7 @@ namespace RegistryPreviewUILib
             UpdateUnsavedFileState(false);
 
             // restore the TextChanged handler
-            MonacoEditor.TextChanged += MonacoEditor_TextChanged;
+            ButtonAction_RestoreTextChangedEvent();
         }
 
         /// <summary>
@@ -437,6 +434,20 @@ namespace RegistryPreviewUILib
 
                 editorContentChangedScripted = false;
             });
+        }
+
+        /// <summary>
+        /// Sets indicator for programatic text change and adds text changed handler
+        /// </summary>
+        /// <remarks>
+        /// Use this always, if buttton actions temporary disable the text changed event
+        /// </remarks>
+        private void ButtonAction_RestoreTextChangedEvent()
+        {
+            // Solves the problem that enabling the event handler fires it one time.
+            // These one time fired event would causes wrong unsaved changes state.
+            editorContentChangedScripted = true;
+            MonacoEditor.TextChanged += MonacoEditor_TextChanged;
         }
 
         // Commands to show data preview

--- a/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Events.cs
+++ b/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Events.cs
@@ -155,7 +155,28 @@ namespace RegistryPreviewUILib
         /// </summary>
         private void SaveButton_Click(object sender, RoutedEventArgs e)
         {
+            if (string.IsNullOrEmpty(_appFileName))
+            {
+                // Save out a new REG file and then open it - we have to use the direct Win32 method because FileOpenPicker crashes when it's
+                // called while running as admin
+                IntPtr windowHandle = WinRT.Interop.WindowNative.GetWindowHandle(_mainWindow);
+                string filename = SaveFilePicker.ShowDialog(
+                    windowHandle,
+                    resourceLoader.GetString("SuggestFileName"),
+                    resourceLoader.GetString("FilterRegistryName") + '\0' + "*.reg" + '\0' + resourceLoader.GetString("FilterAllFiles") + '\0' + "*.*" + '\0' + '\0',
+                    resourceLoader.GetString("SaveDialogTitle"));
+
+                if (filename == string.Empty)
+                {
+                    return;
+                }
+
+                _appFileName = filename;
+            }
+
+            // save and update window title
             SaveFile();
+            _updateWindowTitleFunction(_appFileName);
         }
 
         /// <summary>

--- a/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Events.cs
+++ b/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Events.cs
@@ -22,6 +22,9 @@ namespace RegistryPreviewUILib
     {
         private readonly DispatcherQueue _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
 
+        // Indicator if we loaded or reloaded a file
+        private static bool newFileLoaded;
+
         /// <summary>
         /// Event that is will prevent the app from closing if the "save file" flag is active
         /// </summary>
@@ -143,6 +146,9 @@ namespace RegistryPreviewUILib
             {
                 // mute the TextChanged handler to make for clean UI
                 MonacoEditor.TextChanged -= MonacoEditor_TextChanged;
+                newFileLoaded = true;
+
+                // update file name
                 _appFileName = storageFile.Path;
                 UpdateToolBarAndUI(await OpenRegistryFile(_appFileName));
 
@@ -214,6 +220,7 @@ namespace RegistryPreviewUILib
         private async void RefreshButton_Click(object sender, RoutedEventArgs e)
         {
             // mute the TextChanged handler to make for clean UI
+            newFileLoaded = true;
             MonacoEditor.TextChanged -= MonacoEditor_TextChanged;
 
             // reload the current Registry file and update the toolbar accordingly.
@@ -445,8 +452,13 @@ namespace RegistryPreviewUILib
             _dispatcherQueue.TryEnqueue(() =>
             {
                 RefreshRegistryFile();
-                saveButton.IsEnabled = true;
-                UpdateUnsavedFileIndicator(true);
+                if (!newFileLoaded)
+                {
+                    saveButton.IsEnabled = true;
+                    UpdateUnsavedFileIndicator(true);
+                }
+
+                newFileLoaded = false;
             });
         }
 

--- a/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Events.cs
+++ b/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Events.cs
@@ -109,7 +109,7 @@ namespace RegistryPreviewUILib
                 {
                     case ContentDialogResult.Primary:
                         // Save, then continue the file open
-                        if (!AskFileName(_appFileName) ||
+                        if (!AskFileName(string.Empty) ||
                             !SaveFile())
                         {
                             return;
@@ -166,7 +166,7 @@ namespace RegistryPreviewUILib
         /// </summary>
         private void SaveButton_Click(object sender, RoutedEventArgs e)
         {
-            if (!AskFileName(_appFileName))
+            if (!AskFileName(string.Empty))
             {
                 return;
             }
@@ -180,6 +180,7 @@ namespace RegistryPreviewUILib
         /// </summary>
         private async void SaveAsButton_Click(object sender, RoutedEventArgs e)
         {
+            newFileLoaded = true;
             if (!AskFileName(_appFileName) || !SaveFile())
             {
                 return;
@@ -324,7 +325,7 @@ namespace RegistryPreviewUILib
                 {
                     case ContentDialogResult.Primary:
                         // Save, then continue the file open
-                        if (!AskFileName(_appFileName) ||
+                        if (!AskFileName(string.Empty) ||
                             !SaveFile())
                         {
                             return;

--- a/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Events.cs
+++ b/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Events.cs
@@ -106,7 +106,12 @@ namespace RegistryPreviewUILib
                 {
                     case ContentDialogResult.Primary:
                         // Save, then continue the file open
-                        SaveFile();
+                        bool success = SaveFile();
+                        if (!success)
+                        {
+                            return;
+                        }
+
                         break;
                     case ContentDialogResult.Secondary:
                         // Don't save and continue the file open!
@@ -175,7 +180,7 @@ namespace RegistryPreviewUILib
             }
 
             // save and update window title
-            SaveFile();
+            _ = SaveFile();
             _updateWindowTitleFunction(_appFileName);
         }
 
@@ -199,7 +204,7 @@ namespace RegistryPreviewUILib
             }
 
             _appFileName = filename;
-            SaveFile();
+            _ = SaveFile();
             UpdateToolBarAndUI(await OpenRegistryFile(_appFileName));
         }
 
@@ -338,7 +343,12 @@ namespace RegistryPreviewUILib
                 {
                     case ContentDialogResult.Primary:
                         // Save, then continue the file open
-                        SaveFile();
+                        bool success = SaveFile();
+                        if (!success)
+                        {
+                            return;
+                        }
+
                         break;
                     case ContentDialogResult.Secondary:
                         // Don't save and continue the file open!

--- a/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Events.cs
+++ b/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Events.cs
@@ -109,7 +109,7 @@ namespace RegistryPreviewUILib
                 {
                     case ContentDialogResult.Primary:
                         // Save, then continue the file open
-                        if (!AskFileName(false) ||
+                        if (!AskFileName(_appFileName) ||
                             !SaveFile())
                         {
                             return;
@@ -166,7 +166,7 @@ namespace RegistryPreviewUILib
         /// </summary>
         private void SaveButton_Click(object sender, RoutedEventArgs e)
         {
-            if (!AskFileName(false))
+            if (!AskFileName(_appFileName))
             {
                 return;
             }
@@ -180,7 +180,7 @@ namespace RegistryPreviewUILib
         /// </summary>
         private async void SaveAsButton_Click(object sender, RoutedEventArgs e)
         {
-            if (!AskFileName(true) || !SaveFile())
+            if (!AskFileName(_appFileName) || !SaveFile())
             {
                 return;
             }
@@ -324,7 +324,7 @@ namespace RegistryPreviewUILib
                 {
                     case ContentDialogResult.Primary:
                         // Save, then continue the file open
-                        if (!AskFileName(false) ||
+                        if (!AskFileName(_appFileName) ||
                             !SaveFile())
                         {
                             return;

--- a/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Events.cs
+++ b/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Events.cs
@@ -23,6 +23,7 @@ namespace RegistryPreviewUILib
         private readonly DispatcherQueue _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
 
         // Indicator if we loaded/reloaded/saved a file and need to skip TextChanged event one time.
+        // (Solves the problem that enabling the event handler fires it one time.)
         private static bool editorContentChangedScripted;
 
         /// <summary>

--- a/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Events.cs
+++ b/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Events.cs
@@ -169,6 +169,7 @@ namespace RegistryPreviewUILib
             }
 
             // save and update window title
+            // error handling and ui update happens in SaveFile() method
             _ = SaveFile();
         }
 

--- a/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Events.cs
+++ b/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Events.cs
@@ -109,8 +109,8 @@ namespace RegistryPreviewUILib
                 {
                     case ContentDialogResult.Primary:
                         // Save, then continue the file open
-                        bool success = SaveFile();
-                        if (!success)
+                        if (!AskFileName(false) ||
+                            !SaveFile())
                         {
                             return;
                         }
@@ -166,23 +166,9 @@ namespace RegistryPreviewUILib
         /// </summary>
         private void SaveButton_Click(object sender, RoutedEventArgs e)
         {
-            if (string.IsNullOrEmpty(_appFileName))
+            if (!AskFileName(false))
             {
-                // Save out a new REG file and then open it - we have to use the direct Win32 method because FileOpenPicker crashes when it's
-                // called while running as admin
-                IntPtr windowHandle = WinRT.Interop.WindowNative.GetWindowHandle(_mainWindow);
-                string filename = SaveFilePicker.ShowDialog(
-                    windowHandle,
-                    resourceLoader.GetString("SuggestFileName"),
-                    resourceLoader.GetString("FilterRegistryName") + '\0' + "*.reg" + '\0' + resourceLoader.GetString("FilterAllFiles") + '\0' + "*.*" + '\0' + '\0',
-                    resourceLoader.GetString("SaveDialogTitle"));
-
-                if (filename == string.Empty)
-                {
-                    return;
-                }
-
-                _appFileName = filename;
+                return;
             }
 
             // save and update window title
@@ -195,21 +181,11 @@ namespace RegistryPreviewUILib
         /// </summary>
         private async void SaveAsButton_Click(object sender, RoutedEventArgs e)
         {
-            // Save out a new REG file and then open it - we have to use the direct Win32 method because FileOpenPicker crashes when it's
-            // called while running as admin
-            IntPtr windowHandle = WinRT.Interop.WindowNative.GetWindowHandle(_mainWindow);
-            string filename = SaveFilePicker.ShowDialog(
-                windowHandle,
-                resourceLoader.GetString("SuggestFileName"),
-                resourceLoader.GetString("FilterRegistryName") + '\0' + "*.reg" + '\0' + resourceLoader.GetString("FilterAllFiles") + '\0' + "*.*" + '\0' + '\0',
-                resourceLoader.GetString("SaveDialogTitle"));
-
-            if (filename == string.Empty)
+            if (!AskFileName(true))
             {
                 return;
             }
 
-            _appFileName = filename;
             _ = SaveFile();
             UpdateToolBarAndUI(await OpenRegistryFile(_appFileName));
         }
@@ -350,8 +326,8 @@ namespace RegistryPreviewUILib
                 {
                     case ContentDialogResult.Primary:
                         // Save, then continue the file open
-                        bool success = SaveFile();
-                        if (!success)
+                        if (!AskFileName(false) ||
+                            !SaveFile())
                         {
                             return;
                         }

--- a/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Events.cs
+++ b/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Events.cs
@@ -22,7 +22,7 @@ namespace RegistryPreviewUILib
     {
         private readonly DispatcherQueue _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
 
-        // Indicator if we loaded or reloaded a file
+        // Indicator if we loaded/reloaded/saved a file and need to skip TextChangedEevent one time.
         private static bool newFileLoaded;
 
         /// <summary>
@@ -173,7 +173,6 @@ namespace RegistryPreviewUILib
 
             // save and update window title
             _ = SaveFile();
-            _updateWindowTitleFunction(_appFileName);
         }
 
         /// <summary>
@@ -181,12 +180,11 @@ namespace RegistryPreviewUILib
         /// </summary>
         private async void SaveAsButton_Click(object sender, RoutedEventArgs e)
         {
-            if (!AskFileName(true))
+            if (!AskFileName(true) || !SaveFile())
             {
                 return;
             }
 
-            _ = SaveFile();
             UpdateToolBarAndUI(await OpenRegistryFile(_appFileName));
         }
 

--- a/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Events.cs
+++ b/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Events.cs
@@ -119,7 +119,6 @@ namespace RegistryPreviewUILib
                         break;
                     case ContentDialogResult.Secondary:
                         // Don't save and continue the file open!
-                        UpdateUnsavedFileState(false);
                         break;
                     default:
                         // Don't open the new file!

--- a/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Utilities.cs
+++ b/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Utilities.cs
@@ -63,7 +63,6 @@ namespace RegistryPreviewUILib
 
             // update the current window's title with the current filename
             _updateWindowTitleFunction(filename);
-            UpdateUnsavedFileIndicator(false);
 
             // Load in the whole file in one call and plop it all into editor
             FileStream fileStream = null;
@@ -1016,7 +1015,6 @@ namespace RegistryPreviewUILib
 
                 // only change when the save is successful
                 _updateWindowTitleFunction(_appFileName);
-                UpdateUnsavedFileIndicator(false);
                 saveButton.IsEnabled = false;
             }
             catch (UnauthorizedAccessException ex)

--- a/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Utilities.cs
+++ b/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Utilities.cs
@@ -888,6 +888,8 @@ namespace RegistryPreviewUILib
             }
             catch
             {
+                // Normally nothing to catch here.
+                // But for safety the try-catch ensures that we always release the content dialog lock and exit correctly.
             }
             finally
             {

--- a/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Utilities.cs
+++ b/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Utilities.cs
@@ -970,7 +970,7 @@ namespace RegistryPreviewUILib
                     _updateWindowTitleFunction(_unsavedFileIndicator + currentTitle);
                 }
             }
-            else if (!unsavedChanges)
+            else
             {
                 saveButton.IsEnabled = false;
 

--- a/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Utilities.cs
+++ b/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Utilities.cs
@@ -25,8 +25,8 @@ namespace RegistryPreviewUILib
     {
         private const string NEWFILEHEADER = "Windows Registry Editor Version 5.00\r\n\r\n";
 
-        private static readonly string _usavedFileIndicator = "* ";
-        private static readonly char[] _usavedFileIndicatorChars = [' ', '*'];
+        private static readonly string _unsavedFileIndicator = "* ";
+        private static readonly char[] _unsavedFileIndicatorChars = [' ', '*'];
         private static SemaphoreSlim _dialogSemaphore = new(1);
 
         private string lastKeyPath;
@@ -964,19 +964,19 @@ namespace RegistryPreviewUILib
         public void UpdateUnsavedFileIndicator(bool show)
         {
             // get and cut current title
-            string currentTitel = Regex.Replace(_mainWindow.Title, APPNAME + @"$|\s-\s" + APPNAME + @"$", string.Empty);
+            string currentTitle = Regex.Replace(_mainWindow.Title, APPNAME + @"$|\s-\s" + APPNAME + @"$", string.Empty);
 
             // verify
-            bool titleContiansIndicator = currentTitel.StartsWith(_usavedFileIndicator, StringComparison.CurrentCultureIgnoreCase);
+            bool titleContainsIndicator = currentTitle.StartsWith(_unsavedFileIndicator, StringComparison.CurrentCultureIgnoreCase);
 
             // update
-            if (!titleContiansIndicator && show)
+            if (!titleContainsIndicator && show)
             {
-                _updateWindowTitleFunction(_usavedFileIndicator + currentTitel);
+                _updateWindowTitleFunction(_unsavedFileIndicator + currentTitle);
             }
-            else if (titleContiansIndicator && !show)
+            else if (titleContainsIndicator && !show)
             {
-                _updateWindowTitleFunction(currentTitel.TrimStart(_usavedFileIndicatorChars));
+                _updateWindowTitleFunction(currentTitle.TrimStart(_unsavedFileIndicatorChars));
             }
         }
 

--- a/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Utilities.cs
+++ b/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Utilities.cs
@@ -63,6 +63,7 @@ namespace RegistryPreviewUILib
 
             // update the current window's title with the current filename
             _updateWindowTitleFunction(filename);
+            UpdateUnsavedFileIndicator(false);
 
             // Load in the whole file in one call and plop it all into editor
             FileStream fileStream = null;
@@ -1014,6 +1015,7 @@ namespace RegistryPreviewUILib
                 streamWriter.Close();
 
                 // only change when the save is successful
+                _updateWindowTitleFunction(_appFileName);
                 UpdateUnsavedFileIndicator(false);
                 saveButton.IsEnabled = false;
             }

--- a/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Utilities.cs
+++ b/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Utilities.cs
@@ -900,8 +900,8 @@ namespace RegistryPreviewUILib
                 _appFileName = filename;
             }
 
-            SaveFile();
-            return true;
+            bool r = SaveFile();
+            return r;
         }
 
         /// <summary>
@@ -983,8 +983,10 @@ namespace RegistryPreviewUILib
         /// <summary>
         /// Wrapper method that saves the current file in place, using the current text in editor.
         /// </summary>
-        private void SaveFile()
+        private bool SaveFile()
         {
+            bool saveSuccess = true;
+
             ChangeCursor(gridPreview, true);
 
             // set up the FileStream for all writing
@@ -1013,6 +1015,8 @@ namespace RegistryPreviewUILib
             }
             catch (UnauthorizedAccessException ex)
             {
+                saveSuccess = false;
+
                 // this exception is thrown if the file is there but marked as read only
                 ShowMessageBox(
                     resourceLoader.GetString("ErrorDialogTitle"),
@@ -1021,6 +1025,8 @@ namespace RegistryPreviewUILib
             }
             catch
             {
+                saveSuccess = false;
+
                 // this catch handles all other exceptions thrown when trying to write the file out
                 ShowMessageBox(
                     resourceLoader.GetString("ErrorDialogTitle"),
@@ -1038,6 +1044,8 @@ namespace RegistryPreviewUILib
 
             // restore the cursor
             ChangeCursor(gridPreview, false);
+
+            return saveSuccess;
         }
 
         /// <summary>

--- a/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Utilities.cs
+++ b/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Utilities.cs
@@ -30,6 +30,7 @@ namespace RegistryPreviewUILib
         private static SemaphoreSlim _dialogSemaphore = new(1);
 
         private string lastKeyPath;
+
         public delegate void UpdateWindowTitleFunction(string title);
 
         /// <summary>

--- a/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Utilities.cs
+++ b/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Utilities.cs
@@ -858,7 +858,7 @@ namespace RegistryPreviewUILib
             {
                 case ContentDialogResult.Primary:
                     // Save, then close
-                    if (!AskFileName(_appFileName) ||
+                    if (!AskFileName(string.Empty) ||
                         !SaveFile())
                     {
                         return;

--- a/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Utilities.cs
+++ b/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Utilities.cs
@@ -958,7 +958,7 @@ namespace RegistryPreviewUILib
         /// <summary>
         /// Ask the user for the file path if it is unknown because of an unsaved file
         /// </summary>
-        /// <param name="fileName">If not empty always aks for a file path and use the value as name.</param>
+        /// <param name="fileName">If not empty always ask for a file path and use the value as name.</param>
         /// <returns>Returns true if user selected a path, otherwise false</returns>
         public bool AskFileName(string fileName)
         {

--- a/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Utilities.cs
+++ b/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Utilities.cs
@@ -858,7 +858,7 @@ namespace RegistryPreviewUILib
             {
                 case ContentDialogResult.Primary:
                     // Save, then close
-                    if (!AskFileName(false) ||
+                    if (!AskFileName(_appFileName) ||
                         !SaveFile())
                     {
                         return;
@@ -958,18 +958,20 @@ namespace RegistryPreviewUILib
         /// <summary>
         /// Ask the user for the file path if it is unknown because of an unsaved file
         /// </summary>
-        /// <param name="askAlways">Ask regardless of the known file name in case of save as action.</param>
+        /// <param name="fileName">If not empty always aks for a file path and use the value as name.</param>
         /// <returns>Returns true if user selected a path, otherwise false</returns>
-        public bool AskFileName(bool askAlways)
+        public bool AskFileName(string fileName)
         {
-            if (string.IsNullOrEmpty(_appFileName) || askAlways )
+            if (string.IsNullOrEmpty(_appFileName) || !string.IsNullOrEmpty(fileName) )
             {
+                string fName = string.IsNullOrEmpty(fileName) ? resourceLoader.GetString("SuggestFileName") : fileName;
+
                 // Save out a new REG file and then open it - we have to use the direct Win32 method because FileOpenPicker crashes when it's
                 // called while running as admin
                 IntPtr windowHandle = WinRT.Interop.WindowNative.GetWindowHandle(_mainWindow);
                 string filename = SaveFilePicker.ShowDialog(
                     windowHandle,
-                    resourceLoader.GetString("SuggestFileName"),
+                    fName,
                     resourceLoader.GetString("FilterRegistryName") + '\0' + "*.reg" + '\0' + resourceLoader.GetString("FilterAllFiles") + '\0' + "*.*" + '\0' + '\0',
                     resourceLoader.GetString("SaveDialogTitle"));
 

--- a/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Utilities.cs
+++ b/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Utilities.cs
@@ -858,9 +858,9 @@ namespace RegistryPreviewUILib
             {
                 case ContentDialogResult.Primary:
                     // Save, then close
-                    if (!DirtyCloseSaveFile())
+                    if (!AskFileName(false) ||
+                        !SaveFile())
                     {
-                        // save cancelled
                         return;
                     }
 
@@ -877,31 +877,6 @@ namespace RegistryPreviewUILib
 
             // if we got here, we should try to close again
             Application.Current.Exit();
-        }
-
-        private bool DirtyCloseSaveFile()
-        {
-            if (string.IsNullOrEmpty(_appFileName))
-            {
-                // Save out a new REG file and then open it - we have to use the direct Win32 method because FileOpenPicker crashes when it's
-                // called while running as admin
-                IntPtr windowHandle = WinRT.Interop.WindowNative.GetWindowHandle(_mainWindow);
-                string filename = SaveFilePicker.ShowDialog(
-                    windowHandle,
-                    resourceLoader.GetString("SuggestFileName"),
-                    resourceLoader.GetString("FilterRegistryName") + '\0' + "*.reg" + '\0' + resourceLoader.GetString("FilterAllFiles") + '\0' + "*.*" + '\0' + '\0',
-                    resourceLoader.GetString("SaveDialogTitle"));
-
-                if (filename == string.Empty)
-                {
-                    return false;
-                }
-
-                _appFileName = filename;
-            }
-
-            bool r = SaveFile();
-            return r;
         }
 
         /// <summary>
@@ -978,6 +953,35 @@ namespace RegistryPreviewUILib
             {
                 _updateWindowTitleFunction(currentTitle.TrimStart(_unsavedFileIndicatorChars));
             }
+        }
+
+        /// <summary>
+        /// Ask the user for the file path if it is unknown because of an unsaved file
+        /// </summary>
+        /// <param name="askAlways">Ask regardless of the known file name in case of save as action.</param>
+        /// <returns>Returns true if user selected a path, otherwise false</returns>
+        public bool AskFileName(bool askAlways)
+        {
+            if (string.IsNullOrEmpty(_appFileName) || askAlways )
+            {
+                // Save out a new REG file and then open it - we have to use the direct Win32 method because FileOpenPicker crashes when it's
+                // called while running as admin
+                IntPtr windowHandle = WinRT.Interop.WindowNative.GetWindowHandle(_mainWindow);
+                string filename = SaveFilePicker.ShowDialog(
+                    windowHandle,
+                    resourceLoader.GetString("SuggestFileName"),
+                    resourceLoader.GetString("FilterRegistryName") + '\0' + "*.reg" + '\0' + resourceLoader.GetString("FilterAllFiles") + '\0' + "*.*" + '\0' + '\0',
+                    resourceLoader.GetString("SaveDialogTitle"));
+
+                if (filename == string.Empty)
+                {
+                    return false;
+                }
+
+                _appFileName = filename;
+            }
+
+            return true;
         }
 
         /// <summary>

--- a/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Utilities.cs
+++ b/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewMainPage.Utilities.cs
@@ -876,8 +876,7 @@ namespace RegistryPreviewUILib
                         break;
                     case ContentDialogResult.Secondary:
                         // Don't save, and then close!
-                        UpdateUnsavedFileIndicator(false);
-                        saveButton.IsEnabled = false;
+                        UpdateUnsavedFileState(false);
                         break;
                     default:
                         // Cancel closing!
@@ -953,22 +952,30 @@ namespace RegistryPreviewUILib
             type.InvokeMember("ProtectedCursor", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.SetProperty | BindingFlags.Instance, null, uiElement, new object[] { cursor }, CultureInfo.InvariantCulture);
         }
 
-        public void UpdateUnsavedFileIndicator(bool show)
+        public void UpdateUnsavedFileState(bool unsavedChanges)
         {
-            // get and cut current title
+            // get, cut and analyze the current title
             string currentTitle = Regex.Replace(_mainWindow.Title, APPNAME + @"$|\s-\s" + APPNAME + @"$", string.Empty);
-
-            // verify
             bool titleContainsIndicator = currentTitle.StartsWith(_unsavedFileIndicator, StringComparison.CurrentCultureIgnoreCase);
 
-            // update
-            if (!titleContainsIndicator && show)
+            // update window title and save button state
+            if (unsavedChanges)
             {
-                _updateWindowTitleFunction(_unsavedFileIndicator + currentTitle);
+                saveButton.IsEnabled = true;
+
+                if (!titleContainsIndicator)
+                {
+                    _updateWindowTitleFunction(_unsavedFileIndicator + currentTitle);
+                }
             }
-            else if (titleContainsIndicator && !show)
+            else if (!unsavedChanges)
             {
-                _updateWindowTitleFunction(currentTitle.TrimStart(_unsavedFileIndicatorChars));
+                saveButton.IsEnabled = false;
+
+                if (titleContainsIndicator)
+                {
+                    _updateWindowTitleFunction(currentTitle.TrimStart(_unsavedFileIndicatorChars));
+                }
             }
         }
 
@@ -1033,8 +1040,8 @@ namespace RegistryPreviewUILib
                 streamWriter.Close();
 
                 // only change when the save is successful
+                UpdateUnsavedFileState(false);
                 _updateWindowTitleFunction(_appFileName);
-                saveButton.IsEnabled = false;
             }
             catch (UnauthorizedAccessException ex)
             {

--- a/src/modules/registrypreview/RegistryPreviewUILib/Strings/en-US/Resources.resw
+++ b/src/modules/registrypreview/RegistryPreviewUILib/Strings/en-US/Resources.resw
@@ -258,11 +258,17 @@
   <data name="YesNoCancelDialogCloseButtonText" xml:space="preserve">
     <value>Cancel</value>
   </data>
+  <data name="ReloadDialogCloseButtonText" xml:space="preserve">
+    <value>No</value>
+  </data>
   <data name="YesNoCancelDialogContent" xml:space="preserve">
     <value>Save changes?</value>
   </data>
   <data name="YesNoCancelDialogPrimaryButtonText" xml:space="preserve">
     <value>Save</value>
+  </data>
+  <data name="ReloadDialogPrimaryButtonText" xml:space="preserve">
+    <value>Yes</value>
   </data>
   <data name="YesNoCancelDialogSecondaryButtonText" xml:space="preserve">
     <value>Don't save</value>
@@ -362,5 +368,8 @@
   </data>
   <data name="NewButton.Label" xml:space="preserve">
     <value>New</value>
+  </data>
+  <data name="ReloadDialogContent" xml:space="preserve">
+    <value>Unsaved changes. Reload anyway?</value>
   </data>
 </root>

--- a/src/modules/registrypreview/RegistryPreviewUILib/Strings/en-US/Resources.resw
+++ b/src/modules/registrypreview/RegistryPreviewUILib/Strings/en-US/Resources.resw
@@ -370,6 +370,6 @@
     <value>New</value>
   </data>
   <data name="ReloadDialogContent" xml:space="preserve">
-    <value>Unsaved changes. Reload anyway?</value>
+    <value>You lose any unsaved changes. Reload anyway?</value>
   </data>
 </root>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

### This PR implements various fixes and improvements into RegistryPreview for saving files:
1. Adds an unsaved file indicator in the title bar like in Notepad. (As indicator we show the * character before the file title.)
2. The save button behaves like a "save as" button, if the file does not exist on disk like in Notepad. (Without fix when running as non-admin you get an access denied error message.)
3. If the app gets closed without saving and the file does not exist on disk, then the user is now asked for the path. (Fixes crash on clicking save button while closing the app.)
4. Failed save actions are handled now correctly on dirty closing, opening files and all other actions that require saving the current state. They will stop the process.
5. A fix for an incorrect enabled state of the save button after opening, reloading and saving a file.
6. Reuse file name on save as button, if known. Otherwise use "new file" template name like in Notepad.
7. Fix an app crash if you click the window's close button a second time while the "Should save?" dialog is opened.
8. Added an reload dialog in case of unsaved changes.

![image](https://github.com/user-attachments/assets/9045446e-e9a3-4b81-8aa0-515b0821a969)

![image](https://github.com/user-attachments/assets/0888fbd2-851b-4101-a177-be9a3675b5ae)


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #36876, #36875
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Local test build.
