### PR TITLE
Set Command Palette window as the topmost when shown and move to the bottom when hidden

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml.cs
@@ -231,6 +231,10 @@ public sealed partial class MainWindow : WindowEx,
 
         PInvoke.SetForegroundWindow(hwnd);
         PInvoke.SetActiveWindow(hwnd);
+
+        // Push our window to the top of the Z-order and make it the topmost, so that it appears above all other windows.
+        // We want to remove the topmost status when we hide the window (because we cloak it instead of hiding it).
+        PInvoke.SetWindowPos(hwnd, HWND.HWND_TOPMOST, 0, 0, 0, 0, SET_WINDOW_POS_FLAGS.SWP_NOMOVE | SET_WINDOW_POS_FLAGS.SWP_NOSIZE);
     }
 
     private DisplayArea GetScreen(HWND currentHwnd, MonitorBehavior target)
@@ -308,6 +312,10 @@ public sealed partial class MainWindow : WindowEx,
             BOOL value = true;
             PInvoke.DwmSetWindowAttribute(_hwnd, DWMWINDOWATTRIBUTE.DWMWA_CLOAK, &value, (uint)sizeof(BOOL));
         }
+
+        // Because we're only cloaking the window, bury it at the bottom in case something can
+        // see it - e.g. some accessibility helper (note: this also removes the top-most status).
+        PInvoke.SetWindowPos(_hwnd, HWND.HWND_BOTTOM, 0, 0, 0, 0, SET_WINDOW_POS_FLAGS.SWP_NOMOVE | SET_WINDOW_POS_FLAGS.SWP_NOSIZE);
     }
 
     internal void MainWindow_Closed(object sender, WindowEventArgs args)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/NativeMethods.txt
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/NativeMethods.txt
@@ -6,6 +6,8 @@ SetForegroundWindow
 GetWindowRect
 GetCursorPos
 SetWindowPos
+HWND_TOPMOST
+HWND_BOTTOM
 IsIconic
 RegisterHotKey
 UnregisterHotKey


### PR DESCRIPTION
## Summary of the Pull Request

Ensures the Command Palette main window is brought to the front and made topmost when shown. When the palette is hidden (cloaked but not destroyed), it is moved to the bottom of the window stack to avoid interfering with the user workflow. Dynamic removal of the topmost flag is a precaution to prevent the cloak window from bothering user in accessibility tools that too much -- in case they don't recognize cloak windows as not visible).

## PR Checklist

- [x] **Closes:** #38726 
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [x] **Tests:** Nothing to test
- [x] **Localization:** Nothing to localize
- [x] **Dev docs:** Nothing to update
- [x] **New binaries:** No new binaries
- [x] **Documentation updated:** nothing to update

## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed

I've tested that the Command Palette window is display over other top-most windows (e.g. Task Manager). I've tested that the command palette is displayed over the Rainbow gadgets when it was originally under the gadget.