### PR TITLE
[ImageResizer]Fix: Deleting an Image Resizer preset deletes the wrong preset

### DIFF
--- a/src/common/ManagedCommon/IdRecoveryHelper.cs
+++ b/src/common/ManagedCommon/IdRecoveryHelper.cs
@@ -11,24 +11,24 @@ using System.Threading.Tasks;
 
 namespace ManagedCommon
 {
-    public static class ImageResizerHelper
+    public static class IdRecoveryHelper
     {
         /// <summary>
         /// Fixes invalid IDs in the given list by assigning unique values.
-        /// It ensures that all IDs are non-zero and unique, correcting any duplicates or empty (zero) IDs.
+        /// It ensures that all IDs are non-empty and unique, correcting any duplicates or empty IDs.
         /// </summary>
-        /// <param name="sizes">The list of size items that may contain invalid IDs.</param>
-        public static void RecoverInvalidIds<T>(ObservableCollection<T> sizes)
-            where T : IImageSize
+        /// <param name="items">The list of items that may contain invalid IDs.</param>
+        public static void RecoverInvalidIds<T>(IEnumerable<T> items)
+            where T : class, IHasId
         {
             var idSet = new HashSet<int>();
             int newId = 0;
 
             // Iterate through the list and fix invalid IDs
-            foreach (var size in sizes)
+            foreach (var item in items)
             {
                 // If the ID is invalid or already exists in the set (duplicate), assign a new unique ID
-                if (!idSet.Add(size.Id))
+                if (!idSet.Add(item.Id))
                 {
                     // Find the next available unique ID
                     while (idSet.Contains(newId))
@@ -36,14 +36,14 @@ namespace ManagedCommon
                         newId++;
                     }
 
-                    size.Id = newId;
+                    item.Id = newId;
                     idSet.Add(newId); // Add the newly assigned ID to the set
                 }
             }
         }
     }
 
-    public interface IImageSize
+    public interface IHasId
     {
         int Id { get; set; }
     }

--- a/src/common/ManagedCommon/IdRecoveryHelper.cs
+++ b/src/common/ManagedCommon/IdRecoveryHelper.cs
@@ -23,9 +23,10 @@ namespace ManagedCommon
         {
             var idSet = new HashSet<int>();
             int newId = 0;
+            var sortedItems = items.OrderBy(i => i.Id).ToList(); // Sort items by ID for consistent processing
 
             // Iterate through the list and fix invalid IDs
-            foreach (var item in items)
+            foreach (var item in sortedItems)
             {
                 // If the ID is invalid or already exists in the set (duplicate), assign a new unique ID
                 if (!idSet.Add(item.Id))

--- a/src/common/ManagedCommon/ImageResizerHelper.cs
+++ b/src/common/ManagedCommon/ImageResizerHelper.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ManagedCommon
+{
+    public static class ImageResizerHelper
+    {
+        /// <summary>
+        /// Fixes invalid IDs in the given list by assigning unique values.
+        /// It ensures that all IDs are non-zero and unique, correcting any duplicates or empty (zero) IDs.
+        /// </summary>
+        /// <param name="sizes">The list of size items that may contain invalid IDs.</param>
+        public static void RecoverInvalidIds<T>(ObservableCollection<T> sizes)
+            where T : IImageSize
+        {
+            var idSet = new HashSet<int>();
+            int newId = 0;
+
+            // Iterate through the list and fix invalid IDs
+            foreach (var size in sizes)
+            {
+                // If the ID is invalid or already exists in the set (duplicate), assign a new unique ID
+                if (!idSet.Add(size.Id))
+                {
+                    // Find the next available unique ID
+                    while (idSet.Contains(newId))
+                    {
+                        newId++;
+                    }
+
+                    size.Id = newId;
+                    idSet.Add(newId); // Add the newly assigned ID to the set
+                }
+            }
+        }
+    }
+
+    public interface IImageSize
+    {
+        int Id { get; set; }
+    }
+}

--- a/src/modules/imageresizer/ui/Models/ResizeSize.cs
+++ b/src/modules/imageresizer/ui/Models/ResizeSize.cs
@@ -15,7 +15,7 @@ using ManagedCommon;
 
 namespace ImageResizer.Models
 {
-    public class ResizeSize : Observable, IImageSize
+    public class ResizeSize : Observable, IHasId
     {
         private static readonly Dictionary<string, string> _tokens = new Dictionary<string, string>
         {

--- a/src/modules/imageresizer/ui/Models/ResizeSize.cs
+++ b/src/modules/imageresizer/ui/Models/ResizeSize.cs
@@ -11,10 +11,11 @@ using System.Text.Json.Serialization;
 
 using ImageResizer.Helpers;
 using ImageResizer.Properties;
+using ManagedCommon;
 
 namespace ImageResizer.Models
 {
-    public class ResizeSize : Observable
+    public class ResizeSize : Observable, IImageSize
     {
         private static readonly Dictionary<string, string> _tokens = new Dictionary<string, string>
         {
@@ -24,6 +25,7 @@ namespace ImageResizer.Models
             ["$phone$"] = Resources.Phone,
         };
 
+        private int _id;
         private string _name;
         private ResizeFit _fit = ResizeFit.Fit;
         private double _width;
@@ -31,8 +33,9 @@ namespace ImageResizer.Models
         private bool _showHeight = true;
         private ResizeUnit _unit = ResizeUnit.Pixel;
 
-        public ResizeSize(string name, ResizeFit fit, double width, double height, ResizeUnit unit)
+        public ResizeSize(int id, string name, ResizeFit fit, double width, double height, ResizeUnit unit)
         {
+            Id = id;
             Name = name;
             Fit = fit;
             Width = width;
@@ -42,6 +45,13 @@ namespace ImageResizer.Models
 
         public ResizeSize()
         {
+        }
+
+        [JsonPropertyName("Id")]
+        public int Id
+        {
+            get => _id;
+            set => Set(ref _id, value);
         }
 
         [JsonPropertyName("name")]

--- a/src/modules/imageresizer/ui/Properties/Settings.cs
+++ b/src/modules/imageresizer/ui/Properties/Settings.cs
@@ -19,6 +19,7 @@ using System.Threading;
 using System.Windows.Media.Imaging;
 
 using ImageResizer.Models;
+using ManagedCommon;
 
 namespace ImageResizer.Properties
 {
@@ -63,10 +64,10 @@ namespace ImageResizer.Properties
             FileName = "%1 (%2)";
             Sizes = new ObservableCollection<ResizeSize>
             {
-                new ResizeSize("$small$", ResizeFit.Fit, 854, 480, ResizeUnit.Pixel),
-                new ResizeSize("$medium$", ResizeFit.Fit, 1366, 768, ResizeUnit.Pixel),
-                new ResizeSize("$large$", ResizeFit.Fit, 1920, 1080, ResizeUnit.Pixel),
-                new ResizeSize("$phone$", ResizeFit.Fit, 320, 568, ResizeUnit.Pixel),
+                new ResizeSize(0, "$small$", ResizeFit.Fit, 854, 480, ResizeUnit.Pixel),
+                new ResizeSize(1, "$medium$", ResizeFit.Fit, 1366, 768, ResizeUnit.Pixel),
+                new ResizeSize(2, "$large$", ResizeFit.Fit, 1920, 1080, ResizeUnit.Pixel),
+                new ResizeSize(3, "$phone$", ResizeFit.Fit, 320, 568, ResizeUnit.Pixel),
             };
             KeepDateModified = false;
             FallbackEncoder = new System.Guid("19e4a5aa-5662-4fc5-a0c0-1758028e1057");
@@ -480,6 +481,9 @@ namespace ImageResizer.Properties
                 {
                     Sizes.Clear();
                     Sizes.AddRange(jsonSettings.Sizes);
+
+                    // Ensure Ids are unique and handle missing Ids
+                    ImageResizerHelper.RecoverInvalidIds(Sizes);
                 }
             });
 

--- a/src/modules/imageresizer/ui/Properties/Settings.cs
+++ b/src/modules/imageresizer/ui/Properties/Settings.cs
@@ -483,7 +483,7 @@ namespace ImageResizer.Properties
                     Sizes.AddRange(jsonSettings.Sizes);
 
                     // Ensure Ids are unique and handle missing Ids
-                    ImageResizerHelper.RecoverInvalidIds(Sizes);
+                    IdRecoveryHelper.RecoverInvalidIds(Sizes);
                 }
             });
 

--- a/src/settings-ui/Settings.UI.Library/ImageSize.cs
+++ b/src/settings-ui/Settings.UI.Library/ImageSize.cs
@@ -13,7 +13,7 @@ using Settings.UI.Library.Resources;
 
 namespace Microsoft.PowerToys.Settings.UI.Library;
 
-public partial class ImageSize : INotifyPropertyChanged, IImageSize
+public partial class ImageSize : INotifyPropertyChanged, IHasId
 {
     public event PropertyChangedEventHandler PropertyChanged;
 

--- a/src/settings-ui/Settings.UI.Library/ImageSize.cs
+++ b/src/settings-ui/Settings.UI.Library/ImageSize.cs
@@ -8,11 +8,12 @@ using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using ManagedCommon;
 using Settings.UI.Library.Resources;
 
 namespace Microsoft.PowerToys.Settings.UI.Library;
 
-public partial class ImageSize : INotifyPropertyChanged
+public partial class ImageSize : INotifyPropertyChanged, IImageSize
 {
     public event PropertyChangedEventHandler PropertyChanged;
 

--- a/src/settings-ui/Settings.UI/ViewModels/ImageResizerViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/ImageResizerViewModel.cs
@@ -67,7 +67,7 @@ public partial class ImageResizerViewModel : Observable
         try
         {
             Settings = _settingsUtils.GetSettings<ImageResizerSettings>(ModuleName);
-            ImageResizerHelper.RecoverInvalidIds(Settings.Properties.ImageresizerSizes.Value);
+            IdRecoveryHelper.RecoverInvalidIds(Settings.Properties.ImageresizerSizes.Value);
         }
         catch (Exception e)
         {

--- a/src/settings-ui/Settings.UI/ViewModels/ImageResizerViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/ImageResizerViewModel.cs
@@ -67,6 +67,7 @@ public partial class ImageResizerViewModel : Observable
         try
         {
             Settings = _settingsUtils.GetSettings<ImageResizerSettings>(ModuleName);
+            ImageResizerHelper.RecoverInvalidIds(Settings.Properties.ImageresizerSizes.Value);
         }
         catch (Exception e)
         {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
**Root cause:** 

In PR [#36903](https://github.com/microsoft/PowerToys/pull/36903), the Image Resizer settings UI introduced an ID for refactoring. However, the Image Resizer itself did not add the ID to the corresponding property.

This leads to the following reproducible issue:
- Use Image Resizer to resize an image, which updates the config without an ID.
- Open the settings UI and navigate to the Image Resizer config page, where the config loads with a default ID = 0.
- Deleting an item in the UI will always remove the first entry due to the missing ID assignment.

**Fix in this PR**

1. Add an ID property to the class.
2. Implement a `RecoverInvalidIds` function to handle lost or incorrectly assigned IDs in the config when loading it.

**Fix these issues**
https://github.com/microsoft/PowerToys/issues/38432
https://github.com/microsoft/PowerToys/issues/38056

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
**Scenario 1: Ensure the Issue Does Not Reoccur**

1. In the Settings UI, clear all Image Resizer presets.
2. Add a few new presets.
3. Verify that AppData\Local\Microsoft\PowerToys\Image Resizer\settings.json contains IDs and that each ID is unique.
4. Close the Settings UI (this step is required; during this step, another caching-related bug was discovered).
5. Resize an image.
6. Recheck the settings.json file to ensure the IDs are still present and remain unique.
7. Reopen the Settings UI and delete the last preset—confirm that the correct preset is deleted.

**Scenario 2: RecoverInvalidIds via the Settings UI**

1. Open AppData\Local\Microsoft\PowerToys\Image Resizer\settings.json and remove the id fields from the presets.
2. Try deleting presets in the Settings UI. Check whether the correct preset is deleted and that the id field is restored in settings.json.

**Scenario 3: RecoverInvalidIds via the Image Resizer UI**

1. Open AppData\Local\Microsoft\PowerToys\Image Resizer\settings.json and remove the id fields from the presets.
2. Resize an image and verify that the id field is automatically restored.
