### PR TITLE
🚀 Add SpeedTest Plugin for PowerToys Run to Third-Party plugin

### DIFF
--- a/doc/thirdPartyRunPlugins.md
+++ b/doc/thirdPartyRunPlugins.md
@@ -68,4 +68,5 @@ Below are community created plugins that target a website or software.  They are
 | [Bilibili](https://github.com/Whuihuan/PowerToysRun-Bilibili) | [Whuihuan](https://github.com/Whuihuan) | Use AVID or BVID to parse and jump to Bilibili |
 | [YubicoOauthOTP](https://github.com/dlnilsson/Community.PowerToys.Run.Plugin.YubicoOauthOTP) | [dlnilsson](https://github.com/dlnilsson) | Display generated codes from OATH accounts stored on the YubiKey in powerToys Run  |
 | [Firefox Bookmark](https://github.com/8LWXpg/PowerToysRun-FirefoxBookmark) | [8LWXpg](https://github.com/8LWXpg) | Open bookmarks in Firefox based browser |
-[Linear](https://github.com/vednig/powertoys-linear) | [vednig](https://github.com/vednig) | Create Linear Issues directly from Powertoys Run |
+| [Linear](https://github.com/vednig/powertoys-linear) | [vednig](https://github.com/vednig) | Create Linear Issues directly from Powertoys Run |
+| [SpeedTest](https://github.com/ruslanlap/PowerToysRun-SpeedTest) | [ruslanlap](https://github.com/ruslanlap) | One-command internet speed tests with real-time results, modern UI, and shareable links. |


### PR DESCRIPTION
# 🚀 Add SpeedTest Plugin for PowerToys Run

This PR introduces the **SpeedTest** plugin—a new PowerToys Run extension that lets you run internet speed tests instantly, without opening a browser or separate application. Also was problem with formating previous Plugin "Linear"

🔗 **Learn more**  
| Plugin | Author | Description |  
|:-------|:------:|:------------|  
| [SpeedTest](https://github.com/ruslanlap/PowerToysRun-SpeedTest) | [ruslanlap](https://github.com/ruslanlap) | One-command internet speed tests with real-time results, modern UI, and shareable links. |

---

## ✨ Plugin Highlights

- **One-command tests**  
  Run a full speed test (download, upload, ping, server) via PowerToys Run ().   and hit Enter! (or change to  or any other keyword in the settings)
- **Modern, theme-aware UI**  
  WPF-based window adapts automatically to light or dark Windows modes.  
- **Live progress & shareable links**  
  Watch your test run in real time and copy a result URL when it finishes.  
- **All-local, privacy-first**  
  No third-party tracking—uses the bundled Speedtest CLI for 100% local execution.  
- **Robust error handling**  
  Friendly messages for network failures, permission issues, or unexpected errors.  
- **x64 & ARM64 builds**  
  Native-optimized releases for both CPU architectures.  
- **Open source & community-driven**  
  Contributions, issues, and feature requests are welcome—let's make it even better!

---

Thank you for reviewing the **SpeedTest** plugin! 🚀  
I'm excited to help PowerToys Run users check their internet speeds faster than ever.