### PR TITLE
CmdPal: Disable registry virtualization

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Package-Dev.appxmanifest
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Package-Dev.appxmanifest
@@ -29,6 +29,7 @@
     <DisplayName>ms-resource:AppNameDev</DisplayName>
     <PublisherDisplayName>A Lone Developer</PublisherDisplayName>
     <Logo>Assets\StoreLogo.png</Logo>
+    <desktop6:RegistryWriteVirtualization>disabled</desktop6:RegistryWriteVirtualization>
   </Properties>
 
   <Dependencies>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Package.appxmanifest
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Package.appxmanifest
@@ -29,6 +29,7 @@
     <DisplayName>ms-resource:AppName</DisplayName>
     <PublisherDisplayName>Microsoft Corporation</PublisherDisplayName>
     <Logo>Assets\StoreLogo.png</Logo>
+    <desktop6:RegistryWriteVirtualization>disabled</desktop6:RegistryWriteVirtualization>
   </Properties>
 
   <Dependencies>


### PR DESCRIPTION
I forgot that packages write to a virtualized registry, rather than the real one. As it turns out, the registry plugin requires being able to write to the registry to be able to open the correct location

Closes #38053

