### PR TITLE
[CmdPal] Registry: typing "\" causes the page to throw an exception

### DIFF
--- a/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Registry/Helpers/RegistryHelper.cs
+++ b/src/modules/cmdpal/Exts/Microsoft.CmdPal.Ext.Registry/Helpers/RegistryHelper.cs
@@ -53,7 +53,11 @@ internal static class RegistryHelper
         }
 
         var baseKey = query.Split('\\').FirstOrDefault() ?? string.Empty;
-        var subKey = query.Replace(baseKey, string.Empty, StringComparison.InvariantCultureIgnoreCase).TrimStart('\\');
+        var subKey = string.Empty;
+        if (!string.IsNullOrEmpty(baseKey))
+        {
+            subKey = query.Replace(baseKey, string.Empty, StringComparison.InvariantCultureIgnoreCase).TrimStart('\\');
+        }
 
         var baseKeyResult = _baseKeys
             .Where(found => found.Key.StartsWith(baseKey, StringComparison.InvariantCultureIgnoreCase))


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Calling `string.Replace` with an empty string as the first parameter was raising an exception. Added a check to prevent this.

![image](https://github.com/user-attachments/assets/42ee67f2-a648-4543-9994-0e37de50dcdf)

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

