### PR TITLE
Scale the toast window for DPI

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ShortcutControl/NativeMethods.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ShortcutControl/NativeMethods.cs
@@ -52,12 +52,6 @@ public static class NativeMethods
     [DllImport("user32.dll")]
     public static extern int GetDpiForWindow(System.IntPtr hWnd);
 
-    [DllImport("User32.dll")]
-    public static extern IntPtr MonitorFromWindow(IntPtr hwnd, uint dwFlags);
-
-    [DllImport("Shcore.dll")]
-    public static extern int GetDpiForMonitor(IntPtr hmonitor, int dpiType, out uint dpiX, out uint dpiY);
-
     [DllImport("user32.dll")]
     public static extern bool IsWindowVisible(IntPtr hWnd);
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ShortcutControl/NativeMethods.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ShortcutControl/NativeMethods.cs
@@ -52,6 +52,12 @@ public static class NativeMethods
     [DllImport("user32.dll")]
     public static extern int GetDpiForWindow(System.IntPtr hWnd);
 
+    [DllImport("User32.dll")]
+    public static extern IntPtr MonitorFromWindow(IntPtr hwnd, uint dwFlags);
+
+    [DllImport("Shcore.dll")]
+    public static extern int GetDpiForMonitor(IntPtr hmonitor, int dpiType, out uint dpiX, out uint dpiY);
+
     [DllImport("user32.dll")]
     public static extern bool IsWindowVisible(IntPtr hWnd);
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/NativeMethods.txt
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/NativeMethods.txt
@@ -19,6 +19,7 @@ SetFocus
 SetActiveWindow
 MonitorFromWindow
 GetMonitorInfo
+GetDpiForMonitor
 SHCreateStreamOnFileEx
 CoAllowSetForegroundWindow
 SHCreateStreamOnFileEx

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ToastWindow.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ToastWindow.xaml.cs
@@ -51,7 +51,13 @@ public sealed partial class ToastWindow : Window,
             Width = Convert.ToInt32(ToastText.ActualWidth),
             Height = Convert.ToInt32(ToastText.ActualHeight),
         };
-        AppWindow.Resize(intSize);
+        var scaleAdjustment = ToastText.XamlRoot.RasterizationScale;
+        var scaled = new SizeInt32
+        {
+            Width = (int)Math.Round(intSize.Width * scaleAdjustment),
+            Height = (int)Math.Round(intSize.Height * scaleAdjustment),
+        };
+        AppWindow.Resize(scaled);
 
         var displayArea = DisplayArea.GetFromWindowId(AppWindow.Id, DisplayAreaFallback.Nearest);
         if (displayArea is not null)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ToastWindow.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ToastWindow.xaml.cs
@@ -8,13 +8,14 @@ using ManagedCommon;
 using Microsoft.CmdPal.UI.Helpers;
 using Microsoft.CmdPal.UI.ViewModels;
 using Microsoft.CmdPal.UI.ViewModels.Messages;
-using Microsoft.PowerToys.Settings.UI.Helpers;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Windows.Graphics;
 using Windows.Win32;
 using Windows.Win32.Foundation;
+using Windows.Win32.Graphics.Gdi;
+using Windows.Win32.UI.HiDpi;
 using Windows.Win32.UI.WindowsAndMessaging;
 using RS_ = Microsoft.CmdPal.UI.Helpers.ResourceLoaderInstance;
 
@@ -50,8 +51,8 @@ public sealed partial class ToastWindow : Window,
     {
         try
         {
-            var monitor = NativeMethods.MonitorFromWindow(hwnd.Value, 2); // MONITOR_DEFAULTTONEAREST
-            _ = NativeMethods.GetDpiForMonitor(monitor, 0, out var dpiX, out _); // MDT_EFFECTIVE_DPI = 0
+            var monitor = PInvoke.MonitorFromWindow(hwnd, MONITOR_FROM_FLAGS.MONITOR_DEFAULTTONEAREST);
+            _ = PInvoke.GetDpiForMonitor(monitor, MONITOR_DPI_TYPE.MDT_EFFECTIVE_DPI, out var dpiX, out _);
             return dpiX / 96.0;
         }
         catch (Exception ex)


### PR DESCRIPTION
Ah of course, AppWindow.Resize doesn't use DIPs. Why would it? It's not like literally everything else in XAML does.

Related to half of https://github.com/zadjii-msft/PowerToys/issues/508