### PR TITLE
Update Fallback commands async, once

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
@@ -104,13 +104,6 @@ public partial class MainListPage : DynamicListPage,
         {
             UpdateFallbacks(newSearch, commands.ToImmutableArray());
 
-            // This gets called on a background thread, because ListViewModel
-            // updates the .SearchText of all extensions on a BG thread.
-            foreach (var command in commands)
-            {
-                command.TryUpdateFallbackText(newSearch);
-            }
-
             // Cleared out the filter text? easy. Reset _filteredItems, and bail out.
             if (string.IsNullOrEmpty(newSearch))
             {


### PR DESCRIPTION
The problem: 

> * we need to go update all the Fallback commands. (these are ones that extensions can use to react to the search text - basically, "what the user typed wasn't found immediately, but here's something they can fall back on"
>   * this is wacky, because the way I had it, I update each item, and if it "changes visibility", then we need to update the main list, because we've already removed it from the list. So we need to re-update the list to account for that
>     * you missed it reading that (and i missed it writing it) but that basically means we re-populate the list F={num fallbacks} times, because each one sends the "do it again" message
>     * That results in us basically creating (F+1)*(N=num items+apps) view models, initializing them, and not needing most of them

The crux here being a single thread, to update all the fallback items,
that then only raises _one_ items changed at the very end.

I don't love this, one misbehaving fallback could stop all the others. In theory, we should do a parallel update of all these things, with a like, 1s timeout on each leg. 

But it has gotta be faster till we can do #38140 (or similar)

Closes: (not sure I filed one). But the first typed character _felt_ slow.


