### PR TITLE
CmdPal: Allow mouse X1 button to navigate back

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
@@ -16,8 +16,10 @@ using Microsoft.CommandPalette.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.PowerToys.Telemetry;
 using Microsoft.UI.Dispatching;
+using Microsoft.UI.Input;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media.Animation;
 using DispatcherQueue = Microsoft.UI.Dispatching.DispatcherQueue;
 
@@ -75,6 +77,8 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
 
         WeakReferenceMessenger.Default.Register<ClearSearchMessage>(this);
         WeakReferenceMessenger.Default.Register<LaunchUriMessage>(this);
+
+        AddHandler(PointerPressedEvent, new PointerEventHandler(ShellPage_OnPointerPressed), true);
 
         RootFrame.Navigate(typeof(LoadingPage), ViewModel);
     }
@@ -636,6 +640,26 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
         if (sender is Button button && button.DataContext is CommandViewModel commandViewModel)
         {
             WeakReferenceMessenger.Default.Send<PerformCommandMessage>(new(commandViewModel.Model));
+        }
+    }
+
+    private void ShellPage_OnPointerPressed(object sender, PointerRoutedEventArgs e)
+    {
+        try
+        {
+            var ptr = e.Pointer;
+            if (ptr.PointerDeviceType == PointerDeviceType.Mouse)
+            {
+                var ptrPt = e.GetCurrentPoint(this);
+                if (ptrPt.Properties.IsXButton1Pressed)
+                {
+                    WeakReferenceMessenger.Default.Send(new NavigateBackMessage());
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError("Error handling mouse button press event", ex);
         }
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request
Enables navigation to the previous page when the mouse X1 (back) button is pressed. This improves user experience for those using multi-button mice, making navigation more intuitive.

## PR Checklist

- [x] **Closes:** #40499
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** All end-user-facing strings can be localized
- [x] **Dev docs:** nope
- [x] **New binaries:** nada
- [x] **Documentation updated:** nothing to add

## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed

