### PR TITLE
build: adjust for changes in the Az.Accounts module

### DIFF
--- a/.pipelines/v2/templates/job-publish-symbols-using-symbolrequestprod-api.yml
+++ b/.pipelines/v2/templates/job-publish-symbols-using-symbolrequestprod-api.yml
@@ -68,7 +68,7 @@ jobs:
       pwsh: true
       ScriptType: InlineScript
       Inline: |-
-        $AzToken = (Get-AzAccessToken -ResourceUrl api://30471ccf-0966-45b9-a979-065dbedb24c1).Token
+        $AzToken = (Get-AzAccessToken -AsSecureString -ResourceUrl api://30471ccf-0966-45b9-a979-065dbedb24c1).Token | ConvertFrom-SecureString -AsPlainText
         Write-Host "##vso[task.setvariable variable=SymbolAccessToken;issecret=true]$AzToken"
 
 


### PR DESCRIPTION
They made secure strings the default. Doing it this way maintains compatibility with the version before and after the default changed.

This fixes symbol publication.