### PR TITLE
[CmdPal] Better support for long labels in empty content and commandbar

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml
@@ -72,8 +72,8 @@
         ColumnSpacing="8">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="Auto" />
         </Grid.ColumnDefinitions>
 
         <Grid
@@ -133,6 +133,8 @@
             VerticalAlignment="Center"
             Style="{StaticResource CaptionTextBlockStyle}"
             Text="{x:Bind CurrentPageViewModel.Title, Mode=OneWay}"
+            TextTrimming="CharacterEllipsis"
+            TextWrapping="NoWrap"
             Visibility="{x:Bind CurrentPageViewModel.IsNested, Mode=OneWay}" />
         <StackPanel
             Grid.Column="2"

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml
@@ -138,14 +138,15 @@
             </controls:Case>
             <controls:Case Value="True">
                 <StackPanel
+                    Margin="16"
                     HorizontalAlignment="Center"
                     VerticalAlignment="Center"
                     Orientation="Vertical"
                     Spacing="4">
                     <cpcontrols:IconBox
                         x:Name="IconBorder"
-                        Width="56"
-                        Height="56"
+                        Width="48"
+                        Height="48"
                         Margin="8"
                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                         SourceKey="{x:Bind ViewModel.EmptyContent.Icon, Mode=OneWay}"
@@ -154,11 +155,15 @@
                         Margin="0,4,0,0"
                         HorizontalAlignment="Center"
                         FontWeight="SemiBold"
-                        Text="{x:Bind ViewModel.EmptyContent.Title, Mode=OneWay}" />
+                        Text="{x:Bind ViewModel.EmptyContent.Title, Mode=OneWay}"
+                        TextAlignment="Center"
+                        TextWrapping="Wrap" />
                     <TextBlock
                         HorizontalAlignment="Center"
                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                        Text="{x:Bind ViewModel.EmptyContent.Subtitle, Mode=OneWay}" />
+                        Text="{x:Bind ViewModel.EmptyContent.Subtitle, Mode=OneWay}"
+                        TextAlignment="Center"
+                        TextWrapping="Wrap" />
                 </StackPanel>
             </controls:Case>
         </controls:SwitchPresenter>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml
@@ -138,7 +138,7 @@
             </controls:Case>
             <controls:Case Value="True">
                 <StackPanel
-                    Margin="16"
+                    Margin="24"
                     HorizontalAlignment="Center"
                     VerticalAlignment="Center"
                     Orientation="Vertical"


### PR DESCRIPTION
Closes: #38970

Before:
<img width="605" alt="image" src="https://github.com/user-attachments/assets/8310e08f-c471-4663-9000-bfd1eb8c99f3" />

After:
<img width="514" alt="image" src="https://github.com/user-attachments/assets/b1e4c5f6-cd6b-42b2-9a23-3e1e3642202a" />
