### PR TITLE
Fixes a race in extension startup

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandManager.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -209,7 +210,7 @@ public partial class TopLevelCommandManager : ObservableObject,
         extensionService.OnExtensionAdded -= ExtensionService_OnExtensionAdded;
         extensionService.OnExtensionRemoved -= ExtensionService_OnExtensionRemoved;
 
-        var extensions = await extensionService.GetInstalledExtensionsAsync();
+        var extensions = (await extensionService.GetInstalledExtensionsAsync()).ToImmutableList();
         _extensionCommandProviders.Clear();
         if (extensions != null)
         {
@@ -241,6 +242,7 @@ public partial class TopLevelCommandManager : ObservableObject,
         // TODO This most definitely needs a lock
         foreach (var extension in extensions)
         {
+            Logger.LogDebug($"Starting {extension.PackageFullName}");
             try
             {
                 // start it ...


### PR DESCRIPTION
This only repros on my desktop, so I suppose that means a slower machine is needed

I was mistaken, and assumed we were already operating on a copy here. We weren't. That meant that it was possible for another extension to be detected, change the list, and crash the whole palette.

## Validation Steps Performed

No longer does my desktop crash on startup