### PR TITLE
[PowerRename] Use file modification date when renaming with `$YY-$MM-$DD` patterns

### DIFF
--- a/src/modules/powerrename/PowerRenameUILib/Strings/en-us/Resources.resw
+++ b/src/modules/powerrename/PowerRenameUILib/Strings/en-us/Resources.resw
@@ -184,7 +184,7 @@
     <value>A counter showing multiple customized properties.</value>
   </data>
   <data name="DateTimeCheatSheet_Title.Text" xml:space="preserve">
-    <value>Replace using file creation date and time</value>
+    <value>Replace using file modification date and time</value>
   </data>
   <data name="DateTimeCheatSheet_FullYear" xml:space="preserve">
     <value>Year represented by a full four or five digits, depending on the calendar used.</value>

--- a/src/modules/powerrename/lib/PowerRenameItem.cpp
+++ b/src/modules/powerrename/lib/PowerRenameItem.cpp
@@ -70,11 +70,11 @@ IFACEMETHODIMP CPowerRenameItem::GetTime(_Outptr_ SYSTEMTIME* time)
         HANDLE hFile = CreateFileW(m_path, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
         if (hFile != INVALID_HANDLE_VALUE)
         {
-            FILETIME CreationTime;
-            if (GetFileTime(hFile, &CreationTime, NULL, NULL))
+            FILETIME ModificationTime;
+            if (GetFileTime(hFile, NULL, NULL, &ModificationTime))
             {
                 SYSTEMTIME SystemTime, LocalTime;
-                if (FileTimeToSystemTime(&CreationTime, &SystemTime))
+                if (FileTimeToSystemTime(&ModificationTime, &SystemTime))
                 {
                     if (SystemTimeToTzSpecificLocalTime(NULL, &SystemTime, &LocalTime))
                     {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This changes the behavior when renaming with date/time values to use the "Date Modified" file attribute as it is often more relevant than the currently used "Date Created" value.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [X] **Closes:** #36040
- [x] **Communication:** [Commented in the contributing requests thread](https://github.com/microsoft/PowerToys/issues/28769#issuecomment-2753058662)
- [ ] **Tests:** Added/updated and all pass
- [X] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Also updates the UI string to reflect the file time type change.

Currently PowerRename can rename a file with `$YY-$MM-$DD $etc` formatted timestamp data, based on the file's "Date Created" time. However, the "Date Modified" field is often much more useful.
A common use-case for bulk renaming files and an example of "Date Created"s failings is standardizing filenames when copying files from a camera's SD card. Since the files are all freshly copied their "Date Created" field is set to the time of the transfer instead of the desired time of when the photo was taken, which is usually preserved in the "Date Modified" field.

Ideally the time metadata source used could be controlled with a settings option (See #6151).

Ideally (for the camera SD card backup case) image EXIF data could also be used in renaming (See #3880, I think this issue was potentially closed in error due to a misunderstanding). Currently [exiftool](https://exiftool.org/) seems to be the most feature-complete tool that works with EXIF data.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
**This change is currently untested.** I've tried to compile yet have not been successful for reasons unrelated to the contents of this PR (aka ran out of harddrive space trying to get Visual Studio set up to compile in a VM)