### PR TITLE
CmdPal: experiments with the great context menu

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml
@@ -41,6 +41,8 @@
                 <Style.Setters>
                     <Setter Property="Margin" Value="0" />
                     <Setter Property="Padding" Value="0" />
+                    <Setter Property="Background" Value="Transparent" />
+                    <Setter Property="BorderBrush" Value="{ThemeResource DividerStrokeColorDefaultBrush}" />
                 </Style.Setters>
             </Style>
 
@@ -51,6 +53,9 @@
                 ShouldConstrainToRootBounds="False"
                 >
                 <cpcontrols:ContextMenu x:Name="ContextControl" />
+                <Flyout.SystemBackdrop>
+                    <DesktopAcrylicBackdrop />
+                </Flyout.SystemBackdrop>
             </Flyout>
 
             <Style x:Key="HotkeyStyle" TargetType="Border">

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml
@@ -47,7 +47,9 @@
             <Flyout
                 x:Name="ContextMenuFlyout"
                 FlyoutPresenterStyle="{StaticResource ContextMenuFlyoutStyle}"
-                Opened="ContextMenuFlyout_Opened">
+                Opened="ContextMenuFlyout_Opened"
+                ShouldConstrainToRootBounds="False"
+                >
                 <cpcontrols:ContextMenu x:Name="ContextControl" />
             </Flyout>
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml
@@ -49,7 +49,6 @@
             <Flyout
                 x:Name="ContextMenuFlyout"
                 FlyoutPresenterStyle="{StaticResource ContextMenuFlyoutStyle}"
-                Opened="ContextMenuFlyout_Opened"
                 ShouldConstrainToRootBounds="False"
                 >
                 <cpcontrols:ContextMenu x:Name="ContextControl" />

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml.cs
@@ -144,11 +144,4 @@ public sealed partial class CommandBar : UserControl,
     {
         WeakReferenceMessenger.Default.Send<OpenContextMenuMessage>(new OpenContextMenuMessage(null, null, null, ContextMenuFilterLocation.Bottom));
     }
-
-    private void ContextMenuFlyout_Opened(object sender, object e)
-    {
-        // We need to wait until our flyout is opened to try and toss focus
-        // at its search box. The control isn't in the UI tree before that
-        ContextControl.FocusSearchBox();
-    }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContextMenu.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContextMenu.xaml
@@ -112,7 +112,7 @@
                 <Rectangle
                     Height="1"
                     Margin="-16,-12,-12,-12"
-                    Fill="{ThemeResource MenuFlyoutSeparatorThemeBrush}" />
+                    Fill="{ThemeResource MenuFlyoutSeparatorBackground}" />
             </DataTemplate>
         </ResourceDictionary>
     </UserControl.Resources>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContextMenu.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContextMenu.xaml.cs
@@ -2,13 +2,19 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Globalization;
+using System.Runtime.InteropServices;
+using System.Text;
+
 using CommunityToolkit.Mvvm.Messaging;
+
 using Microsoft.CmdPal.Core.ViewModels;
 using Microsoft.CmdPal.Core.ViewModels.Messages;
 using Microsoft.UI.Input;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
+
 using Windows.System;
 using Windows.UI.Core;
 
@@ -34,6 +40,8 @@ public sealed partial class ContextMenu : UserControl,
         {
             ViewModel.PropertyChanged += ViewModel_PropertyChanged;
         }
+
+        this.PreviewKeyDown += UserControl_KeyDown_Enhanced;
     }
 
     public void Receive(OpenContextMenuMessage message)
@@ -276,14 +284,225 @@ public sealed partial class ContextMenu : UserControl,
         CommandsDropdown.SelectedIndex = 0;
     }
 
+    private ContextKeybindingResult InvokeCommand(CommandItemViewModel command) => ViewModel.InvokeCommand(command);
+
     /// <summary>
-    /// Manually focuses our search box. This needs to be called after we're actually
-    /// In the UI tree - if we're in a Flyout, that's not until Opened()
+    /// Converts a VirtualKey to its corresponding character string,
+    /// taking into account current keyboard state (Shift, Caps Lock, etc.)
     /// </summary>
-    internal void FocusSearchBox()
+    private static string? GetCharacterFromVirtualKey(VirtualKey key)
     {
-        ContextFilterBox.Focus(FocusState.Programmatic);
+        // Get current keyboard state
+        var keyboardState = new byte[256];
+        if (!GetKeyboardState(keyboardState))
+        {
+            return null;
+        }
+
+        // Convert VirtualKey to Windows virtual key code
+        var virtualKeyCode = (uint)key;
+
+        // Get scan code
+        var scanCode = MapVirtualKey(virtualKeyCode, 0);
+
+        // Convert to Unicode characters
+        var buffer = new StringBuilder(5);
+        var result = ToUnicode(
+            virtualKeyCode,
+            scanCode,
+            keyboardState,
+            buffer,
+            buffer.Capacity,
+            0);
+
+        if (result > 0)
+        {
+            var character = buffer.ToString();
+
+            // Filter out control characters and ensure it's printable
+            if (IsPrintableCharacter(character))
+            {
+                return character;
+            }
+        }
+
+        return null;
     }
 
-    private ContextKeybindingResult InvokeCommand(CommandItemViewModel command) => ViewModel.InvokeCommand(command);
+    /// <summary>
+    /// Alternative method using InputKeyboardSource for getting modifier states
+    /// </summary>
+    private static string? GetCharacterFromVirtualKeyAlternative(VirtualKey key)
+    {
+        // Get modifier states
+        var shiftState = Microsoft.UI.Input.InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Shift);
+        var ctrlState = Microsoft.UI.Input.InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Control);
+        var altState = Microsoft.UI.Input.InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.Menu);
+        var capsLockState = Microsoft.UI.Input.InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.CapitalLock);
+
+        var isShiftPressed = shiftState.HasFlag(CoreVirtualKeyStates.Down);
+        var isCtrlPressed = ctrlState.HasFlag(CoreVirtualKeyStates.Down);
+        var isAltPressed = altState.HasFlag(CoreVirtualKeyStates.Down);
+        var isCapsLockOn = capsLockState.HasFlag(CoreVirtualKeyStates.Locked);
+
+        // Don't handle if Ctrl is pressed (could be shortcuts)
+        if (isCtrlPressed)
+        {
+            return null;
+        }
+
+        return ConvertVirtualKeyToChar(key, isShiftPressed, isCapsLockOn, isAltPressed);
+    }
+
+    /// <summary>
+    /// Manual conversion for common keys (fallback method)
+    /// </summary>
+    private static string? ConvertVirtualKeyToChar(VirtualKey key, bool isShiftPressed, bool isCapsLockOn, bool isAltPressed)
+    {
+        // Letters
+        if (key >= VirtualKey.A && key <= VirtualKey.Z)
+        {
+            var baseChar = (char)('a' + (key - VirtualKey.A));
+            var shouldBeUppercase = isShiftPressed ^ isCapsLockOn; // XOR for proper caps lock behavior
+            return shouldBeUppercase ? char.ToUpper(baseChar, CultureInfo.CurrentUICulture).ToString() : baseChar.ToString();
+        }
+
+        // Numbers and their shifted symbols
+        if (key >= VirtualKey.Number0 && key <= VirtualKey.Number9)
+        {
+            if (isShiftPressed)
+            {
+                return key switch
+                {
+                    VirtualKey.Number1 => "!",
+                    VirtualKey.Number2 => "@",
+                    VirtualKey.Number3 => "#",
+                    VirtualKey.Number4 => "$",
+                    VirtualKey.Number5 => "%",
+                    VirtualKey.Number6 => "^",
+                    VirtualKey.Number7 => "&",
+                    VirtualKey.Number8 => "*",
+                    VirtualKey.Number9 => "(",
+                    VirtualKey.Number0 => ")",
+                    _ => null,
+                };
+            }
+            else
+            {
+                return ((char)('0' + (key - VirtualKey.Number0))).ToString();
+            }
+        }
+
+        // Numpad numbers
+        if (key >= VirtualKey.NumberPad0 && key <= VirtualKey.NumberPad9)
+        {
+            return ((char)('0' + (key - VirtualKey.NumberPad0))).ToString();
+        }
+
+        // Special keys
+        return key switch
+        {
+            VirtualKey.Space => " ",
+            VirtualKey.Tab => "\t",
+
+            // Numpad operators
+            VirtualKey.Add => "+",
+            VirtualKey.Subtract => "-",
+            VirtualKey.Multiply => "*",
+            VirtualKey.Divide => "/",
+            VirtualKey.Decimal => ".",
+
+            _ => null,
+        };
+    }
+
+    /// <summary>
+    /// Checks if a character is printable (not a control character)
+    /// </summary>
+    private static bool IsPrintableCharacter(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return false;
+        }
+
+        foreach (var c in text)
+        {
+            // Check if character is printable
+            // Control characters are in ranges 0x00-0x1F and 0x7F-0x9F
+            if (char.IsControl(c))
+            {
+                return false;
+            }
+
+            // Additional check for common non-printable Unicode categories
+            var category = char.GetUnicodeCategory(c);
+            if (category == System.Globalization.UnicodeCategory.Control ||
+                category == System.Globalization.UnicodeCategory.Format ||
+                category == System.Globalization.UnicodeCategory.Surrogate ||
+                category == System.Globalization.UnicodeCategory.PrivateUse ||
+                category == System.Globalization.UnicodeCategory.OtherNotAssigned)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Enhanced version that also handles special navigation keys
+    /// </summary>
+    private void UserControl_KeyDown_Enhanced(object sender, KeyRoutedEventArgs e)
+    {
+        if (ContextFilterBox.FocusState != FocusState.Unfocused)
+        {
+            return;
+        }
+
+        var character = GetCharacterFromVirtualKey(e.Key);
+        if (string.IsNullOrEmpty(character))
+        {
+            character = GetCharacterFromVirtualKeyAlternative(e.Key);
+        }
+
+        if (string.IsNullOrEmpty(character))
+        {
+            return;
+        }
+
+        ContextFilterBox.Focus(FocusState.Keyboard);
+
+        // Insert character at current position
+        var selectionStart = ContextFilterBox.SelectionStart;
+        var selectionLength = ContextFilterBox.SelectionLength;
+        var currentText = ContextFilterBox.Text ?? string.Empty;
+
+        // Replace selection or insert at cursor
+        if (selectionLength > 0)
+        {
+            currentText = currentText.Remove(selectionStart, selectionLength);
+        }
+
+        ContextFilterBox.Text = currentText.Insert(selectionStart, character);
+        ContextFilterBox.SelectionStart = selectionStart + character.Length;
+        ContextFilterBox.SelectionLength = 0;
+
+        e.Handled = true;
+    }
+
+    [DllImport("user32.dll")]
+    private static extern bool GetKeyboardState(byte[] lpKeyState);
+
+    [DllImport("user32.dll")]
+    private static extern uint MapVirtualKey(uint uCode, uint uMapType);
+
+    [DllImport("user32.dll")]
+    private static extern int ToUnicode(
+        uint wVirtKey,
+        uint wScanCode,
+        byte[] lpKeyState,
+        [Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pwszBuff,
+        int cchBuff,
+        uint wFlags);
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml.cs
@@ -318,7 +318,7 @@ public sealed partial class ListPage : Page,
                                 element,
                                 Microsoft.UI.Xaml.Controls.Primitives.FlyoutPlacementMode.BottomEdgeAlignedLeft,
                                 pos,
-                                ContextMenuFilterLocation.Top));
+                                ContextMenuFilterLocation.Bottom));
                     });
         }
     }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml.cs
@@ -14,6 +14,7 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Navigation;
+using Windows.Foundation;
 
 namespace Microsoft.CmdPal.UI;
 
@@ -309,6 +310,7 @@ public sealed partial class ListPage : Page,
             ViewModel?.UpdateSelectedItemCommand.Execute(item);
 
             var pos = e.GetPosition(element);
+            pos = new Point(pos.X + 5, pos.Y );
 
             _ = DispatcherQueue.TryEnqueue(
                 () =>


### PR DESCRIPTION
## Summary of the Pull Request

This is **not** expected to be a production-worthy branch—consider it more of a dumping ground for sharing ideas.

- [x] ~Always place the context menu in its natural position when invoked by mouse 🐭~ 
    - Superseded by #41133
    - Make the position predictable
- [x] Mouse cursor changes to a resize arrow after opening the context menu 🐭  
    - Figure out the root cause / find a better workaround / report or fix in WinUI
- [ ] Prominent search box  
    - The area feels cramped and too busy; it draws too much attention
    - Remove explicit focus, but focus the box if the user starts typing with the menu open
    - Drop the accent bottom line (like the Start menu search)
- [ ] Fluent menu items don't have pills (only list items do)
- [ ] If ListView in context menu has focus, cyclic navigation won't work
- [x] ~Match CmdPal aesthetics~    
    - [x] ~Backdrop (acrylic)~
      - Superseded by #41136
    - [x] ~WinUI × System × CmdPal popup style~
    - [x] menu item separators draw too much attention; should be more subtle, the negative space / absence of content should provide the separation
        - Move to #41130 
        - (solved) night is day, dead are walking amongst the living and **_background is foreground_** 
      <img width="389" height="174" alt="image" src="https://github.com/user-attachments/assets/e0e8bbc8-be21-4d64-a92c-839bd0f7eea3" />

- [ ] Contextual context menu  
    - IMO, the More Actions menu (in the command bar) and the context menu (invoked via contextual action, e.g., (🐭⌨️) should behave a bit differently
    - The contextual menu (🐭⌨️) should always be available, even if there’s only a primary or secondary command (blame [Mr. Fitss](https://en.wikipedia.org/wiki/Fitts%27s_law))


https://github.com/user-attachments/assets/c79b5a46-f220-4d5b-8d1a-db3653384807

Updated separator brush:

<img width="894" height="579" alt="image" src="https://github.com/user-attachments/assets/f0f51a3b-3ba9-4286-a8cc-e066630459dd" />


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

