### PR TITLE
Aligning Kill Process with End Task naming

### DIFF
--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowWalker/Commands/CloseWindowCommand.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowWalker/Commands/CloseWindowCommand.cs
@@ -20,7 +20,7 @@ internal sealed partial class CloseWindowCommand : InvokableCommand
 
     public CloseWindowCommand(Window window)
     {
-        Icon = new IconInfo("\xE8BB");
+        Icon = new IconInfo("\uE894");
         Name = $"{Resources.windowwalker_Close}";
         _window = window;
     }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowWalker/Commands/EndTaskCommand.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowWalker/Commands/EndTaskCommand.cs
@@ -15,13 +15,13 @@ using Microsoft.CommandPalette.Extensions.Toolkit;
 
 namespace Microsoft.CmdPal.Ext.WindowWalker.Commands;
 
-internal sealed partial class KillProcessCommand : InvokableCommand
+internal sealed partial class EndTaskCommand : InvokableCommand
 {
     private readonly Window _window;
 
-    public KillProcessCommand(Window window)
+    public EndTaskCommand(Window window)
     {
-        Icon = new IconInfo("\xE74D"); // Delete symbol
+        Icon = new IconInfo("\uF140");
         Name = $"{Resources.windowwalker_Kill}";
         _window = window;
     }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowWalker/Components/ContextMenuHelper.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowWalker/Components/ContextMenuHelper.cs
@@ -33,7 +33,7 @@ internal sealed class ContextMenuHelper
         if (!windowData.Process.IsShellProcess && !(windowData.Process.IsUwpApp && string.Equals(windowData.Process.Name, "ApplicationFrameHost.exe", StringComparison.OrdinalIgnoreCase))
             && !(windowData.Process.IsFullAccessDenied && SettingsManager.Instance.HideKillProcessOnElevatedProcesses))
         {
-            contextMenu.Add(new CommandContextItem(new KillProcessCommand(windowData))
+            contextMenu.Add(new CommandContextItem(new EndTaskCommand(windowData))
             {
                 RequestedShortcut = KeyChordHelpers.FromModifiers(true, false, false, false, (int)VirtualKey.Delete, 0),
                 IsCritical = true,

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowWalker/Properties/Resources.Designer.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowWalker/Properties/Resources.Designer.cs
@@ -124,7 +124,7 @@ namespace Microsoft.CmdPal.Ext.WindowWalker.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Info: Killing the Explorer process isn&apos;t possible..
+        ///   Looks up a localized string similar to Info: Ending the Explorer process isn&apos;t possible..
         /// </summary>
         public static string windowwalker_ExplorerInfoTitle {
             get {
@@ -133,7 +133,7 @@ namespace Microsoft.CmdPal.Ext.WindowWalker.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Kill process.
+        ///   Looks up a localized string similar to End task.
         /// </summary>
         public static string windowwalker_Kill {
             get {
@@ -142,7 +142,7 @@ namespace Microsoft.CmdPal.Ext.WindowWalker.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Your are going to kill the following process:.
+        ///   Looks up a localized string similar to You are going to end the following process:.
         /// </summary>
         public static string windowwalker_KillMessage {
             get {
@@ -160,7 +160,7 @@ namespace Microsoft.CmdPal.Ext.WindowWalker.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Kill process confirmation.
+        ///   Looks up a localized string similar to End task confirmation.
         /// </summary>
         public static string windowwalker_KillMessageTitle {
             get {

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowWalker/Properties/Resources.resx
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowWalker/Properties/Resources.resx
@@ -166,23 +166,23 @@
     <comment>Explorer is here the program File Explorer</comment>
   </data>
   <data name="windowwalker_ExplorerInfoTitle" xml:space="preserve">
-    <value>Info: Killing the Explorer process isn't possible.</value>
+    <value>Info: Ending the Explorer process isn't possible.</value>
     <comment>Explorer is here the program File Explorer</comment>
   </data>
   <data name="windowwalker_Close" xml:space="preserve">
     <value>Close window</value>
   </data>
   <data name="windowwalker_Kill" xml:space="preserve">
-    <value>Kill process</value>
+    <value>End task</value>
   </data>
   <data name="windowwalker_KillMessage" xml:space="preserve">
-    <value>Your are going to kill the following process:</value>
+    <value>You are going to end the following process:</value>
   </data>
   <data name="windowwalker_KillMessageQuestion" xml:space="preserve">
     <value>Continue?</value>
   </data>
   <data name="windowwalker_KillMessageTitle" xml:space="preserve">
-    <value>Kill process confirmation</value>
+    <value>End task confirmation</value>
   </data>
   <data name="windowwalker_KillMessageUwp" xml:space="preserve">
     <value>Because this is an app process, all instances of the app will be killed. Continue?</value>


### PR DESCRIPTION
- Renaming "Kill process" to "End task" to align with Windows.
- Updating End task and Close window icons to align with End Task in Windows.