### PR TITLE
CmdPal: Fix opening SUI pages in other languages

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/SettingsWindow.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/SettingsWindow.xaml.cs
@@ -42,12 +42,8 @@ public sealed partial class SettingsWindow : Window,
 
     private void NavView_ItemInvoked(NavigationView sender, NavigationViewItemInvokedEventArgs args)
     {
-        var selectedItem = args.InvokedItem;
-
-        if (selectedItem is not null)
-        {
-            Navigate(selectedItem.ToString()!);
-        }
+        var selectedItem = args.InvokedItemContainer;
+        Navigate((selectedItem.Tag as string)!);
     }
 
     private void Navigate(string page)


### PR DESCRIPTION
What we were doing only worked in English. The `.ToString` would get you the text of the nav item, not the `Tag`

`InvokedItemContainer` gets you the `NavigationViewItem`.
