### PR TITLE
[CmdPal]Fix resetting the hotkey in Settings

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsModel.cs
@@ -22,7 +22,9 @@ public partial class SettingsModel : ObservableObject
 
     ///////////////////////////////////////////////////////////////////////////
     // SETTINGS HERE
-    public HotkeySettings? Hotkey { get; set; } = new HotkeySettings(true, false, true, false, 0x20); // win+alt+space
+    public static HotkeySettings DefaultActivationShortcut { get; } = new HotkeySettings(true, false, true, false, 0x20); // win+alt+space
+
+    public HotkeySettings? Hotkey { get; set; } = DefaultActivationShortcut;
 
     public bool ShowAppDetails { get; set; }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsViewModel.cs
@@ -3,22 +3,26 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using Microsoft.CmdPal.UI.ViewModels.Settings;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.CmdPal.UI.ViewModels;
 
-public partial class SettingsViewModel
+public partial class SettingsViewModel : INotifyPropertyChanged
 {
     private readonly SettingsModel _settings;
     private readonly IServiceProvider _serviceProvider;
+
+    public event PropertyChangedEventHandler? PropertyChanged;
 
     public HotkeySettings? Hotkey
     {
         get => _settings.Hotkey;
         set
         {
-            _settings.Hotkey = value;
+            _settings.Hotkey = value ?? SettingsModel.DefaultActivationShortcut;
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Hotkey)));
             Save();
         }
     }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Clicking the Reset button on the Activation Shortcut control sets it to null. Should set to the default hotkey instead.

![image](https://github.com/user-attachments/assets/8401f202-94b6-4515-a8ed-e842ca2c4335)

This PR sets it to the default value instead and notifies the property changed so that UI is updated too with the reset instead of just showing a clean hotkey.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
With the default hotkey set, try resetting. Verify nothing changes.
With another hotkey set, try resetting. Verify it's now default.
