### PR TITLE
CmdPal: Implement IDetailsCommand in details

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/DetailsCommandViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/DetailsCommandViewModel.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CmdPal.UI.ViewModels.Models;
+using Microsoft.CommandPalette.Extensions;
+
+namespace Microsoft.CmdPal.UI.ViewModels;
+
+public partial class DetailsCommandViewModel(
+    IDetailsElement _detailsElement,
+    WeakReference<IPageContext> context) : DetailsElementViewModel(_detailsElement, context)
+{
+    private readonly ExtensionObject<IDetailsCommand> _dataModel =
+        new(_detailsElement.Data as IDetailsCommand);
+
+    public string Text { get; private set; } = string.Empty;
+
+    public IconInfoViewModel Icon { get; private set; } = new(null);
+
+    public ICommand? Command { get; private set; }
+
+    public override void InitializeProperties()
+    {
+        base.InitializeProperties();
+        var model = _dataModel.Unsafe;
+        if (model == null)
+        {
+            return;
+        }
+
+        Text = model.Command.Name ?? string.Empty;
+        Icon = new(model.Command.Icon);
+        Command = model.Command;
+
+        UpdateProperty(nameof(Text));
+        UpdateProperty(nameof(Icon));
+        UpdateProperty(nameof(Command));
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/DetailsCommandsViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/DetailsCommandsViewModel.cs
@@ -7,18 +7,16 @@ using Microsoft.CommandPalette.Extensions;
 
 namespace Microsoft.CmdPal.UI.ViewModels;
 
-public partial class DetailsCommandViewModel(
+public partial class DetailsCommandsViewModel(
     IDetailsElement _detailsElement,
     WeakReference<IPageContext> context) : DetailsElementViewModel(_detailsElement, context)
 {
-    private readonly ExtensionObject<IDetailsCommand> _dataModel =
-        new(_detailsElement.Data as IDetailsCommand);
+    public List<CommandViewModel> Commands { get; private set; } = [];
 
-    public string Text { get; private set; } = string.Empty;
+    public bool HasCommands => Commands.Count > 0;
 
-    public IconInfoViewModel Icon { get; private set; } = new(null);
-
-    public ICommand? Command { get; private set; }
+    private readonly ExtensionObject<IDetailsCommands> _dataModel =
+        new(_detailsElement.Data as IDetailsCommands);
 
     public override void InitializeProperties()
     {
@@ -29,12 +27,16 @@ public partial class DetailsCommandViewModel(
             return;
         }
 
-        Text = model.Command.Name ?? string.Empty;
-        Icon = new(model.Command.Icon);
-        Command = model.Command;
-
-        UpdateProperty(nameof(Text));
-        UpdateProperty(nameof(Icon));
-        UpdateProperty(nameof(Command));
+        Commands = model
+            .Commands?
+            .Select(c =>
+            {
+                var vm = new CommandViewModel(c, PageContext);
+                vm.InitializeProperties();
+                return vm;
+            })
+            .ToList() ?? [];
+        UpdateProperty(nameof(HasCommands));
+        UpdateProperty(nameof(Commands));
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/DetailsViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/DetailsViewModel.cs
@@ -49,6 +49,7 @@ public partial class DetailsViewModel(IDetails _details, WeakReference<IPageCont
                 {
                     IDetailsSeparator => new DetailsSeparatorViewModel(element, this.PageContext),
                     IDetailsLink => new DetailsLinkViewModel(element, this.PageContext),
+                    IDetailsCommand => new DetailsCommandViewModel(element, this.PageContext),
                     IDetailsTags => new DetailsTagsViewModel(element, this.PageContext),
                     _ => null,
                 };

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/DetailsViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/DetailsViewModel.cs
@@ -49,7 +49,7 @@ public partial class DetailsViewModel(IDetails _details, WeakReference<IPageCont
                 {
                     IDetailsSeparator => new DetailsSeparatorViewModel(element, this.PageContext),
                     IDetailsLink => new DetailsLinkViewModel(element, this.PageContext),
-                    IDetailsCommand => new DetailsCommandViewModel(element, this.PageContext),
+                    IDetailsCommands => new DetailsCommandsViewModel(element, this.PageContext),
                     IDetailsTags => new DetailsTagsViewModel(element, this.PageContext),
                     _ => null,
                 };

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Converters/DetailsDataTemplateSelector.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Converters/DetailsDataTemplateSelector.cs
@@ -18,6 +18,8 @@ public partial class DetailsDataTemplateSelector : DataTemplateSelector
 
     public DataTemplate? TagTemplate { get; set; }
 
+    public DataTemplate? CommandTemplate { get; set; }
+
     protected override DataTemplate? SelectTemplateCore(object item)
     {
         if (item is DetailsElementViewModel element)
@@ -27,6 +29,7 @@ public partial class DetailsDataTemplateSelector : DataTemplateSelector
             {
                 DetailsSeparatorViewModel => SeparatorTemplate,
                 DetailsLinkViewModel => LinkTemplate,
+                DetailsCommandViewModel => CommandTemplate,
                 DetailsTagsViewModel => TagTemplate,
                 _ => null,
             };

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Converters/DetailsDataTemplateSelector.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Converters/DetailsDataTemplateSelector.cs
@@ -29,7 +29,7 @@ public partial class DetailsDataTemplateSelector : DataTemplateSelector
             {
                 DetailsSeparatorViewModel => SeparatorTemplate,
                 DetailsLinkViewModel => LinkTemplate,
-                DetailsCommandViewModel => CommandTemplate,
+                DetailsCommandsViewModel => CommandTemplate,
                 DetailsTagsViewModel => TagTemplate,
                 _ => null,
             };

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml
@@ -29,9 +29,9 @@
 
             <cmdpalUI:DetailsDataTemplateSelector
                 x:Key="DetailsDataTemplateSelector"
+                CommandTemplate="{StaticResource DetailsCommandsTemplate}"
                 LinkTemplate="{StaticResource DetailsLinkTemplate}"
                 SeparatorTemplate="{StaticResource DetailsSeparatorTemplate}"
-                CommandTemplate="{StaticResource DetailsCommandTemplate}"
                 TagTemplate="{StaticResource DetailsTagsTemplate}" />
 
             <converters:BoolToVisibilityConverter
@@ -49,6 +49,27 @@
                     Icon="{x:Bind Icon, Mode=OneWay}"
                     Text="{x:Bind Text, Mode=OneWay}"
                     ToolTipService.ToolTip="{x:Bind ToolTip, Mode=OneWay}" />
+            </DataTemplate>
+
+            <DataTemplate x:Key="CommandTemplate" x:DataType="viewModels:CommandViewModel">
+                <StackPanel Orientation="Vertical">
+                    <Button
+                        Name="Command"
+                        HorizontalAlignment="Stretch"
+                        HorizontalContentAlignment="Left"
+                        Click="Command_Click"
+                        Style="{StaticResource SubtleButtonStyle}">
+                        <StackPanel VerticalAlignment="Center" Orientation="Horizontal">
+                            <cpcontrols:IconBox
+                                Width="16"
+                                Height="16"
+                                Margin="0,3,8,0"
+                                SourceKey="{x:Bind Icon, Mode=OneWay}"
+                                SourceRequested="{x:Bind help:IconCacheProvider.SourceRequested}" />
+                            <TextBlock Text="{x:Bind Name}" />
+                        </StackPanel>
+                    </Button>
+                </StackPanel>
             </DataTemplate>
 
             <DataTemplate x:Key="DetailsLinkTemplate" x:DataType="viewModels:DetailsLinkViewModel">
@@ -72,25 +93,16 @@
                         Visibility="{x:Bind IsLink, Mode=OneWay}" />
                 </StackPanel>
             </DataTemplate>
-            <DataTemplate x:Key="DetailsCommandTemplate" x:DataType="viewModels:DetailsCommandViewModel">
-                <StackPanel Margin="0,0,0,0" Padding="0,0,0,0" Orientation="Vertical">
-                    <Button
-                    Style="{StaticResource SubtleButtonStyle}"
-                    HorizontalAlignment="Stretch"
-                    HorizontalContentAlignment="Left"
-                    >
-                        <StackPanel Orientation="Horizontal">
-                            <cpcontrols:IconBox
-                                Width="16"
-                                Height="16"
-                                Margin="4,0,4,0"
-                                VerticalAlignment="Center"
-                                SourceKey="{x:Bind Icon, Mode=OneWay}"
-                                SourceRequested="{x:Bind help:IconCacheProvider.SourceRequested}" />
-                            <TextBlock
-                                Text="{x:Bind Text}" />
-                        </StackPanel>
-                    </Button>
+            <DataTemplate x:Key="DetailsCommandsTemplate" x:DataType="viewModels:DetailsCommandsViewModel">
+                <StackPanel Orientation="Vertical" Spacing="4">
+                    <TextBlock
+                        IsTextSelectionEnabled="True"
+                        Text="{x:Bind Key, Mode=OneWay}"
+                        TextWrapping="WrapWholeWords" />
+                    <ItemsControl
+                        ItemTemplate="{StaticResource CommandTemplate}"
+                        ItemsSource="{x:Bind Commands, Mode=OneWay}"
+                        Visibility="{x:Bind HasCommands, Mode=OneWay}" />
                 </StackPanel>
             </DataTemplate>
             <DataTemplate x:Key="DetailsSeparatorTemplate" x:DataType="viewModels:DetailsSeparatorViewModel">

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml
@@ -31,6 +31,7 @@
                 x:Key="DetailsDataTemplateSelector"
                 LinkTemplate="{StaticResource DetailsLinkTemplate}"
                 SeparatorTemplate="{StaticResource DetailsSeparatorTemplate}"
+                CommandTemplate="{StaticResource DetailsCommandTemplate}"
                 TagTemplate="{StaticResource DetailsTagsTemplate}" />
 
             <converters:BoolToVisibilityConverter
@@ -69,6 +70,27 @@
                         FontSize="12"
                         NavigateUri="{x:Bind Link, Mode=OneWay}"
                         Visibility="{x:Bind IsLink, Mode=OneWay}" />
+                </StackPanel>
+            </DataTemplate>
+            <DataTemplate x:Key="DetailsCommandTemplate" x:DataType="viewModels:DetailsCommandViewModel">
+                <StackPanel Margin="0,0,0,0" Padding="0,0,0,0" Orientation="Vertical">
+                    <Button
+                    Style="{StaticResource SubtleButtonStyle}"
+                    HorizontalAlignment="Stretch"
+                    HorizontalContentAlignment="Left"
+                    >
+                        <StackPanel Orientation="Horizontal">
+                            <cpcontrols:IconBox
+                                Width="16"
+                                Height="16"
+                                Margin="4,0,4,0"
+                                VerticalAlignment="Center"
+                                SourceKey="{x:Bind Icon, Mode=OneWay}"
+                                SourceRequested="{x:Bind help:IconCacheProvider.SourceRequested}" />
+                            <TextBlock
+                                Text="{x:Bind Text}" />
+                        </StackPanel>
+                    </Button>
                 </StackPanel>
             </DataTemplate>
             <DataTemplate x:Key="DetailsSeparatorTemplate" x:DataType="viewModels:DetailsSeparatorViewModel">

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
@@ -629,4 +629,12 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
             return iconInfoVM?.HasIcon(requestedTheme == Microsoft.UI.Xaml.ElementTheme.Light) ?? false;
         }
     }
+
+    private void Command_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+    {
+        if (sender is Button button && button.DataContext is CommandViewModel commandViewModel)
+        {
+            WeakReferenceMessenger.Default.Send<PerformCommandMessage>(new(commandViewModel.Model));
+        }
+    }
 }

--- a/src/modules/cmdpal/ext/SamplePagesExtension/Pages/SampleListPageWithDetails.cs
+++ b/src/modules/cmdpal/ext/SamplePagesExtension/Pages/SampleListPageWithDetails.cs
@@ -5,6 +5,7 @@
 using System;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
+using Microsoft.UI.Xaml;
 
 namespace SamplePagesExtension;
 
@@ -127,6 +128,29 @@ internal sealed partial class SampleListPageWithDetails : ListPage
                                     new Tag("in") { Foreground = RandomColor(), Background = RandomColor() },
                                     new Tag("it") { Foreground = RandomColor(), Background = RandomColor() },
                                 ],
+                            },
+                        },
+                        new DetailsElement()
+                        {
+                            Key = "Commands",
+                            Data = new DetailsCommand()
+                            {
+                                Command = new ToastCommand("Hey! You clicked it!", MessageState.Success)
+                                {
+                                    Name = "Do something amazing",
+                                    Icon = new("\uE945"),
+                                },
+                            },
+                        },
+                        new DetailsElement()
+                        {
+                            Data = new DetailsCommand()
+                            {
+                                Command = new ToastCommand("I warned you!", MessageState.Error)
+                                {
+                                    Name = "Don't click me",
+                                    Icon = new("\uEA39"),
+                                },
                             },
                         },
                     ],

--- a/src/modules/cmdpal/ext/SamplePagesExtension/Pages/SampleListPageWithDetails.cs
+++ b/src/modules/cmdpal/ext/SamplePagesExtension/Pages/SampleListPageWithDetails.cs
@@ -133,24 +133,20 @@ internal sealed partial class SampleListPageWithDetails : ListPage
                         new DetailsElement()
                         {
                             Key = "Commands",
-                            Data = new DetailsCommand()
+                            Data = new DetailsCommands()
                             {
-                                Command = new ToastCommand("Hey! You clicked it!", MessageState.Success)
-                                {
-                                    Name = "Do something amazing",
-                                    Icon = new("\uE945"),
-                                },
-                            },
-                        },
-                        new DetailsElement()
-                        {
-                            Data = new DetailsCommand()
-                            {
-                                Command = new ToastCommand("I warned you!", MessageState.Error)
-                                {
-                                    Name = "Don't click me",
-                                    Icon = new("\uEA39"),
-                                },
+                                Commands = [
+                                    new ToastCommand("Hey! You clicked it!", MessageState.Success)
+                                    {
+                                        Name = "Do something amazing",
+                                        Icon = new("\uE945"),
+                                    },
+                                    new ToastCommand("I warned you!", MessageState.Error)
+                                    {
+                                        Name = "Don't click me",
+                                        Icon = new("\uEA39"),
+                                    },
+                               ],
                             },
                         },
                     ],

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/DetailsCommands.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/DetailsCommands.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.CommandPalette.Extensions.Toolkit;
 
-public partial class DetailsCommand : IDetailsCommand
+public partial class DetailsCommands : IDetailsCommands
 {
-    public ICommand? Command { get; set; }
+    public ICommand[]? Commands { get; set; }
 }

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions/Microsoft.CommandPalette.Extensions.idl
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions/Microsoft.CommandPalette.Extensions.idl
@@ -182,8 +182,8 @@ namespace Microsoft.CommandPalette.Extensions
         String Text { get; };
     }
     [contract(Microsoft.CommandPalette.Extensions.ExtensionsContract, 1)]
-    interface IDetailsCommand requires IDetailsData {
-        ICommand Command { get; };
+    interface IDetailsCommands requires IDetailsData {
+        ICommand[] Commands { get; };
     }
     [uuid("58070392-02bb-4e89-9beb-47ceb8c3d741")]
     [contract(Microsoft.CommandPalette.Extensions.ExtensionsContract, 1)]


### PR DESCRIPTION
Implemented IDetailsCommands in details. This will close #38339.

This works very similar to Tags in that it is a list of commands. This was done to allow for styling without the 12 spacing of the ItemsRepeater and looks like you'd find in the OS-inbox like:

![image](https://github.com/user-attachments/assets/97ee1952-13bb-4c8b-a074-0347b04e0c2c)

![image](https://github.com/user-attachments/assets/8f6f1f72-4ea0-441d-893e-ae26aabdc922)

Also added to our sample extension:

![image](https://github.com/user-attachments/assets/ab3ce521-3479-448f-b4d6-9dfd09feb24f)
