### PR TITLE
CmdPal: add appLicensing for offline install; disable startup

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Package-Dev.appxmanifest
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Package-Dev.appxmanifest
@@ -66,7 +66,7 @@
         <uap5:Extension Category="windows.startupTask">
           <uap5:StartupTask
             TaskId="CmdPalStartup"
-            Enabled="true"
+            Enabled="false"
             DisplayName="ms-resource:StartupTaskNameDev" />
         </uap5:Extension>
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Package.appxmanifest
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Package.appxmanifest
@@ -66,7 +66,7 @@
         <uap5:Extension Category="windows.startupTask">
           <uap5:StartupTask
             TaskId="CmdPalStartup"
-            Enabled="true"
+            Enabled="false"
             DisplayName="ms-resource:StartupTaskName" />
         </uap5:Extension>
 
@@ -78,5 +78,6 @@
   <Capabilities>
     <rescap:Capability Name="runFullTrust" />
     <rescap:Capability Name="unvirtualizedResources" />
+    <rescap:Capability Name="appLicensing" />
   </Capabilities>
 </Package>


### PR DESCRIPTION
- `appLicensing` avoids the issue where installation requires access to the store servers for licensing.
- It was decided that PowerToys would manage CmdPal's startup.