### PR TITLE
CmdPal: Hide Open URL fallback item when search query is empty or doesn't contain valid URL

### DIFF
--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/FallbackOpenURLItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/FallbackOpenURLItem.cs
@@ -33,6 +33,8 @@ internal sealed partial class FallbackOpenURLItem : FallbackCommandItem
     {
         if (!IsValidUrl(query))
         {
+            _executeItem.Url = string.Empty;
+            _executeItem.Name = string.Empty;
             Title = string.Empty;
             Subtitle = string.Empty;
             return;


### PR DESCRIPTION
## Summary of the Pull Request
Clears and hides fallback item for URL when query changes and URL is no longer a valid URL. Fixes the situation when the item remains visible in the list with generic text and pointing the last valid URL it was updated with.

## PR Checklist

- [x] Closes: #40512
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** no new strings
- [x] **Dev docs:** nothing to update
- [x] **New binaries:** none
- [x] **Documentation updated:** none

## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed
Entered URL to search field. Observed the Open URL item is present. Cleared URL. Observed that Open URL item is not present.

