### PR TITLE
[Settings] Fix null CmdPal HotKey crash

### DIFF
--- a/src/settings-ui/Settings.UI.Library/CmdPalProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/CmdPalProperties.cs
@@ -4,9 +4,7 @@
 
 using System;
 using System.IO;
-using System.IO.Abstractions;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 
 namespace Microsoft.PowerToys.Settings.UI.Library
 {
@@ -46,17 +44,13 @@ namespace Microsoft.PowerToys.Settings.UI.Library
                 if (doc.RootElement.TryGetProperty(nameof(Hotkey), out JsonElement hotkeyElement))
                 {
                     Hotkey = JsonSerializer.Deserialize<HotkeySettings>(hotkeyElement.GetRawText());
-
-                    if (Hotkey == null)
-                    {
-                        Hotkey = DefaultHotkeyValue;
-                    }
                 }
             }
             catch (Exception)
             {
-                Hotkey = DefaultHotkeyValue;
             }
+
+            Hotkey ??= DefaultHotkeyValue;
         }
     }
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

Handle CmdPal HotKey initialization.
I have been able to reproduce it removing HotKey from CmdPal settings.json.
Don't know the root cause, but the fix fallback to default HotKey preventing settings app from crashing when HotKey  is null.

- [x] **Closes:** #38748
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Verified that settings app doesn't crash after removing HotKey from CmdPal settings.json