### PR TITLE
Add non-updating mode for Crop-And-Lock

### DIFF
--- a/doc/devdocs/modules/cropandlock.md
+++ b/doc/devdocs/modules/cropandlock.md
@@ -20,6 +20,9 @@ Creates a window showing the selected area of the original window. Changes in th
 ### Reparent Mode
 Creates a window that replaces the original window, showing only the selected area. The application is controlled through the cropped window.
 
+### Screenshot Mode
+Creates a window showing a freezed snapshot of the original window. 
+
 ## Code Structure
 
 ### Project Layout
@@ -30,6 +33,7 @@ The Crop and Lock module is part of the PowerToys solution. All the logic-relate
 - **OverlayWindow.cpp**: Thumbnail module type's window concrete implementation.
 - **ReparentCropAndLockWindow.cpp**: Defines the UI for the reparent mode.
 - **ChildWindow.cpp**: Reparent module type's window concrete implementation.
+- **ScreenshotCropAndLockWindow.cpp**: Defines the UI for the screenshot mode.
 
 ## Known Issues
 

--- a/src/common/interop/shared_constants.h
+++ b/src/common/interop/shared_constants.h
@@ -121,6 +121,7 @@ namespace CommonSharedConstants
     // Path to the events used by CropAndLock
     const wchar_t CROP_AND_LOCK_REPARENT_EVENT[] = L"Local\\PowerToysCropAndLockReparentEvent-6060860a-76a1-44e8-8d0e-6355785e9c36";
     const wchar_t CROP_AND_LOCK_THUMBNAIL_EVENT[] = L"Local\\PowerToysCropAndLockThumbnailEvent-1637be50-da72-46b2-9220-b32b206b2434";
+    const wchar_t CROP_AND_LOCK_SCREENSHOT_EVENT[] = L"Local\\PowerToysCropAndLockScreenshotEvent-ff077ab2-8360-4bd1-864a-637389d35593";
     const wchar_t CROP_AND_LOCK_EXIT_EVENT[] = L"Local\\PowerToysCropAndLockExitEvent-d995d409-7b70-482b-bad6-e7c8666f375a";
 
     // Path to the events used by EnvironmentVariables

--- a/src/modules/CropAndLock/CropAndLock/CropAndLock.vcxproj
+++ b/src/modules/CropAndLock/CropAndLock/CropAndLock.vcxproj
@@ -112,6 +112,7 @@
     <ClCompile Include="ChildWindow.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="ReparentCropAndLockWindow.cpp" />
+    <ClCompile Include="ScreenshotCropAndLockWindow.cpp" />
     <ClCompile Include="ThumbnailCropAndLockWindow.cpp" />
     <ClCompile Include="OverlayWindow.cpp" />
     <ClCompile Include="pch.cpp">
@@ -126,6 +127,7 @@
     <ClInclude Include="DisplaysUtil.h" />
     <ClInclude Include="ModuleConstants.h" />
     <ClInclude Include="ReparentCropAndLockWindow.h" />
+    <ClInclude Include="ScreenshotCropAndLockWindow.h" />
     <ClInclude Include="ThumbnailCropAndLockWindow.h" />
     <ClInclude Include="SettingsWindow.h" />
     <ClInclude Include="OverlayWindow.h" />

--- a/src/modules/CropAndLock/CropAndLock/CropAndLock.vcxproj.filters
+++ b/src/modules/CropAndLock/CropAndLock/CropAndLock.vcxproj.filters
@@ -12,6 +12,7 @@
     <ClCompile Include="ReparentCropAndLockWindow.cpp" />
     <ClCompile Include="ChildWindow.cpp" />
     <ClCompile Include="trace.cpp" />
+    <ClCompile Include="ScreenshotCropAndLockWindow.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
@@ -28,6 +29,7 @@
     <ClInclude Include="trace.h" />
     <ClInclude Include="ModuleConstants.h" />
     <ClInclude Include="DispatcherQueue.desktop.interop.h" />
+    <ClInclude Include="ScreenshotCropAndLockWindow.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="CropAndLock.rc" />

--- a/src/modules/CropAndLock/CropAndLock/ScreenshotCropAndLockWindow.cpp
+++ b/src/modules/CropAndLock/CropAndLock/ScreenshotCropAndLockWindow.cpp
@@ -1,0 +1,181 @@
+﻿#include "pch.h"
+#include "ScreenshotCropAndLockWindow.h"
+
+const std::wstring ScreenshotCropAndLockWindow::ClassName = L"CropAndLock.ScreenshotCropAndLockWindow";
+std::once_flag ScreenshotCropAndLockWindowClassRegistration;
+
+void ScreenshotCropAndLockWindow::RegisterWindowClass()
+{
+    auto instance = winrt::check_pointer(GetModuleHandleW(nullptr));
+    WNDCLASSEXW wcex = {};
+    wcex.cbSize = sizeof(wcex);
+    wcex.style = CS_HREDRAW | CS_VREDRAW;
+    wcex.lpfnWndProc = WndProc;
+    wcex.hInstance = instance;
+    wcex.hIcon = LoadIconW(instance, IDI_APPLICATION);
+    wcex.hCursor = LoadCursorW(nullptr, IDC_ARROW);
+    wcex.hbrBackground = static_cast<HBRUSH>(GetStockObject(BLACK_BRUSH));
+    wcex.lpszClassName = ClassName.c_str();
+    wcex.hIconSm = LoadIconW(wcex.hInstance, IDI_APPLICATION);
+    winrt::check_bool(RegisterClassExW(&wcex));
+}
+
+ScreenshotCropAndLockWindow::ScreenshotCropAndLockWindow(std::wstring const& titleString, int width, int height)
+{
+    auto instance = winrt::check_pointer(GetModuleHandleW(nullptr));
+
+    std::call_once(ScreenshotCropAndLockWindowClassRegistration, []() { RegisterWindowClass(); });
+
+    auto exStyle = 0;
+    auto style = WS_OVERLAPPEDWINDOW | WS_CLIPCHILDREN;
+
+    RECT rect = { 0, 0, width, height };
+    winrt::check_bool(AdjustWindowRectEx(&rect, style, false, exStyle));
+    auto adjustedWidth = rect.right - rect.left;
+    auto adjustedHeight = rect.bottom - rect.top;
+
+    winrt::check_bool(CreateWindowExW(exStyle, ClassName.c_str(), titleString.c_str(), style, CW_USEDEFAULT, CW_USEDEFAULT, adjustedWidth, adjustedHeight, nullptr, nullptr, instance, this));
+    WINRT_ASSERT(m_window);
+}
+
+ScreenshotCropAndLockWindow::~ScreenshotCropAndLockWindow()
+{
+    DestroyWindow(m_window);
+}
+
+LRESULT ScreenshotCropAndLockWindow::MessageHandler(UINT const message, WPARAM const wparam, LPARAM const lparam)
+{
+    switch (message)
+    {
+    case WM_DESTROY:
+        if (m_closedCallback != nullptr && !m_destroyed)
+        {
+            m_destroyed = true;
+            m_closedCallback(m_window);
+        }
+        break;
+    case WM_PAINT:
+        if (m_captured && m_bitmap)
+        {
+            PAINTSTRUCT ps;
+            HDC hdc = BeginPaint(m_window, &ps);
+            HDC memDC = CreateCompatibleDC(hdc);
+            SelectObject(memDC, m_bitmap.get());
+
+            RECT clientRect = {};
+            GetClientRect(m_window, &clientRect);
+            int clientWidth = clientRect.right - clientRect.left;
+            int clientHeight = clientRect.bottom - clientRect.top;
+
+            int srcWidth = m_destRect.right - m_destRect.left;
+            int srcHeight = m_destRect.bottom - m_destRect.top;
+
+            float srcAspect = static_cast<float>(srcWidth) / srcHeight;
+            float dstAspect = static_cast<float>(clientWidth) / clientHeight;
+
+            int drawWidth = clientWidth;
+            int drawHeight = static_cast<int>(clientWidth / srcAspect);
+            if (dstAspect > srcAspect)
+            {
+                drawHeight = clientHeight;
+                drawWidth = static_cast<int>(clientHeight * srcAspect);
+            }
+
+            int offsetX = (clientWidth - drawWidth) / 2;
+            int offsetY = (clientHeight - drawHeight) / 2;
+
+            SetStretchBltMode(hdc, HALFTONE);
+            StretchBlt(hdc, offsetX, offsetY, drawWidth, drawHeight, memDC, 0, 0, srcWidth, srcHeight, SRCCOPY);
+            DeleteDC(memDC);
+            EndPaint(m_window, &ps);
+        }
+        break;
+    default:
+        return base_type::MessageHandler(message, wparam, lparam);
+    }
+    return 0;
+}
+
+void ScreenshotCropAndLockWindow::CropAndLock(HWND windowToCrop, RECT cropRect)
+{
+    if (m_captured)
+    {
+        return;
+    }
+
+    // Get full window bounds
+    RECT windowRect{};
+    winrt::check_hresult(DwmGetWindowAttribute(
+        windowToCrop,
+        DWMWA_EXTENDED_FRAME_BOUNDS,
+        &windowRect,
+        sizeof(windowRect)));
+
+    RECT clientRect = ClientAreaInScreenSpace(windowToCrop);
+    auto offsetX = clientRect.left - windowRect.left;
+    auto offsetY = clientRect.top - windowRect.top;
+
+    m_sourceRect = {
+        cropRect.left + offsetX,
+        cropRect.top + offsetY,
+        cropRect.right + offsetX,
+        cropRect.bottom + offsetY
+    };
+
+    int fullWidth = windowRect.right - windowRect.left;
+    int fullHeight = windowRect.bottom - windowRect.top;
+
+    HDC fullDC = CreateCompatibleDC(nullptr);
+    HBITMAP fullBitmap = CreateCompatibleBitmap(GetDC(nullptr), fullWidth, fullHeight);
+    HGDIOBJ oldFullBitmap = SelectObject(fullDC, fullBitmap);
+
+    // Capture full window
+    winrt::check_bool(PrintWindow(windowToCrop, fullDC, PW_RENDERFULLCONTENT));
+
+
+    // Crop
+    int cropWidth = m_sourceRect.right - m_sourceRect.left;
+    int cropHeight = m_sourceRect.bottom - m_sourceRect.top;
+
+    HDC cropDC = CreateCompatibleDC(nullptr);
+    HBITMAP cropBitmap = CreateCompatibleBitmap(GetDC(nullptr), cropWidth, cropHeight);
+    HGDIOBJ oldCropBitmap = SelectObject(cropDC, cropBitmap);
+
+    BitBlt(
+        cropDC,
+        0,
+        0,
+        cropWidth,
+        cropHeight,
+        fullDC,
+        m_sourceRect.left,
+        m_sourceRect.top,
+        SRCCOPY);
+
+    SelectObject(fullDC, oldFullBitmap);
+    DeleteObject(fullBitmap);
+    DeleteDC(fullDC);
+
+    SelectObject(cropDC, oldCropBitmap);
+    DeleteDC(cropDC);
+    m_bitmap.reset(cropBitmap);
+
+    // Resize our window
+    RECT dest{ 0, 0, cropWidth, cropHeight };
+    LONG_PTR exStyle = GetWindowLongPtrW(m_window, GWL_EXSTYLE);
+    LONG_PTR style = GetWindowLongPtrW(m_window, GWL_STYLE);
+
+    winrt::check_bool(AdjustWindowRectEx(&dest, static_cast<DWORD>(style), FALSE, static_cast<DWORD>(exStyle)));
+
+    winrt::check_bool(SetWindowPos(
+        m_window, HWND_TOPMOST, 0, 0, dest.right - dest.left, dest.bottom - dest.top, SWP_NOMOVE | SWP_SHOWWINDOW));
+
+    m_destRect = { 0, 0, cropWidth, cropHeight };
+    m_captured = true;
+    InvalidateRect(m_window, nullptr, FALSE);
+}
+
+void ScreenshotCropAndLockWindow::Hide()
+{
+    ShowWindow(m_window, SW_HIDE);
+}

--- a/src/modules/CropAndLock/CropAndLock/ScreenshotCropAndLockWindow.h
+++ b/src/modules/CropAndLock/CropAndLock/ScreenshotCropAndLockWindow.h
@@ -1,0 +1,29 @@
+#pragma once
+#include <robmikh.common/DesktopWindow.h>
+#include "CropAndLockWindow.h"
+
+struct ScreenshotCropAndLockWindow : robmikh::common::desktop::DesktopWindow<ScreenshotCropAndLockWindow>, CropAndLockWindow
+{
+    static const std::wstring ClassName;
+    ScreenshotCropAndLockWindow(std::wstring const& titleString, int width, int height);
+    ~ScreenshotCropAndLockWindow() override;
+    LRESULT MessageHandler(UINT const message, WPARAM const wparam, LPARAM const lparam);
+
+    HWND Handle() override { return m_window; }
+    void CropAndLock(HWND windowToCrop, RECT cropRect) override;
+    void OnClosed(std::function<void(HWND)> callback) override { m_closedCallback = callback; }
+
+private:
+    static void RegisterWindowClass();
+
+    void Hide();
+
+private:
+    std::unique_ptr<void, decltype(&DeleteObject)> m_bitmap{ nullptr, &DeleteObject };
+    RECT m_destRect = {};
+    RECT m_sourceRect = {};
+
+    bool m_captured = false;
+    bool m_destroyed = false;
+    std::function<void(HWND)> m_closedCallback;
+};

--- a/src/modules/CropAndLock/CropAndLock/SettingsWindow.h
+++ b/src/modules/CropAndLock/CropAndLock/SettingsWindow.h
@@ -4,4 +4,5 @@ enum class CropAndLockType
 {
 	Reparent,
 	Thumbnail,
+	Screenshot,
 };

--- a/src/modules/CropAndLock/CropAndLock/main.cpp
+++ b/src/modules/CropAndLock/CropAndLock/main.cpp
@@ -2,6 +2,7 @@
 #include "SettingsWindow.h"
 #include "OverlayWindow.h"
 #include "CropAndLockWindow.h"
+#include "ScreenshotCropAndLockWindow.h"
 #include "ThumbnailCropAndLockWindow.h"
 #include "ReparentCropAndLockWindow.h"
 #include "ModuleConstants.h"
@@ -133,6 +134,7 @@ int WINAPI wWinMain(_In_ HINSTANCE, _In_opt_ HINSTANCE, _In_ PWSTR lpCmdLine, _I
     // Handles and thread for the events sent from runner
     HANDLE m_reparent_event_handle;
     HANDLE m_thumbnail_event_handle;
+    HANDLE m_screenshot_event_handle;
     HANDLE m_exit_event_handle;
     std::thread m_event_triggers_thread;
 
@@ -181,6 +183,11 @@ int WINAPI wWinMain(_In_ HINSTANCE, _In_opt_ HINSTANCE, _In_ PWSTR lpCmdLine, _I
                 Logger::trace(L"Creating a thumbnail window");
                 Trace::CropAndLock::CreateThumbnailWindow();
                 break;
+            case CropAndLockType::Screenshot:
+                croppedWindow = std::make_shared<ScreenshotCropAndLockWindow>(title, 800, 600);
+                Logger::trace(L"Creating a screenshot window");
+                Trace::CropAndLock::CreateScreenshotWindow();
+                break;
             default:
                 return;
             }
@@ -215,8 +222,9 @@ int WINAPI wWinMain(_In_ HINSTANCE, _In_opt_ HINSTANCE, _In_ PWSTR lpCmdLine, _I
     // Start a thread to listen on the events.
     m_reparent_event_handle = CreateEventW(nullptr, false, false, CommonSharedConstants::CROP_AND_LOCK_REPARENT_EVENT);
     m_thumbnail_event_handle = CreateEventW(nullptr, false, false, CommonSharedConstants::CROP_AND_LOCK_THUMBNAIL_EVENT);
+    m_screenshot_event_handle = CreateEventW(nullptr, false, false, CommonSharedConstants::CROP_AND_LOCK_SCREENSHOT_EVENT);
     m_exit_event_handle = CreateEventW(nullptr, false, false, CommonSharedConstants::CROP_AND_LOCK_EXIT_EVENT);
-    if (!m_reparent_event_handle || !m_thumbnail_event_handle || !m_exit_event_handle)
+    if (!m_reparent_event_handle || !m_thumbnail_event_handle || !m_screenshot_event_handle || !m_exit_event_handle)
     {
         Logger::warn(L"Failed to create events. {}", get_last_error_or_default(GetLastError()));
         return 1;
@@ -224,10 +232,10 @@ int WINAPI wWinMain(_In_ HINSTANCE, _In_opt_ HINSTANCE, _In_ PWSTR lpCmdLine, _I
 
     m_event_triggers_thread = std::thread([&]() {
         MSG msg;
-        HANDLE event_handles[3] = { m_reparent_event_handle, m_thumbnail_event_handle, m_exit_event_handle };
+        HANDLE event_handles[4] = { m_reparent_event_handle, m_thumbnail_event_handle, m_screenshot_event_handle, m_exit_event_handle };
         while (m_running)
         {
-            DWORD dwEvt = MsgWaitForMultipleObjects(3, event_handles, false, INFINITE, QS_ALLINPUT);
+            DWORD dwEvt = MsgWaitForMultipleObjects(4, event_handles, false, INFINITE, QS_ALLINPUT);
             if (!m_running)
             {
                 break;
@@ -260,12 +268,24 @@ int WINAPI wWinMain(_In_ HINSTANCE, _In_opt_ HINSTANCE, _In_ PWSTR lpCmdLine, _I
             }
             case WAIT_OBJECT_0 + 2:
             {
+                // Screenshot Event
+                bool enqueueSucceeded = controller.DispatcherQueue().TryEnqueue([&]() {
+                    ProcessCommand(CropAndLockType::Screenshot);
+                });
+                if (!enqueueSucceeded)
+                {
+                    Logger::error("Couldn't enqueue message to screenshot a window.");
+                }
+                break;
+            }
+            case WAIT_OBJECT_0 + 3:
+            {
                 // Exit Event
                 Logger::trace(L"Received an exit event.");
                 PostThreadMessage(mainThreadId, WM_QUIT, 0, 0);
                 break;
             }
-            case WAIT_OBJECT_0 + 3:
+            case WAIT_OBJECT_0 + 4:
                 if (PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE))
                 {
                     TranslateMessage(&msg);
@@ -295,6 +315,7 @@ int WINAPI wWinMain(_In_ HINSTANCE, _In_opt_ HINSTANCE, _In_ PWSTR lpCmdLine, _I
     SetEvent(m_reparent_event_handle);
     CloseHandle(m_reparent_event_handle);
     CloseHandle(m_thumbnail_event_handle);
+    CloseHandle(m_screenshot_event_handle);
     CloseHandle(m_exit_event_handle);
     m_event_triggers_thread.join();
 

--- a/src/modules/CropAndLock/CropAndLock/trace.cpp
+++ b/src/modules/CropAndLock/CropAndLock/trace.cpp
@@ -41,6 +41,15 @@ void Trace::CropAndLock::ActivateThumbnail() noexcept
         TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));
 }
 
+void Trace::CropAndLock::ActivateScreenshot() noexcept
+{
+    TraceLoggingWriteWrapper(
+        g_hProvider,
+        "CropAndLock_ActivateScreenshot",
+        ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
+        TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));
+}
+
 void Trace::CropAndLock::CreateReparentWindow() noexcept
 {
     TraceLoggingWriteWrapper(
@@ -59,8 +68,17 @@ void Trace::CropAndLock::CreateThumbnailWindow() noexcept
         TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));
 }
 
+void Trace::CropAndLock::CreateScreenshotWindow() noexcept
+{
+    TraceLoggingWriteWrapper(
+        g_hProvider,
+        "CropAndLock_CreateScreenshotWindow",
+        ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
+        TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));
+}
+
 // Event to send settings telemetry.
-void Trace::CropAndLock::SettingsTelemetry(PowertoyModuleIface::Hotkey& reparentHotkey, PowertoyModuleIface::Hotkey& thumbnailHotkey) noexcept
+void Trace::CropAndLock::SettingsTelemetry(PowertoyModuleIface::Hotkey& reparentHotkey, PowertoyModuleIface::Hotkey& thumbnailHotkey, PowertoyModuleIface::Hotkey& screenshotHotkey) noexcept
 {
     std::wstring hotKeyStrReparent =
         std::wstring(reparentHotkey.win ? L"Win + " : L"") +
@@ -76,11 +94,19 @@ void Trace::CropAndLock::SettingsTelemetry(PowertoyModuleIface::Hotkey& reparent
         std::wstring(thumbnailHotkey.alt ? L"Alt + " : L"") +
         std::wstring(L"VK ") + std::to_wstring(thumbnailHotkey.key);
 
+    std::wstring hotKeyStrScreenshot =
+        std::wstring(screenshotHotkey.win ? L"Win + " : L"") +
+        std::wstring(screenshotHotkey.ctrl ? L"Ctrl + " : L"") +
+        std::wstring(screenshotHotkey.shift ? L"Shift + " : L"") +
+        std::wstring(screenshotHotkey.alt ? L"Alt + " : L"") +
+        std::wstring(L"VK ") + std::to_wstring(screenshotHotkey.key);
+
     TraceLoggingWriteWrapper(
         g_hProvider,
         "CropAndLock_Settings",
         ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
         TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE),
         TraceLoggingWideString(hotKeyStrReparent.c_str(), "ReparentHotKey"),
-        TraceLoggingWideString(hotKeyStrThumbnail.c_str(), "ThumbnailHotkey"));
+        TraceLoggingWideString(hotKeyStrThumbnail.c_str(), "ThumbnailHotkey"),
+        TraceLoggingWideString(hotKeyStrScreenshot.c_str(), "ScreenshotHotkey"));
 }

--- a/src/modules/CropAndLock/CropAndLock/trace.h
+++ b/src/modules/CropAndLock/CropAndLock/trace.h
@@ -12,8 +12,10 @@ public:
         static void Enable(bool enabled) noexcept;
         static void ActivateReparent() noexcept;
         static void ActivateThumbnail() noexcept;
+        static void ActivateScreenshot() noexcept;
         static void CreateReparentWindow() noexcept;
         static void CreateThumbnailWindow() noexcept;
-        static void SettingsTelemetry(PowertoyModuleIface::Hotkey&, PowertoyModuleIface::Hotkey&) noexcept;
+        static void CreateScreenshotWindow() noexcept;
+        static void SettingsTelemetry(PowertoyModuleIface::Hotkey&, PowertoyModuleIface::Hotkey&, PowertoyModuleIface::Hotkey&) noexcept;
     };
 };

--- a/src/settings-ui/Settings.UI.Library/CropAndLockProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/CropAndLockProperties.cs
@@ -11,11 +11,13 @@ namespace Microsoft.PowerToys.Settings.UI.Library
     {
         public static readonly HotkeySettings DefaultReparentHotkeyValue = new HotkeySettings(true, true, false, true, 0x52); // Ctrl+Win+Shift+R
         public static readonly HotkeySettings DefaultThumbnailHotkeyValue = new HotkeySettings(true, true, false, true, 0x54); // Ctrl+Win+Shift+T
+        public static readonly HotkeySettings DefaultScreenshotHotkeyValue = new HotkeySettings(true, true, false, true, 0x53); // Ctrl+Win+Shift+S
 
         public CropAndLockProperties()
         {
             ReparentHotkey = new KeyboardKeysProperty(DefaultReparentHotkeyValue);
             ThumbnailHotkey = new KeyboardKeysProperty(DefaultThumbnailHotkeyValue);
+            ScreenshotHotkey = new KeyboardKeysProperty(DefaultScreenshotHotkeyValue);
         }
 
         [JsonPropertyName("reparent-hotkey")]
@@ -23,5 +25,8 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 
         [JsonPropertyName("thumbnail-hotkey")]
         public KeyboardKeysProperty ThumbnailHotkey { get; set; }
+
+        [JsonPropertyName("screenshot-hotkey")]
+        public KeyboardKeysProperty ScreenshotHotkey { get; set; }
     }
 }

--- a/src/settings-ui/Settings.UI/SettingsXAML/OOBE/Views/OobeCropAndLock.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/OOBE/Views/OobeCropAndLock.xaml
@@ -16,6 +16,8 @@
 
                 <controls:ShortcutWithTextLabelControl x:Name="ReparentHotkeyControl" x:Uid="Oobe_CropAndLock_HowToUse_Reparent" />
 
+                <controls:ShortcutWithTextLabelControl x:Name="ScreenshotHotkeyControl" x:Uid="Oobe_CropAndLock_HowToUse_Screenshot" />
+
                 <StackPanel Orientation="Horizontal" Spacing="8">
                     <Button x:Uid="OOBE_Settings" Click="SettingsLaunchButton_Click" />
 

--- a/src/settings-ui/Settings.UI/SettingsXAML/OOBE/Views/OobeCropAndLock.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/OOBE/Views/OobeCropAndLock.xaml.cs
@@ -37,6 +37,7 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.Views
             ViewModel.LogOpeningModuleEvent();
             ReparentHotkeyControl.Keys = SettingsRepository<CropAndLockSettings>.GetInstance(new SettingsUtils()).SettingsConfig.Properties.ReparentHotkey.Value.GetKeysList();
             ThumbnailHotkeyControl.Keys = SettingsRepository<CropAndLockSettings>.GetInstance(new SettingsUtils()).SettingsConfig.Properties.ThumbnailHotkey.Value.GetKeysList();
+            ScreenshotHotkeyControl.Keys = SettingsRepository<CropAndLockSettings>.GetInstance(new SettingsUtils()).SettingsConfig.Properties.ScreenshotHotkey.Value.GetKeysList();
         }
 
         protected override void OnNavigatedFrom(NavigationEventArgs e)

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/CropAndLockPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/CropAndLockPage.xaml
@@ -46,6 +46,12 @@
                             AllowDisable="True"
                             HotkeySettings="{x:Bind Path=ViewModel.ReparentActivationShortcut, Mode=TwoWay}" />
                     </tkcontrols:SettingsCard>
+                    <tkcontrols:SettingsCard x:Uid="CropAndLock_ScreenshotActivation_Shortcut" HeaderIcon="{ui:FontIcon Glyph=&#xEDA7;}">
+                        <controls:ShortcutControl
+                            MinWidth="{StaticResource SettingActionControlMinWidth}"
+                            AllowDisable="True"
+                            HotkeySettings="{x:Bind Path=ViewModel.ScreenshotActivationShortcut, Mode=TwoWay}" />
+                    </tkcontrols:SettingsCard>
                 </controls:SettingsGroup>
             </StackPanel>
         </controls:SettingsPageControl.ModuleContent>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -5079,4 +5079,13 @@ To record a specific window, enter the hotkey with the Alt key in the opposite m
   <data name="GeneralPage_EnableViewDiagnosticDataText.Text" xml:space="preserve">
     <value>Stores diagnostic data locally in .xml format; folder may include .etl files as well. May use up 1 GB or more of disk space.</value>
   </data>
+  <data name="Oobe_CropAndLock_HowToUse_Screenshot.Text" xml:space="preserve">
+    <value>to crop and create a temporary screenshot of another window.</value>
+  </data>
+  <data name="CropAndLock_ScreenshotActivation_Shortcut.Description" xml:space="preserve">
+    <value>Creates a cropped, not-updating copy of another window</value>
+  </data>
+  <data name="CropAndLock_ScreenshotActivation_Shortcut.Header" xml:space="preserve">
+    <value>Temporary screenshot shortcut</value>
+  </data>
 </root>

--- a/src/settings-ui/Settings.UI/ViewModels/CropAndLockViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/CropAndLockViewModel.cs
@@ -46,6 +46,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
 
             _reparentHotkey = Settings.Properties.ReparentHotkey.Value;
             _thumbnailHotkey = Settings.Properties.ThumbnailHotkey.Value;
+            _screenshotHotkey = Settings.Properties.ScreenshotHotkey.Value;
 
             // set the callback functions value to handle outgoing IPC message.
             SendConfigMSG = ipcMSGCallBackFunc;
@@ -159,6 +160,36 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             }
         }
 
+        public HotkeySettings ScreenshotActivationShortcut
+        {
+            get => _screenshotHotkey;
+            set
+            {
+                if (value != _screenshotHotkey)
+                {
+                    if (value == null)
+                    {
+                        _screenshotHotkey = CropAndLockProperties.DefaultScreenshotHotkeyValue;
+                    }
+                    else
+                    {
+                        _screenshotHotkey = value;
+                    }
+
+                    Settings.Properties.ScreenshotHotkey.Value = _screenshotHotkey;
+                    NotifyPropertyChanged();
+
+                    // Using InvariantCulture as this is an IPC message
+                    SendConfigMSG(
+                        string.Format(
+                            CultureInfo.InvariantCulture,
+                            "{{ \"powertoys\": {{ \"{0}\": {1} }} }}",
+                            CropAndLockSettings.ModuleName,
+                            JsonSerializer.Serialize(Settings, SourceGenerationContextContext.Default.CropAndLockSettings)));
+                }
+            }
+        }
+
         public void NotifyPropertyChanged([CallerMemberName] string propertyName = null)
         {
             OnPropertyChanged(propertyName);
@@ -176,5 +207,6 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         private bool _isEnabled;
         private HotkeySettings _reparentHotkey;
         private HotkeySettings _thumbnailHotkey;
+        private HotkeySettings _screenshotHotkey;
     }
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Adds a "screenshot" mode to Crop And Lock, which allows creating a window showing a freezed snapshot of the original window. 


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] **Closes:** #31799, #33071 (also requested in the already closed duplicate issues #28633, #33812, #37337, )
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass (crop-and-lock utility doesn't have any tests)
- [x] **Localization:** All end-user-facing strings can be localized
- [x] **Dev docs:** Added/updated
- [x] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [x] **Documentation updated:** https://github.com/MicrosoftDocs/windows-dev-docs/pull/5528

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
It was asked why this feature is needed at all, because it could be done with snipping tool and just AoT that window as well. While this is true, PowerToys goal always was to improve and speed up workflows. Instead of capturing the screenshot, opening it, and then apply "Crop and Lock" or "Always on Top" on the screenshots window, this PR aims to provide this functionality in a single step.

Example use cases:
- _when I want to compare between two situations like previous output result and current output result._ (#31799)
- _Allow cropping a section of a large code file (say top while working at the bottom) as reference while working elsewhere in the file._ (#33071)
- _Can be useful for the work in the same document, like excel or word where you are actively checking the data from the same document._ (#28633)
- _In lot's of older applications, if you need to get some information or data from one dialog do another, but because of dialog modality it's not possible to have both windows open at the same time._ (#33812)
- _nowadays quite a lot is happening inside the browser. Quite often, I want to keep a small portion of the current website visible and switch to e.g. the writing tool also running in a different tab in the same browser window._ (#31799)


I've used win+ctrl+shift+s as the default activation shortcut, as it's not yet used by other powertoys utilities, has similarity with the normal win+shift+s shortcut hotkey and is consistent with the other Crop and Lock shortcuts win+ctrl+shift+r (Reparent Mode) and win+ctrl+shift+t (Thumbnail Mode).

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Compatibility tested manually with a large set of applications I have installed on my computer. However, automated tests don't really make sense as there is not much business logic which could be tested.