### PR TITLE
CmdPal: Improving search for URLs and ensuring valid exe/file for run fallback

### DIFF
--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Shell/FallbackExecuteItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Shell/FallbackExecuteItem.cs
@@ -2,6 +2,8 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.IO;
 using Microsoft.CmdPal.Ext.Shell.Commands;
 using Microsoft.CmdPal.Ext.Shell.Helpers;
 using Microsoft.CmdPal.Ext.Shell.Properties;
@@ -27,6 +29,18 @@ internal sealed partial class FallbackExecuteItem : FallbackCommandItem
 
     public override void UpdateQuery(string query)
     {
+        // Check if the query is a valid path to an exe/file
+        var isValidPath = IsValidPath(query);
+
+        // if not, let's bounce
+        if (!isValidPath)
+        {
+            Title = string.Empty;
+            MoreCommands = [];
+            return;
+        }
+
+        // if so, proceed good sir
         _executeItem.Cmd = query;
         _executeItem.Name = string.IsNullOrEmpty(query) ? string.Empty : Properties.Resources.generic_run_command;
         Title = query;
@@ -34,5 +48,84 @@ internal sealed partial class FallbackExecuteItem : FallbackCommandItem
             new CommandContextItem(new ExecuteItem(query, _settings, RunAsType.Administrator)),
             new CommandContextItem(new ExecuteItem(query, _settings, RunAsType.OtherUser)),
         ];
+    }
+
+    /// <summary>
+    /// Checks if the provided string is a valid path to a file or executable
+    /// </summary>
+    /// <param name="path">The path to check</param>
+    /// <returns>True if the path is valid, false otherwise</returns>
+    private bool IsValidPath(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return false;
+        }
+
+        try
+        {
+            // Check if it's a valid absolute path that exists
+            if (File.Exists(path))
+            {
+                return true;
+            }
+
+            // Check if the command exists in PATH
+            if (ExistsInPath(path))
+            {
+                return true;
+            }
+
+            // Check if it's a valid path with arguments
+            var parts = path.Split(' ', 2);
+            if (parts.Length > 0)
+            {
+                var executable = parts[0];
+
+                // Check if the executable part exists directly or in PATH
+                if (File.Exists(executable) || ExistsInPath(executable))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+        catch
+        {
+            // Path was malformed or caused an exception during validation
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Checks if a file exists in any of the PATH directories
+    /// </summary>
+    /// <param name="filename">The filename to check</param>
+    /// <returns>True if the file exists in PATH, false otherwise</returns>
+    private bool ExistsInPath(string filename)
+    {
+        if (File.Exists(filename))
+        {
+            return true;
+        }
+        else
+        {
+            var values = Environment.GetEnvironmentVariable("PATH");
+            if (values != null)
+            {
+                foreach (var path in values.Split(';'))
+                {
+                    var path1 = Path.Combine(path, filename);
+                    var path2 = Path.Combine(path, filename + ".exe");
+                    if (File.Exists(path1) || File.Exists(path2))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
     }
 }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/FallbackExecuteSearchItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/FallbackExecuteSearchItem.cs
@@ -15,14 +15,15 @@ internal sealed partial class FallbackExecuteSearchItem : FallbackCommandItem
 {
     private readonly SearchWebCommand _executeItem;
     private static readonly CompositeFormat PluginOpen = System.Text.CompositeFormat.Parse(Properties.Resources.plugin_open);
+    private static readonly CompositeFormat PluginSearch = System.Text.CompositeFormat.Parse(Properties.Resources.plugin_search);
 
     public FallbackExecuteSearchItem(SettingsManager settings)
         : base(new SearchWebCommand(string.Empty, settings), Resources.command_item_title)
     {
         _executeItem = (SearchWebCommand)this.Command!;
-        Title = string.Empty;
+        Subtitle = string.Empty;
         _executeItem.Name = string.Empty;
-        Subtitle = string.Format(CultureInfo.CurrentCulture, PluginOpen, BrowserInfo.Name ?? BrowserInfo.MSEdgeName);
+        Title = string.Format(CultureInfo.CurrentCulture, PluginOpen, BrowserInfo.Name ?? BrowserInfo.MSEdgeName);
         Icon = IconHelpers.FromRelativePath("Assets\\WebSearch.png");
     }
 
@@ -30,6 +31,6 @@ internal sealed partial class FallbackExecuteSearchItem : FallbackCommandItem
     {
         _executeItem.Arguments = query;
         _executeItem.Name = string.IsNullOrEmpty(query) ? string.Empty : Properties.Resources.open_in_default_browser;
-        Title = query;
+        Subtitle = string.Format(CultureInfo.CurrentCulture, PluginSearch, query);
     }
 }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/FallbackOpenURLItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/FallbackOpenURLItem.cs
@@ -16,7 +16,6 @@ namespace Microsoft.CmdPal.Ext.WebSearch;
 internal sealed partial class FallbackOpenURLItem : FallbackCommandItem
 {
     private readonly OpenURLCommand _executeItem;
-    private static readonly CompositeFormat PluginOpenURL = System.Text.CompositeFormat.Parse(Properties.Resources.plugin_open_url);
     private static readonly CompositeFormat PluginOpenUrlInBrowser = System.Text.CompositeFormat.Parse(Properties.Resources.plugin_open_url_in_browser);
 
     public FallbackOpenURLItem(SettingsManager settings)
@@ -40,7 +39,7 @@ internal sealed partial class FallbackOpenURLItem : FallbackCommandItem
 
         var success = Uri.TryCreate(query, UriKind.Absolute, out var uri);
 
-        // if url not contain schema, add http:// by default.
+        // if url not contain schema, add https:// by default.
         if (!success)
         {
             query = "https://" + query;
@@ -49,8 +48,8 @@ internal sealed partial class FallbackOpenURLItem : FallbackCommandItem
         _executeItem.Url = query;
         _executeItem.Name = string.IsNullOrEmpty(query) ? string.Empty : Properties.Resources.open_in_default_browser;
 
-        Title = string.Format(CultureInfo.CurrentCulture, PluginOpenURL, query);
-        Subtitle = string.Format(CultureInfo.CurrentCulture, PluginOpenUrlInBrowser, BrowserInfo.Name ?? BrowserInfo.MSEdgeName);
+        Title = query;
+        Subtitle = string.Format(CultureInfo.CurrentCulture, PluginOpenUrlInBrowser, query, BrowserInfo.Name ?? BrowserInfo.MSEdgeName);
     }
 
     public static bool IsValidUrl(string url)

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/Properties/Resources.Designer.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/Properties/Resources.Designer.cs
@@ -196,7 +196,7 @@ namespace Microsoft.CmdPal.Ext.WebSearch.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Open &quot;{0}&quot;.
+        ///   Looks up a localized string similar to {0}.
         /// </summary>
         public static string plugin_open_url {
             get {
@@ -205,11 +205,20 @@ namespace Microsoft.CmdPal.Ext.WebSearch.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Open url in {0}.
+        ///   Looks up a localized string similar to Open {0} in {1}.
         /// </summary>
         public static string plugin_open_url_in_browser {
             get {
                 return ResourceManager.GetString("plugin_open_url_in_browser", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Search for.
+        /// </summary>
+        public static string plugin_search {
+            get {
+                return ResourceManager.GetString("plugin_search", resourceCulture);
             }
         }
         

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/Properties/Resources.resx
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/Properties/Resources.resx
@@ -164,10 +164,10 @@
     <value>Search the web in {0}</value>
   </data>
   <data name="plugin_open_url" xml:space="preserve">
-    <value>Open "{0}"</value>
+    <value>{0}</value>
   </data>
   <data name="plugin_open_url_in_browser" xml:space="preserve">
-    <value>Open url in {0}</value>
+    <value>Open {0} in {1}</value>
   </data>
   <data name="plugin_search_failed" xml:space="preserve">
     <value>Failed to open {0}.</value>
@@ -177,5 +177,8 @@
   </data>
   <data name="settings_page_name" xml:space="preserve">
     <value>Settings</value>
+  </data>
+  <data name="plugin_search" xml:space="preserve">
+    <value>Search for</value>
   </data>
 </root>


### PR DESCRIPTION
Includes adding validation for executable paths, refining the handling of web search and URL commands, and updating resource strings for better clarity and search result scoring.

### Enhancements to Path Validation:
* Added a new `IsValidPath` method in `FallbackExecuteItem` to validate whether a query is a valid file or executable path. This includes checks for absolute paths, existence in the system PATH, and handling paths with arguments. [[1]](diffhunk://#diff-d1ca64d70b7ca98311ff1be77103ae01a37c790ad0fccaa76063abe751c66f7bR32-R43) [[2]](diffhunk://#diff-d1ca64d70b7ca98311ff1be77103ae01a37c790ad0fccaa76063abe751c66f7bR52-R130)
* Introduced the `ExistsInPath` helper method to check if a file exists within directories listed in the system PATH.

### Improvements to Web Search and URL Handling:
* Modified the resource strings for Title/Subtitle to allow for better search result scoring.

**Example of URL search**
![image](https://github.com/user-attachments/assets/8e8812c5-c2a2-41ab-962b-c3ccb5244448)

**Example of valid path search**
![image](https://github.com/user-attachments/assets/d3933c8c-4778-4758-b01f-b62ae36f2c8e)

**Example of valid file/executable search**
![image](https://github.com/user-attachments/assets/c6a2333b-d7a0-4e21-8db4-71a0f455f793)



Addresses: #39419