### PR TITLE
[CmdPal] Removing App tag

### DIFF
--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/AppListItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/AppListItem.cs
@@ -14,7 +14,6 @@ namespace Microsoft.CmdPal.Ext.Apps.Programs;
 internal sealed partial class AppListItem : ListItem
 {
     private readonly AppItem _app;
-    private static readonly Tag _appTag = new("App");
 
     private readonly Lazy<Details> _details;
     private readonly Lazy<IconInfo> _icon;
@@ -29,7 +28,6 @@ internal sealed partial class AppListItem : ListItem
         _app = app;
         Title = app.Name;
         Subtitle = app.Subtitle;
-        Tags = [_appTag];
         MoreCommands = _app.Commands!.ToArray();
 
         _details = new Lazy<Details>(() =>


### PR DESCRIPTION
The "App" tag is pretty redundant and is adding a lot of visual noise. Closes #38968 

New:
![image](https://github.com/user-attachments/assets/5eff195c-5aaf-477a-b988-4b3b14583569)
