### PR TITLE
CmdPal: fix a perf regression loading pages

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListItemViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListItemViewModel.cs
@@ -107,17 +107,17 @@ public partial class ListItemViewModel(IListItem model, WeakReference<IPageConte
 
     private void UpdateTags(ITag[]? newTagsFromModel)
     {
+        var newTags = newTagsFromModel?.Select(t =>
+        {
+            var vm = new TagViewModel(t, PageContext);
+            vm.InitializeProperties();
+            return vm;
+        })
+            .ToList() ?? [];
+
         DoOnUiThread(
             () =>
             {
-                var newTags = newTagsFromModel?.Select(t =>
-                {
-                    var vm = new TagViewModel(t, PageContext);
-                    vm.InitializeProperties();
-                    return vm;
-                })
-                    .ToList() ?? [];
-
                 // Tags being an ObservableCollection instead of a List lead to
                 // many COM exception issues.
                 Tags = new(newTags);

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ShellViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ShellViewModel.cs
@@ -4,7 +4,6 @@
 
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
-using CommunityToolkit.Common;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
@@ -109,13 +108,11 @@ public partial class ShellViewModel(IServiceProvider _serviceProvider, TaskSched
                     // TODO GH #239 switch back when using the new MD text block
                     // _ = _queue.EnqueueAsync(() =>
                     _ = Task.Factory.StartNew(
-                        async () =>
+                        () =>
                         {
                             // bool f = await viewModel.InitializeCommand.ExecutionTask.;
                             // var result = viewModel.InitializeCommand.ExecutionTask.GetResultOrDefault()!;
                             // var result = viewModel.InitializeCommand.ExecutionTask.GetResultOrDefault<bool?>()!;
-                            var result = await viewModel.InitializeAsync();
-
                             CurrentPage = viewModel; // result ? viewModel : null;
                             ////LoadedState = result ? ViewModelLoadedState.Loaded : ViewModelLoadedState.Error;
                         },


### PR DESCRIPTION
This was especially noticeable with the icons extension.

Turns out in #39051, when I was experimenting with getting AoT clean, I accidentally called this twice. Then we actually committed that straight up.

This PR reverts that. It also moves a similar case where we were initializing all the tags on the UI thread. That's wrong too - we need to fetch properties off the UI thread, then update the list on the UI thread.

Closes nothing, I didn't file this yet.
