### PR TITLE
CmdPal: Auto-focus first content

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentPageViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentPageViewModel.cs
@@ -79,6 +79,9 @@ public partial class ContentPageViewModel : PageViewModel, ICommandBarContext
             throw;
         }
 
+        var oneContent = newContent.Count == 1;
+        newContent.ForEach(c => c.OnlyControlOnPage = oneContent);
+
         // Now, back to a UI thread to update the observable collection
         DoOnUiThread(
         () =>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentViewModel.cs
@@ -7,4 +7,5 @@ namespace Microsoft.CmdPal.UI.ViewModels;
 public abstract partial class ContentViewModel(WeakReference<IPageContext> context) :
     ExtensionObjectViewModel(context)
 {
+    public bool OnlyControlOnPage { get; internal set; }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContentFormControl.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContentFormControl.xaml.cs
@@ -113,6 +113,11 @@ public sealed partial class ContentFormControl : UserControl
         {
             element.Loaded -= OnFrameworkElementLoaded;
 
+            if (!ViewModel?.OnlyControlOnPage ?? true)
+            {
+                return;
+            }
+
             // Focus on the first focusable element asynchronously to ensure the visual tree is fully built
             element.DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Normal, () =>
             {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContentFormControl.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContentFormControl.xaml.cs
@@ -135,16 +135,10 @@ public sealed partial class ContentFormControl : UserControl
             if (child is Control control &&
                 control.IsEnabled &&
                 control.IsTabStop &&
-                control.Visibility == Visibility.Visible)
+                control.Visibility == Visibility.Visible &&
+                control.AllowFocusOnInteraction)
             {
-                // TextBox and ComboBox are the most common form input controls
-                if (control is TextBox || control is ComboBox ||
-                    control is CheckBox || control is RadioButton ||
-                    control is ToggleSwitch || control is Slider ||
-                    control is NumberBox || control is DatePicker)
-                {
-                    return control;
-                }
+                return control;
             }
 
             // Recursively check children

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContentFormControl.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContentFormControl.xaml.cs
@@ -5,7 +5,9 @@
 using AdaptiveCards.ObjectModel.WinUI3;
 using AdaptiveCards.Rendering.WinUI3;
 using Microsoft.CmdPal.UI.ViewModels;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
 
 namespace Microsoft.CmdPal.UI.Controls;
 
@@ -96,9 +98,64 @@ public sealed partial class ContentFormControl : UserControl
         if (_renderedCard.FrameworkElement != null)
         {
             ContentGrid.Children.Add(_renderedCard.FrameworkElement);
+
+            // Use the Loaded event to ensure we focus after the card is in the visual tree
+            _renderedCard.FrameworkElement.Loaded += OnFrameworkElementLoaded;
         }
 
         _renderedCard.Action += Rendered_Action;
+    }
+
+    private void OnFrameworkElementLoaded(object sender, RoutedEventArgs e)
+    {
+        // Unhook the event handler to avoid multiple registrations
+        if (sender is FrameworkElement element)
+        {
+            element.Loaded -= OnFrameworkElementLoaded;
+
+            // Focus on the first focusable element asynchronously to ensure the visual tree is fully built
+            element.DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Normal, () =>
+            {
+                var focusableElement = FindFirstFocusableElement(element);
+                focusableElement?.Focus(FocusState.Programmatic);
+            });
+        }
+    }
+
+    private Control? FindFirstFocusableElement(DependencyObject parent)
+    {
+        var childCount = VisualTreeHelper.GetChildrenCount(parent);
+
+        // Process children first (depth-first search)
+        for (var i = 0; i < childCount; i++)
+        {
+            var child = VisualTreeHelper.GetChild(parent, i);
+
+            // If the child is a focusable control like TextBox, ComboBox, etc.
+            if (child is Control control &&
+                control.IsEnabled &&
+                control.IsTabStop &&
+                control.Visibility == Visibility.Visible)
+            {
+                // TextBox and ComboBox are the most common form input controls
+                if (control is TextBox || control is ComboBox ||
+                    control is CheckBox || control is RadioButton ||
+                    control is ToggleSwitch || control is Slider ||
+                    control is NumberBox || control is DatePicker)
+                {
+                    return control;
+                }
+            }
+
+            // Recursively check children
+            var result = FindFirstFocusableElement(child);
+            if (result != null)
+            {
+                return result;
+            }
+        }
+
+        return null;
     }
 
     private void Rendered_Action(RenderedAdaptiveCard sender, AdaptiveActionEventArgs args) =>


### PR DESCRIPTION
This lets us auto-focus the first input on a `IFormContent`, if there's only one `IContent` on the page.

This dramatically improves the usability for forms, since we'll immediately put focus into them

Closes #38436 