### PR TITLE
[CmdPal] Added fallback for time and date

### DIFF
--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/FallbackTimeDateItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/FallbackTimeDateItem.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Globalization;
 using Microsoft.CmdPal.Ext.TimeDate.Helpers;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
@@ -24,11 +25,11 @@ internal sealed partial class FallbackTimeDateItem : FallbackCommandItem
         _settingsManager = settings;
         _validOptions = new(StringComparer.OrdinalIgnoreCase)
         {
-            ResultHelper.SelectStringFromResources(true, string.Empty, "Microsoft_plugin_timedate_SearchTagWeek"),
-            ResultHelper.SelectStringFromResources(true, string.Empty, "Microsoft_plugin_timedate_SearchTagDate"),
-            ResultHelper.SelectStringFromResources(true, string.Empty, "Microsoft_plugin_timedate_Year"),
-            ResultHelper.SelectStringFromResources(true, string.Empty, "Microsoft_plugin_timedate_Now"),
-            ResultHelper.SelectStringFromResources(true, string.Empty, "Microsoft_plugin_timedate_Time"),
+            Resources.ResourceManager.GetString("Microsoft_plugin_timedate_SearchTagWeek", CultureInfo.CurrentCulture),
+            Resources.ResourceManager.GetString("Microsoft_plugin_timedate_SearchTagDate", CultureInfo.CurrentCulture),
+            Resources.ResourceManager.GetString("Microsoft_plugin_timedate_Year", CultureInfo.CurrentCulture),
+            Resources.ResourceManager.GetString("Microsoft_plugin_timedate_Now", CultureInfo.CurrentCulture),
+            Resources.ResourceManager.GetString("Microsoft_plugin_timedate_Time", CultureInfo.CurrentCulture),
         };
     }
 

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/FallbackTimeDateItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/FallbackTimeDateItem.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using Microsoft.CmdPal.Ext.TimeDate.Helpers;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+
+namespace Microsoft.CmdPal.Ext.TimeDate;
+
+internal sealed partial class FallbackTimeDateItem : FallbackCommandItem
+{
+    private SettingsManager _settingsManager;
+
+    public FallbackTimeDateItem(SettingsManager settings)
+         : base(new NoOpCommand(), Resources.Microsoft_plugin_timedate_fallback_display_title)
+    {
+        Title = string.Empty;
+        Subtitle = string.Empty;
+        _settingsManager = settings;
+    }
+
+    public override void UpdateQuery(string query)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            Title = string.Empty;
+            Subtitle = string.Empty;
+            Command = new NoOpCommand();
+            return;
+        }
+
+        var items = TimeDateCalculator.ExecuteSearch(_settingsManager, query);
+
+        if (items.Count > 0 &&
+            items[0].Title != Resources.Microsoft_plugin_timedate_InvalidInput_ErrorMessageTitle &&
+            items[0].Title != Resources.Microsoft_plugin_timedate_ErrorResultTitle)
+        {
+            Title = items[0].Title;
+            Subtitle = items[0].Subtitle;
+            Icon = items[0].Icon;
+        }
+        else
+        {
+            Title = string.Empty;
+            Subtitle = string.Empty;
+            Command = new NoOpCommand();
+        }
+    }
+}

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/FallbackTimeDateItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/FallbackTimeDateItem.cs
@@ -24,7 +24,11 @@ internal sealed partial class FallbackTimeDateItem : FallbackCommandItem
         _settingsManager = settings;
         _validOptions = new(StringComparer.OrdinalIgnoreCase)
         {
-            "week", "year", "now", "time",
+            ResultHelper.SelectStringFromResources(true, string.Empty, "Microsoft_plugin_timedate_SearchTagWeek"),
+            ResultHelper.SelectStringFromResources(true, string.Empty, "Microsoft_plugin_timedate_SearchTagDate"),
+            ResultHelper.SelectStringFromResources(true, string.Empty, "Microsoft_plugin_timedate_Year"),
+            ResultHelper.SelectStringFromResources(true, string.Empty, "Microsoft_plugin_timedate_Now"),
+            ResultHelper.SelectStringFromResources(true, string.Empty, "Microsoft_plugin_timedate_Time"),
         };
     }
 
@@ -38,7 +42,7 @@ internal sealed partial class FallbackTimeDateItem : FallbackCommandItem
             return;
         }
 
-        var availableResults = AvailableResultsList.GetList(true, _settingsManager);
+        var availableResults = AvailableResultsList.GetList(false, _settingsManager);
         ListItem result = null;
         var maxScore = 0;
 

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/FallbackTimeDateItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/FallbackTimeDateItem.cs
@@ -34,7 +34,7 @@ internal sealed partial class FallbackTimeDateItem : FallbackCommandItem
 
     public override void UpdateQuery(string query)
     {
-        if (string.IsNullOrWhiteSpace(query) || !_validOptions.Contains(query))
+        if (!_settingsManager.EnableFallbackItems || string.IsNullOrWhiteSpace(query) || !_validOptions.Contains(query))
         {
             Title = string.Empty;
             Subtitle = string.Empty;

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/FallbackTimeDateItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/FallbackTimeDateItem.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Globalization;
+using System.Linq;
 using Microsoft.CmdPal.Ext.TimeDate.Helpers;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
@@ -25,17 +26,22 @@ internal sealed partial class FallbackTimeDateItem : FallbackCommandItem
         _settingsManager = settings;
         _validOptions = new(StringComparer.OrdinalIgnoreCase)
         {
-            Resources.ResourceManager.GetString("Microsoft_plugin_timedate_SearchTagWeek", CultureInfo.CurrentCulture),
             Resources.ResourceManager.GetString("Microsoft_plugin_timedate_SearchTagDate", CultureInfo.CurrentCulture),
-            Resources.ResourceManager.GetString("Microsoft_plugin_timedate_Year", CultureInfo.CurrentCulture),
-            Resources.ResourceManager.GetString("Microsoft_plugin_timedate_Now", CultureInfo.CurrentCulture),
-            Resources.ResourceManager.GetString("Microsoft_plugin_timedate_Time", CultureInfo.CurrentCulture),
+            Resources.ResourceManager.GetString("Microsoft_plugin_timedate_SearchTagDateNow", CultureInfo.CurrentCulture),
+
+            Resources.ResourceManager.GetString("Microsoft_plugin_timedate_SearchTagTime", CultureInfo.CurrentCulture),
+            Resources.ResourceManager.GetString("Microsoft_plugin_timedate_SearchTagTimeNow", CultureInfo.CurrentCulture),
+
+            Resources.ResourceManager.GetString("Microsoft_plugin_timedate_SearchTagFormat", CultureInfo.CurrentCulture),
+            Resources.ResourceManager.GetString("Microsoft_plugin_timedate_SearchTagFormatNow", CultureInfo.CurrentCulture),
+
+            Resources.ResourceManager.GetString("Microsoft_plugin_timedate_SearchTagWeek", CultureInfo.CurrentCulture),
         };
     }
 
     public override void UpdateQuery(string query)
     {
-        if (!_settingsManager.EnableFallbackItems || string.IsNullOrWhiteSpace(query) || !_validOptions.Contains(query))
+        if (!_settingsManager.EnableFallbackItems || string.IsNullOrWhiteSpace(query) || !IsValidQuery(query))
         {
             Title = string.Empty;
             Subtitle = string.Empty;
@@ -69,5 +75,30 @@ internal sealed partial class FallbackTimeDateItem : FallbackCommandItem
             Subtitle = string.Empty;
             Command = new NoOpCommand();
         }
+    }
+
+    private bool IsValidQuery(string query)
+    {
+        if (_validOptions.Contains(query))
+        {
+            return true;
+        }
+
+        foreach (var option in _validOptions)
+        {
+            if (option == null)
+            {
+                continue;
+            }
+
+            var parts = option.Split(';', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+
+            if (parts.Any(part => string.Equals(part, query, StringComparison.OrdinalIgnoreCase)))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Helpers/AvailableResultsList.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Helpers/AvailableResultsList.cs
@@ -68,7 +68,7 @@ internal static class AvailableResultsList
                 },
         });
 
-        if (isKeywordSearch || !settings.OnlyDateTimeNowGlobal)
+        if (isKeywordSearch)
         {
             // We use long instead of int for unix time stamp because int is too small after 03:14:07 UTC 2038-01-19
             var unixTimestamp = ((DateTimeOffset)dateTimeNowUtc).ToUnixTimeSeconds();

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Helpers/AvailableResultsList.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Helpers/AvailableResultsList.cs
@@ -33,6 +33,7 @@ internal static class AvailableResultsList
         var dateTimeNowUtc = dateTimeNow.ToUniversalTime();
         var firstWeekRule = firstWeekOfYear ?? TimeAndDateHelper.GetCalendarWeekRule(settings.FirstWeekOfYear);
         var firstDayOfTheWeek = firstDayOfWeek ?? TimeAndDateHelper.GetFirstDayOfWeek(settings.FirstDayOfWeek);
+        var weekOfYear = calendar.GetWeekOfYear(dateTimeNow, firstWeekRule, firstDayOfTheWeek);
 
         results.AddRange(new[]
         {
@@ -60,12 +61,12 @@ internal static class AvailableResultsList
                 IconType = ResultIconType.DateTime,
             },
             new AvailableResult()
-                {
-                    Value = TimeAndDateHelper.GetNumberOfDayInWeek(dateTimeNow, firstDayOfTheWeek).ToString(CultureInfo.CurrentCulture),
-                    Label = Resources.Microsoft_plugin_timedate_DayOfWeek,
-                    AlternativeSearchTag = ResultHelper.SelectStringFromResources(isSystemDateTime, "Microsoft_plugin_timedate_SearchTagDate"),
-                    IconType = ResultIconType.Date,
-                },
+            {
+                Value = weekOfYear.ToString(CultureInfo.CurrentCulture),
+                Label = Resources.Microsoft_plugin_timedate_WeekOfYear,
+                AlternativeSearchTag = ResultHelper.SelectStringFromResources(isSystemDateTime, "Microsoft_plugin_timedate_SearchTagDate"),
+                IconType = ResultIconType.Date,
+            },
         });
 
         if (isKeywordSearch)
@@ -73,7 +74,6 @@ internal static class AvailableResultsList
             // We use long instead of int for unix time stamp because int is too small after 03:14:07 UTC 2038-01-19
             var unixTimestamp = ((DateTimeOffset)dateTimeNowUtc).ToUnixTimeSeconds();
             var unixTimestampMilliseconds = ((DateTimeOffset)dateTimeNowUtc).ToUnixTimeMilliseconds();
-            var weekOfYear = calendar.GetWeekOfYear(dateTimeNow, firstWeekRule, firstDayOfTheWeek);
             var era = DateTimeFormatInfo.CurrentInfo.GetEraName(calendar.GetEra(dateTimeNow));
             var eraShort = DateTimeFormatInfo.CurrentInfo.GetAbbreviatedEraName(calendar.GetEra(dateTimeNow));
 
@@ -224,6 +224,13 @@ internal static class AvailableResultsList
                 },
                 new AvailableResult()
                 {
+                    Value = TimeAndDateHelper.GetNumberOfDayInWeek(dateTimeNow, firstDayOfTheWeek).ToString(CultureInfo.CurrentCulture),
+                    Label = Resources.Microsoft_plugin_timedate_DayOfWeek,
+                    AlternativeSearchTag = ResultHelper.SelectStringFromResources(isSystemDateTime, "Microsoft_plugin_timedate_SearchTagDate"),
+                    IconType = ResultIconType.Date,
+                },
+                new AvailableResult()
+                {
                     Value = dateTimeNow.Day.ToString(CultureInfo.CurrentCulture),
                     Label = Resources.Microsoft_plugin_timedate_DayOfMonth,
                     AlternativeSearchTag = ResultHelper.SelectStringFromResources(isSystemDateTime, "Microsoft_plugin_timedate_SearchTagDate"),
@@ -247,13 +254,6 @@ internal static class AvailableResultsList
                 {
                     Value = TimeAndDateHelper.GetWeekOfMonth(dateTimeNow, firstDayOfTheWeek).ToString(CultureInfo.CurrentCulture),
                     Label = Resources.Microsoft_plugin_timedate_WeekOfMonth,
-                    AlternativeSearchTag = ResultHelper.SelectStringFromResources(isSystemDateTime, "Microsoft_plugin_timedate_SearchTagDate"),
-                    IconType = ResultIconType.Date,
-                },
-                new AvailableResult()
-                {
-                    Value = weekOfYear.ToString(CultureInfo.CurrentCulture),
-                    Label = Resources.Microsoft_plugin_timedate_WeekOfYear,
                     AlternativeSearchTag = ResultHelper.SelectStringFromResources(isSystemDateTime, "Microsoft_plugin_timedate_SearchTagDate"),
                     IconType = ResultIconType.Date,
                 },

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Helpers/AvailableResultsList.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Helpers/AvailableResultsList.cs
@@ -59,6 +59,13 @@ internal static class AvailableResultsList
                 AlternativeSearchTag = ResultHelper.SelectStringFromResources(isSystemDateTime, "Microsoft_plugin_timedate_SearchTagFormat"),
                 IconType = ResultIconType.DateTime,
             },
+            new AvailableResult()
+                {
+                    Value = TimeAndDateHelper.GetNumberOfDayInWeek(dateTimeNow, firstDayOfTheWeek).ToString(CultureInfo.CurrentCulture),
+                    Label = Resources.Microsoft_plugin_timedate_DayOfWeek,
+                    AlternativeSearchTag = ResultHelper.SelectStringFromResources(isSystemDateTime, "Microsoft_plugin_timedate_SearchTagDate"),
+                    IconType = ResultIconType.Date,
+                },
         });
 
         if (isKeywordSearch || !settings.OnlyDateTimeNowGlobal)
@@ -212,13 +219,6 @@ internal static class AvailableResultsList
                 {
                     Value = DateTimeFormatInfo.CurrentInfo.GetDayName(dateTimeNow.DayOfWeek),
                     Label = Resources.Microsoft_plugin_timedate_Day,
-                    AlternativeSearchTag = ResultHelper.SelectStringFromResources(isSystemDateTime, "Microsoft_plugin_timedate_SearchTagDate"),
-                    IconType = ResultIconType.Date,
-                },
-                new AvailableResult()
-                {
-                    Value = TimeAndDateHelper.GetNumberOfDayInWeek(dateTimeNow, firstDayOfTheWeek).ToString(CultureInfo.CurrentCulture),
-                    Label = Resources.Microsoft_plugin_timedate_DayOfWeek,
                     AlternativeSearchTag = ResultHelper.SelectStringFromResources(isSystemDateTime, "Microsoft_plugin_timedate_SearchTagDate"),
                     IconType = ResultIconType.Date,
                 },

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Helpers/SettingsManager.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Helpers/SettingsManager.cs
@@ -75,11 +75,11 @@ public class SettingsManager : JsonSettingsManager
         Resources.Microsoft_plugin_timedate_SettingFirstDayOfWeek,
         _firstDayOfWeekChoices);
 
-    private readonly ToggleSetting _onlyDateTimeNowGlobal = new(
-        Namespaced(nameof(OnlyDateTimeNowGlobal)),
-        Resources.Microsoft_plugin_timedate_SettingOnlyDateTimeNowGlobal,
-        Resources.Microsoft_plugin_timedate_SettingOnlyDateTimeNowGlobal_Description,
-        true); // TODO -- double check default value
+    private readonly ToggleSetting _enableFallbackItems = new(
+        Namespaced(nameof(EnableFallbackItems)),
+        Resources.Microsoft_plugin_timedate_SettingEnableFallbackItems,
+        Resources.Microsoft_plugin_timedate_SettingEnableFallbackItems_Description,
+        true);
 
     private readonly ToggleSetting _timeWithSeconds = new(
         Namespaced(nameof(TimeWithSecond)),
@@ -145,7 +145,7 @@ public class SettingsManager : JsonSettingsManager
         }
     }
 
-    public bool OnlyDateTimeNowGlobal => _onlyDateTimeNowGlobal.Value;
+    public bool EnableFallbackItems => _enableFallbackItems.Value;
 
     public bool TimeWithSecond => _timeWithSeconds.Value;
 
@@ -172,6 +172,7 @@ public class SettingsManager : JsonSettingsManager
         Settings.Add(_onlyDateTimeNowGlobal);
         Settings.Add(_hideNumberMessageOnGlobalQuery); */
 
+        Settings.Add(_enableFallbackItems);
         Settings.Add(_timeWithSeconds);
         Settings.Add(_dateWithWeekday);
         Settings.Add(_firstWeekOfYear);

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Helpers/SettingsManager.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Helpers/SettingsManager.cs
@@ -93,12 +93,6 @@ public class SettingsManager : JsonSettingsManager
         Resources.Microsoft_plugin_timedate_SettingDateWithWeekday_Description,
         false); // TODO -- double check default value
 
-    private readonly ToggleSetting _hideNumberMessageOnGlobalQuery = new(
-        Namespaced(nameof(HideNumberMessageOnGlobalQuery)),
-        Resources.Microsoft_plugin_timedate_SettingHideNumberMessageOnGlobalQuery,
-        Resources.Microsoft_plugin_timedate_SettingHideNumberMessageOnGlobalQuery,
-        true); // TODO -- double check default value
-
     private readonly TextSetting _customFormats = new(
         Namespaced(nameof(CustomFormats)),
         Resources.Microsoft_plugin_timedate_Setting_CustomFormats,
@@ -151,8 +145,6 @@ public class SettingsManager : JsonSettingsManager
 
     public bool DateWithWeekday => _dateWithWeekday.Value;
 
-    public bool HideNumberMessageOnGlobalQuery => _hideNumberMessageOnGlobalQuery.Value;
-
     public List<string> CustomFormats => _customFormats.Value.Split(TEXTBOXNEWLINE).ToList();
 
     internal static string SettingsJsonPath()
@@ -167,10 +159,6 @@ public class SettingsManager : JsonSettingsManager
     public SettingsManager()
     {
         FilePath = SettingsJsonPath();
-
-        /* The following two settings make no sense with current CmdPal behavior.
-        Settings.Add(_onlyDateTimeNowGlobal);
-        Settings.Add(_hideNumberMessageOnGlobalQuery); */
 
         Settings.Add(_enableFallbackItems);
         Settings.Add(_timeWithSeconds);

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Helpers/TimeDateCalculator.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Helpers/TimeDateCalculator.cs
@@ -40,7 +40,7 @@ public sealed partial class TimeDateCalculator
         var lastInputParsingErrorMsg = string.Empty;
 
         // Switch search type
-        if (isEmptySearchInput || (!isKeywordSearch && settings.OnlyDateTimeNowGlobal))
+        if (isEmptySearchInput || (!isKeywordSearch))
         {
             // Return all results for system time/date on empty keyword search
             // or only time, date and now results for system time on global queries if the corresponding setting is enabled

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Helpers/TimeDateCalculator.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Helpers/TimeDateCalculator.cs
@@ -91,23 +91,6 @@ public sealed partial class TimeDateCalculator
             }
         }
 
-        /*htcfreek:Code obsolete with current CmdPal behavior.
-        // If search term is only a number that can't be parsed return an error message
-        if (!isEmptySearchInput && results.Count == 0 && Regex.IsMatch(query, @"\w+\d+.*$") && !query.Any(char.IsWhiteSpace) && (TimeAndDateHelper.IsSpecialInputParsing(query) || !Regex.IsMatch(query, @"\d+[\.:/]\d+")))
-        {
-            // Without plugin key word show only if message is not hidden by setting
-            if (!settings.HideNumberMessageOnGlobalQuery)
-            {
-                var er = ResultHelper.CreateInvalidInputErrorResult();
-                if (!string.IsNullOrEmpty(lastInputParsingErrorMsg))
-                {
-                    er.Details = new Details() { Body = lastInputParsingErrorMsg };
-                }
-
-                results.Add(er);
-            }
-        } */
-
         if (results.Count == 0)
         {
             var er = ResultHelper.CreateInvalidInputErrorResult();

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Properties/Resources.Designer.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Properties/Resources.Designer.cs
@@ -619,7 +619,7 @@ namespace Microsoft.CmdPal.Ext.TimeDate {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Week.
+        ///   Looks up a localized string similar to Current Week; Calendar week; Week of the year; Week.
         /// </summary>
         public static string Microsoft_plugin_timedate_SearchTagWeek {
             get {
@@ -813,33 +813,6 @@ namespace Microsoft.CmdPal.Ext.TimeDate {
         public static string Microsoft_plugin_timedate_SettingFirstWeekRule_FirstFullWeek {
             get {
                 return ResourceManager.GetString("Microsoft_plugin_timedate_SettingFirstWeekRule_FirstFullWeek", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Hide &apos;Invalid number input&apos; error message on global queries.
-        /// </summary>
-        public static string Microsoft_plugin_timedate_SettingHideNumberMessageOnGlobalQuery {
-            get {
-                return ResourceManager.GetString("Microsoft_plugin_timedate_SettingHideNumberMessageOnGlobalQuery", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Show only &apos;Time&apos;, &apos;Date&apos; and &apos;Now&apos; result for system time on global queries.
-        /// </summary>
-        public static string Microsoft_plugin_timedate_SettingOnlyDateTimeNowGlobal {
-            get {
-                return ResourceManager.GetString("Microsoft_plugin_timedate_SettingOnlyDateTimeNowGlobal", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Regardless of this setting, for global queries the first word of the query has to be a complete match..
-        /// </summary>
-        public static string Microsoft_plugin_timedate_SettingOnlyDateTimeNowGlobal_Description {
-            get {
-                return ResourceManager.GetString("Microsoft_plugin_timedate_SettingOnlyDateTimeNowGlobal_Description", resourceCulture);
             }
         }
         

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Properties/Resources.Designer.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Properties/Resources.Designer.cs
@@ -682,6 +682,24 @@ namespace Microsoft.CmdPal.Ext.TimeDate {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Enable fallback items for TimeDate (week, year, now, time, date).
+        /// </summary>
+        public static string Microsoft_plugin_timedate_SettingEnableFallbackItems {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_timedate_SettingEnableFallbackItems", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Show time and date results when typing keywords like &quot;week&quot;, &quot;year&quot;, &quot;now&quot;, &quot;time&quot;, or &quot;date&quot;.
+        /// </summary>
+        public static string Microsoft_plugin_timedate_SettingEnableFallbackItems_Description {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_timedate_SettingEnableFallbackItems_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to First day of the week.
         /// </summary>
         public static string Microsoft_plugin_timedate_SettingFirstDayOfWeek {

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Properties/Resources.Designer.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Properties/Resources.Designer.cs
@@ -95,7 +95,7 @@ namespace Microsoft.CmdPal.Ext.TimeDate {
                 return ResourceManager.GetString("Microsoft_plugin_timedate_DateAndTime", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Date and time UTC.
         /// </summary>
@@ -615,6 +615,15 @@ namespace Microsoft.CmdPal.Ext.TimeDate {
         public static string Microsoft_plugin_timedate_SearchTagTimeNow {
             get {
                 return ResourceManager.GetString("Microsoft_plugin_timedate_SearchTagTimeNow", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Week.
+        /// </summary>
+        public static string Microsoft_plugin_timedate_SearchTagWeek {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_timedate_SearchTagWeek", resourceCulture);
             }
         }
         

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Properties/Resources.Designer.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Properties/Resources.Designer.cs
@@ -95,7 +95,7 @@ namespace Microsoft.CmdPal.Ext.TimeDate {
                 return ResourceManager.GetString("Microsoft_plugin_timedate_DateAndTime", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Date and time UTC.
         /// </summary>
@@ -210,6 +210,15 @@ namespace Microsoft.CmdPal.Ext.TimeDate {
         public static string Microsoft_plugin_timedate_Excel1904 {
             get {
                 return ResourceManager.GetString("Microsoft_plugin_timedate_Excel1904", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Open Time Data Command.
+        /// </summary>
+        public static string Microsoft_plugin_timedate_fallback_display_title {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_timedate_fallback_display_title", resourceCulture);
             }
         }
         

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Properties/Resources.resx
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Properties/Resources.resx
@@ -433,4 +433,7 @@
   <data name="Microsoft_plugin_timedate_DaysInMonth" xml:space="preserve">
     <value>Days in month</value>
   </data>
+  <data name="Microsoft_plugin_timedate_fallback_display_title" xml:space="preserve">
+    <value>Open Time Data Command</value>
+  </data>
 </root>

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Properties/Resources.resx
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Properties/Resources.resx
@@ -436,4 +436,7 @@
   <data name="Microsoft_plugin_timedate_fallback_display_title" xml:space="preserve">
     <value>Open Time Data Command</value>
   </data>
+  <data name="Microsoft_plugin_timedate_SearchTagWeek" xml:space="preserve">
+    <value>Week</value>
+  </data>
 </root>

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Properties/Resources.resx
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Properties/Resources.resx
@@ -439,4 +439,10 @@
   <data name="Microsoft_plugin_timedate_SearchTagWeek" xml:space="preserve">
     <value>Week</value>
   </data>
+  <data name="Microsoft_plugin_timedate_SettingEnableFallbackItems" xml:space="preserve">
+    <value>Enable fallback items for TimeDate (week, year, now, time, date)</value>
+  </data>
+  <data name="Microsoft_plugin_timedate_SettingEnableFallbackItems_Description" xml:space="preserve">
+    <value>Show time and date results when typing keywords like "week", "year", "now", "time", or "date"</value>
+  </data>
 </root>

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Properties/Resources.resx
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Properties/Resources.resx
@@ -265,15 +265,6 @@
   <data name="Microsoft_plugin_timedate_SettingDateWithWeekday_Description" xml:space="preserve">
     <value>This setting applies to the 'Date' and 'Now' result.</value>
   </data>
-  <data name="Microsoft_plugin_timedate_SettingHideNumberMessageOnGlobalQuery" xml:space="preserve">
-    <value>Hide 'Invalid number input' error message on global queries</value>
-  </data>
-  <data name="Microsoft_plugin_timedate_SettingOnlyDateTimeNowGlobal" xml:space="preserve">
-    <value>Show only 'Time', 'Date' and 'Now' result for system time on global queries</value>
-  </data>
-  <data name="Microsoft_plugin_timedate_SettingOnlyDateTimeNowGlobal_Description" xml:space="preserve">
-    <value>Regardless of this setting, for global queries the first word of the query has to be a complete match.</value>
-  </data>
   <data name="Microsoft_plugin_timedate_SettingTimeWithSeconds" xml:space="preserve">
     <value>Show time with seconds</value>
   </data>
@@ -437,7 +428,7 @@
     <value>Open Time Data Command</value>
   </data>
   <data name="Microsoft_plugin_timedate_SearchTagWeek" xml:space="preserve">
-    <value>Week</value>
+    <value>Current Week; Calendar week; Week of the year; Week</value>
   </data>
   <data name="Microsoft_plugin_timedate_SettingEnableFallbackItems" xml:space="preserve">
     <value>Enable fallback items for TimeDate (week, year, now, time, date)</value>

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/TimeDateCommandsProvider.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/TimeDateCommandsProvider.cs
@@ -18,6 +18,7 @@ public partial class TimeDateCommandsProvider : CommandProvider
     private static readonly SettingsManager _settingsManager = new();
     private static readonly CompositeFormat MicrosoftPluginTimedatePluginDescription = System.Text.CompositeFormat.Parse(Resources.Microsoft_plugin_timedate_plugin_description);
     private static readonly TimeDateExtensionPage _timeDateExtensionPage = new(_settingsManager);
+    private readonly FallbackTimeDateItem _fallbackTimeDateItem = new(_settingsManager);
 
     public TimeDateCommandsProvider()
     {
@@ -45,4 +46,6 @@ public partial class TimeDateCommandsProvider : CommandProvider
     }
 
     public override ICommandItem[] TopLevelCommands() => [_command];
+
+    public override IFallbackCommandItem[] FallbackCommands() => [_fallbackTimeDateItem];
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
This PR adds fallback functionality to the TimeDate extension for Command Palette. With this change, users can directly enter time/date-related queries without first selecting the TimeDate command. The fallback command processes the query and displays date/time information directly in the results list when appropriate.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #38890
- [x] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Added new `FallbackTimeDateItem` class to handle fallback command processing
Updated resources to include a display title for the fallback command
Modified `TimeDateCommandsProvider` to expose the fallback command
Reuses existing calculation logic from `TimeDateCalculator`

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manually tested.
![Animation](https://github.com/user-attachments/assets/579afa93-295b-45c1-b496-73b143066a02)

Added option in setting for fallback enabling/disabling
![Animation](https://github.com/user-attachments/assets/b8593bb7-af59-4b23-a37a-b7ff31747a81)
