### PR TITLE
CmdPal: Start extensions in parallel

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandManager.cs
@@ -256,32 +256,6 @@ public partial class TopLevelCommandManager : ObservableObject,
         var timer = new Stopwatch();
         timer.Start();
 
-        /*
-
-       // TODO This most definitely needs a lock
-       foreach (var extension in extensions)
-       {
-           Logger.LogDebug($"Starting {extension.PackageFullName}");
-           try
-           {
-               // start it ...
-               await extension.StartExtensionAsync();
-
-               // ... and fetch the command provider from it.
-               CommandProviderWrapper wrapper = new(extension, _taskScheduler);
-               _extensionCommandProviders.Add(wrapper);
-               await LoadTopLevelCommandsFromProvider(wrapper);
-           }
-           catch (Exception ex)
-           {
-               Logger.LogError(ex.ToString());
-           }
-       }
-
-       // */
-
-        // /*
-
         // Start all extensions in parallel
         var startTasks = extensions.Select(async extension =>
         {
@@ -301,21 +275,12 @@ public partial class TopLevelCommandManager : ObservableObject,
         // Wait for all extensions to start
         var wrappers = (await Task.WhenAll(startTasks)).Where(wrapper => wrapper != null).ToList();
 
-        // Load commands serially
         foreach (var wrapper in wrappers)
         {
             _extensionCommandProviders.Add(wrapper!);
-
-            // try
-            // {
-            //    await LoadTopLevelCommandsFromProvider(wrapper!);
-            // }
-            // catch (Exception ex)
-            // {
-            //    Logger.LogError($"Failed to load commands for extension {wrapper!.ExtensionHost?.Extension?.PackageFullName}: {ex}");
-            // }
         }
 
+        // Load the commands from the providers in parallel
         var loadTasks = wrappers.Select(async wrapper =>
         {
             try
@@ -343,9 +308,8 @@ public partial class TopLevelCommandManager : ObservableObject,
             }
         }
 
-        // */
         timer.Stop();
-        Logger.LogDebug($"Loading extensions took {timer.ElapsedMilliseconds} ms ************");
+        Logger.LogDebug($"Loading extensions took {timer.ElapsedMilliseconds} ms");
     }
 
     private void ExtensionService_OnExtensionRemoved(IExtensionService sender, IEnumerable<IExtensionWrapper> extensions)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandManager.cs
@@ -262,7 +262,7 @@ public partial class TopLevelCommandManager : ObservableObject,
             Logger.LogDebug($"Starting {extension.PackageFullName}");
             try
             {
-                await extension.StartExtensionAsync();
+                await extension.StartExtensionAsync().WaitAsync(TimeSpan.FromSeconds(10));
                 return new CommandProviderWrapper(extension, _taskScheduler);
             }
             catch (Exception ex)
@@ -285,7 +285,11 @@ public partial class TopLevelCommandManager : ObservableObject,
         {
             try
             {
-                return await LoadTopLevelCommandsFromProvider(wrapper!);
+                return await LoadTopLevelCommandsFromProvider(wrapper!).WaitAsync(TimeSpan.FromSeconds(10));
+            }
+            catch (TimeoutException)
+            {
+                Logger.LogError($"Loading commands from {wrapper!.ExtensionHost?.Extension?.PackageFullName} timed out");
             }
             catch (Exception ex)
             {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandManager.cs
@@ -86,29 +86,39 @@ public partial class TopLevelCommandManager : ObservableObject,
         //        TopLevelCommands.Add(topLevelViewModel);
         //    }
         // };
-        var commands = await Task.Factory.StartNew(
-            () =>
-            {
-                List<TopLevelViewModel> commands = [];
+        // var commands = await Task.Factory.StartNew(
+        //    () =>
+        //    {
+        //        List<TopLevelViewModel> commands = [];
 
-                // lock (TopLevelCommands)
-                // {
-                foreach (var item in commandProvider.TopLevelItems)
-                {
-                    commands.Add(item);
-                }
+        // // lock (TopLevelCommands)
+        //        // {
+        //        foreach (var item in commandProvider.TopLevelItems)
+        //        {
+        //            commands.Add(item);
+        //        }
 
-                foreach (var item in commandProvider.FallbackItems)
-                {
-                    commands.Add(item);
-                }
+        // foreach (var item in commandProvider.FallbackItems)
+        //        {
+        //            commands.Add(item);
+        //        }
 
-                // }
-                return commands;
-            },
-            CancellationToken.None,
-            TaskCreationOptions.None,
-            _taskScheduler);
+        // // }
+        //        return commands;
+        //    },
+        //    CancellationToken.None,
+        //    TaskCreationOptions.None,
+        //    _taskScheduler);
+        List<TopLevelViewModel> commands = [];
+        foreach (var item in commandProvider.TopLevelItems)
+        {
+            commands.Add(item);
+        }
+
+        foreach (var item in commandProvider.FallbackItems)
+        {
+            commands.Add(item);
+        }
 
         commandProvider.CommandsChanged -= CommandProvider_CommandsChanged;
         commandProvider.CommandsChanged += CommandProvider_CommandsChanged;
@@ -257,59 +267,111 @@ public partial class TopLevelCommandManager : ObservableObject,
         timer.Start();
 
         // Start all extensions in parallel
-        var startTasks = extensions.Select(async extension =>
-        {
-            Logger.LogDebug($"Starting {extension.PackageFullName}");
-            try
-            {
-                await extension.StartExtensionAsync();
-                return new CommandProviderWrapper(extension, _taskScheduler);
-            }
-            catch (Exception ex)
-            {
-                Logger.LogError($"Failed to start extension {extension.PackageFullName}: {ex}");
-                return null; // Return null for failed extensions
-            }
-        });
+        var startTasks = extensions.Select(StartExtensionGetProviderAsync);
 
         // Wait for all extensions to start
-        var wrappers = (await Task.WhenAll(startTasks)).Where(wrapper => wrapper != null).ToList();
+        var wrappers = (await Task.WhenAll(startTasks)).Where(wrapper => wrapper != null).Select(w => w!).ToList();
 
+        // Add all the providers we've started to the list.
         foreach (var wrapper in wrappers)
         {
             _extensionCommandProviders.Add(wrapper!);
         }
 
-        // Load the commands from the providers in parallel
-        var loadTasks = wrappers.Select(async wrapper =>
-        {
-            try
-            {
-                return await LoadTopLevelCommandsFromProvider(wrapper!);
-            }
-            catch (Exception ex)
-            {
-                Logger.LogError($"Failed to load commands for extension {wrapper!.ExtensionHost?.Extension?.PackageFullName}: {ex}");
-            }
-
-            return null;
-        });
+        // Now that they're all started, load the commands from the providers in parallel.
+        var loadTasks = wrappers.Select(LoadCommandsFromProviderWithTimeout);
 
         var commandSets = (await Task.WhenAll(loadTasks)).Where(results => results != null).Select(r => r!).ToList();
 
-        lock (TopLevelCommands)
-        {
-            foreach (var commands in commandSets)
+        await Task.Factory.StartNew(
+            () =>
             {
-                foreach (var c in commands)
+                Logger.LogInfo($"Adding commands for {commandSets} providers");
+
+                // After we got all the commands from all the providers, add them here to our top-level items. Putting them in the top-level in serial after they're all loaded
+                lock (TopLevelCommands)
                 {
-                    TopLevelCommands.Add(c);
+                    foreach (var commands in commandSets)
+                    {
+                        foreach (var c in commands)
+                        {
+                            TopLevelCommands.Add(c);
+                        }
+                    }
                 }
-            }
-        }
+            },
+            CancellationToken.None,
+            TaskCreationOptions.None,
+            _taskScheduler);
 
         timer.Stop();
         Logger.LogDebug($"Loading extensions took {timer.ElapsedMilliseconds} ms");
+    }
+
+    private async Task<IEnumerable<TopLevelViewModel>?> LoadCommandsFromProviderWithTimeout(CommandProviderWrapper wrapper, int milliseconds = 5000)
+    {
+        // var task = LoadCommandsFromProviderAsync(wrapper);
+        // var first = await Task.WhenAny(task, Task.Delay(milliseconds));
+        // if (first == task)
+        // {
+        //    // task completed within timeout
+        //    return await task; // Return the result of the task
+        // }
+        // else
+        // {
+        //    // timeout logic
+        //    Logger.LogError($"Loading commands from {wrapper!.ExtensionHost?.Extension?.PackageFullName} timed out");
+        //    return null; // or handle timeout as needed
+        // }
+        var timer = new Stopwatch();
+        timer.Start();
+        try
+        {
+            var commands = await LoadCommandsFromProviderAsync(wrapper).WaitAsync(TimeSpan.FromMilliseconds(milliseconds));
+            Logger.LogInfo(commands != null ? $"Loaded {commands.Count()} commands from {wrapper.Extension?.ExtensionUniqueId}" : $"Failed to load commands from {wrapper.Extension?.ExtensionUniqueId}");
+
+            timer.Stop();
+            Logger.LogDebug($"Loading {wrapper.Extension?.ExtensionUniqueId} took {timer.ElapsedMilliseconds} ms");
+            return commands;
+
+            // return await TaskExtensions.TimeoutAfter(LoadCommandsFromProviderAsync(wrapper), );
+        }
+        catch (TimeoutException)
+        {
+            Logger.LogError($"Loading commands from {wrapper!.ExtensionHost?.Extension?.PackageFullName} timed out");
+            timer.Stop();
+            Logger.LogDebug($"Loading {wrapper.Extension?.ExtensionUniqueId} took {timer.ElapsedMilliseconds} ms");
+            return null; // or handle timeout as needed
+        }
+    }
+
+    private async Task<IEnumerable<TopLevelViewModel>?> LoadCommandsFromProviderAsync(CommandProviderWrapper wrapper)
+    {
+        try
+        {
+            return await LoadTopLevelCommandsFromProvider(wrapper);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError($"Failed to load commands for extension {wrapper!.ExtensionHost?.Extension?.PackageFullName}: {ex}");
+        }
+
+        return null;
+    }
+
+    private async Task<CommandProviderWrapper?> StartExtensionGetProviderAsync(IExtensionWrapper extension)
+    {
+        Logger.LogDebug($"Starting {extension.PackageFullName}");
+        try
+        {
+            await extension.StartExtensionAsync();
+            return new CommandProviderWrapper(extension, _taskScheduler);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError($"Failed to start extension {extension.PackageFullName}: {ex}");
+            return null; // Return null for failed extensions
+        }
     }
 
     private void ExtensionService_OnExtensionRemoved(IExtensionService sender, IEnumerable<IExtensionWrapper> extensions)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandManager.cs
@@ -76,39 +76,17 @@ public partial class TopLevelCommandManager : ObservableObject,
 
         var settings = _serviceProvider.GetService<SettingsModel>()!;
 
-        // var makeAndAdd = (ICommandItem? i, bool fallback) =>
-        // {
-        //    var commandItemViewModel = new CommandItemViewModel(new(i), weakSelf);
-        //    var topLevelViewModel = new TopLevelViewModel(commandItemViewModel, fallback, commandProvider.ExtensionHost, commandProvider.ProviderId, settings, _serviceProvider);
+        List<TopLevelViewModel> commands = [];
 
-        // lock (TopLevelCommands)
-        //    {
-        //        TopLevelCommands.Add(topLevelViewModel);
-        //    }
-        // };
-        var commands = await Task.Factory.StartNew(
-            () =>
-            {
-                List<TopLevelViewModel> commands = [];
+        foreach (var item in commandProvider.TopLevelItems)
+        {
+            commands.Add(item);
+        }
 
-                // lock (TopLevelCommands)
-                // {
-                foreach (var item in commandProvider.TopLevelItems)
-                {
-                    commands.Add(item);
-                }
-
-                foreach (var item in commandProvider.FallbackItems)
-                {
-                    commands.Add(item);
-                }
-
-                // }
-                return commands;
-            },
-            CancellationToken.None,
-            TaskCreationOptions.None,
-            _taskScheduler);
+        foreach (var item in commandProvider.FallbackItems)
+        {
+            commands.Add(item);
+        }
 
         commandProvider.CommandsChanged -= CommandProvider_CommandsChanged;
         commandProvider.CommandsChanged += CommandProvider_CommandsChanged;


### PR DESCRIPTION
This reduces our extension startup time by approximately 70% on my
machine (I have 17 extensions). I'd guess the gains scale with the
number of extensions. That's 8s -> 3s on average, and now I also get 2.5s reloads.

This retains the order of the list of extensions, by only starting the
processes in parallel. Once we have all the command provider instances,
then actually retrieving the commands.

It also adds a timeout on startup & load, so that one misbehaving extension won't block everyone else.

closes: #38529