### PR TITLE
CmdPal: Isolated ContextMenu into its own component from CommandBar

### DIFF
--- a/.github/actions/spell-check/allow/names.txt
+++ b/.github/actions/spell-check/allow/names.txt
@@ -205,6 +205,8 @@ firefox
 fudan
 gpt
 Inkscape
+keybind
+keybound
 Markdig
 modernwpf
 Moq

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContextMenuStackViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContextMenuStackViewModel.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Messaging;
 using Microsoft.CmdPal.UI.ViewModels.Messages;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 using Windows.System;
@@ -18,7 +19,6 @@ public partial class ContextMenuStackViewModel : ObservableObject
     private readonly IContextMenuContext _context;
     private string _lastSearchText = string.Empty;
 
-    // private Dictionary<KeyChord, CommandContextItemViewModel>? _contextKeybindings;
     public ContextMenuStackViewModel(IContextMenuContext context)
     {
         _context = context;
@@ -78,5 +78,22 @@ public partial class ContextMenuStackViewModel : ObservableObject
         }
 
         return null;
+    }
+
+    // InvokeItemCommand is what this will be in Xaml due to source generator
+    // this comes in when an item in the list is tapped
+    // [RelayCommand]
+    public ContextKeybindingResult InvokeItem(CommandContextItemViewModel item) =>
+        PerformCommand(item);
+
+    private ContextKeybindingResult PerformCommand(CommandItemViewModel? command)
+    {
+        if (command == null)
+        {
+            return ContextKeybindingResult.Unhandled;
+        }
+
+        WeakReferenceMessenger.Default.Send<PerformCommandMessage>(new(command.Command.Model, command.Model));
+        return ContextKeybindingResult.Hide;
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Messages/CloseContextMenuMessage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Messages/CloseContextMenuMessage.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CmdPal.UI.ViewModels.Messages;
+
+/// <summary>
+/// Used to close open context menus
+/// </summary>
+public record CloseContextMenuMessage
+{
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml
@@ -198,7 +198,7 @@
                         <cpcontrols:ContextMenu 
                             x:Name="ContextMenu"
                             x:Uid="ContextMenu" 
-                            ViewModel="{x:Bind ViewModel.ContextMenu}"/>
+                            ViewModel="{x:Bind ViewModel.ContextMenu, Mode=OneWay}"/>
                     
                     </Flyout>
                 </Button.Flyout>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml
@@ -191,15 +191,13 @@
                 ToolTipService.ToolTip="Ctrl+K"
                 Visibility="{x:Bind ViewModel.ShouldShowContextMenu, Mode=OneWay}">
                 <Button.Flyout>
-                    <Flyout
-                        Closing="Flyout_Closing"
-                        Placement="TopEdgeAlignedRight">
+                    <Flyout Closing="Flyout_Closing" Placement="TopEdgeAlignedRight">
 
-                        <cpcontrols:ContextMenu 
+                        <cpcontrols:ContextMenu
                             x:Name="ContextMenu"
-                            x:Uid="ContextMenu" 
-                            ViewModel="{x:Bind ViewModel.ContextMenu, Mode=OneWay}"/>
-                    
+                            x:Uid="ContextMenu"
+                            ViewModel="{x:Bind ViewModel.ContextMenu, Mode=OneWay}" />
+
                     </Flyout>
                 </Button.Flyout>
             </Button>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml
@@ -17,88 +17,17 @@
 
     <UserControl.Resources>
         <ResourceDictionary>
-            <converters:StringVisibilityConverter
-                x:Key="StringNotEmptyToVisibilityConverter"
-                EmptyValue="Collapsed"
-                NotEmptyValue="Visible" />
             <converters:BoolToVisibilityConverter
                 x:Key="BoolToInvertedVisibilityConverter"
                 FalseValue="Visible"
                 TrueValue="Collapsed" />
 
             <cmdpalUI:MessageStateToSeverityConverter x:Key="MessageStateToSeverityConverter" />
-            <cmdpalUI:KeyChordToStringConverter x:Key="KeyChordToStringConverter" />
 
             <StackLayout
                 x:Name="VerticalStackLayout"
                 Orientation="Vertical"
                 Spacing="4" />
-
-            <cmdpalUI:ContextItemTemplateSelector
-                x:Key="ContextItemTemplateSelector"
-                Critical="{StaticResource CriticalContextMenuViewModelTemplate}"
-                Default="{StaticResource DefaultContextMenuViewModelTemplate}" />
-
-            <!--  Template for context items in the context item menu  -->
-            <DataTemplate x:Key="DefaultContextMenuViewModelTemplate" x:DataType="viewmodels:CommandContextItemViewModel">
-                <Grid AutomationProperties.Name="{x:Bind Title, Mode=OneWay}">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="32" />
-                        <ColumnDefinition Width="*" />
-                        <ColumnDefinition Width="Auto" />
-                    </Grid.ColumnDefinitions>
-                    <cpcontrols:IconBox
-                        Width="16"
-                        Height="16"
-                        Margin="4,0,0,0"
-                        HorizontalAlignment="Left"
-                        SourceKey="{x:Bind Icon, Mode=OneWay}"
-                        SourceRequested="{x:Bind help:IconCacheProvider.SourceRequested}" />
-                    <TextBlock
-                        Grid.Column="1"
-                        VerticalAlignment="Center"
-                        Text="{x:Bind Title, Mode=OneWay}" />
-                    <TextBlock
-                        Grid.Column="2"
-                        Margin="16,0,0,0"
-                        HorizontalAlignment="Right"
-                        VerticalAlignment="Center"
-                        Foreground="{ThemeResource MenuFlyoutItemKeyboardAcceleratorTextForeground}"
-                        Style="{StaticResource CaptionTextBlockStyle}"
-                        Text="{x:Bind RequestedShortcut, Mode=OneWay, Converter={StaticResource KeyChordToStringConverter}}" />
-                </Grid>
-            </DataTemplate>
-
-            <!--  Template for context items flagged as critical  -->
-            <DataTemplate x:Key="CriticalContextMenuViewModelTemplate" x:DataType="viewmodels:CommandContextItemViewModel">
-                <Grid AutomationProperties.Name="{x:Bind Title, Mode=OneWay}">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="32" />
-                        <ColumnDefinition Width="*" />
-                        <ColumnDefinition Width="Auto" />
-                    </Grid.ColumnDefinitions>
-                    <cpcontrols:IconBox
-                        Width="16"
-                        Height="16"
-                        Margin="4,0,0,0"
-                        HorizontalAlignment="Left"
-                        Foreground="{ThemeResource SystemFillColorCriticalBrush}"
-                        SourceKey="{x:Bind Icon, Mode=OneWay}"
-                        SourceRequested="{x:Bind help:IconCacheProvider.SourceRequested}" />
-                    <TextBlock
-                        Grid.Column="1"
-                        VerticalAlignment="Center"
-                        Style="{StaticResource ContextItemTitleTextBlockCriticalStyle}"
-                        Text="{x:Bind Title, Mode=OneWay}" />
-                    <TextBlock
-                        Grid.Column="2"
-                        Margin="16,0,0,0"
-                        HorizontalAlignment="Right"
-                        VerticalAlignment="Center"
-                        Style="{StaticResource ContextItemCaptionTextBlockCriticalStyle}"
-                        Text="{x:Bind RequestedShortcut, Mode=OneWay, Converter={StaticResource KeyChordToStringConverter}}" />
-                </Grid>
-            </DataTemplate>
 
         </ResourceDictionary>
     </UserControl.Resources>
@@ -264,40 +193,13 @@
                 <Button.Flyout>
                     <Flyout
                         Closing="Flyout_Closing"
-                        Opened="Flyout_Opened"
                         Placement="TopEdgeAlignedRight">
-                        <StackPanel>
 
-                            <ListView
-                                x:Name="CommandsDropdown"
-                                MinWidth="248"
-                                Margin="-16,-12,-16,-12"
-                                IsItemClickEnabled="True"
-                                ItemClick="CommandsDropdown_ItemClick"
-                                ItemTemplateSelector="{StaticResource ContextItemTemplateSelector}"
-                                ItemsSource="{x:Bind ViewModel.ContextMenu.FilteredItems, Mode=OneWay}"
-                                KeyDown="CommandsDropdown_KeyDown"
-                                SelectionMode="Single">
-                                <ListView.ItemContainerStyle>
-                                    <Style BasedOn="{StaticResource DefaultListViewItemStyle}" TargetType="ListViewItem">
-                                        <Setter Property="MinHeight" Value="0" />
-                                        <Setter Property="Padding" Value="12,7,12,7" />
-                                    </Style>
-                                </ListView.ItemContainerStyle>
-                                <ListView.ItemContainerTransitions>
-                                    <TransitionCollection />
-                                </ListView.ItemContainerTransitions>
-                            </ListView>
-
-                            <TextBox
-                                x:Name="ContextFilterBox"
-                                x:Uid="ContextFilterBox"
-                                Margin="-12,12,-12,-12"
-                                KeyDown="ContextFilterBox_KeyDown"
-                                PreviewKeyDown="ContextFilterBox_PreviewKeyDown"
-                                TextChanged="ContextFilterBox_TextChanged" />
-
-                        </StackPanel>
+                        <cpcontrols:ContextMenu 
+                            x:Name="ContextMenu"
+                            x:Uid="ContextMenu" 
+                            ViewModel="{x:Bind ViewModel.ContextMenu}"/>
+                    
                     </Flyout>
                 </Button.Flyout>
             </Button>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml.cs
@@ -129,7 +129,6 @@ public sealed partial class CommandBar : UserControl,
     private void Flyout_Closing(FlyoutBase sender, FlyoutBaseClosingEventArgs args)
     {
         ViewModel?.ClearContextStack();
-        WeakReferenceMessenger.Default.Send<CloseContextMenuMessage>();
         WeakReferenceMessenger.Default.Send<FocusSearchBoxMessage>();
     }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml.cs
@@ -18,6 +18,7 @@ namespace Microsoft.CmdPal.UI.Controls;
 
 public sealed partial class CommandBar : UserControl,
     IRecipient<OpenContextMenuMessage>,
+    IRecipient<CloseContextMenuMessage>,
     IRecipient<TryCommandKeybindingMessage>,
     ICurrentPageAware
 {
@@ -39,6 +40,7 @@ public sealed partial class CommandBar : UserControl,
 
         // RegisterAll isn't AOT compatible
         WeakReferenceMessenger.Default.Register<OpenContextMenuMessage>(this);
+        WeakReferenceMessenger.Default.Register<CloseContextMenuMessage>(this);
         WeakReferenceMessenger.Default.Register<TryCommandKeybindingMessage>(this);
 
         ViewModel.PropertyChanged += ViewModel_PropertyChanged;
@@ -56,7 +58,16 @@ public sealed partial class CommandBar : UserControl,
             ShowMode = FlyoutShowMode.Standard,
         };
         MoreCommandsButton.Flyout.ShowAt(MoreCommandsButton, options);
-        UpdateUiForStackChange();
+    }
+
+    public void Receive(CloseContextMenuMessage message)
+    {
+        if (!ViewModel.ShouldShowContextMenu)
+        {
+            return;
+        }
+
+        MoreCommandsButton.Flyout.Hide();
     }
 
     public void Receive(TryCommandKeybindingMessage msg)
@@ -76,14 +87,8 @@ public sealed partial class CommandBar : UserControl,
         {
             if (!MoreCommandsButton.Flyout.IsOpen)
             {
-                var options = new FlyoutShowOptions
-                {
-                    ShowMode = FlyoutShowMode.Standard,
-                };
-                MoreCommandsButton.Flyout.ShowAt(MoreCommandsButton, options);
+                WeakReferenceMessenger.Default.Send<OpenContextMenuMessage>();
             }
-
-            UpdateUiForStackChange();
 
             msg.Handled = true;
         }
@@ -121,60 +126,10 @@ public sealed partial class CommandBar : UserControl,
         e.Handled = true;
     }
 
-    private void CommandsDropdown_ItemClick(object sender, ItemClickEventArgs e)
-    {
-        if (e.ClickedItem is CommandContextItemViewModel item)
-        {
-            if (ViewModel?.InvokeItem(item) == ContextKeybindingResult.Hide)
-            {
-                MoreCommandsButton.Flyout.Hide();
-            }
-            else
-            {
-                UpdateUiForStackChange();
-            }
-        }
-    }
-
-    private void CommandsDropdown_KeyDown(object sender, KeyRoutedEventArgs e)
-    {
-        if (e.Handled)
-        {
-            return;
-        }
-
-        var ctrlPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down);
-        var altPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Menu).HasFlag(CoreVirtualKeyStates.Down);
-        var shiftPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down);
-        var winPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.LeftWindows).HasFlag(CoreVirtualKeyStates.Down) ||
-            InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.RightWindows).HasFlag(CoreVirtualKeyStates.Down);
-
-        var result = ViewModel?.CheckKeybinding(ctrlPressed, altPressed, shiftPressed, winPressed, e.Key);
-
-        if (result == ContextKeybindingResult.Hide)
-        {
-            e.Handled = true;
-            MoreCommandsButton.Flyout.Hide();
-            WeakReferenceMessenger.Default.Send<FocusSearchBoxMessage>();
-        }
-        else if (result == ContextKeybindingResult.KeepOpen)
-        {
-            e.Handled = true;
-        }
-        else if (result == ContextKeybindingResult.Unhandled)
-        {
-            e.Handled = false;
-        }
-    }
-
-    private void Flyout_Opened(object sender, object e)
-    {
-        UpdateUiForStackChange();
-    }
-
     private void Flyout_Closing(FlyoutBase sender, FlyoutBaseClosingEventArgs args)
     {
         ViewModel?.ClearContextStack();
+        WeakReferenceMessenger.Default.Send<CloseContextMenuMessage>();
         WeakReferenceMessenger.Default.Send<FocusSearchBoxMessage>();
     }
 
@@ -183,102 +138,7 @@ public sealed partial class CommandBar : UserControl,
         var prop = e.PropertyName;
         if (prop == nameof(ViewModel.ContextMenu))
         {
-            UpdateUiForStackChange();
+            ContextMenu.UpdateUiForStackChange();
         }
-    }
-
-    private void ContextFilterBox_TextChanged(object sender, TextChangedEventArgs e)
-    {
-        ViewModel.ContextMenu?.SetSearchText(ContextFilterBox.Text);
-
-        if (CommandsDropdown.SelectedIndex == -1)
-        {
-            CommandsDropdown.SelectedIndex = 0;
-        }
-    }
-
-    private void ContextFilterBox_KeyDown(object sender, KeyRoutedEventArgs e)
-    {
-        var ctrlPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down);
-        var altPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Menu).HasFlag(CoreVirtualKeyStates.Down);
-        var shiftPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down);
-        var winPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.LeftWindows).HasFlag(CoreVirtualKeyStates.Down) ||
-            InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.RightWindows).HasFlag(CoreVirtualKeyStates.Down);
-
-        if (e.Key == VirtualKey.Enter)
-        {
-            if (CommandsDropdown.SelectedItem is CommandContextItemViewModel item)
-            {
-                if (ViewModel?.InvokeItem(item) == ContextKeybindingResult.Hide)
-                {
-                    MoreCommandsButton.Flyout.Hide();
-                    WeakReferenceMessenger.Default.Send<FocusSearchBoxMessage>();
-                }
-                else
-                {
-                    UpdateUiForStackChange();
-                }
-
-                e.Handled = true;
-            }
-        }
-        else if (e.Key == VirtualKey.Escape ||
-            (e.Key == VirtualKey.Left && altPressed))
-        {
-            if (ViewModel.CanPopContextStack())
-            {
-                ViewModel.PopContextStack();
-                UpdateUiForStackChange();
-            }
-            else
-            {
-                MoreCommandsButton.Flyout.Hide();
-                WeakReferenceMessenger.Default.Send<FocusSearchBoxMessage>();
-            }
-
-            e.Handled = true;
-        }
-
-        CommandsDropdown_KeyDown(sender, e);
-    }
-
-    private void ContextFilterBox_PreviewKeyDown(object sender, KeyRoutedEventArgs e)
-    {
-        if (e.Key == VirtualKey.Up)
-        {
-            // navigate previous
-            if (CommandsDropdown.SelectedIndex > 0)
-            {
-                CommandsDropdown.SelectedIndex--;
-            }
-            else
-            {
-                CommandsDropdown.SelectedIndex = CommandsDropdown.Items.Count - 1;
-            }
-
-            e.Handled = true;
-        }
-        else if (e.Key == VirtualKey.Down)
-        {
-            // navigate next
-            if (CommandsDropdown.SelectedIndex < CommandsDropdown.Items.Count - 1)
-            {
-                CommandsDropdown.SelectedIndex++;
-            }
-            else
-            {
-                CommandsDropdown.SelectedIndex = 0;
-            }
-
-            e.Handled = true;
-        }
-    }
-
-    private void UpdateUiForStackChange()
-    {
-        ContextFilterBox.Text = string.Empty;
-        ViewModel.ContextMenu?.SetSearchText(string.Empty);
-        CommandsDropdown.SelectedIndex = 0;
-        ContextFilterBox.Focus(FocusState.Programmatic);
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContextMenu.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContextMenu.xaml
@@ -1,0 +1,128 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<UserControl
+    x:Class="Microsoft.CmdPal.UI.Controls.ContextMenu"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:animations="using:CommunityToolkit.WinUI.Animations"
+    xmlns:cmdpalUI="using:Microsoft.CmdPal.UI"
+    xmlns:cpcontrols="using:Microsoft.CmdPal.UI.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:help="using:Microsoft.CmdPal.UI.Helpers"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:ui="using:CommunityToolkit.WinUI"
+    xmlns:viewmodels="using:Microsoft.CmdPal.UI.ViewModels"
+    Background="Transparent"
+    mc:Ignorable="d">
+
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <cmdpalUI:KeyChordToStringConverter x:Key="KeyChordToStringConverter" />
+
+            <StackLayout
+                x:Name="VerticalStackLayout"
+                Orientation="Vertical"
+                Spacing="4" />
+
+            <cmdpalUI:ContextItemTemplateSelector
+                x:Key="ContextItemTemplateSelector"
+                Critical="{StaticResource CriticalContextMenuViewModelTemplate}"
+                Default="{StaticResource DefaultContextMenuViewModelTemplate}" />
+
+            <!--  Template for context items in the context item menu  -->
+            <DataTemplate x:Key="DefaultContextMenuViewModelTemplate" x:DataType="viewmodels:CommandContextItemViewModel">
+                <Grid AutomationProperties.Name="{x:Bind Title, Mode=OneWay}">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="32" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <cpcontrols:IconBox
+                        Width="16"
+                        Height="16"
+                        Margin="4,0,0,0"
+                        HorizontalAlignment="Left"
+                        SourceKey="{x:Bind Icon, Mode=OneWay}"
+                        SourceRequested="{x:Bind help:IconCacheProvider.SourceRequested}" />
+                    <TextBlock
+                        Grid.Column="1"
+                        VerticalAlignment="Center"
+                        Text="{x:Bind Title, Mode=OneWay}" />
+                    <TextBlock
+                        Grid.Column="2"
+                        Margin="16,0,0,0"
+                        HorizontalAlignment="Right"
+                        VerticalAlignment="Center"
+                        Foreground="{ThemeResource MenuFlyoutItemKeyboardAcceleratorTextForeground}"
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        Text="{x:Bind RequestedShortcut, Mode=OneWay, Converter={StaticResource KeyChordToStringConverter}}" />
+                </Grid>
+            </DataTemplate>
+
+            <!--  Template for context items flagged as critical  -->
+            <DataTemplate x:Key="CriticalContextMenuViewModelTemplate" x:DataType="viewmodels:CommandContextItemViewModel">
+                <Grid AutomationProperties.Name="{x:Bind Title, Mode=OneWay}">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="32" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <cpcontrols:IconBox
+                        Width="16"
+                        Height="16"
+                        Margin="4,0,0,0"
+                        HorizontalAlignment="Left"
+                        Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+                        SourceKey="{x:Bind Icon, Mode=OneWay}"
+                        SourceRequested="{x:Bind help:IconCacheProvider.SourceRequested}" />
+                    <TextBlock
+                        Grid.Column="1"
+                        VerticalAlignment="Center"
+                        Style="{StaticResource ContextItemTitleTextBlockCriticalStyle}"
+                        Text="{x:Bind Title, Mode=OneWay}" />
+                    <TextBlock
+                        Grid.Column="2"
+                        Margin="16,0,0,0"
+                        HorizontalAlignment="Right"
+                        VerticalAlignment="Center"
+                        Style="{StaticResource ContextItemCaptionTextBlockCriticalStyle}"
+                        Text="{x:Bind RequestedShortcut, Mode=OneWay, Converter={StaticResource KeyChordToStringConverter}}" />
+                </Grid>
+            </DataTemplate>
+
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <StackPanel>
+
+        <ListView
+        x:Name="CommandsDropdown"
+        MinWidth="248"
+        Margin="-16,-12,-16,-12"
+        IsItemClickEnabled="True"
+        ItemClick="CommandsDropdown_ItemClick"
+        ItemTemplateSelector="{StaticResource ContextItemTemplateSelector}"
+        ItemsSource="{x:Bind ViewModel.FilteredItems, Mode=OneWay}"
+        KeyDown="CommandsDropdown_KeyDown"
+        SelectionMode="Single">
+            <ListView.ItemContainerStyle>
+                <Style BasedOn="{StaticResource DefaultListViewItemStyle}" TargetType="ListViewItem">
+                    <Setter Property="MinHeight" Value="0" />
+                    <Setter Property="Padding" Value="12,7,12,7" />
+                </Style>
+            </ListView.ItemContainerStyle>
+            <ListView.ItemContainerTransitions>
+                <TransitionCollection />
+            </ListView.ItemContainerTransitions>
+        </ListView>
+
+        <TextBox
+        x:Name="ContextFilterBox"
+        x:Uid="ContextFilterBox"
+        Margin="-12,12,-12,-12"
+        KeyDown="ContextFilterBox_KeyDown"
+        PreviewKeyDown="ContextFilterBox_PreviewKeyDown"
+        TextChanged="ContextFilterBox_TextChanged" />
+
+    </StackPanel>
+
+</UserControl>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContextMenu.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContextMenu.xaml
@@ -95,15 +95,15 @@
     <StackPanel>
 
         <ListView
-        x:Name="CommandsDropdown"
-        MinWidth="248"
-        Margin="-16,-12,-16,-12"
-        IsItemClickEnabled="True"
-        ItemClick="CommandsDropdown_ItemClick"
-        ItemTemplateSelector="{StaticResource ContextItemTemplateSelector}"
-        ItemsSource="{x:Bind ViewModel.FilteredItems, Mode=OneWay}"
-        KeyDown="CommandsDropdown_KeyDown"
-        SelectionMode="Single">
+            x:Name="CommandsDropdown"
+            MinWidth="248"
+            Margin="-16,-12,-16,-12"
+            IsItemClickEnabled="True"
+            ItemClick="CommandsDropdown_ItemClick"
+            ItemTemplateSelector="{StaticResource ContextItemTemplateSelector}"
+            ItemsSource="{x:Bind ViewModel.FilteredItems, Mode=OneWay}"
+            KeyDown="CommandsDropdown_KeyDown"
+            SelectionMode="Single">
             <ListView.ItemContainerStyle>
                 <Style BasedOn="{StaticResource DefaultListViewItemStyle}" TargetType="ListViewItem">
                     <Setter Property="MinHeight" Value="0" />
@@ -116,12 +116,12 @@
         </ListView>
 
         <TextBox
-        x:Name="ContextFilterBox"
-        x:Uid="ContextFilterBox"
-        Margin="-12,12,-12,-12"
-        KeyDown="ContextFilterBox_KeyDown"
-        PreviewKeyDown="ContextFilterBox_PreviewKeyDown"
-        TextChanged="ContextFilterBox_TextChanged" />
+            x:Name="ContextFilterBox"
+            x:Uid="ContextFilterBox"
+            Margin="-12,12,-12,-12"
+            KeyDown="ContextFilterBox_KeyDown"
+            PreviewKeyDown="ContextFilterBox_PreviewKeyDown"
+            TextChanged="ContextFilterBox_TextChanged" />
 
     </StackPanel>
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContextMenu.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContextMenu.xaml.cs
@@ -1,0 +1,216 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.Messaging;
+using Microsoft.CmdPal.UI.ViewModels;
+using Microsoft.CmdPal.UI.ViewModels.Messages;
+using Microsoft.CmdPal.UI.Views;
+using Microsoft.UI.Input;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Input;
+using Windows.System;
+using Windows.UI.Core;
+
+namespace Microsoft.CmdPal.UI.Controls;
+
+public sealed partial class ContextMenu : UserControl,
+    IRecipient<TryCommandKeybindingMessage>,
+    IRecipient<CloseContextMenuMessage>,
+    IRecipient<OpenContextMenuMessage>
+{
+    public ContextMenuStackViewModel? ViewModel { get; set; }
+
+    public ContextMenu()
+    {
+        this.InitializeComponent();
+
+        // RegisterAll isn't AOT compatible
+        WeakReferenceMessenger.Default.Register<TryCommandKeybindingMessage>(this);
+        WeakReferenceMessenger.Default.Register<CloseContextMenuMessage>(this);
+        WeakReferenceMessenger.Default.Register<OpenContextMenuMessage>(this);
+    }
+
+    public void Receive(OpenContextMenuMessage msg)
+    {
+        UpdateUiForStackChange();
+    }
+
+    public void Receive(CloseContextMenuMessage msg)
+    {
+        UpdateUiForStackChange();
+    }
+
+    public void Receive(TryCommandKeybindingMessage msg)
+    {
+        var keyboundCommandModel = ViewModel?.CheckKeybinding(msg.Ctrl, msg.Alt, msg.Shift, msg.Win, msg.Key);
+
+        if (keyboundCommandModel == null)
+        {
+            return;
+        }
+
+        var result = ViewModel?.InvokeItem(keyboundCommandModel);
+
+        if (result == null)
+        {
+            return;
+        }
+
+        if (result == ContextKeybindingResult.Hide)
+        {
+            msg.Handled = true;
+        }
+        else if (result == ContextKeybindingResult.KeepOpen)
+        {
+            UpdateUiForStackChange();
+
+            msg.Handled = true;
+        }
+        else if (result == ContextKeybindingResult.Unhandled)
+        {
+            msg.Handled = false;
+        }
+    }
+
+    private void CommandsDropdown_ItemClick(object sender, ItemClickEventArgs e)
+    {
+        if (e.ClickedItem is CommandContextItemViewModel item)
+        {
+            ViewModel?.InvokeItem(item);
+            UpdateUiForStackChange();
+        }
+    }
+
+    private void CommandsDropdown_KeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        if (e.Handled)
+        {
+            return;
+        }
+
+        var ctrlPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down);
+        var altPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Menu).HasFlag(CoreVirtualKeyStates.Down);
+        var shiftPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down);
+        var winPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.LeftWindows).HasFlag(CoreVirtualKeyStates.Down) ||
+            InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.RightWindows).HasFlag(CoreVirtualKeyStates.Down);
+
+        var keyboundCommandModel = ViewModel?.CheckKeybinding(ctrlPressed, altPressed, shiftPressed, winPressed, e.Key);
+
+        if (keyboundCommandModel == null)
+        {
+            return;
+        }
+
+        var result = ViewModel?.InvokeItem(keyboundCommandModel);
+
+        if (result == null)
+        {
+            return;
+        }
+        else if (result == ContextKeybindingResult.Hide)
+        {
+            e.Handled = true;
+            WeakReferenceMessenger.Default.Send<CloseContextMenuMessage>();
+            WeakReferenceMessenger.Default.Send<FocusSearchBoxMessage>();
+        }
+        else if (result == ContextKeybindingResult.KeepOpen)
+        {
+            e.Handled = true;
+        }
+        else if (result == ContextKeybindingResult.Unhandled)
+        {
+            e.Handled = false;
+        }
+    }
+
+    private void ContextFilterBox_TextChanged(object sender, TextChangedEventArgs e)
+    {
+        ViewModel?.SetSearchText(ContextFilterBox.Text);
+
+        if (CommandsDropdown.SelectedIndex == -1)
+        {
+            CommandsDropdown.SelectedIndex = 0;
+        }
+    }
+
+    private void ContextFilterBox_KeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        var ctrlPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down);
+        var altPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Menu).HasFlag(CoreVirtualKeyStates.Down);
+        var shiftPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down);
+        var winPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.LeftWindows).HasFlag(CoreVirtualKeyStates.Down) ||
+            InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.RightWindows).HasFlag(CoreVirtualKeyStates.Down);
+
+        if (e.Key == VirtualKey.Enter)
+        {
+            if (CommandsDropdown.SelectedItem is CommandContextItemViewModel item)
+            {
+                if (ViewModel?.InvokeItem(item) == ContextKeybindingResult.Hide)
+                {
+                    WeakReferenceMessenger.Default.Send<CloseContextMenuMessage>();
+                    WeakReferenceMessenger.Default.Send<FocusSearchBoxMessage>();
+                }
+                else
+                {
+                    UpdateUiForStackChange();
+                }
+
+                e.Handled = true;
+            }
+        }
+        else if (e.Key == VirtualKey.Escape ||
+            (e.Key == VirtualKey.Left && altPressed))
+        {
+            WeakReferenceMessenger.Default.Send<CloseContextMenuMessage>();
+            UpdateUiForStackChange();
+
+            e.Handled = true;
+        }
+
+        CommandsDropdown_KeyDown(sender, e);
+    }
+
+    private void ContextFilterBox_PreviewKeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        if (e.Key == VirtualKey.Up)
+        {
+            // navigate previous
+            if (CommandsDropdown.SelectedIndex > 0)
+            {
+                CommandsDropdown.SelectedIndex--;
+            }
+            else
+            {
+                CommandsDropdown.SelectedIndex = CommandsDropdown.Items.Count - 1;
+            }
+
+            e.Handled = true;
+        }
+        else if (e.Key == VirtualKey.Down)
+        {
+            // navigate next
+            if (CommandsDropdown.SelectedIndex < CommandsDropdown.Items.Count - 1)
+            {
+                CommandsDropdown.SelectedIndex++;
+            }
+            else
+            {
+                CommandsDropdown.SelectedIndex = 0;
+            }
+
+            e.Handled = true;
+        }
+    }
+
+    public void UpdateUiForStackChange()
+    {
+        ContextFilterBox.Text = string.Empty;
+        ViewModel?.SetSearchText(string.Empty);
+        CommandsDropdown.SelectedIndex = 0;
+        ContextFilterBox.Focus(FocusState.Programmatic);
+    }
+}

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowWalker/Commands/CloseWindowCommand.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowWalker/Commands/CloseWindowCommand.cs
@@ -20,7 +20,7 @@ internal sealed partial class CloseWindowCommand : InvokableCommand
 
     public CloseWindowCommand(Window window)
     {
-        Icon = new IconInfo("\xE8BB");
+        Icon = new IconInfo("\uE894");
         Name = $"{Resources.windowwalker_Close}";
         _window = window;
     }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowWalker/Commands/EndTaskCommand.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowWalker/Commands/EndTaskCommand.cs
@@ -15,13 +15,13 @@ using Microsoft.CommandPalette.Extensions.Toolkit;
 
 namespace Microsoft.CmdPal.Ext.WindowWalker.Commands;
 
-internal sealed partial class KillProcessCommand : InvokableCommand
+internal sealed partial class EndTaskCommand : InvokableCommand
 {
     private readonly Window _window;
 
-    public KillProcessCommand(Window window)
+    public EndTaskCommand(Window window)
     {
-        Icon = new IconInfo("\xE74D"); // Delete symbol
+        Icon = new IconInfo("\uF140"); // Delete symbol
         Name = $"{Resources.windowwalker_Kill}";
         _window = window;
     }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowWalker/Components/ContextMenuHelper.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowWalker/Components/ContextMenuHelper.cs
@@ -33,7 +33,7 @@ internal sealed class ContextMenuHelper
         if (!windowData.Process.IsShellProcess && !(windowData.Process.IsUwpApp && string.Equals(windowData.Process.Name, "ApplicationFrameHost.exe", StringComparison.OrdinalIgnoreCase))
             && !(windowData.Process.IsFullAccessDenied && SettingsManager.Instance.HideKillProcessOnElevatedProcesses))
         {
-            contextMenu.Add(new CommandContextItem(new KillProcessCommand(windowData))
+            contextMenu.Add(new CommandContextItem(new EndTaskCommand(windowData))
             {
                 RequestedShortcut = KeyChordHelpers.FromModifiers(true, false, false, false, (int)VirtualKey.Delete, 0),
                 IsCritical = true,

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowWalker/Properties/Resources.Designer.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowWalker/Properties/Resources.Designer.cs
@@ -133,7 +133,7 @@ namespace Microsoft.CmdPal.Ext.WindowWalker.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Kill process.
+        ///   Looks up a localized string similar to End task.
         /// </summary>
         public static string windowwalker_Kill {
             get {
@@ -142,7 +142,7 @@ namespace Microsoft.CmdPal.Ext.WindowWalker.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Your are going to kill the following process:.
+        ///   Looks up a localized string similar to You are going to kill the following process:.
         /// </summary>
         public static string windowwalker_KillMessage {
             get {
@@ -160,7 +160,7 @@ namespace Microsoft.CmdPal.Ext.WindowWalker.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Kill process confirmation.
+        ///   Looks up a localized string similar to End task confirmation.
         /// </summary>
         public static string windowwalker_KillMessageTitle {
             get {

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowWalker/Properties/Resources.resx
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowWalker/Properties/Resources.resx
@@ -173,16 +173,16 @@
     <value>Close window</value>
   </data>
   <data name="windowwalker_Kill" xml:space="preserve">
-    <value>Kill process</value>
+    <value>End task</value>
   </data>
   <data name="windowwalker_KillMessage" xml:space="preserve">
-    <value>Your are going to kill the following process:</value>
+    <value>You are going to kill the following process:</value>
   </data>
   <data name="windowwalker_KillMessageQuestion" xml:space="preserve">
     <value>Continue?</value>
   </data>
   <data name="windowwalker_KillMessageTitle" xml:space="preserve">
-    <value>Kill process confirmation</value>
+    <value>End task confirmation</value>
   </data>
   <data name="windowwalker_KillMessageUwp" xml:space="preserve">
     <value>Because this is an app process, all instances of the app will be killed. Continue?</value>

--- a/src/modules/cmdpal/ext/SamplePagesExtension/Pages/SampleListPage.cs
+++ b/src/modules/cmdpal/ext/SamplePagesExtension/Pages/SampleListPage.cs
@@ -98,7 +98,8 @@ internal sealed partial class SampleListPage : ListPage
                             new CommandContextItem(
                                 new ToastCommand("Nested B invoked") { Name = "Do it", Icon = new IconInfo("B") })
                             {
-                                Title = "Nested B...",
+                                Title = "Nested B (Critical)...",
+                                IsCritical = true,
                                 RequestedShortcut = KeyChordHelpers.FromModifiers(ctrl: true, vkey: VirtualKey.B),
                                 MoreCommands = [
                                     new CommandContextItem(


### PR DESCRIPTION
## Summary of the Pull Request

Pulled ContextMenu into its own component since it was taking nearly half of the code in CommandBar. 

This should also keep adding functionality to ContextMenu (separators, styling, etc.) cleaner. Hopefully will also make having a right-click on listitem context menu easier.

Shouldn't notice any change in user experience as it's just reorganization.


Addendum:
Also renames "Kill process" in Window Walker to "End task" to align with other stuff.