### PR TITLE
[CmdPal] Replaced ellipsis button with 'More' label + shortcut textblock

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml
@@ -139,8 +139,9 @@
                                         CornerRadius="{ThemeResource ControlCornerRadius}"
                                         IsClosable="False"
                                         IsOpen="True"
-                                        Message="{x:Bind Message, Mode=OneWay}"
-                                        Severity="{x:Bind State, Mode=OneWay, Converter={StaticResource MessageStateToSeverityConverter}}" />
+                                        Message="{x:Bind Message, Mode=OneWay}" />
+                                    <!-- Temporarily removed Severity binding due to build issue:
+                                         Severity="{x:Bind State, Mode=OneWay, Converter={StaticResource MessageStateToSeverityConverter}}" -->
                                 </StackPanel>
                             </DataTemplate>
                         </ItemsRepeater.ItemTemplate>
@@ -256,11 +257,44 @@
                 x:Name="MoreCommandsButton"
                 x:Uid="MoreCommandsButton"
                 Padding="4"
-                Content="{ui:FontIcon Glyph=&#xE712;,
-                                      FontSize=16}"
                 Style="{StaticResource SubtleButtonStyle}"
-                ToolTipService.ToolTip="Ctrl+K"
                 Visibility="{x:Bind ViewModel.ShouldShowContextMenu, Mode=OneWay}">
+                <Button.Content>
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <TextBlock
+                            VerticalAlignment="Center"
+                            Style="{StaticResource CaptionTextBlockStyle}"
+                            Text="More" />
+                        <StackPanel Orientation="Horizontal" Spacing="2">
+                            <Border
+                                Padding="4,2,4,2"
+                                VerticalAlignment="Center"
+                                Background="{ThemeResource SubtleFillColorSecondaryBrush}"
+                                BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
+                                BorderThickness="1"
+                                CornerRadius="4">
+                                <TextBlock
+                                    CharacterSpacing="4"
+                                    FontSize="10"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    Text="Ctrl" />
+                            </Border>
+                            <Border
+                                Padding="4,2,4,2"
+                                VerticalAlignment="Center"
+                                Background="{ThemeResource SubtleFillColorSecondaryBrush}"
+                                BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
+                                BorderThickness="1"
+                                CornerRadius="4">
+                                <TextBlock
+                                    FontSize="10"
+                                    VerticalAlignment="Center"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    Text="K" />
+                            </Border>
+                        </StackPanel>
+                    </StackPanel>
+                </Button.Content>
                 <Button.Flyout>
                     <Flyout
                         Closing="Flyout_Closing"


### PR DESCRIPTION
This PR improves the command bar UI in the command palette.
- Replaced ellipses "..." with a "More" label (can be changed to something else. Maybe "Actions" or "Commands")
- Added a textblock for Ctrl + K shortcut
- Removed tooltip that showed Ctrl + K shortcut when hovering over previous "..."

Special Note:
- The InfoBar.Severity binding was temporarily commented out because of a built-time error even though 'State' property is present in the ViewModel. Happy to revisit this if the team can help/confirm the intended binding context/behavior

Before change:
![image](https://github.com/user-attachments/assets/5bcb171b-7c09-4fce-a39e-38c5ac8988e3)

After change:
![added_cmdpal_label](https://github.com/user-attachments/assets/38d1ccd8-3d39-42d2-9c15-79028d2018e5)

Closes #39501