### PR TITLE
Script: Fix a syntax error

### DIFF
--- a/tools/build/build-installer.ps1
+++ b/tools/build/build-installer.ps1
@@ -81,7 +81,7 @@ function RunMSBuild {
 
     $base = @(
         $Solution
-        "/p:Platform=`"$Platform`""
+        "/p:Platform=$Platform"
         "/p:Configuration=$Configuration"
         "/p:CIBuild=true"
         '/verbosity:normal'


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] **Closes:** #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

## AI Summary
This pull request includes a minor change to the `tools/build/build-installer.ps1` script. The change removes unnecessary escaping of double quotes around the `$Platform` variable in the MSBuild command.

* [`tools/build/build-installer.ps1`](diffhunk://#diff-21888769485d767c43c0895fe315e6f6d7384da62f60ef917d8a61a610da10b9L84-R84): Simplified the MSBuild command by removing escaped double quotes around `$Platform` to improve readability and maintain consistency.