### PR TITLE
[Fuzzing test] Use valid areaPath in OneFuzz configuration

### DIFF
--- a/src/modules/AdvancedPaste/AdvancedPaste.FuzzTests/OneFuzzConfig.json
+++ b/src/modules/AdvancedPaste/AdvancedPaste.FuzzTests/OneFuzzConfig.json
@@ -17,7 +17,7 @@
         "org": "microsoft",
         "project": "OS",
         "AssignedTo": "leilzh@microsoft.com",
-        "AreaPath": "OS\\Windows Client and Services\\WinPD\\DEEP-Developer Experience, Ecosystem and Partnerships\\SHINE\\PowerToys",
+        "AreaPath": "OS\\Windows Client and Services\\WinPD\\DEEP-Developer Experience, Ecosystem and Partnerships\\DIVE\\SALT",
         "IterationPath": "OS\\Future"
       },
       "jobNotificationEmail": "leilzh@microsoft.com",

--- a/src/modules/Hosts/Hosts.FuzzTests/OneFuzzConfig.json
+++ b/src/modules/Hosts/Hosts.FuzzTests/OneFuzzConfig.json
@@ -17,7 +17,7 @@
         "org": "microsoft",
         "project": "OS",
         "AssignedTo": "mengyuanchen@microsoft.com",
-        "AreaPath": "OS\\Windows Client and Services\\WinPD\\DEEP-Developer Experience, Ecosystem and Partnerships\\SHINE\\PowerToys",
+        "AreaPath": "OS\\Windows Client and Services\\WinPD\\DEEP-Developer Experience, Ecosystem and Partnerships\\DIVE\\SALT",
         "IterationPath": "OS\\Future"
       },
       "jobNotificationEmail": "mengyuanchen@microsoft.com",
@@ -58,7 +58,7 @@
         "org": "microsoft",
         "project": "OS",
         "AssignedTo": "mengyuanchen@microsoft.com",
-        "AreaPath": "OS\\Windows Client and Services\\WinPD\\DEEP-Developer Experience, Ecosystem and Partnerships\\SHINE\\PowerToys",
+        "AreaPath": "OS\\Windows Client and Services\\WinPD\\DEEP-Developer Experience, Ecosystem and Partnerships\\DIVE\\SALT",
         "IterationPath": "OS\\Future"
       },
       "jobNotificationEmail": "mengyuanchen@microsoft.com",
@@ -99,7 +99,7 @@
         "org": "microsoft",
         "project": "OS",
         "AssignedTo": "mengyuanchen@microsoft.com",
-        "AreaPath": "OS\\Windows Client and Services\\WinPD\\DEEP-Developer Experience, Ecosystem and Partnerships\\SHINE\\PowerToys",
+        "AreaPath": "OS\\Windows Client and Services\\WinPD\\DEEP-Developer Experience, Ecosystem and Partnerships\\DIVE\\SALT",
         "IterationPath": "OS\\Future"
       },
       "jobNotificationEmail": "mengyuanchen@microsoft.com",
@@ -140,7 +140,7 @@
         "org": "microsoft",
         "project": "OS",
         "AssignedTo": "mengyuanchen@microsoft.com",
-        "AreaPath": "OS\\Windows Client and Services\\WinPD\\DEEP-Developer Experience, Ecosystem and Partnerships\\SHINE\\PowerToys",
+        "AreaPath": "OS\\Windows Client and Services\\WinPD\\DEEP-Developer Experience, Ecosystem and Partnerships\\DIVE\\SALT",
         "IterationPath": "OS\\Future"
       },
       "jobNotificationEmail": "mengyuanchen@microsoft.com",

--- a/src/modules/registrypreview/RegistryPreview.FuzzTests/OneFuzzConfig.json
+++ b/src/modules/registrypreview/RegistryPreview.FuzzTests/OneFuzzConfig.json
@@ -20,7 +20,7 @@
         "org": "microsoft",
         "project": "OS",
         "AssignedTo": "mengyuanchen@microsoft.com",
-        "AreaPath": "OS\\Windows Client and Services\\WinPD\\DEEP-Developer Experience, Ecosystem and Partnerships\\SHINE\\PowerToys",
+        "AreaPath": "OS\\Windows Client and Services\\WinPD\\DEEP-Developer Experience, Ecosystem and Partnerships\\DIVE\\SALT",
         "IterationPath": "OS\\Future"
       },
       "jobNotificationEmail": "mengyuanchen@microsoft.com",
@@ -61,7 +61,7 @@
         "org": "microsoft",
         "project": "OS",
         "AssignedTo": "mengyuanchen@microsoft.com",
-        "AreaPath": "OS\\Windows Client and Services\\WinPD\\DEEP-Developer Experience, Ecosystem and Partnerships\\SHINE\\PowerToys",
+        "AreaPath": "OS\\Windows Client and Services\\WinPD\\DEEP-Developer Experience, Ecosystem and Partnerships\\DIVE\\SALT",
         "IterationPath": "OS\\Future"
       },
       "jobNotificationEmail": "mengyuanchen@microsoft.com",


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
The Area Path "OS\Windows Client and Services\WinPD\DEEP-Developer Experience, Ecosystem and Partnerships\SHINE\PowerToys" is invalid. change it to "OS\Windows Client and Services\WinPD\DEEP-Developer Experience, Ecosystem and Partnerships\DIVE\SALT" for the fuzzing test config

fuzz job errot:
![image](https://github.com/user-attachments/assets/0351b4e9-4649-45e5-ae21-023347d21659)


