### PR TITLE
empowering users to maximize OOBE to their heart desire

### DIFF
--- a/src/settings-ui/Settings.UI/SettingsXAML/OobeWindow.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/OobeWindow.xaml.cs
@@ -31,7 +31,6 @@ namespace Microsoft.PowerToys.Settings.UI
         private WindowId _windowId;
         private IntPtr _hWnd;
         private AppWindow _appWindow;
-        private WindowMessageMonitor _msgMonitor;
         private bool disposedValue;
 
         public OobeWindow(PowerToysModules initialModule)
@@ -47,10 +46,6 @@ namespace Microsoft.PowerToys.Settings.UI
             _appWindow = AppWindow.GetFromWindowId(_windowId);
             _appWindow.SetIcon("Assets\\Settings\\icon.ico");
 
-            OverlappedPresenter presenter = _appWindow.Presenter as OverlappedPresenter;
-            presenter.IsMinimizable = false;
-            presenter.IsMaximizable = false;
-
             var dpi = NativeMethods.GetDpiForWindow(_hWnd);
             _currentDPI = dpi;
             float scalingFactor = (float)dpi / DefaultDPI;
@@ -63,18 +58,6 @@ namespace Microsoft.PowerToys.Settings.UI
             _appWindow.Resize(size);
 
             this.initialModule = initialModule;
-
-            _msgMonitor = new WindowMessageMonitor(this);
-            _msgMonitor.WindowMessageReceived += (_, e) =>
-            {
-                const int WM_NCLBUTTONDBLCLK = 0x00A3;
-                if (e.Message.MessageId == WM_NCLBUTTONDBLCLK)
-                {
-                    // Disable double click on title bar to maximize window
-                    e.Result = 0;
-                    e.Handled = true;
-                }
-            };
 
             this.SizeChanged += OobeWindow_SizeChanged;
 
@@ -149,8 +132,6 @@ namespace Microsoft.PowerToys.Settings.UI
         {
             if (!disposedValue)
             {
-                _msgMonitor?.Dispose();
-
                 disposedValue = true;
             }
         }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Small quality of improvement for users that want to maximize OOBE.  I think this was a design choice we all made for pure design.  I don't see any good reason to not allow the window to maximize.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #https://github.com/microsoft/PowerToys/issues/37785
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

