### PR TITLE
Fix build break because of miss Signing for new files

### DIFF
--- a/.pipelines/ESRPSigning_core.json
+++ b/.pipelines/ESRPSigning_core.json
@@ -221,6 +221,9 @@
 
                 "PowerToys.CmdPalModuleInterface.dll",
                 "CmdPalKeyboardService.dll",
+                "Testably.Abstractions.FileSystem.Interface.dll",
+                "WinUI3Apps\\Testably.Abstractions.FileSystem.Interface.dll",
+
                 "*Microsoft.CmdPal.UI_*.msix"
             ],
             "SigningInfo": {

--- a/.pipelines/ESRPSigning_core.json
+++ b/.pipelines/ESRPSigning_core.json
@@ -220,6 +220,7 @@
                 "WinUI3Apps\\PowerToys.Settings.exe",
 
                 "PowerToys.CmdPalModuleInterface.dll",
+                "CmdPalKeyboardService.dll",
                 "*Microsoft.CmdPal.UI_*.msix"
             ],
             "SigningInfo": {

--- a/.pipelines/ESRPSigning_core.json
+++ b/.pipelines/ESRPSigning_core.json
@@ -221,9 +221,6 @@
 
                 "PowerToys.CmdPalModuleInterface.dll",
                 "CmdPalKeyboardService.dll",
-                "Testably.Abstractions.FileSystem.Interface.dll",
-                "WinUI3Apps\\Testably.Abstractions.FileSystem.Interface.dll",
-
                 "*Microsoft.CmdPal.UI_*.msix"
             ],
             "SigningInfo": {
@@ -334,6 +331,8 @@
                 "TestableIO.System.IO.Abstractions.Wrappers.dll",
                 "WinUI3Apps\\TestableIO.System.IO.Abstractions.Wrappers.dll",
                 "WinUI3Apps\\OpenAI.dll",
+                "Testably.Abstractions.FileSystem.Interface.dll",
+                "WinUI3Apps\\Testably.Abstractions.FileSystem.Interface.dll",
                 "ColorCode.Core.dll", 
                 "ColorCode.UWP.dll",
                 "UnitsNet.dll",


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
There are 2 files newly added last week and cause build break for a week:
1. CmdPalKeyboardService.dll
2. Testably.Abstractions.FileSystem.Interface.dll

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
Kick off the signing build and verified.
