### PR TITLE
Fix the problem which Powertoys Run shows duplicated applications.

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Storage/Win32ProgramRepository.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Storage/Win32ProgramRepository.cs
@@ -96,6 +96,12 @@ namespace Microsoft.Plugin.Program.Storage
             string oldPath = e.OldFullPath;
             string newPath = e.FullPath;
 
+            // fix for https://github.com/microsoft/PowerToys/issues/34391
+            // the msi installer creates a shortcut, which is detected by the PT Run and ends up in calling this OnAppRenamed method
+            // the thread needs to be halted for a short time to avoid locking the new shortcut file as we read it, otherwise the lock causes
+            // in the issue scenario that a warning is popping up during the msi install process.
+            System.Threading.Thread.Sleep(1000);
+
             string extension = Path.GetExtension(newPath);
             Win32Program.ApplicationType oldAppType = Win32Program.GetAppTypeFromPath(oldPath);
             Programs.Win32Program newApp = Win32Program.GetAppFromPath(newPath);

--- a/src/modules/launcher/Wox.Infrastructure/ShellLinkHelper.cs
+++ b/src/modules/launcher/Wox.Infrastructure/ShellLinkHelper.cs
@@ -136,14 +136,9 @@ namespace Wox.Infrastructure
             var link = new ShellLink();
             const int STGM_READ = 0;
 
-            // Make sure not to open exclusive handles.
-            // See: https://github.com/microsoft/WSL/issues/11276
-            const int STGM_SHARE_DENY_NONE = 0x00000040;
-            const int STGM_TRANSACTED = 0x00010000;
-
             try
             {
-                ((IPersistFile)link).Load(path, STGM_READ | STGM_SHARE_DENY_NONE | STGM_TRANSACTED);
+                ((IPersistFile)link).Load(path, STGM_READ);
             }
             catch (System.IO.FileNotFoundException ex)
             {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
1. In the previous PR, we check in a fix to make shelllink helper open .ink file non-exclusively. It would always throw exception. So, in that time this fix is work.
2. We will load all application on the start and filter the duplicated one by "FullPath", which will be retrieved from the shellLink helper. But it failed, so we can not set the correct value.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #37774 
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

