### PR TITLE
[CmdPal > Time&Date] Fix outdated result

### DIFF
--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Pages/TimeDateExtensionPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Pages/TimeDateExtensionPage.cs
@@ -18,8 +18,6 @@ internal sealed partial class TimeDateExtensionPage : DynamicListPage
 
     private IList<ListItem> _results = new List<ListItem>();
 
-    private bool initialized;
-
     private SettingsManager _settingsManager;
 
     public TimeDateExtensionPage(SettingsManager settingsManager)
@@ -35,12 +33,9 @@ internal sealed partial class TimeDateExtensionPage : DynamicListPage
 
     public override IListItem[] GetItems()
     {
-       if (!initialized)
-        {
-            DoExecuteSearch(string.Empty);
-        }
+        DoExecuteSearch(string.Empty);
 
-       lock (_resultsLock)
+        lock (_resultsLock)
         {
             ListItem[] results = _results.ToArray();
             return results;
@@ -49,11 +44,6 @@ internal sealed partial class TimeDateExtensionPage : DynamicListPage
 
     public override void UpdateSearchText(string oldSearch, string newSearch)
     {
-        if (newSearch == oldSearch)
-        {
-            return;
-        }
-
         DoExecuteSearch(newSearch);
     }
 
@@ -84,7 +74,6 @@ internal sealed partial class TimeDateExtensionPage : DynamicListPage
     {
         lock (_resultsLock)
         {
-            initialized = true;
             this._results = result;
         }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

The results in Time&Date ext are cached. This leads to outdated results and makes no sense for a time/date query.
The PR fixes this.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #39973 
- [x] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

