### PR TITLE
WinGet installer fix

### DIFF
--- a/src/common/utils/package.h
+++ b/src/common/utils/package.h
@@ -238,7 +238,7 @@ namespace package {
             PackageManager packageManager;
 
             // Declare use of an external location
-            DeploymentOptions options = DeploymentOptions::ForceApplicationShutdown;
+            DeploymentOptions options = DeploymentOptions::ForceTargetApplicationShutdown;
 
             Collections::IVector<Uri> uris = winrt::single_threaded_vector<Uri>();
             if (!dependencies.empty())


### PR DESCRIPTION
WinGet is currently failing as the installer is sending a ForceApplicationShutdown.  Switching to a TargetApplication instead to see if this can pass validation