### PR TITLE
[ColorPicker]Only close on escape if focused

### DIFF
--- a/src/modules/colorPicker/ColorPickerUI/Helpers/AppStateHandler.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/AppStateHandler.cs
@@ -230,7 +230,7 @@ namespace ColorPicker.Helpers
 
         public bool HandleEnterPressed()
         {
-            if (!IsColorPickerVisible())
+            if (!_colorPickerShown)
             {
                 return false;
             }
@@ -241,14 +241,13 @@ namespace ColorPicker.Helpers
 
         public bool HandleEscPressed()
         {
-            if (!BlockEscapeKeyClosingColorPickerEditor)
+            if (!BlockEscapeKeyClosingColorPickerEditor
+                && (_colorPickerShown || (_colorEditorWindow != null && _colorEditorWindow.IsActive)))
             {
                 return EndUserSession();
             }
-            else
-            {
-                return false;
-            }
+
+            return false;
         }
 
         internal void MoveCursor(int xOffset, int yOffset)

--- a/src/modules/colorPicker/ColorPickerUI/Keyboard/KeyboardMonitor.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Keyboard/KeyboardMonitor.cs
@@ -70,17 +70,10 @@ namespace ColorPicker.Keyboard
             var virtualCode = e.KeyboardData.VirtualCode;
 
             // ESC pressed
-            if (virtualCode == KeyInterop.VirtualKeyFromKey(Key.Escape)
-                && e.KeyboardState == GlobalKeyboardHook.KeyboardState.KeyDown
-                )
+            if (virtualCode == KeyInterop.VirtualKeyFromKey(Key.Escape) && e.KeyboardState == GlobalKeyboardHook.KeyboardState.KeyDown)
             {
-                if (_appStateHandler.IsColorPickerVisible()
-                    || !AppStateHandler.BlockEscapeKeyClosingColorPickerEditor
-                    )
-                {
-                    e.Handled = _appStateHandler.EndUserSession();
-                    return;
-                }
+                e.Handled = _appStateHandler.HandleEscPressed();
+                return;
             }
 
             if ((virtualCode == KeyInterop.VirtualKeyFromKey(Key.Space) || virtualCode == KeyInterop.VirtualKeyFromKey(Key.Enter)) && (e.KeyboardState == GlobalKeyboardHook.KeyboardState.KeyDown))


### PR DESCRIPTION
## Summary of the Pull Request
Only closes the Color Picker editor if the window has focus. Also unifies the esc/backspace behavior.
## PR Checklist

- [x] **Closes:** #33521
- [x] **Communication:** I've discussed this with core contributors already
- [x] **Tests:** All pass
- [x] **Localization:** All end user facing strings can be localized
- [x] **Dev docs:** No need
- [x] **New binaries:** None
- [x] **Documentation updated:** No need

## Detailed Description of the Pull Request / Additional comments
* Removed the closing logic for ESC from `KeyboardMonitor.cs`, both ESC and Backspace now use `HandelEscPressed()`
* `HandleEscPressed()` closes the app if:
  * Closing with escape isn't blocked by the adjust color flyout
  * Either color picker is shown, or the editor window is focused
## Validation Steps Performed
Manually tested:
* Color picker closes on <kbd>Esc</kbd>/<kbd>Backspace</kbd>
* Editor closes on <kbd>Esc</kbd>/<kbd>Backspace</kbd> if it has focus
* Editor doesn't close on <kbd>Esc</kbd>/<kbd>Backspace</kbd> if it doesn't have focus
* Editor doesn't close on <kbd>Esc</kbd>/<kbd>Backspace</kbd> if the adjust color popup is active
* Everything works the same after reactivating the color picker from the editor