### PR TITLE
Bump our telemetry package version

### DIFF
--- a/.pipelines/packages.config
+++ b/.pipelines/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.PowerToys.Telemetry" version="2.0.2" />
+  <package id="Microsoft.PowerToys.Telemetry" version="2.0.3" />
 </packages>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Events/BeginInvoke.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Events/BeginInvoke.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics.Tracing;
-using Microsoft.CommandPalette.Extensions;
 using Microsoft.PowerToys.Telemetry;
 using Microsoft.PowerToys.Telemetry.Events;
 
@@ -13,4 +12,9 @@ namespace Microsoft.CmdPal.UI.Events;
 public class BeginInvoke : EventBase, IEvent
 {
     public PartA_PrivTags PartA_PrivTags => PartA_PrivTags.ProductAndServiceUsage;
+
+    public BeginInvoke()
+    {
+        EventName = "CmdPal_BeginInvoke";
+    }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Events/ColdLaunch.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Events/ColdLaunch.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics.Tracing;
-using Microsoft.CommandPalette.Extensions;
 using Microsoft.PowerToys.Telemetry;
 using Microsoft.PowerToys.Telemetry.Events;
 
@@ -13,4 +12,9 @@ namespace Microsoft.CmdPal.UI.Events;
 public class ColdLaunch : EventBase, IEvent
 {
     public PartA_PrivTags PartA_PrivTags => PartA_PrivTags.ProductAndServiceUsage;
+
+    public ColdLaunch()
+    {
+        EventName = "CmdPal_ColdLaunch";
+    }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Events/OpenPage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Events/OpenPage.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics.Tracing;
-using Microsoft.CommandPalette.Extensions;
 using Microsoft.PowerToys.Telemetry;
 using Microsoft.PowerToys.Telemetry.Events;
 
@@ -17,6 +16,8 @@ public class OpenPage : EventBase, IEvent
     public OpenPage(int pageDepth)
     {
         PageDepth = pageDepth;
+
+        EventName = "CmdPal_OpenPage";
     }
 
     public PartA_PrivTags PartA_PrivTags => PartA_PrivTags.ProductAndServiceUsage;

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Events/ReactivateInstance.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Events/ReactivateInstance.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics.Tracing;
-using Microsoft.CommandPalette.Extensions;
 using Microsoft.PowerToys.Telemetry;
 using Microsoft.PowerToys.Telemetry.Events;
 
@@ -13,4 +12,9 @@ namespace Microsoft.CmdPal.UI.Events;
 public class ReactivateInstance : EventBase, IEvent
 {
     public PartA_PrivTags PartA_PrivTags => PartA_PrivTags.ProductAndServiceUsage;
+
+    public ReactivateInstance()
+    {
+        EventName = "CmdPal_ReactivateInstance";
+    }
 }


### PR DESCRIPTION
Data collection is hard.

Our internal package, which was last bumped around August 2024, mistakenly changed a load bearing string from `ETW_GROUP` to `MSPG_GROUP`. The former sets the ETW group id. The latter does nothing.

This PR represents bumping our dependency to the version with the fix.

Considering that none of our data for CmdPal worked anyways, I took the opportunity to rename a bunch of our events that had totally generic names.

Closes #38704

re: #38032
regressed around: #34078
