### PR TITLE
Include app Microsoft-Windows-AppXDeploymentServer-Operational event log as part of bug report

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -1949,6 +1949,7 @@ Wwanpp
 XAxis
 xclip
 xcopy
+XDeployment
 XDocument
 XElement
 xfd

--- a/doc/devdocs/tools/bug-report-tool.md
+++ b/doc/devdocs/tools/bug-report-tool.md
@@ -17,6 +17,7 @@ The bug report includes the following files:
 * `context-menu-packages.txt` - Information about the packages that are registered for the new Windows 11 context menu.
 * `dotnet-installation-info.txt` - Information about the installed .NET versions.
 * `EventViewer-*.xml` - These files contain event logs from the Windows Event Viewer for the executable specified in the file name.
+* `EventViewer-Microsoft-Windows-AppXDeploymentServer/Operational.xml` - Contains event logs from the AppXDeployment-Server which are useful for diagnosing MSIX installation issues.
 * `gpo-configuration-info.txt` - Information about the configured [GPO](/doc/gpo/README.md).
 * `installationFolderStructure.txt` - Information about the folder structure of the installation. All lines with files have the following structure: `FileName Version MD5Hash`.
 * `last_version_run.json` - Information about the last version of PowerToys that was run.

--- a/tools/BugReportTool/BugReportTool/EventViewer.cpp
+++ b/tools/BugReportTool/BugReportTool/EventViewer.cpp
@@ -146,32 +146,26 @@ namespace
         }
 
     public:
-        EventViewerReporter(const std::filesystem::path& tmpDir, std::wstring processName)
+        EventViewerReporter(const std::filesystem::path& tmpDir, std::wstring queryName, std::wstring fileName, bool isChannel)
         {
-            auto query = GetQuery(processName);
-            auto reportPath = tmpDir;
-            reportPath.append(L"EventViewer-" + processName + L".xml");
-            report = std::wofstream(reportPath);
-
-            hResults = EvtQuery(NULL, NULL, GetQuery(processName).c_str(), EvtQueryChannelPath);
-            if (NULL == hResults)
+            std::wstring query = L"";
+            if (isChannel)
             {
-                report << "Failed to report info for " << processName << ". " << get_last_error_or_default(GetLastError()) << std::endl;
-                return;
+				query = GetQueryByChannel(queryName);
+			}
+			else
+			{
+				query = GetQuery(queryName);
             }
-        }
 
-        EventViewerReporter(const std::filesystem::path& tmpDir, std::wstring channelName, bool isChannel)
-        {
-            auto query = GetQueryByChannel(channelName);
             auto reportPath = tmpDir;
-            reportPath.append(L"EventViewer-" + channelName + L".xml");
+            reportPath.append(L"EventViewer-" + fileName + L".xml");
             report = std::wofstream(reportPath);
 
             hResults = EvtQuery(NULL, NULL, query.c_str(), EvtQueryChannelPath);
             if (NULL == hResults)
             {
-                report << "Failed to report info for channel " << channelName << ". " << get_last_error_or_default(GetLastError()) << std::endl;
+                report << "Failed to report info for " << queryName << ". " << get_last_error_or_default(GetLastError()) << std::endl;
                 return;
             }
         }
@@ -206,11 +200,11 @@ void EventViewer::ReportEventViewerInfo(const std::filesystem::path& tmpDir)
 {
     for (auto& process : processes)
     {
-        EventViewerReporter(tmpDir, process).Report();
+        EventViewerReporter(tmpDir, process, process, false).Report();
     }
 }
 
 void EventViewer::ReportAppXDeploymentLogs(const std::filesystem::path& tmpDir)
 {
-    EventViewerReporter(tmpDir, L"Microsoft-Windows-AppXDeploymentServer/Operational", true).Report();
+    EventViewerReporter(tmpDir, L"Microsoft-Windows-AppXDeploymentServer/Operational", L"AppXDeploymentServerEventLog", true).Report();
 }

--- a/tools/BugReportTool/BugReportTool/EventViewer.h
+++ b/tools/BugReportTool/BugReportTool/EventViewer.h
@@ -4,4 +4,5 @@
 namespace EventViewer
 {
     void ReportEventViewerInfo(const std::filesystem::path& tmpDir);
+    void ReportAppXDeploymentLogs(const std::filesystem::path& tmpDir);
 }

--- a/tools/BugReportTool/BugReportTool/Main.cpp
+++ b/tools/BugReportTool/BugReportTool/Main.cpp
@@ -381,6 +381,9 @@ int wmain(int argc, wchar_t* argv[], wchar_t*)
     // Write event viewer logs info to the temporary folder
     EventViewer::ReportEventViewerInfo(reportDir);
 
+    // Write AppXDeployment-Server event logs to the temporary folder
+    EventViewer::ReportAppXDeploymentLogs(reportDir);
+
     ReportInstallerLogs(tempDir, reportDir);
 
     ReportInstalledContextMenuPackages(reportDir);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

We are missing msix setup event log from Microsoft-Windows-AppXDeploymentServer-Operational from bug report.
This PR includes it back for any installation with Powertoys or CommandPalette

Attach the sample one capture after I setup PowerToys for Microsoft-Windows-AppXDeploymentServer-Operational events
[EventViewer-AppXDeploymentServerEventLog.zip](https://github.com/user-attachments/files/20791324/EventViewer-AppXDeploymentServerEventLog.zip)