### PR TITLE
feat(cmdpal): add pinyin support for Chinese input method

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -95,6 +95,7 @@
     <PackageVersion Include="System.Text.Encoding.CodePages" Version="9.0.4" />
     <PackageVersion Include="System.Text.Json" Version="9.0.4" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
+    <PackageVersion Include="ToolGood.Words.Pinyin" Version="3.1.0.2" />
     <PackageVersion Include="UnicodeInformation" Version="2.6.0" />
     <PackageVersion Include="UnitsNet" Version="5.56.0" />
     <PackageVersion Include="UTF.Unknown" Version="2.5.1" />

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/Microsoft.CommandPalette.Extensions.Toolkit.csproj
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/Microsoft.CommandPalette.Extensions.Toolkit.csproj
@@ -35,6 +35,7 @@
     <PackageReference Include="Microsoft.WindowsAppSDK" />
     <PackageReference Include="Microsoft.Web.WebView2" />
     <PackageReference Include="System.Drawing.Common" />
+    <PackageReference Include="ToolGood.Words.Pinyin" />
     <!-- This line forces the WebView2 version used by Windows App SDK to be the one we expect from Directory.Packages.props . -->
   </ItemGroup>
 

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/StringMatcher.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/StringMatcher.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Globalization;
+using ToolGood.Words.Pinyin;
 
 namespace Microsoft.CommandPalette.Extensions.Toolkit;
 
@@ -70,12 +71,33 @@ public partial class StringMatcher
 
         var bestResult = new MatchResult(false, UserSettingSearchPrecision);
 
-        for (var startIndex = 0; startIndex < stringToCompare.Length; startIndex++)
+        List<string> queryList = [query];
+        List<string> stringToCompareList = [stringToCompare];
+
+        // TODO: Add switch for Chinese.
+        if (true)
         {
-            MatchResult result = FuzzyMatch(query, stringToCompare, opt, startIndex);
-            if (result.Success && (!bestResult.Success || result.Score > bestResult.Score))
+            // Remove IME composition split characters.
+            var input = query.Replace("'", string.Empty);
+            queryList.Add(WordsHelper.GetPinyin(input));
+            if (WordsHelper.HasChinese(stringToCompare))
             {
-                bestResult = result;
+                stringToCompareList.Add(WordsHelper.GetPinyin(stringToCompare));
+            }
+        }
+
+        foreach (var currentQuery in queryList)
+        {
+            foreach (var currentStringToCompare in stringToCompareList)
+            {
+                for (var startIndex = 0; startIndex < currentStringToCompare.Length; startIndex++)
+                {
+                    MatchResult result = FuzzyMatch(currentQuery, currentStringToCompare, opt, startIndex);
+                    if (result.Success && (!bestResult.Success || result.Score > bestResult.Score))
+                    {
+                        bestResult = result;
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

- Add ToolGood.Words.Pinyin package to support pinyin conversion
- Implement pinyin matching in StringMatcher class
- Update project dependencies and Directory.Packages.props

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #38417
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

I've completed a rough implementation of pinyin support, but since I'm currently unsure where to add the toggle for pinyin support, this feature is enabled by default for now.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

