### PR TITLE
Change PowerRename accelerator key from "W" to "R"

### DIFF
--- a/src/modules/powerrename/dll/Resources.resx
+++ b/src/modules/powerrename/dll/Resources.resx
@@ -126,7 +126,7 @@
     <comment>do not loc, product name</comment>
   </data>
   <data name="PowerRename_Context_Menu_Entry" xml:space="preserve">
-    <value>Rename with Po&amp;werRename</value>
+    <value>Rename with Power&amp;Rename</value>
     <comment>PowerRename is a product name. do not loc it. The &amp; allows to use W as a keyboard accelerator.</comment>
   </data>
   <data name="Settings_Description" xml:space="preserve">


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
In the Windows Explorer context menu, using "w" as the accelerator key in Po"w"erRename conflicts with the Ne"w" command. This slows down people who have to do things like create new folders frequently (especially because muscle memory leads to PowerRename launching and then having to be closed before going and creating the new folder with a bunch of mouse clicks).

Changing the accelerator key to "R" - Power"R"ename - only conflicts with "Personalize", which is less commonly used.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
- [x] **Closes:** #25873 #39288
