### PR TITLE
CmdPal: fix duplicated aliases in settings file

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AliasManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AliasManager.cs
@@ -86,16 +86,6 @@ public partial class AliasManager : ObservableObject
             return;
         }
 
-        // If we already have _this exact alias_, do nothing
-        if (newAlias != null &&
-            _aliases.TryGetValue(newAlias.SearchPrefix, out var existingAlias))
-        {
-            if (existingAlias.CommandId == commandId)
-            {
-                return;
-            }
-        }
-
         // Look for the old alias, and remove it
         List<CommandAlias> toRemove = [];
         foreach (var kv in _aliases)


### PR DESCRIPTION
This caused a bunch of reports:
* #38817
* #39460
* probably #39035
* possibly #38390

