### PR TITLE
[Hosts]Add learn more link to warning dialog

### DIFF
--- a/src/modules/Hosts/HostsUILib/HostsMainPage.xaml.cs
+++ b/src/modules/Hosts/HostsUILib/HostsMainPage.xaml.cs
@@ -139,10 +139,23 @@ namespace HostsUILib.Views
                 dialog.XamlRoot = XamlRoot;
                 dialog.Style = Application.Current.Resources["DefaultContentDialogStyle"] as Style;
                 dialog.Title = resourceLoader.GetString("WarningDialog_Title");
-                dialog.Content = new TextBlock
+                dialog.Content = new StackPanel
                 {
-                    Text = resourceLoader.GetString("WarningDialog_Text"),
-                    TextWrapping = TextWrapping.Wrap,
+                    Children =
+                    {
+                        new TextBlock
+                        {
+                            Text = resourceLoader.GetString("WarningDialog_Text"),
+                            TextWrapping = TextWrapping.Wrap,
+                        },
+                        new HyperlinkButton
+                        {
+                            Content = resourceLoader.GetString("WarningDialog_LearnMore"),
+                            NavigateUri = new Uri("https://aka.ms/PowerToysOverview_HostsFileEditor"),
+                            Padding = new Thickness(0),
+                            Margin = new Thickness(0, 5, 0, 5),
+                        },
+                    },
                 };
                 dialog.PrimaryButtonText = resourceLoader.GetString("WarningDialog_AcceptBtn");
                 dialog.PrimaryButtonStyle = Application.Current.Resources["AccentButtonStyle"] as Style;

--- a/src/modules/Hosts/HostsUILib/Strings/en-us/Resources.resw
+++ b/src/modules/Hosts/HostsUILib/Strings/en-us/Resources.resw
@@ -331,6 +331,9 @@
   <data name="WarningDialog_Title" xml:space="preserve">
     <value>Warning</value>
   </data>
+  <data name="WarningDialog_LearnMore" xml:space="preserve">
+    <value>Learn more</value>
+  </data>
   <data name="WindowAdminTitle" xml:space="preserve">
     <value>Administrator: Hosts File Editor</value>
     <comment>Title of the window when running as administrator. "Hosts File Editor" is the name of the utility. "Hosts" refers to the system hosts file, do not loc</comment>


### PR DESCRIPTION
## Summary of the Pull Request
Adds a *Learn more* link pointing [here](https://aka.ms/PowerToysOverview_HostsFileEditor) (the same as in the settings) to the warning dialog that shows up when Hosts File Editor starts
## PR Checklist
- [x] **Closes:** #39859
- [ ] **Communication:** I've discussed this with core contributors already. If work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [x] **Localization:** All end user facing strings can be localized
- [x] **Dev docs:** No need
- [x] **New binaries:** None
- [x] **Documentation updated:** No need
## Detailed Description of the Pull Request / Additional comments
![Image](https://github.com/user-attachments/assets/f26c4fc9-fc3f-45d1-9976-77295b524b97)
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Tested the UI manually