### PR TITLE
[OOBE] Fix release notes error InfoBars

### DIFF
--- a/src/settings-ui/Settings.UI/SettingsXAML/OOBE/Views/OobeWhatsNew.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/OOBE/Views/OobeWhatsNew.xaml
@@ -84,8 +84,7 @@
             Grid.Row="2"
             VerticalAlignment="Top"
             IsClosable="False"
-            IsOpen="False"
-            IsTabStop="True"
+            IsTabStop="False"
             Severity="Error" />
         <InfoBar
             x:Name="ProxyWarningInfoBar"
@@ -93,8 +92,7 @@
             Grid.Row="2"
             VerticalAlignment="Top"
             IsClosable="False"
-            IsOpen="False"
-            IsTabStop="True"
+            IsTabStop="False"
             Severity="Warning" />
 
         <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto">

--- a/src/settings-ui/Settings.UI/SettingsXAML/OOBE/Views/OobeWhatsNew.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/OOBE/Views/OobeWhatsNew.xaml
@@ -16,6 +16,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
@@ -85,7 +86,19 @@
             VerticalAlignment="Top"
             IsClosable="False"
             IsTabStop="False"
-            Severity="Error" />
+            Severity="Error">
+            <InfoBar.ActionButton>
+                <Button
+                    x:Uid="RetryBtn"
+                    HorizontalAlignment="Right"
+                    Click="LoadReleaseNotes_Click">
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <FontIcon FontSize="16" Glyph="&#xE72C;" />
+                        <TextBlock x:Uid="RetryLabel" />
+                    </StackPanel>
+                </Button>
+            </InfoBar.ActionButton>
+        </InfoBar>
         <InfoBar
             x:Name="ProxyWarningInfoBar"
             x:Uid="Oobe_WhatsNew_ProxyAuthenticationWarning"
@@ -93,9 +106,21 @@
             VerticalAlignment="Top"
             IsClosable="False"
             IsTabStop="False"
-            Severity="Warning" />
+            Severity="Warning">
+            <InfoBar.ActionButton>
+                <Button
+                    x:Uid="RetryBtn"
+                    HorizontalAlignment="Right"
+                    Click="LoadReleaseNotes_Click">
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <FontIcon FontSize="16" Glyph="&#xE72C;" />
+                        <TextBlock x:Uid="RetryLabel" />
+                    </StackPanel>
+                </Button>
+            </InfoBar.ActionButton>
+        </InfoBar>
 
-        <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto">
+        <ScrollViewer Grid.Row="3" VerticalScrollBarVisibility="Auto">
             <Grid Margin="32,24,32,24">
                 <ProgressRing
                     x:Name="LoadingProgressRing"

--- a/src/settings-ui/Settings.UI/SettingsXAML/OOBE/Views/OobeWhatsNew.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/OOBE/Views/OobeWhatsNew.xaml.cs
@@ -10,7 +10,6 @@ using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
@@ -130,9 +129,8 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
             try
             {
                 string releaseNotesMarkdown = await GetReleaseNotesMarkdown();
-
-                ProxyWarningInfoBar.Visibility = Microsoft.UI.Xaml.Visibility.Collapsed;
-                ErrorInfoBar.Visibility = Microsoft.UI.Xaml.Visibility.Collapsed;
+                SetInfoBar(ProxyWarningInfoBar, false);
+                SetInfoBar(ErrorInfoBar, false);
 
                 ReleaseNotesMarkdown.Text = releaseNotesMarkdown;
                 ReleaseNotesMarkdown.Visibility = Microsoft.UI.Xaml.Visibility.Visible;
@@ -143,17 +141,17 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
                 Logger.LogError("Exception when loading the release notes", httpEx);
                 if (httpEx.Message.Contains("407", StringComparison.CurrentCulture))
                 {
-                    ProxyWarningInfoBar.Visibility = Microsoft.UI.Xaml.Visibility.Visible;
+                    SetInfoBar(ProxyWarningInfoBar, true);
                 }
                 else
                 {
-                    ErrorInfoBar.Visibility = Microsoft.UI.Xaml.Visibility.Visible;
+                    SetInfoBar(ErrorInfoBar, true);
                 }
             }
             catch (Exception ex)
             {
                 Logger.LogError("Exception when loading the release notes", ex);
-                ErrorInfoBar.Visibility = Microsoft.UI.Xaml.Visibility.Visible;
+                SetInfoBar(ErrorInfoBar, true);
             }
             finally
             {
@@ -247,6 +245,12 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
         private void DataDiagnostics_OpenSettings_Click(Microsoft.UI.Xaml.Documents.Hyperlink sender, Microsoft.UI.Xaml.Documents.HyperlinkClickEventArgs args)
         {
             Common.UI.SettingsDeepLink.OpenSettings(Common.UI.SettingsDeepLink.SettingsWindow.Overview, true);
+        }
+
+        private void SetInfoBar(InfoBar infoBar, bool open)
+        {
+            infoBar.IsOpen = open;
+            infoBar.IsTabStop = open;
         }
     }
 }

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -4895,6 +4895,12 @@ To record a specific window, enter the hotkey with the Alt key in the opposite m
   </data>
   <data name="SettingsPage_NewInfoBadge.Text" xml:space="preserve">
     <value>NEW</value>
-	<comment>Must be all caps</comment>
+    <comment>Must be all caps</comment>
+  </data>
+  <data name="RetryBtn.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Retry</value>
+  </data>
+  <data name="RetryLabel.Text" xml:space="preserve">
+    <value>Retry</value>
   </data>
 </root>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

The InfoBars that should be displayed when release notes fail to fetch are never shown because they are closed.
Changes in the PR properly set `IsOpen` and `TabStop` for both InfoBars instead of `Visibility`.
Also add a retry button.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<img width="816" alt="Screenshot 2025-03-08 124326" src="https://github.com/user-attachments/assets/dceebaf7-ae03-4da5-b129-878e0329261b" />

![Animation](https://github.com/user-attachments/assets/8dcb23c5-0786-4dfc-ab6f-150033069da6)

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Manually tested:

- Verify that the What's New is still working as expected
- Altered the code to throw the required Exception and verified that both InfoBars are displayed
- Tested InfoBar tab navigation + narrator
