### PR TITLE
Updates to WinGet publish script

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -752,6 +752,7 @@ iwr
 jfif
 jgeosdfsdsgmkedfgdfgdfgbkmhcgcflmi
 jjw
+JLO
 jobject
 jpe
 jpnime

--- a/.github/workflows/package-submissions.yml
+++ b/.github/workflows/package-submissions.yml
@@ -1,5 +1,4 @@
 name: WinGet submission on release
-# based off of https://github.com/nushell/nushell/blob/main/.github/workflows/winget-submission.yml
 
 on:
   workflow_dispatch:
@@ -9,23 +8,31 @@ on:
 jobs:
   winget:
     name: Publish winget package
+
+    # winget-create is only supported on Windows
     runs-on: windows-latest
+
+    # winget-create will read the following environment variable to access the GitHub token needed for submitting a PR
+    # See https://aka.ms/winget-create-token
+    env:
+      WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.PT_WINGET }}
+
+    # Only submit stable releases
+    if: ${{ !github.event.release.prerelease }}
     steps:
       - name: Submit Microsoft.PowerToys package to Windows Package Manager Community Repository
         run: |
+          # Get installer info from GitHub release event
+          $assets = '${{ toJSON(github.event.release.assets) }}' | ConvertFrom-Json
+          $x64UserInstallerUrl = $assets | Where-Object -Property name -match 'PowerToysUserSetup.*x64' | Select -ExpandProperty browser_download_url
+          $x64MachineInstallerUrl = $assets | Where-Object -Property name -match 'PowerToysSetup.*x64' | Select -ExpandProperty browser_download_url
+          $arm64UserInstallerUrl = $assets | Where-Object -Property name -match 'PowerToysUserSetup.*arm64' | Select -ExpandProperty browser_download_url
+          $arm64MachineInstallerUrl = $assets | Where-Object -Property name -match 'PowerToysSetup.*arm64' | Select -ExpandProperty browser_download_url
+          $packageVersion = (${{ toJSON(github.event.release.tag_name) }}).Trim('v')
 
-          $wingetPackage = "Microsoft.PowerToys"
-          $gitToken = "${{ secrets.PT_WINGET }}"
-
-          $github = Invoke-RestMethod -uri "https://api.github.com/repos/Microsoft/PowerToys/releases" 
-
-          $targetRelease = $github | Where-Object -Property name -match 'Release'| Select -First 1
-          $installerUserX64Url = $targetRelease | Select -ExpandProperty assets -First 1 | Where-Object -Property name -match 'PowerToysUserSetup.*x64' | Select -ExpandProperty browser_download_url
-          $installerMachineX64Url = $targetRelease | Select -ExpandProperty assets -First 1 | Where-Object -Property name -match 'PowerToysSetup.*x64' | Select -ExpandProperty browser_download_url
-          $installerUserArmUrl = $targetRelease | Select -ExpandProperty assets -First 1 | Where-Object -Property name -match 'PowerToysUserSetup.*arm64' | Select -ExpandProperty browser_download_url
-          $installerMachineArmUrl = $targetRelease | Select -ExpandProperty assets -First 1 | Where-Object -Property name -match 'PowerToysSetup.*arm64' | Select -ExpandProperty browser_download_url
-          $ver = $targetRelease.tag_name -ireplace '^v'
-
-          # getting latest wingetcreate file
-          iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
-          .\wingetcreate.exe update $wingetPackage -s -v $ver -u "$installerUserX64Url|user" "$installerMachineX64Url|machine" "$installerUserArmUrl|user" "$installerMachineArmUrl|machine" -t $gitToken
+          # Update package using wingetcreate
+          curl.exe -JLO https://aka.ms/wingetcreate/latest
+          .\wingetcreate.exe update Microsoft.PowerToys `
+            --version $packageVersion `
+            --urls "$x64UserInstallerUrl|user" "$x64MachineInstallerUrl|machine" "$arm64UserInstallerUrl|user" "$arm64MachineInstallerUrl|machine" `
+            --submit


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Few updates to the WinGet publish workflow action
- Use GitHub release event instead of manually making an API call to GitHub API and then fetching the target release. The target release is directly accessible via the event. The refactor is similar to the GitHub action of [microsoft/edit](https://github.com/microsoft/edit/blob/main/.github/workflows/winget.yml) repo's workflow
- With the latest winget-create release, the preferred method for providing the GitHub token in CI/CD environment is via the environment variable `WINGET_CREATE_GITHUB_TOKEN`. Removed use of `--token` and switched to environment variable. See https://aka.ms/winget-create-token for details.



