### PR TITLE
[Settings]Fix blank icon in the taskbar

### DIFF
--- a/src/settings-ui/Settings.UI/SettingsXAML/MainWindow.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/MainWindow.xaml.cs
@@ -28,18 +28,15 @@ namespace Microsoft.PowerToys.Settings.UI
             var bootTime = new System.Diagnostics.Stopwatch();
             bootTime.Start();
 
+            this.Activated += Window_Activated_SetIcon;
+
             App.ThemeService.ThemeChanged += OnThemeChanged;
             App.ThemeService.ApplyTheme();
 
             ShellPage.SetElevationStatus(App.IsElevated);
             ShellPage.SetIsUserAnAdmin(App.IsUserAnAdmin);
 
-            // Set window icon
             var hWnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
-            WindowId windowId = Win32Interop.GetWindowIdFromWindow(hWnd);
-            AppWindow appWindow = AppWindow.GetFromWindowId(windowId);
-            appWindow.SetIcon("Assets\\Settings\\icon.ico");
-
             var placement = WindowHelper.DeserializePlacementOrDefault(hWnd);
             if (createHidden)
             {
@@ -219,6 +216,15 @@ namespace Microsoft.PowerToys.Settings.UI
             }
 
             App.ThemeService.ThemeChanged -= OnThemeChanged;
+        }
+
+        private void Window_Activated_SetIcon(object sender, WindowActivatedEventArgs args)
+        {
+            // Set window icon
+            var hWnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
+            WindowId windowId = Win32Interop.GetWindowIdFromWindow(hWnd);
+            AppWindow appWindow = AppWindow.GetFromWindowId(windowId);
+            appWindow.SetIcon("Assets\\Settings\\icon.ico");
         }
 
         private void Window_Activated(object sender, WindowActivatedEventArgs args)

--- a/src/settings-ui/Settings.UI/SettingsXAML/OobeWindow.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/OobeWindow.xaml.cs
@@ -41,11 +41,10 @@ namespace Microsoft.PowerToys.Settings.UI
 
             this.InitializeComponent();
 
-            // Set window icon
             _hWnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
             _windowId = Win32Interop.GetWindowIdFromWindow(_hWnd);
             _appWindow = AppWindow.GetFromWindowId(_windowId);
-            _appWindow.SetIcon("Assets\\Settings\\icon.ico");
+            this.Activated += Window_Activated_SetIcon;
 
             OverlappedPresenter presenter = _appWindow.Presenter as OverlappedPresenter;
             presenter.IsMinimizable = false;
@@ -108,6 +107,12 @@ namespace Microsoft.PowerToys.Settings.UI
             {
                 shellPage.NavigateToModule(module);
             }
+        }
+
+        private void Window_Activated_SetIcon(object sender, WindowActivatedEventArgs args)
+        {
+            // Set window icon
+            _appWindow.SetIcon("Assets\\Settings\\icon.ico");
         }
 
         private void OobeWindow_SizeChanged(object sender, WindowSizeChangedEventArgs args)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Randomly, the Settings app would show a blank icon in the Windows taskbar.
This seems to having started to happen sometime after one of the Windows App SDK upgrades.
The proper way to set the taskbar icon seems to be to do it only after the window has been activated, so this PR does that.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Running the Settings app directly from VIsual Studio was the best way to repro this issue, so I did that to verify the icon looked good a couple of times.
I also built an installer locally to double check it still behaved good for me when running PowerToys from its install location.