### PR TITLE
🎥 Add VideoDownloader Plugin for PowerToys Run

### DIFF
--- a/doc/thirdPartyRunPlugins.md
+++ b/doc/thirdPartyRunPlugins.md
@@ -46,6 +46,7 @@ Contact the developers of a plugin directly for assistance with a specific plugi
 | [QuickNotes](https://github.com/ruslanlap/CommunityPowerToysRunPlugin-QuickNotes) | [ruslanlap](https://github.com/ruslanlap) | Create, manage, and search notes directly from PowerToys Run. |
 | [Weather](https://github.com/ruslanlap/PowerToysRun-Weather) | [ruslanlap](https://github.com/ruslanlap) | Get real-time weather information directly from PowerToys Run. |
 | [Pomodoro](https://github.com/ruslanlap/PowerToysRun-Pomodoro) | [ruslanlap](https://github.com/ruslanlap) | Manage Pomodoro productivity sessions directly from PowerToys Run. |
+| [Definition](https://github.com/ruslanlap/PowerToysRun-Definition) | [ruslanlap](https://github.com/ruslanlap) | Lookup word definitions, phonetics, and synonyms directly in PowerToys Run. |
 
 ## Extending software plugins
 

--- a/doc/thirdPartyRunPlugins.md
+++ b/doc/thirdPartyRunPlugins.md
@@ -68,4 +68,5 @@ Below are community created plugins that target a website or software.  They are
 | [Bilibili](https://github.com/Whuihuan/PowerToysRun-Bilibili) | [Whuihuan](https://github.com/Whuihuan) | Use AVID or BVID to parse and jump to Bilibili |
 | [YubicoOauthOTP](https://github.com/dlnilsson/Community.PowerToys.Run.Plugin.YubicoOauthOTP) | [dlnilsson](https://github.com/dlnilsson) | Display generated codes from OATH accounts stored on the YubiKey in powerToys Run  |
 | [Firefox Bookmark](https://github.com/8LWXpg/PowerToysRun-FirefoxBookmark) | [8LWXpg](https://github.com/8LWXpg) | Open bookmarks in Firefox based browser |
-[Linear](https://github.com/vednig/powertoys-linear) | [vednig](https://github.com/vednig) | Create Linear Issues directly from Powertoys Run |
+| [Linear](https://github.com/vednig/powertoys-linear) | [vednig](https://github.com/vednig) | Create Linear Issues directly from Powertoys Run |
+| [SpeedTest](https://github.com/ruslanlap/PowerToysRun-SpeedTest) | [ruslanlap](https://github.com/ruslanlap) | One-command internet speed tests with real-time results, modern UI, and shareable links. |

--- a/doc/thirdPartyRunPlugins.md
+++ b/doc/thirdPartyRunPlugins.md
@@ -71,3 +71,4 @@ Below are community created plugins that target a website or software.  They are
 | [Firefox Bookmark](https://github.com/8LWXpg/PowerToysRun-FirefoxBookmark) | [8LWXpg](https://github.com/8LWXpg) | Open bookmarks in Firefox based browser |
 | [Linear](https://github.com/vednig/powertoys-linear) | [vednig](https://github.com/vednig) | Create Linear Issues directly from Powertoys Run |
 | [SpeedTest](https://github.com/ruslanlap/PowerToysRun-SpeedTest) | [ruslanlap](https://github.com/ruslanlap) | One-command internet speed tests with real-time results, modern UI, and shareable links. |
+| [VideoDownloader](https://github.com/ruslanlap/PowerToysRun-VideoDownloader) | [ruslanlap](https://github.com/ruslanlap) | Download videos from YouTube and 1000+ other sites directly from your keyboard. Features: one-click downloads, multiple formats (MP4/MP3), smart URL detection, custom download folder. | 


### PR DESCRIPTION
This PR introduces the **VideoDownloader** plugin—a new PowerToys Run extension that allows you to download videos from YouTube and 1000+ other sites directly from your keyboard.

🔗 **Learn more**  
| Plugin | Author | Description |  
|:-------|:------:|:------------|  
| [VideoDownloader](https://github.com/ruslanlap/PowerToysRun-VideoDownloader) | [ruslanlap](https://github.com/ruslanlap) | Download videos from YouTube and 1000+ other sites directly from your keyboard. |

---

## ✨ Features

- **One-Click Downloads**  
  Download videos with a single command.
- **Multiple Formats**  
  Supports both video (MP4) and audio-only (MP3) downloads.
- **Smart URL Detection**  
  Automatically recognizes video URLs from various platforms.
- **Lightning Fast**  
  Built with performance in mind.
- **Dark/Light Theme**  
  Seamlessly integrates with your system theme.
- **Custom Download Folder**  
  Choose where to save your downloads.
- **No Dependencies**  
  Auto-downloads required components.
- **1000+ Sites**  
  Works with YouTube, Vimeo, and many more via yt-dlp.

---

Thank you for reviewing the **VideoDownloader** plugin! 🎥  
I'm excited to help PowerToys Run users download videos faster than ever. 