### PR TITLE
[Keyboard Manager] New Keyboard Manager - Keys Remapping Window, Keyboard Hook and Input Validator

### DIFF
--- a/.pipelines/ESRPSigning_core.json
+++ b/.pipelines/ESRPSigning_core.json
@@ -127,6 +127,7 @@
 
                 "PowerToys.KeyboardManager.dll",
                 "KeyboardManagerEditor\\PowerToys.KeyboardManagerEditor.exe",
+                "KeyboardManagerEditorUI\\PowerToys.KeyboardManagerEditorUI.exe",
                 "KeyboardManagerEngine\\PowerToys.KeyboardManagerEngine.exe",
                 "PowerToys.KeyboardManagerEditorLibraryWrapper.dll",
 

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibraryWrapper/KeyboardManagerEditorLibraryWrapper.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibraryWrapper/KeyboardManagerEditorLibraryWrapper.cpp
@@ -519,18 +519,18 @@ bool GetShortcutRemapByType(void* config, int operationType, int index, Shortcut
     {
         auto mappingConfig = static_cast<MappingConfiguration*>(config);
 
-        Shortcut origShortcut(originalKeys);
+        Shortcut originalShortcut(originalKeys);
         Shortcut targetShortcut(targetKeys);
 
         std::wstring app(targetApp ? targetApp : L"");
 
         if (app.empty())
         {
-            return mappingConfig->AddOSLevelShortcut(origShortcut, targetShortcut);
+            return mappingConfig->AddOSLevelShortcut(originalShortcut, targetShortcut);
         }
         else
         {
-            return mappingConfig->AddAppSpecificShortcut(app, origShortcut, targetShortcut);
+            return mappingConfig->AddAppSpecificShortcut(app, originalShortcut, targetShortcut);
         }
     }
 
@@ -577,6 +577,20 @@ bool GetShortcutRemapByType(void* config, int operationType, int index, Shortcut
 
         // Return true if an error was detected (anything other than NoError)
         return result != ShortcutErrorType::NoError;
+    }
+
+    // Function to check if two shortcuts are equal
+    bool AreShortcutsEqual(const wchar_t* lShort, const wchar_t* rShort)
+    {
+        if (!lShort || !rShort)
+        {
+            return false;
+        }
+
+        Shortcut lhs(lShort);
+        Shortcut rhs(rShort);
+
+        return lhs == rhs;
     }
 
     // Function to delete a single key remapping

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibraryWrapper/KeyboardManagerEditorLibraryWrapper.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibraryWrapper/KeyboardManagerEditorLibraryWrapper.cpp
@@ -8,6 +8,7 @@
 
 #include <common/utils/logger_helper.h>
 #include <keyboardmanager/KeyboardManagerEditor/KeyboardManagerEditor.h>
+#include <keyboardmanager/KeyboardManagerEditorLibrary/EditorHelpers.h>
 #include <common/interop/keyboard_layout.h>
 
 extern "C"
@@ -560,6 +561,22 @@ bool GetShortcutRemapByType(void* config, int operationType, int index, Shortcut
     int GetKeyType(int key)
     {
         return static_cast<int>(Helpers::GetKeyType(static_cast<DWORD>(key)));
+    }
+
+    // Function to check if a shortcut is illegal
+    bool IsShortcutIllegal(const wchar_t* shortcutKeys)
+    {
+        if (!shortcutKeys)
+        {
+            return false;
+        }
+
+        Shortcut shortcut(shortcutKeys);
+
+        ShortcutErrorType result = EditorHelpers::IsShortcutIllegal(shortcut);
+
+        // Return true if an error was detected (anything other than NoError)
+        return result != ShortcutErrorType::NoError;
     }
 
     // Function to delete a single key remapping

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibraryWrapper/KeyboardManagerEditorLibraryWrapper.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibraryWrapper/KeyboardManagerEditorLibraryWrapper.cpp
@@ -556,6 +556,12 @@ bool GetShortcutRemapByType(void* config, int operationType, int index, Shortcut
         return static_cast<int>(layoutMap.GetKeyFromName(name));
     }
 
+    // Function to get the type of a key (Win, Ctrl, Alt, Shift, or Action)
+    int GetKeyType(int key)
+    {
+        return static_cast<int>(Helpers::GetKeyType(static_cast<DWORD>(key)));
+    }
+
     // Function to delete a single key remapping
     bool DeleteSingleKeyRemap(void* config, int originalKey)
     {

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibraryWrapper/KeyboardManagerEditorLibraryWrapper.h
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibraryWrapper/KeyboardManagerEditorLibraryWrapper.h
@@ -67,6 +67,9 @@ extern "C"
     __declspec(dllexport) void GetKeyDisplayName(int keyCode, wchar_t* keyName, int maxCount);
     __declspec(dllexport) int GetKeyCodeFromName(const wchar_t* keyName);
     __declspec(dllexport) void FreeString(wchar_t* str);
+
+    __declspec(dllexport) bool DeleteSingleKeyRemap(void* config, int originalKey);
+    __declspec(dllexport) bool DeleteShortcutRemap(void* config, const wchar_t* originalKeys, const wchar_t* targetApp);
 }
 extern "C" __declspec(dllexport) bool CheckIfRemappingsAreValid();
 extern "C" __declspec(dllexport) int GetKeyboardKeysList(bool isShortcut, KeyNamePair* keyList, int maxCount);

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibraryWrapper/KeyboardManagerEditorLibraryWrapper.h
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibraryWrapper/KeyboardManagerEditorLibraryWrapper.h
@@ -67,6 +67,7 @@ extern "C"
     __declspec(dllexport) void GetKeyDisplayName(int keyCode, wchar_t* keyName, int maxCount);
     __declspec(dllexport) int GetKeyCodeFromName(const wchar_t* keyName);
     __declspec(dllexport) void FreeString(wchar_t* str);
+    __declspec(dllexport) int GetKeyType(int keyCode);
 
     __declspec(dllexport) bool DeleteSingleKeyRemap(void* config, int originalKey);
     __declspec(dllexport) bool DeleteShortcutRemap(void* config, const wchar_t* originalKeys, const wchar_t* targetApp);

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibraryWrapper/KeyboardManagerEditorLibraryWrapper.h
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibraryWrapper/KeyboardManagerEditorLibraryWrapper.h
@@ -70,6 +70,7 @@ extern "C"
     __declspec(dllexport) int GetKeyType(int keyCode);
 
     __declspec(dllexport) bool IsShortcutIllegal(const wchar_t* shortcutKeys);
+    __declspec(dllexport) bool AreShortcutsEqual(const wchar_t* lShort, const wchar_t* rShort);
 
     __declspec(dllexport) bool DeleteSingleKeyRemap(void* config, int originalKey);
     __declspec(dllexport) bool DeleteShortcutRemap(void* config, const wchar_t* originalKeys, const wchar_t* targetApp);

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibraryWrapper/KeyboardManagerEditorLibraryWrapper.h
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibraryWrapper/KeyboardManagerEditorLibraryWrapper.h
@@ -69,6 +69,8 @@ extern "C"
     __declspec(dllexport) void FreeString(wchar_t* str);
     __declspec(dllexport) int GetKeyType(int keyCode);
 
+    __declspec(dllexport) bool IsShortcutIllegal(const wchar_t* shortcutKeys);
+
     __declspec(dllexport) bool DeleteSingleKeyRemap(void* config, int originalKey);
     __declspec(dllexport) bool DeleteShortcutRemap(void* config, const wchar_t* originalKeys, const wchar_t* targetApp);
 }

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/App.xaml.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/App.xaml.cs
@@ -81,6 +81,11 @@ namespace KeyboardManagerEditorUI
             Logger.LogError("Unhandled exception", e.Exception);
         }
 
+        public Window? GetWindow()
+        {
+            return window;
+        }
+
         private Window? window;
     }
 }

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/EditorConstants.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/EditorConstants.cs
@@ -15,5 +15,8 @@ namespace KeyboardManagerEditorUI.Helpers
         // Default window size
         public const int DefaultEditorWindowWidth = 960;
         public const int DefaultEditorWindowHeight = 600;
+
+        // Default notification timeout
+        public const int DefaultNotificationTimeout = 1500;
     }
 }

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/ValidationErrorType.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/ValidationErrorType.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KeyboardManagerEditorUI.Helpers
+{
+    public enum ValidationErrorType
+    {
+        NoError,
+        EmptyOriginalKeys,
+        EmptyRemappedKeys,
+        ModifierOnly,
+        EmptyAppName,
+        IllegalShortcut,
+        DuplicateMapping,
+        SelfMapping,
+    }
+}

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/ValidationHelper.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/ValidationHelper.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KeyboardManagerEditorUI.Helpers
+{
+    public static class ValidationHelper
+    {
+        public enum ValidationErrorType
+        {
+            EmptyOriginalKeys,
+            EmptyRemappedKeys,
+            ModifierOnly,
+            EmptyAppName,
+            IllegalShortcut,
+            DuplicateMapping,
+            SelfMapping,
+        }
+
+        public static readonly Dictionary<ValidationErrorType, (string Title, string Message)> ValidationMessages = new()
+        {
+            { ValidationErrorType.EmptyOriginalKeys, ("Missing Original Keys", "Please enter at least one original key to create a remapping.") },
+            { ValidationErrorType.EmptyRemappedKeys, ("Missing Target Keys", "Please enter at least one target key to create a remapping.") },
+            { ValidationErrorType.ModifierOnly, ("Invalid Shortcut", "Shortcuts must contain at least one action key in addition to modifier keys (Ctrl, Alt, Shift, Win).") },
+            { ValidationErrorType.EmptyAppName, ("Missing Application Name", "You've selected app-specific remapping but haven't specified an application name. Please enter the application name.") },
+            { ValidationErrorType.IllegalShortcut, ("Reserved System Shortcut", "Win+L and Ctrl+Alt+Delete are reserved system shortcuts and cannot be remapped.") },
+            { ValidationErrorType.DuplicateMapping, ("Duplicate Remapping", "This key or shortcut is already remapped.") },
+            { ValidationErrorType.SelfMapping, ("Invalid Remapping", "A key or shortcut cannot be remapped to itself. Please choose a different target.") },
+        };
+    }
+}

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Interop/KeyType.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Interop/KeyType.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace KeyboardManagerEditorUI.Interop
+{
+    public enum KeyType
+    {
+        Win = 0,
+        Ctrl = 1,
+        Alt = 2,
+        Shift = 3,
+        Action = 4,
+    }
+}

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Interop/KeyboardManagerInterop.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Interop/KeyboardManagerInterop.cs
@@ -82,6 +82,12 @@ namespace KeyboardManagerEditorUI.Interop
         [DllImport(DllName)]
         internal static extern void FreeString(IntPtr str);
 
+        [DllImport(DllName)]
+        internal static extern bool DeleteSingleKeyRemap(IntPtr mappingConfiguration, int originalKey);
+
+        [DllImport(DllName)]
+        internal static extern bool DeleteShortcutRemap(IntPtr mappingConfiguration, [MarshalAs(UnmanagedType.LPWStr)] string originalKeys, [MarshalAs(UnmanagedType.LPWStr)] string targetApp);
+
         public static string GetStringAndFree(IntPtr handle)
         {
             if (handle == IntPtr.Zero)

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Interop/KeyboardManagerInterop.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Interop/KeyboardManagerInterop.cs
@@ -83,6 +83,9 @@ namespace KeyboardManagerEditorUI.Interop
         internal static extern void FreeString(IntPtr str);
 
         [DllImport(DllName)]
+        internal static extern int GetKeyType(int keyCode);
+
+        [DllImport(DllName)]
         internal static extern bool DeleteSingleKeyRemap(IntPtr mappingConfiguration, int originalKey);
 
         [DllImport(DllName)]

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Interop/KeyboardManagerInterop.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Interop/KeyboardManagerInterop.cs
@@ -90,6 +90,10 @@ namespace KeyboardManagerEditorUI.Interop
         internal static extern bool IsShortcutIllegal([MarshalAs(UnmanagedType.LPWStr)] string shortcutKeys);
 
         [DllImport(DllName)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool AreShortcutsEqual([MarshalAs(UnmanagedType.LPWStr)] string lShort, [MarshalAs(UnmanagedType.LPWStr)] string rShortcut);
+
+        [DllImport(DllName)]
         internal static extern bool DeleteSingleKeyRemap(IntPtr mappingConfiguration, int originalKey);
 
         [DllImport(DllName)]

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Interop/KeyboardManagerInterop.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Interop/KeyboardManagerInterop.cs
@@ -86,6 +86,10 @@ namespace KeyboardManagerEditorUI.Interop
         internal static extern int GetKeyType(int keyCode);
 
         [DllImport(DllName)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool IsShortcutIllegal([MarshalAs(UnmanagedType.LPWStr)] string shortcutKeys);
+
+        [DllImport(DllName)]
         internal static extern bool DeleteSingleKeyRemap(IntPtr mappingConfiguration, int originalKey);
 
         [DllImport(DllName)]

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Interop/KeyboardMappingService.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Interop/KeyboardMappingService.cs
@@ -168,6 +168,21 @@ namespace KeyboardManagerEditorUI.Interop
             return KeyboardManagerInterop.SaveMappingSettings(_configHandle);
         }
 
+        public bool DeleteSingleKeyMapping(int originalKey)
+        {
+            return KeyboardManagerInterop.DeleteSingleKeyRemap(_configHandle, originalKey);
+        }
+
+        public bool DeleteShortcutMapping(string originalKeys, string targetApp = "")
+        {
+            if (string.IsNullOrEmpty(originalKeys))
+            {
+                return false;
+            }
+
+            return KeyboardManagerInterop.DeleteShortcutRemap(_configHandle, originalKeys, targetApp ?? string.Empty);
+        }
+
         public void Dispose()
         {
             Dispose(true);

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Remappings.xaml
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Remappings.xaml
@@ -158,13 +158,23 @@
                                     VerticalAlignment="Center"
                                     FontSize="12"
                                     Text="{x:Bind AppName}" />
-                                <ToggleSwitch
-                                    Grid.ColumnSpan="4"
-                                    Margin="0,0,-112,0"
+                                <Button
+                                    Grid.Column="3"
+                                    Margin="0,0,4,0"
+                                    Padding="8,4"
                                     HorizontalAlignment="Right"
-                                    IsOn="{x:Bind IsEnabled, Mode=TwoWay}"
-                                    OffContent=""
-                                    OnContent="" />
+                                    VerticalAlignment="Center"
+                                    AutomationProperties.Name="Delete remapping"
+                                    Background="Transparent"
+                                    BorderThickness="0"
+                                    Click="DeleteButton_Click"
+                                    ToolTipService.ToolTip="Delete remapping">
+                                    <FontIcon
+                                        FontFamily="{StaticResource SymbolThemeFontFamily}"
+                                        FontSize="16"
+                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                        Glyph="&#xE74D;" />
+                                </Button>
                             </Grid>
                         </DataTemplate>
                     </ListView.ItemTemplate>

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Remappings.xaml
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Remappings.xaml
@@ -208,86 +208,11 @@
             </TeachingTip.IconSource>
         </TeachingTip>
         <TeachingTip
-            x:Name="IllegalShortcutTeachingTip"
-            Title="Reserved System Shortcut"
-            CloseButtonClick="IllegalShortcutTeachingTip_CloseButtonClick"
+            x:Name="ValidationTeachingTip"
+            CloseButtonClick="ValidationTeachingTip_CloseButtonClick"
             CloseButtonContent="OK"
             IsLightDismissEnabled="True"
-            PreferredPlacement="Center"
-            Subtitle="Win+L and Ctrl+Alt+Delete are reserved system shortcuts and cannot be remapped.">
-            <TeachingTip.IconSource>
-                <SymbolIconSource Symbol="Important" />
-            </TeachingTip.IconSource>
-        </TeachingTip>
-        <TeachingTip
-            x:Name="DuplicateRemappingTeachingTip"
-            Title="Duplicate Remapping"
-            CloseButtonClick="DuplicateRemappingTeachingTip_CloseButtonClick"
-            CloseButtonContent="OK"
-            IsLightDismissEnabled="True"
-            PreferredPlacement="Center"
-            Subtitle="This key or shortcut is already remapped for this application context. Each key or shortcut can only be remapped once per application.">
-            <TeachingTip.IconSource>
-                <SymbolIconSource Symbol="Important" />
-            </TeachingTip.IconSource>
-        </TeachingTip>
-        <TeachingTip
-            x:Name="SelfMappingTeachingTip"
-            Title="Invalid Remapping"
-            CloseButtonClick="SelfMappingTeachingTip_CloseButtonClick"
-            CloseButtonContent="OK"
-            IsLightDismissEnabled="True"
-            PreferredPlacement="Center"
-            Subtitle="A key or shortcut cannot be remapped to itself. Please choose a different target.">
-            <TeachingTip.IconSource>
-                <SymbolIconSource Symbol="Important" />
-            </TeachingTip.IconSource>
-        </TeachingTip>
-        <TeachingTip
-            x:Name="EmptyOriginalKeysTeachingTip"
-            Title="Missing Original Keys"
-            CloseButtonClick="EmptyOriginalKeysTeachingTip_CloseButtonClick"
-            CloseButtonContent="OK"
-            IsLightDismissEnabled="True"
-            PreferredPlacement="Center"
-            Subtitle="Please enter at least one original key to create a remapping.">
-            <TeachingTip.IconSource>
-                <SymbolIconSource Symbol="Important" />
-            </TeachingTip.IconSource>
-        </TeachingTip>
-
-        <TeachingTip
-            x:Name="EmptyRemappedKeysTeachingTip"
-            Title="Missing Target Keys"
-            CloseButtonClick="EmptyRemappedKeysTeachingTip_CloseButtonClick"
-            CloseButtonContent="OK"
-            IsLightDismissEnabled="True"
-            PreferredPlacement="Center"
-            Subtitle="Please enter at least one target key to create a remapping.">
-            <TeachingTip.IconSource>
-                <SymbolIconSource Symbol="Important" />
-            </TeachingTip.IconSource>
-        </TeachingTip>
-        <TeachingTip
-            x:Name="EmptyAppNameTeachingTip"
-            Title="Missing Application Name"
-            CloseButtonClick="EmptyAppNameTeachingTip_CloseButtonClick"
-            CloseButtonContent="OK"
-            IsLightDismissEnabled="True"
-            PreferredPlacement="Center"
-            Subtitle="You've selected app-specific remapping but haven't specified an application name. Please enter the application name.">
-            <TeachingTip.IconSource>
-                <SymbolIconSource Symbol="Important" />
-            </TeachingTip.IconSource>
-        </TeachingTip>
-        <TeachingTip
-            x:Name="ModifierOnlyTeachingTip"
-            Title="Invalid Shortcut"
-            CloseButtonClick="ModifierOnlyTeachingTip_CloseButtonClick"
-            CloseButtonContent="OK"
-            IsLightDismissEnabled="True"
-            PreferredPlacement="Center"
-            Subtitle="Shortcuts must contain at least one action key in addition to modifier keys (Ctrl, Alt, Shift, Win).">
+            PreferredPlacement="Center">
             <TeachingTip.IconSource>
                 <SymbolIconSource Symbol="Important" />
             </TeachingTip.IconSource>

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Remappings.xaml
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Remappings.xaml
@@ -202,8 +202,7 @@
             CloseButtonClick="OrphanedKeysTeachingTip_CloseButtonClick"
             CloseButtonContent="Cancel"
             IsLightDismissEnabled="False"
-            PreferredPlacement="Center"
-            Subtitle="The following keys will become orphaned (inaccessible) after remapping:">
+            PreferredPlacement="Center">
             <TeachingTip.IconSource>
                 <SymbolIconSource Symbol="Important" />
             </TeachingTip.IconSource>

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Remappings.xaml
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Remappings.xaml
@@ -232,5 +232,17 @@
                 <SymbolIconSource Symbol="Important" />
             </TeachingTip.IconSource>
         </TeachingTip>
+        <TeachingTip
+            x:Name="SelfMappingTeachingTip"
+            Title="Invalid Remapping"
+            CloseButtonClick="SelfMappingTeachingTip_CloseButtonClick"
+            CloseButtonContent="OK"
+            IsLightDismissEnabled="True"
+            PreferredPlacement="Center"
+            Subtitle="A key or shortcut cannot be remapped to itself. Please choose a different target.">
+            <TeachingTip.IconSource>
+                <SymbolIconSource Symbol="Important" />
+            </TeachingTip.IconSource>
+        </TeachingTip>
     </Grid>
 </Page>

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Remappings.xaml
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Remappings.xaml
@@ -244,5 +244,43 @@
                 <SymbolIconSource Symbol="Important" />
             </TeachingTip.IconSource>
         </TeachingTip>
+        <TeachingTip
+            x:Name="EmptyOriginalKeysTeachingTip"
+            Title="Missing Original Keys"
+            CloseButtonClick="EmptyOriginalKeysTeachingTip_CloseButtonClick"
+            CloseButtonContent="OK"
+            IsLightDismissEnabled="True"
+            PreferredPlacement="Center"
+            Subtitle="Please enter at least one original key to create a remapping.">
+            <TeachingTip.IconSource>
+                <SymbolIconSource Symbol="Important" />
+            </TeachingTip.IconSource>
+        </TeachingTip>
+
+        <TeachingTip
+            x:Name="EmptyRemappedKeysTeachingTip"
+            Title="Missing Target Keys"
+            CloseButtonClick="EmptyRemappedKeysTeachingTip_CloseButtonClick"
+            CloseButtonContent="OK"
+            IsLightDismissEnabled="True"
+            PreferredPlacement="Center"
+            Subtitle="Please enter at least one target key to create a remapping.">
+            <TeachingTip.IconSource>
+                <SymbolIconSource Symbol="Important" />
+            </TeachingTip.IconSource>
+        </TeachingTip>
+
+        <TeachingTip
+            x:Name="EmptyAppNameTeachingTip"
+            Title="Missing Application Name"
+            CloseButtonClick="EmptyAppNameTeachingTip_CloseButtonClick"
+            CloseButtonContent="OK"
+            IsLightDismissEnabled="True"
+            PreferredPlacement="Center"
+            Subtitle="You've selected app-specific remapping but haven't specified an application name. Please enter the application name.">
+            <TeachingTip.IconSource>
+                <SymbolIconSource Symbol="Important" />
+            </TeachingTip.IconSource>
+        </TeachingTip>
     </Grid>
 </Page>

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Remappings.xaml
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Remappings.xaml
@@ -269,7 +269,6 @@
                 <SymbolIconSource Symbol="Important" />
             </TeachingTip.IconSource>
         </TeachingTip>
-
         <TeachingTip
             x:Name="EmptyAppNameTeachingTip"
             Title="Missing Application Name"
@@ -278,6 +277,18 @@
             IsLightDismissEnabled="True"
             PreferredPlacement="Center"
             Subtitle="You've selected app-specific remapping but haven't specified an application name. Please enter the application name.">
+            <TeachingTip.IconSource>
+                <SymbolIconSource Symbol="Important" />
+            </TeachingTip.IconSource>
+        </TeachingTip>
+        <TeachingTip
+            x:Name="ModifierOnlyTeachingTip"
+            Title="Invalid Shortcut"
+            CloseButtonClick="ModifierOnlyTeachingTip_CloseButtonClick"
+            CloseButtonContent="OK"
+            IsLightDismissEnabled="True"
+            PreferredPlacement="Center"
+            Subtitle="Shortcuts must contain at least one action key in addition to modifier keys (Ctrl, Alt, Shift, Win).">
             <TeachingTip.IconSource>
                 <SymbolIconSource Symbol="Important" />
             </TeachingTip.IconSource>

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Remappings.xaml
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Remappings.xaml
@@ -193,5 +193,32 @@
                 <styles:InputControl x:Name="RemappingControl" />
             </Grid>
         </ContentDialog>
+        <TeachingTip
+            x:Name="OrphanedKeysTeachingTip"
+            Title="Orphaned Keys Warning"
+            ActionButtonClick="OrphanedKeysTeachingTip_ActionButtonClick"
+            ActionButtonContent="Continue anyway"
+            ActionButtonStyle="{StaticResource AccentButtonStyle}"
+            CloseButtonClick="OrphanedKeysTeachingTip_CloseButtonClick"
+            CloseButtonContent="Cancel"
+            IsLightDismissEnabled="False"
+            PreferredPlacement="Center"
+            Subtitle="The following keys will become orphaned (inaccessible) after remapping:">
+            <TeachingTip.IconSource>
+                <SymbolIconSource Symbol="Important" />
+            </TeachingTip.IconSource>
+        </TeachingTip>
+        <TeachingTip
+            x:Name="IllegalShortcutTeachingTip"
+            Title="Reserved System Shortcut"
+            CloseButtonClick="IllegalShortcutTeachingTip_CloseButtonClick"
+            CloseButtonContent="OK"
+            IsLightDismissEnabled="True"
+            PreferredPlacement="Center"
+            Subtitle="Win+L and Ctrl+Alt+Delete are reserved system shortcuts and cannot be remapped.">
+            <TeachingTip.IconSource>
+                <SymbolIconSource Symbol="Important" />
+            </TeachingTip.IconSource>
+        </TeachingTip>
     </Grid>
 </Page>

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Remappings.xaml
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Remappings.xaml
@@ -220,5 +220,17 @@
                 <SymbolIconSource Symbol="Important" />
             </TeachingTip.IconSource>
         </TeachingTip>
+        <TeachingTip
+            x:Name="DuplicateRemappingTeachingTip"
+            Title="Duplicate Remapping"
+            CloseButtonClick="DuplicateRemappingTeachingTip_CloseButtonClick"
+            CloseButtonContent="OK"
+            IsLightDismissEnabled="True"
+            PreferredPlacement="Center"
+            Subtitle="This key or shortcut is already remapped for this application context. Each key or shortcut can only be remapped once per application.">
+            <TeachingTip.IconSource>
+                <SymbolIconSource Symbol="Important" />
+            </TeachingTip.IconSource>
+        </TeachingTip>
     </Grid>
 </Page>

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Remappings.xaml.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Remappings.xaml.cs
@@ -196,6 +196,7 @@ namespace KeyboardManagerEditorUI.Pages
             RemappingControl.SetOriginalKeys(new List<string>());
             RemappingControl.SetRemappedKeys(new List<string>());
             RemappingControl.SetApp(false, string.Empty);
+            RemappingControl.SetUpToggleButtonInitialStatus();
 
             RegisterWindowActivationHandler();
 
@@ -222,6 +223,7 @@ namespace KeyboardManagerEditorUI.Pages
                 RemappingControl.SetOriginalKeys(selectedRemapping.OriginalKeys);
                 RemappingControl.SetRemappedKeys(selectedRemapping.RemappedKeys);
                 RemappingControl.SetApp(!selectedRemapping.IsAllApps, selectedRemapping.AppName);
+                RemappingControl.SetUpToggleButtonInitialStatus();
 
                 RegisterWindowActivationHandler();
 

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Remappings.xaml.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Remappings.xaml.cs
@@ -188,6 +188,7 @@ namespace KeyboardManagerEditorUI.Pages
                 RemappingControl.CleanupKeyboardHook();
 
                 RemappingControl.ResetToggleButtons();
+                RemappingControl.UpdateAllAppsCheckBoxState();
             }
         }
 

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Remappings.xaml.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Remappings.xaml.cs
@@ -219,6 +219,36 @@ namespace KeyboardManagerEditorUI.Pages
             bool isAppSpecific = RemappingControl.GetIsAppSpecific();
             string appName = RemappingControl.GetAppName();
 
+            // Check if original keys are empty
+            if (originalKeys == null || originalKeys.Count == 0)
+            {
+                EmptyOriginalKeysTeachingTip.Target = RemappingControl;
+                EmptyOriginalKeysTeachingTip.Tag = args;
+                EmptyOriginalKeysTeachingTip.IsOpen = true;
+                args.Cancel = true;
+                return;
+            }
+
+            // Check if remapped keys are empty
+            if (remappedKeys == null || remappedKeys.Count == 0)
+            {
+                EmptyRemappedKeysTeachingTip.Target = RemappingControl;
+                EmptyRemappedKeysTeachingTip.Tag = args;
+                EmptyRemappedKeysTeachingTip.IsOpen = true;
+                args.Cancel = true;
+                return;
+            }
+
+            // Check if app specific is checked but no app name is provided
+            if (isAppSpecific && string.IsNullOrWhiteSpace(appName))
+            {
+                EmptyAppNameTeachingTip.Target = RemappingControl;
+                EmptyAppNameTeachingTip.Tag = args;
+                EmptyAppNameTeachingTip.IsOpen = true;
+                args.Cancel = true;
+                return;
+            }
+
             // Check if this is a shortcut (multiple keys) and if it's an illegal combination
             if (originalKeys.Count > 1)
             {
@@ -349,6 +379,21 @@ namespace KeyboardManagerEditorUI.Pages
         }
 
         private void SelfMappingTeachingTip_CloseButtonClick(TeachingTip sender, object args)
+        {
+            sender.IsOpen = false;
+        }
+
+        private void EmptyOriginalKeysTeachingTip_CloseButtonClick(TeachingTip sender, object args)
+        {
+            sender.IsOpen = false;
+        }
+
+        private void EmptyRemappedKeysTeachingTip_CloseButtonClick(TeachingTip sender, object args)
+        {
+            sender.IsOpen = false;
+        }
+
+        private void EmptyAppNameTeachingTip_CloseButtonClick(TeachingTip sender, object args)
         {
             sender.IsOpen = false;
         }

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Remappings.xaml.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Remappings.xaml.cs
@@ -215,6 +215,7 @@ namespace KeyboardManagerEditorUI.Pages
         private void KeyDialog_PrimaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
         {
             List<string> originalKeys = RemappingControl.GetOriginalKeys();
+            List<string> remappedKeys = RemappingControl.GetRemappedKeys();
             bool isAppSpecific = RemappingControl.GetIsAppSpecific();
             string appName = RemappingControl.GetAppName();
 
@@ -246,7 +247,16 @@ namespace KeyboardManagerEditorUI.Pages
                 // Show the teaching tip
                 DuplicateRemappingTeachingTip.IsOpen = true;
 
-                // Cancel the dialog closing for now since it will be handled by teaching tip actions
+                args.Cancel = true;
+                return;
+            }
+
+            // Check for self-mapping
+            if (IsSelfMapping(originalKeys, remappedKeys))
+            {
+                SelfMappingTeachingTip.Target = RemappingControl;
+                SelfMappingTeachingTip.Tag = args;
+                SelfMappingTeachingTip.IsOpen = true;
                 args.Cancel = true;
                 return;
             }
@@ -321,6 +331,26 @@ namespace KeyboardManagerEditorUI.Pages
             }
 
             return false;
+        }
+
+        private bool IsSelfMapping(List<string> originalKeys, List<string> remappedKeys)
+        {
+            // If either list is empty, it's not a self-mapping
+            if (originalKeys == null || remappedKeys == null ||
+                originalKeys.Count == 0 || remappedKeys.Count == 0)
+            {
+                return false;
+            }
+
+            string originalKeysString = string.Join(";", originalKeys.Select(k => GetKeyCode(k).ToString(CultureInfo.InvariantCulture)));
+            string remappedKeysString = string.Join(";", remappedKeys.Select(k => GetKeyCode(k).ToString(CultureInfo.InvariantCulture)));
+
+            return KeyboardManagerInterop.AreShortcutsEqual(originalKeysString, remappedKeysString);
+        }
+
+        private void SelfMappingTeachingTip_CloseButtonClick(TeachingTip sender, object args)
+        {
+            sender.IsOpen = false;
         }
 
         private void OrphanedKeysTeachingTip_ActionButtonClick(TeachingTip sender, object args)

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Remappings.xaml.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Remappings.xaml.cs
@@ -239,6 +239,17 @@ namespace KeyboardManagerEditorUI.Pages
                 return;
             }
 
+            // Check if shortcut contains only modifier keys
+            if ((originalKeys.Count > 1 && ContainsOnlyModifierKeys(originalKeys)) ||
+                (remappedKeys.Count > 1 && ContainsOnlyModifierKeys(remappedKeys)))
+            {
+                ModifierOnlyTeachingTip.Target = RemappingControl;
+                ModifierOnlyTeachingTip.Tag = args;
+                ModifierOnlyTeachingTip.IsOpen = true;
+                args.Cancel = true;
+                return;
+            }
+
             // Check if app specific is checked but no app name is provided
             if (isAppSpecific && string.IsNullOrWhiteSpace(appName))
             {
@@ -378,6 +389,29 @@ namespace KeyboardManagerEditorUI.Pages
             return KeyboardManagerInterop.AreShortcutsEqual(originalKeysString, remappedKeysString);
         }
 
+        private bool ContainsOnlyModifierKeys(List<string> keys)
+        {
+            if (keys == null || keys.Count == 0)
+            {
+                return false;
+            }
+
+            foreach (string key in keys)
+            {
+                int keyCode = GetKeyCode(key);
+                var keyType = (KeyType)KeyboardManagerInterop.GetKeyType(keyCode);
+
+                // If any key is an action key, return false
+                if (keyType == KeyType.Action)
+                {
+                    return false;
+                }
+            }
+
+            // All keys are modifier keys
+            return true;
+        }
+
         private void SelfMappingTeachingTip_CloseButtonClick(TeachingTip sender, object args)
         {
             sender.IsOpen = false;
@@ -394,6 +428,11 @@ namespace KeyboardManagerEditorUI.Pages
         }
 
         private void EmptyAppNameTeachingTip_CloseButtonClick(TeachingTip sender, object args)
+        {
+            sender.IsOpen = false;
+        }
+
+        private void ModifierOnlyTeachingTip_CloseButtonClick(TeachingTip sender, object args)
         {
             sender.IsOpen = false;
         }

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Remappings.xaml.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Remappings.xaml.cs
@@ -25,6 +25,7 @@ using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Navigation;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
+using static KeyboardManagerEditorUI.Helpers.ValidationHelper;
 
 namespace KeyboardManagerEditorUI.Pages
 {
@@ -222,20 +223,14 @@ namespace KeyboardManagerEditorUI.Pages
             // Check if original keys are empty
             if (originalKeys == null || originalKeys.Count == 0)
             {
-                EmptyOriginalKeysTeachingTip.Target = RemappingControl;
-                EmptyOriginalKeysTeachingTip.Tag = args;
-                EmptyOriginalKeysTeachingTip.IsOpen = true;
-                args.Cancel = true;
+                ShowValidationError(ValidationErrorType.EmptyOriginalKeys, args);
                 return;
             }
 
             // Check if remapped keys are empty
             if (remappedKeys == null || remappedKeys.Count == 0)
             {
-                EmptyRemappedKeysTeachingTip.Target = RemappingControl;
-                EmptyRemappedKeysTeachingTip.Tag = args;
-                EmptyRemappedKeysTeachingTip.IsOpen = true;
-                args.Cancel = true;
+                ShowValidationError(ValidationErrorType.EmptyRemappedKeys, args);
                 return;
             }
 
@@ -243,20 +238,14 @@ namespace KeyboardManagerEditorUI.Pages
             if ((originalKeys.Count > 1 && ContainsOnlyModifierKeys(originalKeys)) ||
                 (remappedKeys.Count > 1 && ContainsOnlyModifierKeys(remappedKeys)))
             {
-                ModifierOnlyTeachingTip.Target = RemappingControl;
-                ModifierOnlyTeachingTip.Tag = args;
-                ModifierOnlyTeachingTip.IsOpen = true;
-                args.Cancel = true;
+                ShowValidationError(ValidationErrorType.ModifierOnly, args);
                 return;
             }
 
             // Check if app specific is checked but no app name is provided
             if (isAppSpecific && string.IsNullOrWhiteSpace(appName))
             {
-                EmptyAppNameTeachingTip.Target = RemappingControl;
-                EmptyAppNameTeachingTip.Tag = args;
-                EmptyAppNameTeachingTip.IsOpen = true;
-                args.Cancel = true;
+                ShowValidationError(ValidationErrorType.EmptyAppName, args);
                 return;
             }
 
@@ -267,14 +256,7 @@ namespace KeyboardManagerEditorUI.Pages
 
                 if (KeyboardManagerInterop.IsShortcutIllegal(shortcutKeysString))
                 {
-                    IllegalShortcutTeachingTip.Target = RemappingControl;
-                    IllegalShortcutTeachingTip.Tag = args;
-
-                    // Show the teaching tip
-                    IllegalShortcutTeachingTip.IsOpen = true;
-
-                    // Cancel the dialog closing for now since it will be handled by teaching tip actions
-                    args.Cancel = true;
+                    ShowValidationError(ValidationErrorType.IllegalShortcut, args);
                     return;
                 }
             }
@@ -282,23 +264,14 @@ namespace KeyboardManagerEditorUI.Pages
             // Check for duplicate mappings
             if (IsDuplicateMapping(originalKeys, isAppSpecific, appName))
             {
-                DuplicateRemappingTeachingTip.Target = RemappingControl;
-                DuplicateRemappingTeachingTip.Tag = args;
-
-                // Show the teaching tip
-                DuplicateRemappingTeachingTip.IsOpen = true;
-
-                args.Cancel = true;
+                ShowValidationError(ValidationErrorType.DuplicateMapping, args);
                 return;
             }
 
             // Check for self-mapping
             if (IsSelfMapping(originalKeys, remappedKeys))
             {
-                SelfMappingTeachingTip.Target = RemappingControl;
-                SelfMappingTeachingTip.Tag = args;
-                SelfMappingTeachingTip.IsOpen = true;
-                args.Cancel = true;
+                ShowValidationError(ValidationErrorType.SelfMapping, args);
                 return;
             }
 
@@ -328,12 +301,20 @@ namespace KeyboardManagerEditorUI.Pages
             }
         }
 
-        private void IllegalShortcutTeachingTip_CloseButtonClick(TeachingTip sender, object args)
+        private bool ShowValidationError(ValidationErrorType errorType, ContentDialogButtonClickEventArgs args)
         {
-            sender.IsOpen = false;
+            var (title, message) = ValidationMessages[errorType];
+
+            ValidationTeachingTip.Title = title;
+            ValidationTeachingTip.Subtitle = message;
+            ValidationTeachingTip.Target = RemappingControl;
+            ValidationTeachingTip.Tag = args;
+            ValidationTeachingTip.IsOpen = true;
+            args.Cancel = true;
+            return false;
         }
 
-        private void DuplicateRemappingTeachingTip_CloseButtonClick(TeachingTip sender, object args)
+        private void ValidationTeachingTip_CloseButtonClick(TeachingTip sender, object args)
         {
             sender.IsOpen = false;
         }
@@ -454,31 +435,6 @@ namespace KeyboardManagerEditorUI.Pages
 
             // No mapping found for the original key
             return true;
-        }
-
-        private void SelfMappingTeachingTip_CloseButtonClick(TeachingTip sender, object args)
-        {
-            sender.IsOpen = false;
-        }
-
-        private void EmptyOriginalKeysTeachingTip_CloseButtonClick(TeachingTip sender, object args)
-        {
-            sender.IsOpen = false;
-        }
-
-        private void EmptyRemappedKeysTeachingTip_CloseButtonClick(TeachingTip sender, object args)
-        {
-            sender.IsOpen = false;
-        }
-
-        private void EmptyAppNameTeachingTip_CloseButtonClick(TeachingTip sender, object args)
-        {
-            sender.IsOpen = false;
-        }
-
-        private void ModifierOnlyTeachingTip_CloseButtonClick(TeachingTip sender, object args)
-        {
-            sender.IsOpen = false;
         }
 
         private void OrphanedKeysTeachingTip_ActionButtonClick(TeachingTip sender, object args)

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Styles/InputControl.xaml
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Styles/InputControl.xaml
@@ -91,8 +91,7 @@
         <CheckBox
             x:Name="AllAppsCheckBox"
             Margin="0,24,0,12"
-            Content="Only apply this remapping to a specific application"
-            IsChecked="True" />
+            Content="Only apply this remapping to a specific application" />
         <TextBox
             x:Name="AppNameTextBox"
             Header="Application name"

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Styles/InputControl.xaml.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Styles/InputControl.xaml.cs
@@ -372,6 +372,21 @@ namespace KeyboardManagerEditorUI.Styles
             }
         }
 
+        public void SetUpToggleButtonInitialStatus()
+        {
+            // Ensure OriginalToggleBtn is checked
+            if (OriginalToggleBtn != null && OriginalToggleBtn.IsChecked != true)
+            {
+                OriginalToggleBtn.IsChecked = true;
+            }
+
+            // Make sure RemappedToggleBtn is not checked
+            if (RemappedToggleBtn != null && RemappedToggleBtn.IsChecked == true)
+            {
+                RemappedToggleBtn.IsChecked = false;
+            }
+        }
+
         public void Dispose()
         {
             Dispose(true);

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Styles/InputControl.xaml.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Styles/InputControl.xaml.cs
@@ -52,6 +52,9 @@ namespace KeyboardManagerEditorUI.Styles
             this.RemappedKeys.ItemsSource = _remappedKeys;
 
             this.Unloaded += InputControl_Unloaded;
+
+            // Set the default focus state
+            OriginalToggleBtn.IsChecked = true;
         }
 
         private void InputControl_Unloaded(object sender, RoutedEventArgs e)
@@ -123,6 +126,9 @@ namespace KeyboardManagerEditorUI.Styles
             {
                 _keyboardHook.Dispose();
                 _keyboardHook = null;
+
+                _currentlyPressedKeys.Clear();
+                _keyPressOrder.Clear();
             }
         }
 
@@ -265,9 +271,13 @@ namespace KeyboardManagerEditorUI.Styles
                 {
                     OriginalToggleBtn.IsChecked = false;
                 }
-            }
 
-            this.Focus(FocusState.Programmatic);
+                SetKeyboardHook();
+            }
+            else
+            {
+                CleanupKeyboardHook();
+            }
         }
 
         private void OriginalToggleBtn_Checked(object sender, RoutedEventArgs e)
@@ -282,9 +292,9 @@ namespace KeyboardManagerEditorUI.Styles
                 {
                     RemappedToggleBtn.IsChecked = false;
                 }
-            }
 
-            this.Focus(FocusState.Programmatic);
+                SetKeyboardHook();
+            }
         }
 
         public void SetApp(bool isSpecificApp, string appName)
@@ -304,6 +314,18 @@ namespace KeyboardManagerEditorUI.Styles
 
         private void AllAppsCheckBox_Checked(object sender, RoutedEventArgs e)
         {
+            if (RemappedToggleBtn != null && RemappedToggleBtn.IsChecked == true)
+            {
+                RemappedToggleBtn.IsChecked = false;
+            }
+
+            if (OriginalToggleBtn != null && OriginalToggleBtn.IsChecked == true)
+            {
+                OriginalToggleBtn.IsChecked = false;
+            }
+
+            CleanupKeyboardHook();
+
             AppNameTextBox.Visibility = Visibility.Visible;
         }
 
@@ -312,10 +334,42 @@ namespace KeyboardManagerEditorUI.Styles
             AppNameTextBox.Visibility = Visibility.Collapsed;
         }
 
+        private void AppNameTextBox_GotFocus(object sender, RoutedEventArgs e)
+        {
+            // Reset the focus state when the AppNameTextBox is focused
+            if (RemappedToggleBtn != null && RemappedToggleBtn.IsChecked == true)
+            {
+                RemappedToggleBtn.IsChecked = false;
+            }
+
+            if (OriginalToggleBtn != null && OriginalToggleBtn.IsChecked == true)
+            {
+                OriginalToggleBtn.IsChecked = false;
+            }
+
+            CleanupKeyboardHook();
+        }
+
         private void UserControl_Loaded(object sender, RoutedEventArgs e)
         {
             AllAppsCheckBox.Checked += AllAppsCheckBox_Checked;
             AllAppsCheckBox.Unchecked += AllAppsCheckBox_Unchecked;
+
+            AppNameTextBox.GotFocus += AppNameTextBox_GotFocus;
+        }
+
+        public void ResetToggleButtons()
+        {
+            // Reset toggle button status without clearing the key displays
+            if (RemappedToggleBtn != null)
+            {
+                RemappedToggleBtn.IsChecked = false;
+            }
+
+            if (OriginalToggleBtn != null)
+            {
+                OriginalToggleBtn.IsChecked = false;
+            }
         }
 
         public void Dispose()

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Styles/InputControl.xaml.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Styles/InputControl.xaml.cs
@@ -55,6 +55,9 @@ namespace KeyboardManagerEditorUI.Styles
 
             // Set the default focus state
             OriginalToggleBtn.IsChecked = true;
+
+            // Ensure AllAppsCheckBox is in the correct state initially
+            UpdateAllAppsCheckBoxState();
         }
 
         private void InputControl_Unloaded(object sender, RoutedEventArgs e)
@@ -151,6 +154,8 @@ namespace KeyboardManagerEditorUI.Styles
                 {
                     _originalKeys.Add(key);
                 }
+
+                UpdateAllAppsCheckBoxState();
             }
         }
 
@@ -225,6 +230,8 @@ namespace KeyboardManagerEditorUI.Styles
                     _remappedKeys.Add(key);
                 }
             }
+
+            UpdateAllAppsCheckBoxState();
         }
 
         public void SetOriginalKeys(List<string> keys)
@@ -387,6 +394,21 @@ namespace KeyboardManagerEditorUI.Styles
             }
         }
 
+        public void UpdateAllAppsCheckBoxState()
+        {
+            // Only enable app-specific remapping for shortcuts (multiple keys)
+            bool isShortcut = _originalKeys.Count > 1;
+
+            AllAppsCheckBox.IsEnabled = isShortcut;
+
+            // If it's not a shortcut, ensure the checkbox is unchecked and app textbox is hidden
+            if (!isShortcut)
+            {
+                AllAppsCheckBox.IsChecked = false;
+                AppNameTextBox.Visibility = Visibility.Collapsed;
+            }
+       }
+
         public void Dispose()
         {
             Dispose(true);
@@ -435,6 +457,8 @@ namespace KeyboardManagerEditorUI.Styles
             {
                 AppNameTextBox.Text = string.Empty;
             }
+
+            UpdateAllAppsCheckBoxState();
 
             // Reset the focus status
             if (this.FocusState != FocusState.Unfocused)

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Styles/InputControl.xaml.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Styles/InputControl.xaml.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using KeyboardManagerEditorUI.Helpers;
 using KeyboardManagerEditorUI.Interop;
 using Microsoft.PowerToys.Settings.UI.Library;
 using Microsoft.UI.Xaml;
@@ -28,6 +29,11 @@ namespace KeyboardManagerEditorUI.Styles
         private ObservableCollection<string> _remappedKeys = new ObservableCollection<string>();
 
         private HotkeySettingsControlHook? _keyboardHook;
+
+        // TeachingTip for notifications
+        private TeachingTip? currentNotification;
+        private DispatcherTimer? notificationTimer;
+
         private bool _disposed;
 
         // Define newMode as a DependencyProperty for binding
@@ -68,6 +74,13 @@ namespace KeyboardManagerEditorUI.Styles
 
         private void InputControl_KeyDown(int key)
         {
+            VirtualKey virtualKey = (VirtualKey)key;
+
+            if (_currentlyPressedKeys.Contains(virtualKey))
+            {
+                return;
+            }
+
             // if no keys are pressed, clear the lists when a new key is pressed
             if (_currentlyPressedKeys.Count == 0)
             {
@@ -83,7 +96,16 @@ namespace KeyboardManagerEditorUI.Styles
                 _keyPressOrder.Clear();
             }
 
-            VirtualKey virtualKey = (VirtualKey)key;
+            // Count current modifiers
+            int modifierCount = _currentlyPressedKeys.Count(k => IsModifierKey(k));
+
+            // If adding this key would exceed the limits (4 modifiers + 1 action key), don't add it and show notification
+            if ((IsModifierKey(virtualKey) && modifierCount >= 4) ||
+                (!IsModifierKey(virtualKey) && _currentlyPressedKeys.Count >= 5))
+            {
+                ShowNotificationTip("Shortcuts can only have up to 4 modifier keys");
+                return;
+            }
 
             // Check if this is a different variant of a modifier key already pressed
             if (IsModifierKey(virtualKey))
@@ -97,6 +119,67 @@ namespace KeyboardManagerEditorUI.Styles
             {
                 _keyPressOrder.Add(virtualKey);
                 UpdateKeysDisplay();
+            }
+        }
+
+        private void ShowNotificationTip(string message)
+        {
+            // If there's already an active notification, close and remove it first
+            CloseExistingNotification();
+
+            // Create a new notification
+            currentNotification = new TeachingTip
+            {
+                Title = "Input Limit Reached",
+                Subtitle = message,
+                IsLightDismissEnabled = true,
+                PreferredPlacement = TeachingTipPlacementMode.Top,
+                XamlRoot = this.XamlRoot,
+                IconSource = new SymbolIconSource { Symbol = Symbol.Important },
+            };
+
+            // Target the toggle button that triggered the notification
+            currentNotification.Target = NewMode ? RemappedToggleBtn : OriginalToggleBtn;
+
+            // Add the notification to the root panel and show it
+            if (this.Content is Panel rootPanel)
+            {
+                rootPanel.Children.Add(currentNotification);
+                currentNotification.IsOpen = true;
+
+                // Create a timer to auto-dismiss the notification
+                notificationTimer = new DispatcherTimer();
+                notificationTimer.Interval = TimeSpan.FromMilliseconds(EditorConstants.DefaultNotificationTimeout);
+                notificationTimer.Tick += (s, e) =>
+                {
+                    CloseExistingNotification();
+                    notificationTimer = null;
+                };
+                notificationTimer.Start();
+            }
+        }
+
+        // Helper method to close existing notifications
+        private void CloseExistingNotification()
+        {
+            // Stop any running timer
+            if (notificationTimer != null)
+            {
+                notificationTimer.Stop();
+                notificationTimer = null;
+            }
+
+            // Close and remove any existing notification
+            if (currentNotification != null && currentNotification.IsOpen)
+            {
+                currentNotification.IsOpen = false;
+
+                if (this.Content is Panel rootPanel)
+                {
+                    rootPanel.Children.Remove(currentNotification);
+                }
+
+                currentNotification = null;
             }
         }
 
@@ -456,6 +539,7 @@ namespace KeyboardManagerEditorUI.Styles
                 if (disposing)
                 {
                     CleanupKeyboardHook();
+                    CloseExistingNotification();
                     Reset();
                 }
 
@@ -493,6 +577,9 @@ namespace KeyboardManagerEditorUI.Styles
             }
 
             UpdateAllAppsCheckBoxState();
+
+            // Close any existing notifications
+            CloseExistingNotification();
 
             // Reset the focus status
             if (this.FocusState != FocusState.Unfocused)

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Styles/InputControl.xaml.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Styles/InputControl.xaml.cs
@@ -85,10 +85,44 @@ namespace KeyboardManagerEditorUI.Styles
 
             VirtualKey virtualKey = (VirtualKey)key;
 
+            // Check if this is a different variant of a modifier key already pressed
+            if (IsModifierKey(virtualKey))
+            {
+                // Remove existing variant of this modifier key if a new one is pressed
+                // This is to ensure that only one variant of a modifier key is displayed at a time
+                RemoveExistingModifierVariant(virtualKey);
+            }
+
             if (_currentlyPressedKeys.Add(virtualKey))
             {
                 _keyPressOrder.Add(virtualKey);
                 UpdateKeysDisplay();
+            }
+        }
+
+        private void RemoveExistingModifierVariant(VirtualKey key)
+        {
+            KeyType keyType = (KeyType)KeyboardManagerInterop.GetKeyType((int)key);
+
+            // No need to remove if the key is an action key
+            if (keyType == KeyType.Action)
+            {
+                return;
+            }
+
+            foreach (var existingKey in _currentlyPressedKeys.ToList())
+            {
+                if (existingKey != key)
+                {
+                    KeyType existingKeyType = (KeyType)KeyboardManagerInterop.GetKeyType((int)existingKey);
+
+                    // Remove the existing key if it is a modifier key and has the same type as the new key
+                    if (existingKeyType == keyType)
+                    {
+                        _currentlyPressedKeys.Remove(existingKey);
+                        _keyPressOrder.Remove(existingKey);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

> [Target feature branch ``feature/KeyboardManagerWinUI3``]

- Add delete remapping function
![image](https://github.com/user-attachments/assets/abffda6b-2936-4f4e-a0ca-ad0eeee7cace)
- Fix the problem that Keyboard Hook is not cleaned properly when the toggle button lost focus (user clicked other checkbox or switched to another app)
- Make sure original toggle button is checked for InputControl by default on Editor launch
- Disable app setting for single key remapping to keep consistent behavior as current editor
![image](https://github.com/user-attachments/assets/f377a93a-e51e-49a6-aee1-2a27f14285f7)
- Ensuring the Modifier Keys that user input don't repeat
- Make sure the shortcut takes at most 4 modifier keys and show notification to the user
![image](https://github.com/user-attachments/assets/c16733e6-b6a8-4c49-bfb4-ae73ec0374b7)
- Add validation to show teaching tip for reserved illegal shortcuts - Win+L and Ctrl+Alt+Delete
![image](https://github.com/user-attachments/assets/c7468d9d-dbf7-48b7-b10e-b57860541fe4)
- Add validation to check if the user is trying to remap a key or shortcut that's already mapped for the same app context
![image](https://github.com/user-attachments/assets/26a243f3-75e3-498a-8a0d-1e5621c9a62a)
- Add validation to make sure key/shortcut cannot be mapped to itself
![image](https://github.com/user-attachments/assets/534494c9-bfed-4f40-bed8-875005b47a16)
- Add validation to check the original/new keys are not empty. Application name must be entered if the specific app checkbox is checked.
![image](https://github.com/user-attachments/assets/bb40a072-973c-432d-b6a9-0ce5ec8e2578)
![image](https://github.com/user-attachments/assets/8494d472-1b51-423e-90a2-1b0f5eb81b93)
![image](https://github.com/user-attachments/assets/5cedaadd-c9a0-42aa-853d-27124f4a10b5)
- Add validation to check shortcuts must contain at least one action key in addition to modifier keys
![image](https://github.com/user-attachments/assets/ac19e9ab-9e22-4bc4-8fe8-f44967895f55)
- Add validation to warn orphaned key to user
![image](https://github.com/user-attachments/assets/d3eee2e5-cd69-4026-a74e-61f29d8e496e)
- Delete the existing remapping when user modified the content


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
See attached screenshots.
