### PR TITLE
[cmdpal] Run cmdpalette from runner locally

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -176,6 +176,7 @@ CDeclaration
 cdn
 CElems
 CENTERALIGN
+cer
 certlm
 certmgr
 cfp
@@ -355,6 +356,7 @@ DEVMODE
 DEVMODEW
 devpal
 DIALOGEX
+digicert
 dimm
 DISABLEASACTIONKEY
 DISABLENOSCROLL
@@ -1525,6 +1527,7 @@ SIDs
 siex
 sigdn
 SIGNINGSCENARIO
+signtool
 Signtool
 SINGLEKEY
 sipolicy

--- a/src/modules/cmdpal/CmdPalModuleInterface/dllmain.cpp
+++ b/src/modules/cmdpal/CmdPalModuleInterface/dllmain.cpp
@@ -207,12 +207,16 @@ public:
 
         try
         {
-            if (!package::GetRegisteredPackage(L"Microsoft.CommandPalette", false).has_value())
+            std::wstring packageName = L"Microsoft.CommandPalette";
+#ifdef _DEBUG
+            packageName = L"Microsoft.CommandPalette.Dev";
+#endif
+            if (!package::GetRegisteredPackage(packageName, false).has_value())
             {
                 Logger::info(L"CmdPal not installed. Installing...");
 
                 std::wstring installationFolder = get_module_folderpath();
-#if _DEBUG
+#ifdef _DEBUG
                 std::wstring archSubdir = L"x64";
 #ifdef _M_ARM64
                 archSubdir = L"ARM64";

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Microsoft.CmdPal.UI.csproj
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Microsoft.CmdPal.UI.csproj
@@ -23,7 +23,7 @@
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(CIBuild)'=='true'">
+  <PropertyGroup>
     <GenerateAppxPackageOnBuild>true</GenerateAppxPackageOnBuild>
   </PropertyGroup>
 

--- a/src/settings-ui/Settings.UI/SettingsXAML/OobeWindow.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/OobeWindow.xaml.cs
@@ -31,7 +31,6 @@ namespace Microsoft.PowerToys.Settings.UI
         private WindowId _windowId;
         private IntPtr _hWnd;
         private AppWindow _appWindow;
-        private WindowMessageMonitor _msgMonitor;
         private bool disposedValue;
 
         public OobeWindow(PowerToysModules initialModule)
@@ -46,10 +45,6 @@ namespace Microsoft.PowerToys.Settings.UI
             _appWindow = AppWindow.GetFromWindowId(_windowId);
             this.Activated += Window_Activated_SetIcon;
 
-            OverlappedPresenter presenter = _appWindow.Presenter as OverlappedPresenter;
-            presenter.IsMinimizable = false;
-            presenter.IsMaximizable = false;
-
             var dpi = NativeMethods.GetDpiForWindow(_hWnd);
             _currentDPI = dpi;
             float scalingFactor = (float)dpi / DefaultDPI;
@@ -62,18 +57,6 @@ namespace Microsoft.PowerToys.Settings.UI
             _appWindow.Resize(size);
 
             this.initialModule = initialModule;
-
-            _msgMonitor = new WindowMessageMonitor(this);
-            _msgMonitor.WindowMessageReceived += (_, e) =>
-            {
-                const int WM_NCLBUTTONDBLCLK = 0x00A3;
-                if (e.Message.MessageId == WM_NCLBUTTONDBLCLK)
-                {
-                    // Disable double click on title bar to maximize window
-                    e.Result = 0;
-                    e.Handled = true;
-                }
-            };
 
             this.SizeChanged += OobeWindow_SizeChanged;
 
@@ -154,8 +137,6 @@ namespace Microsoft.PowerToys.Settings.UI
         {
             if (!disposedValue)
             {
-                _msgMonitor?.Dispose();
-
                 disposedValue = true;
             }
         }

--- a/src/settings-ui/Settings.UI/SettingsXAML/OobeWindow.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/OobeWindow.xaml.cs
@@ -31,6 +31,7 @@ namespace Microsoft.PowerToys.Settings.UI
         private WindowId _windowId;
         private IntPtr _hWnd;
         private AppWindow _appWindow;
+        private WindowMessageMonitor _msgMonitor;
         private bool disposedValue;
 
         public OobeWindow(PowerToysModules initialModule)
@@ -45,6 +46,10 @@ namespace Microsoft.PowerToys.Settings.UI
             _appWindow = AppWindow.GetFromWindowId(_windowId);
             this.Activated += Window_Activated_SetIcon;
 
+            OverlappedPresenter presenter = _appWindow.Presenter as OverlappedPresenter;
+            presenter.IsMinimizable = false;
+            presenter.IsMaximizable = false;
+
             var dpi = NativeMethods.GetDpiForWindow(_hWnd);
             _currentDPI = dpi;
             float scalingFactor = (float)dpi / DefaultDPI;
@@ -57,6 +62,18 @@ namespace Microsoft.PowerToys.Settings.UI
             _appWindow.Resize(size);
 
             this.initialModule = initialModule;
+
+            _msgMonitor = new WindowMessageMonitor(this);
+            _msgMonitor.WindowMessageReceived += (_, e) =>
+            {
+                const int WM_NCLBUTTONDBLCLK = 0x00A3;
+                if (e.Message.MessageId == WM_NCLBUTTONDBLCLK)
+                {
+                    // Disable double click on title bar to maximize window
+                    e.Result = 0;
+                    e.Handled = true;
+                }
+            };
 
             this.SizeChanged += OobeWindow_SizeChanged;
 
@@ -137,6 +154,8 @@ namespace Microsoft.PowerToys.Settings.UI
         {
             if (!disposedValue)
             {
+                _msgMonitor?.Dispose();
+
                 disposedValue = true;
             }
         }

--- a/tools/build/self-sign.ps1
+++ b/tools/build/self-sign.ps1
@@ -1,4 +1,7 @@
 #https://learn.microsoft.com/en-us/windows/msix/package/signing-known-issues
+# 1. Build the powertoys as usual.
+# 2. Call this script to sign the msix package.
+# First time run needs admin permission to trust the certificate.
 
 param (
     [string]$architecture = "x64",  # Default to x64 if not provided
@@ -127,7 +130,12 @@ $rootDirectory = (Split-Path -Parent(Split-Path -Parent (Split-Path -Parent $MyI
 
 # Dynamically build the directory path based on architecture and build configuration
 # $directoryPath = Join-Path $rootDirectory "$architecture\$buildConfiguration\WinUI3Apps\CmdPal\"
-$directoryPath = Join-Path $rootDirectory "x64\$buildConfiguration\WinUI3Apps\CmdPal\"
+$directoryPath = Join-Path $rootDirectory "$architecture\$buildConfiguration\WinUI3Apps\CmdPal\"
+
+if (-not (Test-Path $directoryPath)) {
+    Write-Error "Path to search for msix files does not exist: $directoryPath"
+    exit 1
+}
 
 Write-Host "Directory path to search for .msix and .appx files: $directoryPath"
 

--- a/tools/build/self-sign.ps1
+++ b/tools/build/self-sign.ps1
@@ -1,0 +1,126 @@
+param (
+    [string]$architecture = "arm64",  # Default to x64 if not provided
+    [string]$buildConfiguration = "Debug"  # Default to Debug if not provided
+)
+
+$signToolPath = $null
+$architecture = "arm64"
+$kitsRootPaths = @(
+    "C:\Program Files (x86)\Windows Kits\10\bin",
+    "C:\Program Files\Windows Kits\10\bin"
+)
+
+$signToolAvailable = Get-Command "signtool" -ErrorAction SilentlyContinue
+if ($signToolAvailable) {
+    Write-Host "SignTool is available in the system PATH."
+    $signToolPath = "signtool"
+}
+else {
+    Write-Host "Searching for latest SignTool matching architecture: $architecture"
+
+    foreach ($root in $kitsRootPaths) {
+        if (Test-Path $root) {
+            $versions = Get-ChildItem -Path $root -Directory | Where-Object {
+                $_.Name -match '^\d+\.\d+\.\d+\.\d+$'
+            } | Sort-Object Name -Descending
+
+            foreach ($version in $versions) {
+                $candidatePath = Join-Path -Path $version.FullName -ChildPath $architecture
+                $exePath = Join-Path -Path $candidatePath -ChildPath "signtool.exe"
+                if (Test-Path $exePath) {
+                    Write-Host "Found SignTool at: $exePath"
+                    $signToolPath = $exePath
+                    break
+                }
+            }
+
+            if ($signToolPath) { break }
+        }
+    }
+
+    if (!$signToolPath) {
+        Write-Host "SignTool not found. Please ensure Windows SDK is installed."
+        exit 1
+    }
+}
+
+Write-Host "`nUsing SignTool: $signToolPath"
+
+# Set the certificate subject and the ECDSA curve
+$certSubject = "CN=PowerToysSelfSignedCert"
+
+# Check if the certificate already exists in the current user's certificate store
+$existingCert = Get-ChildItem -Path Cert:\CurrentUser\My | Where-Object { $_.Subject -like "*PowerToysSelfSignedCert*" }
+
+if ($existingCert) {
+    # If the certificate exists, use the existing certificate
+    Write-Host "Certificate already exists, using the existing certificate"
+    $cert = $existingCert
+}
+else {
+    # If the certificate doesn't exist, create a new self-signed certificate
+    Write-Host "Certificate does not exist, creating a new certificate..."
+    try {
+        $cert = New-SelfSignedCertificate -Subject $certSubject `
+                                          -CertStoreLocation "Cert:\CurrentUser\My" `
+                                          -KeyAlgorithm RSA `
+                                          -Type CodeSigningCert `
+                                          -HashAlgorithm SHA256
+        Write-Host "New certificate created"
+
+        # ✅ Trust the certificate by importing it into 'Trusted Root Certification Authorities'
+        $trustedRootStore = "Cert:\CurrentUser\Root"
+        $imported = Import-Certificate -FilePath (Export-Certificate -Cert $cert -FilePath "$env:TEMP\temp_cert.cer" -Force).FullName -CertStoreLocation $trustedRootStore
+
+        if ($imported) {
+            Write-Host "✅ Certificate successfully trusted (imported to Root store)"
+        } else {
+            Write-Host "⚠️ Failed to trust certificate"
+        }
+    }
+    catch {
+        Write-Host "❌ Error creating certificate: $_"
+        exit 1
+    }
+}
+
+# Output the thumbprint of the certificate (to confirm which certificate is being used)
+Write-Host "Using certificate with thumbprint: $($cert.Thumbprint)"
+
+
+$rootDirectory = (Split-Path -Parent(Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)))
+
+# Dynamically build the directory path based on architecture and build configuration
+$directoryPath = Join-Path $rootDirectory "$architecture\$buildConfiguration\WinUI3Apps\CmdPal\"
+
+Write-Host "Directory path to search for .msix and .appx files: $directoryPath"
+
+# Get all .msix and .appx files from the specified directory
+$filePaths = Get-ChildItem -Path $directoryPath -Recurse | Where-Object {
+    ($_.Extension -eq ".msix" -or $_.Extension -eq ".appx") -and
+    ($_.Name -like "*$architecture*")
+}
+
+if ($filePaths.Count -eq 0) {
+    Write-Host "No .msix or .appx files found in the directory."
+}
+else {
+    # Iterate through each file and sign it
+    foreach ($file in $filePaths) {
+        Write-Host "Signing file: $($file.FullName)"
+        
+        # Use SignTool to sign the file
+        $signToolCommand = "& `"$signToolPath`" sign /sha1 $($cert.Thumbprint) /fd SHA256 /t http://timestamp.digicert.com `"$($file.FullName)`""
+
+        # Execute the sign command
+        try {
+            Invoke-Expression $signToolCommand
+            Write-Host "File $($file.Name) has been successfully signed!"
+        }
+        catch {
+            Write-Host "Error signing file $($file.Name): $_"
+        }
+    }
+}
+
+Write-Host "Signing process completed."


### PR DESCRIPTION
Build and run powertoys runner would result in an error: 
-- Of course, disable&enable that would cause the error too.

dev_commandPal is not found.

This is because:
1. We do not produce a msix file for installation at normal build time.
2. 1 can be solved by remove the condition for generateMsixFile, while
3. If you don't sign it with a trusted certificate, it would not be registerd.

So this pr 
1. Handles the launch problem for command palette from runner
2. Self sign the msix file to make it available during dev_commandpalette registration

Dev experience may be not straight forward though.
I'd like to check in a one stop build script to make build&sign work in local environment. 
<img width="1039" alt="image" src="https://github.com/user-attachments/assets/6f680221-2ed9-45d3-a7da-9264b6e5e270" />
