### PR TITLE
[MWB][Logger] Make logger actually track the code

### DIFF
--- a/src/modules/MouseWithoutBorders/App/Core/Logger.cs
+++ b/src/modules/MouseWithoutBorders/App/Core/Logger.cs
@@ -46,13 +46,13 @@ internal static class Logger
         Logger.Log(log);
     }
 
-    internal static void Log(Exception e)
+    internal static void Log(Exception e, [System.Runtime.CompilerServices.CallerMemberName] string memberName = "", [System.Runtime.CompilerServices.CallerFilePath] string sourceFilePath = "", [System.Runtime.CompilerServices.CallerLineNumber] int sourceLineNumber = 0)
     {
         if (e is not KnownException)
         {
             string exText = e.ToString();
 
-            Log($"!Exception!: {exText}");
+            Log($"!Exception!: {exText}", memberName, sourceFilePath, sourceLineNumber);
 
             if (DateTime.UtcNow.Hour != lastHour)
             {
@@ -77,18 +77,18 @@ internal static class Logger
     private const string HeaderRECEIVED =
         "Be{0},Ke{1},Mo{2},He{3},Mx{4},Tx{5},Im{6},By{7},Cl{8},Dr{9},De{10},Ed{11},In{12},Ni{13},Pc{14}/{15}";
 
-    internal static void LogDebug(string log, bool clearLog = false)
+    internal static void LogDebug(string log, bool clearLog = false, [System.Runtime.CompilerServices.CallerMemberName] string memberName = "", [System.Runtime.CompilerServices.CallerFilePath] string sourceFilePath = "", [System.Runtime.CompilerServices.CallerLineNumber] int sourceLineNumber = 0)
     {
 #if DEBUG
-        Log(log, clearLog);
+        Log(log, clearLog, memberName, sourceFilePath, sourceLineNumber);
 #endif
     }
 
-    internal static void Log(string log, bool clearLog = false)
+    internal static void Log(string log, bool clearLog = false, [System.Runtime.CompilerServices.CallerMemberName] string memberName = "", [System.Runtime.CompilerServices.CallerFilePath] string sourceFilePath = "", [System.Runtime.CompilerServices.CallerLineNumber] int sourceLineNumber = 0)
     {
         log = DateTime.Now.ToString("MM/dd HH:mm:ss.fff", CultureInfo.InvariantCulture) + $"({Thread.CurrentThread.ManagedThreadId})" + log;
 
-        ManagedCommon.Logger.LogInfo(log);
+        ManagedCommon.Logger.LogInfo(log, memberName, sourceFilePath, sourceLineNumber);
         lock (AllLogsLock)
         {
             if (clearLog)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [X] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
For the logger, it defaults to log the file path for easy debugging, while for MWB, logger is wrapped, so the info is lost. 
Raise the pr to bring info back to logs for debug.


<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Before:
<img width="523" alt="image" src="https://github.com/user-attachments/assets/195779aa-f655-4062-8bd2-8bdd19ccd47b" />

After:
<img width="525" alt="image" src="https://github.com/user-attachments/assets/bf09df11-dde0-4a3d-b21b-982d5e482762" />


