### PR TITLE
[PowerAccent] Cancel previous ShowToolbar task if a new one is triggered

### DIFF
--- a/src/modules/poweraccent/PowerAccent.Core/PowerAccent.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/PowerAccent.cs
@@ -62,11 +62,11 @@ public partial class PowerAccent : IDisposable
 
     private void SetEvents()
     {
-        _keyboardListener.SetShowToolbarEvent(new PowerToys.PowerAccentKeyboardService.ShowToolbar((LetterKey letterKey) =>
+        _keyboardListener.SetShowToolbarEvent(new PowerToys.PowerAccentKeyboardService.ShowToolbar((LetterKey letterKey, TriggerKey trigger ) =>
         {
             System.Windows.Application.Current.Dispatcher.Invoke(() =>
             {
-                ShowToolbar(letterKey);
+                ShowToolbar(letterKey, trigger);
             });
         }));
 
@@ -92,17 +92,15 @@ public partial class PowerAccent : IDisposable
         }));
     }
 
-    private void ShowToolbar(LetterKey letterKey)
+    private void ShowToolbar(LetterKey letterKey, TriggerKey trigger)
     {
         _visible = true;
 
         _characters = GetCharacters(letterKey);
         _characterDescriptions = GetCharacterDescriptions(_characters);
         _showUnicodeDescription = _settingService.ShowUnicodeDescription;
-        System.Windows.Application.Current.Dispatcher.Invoke(() =>
-        {
-            OnChangeDisplay?.Invoke(true, _characters);
-        });
+        OnChangeDisplay?.Invoke(true, _characters);
+        ProcessNextChar(trigger, false);
     }
 
     private string[] GetCharacters(LetterKey letterKey)
@@ -226,6 +224,8 @@ public partial class PowerAccent : IDisposable
                 }
         }
 
+        Logger.LogInfo("SendInputAndHideToolbar");
+
         OnChangeDisplay?.Invoke(false, null);
         _selectedIndex = -1;
         _visible = false;
@@ -233,6 +233,7 @@ public partial class PowerAccent : IDisposable
 
     private void ProcessNextChar(TriggerKey triggerKey, bool shiftPressed)
     {
+        Logger.LogInfo("ProcessNextChar");
         if (_visible && _selectedIndex == -1)
         {
             if (triggerKey == TriggerKey.Left)

--- a/src/modules/poweraccent/PowerAccent.Core/PowerAccent.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/PowerAccent.cs
@@ -41,8 +41,6 @@ public partial class PowerAccent : IDisposable
 
     private readonly CharactersUsageInfo _usageInfo;
 
-    private CancellationTokenSource _cancellationTokenSource;
-
     public PowerAccent()
     {
         Logger.InitializeLogger("\\QuickAccent\\Logs");
@@ -101,25 +99,10 @@ public partial class PowerAccent : IDisposable
         _characters = GetCharacters(letterKey);
         _characterDescriptions = GetCharacterDescriptions(_characters);
         _showUnicodeDescription = _settingService.ShowUnicodeDescription;
-
-        _cancellationTokenSource?.Cancel();
-        _cancellationTokenSource = new CancellationTokenSource();
-
-        Task.Delay(_settingService.InputTime, _cancellationTokenSource.Token).ContinueWith(
-        t =>
+        System.Windows.Application.Current.Dispatcher.Invoke(() =>
         {
-            // Skip if the task was cancelled.
-            if (t.IsCanceled)
-            {
-                return;
-            }
-
-            if (_visible)
-            {
-                OnChangeDisplay?.Invoke(true, _characters);
-            }
-        },
-        TaskScheduler.FromCurrentSynchronizationContext());
+            OnChangeDisplay?.Invoke(true, _characters);
+        });
     }
 
     private string[] GetCharacters(LetterKey letterKey)

--- a/src/modules/poweraccent/PowerAccent.Core/PowerAccent.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/PowerAccent.cs
@@ -224,8 +224,6 @@ public partial class PowerAccent : IDisposable
                 }
         }
 
-        Logger.LogInfo("SendInputAndHideToolbar");
-
         OnChangeDisplay?.Invoke(false, null);
         _selectedIndex = -1;
         _visible = false;
@@ -233,7 +231,6 @@ public partial class PowerAccent : IDisposable
 
     private void ProcessNextChar(TriggerKey triggerKey, bool shiftPressed)
     {
-        Logger.LogInfo("ProcessNextChar");
         if (_visible && _selectedIndex == -1)
         {
             if (triggerKey == TriggerKey.Left)

--- a/src/modules/poweraccent/PowerAccent.UI/Selector.xaml.cs
+++ b/src/modules/poweraccent/PowerAccent.UI/Selector.xaml.cs
@@ -6,6 +6,8 @@ using System;
 using System.ComponentModel;
 using System.Windows;
 
+using ManagedCommon;
+
 using Wpf.Ui.Controls;
 
 using Point = PowerAccent.Core.Point;
@@ -57,6 +59,7 @@ public partial class Selector : FluentWindow, IDisposable, INotifyPropertyChange
 
     private void PowerAccent_OnSelectionCharacter(int index, string character)
     {
+        Logger.LogInfo($"Ionut index {index}");
         _selectedIndex = index;
         characters.SelectedIndex = _selectedIndex;
         characterName.Text = _powerAccent.CharacterDescriptions[_selectedIndex];

--- a/src/modules/poweraccent/PowerAccent.UI/Selector.xaml.cs
+++ b/src/modules/poweraccent/PowerAccent.UI/Selector.xaml.cs
@@ -6,8 +6,6 @@ using System;
 using System.ComponentModel;
 using System.Windows;
 
-using ManagedCommon;
-
 using Wpf.Ui.Controls;
 
 using Point = PowerAccent.Core.Point;
@@ -59,7 +57,6 @@ public partial class Selector : FluentWindow, IDisposable, INotifyPropertyChange
 
     private void PowerAccent_OnSelectionCharacter(int index, string character)
     {
-        Logger.LogInfo($"Ionut index {index}");
         _selectedIndex = index;
         characters.SelectedIndex = _selectedIndex;
         characterName.Text = _powerAccent.CharacterDescriptions[_selectedIndex];

--- a/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.cpp
+++ b/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.cpp
@@ -228,14 +228,17 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
         {
             if (triggerPressed == VK_LEFT)
             {
+                Logger::debug(L"Next toolbar position - left");
                 m_nextCharCb(TriggerKey::Left, m_leftShiftPressed || m_rightShiftPressed);
             }
             else if (triggerPressed == VK_RIGHT)
             {
+                Logger::debug(L"Next toolbar position - right");
                 m_nextCharCb(TriggerKey::Right, m_leftShiftPressed || m_rightShiftPressed);
             }
             else if (triggerPressed == VK_SPACE)
             {
+                Logger::debug(L"Next toolbar position - space");
                 m_nextCharCb(TriggerKey::Space, m_leftShiftPressed || m_rightShiftPressed);
             }
 
@@ -270,7 +273,6 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
                     // False start, we should output the space if it was the trigger.
                     if (m_triggeredWithSpace)
                     {
-                        Logger::debug(L"m_hideToolbarCb space");
                         m_hideToolbarCb(InputType::Space);
                     }
                     else if (m_triggeredWithLeftArrow)
@@ -300,7 +302,6 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
 
         if (letterPressed == LetterKey::None || (triggerPressed == VK_SPACE || triggerPressed == VK_LEFT  || triggerPressed == VK_RIGHT ))
         {
-            Logger::debug(L"m_activationKeyHold cancel");
             m_activationKeyHold = false;
             toolbarCV.notify_all();
         }

--- a/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.cpp
+++ b/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.cpp
@@ -211,6 +211,7 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
             m_triggeredWithLeftArrow = triggerPressed == VK_LEFT;
             m_triggeredWithRightArrow = triggerPressed == VK_RIGHT;
             m_activationKeyHold = true;
+            m_bothKeysPressed = true;
             if (toolbarThread != nullptr)
             {
                 toolbarCV.notify_all();
@@ -263,8 +264,9 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
         {
             letterPressed = LetterKey::None;
 
-            if (m_toolbarVisible || m_activationKeyHold)
+            if (m_toolbarVisible || m_bothKeysPressed)
             {
+                m_bothKeysPressed = false;
                 if (m_stopwatch.elapsed() < m_settings.inputTime)
                 {
                     Logger::debug(L"Activation too fast. Do nothing.");
@@ -292,14 +294,13 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
                 Logger::debug(L"Hide toolbar event and input char");
 
                 m_hideToolbarCb(InputType::Char);
-
                 m_toolbarVisible = false;
             }
         }
 
         auto triggerPressed = info.vkCode;
 
-        if (letterPressed == LetterKey::None || (triggerPressed == VK_SPACE || triggerPressed == VK_LEFT  || triggerPressed == VK_RIGHT ))
+        if (m_activationKeyHold && (letterPressed == LetterKey::None || (triggerPressed == VK_SPACE || triggerPressed == VK_LEFT || triggerPressed == VK_RIGHT)))
         {
             m_activationKeyHold = false;
             toolbarCV.notify_all();

--- a/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.cpp
+++ b/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.cpp
@@ -154,7 +154,6 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
 
     void KeyboardListener::BeginShowToolbar(std::chrono::milliseconds delay, LetterKey key, TriggerKey trigger)
     {
-        Logger::debug(L"BeginShowToolbar space");
         std::unique_lock<std::mutex> lock(toolbarMutex);
         auto result = toolbarCV.wait_for(lock, delay);
         if (result == std::cv_status::timeout)
@@ -264,7 +263,7 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
         {
             letterPressed = LetterKey::None;
 
-            if (m_toolbarVisible)
+            if (m_toolbarVisible || m_activationKeyHold)
             {
                 if (m_stopwatch.elapsed() < m_settings.inputTime)
                 {

--- a/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.h
+++ b/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.h
@@ -45,7 +45,7 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
         static LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam);
 
     private:
-        void BeginShowToolbar(std::chrono::milliseconds delay, LetterKey key);
+        void BeginShowToolbar(std::chrono::milliseconds delay, LetterKey key, TriggerKey trigger);
         bool OnKeyDown(KBDLLHOOKSTRUCT info) noexcept;
         bool OnKeyUp(KBDLLHOOKSTRUCT info) noexcept;
         bool IsSuppressedByGameMode();
@@ -59,7 +59,7 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
         std::mutex toolbarMutex;
         std::condition_variable toolbarCV;
         PowerAccentSettings m_settings;
-        std::function<void(LetterKey)> m_showToolbarCb;
+        std::function<void(LetterKey, TriggerKey)> m_showToolbarCb;
         std::function<void(InputType)> m_hideToolbarCb;
         std::function<void(TriggerKey, bool)> m_nextCharCb;
         std::function<bool(LetterKey)> m_isLanguageLetterCb;

--- a/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.h
+++ b/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.h
@@ -53,8 +53,9 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
 
         static inline KeyboardListener* s_instance;
         HHOOK s_llKeyboardHook = nullptr;
-        bool m_toolbarVisible;
+        std::atomic<bool> m_toolbarVisible;
         bool m_activationKeyHold;
+        bool m_bothKeysPressed = false;
         std::unique_ptr<std::thread> toolbarThread;
         std::mutex toolbarMutex;
         std::condition_variable toolbarCV;

--- a/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.h
+++ b/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.h
@@ -2,6 +2,7 @@
 
 #include "KeyboardListener.g.h"
 #include <mutex>
+#include <thread>
 #include <spdlog/stopwatch.h>
 
 namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
@@ -44,6 +45,7 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
         static LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam);
 
     private:
+        void BeginShowToolbar(std::chrono::milliseconds delay, LetterKey key);
         bool OnKeyDown(KBDLLHOOKSTRUCT info) noexcept;
         bool OnKeyUp(KBDLLHOOKSTRUCT info) noexcept;
         bool IsSuppressedByGameMode();
@@ -52,6 +54,10 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
         static inline KeyboardListener* s_instance;
         HHOOK s_llKeyboardHook = nullptr;
         bool m_toolbarVisible;
+        bool m_activationKeyHold;
+        std::unique_ptr<std::thread> toolbarThread;
+        std::mutex toolbarMutex;
+        std::condition_variable toolbarCV;
         PowerAccentSettings m_settings;
         std::function<void(LetterKey)> m_showToolbarCb;
         std::function<void(InputType)> m_hideToolbarCb;

--- a/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.idl
+++ b/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.idl
@@ -67,7 +67,7 @@ namespace PowerToys
             Char
         };
 
-        [version(1.0), uuid(37197089-5438-4479-af57-30ab3f3c8be4)] delegate void ShowToolbar(LetterKey key);
+        [version(1.0), uuid(37197089-5438-4479-af57-30ab3f3c8be4)] delegate void ShowToolbar(LetterKey key, TriggerKey trigger);
         [version(1.0), uuid(8eb79d6b-1826-424f-9fbc-af21ae19725e)] delegate void HideToolbar(InputType inputType);
         [version(1.0), uuid(db72d45c-a5a2-446f-bdc1-506e9121764a)] delegate void NextChar(TriggerKey inputSpace, boolean shiftPressed);
         [version(1.0), uuid(20be2919-2b91-4313-b6e0-4c3484fe91ef)] delegate void IsLanguageLetter(LetterKey key, [out] boolean* result);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Now cancel the task of ShowToolbar if another is started,
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [X] **Closes:** #35803
- [X] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
ShowToolbar  would start a task with the delay of the normal input delay, this is an issue since if you release the activation key and then press it again a new task would be created, then the previous task could end and show the toolbar. This creates scenarios where showing of the toolbar is not always at the same time.
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Tested by using 300ms delay.
Tested by using 5000ms delay. Hold the spacebar for 3 seconds release and then hold it again for 5 seconds. Previously the taskbar would be triggered at the second hold after holding it for 2 seconds, Now it is shown after holding it for 5 seconds.
