### PR TITLE
[PowerToysRun][Docs] Add SpeedTest to Third-Party plugins

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -9,6 +9,7 @@ ACCEPTFILES
 ACCESSDENIED
 ACCESSTOKEN
 acfs
+ACIE
 AClient
 AColumn
 acrt
@@ -48,6 +49,7 @@ ansicolor
 ANull
 AOC
 aocfnapldcnfbofgmbbllojgocaelgdd
+AOklab
 APARTMENTTHREADED
 APeriod
 apicontract
@@ -103,6 +105,7 @@ azcliversion
 azman
 backtracer
 bbwe
+BCIE
 bck
 BESTEFFORT
 bezelled
@@ -132,6 +135,7 @@ bms
 BNDBk
 BNumber
 BODGY
+BOklab
 BOOTSTRAPPERINSTALLFOLDER
 bostrot
 BOTTOMALIGN
@@ -184,6 +188,7 @@ CHILDACTIVATE
 CHILDWINDOW
 CHOOSEFONT
 cidl
+CIELCh
 cim
 CImage
 cla
@@ -269,6 +274,7 @@ CTest
 CTEXT
 Ctl
 CTLCOLORSTATIC
+culori
 currentculture
 CURRENTDIR
 CURSORINFO
@@ -347,6 +353,7 @@ DEVMODE
 DEVMODEW
 devpal
 DIALOGEX
+dictionaryapi
 digicert
 dimm
 DISABLEASACTIONKEY
@@ -446,6 +453,7 @@ eula
 eurochange
 eventlog
 eventvwr
+Evercoder
 evt
 EWXFORCE
 EWXFORCEIFHUNG
@@ -628,12 +636,12 @@ homljgmgpmcbpjbnjpfijnhipfkiclkd
 HORZRES
 HORZSIZE
 Hostbackdropbrush
+Hostx
 hotkeycontrol
 HOTKEYF
 hotkeys
 hotlight
 hotspot
-Hostx
 HPAINTBUFFER
 HRAWINPUT
 HREDRAW
@@ -677,7 +685,6 @@ IDR
 IDXGI
 ietf
 IEXPLORE
-iextn
 IFACEMETHOD
 IFACEMETHODIMP
 IFile
@@ -781,6 +788,7 @@ lastcodeanalysissucceeded
 Lastdevice
 LASTEXITCODE
 LAYOUTRTL
+LCh
 LCIDTo
 Lclean
 Ldone
@@ -807,7 +815,6 @@ LMENU
 lnks
 LOADFROMFILE
 LOBYTE
-localappdata
 LOCALDISPLAY
 localpackage
 LOCALSYSTEM
@@ -1083,8 +1090,8 @@ NOTOPMOST
 NOTRACK
 NOTSRCCOPY
 NOTSRCERASE
-NOTXORPEN
 notwindows
+NOTXORPEN
 NOZORDER
 NPH
 npmjs
@@ -1279,7 +1286,6 @@ pstm
 PStr
 pstream
 pstrm
-pswd
 PSYSTEM
 psz
 ptb
@@ -1310,8 +1316,8 @@ QUNS
 QXZ
 RAII
 RAlt
-Rappl
 randi
+Rappl
 Rasterization
 Rasterize
 RAWINPUTDEVICE
@@ -1471,16 +1477,12 @@ SHELLDLL
 shellex
 SHELLEXECUTEINFO
 SHELLEXECUTEINFOW
-SHELLEXTENSION
 SHELLICONSIZE
-SHELLNEWVALUE
 SHFILEINFO
 SHFILEOPSTRUCT
 SHGDN
 SHGDNF
 SHGFI
-SHGFIICON
-SHGFILARGEICON
 SHIL
 shinfo
 shlwapi
@@ -1513,8 +1515,8 @@ SIDs
 siex
 sigdn
 SIGNINGSCENARIO
-signtool
 Signtool
+signtool
 SINGLEKEY
 sipolicy
 SIZEBOX
@@ -1983,11 +1985,3 @@ ZOOMITX
 ZXk
 ZXNs
 zzz
-ACIE
-AOklab
-BCIE
-BOklab
-culori
-Evercoder
-LCh
-CIELCh

--- a/doc/thirdPartyRunPlugins.md
+++ b/doc/thirdPartyRunPlugins.md
@@ -46,8 +46,6 @@ Contact the developers of a plugin directly for assistance with a specific plugi
 | [QuickNotes](https://github.com/ruslanlap/CommunityPowerToysRunPlugin-QuickNotes) | [ruslanlap](https://github.com/ruslanlap) | Create, manage, and search notes directly from PowerToys Run. |
 | [Weather](https://github.com/ruslanlap/PowerToysRun-Weather) | [ruslanlap](https://github.com/ruslanlap) | Get real-time weather information directly from PowerToys Run. |
 | [Pomodoro](https://github.com/ruslanlap/PowerToysRun-Pomodoro) | [ruslanlap](https://github.com/ruslanlap) | Manage Pomodoro productivity sessions directly from PowerToys Run. |
-| [Definition](https://github.com/ruslanlap/PowerToysRun-Definition) | [ruslanlap](https://github.com/ruslanlap) | Lookup word definitions, phonetics, and synonyms directly in PowerToys Run. Type `def <word>` to instantly fetch comprehensive dictionary data from dictionaryapi.dev. Supports multiple definitions, examples, and usage contexts. |
-
 
 ## Extending software plugins
 

--- a/doc/thirdPartyRunPlugins.md
+++ b/doc/thirdPartyRunPlugins.md
@@ -47,7 +47,7 @@ Contact the developers of a plugin directly for assistance with a specific plugi
 | [Weather](https://github.com/ruslanlap/PowerToysRun-Weather) | [ruslanlap](https://github.com/ruslanlap) | Get real-time weather information directly from PowerToys Run. |
 | [Pomodoro](https://github.com/ruslanlap/PowerToysRun-Pomodoro) | [ruslanlap](https://github.com/ruslanlap) | Manage Pomodoro productivity sessions directly from PowerToys Run. |
 | [Definition](https://github.com/ruslanlap/PowerToysRun-Definition) | [ruslanlap](https://github.com/ruslanlap) | Lookup word definitions, phonetics, and synonyms directly in PowerToys Run. Simply type def <word> to fetch definitions from dictionaryapi.dev. |
-| [SpeedTest](https://github.com/ruslanlap/PowerToysRun-SpeedTest) | [ruslanlap](https://github.com/ruslanlap) | Run internet speed tests directly from PowerToys Run. One-command speed test with real-time results, modern UI, and shareable results. |
+
 
 ## Extending software plugins
 
@@ -71,3 +71,4 @@ Below are community created plugins that target a website or software.  They are
 | [YubicoOauthOTP](https://github.com/dlnilsson/Community.PowerToys.Run.Plugin.YubicoOauthOTP) | [dlnilsson](https://github.com/dlnilsson) | Display generated codes from OATH accounts stored on the YubiKey in powerToys Run  |
 | [Firefox Bookmark](https://github.com/8LWXpg/PowerToysRun-FirefoxBookmark) | [8LWXpg](https://github.com/8LWXpg) | Open bookmarks in Firefox based browser |
 [Linear](https://github.com/vednig/powertoys-linear) | [vednig](https://github.com/vednig) | Create Linear Issues directly from Powertoys Run |
+| [SpeedTest](https://github.com/ruslanlap/PowerToysRun-SpeedTest) | [ruslanlap](https://github.com/ruslanlap) | Run internet speed tests directly from PowerToys Run. One-command speed test with real-time results, modern UI, and shareable results. |

--- a/doc/thirdPartyRunPlugins.md
+++ b/doc/thirdPartyRunPlugins.md
@@ -46,6 +46,7 @@ Contact the developers of a plugin directly for assistance with a specific plugi
 | [QuickNotes](https://github.com/ruslanlap/CommunityPowerToysRunPlugin-QuickNotes) | [ruslanlap](https://github.com/ruslanlap) | Create, manage, and search notes directly from PowerToys Run. |
 | [Weather](https://github.com/ruslanlap/PowerToysRun-Weather) | [ruslanlap](https://github.com/ruslanlap) | Get real-time weather information directly from PowerToys Run. |
 | [Pomodoro](https://github.com/ruslanlap/PowerToysRun-Pomodoro) | [ruslanlap](https://github.com/ruslanlap) | Manage Pomodoro productivity sessions directly from PowerToys Run. |
+| [Definition](https://github.com/ruslanlap/PowerToysRun-Definition) | [ruslanlap](https://github.com/ruslanlap) | Lookup word definitions, phonetics, and synonyms directly in PowerToys Run. Simply type def <word> to fetch definitions from dictionaryapi.dev. |
 | [SpeedTest](https://github.com/ruslanlap/PowerToysRun-SpeedTest) | [ruslanlap](https://github.com/ruslanlap) | Run internet speed tests directly from PowerToys Run. One-command speed test with real-time results, modern UI, and shareable results. |
 
 ## Extending software plugins

--- a/doc/thirdPartyRunPlugins.md
+++ b/doc/thirdPartyRunPlugins.md
@@ -46,6 +46,7 @@ Contact the developers of a plugin directly for assistance with a specific plugi
 | [QuickNotes](https://github.com/ruslanlap/CommunityPowerToysRunPlugin-QuickNotes) | [ruslanlap](https://github.com/ruslanlap) | Create, manage, and search notes directly from PowerToys Run. |
 | [Weather](https://github.com/ruslanlap/PowerToysRun-Weather) | [ruslanlap](https://github.com/ruslanlap) | Get real-time weather information directly from PowerToys Run. |
 | [Pomodoro](https://github.com/ruslanlap/PowerToysRun-Pomodoro) | [ruslanlap](https://github.com/ruslanlap) | Manage Pomodoro productivity sessions directly from PowerToys Run. |
+| [SpeedTest](https://github.com/ruslanlap/PowerToysRun-SpeedTest) | [ruslanlap](https://github.com/ruslanlap) | Run internet speed tests directly from PowerToys Run. One-command speed test with real-time results, modern UI, and shareable results. |
 
 ## Extending software plugins
 

--- a/doc/thirdPartyRunPlugins.md
+++ b/doc/thirdPartyRunPlugins.md
@@ -46,7 +46,7 @@ Contact the developers of a plugin directly for assistance with a specific plugi
 | [QuickNotes](https://github.com/ruslanlap/CommunityPowerToysRunPlugin-QuickNotes) | [ruslanlap](https://github.com/ruslanlap) | Create, manage, and search notes directly from PowerToys Run. |
 | [Weather](https://github.com/ruslanlap/PowerToysRun-Weather) | [ruslanlap](https://github.com/ruslanlap) | Get real-time weather information directly from PowerToys Run. |
 | [Pomodoro](https://github.com/ruslanlap/PowerToysRun-Pomodoro) | [ruslanlap](https://github.com/ruslanlap) | Manage Pomodoro productivity sessions directly from PowerToys Run. |
-| [Definition](https://github.com/ruslanlap/PowerToysRun-Definition) | [ruslanlap](https://github.com/ruslanlap) | Lookup word definitions, phonetics, and synonyms directly in PowerToys Run. Simply type def <word> to fetch definitions from dictionaryapi.dev. |
+| [Definition](https://github.com/ruslanlap/PowerToysRun-Definition) | [ruslanlap](https://github.com/ruslanlap) | Lookup word definitions, phonetics, and synonyms directly in PowerToys Run. Type `def <word>` to instantly fetch comprehensive dictionary data from dictionaryapi.dev. Supports multiple definitions, examples, and usage contexts. |
 
 
 ## Extending software plugins
@@ -70,5 +70,5 @@ Below are community created plugins that target a website or software.  They are
 | [Bilibili](https://github.com/Whuihuan/PowerToysRun-Bilibili) | [Whuihuan](https://github.com/Whuihuan) | Use AVID or BVID to parse and jump to Bilibili |
 | [YubicoOauthOTP](https://github.com/dlnilsson/Community.PowerToys.Run.Plugin.YubicoOauthOTP) | [dlnilsson](https://github.com/dlnilsson) | Display generated codes from OATH accounts stored on the YubiKey in powerToys Run  |
 | [Firefox Bookmark](https://github.com/8LWXpg/PowerToysRun-FirefoxBookmark) | [8LWXpg](https://github.com/8LWXpg) | Open bookmarks in Firefox based browser |
-[Linear](https://github.com/vednig/powertoys-linear) | [vednig](https://github.com/vednig) | Create Linear Issues directly from Powertoys Run |
-| [SpeedTest](https://github.com/ruslanlap/PowerToysRun-SpeedTest) | [ruslanlap](https://github.com/ruslanlap) | Run internet speed tests directly from PowerToys Run. One-command speed test with real-time results, modern UI, and shareable results. |
+| [Linear](https://github.com/vednig/powertoys-linear) | [vednig](https://github.com/vednig) | Create Linear Issues directly from Powertoys Run |
+| [SpeedTest](https://github.com/ruslanlap/PowerToysRun-SpeedTest) | [ruslanlap](https://github.com/ruslanlap) | Run internet speed tests directly from PowerToys Run with a single command. Provides detailed upload/download speeds and ping metrics with a modern interface. Results can be easily copied and shared. |


### PR DESCRIPTION
# 🚀 Add SpeedTest Plugin for PowerToys Run

This PR introduces the **SpeedTest** plugin—a new PowerToys Run extension that lets you run internet speed tests instantly, without opening a browser or separate application.

🔗 **Learn more**  
| Plugin | Author | Description |  
|:-------|:------:|:------------|  
| [SpeedTest](https://github.com/ruslanlap/PowerToysRun-SpeedTest) | [ruslanlap](https://github.com/ruslanlap) | One-command internet speed tests with real-time results, modern UI, and shareable links. |

---

## ✨ Plugin Highlights

- **One-command tests**  
  Run a full speed test (download, upload, ping, server) via PowerToys Run ().   and hit Enter! (or change to  or any other keyword in the settings)
- **Modern, theme-aware UI**  
  WPF-based window adapts automatically to light or dark Windows modes.  
- **Live progress & shareable links**  
  Watch your test run in real time and copy a result URL when it finishes.  
- **All-local, privacy-first**  
  No third-party tracking—uses the bundled Speedtest CLI for 100% local execution.  
- **Robust error handling**  
  Friendly messages for network failures, permission issues, or unexpected errors.  
- **x64 & ARM64 builds**  
  Native-optimized releases for both CPU architectures.  
- **Open source & community-driven**  
  Contributions, issues, and feature requests are welcome—let's make it even better!

---

Thank you for reviewing the **SpeedTest** plugin! 🚀  
I'm excited to help PowerToys Run users check their internet speeds faster than ever.