### PR TITLE
Fix PDF thumbnail generation – add `System.Drawing` reference and reset stream position

### DIFF
--- a/src/modules/previewpane/PdfThumbnailProvider/PdfThumbnailProvider.cs
+++ b/src/modules/previewpane/PdfThumbnailProvider/PdfThumbnailProvider.cs
@@ -1,9 +1,10 @@
-﻿// Copyright (c) Microsoft Corporation
+// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 using Windows.Data.Pdf;
 using Windows.Storage;
 using Windows.Storage.Streams;
+using System.Drawing;
 
 namespace Microsoft.PowerToys.ThumbnailHandler.Pdf
 {
@@ -94,6 +95,8 @@ namespace Microsoft.PowerToys.ThumbnailHandler.Pdf
             {
                 DestinationHeight = height,
             }).GetAwaiter().GetResult();
+
+            stream.Seek(0);
 
             imageOfPage = Image.FromStream(stream.AsStream());
 


### PR DESCRIPTION
##  Problem
[PdfThumbnailProvider](cci:1://file:///d:/Github/PowerToys/src/modules/previewpane/PdfThumbnailProvider/PdfThumbnailProvider.cs:15:8-18:9) could fail at compile-time **and/or** produce empty or invalid thumbnails at runtime:

1.  [Image](cci:1://file:///d:/Github/PowerToys/src/modules/previewpane/PdfThumbnailProvider/PdfThumbnailProvider.cs:81:8-103:9) / `Bitmap` types come from **System.Drawing**, but the namespace was missing, causing build errors in environments that don’t rely on implicit global usings.
2.  After rendering the first PDF page to an in-memory stream, the stream’s cursor remained at the end.  
    `Image.FromStream(stream.AsStream())` therefore read **zero bytes**, throwing an exception or creating an empty bitmap.

##  Fix
* Added explicit `using System.Drawing;`.
* Added `stream.Seek(0);` right before `Image.FromStream(...)` to rewind the stream to the beginning.

```csharp
using System.Drawing;   // new
...
page.RenderToStreamAsync(...).GetAwaiter().GetResult();
stream.Seek(0);         // rewind so Image.FromStream reads data
imageOfPage = Image.FromStream(stream.AsStream());
```
## Testing

- Rebuilt the solution – compilation succeeds without missing-namespace errors.
- Ran thumbnail handler against multiple PDFs; thumbnails now render correctly and no runtime exceptions are thrown.

## Impact
Users regain reliable PDF thumbnail previews in Explorer, improving usability and preventing crashes or blank icons.