### PR TITLE
CmdPal: Update the alias tags, before triggering the UI to change

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelViewModel.cs
@@ -208,12 +208,11 @@ public sealed partial class TopLevelViewModel : ObservableObject, IListItem
             tags.Add(new Tag() { Text = Alias.SearchPrefix });
         }
 
-        PropChanged?.Invoke(this, new PropChangedEventArgs(nameof(Tags)));
-
         DoOnUiThread(
             () =>
             {
                 ListHelpers.InPlaceUpdateList(Tags, tags);
+                PropChanged?.Invoke(this, new PropChangedEventArgs(nameof(Tags)));
             });
     }
 


### PR DESCRIPTION
Yea, this one hurts. Pretty obviously, we're sending the PropChanged _before_ the `Tags` are actually updated.

Noticed on 0.0.16+ builds
