### PR TITLE
[PTRun][UnitConverter]Add support for `sq` prefix for square units

### DIFF
--- a/.github/actions/spell-check/allow/code.txt
+++ b/.github/actions/spell-check/allow/code.txt
@@ -232,6 +232,9 @@ SWAPBUTTON
 SYSTEMDOCKED
 TABLETPC
 
+# Units
+nmi
+
 # MATH
 
 artanh

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter.UnitTest/InputInterpreterTests.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter.UnitTest/InputInterpreterTests.cs
@@ -71,10 +71,20 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter.UnitTest
         [DataRow(new string[] { "5", "f", "in", "celsius" }, new string[] { "5", "°F", "in", "DegreeCelsius" })]
         [DataRow(new string[] { "5", "c", "in", "f" }, new string[] { "5", "°C", "in", "°F" })]
         [DataRow(new string[] { "5", "f", "in", "c" }, new string[] { "5", "°F", "in", "°C" })]
-#pragma warning restore CA1861 // Avoid constant arrays as arguments
         public void PrefixesDegrees(string[] input, string[] expectedResult)
         {
             InputInterpreter.DegreePrefixer(ref input);
+            CollectionAssert.AreEqual(expectedResult, input);
+        }
+
+        [DataTestMethod]
+        [DataRow(new string[] { "7", "cm/sqs", "in", "m/s^2" }, new string[] { "7", "cm/s²", "in", "m/s^2" })]
+        [DataRow(new string[] { "7", "sqft", "in", "sqcm" }, new string[] { "7", "ft²", "in", "cm²" })]
+        [DataRow(new string[] { "7", "BTU/s·sqin", "in", "cal/h·sqcm" }, new string[] { "7", "BTU/s·in²", "in", "cal/h·cm²" })]
+#pragma warning restore CA1861 // Avoid constant arrays as arguments
+        public void HandlesSquareNotation(string[] input, string[] expectedResult)
+        {
+            InputInterpreter.SquareHandler(ref input);
             CollectionAssert.AreEqual(expectedResult, input);
         }
 

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/InputInterpreter.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.UnitConverter/InputInterpreter.cs
@@ -259,6 +259,12 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
             }
         }
 
+        public static void SquareHandler(ref string[] split)
+        {
+            split[1] = Regex.Replace(split[1], "sq(s|μm|mm|cm|dm|m|km|mil|in|ft|yd|mi|nmi)", "$1²");
+            split[3] = Regex.Replace(split[3], "sq(s|μm|mm|cm|dm|m|km|mil|in|ft|yd|mi|nmi)", "$1²");
+        }
+
         public static ConvertModel Parse(Query query)
         {
             string[] split = query.Search.Split(' ');
@@ -279,6 +285,7 @@ namespace Community.PowerToys.Run.Plugin.UnitConverter
             InputInterpreter.KPHHandler(ref split);
             InputInterpreter.GallonHandler(ref split, CultureInfo.CurrentCulture);
             InputInterpreter.OunceHandler(ref split, CultureInfo.CurrentCulture);
+            InputInterpreter.SquareHandler(ref split);
             if (!double.TryParse(split[0], out double value))
             {
                 return null;


### PR DESCRIPTION
## Summary of the Pull Request
Adds support for using `sq` instead of `^2`, for example `sqcm` instead of `cm^2`.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #37553, #37648
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [x] **Dev docs:** No need
- [x] **New binaries:** None
- [ ] **Documentation updated:** Not yet
## Detailed Description of the Pull Request / Additional comments
* Replaces `sq` with `²` if before a unit that can be square.
* Works for the following units: s, μm, mm, cm, dm, m, km, mil, in, ft, yd, mi, nmi, ft (US)
* Unlike the original PR, this also works with more complex units, such as `m/sqs` instead of `m/s^2`.

Screenshots that weren't possible before:
![image](https://github.com/user-attachments/assets/1e36a360-db89-4d6f-9b7f-061c636d4a21)
![image](https://github.com/user-attachments/assets/9cca3d05-bf41-4f8f-a65f-802b798e7dce)
## Validation Steps Performed
Added tests, manually tested a bunch of units