### PR TITLE
[CmdPal][Calc]Trim leading `=` to support pasting formulas

### DIFF
--- a/src/modules/cmdpal/README.md
+++ b/src/modules/cmdpal/README.md
@@ -13,7 +13,7 @@ The official API documentation can be found [on this docs site](https://learn.mi
 
 We've also got samples, so that you can see how the APIs in-action. 
 
-* We've got [generic samples] in the repo 
+* We've got [generic samples] in the repo
 * We've got [real samples] in the repo too
 * And we've even got [real extensions that we've "shipped" already]
 
@@ -39,7 +39,7 @@ Projects of interest are:
 
 
 [Initial SDK Spec]: ./doc/initial-sdk-spec/initial-sdk-spec.md
-[generic samples]: ./Exts/SamplePagesExtension
+[generic samples]: ./Exts/SamplePagesExtension 
 [real samples]: ./Exts/ProcessMonitorExtension
 [real extensions that we've "shipped" already]: https://github.com/zadjii/CmdPalExtensions/blob/main/src/extensions
 


### PR DESCRIPTION
## Summary of the Pull Request
Removes a leading `=` from calculator queries to support pasting formulas that start with `=` (when pasting, the action key doesn't trigger, therefore it doesn't get trimmed).
## PR Checklist
- [x] Closes: #39515
- [x] **Communication:** I've discussed this with core contributors already
- [ ] **Tests:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [ ] **Dev docs:** No need
- [x] **New binaries:** None
- [x] **Documentation updated:** No need
## Detailed Description of the Pull Request / Additional comments
## Validation Steps Performed
### NOT TESTED!
Package deployment is broken on my machine, so I wasn't able to test this at all (gotta love win packages)