### PR TITLE
Add timeout for ui test job

### DIFF
--- a/.pipelines/v2/templates/job-test-project.yml
+++ b/.pipelines/v2/templates/job-test-project.yml
@@ -18,6 +18,7 @@ parameters:
 jobs:
 - job: Test${{ parameters.platform }}${{ parameters.configuration }}
   displayName: Test ${{ parameters.platform }} ${{ parameters.configuration }}
+  timeoutInMinutes: 300
   variables:
     BuildPlatform: ${{ parameters.platform }}
     BuildConfiguration: ${{ parameters.configuration }}


### PR DESCRIPTION
This pull request makes a small but significant change to the `.pipelines/v2/templates/job-test-project.yml` file by adding a timeout setting for test jobs.

* [`.pipelines/v2/templates/job-test-project.yml`](diffhunk://#diff-c974373b0fb1357dfc0d236a86c304ad1d95acb861f83d472db3a7193e1d88a6R21): Added a `timeoutInMinutes` parameter with a value of 300 to ensure that test jobs have a maximum runtime limit.

