### PR TITLE
Fix COM object creation in ExtensionWrapper

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Models/ExtensionWrapper.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Models/ExtensionWrapper.cs
@@ -107,17 +107,17 @@ public class ExtensionWrapper : IExtensionWrapper
                 {
                     Logger.LogDebug($"Starting {ExtensionDisplayName} ({ExtensionClassId})");
 
-                    var extensionPtr = nint.Zero;
-                    try
+                    unsafe
                     {
-                        // -2147024809: E_INVALIDARG
-                        // -2147467262: E_NOINTERFACE
-                        // -2147024893: E_PATH_NOT_FOUND
-                        var guid = typeof(IExtension).GUID;
-
-                        unsafe
+                        var extensionPtr = (void*)nint.Zero;
+                        try
                         {
-                            var hr = PInvoke.CoCreateInstance(Guid.Parse(ExtensionClassId), null, CLSCTX.CLSCTX_LOCAL_SERVER, guid, out var extensionObj);
+                            // -2147024809: E_INVALIDARG
+                            // -2147467262: E_NOINTERFACE
+                            // -2147024893: E_PATH_NOT_FOUND
+                            var guid = typeof(IExtension).GUID;
+
+                            var hr = PInvoke.CoCreateInstance(Guid.Parse(ExtensionClassId), null, CLSCTX.CLSCTX_LOCAL_SERVER, guid, out extensionPtr);
 
                             if (hr.Value == -2147024893)
                             {
@@ -128,28 +128,15 @@ public class ExtensionWrapper : IExtensionWrapper
                                 return;
                             }
 
-                            extensionPtr = Marshal.GetIUnknownForObject((nint)extensionObj);
-                            if (hr < 0)
-                            {
-                                Logger.LogDebug($"Failed to instantiate {ExtensionDisplayName}: {hr}");
-                                Marshal.ThrowExceptionForHR(hr);
-                            }
-
-                            // extensionPtr = Marshal.GetIUnknownForObject(extensionObj);
-                            extensionPtr = (nint)extensionObj;
-                            if (hr < 0)
-                            {
-                                Marshal.ThrowExceptionForHR(hr);
-                            }
-
-                            _extensionObject = MarshalInterface<IExtension>.FromAbi(extensionPtr);
+                            Marshal.ThrowExceptionForHR(hr);
+                            _extensionObject = MarshalInterface<IExtension>.FromAbi((nint)extensionPtr);
                         }
-                    }
-                    finally
-                    {
-                        if (extensionPtr != nint.Zero)
+                        finally
                         {
-                            Marshal.Release(extensionPtr);
+                            if ((nint)extensionPtr != nint.Zero)
+                            {
+                                Marshal.Release((nint)extensionPtr);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Removes extra call to Marshal.GetIUnknownForObject. This method is meant to take a .NET object that implements a COM interface and return a pointer to a COM instance that can be passed to native COM code, but the code was passing a COM instance pointer.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [X] **Closes:** No associated issue
- [X] **Communication:** Working with @moooyo on AOT and COM
- [X] **Tests:** No change in behavior expected, so no new tests
- [X] **Localization:** No new strings
- [X] **Dev docs:** No change in behavior
- [X] **New binaries:** none


