### PR TITLE
[UX] Settings - fix header position

### DIFF
--- a/src/settings-ui/Settings.UI/SettingsXAML/Controls/SettingsPageControl/SettingsPageControl.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Controls/SettingsPageControl/SettingsPageControl.xaml
@@ -12,6 +12,7 @@
 
     <UserControl.Resources>
         <x:Double x:Key="PageMaxWidth">1000</x:Double>
+        <x:Double x:Key="PageHeaderMaxWidth">1020</x:Double>
         <tkconverters:DoubleToVisibilityConverter
             x:Name="doubleToVisibilityConverter"
             FalseValue="Collapsed"
@@ -26,7 +27,7 @@
         </Grid.RowDefinitions>
         <TextBlock
             x:Name="Header"
-            MaxWidth="{StaticResource PageMaxWidth}"
+            MaxWidth="{StaticResource PageHeaderMaxWidth}"
             HorizontalAlignment="Stretch"
             VerticalAlignment="Stretch"
             AutomationProperties.HeadingLevel="1"


### PR DESCRIPTION
## Summary of the Pull Request
Due to a padding in the scrollviewer hosting the settingspage content, the title drifts away upon resizing the settings window.
This PR fixes that issue by adding the (20px) padding to the maxwidth of the header textblock.

Before:
![header](https://github.com/user-attachments/assets/6704a59d-843c-49a7-a109-e22e2cecccfe)

After:
![header2](https://github.com/user-attachments/assets/c9b0aa46-fcab-43ac-be87-ea423d810606)



## PR Checklist

- [x] **Closes:** #40159
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

