### PR TITLE
[PT Run] Async the OnRename to unblock thread

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program.UnitTests/Storage/Win32ProgramRepositoryTest.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program.UnitTests/Storage/Win32ProgramRepositoryTest.cs
@@ -7,7 +7,7 @@ using System.Diagnostics;
 using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
-
+using System.Threading.Tasks;
 using Microsoft.Plugin.Program.Storage;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -114,7 +114,7 @@ namespace Microsoft.Plugin.Program.UnitTests.Storage
 
         [DataTestMethod]
         [DataRow("directory", "oldpath.appref-ms", "newpath.appref-ms")]
-        public void Win32ProgramRepositoryMustCallOnAppRenamedForApprefAppsWhenRenamedEventIsRaised(string directory, string oldpath, string newpath)
+        public async Task Win32ProgramRepositoryMustCallOnAppRenamedForApprefAppsWhenRenamedEventIsRaised(string directory, string oldpath, string newpath)
         {
             // Arrange
             Win32ProgramRepository win32ProgramRepository = new Win32ProgramRepository(_fileSystemWatchers, _settings, _pathsToWatch);
@@ -129,6 +129,9 @@ namespace Microsoft.Plugin.Program.UnitTests.Storage
 
             // Act
             _fileSystemMocks[0].Raise(m => m.Renamed += null, e);
+
+            // We need to wait more than one second to make sure our test can pass
+            await Task.Delay(2 * Win32ProgramRepository.OnRenamedEventWaitTime).ConfigureAwait(false);
 
             // Assert
             Assert.AreEqual(1, win32ProgramRepository.Count());
@@ -183,7 +186,7 @@ namespace Microsoft.Plugin.Program.UnitTests.Storage
 
         [DataTestMethod]
         [DataRow("directory", "oldpath.appref-ms", "newpath.appref-ms")]
-        public void Win32ProgramRepositoryMustCallOnAppRenamedForExeAppsWhenRenamedEventIsRaised(string directory, string oldpath, string newpath)
+        public async Task Win32ProgramRepositoryMustCallOnAppRenamedForExeAppsWhenRenamedEventIsRaised(string directory, string oldpath, string newpath)
         {
             // Arrange
             Win32ProgramRepository win32ProgramRepository = new Win32ProgramRepository(_fileSystemWatchers, _settings, _pathsToWatch);
@@ -203,6 +206,9 @@ namespace Microsoft.Plugin.Program.UnitTests.Storage
 
             // Act
             _fileSystemMocks[0].Raise(m => m.Renamed += null, e);
+
+            // We need to wait more than one second to make sure our test can pass
+            await Task.Delay(2 * Win32ProgramRepository.OnRenamedEventWaitTime).ConfigureAwait(false);
 
             // Assert
             Assert.AreEqual(1, win32ProgramRepository.Count());
@@ -287,7 +293,7 @@ namespace Microsoft.Plugin.Program.UnitTests.Storage
 
         [DataTestMethod]
         [DataRow("directory", "oldpath.url", "newpath.url")]
-        public void Win32ProgramRepositoryMustCallOnAppRenamedForUrlAppsWhenRenamedEventIsRaised(string directory, string oldpath, string newpath)
+        public async Task Win32ProgramRepositoryMustCallOnAppRenamedForUrlAppsWhenRenamedEventIsRaised(string directory, string oldpath, string newpath)
         {
             // Arrange
             Win32ProgramRepository win32ProgramRepository = new Win32ProgramRepository(_fileSystemWatchers, _settings, _pathsToWatch);
@@ -307,6 +313,9 @@ namespace Microsoft.Plugin.Program.UnitTests.Storage
 
             // Act
             _fileSystemMocks[0].Raise(m => m.Renamed += null, e);
+
+            // We need to wait more than one second to make sure our test can pass
+            await Task.Delay(2 * Win32ProgramRepository.OnRenamedEventWaitTime).ConfigureAwait(false);
 
             // Assert
             Assert.AreEqual(1, win32ProgramRepository.Count());
@@ -347,7 +356,7 @@ namespace Microsoft.Plugin.Program.UnitTests.Storage
 
         [DataTestMethod]
         [DataRow("directory", "oldpath.lnk", "path.lnk")]
-        public void Win32ProgramRepositoryMustCallOnAppRenamedForLnkAppsWhenRenamedEventIsRaised(string directory, string oldpath, string path)
+        public async Task Win32ProgramRepositoryMustCallOnAppRenamedForLnkAppsWhenRenamedEventIsRaised(string directory, string oldpath, string path)
         {
             // Arrange
             Win32ProgramRepository win32ProgramRepository = new Win32ProgramRepository(_fileSystemWatchers, _settings, _pathsToWatch);
@@ -381,6 +390,9 @@ namespace Microsoft.Plugin.Program.UnitTests.Storage
 
             // Act
             _fileSystemMocks[0].Raise(m => m.Renamed += null, e);
+
+            // We need to wait more than one second to make sure our test can pass
+            await Task.Delay(2 * Win32ProgramRepository.OnRenamedEventWaitTime).ConfigureAwait(false);
 
             // Assert
             Assert.AreEqual(1, win32ProgramRepository.Count());

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Storage/Win32ProgramRepository.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Storage/Win32ProgramRepository.cs
@@ -33,6 +33,8 @@ namespace Microsoft.Plugin.Program.Storage
 
         private static ConcurrentQueue<string> commonEventHandlingQueue = new ConcurrentQueue<string>();
 
+        public static readonly int OnRenamedEventWaitTime = 1000;
+
         public Win32ProgramRepository(IList<IFileSystemWatcherWrapper> fileSystemWatcherHelpers, ProgramPluginSettings settings, string[] pathsToWatch)
         {
             _fileSystemWatcherHelpers = fileSystemWatcherHelpers;
@@ -100,7 +102,7 @@ namespace Microsoft.Plugin.Program.Storage
             // the msi installer creates a shortcut, which is detected by the PT Run and ends up in calling this OnAppRenamed method
             // the thread needs to be halted for a short time to avoid locking the new shortcut file as we read it, otherwise the lock causes
             // in the issue scenario that a warning is popping up during the msi install process.
-            await Task.Delay(1000).ConfigureAwait(false);
+            await Task.Delay(OnRenamedEventWaitTime).ConfigureAwait(false);
 
             string extension = Path.GetExtension(newPath);
             Win32Program.ApplicationType oldAppType = Win32Program.GetAppTypeFromPath(oldPath);

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Storage/Win32ProgramRepository.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Storage/Win32ProgramRepository.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Plugin.Program.Storage
             }
         }
 
-        private async Task DoOnAppRenamed(object sender, RenamedEventArgs e)
+        private async Task DoOnAppRenamedAsync(object sender, RenamedEventArgs e)
         {
             string oldPath = e.OldFullPath;
             string newPath = e.FullPath;
@@ -124,7 +124,7 @@ namespace Microsoft.Plugin.Program.Storage
             }
             catch (Exception ex)
             {
-                Log.Exception($"OnAppRenamed-{extension} Program|{e.OldName}|Unable to create program from {oldPath}", ex, GetType());
+                Log.Exception($"DoOnAppRenamedAsync-{extension} Program|{e.OldName}|Unable to create program from {oldPath}", ex, GetType());
             }
 
             // To remove the old app which has been renamed and to add the new application.
@@ -150,7 +150,14 @@ namespace Microsoft.Plugin.Program.Storage
         {
             Task.Run(async () =>
             {
-                await DoOnAppRenamed(sender, e).ConfigureAwait(false);
+                try
+                {
+                    await DoOnAppRenamedAsync(sender, e).ConfigureAwait(false);
+                }
+                catch (Exception e)
+                {
+                    Log.Exception($"OnAppRenamed throw exception.", e, e.GetType());
+                }
             }).ConfigureAwait(false);
         }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
In order to solve the concern about this PR: https://github.com/microsoft/PowerToys/pull/37924/files#diff-5f8702652973666fc4791347d4370d8cbb7f6cb63574cbfede0b493790a5fca7

TL;DR:
Fire and forget is better than block the current thread. This could cause another issue.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Tested on my local machine with VS.
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

