### PR TITLE
Add the detail section

### DIFF
--- a/.pipelines/verifyNoticeMdAgainstNugetPackages.ps1
+++ b/.pipelines/verifyNoticeMdAgainstNugetPackages.ps1
@@ -79,7 +79,7 @@ $noticeMatch = [regex]::Match($noticeFile, $noticePattern)
 if ($noticeMatch.Success) {
     $currentNoticePackageList = $noticeMatch.Groups[1].Value.Trim()
 } else {
-    Write-Host -ForegroundColor Yellow "Warning: Could not find 'NuGet Packages used by PowerToys' section in NOTICE.md"
+    Write-Warning "Warning: Could not find 'NuGet Packages used by PowerToys' section in NOTICE.md"
     $currentNoticePackageList = ""
 }
 

--- a/.pipelines/verifyNoticeMdAgainstNugetPackages.ps1
+++ b/.pipelines/verifyNoticeMdAgainstNugetPackages.ps1
@@ -72,9 +72,57 @@ $returnList = [System.Collections.Generic.HashSet[string]]($totalList) -join "`r
 
 Write-Host $returnList
 
+# Extract the current package list from NOTICE.md
+$noticePattern = "## NuGet Packages used by PowerToys\s*((?:\r?\n- .+)+)"
+$noticeMatch = [regex]::Match($noticeFile, $noticePattern)
+
+if ($noticeMatch.Success) {
+    $currentNoticePackageList = $noticeMatch.Groups[1].Value.Trim()
+} else {
+    Write-Host -ForegroundColor Yellow "Warning: Could not find 'NuGet Packages used by PowerToys' section in NOTICE.md"
+    $currentNoticePackageList = ""
+}
+
 if (!$noticeFile.Trim().EndsWith($returnList.Trim()))
 {
 	Write-Host -ForegroundColor Red "Notice.md does not match NuGet list."
+
+	# Show detailed differences
+	$generatedPackages = $returnList -split "`r`n|`n" | Where-Object { $_.Trim() -ne "" } | Sort-Object
+	$noticePackages = $currentNoticePackageList -split "`r`n|`n" | Where-Object { $_.Trim() -ne "" } | ForEach-Object { $_.Trim() } | Sort-Object
+
+	Write-Host ""
+	Write-Host -ForegroundColor Cyan "=== DETAILED DIFFERENCE ANALYSIS ==="
+	Write-Host ""
+
+	# Find packages in proj file list but not in NOTICE.md
+	$missingFromNotice = $generatedPackages | Where-Object { $noticePackages -notcontains $_ }
+	if ($missingFromNotice.Count -gt 0) {
+		Write-Host -ForegroundColor Red "MissingFromNotice:"
+		foreach ($pkg in $missingFromNotice) {
+			Write-Host -ForegroundColor Red "  $pkg"
+		}
+		Write-Host ""
+	}
+
+	# Find packages in NOTICE.md but not in proj file list
+	$extraInNotice = $noticePackages | Where-Object { $generatedPackages -notcontains $_ }
+	if ($extraInNotice.Count -gt 0) {
+		Write-Host -ForegroundColor Yellow "ExtraInNotice:"
+		foreach ($pkg in $extraInNotice) {
+			Write-Host -ForegroundColor Yellow "  $pkg"
+		}
+		Write-Host ""
+	}
+
+	# Show counts for summary
+	Write-Host -ForegroundColor Cyan "Summary:"
+	Write-Host "  Proj file list has $($generatedPackages.Count) packages"
+	Write-Host "  NOTICE.md has $($noticePackages.Count) packages"
+	Write-Host "  MissingFromNotice: $($missingFromNotice.Count) packages"
+	Write-Host "  ExtraInNotice: $($extraInNotice.Count) packages"
+	Write-Host ""
+
 	exit 1
 }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
The `verifyNoticeMdAgainstNugetPackages.ps1` script previously only reported "Notice.md does not match NuGet list." without providing any details about which packages were different, making it difficult to debug discrepancies.

## Changes Made

This enhancement adds detailed difference reporting when NuGet packages don't match:

- **Extracts current package list from NOTICE.md** using regex pattern matching
- **Shows packages missing from NOTICE.md** (highlighted in red)
- **Shows packages in NOTICE.md but not in generated list** (highlighted in yellow)
- **Provides summary statistics** with package counts
- **Maintains backward compatibility** - all existing functionality preserved

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
If there is no difference, the same behaviour.

If there is difference, here is the example:
![image](https://github.com/user-attachments/assets/63dad21a-9db5-4d20-8a2c-ddd44ce1ee80)

## Edge Cases Handled

- **Missing NuGet section**: Shows warning and treats as empty package list
- **Empty package lists**: Handles gracefully with appropriate counts
- **Matching lists**: No additional output (preserves existing behavior)

This enhancement significantly improves the debugging experience when NuGet package verification fails by providing specific, actionable information about which packages need attention.
