### PR TITLE
CmdPal: minor calc updates

### DIFF
--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Helper/CalculatorIcons.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Helper/CalculatorIcons.cs
@@ -8,9 +8,11 @@ namespace Microsoft.CmdPal.Ext.Calc.Helper;
 
 public static class CalculatorIcons
 {
-    public static IconInfo ResultIcon => new IconInfo("\uE94E");
+    public static IconInfo ResultIcon => new("\uE94E");
 
-    public static IconInfo ErrorIcon => new IconInfo("\uE783");
+    public static IconInfo SaveIcon => new("\uE74E");
+
+    public static IconInfo ErrorIcon => new("\uE783");
 
     public static IconInfo ProviderIcon => IconHelpers.FromRelativePath("Assets\\Calculator.svg");
 }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Helper/SaveCommand.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Helper/SaveCommand.cs
@@ -2,7 +2,6 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using Microsoft.CmdPal.Ext.Calc.Properties;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
@@ -19,6 +18,7 @@ public sealed partial class SaveCommand : InvokableCommand
     public SaveCommand(string result)
     {
         Name = Resources.calculator_save_command_name;
+        Icon = CalculatorIcons.SaveIcon;
         _result = result;
     }
 

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Pages/FallbackCalculatorItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Pages/FallbackCalculatorItem.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CmdPal.Ext.Calc.Pages;
 public sealed partial class FallbackCalculatorItem : FallbackCommandItem
 {
     private readonly CopyTextCommand _copyCommand = new(string.Empty);
-    private SettingsManager _settings;
+    private readonly SettingsManager _settings;
 
     public FallbackCalculatorItem(SettingsManager settings)
         : base(new NoOpCommand(), Resources.calculator_title)
@@ -34,7 +34,7 @@ public sealed partial class FallbackCalculatorItem : FallbackCommandItem
             _copyCommand.Name = string.Empty;
             Title = string.Empty;
             Subtitle = string.Empty;
-
+            MoreCommands = [];
             return;
         }
 
@@ -46,5 +46,7 @@ public sealed partial class FallbackCalculatorItem : FallbackCommandItem
         // so that we will still string match the original query
         // Otherwise, something like 1+2 will have a title of "3" and not match
         Subtitle = query;
+
+        MoreCommands = result.MoreCommands;
     }
 }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Properties/Resources.Designer.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Properties/Resources.Designer.cs
@@ -70,11 +70,29 @@ namespace Microsoft.CmdPal.Ext.Calc.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Copy binary.
+        /// </summary>
+        public static string calculator_copy_binary {
+            get {
+                return ResourceManager.GetString("calculator_copy_binary", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Copy.
         /// </summary>
         public static string calculator_copy_command_name {
             get {
                 return ResourceManager.GetString("calculator_copy_command_name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Copy hexadecimal.
+        /// </summary>
+        public static string calculator_copy_hex {
+            get {
+                return ResourceManager.GetString("calculator_copy_hex", resourceCulture);
             }
         }
         

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Properties/Resources.resx
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Properties/Resources.resx
@@ -193,4 +193,10 @@
   <data name="calculator_not_covert_to_decimal" xml:space="preserve">
     <value>Result value was either too large or too small for a decimal number</value>
   </data>
+  <data name="calculator_copy_hex" xml:space="preserve">
+    <value>Copy hexadecimal</value>
+  </data>
+  <data name="calculator_copy_binary" xml:space="preserve">
+    <value>Copy binary</value>
+  </data>
 </root>


### PR DESCRIPTION
![calc-updates-000](https://github.com/user-attachments/assets/4d3e4d52-787d-4b8f-a128-713decee5462)


This targets #38629.

I added the history back to the calc page at all times (even if the equation failed to parse). That feels a bit cleaner now. 

I also drive-by added the other number formats from #38372 to the context menu. 