### PR TITLE
Dismiss the details pane when the list gets emptied

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListViewModel.cs
@@ -328,7 +328,19 @@ public partial class ListViewModel : PageViewModel, IDisposable
     }
 
     [RelayCommand]
-    private void UpdateSelectedItem(ListItemViewModel item)
+    private void UpdateSelectedItem(ListItemViewModel? item)
+    {
+        if (item != null)
+        {
+            SetSelectedItem(item);
+        }
+        else
+        {
+            ClearSelectedItem();
+        }
+    }
+
+    private void SetSelectedItem(ListItemViewModel item)
     {
         if (!item.SafeSlowInit())
         {
@@ -354,6 +366,23 @@ public partial class ListViewModel : PageViewModel, IDisposable
                }
 
                TextToSuggest = item.TextToSuggest;
+           });
+    }
+
+    private void ClearSelectedItem()
+    {
+        // GH #322:
+        // For inexplicable reasons, if you try updating the command bar and
+        // the details on the same UI thread tick as updating the list, we'll
+        // explode
+        DoOnUiThread(
+           () =>
+           {
+               WeakReferenceMessenger.Default.Send<UpdateCommandBarMessage>(new(null));
+
+               WeakReferenceMessenger.Default.Send<HideDetailsMessage>();
+
+               TextToSuggest = string.Empty;
            });
     }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml.cs
@@ -124,14 +124,12 @@ public sealed partial class ListPage : Page,
     [System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "VS is too aggressive at pruning methods bound in XAML")]
     private void ItemsList_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
-        if (ItemsList.SelectedItem is ListItemViewModel item)
+        var vm = ViewModel;
+        var li = ItemsList.SelectedItem as ListItemViewModel;
+        _ = Task.Run(() =>
         {
-            var vm = ViewModel;
-            _ = Task.Run(() =>
-            {
-                vm?.UpdateSelectedItemCommand.Execute(item);
-            });
-        }
+            vm?.UpdateSelectedItemCommand.Execute(li);
+        });
 
         // There's mysterious behavior here, where the selection seemingly
         // changes to _nothing_ when we're backspacing to a single character.

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
@@ -418,9 +418,6 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
     {
         _ = DispatcherQueue.TryEnqueue(() =>
         {
-            // Also hide our details pane about here, if we had one
-            HideDetails();
-
             if (_settingsWindow == null)
             {
                 _settingsWindow = new SettingsWindow();


### PR DESCRIPTION
I cannot find an issue for this. I swear I filed it somewhere.

If you open winget, search for "terminal", wait till it loads, then hit `esc`, we'll clear the search and empty the list, but never actually hide the details pane. That looks weird.

This fixes that.

Closes _nothing i guess_.
