### PR TITLE
CmdPal: Give FG back to the previous window

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/NativeMethods.txt
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/NativeMethods.txt
@@ -43,3 +43,9 @@ MessageBox
 DwmGetWindowAttribute
 DwmSetWindowAttribute
 DWM_CLOAKED_APP
+
+EnumWindows
+IsWindowVisible
+GetClientRect
+GetWindowLong
+WINDOW_EX_STYLE


### PR DESCRIPTION
this is a port of ce15032 onto main, for just the FG change.

When we cloak our window, we want to make sure to _manually_ give FG back to another window. Because apparently cloaked windows can have FG. beacause that makes sense :facepalm:

Closes #39638
