### PR TITLE
[CNF] Only enable experimental features if they exist

### DIFF
--- a/src/settings-ui/Settings.UI/Assets/Settings/Scripts/EnableModule.ps1
+++ b/src/settings-ui/Settings.UI/Assets/Settings/Scripts/EnableModule.ps1
@@ -4,10 +4,17 @@ Param(
   [string]$scriptPath
 )
 
-Write-Host "Enabling experimental feature: PSFeedbackProvider"
-Enable-ExperimentalFeature PSFeedbackProvider
-Write-Host "Enabling experimental feature: PSCommandNotFoundSuggestion"
-Enable-ExperimentalFeature PSCommandNotFoundSuggestion
+$experimentalFeatures = Get-ExperimentalFeature;
+if ($experimentalFeatures.Name -contains "PSFeedbackProvider")
+{
+  Write-Host "Enabling experimental feature: PSFeedbackProvider"
+  Enable-ExperimentalFeature PSFeedbackProvider
+}
+if ($experimentalFeatures.Name -contains "PSCommandNotFoundSuggestion")
+{
+  Write-Host "Enabling experimental feature: PSCommandNotFoundSuggestion"
+  Enable-ExperimentalFeature PSCommandNotFoundSuggestion
+}
 
 $wingetModules = Get-Module -ListAvailable -Name Microsoft.WinGet.Client
 if ($wingetModules) {


### PR DESCRIPTION
## Summary of the Pull Request
Updates the WinGet Command Not Found script to only enable the experimental features if they actually exist. 

PowerShell graduated the PSCommandNotFoundSuggestion experimental feature in v[7.5.0-preview.5](https://github.com/PowerShell/PowerShell/compare/v7.5.0-preview.4...v7.5.0-preview.5) 🎉. Might as well future proof this.

## Validation Steps Performed
✅ PowerShell v7.5.0 --> PSFeedbackProvider detected, PSCommandNotFoundSuggestion not
✅ PowerShell v7.4.5 --> PSFeedbackProvider and PSCommandNotFoundSuggestion detected