### PR TITLE
[UI Tests] Fix incorrect Settings Page launch method in UI test framework

### DIFF
--- a/src/common/UITestAutomation/SessionHelper.cs
+++ b/src/common/UITestAutomation/SessionHelper.cs
@@ -53,7 +53,7 @@ namespace Microsoft.PowerToys.UITest
                 };
                 this.ExitExe(runnerProcessInfo.FileName);
                 this.runner = Process.Start(runnerProcessInfo);
-                Thread.Sleep(3000);
+                Thread.Sleep(5000);
             }
         }
 
@@ -149,8 +149,11 @@ namespace Microsoft.PowerToys.UITest
                 {
                     var windowName = "PowerToys Settings";
                     var settingsWindow = ApiHelper.FindDesktopWindowHandler([windowName, AdministratorPrefix + windowName]);
-                    var hexHwnd = settingsWindow[0].HWnd.ToString("x");
-                    opts.AddAdditionalCapability("appTopLevelWindow", hexHwnd);
+                    if (settingsWindow.Count > 0)
+                    {
+                        var hexHwnd = settingsWindow[0].HWnd.ToString("x");
+                        opts.AddAdditionalCapability("appTopLevelWindow", hexHwnd);
+                    }
                 }
             }
             else

--- a/src/common/UITestAutomation/UITestBase.cs
+++ b/src/common/UITestAutomation/UITestBase.cs
@@ -77,16 +77,6 @@ namespace Microsoft.PowerToys.UITest
 
             this.sessionHelper = new SessionHelper(scope).Init();
             this.Session = new Session(this.sessionHelper.GetRoot(), this.sessionHelper.GetDriver(), scope, size);
-
-            if (this.scope == PowerToysModule.PowerToysSettings)
-            {
-                // close Debug warning dialog if any
-                // Such debug warning dialog seems only appear in PowerToys Settings
-                if (this.FindAll("DEBUG").Count > 0)
-                {
-                    this.Find("DEBUG").Find<Button>("Close").Click();
-                }
-            }
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
### Root Cause
The UI test framework previously attempted to launch PowerToys.Settings.exe directly.
However, this bypasses the PowerToys Runner, which is required for proper interaction
and communication between runner.

### Fix
1. This change updates the launch mechanism to start PowerToys through the Runner
with the appropriate argument ("--open-settings").
2. Prevents the Debug dialog from appearing in test runs

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

