### PR TITLE
CmdPal: Ensure that DismissMessage handler calls HideWindow on UI thread

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml.cs
@@ -307,8 +307,14 @@ public sealed partial class MainWindow : WindowEx,
         // This might come in on a background thread
         DispatcherQueue.TryEnqueue(() => Close());
 
-    public void Receive(DismissMessage message) =>
-        HideWindow();
+    public void Receive(DismissMessage message)
+    {
+        // This might come in off the UI thread. Make sure to hop back.
+        DispatcherQueue.TryEnqueue(() =>
+        {
+            HideWindow();
+        });
+    }
 
     private void HideWindow()
     {


### PR DESCRIPTION
## Summary of the Pull Request
Otherwise, it silently fails to hide the window.
The problem is not visible to naked eye, since the window is already cloaked.

## PR Checklist

- [x] **Closes:** #40535 
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** All end-user-facing strings can be localized
- [x] **Dev docs:** Added/updated
- [x] **New binaries:** Added on the required places
- [x] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed
Tested with an extension that return CommandResult.Dismiss and then works with focused app (https://github.com/CoreyHayward/CmdPal-InputTyper).