### PR TITLE
[ColorPicker]Add option to choose what clicking individual mouse buttons does

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -797,6 +797,7 @@ LCIDTo
 Lclean
 Ldone
 Ldr
+leftclickaction
 LEFTSCROLLBAR
 LEFTTEXT
 LError
@@ -921,6 +922,7 @@ metafile
 mfc
 Mgmt
 Microwaved
+middleclickaction
 midl
 mii
 mindaro
@@ -1391,6 +1393,7 @@ rgh
 rgn
 rgs
 RIDEV
+rightclickaction
 RIGHTSCROLLBAR
 riid
 ringbuffer

--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -797,7 +797,6 @@ LCIDTo
 Lclean
 Ldone
 Ldr
-leftclickaction
 LEFTSCROLLBAR
 LEFTTEXT
 LError
@@ -1264,6 +1263,7 @@ prg
 prgh
 prgms
 pri
+primaryclickaction
 PRINTCLIENT
 printmanagement
 prm
@@ -1393,7 +1393,6 @@ rgh
 rgn
 rgs
 RIDEV
-rightclickaction
 RIGHTSCROLLBAR
 riid
 ringbuffer
@@ -1442,6 +1441,7 @@ sdns
 searchterm
 searchtext
 SEARCHUI
+secondaryclickaction
 SECONDARYDISPLAY
 secpol
 SEEMASKINVOKEIDLIST

--- a/src/modules/colorPicker/ColorPickerUI/Helpers/AppStateHandler.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/AppStateHandler.cs
@@ -107,21 +107,14 @@ namespace ColorPicker.Helpers
             }
         }
 
-        public void OnColorPickerMouseDown()
+        public void OpenColorEditor()
         {
-            if (_userSettings.ActivationAction.Value == ColorPickerActivationAction.OpenColorPickerAndThenEditor || _userSettings.ActivationAction.Value == ColorPickerActivationAction.OpenEditor)
+            lock (_colorPickerVisibilityLock)
             {
-                lock (_colorPickerVisibilityLock)
-                {
-                    HideColorPicker();
-                }
+                HideColorPicker();
+            }
 
-                ShowColorPickerEditor();
-            }
-            else
-            {
-                EndUserSession();
-            }
+            ShowColorPickerEditor();
         }
 
         public static void SetTopMost()

--- a/src/modules/colorPicker/ColorPickerUI/Mouse/IMouseInfoProvider.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Mouse/IMouseInfoProvider.cs
@@ -16,7 +16,7 @@ namespace ColorPicker.Mouse
         // position and bool indicating zoom in or zoom out
         event EventHandler<Tuple<System.Windows.Point, bool>> OnMouseWheel;
 
-        event MouseDownEventHandler OnMouseDown;
+        event PrimaryMouseDownEventHandler OnPrimaryMouseDown;
 
         event SecondaryMouseUpEventHandler OnSecondaryMouseUp;
 

--- a/src/modules/colorPicker/ColorPickerUI/Mouse/IMouseInfoProvider.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Mouse/IMouseInfoProvider.cs
@@ -16,11 +16,11 @@ namespace ColorPicker.Mouse
         // position and bool indicating zoom in or zoom out
         event EventHandler<Tuple<System.Windows.Point, bool>> OnMouseWheel;
 
-        event MouseUpEventHandler OnMouseDown;
+        event MouseDownEventHandler OnMouseDown;
 
         event SecondaryMouseUpEventHandler OnSecondaryMouseUp;
 
-        event MiddleMouseUpEventHandler OnMiddleMouseDown;
+        event MiddleMouseDownEventHandler OnMiddleMouseDown;
 
         System.Windows.Point CurrentPosition { get; }
 

--- a/src/modules/colorPicker/ColorPickerUI/Mouse/IMouseInfoProvider.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Mouse/IMouseInfoProvider.cs
@@ -20,6 +20,8 @@ namespace ColorPicker.Mouse
 
         event SecondaryMouseUpEventHandler OnSecondaryMouseUp;
 
+        event MiddleMouseUpEventHandler OnMiddleMouseDown;
+
         System.Windows.Point CurrentPosition { get; }
 
         Color CurrentColor { get; }

--- a/src/modules/colorPicker/ColorPickerUI/Mouse/MouseHook.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Mouse/MouseHook.cs
@@ -13,11 +13,11 @@ using static ColorPicker.NativeMethods;
 
 namespace ColorPicker.Mouse
 {
-    public delegate void MouseUpEventHandler(object sender, IntPtr wParam);
+    public delegate void MouseDownEventHandler(object sender, IntPtr wParam);
 
     public delegate void SecondaryMouseUpEventHandler(object sender, IntPtr wParam);
 
-    public delegate void MiddleMouseUpEventHandler(object sender, IntPtr wParam);
+    public delegate void MiddleMouseDownEventHandler(object sender, IntPtr wParam);
 
     internal class MouseHook
     {
@@ -37,9 +37,9 @@ namespace ColorPicker.Mouse
         private IntPtr _mouseHookHandle;
         private HookProc _mouseDelegate;
 
-        private event MouseUpEventHandler MouseDown;
+        private event MouseDownEventHandler MouseDown;
 
-        public event MouseUpEventHandler OnMouseDown
+        public event MouseDownEventHandler OnMouseDown
         {
             add
             {
@@ -71,9 +71,9 @@ namespace ColorPicker.Mouse
             }
         }
 
-        private event MiddleMouseUpEventHandler MiddleMouseDown;
+        private event MiddleMouseDownEventHandler MiddleMouseDown;
 
-        public event MiddleMouseUpEventHandler OnMiddleMouseDown
+        public event MiddleMouseDownEventHandler OnMiddleMouseDown
         {
             add
             {

--- a/src/modules/colorPicker/ColorPickerUI/Mouse/MouseHook.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Mouse/MouseHook.cs
@@ -13,7 +13,7 @@ using static ColorPicker.NativeMethods;
 
 namespace ColorPicker.Mouse
 {
-    public delegate void MouseDownEventHandler(object sender, IntPtr wParam);
+    public delegate void PrimaryMouseDownEventHandler(object sender, IntPtr wParam);
 
     public delegate void SecondaryMouseUpEventHandler(object sender, IntPtr wParam);
 
@@ -37,19 +37,19 @@ namespace ColorPicker.Mouse
         private IntPtr _mouseHookHandle;
         private HookProc _mouseDelegate;
 
-        private event MouseDownEventHandler MouseDown;
+        private event PrimaryMouseDownEventHandler PrimaryMouseDown;
 
-        public event MouseDownEventHandler OnMouseDown
+        public event PrimaryMouseDownEventHandler OnPrimaryMouseDown
         {
             add
             {
                 Subscribe();
-                MouseDown += value;
+                PrimaryMouseDown += value;
             }
 
             remove
             {
-                MouseDown -= value;
+                PrimaryMouseDown -= value;
                 Unsubscribe();
             }
         }
@@ -146,9 +146,9 @@ namespace ColorPicker.Mouse
                 MSLLHOOKSTRUCT mouseHookStruct = (MSLLHOOKSTRUCT)Marshal.PtrToStructure(lParam, typeof(MSLLHOOKSTRUCT));
                 if (wParam.ToInt32() == WM_LBUTTONDOWN)
                 {
-                    if (MouseDown != null)
+                    if (PrimaryMouseDown != null)
                     {
-                        MouseDown.Invoke(null, wParam);
+                        PrimaryMouseDown.Invoke(null, wParam);
                     }
 
                     return new IntPtr(-1);

--- a/src/modules/colorPicker/ColorPickerUI/Mouse/MouseHook.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Mouse/MouseHook.cs
@@ -7,16 +7,17 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Windows.Input;
 
-using ColorPicker.Helpers;
 using ManagedCommon;
 
 using static ColorPicker.NativeMethods;
 
 namespace ColorPicker.Mouse
 {
-    public delegate void MouseUpEventHandler(object sender, System.Drawing.Point p);
+    public delegate void MouseUpEventHandler(object sender, IntPtr wParam);
 
     public delegate void SecondaryMouseUpEventHandler(object sender, IntPtr wParam);
+
+    public delegate void MiddleMouseUpEventHandler(object sender, IntPtr wParam);
 
     internal class MouseHook
     {
@@ -30,6 +31,8 @@ namespace ColorPicker.Mouse
         private const int WM_RBUTTONUP = 0x0205;
         [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1310:Field names should not contain underscore", Justification = "Interop object")]
         private const int WM_RBUTTONDOWN = 0x0204;
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1310:Field names should not contain underscore", Justification = "Interop object")]
+        private const int WM_MBUTTONDOWN = 0x0207;
 
         private IntPtr _mouseHookHandle;
         private HookProc _mouseDelegate;
@@ -64,6 +67,23 @@ namespace ColorPicker.Mouse
             remove
             {
                 SecondaryMouseUp -= value;
+                Unsubscribe();
+            }
+        }
+
+        private event MiddleMouseUpEventHandler MiddleMouseDown;
+
+        public event MiddleMouseUpEventHandler OnMiddleMouseDown
+        {
+            add
+            {
+                Subscribe();
+                MiddleMouseDown += value;
+            }
+
+            remove
+            {
+                MiddleMouseDown -= value;
                 Unsubscribe();
             }
         }
@@ -128,7 +148,7 @@ namespace ColorPicker.Mouse
                 {
                     if (MouseDown != null)
                     {
-                        MouseDown.Invoke(null, new System.Drawing.Point(mouseHookStruct.pt.x, mouseHookStruct.pt.y));
+                        MouseDown.Invoke(null, wParam);
                     }
 
                     return new IntPtr(-1);
@@ -147,6 +167,16 @@ namespace ColorPicker.Mouse
                 if (wParam.ToInt32() == WM_RBUTTONDOWN)
                 {
                     // Consume the event to avoid triggering context menus while in a Color Picker session.
+                    return new IntPtr(-1);
+                }
+
+                if (wParam.ToInt32() == WM_MBUTTONDOWN)
+                {
+                    if (MiddleMouseDown != null)
+                    {
+                        MiddleMouseDown.Invoke(null, wParam);
+                    }
+
                     return new IntPtr(-1);
                 }
 

--- a/src/modules/colorPicker/ColorPickerUI/Mouse/MouseInfoProvider.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Mouse/MouseInfoProvider.cs
@@ -56,11 +56,11 @@ namespace ColorPicker.Mouse
 
         public event EventHandler<Tuple<System.Windows.Point, bool>> OnMouseWheel;
 
-        public event MouseUpEventHandler OnMouseDown;
+        public event MouseDownEventHandler OnMouseDown;
 
         public event SecondaryMouseUpEventHandler OnSecondaryMouseUp;
 
-        public event MiddleMouseUpEventHandler OnMiddleMouseDown;
+        public event MiddleMouseDownEventHandler OnMiddleMouseDown;
 
         public System.Windows.Point CurrentPosition
         {

--- a/src/modules/colorPicker/ColorPickerUI/Mouse/MouseInfoProvider.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Mouse/MouseInfoProvider.cs
@@ -56,7 +56,7 @@ namespace ColorPicker.Mouse
 
         public event EventHandler<Tuple<System.Windows.Point, bool>> OnMouseWheel;
 
-        public event MouseDownEventHandler OnMouseDown;
+        public event PrimaryMouseDownEventHandler OnPrimaryMouseDown;
 
         public event SecondaryMouseUpEventHandler OnSecondaryMouseUp;
 
@@ -148,7 +148,7 @@ namespace ColorPicker.Mouse
                 _timer.Start();
             }
 
-            _mouseHook.OnMouseDown += MouseHook_OnMouseDown;
+            _mouseHook.OnPrimaryMouseDown += MouseHook_OnPrimaryMouseDown;
             _mouseHook.OnMouseWheel += MouseHook_OnMouseWheel;
             _mouseHook.OnSecondaryMouseUp += MouseHook_OnSecondaryMouseUp;
             _mouseHook.OnMiddleMouseDown += MouseHook_OnMiddleMouseDown;
@@ -170,10 +170,10 @@ namespace ColorPicker.Mouse
             OnMouseWheel?.Invoke(this, new Tuple<System.Windows.Point, bool>(_previousMousePosition, zoomIn));
         }
 
-        private void MouseHook_OnMouseDown(object sender, IntPtr wParam)
+        private void MouseHook_OnPrimaryMouseDown(object sender, IntPtr wParam)
         {
             DisposeHook();
-            OnMouseDown?.Invoke(this, wParam);
+            OnPrimaryMouseDown?.Invoke(this, wParam);
         }
 
         private void MouseHook_OnSecondaryMouseUp(object sender, IntPtr wParam)
@@ -201,7 +201,7 @@ namespace ColorPicker.Mouse
             }
 
             _previousMousePosition = new System.Windows.Point(-1, 1);
-            _mouseHook.OnMouseDown -= MouseHook_OnMouseDown;
+            _mouseHook.OnPrimaryMouseDown -= MouseHook_OnPrimaryMouseDown;
             _mouseHook.OnMouseWheel -= MouseHook_OnMouseWheel;
             _mouseHook.OnSecondaryMouseUp -= MouseHook_OnSecondaryMouseUp;
             _mouseHook.OnMiddleMouseDown -= MouseHook_OnMiddleMouseDown;

--- a/src/modules/colorPicker/ColorPickerUI/Mouse/MouseInfoProvider.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Mouse/MouseInfoProvider.cs
@@ -60,6 +60,8 @@ namespace ColorPicker.Mouse
 
         public event SecondaryMouseUpEventHandler OnSecondaryMouseUp;
 
+        public event MiddleMouseUpEventHandler OnMiddleMouseDown;
+
         public System.Windows.Point CurrentPosition
         {
             get
@@ -149,6 +151,7 @@ namespace ColorPicker.Mouse
             _mouseHook.OnMouseDown += MouseHook_OnMouseDown;
             _mouseHook.OnMouseWheel += MouseHook_OnMouseWheel;
             _mouseHook.OnSecondaryMouseUp += MouseHook_OnSecondaryMouseUp;
+            _mouseHook.OnMiddleMouseDown += MouseHook_OnMiddleMouseDown;
 
             if (_userSettings.ChangeCursor.Value)
             {
@@ -167,16 +170,22 @@ namespace ColorPicker.Mouse
             OnMouseWheel?.Invoke(this, new Tuple<System.Windows.Point, bool>(_previousMousePosition, zoomIn));
         }
 
-        private void MouseHook_OnMouseDown(object sender, Point p)
+        private void MouseHook_OnMouseDown(object sender, IntPtr wParam)
         {
             DisposeHook();
-            OnMouseDown?.Invoke(this, p);
+            OnMouseDown?.Invoke(this, wParam);
         }
 
         private void MouseHook_OnSecondaryMouseUp(object sender, IntPtr wParam)
         {
             DisposeHook();
             OnSecondaryMouseUp?.Invoke(this, wParam);
+        }
+
+        private void MouseHook_OnMiddleMouseDown(object sender, IntPtr wParam)
+        {
+            DisposeHook();
+            OnMiddleMouseDown?.Invoke(this, wParam);
         }
 
         private void CopiedColorRepresentation_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
@@ -195,6 +204,7 @@ namespace ColorPicker.Mouse
             _mouseHook.OnMouseDown -= MouseHook_OnMouseDown;
             _mouseHook.OnMouseWheel -= MouseHook_OnMouseWheel;
             _mouseHook.OnSecondaryMouseUp -= MouseHook_OnSecondaryMouseUp;
+            _mouseHook.OnMiddleMouseDown -= MouseHook_OnMiddleMouseDown;
 
             if (_userSettings.ChangeCursor.Value)
             {

--- a/src/modules/colorPicker/ColorPickerUI/Settings/IUserSettings.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Settings/IUserSettings.cs
@@ -21,6 +21,12 @@ namespace ColorPicker.Settings
 
         SettingItem<ColorPickerActivationAction> ActivationAction { get; }
 
+        SettingItem<ColorPickerClickAction> LeftClickAction { get; }
+
+        SettingItem<ColorPickerClickAction> MiddleClickAction { get; }
+
+        SettingItem<ColorPickerClickAction> RightClickAction { get; }
+
         RangeObservableCollection<string> ColorHistory { get; }
 
         SettingItem<int> ColorHistoryLimit { get; }

--- a/src/modules/colorPicker/ColorPickerUI/Settings/IUserSettings.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Settings/IUserSettings.cs
@@ -21,11 +21,11 @@ namespace ColorPicker.Settings
 
         SettingItem<ColorPickerActivationAction> ActivationAction { get; }
 
-        SettingItem<ColorPickerClickAction> LeftClickAction { get; }
+        SettingItem<ColorPickerClickAction> PrimaryClickAction { get; }
 
         SettingItem<ColorPickerClickAction> MiddleClickAction { get; }
 
-        SettingItem<ColorPickerClickAction> RightClickAction { get; }
+        SettingItem<ColorPickerClickAction> SecondaryClickAction { get; }
 
         RangeObservableCollection<string> ColorHistory { get; }
 

--- a/src/modules/colorPicker/ColorPickerUI/Settings/UserSettings.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Settings/UserSettings.cs
@@ -49,7 +49,10 @@ namespace ColorPicker.Settings
             ChangeCursor = new SettingItem<bool>(true);
             ActivationShortcut = new SettingItem<string>(DefaultActivationShortcut);
             CopiedColorRepresentation = new SettingItem<string>(ColorRepresentationType.HEX.ToString());
-            ActivationAction = new SettingItem<ColorPickerActivationAction>(ColorPickerActivationAction.OpenEditor);
+            ActivationAction = new SettingItem<ColorPickerActivationAction>(ColorPickerActivationAction.OpenColorPicker);
+            LeftClickAction = new SettingItem<ColorPickerClickAction>(ColorPickerClickAction.PickColorThenEditor);
+            MiddleClickAction = new SettingItem<ColorPickerClickAction>(ColorPickerClickAction.PickColorAndClose);
+            RightClickAction = new SettingItem<ColorPickerClickAction>(ColorPickerClickAction.Close);
             ColorHistoryLimit = new SettingItem<int>(20);
             ColorHistory.CollectionChanged += ColorHistory_CollectionChanged;
             ShowColorName = new SettingItem<bool>(false);
@@ -77,6 +80,12 @@ namespace ColorPicker.Settings
         public SettingItem<string> CopiedColorRepresentationFormat { get; set; }
 
         public SettingItem<ColorPickerActivationAction> ActivationAction { get; private set; }
+
+        public SettingItem<ColorPickerClickAction> LeftClickAction { get; private set; }
+
+        public SettingItem<ColorPickerClickAction> MiddleClickAction { get; private set; }
+
+        public SettingItem<ColorPickerClickAction> RightClickAction { get; private set; }
 
         public RangeObservableCollection<string> ColorHistory { get; private set; } = new RangeObservableCollection<string>();
 
@@ -121,6 +130,9 @@ namespace ColorPicker.Settings
                                 CopiedColorRepresentation.Value = settings.Properties.CopiedColorRepresentation;
                                 CopiedColorRepresentationFormat = new SettingItem<string>(string.Empty);
                                 ActivationAction.Value = settings.Properties.ActivationAction;
+                                LeftClickAction.Value = settings.Properties.LeftClickAction;
+                                MiddleClickAction.Value = settings.Properties.MiddleClickAction;
+                                RightClickAction.Value = settings.Properties.RightClickAction;
                                 ColorHistoryLimit.Value = settings.Properties.ColorHistoryLimit;
                                 ShowColorName.Value = settings.Properties.ShowColorName;
 

--- a/src/modules/colorPicker/ColorPickerUI/Settings/UserSettings.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Settings/UserSettings.cs
@@ -50,9 +50,9 @@ namespace ColorPicker.Settings
             ActivationShortcut = new SettingItem<string>(DefaultActivationShortcut);
             CopiedColorRepresentation = new SettingItem<string>(ColorRepresentationType.HEX.ToString());
             ActivationAction = new SettingItem<ColorPickerActivationAction>(ColorPickerActivationAction.OpenColorPicker);
-            LeftClickAction = new SettingItem<ColorPickerClickAction>(ColorPickerClickAction.PickColorThenEditor);
+            PrimaryClickAction = new SettingItem<ColorPickerClickAction>(ColorPickerClickAction.PickColorThenEditor);
             MiddleClickAction = new SettingItem<ColorPickerClickAction>(ColorPickerClickAction.PickColorAndClose);
-            RightClickAction = new SettingItem<ColorPickerClickAction>(ColorPickerClickAction.Close);
+            SecondaryClickAction = new SettingItem<ColorPickerClickAction>(ColorPickerClickAction.Close);
             ColorHistoryLimit = new SettingItem<int>(20);
             ColorHistory.CollectionChanged += ColorHistory_CollectionChanged;
             ShowColorName = new SettingItem<bool>(false);
@@ -81,11 +81,11 @@ namespace ColorPicker.Settings
 
         public SettingItem<ColorPickerActivationAction> ActivationAction { get; private set; }
 
-        public SettingItem<ColorPickerClickAction> LeftClickAction { get; private set; }
+        public SettingItem<ColorPickerClickAction> PrimaryClickAction { get; private set; }
 
         public SettingItem<ColorPickerClickAction> MiddleClickAction { get; private set; }
 
-        public SettingItem<ColorPickerClickAction> RightClickAction { get; private set; }
+        public SettingItem<ColorPickerClickAction> SecondaryClickAction { get; private set; }
 
         public RangeObservableCollection<string> ColorHistory { get; private set; } = new RangeObservableCollection<string>();
 
@@ -130,9 +130,9 @@ namespace ColorPicker.Settings
                                 CopiedColorRepresentation.Value = settings.Properties.CopiedColorRepresentation;
                                 CopiedColorRepresentationFormat = new SettingItem<string>(string.Empty);
                                 ActivationAction.Value = settings.Properties.ActivationAction;
-                                LeftClickAction.Value = settings.Properties.LeftClickAction;
+                                PrimaryClickAction.Value = settings.Properties.PrimaryClickAction;
                                 MiddleClickAction.Value = settings.Properties.MiddleClickAction;
-                                RightClickAction.Value = settings.Properties.RightClickAction;
+                                SecondaryClickAction.Value = settings.Properties.SecondaryClickAction;
                                 ColorHistoryLimit.Value = settings.Properties.ColorHistoryLimit;
                                 ShowColorName.Value = settings.Properties.ShowColorName;
 

--- a/src/modules/colorPicker/ColorPickerUI/ViewModels/MainViewModel.cs
+++ b/src/modules/colorPicker/ColorPickerUI/ViewModels/MainViewModel.cs
@@ -80,7 +80,7 @@ namespace ColorPicker.ViewModels
             {
                 SetColorDetails(mouseInfoProvider.CurrentColor);
                 mouseInfoProvider.MouseColorChanged += Mouse_ColorChanged;
-                mouseInfoProvider.OnMouseDown += MouseInfoProvider_OnMouseDown;
+                mouseInfoProvider.OnPrimaryMouseDown += MouseInfoProvider_OnPrimaryMouseDown;
                 mouseInfoProvider.OnMouseWheel += MouseInfoProvider_OnMouseWheel;
                 mouseInfoProvider.OnSecondaryMouseUp += MouseInfoProvider_OnSecondaryMouseUp;
                 mouseInfoProvider.OnMiddleMouseDown += MouseInfoProvider_OnMiddleMouseDown;
@@ -115,7 +115,7 @@ namespace ColorPicker.ViewModels
 
         private void AppStateHandler_EnterPressed(object sender, EventArgs e)
         {
-            MouseInfoProvider_OnMouseDown(null, default);
+            MouseInfoProvider_OnPrimaryMouseDown(null, default);
         }
 
         /// <summary>
@@ -169,19 +169,19 @@ namespace ColorPicker.ViewModels
             SetColorDetails(color);
         }
 
-        private void MouseInfoProvider_OnMouseDown(object sender, IntPtr wParam)
+        private void MouseInfoProvider_OnPrimaryMouseDown(object sender, IntPtr wParam)
         {
-            HandleMouseClickAction(_userSettings.LeftClickAction.Value);
-        }
-
-        private void MouseInfoProvider_OnSecondaryMouseUp(object sender, IntPtr wParam)
-        {
-            HandleMouseClickAction(_userSettings.RightClickAction.Value);
+            HandleMouseClickAction(_userSettings.PrimaryClickAction.Value);
         }
 
         private void MouseInfoProvider_OnMiddleMouseDown(object sender, IntPtr wParam)
         {
             HandleMouseClickAction(_userSettings.MiddleClickAction.Value);
+        }
+
+        private void MouseInfoProvider_OnSecondaryMouseUp(object sender, IntPtr wParam)
+        {
+            HandleMouseClickAction(_userSettings.SecondaryClickAction.Value);
         }
 
         private void HandleMouseClickAction(ColorPickerClickAction action)

--- a/src/settings-ui/Settings.UI.Library/ColorPickerProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/ColorPickerProperties.cs
@@ -39,9 +39,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             VisibleColorFormats.Add("HEX Int", new KeyValuePair<bool, string>(false, ColorFormatHelper.GetDefaultFormat("HEX Int")));
             ShowColorName = false;
             ActivationAction = ColorPickerActivationAction.OpenColorPicker;
-            LeftClickAction = ColorPickerClickAction.PickColorThenEditor;
+            PrimaryClickAction = ColorPickerClickAction.PickColorThenEditor;
             MiddleClickAction = ColorPickerClickAction.PickColorAndClose;
-            RightClickAction = ColorPickerClickAction.Close;
+            SecondaryClickAction = ColorPickerClickAction.Close;
             CopiedColorRepresentation = "HEX";
         }
 
@@ -58,14 +58,14 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         [JsonPropertyName("activationaction")]
         public ColorPickerActivationAction ActivationAction { get; set; }
 
-        [JsonPropertyName("leftclickaction")]
-        public ColorPickerClickAction LeftClickAction { get; set; }
+        [JsonPropertyName("primaryclickaction")]
+        public ColorPickerClickAction PrimaryClickAction { get; set; }
 
         [JsonPropertyName("middleclickaction")]
         public ColorPickerClickAction MiddleClickAction { get; set; }
 
-        [JsonPropertyName("rightclickaction")]
-        public ColorPickerClickAction RightClickAction { get; set; }
+        [JsonPropertyName("secondarytclickaction")]
+        public ColorPickerClickAction SecondaryClickAction { get; set; }
 
         // Property ColorHistory is not used, the color history is saved separately in the colorHistory.json file
         [JsonPropertyName("colorhistory")]

--- a/src/settings-ui/Settings.UI.Library/ColorPickerProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/ColorPickerProperties.cs
@@ -38,7 +38,10 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             VisibleColorFormats.Add("Decimal", new KeyValuePair<bool, string>(false, ColorFormatHelper.GetDefaultFormat("Decimal")));
             VisibleColorFormats.Add("HEX Int", new KeyValuePair<bool, string>(false, ColorFormatHelper.GetDefaultFormat("HEX Int")));
             ShowColorName = false;
-            ActivationAction = ColorPickerActivationAction.OpenColorPickerAndThenEditor;
+            ActivationAction = ColorPickerActivationAction.OpenColorPicker;
+            LeftClickAction = ColorPickerClickAction.PickColorThenEditor;
+            MiddleClickAction = ColorPickerClickAction.PickColorAndClose;
+            RightClickAction = ColorPickerClickAction.Close;
             CopiedColorRepresentation = "HEX";
         }
 
@@ -54,6 +57,15 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 
         [JsonPropertyName("activationaction")]
         public ColorPickerActivationAction ActivationAction { get; set; }
+
+        [JsonPropertyName("leftclickaction")]
+        public ColorPickerClickAction LeftClickAction { get; set; }
+
+        [JsonPropertyName("middleclickaction")]
+        public ColorPickerClickAction MiddleClickAction { get; set; }
+
+        [JsonPropertyName("rightclickaction")]
+        public ColorPickerClickAction RightClickAction { get; set; }
 
         // Property ColorHistory is not used, the color history is saved separately in the colorHistory.json file
         [JsonPropertyName("colorhistory")]

--- a/src/settings-ui/Settings.UI.Library/ColorPickerProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/ColorPickerProperties.cs
@@ -64,7 +64,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         [JsonPropertyName("middleclickaction")]
         public ColorPickerClickAction MiddleClickAction { get; set; }
 
-        [JsonPropertyName("secondarytclickaction")]
+        [JsonPropertyName("secondaryclickaction")]
         public ColorPickerClickAction SecondaryClickAction { get; set; }
 
         // Property ColorHistory is not used, the color history is saved separately in the colorHistory.json file

--- a/src/settings-ui/Settings.UI.Library/ColorPickerPropertiesVersion1.cs
+++ b/src/settings-ui/Settings.UI.Library/ColorPickerPropertiesVersion1.cs
@@ -25,7 +25,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             VisibleColorFormats.Add("RGB", true);
             VisibleColorFormats.Add("HSL", true);
             ShowColorName = false;
-            ActivationAction = ColorPickerActivationAction.OpenColorPickerAndThenEditor;
+            ActivationAction = ColorPickerActivationAction.OpenColorPicker;
         }
 
         public HotkeySettings ActivationShortcut { get; set; }

--- a/src/settings-ui/Settings.UI.Library/ColorPickerSettings.cs
+++ b/src/settings-ui/Settings.UI.Library/ColorPickerSettings.cs
@@ -9,6 +9,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 
 using ManagedCommon;
+using Microsoft.PowerToys.Settings.UI.Library.Enumerations;
 using Microsoft.PowerToys.Settings.UI.Library.Interfaces;
 
 namespace Microsoft.PowerToys.Settings.UI.Library
@@ -23,7 +24,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         public ColorPickerSettings()
         {
             Properties = new ColorPickerProperties();
-            Version = "2";
+            Version = "2.1";
             Name = ModuleName;
         }
 
@@ -47,7 +48,21 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 
         // This can be utilized in the future if the settings.json file is to be modified/deleted.
         public bool UpgradeSettingsConfiguration()
-            => false;
+        {
+            // Upgrading V1 to V2 doesn't set the version to 2.0, therefore V2 settings still report Version == 1.0
+            if (Version == "1.0")
+            {
+                if (!Enum.IsDefined(Properties.ActivationAction))
+                {
+                    Properties.ActivationAction = ColorPickerActivationAction.OpenColorPicker;
+                }
+
+                Version = "2.1";
+                return true;
+            }
+
+            return false;
+        }
 
         public static object UpgradeSettings(object oldSettingsObject)
         {

--- a/src/settings-ui/Settings.UI.Library/Enumerations/ColorPickerActivationAction.cs
+++ b/src/settings-ui/Settings.UI.Library/Enumerations/ColorPickerActivationAction.cs
@@ -9,10 +9,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.Enumerations
         // Activation shortcut opens editor
         OpenEditor,
 
-        // Activation shortcut opens color picker and after picking a color is copied into clipboard and opens editor
-        OpenColorPickerAndThenEditor,
-
-        // Activation shortcut opens color picker only and picking color copies color into clipboard
-        OpenOnlyColorPicker,
+        // Activation shortcut opens color picker and after picking a color is copied into clipboard and editor optionally opens depending on which mouse button was pressed
+        OpenColorPicker,
     }
 }

--- a/src/settings-ui/Settings.UI.Library/Enumerations/ColorPickerClickAction.cs
+++ b/src/settings-ui/Settings.UI.Library/Enumerations/ColorPickerClickAction.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.PowerToys.Settings.UI.Library.Enumerations
+{
+    public enum ColorPickerClickAction
+    {
+        // Clicking copies the picked color and opens the editor
+        PickColorThenEditor,
+
+        // Clicking only copies the picked color and then exits color picker
+        PickColorAndClose,
+
+        // Clicking exits color picker, without copying anything
+        Close,
+    }
+}

--- a/src/settings-ui/Settings.UI.Library/SettingsUtils.cs
+++ b/src/settings-ui/Settings.UI.Library/SettingsUtils.cs
@@ -130,6 +130,13 @@ namespace Microsoft.PowerToys.Settings.UI.Library
                     T2 oldSettings = GetSettings<T2>(powertoy, fileName);
                     T newSettings = (T)settingsUpgrader(oldSettings);
                     Logger.LogInfo($"Settings file {fileName} for {powertoy} was read successfully in the old format.");
+
+                    // If the file needs to be modified, to save the new configurations accordingly.
+                    if (newSettings.UpgradeSettingsConfiguration())
+                    {
+                        SaveSettings(newSettings.ToJsonString(), powertoy, fileName);
+                    }
+
                     return newSettings;
                 }
                 catch (Exception)

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/ColorPickerPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/ColorPickerPage.xaml
@@ -60,8 +60,8 @@
                         HeaderIcon="{ui:FontIcon Glyph=&#xE962;}"
                         IsEnabled="{x:Bind ViewModel.IsEnabled, Mode=OneWay}">
                         <tkcontrols:SettingsExpander.Items>
-                            <tkcontrols:SettingsCard x:Uid="ColorPicker_LeftClick" IsEnabled="{x:Bind ViewModel.IsEnabled, Mode=OneWay}">
-                                <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}" SelectedIndex="{x:Bind ViewModel.LeftClickBehavior, Mode=TwoWay}">
+                            <tkcontrols:SettingsCard x:Uid="ColorPicker_PrimaryClick" IsEnabled="{x:Bind ViewModel.IsEnabled, Mode=OneWay}">
+                                <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}" SelectedIndex="{x:Bind ViewModel.PrimaryClickBehavior, Mode=TwoWay}">
                                     <ComboBoxItem x:Uid="ColorPicker_PickColorThenEditor" />
                                     <ComboBoxItem x:Uid="ColorPicker_PickColorAndClose" />
                                     <ComboBoxItem x:Uid="ColorPicker_Close" />
@@ -74,8 +74,8 @@
                                     <ComboBoxItem x:Uid="ColorPicker_Close" />
                                 </ComboBox>
                             </tkcontrols:SettingsCard>
-                            <tkcontrols:SettingsCard x:Uid="ColorPicker_RightClick" IsEnabled="{x:Bind ViewModel.IsEnabled, Mode=OneWay}">
-                                <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}" SelectedIndex="{x:Bind ViewModel.RightClickBehavior, Mode=TwoWay}">
+                            <tkcontrols:SettingsCard x:Uid="ColorPicker_SecondaryClick" IsEnabled="{x:Bind ViewModel.IsEnabled, Mode=OneWay}">
+                                <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}" SelectedIndex="{x:Bind ViewModel.SecondaryClickBehavior, Mode=TwoWay}">
                                     <ComboBoxItem x:Uid="ColorPicker_PickColorThenEditor" />
                                     <ComboBoxItem x:Uid="ColorPicker_PickColorAndClose" />
                                     <ComboBoxItem x:Uid="ColorPicker_Close" />

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/ColorPickerPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/ColorPickerPage.xaml
@@ -50,12 +50,39 @@
 
                     <tkcontrols:SettingsCard x:Uid="ColorPicker_ActivationAction" HeaderIcon="{ui:FontIcon Glyph=&#xEC4E;}">
                         <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}" SelectedIndex="{x:Bind Path=ViewModel.ActivationBehavior, Mode=TwoWay}">
-                            <ComboBoxItem x:Uid="EditorFirst" />
-                            <ComboBoxItem x:Uid="ColorPickerFirst" />
-                            <ComboBoxItem x:Uid="ColorPickerOnly" />
+                            <ComboBoxItem x:Uid="ColorPicker_OpenEditor" />
+                            <ComboBoxItem x:Uid="ColorPicker_PickColor" />
                         </ComboBox>
                     </tkcontrols:SettingsCard>
 
+                    <tkcontrols:SettingsExpander
+                        x:Uid="ColorPicker_MouseActions"
+                        HeaderIcon="{ui:FontIcon Glyph=&#xE962;}"
+                        IsEnabled="{x:Bind ViewModel.IsEnabled, Mode=OneWay}">
+                        <tkcontrols:SettingsExpander.Items>
+                            <tkcontrols:SettingsCard x:Uid="ColorPicker_LeftClick" IsEnabled="{x:Bind ViewModel.IsEnabled, Mode=OneWay}">
+                                <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}" SelectedIndex="{x:Bind ViewModel.LeftClickBehavior, Mode=TwoWay}">
+                                    <ComboBoxItem x:Uid="ColorPicker_PickColorThenEditor" />
+                                    <ComboBoxItem x:Uid="ColorPicker_PickColorAndClose" />
+                                    <ComboBoxItem x:Uid="ColorPicker_Close" />
+                                </ComboBox>
+                            </tkcontrols:SettingsCard>
+                            <tkcontrols:SettingsCard x:Uid="ColorPicker_MiddleClick" IsEnabled="{x:Bind ViewModel.IsEnabled, Mode=OneWay}">
+                                <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}" SelectedIndex="{x:Bind ViewModel.MiddleClickBehavior, Mode=TwoWay}">
+                                    <ComboBoxItem x:Uid="ColorPicker_PickColorThenEditor" />
+                                    <ComboBoxItem x:Uid="ColorPicker_PickColorAndClose" />
+                                    <ComboBoxItem x:Uid="ColorPicker_Close" />
+                                </ComboBox>
+                            </tkcontrols:SettingsCard>
+                            <tkcontrols:SettingsCard x:Uid="ColorPicker_RightClick" IsEnabled="{x:Bind ViewModel.IsEnabled, Mode=OneWay}">
+                                <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}" SelectedIndex="{x:Bind ViewModel.RightClickBehavior, Mode=TwoWay}">
+                                    <ComboBoxItem x:Uid="ColorPicker_PickColorThenEditor" />
+                                    <ComboBoxItem x:Uid="ColorPicker_PickColorAndClose" />
+                                    <ComboBoxItem x:Uid="ColorPicker_Close" />
+                                </ComboBox>
+                            </tkcontrols:SettingsCard>
+                        </tkcontrols:SettingsExpander.Items>
+                    </tkcontrols:SettingsExpander>
                 </controls:SettingsGroup>
 
                 <controls:SettingsGroup x:Uid="ColorFormats" IsEnabled="{x:Bind ViewModel.IsEnabled, Mode=OneWay}">

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -1507,17 +1507,38 @@ Made with 💗 by Microsoft and the PowerToys community.</value>
   <data name="ColorPicker_CopiedColorRepresentation.Header" xml:space="preserve">
     <value>Default color format</value>
   </data>
-  <data name="ColorPickerFirst.Content" xml:space="preserve">
-    <value>Pick a color and open editor</value>
-  </data>
-  <data name="EditorFirst.Content" xml:space="preserve">
-    <value>Open editor</value>
-  </data>
-  <data name="ColorPickerOnly.Content" xml:space="preserve">
-    <value>Only pick a color</value>
-  </data>
   <data name="ColorPicker_ActivationAction.Header" xml:space="preserve">
     <value>Activation behavior</value>
+  </data>
+  <data name="ColorPicker_OpenEditor.Content" xml:space="preserve">
+    <value>Open editor</value>
+  </data>
+  <data name="ColorPicker_PickColor.Content" xml:space="preserve">
+    <value>Pick a color first</value>
+  </data>
+  <data name="ColorPicker_MouseActions.Header" xml:space="preserve">
+    <value>Mouse actions</value>
+  </data>
+  <data name="ColorPicker_MouseActions.Description" xml:space="preserve">
+    <value>Choose what clicking individual buttons does</value>
+  </data>
+  <data name="ColorPicker_LeftClick.Header" xml:space="preserve">
+    <value>Left click</value>
+  </data>
+  <data name="ColorPicker_RightClick.Header" xml:space="preserve">
+    <value>Right click</value>
+  </data>
+  <data name="ColorPicker_MiddleClick.Header" xml:space="preserve">
+    <value>Scroll wheel click</value>
+  </data>
+  <data name="ColorPicker_PickColorThenEditor.Content" xml:space="preserve">
+    <value>Pick a color and open editor</value>
+  </data>
+  <data name="ColorPicker_PickColorAndClose.Content" xml:space="preserve">
+    <value>Pick a color and close</value>
+  </data>
+  <data name="ColorPicker_Close.Content" xml:space="preserve">
+    <value>Close</value>
   </data>
   <data name="ColorFormats.Header" xml:space="preserve">
     <value>Picker behavior</value>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -1522,14 +1522,14 @@ Made with 💗 by Microsoft and the PowerToys community.</value>
   <data name="ColorPicker_MouseActions.Description" xml:space="preserve">
     <value>Choose what clicking individual buttons does</value>
   </data>
-  <data name="ColorPicker_LeftClick.Header" xml:space="preserve">
-    <value>Left click</value>
-  </data>
-  <data name="ColorPicker_RightClick.Header" xml:space="preserve">
-    <value>Right click</value>
+  <data name="ColorPicker_PrimaryClick.Header" xml:space="preserve">
+    <value>Primary click</value>
   </data>
   <data name="ColorPicker_MiddleClick.Header" xml:space="preserve">
-    <value>Scroll wheel click</value>
+    <value>Middle click</value>
+  </data>
+  <data name="ColorPicker_SecondaryClick.Header" xml:space="preserve">
+    <value>Secondary click</value>
   </data>
   <data name="ColorPicker_PickColorThenEditor.Content" xml:space="preserve">
     <value>Pick a color and open editor</value>

--- a/src/settings-ui/Settings.UI/ViewModels/ColorPickerViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/ColorPickerViewModel.cs
@@ -182,16 +182,16 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             }
         }
 
-        public int LeftClickBehavior
+        public int PrimaryClickBehavior
         {
-            get => (int)_colorPickerSettings.Properties.LeftClickAction;
+            get => (int)_colorPickerSettings.Properties.PrimaryClickAction;
 
             set
             {
-                if (value != (int)_colorPickerSettings.Properties.LeftClickAction)
+                if (value != (int)_colorPickerSettings.Properties.PrimaryClickAction)
                 {
-                    _colorPickerSettings.Properties.LeftClickAction = (ColorPickerClickAction)value;
-                    OnPropertyChanged(nameof(LeftClickBehavior));
+                    _colorPickerSettings.Properties.PrimaryClickAction = (ColorPickerClickAction)value;
+                    OnPropertyChanged(nameof(PrimaryClickBehavior));
                     NotifySettingsChanged();
                 }
             }
@@ -212,16 +212,16 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             }
         }
 
-        public int RightClickBehavior
+        public int SecondaryClickBehavior
         {
-            get => (int)_colorPickerSettings.Properties.RightClickAction;
+            get => (int)_colorPickerSettings.Properties.SecondaryClickAction;
 
             set
             {
-                if (value != (int)_colorPickerSettings.Properties.RightClickAction)
+                if (value != (int)_colorPickerSettings.Properties.SecondaryClickAction)
                 {
-                    _colorPickerSettings.Properties.RightClickAction = (ColorPickerClickAction)value;
-                    OnPropertyChanged(nameof(RightClickBehavior));
+                    _colorPickerSettings.Properties.SecondaryClickAction = (ColorPickerClickAction)value;
+                    OnPropertyChanged(nameof(SecondaryClickBehavior));
                     NotifySettingsChanged();
                 }
             }

--- a/src/settings-ui/Settings.UI/ViewModels/ColorPickerViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/ColorPickerViewModel.cs
@@ -182,6 +182,51 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             }
         }
 
+        public int LeftClickBehavior
+        {
+            get => (int)_colorPickerSettings.Properties.LeftClickAction;
+
+            set
+            {
+                if (value != (int)_colorPickerSettings.Properties.LeftClickAction)
+                {
+                    _colorPickerSettings.Properties.LeftClickAction = (ColorPickerClickAction)value;
+                    OnPropertyChanged(nameof(LeftClickBehavior));
+                    NotifySettingsChanged();
+                }
+            }
+        }
+
+        public int MiddleClickBehavior
+        {
+            get => (int)_colorPickerSettings.Properties.MiddleClickAction;
+
+            set
+            {
+                if (value != (int)_colorPickerSettings.Properties.MiddleClickAction)
+                {
+                    _colorPickerSettings.Properties.MiddleClickAction = (ColorPickerClickAction)value;
+                    OnPropertyChanged(nameof(MiddleClickBehavior));
+                    NotifySettingsChanged();
+                }
+            }
+        }
+
+        public int RightClickBehavior
+        {
+            get => (int)_colorPickerSettings.Properties.RightClickAction;
+
+            set
+            {
+                if (value != (int)_colorPickerSettings.Properties.RightClickAction)
+                {
+                    _colorPickerSettings.Properties.RightClickAction = (ColorPickerClickAction)value;
+                    OnPropertyChanged(nameof(RightClickBehavior));
+                    NotifySettingsChanged();
+                }
+            }
+        }
+
         public bool ShowColorName
         {
             get => _colorPickerSettings.Properties.ShowColorName;


### PR DESCRIPTION
## Summary of the Pull Request
Enables the users to choose what left, right, and middle click does when color picker is open.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #39006
- [x] **Communication:** I've discussed this with core contributors already
- [x] **Tests:** All pass
- [x] **Localization:** All end user facing strings can be localized
- [x] **Dev docs:** No need
- [x] **New binaries:** None
- [x] **Documentation updated:** No need
## Detailed Description of the Pull Request / Additional comments
![Screenshot of the settings](https://github.com/user-attachments/assets/a3e1349b-6bb9-4e2f-97f3-a5106a7d92ce)
Adds option to choose from 3 click behaviors for each standard mouse button:
* **Pick color and open editor**: Copies color to clipboard, saves it to the color history and opens the editor
* **Pick color and close**: Copies color to clipboard, saves it to the color history and exits
* **Close**: Closes color picker without copying the color

Pressing <kbd>Enter</kbd> or <kbd>Space</kbd> does what clicking the primary button would.
Left and middle click actions execute on mouse down, right click on mouse up for reasons discussed previously (I can't find the conversation now)
Default settings are chosen in such a way that very little or nothing changes by updating.
## Validation Steps Performed
Tested:
* Migrating settings from v2.0 to v2.1 (v1 to v2.1 not tested)
* Settings page displays and saves settings correctly
* Default settings load correctly
* All three click actions do what they are supposed to
* Activation behavior works as expected, doesn't affect click actions