### PR TITLE
[cmdpal] Fix TimeAndDate extension crash issue when typing query

### DIFF
--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Pages/TimeDateExtensionPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Pages/TimeDateExtensionPage.cs
@@ -17,6 +17,7 @@ internal sealed partial class TimeDateExtensionPage : DynamicListPage
     private readonly Lock _resultsLock = new();
 
     private IList<ListItem> _results = new List<ListItem>();
+    private bool _dataLoaded;
 
     private SettingsManager _settingsManager;
 
@@ -33,11 +34,23 @@ internal sealed partial class TimeDateExtensionPage : DynamicListPage
 
     public override IListItem[] GetItems()
     {
+        ListItem[] results;
+        lock (_resultsLock)
+        {
+            if (_dataLoaded)
+            {
+                results = _results.ToArray();
+                _dataLoaded = false;
+                return results;
+            }
+        }
+
         DoExecuteSearch(string.Empty);
 
         lock (_resultsLock)
         {
-            ListItem[] results = _results.ToArray();
+            results = _results.ToArray();
+            _dataLoaded = false;
             return results;
         }
     }
@@ -75,6 +88,7 @@ internal sealed partial class TimeDateExtensionPage : DynamicListPage
         lock (_resultsLock)
         {
             this._results = result;
+            _dataLoaded = true;
         }
 
         RaiseItemsChanged(this._results.Count);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
When we call RaiseItemsChanged, it will trigger function GetItems. So if you enter this function through typing query, it will trap in an inf loop. Eventually leading to crash.

related change: https://github.com/microsoft/PowerToys/pull/40050

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #39973
- [x] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

