### PR TITLE
Fix RunAsAdmin For CmdPal when PowerToys is running as Admin

### DIFF
--- a/src/modules/cmdpal/CmdPalModuleInterface/dllmain.cpp
+++ b/src/modules/cmdpal/CmdPalModuleInterface/dllmain.cpp
@@ -217,7 +217,7 @@ public:
         CmdPal::m_enabled.store(true);
 
         std::wstring packageName = L"Microsoft.CommandPalette";
-        std::wstring launchPath = L"x-cmdpal://background";
+        std::wstring launchPath = L"explorer.exe x-cmdpal://background";
 #ifdef IS_DEV_BRANDING
         packageName = L"Microsoft.CommandPalette.Dev";
 #endif


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Since we change the launch method by this PR #39269 , we will start cmdpal as admin too if powertoys run as admin.
The fix is leveraging explorer (which will not run as admin) to start the cmdpal

Moreover, without this fix, some of extension cannot be "loaded" when cmdpal run as admin, e.g. winget will be missing, and my own new extension developed by myself will not be loaded successful as well.