### PR TITLE
Dev/mjolley/context menu refactor

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandBarViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandBarViewModel.cs
@@ -97,7 +97,9 @@ public partial class CommandBarViewModel : ObservableObject,
 
         SecondaryCommand = SelectedItem.SecondaryCommand;
 
-        ShouldShowContextMenu = SelectedItem.MoreCommands.Count() > 1;
+        ShouldShowContextMenu = SelectedItem.MoreCommands
+            .OfType<CommandContextItemViewModel>()
+            .Count() > 1;
 
         OnPropertyChanged(nameof(HasSecondaryCommand));
         OnPropertyChanged(nameof(SecondaryCommand));

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandBarViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandBarViewModel.cs
@@ -6,6 +6,7 @@ using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Messaging;
 using Microsoft.CmdPal.UI.ViewModels.Messages;
+using Microsoft.CommandPalette.Extensions.Toolkit;
 using Windows.System;
 
 namespace Microsoft.CmdPal.UI.ViewModels;
@@ -47,11 +48,6 @@ public partial class CommandBarViewModel : ObservableObject,
 
     [ObservableProperty]
     public partial PageViewModel? CurrentPage { get; set; }
-
-    [ObservableProperty]
-    public partial ObservableCollection<ContextMenuStackViewModel> ContextMenuStack { get; set; } = [];
-
-    public ContextMenuStackViewModel? ContextMenu => ContextMenuStack.LastOrDefault();
 
     public CommandBarViewModel()
     {
@@ -101,18 +97,7 @@ public partial class CommandBarViewModel : ObservableObject,
 
         SecondaryCommand = SelectedItem.SecondaryCommand;
 
-        if (SelectedItem.MoreCommands.Count() > 1)
-        {
-            ShouldShowContextMenu = true;
-
-            ContextMenuStack.Clear();
-            ContextMenuStack.Add(new ContextMenuStackViewModel(SelectedItem));
-            OnPropertyChanged(nameof(ContextMenu));
-        }
-        else
-        {
-            ShouldShowContextMenu = false;
-        }
+        ShouldShowContextMenu = SelectedItem.MoreCommands.Count() > 1;
 
         OnPropertyChanged(nameof(HasSecondaryCommand));
         OnPropertyChanged(nameof(SecondaryCommand));
@@ -139,8 +124,18 @@ public partial class CommandBarViewModel : ObservableObject,
 
     public ContextKeybindingResult CheckKeybinding(bool ctrl, bool alt, bool shift, bool win, VirtualKey key)
     {
-        var matchedItem = ContextMenu?.CheckKeybinding(ctrl, alt, shift, win, key);
-        return matchedItem != null ? PerformCommand(matchedItem) : ContextKeybindingResult.Unhandled;
+        var keybindings = SelectedItem?.Keybindings();
+        if (keybindings != null)
+        {
+            // Does the pressed key match any of the keybindings?
+            var pressedKeyChord = KeyChordHelpers.FromModifiers(ctrl, alt, shift, win, key, 0);
+            if (keybindings.TryGetValue(pressedKeyChord, out var matchedItem))
+            {
+                return matchedItem != null ? PerformCommand(matchedItem) : ContextKeybindingResult.Unhandled;
+            }
+        }
+
+        return ContextKeybindingResult.Unhandled;
     }
 
     private ContextKeybindingResult PerformCommand(CommandItemViewModel? command)
@@ -152,9 +147,6 @@ public partial class CommandBarViewModel : ObservableObject,
 
         if (command.HasMoreCommands)
         {
-            ContextMenuStack.Add(new ContextMenuStackViewModel(command));
-            OnPropertyChanging(nameof(ContextMenu));
-            OnPropertyChanged(nameof(ContextMenu));
             return ContextKeybindingResult.KeepOpen;
         }
         else
@@ -162,33 +154,6 @@ public partial class CommandBarViewModel : ObservableObject,
             WeakReferenceMessenger.Default.Send<PerformCommandMessage>(new(command.Command.Model, command.Model));
             return ContextKeybindingResult.Hide;
         }
-    }
-
-    public bool CanPopContextStack()
-    {
-        return ContextMenuStack.Count > 1;
-    }
-
-    public void PopContextStack()
-    {
-        if (ContextMenuStack.Count > 1)
-        {
-            ContextMenuStack.RemoveAt(ContextMenuStack.Count - 1);
-        }
-
-        OnPropertyChanging(nameof(ContextMenu));
-        OnPropertyChanged(nameof(ContextMenu));
-    }
-
-    public void ClearContextStack()
-    {
-        while (ContextMenuStack.Count > 1)
-        {
-            ContextMenuStack.RemoveAt(ContextMenuStack.Count - 1);
-        }
-
-        OnPropertyChanging(nameof(ContextMenu));
-        OnPropertyChanged(nameof(ContextMenu));
     }
 }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandContextItemViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandContextItemViewModel.cs
@@ -2,6 +2,8 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using CommunityToolkit.Mvvm.Messaging;
+using Microsoft.CmdPal.UI.ViewModels.Messages;
 using Microsoft.CmdPal.UI.ViewModels.Models;
 using Microsoft.CommandPalette.Extensions;
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandContextItemViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandContextItemViewModel.cs
@@ -7,7 +7,7 @@ using Microsoft.CommandPalette.Extensions;
 
 namespace Microsoft.CmdPal.UI.ViewModels;
 
-public partial class CommandContextItemViewModel(ICommandContextItem contextItem, WeakReference<IPageContext> context) : CommandItemViewModel(new(contextItem), context)
+public partial class CommandContextItemViewModel(ICommandContextItem contextItem, WeakReference<IPageContext> context) : CommandItemViewModel(new(contextItem), context), IContextItemViewModel
 {
     private readonly KeyChord nullKeyChord = new(0, 0, 0);
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandItemViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandItemViewModel.cs
@@ -46,25 +46,27 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel, ICommandBa
 
     public CommandViewModel Command { get; private set; }
 
-    public List<CommandContextItemViewModel> MoreCommands { get; private set; } = [];
+    public List<IContextItemViewModel> MoreCommands { get; private set; } = [];
 
-    IEnumerable<CommandContextItemViewModel> IContextMenuContext.MoreCommands => MoreCommands;
+    IEnumerable<IContextItemViewModel> IContextMenuContext.MoreCommands => MoreCommands;
 
-    public bool HasMoreCommands => MoreCommands.Count > 0;
+    private List<CommandContextItemViewModel> ActualCommands => MoreCommands.OfType<CommandContextItemViewModel>().ToList();
+
+    public bool HasMoreCommands => ActualCommands.Count > 0;
 
     public string SecondaryCommandName => SecondaryCommand?.Name ?? string.Empty;
 
     public CommandItemViewModel? PrimaryCommand => this;
 
-    public CommandItemViewModel? SecondaryCommand => HasMoreCommands ? MoreCommands[0] : null;
+    public CommandItemViewModel? SecondaryCommand => HasMoreCommands ? ActualCommands[0] : null;
 
     public bool ShouldBeVisible => !string.IsNullOrEmpty(Name);
 
-    public List<CommandContextItemViewModel> AllCommands
+    public List<IContextItemViewModel> AllCommands
     {
         get
         {
-            List<CommandContextItemViewModel> l = _defaultCommandContextItem == null ?
+            List<IContextItemViewModel> l = _defaultCommandContextItem == null ?
                 new() :
                 [_defaultCommandContextItem];
 
@@ -177,18 +179,29 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel, ICommandBa
         if (more != null)
         {
             MoreCommands = more
-                .Where(contextItem => contextItem is ICommandContextItem)
-                .Select(contextItem => (contextItem as ICommandContextItem)!)
-                .Select(contextItem => new CommandContextItemViewModel(contextItem, PageContext))
+                .Select(item =>
+                {
+                    if (item is CommandContextItem contextItem)
+                    {
+                        return new CommandContextItemViewModel(contextItem, PageContext) as IContextItemViewModel;
+                    }
+                    else
+                    {
+                        return new SeparatorContextItemViewModel() as IContextItemViewModel;
+                    }
+                })
                 .ToList();
         }
 
         // Here, we're already theoretically in the async context, so we can
         // use Initialize straight up
-        MoreCommands.ForEach(contextItem =>
-        {
-            contextItem.SlowInitializeProperties();
-        });
+        MoreCommands
+            .OfType<CommandContextItemViewModel>()
+            .ToList()
+            .ForEach(contextItem =>
+            {
+                contextItem.SlowInitializeProperties();
+            });
 
         if (!string.IsNullOrEmpty(model.Command?.Name))
         {
@@ -323,19 +336,30 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel, ICommandBa
                 if (more != null)
                 {
                     var newContextMenu = more
-                        .Where(contextItem => contextItem is ICommandContextItem)
-                        .Select(contextItem => (contextItem as ICommandContextItem)!)
-                        .Select(contextItem => new CommandContextItemViewModel(contextItem, PageContext))
+                        .Select(item =>
+                        {
+                            if (item is CommandContextItem contextItem)
+                            {
+                                return new CommandContextItemViewModel(contextItem, PageContext) as IContextItemViewModel;
+                            }
+                            else
+                            {
+                                return new SeparatorContextItemViewModel() as IContextItemViewModel;
+                            }
+                        })
                         .ToList();
                     lock (MoreCommands)
                     {
                         ListHelpers.InPlaceUpdateList(MoreCommands, newContextMenu);
                     }
 
-                    newContextMenu.ForEach(contextItem =>
-                    {
-                        contextItem.InitializeProperties();
-                    });
+                    newContextMenu
+                        .OfType<CommandContextItemViewModel>()
+                        .ToList()
+                        .ForEach(contextItem =>
+                        {
+                            contextItem.InitializeProperties();
+                        });
                 }
                 else
                 {
@@ -376,7 +400,9 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel, ICommandBa
 
         lock (MoreCommands)
         {
-            MoreCommands.ForEach(c => c.SafeCleanup());
+            MoreCommands.OfType<CommandContextItemViewModel>()
+                        .ToList()
+                        .ForEach(c => c.SafeCleanup());
             MoreCommands.Clear();
         }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandItemViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandItemViewModel.cs
@@ -181,7 +181,7 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel, ICommandBa
             MoreCommands = more
                 .Select(item =>
                 {
-                    if (item is CommandContextItem contextItem)
+                    if (item is ICommandContextItem contextItem)
                     {
                         return new CommandContextItemViewModel(contextItem, PageContext) as IContextItemViewModel;
                     }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentPageViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentPageViewModel.cs
@@ -21,9 +21,9 @@ public partial class ContentPageViewModel : PageViewModel, ICommandBarContext
     [ObservableProperty]
     public partial ObservableCollection<ContentViewModel> Content { get; set; } = [];
 
-    public List<CommandContextItemViewModel> Commands { get; private set; } = [];
+    public List<IContextItemViewModel> Commands { get; private set; } = [];
 
-    public bool HasCommands => Commands.Count > 0;
+    public bool HasCommands => ActualCommands.Count > 0;
 
     public DetailsViewModel? Details { get; private set; }
 
@@ -31,18 +31,19 @@ public partial class ContentPageViewModel : PageViewModel, ICommandBarContext
     public bool HasDetails => Details != null;
 
     /////// ICommandBarContext ///////
-    public IEnumerable<CommandContextItemViewModel> MoreCommands => Commands.Skip(1);
+    public IEnumerable<IContextItemViewModel> MoreCommands => Commands.Skip(1);
 
-    public bool HasMoreCommands => Commands.Count > 1;
+    private List<CommandContextItemViewModel> ActualCommands => Commands.OfType<CommandContextItemViewModel>().ToList();
+
+    public bool HasMoreCommands => ActualCommands.Count > 1;
 
     public string SecondaryCommandName => SecondaryCommand?.Name ?? string.Empty;
 
-    public CommandItemViewModel? PrimaryCommand => HasCommands ? Commands[0] : null;
+    public CommandItemViewModel? PrimaryCommand => HasCommands ? ActualCommands[0] : null;
 
-    public CommandItemViewModel? SecondaryCommand => HasMoreCommands ? Commands[1] : null;
+    public CommandItemViewModel? SecondaryCommand => HasMoreCommands ? ActualCommands[1] : null;
 
-    public List<CommandContextItemViewModel> AllCommands => Commands;
-    /////// /ICommandBarContext ///////
+    public List<IContextItemViewModel> AllCommands => Commands;
 
     // Remember - "observable" properties from the model (via PropChanged)
     // cannot be marked [ObservableProperty]
@@ -113,14 +114,27 @@ public partial class ContentPageViewModel : PageViewModel, ICommandBarContext
         }
 
         Commands = model.Commands
-            .Where(contextItem => contextItem is ICommandContextItem)
-            .Select(contextItem => (contextItem as ICommandContextItem)!)
-            .Select(contextItem => new CommandContextItemViewModel(contextItem, PageContext))
-            .ToList();
-        Commands.ForEach(contextItem =>
-        {
-            contextItem.InitializeProperties();
-        });
+                .ToList()
+                .Select(item =>
+                {
+                    if (item is CommandContextItem contextItem)
+                    {
+                        return new CommandContextItemViewModel(contextItem, PageContext) as IContextItemViewModel;
+                    }
+                    else
+                    {
+                        return new SeparatorContextItemViewModel() as IContextItemViewModel;
+                    }
+                })
+                .ToList();
+
+        Commands
+            .OfType<CommandContextItemViewModel>()
+            .ToList()
+            .ForEach(contextItem =>
+            {
+                contextItem.InitializeProperties();
+            });
 
         var extensionDetails = model.Details;
         if (extensionDetails != null)
@@ -159,19 +173,32 @@ public partial class ContentPageViewModel : PageViewModel, ICommandBarContext
                 if (more != null)
                 {
                     var newContextMenu = more
-                        .Where(contextItem => contextItem is ICommandContextItem)
-                        .Select(contextItem => (contextItem as ICommandContextItem)!)
-                        .Select(contextItem => new CommandContextItemViewModel(contextItem, PageContext))
-                        .ToList();
+                            .ToList()
+                            .Select(item =>
+                            {
+                                if (item is CommandContextItem contextItem)
+                                {
+                                    return new CommandContextItemViewModel(contextItem, PageContext) as IContextItemViewModel;
+                                }
+                                else
+                                {
+                                    return new SeparatorContextItemViewModel() as IContextItemViewModel;
+                                }
+                            })
+                            .ToList();
+
                     lock (Commands)
                     {
                         ListHelpers.InPlaceUpdateList(Commands, newContextMenu);
                     }
 
-                    Commands.ForEach(contextItem =>
-                    {
-                        contextItem.SlowInitializeProperties();
-                    });
+                    Commands
+                        .OfType<CommandContextItemViewModel>()
+                        .ToList()
+                        .ForEach(contextItem =>
+                        {
+                            contextItem.SlowInitializeProperties();
+                        });
                 }
                 else
                 {
@@ -246,10 +273,11 @@ public partial class ContentPageViewModel : PageViewModel, ICommandBarContext
         base.UnsafeCleanup();
 
         Details?.SafeCleanup();
-        foreach (var item in Commands)
-        {
-            item.SafeCleanup();
-        }
+
+        Commands
+            .OfType<CommandContextItemViewModel>()
+            .ToList()
+            .ForEach(item => item.SafeCleanup());
 
         Commands.Clear();
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContextMenuStackViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContextMenuStackViewModel.cs
@@ -18,7 +18,6 @@ public partial class ContextMenuStackViewModel : ObservableObject
     private readonly IContextMenuContext _context;
     private string _lastSearchText = string.Empty;
 
-    // private Dictionary<KeyChord, CommandContextItemViewModel>? _contextKeybindings;
     public ContextMenuStackViewModel(IContextMenuContext context)
     {
         _context = context;

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContextMenuViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContextMenuViewModel.cs
@@ -32,7 +32,7 @@ public partial class ContextMenuViewModel : ObservableObject,
     }
 
     [ObservableProperty]
-    public partial ObservableCollection<CommandContextItemViewModel> FilteredItems { get; set; } = [];
+    public partial ObservableCollection<IContextItemViewModel> FilteredItems { get; set; } = [];
 
     private string _lastSearchText = string.Empty;
 
@@ -97,7 +97,9 @@ public partial class ContextMenuViewModel : ObservableObject,
 
         _lastSearchText = searchText;
 
-        var commands = SelectedItem.AllCommands.Where(c => c.ShouldBeVisible);
+        var commands = SelectedItem.AllCommands
+                            .OfType<CommandContextItemViewModel>()
+                            .Where(c => c.ShouldBeVisible);
         if (string.IsNullOrEmpty(searchText))
         {
             ListHelpers.InPlaceUpdateList(FilteredItems, commands);

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/IContextItemViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/IContextItemViewModel.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.CmdPal.UI.ViewModels;
+
+public interface IContextItemViewModel
+{
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Messages/CloseContextMenuMessage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Messages/CloseContextMenuMessage.cs
@@ -5,8 +5,8 @@
 namespace Microsoft.CmdPal.UI.ViewModels.Messages;
 
 /// <summary>
-/// Used to announce the context menu should open
+/// Used to announce that a context menu should close
 /// </summary>
-public record OpenContextMenuMessage
+public record CloseContextMenuMessage
 {
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Messages/UpdateCommandBarMessage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Messages/UpdateCommandBarMessage.cs
@@ -16,11 +16,11 @@ public record UpdateCommandBarMessage(ICommandBarContext? ViewModel)
 
 public interface IContextMenuContext : INotifyPropertyChanged
 {
-    public IEnumerable<CommandContextItemViewModel> MoreCommands { get; }
+    public IEnumerable<IContextItemViewModel> MoreCommands { get; }
 
     public bool HasMoreCommands { get; }
 
-    public List<CommandContextItemViewModel> AllCommands { get; }
+    public List<IContextItemViewModel> AllCommands { get; }
 
     /// <summary>
     /// Generates a mapping of key -> command item for this particular item's
@@ -33,6 +33,7 @@ public interface IContextMenuContext : INotifyPropertyChanged
     public Dictionary<KeyChord, CommandContextItemViewModel> Keybindings()
     {
         return MoreCommands
+            .OfType<CommandContextItemViewModel>()
             .Where(c => c.HasRequestedShortcut)
             .ToDictionary(
             c => c.RequestedShortcut ?? new KeyChord(0, 0, 0),

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SeparatorContextItemViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SeparatorContextItemViewModel.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CmdPal.UI.ViewModels.Models;
+using Microsoft.CommandPalette.Extensions;
+
+namespace Microsoft.CmdPal.UI.ViewModels;
+
+public partial class SeparatorContextItemViewModel() : IContextItemViewModel
+{
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelViewModel.cs
@@ -53,12 +53,17 @@ public sealed partial class TopLevelViewModel : ObservableObject, IListItem
     ICommand? ICommandItem.Command => _commandItemViewModel.Command.Model.Unsafe;
 
     IContextItem?[] ICommandItem.MoreCommands => _commandItemViewModel.MoreCommands
-                                                    .OfType<CommandContextItemViewModel>()
-                                                    .Select(i => i.Model.Unsafe).ToArray();
-
-    // Yo. You gotta throw that unsafe interface ExtensionObject jam on the SeparatorItemViewModel.
-    // Good luck champ!
-
+                                                    .Select(item =>
+                                                    {
+                                                        if (item is SeparatorContextItemViewModel)
+                                                        {
+                                                            return item as IContextItem;
+                                                        }
+                                                        else
+                                                        {
+                                                            return ((CommandContextItemViewModel)item).Model.Unsafe as IContextItem;
+                                                        }
+                                                    }).ToArray();
 
     ////// IListItem
     ITag[] IListItem.Tags => Tags.ToArray();

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelViewModel.cs
@@ -52,7 +52,13 @@ public sealed partial class TopLevelViewModel : ObservableObject, IListItem
 
     ICommand? ICommandItem.Command => _commandItemViewModel.Command.Model.Unsafe;
 
-    IContextItem?[] ICommandItem.MoreCommands => _commandItemViewModel.MoreCommands.Select(i => i.Model.Unsafe).ToArray();
+    IContextItem?[] ICommandItem.MoreCommands => _commandItemViewModel.MoreCommands
+                                                    .OfType<CommandContextItemViewModel>()
+                                                    .Select(i => i.Model.Unsafe).ToArray();
+
+    // Yo. You gotta throw that unsafe interface ExtensionObject jam on the SeparatorItemViewModel.
+    // Good luck champ!
+
 
     ////// IListItem
     ITag[] IListItem.Tags => Tags.ToArray();

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml
@@ -199,8 +199,7 @@
                         Closed="Flyout_Closed"
                         Placement="TopEdgeAlignedRight">
 
-                        <cpcontrols:ContextMenu
-                            ViewModel="{x:Bind ViewModel.ContextMenu, Mode=OneWay}"/>
+                        <cpcontrols:ContextMenu />
 
                     </Flyout>
                 </Button.Flyout>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml
@@ -27,78 +27,11 @@
                 TrueValue="Collapsed" />
 
             <cmdpalUI:MessageStateToSeverityConverter x:Key="MessageStateToSeverityConverter" />
-            <cmdpalUI:KeyChordToStringConverter x:Key="KeyChordToStringConverter" />
 
             <StackLayout
                 x:Name="VerticalStackLayout"
                 Orientation="Vertical"
                 Spacing="4" />
-
-            <cmdpalUI:ContextItemTemplateSelector
-                x:Key="ContextItemTemplateSelector"
-                Critical="{StaticResource CriticalContextMenuViewModelTemplate}"
-                Default="{StaticResource DefaultContextMenuViewModelTemplate}" />
-
-            <!--  Template for context items in the context item menu  -->
-            <DataTemplate x:Key="DefaultContextMenuViewModelTemplate" x:DataType="viewmodels:CommandContextItemViewModel">
-                <Grid AutomationProperties.Name="{x:Bind Title, Mode=OneWay}">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="32" />
-                        <ColumnDefinition Width="*" />
-                        <ColumnDefinition Width="Auto" />
-                    </Grid.ColumnDefinitions>
-                    <cpcontrols:IconBox
-                        Width="16"
-                        Height="16"
-                        Margin="4,0,0,0"
-                        HorizontalAlignment="Left"
-                        SourceKey="{x:Bind Icon, Mode=OneWay}"
-                        SourceRequested="{x:Bind help:IconCacheProvider.SourceRequested}" />
-                    <TextBlock
-                        Grid.Column="1"
-                        VerticalAlignment="Center"
-                        Text="{x:Bind Title, Mode=OneWay}" />
-                    <TextBlock
-                        Grid.Column="2"
-                        Margin="16,0,0,0"
-                        HorizontalAlignment="Right"
-                        VerticalAlignment="Center"
-                        Foreground="{ThemeResource MenuFlyoutItemKeyboardAcceleratorTextForeground}"
-                        Style="{StaticResource CaptionTextBlockStyle}"
-                        Text="{x:Bind RequestedShortcut, Mode=OneWay, Converter={StaticResource KeyChordToStringConverter}}" />
-                </Grid>
-            </DataTemplate>
-
-            <!--  Template for context items flagged as critical  -->
-            <DataTemplate x:Key="CriticalContextMenuViewModelTemplate" x:DataType="viewmodels:CommandContextItemViewModel">
-                <Grid AutomationProperties.Name="{x:Bind Title, Mode=OneWay}">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="32" />
-                        <ColumnDefinition Width="*" />
-                        <ColumnDefinition Width="Auto" />
-                    </Grid.ColumnDefinitions>
-                    <cpcontrols:IconBox
-                        Width="16"
-                        Height="16"
-                        Margin="4,0,0,0"
-                        HorizontalAlignment="Left"
-                        Foreground="{ThemeResource SystemFillColorCriticalBrush}"
-                        SourceKey="{x:Bind Icon, Mode=OneWay}"
-                        SourceRequested="{x:Bind help:IconCacheProvider.SourceRequested}" />
-                    <TextBlock
-                        Grid.Column="1"
-                        VerticalAlignment="Center"
-                        Style="{StaticResource ContextItemTitleTextBlockCriticalStyle}"
-                        Text="{x:Bind Title, Mode=OneWay}" />
-                    <TextBlock
-                        Grid.Column="2"
-                        Margin="16,0,0,0"
-                        HorizontalAlignment="Right"
-                        VerticalAlignment="Center"
-                        Style="{StaticResource ContextItemCaptionTextBlockCriticalStyle}"
-                        Text="{x:Bind RequestedShortcut, Mode=OneWay, Converter={StaticResource KeyChordToStringConverter}}" />
-                </Grid>
-            </DataTemplate>
 
         </ResourceDictionary>
     </UserControl.Resources>
@@ -263,41 +196,12 @@
                 Visibility="{x:Bind ViewModel.ShouldShowContextMenu, Mode=OneWay}">
                 <Button.Flyout>
                     <Flyout
-                        Closing="Flyout_Closing"
-                        Opened="Flyout_Opened"
+                        Closed="Flyout_Closed"
                         Placement="TopEdgeAlignedRight">
-                        <StackPanel>
 
-                            <ListView
-                                x:Name="CommandsDropdown"
-                                MinWidth="248"
-                                Margin="-16,-12,-16,-12"
-                                IsItemClickEnabled="True"
-                                ItemClick="CommandsDropdown_ItemClick"
-                                ItemTemplateSelector="{StaticResource ContextItemTemplateSelector}"
-                                ItemsSource="{x:Bind ViewModel.ContextMenu.FilteredItems, Mode=OneWay}"
-                                KeyDown="CommandsDropdown_KeyDown"
-                                SelectionMode="Single">
-                                <ListView.ItemContainerStyle>
-                                    <Style BasedOn="{StaticResource DefaultListViewItemStyle}" TargetType="ListViewItem">
-                                        <Setter Property="MinHeight" Value="0" />
-                                        <Setter Property="Padding" Value="12,7,12,7" />
-                                    </Style>
-                                </ListView.ItemContainerStyle>
-                                <ListView.ItemContainerTransitions>
-                                    <TransitionCollection />
-                                </ListView.ItemContainerTransitions>
-                            </ListView>
+                        <cpcontrols:ContextMenu
+                            ViewModel="{x:Bind ViewModel.ContextMenu, Mode=OneWay}"/>
 
-                            <TextBox
-                                x:Name="ContextFilterBox"
-                                x:Uid="ContextFilterBox"
-                                Margin="-12,12,-12,-12"
-                                KeyDown="ContextFilterBox_KeyDown"
-                                PreviewKeyDown="ContextFilterBox_PreviewKeyDown"
-                                TextChanged="ContextFilterBox_TextChanged" />
-
-                        </StackPanel>
                     </Flyout>
                 </Button.Flyout>
             </Button>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml.cs
@@ -42,8 +42,6 @@ public sealed partial class CommandBar : UserControl,
         WeakReferenceMessenger.Default.Register<OpenContextMenuMessage>(this);
         WeakReferenceMessenger.Default.Register<CloseContextMenuMessage>(this);
         WeakReferenceMessenger.Default.Register<TryCommandKeybindingMessage>(this);
-
-        ViewModel.PropertyChanged += ViewModel_PropertyChanged;
     }
 
     public void Receive(OpenContextMenuMessage message)
@@ -129,18 +127,8 @@ public sealed partial class CommandBar : UserControl,
         e.Handled = true;
     }
 
-    private void ViewModel_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
-    {
-        var prop = e.PropertyName;
-        if (prop == nameof(ViewModel.ContextMenu))
-        {
-            // UpdateUiForStackChange();
-        }
-    }
-
     private void Flyout_Closed(object sender, object e)
     {
-        ViewModel?.ClearContextStack();
         WeakReferenceMessenger.Default.Send<CloseContextMenuMessage>();
         WeakReferenceMessenger.Default.Send<FocusSearchBoxMessage>();
     }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml.cs
@@ -18,6 +18,7 @@ namespace Microsoft.CmdPal.UI.Controls;
 
 public sealed partial class CommandBar : UserControl,
     IRecipient<OpenContextMenuMessage>,
+    IRecipient<CloseContextMenuMessage>,
     IRecipient<TryCommandKeybindingMessage>,
     ICurrentPageAware
 {
@@ -39,6 +40,7 @@ public sealed partial class CommandBar : UserControl,
 
         // RegisterAll isn't AOT compatible
         WeakReferenceMessenger.Default.Register<OpenContextMenuMessage>(this);
+        WeakReferenceMessenger.Default.Register<CloseContextMenuMessage>(this);
         WeakReferenceMessenger.Default.Register<TryCommandKeybindingMessage>(this);
 
         ViewModel.PropertyChanged += ViewModel_PropertyChanged;
@@ -56,7 +58,15 @@ public sealed partial class CommandBar : UserControl,
             ShowMode = FlyoutShowMode.Standard,
         };
         MoreCommandsButton.Flyout.ShowAt(MoreCommandsButton, options);
-        UpdateUiForStackChange();
+    }
+
+    public void Receive(CloseContextMenuMessage message)
+    {
+        if (MoreCommandsButton.Flyout.IsOpen)
+        {
+            MoreCommandsButton.Flyout.Hide();
+            return;
+        }
     }
 
     public void Receive(TryCommandKeybindingMessage msg)
@@ -82,8 +92,6 @@ public sealed partial class CommandBar : UserControl,
                 };
                 MoreCommandsButton.Flyout.ShowAt(MoreCommandsButton, options);
             }
-
-            UpdateUiForStackChange();
 
             msg.Handled = true;
         }
@@ -121,164 +129,19 @@ public sealed partial class CommandBar : UserControl,
         e.Handled = true;
     }
 
-    private void CommandsDropdown_ItemClick(object sender, ItemClickEventArgs e)
-    {
-        if (e.ClickedItem is CommandContextItemViewModel item)
-        {
-            if (ViewModel?.InvokeItem(item) == ContextKeybindingResult.Hide)
-            {
-                MoreCommandsButton.Flyout.Hide();
-            }
-            else
-            {
-                UpdateUiForStackChange();
-            }
-        }
-    }
-
-    private void CommandsDropdown_KeyDown(object sender, KeyRoutedEventArgs e)
-    {
-        if (e.Handled)
-        {
-            return;
-        }
-
-        var ctrlPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down);
-        var altPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Menu).HasFlag(CoreVirtualKeyStates.Down);
-        var shiftPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down);
-        var winPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.LeftWindows).HasFlag(CoreVirtualKeyStates.Down) ||
-            InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.RightWindows).HasFlag(CoreVirtualKeyStates.Down);
-
-        var result = ViewModel?.CheckKeybinding(ctrlPressed, altPressed, shiftPressed, winPressed, e.Key);
-
-        if (result == ContextKeybindingResult.Hide)
-        {
-            e.Handled = true;
-            MoreCommandsButton.Flyout.Hide();
-            WeakReferenceMessenger.Default.Send<FocusSearchBoxMessage>();
-        }
-        else if (result == ContextKeybindingResult.KeepOpen)
-        {
-            e.Handled = true;
-        }
-        else if (result == ContextKeybindingResult.Unhandled)
-        {
-            e.Handled = false;
-        }
-    }
-
-    private void Flyout_Opened(object sender, object e)
-    {
-        UpdateUiForStackChange();
-    }
-
-    private void Flyout_Closing(FlyoutBase sender, FlyoutBaseClosingEventArgs args)
-    {
-        ViewModel?.ClearContextStack();
-        WeakReferenceMessenger.Default.Send<FocusSearchBoxMessage>();
-    }
-
     private void ViewModel_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
     {
         var prop = e.PropertyName;
         if (prop == nameof(ViewModel.ContextMenu))
         {
-            UpdateUiForStackChange();
+            // UpdateUiForStackChange();
         }
     }
 
-    private void ContextFilterBox_TextChanged(object sender, TextChangedEventArgs e)
+    private void Flyout_Closed(object sender, object e)
     {
-        ViewModel.ContextMenu?.SetSearchText(ContextFilterBox.Text);
-
-        if (CommandsDropdown.SelectedIndex == -1)
-        {
-            CommandsDropdown.SelectedIndex = 0;
-        }
-    }
-
-    private void ContextFilterBox_KeyDown(object sender, KeyRoutedEventArgs e)
-    {
-        var ctrlPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down);
-        var altPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Menu).HasFlag(CoreVirtualKeyStates.Down);
-        var shiftPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down);
-        var winPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.LeftWindows).HasFlag(CoreVirtualKeyStates.Down) ||
-            InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.RightWindows).HasFlag(CoreVirtualKeyStates.Down);
-
-        if (e.Key == VirtualKey.Enter)
-        {
-            if (CommandsDropdown.SelectedItem is CommandContextItemViewModel item)
-            {
-                if (ViewModel?.InvokeItem(item) == ContextKeybindingResult.Hide)
-                {
-                    MoreCommandsButton.Flyout.Hide();
-                    WeakReferenceMessenger.Default.Send<FocusSearchBoxMessage>();
-                }
-                else
-                {
-                    UpdateUiForStackChange();
-                }
-
-                e.Handled = true;
-            }
-        }
-        else if (e.Key == VirtualKey.Escape ||
-            (e.Key == VirtualKey.Left && altPressed))
-        {
-            if (ViewModel.CanPopContextStack())
-            {
-                ViewModel.PopContextStack();
-                UpdateUiForStackChange();
-            }
-            else
-            {
-                MoreCommandsButton.Flyout.Hide();
-                WeakReferenceMessenger.Default.Send<FocusSearchBoxMessage>();
-            }
-
-            e.Handled = true;
-        }
-
-        CommandsDropdown_KeyDown(sender, e);
-    }
-
-    private void ContextFilterBox_PreviewKeyDown(object sender, KeyRoutedEventArgs e)
-    {
-        if (e.Key == VirtualKey.Up)
-        {
-            // navigate previous
-            if (CommandsDropdown.SelectedIndex > 0)
-            {
-                CommandsDropdown.SelectedIndex--;
-            }
-            else
-            {
-                CommandsDropdown.SelectedIndex = CommandsDropdown.Items.Count - 1;
-            }
-
-            e.Handled = true;
-        }
-        else if (e.Key == VirtualKey.Down)
-        {
-            // navigate next
-            if (CommandsDropdown.SelectedIndex < CommandsDropdown.Items.Count - 1)
-            {
-                CommandsDropdown.SelectedIndex++;
-            }
-            else
-            {
-                CommandsDropdown.SelectedIndex = 0;
-            }
-
-            e.Handled = true;
-        }
-    }
-
-    private void UpdateUiForStackChange()
-    {
-        ContextFilterBox.Text = string.Empty;
-        ViewModel.ContextMenu?.SetSearchText(string.Empty);
-        CommandsDropdown.SelectedIndex = 0;
-        ContextFilterBox.Focus(FocusState.Programmatic);
+        ViewModel?.ClearContextStack();
+        WeakReferenceMessenger.Default.Send<CloseContextMenuMessage>();
+        WeakReferenceMessenger.Default.Send<FocusSearchBoxMessage>();
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContextMenu.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContextMenu.xaml
@@ -1,0 +1,128 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<UserControl
+    x:Class="Microsoft.CmdPal.UI.Controls.ContextMenu"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:animations="using:CommunityToolkit.WinUI.Animations"
+    xmlns:cmdpalUI="using:Microsoft.CmdPal.UI"
+    xmlns:converters="using:CommunityToolkit.WinUI.Converters"
+    xmlns:cpcontrols="using:Microsoft.CmdPal.UI.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:help="using:Microsoft.CmdPal.UI.Helpers"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:ui="using:CommunityToolkit.WinUI"
+    xmlns:viewmodels="using:Microsoft.CmdPal.UI.ViewModels"
+    Background="Transparent"
+    mc:Ignorable="d">
+
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <cmdpalUI:KeyChordToStringConverter x:Key="KeyChordToStringConverter" />
+
+            <StackLayout
+                x:Name="VerticalStackLayout"
+                Orientation="Vertical"
+                Spacing="4" />
+
+            <cmdpalUI:ContextItemTemplateSelector
+                x:Key="ContextItemTemplateSelector"
+                Critical="{StaticResource CriticalContextMenuViewModelTemplate}"
+                Default="{StaticResource DefaultContextMenuViewModelTemplate}" />
+
+            <!--  Template for context items in the context item menu  -->
+            <DataTemplate x:Key="DefaultContextMenuViewModelTemplate" x:DataType="viewmodels:CommandContextItemViewModel">
+                <Grid AutomationProperties.Name="{x:Bind Title, Mode=OneWay}">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="32" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <cpcontrols:IconBox
+                        Width="16"
+                        Height="16"
+                        Margin="4,0,0,0"
+                        HorizontalAlignment="Left"
+                        SourceKey="{x:Bind Icon, Mode=OneWay}"
+                        SourceRequested="{x:Bind help:IconCacheProvider.SourceRequested}" />
+                    <TextBlock
+                        Grid.Column="1"
+                        VerticalAlignment="Center"
+                        Text="{x:Bind Title, Mode=OneWay}" />
+                    <TextBlock
+                        Grid.Column="2"
+                        Margin="16,0,0,0"
+                        HorizontalAlignment="Right"
+                        VerticalAlignment="Center"
+                        Foreground="{ThemeResource MenuFlyoutItemKeyboardAcceleratorTextForeground}"
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        Text="{x:Bind RequestedShortcut, Mode=OneWay, Converter={StaticResource KeyChordToStringConverter}}" />
+                </Grid>
+            </DataTemplate>
+
+            <!--  Template for context items flagged as critical  -->
+            <DataTemplate x:Key="CriticalContextMenuViewModelTemplate" x:DataType="viewmodels:CommandContextItemViewModel">
+                <Grid AutomationProperties.Name="{x:Bind Title, Mode=OneWay}">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="32" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <cpcontrols:IconBox
+                        Width="16"
+                        Height="16"
+                        Margin="4,0,0,0"
+                        HorizontalAlignment="Left"
+                        Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+                        SourceKey="{x:Bind Icon, Mode=OneWay}"
+                        SourceRequested="{x:Bind help:IconCacheProvider.SourceRequested}" />
+                    <TextBlock
+                        Grid.Column="1"
+                        VerticalAlignment="Center"
+                        Style="{StaticResource ContextItemTitleTextBlockCriticalStyle}"
+                        Text="{x:Bind Title, Mode=OneWay}" />
+                    <TextBlock
+                        Grid.Column="2"
+                        Margin="16,0,0,0"
+                        HorizontalAlignment="Right"
+                        VerticalAlignment="Center"
+                        Style="{StaticResource ContextItemCaptionTextBlockCriticalStyle}"
+                        Text="{x:Bind RequestedShortcut, Mode=OneWay, Converter={StaticResource KeyChordToStringConverter}}" />
+                </Grid>
+            </DataTemplate>
+
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <StackPanel>
+
+        <ListView
+            x:Name="CommandsDropdown"
+            MinWidth="248"
+            Margin="-16,-12,-16,-12"
+            IsItemClickEnabled="True"
+            ItemClick="CommandsDropdown_ItemClick"
+            ItemTemplateSelector="{StaticResource ContextItemTemplateSelector}"
+            ItemsSource="{x:Bind ViewModel.FilteredItems, Mode=OneWay}"
+            KeyDown="CommandsDropdown_KeyDown"
+            SelectionMode="Single">
+            <ListView.ItemContainerStyle>
+                <Style BasedOn="{StaticResource DefaultListViewItemStyle}" TargetType="ListViewItem">
+                    <Setter Property="MinHeight" Value="0" />
+                    <Setter Property="Padding" Value="12,7,12,7" />
+                </Style>
+            </ListView.ItemContainerStyle>
+            <ListView.ItemContainerTransitions>
+                <TransitionCollection />
+            </ListView.ItemContainerTransitions>
+        </ListView>
+
+        <TextBox
+            x:Name="ContextFilterBox"
+            x:Uid="ContextFilterBox"
+            Margin="-12,12,-12,-12"
+            KeyDown="ContextFilterBox_KeyDown"
+            PreviewKeyDown="ContextFilterBox_PreviewKeyDown"
+            TextChanged="ContextFilterBox_TextChanged" />
+
+    </StackPanel>
+</UserControl>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContextMenu.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContextMenu.xaml
@@ -27,7 +27,8 @@
             <cmdpalUI:ContextItemTemplateSelector
                 x:Key="ContextItemTemplateSelector"
                 Critical="{StaticResource CriticalContextMenuViewModelTemplate}"
-                Default="{StaticResource DefaultContextMenuViewModelTemplate}" />
+                Default="{StaticResource DefaultContextMenuViewModelTemplate}"
+                Separator="{StaticResource SeparatorContextMenuViewModelTemplate}" />
 
             <!--  Template for context items in the context item menu  -->
             <DataTemplate x:Key="DefaultContextMenuViewModelTemplate" x:DataType="viewmodels:CommandContextItemViewModel">
@@ -90,6 +91,22 @@
                 </Grid>
             </DataTemplate>
 
+            <!-- Template for context item separators -->
+            <DataTemplate x:Key="SeparatorContextMenuViewModelTemplate" x:DataType="viewmodels:SeparatorContextItemViewModel">
+                <StackPanel Margin="0,8,8,0" Orientation="Vertical">
+                    <Border
+                        Margin="8,0,0,0"
+                        BorderBrush="{ThemeResource TextFillColorSecondaryBrush}"
+                        BorderThickness="0,0,0,2">
+                        <TextBlock
+                            Margin="-8,0,0,8"
+                            FontWeight="SemiBold"
+                            IsTextSelectionEnabled="True"
+                            Text=" "
+                            TextWrapping="WrapWholeWords" />
+                    </Border>
+                </StackPanel>
+            </DataTemplate>
         </ResourceDictionary>
     </UserControl.Resources>
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContextMenu.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContextMenu.xaml
@@ -93,17 +93,11 @@
 
             <!-- Template for context item separators -->
             <DataTemplate x:Key="SeparatorContextMenuViewModelTemplate" x:DataType="viewmodels:SeparatorContextItemViewModel">
-                <StackPanel Margin="0,8,8,0" Orientation="Vertical">
+                <StackPanel Margin="0,0,0,0" Orientation="Vertical">
                     <Border
-                        Margin="8,0,0,0"
-                        BorderBrush="{ThemeResource TextFillColorSecondaryBrush}"
-                        BorderThickness="0,0,0,2">
-                        <TextBlock
-                            Margin="-8,0,0,8"
-                            FontWeight="SemiBold"
-                            IsTextSelectionEnabled="True"
-                            Text=" "
-                            TextWrapping="WrapWholeWords" />
+                        Margin="0,0,0,0"
+                        BorderBrush="{ThemeResource MenuFlyoutSeparatorThemeBrush}"
+                        BorderThickness="0,0,0,1">
                     </Border>
                 </StackPanel>
             </DataTemplate>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContextMenu.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContextMenu.xaml.cs
@@ -19,9 +19,10 @@ namespace Microsoft.CmdPal.UI.Controls;
 
 public sealed partial class ContextMenu : UserControl,
     IRecipient<OpenContextMenuMessage>,
+    IRecipient<UpdateCommandBarMessage>,
     IRecipient<TryCommandKeybindingMessage>
 {
-    public ContextMenuStackViewModel? ViewModel { get; set; }
+    public ContextMenuViewModel ViewModel { get; } = new();
 
     public ContextMenu()
     {
@@ -29,6 +30,7 @@ public sealed partial class ContextMenu : UserControl,
 
         // RegisterAll isn't AOT compatible
         WeakReferenceMessenger.Default.Register<OpenContextMenuMessage>(this);
+        WeakReferenceMessenger.Default.Register<UpdateCommandBarMessage>(this);
         WeakReferenceMessenger.Default.Register<TryCommandKeybindingMessage>(this);
 
         if (ViewModel != null)
@@ -38,6 +40,11 @@ public sealed partial class ContextMenu : UserControl,
     }
 
     public void Receive(OpenContextMenuMessage message)
+    {
+        UpdateUiForStackChange();
+    }
+
+    public void Receive(UpdateCommandBarMessage message)
     {
         UpdateUiForStackChange();
     }
@@ -91,7 +98,7 @@ public sealed partial class ContextMenu : UserControl,
     private void ViewModel_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
     {
         var prop = e.PropertyName;
-        if (prop == nameof(ContextMenuStackViewModel.FilteredItems))
+        if (prop == nameof(ContextMenuViewModel.FilteredItems))
         {
             UpdateUiForStackChange();
         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContextMenu.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContextMenu.xaml.cs
@@ -1,0 +1,177 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using CommunityToolkit.Mvvm.Messaging;
+using Microsoft.CmdPal.Ext.System;
+using Microsoft.CmdPal.UI.ViewModels;
+using Microsoft.CmdPal.UI.ViewModels.Messages;
+using Microsoft.CmdPal.UI.Views;
+using Microsoft.UI.Input;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Input;
+using Windows.System;
+using Windows.UI.Core;
+
+namespace Microsoft.CmdPal.UI.Controls;
+
+public sealed partial class ContextMenu : UserControl,
+    IRecipient<OpenContextMenuMessage>,
+    IRecipient<TryCommandKeybindingMessage>
+{
+    public ContextMenuStackViewModel? ViewModel { get; set; }
+
+    public ContextMenu()
+    {
+        this.InitializeComponent();
+
+        // RegisterAll isn't AOT compatible
+        WeakReferenceMessenger.Default.Register<OpenContextMenuMessage>(this);
+        WeakReferenceMessenger.Default.Register<TryCommandKeybindingMessage>(this);
+
+        if (ViewModel != null)
+        {
+            ViewModel.PropertyChanged += ViewModel_PropertyChanged;
+        }
+    }
+
+    public void Receive(OpenContextMenuMessage message)
+    {
+        UpdateUiForStackChange();
+    }
+
+    public void Receive(TryCommandKeybindingMessage msg)
+    {
+        var result = ViewModel?.CheckKeybinding(msg.Ctrl, msg.Alt, msg.Shift, msg.Win, msg.Key);
+
+        if (result != null)
+        {
+            WeakReferenceMessenger.Default.Send<PerformCommandMessage>(new(result.Command.Model, result.Model));
+            WeakReferenceMessenger.Default.Send<CloseContextMenuMessage>();
+            msg.Handled = true;
+        }
+    }
+
+    private void CommandsDropdown_ItemClick(object sender, ItemClickEventArgs e)
+    {
+        if (e.ClickedItem is CommandContextItemViewModel item)
+        {
+            WeakReferenceMessenger.Default.Send<PerformCommandMessage>(new(item.Command.Model, item.Model));
+            WeakReferenceMessenger.Default.Send<CloseContextMenuMessage>();
+            UpdateUiForStackChange();
+        }
+    }
+
+    private void CommandsDropdown_KeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        if (e.Handled)
+        {
+            return;
+        }
+
+        var ctrlPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down);
+        var altPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Menu).HasFlag(CoreVirtualKeyStates.Down);
+        var shiftPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down);
+        var winPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.LeftWindows).HasFlag(CoreVirtualKeyStates.Down) ||
+            InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.RightWindows).HasFlag(CoreVirtualKeyStates.Down);
+
+        var result = ViewModel?.CheckKeybinding(ctrlPressed, altPressed, shiftPressed, winPressed, e.Key);
+
+        if (result != null)
+        {
+            WeakReferenceMessenger.Default.Send<PerformCommandMessage>(new(result.Command.Model, result.Model));
+            WeakReferenceMessenger.Default.Send<CloseContextMenuMessage>();
+            UpdateUiForStackChange();
+            e.Handled = true;
+        }
+    }
+
+    private void ViewModel_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        var prop = e.PropertyName;
+        if (prop == nameof(ContextMenuStackViewModel.FilteredItems))
+        {
+            UpdateUiForStackChange();
+        }
+    }
+
+    private void ContextFilterBox_TextChanged(object sender, TextChangedEventArgs e)
+    {
+        ViewModel?.SetSearchText(ContextFilterBox.Text);
+
+        if (CommandsDropdown.SelectedIndex == -1)
+        {
+            CommandsDropdown.SelectedIndex = 0;
+        }
+    }
+
+    private void ContextFilterBox_KeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        var ctrlPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Control).HasFlag(CoreVirtualKeyStates.Down);
+        var altPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Menu).HasFlag(CoreVirtualKeyStates.Down);
+        var shiftPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift).HasFlag(CoreVirtualKeyStates.Down);
+        var winPressed = InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.LeftWindows).HasFlag(CoreVirtualKeyStates.Down) ||
+            InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.RightWindows).HasFlag(CoreVirtualKeyStates.Down);
+
+        if (e.Key == VirtualKey.Enter)
+        {
+            if (CommandsDropdown.SelectedItem is CommandContextItemViewModel item)
+            {
+                WeakReferenceMessenger.Default.Send<PerformCommandMessage>(new(item.Command.Model, item.Model));
+                WeakReferenceMessenger.Default.Send<CloseContextMenuMessage>();
+                UpdateUiForStackChange();
+                e.Handled = true;
+            }
+        }
+        else if (e.Key == VirtualKey.Escape ||
+            (e.Key == VirtualKey.Left && altPressed))
+        {
+            WeakReferenceMessenger.Default.Send<CloseContextMenuMessage>();
+            e.Handled = true;
+        }
+
+        CommandsDropdown_KeyDown(sender, e);
+    }
+
+    private void ContextFilterBox_PreviewKeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        if (e.Key == VirtualKey.Up)
+        {
+            // navigate previous
+            if (CommandsDropdown.SelectedIndex > 0)
+            {
+                CommandsDropdown.SelectedIndex--;
+            }
+            else
+            {
+                CommandsDropdown.SelectedIndex = CommandsDropdown.Items.Count - 1;
+            }
+
+            e.Handled = true;
+        }
+        else if (e.Key == VirtualKey.Down)
+        {
+            // navigate next
+            if (CommandsDropdown.SelectedIndex < CommandsDropdown.Items.Count - 1)
+            {
+                CommandsDropdown.SelectedIndex++;
+            }
+            else
+            {
+                CommandsDropdown.SelectedIndex = 0;
+            }
+
+            e.Handled = true;
+        }
+    }
+
+    private void UpdateUiForStackChange()
+    {
+        ContextFilterBox.Text = string.Empty;
+        ViewModel?.SetSearchText(string.Empty);
+        CommandsDropdown.SelectedIndex = 0;
+        ContextFilterBox.Focus(FocusState.Programmatic);
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Converters/ContextItemTemplateSelector.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Converters/ContextItemTemplateSelector.cs
@@ -14,8 +14,15 @@ internal sealed partial class ContextItemTemplateSelector : DataTemplateSelector
 
     public DataTemplate? Critical { get; set; }
 
+    public DataTemplate? Separator { get; set; }
+
     protected override DataTemplate? SelectTemplateCore(object item)
     {
+        if (item is SeparatorContextItemViewModel)
+        {
+            return Separator;
+        }
+
         return ((CommandContextItemViewModel)item).IsCritical ? Critical : Default;
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Converters/ContextItemTemplateSelector.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Converters/ContextItemTemplateSelector.cs
@@ -30,6 +30,8 @@ internal sealed partial class ContextItemTemplateSelector : DataTemplateSelector
             if (item is SeparatorContextItemViewModel)
             {
                 li.IsEnabled = false;
+                li.AllowFocusWhenDisabled = false;
+                li.AllowFocusOnInteraction = false;
                 dataTemplate = Separator;
             }
             else

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Converters/ContextItemTemplateSelector.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Converters/ContextItemTemplateSelector.cs
@@ -2,9 +2,12 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.Bot.AdaptiveExpressions.Core;
 using Microsoft.CmdPal.UI.ViewModels;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
 
 namespace Microsoft.CmdPal.UI;
 
@@ -16,13 +19,25 @@ internal sealed partial class ContextItemTemplateSelector : DataTemplateSelector
 
     public DataTemplate? Separator { get; set; }
 
-    protected override DataTemplate? SelectTemplateCore(object item)
+    protected override DataTemplate? SelectTemplateCore(object item, DependencyObject dependencyObject)
     {
-        if (item is SeparatorContextItemViewModel)
+        DataTemplate? dataTemplate = Default;
+
+        if (dependencyObject is ListViewItem li)
         {
-            return Separator;
+            li.IsEnabled = true;
+
+            if (item is SeparatorContextItemViewModel)
+            {
+                li.IsEnabled = false;
+                dataTemplate = Separator;
+            }
+            else
+            {
+                dataTemplate = ((CommandContextItemViewModel)item).IsCritical ? Critical : Default;
+            }
         }
 
-        return ((CommandContextItemViewModel)item).IsCritical ? Critical : Default;
+        return dataTemplate;
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml
@@ -135,12 +135,12 @@
                         </GroupStyle.HeaderTemplate>
                     </GroupStyle>
                 </ListView.GroupStyle>-->
-                <!--<ListView.ContextFlyout>
+                <ListView.ContextFlyout>
                     <Flyout
                         Placement="BottomEdgeAlignedLeft">
                         <cpcontrols:ContextMenu />
                     </Flyout>
-                </ListView.ContextFlyout>-->
+                </ListView.ContextFlyout>
                 </ListView>
             </controls:Case>
             <controls:Case Value="True">

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml
@@ -135,12 +135,12 @@
                         </GroupStyle.HeaderTemplate>
                     </GroupStyle>
                 </ListView.GroupStyle>-->
-                    <ListView.ContextFlyout>
-                        <Flyout
-                            Placement="BottomEdgeAlignedLeft">
-                            <cpcontrols:ContextMenu />
-                        </Flyout>
-                    </ListView.ContextFlyout>
+                <!--<ListView.ContextFlyout>
+                    <Flyout
+                        Placement="BottomEdgeAlignedLeft">
+                        <cpcontrols:ContextMenu />
+                    </Flyout>
+                </ListView.ContextFlyout>-->
                 </ListView>
             </controls:Case>
             <controls:Case Value="True">

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml
@@ -82,7 +82,7 @@
                         TextWrapping="NoWrap"
                         Visibility="{x:Bind Subtitle, Mode=OneWay, Converter={StaticResource StringVisibilityConverter}}" />
                 </StackPanel>
-
+                
                 <ItemsControl
                     Grid.RowSpan="2"
                     Grid.Column="2"
@@ -116,6 +116,7 @@
                     IsDoubleTapEnabled="True"
                     IsItemClickEnabled="True"
                     ItemClick="ItemsList_ItemClick"
+                    RightTapped="ItemsList_RightTapped"
                     ItemTemplate="{StaticResource ListItemViewModelTemplate}"
                     ItemsSource="{x:Bind ViewModel.FilteredItems, Mode=OneWay}"
                     SelectionChanged="ItemsList_SelectionChanged">
@@ -134,6 +135,12 @@
                         </GroupStyle.HeaderTemplate>
                     </GroupStyle>
                 </ListView.GroupStyle>-->
+                    <ListView.ContextFlyout>
+                        <Flyout
+                            Placement="BottomEdgeAlignedLeft">
+                            <cpcontrols:ContextMenu />
+                        </Flyout>
+                    </ListView.ContextFlyout>
                 </ListView>
             </controls:Case>
             <controls:Case Value="True">

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml.cs
@@ -294,4 +294,18 @@ public sealed partial class ListPage : Page,
 
         return null;
     }
+
+    private void ItemsList_RightTapped(object sender, RightTappedRoutedEventArgs e)
+    {
+        if (e.OriginalSource is FrameworkElement element &&
+            element.DataContext is ListItemViewModel item)
+        {
+            if (ItemsList.SelectedItem != item)
+            {
+                ItemsList.SelectedItem = item;
+            }
+
+            ItemsList.ContextFlyout.ShowAt(this);
+        }
+    }
 }

--- a/src/modules/cmdpal/ext/SamplePagesExtension/Pages/SampleListPage.cs
+++ b/src/modules/cmdpal/ext/SamplePagesExtension/Pages/SampleListPage.cs
@@ -81,6 +81,7 @@ internal sealed partial class SampleListPage : ListPage
                         Title = "I'm a second command",
                         RequestedShortcut = KeyChordHelpers.FromModifiers(ctrl: true, vkey: VirtualKey.Number1),
                     },
+                    new SeparatorContextItem(),
                     new CommandContextItem(
                         new ToastCommand("Third command invoked", MessageState.Error) { Name = "Do 3", Icon = new IconInfo("\uF148") }) // dial 3
                     {

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/SeparatorContextItem.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/SeparatorContextItem.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CommandPalette.Extensions.Toolkit;
+
+public partial class SeparatorContextItem : ISeparatorContextItem
+{
+}


### PR DESCRIPTION
Refactored ContextMenu into it's own control to allow displaying in CommandBar and in response to right click on list items.

- Adds "critical" styling to context menu items flagged as `IsCritical`. This will use the theme to style with correct color.
- Added `SeparatorContextItem` and modified `MoreCommands` to allow for both `CommandContextItem`s and `SeparatorContextItem`s.
- Right clicking a list item with a context menu will open the context menu at the position of the click.

![image](https://github.com/user-attachments/assets/3bef6b04-28bb-4a17-b731-d9ed20c0566f)


This PR covers:

- #38308
- #39211
- #38307
- #38261