### PR TITLE
cmdpal: unset the command if we don't find a command

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandItemViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandItemViewModel.cs
@@ -190,7 +190,7 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel, ICommandBa
             contextItem.SlowInitializeProperties();
         });
 
-        if (!string.IsNullOrEmpty(model.Command.Name))
+        if (!string.IsNullOrEmpty(model.Command?.Name))
         {
             _defaultCommandContextItem = new(new CommandContextItem(model.Command!), PageContext)
             {

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.System/FallbackSystemCommandItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.System/FallbackSystemCommandItem.cs
@@ -32,6 +32,7 @@ internal sealed partial class FallbackSystemCommandItem : FallbackCommandItem
     {
         if (string.IsNullOrWhiteSpace(query))
         {
+            Command = null;
             Title = string.Empty;
             Subtitle = string.Empty;
             return;
@@ -58,6 +59,7 @@ internal sealed partial class FallbackSystemCommandItem : FallbackCommandItem
 
         if (result == null)
         {
+            Command = null;
             Title = string.Empty;
             Subtitle = string.Empty;
 

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.System/Pages/SystemCommandPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.System/Pages/SystemCommandPage.cs
@@ -10,12 +10,12 @@ namespace Microsoft.CmdPal.Ext.System.Pages;
 
 public sealed partial class SystemCommandPage : ListPage
 {
-    private SettingsManager _settingsManager;
+    private readonly SettingsManager _settingsManager;
 
     public SystemCommandPage(SettingsManager settingsManager)
     {
-        Title = Resources.Microsoft_plugin_ext_system_page_name;
-        Name = Resources.Microsoft_plugin_ext_system_page_name;
+        Title = Resources.Microsoft_plugin_ext_system_page_title;
+        Name = Resources.Microsoft_plugin_command_name_open;
         Icon = IconHelpers.FromRelativePath("Assets\\SystemCommand.svg");
         _settingsManager = settingsManager;
         ShowDetails = true;

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.System/Properties/Resources.Designer.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.System/Properties/Resources.Designer.cs
@@ -205,11 +205,20 @@ namespace Microsoft.CmdPal.Ext.System {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Windows System Command.
+        ///   Looks up a localized string similar to System Commands.
         /// </summary>
         public static string Microsoft_plugin_ext_system_page_name {
             get {
                 return ResourceManager.GetString("Microsoft_plugin_ext_system_page_name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Windows System Commands.
+        /// </summary>
+        public static string Microsoft_plugin_ext_system_page_title {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_ext_system_page_title", resourceCulture);
             }
         }
         

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.System/Properties/Resources.resx
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.System/Properties/Resources.resx
@@ -160,8 +160,11 @@
   <data name="Microsoft_plugin_ext_settings_hideDisconnectedNetworkInfo" xml:space="preserve">
     <value>Hide disconnected network info</value>
   </data>
+  <data name="Microsoft_plugin_ext_system_page_title" xml:space="preserve">
+    <value>Windows System Commands</value>
+  </data>
   <data name="Microsoft_plugin_ext_system_page_name" xml:space="preserve">
-    <value>Windows System Command</value>
+    <value>System Commands</value>
   </data>
   <data name="Microsoft_plugin_sys_AdapterName" xml:space="preserve">
     <value>Adapter name</value>

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.System/SystemCommandExtensionProvider.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.System/SystemCommandExtensionProvider.cs
@@ -14,7 +14,7 @@ public partial class SystemCommandExtensionProvider : CommandProvider
     private readonly ICommandItem[] _commands;
     private static readonly SettingsManager _settingsManager = new();
     public static readonly SystemCommandPage Page = new(_settingsManager);
-    private readonly FallbackSystemCommandItem _fallbackFileItem = new(_settingsManager);
+    private readonly FallbackSystemCommandItem _fallbackSystemItem = new(_settingsManager);
 
     public SystemCommandExtensionProvider()
     {
@@ -23,7 +23,7 @@ public partial class SystemCommandExtensionProvider : CommandProvider
         _commands = [
             new CommandItem(Page)
             {
-                Title = Resources.Microsoft_plugin_ext_system_page_name,
+                Title = Resources.Microsoft_plugin_ext_system_page_title,
                 Icon = Page.Icon,
                 MoreCommands = [new CommandContextItem(_settingsManager.Settings.SettingsPage)],
             },
@@ -38,5 +38,5 @@ public partial class SystemCommandExtensionProvider : CommandProvider
         return _commands;
     }
 
-    public override IFallbackCommandItem[] FallbackCommands() => [_fallbackFileItem];
+    public override IFallbackCommandItem[] FallbackCommands() => [_fallbackSystemItem];
 }


### PR DESCRIPTION
On a reload, the system commands fallback would leave the "restart" fallback behind, for the same reason as what we found around e40372c & ef264d9 in #38455


closes nothing, these are just nits