### PR TITLE
[PowerRename] Add 12-hour time format patterns with AM/PM support (#30703)

### DIFF
--- a/src/modules/powerrename/PowerRenameUILib/PowerRenameXAML/MainWindow.xaml.cpp
+++ b/src/modules/powerrename/PowerRenameUILib/PowerRenameXAML/MainWindow.xaml.cpp
@@ -195,8 +195,15 @@ namespace winrt::PowerRenameUI::implementation
         m_dateTimeShortcuts.Append(winrt::make<PatternSnippet>(L"$DDD", manager.MainResourceMap().GetValue(L"Resources/DateTimeCheatSheet_DayNameAbbr").ValueAsString()));
         m_dateTimeShortcuts.Append(winrt::make<PatternSnippet>(L"$DD", manager.MainResourceMap().GetValue(L"Resources/DateTimeCheatSheet_DayDigitLZero").ValueAsString()));
         m_dateTimeShortcuts.Append(winrt::make<PatternSnippet>(L"$D", manager.MainResourceMap().GetValue(L"Resources/DateTimeCheatSheet_DayDigit").ValueAsString()));
-        m_dateTimeShortcuts.Append(winrt::make<PatternSnippet>(L"$hh", manager.MainResourceMap().GetValue(L"Resources/DateTimeCheatSheet_HoursLZero").ValueAsString()));
-        m_dateTimeShortcuts.Append(winrt::make<PatternSnippet>(L"$h", manager.MainResourceMap().GetValue(L"Resources/DateTimeCheatSheet_Hours").ValueAsString()));
+        
+        m_dateTimeShortcuts.Append(winrt::make<PatternSnippet>(L"$HH", manager.MainResourceMap().GetValue(L"Resources/DateTimeCheatSheet_Hours12LZero").ValueAsString()));
+        m_dateTimeShortcuts.Append(winrt::make<PatternSnippet>(L"$H", manager.MainResourceMap().GetValue(L"Resources/DateTimeCheatSheet_Hours12").ValueAsString()));
+        m_dateTimeShortcuts.Append(winrt::make<PatternSnippet>(L"$TT", manager.MainResourceMap().GetValue(L"Resources/DateTimeCheatSheet_AMPMUpperCase").ValueAsString()));
+        m_dateTimeShortcuts.Append(winrt::make<PatternSnippet>(L"$tt", manager.MainResourceMap().GetValue(L"Resources/DateTimeCheatSheet_AMPMLowerCase").ValueAsString()));
+        
+        m_dateTimeShortcuts.Append(winrt::make<PatternSnippet>(L"$hh", manager.MainResourceMap().GetValue(L"Resources/DateTimeCheatSheet_Hours24LZero").ValueAsString()));
+        m_dateTimeShortcuts.Append(winrt::make<PatternSnippet>(L"$h", manager.MainResourceMap().GetValue(L"Resources/DateTimeCheatSheet_Hours24").ValueAsString()));
+        
         m_dateTimeShortcuts.Append(winrt::make<PatternSnippet>(L"$mm", manager.MainResourceMap().GetValue(L"Resources/DateTimeCheatSheet_MinutesLZero").ValueAsString()));
         m_dateTimeShortcuts.Append(winrt::make<PatternSnippet>(L"$m", manager.MainResourceMap().GetValue(L"Resources/DateTimeCheatSheet_Minutes").ValueAsString()));
         m_dateTimeShortcuts.Append(winrt::make<PatternSnippet>(L"$ss", manager.MainResourceMap().GetValue(L"Resources/DateTimeCheatSheet_SecondsLZero").ValueAsString()));

--- a/src/modules/powerrename/PowerRenameUILib/Strings/en-us/Resources.resw
+++ b/src/modules/powerrename/PowerRenameUILib/Strings/en-us/Resources.resw
@@ -219,11 +219,23 @@
   <data name="DateTimeCheatSheet_DayDigit" xml:space="preserve">
     <value>Day of the month as digits without leading zeros for single-digit days.</value>
   </data>
-  <data name="DateTimeCheatSheet_HoursLZero" xml:space="preserve">
-    <value>Hours with leading zeros for single-digit hours.</value>
+  <data name="DateTimeCheatSheet_Hours12LZero" xml:space="preserve">
+    <value>Hours in 12-hour format (01-12) with leading zero.</value>
   </data>
-  <data name="DateTimeCheatSheet_Hours" xml:space="preserve">
-    <value>Hours without leading zeros for single-digit hours.</value>
+  <data name="DateTimeCheatSheet_Hours12" xml:space="preserve">
+    <value>Hours in 12-hour format (1-12) without leading zero.</value>
+  </data>
+  <data name="DateTimeCheatSheet_AMPMUpperCase" xml:space="preserve">
+    <value>AM/PM indicator in uppercase (AM or PM).</value>
+  </data>
+  <data name="DateTimeCheatSheet_AMPMLowerCase" xml:space="preserve">
+    <value>AM/PM indicator in lowercase (am or pm).</value>
+  </data>
+  <data name="DateTimeCheatSheet_Hours24LZero" xml:space="preserve">
+    <value>Hours in 24-hour format (00-23) with leading zero.</value>
+  </data>
+  <data name="DateTimeCheatSheet_Hours24" xml:space="preserve">
+    <value>Hours in 24-hour format (0-23) without leading zero.</value>
   </data>
   <data name="DateTimeCheatSheet_MinutesLZero" xml:space="preserve">
     <value>Minutes with leading zeros for single-digit minutes.</value>

--- a/src/modules/powerrename/lib/Helpers.cpp
+++ b/src/modules/powerrename/lib/Helpers.cpp
@@ -248,7 +248,19 @@ HRESULT GetTransformedFileName(_Out_ PWSTR result, UINT cchMax, _In_ PCWSTR sour
 bool isFileTimeUsed(_In_ PCWSTR source)
 {
     bool used = false;
-    static const std::array patterns = { std::wregex{ L"(([^\\$]|^)(\\$\\$)*)\\$Y" }, std::wregex{ L"(([^\\$]|^)(\\$\\$)*)\\$M" }, std::wregex{ L"(([^\\$]|^)(\\$\\$)*)\\$D" }, std::wregex{ L"(([^\\$]|^)(\\$\\$)*)\\$h" }, std::wregex{ L"(([^\\$]|^)(\\$\\$)*)\\$m" }, std::wregex{ L"(([^\\$]|^)(\\$\\$)*)\\$s" }, std::wregex{ L"(([^\\$]|^)(\\$\\$)*)\\$f" } };
+    static const std::array patterns = {
+        std::wregex{ L"(([^\\$]|^)(\\$\\$)*)\\$Y" }, 
+        std::wregex{ L"(([^\\$]|^)(\\$\\$)*)\\$M" }, 
+        std::wregex{ L"(([^\\$]|^)(\\$\\$)*)\\$D" }, 
+        std::wregex{ L"(([^\\$]|^)(\\$\\$)*)\\$h" }, 
+        std::wregex{ L"(([^\\$]|^)(\\$\\$)*)\\$m" }, 
+        std::wregex{ L"(([^\\$]|^)(\\$\\$)*)\\$s" }, 
+        std::wregex{ L"(([^\\$]|^)(\\$\\$)*)\\$f" },
+        std::wregex{ L"(([^\\$]|^)(\\$\\$)*)\\$H" },
+        std::wregex{ L"(([^\\$]|^)(\\$\\$)*)\\$T" },
+        std::wregex{ L"(([^\\$]|^)(\\$\\$)*)\\$t" }
+    };
+    
     for (size_t i = 0; !used && i < patterns.size(); i++)
     {
         if (std::regex_search(source, patterns[i]))
@@ -274,6 +286,13 @@ HRESULT GetDatedFileName(_Out_ PWSTR result, UINT cchMax, _In_ PCWSTR source, SY
         {
             StringCchCopy(localeName, LOCALE_NAME_MAX_LENGTH, L"en_US");
         }
+
+        int hour12 = (fileTime.wHour % 12);
+        if (hour12 == 0)
+        {
+            hour12 = 12;
+        }
+        const wchar_t* ampm = (fileTime.wHour < 12) ? L"AM" : L"PM";
 
         StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%04d"), L"$01", fileTime.wYear);
         res = regex_replace(res, std::wregex(L"(([^\\$]|^)(\\$\\$)*)\\$YYYY"), replaceTerm);
@@ -315,6 +334,18 @@ HRESULT GetDatedFileName(_Out_ PWSTR result, UINT cchMax, _In_ PCWSTR source, SY
 
         StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%d"), L"$01", fileTime.wDay);
         res = regex_replace(res, std::wregex(L"(([^\\$]|^)(\\$\\$)*)\\$D"), replaceTerm);
+
+        StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%02d"), L"$01", hour12);
+        res = regex_replace(res, std::wregex(L"(([^\\$]|^)(\\$\\$)*)\\$HH"), replaceTerm);
+
+        StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%d"), L"$01", hour12);
+        res = regex_replace(res, std::wregex(L"(([^\\$]|^)(\\$\\$)*)\\$H"), replaceTerm);
+
+        StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%s"), L"$01", ampm);
+        res = regex_replace(res, std::wregex(L"(([^\\$]|^)(\\$\\$)*)\\$TT"), replaceTerm);
+
+        StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%s"), L"$01", (fileTime.wHour < 12) ? L"am" : L"pm");
+        res = regex_replace(res, std::wregex(L"(([^\\$]|^)(\\$\\$)*)\\$tt"), replaceTerm);
 
         StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%02d"), L"$01", fileTime.wHour);
         res = regex_replace(res, std::wregex(L"(([^\\$]|^)(\\$\\$)*)\\$hh"), replaceTerm);

--- a/src/modules/powerrename/lib/Helpers.cpp
+++ b/src/modules/powerrename/lib/Helpers.cpp
@@ -292,7 +292,6 @@ HRESULT GetDatedFileName(_Out_ PWSTR result, UINT cchMax, _In_ PCWSTR source, SY
         {
             hour12 = 12;
         }
-        const wchar_t* ampm = (fileTime.wHour < 12) ? L"AM" : L"PM";
 
         StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%04d"), L"$01", fileTime.wYear);
         res = regex_replace(res, std::wregex(L"(([^\\$]|^)(\\$\\$)*)\\$YYYY"), replaceTerm);
@@ -341,7 +340,7 @@ HRESULT GetDatedFileName(_Out_ PWSTR result, UINT cchMax, _In_ PCWSTR source, SY
         StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%d"), L"$01", hour12);
         res = regex_replace(res, std::wregex(L"(([^\\$]|^)(\\$\\$)*)\\$H"), replaceTerm);
 
-        StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%s"), L"$01", ampm);
+        StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%s"), L"$01", (fileTime.wHour < 12) ? L"AM" : L"PM");
         res = regex_replace(res, std::wregex(L"(([^\\$]|^)(\\$\\$)*)\\$TT"), replaceTerm);
 
         StringCchPrintf(replaceTerm, MAX_PATH, TEXT("%s%s"), L"$01", (fileTime.wHour < 12) ? L"am" : L"pm");

--- a/src/modules/powerrename/unittests/PowerRenameRegExBoostTests.cpp
+++ b/src/modules/powerrename/unittests/PowerRenameRegExBoostTests.cpp
@@ -127,5 +127,53 @@ TEST_METHOD(VerifyLookbehind)
         CoTaskMemFree(result);
     }
 }
+
+TEST_METHOD (Verify12and24HourTimeFormats)
+{
+    CComPtr<IPowerRenameRegEx> renameRegEx;
+    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
+    DWORD flags = MatchAllOccurrences | UseRegularExpressions;
+    Assert::IsTrue(renameRegEx->PutFlags(flags) == S_OK);
+
+    struct TimeTestCase {
+        SYSTEMTIME time;        // Input time
+        PCWSTR formatString;    // Format pattern
+        PCWSTR expectedResult;  // Expected output
+        PCWSTR description;     // Description of what we're testing
+    };
+
+    struct TimeTestCase testCases[] = {
+        // Midnight (00:00 / 12:00 AM)
+        { { 2025, 4, 4, 10, 0, 0, 0, 0 }, L"[$hh:$mm] [$H:$mm $tt]", L"[00:00] [12:00 am]", L"Midnight formatting" },
+
+        // Noon (12:00 / 12:00 PM)
+        { { 2025, 4, 4, 10, 12, 0, 0, 0 }, L"[$hh:$mm] [$H:$mm $tt]", L"[12:00] [12:00 pm]", L"Noon formatting" },
+
+        // 1:05 AM
+        { { 2025, 4, 4, 10, 1, 5, 0, 0 }, L"[$h:$m] [$H:$m $tt] [$hh:$mm] [$HH:$mm $TT]", 
+          L"[1:5] [1:5 am] [01:05] [01:05 AM]", L"1 AM with various formats" },
+
+        // 11 PM
+        { { 2025, 4, 4, 10, 23, 45, 0, 0 }, L"[$h:$m] [$H:$m $tt] [$hh:$mm] [$HH:$mm $TT]", 
+          L"[23:45] [11:45 pm] [23:45] [11:45 PM]", L"11 PM with various formats" },
+
+        // Mixed formats in complex pattern
+        { { 2025, 4, 4, 10, 14, 30, 0, 0 }, L"Date: $YYYY-$MM-$DD Time: $hh:$mm (24h) / $H:$mm $tt (12h)", 
+          L"Date: 2025-04-10 Time: 14:30 (24h) / 2:30 pm (12h)", L"Complex combined format" },
+    };
+
+    for (int i = 0; i < ARRAYSIZE(testCases); i++)
+    {
+        PWSTR result = nullptr;
+        Assert::IsTrue(renameRegEx->PutSearchTerm(L"test") == S_OK);
+        Assert::IsTrue(renameRegEx->PutReplaceTerm(testCases[i].formatString) == S_OK);
+        Assert::IsTrue(renameRegEx->PutFileTime(testCases[i].time) == S_OK);
+        unsigned long index = {};
+        Assert::IsTrue(renameRegEx->Replace(L"test", &result, index) == S_OK);
+        Assert::IsTrue(wcscmp(result, testCases[i].expectedResult) == 0, 
+                      (std::wstring(L"Failed test case: ") + testCases[i].description).c_str());
+        CoTaskMemFree(result);
+    }
+}
 };
 }

--- a/src/modules/powerrename/unittests/PowerRenameRegExTests.cpp
+++ b/src/modules/powerrename/unittests/PowerRenameRegExTests.cpp
@@ -207,5 +207,53 @@ TEST_METHOD(VerifyLookbehindFails)
     }
 }
 
+TEST_METHOD (Verify12and24HourTimeFormats)
+{
+    CComPtr<IPowerRenameRegEx> renameRegEx;
+    Assert::IsTrue(CPowerRenameRegEx::s_CreateInstance(&renameRegEx) == S_OK);
+    DWORD flags = MatchAllOccurrences | UseRegularExpressions;
+    Assert::IsTrue(renameRegEx->PutFlags(flags) == S_OK);
+
+    struct TimeTestCase {
+        SYSTEMTIME time;        // Input time
+        PCWSTR formatString;    // Format pattern
+        PCWSTR expectedResult;  // Expected output
+        PCWSTR description;     // Description of what we're testing
+    };
+
+    struct TimeTestCase testCases[] = {
+        // Midnight (00:00 / 12:00 AM)
+        { { 2025, 4, 4, 10, 0, 0, 0, 0 }, L"[$hh:$mm] [$H:$mm $tt]", L"[00:00] [12:00 am]", L"Midnight formatting" },
+
+        // Noon (12:00 / 12:00 PM)
+        { { 2025, 4, 4, 10, 12, 0, 0, 0 }, L"[$hh:$mm] [$H:$mm $tt]", L"[12:00] [12:00 pm]", L"Noon formatting" },
+
+        // 1:05 AM
+        { { 2025, 4, 4, 10, 1, 5, 0, 0 }, L"[$h:$m] [$H:$m $tt] [$hh:$mm] [$HH:$mm $TT]", 
+          L"[1:5] [1:5 am] [01:05] [01:05 AM]", L"1 AM with various formats" },
+
+        // 11 PM
+        { { 2025, 4, 4, 10, 23, 45, 0, 0 }, L"[$h:$m] [$H:$m $tt] [$hh:$mm] [$HH:$mm $TT]", 
+          L"[23:45] [11:45 pm] [23:45] [11:45 PM]", L"11 PM with various formats" },
+
+        // Mixed formats in complex pattern
+        { { 2025, 4, 4, 10, 14, 30, 0, 0 }, L"Date: $YYYY-$MM-$DD Time: $hh:$mm (24h) / $H:$mm $tt (12h)", 
+          L"Date: 2025-04-10 Time: 14:30 (24h) / 2:30 pm (12h)", L"Complex combined format" },
+    };
+
+    for (int i = 0; i < ARRAYSIZE(testCases); i++)
+    {
+        PWSTR result = nullptr;
+        Assert::IsTrue(renameRegEx->PutSearchTerm(L"test") == S_OK);
+        Assert::IsTrue(renameRegEx->PutReplaceTerm(testCases[i].formatString) == S_OK);
+        Assert::IsTrue(renameRegEx->PutFileTime(testCases[i].time) == S_OK);
+        unsigned long index = {};
+        Assert::IsTrue(renameRegEx->Replace(L"test", &result, index) == S_OK);
+        Assert::IsTrue(wcscmp(result, testCases[i].expectedResult) == 0, 
+                       (std::wstring(L"Failed test case: ") + testCases[i].description).c_str());
+        CoTaskMemFree(result);
+    }
+}
+
 };
 }


### PR DESCRIPTION
## Summary of the Pull Request
Add support for 12-hour time format patterns in PowerRename. This adds new patterns:
- `$HH` - Hours in 12-hour format with leading zero (01-12)
- `$H` - Hours in 12-hour format without leading zero (1-12)
- `$TT` - AM/PM indicator in uppercase (AM or PM)
- `$tt` - AM/PM indicator in lowercase (am or pm)

## PR Checklist
- [x] **Closes:** #30703
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
  - Midnight (12:00 AM / 00:00)
  - Noon (12:00 PM)
  - Single-digit hours
  - AM/PM transitions
  - Mixed format patterns
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Existing docs are incomplete
- [ ] **New binaries:** N/A - No new binaries added
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments
This PR enhances PowerRename's time formatting capabilities by adding support for 12-hour time formats. Changes include:

1. Added new time patterns (`$HH`, `$H`, `$TT`, `$tt`) for 12-hour format support
2. Updated `GetDatedFileName` to handle 12-hour time conversion
3. Added unit tests for both standard and Boost regex implementations
4. Added string resources for pattern descriptions

## Validation Steps Performed

Unit Tests:
   - Verified midnight displays as "12:00 AM" in 12-hour format
   - Verified noon displays as "12:00 PM"
   - Tested single-digit hours (1-9) with/without leading zeros
   - Tested double-digit hours (10-12)
   - Verified PM hours (12:00-23:59) convert correctly
   - Tested mixing 12/24 hour formats in same pattern