### PR TITLE
Support pipeline running on win11 x64

### DIFF
--- a/.pipelines/v2/templates/job-test-project.yml
+++ b/.pipelines/v2/templates/job-test-project.yml
@@ -28,11 +28,15 @@ jobs:
     ${{ if eq(variables['System.CollectionId'], 'cb55739e-4afe-46a3-970f-1b49d8ee7564') }}:
       ${{ if ne(parameters.platform, 'ARM64') }}:
         name: SHINE-INT-Testing-x64
+        ${{ if and(eq(parameters.isUIAutomationPipeline, true), eq(parameters.platform, 'win11-x64')) }}:
+          demands: ImageOverride -equals SHINE-W11-Testing
       ${{ else }}:
         name: SHINE-INT-Testing-arm64
     ${{ else }}:
       ${{ if ne(parameters.platform, 'ARM64') }}:
         name: SHINE-OSS-Testing-x64
+        ${{ if and(eq(parameters.isUIAutomationPipeline, true), eq(parameters.platform, 'win11-x64')) }}:
+          demands: ImageOverride -equals SHINE-W11-Testing
       ${{ else }}:
         name: SHINE-OSS-Testing-arm64
   steps:

--- a/.pipelines/v2/templates/job-test-project.yml
+++ b/.pipelines/v2/templates/job-test-project.yml
@@ -20,7 +20,10 @@ jobs:
   displayName: Test ${{ parameters.platform }} ${{ parameters.configuration }}
   timeoutInMinutes: 300
   variables:
-    BuildPlatform: ${{ if eq(parameters.platform, 'x64Win10') || eq(parameters.platform, 'x64Win11') }}x64${{ else }}${{ parameters.platform }}${{ end }}
+    ${{ if or(eq(parameters.platform, 'x64Win10'), eq(parameters.platform, 'x64Win11')) }}:
+      BuildPlatform: x64
+    ${{ else }}:
+      BuildPlatform: ${{ parameters.platform }}
     BuildConfiguration: ${{ parameters.configuration }}
     SrcPath: $(Build.Repository.LocalPath)
     TestArtifactsName: build-${{ variables.BuildPlatform }}-${{ parameters.configuration }}${{ parameters.inputArtifactStem }}

--- a/.pipelines/v2/templates/job-test-project.yml
+++ b/.pipelines/v2/templates/job-test-project.yml
@@ -23,7 +23,7 @@ jobs:
     BuildPlatform: ${{ parameters.platform }}
     BuildConfiguration: ${{ parameters.configuration }}
     SrcPath: $(Build.Repository.LocalPath)
-    TestArtifactsName: build-${{ parameters.platform }}-${{ parameters.configuration }}${{ parameters.inputArtifactStem }}
+    TestArtifactsName: build-${{ parameters.platform == 'x64Win10' || parameters.platform == 'x64Win11' ? 'x64' : parameters.platform }}-${{ parameters.configuration }}${{ parameters.inputArtifactStem }}
   pool:
     ${{ if eq(variables['System.CollectionId'], 'cb55739e-4afe-46a3-970f-1b49d8ee7564') }}:
       ${{ if ne(parameters.platform, 'ARM64') }}:

--- a/.pipelines/v2/templates/job-test-project.yml
+++ b/.pipelines/v2/templates/job-test-project.yml
@@ -20,10 +20,10 @@ jobs:
   displayName: Test ${{ parameters.platform }} ${{ parameters.configuration }}
   timeoutInMinutes: 300
   variables:
-    BuildPlatform: ${{ parameters.platform }}
+    BuildPlatform: ${{ if eq(parameters.platform, 'x64Win10') || eq(parameters.platform, 'x64Win11') }}x64${{ else }}${{ parameters.platform }}${{ end }}
     BuildConfiguration: ${{ parameters.configuration }}
     SrcPath: $(Build.Repository.LocalPath)
-    TestArtifactsName: build-${{ parameters.platform == 'x64Win10' || parameters.platform == 'x64Win11' ? 'x64' : parameters.platform }}-${{ parameters.configuration }}${{ parameters.inputArtifactStem }}
+    TestArtifactsName: build-${{ variables.BuildPlatform }}-${{ parameters.configuration }}${{ parameters.inputArtifactStem }}
   pool:
     ${{ if eq(variables['System.CollectionId'], 'cb55739e-4afe-46a3-970f-1b49d8ee7564') }}:
       ${{ if ne(parameters.platform, 'ARM64') }}:

--- a/.pipelines/v2/templates/job-test-project.yml
+++ b/.pipelines/v2/templates/job-test-project.yml
@@ -28,14 +28,14 @@ jobs:
     ${{ if eq(variables['System.CollectionId'], 'cb55739e-4afe-46a3-970f-1b49d8ee7564') }}:
       ${{ if ne(parameters.platform, 'ARM64') }}:
         name: SHINE-INT-Testing-x64
-        ${{ if and(eq(parameters.isUIAutomationPipeline, true), eq(parameters.platform, 'win11-x64')) }}:
+        ${{ if and(eq(parameters.isUIAutomationPipeline, true), eq(parameters.platform, 'x64Win11')) }}:
           demands: ImageOverride -equals SHINE-W11-Testing
       ${{ else }}:
         name: SHINE-INT-Testing-arm64
     ${{ else }}:
       ${{ if ne(parameters.platform, 'ARM64') }}:
         name: SHINE-OSS-Testing-x64
-        ${{ if and(eq(parameters.isUIAutomationPipeline, true), eq(parameters.platform, 'win11-x64')) }}:
+        ${{ if and(eq(parameters.isUIAutomationPipeline, true), eq(parameters.platform, 'x64Win11')) }}:
           demands: ImageOverride -equals SHINE-W11-Testing
       ${{ else }}:
         name: SHINE-OSS-Testing-arm64

--- a/.pipelines/v2/templates/pipeline-ui-tests-automation.yml
+++ b/.pipelines/v2/templates/pipeline-ui-tests-automation.yml
@@ -48,8 +48,8 @@ stages:
             useVSPreview: ${{ parameters.useVSPreview }}
 
     - ${{ if eq(platform, 'x64') }}:
-      - stage: Test_${{ platform }}
-        displayName: Test ${{ platform }}
+      - stage: Test_x64Win10
+        displayName: Test x64Win10
         dependsOn:
           - Build_${{platform}}
         jobs:
@@ -59,6 +59,13 @@ stages:
                 configuration: Release
                 useLatestWebView2: ${{ parameters.useLatestWebView2 }}
                 isUIAutomationPipeline: true
+
+    - ${{ if eq(platform, 'x64') }}:
+      - stage: Test_x64Win11
+        displayName: Test x64Win11
+        dependsOn:
+          - Build_${{platform}}
+        jobs:
             - template: job-test-project.yml
               parameters:
                 platform: x64Win11

--- a/.pipelines/v2/templates/pipeline-ui-tests-automation.yml
+++ b/.pipelines/v2/templates/pipeline-ui-tests-automation.yml
@@ -11,7 +11,8 @@ parameters:
   - name: buildPlatforms
     type: object
     default:
-      - x64
+      - win10-x64
+      - win11-x64
       - arm64
   - name: enableMsBuildCaching
     type: boolean

--- a/.pipelines/v2/templates/pipeline-ui-tests-automation.yml
+++ b/.pipelines/v2/templates/pipeline-ui-tests-automation.yml
@@ -11,8 +11,7 @@ parameters:
   - name: buildPlatforms
     type: object
     default:
-      - x64Win10
-      - x64Win11
+      - x64
       - arm64
   - name: enableMsBuildCaching
     type: boolean
@@ -48,6 +47,32 @@ stages:
             buildTests: true
             useVSPreview: ${{ parameters.useVSPreview }}
 
+    - ${{ if eq(platform, 'x64') }}:
+      - stage: Test x64Win10
+        displayName: Test x64Win10
+        dependsOn:
+          - Build_${{platform}}
+        jobs:
+          - template: job-test-project.yml
+            parameters:
+              platform: x64Win10
+              configuration: Release
+              useLatestWebView2: ${{ parameters.useLatestWebView2 }}
+              isUIAutomationPipeline: true
+
+      - stage: Test x64Win11
+        displayName: Test x64Win11
+        dependsOn:
+          - Build_${{platform}}
+        jobs:
+          - template: job-test-project.yml
+            parameters:
+              platform: x64Win11
+              configuration: Release
+              useLatestWebView2: ${{ parameters.useLatestWebView2 }}
+              isUIAutomationPipeline: true
+
+    ${{ else }}:
     - stage: Test_${{ platform }}
       displayName: Test ${{ platform }}
       dependsOn:

--- a/.pipelines/v2/templates/pipeline-ui-tests-automation.yml
+++ b/.pipelines/v2/templates/pipeline-ui-tests-automation.yml
@@ -53,22 +53,18 @@ stages:
         dependsOn:
           - Build_${{platform}}
         jobs:
-          - job: Test_x64Win10
-            steps:
-              - template: job-test-project.yml
-                parameters:
-                  platform: x64Win10
-                  configuration: Release
-                  useLatestWebView2: ${{ parameters.useLatestWebView2 }}
-                  isUIAutomationPipeline: true
-          - job: Test_x64Win11
-            steps:
-              - template: job-test-project.yml
-                parameters:
-                  platform: x64Win11
-                  configuration: Release
-                  useLatestWebView2: ${{ parameters.useLatestWebView2 }}
-                  isUIAutomationPipeline: true
+            - template: job-test-project.yml
+              parameters:
+                platform: x64Win10
+                configuration: Release
+                useLatestWebView2: ${{ parameters.useLatestWebView2 }}
+                isUIAutomationPipeline: true
+            - template: job-test-project.yml
+              parameters:
+                platform: x64Win11
+                configuration: Release
+                useLatestWebView2: ${{ parameters.useLatestWebView2 }}
+                isUIAutomationPipeline: true
 
     - ${{ if ne(platform, 'x64') }}:
       - stage: Test_${{ platform }}

--- a/.pipelines/v2/templates/pipeline-ui-tests-automation.yml
+++ b/.pipelines/v2/templates/pipeline-ui-tests-automation.yml
@@ -48,29 +48,27 @@ stages:
             useVSPreview: ${{ parameters.useVSPreview }}
 
     - ${{ if eq(platform, 'x64') }}:
-      - stage: Test x64Win10
-        displayName: Test x64Win10
+      - stage: Test x64
+        displayName: Test x64
         dependsOn:
           - Build_${{platform}}
         jobs:
-          - template: job-test-project.yml
-            parameters:
-              platform: x64Win10
-              configuration: Release
-              useLatestWebView2: ${{ parameters.useLatestWebView2 }}
-              isUIAutomationPipeline: true
-
-      - stage: Test x64Win11
-        displayName: Test x64Win11
-        dependsOn:
-          - Build_${{platform}}
-        jobs:
-          - template: job-test-project.yml
-            parameters:
-              platform: x64Win11
-              configuration: Release
-              useLatestWebView2: ${{ parameters.useLatestWebView2 }}
-              isUIAutomationPipeline: true
+          - job: Test_x64Win10
+            steps:
+              - template: job-test-project.yml
+                parameters:
+                  platform: x64Win10
+                  configuration: Release
+                  useLatestWebView2: ${{ parameters.useLatestWebView2 }}
+                  isUIAutomationPipeline: true
+          - job: Test_x64Win11
+            steps:
+              - template: job-test-project.yml
+                parameters:
+                  platform: x64Win11
+                  configuration: Release
+                  useLatestWebView2: ${{ parameters.useLatestWebView2 }}
+                  isUIAutomationPipeline: true
 
     ${{ else }}:
     - stage: Test_${{ platform }}

--- a/.pipelines/v2/templates/pipeline-ui-tests-automation.yml
+++ b/.pipelines/v2/templates/pipeline-ui-tests-automation.yml
@@ -70,15 +70,15 @@ stages:
                   useLatestWebView2: ${{ parameters.useLatestWebView2 }}
                   isUIAutomationPipeline: true
 
-    ${{ else }}:
-    - stage: Test_${{ platform }}
-      displayName: Test ${{ platform }}
-      dependsOn:
-        - Build_${{platform}}
-      jobs:
-        - template: job-test-project.yml
-          parameters:
-            platform: ${{ platform }}
-            configuration: Release
-            useLatestWebView2: ${{ parameters.useLatestWebView2 }}
-            isUIAutomationPipeline: true
+    - ${{ if ne(platform, 'x64') }}:
+      - stage: Test_${{ platform }}
+        displayName: Test ${{ platform }}
+        dependsOn:
+          - Build_${{platform}}
+        jobs:
+          - template: job-test-project.yml
+            parameters:
+              platform: ${{ platform }}
+              configuration: Release
+              useLatestWebView2: ${{ parameters.useLatestWebView2 }}
+              isUIAutomationPipeline: true

--- a/.pipelines/v2/templates/pipeline-ui-tests-automation.yml
+++ b/.pipelines/v2/templates/pipeline-ui-tests-automation.yml
@@ -48,8 +48,8 @@ stages:
             useVSPreview: ${{ parameters.useVSPreview }}
 
     - ${{ if eq(platform, 'x64') }}:
-      - stage: Test x64
-        displayName: Test x64
+      - stage: Test_${{ platform }}
+        displayName: Test ${{ platform }}
         dependsOn:
           - Build_${{platform}}
         jobs:

--- a/.pipelines/v2/templates/pipeline-ui-tests-automation.yml
+++ b/.pipelines/v2/templates/pipeline-ui-tests-automation.yml
@@ -11,8 +11,8 @@ parameters:
   - name: buildPlatforms
     type: object
     default:
-      - win10-x64
-      - win11-x64
+      - x64Win10
+      - x64Win11
       - arm64
   - name: enableMsBuildCaching
     type: boolean


### PR DESCRIPTION
This pull request introduces enhancements to the pipeline configurations for testing different platforms, with a focus on Windows 10 and Windows 11 for x64 architecture. The changes aim to improve flexibility and clarity in platform-specific test configurations.

### Updates to platform-specific variables and jobs:
* [`.pipelines/v2/templates/job-test-project.yml`](diffhunk://#diff-c974373b0fb1357dfc0d236a86c304ad1d95acb861f83d472db3a7193e1d88a6R23-R42): Updated the `BuildPlatform` variable to explicitly set `x64` for `x64Win10` and `x64Win11` platforms, ensuring consistent naming in artifact generation. Added conditional demands for `SHINE-W11-Testing` when running UI automation pipelines on `x64Win11`.

### Addition of new test stages for x64 platforms:
* [`.pipelines/v2/templates/pipeline-ui-tests-automation.yml`](diffhunk://#diff-68219acb736b89e7c4ce1939130f504198cbc8c077aa540d5e1b5649f206749eR50-R76): Introduced new test stages `Test_x64Win10` and `Test_x64Win11` for x64 architecture, with dependencies on the corresponding build stage. These stages utilize the `job-test-project.yml` template with parameters tailored for UI automation pipelines.

