### PR TITLE
release: don't publish private symbols for 100 years

### DIFF
--- a/.pipelines/v2/release.yml
+++ b/.pipelines/v2/release.yml
@@ -148,5 +148,7 @@ extends:
             parameters:
               versionNumber: ${{ parameters.versionNumber }}
               includePublicSymbolServer: ${{ parameters.publishSymbolsToPublic }}
+              ${{ if ne(parameters.publishSymbolsToPublic, true) }}:
+                symbolExpiryTime: 10 # For private builds, expire symbols within 10 days. The default is 100 years.
               subscription: $(SymbolPublishingServiceConnection)
               symbolProject: $(SymbolPublishingProject)


### PR DESCRIPTION
We were previously publishing all symbols, even for internal/private builds, for 100 years.