### PR TITLE
Replace our nuget.org feed with a public azure artifacts feed

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -2,10 +2,10 @@
 <configuration>
 	<packageSources>
 		<clear />
-		<add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+		<add key="PowerToysPublicDependencies" value="https://pkgs.dev.azure.com/shine-oss/PowerToys/_packaging/PowerToysPublicDependencies/nuget/v3/index.json" />
 	</packageSources>
 	<packageSourceMapping>
-		<packageSource key="nuget.org">
+		<packageSource key="PowerToysPublicDependencies">
 			<package pattern="*" />
 		</packageSource>
 	</packageSourceMapping>


### PR DESCRIPTION
_This madness has gone on too long, I say_

This replaces our default nuget.org feed with a public azure artifacts feed in the shine-oss org. This is what literally everyone else does, I don't know why we don't. 

This should unblock _wait where'd that issue go_ since we can just add the community toolkit labs feed as an upstream

This has the negative side effect that it did prompt me to log in to azure artifacts with my MSA. I've cancelled like 5 prompts now, but it seems to still be working on it?
