### PR TITLE
build: stage the command palette as a separate artifact

### DIFF
--- a/.pipelines/v2/templates/job-build-project.yml
+++ b/.pipelines/v2/templates/job-build-project.yml
@@ -394,13 +394,13 @@ jobs:
           **\UnitTests-FancyZones.dll
           !**\obj\**
 
-  - ${{ if eq(parameters.codeSign, true) }}:
-    - pwsh: |-
-        $Package = (Get-ChildItem -Recurse -Filter "Microsoft.CmdPal.UI_*.msix" | Select -First 1)
-        $PackageFilename = $Package.FullName
-        Write-Host "##vso[task.setvariable variable=CmdPalPackagePath]${PackageFilename}"
-      displayName: Locate the MSIX
+  - pwsh: |-
+      $Package = (Get-ChildItem -Recurse -Filter "Microsoft.CmdPal.UI_*.msix" | Select -First 1)
+      $PackageFilename = $Package.FullName
+      Write-Host "##vso[task.setvariable variable=CmdPalPackagePath]${PackageFilename}"
+    displayName: Locate the CmdPal MSIX
 
+  - ${{ if eq(parameters.codeSign, true) }}:
     - pwsh: |-
         & "$(MakeAppxPath)" unpack /p "$(CmdPalPackagePath)" /d "$(JobOutputDirectory)/CmdPalPackageContents"
       displayName: Unpack the MSIX for signing
@@ -420,6 +420,8 @@ jobs:
         $PackageFilename = Join-Path $outDir.FullName (Split-Path -Leaf "$(CmdPalPackagePath)")
         & "$(MakeAppxPath)" pack /h SHA256 /o /p $PackageFilename /d "$(JobOutputDirectory)/CmdPalPackageContents"
         Copy-Item -Force $PackageFilename "$(CmdPalPackagePath)"
+        Remove-Item -Force -Recurse "$(JobOutputDirectory)/CmdPalPackageContents" -ErrorAction:Ignore
+        Remove-Item -Force -Recurse "$(JobOutputDirectory)/_appx" -ErrorAction:Ignore
       displayName: Re-pack the new CmdPal package after signing
 
     - template: steps-esrp-signing.yml
@@ -441,6 +443,10 @@ jobs:
           signType: batchSigning
           batchSignPolicyFile: '$(build.sourcesdirectory)\.pipelines\ESRPSigning_DSC.json'
           ciPolicyFile: '$(build.sourcesdirectory)\.pipelines\CIPolicy.xml'
+
+  - pwsh: |-
+      Copy-Item -Verbose -Force "$(CmdPalPackagePath)" "$(JobOutputDirectory)"
+    displayName: Stage the final CmdPal package
 
   - template: steps-build-installer.yml
     parameters:


### PR DESCRIPTION
This will ensure that the command palette package is copied to the artifact directory.
If code signing was enabled, the final copied package will be the signed version.

Minor build rule rearranging was required to collect the command palette package path for the staging step when signing was _disabled_. I did this solely so that we could verify the results in CI.

Review with whitespace disabled.