### PR TITLE
Don't open exclusive handles when reading shortcuts

### DIFF
--- a/src/modules/launcher/Wox.Infrastructure/ShellLinkHelper.cs
+++ b/src/modules/launcher/Wox.Infrastructure/ShellLinkHelper.cs
@@ -136,9 +136,13 @@ namespace Wox.Infrastructure
             var link = new ShellLink();
             const int STGM_READ = 0;
 
+            // Make sure not to open exclusive handles.
+            // See: https://github.com/microsoft/WSL/issues/11276
+            const int STGM_SHARE_DENY_NONE = 0x00000040;
+
             try
             {
-                ((IPersistFile)link).Load(path, STGM_READ);
+                ((IPersistFile)link).Load(path, STGM_READ | STGM_SHARE_DENY_NONE);
             }
             catch (System.IO.FileNotFoundException ex)
             {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->

This updates the `ShellLinkHelper` logic to pass the `STGM_SHARE_DENY_NONE` when reading desktop shortcuts to make sure that powertoys doesn't interfere with other programs. 

See: https://github.com/microsoft/WSL/issues/11276#issuecomment-2680560973 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #34391
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

