### PR TITLE
Add retry in attach

### DIFF
--- a/src/modules/Hosts/Hosts.UITests/HostsSettingTests.cs
+++ b/src/modules/Hosts/Hosts.UITests/HostsSettingTests.cs
@@ -58,9 +58,6 @@ namespace Hosts.UITests
 
             this.Find<Button>("Launch Hosts File Editor").Click();
 
-            // wait for 500 ms to make sure Hosts File Editor is launched
-            Task.Delay(500).Wait();
-
             this.Session.Attach(PowerToysModule.Hosts, WindowSize.Small_Vertical);
 
             // Should show warning dialog


### PR DESCRIPTION
This pull request introduces improvements to the window attachment process in the `Session.Attach` method and removes a hardcoded delay in the `TestWarningDialog` test. The changes enhance reliability and maintainability by implementing a retry mechanism and eliminating unnecessary delays.

### Improvements to window attachment:

* [`src/common/UITestAutomation/Session.cs`](diffhunk://#diff-5bb9c8f423afc54b5ad5efd4a530027f691a770d449697a6027a1468e7a20e7bL483-R504): Updated the `Session.Attach` method to include a retry mechanism with a 2-minute timeout and 5-second intervals when searching for a window by its title. This ensures more robust handling of scenarios where the target window is not immediately available.

### Test reliability enhancements:

* [`src/modules/Hosts/Hosts.UITests/HostsSettingTests.cs`](diffhunk://#diff-3782109c99cd66a2c1b870a83d1f9d9807422479c89e03799b311ef5f13a2098L61-L63): Removed the hardcoded 500 ms delay in the `TestWarningDialog` test, relying instead on the improved `Session.Attach` method for synchronization. This reduces unnecessary waiting and improves test execution efficiency.
