### PR TITLE
Fully initialize context menus when they change

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandBarViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandBarViewModel.cs
@@ -119,7 +119,6 @@ public partial class CommandBarViewModel : ObservableObject,
         }
 
         OnPropertyChanged(nameof(HasSecondaryCommand));
-        OnPropertyChanged(nameof(ShouldShowContextMenu));
         OnPropertyChanged(nameof(SecondaryCommand));
         OnPropertyChanged(nameof(ShouldShowContextMenu));
     }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandBarViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandBarViewModel.cs
@@ -29,8 +29,6 @@ public partial class CommandBarViewModel : ObservableObject,
 
             field = value;
             SetSelectedItem(value);
-
-            OnPropertyChanged(nameof(SelectedItem));
         }
     }
 
@@ -117,11 +115,6 @@ public partial class CommandBarViewModel : ObservableObject,
         {
             ShouldShowContextMenu = false;
         }
-
-        OnPropertyChanged(nameof(HasSecondaryCommand));
-        OnPropertyChanged(nameof(ShouldShowContextMenu));
-        OnPropertyChanged(nameof(SecondaryCommand));
-        OnPropertyChanged(nameof(ShouldShowContextMenu));
     }
 
     // InvokeItemCommand is what this will be in Xaml due to source generator

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandBarViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandBarViewModel.cs
@@ -29,6 +29,8 @@ public partial class CommandBarViewModel : ObservableObject,
 
             field = value;
             SetSelectedItem(value);
+
+            OnPropertyChanged(nameof(SelectedItem));
         }
     }
 
@@ -115,6 +117,11 @@ public partial class CommandBarViewModel : ObservableObject,
         {
             ShouldShowContextMenu = false;
         }
+
+        OnPropertyChanged(nameof(HasSecondaryCommand));
+        OnPropertyChanged(nameof(ShouldShowContextMenu));
+        OnPropertyChanged(nameof(SecondaryCommand));
+        OnPropertyChanged(nameof(ShouldShowContextMenu));
     }
 
     // InvokeItemCommand is what this will be in Xaml due to source generator

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentPageViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentPageViewModel.cs
@@ -167,7 +167,7 @@ public partial class ContentPageViewModel : PageViewModel, ICommandBarContext
 
                     Commands.ForEach(contextItem =>
                     {
-                        contextItem.InitializeProperties();
+                        contextItem.SlowInitializeProperties();
                     });
                 }
                 else

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListViewModel.cs
@@ -454,6 +454,8 @@ public partial class ListViewModel : PageViewModel, IDisposable
             return;
         }
 
+        UpdateProperty(nameof(EmptyContent));
+
         DoOnUiThread(
            () =>
            {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListViewModel.cs
@@ -454,8 +454,6 @@ public partial class ListViewModel : PageViewModel, IDisposable
             return;
         }
 
-        UpdateProperty(nameof(EmptyContent));
-
         DoOnUiThread(
            () =>
            {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListViewModel.cs
@@ -436,7 +436,7 @@ public partial class ListViewModel : PageViewModel, IDisposable
                 break;
             case nameof(EmptyContent):
                 EmptyContent = new(new(model.EmptyContent), PageContext);
-                EmptyContent.InitializeProperties();
+                EmptyContent.SlowInitializeProperties();
                 break;
             case nameof(IsLoading):
                 UpdateEmptyContent();


### PR DESCRIPTION
If we don't slow-initialize the whole menu when it changes, then we won't see that there's secondary (& more) commands.  

Tested this with the extension from [waaverecords/CmdPal.Ext.Spotify#4](https://github.com/waaverecords/CmdPal.Ext.Spotify/pull/4)

Closes #38959 


Also seemingly closes #38347 - seems that needed additional bumping of the `EmptyContent`'s