### PR TITLE
[CmdPal]Fix Calc and Command extension fallback command icons

### DIFF
--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Calc/CalculatorCommandProvider.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Calc/CalculatorCommandProvider.cs
@@ -141,6 +141,7 @@ public sealed partial class SaveCommand : InvokableCommand
 internal sealed partial class FallbackCalculatorItem : FallbackCommandItem
 {
     private readonly CopyTextCommand _copyCommand = new(string.Empty);
+    private static readonly IconInfo _cachedIcon = IconHelpers.FromRelativePath("Assets\\Calculator.svg");
 
     public FallbackCalculatorItem()
         : base(new NoOpCommand(), Resources.calculator_title)
@@ -149,7 +150,7 @@ internal sealed partial class FallbackCalculatorItem : FallbackCommandItem
         _copyCommand.Name = string.Empty;
         Title = string.Empty;
         Subtitle = Resources.calculator_placeholder_text;
-        Icon = new IconInfo("\ue8ef"); // Calculator
+        Icon = _cachedIcon;
     }
 
     public override void UpdateQuery(string query)

--- a/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.Shell/FallbackExecuteItem.cs
+++ b/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.Shell/FallbackExecuteItem.cs
@@ -20,7 +20,7 @@ internal sealed partial class FallbackExecuteItem : FallbackCommandItem
         Title = string.Empty;
         _executeItem.Name = string.Empty;
         Subtitle = Properties.Resources.generic_run_command;
-        Icon = new IconInfo("\uE756");
+        Icon = Icons.RunV2; // Defined in Icons.cs and contains the execute command icon.
     }
 
     public override void UpdateQuery(string query)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Icons for the fallback commands of the calculator and run command extensions were wrong. This PR uses the correct icons for the fallback commands.

Screenshot with the changes from this PR:
![image](https://github.com/user-attachments/assets/74010e30-dba2-4f9c-a809-7287c180db69)


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #38134 
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Run Command Palette and verify icons are good.
