### PR TITLE
Fixing command duplicates when loading commands from provider

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandManager.cs
@@ -137,7 +137,7 @@ public partial class TopLevelCommandManager : ObservableObject,
                 var thisCommand = wrapper.ItemViewModel.Model.Unsafe;
                 if (thisCommand != null)
                 {
-                    var isTheSame = thisCommand == firstCommand;
+                    var isTheSame = wrapper == firstCommand;
                     if (isTheSame)
                     {
                         startIndex = i;


### PR DESCRIPTION
There is a bug in command palette where the top level commands from extensions gets duplicated after the extension raises items changed, or when it is requested by CmdPal for any reason. This didn't happen when we kill CmdPal and open it again.

When investigating, I noticed that the `UpdateCommandsForProvider` method was not deleting the top level commands for the extension.
This seems to be happening because the comparison `var isTheSame = wrapper == firstCommand;` is not comparing objects of the same type. It was comparing a `TopLevelViewModel` with a `CommandItem`, and it was never set to `true`.

I change it to compare the `TopLevelViewModel` of both commands, and now it seems to be detecting correctly.

Another option of fix could be comparing the `CommandItem`s. 