### PR TITLE
Add securityContext to configuration files

### DIFF
--- a/.config/configuration.vsEnterprise.winget
+++ b/.config/configuration.vsEnterprise.winget
@@ -6,12 +6,16 @@ properties:
       directives:
         description: Enable Developer Mode
         allowPrerelease: true
+        # Requires elevation for the set operation
+        securityContext: elevated
       settings:
         Ensure: Present
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       id: vsPackage
       directives:
         description: Install Visual Studio 2022 Enterprise (Any edition will work)
+        # Requires elevation for the set operation
+        securityContext: elevated
       settings:
         id: Microsoft.VisualStudio.2022.Enterprise
         source: winget
@@ -21,6 +25,8 @@ properties:
       directives:
         description: Install required VS workloads
         allowPrerelease: true
+        # Requires elevation for the get and set operations
+        securityContext: elevated
       settings:
         productId: Microsoft.VisualStudio.Product.Enterprise
         channelId: VisualStudio.17.Release

--- a/.config/configuration.vsProfessional.winget
+++ b/.config/configuration.vsProfessional.winget
@@ -6,12 +6,16 @@ properties:
       directives:
         description: Enable Developer Mode
         allowPrerelease: true
+        # Requires elevation for the set operation
+        securityContext: elevated
       settings:
         Ensure: Present
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       id: vsPackage
       directives:
         description: Install Visual Studio 2022 Professional (Any edition will work)
+        # Requires elevation for the set operation
+        securityContext: elevated
       settings:
         id: Microsoft.VisualStudio.2022.Professional
         source: winget
@@ -21,6 +25,8 @@ properties:
       directives:
         description: Install required VS workloads
         allowPrerelease: true
+        # Requires elevation for the get and set operations
+        securityContext: elevated
       settings:
         productId: Microsoft.VisualStudio.Product.Professional
         channelId: VisualStudio.17.Release

--- a/.config/configuration.winget
+++ b/.config/configuration.winget
@@ -6,12 +6,16 @@ properties:
       directives:
         description: Enable Developer Mode
         allowPrerelease: true
+        # Requires elevation for the set operation
+        securityContext: elevated
       settings:
         Ensure: Present
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       id: vsPackage
       directives:
         description: Install Visual Studio 2022 Community (Any edition will work)
+        # Requires elevation for the set operation
+        securityContext: elevated
       settings:
         id: Microsoft.VisualStudio.2022.Community
         source: winget
@@ -21,6 +25,8 @@ properties:
       directives:
         description: Install required VS workloads
         allowPrerelease: true
+        # Requires elevation for the get and set operations
+        securityContext: elevated
       settings:
         productId: Microsoft.VisualStudio.Product.Community
         channelId: VisualStudio.17.Release


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Setting developer mode, installing Visual Studio 2022 & fetching and installing VS components all require elevation. Added `securityContext: elevated` for these resources. These configurations can now be invoked from user context, and will prompt for a single UAC to run resources that require elevation in a separate process.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes: #37636**
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Ran the configurations in a clean VM and noticed that all these resources required elevation
