### PR TITLE
[GPO]Fix missing resource string for NewPlus in 0.90

### DIFF
--- a/src/gpo/assets/PowerToys.admx
+++ b/src/gpo/assets/PowerToys.admx
@@ -684,7 +684,7 @@
     </policy>
     <policy name="NewPlusReplaceVariablesInTemplateFilenames" class="Both" displayName="$(string.NewPlusReplaceVariablesInTemplateFilenames)" explainText="$(string.NewPlusReplaceVariablesInTemplateFilenamesDescription)" key="Software\Policies\PowerToys" valueName="NewPlusReplaceVariablesInTemplateFilenames">
       <parentCategory ref="NewPlus" />
-      <supportedOn ref="SUPPORTED_POWERTOYS_0_89_0" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_90_0" />
       <enabledValue>
         <decimal value="1" />
       </enabledValue>

--- a/src/gpo/assets/en-US/PowerToys.adml
+++ b/src/gpo/assets/en-US/PowerToys.adml
@@ -299,7 +299,8 @@ If you don't configure this policy, the user will be able to control the setting
       <string id="MwbPolicyDefinedIpMappingRules">Predefined IP Address mapping rules</string>
       <string id="NewPlusHideTemplateFilenameExtension">Hide template filename extension</string>
       <string id="AllowDiagnosticData">Allow sending diagnostic data</string>
-      <string id="ConfigureRunAtStartup">Configure the run at startup setting</string>      
+      <string id="ConfigureRunAtStartup">Configure the run at startup setting</string>
+      <string id="NewPlusReplaceVariablesInTemplateFilenames">Replace variables in template filenames</string>
     </stringTable>
 
     <presentationTable>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

While testing the 0.90 RC, there's a missing string in the adml file that got lost in a merge for the NewPlus feature about replacing variable in filenames. https://github.com/microsoft/PowerToys/pull/37074/
This PR re-adds this string.
It also identifies the policy as only being available on 0.90 and higher.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Copied the admx and adml files and verified gpedit opened correctly without the error message that a string is missing.