### PR TITLE
CmdPal: Sync access to TopLevelCommandManager from UpdateCommandsForProvider

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.Common/Helpers/SupersedingAsyncGate.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Common/Helpers/SupersedingAsyncGate.cs
@@ -1,0 +1,139 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.CmdPal.Common.Helpers;
+
+/// <summary>
+/// An async gate that ensures only one operation runs at a time.
+/// If ExecuteAsync is called while already executing, it cancels the current execution
+/// and starts the operation again (superseding behavior).
+/// </summary>
+public class SupersedingAsyncGate : IDisposable
+{
+    private readonly Func<CancellationToken, Task> _action;
+    private readonly Lock _lock = new();
+    private int _callId;
+    private TaskCompletionSource<bool>? _currentTcs;
+    private CancellationTokenSource? _currentCancellationSource;
+    private Task? _executingTask;
+
+    public SupersedingAsyncGate(Func<CancellationToken, Task> action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        _action = action;
+    }
+
+    /// <summary>
+    /// Executes the configured action. If another execution is running, this call will
+    /// cancel the current execution and restart the operation.
+    /// </summary>
+    /// <param name="cancellationToken">Optional external cancellation token</param>
+    public async Task ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        TaskCompletionSource<bool> tcs;
+
+        lock (_lock)
+        {
+            _currentCancellationSource?.Cancel();
+            _currentTcs?.TrySetException(new OperationCanceledException("Superseded by newer call"));
+
+            tcs = new();
+            _currentTcs = tcs;
+            _callId++;
+
+            var shouldStartExecution = _executingTask is null;
+            if (shouldStartExecution)
+            {
+                _executingTask = Task.Run(ExecuteLoop, CancellationToken.None);
+            }
+        }
+
+        await using var ctr = cancellationToken.Register(() => tcs.TrySetCanceled(cancellationToken));
+        await tcs.Task;
+    }
+
+    private async Task ExecuteLoop()
+    {
+        try
+        {
+            while (true)
+            {
+                TaskCompletionSource<bool>? currentTcs;
+                CancellationTokenSource? currentCts;
+                int currentCallId;
+
+                lock (_lock)
+                {
+                    currentTcs = _currentTcs;
+                    currentCallId = _callId;
+
+                    if (currentTcs is null)
+                    {
+                        break;
+                    }
+
+                    _currentCancellationSource?.Dispose();
+                    _currentCancellationSource = new();
+                    currentCts = _currentCancellationSource;
+                }
+
+                try
+                {
+                    await _action(currentCts.Token);
+                    CompleteIfCurrent(currentTcs, currentCallId, static t => t.TrySetResult(true));
+                }
+                catch (OperationCanceledException)
+                {
+                    CompleteIfCurrent(currentTcs, currentCallId, tcs => tcs.SetCanceled(currentCts.Token));
+                }
+                catch (Exception ex)
+                {
+                    CompleteIfCurrent(currentTcs, currentCallId, tcs => tcs.TrySetException(ex));
+                }
+            }
+        }
+        finally
+        {
+            lock (_lock)
+            {
+                _currentTcs = null;
+                _currentCancellationSource?.Dispose();
+                _currentCancellationSource = null;
+                _executingTask = null;
+            }
+        }
+    }
+
+    private void CompleteIfCurrent(
+        TaskCompletionSource<bool> candidate,
+        int id,
+        Action<TaskCompletionSource<bool>> complete)
+    {
+        lock (_lock)
+        {
+            if (_currentTcs == candidate && _callId == id)
+            {
+                complete(candidate);
+                _currentTcs = null;
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (_lock)
+        {
+            _currentCancellationSource?.Cancel();
+            _currentCancellationSource?.Dispose();
+            _currentTcs?.TrySetException(new ObjectDisposedException(nameof(SupersedingAsyncGate)));
+            _currentTcs = null;
+        }
+
+        GC.SuppressFinalize(this);
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandManager.cs
@@ -207,7 +207,10 @@ public partial class TopLevelCommandManager : ObservableObject,
         clone.InsertRange(startIndex, newItems);
 
         // now update the actual observable list with the new contents
-        ListHelpers.InPlaceUpdateList(TopLevelCommands, clone);
+        lock (TopLevelCommands)
+        {
+            ListHelpers.InPlaceUpdateList(TopLevelCommands, clone);
+        }
     }
 
     public async Task ReloadAllCommandsAsync()

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandManager.cs
@@ -157,7 +157,7 @@ public partial class TopLevelCommandManager : ObservableObject,
         }
 
         // modify the TopLevelCommands under shared lock; event if we clone it, we don't want
-        // TopLevelCommands to get modified while we're working on it. Otherwise , we might
+        // TopLevelCommands to get modified while we're working on it. Otherwise, we might
         // out clone would be stale at the end of this method.
         lock (TopLevelCommands)
         {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelViewModel.cs
@@ -47,6 +47,8 @@ public sealed partial class TopLevelViewModel : ObservableObject, IListItem
 
     public CommandItemViewModel ItemViewModel => _commandItemViewModel;
 
+    public string CommandProviderId => _commandProviderId;
+
     ////// ICommandItem
     public string Title => _commandItemViewModel.Title;
 
@@ -346,5 +348,10 @@ public sealed partial class TopLevelViewModel : ObservableObject, IListItem
     public PerformCommandMessage GetPerformCommandMessage()
     {
         return new PerformCommandMessage(this.CommandViewModel.Model, new Core.ViewModels.Models.ExtensionObject<IListItem>(this));
+    }
+
+    public override string ToString()
+    {
+        return $"{nameof(TopLevelViewModel)}: {Id} ({Title}) - display: {DisplayTitle} - fallback: {IsFallback} - enabled: {IsEnabled}";
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request

Fixes unsynchronized access to `LoadTopLevelCommands` in `TopLevelCommandManager.UpdateCommandsForProvider`, which previously led to `InvalidOperationException: Collection was modified`.

Addressing this also uncovered another issue: overlapping invocations of `ReloadAllCommandsAsync` were causing duplication of items in the main list -- so I'm fixing that as well.

## PR Checklist

- [x] Closes
    - Fixes #38194 
    - Partially solves #40776
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:**
- [x] **Localization:** none
- [x] **Dev docs:** none
- [x] **New binaries:** nope
- [x] **Documentation updated:** no need

## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed
Tested with bookmarks.
