### PR TITLE
37405 Advanced Paste: Image To Text doesn't work with English (Canada)

### DIFF
--- a/src/modules/AdvancedPaste/AdvancedPaste/Helpers/OcrHelpers.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/Helpers/OcrHelpers.cs
@@ -18,10 +18,19 @@ public static class OcrHelpers
 {
     public static async Task<string> ExtractTextAsync(SoftwareBitmap bitmap, CancellationToken cancellationToken)
     {
-        var ocrLanguage = GetOCRLanguage() ?? throw new InvalidOperationException("Unable to determine OCR language");
+        var ocrLanguage = GetOCRLanguage();
         cancellationToken.ThrowIfCancellationRequested();
 
-        var ocrEngine = OcrEngine.TryCreateFromLanguage(ocrLanguage) ?? throw new InvalidOperationException("Unable to create OCR engine");
+        OcrEngine ocrEngine;
+        if (ocrLanguage is not null)
+        {
+            ocrEngine = OcrEngine.TryCreateFromLanguage(ocrLanguage) ?? throw new InvalidOperationException("Unable to create OCR engine");
+        }
+        else
+        {
+            ocrEngine = OcrEngine.TryCreateFromUserProfileLanguages() ?? throw new InvalidOperationException("Unable to create OCR engine");
+        }
+
         cancellationToken.ThrowIfCancellationRequested();
 
         var ocrResult = await ocrEngine.RecognizeAsync(bitmap);

--- a/src/modules/AdvancedPaste/AdvancedPaste/Helpers/OcrHelpers.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/Helpers/OcrHelpers.cs
@@ -24,11 +24,11 @@ public static class OcrHelpers
         OcrEngine ocrEngine;
         if (ocrLanguage is not null)
         {
-            ocrEngine = OcrEngine.TryCreateFromLanguage(ocrLanguage) ?? throw new InvalidOperationException("Unable to create OCR engine");
+            ocrEngine = OcrEngine.TryCreateFromLanguage(ocrLanguage) ?? throw new InvalidOperationException("Unable to create OCR engine from specified language");
         }
         else
         {
-            ocrEngine = OcrEngine.TryCreateFromUserProfileLanguages() ?? throw new InvalidOperationException("Unable to create OCR engine");
+            ocrEngine = OcrEngine.TryCreateFromUserProfileLanguages() ?? throw new InvalidOperationException("Unable to create OCR engine from user profile languages");
         }
 
         cancellationToken.ThrowIfCancellationRequested();

--- a/src/modules/AdvancedPaste/AdvancedPaste/Helpers/OcrHelpers.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/Helpers/OcrHelpers.cs
@@ -28,7 +28,7 @@ public static class OcrHelpers
         }
         else
         {
-            ocrEngine = OcrEngine.TryCreateFromUserProfileLanguages() ?? throw new InvalidOperationException("Unable to create OCR engine from user profile languages");
+            ocrEngine = OcrEngine.TryCreateFromUserProfileLanguages() ?? throw new InvalidOperationException("Unable to create OCR engine from user profile language");
         }
 
         cancellationToken.ThrowIfCancellationRequested();


### PR DESCRIPTION
## Summary of the Pull Request
Fix advanced paste failing to create ocrEngine on some English language tags. (en-CA, others)

## PR Checklist

- [x] **Closes:** #37405
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments

When attempting to use AdvancedPaste Image to Text, and error was shown with stack trace in logs. 

Method GetOCRLanguage compared the current language tag (en-CA) to OcrEngine.AvailableRecognizerLanguages. The returned list on my PC was en-GB, en-US. Both of these should work for OCR against en-CA. 

Added check if GetOCRLanguage returned null, call TryCreateFromUserProfileLanguages. In my cases, this succeeds, however I do not know what that behaviour may lead to in other language combinations.

## Validation Steps Performed

Built installer
Installed in a fresh vm with language set to en-CA
Attempted Image to Text
OCR was successful