### PR TITLE
CmdPal: Filtering out pinned apps on search

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
@@ -164,6 +164,12 @@ public partial class MainListPage : DynamicListPage,
                 if (_includeApps)
                 {
                     IEnumerable<IListItem> apps = AllAppsCommandProvider.Page.GetItems();
+
+                    // Remove any top level pinned apps and use the apps from AllAppsCommandProvider.Page.GetItems()
+                    _filteredItems = _filteredItems.Where(item =>
+                                                        item is not TopLevelViewModel topLevelViewModel ||
+                                                        !apps.Any(app => app.Command.Id == topLevelViewModel.Id));
+
                     _filteredItems = _filteredItems.Concat(apps);
                 }
             }


### PR DESCRIPTION
Closes #40781 

Filters out TopLevelCommands whose Id matches an app coming from the `AllAppsCommandProvider.Page.GetItems()`.

Hate adding processing there, but without adding some type of `bool HideMeOnSearch` to something low enough (like ICommandItem), I don't see another way to distinguish these.