### PR TITLE
[CmdPal][Calc]Parse result returned by ExprTk correctly

### DIFF
--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Helper/CalculateEngine.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Helper/CalculateEngine.cs
@@ -82,7 +82,7 @@ public static class CalculateEngine
             return default;
         }
 
-        var decimalResult = Convert.ToDecimal(result, cultureInfo);
+        var decimalResult = Convert.ToDecimal(result, new CultureInfo("en-US"));
 
         var roundedResult = FormatMax15Digits(decimalResult, cultureInfo);
 


### PR DESCRIPTION
## Summary of the Pull Request
The ExprTk result was previously parsed with CurrentCulture, which means that calculator was broken on every device which's culture info differed from what ExprTk returns.
It would probably be better to just obtain the result as a double directly, but that can wait.
## PR Checklist
- [x] **Closes:** #40305
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [x] **Localization:** All end-user-facing strings can be localized
- [x] **Dev docs:** No need
- [x] **New binaries:** None
- [x] **Documentation updated:** No need

## Detailed Description of the Pull Request / Additional comments
ExprTk, the math library that CmdPal's Calculator uses, returns the result as a string formatted in `en-US`, therefore we need to also parse it as `en-US`.
## Validation Steps Performed
Small and large numbers work correctly with all decimal separators