### PR TITLE
[PTRun Unit Converter] Support for 'sq' prefixed units

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -990,6 +990,7 @@ NIF
 NLog
 NLSTEXT
 NMAKE
+nmi
 NNN
 NOACTIVATE
 NOAGGREGATION
@@ -1493,6 +1494,16 @@ spsi
 spsia
 spsrm
 spsv
+sqcm
+sqdm
+sqft
+sqin
+sqkm
+sqm
+sqmi
+sqmm
+sqnmi
+sqyd
 SRCAND
 SRCCOPY
 SRCERASE

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/InputInterpreter.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/InputInterpreter.cs
@@ -267,74 +267,74 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
             switch (split[1].ToLower(culture))
             {
                 case "sqcm":
-                    split[1] = "cm^2";
+                    split[1] = "cm²";
                     break;
                 case "sqdm":
-                    split[1] = "dm^2";
+                    split[1] = "dm²";
                     break;
                 case "sqft":
-                    split[1] = "ft^2";
+                    split[1] = "ft²";
                     break;
                 case "sqin":
-                    split[1] = "in^2";
+                    split[1] = "in²";
                     break;
                 case "sqkm":
-                    split[1] = "km^2";
+                    split[1] = "km²";
                     break;
                 case "sqm":
-                    split[1] = "m^2";
+                    split[1] = "m²";
                     break;
                 case "sqmi":
-                    split[1] = "mi^2";
+                    split[1] = "mi²";
                     break;
                 case "sqmm":
-                    split[1] = "mm^2";
+                    split[1] = "mm²";
                     break;
                 case "sqnmi":
-                    split[1] = "nmi^2";
+                    split[1] = "nmi²";
                     break;
                 case "sqyd":
-                    split[1] = "yd^2";
+                    split[1] = "yd²";
                     break;
-                case "squm":
-                    split[1] = "µm^2";
+                case "sqµm":
+                    split[1] = "µm²";
                     break;
             }
 
             switch (split[3].ToLower(culture))
             {
                 case "sqcm":
-                    split[3] = "cm^2";
+                    split[3] = "cm²";
                     break;
                 case "sqdm":
-                    split[3] = "dm^2";
+                    split[3] = "dm²";
                     break;
                 case "sqft":
-                    split[3] = "ft^2";
+                    split[3] = "ft²";
                     break;
                 case "sqin":
-                    split[3] = "in^2";
+                    split[3] = "in²";
                     break;
                 case "sqkm":
-                    split[3] = "km^2";
+                    split[3] = "km²";
                     break;
                 case "sqm":
-                    split[3] = "m^2";
+                    split[3] = "m²";
                     break;
                 case "sqmi":
-                    split[3] = "mi^2";
+                    split[3] = "mi²";
                     break;
                 case "sqmm":
-                    split[3] = "mm^2";
+                    split[3] = "mm²";
                     break;
                 case "sqnmi":
-                    split[3] = "nmi^2";
+                    split[3] = "nmi²";
                     break;
                 case "sqyd":
-                    split[3] = "yd^2";
+                    split[3] = "yd²";
                     break;
                 case "sqµm":
-                    split[3] = "µm^2";
+                    split[3] = "µm²";
                     break;
             }
         }

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/InputInterpreter.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/InputInterpreter.cs
@@ -259,6 +259,86 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
             }
         }
 
+        /// <summary>
+        /// Convert between 'sq' notation and '^2' notation for square units.
+        /// </summary>
+        public static void SquareHandler(ref string[] split, CultureInfo culture)
+        {
+            switch (split[1].ToLower(culture))
+            {
+                case "sqcm":
+                    split[1] = "cm^2";
+                    break;
+                case "sqdm":
+                    split[1] = "dm^2";
+                    break;
+                case "sqft":
+                    split[1] = "ft^2";
+                    break;
+                case "sqin":
+                    split[1] = "in^2";
+                    break;
+                case "sqkm":
+                    split[1] = "km^2";
+                    break;
+                case "sqm":
+                    split[1] = "m^2";
+                    break;
+                case "sqmi":
+                    split[1] = "mi^2";
+                    break;
+                case "sqmm":
+                    split[1] = "mm^2";
+                    break;
+                case "sqnmi":
+                    split[1] = "nmi^2";
+                    break;
+                case "sqyd":
+                    split[1] = "yd^2";
+                    break;
+                case "squm":
+                    split[1] = "µm^2";
+                    break;
+            }
+
+            switch (split[3].ToLower(culture))
+            {
+                case "sqcm":
+                    split[3] = "cm^2";
+                    break;
+                case "sqdm":
+                    split[3] = "dm^2";
+                    break;
+                case "sqft":
+                    split[3] = "ft^2";
+                    break;
+                case "sqin":
+                    split[3] = "in^2";
+                    break;
+                case "sqkm":
+                    split[3] = "km^2";
+                    break;
+                case "sqm":
+                    split[3] = "m^2";
+                    break;
+                case "sqmi":
+                    split[3] = "mi^2";
+                    break;
+                case "sqmm":
+                    split[3] = "mm^2";
+                    break;
+                case "sqnmi":
+                    split[3] = "nmi^2";
+                    break;
+                case "sqyd":
+                    split[3] = "yd^2";
+                    break;
+                case "sqµm":
+                    split[3] = "µm^2";
+                    break;
+            }
+        }
+
         public static ConvertModel Parse(Query query)
         {
             string[] split = query.Search.Split(' ');
@@ -279,6 +359,7 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
             InputInterpreter.KPHHandler(ref split);
             InputInterpreter.GallonHandler(ref split, CultureInfo.CurrentCulture);
             InputInterpreter.OunceHandler(ref split, CultureInfo.CurrentCulture);
+            InputInterpreter.SquareHandler(ref split, CultureInfo.CurrentCulture);
             if (!double.TryParse(split[0], out double value))
             {
                 return null;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Adds support for square units prefixed with `sq`. For example, `sqm` for square metres, instead of `m^2`.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #37553 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Used simple substitution to swap `sq` prefixed units with their `^2` equivalent. For example, `sqft` is substituted with `ft²`, which is supported by UnitsNet.

For example, converting square feet to square metres can be done as follows:

![image](https://github.com/user-attachments/assets/4af0849b-9cab-4f2d-b341-3662fe8001c2)

Rather than:

![image](https://github.com/user-attachments/assets/361c8421-4ed6-41a7-83cb-e2236ba590d7)

This is additional to `^2` suffixed units, which are still available.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Basic testing done for each unit.