### PR TITLE
[peek, explorer] Update QOI reader for 3-channel images

### DIFF
--- a/src/common/FilePreviewCommon/QoiImage.cs
+++ b/src/common/FilePreviewCommon/QoiImage.cs
@@ -92,6 +92,9 @@ namespace Microsoft.PowerToys.FilePreviewCommon
                 var run = 0;
                 var chunksLen = fileSize - QOI_PADDING_LENGTH;
 
+                var x = 0;
+                var rowAdd = bitmapData.Stride - (channels * bitmapData.Width);
+
                 for (var dataIndex = 0; dataIndex < dataLength; dataIndex += channels)
                 {
                     if (run > 0)
@@ -152,6 +155,14 @@ namespace Microsoft.PowerToys.FilePreviewCommon
                         {
                             bitmapPixel[3] = pixel.A;
                         }
+                    }
+
+                    x++;
+                    if (x == bitmapData.Width)
+                    {
+                        // We align dataIndex with the stride
+                        dataIndex += rowAdd;
+                        x = 0;
                     }
                 }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Make sure we account for Bitmap row length being a multiple of 4 when reading Qoi files.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #31948
- [ ] **Communication:** Not discussed, but a bug fix
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments



<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Built and run and restarted file explorer.
Sample files from my comment on the issue (after rewriting each one to force the thumbnail to regenrate):
![image](https://github.com/user-attachments/assets/5874f958-0f03-4683-abe3-d54c979ad2a1)
