### PR TITLE
Standardise name + syntax of color formats, alphabetise

### DIFF
--- a/src/common/ManagedCommon/ColorFormatHelper.cs
+++ b/src/common/ManagedCommon/ColorFormatHelper.cs
@@ -599,22 +599,23 @@ namespace ManagedCommon
         {
             switch (formatName)
             {
-                case "HEX": return "%Rex%Grx%Blx";
-                case "RGB": return "rgb(%Re, %Gr, %Bl)";
-                case "HSL": return "hsl(%Hu, %Sl%, %Ll%)";
-                case "HSV": return "hsv(%Hu, %Sb%, %Va%)";
-                case "CMYK": return "cmyk(%Cy%, %Ma%, %Ye%, %Bk%)";
-                case "HSB": return "hsb(%Hu, %Sb%, %Br%)";
-                case "HSI": return "hsi(%Hu, %Si%, %In%)";
-                case "HWB": return "hwb(%Hu, %Wh%, %Bn%)";
-                case "NCol": return "%Hn, %Wh%, %Bn%";
-                case "CIEXYZ": return "XYZ(%Xv, %Yv, %Zv)";
+                // Alphabetised to help user sift through them
                 case "CIELAB": return "CIELab(%Lc, %Ca, %Cb)";
-                case "Oklab": return "oklab(%Lo, %Oa, %Ob)";
-                case "Oklch": return "oklch(%Lo, %Oc, %Oh)";
-                case "VEC4": return "(%Reff, %Grff, %Blff, 1f)";
+                case "CIEXYZ": return "XYZ(%Xv, %Yv, %Zv)";
+                case "CMYK": return "cmyk(%Cy%, %Ma%, %Ye%, %Bk%)";
                 case "Decimal": return "%Dv";
                 case "HEX Int": return "0xFF%ReX%GrX%BlX";
+                case "HEX": return "#%Rex%Grx%Blx";
+                case "HSB": return "hsb(%Hu, %Sb%, %Br%)";
+                case "HSI": return "hsi(%Hu, %Si%, %In%)";
+                case "HSL": return "hsl(%Hu %Sl% %Ll%)";
+                case "HSV": return "hsv(%Hu, %Sb%, %Va%)";
+                case "HWB": return "hwb(%Hu %Wh% %Bn%)";
+                case "NCol": return "%Hn, %Wh%, %Bn%";
+                case "Oklab": return "oklab(%Lo %Oa %Ob)";
+                case "OKLCh": return "oklch(%Lo %Oc %Oh)";
+                case "RGB": return "rgb(%Re %Gr %Bl)";
+                case "VEC4": return "(%Reff, %Grff, %Blff, 1f)";
                 default: return string.Empty;
             }
         }


### PR DESCRIPTION
Label / name and syntax of color formats used by Color Picker adjusted to conform with https://www.w3.org/TR/css-color-4/ where specified.

Also, alphabetised list of color formats to assist user in selection.

## PR Checklist

- [x] **Closes:** N/A
- [x] **Communication:** I've not  "discussed this with core contributors" - don't know who they are or how to contact 
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [x] **Dev docs:** Added/updated N/A
- [x] **New binaries:** Added on the required places N/A

