### PR TITLE
Add QuickNotes plugin to third-party plugins list

### DIFF
--- a/doc/thirdPartyRunPlugins.md
+++ b/doc/thirdPartyRunPlugins.md
@@ -43,6 +43,7 @@ Contact the developers of a plugin directly for assistance with a specific plugi
 | [TailwindCSS](https://github.com/skttl/ptrun-tailwindcss) | [skttl](https://github.com/skttl) | Search the documentation of TailwindCSS |
 | [HttpStatusCodes](https://github.com/grzhan/HttpStatusCodePowerToys) | [grzhan](https://github.com/grzhan) | Search for http status codes |
 | [SVGL](https://github.com/Sameerjs6/powertoys-svgl) | [SameerJS6](https://github.com/SameerJS6) | Search, Browse and copy SVG logos from SVGL. |
+| [QuickNotes](https://github.com/ruslanlap/CommunityPowerToysRunPlugin-QuickNotes) | [ruslanlap](https://github.com/ruslanlap) | Create, manage, and search notes directly from PowerToys Run |
 
 ## Extending software plugins
 


### PR DESCRIPTION
## Description
This PR adds the QuickNotes plugin to the third-party plugins list.

QuickNotes is a plugin for PowerToys Run that allows users to quickly create, manage, and search notes directly from the PowerToys Run interface. Users can create notes with a simple command (qq), search through existing notes, edit notes, and manage their collection efficiently.

## Features
- Quick note creation with timestamps
- Powerful search with highlighted search terms
- Easy editing and management
- Backup and export capabilities
- Clipboard integration
- Theme support (light/dark)

## Repository
https://github.com/ruslanlap/CommunityPowerToysRunPlugin-QuickNotes