### PR TITLE
[cmdpal] Fix winget extension crash issue

### DIFF
--- a/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WinGet/Pages/InstallPackageListItem.cs
+++ b/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WinGet/Pages/InstallPackageListItem.cs
@@ -32,8 +32,11 @@ public partial class InstallPackageListItem : ListItem
         _package = package;
 
         PackageVersionInfo version = _package.DefaultInstallVersion;
-        string versionText = version.Version;
-        string versionTagText = versionText == "Unknown" && version.PackageCatalog.Info.Id == "StoreEdgeFD" ? "msstore" : versionText;
+        var versionTagText = "Unknown";
+        if (version != null)
+        {
+            versionTagText = version.Version == "Unknown" && version.PackageCatalog.Info.Id == "StoreEdgeFD" ? "msstore" : version.Version;
+        }
 
         Title = _package.Name;
         Subtitle = _package.Id;
@@ -49,8 +52,8 @@ public partial class InstallPackageListItem : ListItem
         CatalogPackageMetadata? metadata = version?.GetCatalogPackageMetadata();
         if (metadata != null)
         {
-            string description = string.IsNullOrEmpty(metadata.Description) ? metadata.ShortDescription : metadata.Description;
-            string detailsBody = $"""
+            var description = string.IsNullOrEmpty(metadata.Description) ? metadata.ShortDescription : metadata.Description;
+            var detailsBody = $"""
 
 {description}
 """;
@@ -102,8 +105,8 @@ public partial class InstallPackageListItem : ListItem
         UriCreationOptions options = default;
         foreach (KeyValuePair<string, (string, string)> kv in simpleData)
         {
-            string text = string.IsNullOrEmpty(kv.Value.Item1) ? kv.Value.Item2 : kv.Value.Item1;
-            string target = kv.Value.Item2;
+            var text = string.IsNullOrEmpty(kv.Value.Item1) ? kv.Value.Item2 : kv.Value.Item1;
+            var target = kv.Value.Item2;
             if (!string.IsNullOrEmpty(text))
             {
                 Uri? uri = null;
@@ -153,7 +156,7 @@ public partial class InstallPackageListItem : ListItem
             if (WinGetStatics.AppSearchCallback != null)
             {
                 Func<string, ICommandItem?> callback = WinGetStatics.AppSearchCallback;
-                ICommandItem? installedApp = callback(_package.DefaultInstallVersion.DisplayName);
+                ICommandItem? installedApp = callback(_package.DefaultInstallVersion == null ? _package.Name : _package.DefaultInstallVersion.DisplayName);
                 if (installedApp != null)
                 {
                     this.Command = installedApp.Command;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
I don't know why defaultInstalledVersion becomes null. But, at least we need to fix it...


Test case: vscode.
![image](https://github.com/user-attachments/assets/17d14d62-066d-4032-b40c-f7339c25f899)


Closes https://github.com/zadjii-msft/PowerToys/issues/572