### PR TITLE
Adding fallback command for Windows Settings extension

### DIFF
--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/Helpers/ResultHelper.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/Helpers/ResultHelper.cs
@@ -22,8 +22,7 @@ namespace Microsoft.CmdPal.Ext.WindowsSettings;
 internal static class ResultHelper
 {
     internal static List<ListItem> GetResultList(
-        in IEnumerable<Classes.WindowsSetting> list,
-        string query)
+        in IEnumerable<Classes.WindowsSetting> list)
     {
         var resultList = new List<ListItem>(list.Count());
 

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/Helpers/ScoringHelper.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/Helpers/ScoringHelper.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CmdPal.Ext.WindowsSettings.Classes;
+
+namespace Microsoft.CmdPal.Ext.WindowsSettings.Helpers;
+
+internal static class ScoringHelper
+{
+    // Rank settings by how they matched the search query. Order is:
+    // 1. Exact Name (10 points)
+    // 2. Name Starts With (8 points)
+    // 3. Name (5 points)
+    // 4. Area (4 points)
+    // 5. AltName (2 points)
+    // 6. Settings path (1 point)
+    internal static (WindowsSetting Setting, int Score) SearchScoringPredicate(string query, WindowsSetting setting)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            // If no search string is entered skip query comparison.
+            return (setting, 0);
+        }
+
+        if (string.Equals(setting.Name, query, StringComparison.OrdinalIgnoreCase))
+        {
+            return (setting, 10);
+        }
+
+        if (setting.Name.StartsWith(query, StringComparison.CurrentCultureIgnoreCase))
+        {
+            return (setting, 8);
+        }
+
+        if (setting.Name.Contains(query, StringComparison.CurrentCultureIgnoreCase))
+        {
+            return (setting, 5);
+        }
+
+        if (!(setting.Areas is null))
+        {
+            foreach (var area in setting.Areas)
+            {
+                // Search for areas on normal queries.
+                if (area.Contains(query, StringComparison.CurrentCultureIgnoreCase))
+                {
+                    return (setting, 4);
+                }
+
+                // Search for Area only on queries with action char.
+                if (area.Contains(query.Replace(":", string.Empty), StringComparison.CurrentCultureIgnoreCase)
+                && query.EndsWith(":", StringComparison.CurrentCultureIgnoreCase))
+                {
+                    return (setting, 4);
+                }
+            }
+        }
+
+        if (!(setting.AltNames is null))
+        {
+            foreach (var altName in setting.AltNames)
+            {
+                if (altName.Contains(query, StringComparison.CurrentCultureIgnoreCase))
+                {
+                    return (setting, 2);
+                }
+            }
+        }
+
+        // Search by key char '>' for app name and settings path
+        if (query.Contains('>') && ResultHelper.FilterBySettingsPath(setting, query))
+        {
+            return (setting, 1);
+        }
+
+        return (setting, 0);
+    }
+}

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/Pages/FallbackWindowsSettingsItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/Pages/FallbackWindowsSettingsItem.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Xml.Linq;
+using Microsoft.CmdPal.Ext.WindowsSettings.Classes;
+using Microsoft.CmdPal.Ext.WindowsSettings.Commands;
+using Microsoft.CmdPal.Ext.WindowsSettings.Helpers;
+using Microsoft.CmdPal.Ext.WindowsSettings.Properties;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+
+namespace Microsoft.CmdPal.Ext.WindowsSettings.Pages;
+
+internal sealed partial class FallbackWindowsSettingsItem : FallbackCommandItem
+{
+    private readonly Classes.WindowsSettings _windowsSettings;
+
+    public FallbackWindowsSettingsItem(Classes.WindowsSettings windowsSettings)
+        : base(new NoOpCommand(), "Windows Settings")
+    {
+        Icon = IconHelpers.FromRelativePath("Assets\\WindowsSettings.svg");
+        _windowsSettings = windowsSettings;
+    }
+
+    public override void UpdateQuery(string query)
+    {
+        Command = new NoOpCommand();
+        Title = string.Empty;
+        Subtitle = string.Empty;
+        Icon = null;
+        MoreCommands = null;
+
+        if (string.IsNullOrWhiteSpace(query) ||
+            _windowsSettings?.Settings is null)
+        {
+            return;
+        }
+
+        var filteredList = _windowsSettings.Settings
+            .Select(setting => ScoringHelper.SearchScoringPredicate(query, setting))
+            .Where(scoredSetting => scoredSetting.Score > 0)
+            .OrderByDescending(scoredSetting => scoredSetting.Score);
+
+        if (!filteredList.Any())
+        {
+            return;
+        }
+
+        if (filteredList.Count() == 1 ||
+            filteredList.Any(a => a.Score == 10))
+        {
+            var setting = filteredList.First().Setting;
+
+            Title = setting.Name;
+            Subtitle = setting.JoinedFullSettingsPath;
+            Icon = IconHelpers.FromRelativePath("Assets\\WindowsSettings.svg");
+            Command = new OpenSettingsCommand(setting)
+            {
+                Icon = IconHelpers.FromRelativePath("Assets\\WindowsSettings.svg"),
+                Name = setting.Name,
+            };
+
+            // There is a case with MMC snap-ins where we don't have .msc files fort them. Then we need to show the note for this results in subtitle too.
+            // These results have mmc.exe as command and their note property is filled.
+            if (setting.Command == "mmc.exe" && !string.IsNullOrEmpty(setting.Note))
+            {
+                Subtitle += $"\u0020\u0020\u002D\u0020\u0020{Resources.Note}: {setting.Note}"; // "\u0020\u0020\u002D\u0020\u0020" = "<space><space><minus><space><space>"
+            }
+
+            return;
+        }
+
+        // We found more than one result. Make our command take
+        // us to the Windows Settings search page, prepopulated with this search.
+        var settingsPage = new WindowsSettingsListPage(_windowsSettings, query);
+        Title = "Open Windows Settings";
+        Icon = IconHelpers.FromRelativePath("Assets\\WindowsSettings.svg");
+        Subtitle = $"Navigate to specific Windows settings that include {query}";
+        Command = settingsPage;
+
+        return;
+    }
+}

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/Pages/WindowsSettingsListPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/Pages/WindowsSettingsListPage.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CmdPal.Ext.WindowsSettings.Classes;
+using Microsoft.CmdPal.Ext.WindowsSettings.Helpers;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 
@@ -23,6 +24,12 @@ internal sealed partial class WindowsSettingsListPage : DynamicListPage
         _windowsSettings = windowsSettings;
     }
 
+    public WindowsSettingsListPage(Classes.WindowsSettings windowsSettings, string query)
+        : this(windowsSettings)
+    {
+        SearchText = query;
+    }
+
     public List<ListItem> Query(string query)
     {
         if (_windowsSettings?.Settings is null)
@@ -31,87 +38,21 @@ internal sealed partial class WindowsSettingsListPage : DynamicListPage
         }
 
         var filteredList = _windowsSettings.Settings
-            .Select(SearchScoringPredicate)
+            .Select(setting => ScoringHelper.SearchScoringPredicate(query, setting))
             .Where(scoredSetting => scoredSetting.Score > 0)
             .OrderByDescending(scoredSetting => scoredSetting.Score)
             .Select(scoredSetting => scoredSetting.Setting);
 
-        var newList = ResultHelper.GetResultList(filteredList, query);
+        var newList = ResultHelper.GetResultList(filteredList);
         return newList;
-
-        // Rank settings by how they matched the search query. Order is:
-        // 1. Exact Name (10 points)
-        // 2. Name Starts With (8 points)
-        // 3. Name (5 points)
-        // 4. Area (4 points)
-        // 5. AltName (2 points)
-        // 6. Settings path (1 point)
-        (WindowsSetting Setting, int Score) SearchScoringPredicate(WindowsSetting setting)
-        {
-            if (string.IsNullOrWhiteSpace(query))
-            {
-                // If no search string is entered skip query comparison.
-                return (setting, 0);
-            }
-
-            if (string.Equals(setting.Name, query, StringComparison.OrdinalIgnoreCase))
-            {
-                return (setting, 10);
-            }
-
-            if (setting.Name.StartsWith(query, StringComparison.CurrentCultureIgnoreCase))
-            {
-                return (setting, 8);
-            }
-
-            if (setting.Name.Contains(query, StringComparison.CurrentCultureIgnoreCase))
-            {
-                return (setting, 5);
-            }
-
-            if (!(setting.Areas is null))
-            {
-                foreach (var area in setting.Areas)
-                {
-                    // Search for areas on normal queries.
-                    if (area.Contains(query, StringComparison.CurrentCultureIgnoreCase))
-                    {
-                        return (setting, 4);
-                    }
-
-                    // Search for Area only on queries with action char.
-                    if (area.Contains(query.Replace(":", string.Empty), StringComparison.CurrentCultureIgnoreCase)
-                    && query.EndsWith(":", StringComparison.CurrentCultureIgnoreCase))
-                    {
-                        return (setting, 4);
-                    }
-                }
-            }
-
-            if (!(setting.AltNames is null))
-            {
-                foreach (var altName in setting.AltNames)
-                {
-                    if (altName.Contains(query, StringComparison.CurrentCultureIgnoreCase))
-                    {
-                        return (setting, 2);
-                    }
-                }
-            }
-
-            // Search by key char '>' for app name and settings path
-            if (query.Contains('>') && ResultHelper.FilterBySettingsPath(setting, query))
-            {
-                return (setting, 1);
-            }
-
-            return (setting, 0);
-        }
     }
 
     public override void UpdateSearchText(string oldSearch, string newSearch)
     {
-        RaiseItemsChanged(0);
+        if (oldSearch != newSearch)
+        {
+            RaiseItemsChanged(0);
+        }
     }
 
     public override IListItem[] GetItems()

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/WindowsSettingsCommandsProvider.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/WindowsSettingsCommandsProvider.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.CmdPal.Ext.WindowsSettings.Helpers;
+using Microsoft.CmdPal.Ext.WindowsSettings.Pages;
 using Microsoft.CmdPal.Ext.WindowsSettings.Properties;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
@@ -17,6 +18,8 @@ public partial class WindowsSettingsCommandsProvider : CommandProvider
     private readonly WindowsSettings.Classes.WindowsSettings? _windowsSettings;
 #pragma warning restore CS8632 // The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
 
+    private readonly FallbackWindowsSettingsItem _fallback;
+
     public WindowsSettingsCommandsProvider()
     {
         Id = "Windows.Settings";
@@ -29,6 +32,7 @@ public partial class WindowsSettingsCommandsProvider : CommandProvider
             Title = "Windows Settings",
             Subtitle = "Navigate to specific Windows settings",
         };
+        _fallback = new(_windowsSettings);
 
         UnsupportedSettingsHelper.FilterByBuild(_windowsSettings);
 
@@ -42,4 +46,6 @@ public partial class WindowsSettingsCommandsProvider : CommandProvider
             _searchSettingsListItem
         ];
     }
+
+    public override IFallbackCommandItem[] FallbackCommands() => [_fallback];
 }


### PR DESCRIPTION
Two changes:

- Added a new fallback command for Windows Settings extension. If only one setting or one exact match for the query was found, display that setting in the list and open that setting on <Enter>. If more than one setting was found, display a message to open Windows Settings to see the search results for your query.

![image](https://github.com/user-attachments/assets/bd5708a5-b1d5-466e-9c62-cd1cd7bb1f74)

![image](https://github.com/user-attachments/assets/69e39270-86b2-4f0f-85fd-fe4ef69c2e93)

![image](https://github.com/user-attachments/assets/e5da90e1-f89b-480c-bd26-214c68ac013a)

- Modified the titles/subtitles of the extension to pull from Resources to aid in internationalization.

Addresses: #38548 and possibly #40308