### PR TITLE
[CmdPal][Apps]Add copy path command

### DIFF
--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Commands/CopyPathCommand.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Commands/CopyPathCommand.cs
@@ -35,7 +35,7 @@ internal sealed partial class CopyPathCommand : InvokableCommand
         }
         catch (Exception ex)
         {
-            Logger.LogError(ex.Message);
+            Logger.LogError("Copy failed: " + ex.Message);
             return CommandResult.ShowToast(
                 new ToastArgs
                 {

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Commands/CopyPathCommand.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Commands/CopyPathCommand.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using ManagedCommon;
+using Microsoft.CmdPal.Ext.Apps.Properties;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+
+namespace Microsoft.CmdPal.Ext.Apps.Commands;
+
+internal sealed partial class CopyPathCommand : InvokableCommand
+{
+    private static readonly IconInfo TheIcon = new("\ue8c8");
+
+    private readonly string _target;
+
+    public CopyPathCommand(string target)
+    {
+        Name = Resources.copy_path;
+        Icon = TheIcon;
+
+        _target = target;
+    }
+
+    public override CommandResult Invoke()
+    {
+        try
+        {
+            ClipboardHelper.SetText(_target);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex.Message);
+            return CommandResult.ShowToast(Resources.copy_failed + ": " + ex.Message);
+        }
+
+        return CommandResult.KeepOpen();
+    }
+}

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Commands/CopyPathCommand.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Commands/CopyPathCommand.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Globalization;
+using System.Text;
 using ManagedCommon;
 using Microsoft.CmdPal.Ext.Apps.Properties;
 using Microsoft.CommandPalette.Extensions.Toolkit;
@@ -23,6 +25,8 @@ internal sealed partial class CopyPathCommand : InvokableCommand
         _target = target;
     }
 
+    private static readonly CompositeFormat CopyFailedFormat = CompositeFormat.Parse(Resources.copy_failed);
+
     public override CommandResult Invoke()
     {
         try
@@ -32,9 +36,14 @@ internal sealed partial class CopyPathCommand : InvokableCommand
         catch (Exception ex)
         {
             Logger.LogError(ex.Message);
-            return CommandResult.ShowToast(Resources.copy_failed + ": " + ex.Message);
+            return CommandResult.ShowToast(
+                new ToastArgs
+                {
+                    Message = string.Format(CultureInfo.CurrentCulture, CopyFailedFormat, ex.Message),
+                    Result = CommandResult.KeepOpen(),
+                });
         }
 
-        return CommandResult.KeepOpen();
+        return CommandResult.ShowToast(Resources.copied_to_clipboard);
     }
 }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Programs/UWPApplication.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Programs/UWPApplication.cs
@@ -87,6 +87,10 @@ public class UWPApplication : IProgram
 
         commands.Add(
             new CommandContextItem(
+                new CopyPathCommand(Location)));
+
+        commands.Add(
+            new CommandContextItem(
                 new OpenPathCommand(Location)
                 {
                     Name = Resources.open_containing_folder,

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Programs/Win32Program.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Programs/Win32Program.cs
@@ -199,6 +199,9 @@ public class Win32Program : IProgram
         }
 
         commands.Add(new CommandContextItem(
+                    new CopyPathCommand(FullPath)));
+
+        commands.Add(new CommandContextItem(
                     new OpenPathCommand(ParentDirectory)));
 
         commands.Add(new CommandContextItem(

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Properties/Resources.Designer.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Properties/Resources.Designer.cs
@@ -79,7 +79,16 @@ namespace Microsoft.CmdPal.Ext.Apps.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Copy failed.
+        ///   Looks up a localized string similar to Copied to clipboard!.
+        /// </summary>
+        internal static string copied_to_clipboard {
+            get {
+                return ResourceManager.GetString("copied_to_clipboard", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Copy failed ({0}). Please try again..
         /// </summary>
         internal static string copy_failed {
             get {

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Properties/Resources.Designer.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Properties/Resources.Designer.cs
@@ -79,6 +79,24 @@ namespace Microsoft.CmdPal.Ext.Apps.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Copy failed.
+        /// </summary>
+        internal static string copy_failed {
+            get {
+                return ResourceManager.GetString("copy_failed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Copy path.
+        /// </summary>
+        internal static string copy_path {
+            get {
+                return ResourceManager.GetString("copy_path", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Include apps found on the desktop.
         /// </summary>
         internal static string enable_desktop_source {

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Properties/Resources.resx
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Properties/Resources.resx
@@ -163,11 +163,17 @@
   <data name="open_location" xml:space="preserve">
     <value>Open location</value>
   </data>
+  <data name="copy_path" xml:space="preserve">
+    <value>Copy path</value>
+  </data>
   <data name="run_as_administrator" xml:space="preserve">
     <value>Run as administrator</value>
   </data>
   <data name="run_as_different_user" xml:space="preserve">
     <value>Run as different user</value>
+  </data>
+  <data name="copy_failed" xml:space="preserve">
+    <value>Copy failed</value>
   </data>
   <data name="enable_start_menu_source" xml:space="preserve">
     <value>Include apps found in the Start Menu</value>

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Properties/Resources.resx
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Properties/Resources.resx
@@ -173,7 +173,11 @@
     <value>Run as different user</value>
   </data>
   <data name="copy_failed" xml:space="preserve">
-    <value>Copy failed</value>
+    <value>Copy failed ({0}). Please try again.</value>
+    <comment>{0} is the error message</comment>
+  </data>
+  <data name="copied_to_clipboard" xml:space="preserve">
+    <value>Copied to clipboard!</value>
   </data>
   <data name="enable_start_menu_source" xml:space="preserve">
     <value>Include apps found in the Start Menu</value>


### PR DESCRIPTION
## Summary of the Pull Request
Adds a *Copy path* command to the <kbd>Ctrl</kbd>+<kbd>K</kbd> menu in the All apps extension
## PR Checklist
- [x] **Closes:** #39500 (as mentioned in the discussion, the other requests will be tracked over in #﻿39501)
- [x] **Communication:** I've discussed this with core contributors already + has Help wanted
- [x] **Tests:** All pass
- [x] **Localization:** All end user facing strings can be localized
- [x] **Dev docs:** No need
- [x] **New binaries:** None
- [x] **Documentation updated:** No need
## Detailed Description of the Pull Request / Additional comments
Copies the exe full path for standard programs. Copies the package directory for UWPs.
Shows a *Copied to clipboard!* toast on a successful copy and closes.
Shows a toast when copying fails, keeps CmdPal open.
![image](https://github.com/user-attachments/assets/ad89a583-13c8-475c-973b-b0f5e7556e31)
## Validation Steps Performed
Manually tested copying for UWPs and Win32 programs