### PR TITLE
Fix the WinGet missing / Admin crash

### DIFF
--- a/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WinGet/Pages/InstallPackageListItem.cs
+++ b/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WinGet/Pages/InstallPackageListItem.cs
@@ -189,7 +189,7 @@ public partial class InstallPackageListItem : ListItem
 
     private void InstallStateChangedHandler(object? sender, InstallPackageCommand e)
     {
-        if (!ApiInformation.IsApiContractPresent("Microsoft.Management.Deployment", 12))
+        if (!ApiInformation.IsApiContractPresent("Microsoft.Management.Deployment.WindowsPackageManagerContract", 12))
         {
             Logger.LogError($"RefreshPackageCatalogAsync isn't available");
             e.FakeChangeStatus();

--- a/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WinGet/WinGetStatics.cs
+++ b/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WinGet/WinGetStatics.cs
@@ -52,7 +52,7 @@ internal static class WinGetStatics
             _storeCatalog,
         ];
 
-        if (ApiInformation.IsApiContractPresent("Microsoft.Management.Deployment", 8))
+        if (ApiInformation.IsApiContractPresent("Microsoft.Management.Deployment.WindowsPackageManagerContract", 8))
         {
             foreach (var catalogReference in AvailableCatalogs)
             {

--- a/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WinGet/WinGetStatics.cs
+++ b/src/modules/cmdpal/exts/Microsoft.CmdPal.Ext.WinGet/WinGetStatics.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 using Microsoft.Management.Deployment;
+using Windows.Foundation.Metadata;
 using WindowsPackageManager.Interop;
 
 namespace Microsoft.CmdPal.Ext.WinGet;
@@ -51,9 +52,12 @@ internal static class WinGetStatics
             _storeCatalog,
         ];
 
-        foreach (var catalogReference in AvailableCatalogs)
+        if (ApiInformation.IsApiContractPresent("Microsoft.Management.Deployment", 8))
         {
-            catalogReference.PackageCatalogBackgroundUpdateInterval = new(0);
+            foreach (var catalogReference in AvailableCatalogs)
+            {
+                catalogReference.PackageCatalogBackgroundUpdateInterval = new(0);
+            }
         }
 
         // Immediately start the lazy-init of the all packages catalog, but


### PR DESCRIPTION
This is a fix for a pair of related crashes. 

Basically, we'd crash on startup if we failed to initialize WinGet. This could happen in two different places:
* If WinGet wasn't installed, then we'd explode, cause obviously we can't call its APIs
* If we're running as Admin, we won't be able to instantiate it's COM server. 

Regardless of how it happens, I've defaulted us to just _not enabling the winget built-in_. That's the simplest solution here. 

As I was helpfully reminded, there's also an elevated WindowsPackageManagerFactory we could use too - though, that wouldn't solve the case of "winget isn't installed"

Closes #38460
Closes #38440 (most likely)