### PR TITLE
cmdpal: Skip dependency installs for extensions

### DIFF
--- a/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WinGet/Pages/InstallPackageCommand.cs
+++ b/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WinGet/Pages/InstallPackageCommand.cs
@@ -17,7 +17,6 @@ namespace Microsoft.CmdPal.Ext.WinGet.Pages;
 public partial class InstallPackageCommand : InvokableCommand
 {
     private readonly CatalogPackage _package;
-
     private readonly StatusMessage _installBanner = new();
     private IAsyncOperationWithProgress<InstallResult, InstallProgress>? _installAction;
     private IAsyncOperationWithProgress<UninstallResult, UninstallProgress>? _unInstallAction;
@@ -42,6 +41,8 @@ public partial class InstallPackageCommand : InvokableCommand
     private static readonly CompositeFormat QueuedPackageUninstall = System.Text.CompositeFormat.Parse(Properties.Resources.winget_queued_package_uninstall);
     private static readonly CompositeFormat UninstallPackageFinishing = System.Text.CompositeFormat.Parse(Properties.Resources.winget_uninstall_package_finishing);
     private static readonly CompositeFormat DownloadProgress = System.Text.CompositeFormat.Parse(Properties.Resources.winget_download_progress);
+
+    internal bool SkipDependencies { get; set; }
 
     public InstallPackageCommand(CatalogPackage package, bool isInstalled)
     {
@@ -96,6 +97,9 @@ public partial class InstallPackageCommand : InvokableCommand
 
             var installOptions = WinGetStatics.WinGetFactory.CreateInstallOptions();
             installOptions.PackageInstallScope = PackageInstallScope.Any;
+
+            installOptions.SkipDependencies = SkipDependencies;
+
             _installAction = WinGetStatics.Manager.InstallPackageAsync(_package, installOptions);
 
             var handler = new AsyncOperationProgressHandler<InstallResult, InstallProgress>(OnInstallProgress);

--- a/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WinGet/Pages/WinGetExtensionPage.cs
+++ b/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WinGet/Pages/WinGetExtensionPage.cs
@@ -42,6 +42,8 @@ internal sealed partial class WinGetExtensionPage : DynamicListPage, IDisposable
 
     private readonly StatusMessage _errorMessage = new() { State = MessageState.Error };
 
+    private bool IsExtensionsPage => HasTag && _tag == ExtensionsTag;
+
     public WinGetExtensionPage(string tag = "")
     {
         Icon = tag == ExtensionsTag ? ExtensionsIcon : WinGetIcon;

--- a/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WinGet/Pages/WinGetExtensionPage.cs
+++ b/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WinGet/Pages/WinGetExtensionPage.cs
@@ -42,6 +42,8 @@ internal sealed partial class WinGetExtensionPage : DynamicListPage, IDisposable
 
     private readonly StatusMessage _errorMessage = new() { State = MessageState.Error };
 
+    private bool IsExtensionsPage => HasTag && _tag == ExtensionsTag;
+
     public WinGetExtensionPage(string tag = "")
     {
         Icon = tag == ExtensionsTag ? ExtensionsIcon : WinGetIcon;
@@ -57,7 +59,7 @@ internal sealed partial class WinGetExtensionPage : DynamicListPage, IDisposable
         {
             // emptySearchForTag ===
             // we don't have results yet, we haven't typed anything, and we're searching for a tag
-            var emptySearchForTag = _results == null &&
+            bool emptySearchForTag = _results == null &&
                 string.IsNullOrEmpty(SearchText) &&
                 HasTag;
 
@@ -70,7 +72,7 @@ internal sealed partial class WinGetExtensionPage : DynamicListPage, IDisposable
 
             if (_results != null && _results.Any())
             {
-                var results = _results.Select(PackageToListItem).ToArray();
+                ListItem[] results = _results.Select(PackageToListItem).ToArray();
                 IsLoading = false;
                 return results;
             }
@@ -112,7 +114,7 @@ internal sealed partial class WinGetExtensionPage : DynamicListPage, IDisposable
 
         _cancellationTokenSource = new CancellationTokenSource();
 
-        var cancellationToken = _cancellationTokenSource.Token;
+        CancellationToken cancellationToken = _cancellationTokenSource.Token;
 
         IsLoading = true;
 
@@ -129,7 +131,7 @@ internal sealed partial class WinGetExtensionPage : DynamicListPage, IDisposable
     {
         try
         {
-            var results = await searchTask;
+            IEnumerable<CatalogPackage> results = await searchTask;
 
             // Ensure this is still the latest task
             if (_currentSearchTask == searchTask)
@@ -175,17 +177,17 @@ internal sealed partial class WinGetExtensionPage : DynamicListPage, IDisposable
             return [];
         }
 
-        var searchDebugText = $"{query}{(HasTag ? "+" : string.Empty)}{_tag}";
+        string searchDebugText = $"{query}{(HasTag ? "+" : string.Empty)}{_tag}";
         Logger.LogDebug($"Starting search for '{searchDebugText}'");
         HashSet<CatalogPackage> results = new(new PackageIdCompare());
 
         // Default selector: this is the way to do a `winget search <query>`
-        var selector = WinGetStatics.WinGetFactory.CreatePackageMatchFilter();
+        PackageMatchFilter selector = WinGetStatics.WinGetFactory.CreatePackageMatchFilter();
         selector.Field = Microsoft.Management.Deployment.PackageMatchField.CatalogDefault;
         selector.Value = query;
         selector.Option = PackageFieldMatchOption.ContainsCaseInsensitive;
 
-        var opts = WinGetStatics.WinGetFactory.CreateFindPackagesOptions();
+        FindPackagesOptions opts = WinGetStatics.WinGetFactory.CreateFindPackagesOptions();
         opts.Selectors.Add(selector);
 
         // testing
@@ -194,7 +196,7 @@ internal sealed partial class WinGetExtensionPage : DynamicListPage, IDisposable
         // Selectors is "OR", Filters is "AND"
         if (HasTag)
         {
-            var tagFilter = WinGetStatics.WinGetFactory.CreatePackageMatchFilter();
+            PackageMatchFilter tagFilter = WinGetStatics.WinGetFactory.CreatePackageMatchFilter();
             tagFilter.Field = Microsoft.Management.Deployment.PackageMatchField.Tag;
             tagFilter.Value = _tag;
             tagFilter.Option = PackageFieldMatchOption.ContainsCaseInsensitive;
@@ -205,11 +207,11 @@ internal sealed partial class WinGetExtensionPage : DynamicListPage, IDisposable
         // Clean up here, then...
         ct.ThrowIfCancellationRequested();
 
-        var catalogTask = HasTag ? WinGetStatics.CompositeWingetCatalog : WinGetStatics.CompositeAllCatalog;
+        Lazy<Task<PackageCatalog>> catalogTask = HasTag ? WinGetStatics.CompositeWingetCatalog : WinGetStatics.CompositeAllCatalog;
 
         // Both these catalogs should have been instantiated by the
         // WinGetStatics static ctor when we were created.
-        var catalog = await catalogTask.Value;
+        PackageCatalog catalog = await catalogTask.Value;
 
         if (catalog == null)
         {
@@ -225,8 +227,8 @@ internal sealed partial class WinGetExtensionPage : DynamicListPage, IDisposable
 
             // BODGY, re: microsoft/winget-cli#5151
             // FindPackagesAsync isn't actually async.
-            var internalSearchTask = Task.Run(() => catalog.FindPackages(opts), ct);
-            var searchResults = await internalSearchTask;
+            Task<FindPackagesResult> internalSearchTask = Task.Run(() => catalog.FindPackages(opts), ct);
+            FindPackagesResult searchResults = await internalSearchTask;
 
             // TODO more error handling like this:
             if (searchResults.Status != FindPackagesResultStatus.Ok)
@@ -237,12 +239,12 @@ internal sealed partial class WinGetExtensionPage : DynamicListPage, IDisposable
             }
 
             Logger.LogDebug($"    got results for ({query})", memberName: nameof(DoSearchAsync));
-            foreach (var match in searchResults.Matches.ToArray())
+            foreach (Management.Deployment.MatchResult? match in searchResults.Matches.ToArray())
             {
                 ct.ThrowIfCancellationRequested();
 
                 // Print the packages
-                var package = match.CatalogPackage;
+                CatalogPackage package = match.CatalogPackage;
 
                 results.Add(package);
             }

--- a/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WinGet/Pages/WinGetExtensionPage.cs
+++ b/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WinGet/Pages/WinGetExtensionPage.cs
@@ -42,8 +42,6 @@ internal sealed partial class WinGetExtensionPage : DynamicListPage, IDisposable
 
     private readonly StatusMessage _errorMessage = new() { State = MessageState.Error };
 
-    private bool IsExtensionsPage => HasTag && _tag == ExtensionsTag;
-
     public WinGetExtensionPage(string tag = "")
     {
         Icon = tag == ExtensionsTag ? ExtensionsIcon : WinGetIcon;


### PR DESCRIPTION
It appears there are two issues in WinGet regarding the installation of dependencies.

https://github.com/microsoft/winget-cli/issues/4661 https://github.com/microsoft/winget-cli/issues/4679

For CmdPal 0.1, we're going to skip installing dependencies to make extension installation more robust. This will mostly work because extensions will depend on the same frameworks as the command palette itself (for now).

We will revert this once these two issues are fixed.