### PR TITLE
Lazy-fetch the settings for extensions

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandProviderWrapper.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandProviderWrapper.cs
@@ -66,6 +66,9 @@ public sealed class CommandProviderWrapper
         DisplayName = provider.DisplayName;
         Icon = new(provider.Icon);
         Icon.InitializeProperties();
+
+        // Note: explicitly not InitializeProperties'ing the settings here. If
+        // we do that, then we'd regress GH #38321
         Settings = new(provider.Settings, this, _taskScheduler);
 
         Logger.LogDebug($"Initialized command provider {ProviderId}");
@@ -150,7 +153,11 @@ public sealed class CommandProviderWrapper
             Icon = new(model.Icon);
             Icon.InitializeProperties();
 
+            // Note: explicitly not InitializeProperties'ing the settings here. If
+            // we do that, then we'd regress GH #38321
             Settings = new(model.Settings, this, _taskScheduler);
+
+            // We do need to explicitly initialize commands though
             InitializeCommands(commands, fallbacks, serviceProvider, pageContext);
 
             Logger.LogDebug($"Loaded commands from {DisplayName} ({ProviderId})");
@@ -191,37 +198,6 @@ public sealed class CommandProviderWrapper
         }
     }
 
-    // private void UnsafeLoadSettings()
-    // {
-    //    Settings?.SafeInitializeProperties();
-    // }
-
-    // private void SafeLoadSettings()
-    // {
-    //    if (!isValid)
-    //    {
-    //        return;
-    //    }
-
-    // if (_loadedSettings)
-    //    {
-    //        return;
-    //    }
-
-    // try
-    //    {
-    //        UnsafeLoadSettings();
-    //    }
-    //    catch (Exception e)
-    //    {
-    //        Logger.LogError($"Failed to load settings from {Extension!.PackageFamilyName}", ex: e);
-    //    }
-    // }
-
-    // public Task LoadSettings()
-    // {
-    //    return Task.Run(SafeLoadSettings);
-    // }
     public override bool Equals(object? obj) => obj is CommandProviderWrapper wrapper && isValid == wrapper.isValid;
 
     public override int GetHashCode() => _commandProvider.GetHashCode();

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandProviderWrapper.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandProviderWrapper.cs
@@ -151,9 +151,8 @@ public sealed class CommandProviderWrapper
             Icon = new(model.Icon);
             Icon.InitializeProperties();
 
-            Settings = new(model.Settings, this, _taskScheduler);
-            Settings.InitializeProperties();
-
+            // Settings = new(model.Settings, this, _taskScheduler);
+            // Settings.InitializeProperties();
             InitializeCommands(commands, fallbacks, serviceProvider, pageContext);
 
             Logger.LogDebug($"Loaded commands from {DisplayName} ({ProviderId})");

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandProviderWrapper.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandProviderWrapper.cs
@@ -40,8 +40,6 @@ public sealed class CommandProviderWrapper
 
     public CommandSettingsViewModel? Settings { get; private set; }
 
-    private bool _loadedSettings;
-
     public string ProviderId
     {
         get
@@ -68,8 +66,8 @@ public sealed class CommandProviderWrapper
         DisplayName = provider.DisplayName;
         Icon = new(provider.Icon);
         Icon.InitializeProperties();
+        Settings = new(provider.Settings, this, _taskScheduler);
 
-        // UnsafeLoadSettings();
         Logger.LogDebug($"Initialized command provider {ProviderId}");
     }
 
@@ -152,8 +150,7 @@ public sealed class CommandProviderWrapper
             Icon = new(model.Icon);
             Icon.InitializeProperties();
 
-            // Settings = new(model.Settings, this, _taskScheduler);
-            // Settings.InitializeProperties();
+            Settings = new(model.Settings, this, _taskScheduler);
             InitializeCommands(commands, fallbacks, serviceProvider, pageContext);
 
             Logger.LogDebug($"Loaded commands from {DisplayName} ({ProviderId})");
@@ -194,41 +191,37 @@ public sealed class CommandProviderWrapper
         }
     }
 
-    private void UnsafeLoadSettings()
-    {
-        var model = _commandProvider.Unsafe!;
-        Settings = new(model.Settings, this, _taskScheduler);
-        Settings.InitializeProperties();
-        _loadedSettings = true;
-    }
+    // private void UnsafeLoadSettings()
+    // {
+    //    Settings?.SafeInitializeProperties();
+    // }
 
-    private void SafeLoadSettings()
-    {
-        if (!isValid)
-        {
-            return;
-        }
+    // private void SafeLoadSettings()
+    // {
+    //    if (!isValid)
+    //    {
+    //        return;
+    //    }
 
-        if (_loadedSettings)
-        {
-            return;
-        }
+    // if (_loadedSettings)
+    //    {
+    //        return;
+    //    }
 
-        try
-        {
-            UnsafeLoadSettings();
-        }
-        catch (Exception e)
-        {
-            Logger.LogError($"Failed to load settings from {Extension!.PackageFamilyName}", ex: e);
-        }
-    }
+    // try
+    //    {
+    //        UnsafeLoadSettings();
+    //    }
+    //    catch (Exception e)
+    //    {
+    //        Logger.LogError($"Failed to load settings from {Extension!.PackageFamilyName}", ex: e);
+    //    }
+    // }
 
-    public Task LoadSettings()
-    {
-        return Task.Run(SafeLoadSettings);
-    }
-
+    // public Task LoadSettings()
+    // {
+    //    return Task.Run(SafeLoadSettings);
+    // }
     public override bool Equals(object? obj) => obj is CommandProviderWrapper wrapper && isValid == wrapper.isValid;
 
     public override int GetHashCode() => _commandProvider.GetHashCode();

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandSettingsViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandSettingsViewModel.cs
@@ -2,18 +2,25 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using ManagedCommon;
 using Microsoft.CmdPal.UI.ViewModels.Models;
 using Microsoft.CommandPalette.Extensions;
 
 namespace Microsoft.CmdPal.UI.ViewModels;
 
-public partial class CommandSettingsViewModel(ICommandSettings _unsafeSettings, CommandProviderWrapper provider, TaskScheduler mainThread)
+public partial class CommandSettingsViewModel(ICommandSettings? _unsafeSettings, CommandProviderWrapper provider, TaskScheduler mainThread)
 {
     private readonly ExtensionObject<ICommandSettings> _model = new(_unsafeSettings);
 
     public ContentPageViewModel? SettingsPage { get; private set; }
 
-    public void InitializeProperties()
+    public bool Initialized { get; private set; }
+
+    public bool HasSettings =>
+        _model.Unsafe != null && // We have a settings model AND
+        (!Initialized || SettingsPage != null); // we weren't initialized, OR we were, and we do have a settings page
+
+    private void UnsafeInitializeProperties()
     {
         var model = _model.Unsafe;
         if (model == null)
@@ -26,5 +33,28 @@ public partial class CommandSettingsViewModel(ICommandSettings _unsafeSettings, 
             SettingsPage = new(page, mainThread, provider.ExtensionHost);
             SettingsPage.InitializeProperties();
         }
+    }
+
+    public void SafeInitializeProperties()
+    {
+        try
+        {
+            UnsafeInitializeProperties();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError($"Failed to load settings page", ex: ex);
+        }
+
+        Initialized = true;
+    }
+
+    public void DoOnUiThread(Action action)
+    {
+        Task.Factory.StartNew(
+            action,
+            CancellationToken.None,
+            TaskCreationOptions.None,
+            mainThread);
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandManager.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Immutable;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
@@ -44,6 +45,9 @@ public partial class TopLevelCommandManager : ObservableObject,
 
     public async Task<bool> LoadBuiltinsAsync()
     {
+        var s = new Stopwatch();
+        s.Start();
+
         _builtInCommands.Clear();
 
         // Load built-In commands first. These are all in-proc, and
@@ -55,6 +59,10 @@ public partial class TopLevelCommandManager : ObservableObject,
             _builtInCommands.Add(wrapper);
             await LoadTopLevelCommandsFromProvider(wrapper);
         }
+
+        s.Stop();
+
+        Logger.LogDebug($"Loading built-ins took {s.ElapsedMilliseconds}ms");
 
         return true;
     }
@@ -239,6 +247,9 @@ public partial class TopLevelCommandManager : ObservableObject,
 
     private async Task StartExtensionsAndGetCommands(IEnumerable<IExtensionWrapper> extensions)
     {
+        var s = new Stopwatch();
+        s.Start();
+
         // TODO This most definitely needs a lock
         foreach (var extension in extensions)
         {
@@ -258,6 +269,10 @@ public partial class TopLevelCommandManager : ObservableObject,
                 Logger.LogError(ex.ToString());
             }
         }
+
+        s.Stop();
+
+        Logger.LogDebug($"Loading extensions took {s.ElapsedMilliseconds}ms");
     }
 
     private void ExtensionService_OnExtensionRemoved(IExtensionService sender, IEnumerable<IExtensionWrapper> extensions)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/ExtensionPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/ExtensionPage.xaml
@@ -113,7 +113,24 @@
                                     Visibility="{x:Bind ViewModel.HasSettings}" />
 
                                 <Frame x:Name="SettingsFrame" Visibility="{x:Bind ViewModel.HasSettings}">
-                                    <cmdpalUI:ContentPage ViewModel="{x:Bind ViewModel.SettingsPage, Mode=OneWay}" />
+                                
+                                    <controls:SwitchPresenter
+                                        HorizontalAlignment="Stretch"
+                                        TargetType="x:Boolean"
+                                        Value="{x:Bind ViewModel.LoadingSettings, Mode=OneWay}">
+                                        <controls:Case Value="True">
+                                            <ProgressRing
+                                                Width="36"
+                                                Height="36"
+                                                HorizontalAlignment="Center"
+                                                VerticalAlignment="Center"
+                                                IsIndeterminate="True" />
+                                        </controls:Case>
+                                        <controls:Case Value="False">
+                                            <cmdpalUI:ContentPage ViewModel="{x:Bind ViewModel.SettingsPage, Mode=OneWay}" />
+                                        </controls:Case>
+                                    </controls:SwitchPresenter>
+
                                 </Frame>
 
                                 <TextBlock

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/ExtensionPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/ExtensionPage.xaml
@@ -113,7 +113,7 @@
                                     Visibility="{x:Bind ViewModel.HasSettings}" />
 
                                 <Frame x:Name="SettingsFrame" Visibility="{x:Bind ViewModel.HasSettings}">
-                                
+
                                     <controls:SwitchPresenter
                                         HorizontalAlignment="Stretch"
                                         TargetType="x:Boolean"


### PR DESCRIPTION
This PR stops us from synchronously initializing the settings page for every extension (including built-in's) on startup. That incurs a small penalty that really adds up the more extensions a user has.

Instead, we'll now only initialize the `CommandSettings` object when we first actually need it. 

From a relatively unscientific test, this saves approximately 10% on the initialization of builtin commands, and for my setup, it trims about 28% off extension initialization (across all built-in's / extensions):

branch | Built-in load (ms) | Extension load (ms) | %Δ builtin | %Δ extensions | 
-- | -- | -- | -- | -- |
main | 1455 | 6867.6 | | |
this PR | 1309.2 | 4919 | -10.02% | -28.37%

Closes #38321

