### PR TITLE
[WiX 5] Update WiX 5 signing logic and fix copy file paths

### DIFF
--- a/.pipelines/v2/templates/job-build-project.yml
+++ b/.pipelines/v2/templates/job-build-project.yml
@@ -461,20 +461,20 @@ jobs:
       Copy-Item -Verbose -Force "$(CmdPalPackagePath)" "$(JobOutputDirectory)"
     displayName: Stage the final CmdPal package
 
-  - template: steps-build-installer.yml
-    parameters:
-      codeSign: ${{ parameters.codeSign }}
-      signingIdentity: ${{ parameters.signingIdentity }}
-      versionNumber: ${{ parameters.versionNumber }}
-      additionalBuildOptions: ${{ parameters.additionalBuildOptions }}
+  # - template: steps-build-installer.yml
+  #   parameters:
+  #     codeSign: ${{ parameters.codeSign }}
+  #     signingIdentity: ${{ parameters.signingIdentity }}
+  #     versionNumber: ${{ parameters.versionNumber }}
+  #     additionalBuildOptions: ${{ parameters.additionalBuildOptions }}
 
-  - template: steps-build-installer.yml
-    parameters:
-      codeSign: ${{ parameters.codeSign }}
-      signingIdentity: ${{ parameters.signingIdentity }}
-      versionNumber: ${{ parameters.versionNumber }}
-      additionalBuildOptions: ${{ parameters.additionalBuildOptions }}
-      buildUserInstaller: true # NOTE: This is the distinction between the above and below rules
+  # - template: steps-build-installer.yml
+  #   parameters:
+  #     codeSign: ${{ parameters.codeSign }}
+  #     signingIdentity: ${{ parameters.signingIdentity }}
+  #     versionNumber: ${{ parameters.versionNumber }}
+  #     additionalBuildOptions: ${{ parameters.additionalBuildOptions }}
+  #     buildUserInstaller: true # NOTE: This is the distinction between the above and below rules
 
   - template: steps-build-installer-vnext.yml
     parameters:

--- a/.pipelines/v2/templates/job-build-project.yml
+++ b/.pipelines/v2/templates/job-build-project.yml
@@ -514,9 +514,11 @@ jobs:
       targetFolder: $(JobOutputDirectory)
 
   - task: CopyFiles@2
-    displayName: Stage Installers
+    displayName: Stage VNext Installers
     inputs:
-      contents: "**/PowerToys*SetupVNext-*.exe"
+      contents: |-
+        installer/PowerToysSetupVNext/**/PowerToys*SetupVNext-*.exe
+        !installer/PowerToysSetupVNext/obj/**
       flattenFolders: True
       targetFolder: $(JobOutputDirectory)
 

--- a/.pipelines/v2/templates/job-build-project.yml
+++ b/.pipelines/v2/templates/job-build-project.yml
@@ -461,20 +461,20 @@ jobs:
       Copy-Item -Verbose -Force "$(CmdPalPackagePath)" "$(JobOutputDirectory)"
     displayName: Stage the final CmdPal package
 
-  # - template: steps-build-installer.yml
-  #   parameters:
-  #     codeSign: ${{ parameters.codeSign }}
-  #     signingIdentity: ${{ parameters.signingIdentity }}
-  #     versionNumber: ${{ parameters.versionNumber }}
-  #     additionalBuildOptions: ${{ parameters.additionalBuildOptions }}
+  - template: steps-build-installer.yml
+    parameters:
+      codeSign: ${{ parameters.codeSign }}
+      signingIdentity: ${{ parameters.signingIdentity }}
+      versionNumber: ${{ parameters.versionNumber }}
+      additionalBuildOptions: ${{ parameters.additionalBuildOptions }}
 
-  # - template: steps-build-installer.yml
-  #   parameters:
-  #     codeSign: ${{ parameters.codeSign }}
-  #     signingIdentity: ${{ parameters.signingIdentity }}
-  #     versionNumber: ${{ parameters.versionNumber }}
-  #     additionalBuildOptions: ${{ parameters.additionalBuildOptions }}
-  #     buildUserInstaller: true # NOTE: This is the distinction between the above and below rules
+  - template: steps-build-installer.yml
+    parameters:
+      codeSign: ${{ parameters.codeSign }}
+      signingIdentity: ${{ parameters.signingIdentity }}
+      versionNumber: ${{ parameters.versionNumber }}
+      additionalBuildOptions: ${{ parameters.additionalBuildOptions }}
+      buildUserInstaller: true # NOTE: This is the distinction between the above and below rules
 
   - template: steps-build-installer-vnext.yml
     parameters:

--- a/.pipelines/v2/templates/steps-build-installer-vnext.yml
+++ b/.pipelines/v2/templates/steps-build-installer-vnext.yml
@@ -16,6 +16,14 @@ parameters:
     default: ''
 
 steps:
+  # Install WiX 5.x tools needed for VNext installer
+  - task: DotNetCoreCLI@2
+    displayName: Install WiX 5.x tools
+    inputs:
+      command: 'custom'
+      custom: 'tool'
+      arguments: 'install --global wix'
+
   - pwsh: |-
       & git clean -xfd -e *exe -- .\installer\
     displayName: ${{replace(replace(parameters.buildUserInstaller,'True','👤'),'False','💻')}} Clean installer to reduce cross-contamination
@@ -83,7 +91,7 @@ steps:
       maximumCpuCount: true
 
   - script: |-
-      dotnet tool run wix msi decompile installer\PowerToysSetupVNext\$(InstallerRelativePath)\$(InstallerBasename).msi -x $(build.sourcesdirectory)\extractedMsi
+      wix msi decompile installer\PowerToysSetupVNext\$(InstallerRelativePath)\$(InstallerBasename).msi -x $(build.sourcesdirectory)\extractedMsi
       dir $(build.sourcesdirectory)\extractedMsi
     displayName: "${{replace(replace(parameters.buildUserInstaller,'True','👤'),'False','💻')}} WiX5: Extract and verify MSI"
 
@@ -133,7 +141,7 @@ steps:
   # The entirety of bundle unpacking/re-packing is unnecessary if we are not code signing it.
   - ${{ if eq(parameters.codeSign, true) }}:
     - script: |-
-        dotnet tool run wix burn detach installer\PowerToysSetupVNext\$(InstallerRelativePath)\$(InstallerBasename).exe -engine installer\engine.exe
+        wix burn detach installer\PowerToysSetupVNext\$(InstallerRelativePath)\$(InstallerBasename).exe -engine installer\engine.exe
       displayName: "${{replace(replace(parameters.buildUserInstaller,'True','👤'),'False','💻')}} WiX5: Extract Engine from Bundle"
 
     - template: steps-esrp-signing.yml
@@ -169,7 +177,7 @@ steps:
             ]
 
     - script: |-
-        dotnet tool run wix burn attach installer\PowerToysSetupVNext\$(InstallerRelativePath)\$(InstallerBasename).exe -engine installer\engine.exe -o installer\PowerToysSetupVNext\$(InstallerRelativePath)\$(InstallerBasename).exe
+        wix burn attach installer\PowerToysSetupVNext\$(InstallerRelativePath)\$(InstallerBasename).exe -engine installer\engine.exe -o installer\PowerToysSetupVNext\$(InstallerRelativePath)\$(InstallerBasename).exe
       displayName: "${{replace(replace(parameters.buildUserInstaller,'True','👤'),'False','💻')}} WiX5: Merge Engine into Bundle"
 
     - template: steps-esrp-signing.yml

--- a/.pipelines/v2/templates/steps-build-installer-vnext.yml
+++ b/.pipelines/v2/templates/steps-build-installer-vnext.yml
@@ -16,13 +16,13 @@ parameters:
     default: ''
 
 steps:
-  # Install WiX 5.x tools needed for VNext installer
+  # Install WiX 5.0.2 tools needed for VNext installer (matching project SDK)
   - task: DotNetCoreCLI@2
-    displayName: Install WiX 5.x tools
+    displayName: Install WiX 5.0.2 tools
     inputs:
       command: 'custom'
       custom: 'tool'
-      arguments: 'install --global wix'
+      arguments: 'install --global wix --version 5.0.2'
 
   - pwsh: |-
       & git clean -xfd -e *exe -- .\installer\

--- a/.pipelines/v2/templates/steps-build-installer-vnext.yml
+++ b/.pipelines/v2/templates/steps-build-installer-vnext.yml
@@ -189,23 +189,6 @@ steps:
           signType: batchSigning
           batchSignPolicyFile: '$(build.sourcesdirectory)\.pipelines\ESRPSigning_installer.json'
           ciPolicyFile: '$(build.sourcesdirectory)\.pipelines\CIPolicy.xml'
-          
-    # Verify that the final bootstrapper is signed
-    - pwsh: |-
-        $installerPath = "installer\PowerToysSetupVNext\$(InstallerRelativePath)\$(InstallerBasename).exe"
-        Write-Host "Checking signature of: $installerPath"
-        if (Test-Path $installerPath) {
-          $signature = Get-AuthenticodeSignature $installerPath
-          Write-Host "Signature Status: $($signature.Status)"
-          Write-Host "Signature Certificate Subject: $($signature.SignerCertificate.Subject)"
-          if ($signature.Status -ne "Valid") {
-            Write-Warning "Final bootstrapper is not properly signed!"
-          } else {
-            Write-Host "Final bootstrapper is properly signed."
-          }
-        } else {
-          Write-Error "Installer file not found at: $installerPath"
-        }
-      displayName: ${{replace(replace(parameters.buildUserInstaller,'True','👤'),'False','💻')}} Verify Final Bootstrapper Signature
+
   #### END BOOTSTRAP
   ## END INSTALLER

--- a/.pipelines/v2/templates/steps-build-installer-vnext.yml
+++ b/.pipelines/v2/templates/steps-build-installer-vnext.yml
@@ -83,9 +83,9 @@ steps:
       maximumCpuCount: true
 
   - script: |-
-      "C:\Program Files (x86)\WiX Toolset v3.14\bin\dark.exe" -x $(build.sourcesdirectory)\extractedMsi installer\PowerToysSetupVNext\$(InstallerRelativePath)\$(InstallerBasename).msi
+      dotnet tool run wix msi decompile installer\PowerToysSetupVNext\$(InstallerRelativePath)\$(InstallerBasename).msi -x $(build.sourcesdirectory)\extractedMsi
       dir $(build.sourcesdirectory)\extractedMsi
-    displayName: "${{replace(replace(parameters.buildUserInstaller,'True','👤'),'False','💻')}} Extract and verify MSI"
+    displayName: "${{replace(replace(parameters.buildUserInstaller,'True','👤'),'False','💻')}} WiX5: Extract and verify MSI"
 
   # Check if deps.json files don't reference different dll versions.
   - pwsh: |-
@@ -133,8 +133,8 @@ steps:
   # The entirety of bundle unpacking/re-packing is unnecessary if we are not code signing it.
   - ${{ if eq(parameters.codeSign, true) }}:
     - script: |-
-        "C:\Program Files (x86)\WiX Toolset v3.14\bin\insignia.exe" -ib installer\PowerToysSetupVNext\$(InstallerRelativePath)\$(InstallerBasename).exe -o installer\engine.exe
-      displayName: "${{replace(replace(parameters.buildUserInstaller,'True','👤'),'False','💻')}} Insignia: Extract Engine from Bundle"
+        dotnet tool run wix burn detach installer\PowerToysSetupVNext\$(InstallerRelativePath)\$(InstallerBasename).exe -engine installer\engine.exe
+      displayName: "${{replace(replace(parameters.buildUserInstaller,'True','👤'),'False','💻')}} WiX5: Extract Engine from Bundle"
 
     - template: steps-esrp-signing.yml
       parameters:
@@ -169,8 +169,8 @@ steps:
             ]
 
     - script: |-
-        "C:\Program Files (x86)\WiX Toolset v3.14\bin\insignia.exe" -ab installer\engine.exe installer\PowerToysSetupVNext\$(InstallerRelativePath)\$(InstallerBasename).exe -o installer\PowerToysSetupVNext\$(InstallerRelativePath)\$(InstallerBasename).exe
-      displayName: "${{replace(replace(parameters.buildUserInstaller,'True','👤'),'False','💻')}} Insignia: Merge Engine into Bundle"
+        dotnet tool run wix burn attach installer\PowerToysSetupVNext\$(InstallerRelativePath)\$(InstallerBasename).exe -engine installer\engine.exe -o installer\PowerToysSetupVNext\$(InstallerRelativePath)\$(InstallerBasename).exe
+      displayName: "${{replace(replace(parameters.buildUserInstaller,'True','👤'),'False','💻')}} WiX5: Merge Engine into Bundle"
 
     - template: steps-esrp-signing.yml
       parameters:
@@ -181,5 +181,23 @@ steps:
           signType: batchSigning
           batchSignPolicyFile: '$(build.sourcesdirectory)\.pipelines\ESRPSigning_installer.json'
           ciPolicyFile: '$(build.sourcesdirectory)\.pipelines\CIPolicy.xml'
+          
+    # Verify that the final bootstrapper is signed
+    - pwsh: |-
+        $installerPath = "installer\PowerToysSetupVNext\$(InstallerRelativePath)\$(InstallerBasename).exe"
+        Write-Host "Checking signature of: $installerPath"
+        if (Test-Path $installerPath) {
+          $signature = Get-AuthenticodeSignature $installerPath
+          Write-Host "Signature Status: $($signature.Status)"
+          Write-Host "Signature Certificate Subject: $($signature.SignerCertificate.Subject)"
+          if ($signature.Status -ne "Valid") {
+            Write-Warning "Final bootstrapper is not properly signed!"
+          } else {
+            Write-Host "Final bootstrapper is properly signed."
+          }
+        } else {
+          Write-Error "Installer file not found at: $installerPath"
+        }
+      displayName: ${{replace(replace(parameters.buildUserInstaller,'True','👤'),'False','💻')}} Verify Final Bootstrapper Signature
   #### END BOOTSTRAP
   ## END INSTALLER

--- a/.pipelines/v2/templates/steps-build-installer-vnext.yml
+++ b/.pipelines/v2/templates/steps-build-installer-vnext.yml
@@ -177,8 +177,8 @@ steps:
             ]
 
     - script: |-
-        wix burn attach installer\PowerToysSetupVNext\$(InstallerRelativePath)\$(InstallerBasename).exe -engine installer\engine.exe -o installer\PowerToysSetupVNext\$(InstallerRelativePath)\$(InstallerBasename).exe
-      displayName: "${{replace(replace(parameters.buildUserInstaller,'True','👤'),'False','💻')}} WiX5: Merge Engine into Bundle"
+        wix burn reattach installer\PowerToysSetupVNext\$(InstallerRelativePath)\$(InstallerBasename).exe -engine installer\engine.exe -o installer\PowerToysSetupVNext\$(InstallerRelativePath)\$(InstallerBasename).exe
+      displayName: "${{replace(replace(parameters.buildUserInstaller,'True','👤'),'False','💻')}} WiX5: Reattach Engine to Bundle"
 
     - template: steps-esrp-signing.yml
       parameters:


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
1. Switched to new WiX CLI for signing
<img width="592" height="256" alt="image" src="https://github.com/user-attachments/assets/984942aa-4e88-4767-8491-0726cf435819" />

2. Fixed incorrect copy path for installer
<img width="1905" height="227" alt="image" src="https://github.com/user-attachments/assets/76fc42e1-11d0-4587-860c-7ab51df22a37" />


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

