### PR TITLE
[Fuzzing test] Use valid areaPath in OneFuzz configuration

### DIFF
--- a/src/modules/AdvancedPaste/AdvancedPaste.FuzzTests/OneFuzzConfig.json
+++ b/src/modules/AdvancedPaste/AdvancedPaste.FuzzTests/OneFuzzConfig.json
@@ -17,7 +17,7 @@
         "org": "microsoft",
         "project": "OS",
         "AssignedTo": "leilzh@microsoft.com",
-        "AreaPath": "OS\\Windows Client and Services\\WinPD\\DEEP-Developer Experience, Ecosystem and Partnerships\\DIVE\\SALT",
+        "AreaPath": "OS\\Windows Client and Services\\WinPD\\DFX-Developer Fundamentals and Experiences\\DEFT\\SALT",
         "IterationPath": "OS\\Future"
       },
       "jobNotificationEmail": "leilzh@microsoft.com",

--- a/src/modules/Hosts/Hosts.FuzzTests/OneFuzzConfig.json
+++ b/src/modules/Hosts/Hosts.FuzzTests/OneFuzzConfig.json
@@ -17,7 +17,7 @@
         "org": "microsoft",
         "project": "OS",
         "AssignedTo": "mengyuanchen@microsoft.com",
-        "AreaPath": "OS\\Windows Client and Services\\WinPD\\DEEP-Developer Experience, Ecosystem and Partnerships\\DIVE\\SALT",
+        "AreaPath": "OS\\Windows Client and Services\\WinPD\\DFX-Developer Fundamentals and Experiences\\DEFT\\SALT",
         "IterationPath": "OS\\Future"
       },
       "jobNotificationEmail": "mengyuanchen@microsoft.com",
@@ -58,7 +58,7 @@
         "org": "microsoft",
         "project": "OS",
         "AssignedTo": "mengyuanchen@microsoft.com",
-        "AreaPath": "OS\\Windows Client and Services\\WinPD\\DEEP-Developer Experience, Ecosystem and Partnerships\\DIVE\\SALT",
+        "AreaPath": "OS\\Windows Client and Services\\WinPD\\DFX-Developer Fundamentals and Experiences\\DEFT\\SALT",
         "IterationPath": "OS\\Future"
       },
       "jobNotificationEmail": "mengyuanchen@microsoft.com",
@@ -99,7 +99,7 @@
         "org": "microsoft",
         "project": "OS",
         "AssignedTo": "mengyuanchen@microsoft.com",
-        "AreaPath": "OS\\Windows Client and Services\\WinPD\\DEEP-Developer Experience, Ecosystem and Partnerships\\DIVE\\SALT",
+        "AreaPath": "OS\\Windows Client and Services\\WinPD\\DFX-Developer Fundamentals and Experiences\\DEFT\\SALT",
         "IterationPath": "OS\\Future"
       },
       "jobNotificationEmail": "mengyuanchen@microsoft.com",
@@ -140,7 +140,7 @@
         "org": "microsoft",
         "project": "OS",
         "AssignedTo": "mengyuanchen@microsoft.com",
-        "AreaPath": "OS\\Windows Client and Services\\WinPD\\DEEP-Developer Experience, Ecosystem and Partnerships\\DIVE\\SALT",
+        "AreaPath": "OS\\Windows Client and Services\\WinPD\\DFX-Developer Fundamentals and Experiences\\DEFT\\SALT",
         "IterationPath": "OS\\Future"
       },
       "jobNotificationEmail": "mengyuanchen@microsoft.com",

--- a/src/modules/powerrename/PowerRename.FuzzingTest/OneFuzzConfig.json
+++ b/src/modules/powerrename/PowerRename.FuzzingTest/OneFuzzConfig.json
@@ -12,7 +12,7 @@
         "org": "microsoft",
         "project": "OS",
         "AssignedTo": "leilzh@microsoft.com",
-        "AreaPath": "OS\\Windows Client and Services\\WinPD\\DEEP-Developer Experience, Ecosystem and Partnerships\\DIVE\\SALT",
+        "AreaPath": "OS\\Windows Client and Services\\WinPD\\DFX-Developer Fundamentals and Experiences\\DEFT\\SALT",
         "IterationPath": "OS\\Future"
       },
       "jobNotificationEmail": "PowerToys@microsoft.com",

--- a/src/modules/registrypreview/RegistryPreview.FuzzTests/OneFuzzConfig.json
+++ b/src/modules/registrypreview/RegistryPreview.FuzzTests/OneFuzzConfig.json
@@ -20,7 +20,7 @@
         "org": "microsoft",
         "project": "OS",
         "AssignedTo": "mengyuanchen@microsoft.com",
-        "AreaPath": "OS\\Windows Client and Services\\WinPD\\DEEP-Developer Experience, Ecosystem and Partnerships\\DIVE\\SALT",
+        "AreaPath": "OS\\Windows Client and Services\\WinPD\\DFX-Developer Fundamentals and Experiences\\DEFT\\SALT",
         "IterationPath": "OS\\Future"
       },
       "jobNotificationEmail": "mengyuanchen@microsoft.com",
@@ -61,7 +61,7 @@
         "org": "microsoft",
         "project": "OS",
         "AssignedTo": "mengyuanchen@microsoft.com",
-        "AreaPath": "OS\\Windows Client and Services\\WinPD\\DEEP-Developer Experience, Ecosystem and Partnerships\\DIVE\\SALT",
+        "AreaPath": "OS\\Windows Client and Services\\WinPD\\DFX-Developer Fundamentals and Experiences\\DEFT\\SALT",
         "IterationPath": "OS\\Future"
       },
       "jobNotificationEmail": "mengyuanchen@microsoft.com",


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

![image](https://github.com/user-attachments/assets/7425a02a-5251-40cd-bf6b-ac6740948ad1)

change the Area Path to **OS\\Windows Client and Services\\WinPD\\DFX-Developer Fundamentals and Experiences\\DEFT\\SALT**