### PR TITLE
Fix: File explorer preview didn't work with per-user installation

### DIFF
--- a/.pipelines/ESRPSigning_core.json
+++ b/.pipelines/ESRPSigning_core.json
@@ -121,11 +121,11 @@
             "WinUI3Apps\\PowerToys.EnvironmentVariables.dll",
             "WinUI3Apps\\PowerToys.EnvironmentVariables.exe",
 
-            "WinUI3Apps\\PowerToys.ImageResizer.exe",
-            "WinUI3Apps\\PowerToys.ImageResizer.dll",
-            "WinUI3Apps\\PowerToys.ImageResizerExt.dll",
-            "WinUI3Apps\\PowerToys.ImageResizerContextMenu.dll",
-            "WinUI3Apps\\ImageResizerContextMenuPackage.msix",
+            "PowerToys.ImageResizer.exe",
+            "PowerToys.ImageResizer.dll",
+            "PowerToys.ImageResizerExt.dll",
+            "PowerToys.ImageResizerContextMenu.dll",
+            "ImageResizerContextMenuPackage.msix",
 
             "PowerToys.KeyboardManager.dll",
             "KeyboardManagerEditor\\PowerToys.KeyboardManagerEditor.exe",

--- a/.pipelines/ESRPSigning_core.json
+++ b/.pipelines/ESRPSigning_core.json
@@ -121,11 +121,11 @@
             "WinUI3Apps\\PowerToys.EnvironmentVariables.dll",
             "WinUI3Apps\\PowerToys.EnvironmentVariables.exe",
 
-            "PowerToys.ImageResizer.exe",
-            "PowerToys.ImageResizer.dll",
-            "PowerToys.ImageResizerExt.dll",
-            "PowerToys.ImageResizerContextMenu.dll",
-            "ImageResizerContextMenuPackage.msix",
+            "WinUI3Apps\\PowerToys.ImageResizer.exe",
+            "WinUI3Apps\\PowerToys.ImageResizer.dll",
+            "WinUI3Apps\\PowerToys.ImageResizerExt.dll",
+            "WinUI3Apps\\PowerToys.ImageResizerContextMenu.dll",
+            "WinUI3Apps\\ImageResizerContextMenuPackage.msix",
 
             "PowerToys.KeyboardManager.dll",
             "KeyboardManagerEditor\\PowerToys.KeyboardManagerEditor.exe",

--- a/installer/PowerToysSetup/ImageResizer.wxs
+++ b/installer/PowerToysSetup/ImageResizer.wxs
@@ -5,10 +5,10 @@
   <?include $(sys.CURRENTDIR)\Common.wxi?>
 
   <?define ImageResizerAssetsFiles=?>
-  <?define ImageResizerAssetsFilesPath=$(var.BinDir)Assets\ImageResizer\?>
+  <?define ImageResizerAssetsFilesPath=$(var.BinDir)WinUI3Apps\Assets\ImageResizer\?>
 
   <Fragment>
-    <DirectoryRef Id="BaseApplicationsAssetsFolder">
+    <DirectoryRef Id="WinUI3AppsAssetsFolder">
       <Directory Id="ImageResizerAssetsFolder" Name="ImageResizer" />
     </DirectoryRef>
 
@@ -18,7 +18,7 @@
 
       <Component Id="Module_ImageResizer_Registry" Win64="yes">
         <RegistryKey Root="$(var.RegistryScope)" Key="Software\Classes\CLSID\{51B4D7E5-7568-4234-B4BB-47FB3C016A69}\InprocServer32">
-          <RegistryValue Value="[INSTALLFOLDER]PowerToys.ImageResizerExt.dll" Type="string" />
+          <RegistryValue Value="[WinUI3AppsInstallFolder]PowerToys.ImageResizerExt.dll" Type="string" />
           <RegistryValue Name="ThreadingModel" Value="Apartment" Type="string" />
         </RegistryKey>
 

--- a/installer/PowerToysSetup/Resources.wxs
+++ b/installer/PowerToysSetup/Resources.wxs
@@ -186,7 +186,7 @@
         <RegistryKey Root="$(var.RegistryScope)" Key="Software\Classes\powertoys\components">
           <RegistryValue Type="string" Name="ImageResizer_$(var.IdSafeLanguage)_Component" Value="" KeyPath="yes"/>
         </RegistryKey>
-        <File Id="ImageResizer_$(var.IdSafeLanguage)_File" Source="$(var.BinDir)\$(var.Language)\PowerToys.ImageResizer.resources.dll" />
+        <File Id="ImageResizer_$(var.IdSafeLanguage)_File" Source="$(var.BinDir)\WinUI3Apps\$(var.Language)\PowerToys.ImageResizer.resources.dll" />
       </Component>
       <Component
           Id="ColorPicker_$(var.IdSafeLanguage)_Component"

--- a/installer/PowerToysSetup/generateAllFileComponents.ps1
+++ b/installer/PowerToysSetup/generateAllFileComponents.ps1
@@ -179,7 +179,7 @@ Generate-FileList -fileDepsJson "" -fileListName HostsAssetsFiles -wxsFilePath $
 Generate-FileComponents -fileListName "HostsAssetsFiles" -wxsFilePath $PSScriptRoot\Hosts.wxs -regroot $registryroot
 
 #ImageResizer
-Generate-FileList -fileDepsJson "" -fileListName ImageResizerAssetsFiles -wxsFilePath $PSScriptRoot\ImageResizer.wxs -depsPath "$PSScriptRoot..\..\..\$platform\Release\Assets\ImageResizer"
+Generate-FileList -fileDepsJson "" -fileListName ImageResizerAssetsFiles -wxsFilePath $PSScriptRoot\ImageResizer.wxs -depsPath "$PSScriptRoot..\..\..\$platform\Release\WinUI3Apps\Assets\ImageResizer"
 Generate-FileComponents -fileListName "ImageResizerAssetsFiles" -wxsFilePath $PSScriptRoot\ImageResizer.wxs -regroot $registryroot
 
 #New+

--- a/src/modules/imageresizer/ImageResizerContextMenu/ImageResizerContextMenu.vcxproj
+++ b/src/modules/imageresizer/ImageResizerContextMenu/ImageResizerContextMenu.vcxproj
@@ -34,7 +34,7 @@
     <TargetName>PowerToys.ImageResizerContextMenu</TargetName>
     <!-- Needs a different int dir to avoid conflicts in msix creation. -->
     <IntDir>$(SolutionDir)$(Platform)\$(Configuration)\TemporaryBuild\obj\$(ProjectName)\</IntDir>
-    <OutDir>..\..\..\..\$(Platform)\$(Configuration)\</OutDir>
+    <OutDir>..\..\..\..\$(Platform)\$(Configuration)\WinUI3Apps\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>

--- a/src/modules/imageresizer/ImageResizerLib/ImageResizerLib.vcxproj
+++ b/src/modules/imageresizer/ImageResizerLib/ImageResizerLib.vcxproj
@@ -29,7 +29,7 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
-    <OutDir>..\..\..\..\$(Platform)\$(Configuration)\</OutDir>
+    <OutDir>..\..\..\..\$(Platform)\$(Configuration)\WinUI3Apps\</OutDir>
   </PropertyGroup>
   <PropertyGroup>
     <TargetName>PowerToys.$(ProjectName)</TargetName>

--- a/src/modules/imageresizer/dll/ImageResizerExt.vcxproj
+++ b/src/modules/imageresizer/dll/ImageResizerExt.vcxproj
@@ -26,7 +26,7 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <IgnoreImportLibrary>true</IgnoreImportLibrary>
-    <OutDir>..\..\..\..\$(Platform)\$(Configuration)\</OutDir>
+    <OutDir>..\..\..\..\$(Platform)\$(Configuration)\WinUI3Apps\</OutDir>
     <TargetName>PowerToys.ImageResizerExt</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup>

--- a/src/modules/imageresizer/ui/ImageResizerUI.csproj
+++ b/src/modules/imageresizer/ui/ImageResizerUI.csproj
@@ -5,7 +5,7 @@
   
   <PropertyGroup>
     <AssemblyTitle>PowerToys.ImageResizer</AssemblyTitle>
-    <OutputPath>..\..\..\..\$(Platform)\$(Configuration)</OutputPath>
+    <OutputPath>..\..\..\..\$(Platform)\$(Configuration)\WinUI3Apps\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <GenerateSatelliteAssembliesForCore>true</GenerateSatelliteAssembliesForCore>

--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -149,7 +149,7 @@ int runner(bool isProcessElevated, bool openSettings, std::string settingsWindow
         std::vector<std::wstring_view> knownModules = {
             L"PowerToys.FancyZonesModuleInterface.dll",
             L"PowerToys.powerpreview.dll",
-            L"PowerToys.ImageResizerExt.dll",
+            L"WinUI3Apps/PowerToys.ImageResizerExt.dll",
             L"PowerToys.KeyboardManager.dll",
             L"PowerToys.Launcher.dll",
             L"WinUI3Apps/PowerToys.PowerRenameExt.dll",


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This Bug started when the Win11 context menu integration was first introduced by Image Resizer in version v0.60.0.

Move Image Resizer to the WinUI3Apps folder to fix file preview issue when PowerToys is installed on a non-C:\Program Files.
This aligns with the current structure used by File Locksmith and PowerRename, which are not WinUI 3 apps either, but are already located there.

### Root Cause:
When registering an MSIX package, the Windows API adds certain user permissions to the installation folders. Since Image Resizer was previously placed under the main PowerToys directory, these permission changes could prevent Explorer from loading its preview handler properly in per-user scenarios.

![image](https://github.com/user-attachments/assets/a8626314-19ce-4e25-87d6-d5e74a015e68)

Interestingly, this issue only affects per-user installs, not machine-wide installs (e.g., to Program Files), even though both locations receive additional permissions. The exact reason is still unclear and requires further investigation.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #24384 #29644 #32113 #34139 #37866 #40345
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

