### PR TITLE
[CI]Bring back .NET 6 for signing tasks to fix pipelines

### DIFF
--- a/.pipelines/v2/templates/job-build-project.yml
+++ b/.pipelines/v2/templates/job-build-project.yml
@@ -149,6 +149,11 @@ jobs:
   - template: steps-ensure-dotnet-version.yml
     parameters:
       sdk: true
+      version: '6.0' # .NET 6.0 is required in CI for ESRP code signing tasks. Please do not remove.
+
+  - template: steps-ensure-dotnet-version.yml
+    parameters:
+      sdk: true
       version: '8.0'
 
   - template: steps-ensure-dotnet-version.yml


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
After https://github.com/microsoft/PowerToys/pull/37574 was merged, Dart signing tasks started failing, since those still require .NET 6
This PR brings back .NET 6.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Triggered Dart CI and waiting for it to succeed.
