### PR TITLE
[cmdpal] Ref to AotCompatibility in some cmdpal project.

### DIFF
--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Microsoft.CmdPal.Ext.Calc.csproj
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Microsoft.CmdPal.Ext.Calc.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\..\..\Common.Dotnet.CsWinRT.props" />
+  <Import Project="..\..\..\..\Common.Dotnet.AotCompatibility.props" />
   <PropertyGroup>
     <RootNamespace>Microsoft.CmdPal.Ext.Calc</RootNamespace>
     <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\WinUI3Apps\CmdPal</OutputPath>

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Registry/Microsoft.CmdPal.Ext.Registry.csproj
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Registry/Microsoft.CmdPal.Ext.Registry.csproj
@@ -1,5 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\..\..\Common.Dotnet.CsWinRT.props" />
+  <Import Project="..\..\..\..\Common.Dotnet.AotCompatibility.props" />
+
   <PropertyGroup>
     <RootNamespace>Microsoft.CmdPal.Ext.Registry</RootNamespace>
     <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\WinUI3Apps\CmdPal</OutputPath>

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Shell/Microsoft.CmdPal.Ext.Shell.csproj
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Shell/Microsoft.CmdPal.Ext.Shell.csproj
@@ -1,5 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\..\..\Common.Dotnet.CsWinRT.props" />
+  <Import Project="..\..\..\..\Common.Dotnet.AotCompatibility.props" />
+
   <PropertyGroup>
 	<Nullable>enable</Nullable>
     <RootNamespace>Microsoft.CmdPal.Ext.Shell</RootNamespace>

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Microsoft.CmdPal.Ext.TimeDate.csproj
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Microsoft.CmdPal.Ext.TimeDate.csproj
@@ -2,9 +2,6 @@
   <Import Project="..\..\..\..\Common.Dotnet.CsWinRT.props" />
 	<Import Project="..\..\..\..\Common.Dotnet.AotCompatibility.props" />
 
-
-	<Import Project="..\..\Microsoft.CmdPal.UI\CmdPal.pre.props" />
-
   <PropertyGroup>
     <RootNamespace>Microsoft.CmdPal.Ext.TimeDate</RootNamespace>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Microsoft.CmdPal.Ext.TimeDate.csproj
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Microsoft.CmdPal.Ext.TimeDate.csproj
@@ -1,6 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\..\..\Common.Dotnet.CsWinRT.props" />
-  <Import Project="..\..\Microsoft.CmdPal.UI\CmdPal.pre.props" />
+	<Import Project="..\..\..\..\Common.Dotnet.AotCompatibility.props" />
+
+
+	<Import Project="..\..\Microsoft.CmdPal.UI\CmdPal.pre.props" />
+
   <PropertyGroup>
     <RootNamespace>Microsoft.CmdPal.Ext.TimeDate</RootNamespace>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowWalker/Microsoft.CmdPal.Ext.WindowWalker.csproj
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowWalker/Microsoft.CmdPal.Ext.WindowWalker.csproj
@@ -1,5 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\..\..\Common.Dotnet.CsWinRT.props" />
+  <Import Project="..\..\..\..\Common.Dotnet.AotCompatibility.props" />
+
   <PropertyGroup>
 	<Nullable>enable</Nullable>
     <RootNamespace>Microsoft.CmdPal.Ext.WindowWalker</RootNamespace>

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsServices/Microsoft.CmdPal.Ext.WindowsServices.csproj
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsServices/Microsoft.CmdPal.Ext.WindowsServices.csproj
@@ -1,5 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\..\..\Common.Dotnet.CsWinRT.props" />
+  <Import Project="..\..\..\..\Common.Dotnet.AotCompatibility.props" />
+
   <PropertyGroup>
     <RootNamespace>Microsoft.CmdPal.Ext.WindowsServices</RootNamespace>
     <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\WinUI3Apps\CmdPal</OutputPath>

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsTerminal/Microsoft.CmdPal.Ext.WindowsTerminal.csproj
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsTerminal/Microsoft.CmdPal.Ext.WindowsTerminal.csproj
@@ -1,6 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\..\..\Common.Dotnet.CsWinRT.props" />
+  <Import Project="..\..\..\..\Common.Dotnet.AotCompatibility.props" />
   <Import Project="..\..\Microsoft.CmdPal.UI\CmdPal.pre.props" />
+
   <PropertyGroup>
     <RootNamespace>Microsoft.CmdPal.Ext.WindowsTerminal</RootNamespace>
     <!-- <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\WinUI3Apps\CmdPal</OutputPath> -->


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Safe change, no testing needed.


This pull request adds an import statement for `Common.Dotnet.AotCompatibility.props` across multiple project files to improve AOT compilation support. 
- **Microsoft.CmdPal.Ext.Calc.csproj**: Added import for `Common.Dotnet.AotCompatibility.props`.
- **Microsoft.CmdPal.Ext.Registry.csproj**: Added import for `Common.Dotnet.AotCompatibility.props`.
- **Microsoft.CmdPal.Ext.Shell.csproj**: Added import for `Common.Dotnet.AotCompatibility.props`.
- **Microsoft.CmdPal.Ext.TimeDate.csproj**: Reordered imports, adding `Common.Dotnet.AotCompatibility.props` and re-adding `CmdPal.pre.props`.
- **Microsoft.CmdPal.Ext.WindowWalker.csproj**: Added import for `Common.Dotnet.AotCompatibility.props`.

AOT Checklist after this change:
**UI:**

- [ ] Microsoft.CmdPal.UI
- [ ] Microsoft.CmdPal.UI.ViewModels
      - See 61bad789f

**Ext Sdk:**
- [x] - Microsoft.CommandPalette.Extensions.Toolkit (already done prior)

**Extensions:**

- [ ] Microsoft.CmdPal.Ext.Apps
- [ ] Microsoft.CmdPal.Ext.Bookmarks
- [x] Microsoft.CmdPal.Ext.Calc
- [ ] Microsoft.CmdPal.Ext.ClipboardHistory
- [ ] Microsoft.CmdPal.Ext.Indexer
- [x] Microsoft.CmdPal.Ext.Registry
- [x] Microsoft.CmdPal.Ext.Shell
- [ ] Microsoft.CmdPal.Ext.System
- [x] Microsoft.CmdPal.Ext.TimeDate
- [ ] Microsoft.CmdPal.Ext.WebSearch
- [x] Microsoft.CmdPal.Ext.WindowsServices
- [ ] Microsoft.CmdPal.Ext.WindowsSettings
- [x] Microsoft.CmdPal.Ext.WindowsTerminal
- [x] Microsoft.CmdPal.Ext.WindowWalker
- [ ] Microsoft.CmdPal.Ext.WinGet

**Dependencies inside:**
- [ ] ManagedTelemetry
- [x] PowerToys.ManagedCommon
- [ ] Microsoft.CmdPal.Common
- [x] Microsoft.CommandPalette.Extensions.Toolkit (already done prior)