### PR TITLE
[Installer]Properly update CmdPal on upgrade

### DIFF
--- a/installer/PowerToysSetup/Product.wxs
+++ b/installer/PowerToysSetup/Product.wxs
@@ -179,6 +179,9 @@
       <Custom Action="UnRegisterContextMenuPackages" Before="RemoveFiles">
         Installed AND (REMOVE="ALL")
       </Custom>
+      <Custom Action="UnRegisterCmdPalPackage" Before="RemoveFiles">
+        Installed AND (NOT UPGRADINGPRODUCTCODE) AND (REMOVE="ALL")
+      </Custom>
       <Custom Action="UnsetAdvancedPasteAPIKey" Before="RemoveFiles">
         Installed AND (NOT UPGRADINGPRODUCTCODE) AND (REMOVE="ALL")
       </Custom>
@@ -437,6 +440,14 @@
                 Execute="deferred"
                 BinaryKey="PTCustomActions"
                 DllEntry="UnRegisterContextMenuPackagesCA"
+                  />
+
+    <CustomAction Id="UnRegisterCmdPalPackage"
+                  Return="ignore"
+                  Impersonate="yes"
+                  Execute="deferred"
+                  BinaryKey="PTCustomActions"
+                  DllEntry="UnRegisterCmdPalPackageCA"
                   />
 
     <CustomAction Id="CheckGPO"

--- a/installer/PowerToysSetupCustomActions/CustomAction.cpp
+++ b/installer/PowerToysSetupCustomActions/CustomAction.cpp
@@ -1081,6 +1081,41 @@ UINT __stdcall InstallCmdPalPackageCA(MSIHANDLE hInstall)
     return WcaFinalize(er);
 }
 
+UINT __stdcall UnRegisterCmdPalPackageCA(MSIHANDLE hInstall)
+{
+    using namespace winrt::Windows::Foundation;
+    using namespace winrt::Windows::Management::Deployment;
+
+    HRESULT hr = S_OK;
+    UINT er = ERROR_SUCCESS;
+
+    hr = WcaInitialize(hInstall, "UnRegisterCmdPalPackageCA");
+
+    try
+    {
+        // Packages to unregister
+        std::wstring packageToRemoveDisplayName {L"Microsoft.CommandPalette"};
+
+        if (!package::UnRegisterPackage(packageToRemoveDisplayName))
+        {
+            Logger::error(L"Failed to unregister package: " + packageToRemoveDisplayName);
+            er = ERROR_INSTALL_FAILURE;
+        }
+    }
+    catch (std::exception &e)
+    {
+        std::string errorMessage{"Exception thrown while trying to unregister packages: "};
+        errorMessage += e.what();
+        Logger::error(errorMessage);
+
+        er = ERROR_INSTALL_FAILURE;
+    }
+
+    er = er == ERROR_SUCCESS ? (SUCCEEDED(hr) ? ERROR_SUCCESS : ERROR_INSTALL_FAILURE) : er;
+    return WcaFinalize(er);
+}
+
+
 UINT __stdcall UnRegisterContextMenuPackagesCA(MSIHANDLE hInstall)
 {
     using namespace winrt::Windows::Foundation;
@@ -1094,7 +1129,7 @@ UINT __stdcall UnRegisterContextMenuPackagesCA(MSIHANDLE hInstall)
     try
     {
         // Packages to unregister
-        const std::vector<std::wstring> packagesToRemoveDisplayName{{L"PowerRenameContextMenu"}, {L"ImageResizerContextMenu"}, {L"FileLocksmithContextMenu"}, {L"NewPlusContextMenu"}, {L"Microsoft.CommandPalette"}};
+        const std::vector<std::wstring> packagesToRemoveDisplayName{{L"PowerRenameContextMenu"}, {L"ImageResizerContextMenu"}, {L"FileLocksmithContextMenu"}, {L"NewPlusContextMenu"}};
 
         for (auto const &package : packagesToRemoveDisplayName)
         {

--- a/installer/PowerToysSetupCustomActions/CustomAction.cpp
+++ b/installer/PowerToysSetupCustomActions/CustomAction.cpp
@@ -1104,7 +1104,7 @@ UINT __stdcall UnRegisterCmdPalPackageCA(MSIHANDLE hInstall)
     }
     catch (std::exception &e)
     {
-        std::string errorMessage{"Exception thrown while trying to unregister packages: "};
+        std::string errorMessage{"Exception thrown while trying to unregister the CmdPal package: "};
         errorMessage += e.what();
         Logger::error(errorMessage);
 

--- a/installer/PowerToysSetupCustomActions/CustomAction.def
+++ b/installer/PowerToysSetupCustomActions/CustomAction.def
@@ -20,6 +20,7 @@ EXPORTS
 	InstallDSCModuleCA
 	InstallCmdPalPackageCA
 	UnApplyModulesRegistryChangeSetsCA
+	UnRegisterCmdPalPackageCA
 	UnRegisterContextMenuPackagesCA
 	UninstallEmbeddedMSIXCA
 	UninstallDSCModuleCA


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Currently, when PowerToys does an upgrade, it uninstalls the previous CmdPal package and installs the new one.
This is not the correct way to do a packaged application update, as that will reset all Settings, since local state gets deleted when a msix package is uninstalled.
This PR adds a custom action specific to remove CmdPal package only on an uninstall that's not part of an upgrade.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Waiting for the 2 release builds:
0.89.55 PowerToys with 0.0.5 CmdPal https://microsoft.visualstudio.com/Dart/_build/results?buildId=118699807&view=results
[10:48](https://janea.slack.com/archives/D4G3P9N73/p1742510934946949)
0.89.56 PowerToys with 0.0.6 CmdPal https://microsoft.visualstudio.com/Dart/_build/results?buildId=118699834&view=results
Will test the upgrade scenario to make sure it doesn't clear Settings, when upgrading from 0.89.55 to 0.89.56. Will also uninstall 0.89.56 to make sure CmdPal is still properly uninstalled.