### PR TITLE
The default generated file path exceeds the length limit 260 for EnvironmentVariablesUILib.csproj

### DIFF
--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesUILib.csproj
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesUILib.csproj
@@ -15,6 +15,8 @@
     <ProjectPriFileName>PowerToys.EnvironmentVariablesUILib.pri</ProjectPriFileName>
     <GenerateLibraryLayout>true</GenerateLibraryLayout>
     <IsPackable>true</IsPackable>
+    <!-- The default generated file path exceeds the length limit 260 on the build agent. Using a shorter path as a workaround. -->
+    <CompilerGeneratedFilesOutputPath>$(ProjectDir)obj\g</CompilerGeneratedFilesOutputPath>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -53,4 +55,8 @@
     <PackageReference Include="System.Text.Json" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>
+
+  <Target Name="EnsureCompilerGeneratedFilesOutputPathExists" BeforeTargets="XamlPreCompile">
+    <MakeDir Directories="$(CompilerGeneratedFilesOutputPath)" />
+  </Target>
 </Project>


### PR DESCRIPTION
## Summary of the Pull Request
The default generated file path exceeds the length limit 260 for EnvironmentVariablesUILib.csproj
e.g. 
D:\a\_work\1\s\src\modules\EnvironmentVariables\EnvironmentVariablesUILib\obj\Release\generated\CommunityToolkit.Mvvm.SourceGenerators\CommunityToolkit.Mvvm.SourceGenerators.ObservablePropertyGenerator\EnvironmentVariablesUILib.Models.ProfileVariablesSet.g.cs is too long, and it caused issue.

## How to repro locally
Make a longer path, e.g. %USERPROFILE%\source\repos\Powertoys
Then try to build the EnvironmentVariablesUILib.csproj (Do nuget restore EnvironmentVariablesUILib.csproj first) by the following:
msbuild /p:Configuration=Debug /p:EnsureSourceGeneratorsRun=true /p:EmitCompilerGeneratedFiles=true EnvironmentVariablesUILib.csproj

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
   - [x] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
   https://microsoft.visualstudio.com/Dart/_build/results?buildId=117251404&view=results