### PR TITLE
[Keyboard Manager] New Keyboard Manager - Text Remapping Page and Code-behind functionalities

### DIFF
--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibraryWrapper/KeyboardManagerEditorLibraryWrapper.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibraryWrapper/KeyboardManagerEditorLibraryWrapper.cpp
@@ -515,12 +515,26 @@ bool GetShortcutRemapByType(void* config, int operationType, int index, Shortcut
     bool AddShortcutRemap(void* config,
                           const wchar_t* originalKeys,
                           const wchar_t* targetKeys,
-                          const wchar_t* targetApp)
+                          const wchar_t* targetApp,
+                          int operationType = 0)
     {
         auto mappingConfig = static_cast<MappingConfiguration*>(config);
 
         Shortcut originalShortcut(originalKeys);
-        Shortcut targetShortcut(targetKeys);
+
+        KeyShortcutTextUnion targetShortcut;
+
+        switch (operationType)
+        {
+        case 3:
+            targetShortcut = std::wstring(targetKeys);
+            break;
+        
+        default:
+            targetShortcut = Shortcut(targetKeys);
+            std::get<Shortcut>(targetShortcut).operationType = static_cast<Shortcut::OperationType>(operationType);
+            break;
+        }
 
         std::wstring app(targetApp ? targetApp : L"");
 
@@ -606,6 +620,18 @@ bool GetShortcutRemapByType(void* config, int operationType, int index, Shortcut
             return true;
         }
 
+        return false;
+    }
+
+    bool DeleteSingleKeyToTextRemap(void* config, int originalKey)
+    {
+        auto mappingConfig = static_cast<MappingConfiguration*>(config);
+        auto it = mappingConfig->singleKeyToTextReMap.find(originalKey);
+        if (it != mappingConfig->singleKeyToTextReMap.end())
+        {
+            mappingConfig->singleKeyToTextReMap.erase(it);
+            return true;
+        }
         return false;
     }
 

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibraryWrapper/KeyboardManagerEditorLibraryWrapper.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibraryWrapper/KeyboardManagerEditorLibraryWrapper.cpp
@@ -685,20 +685,6 @@ bool GetShortcutRemapByType(void* config, int operationType, int index, Shortcut
     }
 }
 
-// Test function to call the remapping helper function
-bool CheckIfRemappingsAreValid()
-{
-    RemapBuffer remapBuffer;
-
-    // Mock valid key to key remappings
-    remapBuffer.push_back(RemapBufferRow{ RemapBufferItem({ (DWORD)0x41, (DWORD)0x42 }), std::wstring() });
-    remapBuffer.push_back(RemapBufferRow{ RemapBufferItem({ (DWORD)0x42, (DWORD)0x43 }), std::wstring() });
-
-    auto result = LoadingAndSavingRemappingHelper::CheckIfRemappingsAreValid(remapBuffer);
-
-    return result == ShortcutErrorType::NoError;
-}
-
 // Get the list of keyboard keys in Editor
 int GetKeyboardKeysList(bool isShortcut, KeyNamePair* keyList, int maxCount)
 {

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibraryWrapper/KeyboardManagerEditorLibraryWrapper.h
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibraryWrapper/KeyboardManagerEditorLibraryWrapper.h
@@ -77,5 +77,4 @@ extern "C"
     __declspec(dllexport) bool DeleteSingleKeyToTextRemap(void* config, int originalKey);
     __declspec(dllexport) bool DeleteShortcutRemap(void* config, const wchar_t* originalKeys, const wchar_t* targetApp);
 }
-extern "C" __declspec(dllexport) bool CheckIfRemappingsAreValid();
 extern "C" __declspec(dllexport) int GetKeyboardKeysList(bool isShortcut, KeyNamePair* keyList, int maxCount);

--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibraryWrapper/KeyboardManagerEditorLibraryWrapper.h
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibraryWrapper/KeyboardManagerEditorLibraryWrapper.h
@@ -62,7 +62,8 @@ extern "C"
     __declspec(dllexport) bool AddShortcutRemap(void* config,
                                                 const wchar_t* originalKeys,
                                                 const wchar_t* targetKeys,
-                                                const wchar_t* targetApp);
+                                                const wchar_t* targetApp,
+                                                int operationType);
 
     __declspec(dllexport) void GetKeyDisplayName(int keyCode, wchar_t* keyName, int maxCount);
     __declspec(dllexport) int GetKeyCodeFromName(const wchar_t* keyName);
@@ -73,6 +74,7 @@ extern "C"
     __declspec(dllexport) bool AreShortcutsEqual(const wchar_t* lShort, const wchar_t* rShort);
 
     __declspec(dllexport) bool DeleteSingleKeyRemap(void* config, int originalKey);
+    __declspec(dllexport) bool DeleteSingleKeyToTextRemap(void* config, int originalKey);
     __declspec(dllexport) bool DeleteShortcutRemap(void* config, const wchar_t* originalKeys, const wchar_t* targetApp);
 }
 extern "C" __declspec(dllexport) bool CheckIfRemappingsAreValid();

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/KeyInputMode.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/KeyInputMode.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace KeyboardManagerEditorUI.Helpers
+{
+    public enum KeyInputMode
+    {
+        OriginalKeys,
+        RemappedKeys,
+    }
+}

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/KeyboardHookHelper.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/KeyboardHookHelper.cs
@@ -88,18 +88,18 @@ namespace KeyboardManagerEditorUI.Helpers
             }
 
             // Count current modifiers
-            int modifierCount = _currentlyPressedKeys.Count(k => _activeTarget.IsModifierKey(k));
+            int modifierCount = _currentlyPressedKeys.Count(k => RemappingHelper.IsModifierKey(k));
 
             // If adding this key would exceed the limits (4 modifiers + 1 action key), don't add it and show notification
-            if ((_activeTarget.IsModifierKey(virtualKey) && modifierCount >= 4) ||
-                (!_activeTarget.IsModifierKey(virtualKey) && _currentlyPressedKeys.Count >= 5))
+            if ((RemappingHelper.IsModifierKey(virtualKey) && modifierCount >= 4) ||
+                (!RemappingHelper.IsModifierKey(virtualKey) && _currentlyPressedKeys.Count >= 5))
             {
                 _activeTarget.OnInputLimitReached();
                 return;
             }
 
             // Check if this is a different variant of a modifier key already pressed
-            if (_activeTarget.IsModifierKey(virtualKey))
+            if (RemappingHelper.IsModifierKey(virtualKey))
             {
                 // Remove existing variant of this modifier key if a new one is pressed
                 // This is to ensure that only one variant of a modifier key is displayed at a time
@@ -151,7 +151,7 @@ namespace KeyboardManagerEditorUI.Helpers
                     continue;
                 }
 
-                if (_activeTarget.IsModifierKey(key))
+                if (RemappingHelper.IsModifierKey(key))
                 {
                     if (!modifierKeys.Contains(key))
                     {
@@ -233,8 +233,6 @@ namespace KeyboardManagerEditorUI.Helpers
         }
 
         void ClearKeys();
-
-        bool IsModifierKey(VirtualKey key);
 
         void OnInputLimitReached();
     }

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/KeyboardHookHelper.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/KeyboardHookHelper.cs
@@ -1,0 +1,241 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using KeyboardManagerEditorUI.Interop;
+using Microsoft.PowerToys.Settings.UI.Library;
+using Windows.System;
+
+namespace KeyboardManagerEditorUI.Helpers
+{
+    public class KeyboardHookHelper : IDisposable
+    {
+        private static KeyboardHookHelper? _instance;
+
+        public static KeyboardHookHelper Instance => _instance ??= new KeyboardHookHelper();
+
+        private KeyboardMappingService _mappingService;
+
+        private HotkeySettingsControlHook? _keyboardHook;
+
+        // The active page using this keyboard hook
+        private IKeyboardHookTarget? _activeTarget;
+
+        private HashSet<VirtualKey> _currentlyPressedKeys = new();
+        private List<VirtualKey> _keyPressOrder = new();
+
+        private bool _disposed;
+
+        // Singleton to make sure only one instance of the hook is active
+        private KeyboardHookHelper()
+        {
+            _mappingService = new KeyboardMappingService();
+        }
+
+        public void ActivateHook(IKeyboardHookTarget target)
+        {
+            CleanupHook();
+
+            _activeTarget = target;
+
+            _currentlyPressedKeys.Clear();
+            _keyPressOrder.Clear();
+
+            _keyboardHook = new HotkeySettingsControlHook(
+                KeyDown,
+                KeyUp,
+                () => true,
+                (key, extraInfo) => true);
+        }
+
+        public void CleanupHook()
+        {
+            if (_keyboardHook != null)
+            {
+                _keyboardHook.Dispose();
+                _keyboardHook = null;
+            }
+
+            _currentlyPressedKeys.Clear();
+            _keyPressOrder.Clear();
+            _activeTarget = null;
+        }
+
+        private void KeyDown(int key)
+        {
+            if (_activeTarget == null)
+            {
+                return;
+            }
+
+            VirtualKey virtualKey = (VirtualKey)key;
+
+            if (_currentlyPressedKeys.Contains(virtualKey))
+            {
+                return;
+            }
+
+            // if no keys are pressed, clear the lists when a new key is pressed
+            if (_currentlyPressedKeys.Count == 0)
+            {
+                _activeTarget.ClearKeys();
+                _keyPressOrder.Clear();
+            }
+
+            // Count current modifiers
+            int modifierCount = _currentlyPressedKeys.Count(k => _activeTarget.IsModifierKey(k));
+
+            // If adding this key would exceed the limits (4 modifiers + 1 action key), don't add it and show notification
+            if ((_activeTarget.IsModifierKey(virtualKey) && modifierCount >= 4) ||
+                (!_activeTarget.IsModifierKey(virtualKey) && _currentlyPressedKeys.Count >= 5))
+            {
+                _activeTarget.OnInputLimitReached();
+                return;
+            }
+
+            // Check if this is a different variant of a modifier key already pressed
+            if (_activeTarget.IsModifierKey(virtualKey))
+            {
+                // Remove existing variant of this modifier key if a new one is pressed
+                // This is to ensure that only one variant of a modifier key is displayed at a time
+                RemoveExistingModifierVariant(virtualKey);
+            }
+
+            if (_currentlyPressedKeys.Add(virtualKey))
+            {
+                _keyPressOrder.Add(virtualKey);
+
+                // Notify the target page
+                _activeTarget.OnKeyDown(virtualKey, GetFormattedKeyList());
+            }
+        }
+
+        private void KeyUp(int key)
+        {
+            if (_activeTarget == null)
+            {
+                return;
+            }
+
+            VirtualKey virtualKey = (VirtualKey)key;
+
+            if (_currentlyPressedKeys.Remove(virtualKey))
+            {
+                _keyPressOrder.Remove(virtualKey);
+
+                _activeTarget.OnKeyUp(virtualKey, GetFormattedKeyList());
+            }
+        }
+
+        // Display the modifier keys and the action key in order, e.g. "Ctrl + Alt + A"
+        private List<string> GetFormattedKeyList()
+        {
+            if (_activeTarget == null)
+            {
+                return new List<string>();
+            }
+
+            List<string> keyList = new List<string>();
+            List<VirtualKey> modifierKeys = new List<VirtualKey>();
+            VirtualKey? actionKey = null;
+
+            foreach (var key in _keyPressOrder)
+            {
+                if (!_currentlyPressedKeys.Contains(key))
+                {
+                    continue;
+                }
+
+                if (_activeTarget.IsModifierKey(key))
+                {
+                    if (!modifierKeys.Contains(key))
+                    {
+                        modifierKeys.Add(key);
+                    }
+                }
+                else
+                {
+                    actionKey = key;
+                }
+            }
+
+            foreach (var key in modifierKeys)
+            {
+                keyList.Add(_mappingService.GetKeyDisplayName((int)key));
+            }
+
+            if (actionKey.HasValue)
+            {
+                keyList.Add(_mappingService.GetKeyDisplayName((int)actionKey.Value));
+            }
+
+            return keyList;
+        }
+
+        private void RemoveExistingModifierVariant(VirtualKey key)
+        {
+            KeyType keyType = (KeyType)KeyboardManagerInterop.GetKeyType((int)key);
+
+            // No need to remove if the key is an action key
+            if (keyType == KeyType.Action)
+            {
+                return;
+            }
+
+            foreach (var existingKey in _currentlyPressedKeys.ToList())
+            {
+                if (existingKey != key)
+                {
+                    KeyType existingKeyType = (KeyType)KeyboardManagerInterop.GetKeyType((int)existingKey);
+
+                    // Remove the existing key if it is a modifier key and has the same type as the new key
+                    if (existingKeyType == keyType)
+                    {
+                        _currentlyPressedKeys.Remove(existingKey);
+                        _keyPressOrder.Remove(existingKey);
+                    }
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    CleanupHook();
+                    _mappingService?.Dispose();
+                }
+
+                _disposed = true;
+            }
+        }
+    }
+
+    public interface IKeyboardHookTarget
+    {
+        void OnKeyDown(VirtualKey key, List<string> formattedKeys);
+
+        void OnKeyUp(VirtualKey key, List<string> formattedKeys)
+        {
+        }
+
+        void ClearKeys();
+
+        bool IsModifierKey(VirtualKey key);
+
+        void OnInputLimitReached();
+    }
+}

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/RemappingHelper.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/RemappingHelper.cs
@@ -10,6 +10,7 @@ using System.Text;
 using System.Threading.Tasks;
 using KeyboardManagerEditorUI.Interop;
 using ManagedCommon;
+using Windows.System;
 
 namespace KeyboardManagerEditorUI.Helpers
 {
@@ -123,6 +124,21 @@ namespace KeyboardManagerEditorUI.Helpers
                 Logger.LogError($"Error deleting remapping: {ex.Message}");
                 return false;
             }
+        }
+
+        public static bool IsModifierKey(VirtualKey key)
+        {
+            return key == VirtualKey.Control
+                || key == VirtualKey.LeftControl
+                || key == VirtualKey.RightControl
+                || key == VirtualKey.Menu
+                || key == VirtualKey.LeftMenu
+                || key == VirtualKey.RightMenu
+                || key == VirtualKey.Shift
+                || key == VirtualKey.LeftShift
+                || key == VirtualKey.RightShift
+                || key == VirtualKey.LeftWindows
+                || key == VirtualKey.RightWindows;
         }
     }
 }

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/TextMapping.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/TextMapping.cs
@@ -8,13 +8,16 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace KeyboardManagerEditorUI.Interop
+namespace KeyboardManagerEditorUI.Helpers
 {
-    public enum ShortcutOperationType
+    public class TextMapping
     {
-        RemapShortcut = 0,
-        RunProgram = 1,
-        OpenUri = 2,
-        RemapText = 3,
+        public List<string> Keys { get; set; } = new List<string>();
+
+        public string Text { get; set; } = string.Empty;
+
+        public bool IsAllApps { get; set; } = true;
+
+        public string AppName { get; set; } = "All Apps";
     }
 }

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/ValidationErrorType.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/ValidationErrorType.cs
@@ -20,5 +20,6 @@ namespace KeyboardManagerEditorUI.Helpers
         IllegalShortcut,
         DuplicateMapping,
         SelfMapping,
+        EmptyTargetText,
     }
 }

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/ValidationHelper.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/ValidationHelper.cs
@@ -112,7 +112,8 @@ namespace KeyboardManagerEditorUI.Helpers
             // For shortcut remapping
             else
             {
-                string originalKeysString = string.Join(";", originalKeys.Select(k => KeyboardManagerInterop.GetKeyCodeFromName(k).ToString(CultureInfo.InvariantCulture)));
+                string originalKeysString = string.Join(";", originalKeys.Select(
+                    k => KeyboardManagerInterop.GetKeyCodeFromName(k).ToString(CultureInfo.InvariantCulture)));
 
                 // Check if the shortcut is already remapped in the same app context
                 foreach (var mapping in mappingService.GetShortcutMappingsByType(ShortcutOperationType.RemapShortcut))
@@ -127,7 +128,8 @@ namespace KeyboardManagerEditorUI.Helpers
                         }
 
                         // If both are for the same specific app
-                        else if (isAppSpecific && !string.IsNullOrEmpty(mapping.TargetApp) && string.Equals(mapping.TargetApp, appName, StringComparison.OrdinalIgnoreCase))
+                        else if (isAppSpecific && !string.IsNullOrEmpty(mapping.TargetApp)
+                            && string.Equals(mapping.TargetApp, appName, StringComparison.OrdinalIgnoreCase))
                         {
                             return true;
                         }

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/ValidationHelper.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/ValidationHelper.cs
@@ -62,7 +62,7 @@ namespace KeyboardManagerEditorUI.Helpers
             // Check if this is a shortcut (multiple keys) and if it's an illegal combination
             if (originalKeys.Count > 1)
             {
-                string shortcutKeysString = string.Join(";", originalKeys.Select(k => KeyboardManagerInterop.GetKeyCodeFromName(k).ToString(CultureInfo.InvariantCulture)));
+                string shortcutKeysString = string.Join(";", originalKeys.Select(k => mappingService.GetKeyCodeFromName(k).ToString(CultureInfo.InvariantCulture)));
 
                 if (KeyboardManagerInterop.IsShortcutIllegal(shortcutKeysString))
                 {
@@ -101,7 +101,7 @@ namespace KeyboardManagerEditorUI.Helpers
             // For single key remapping
             if (originalKeys.Count == 1)
             {
-                int originalKeyCode = KeyboardManagerInterop.GetKeyCodeFromName(originalKeys[0]);
+                int originalKeyCode = mappingService.GetKeyCodeFromName(originalKeys[0]);
                 if (originalKeyCode == 0)
                 {
                     return false;
@@ -115,7 +115,7 @@ namespace KeyboardManagerEditorUI.Helpers
                         // Skip if the remapping is the same as the one being edited
                         if (isEditMode && editingRemapping != null &&
                             editingRemapping.OriginalKeys.Count == 1 &&
-                            KeyboardManagerInterop.GetKeyCodeFromName(editingRemapping.OriginalKeys[0]) == originalKeyCode)
+                            mappingService.GetKeyCodeFromName(editingRemapping.OriginalKeys[0]) == originalKeyCode)
                         {
                             continue;
                         }
@@ -129,14 +129,14 @@ namespace KeyboardManagerEditorUI.Helpers
             else
             {
                 string originalKeysString = string.Join(";", originalKeys.Select(
-                    k => KeyboardManagerInterop.GetKeyCodeFromName(k).ToString(CultureInfo.InvariantCulture)));
+                    k => mappingService.GetKeyCodeFromName(k).ToString(CultureInfo.InvariantCulture)));
 
                 // Don't check for duplicates if the original keys are the same as the remapping being edited
                 bool isEditingExistingRemapping = false;
                 if (isEditMode && editingRemapping != null)
                 {
                     string editingOriginalKeysString = string.Join(";", editingRemapping.OriginalKeys.Select(k =>
-                                    KeyboardManagerInterop.GetKeyCodeFromName(k).ToString(CultureInfo.InvariantCulture)));
+                                    mappingService.GetKeyCodeFromName(k).ToString(CultureInfo.InvariantCulture)));
 
                     if (KeyboardManagerInterop.AreShortcutsEqual(originalKeysString, editingOriginalKeysString))
                     {
@@ -181,8 +181,13 @@ namespace KeyboardManagerEditorUI.Helpers
             return false;
         }
 
-        public static bool IsSelfMapping(List<string> originalKeys, List<string> remappedKeys)
+        public static bool IsSelfMapping(List<string> originalKeys, List<string> remappedKeys, KeyboardMappingService mappingService)
         {
+            if (mappingService == null)
+            {
+                return false;
+            }
+
             // If either list is empty, it's not a self-mapping
             if (originalKeys == null || remappedKeys == null ||
                 originalKeys.Count == 0 || remappedKeys.Count == 0)
@@ -190,8 +195,8 @@ namespace KeyboardManagerEditorUI.Helpers
                 return false;
             }
 
-            string originalKeysString = string.Join(";", originalKeys.Select(k => KeyboardManagerInterop.GetKeyCodeFromName(k).ToString(CultureInfo.InvariantCulture)));
-            string remappedKeysString = string.Join(";", remappedKeys.Select(k => KeyboardManagerInterop.GetKeyCodeFromName(k).ToString(CultureInfo.InvariantCulture)));
+            string originalKeysString = string.Join(";", originalKeys.Select(k => mappingService.GetKeyCodeFromName(k).ToString(CultureInfo.InvariantCulture)));
+            string remappedKeysString = string.Join(";", remappedKeys.Select(k => mappingService.GetKeyCodeFromName(k).ToString(CultureInfo.InvariantCulture)));
 
             return KeyboardManagerInterop.AreShortcutsEqual(originalKeysString, remappedKeysString);
         }

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/ValidationHelper.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/ValidationHelper.cs
@@ -23,6 +23,7 @@ namespace KeyboardManagerEditorUI.Helpers
             { ValidationErrorType.IllegalShortcut, ("Reserved System Shortcut", "Win+L and Ctrl+Alt+Delete are reserved system shortcuts and cannot be remapped.") },
             { ValidationErrorType.DuplicateMapping, ("Duplicate Remapping", "This key or shortcut is already remapped.") },
             { ValidationErrorType.SelfMapping, ("Invalid Remapping", "A key or shortcut cannot be remapped to itself. Please choose a different target.") },
+            { ValidationErrorType.EmptyTargetText, ("Missing Target Text", "Please enter the text to be inserted when the shortcut is pressed.") },
         };
 
         public static ValidationErrorType ValidateKeyMapping(

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/ValidationHelper.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/ValidationHelper.cs
@@ -85,6 +85,52 @@ namespace KeyboardManagerEditorUI.Helpers
             return ValidationErrorType.NoError;
         }
 
+        public static ValidationErrorType ValidateTextMapping(
+            List<string> keys,
+            string textContent,
+            bool isAppSpecific,
+            string appName,
+            KeyboardMappingService mappingService)
+        {
+            // Check if original keys are empty
+            if (keys == null || keys.Count == 0)
+            {
+                return ValidationErrorType.EmptyOriginalKeys;
+            }
+
+            // Check if text content is empty
+            if (string.IsNullOrWhiteSpace(textContent))
+            {
+                return ValidationErrorType.EmptyTargetText;
+            }
+
+            // Check if shortcut contains only modifier keys
+            if (keys.Count > 1 && ContainsOnlyModifierKeys(keys))
+            {
+                return ValidationErrorType.ModifierOnly;
+            }
+
+            // Check if app specific is checked but no app name is provided
+            if (isAppSpecific && string.IsNullOrWhiteSpace(appName))
+            {
+                return ValidationErrorType.EmptyAppName;
+            }
+
+            // Check if this is a shortcut (multiple keys) and if it's an illegal combination
+            if (keys.Count > 1)
+            {
+                string shortcutKeysString = string.Join(";", keys.Select(k => mappingService.GetKeyCodeFromName(k).ToString(CultureInfo.InvariantCulture)));
+
+                if (KeyboardManagerInterop.IsShortcutIllegal(shortcutKeysString))
+                {
+                    return ValidationErrorType.IllegalShortcut;
+                }
+            }
+
+            // No errors found
+            return ValidationErrorType.NoError;
+        }
+
         public static bool IsDuplicateMapping(
             List<string> originalKeys,
             bool isAppSpecific,

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/ValidationHelper.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/ValidationHelper.cs
@@ -77,7 +77,7 @@ namespace KeyboardManagerEditorUI.Helpers
             }
 
             // Check for self-mapping
-            if (IsSelfMapping(originalKeys, remappedKeys))
+            if (IsSelfMapping(originalKeys, remappedKeys, mappingService))
             {
                 return ValidationErrorType.SelfMapping;
             }

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Interop/KeyboardManagerInterop.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Interop/KeyboardManagerInterop.cs
@@ -15,6 +15,7 @@ namespace KeyboardManagerEditorUI.Interop
     {
         private const string DllName = "Powertoys.KeyboardManagerEditorLibraryWrapper.dll";
 
+        // Configuration Management
         [DllImport(DllName)]
         internal static extern IntPtr CreateMappingConfiguration();
 
@@ -29,6 +30,7 @@ namespace KeyboardManagerEditorUI.Interop
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool SaveMappingSettings(IntPtr config);
 
+        // Get Mapping Functions
         [DllImport(DllName)]
         internal static extern int GetSingleKeyRemapCount(IntPtr config);
 
@@ -57,6 +59,7 @@ namespace KeyboardManagerEditorUI.Interop
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool GetShortcutRemapByType(IntPtr config, int operationType, int index, ref ShortcutMapping mapping);
 
+        // Add Mapping Functions
         [DllImport(DllName)]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool AddSingleKeyRemap(IntPtr config, int originalKey, int targetKey);
@@ -78,26 +81,7 @@ namespace KeyboardManagerEditorUI.Interop
             [MarshalAs(UnmanagedType.LPWStr)] string targetApp,
             int operationType = 0);
 
-        [DllImport(DllName)]
-        internal static extern int GetKeyCodeFromName([MarshalAs(UnmanagedType.LPWStr)] string keyName);
-
-        [DllImport(DllName, CharSet = CharSet.Unicode)]
-        internal static extern void GetKeyDisplayName(int keyCode, [Out] StringBuilder keyName, int maxLength);
-
-        [DllImport(DllName)]
-        internal static extern void FreeString(IntPtr str);
-
-        [DllImport(DllName)]
-        internal static extern int GetKeyType(int keyCode);
-
-        [DllImport(DllName)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern bool IsShortcutIllegal([MarshalAs(UnmanagedType.LPWStr)] string shortcutKeys);
-
-        [DllImport(DllName)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern bool AreShortcutsEqual([MarshalAs(UnmanagedType.LPWStr)] string lShort, [MarshalAs(UnmanagedType.LPWStr)] string rShortcut);
-
+        // Delete Mapping Functions
         [DllImport(DllName)]
         internal static extern bool DeleteSingleKeyRemap(IntPtr mappingConfiguration, int originalKey);
 
@@ -107,6 +91,29 @@ namespace KeyboardManagerEditorUI.Interop
 
         [DllImport(DllName)]
         internal static extern bool DeleteShortcutRemap(IntPtr mappingConfiguration, [MarshalAs(UnmanagedType.LPWStr)] string originalKeys, [MarshalAs(UnmanagedType.LPWStr)] string targetApp);
+
+        // Key Utility Functions
+        [DllImport(DllName)]
+        internal static extern int GetKeyCodeFromName([MarshalAs(UnmanagedType.LPWStr)] string keyName);
+
+        [DllImport(DllName, CharSet = CharSet.Unicode)]
+        internal static extern void GetKeyDisplayName(int keyCode, [Out] StringBuilder keyName, int maxLength);
+
+        [DllImport(DllName)]
+        internal static extern int GetKeyType(int keyCode);
+
+        // Validation Functions
+        [DllImport(DllName)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool IsShortcutIllegal([MarshalAs(UnmanagedType.LPWStr)] string shortcutKeys);
+
+        [DllImport(DllName)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool AreShortcutsEqual([MarshalAs(UnmanagedType.LPWStr)] string lShort, [MarshalAs(UnmanagedType.LPWStr)] string rShortcut);
+
+        // String Management Functions
+        [DllImport(DllName)]
+        internal static extern void FreeString(IntPtr str);
 
         public static string GetStringAndFree(IntPtr handle)
         {

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Interop/KeyboardManagerInterop.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Interop/KeyboardManagerInterop.cs
@@ -75,7 +75,8 @@ namespace KeyboardManagerEditorUI.Interop
             IntPtr config,
             [MarshalAs(UnmanagedType.LPWStr)] string originalKeys,
             [MarshalAs(UnmanagedType.LPWStr)] string targetKeys,
-            [MarshalAs(UnmanagedType.LPWStr)] string targetApp);
+            [MarshalAs(UnmanagedType.LPWStr)] string targetApp,
+            int operationType = 0);
 
         [DllImport(DllName)]
         internal static extern int GetKeyCodeFromName([MarshalAs(UnmanagedType.LPWStr)] string keyName);
@@ -99,6 +100,10 @@ namespace KeyboardManagerEditorUI.Interop
 
         [DllImport(DllName)]
         internal static extern bool DeleteSingleKeyRemap(IntPtr mappingConfiguration, int originalKey);
+
+        [DllImport(DllName)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool DeleteSingleKeyToTextRemap(IntPtr config, int originalKey);
 
         [DllImport(DllName)]
         internal static extern bool DeleteShortcutRemap(IntPtr mappingConfiguration, [MarshalAs(UnmanagedType.LPWStr)] string originalKeys, [MarshalAs(UnmanagedType.LPWStr)] string targetApp);

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Interop/KeyboardManagerInterop.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Interop/KeyboardManagerInterop.cs
@@ -63,6 +63,10 @@ namespace KeyboardManagerEditorUI.Interop
 
         [DllImport(DllName)]
         [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool AddSingleKeyToTextRemap(IntPtr config, int originalKey, [MarshalAs(UnmanagedType.LPWStr)] string targetText);
+
+        [DllImport(DllName)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool AddSingleKeyToShortcutRemap(IntPtr config, int originalKey, [MarshalAs(UnmanagedType.LPWStr)] string targetKeys);
 
         [DllImport(DllName)]

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Interop/KeyboardMappingService.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Interop/KeyboardMappingService.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
+using ManagedCommon;
 
 namespace KeyboardManagerEditorUI.Interop
 {
@@ -21,6 +22,7 @@ namespace KeyboardManagerEditorUI.Interop
             _configHandle = KeyboardManagerInterop.CreateMappingConfiguration();
             if (_configHandle == IntPtr.Zero)
             {
+                Logger.LogError("Failed to create mapping configuration");
                 throw new InvalidOperationException("Failed to create mapping configuration");
             }
 

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Interop/KeyboardMappingService.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Interop/KeyboardMappingService.cs
@@ -175,14 +175,14 @@ namespace KeyboardManagerEditorUI.Interop
             return KeyboardManagerInterop.AddSingleKeyToTextRemap(_configHandle, originalKey, targetText);
         }
 
-        public bool AddShortcutMapping(string originalKeys, string targetKeys, string targetApp = "")
+        public bool AddShortcutMapping(string originalKeys, string targetKeys, string targetApp = "", ShortcutOperationType operationType = ShortcutOperationType.RemapShortcut)
         {
             if (string.IsNullOrEmpty(originalKeys) || string.IsNullOrEmpty(targetKeys))
             {
                 return false;
             }
 
-            return KeyboardManagerInterop.AddShortcutRemap(_configHandle, originalKeys, targetKeys, targetApp);
+            return KeyboardManagerInterop.AddShortcutRemap(_configHandle, originalKeys, targetKeys, targetApp, (int)operationType);
         }
 
         public bool SaveSettings()
@@ -193,6 +193,16 @@ namespace KeyboardManagerEditorUI.Interop
         public bool DeleteSingleKeyMapping(int originalKey)
         {
             return KeyboardManagerInterop.DeleteSingleKeyRemap(_configHandle, originalKey);
+        }
+
+        public bool DeleteSingleKeyToTextMapping(int originalKey)
+        {
+            if (originalKey == 0)
+            {
+                return false;
+            }
+
+            return KeyboardManagerInterop.DeleteSingleKeyToTextRemap(_configHandle, originalKey);
         }
 
         public bool DeleteShortcutMapping(string originalKeys, string targetApp = "")

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Interop/KeyboardMappingService.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Interop/KeyboardMappingService.cs
@@ -165,6 +165,16 @@ namespace KeyboardManagerEditorUI.Interop
             }
         }
 
+        public bool AddSingleKeyToTextMapping(int originalKey, string targetText)
+        {
+            if (string.IsNullOrEmpty(targetText))
+            {
+                return false;
+            }
+
+            return KeyboardManagerInterop.AddSingleKeyToTextRemap(_configHandle, originalKey, targetText);
+        }
+
         public bool AddShortcutMapping(string originalKeys, string targetKeys, string targetApp = "")
         {
             if (string.IsNullOrEmpty(originalKeys) || string.IsNullOrEmpty(targetKeys))

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Interop/KeyboardMappingService.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Interop/KeyboardMappingService.cs
@@ -131,6 +131,16 @@ namespace KeyboardManagerEditorUI.Interop
             return keyName.ToString();
         }
 
+        public int GetKeyCodeFromName(string keyName)
+        {
+            if (string.IsNullOrEmpty(keyName))
+            {
+                return 0;
+            }
+
+            return KeyboardManagerInterop.GetKeyCodeFromName(keyName);
+        }
+
         public bool AddSingleKeyMapping(int originalKey, int targetKey)
         {
             return KeyboardManagerInterop.AddSingleKeyRemap(_configHandle, originalKey, targetKey);

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/KeyboardManagerEditorUI.csproj
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/KeyboardManagerEditorUI.csproj
@@ -31,6 +31,7 @@
     <None Remove="Styles\CommonStyle.xaml" />
     <None Remove="Styles\InputControl.xaml" />
     <None Remove="Styles\KeyVisual.xaml" />
+    <None Remove="Styles\TextPageInputControl.xaml" />
   </ItemGroup>
 
   <ItemGroup>
@@ -56,6 +57,11 @@
     <ProjectReference Include="..\..\..\common\ManagedCommon\ManagedCommon.csproj" />
     <ProjectReference Include="..\..\..\settings-ui\Settings.UI.Library\Settings.UI.Library.csproj" />
     <ProjectReference Include="..\..\..\common\Common.UI\Common.UI.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Page Update="Styles\TextPageInputControl.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
   </ItemGroup>
   <ItemGroup>
     <Page Update="Styles\CommonStyle.xaml">

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/MainWindow.xaml
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/MainWindow.xaml
@@ -49,14 +49,14 @@
                         <FontIcon Glyph="&#xEDA7;" />
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
-                <NavigationViewItem Content="Programs" Tag="Programs">
-                    <NavigationViewItem.Icon>
-                        <FontIcon Glyph="&#xECAA;" />
-                    </NavigationViewItem.Icon>
-                </NavigationViewItem>
                 <NavigationViewItem Content="Text" Tag="Text">
                     <NavigationViewItem.Icon>
                         <FontIcon Glyph="&#xE8D2;" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
+                <NavigationViewItem Content="Programs" Tag="Programs">
+                    <NavigationViewItem.Icon>
+                        <FontIcon Glyph="&#xECAA;" />
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
                 <NavigationViewItem Content="URLs" Tag="URLs">

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/MainWindow.xaml.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/MainWindow.xaml.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.WindowsRuntime;
+using KeyboardManagerEditorUI.Helpers;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
@@ -29,12 +30,34 @@ namespace KeyboardManagerEditorUI
             this.ExtendsContentIntoTitleBar = true;
             this.SetTitleBar(titleBar);
 
+            this.Activated += MainWindow_Activated;
+            this.Closed += MainWindow_Closed;
+
             // Set the default page
             RootView.SelectedItem = RootView.MenuItems[0];
         }
 
+        private void MainWindow_Activated(object sender, WindowActivatedEventArgs args)
+        {
+            if (args.WindowActivationState == WindowActivationState.Deactivated)
+            {
+                // Release the keyboard hook when the window is deactivated
+                KeyboardHookHelper.Instance.CleanupHook();
+            }
+        }
+
+        private void MainWindow_Closed(object sender, WindowEventArgs args)
+        {
+            KeyboardHookHelper.Instance.Dispose();
+            this.Activated -= MainWindow_Activated;
+            this.Closed -= MainWindow_Closed;
+        }
+
         private void RootView_SelectionChanged(NavigationView sender, NavigationViewSelectionChangedEventArgs args)
         {
+            // Cleanup the keyboard hook when the selected page changes
+            KeyboardHookHelper.Instance.CleanupHook();
+
             if (args.SelectedItem is NavigationViewItem selectedItem)
             {
                 switch ((string)selectedItem.Tag)

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/ExistingUI.xaml.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/ExistingUI.xaml.cs
@@ -45,9 +45,6 @@ namespace KeyboardManagerEditorUI.Pages
         [DllImport("PowerToys.KeyboardManagerEditorLibraryWrapper.dll", CallingConvention = CallingConvention.Cdecl)]
         private static extern int GetKeyboardKeysList(bool isShortcut, [Out] KeyNamePair[] keyList, int maxCount);
 
-        [DllImport("PowerToys.KeyboardManagerEditorLibraryWrapper.dll", CallingConvention = CallingConvention.Cdecl)]
-        private static extern bool CheckIfRemappingsAreValid();
-
         public List<KeyboardKey> KeysList { get; private set; } = new List<KeyboardKey>();
 
         public ExistingUI()
@@ -78,14 +75,6 @@ namespace KeyboardManagerEditorUI.Pages
                     KeyCode = keyNamePairs[i].KeyCode,
                     KeyName = keyNamePairs[i].KeyName,
                 });
-            }
-        }
-
-        private void KeyComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
-        {
-            if (e.AddedItems.Count > 0 && e.AddedItems[0] is KeyboardKey key)
-            {
-                Console.WriteLine($"selected key: {key.KeyName} (code: {key.KeyCode})");
             }
         }
 

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Programs.xaml
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Programs.xaml
@@ -62,6 +62,12 @@
                     VerticalAlignment="Center"
                     Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                     Text="Program" />
+                <Rectangle
+                    Grid.ColumnSpan="4"
+                    Height="1"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Bottom"
+                    Fill="{ThemeResource CardStrokeColorDefaultBrush}" />
                 <ListView
                     Grid.Row="1"
                     Grid.ColumnSpan="4"

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Remappings.xaml.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Remappings.xaml.cs
@@ -236,7 +236,7 @@ namespace KeyboardManagerEditorUI.Pages
 
             // Validate the remapping
             ValidationErrorType errorType = ValidationHelper.ValidateKeyMapping(
-                originalKeys, remappedKeys, isAppSpecific, appName, _mappingService);
+                originalKeys, remappedKeys, isAppSpecific, appName, _mappingService, _isEditMode, _editingRemapping);
 
             if (errorType != ValidationErrorType.NoError)
             {

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Remappings.xaml.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Remappings.xaml.cs
@@ -270,7 +270,7 @@ namespace KeyboardManagerEditorUI.Pages
             }
 
             // If no errors, proceed to save the remapping
-            bool saved = SaveCurrentMapping();
+            bool saved = RemappingHelper.SaveMapping(_mappingService!, originalKeys, remappedKeys, isAppSpecific, appName);
             if (saved)
             {
                 // Display the remapping in the list after saving
@@ -306,7 +306,7 @@ namespace KeyboardManagerEditorUI.Pages
                 DeleteRemapping(_editingRemapping);
             }
 
-            bool saved = SaveCurrentMapping();
+            bool saved = RemappingHelper.SaveMapping(_mappingService!, RemappingControl.GetOriginalKeys(), RemappingControl.GetRemappedKeys(), RemappingControl.GetIsAppSpecific(), RemappingControl.GetAppName());
             if (saved)
             {
                 KeyDialog.Hide();
@@ -352,71 +352,6 @@ namespace KeyboardManagerEditorUI.Pages
         public static int GetKeyCode(string keyName)
         {
             return KeyboardManagerInterop.GetKeyCodeFromName(keyName);
-        }
-
-        private bool SaveCurrentMapping()
-        {
-            if (_mappingService == null)
-            {
-                Logger.LogError("Mapping service is null, cannot save mapping");
-                return false;
-            }
-
-            try
-            {
-                List<string> originalKeys = RemappingControl.GetOriginalKeys();
-                List<string> remappedKeys = RemappingControl.GetRemappedKeys();
-                bool isAppSpecific = RemappingControl.GetIsAppSpecific();
-                string appName = RemappingControl.GetAppName();
-
-                if (originalKeys == null || originalKeys.Count == 0 || remappedKeys == null || remappedKeys.Count == 0)
-                {
-                    return false;
-                }
-
-                if (originalKeys.Count == 1)
-                {
-                    int originalKey = GetKeyCode(originalKeys[0]);
-                    if (originalKey != 0)
-                    {
-                        if (remappedKeys.Count == 1)
-                        {
-                            int targetKey = GetKeyCode(remappedKeys[0]);
-                            if (targetKey != 0)
-                            {
-                                _mappingService.AddSingleKeyMapping(originalKey, targetKey);
-                            }
-                        }
-                        else
-                        {
-                            string targetKeys = string.Join(";", remappedKeys.Select(k => GetKeyCode(k).ToString(CultureInfo.InvariantCulture)));
-                            _mappingService.AddSingleKeyMapping(originalKey, targetKeys);
-                        }
-                    }
-                }
-                else
-                {
-                    string originalKeysString = string.Join(";", originalKeys.Select(k => GetKeyCode(k).ToString(CultureInfo.InvariantCulture)));
-                    string targetKeysString = string.Join(";", remappedKeys.Select(k => GetKeyCode(k).ToString(CultureInfo.InvariantCulture)));
-
-                    if (isAppSpecific && !string.IsNullOrEmpty(appName))
-                    {
-                        _mappingService.AddShortcutMapping(originalKeysString, targetKeysString, appName);
-                    }
-                    else
-                    {
-                        _mappingService.AddShortcutMapping(originalKeysString, targetKeysString);
-                    }
-                }
-
-                _mappingService.SaveSettings();
-                return true;
-            }
-            catch (Exception ex)
-            {
-                Logger.LogError("Error saving shortcut mapping: " + ex.Message);
-                return false;
-            }
         }
 
         private void DeleteButton_Click(object sender, RoutedEventArgs e)

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Remappings.xaml.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Remappings.xaml.cs
@@ -68,7 +68,7 @@ namespace KeyboardManagerEditorUI.Pages
         {
             // Make sure we unregister the handler when the page is unloaded
             UnregisterWindowActivationHandler();
-            RemappingControl.CleanupKeyboardHook();
+            KeyboardHookHelper.Instance.CleanupHook();
         }
 
         private void RegisterWindowActivationHandler()
@@ -98,7 +98,7 @@ namespace KeyboardManagerEditorUI.Pages
             if (args.WindowActivationState == WindowActivationState.Deactivated)
             {
                 // Make sure to cleanup the keyboard hook when the window loses focus
-                RemappingControl.CleanupKeyboardHook();
+                KeyboardHookHelper.Instance.CleanupHook();
 
                 RemappingControl.ResetToggleButtons();
                 RemappingControl.UpdateAllAppsCheckBoxState();
@@ -124,7 +124,7 @@ namespace KeyboardManagerEditorUI.Pages
 
             UnregisterWindowActivationHandler();
 
-            RemappingControl.CleanupKeyboardHook();
+            KeyboardHookHelper.Instance.CleanupHook();
         }
 
         private async void ListView_ItemClick(object sender, ItemClickEventArgs e)
@@ -148,7 +148,7 @@ namespace KeyboardManagerEditorUI.Pages
 
                 UnregisterWindowActivationHandler();
 
-                RemappingControl.CleanupKeyboardHook();
+                KeyboardHookHelper.Instance.CleanupHook();
 
                 // Reset the edit status
                 _isEditMode = false;

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Remappings.xaml.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Remappings.xaml.cs
@@ -266,7 +266,10 @@ namespace KeyboardManagerEditorUI.Pages
             // If in edit mode, delete the existing remapping before saving the new one
             if (_isEditMode && _editingRemapping != null)
             {
-                DeleteRemapping(_editingRemapping);
+                if (!RemappingHelper.DeleteRemapping(_mappingService!, _editingRemapping))
+                {
+                    return;
+                }
             }
 
             // If no errors, proceed to save the remapping
@@ -303,10 +306,14 @@ namespace KeyboardManagerEditorUI.Pages
 
             if (_isEditMode && _editingRemapping != null)
             {
-                DeleteRemapping(_editingRemapping);
+                if (!RemappingHelper.DeleteRemapping(_mappingService!, _editingRemapping))
+                {
+                    return;
+                }
             }
 
-            bool saved = RemappingHelper.SaveMapping(_mappingService!, RemappingControl.GetOriginalKeys(), RemappingControl.GetRemappedKeys(), RemappingControl.GetIsAppSpecific(), RemappingControl.GetAppName());
+            bool saved = RemappingHelper.SaveMapping(
+                _mappingService!, RemappingControl.GetOriginalKeys(), RemappingControl.GetRemappedKeys(), RemappingControl.GetIsAppSpecific(), RemappingControl.GetAppName());
             if (saved)
             {
                 KeyDialog.Hide();
@@ -358,7 +365,10 @@ namespace KeyboardManagerEditorUI.Pages
         {
             if (sender is Button button && button.DataContext is Remapping remapping)
             {
-                DeleteRemapping(remapping);
+                if (RemappingHelper.DeleteRemapping(_mappingService!, remapping))
+                {
+                    LoadMappings();
+                }
             }
         }
 

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Text.xaml
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Text.xaml
@@ -181,6 +181,8 @@
         <ContentDialog
             x:Name="KeyDialog"
             Title="Text Shortcut"
+            Width="480"
+            Height="360"
             MinWidth="600"
             MaxWidth="600"
             PrimaryButtonClick="KeyDialog_PrimaryButtonClick"

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Text.xaml
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Text.xaml
@@ -62,6 +62,12 @@
                     VerticalAlignment="Center"
                     Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                     Text="Text" />
+                <Rectangle
+                    Grid.ColumnSpan="4"
+                    Height="1"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Bottom"
+                    Fill="{ThemeResource CardStrokeColorDefaultBrush}" />
                 <ListView
                     Grid.Row="1"
                     Grid.ColumnSpan="4"

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Text.xaml
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Text.xaml
@@ -17,7 +17,6 @@
                 Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                 Text="Text shortcuts allow you to insert text in any input field when you use the configured keyboard shortcut"
                 TextWrapping="Wrap" />
-
             <Button
                 x:Name="NewShortcutBtn"
                 Height="36"
@@ -31,7 +30,6 @@
                     <TextBlock VerticalAlignment="Center" Text="New" />
                 </StackPanel>
             </Button>
-
             <Grid
                 HorizontalAlignment="Stretch"
                 Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
@@ -48,19 +46,16 @@
                     <ColumnDefinition Width="120" />
                     <ColumnDefinition Width="84" />
                 </Grid.ColumnDefinitions>
-
                 <TextBlock
                     Grid.Column="0"
                     Margin="16,-2,0,0"
                     VerticalAlignment="Center"
                     Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                    Text="Shortcut" />
-
+                    Text="Original key(s)" />
                 <AppBarSeparator
                     Grid.Column="1"
                     Margin="-6,4,0,4"
                     HorizontalAlignment="Left" />
-
                 <TextBlock
                     Grid.Column="1"
                     Margin="12,-2,0,0"
@@ -68,19 +63,23 @@
                     VerticalAlignment="Center"
                     Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                     Text="Text" />
-
+                <AppBarSeparator
+                    Grid.Column="2"
+                    Margin="-6,4,0,4"
+                    HorizontalAlignment="Left" />
                 <TextBlock
                     Grid.Column="2"
                     Margin="12,-2,0,0"
                     HorizontalAlignment="Left"
                     VerticalAlignment="Center"
                     Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                    Text="App" />
+                    Text="Applicable apps" />
 
                 <Rectangle
                     Grid.Row="0"
                     Grid.ColumnSpan="4"
                     Height="1"
+                    HorizontalAlignment="Stretch"
                     VerticalAlignment="Bottom"
                     Fill="{ThemeResource CardStrokeColorDefaultBrush}" />
 
@@ -94,16 +93,27 @@
                     SelectionMode="None">
                     <ListView.ItemTemplate>
                         <DataTemplate x:DataType="helper:TextMapping">
-                            <Grid Margin="8,4" HorizontalAlignment="Stretch">
+                            <Grid Height="Auto" MinHeight="48">
                                 <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="220" />
+                                    <ColumnDefinition Width="236" />
                                     <ColumnDefinition Width="*" />
                                     <ColumnDefinition Width="120" />
                                     <ColumnDefinition Width="48" />
                                 </Grid.ColumnDefinitions>
+                                <Rectangle
+                                    Grid.ColumnSpan="5"
+                                    Height="1"
+                                    Margin="-16,0,-16,0"
+                                    HorizontalAlignment="Stretch"
+                                    VerticalAlignment="Bottom"
+                                    Fill="{ThemeResource CardStrokeColorDefaultBrush}"
+                                    Opacity="0.8" />
 
                                 <!--  Shortcut keys  -->
-                                <ItemsControl ItemsSource="{x:Bind Keys}">
+                                <ItemsControl
+                                    Grid.Column="0"
+                                    VerticalAlignment="Center"
+                                    ItemsSource="{x:Bind Keys}">
                                     <ItemsControl.ItemsPanel>
                                         <ItemsPanelTemplate>
                                             <controls:WrapPanel
@@ -125,15 +135,20 @@
                                 <!--  Text content  -->
                                 <TextBlock
                                     Grid.Column="1"
+                                    Margin="-4,0,0,0"
+                                    HorizontalAlignment="Left"
                                     VerticalAlignment="Center"
-                                    Foreground="{ThemeResource TextFillColorPrimaryBrush}"
+                                    FontSize="12"
                                     Text="{x:Bind Text}"
                                     TextTrimming="CharacterEllipsis" />
 
                                 <!--  App name  -->
                                 <TextBlock
                                     Grid.Column="2"
+                                    Margin="-4,0,0,0"
+                                    HorizontalAlignment="Left"
                                     VerticalAlignment="Center"
+                                    FontSize="12"
                                     Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                     Text="{x:Bind AppName}"
                                     TextTrimming="CharacterEllipsis" />

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Text.xaml
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Text.xaml
@@ -3,6 +3,7 @@
     x:Class="KeyboardManagerEditorUI.Pages.Text"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:CommunityToolkit.WinUI.UI.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:helper="using:KeyboardManagerEditorUI.Helpers"
     xmlns:local="using:KeyboardManagerEditorUI.Pages"
@@ -14,8 +15,9 @@
         <StackPanel Orientation="Vertical" Spacing="12">
             <TextBlock
                 Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                Text="Text shortcuts allow you to insert text in any inputfield when you use the configured text"
+                Text="Text shortcuts allow you to insert text in any input field when you use the configured keyboard shortcut"
                 TextWrapping="Wrap" />
+
             <Button
                 x:Name="NewShortcutBtn"
                 Height="36"
@@ -29,6 +31,7 @@
                     <TextBlock VerticalAlignment="Center" Text="New" />
                 </StackPanel>
             </Button>
+
             <Grid
                 HorizontalAlignment="Stretch"
                 Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
@@ -41,20 +44,23 @@
                 </Grid.RowDefinitions>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="236" />
-                    <ColumnDefinition Width="236" />
                     <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="120" />
                     <ColumnDefinition Width="84" />
                 </Grid.ColumnDefinitions>
+
                 <TextBlock
                     Grid.Column="0"
                     Margin="16,-2,0,0"
                     VerticalAlignment="Center"
                     Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                     Text="Shortcut" />
+
                 <AppBarSeparator
                     Grid.Column="1"
                     Margin="-6,4,0,4"
                     HorizontalAlignment="Left" />
+
                 <TextBlock
                     Grid.Column="1"
                     Margin="12,-2,0,0"
@@ -62,43 +68,48 @@
                     VerticalAlignment="Center"
                     Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                     Text="Text" />
+
+                <TextBlock
+                    Grid.Column="2"
+                    Margin="12,-2,0,0"
+                    HorizontalAlignment="Left"
+                    VerticalAlignment="Center"
+                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                    Text="App" />
+
                 <Rectangle
+                    Grid.Row="0"
                     Grid.ColumnSpan="4"
                     Height="1"
-                    HorizontalAlignment="Stretch"
                     VerticalAlignment="Bottom"
                     Fill="{ThemeResource CardStrokeColorDefaultBrush}" />
+
                 <ListView
+                    x:Name="MappingsList"
                     Grid.Row="1"
                     Grid.ColumnSpan="4"
                     IsItemClickEnabled="True"
                     ItemClick="ListView_ItemClick"
-                    ItemsSource="{x:Bind Shortcuts}"
+                    ItemsSource="{x:Bind TextMappings}"
                     SelectionMode="None">
                     <ListView.ItemTemplate>
-                        <DataTemplate x:DataType="helper:URLShortcut">
-                            <Grid Height="48">
+                        <DataTemplate x:DataType="helper:TextMapping">
+                            <Grid Margin="8,4" HorizontalAlignment="Stretch">
                                 <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="232" />
-                                    <ColumnDefinition Width="238" />
+                                    <ColumnDefinition Width="220" />
                                     <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="84" />
+                                    <ColumnDefinition Width="120" />
+                                    <ColumnDefinition Width="48" />
                                 </Grid.ColumnDefinitions>
-                                <Rectangle
-                                    Grid.ColumnSpan="5"
-                                    Height="1"
-                                    Margin="-16,0,-16,0"
-                                    HorizontalAlignment="Stretch"
-                                    VerticalAlignment="Bottom"
-                                    Fill="{ThemeResource CardStrokeColorDefaultBrush}"
-                                    Opacity="0.8" />
-                                <ItemsControl
-                                    Grid.Column="0"
-                                    VerticalAlignment="Center"
-                                    ItemsSource="{x:Bind Shortcut}">
+
+                                <!--  Shortcut keys  -->
+                                <ItemsControl ItemsSource="{x:Bind Keys}">
                                     <ItemsControl.ItemsPanel>
                                         <ItemsPanelTemplate>
-                                            <StackPanel Orientation="Horizontal" Spacing="4" />
+                                            <controls:WrapPanel
+                                                MaxWidth="230"
+                                                HorizontalSpacing="4"
+                                                Orientation="Horizontal" />
                                         </ItemsPanelTemplate>
                                     </ItemsControl.ItemsPanel>
                                     <ItemsControl.ItemTemplate>
@@ -110,62 +121,70 @@
                                         </DataTemplate>
                                     </ItemsControl.ItemTemplate>
                                 </ItemsControl>
+
+                                <!--  Text content  -->
                                 <TextBlock
                                     Grid.Column="1"
-                                    Grid.ColumnSpan="2"
-                                    Margin="0,0,0,0"
                                     VerticalAlignment="Center"
-                                    FontSize="12"
-                                    Text="{x:Bind URL}"
+                                    Foreground="{ThemeResource TextFillColorPrimaryBrush}"
+                                    Text="{x:Bind Text}"
                                     TextTrimming="CharacterEllipsis" />
-                                <ToggleSwitch
-                                    Grid.ColumnSpan="4"
-                                    Margin="0,0,-112,0"
+
+                                <!--  App name  -->
+                                <TextBlock
+                                    Grid.Column="2"
+                                    VerticalAlignment="Center"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    Text="{x:Bind AppName}"
+                                    TextTrimming="CharacterEllipsis" />
+
+                                <!--  Delete button  -->
+                                <Button
+                                    Grid.Column="3"
+                                    Margin="0,0,4,0"
+                                    Padding="8,4"
                                     HorizontalAlignment="Right"
-                                    IsOn="True"
-                                    OffContent=""
-                                    OnContent="" />
+                                    VerticalAlignment="Center"
+                                    AutomationProperties.Name="Delete remapping"
+                                    Background="Transparent"
+                                    BorderThickness="0"
+                                    Click="DeleteButton_Click"
+                                    ToolTipService.ToolTip="Delete">
+                                    <FontIcon
+                                        FontFamily="{StaticResource SymbolThemeFontFamily}"
+                                        FontSize="16"
+                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                        Glyph="&#xE74D;" />
+                                </Button>
                             </Grid>
                         </DataTemplate>
                     </ListView.ItemTemplate>
                 </ListView>
             </Grid>
         </StackPanel>
+
         <ContentDialog
             x:Name="KeyDialog"
-            Title="New text shortcut"
-            Width="480"
-            Height="360"
+            Title="Text Shortcut"
             MinWidth="600"
             MaxWidth="600"
+            PrimaryButtonClick="KeyDialog_PrimaryButtonClick"
             PrimaryButtonStyle="{StaticResource AccentButtonStyle}"
             PrimaryButtonText="Save"
             SecondaryButtonText="Cancel">
-            <StackPanel
-                Width="360"
-                Height="360"
-                Orientation="Vertical">
-                <TextBlock Margin="0,12,0,8" Text="Shortcut" />
-                <ToggleButton
-                    x:Name="OriginalToggleBtn"
-                    Padding="0,24,0,24"
-                    HorizontalAlignment="Stretch"
-                    Style="{StaticResource CustomShortcutToggleButtonStyle}">
-                    <ToggleButton.Content>
-                        <StackPanel Orientation="Horizontal" Spacing="8">
-                            <styles:KeyVisual Content="Shift" VisualType="SmallOutline" />
-                            <styles:KeyVisual Content="Win" VisualType="SmallOutline" />
-                            <styles:KeyVisual Content="M" VisualType="SmallOutline" />
-                        </StackPanel>
-                    </ToggleButton.Content>
-                </ToggleButton>
-                <TextBox
-                    Height="200"
-                    Margin="0,24,0,0"
-                    Header="Text to insert"
-                    Text="https://www.microsoft.com"
-                    TextWrapping="Wrap" />
-            </StackPanel>
+            <Grid>
+                <styles:TextPageInputControl x:Name="TextInputControl" />
+            </Grid>
         </ContentDialog>
+
+        <TeachingTip
+            x:Name="ValidationTip"
+            CloseButtonContent="OK"
+            IsLightDismissEnabled="True"
+            PreferredPlacement="Center">
+            <TeachingTip.IconSource>
+                <SymbolIconSource Symbol="Important" />
+            </TeachingTip.IconSource>
+        </TeachingTip>
     </Grid>
 </Page>

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Text.xaml.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Text.xaml.cs
@@ -124,7 +124,7 @@ namespace KeyboardManagerEditorUI.Pages
             }
         }
 
-        private async void KeyDialog_PrimaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
+        private void KeyDialog_PrimaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
         {
             if (_mappingService == null)
             {
@@ -158,7 +158,7 @@ namespace KeyboardManagerEditorUI.Pages
                         int originalKey = _mappingService.GetKeyCodeFromName(_editingMapping.Keys[0]);
                         if (originalKey != 0)
                         {
-                            _mappingService.DeleteSingleKeyMapping(originalKey);
+                            _mappingService.DeleteSingleKeyToTextMapping(originalKey);
                         }
                     }
                     else
@@ -202,12 +202,11 @@ namespace KeyboardManagerEditorUI.Pages
             catch (Exception ex)
             {
                 Logger.LogError("Error saving text mapping: " + ex.Message);
-                await ShowErrorDialog("Error", "An error occurred while saving the mapping.");
                 args.Cancel = true;
             }
         }
 
-        private async void DeleteButton_Click(object sender, RoutedEventArgs e)
+        private void DeleteButton_Click(object sender, RoutedEventArgs e)
         {
             if (_mappingService == null || !(sender is Button button) || !(button.DataContext is TextMapping mapping))
             {
@@ -242,7 +241,6 @@ namespace KeyboardManagerEditorUI.Pages
             catch (Exception ex)
             {
                 Logger.LogError("Error deleting text mapping: " + ex.Message);
-                await ShowErrorDialog("Error", "An error occurred while deleting the mapping.");
             }
         }
 
@@ -255,19 +253,6 @@ namespace KeyboardManagerEditorUI.Pages
                 ValidationTip.IsOpen = true;
                 args.Cancel = true;
             }
-        }
-
-        private async Task ShowErrorDialog(string title, string message)
-        {
-            ContentDialog errorDialog = new ContentDialog
-            {
-                Title = title,
-                Content = message,
-                CloseButtonText = "OK",
-                XamlRoot = this.XamlRoot,
-            };
-
-            await errorDialog.ShowAsync();
         }
 
         public void Dispose()

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Text.xaml.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Text.xaml.cs
@@ -32,30 +32,19 @@ namespace KeyboardManagerEditorUI.Pages
 
         public Text()
         {
+            this.InitializeComponent();
+
             try
             {
-                this.InitializeComponent();
-
-                Logger.LogInfo("Initializing Text tab");
-
-                try
-                {
-                    _mappingService = new KeyboardMappingService();
-                    Logger.LogInfo("KeyboardMappingService initialized");
-                    LoadTextMappings();
-                    Logger.LogInfo("Text mappings loaded");
-                }
-                catch (Exception ex)
-                {
-                    Logger.LogError("Failed to initialize KeyboardMappingService: " + ex.Message);
-                }
-
-                this.Unloaded += Text_Unloaded;
+                _mappingService = new KeyboardMappingService();
+                LoadTextMappings();
             }
             catch (Exception ex)
             {
-                Logger.LogError("Exception in Text constructor: " + ex.ToString());
+                Logger.LogError("Failed to initialize KeyboardMappingService: " + ex.Message);
             }
+
+            this.Unloaded += Text_Unloaded;
         }
 
         private void Text_Unloaded(object sender, RoutedEventArgs e)

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Text.xaml.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Text.xaml.cs
@@ -137,24 +137,12 @@ namespace KeyboardManagerEditorUI.Pages
             string appName = TextInputControl.GetAppName();
 
             // Validate inputs
-            if (keys.Count == 0)
-            {
-                await ShowErrorDialog("Missing Keys", "Please enter at least one key or shortcut.");
-                args.Cancel = true;
-                return;
-            }
+            ValidationErrorType errorType = ValidationHelper.ValidateTextMapping(
+                keys, textContent, isAppSpecific, appName, _mappingService);
 
-            if (string.IsNullOrWhiteSpace(textContent))
+            if (errorType != ValidationErrorType.NoError)
             {
-                await ShowErrorDialog("Missing Text", "Please enter text content to insert.");
-                args.Cancel = true;
-                return;
-            }
-
-            if (isAppSpecific && string.IsNullOrWhiteSpace(appName))
-            {
-                await ShowErrorDialog("Missing Application Name", "Please enter an application name for app-specific mapping.");
-                args.Cancel = true;
+                ShowValidationError(errorType, args);
                 return;
             }
 
@@ -255,6 +243,17 @@ namespace KeyboardManagerEditorUI.Pages
             {
                 Logger.LogError("Error deleting text mapping: " + ex.Message);
                 await ShowErrorDialog("Error", "An error occurred while deleting the mapping.");
+            }
+        }
+
+        private void ShowValidationError(ValidationErrorType errorType, ContentDialogButtonClickEventArgs args)
+        {
+            if (ValidationHelper.ValidationMessages.TryGetValue(errorType, out (string Title, string Message) error))
+            {
+                ValidationTip.Title = error.Title;
+                ValidationTip.Subtitle = error.Message;
+                ValidationTip.IsOpen = true;
+                args.Cancel = true;
             }
         }
 

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Text.xaml.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Text.xaml.cs
@@ -197,11 +197,11 @@ namespace KeyboardManagerEditorUI.Pages
 
                     if (isAppSpecific && !string.IsNullOrEmpty(appName))
                     {
-                        saved = _mappingService.AddShortcutMapping(originalKeysString, textContent, appName);
+                        saved = _mappingService.AddShortcutMapping(originalKeysString, textContent, appName, ShortcutOperationType.RemapText);
                     }
                     else
                     {
-                        saved = _mappingService.AddShortcutMapping(originalKeysString, textContent);
+                        saved = _mappingService.AddShortcutMapping(originalKeysString, textContent, operationType: ShortcutOperationType.RemapText);
                     }
                 }
 
@@ -235,7 +235,7 @@ namespace KeyboardManagerEditorUI.Pages
                     int originalKey = _mappingService.GetKeyCodeFromName(mapping.Keys[0]);
                     if (originalKey != 0)
                     {
-                        deleted = _mappingService.DeleteSingleKeyMapping(originalKey);
+                        deleted = _mappingService.DeleteSingleKeyToTextMapping(originalKey);
                     }
                 }
                 else

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Text.xaml.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/Text.xaml.cs
@@ -5,46 +5,301 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.IO;
+using System.Globalization;
 using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
+using System.Threading.Tasks;
 using KeyboardManagerEditorUI.Helpers;
+using KeyboardManagerEditorUI.Interop;
+using ManagedCommon;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
-using Microsoft.UI.Xaml.Data;
-using Microsoft.UI.Xaml.Input;
-using Microsoft.UI.Xaml.Media;
-using Microsoft.UI.Xaml.Navigation;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
 
 namespace KeyboardManagerEditorUI.Pages
 {
-    /// <summary>
-    /// An empty page that can be used on its own or navigated to within a Frame.
-    /// </summary>
-    public sealed partial class Text : Page
+    public sealed partial class Text : Page, IDisposable
     {
-        public ObservableCollection<URLShortcut> Shortcuts { get; set; }
+        private KeyboardMappingService? _mappingService;
+
+        // Flag to indicate if the user is editing an existing mapping
+        private bool _isEditMode;
+        private TextMapping? _editingMapping;
+
+        private bool _disposed;
+
+        // The list of text mappings
+        public ObservableCollection<TextMapping> TextMappings { get; } = new ObservableCollection<TextMapping>();
 
         public Text()
         {
-            this.InitializeComponent();
+            try
+            {
+                this.InitializeComponent();
 
-            Shortcuts = new ObservableCollection<URLShortcut>();
-            Shortcuts.Add(new URLShortcut() { Shortcut = new List<string>() { "Alt (Left)", "H" }, URL = "Hello" });
-            Shortcuts.Add(new URLShortcut() { Shortcut = new List<string>() { "Win (Left)", "P", }, URL = "PowerToys" });
+                Logger.LogInfo("Initializing Text tab");
+
+                try
+                {
+                    _mappingService = new KeyboardMappingService();
+                    Logger.LogInfo("KeyboardMappingService initialized");
+                    LoadTextMappings();
+                    Logger.LogInfo("Text mappings loaded");
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogError("Failed to initialize KeyboardMappingService: " + ex.Message);
+                }
+
+                this.Unloaded += Text_Unloaded;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError("Exception in Text constructor: " + ex.ToString());
+            }
+        }
+
+        private void Text_Unloaded(object sender, RoutedEventArgs e)
+        {
+            Dispose();
+        }
+
+        private void LoadTextMappings()
+        {
+            if (_mappingService == null)
+            {
+                return;
+            }
+
+            TextMappings.Clear();
+
+            // Load key-to-text mappings
+            var keyToTextMappings = _mappingService.GetKeyToTextMappings();
+            foreach (var mapping in keyToTextMappings)
+            {
+                TextMappings.Add(new TextMapping
+                {
+                    Keys = new List<string> { _mappingService.GetKeyDisplayName(mapping.OriginalKey) },
+                    Text = mapping.TargetText,
+                    IsAllApps = true,
+                    AppName = "All Apps",
+                });
+            }
+
+            // Load shortcut-to-text mappings
+            foreach (var mapping in _mappingService.GetShortcutMappingsByType(ShortcutOperationType.RemapText))
+            {
+                string[] originalKeyCodes = mapping.OriginalKeys.Split(';');
+                var originalKeyNames = new List<string>();
+                foreach (var keyCode in originalKeyCodes)
+                {
+                    if (int.TryParse(keyCode, out int code))
+                    {
+                        originalKeyNames.Add(_mappingService.GetKeyDisplayName(code));
+                    }
+                }
+
+                TextMappings.Add(new TextMapping
+                {
+                    Keys = originalKeyNames,
+                    Text = mapping.TargetText,
+                    IsAllApps = string.IsNullOrEmpty(mapping.TargetApp),
+                    AppName = string.IsNullOrEmpty(mapping.TargetApp) ? "All Apps" : mapping.TargetApp,
+                });
+            }
         }
 
         private async void NewShortcutBtn_Click(object sender, RoutedEventArgs e)
         {
+            _isEditMode = false;
+            _editingMapping = null;
+
+            TextInputControl.ClearKeys();
+            TextInputControl.SetTextContent(string.Empty);
+            TextInputControl.SetAppSpecific(false, string.Empty);
+
             await KeyDialog.ShowAsync();
         }
 
         private async void ListView_ItemClick(object sender, ItemClickEventArgs e)
         {
-            await KeyDialog.ShowAsync();
+            if (e.ClickedItem is TextMapping selectedMapping)
+            {
+                _isEditMode = true;
+                _editingMapping = selectedMapping;
+
+                TextInputControl.SetShortcutKeys(selectedMapping.Keys);
+                TextInputControl.SetTextContent(selectedMapping.Text);
+                TextInputControl.SetAppSpecific(!selectedMapping.IsAllApps, selectedMapping.AppName);
+
+                await KeyDialog.ShowAsync();
+            }
+        }
+
+        private async void KeyDialog_PrimaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
+        {
+            if (_mappingService == null)
+            {
+                return;
+            }
+
+            List<string> keys = TextInputControl.GetShortcutKeys();
+            string textContent = TextInputControl.GetTextContent();
+            bool isAppSpecific = TextInputControl.GetIsAppSpecific();
+            string appName = TextInputControl.GetAppName();
+
+            // Validate inputs
+            if (keys.Count == 0)
+            {
+                await ShowErrorDialog("Missing Keys", "Please enter at least one key or shortcut.");
+                args.Cancel = true;
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(textContent))
+            {
+                await ShowErrorDialog("Missing Text", "Please enter text content to insert.");
+                args.Cancel = true;
+                return;
+            }
+
+            if (isAppSpecific && string.IsNullOrWhiteSpace(appName))
+            {
+                await ShowErrorDialog("Missing Application Name", "Please enter an application name for app-specific mapping.");
+                args.Cancel = true;
+                return;
+            }
+
+            bool saved = false;
+
+            try
+            {
+                // Delete existing mapping if in edit mode
+                if (_isEditMode && _editingMapping != null)
+                {
+                    if (_editingMapping.Keys.Count == 1)
+                    {
+                        int originalKey = _mappingService.GetKeyCodeFromName(_editingMapping.Keys[0]);
+                        if (originalKey != 0)
+                        {
+                            _mappingService.DeleteSingleKeyMapping(originalKey);
+                        }
+                    }
+                    else
+                    {
+                        string originalKeys = string.Join(";", _editingMapping.Keys.Select(k => _mappingService.GetKeyCodeFromName(k).ToString(CultureInfo.InvariantCulture)));
+                        _mappingService.DeleteShortcutMapping(originalKeys, _editingMapping.IsAllApps ? string.Empty : _editingMapping.AppName);
+                    }
+                }
+
+                // Add new mapping
+                if (keys.Count == 1)
+                {
+                    // Single key to text mapping
+                    int originalKey = _mappingService.GetKeyCodeFromName(keys[0]);
+                    if (originalKey != 0)
+                    {
+                        saved = _mappingService.AddSingleKeyToTextMapping(originalKey, textContent);
+                    }
+                }
+                else
+                {
+                    // Shortcut to text mapping
+                    string originalKeysString = string.Join(";", keys.Select(k => _mappingService.GetKeyCodeFromName(k).ToString(CultureInfo.InvariantCulture)));
+
+                    if (isAppSpecific && !string.IsNullOrEmpty(appName))
+                    {
+                        saved = _mappingService.AddShortcutMapping(originalKeysString, textContent, appName);
+                    }
+                    else
+                    {
+                        saved = _mappingService.AddShortcutMapping(originalKeysString, textContent);
+                    }
+                }
+
+                if (saved)
+                {
+                    _mappingService.SaveSettings();
+                    LoadTextMappings(); // Refresh the list
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError("Error saving text mapping: " + ex.Message);
+                await ShowErrorDialog("Error", "An error occurred while saving the mapping.");
+                args.Cancel = true;
+            }
+        }
+
+        private async void DeleteButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (_mappingService == null || !(sender is Button button) || !(button.DataContext is TextMapping mapping))
+            {
+                return;
+            }
+
+            try
+            {
+                bool deleted = false;
+                if (mapping.Keys.Count == 1)
+                {
+                    // Single key mapping
+                    int originalKey = _mappingService.GetKeyCodeFromName(mapping.Keys[0]);
+                    if (originalKey != 0)
+                    {
+                        deleted = _mappingService.DeleteSingleKeyMapping(originalKey);
+                    }
+                }
+                else
+                {
+                    // Shortcut mapping
+                    string originalKeys = string.Join(";", mapping.Keys.Select(k => _mappingService.GetKeyCodeFromName(k)));
+                    deleted = _mappingService.DeleteShortcutMapping(originalKeys, mapping.IsAllApps ? string.Empty : mapping.AppName);
+                }
+
+                if (deleted)
+                {
+                    _mappingService.SaveSettings();
+                    TextMappings.Remove(mapping);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError("Error deleting text mapping: " + ex.Message);
+                await ShowErrorDialog("Error", "An error occurred while deleting the mapping.");
+            }
+        }
+
+        private async Task ShowErrorDialog(string title, string message)
+        {
+            ContentDialog errorDialog = new ContentDialog
+            {
+                Title = title,
+                Content = message,
+                CloseButtonText = "OK",
+                XamlRoot = this.XamlRoot,
+            };
+
+            await errorDialog.ShowAsync();
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    _mappingService?.Dispose();
+                    _mappingService = null;
+                }
+
+                _disposed = true;
+            }
         }
     }
 }

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/URLs.xaml
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/URLs.xaml
@@ -63,7 +63,12 @@
                     VerticalAlignment="Center"
                     Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                     Text="URL" />
-
+                <Rectangle
+                    Grid.ColumnSpan="4"
+                    Height="1"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Bottom"
+                    Fill="{ThemeResource CardStrokeColorDefaultBrush}" />
                 <ListView
                     Grid.Row="1"
                     Grid.ColumnSpan="4"

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Styles/InputControl.xaml
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Styles/InputControl.xaml
@@ -11,7 +11,6 @@
     mc:Ignorable="d">
 
     <StackPanel>
-
         <Grid>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="240" />

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Styles/InputControl.xaml.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Styles/InputControl.xaml.cs
@@ -28,18 +28,17 @@ namespace KeyboardManagerEditorUI.Styles
 
         private bool _disposed;
 
-        // Define newMode as a DependencyProperty for binding
-        public static readonly DependencyProperty NewModeProperty =
+        public static readonly DependencyProperty InputModeProperty =
             DependencyProperty.Register(
-                "NewMode",
-                typeof(bool),
+                "InputMode",
+                typeof(KeyInputMode),
                 typeof(InputControl),
-                new PropertyMetadata(false, OnNewModeChanged));
+                new PropertyMetadata(KeyInputMode.OriginalKeys));
 
-        public bool NewMode
+        public KeyInputMode InputMode
         {
-            get { return (bool)GetValue(NewModeProperty); }
-            set { SetValue(NewModeProperty, value); }
+            get { return (KeyInputMode)GetValue(InputModeProperty); }
+            set { SetValue(InputModeProperty, value); }
         }
 
         public InputControl()
@@ -66,7 +65,7 @@ namespace KeyboardManagerEditorUI.Styles
 
         public void OnKeyDown(VirtualKey key, List<string> formattedKeys)
         {
-            if (NewMode)
+            if (InputMode == KeyInputMode.RemappedKeys)
             {
                 _remappedKeys.Clear();
                 foreach (var keyName in formattedKeys)
@@ -88,7 +87,7 @@ namespace KeyboardManagerEditorUI.Styles
 
         public void ClearKeys()
         {
-            if (NewMode)
+            if (InputMode == KeyInputMode.RemappedKeys)
             {
                 _remappedKeys.Clear();
             }
@@ -120,7 +119,7 @@ namespace KeyboardManagerEditorUI.Styles
             };
 
             // Target the toggle button that triggered the notification
-            currentNotification.Target = NewMode ? RemappedToggleBtn : OriginalToggleBtn;
+            currentNotification.Target = InputMode == KeyInputMode.RemappedKeys ? RemappedToggleBtn : OriginalToggleBtn;
 
             // Add the notification to the root panel and show it
             if (this.Content is Panel rootPanel)
@@ -161,13 +160,6 @@ namespace KeyboardManagerEditorUI.Styles
                 }
 
                 currentNotification = null;
-            }
-        }
-
-        private static void OnNewModeChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-        {
-            if (d is InputControl control)
-            {
             }
         }
 
@@ -242,7 +234,7 @@ namespace KeyboardManagerEditorUI.Styles
             // Only set NewMode to true if RemappedToggleBtn is checked
             if (RemappedToggleBtn.IsChecked == true)
             {
-                NewMode = true;
+                InputMode = KeyInputMode.RemappedKeys;
 
                 // Make sure OriginalToggleBtn is unchecked
                 if (OriginalToggleBtn.IsChecked == true)
@@ -263,7 +255,7 @@ namespace KeyboardManagerEditorUI.Styles
             // Only set NewMode to false if OriginalToggleBtn is checked
             if (OriginalToggleBtn.IsChecked == true)
             {
-                NewMode = false;
+                InputMode = KeyInputMode.OriginalKeys;
 
                 // Make sure RemappedToggleBtn is unchecked
                 if (RemappedToggleBtn.IsChecked == true)
@@ -418,7 +410,7 @@ namespace KeyboardManagerEditorUI.Styles
                 OriginalToggleBtn.IsChecked = false;
             }
 
-            NewMode = false;
+            InputMode = KeyInputMode.OriginalKeys;
 
             // Reset app name text box
             if (AppNameTextBox != null)

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Styles/InputControl.xaml.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Styles/InputControl.xaml.cs
@@ -168,21 +168,6 @@ namespace KeyboardManagerEditorUI.Styles
             KeyboardHookHelper.Instance.CleanupHook();
         }
 
-        public bool IsModifierKey(VirtualKey key)
-        {
-            return key == VirtualKey.Control
-                || key == VirtualKey.LeftControl
-                || key == VirtualKey.RightControl
-                || key == VirtualKey.Menu
-                || key == VirtualKey.LeftMenu
-                || key == VirtualKey.RightMenu
-                || key == VirtualKey.Shift
-                || key == VirtualKey.LeftShift
-                || key == VirtualKey.RightShift
-                || key == VirtualKey.LeftWindows
-                || key == VirtualKey.RightWindows;
-        }
-
         public void SetRemappedKeys(List<string> keys)
         {
             _remappedKeys.Clear();

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Styles/TextPageInputControl.xaml
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Styles/TextPageInputControl.xaml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<UserControl
+    x:Class="KeyboardManagerEditorUI.Styles.TextPageInputControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Loaded="UserControl_Loaded"
+    mc:Ignorable="d">
+
+    <StackPanel>
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="240" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="240" />
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <TextBlock Margin="0,12,0,0" Text="Shortcut key(s)" />
+            <Grid Grid.Column="2">
+                <TextBlock Margin="0,12,0,0" Text="Text" />
+            </Grid>
+
+            <Grid Grid.Row="1" Margin="0,8,0,0">
+                <ToggleButton
+                    x:Name="ShortcutToggleBtn"
+                    Padding="0,24,0,24"
+                    HorizontalAlignment="Stretch"
+                    Checked="ShortcutToggleBtn_Checked"
+                    Style="{StaticResource CustomShortcutToggleButtonStyle}">
+                    <ToggleButton.Content>
+                        <ItemsControl x:Name="ShortcutKeys">
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <StackPanel Orientation="Horizontal" />
+                                </ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <Border
+                                        Margin="2,0"
+                                        Padding="8,4"
+                                        Background="{ThemeResource KeyBackgroundBrush}"
+                                        BorderBrush="{ThemeResource KeyBorderBrush}"
+                                        BorderThickness="1"
+                                        CornerRadius="4">
+                                        <TextBlock Text="{Binding}" />
+                                    </Border>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </ToggleButton.Content>
+                </ToggleButton>
+            </Grid>
+
+            <TextBlock
+                Grid.Row="1"
+                Grid.Column="1"
+                Margin="24,0,24,0"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                Text="&#xE0AB;" />
+
+            <Grid
+                Grid.Row="1"
+                Grid.Column="2"
+                Margin="0,8,0,0">
+                <TextBox
+                    x:Name="TextContentBox"
+                    Height="100"
+                    AcceptsReturn="True"
+                    PlaceholderText="Enter text to insert" />
+            </Grid>
+        </Grid>
+
+        <CheckBox
+            x:Name="AllAppsCheckBox"
+            Margin="0,24,0,12"
+            Content="Only apply this text shortcut to a specific application" />
+        <TextBox
+            x:Name="AppNameTextBox"
+            Header="Application name"
+            IsEnabled="{Binding ElementName=AllAppsCheckBox, Path=IsChecked}"
+            PlaceholderText="e.g.: outlook.exe" />
+    </StackPanel>
+</UserControl>

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Styles/TextPageInputControl.xaml
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Styles/TextPageInputControl.xaml
@@ -10,82 +10,56 @@
     Loaded="UserControl_Loaded"
     mc:Ignorable="d">
 
-    <StackPanel>
-        <Grid>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="240" />
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="240" />
-            </Grid.ColumnDefinitions>
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-            </Grid.RowDefinitions>
+    <StackPanel
+        Width="360"
+        Height="360"
+        Orientation="Vertical">
+        <!--  Shortcut section  -->
+        <TextBlock
+            Margin="0,12,0,8"
+            FontWeight="SemiBold"
+            Foreground="{ThemeResource TextFillColorPrimaryBrush}"
+            Text="Shortcut key(s)" />
 
-            <TextBlock
-                Margin="0,12,0,0"
-                Foreground="{ThemeResource TextFillColorPrimaryBrush}"
-                Text="Shortcut key(s)" />
+        <ToggleButton
+            x:Name="ShortcutToggleBtn"
+            Padding="0,24,0,24"
+            HorizontalAlignment="Stretch"
+            Checked="ShortcutToggleBtn_Checked"
+            Style="{StaticResource CustomShortcutToggleButtonStyle}">
+            <ToggleButton.Content>
+                <ItemsControl x:Name="ShortcutKeys">
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <controls:WrapPanel HorizontalSpacing="4" Orientation="Horizontal" />
+                        </ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <local:KeyVisual Content="{Binding}" VisualType="SmallOutline" />
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </ToggleButton.Content>
+        </ToggleButton>
 
-            <Grid Grid.Column="2">
-                <TextBlock
-                    Margin="0,12,0,0"
-                    Foreground="{ThemeResource TextFillColorPrimaryBrush}"
-                    Text="Text" />
-            </Grid>
+        <!--  Text section  -->
+        <TextBox
+            x:Name="TextContentBox"
+            Height="120"
+            Margin="0,8,0,0"
+            AcceptsReturn="True"
+            Background="{ThemeResource TextControlBackgroundFocused}"
+            BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
+            FontSize="13"
+            Header="Text to insert"
+            PlaceholderText="Enter text that will be inserted when the shortcut is pressed"
+            TextWrapping="Wrap" />
 
-            <Grid Grid.Row="1" Margin="0,8,0,0">
-                <ToggleButton
-                    x:Name="ShortcutToggleBtn"
-                    Padding="0,24,0,24"
-                    HorizontalAlignment="Stretch"
-                    Checked="ShortcutToggleBtn_Checked"
-                    Style="{StaticResource CustomShortcutToggleButtonStyle}">
-                    <ToggleButton.Content>
-                        <ItemsControl x:Name="ShortcutKeys">
-                            <ItemsControl.ItemsPanel>
-                                <ItemsPanelTemplate>
-                                    <controls:WrapPanel HorizontalSpacing="4" Orientation="Horizontal" />
-                                </ItemsPanelTemplate>
-                            </ItemsControl.ItemsPanel>
-                            <ItemsControl.ItemTemplate>
-                                <DataTemplate>
-                                    <local:KeyVisual Content="{Binding}" VisualType="SmallOutline" />
-                                </DataTemplate>
-                            </ItemsControl.ItemTemplate>
-                        </ItemsControl>
-                    </ToggleButton.Content>
-                </ToggleButton>
-            </Grid>
-
-            <TextBlock
-                Grid.Row="1"
-                Grid.Column="1"
-                Margin="24,0,24,0"
-                HorizontalAlignment="Center"
-                VerticalAlignment="Center"
-                FontFamily="{ThemeResource SymbolThemeFontFamily}"
-                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                Text="&#xE0AB;" />
-
-            <Grid
-                Grid.Row="1"
-                Grid.Column="2"
-                Margin="0,8,0,0">
-                <TextBox
-                    x:Name="TextContentBox"
-                    Height="100"
-                    AcceptsReturn="True"
-                    Background="{ThemeResource TextControlBackgroundFocused}"
-                    BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
-                    PlaceholderText="Enter text to insert"
-                    TextWrapping="Wrap" />
-            </Grid>
-        </Grid>
-
+        <!--  App specific section  -->
         <CheckBox
             x:Name="AllAppsCheckBox"
-            Margin="0,24,0,12"
+            Margin="0,8,0,0"
             Content="Only apply this text shortcut to a specific application"
             Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
 

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Styles/TextPageInputControl.xaml
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Styles/TextPageInputControl.xaml
@@ -3,7 +3,9 @@
     x:Class="KeyboardManagerEditorUI.Styles.TextPageInputControl"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:CommunityToolkit.WinUI.UI.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:KeyboardManagerEditorUI.Styles"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     Loaded="UserControl_Loaded"
     mc:Ignorable="d">
@@ -20,9 +22,16 @@
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
 
-            <TextBlock Margin="0,12,0,0" Text="Shortcut key(s)" />
+            <TextBlock
+                Margin="0,12,0,0"
+                Foreground="{ThemeResource TextFillColorPrimaryBrush}"
+                Text="Shortcut key(s)" />
+
             <Grid Grid.Column="2">
-                <TextBlock Margin="0,12,0,0" Text="Text" />
+                <TextBlock
+                    Margin="0,12,0,0"
+                    Foreground="{ThemeResource TextFillColorPrimaryBrush}"
+                    Text="Text" />
             </Grid>
 
             <Grid Grid.Row="1" Margin="0,8,0,0">
@@ -36,20 +45,12 @@
                         <ItemsControl x:Name="ShortcutKeys">
                             <ItemsControl.ItemsPanel>
                                 <ItemsPanelTemplate>
-                                    <StackPanel Orientation="Horizontal" />
+                                    <controls:WrapPanel HorizontalSpacing="4" Orientation="Horizontal" />
                                 </ItemsPanelTemplate>
                             </ItemsControl.ItemsPanel>
                             <ItemsControl.ItemTemplate>
                                 <DataTemplate>
-                                    <Border
-                                        Margin="2,0"
-                                        Padding="8,4"
-                                        Background="{ThemeResource KeyBackgroundBrush}"
-                                        BorderBrush="{ThemeResource KeyBorderBrush}"
-                                        BorderThickness="1"
-                                        CornerRadius="4">
-                                        <TextBlock Text="{Binding}" />
-                                    </Border>
+                                    <local:KeyVisual Content="{Binding}" VisualType="SmallOutline" />
                                 </DataTemplate>
                             </ItemsControl.ItemTemplate>
                         </ItemsControl>
@@ -64,6 +65,7 @@
                 HorizontalAlignment="Center"
                 VerticalAlignment="Center"
                 FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                 Text="&#xE0AB;" />
 
             <Grid
@@ -74,16 +76,23 @@
                     x:Name="TextContentBox"
                     Height="100"
                     AcceptsReturn="True"
-                    PlaceholderText="Enter text to insert" />
+                    Background="{ThemeResource TextControlBackgroundFocused}"
+                    BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
+                    PlaceholderText="Enter text to insert"
+                    TextWrapping="Wrap" />
             </Grid>
         </Grid>
 
         <CheckBox
             x:Name="AllAppsCheckBox"
             Margin="0,24,0,12"
-            Content="Only apply this text shortcut to a specific application" />
+            Content="Only apply this text shortcut to a specific application"
+            Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
+
         <TextBox
             x:Name="AppNameTextBox"
+            Background="{ThemeResource TextControlBackgroundFocused}"
+            BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
             Header="Application name"
             IsEnabled="{Binding ElementName=AllAppsCheckBox, Path=IsChecked}"
             PlaceholderText="e.g.: outlook.exe" />

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Styles/TextPageInputControl.xaml.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Styles/TextPageInputControl.xaml.cs
@@ -83,6 +83,25 @@ namespace KeyboardManagerEditorUI.Styles
             ShowNotificationTip("Shortcuts can only have up to 4 modifier keys");
         }
 
+        public void UpdateAllAppsCheckBoxState()
+        {
+            // Only enable app-specific remapping for shortcuts (multiple keys)
+            bool isShortcut = _shortcutKeys.Count > 1;
+
+            AllAppsCheckBox.IsEnabled = isShortcut;
+
+            // If it's not a shortcut, ensure the checkbox is unchecked and app textbox is hidden
+            if (!isShortcut)
+            {
+                AllAppsCheckBox.IsChecked = false;
+                AppNameTextBox.Visibility = Visibility.Collapsed;
+            }
+            else if (AllAppsCheckBox.IsChecked == true)
+            {
+                AppNameTextBox.Visibility = Visibility.Visible;
+            }
+        }
+
         public void ShowNotificationTip(string message)
         {
             CloseExistingNotification();

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Styles/TextPageInputControl.xaml.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Styles/TextPageInputControl.xaml.cs
@@ -34,6 +34,8 @@ namespace KeyboardManagerEditorUI.Styles
             AllAppsCheckBox.Checked += Control_FocusChanged;
             AllAppsCheckBox.Unchecked += Control_FocusChanged;
             AppNameTextBox.GotFocus += Control_FocusChanged;
+
+            AppNameTextBox.Visibility = AllAppsCheckBox.IsChecked == true ? Visibility.Visible : Visibility.Collapsed;
         }
 
         private void ShortcutToggleBtn_Checked(object sender, RoutedEventArgs e)
@@ -55,6 +57,8 @@ namespace KeyboardManagerEditorUI.Styles
             {
                 _shortcutKeys.Add(keyName);
             }
+
+            UpdateAllAppsCheckBoxState();
         }
 
         private void TextContentBox_GotFocus(object sender, RoutedEventArgs e)
@@ -75,6 +79,11 @@ namespace KeyboardManagerEditorUI.Styles
             if (ShortcutToggleBtn != null && ShortcutToggleBtn.IsChecked == true)
             {
                 ShortcutToggleBtn.IsChecked = false;
+            }
+
+            if (sender as CheckBox == AllAppsCheckBox)
+            {
+                AppNameTextBox.Visibility = AllAppsCheckBox.IsChecked == true ? Visibility.Visible : Visibility.Collapsed;
             }
         }
 
@@ -156,6 +165,7 @@ namespace KeyboardManagerEditorUI.Styles
         public void ClearKeys()
         {
             _shortcutKeys.Clear();
+            UpdateAllAppsCheckBoxState();
         }
 
         public bool IsModifierKey(VirtualKey key)
@@ -205,6 +215,8 @@ namespace KeyboardManagerEditorUI.Styles
                     _shortcutKeys.Add(key);
                 }
             }
+
+            UpdateAllAppsCheckBoxState();
         }
 
         public void SetTextContent(string text)

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Styles/TextPageInputControl.xaml.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Styles/TextPageInputControl.xaml.cs
@@ -85,22 +85,26 @@ namespace KeyboardManagerEditorUI.Styles
 
         public void ShowNotificationTip(string message)
         {
+            CloseExistingNotification();
+
+            currentNotification = new TeachingTip
+            {
+                Title = "Input Limit",
+                Subtitle = message,
+                IsLightDismissEnabled = true,
+                PreferredPlacement = TeachingTipPlacementMode.Top,
+                XamlRoot = this.XamlRoot,
+                IconSource = new SymbolIconSource { Symbol = Symbol.Important },
+                Target = ShortcutToggleBtn,
+            };
+
             if (this.Content is Panel rootPanel)
             {
-                CloseExistingNotification();
-
-                currentNotification = new TeachingTip
-                {
-                    Title = "Input Limit",
-                    Subtitle = message,
-                    IsLightDismissEnabled = true,
-                };
-
                 rootPanel.Children.Add(currentNotification);
                 currentNotification.IsOpen = true;
 
                 notificationTimer = new DispatcherTimer();
-                notificationTimer.Interval = TimeSpan.FromSeconds(3);
+                notificationTimer.Interval = TimeSpan.FromMilliseconds(EditorConstants.DefaultNotificationTimeout);
                 notificationTimer.Tick += (s, e) =>
                 {
                     CloseExistingNotification();

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Styles/TextPageInputControl.xaml.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Styles/TextPageInputControl.xaml.cs
@@ -194,16 +194,6 @@ namespace KeyboardManagerEditorUI.Styles
             UpdateAllAppsCheckBoxState();
         }
 
-        public bool IsModifierKey(VirtualKey key)
-        {
-            return key == VirtualKey.Control || key == VirtualKey.Menu ||
-                   key == VirtualKey.Shift || key == VirtualKey.LeftWindows ||
-                   key == VirtualKey.RightWindows || key == VirtualKey.LeftControl ||
-                   key == VirtualKey.RightControl || key == VirtualKey.LeftMenu ||
-                   key == VirtualKey.RightMenu || key == VirtualKey.LeftShift ||
-                   key == VirtualKey.RightShift;
-        }
-
         public List<string> GetShortcutKeys()
         {
             List<string> keys = new List<string>();

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Styles/TextPageInputControl.xaml.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Styles/TextPageInputControl.xaml.cs
@@ -22,12 +22,18 @@ namespace KeyboardManagerEditorUI.Styles
         {
             this.InitializeComponent();
             this.ShortcutKeys.ItemsSource = _shortcutKeys;
+
+            ShortcutToggleBtn.IsChecked = true;
         }
 
         private void UserControl_Loaded(object sender, RoutedEventArgs e)
         {
-            // Activate keyboard hook when loaded
             KeyboardHookHelper.Instance.ActivateHook(this);
+            TextContentBox.GotFocus += TextContentBox_GotFocus;
+
+            AllAppsCheckBox.Checked += Control_FocusChanged;
+            AllAppsCheckBox.Unchecked += Control_FocusChanged;
+            AppNameTextBox.GotFocus += Control_FocusChanged;
         }
 
         private void ShortcutToggleBtn_Checked(object sender, RoutedEventArgs e)
@@ -51,19 +57,25 @@ namespace KeyboardManagerEditorUI.Styles
             }
         }
 
-        public void ClearKeys()
+        private void TextContentBox_GotFocus(object sender, RoutedEventArgs e)
         {
-            _shortcutKeys.Clear();
+            // Clean up the keyboard hook when the text box gains focus
+            KeyboardHookHelper.Instance.CleanupHook();
+
+            if (ShortcutToggleBtn != null && ShortcutToggleBtn.IsChecked == true)
+            {
+                ShortcutToggleBtn.IsChecked = false;
+            }
         }
 
-        public bool IsModifierKey(VirtualKey key)
+        private void Control_FocusChanged(object sender, RoutedEventArgs e)
         {
-            return key == VirtualKey.Control || key == VirtualKey.Menu ||
-                   key == VirtualKey.Shift || key == VirtualKey.LeftWindows ||
-                   key == VirtualKey.RightWindows || key == VirtualKey.LeftControl ||
-                   key == VirtualKey.RightControl || key == VirtualKey.LeftMenu ||
-                   key == VirtualKey.RightMenu || key == VirtualKey.LeftShift ||
-                   key == VirtualKey.RightShift;
+            KeyboardHookHelper.Instance.CleanupHook();
+
+            if (ShortcutToggleBtn != null && ShortcutToggleBtn.IsChecked == true)
+            {
+                ShortcutToggleBtn.IsChecked = false;
+            }
         }
 
         public void OnInputLimitReached()
@@ -116,6 +128,21 @@ namespace KeyboardManagerEditorUI.Styles
 
                 currentNotification = null;
             }
+        }
+
+        public void ClearKeys()
+        {
+            _shortcutKeys.Clear();
+        }
+
+        public bool IsModifierKey(VirtualKey key)
+        {
+            return key == VirtualKey.Control || key == VirtualKey.Menu ||
+                   key == VirtualKey.Shift || key == VirtualKey.LeftWindows ||
+                   key == VirtualKey.RightWindows || key == VirtualKey.LeftControl ||
+                   key == VirtualKey.RightControl || key == VirtualKey.LeftMenu ||
+                   key == VirtualKey.RightMenu || key == VirtualKey.LeftShift ||
+                   key == VirtualKey.RightShift;
         }
 
         public List<string> GetShortcutKeys()


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

> [Target feature branch ``feature/KeyboardManagerWinUI3``]

Refactor the New Keyboard Manager code to generalize functions (like Keyboard Hook) for use across pages. Implement Code-behind and the Text Remapping Page.

- Implement the Text Remapping page
- Restructure the Key Remappings code
- Implement unified Keyboard Hook for all Pages
- Implement Save and Delete for Text Page
- Adjust the Text Page list UI
- Create Input Control for Text Page
- Validate the user input in Text Page and show teaching tip for the validation error
- Move Remapping Saving into Helper
- Move Remapping Delete into Helper
- Don't check for duplicates if the original keys are the same as the remapping being edited
- Use InputMode to indicate the active toggle for Original Keys/Remapped Keys
- Add Rectangle for all pages

![image](https://github.com/user-attachments/assets/e109d82f-01c5-4da7-9efb-facea4070808)
![image](https://github.com/user-attachments/assets/09cc4462-43eb-4823-9b01-ab630a0bf9ed)
![image](https://github.com/user-attachments/assets/9b85c0f6-cbce-40cc-8e65-b755cb852eae)
![image](https://github.com/user-attachments/assets/ff7945cc-6535-4697-812e-93c2effab14e)
![image](https://github.com/user-attachments/assets/7cf887c8-24f3-45bd-956f-b3d655844974)
![image](https://github.com/user-attachments/assets/d958bb16-66b9-44e0-8918-32ddcc780f02)