### PR TITLE
Change filter box placeholder for main list page only

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
@@ -32,6 +32,7 @@ public partial class MainListPage : DynamicListPage,
     public MainListPage(IServiceProvider serviceProvider)
     {
         Icon = IconHelpers.FromRelativePath("Assets\\StoreLogo.scale-200.png");
+        PlaceholderText = "Type here to search commands...";
         _serviceProvider = serviceProvider;
 
         _tlcManager = _serviceProvider.GetService<TopLevelCommandManager>()!;

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
@@ -32,7 +32,7 @@ public partial class MainListPage : DynamicListPage,
     public MainListPage(IServiceProvider serviceProvider)
     {
         Icon = IconHelpers.FromRelativePath("Assets\\StoreLogo.scale-200.png");
-        PlaceholderText = "Type here to search commands...";
+        PlaceholderText = Properties.Resources.builtin_main_list_page_searchbar_placeholder;
         _serviceProvider = serviceProvider;
 
         _tlcManager = _serviceProvider.GetService<TopLevelCommandManager>()!;

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Properties/Resources.Designer.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Properties/Resources.Designer.cs
@@ -322,7 +322,7 @@ namespace Microsoft.CmdPal.UI.ViewModels.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Type here to search commands....
+        ///   Looks up a localized string similar to Search for apps, files and commands....
         /// </summary>
         public static string builtin_main_list_page_searchbar_placeholder {
             get {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Properties/Resources.Designer.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Properties/Resources.Designer.cs
@@ -322,6 +322,15 @@ namespace Microsoft.CmdPal.UI.ViewModels.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Type here to search commands....
+        /// </summary>
+        public static string builtin_main_list_page_searchbar_placeholder {
+            get {
+                return ResourceManager.GetString("builtin_main_list_page_searchbar_placeholder", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Creates a project for a new Command Palette extension.
         /// </summary>
         public static string builtin_new_extension_subtitle {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Properties/Resources.resx
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Properties/Resources.resx
@@ -227,4 +227,7 @@
   <data name="builtin_disabled_extension" xml:space="preserve">
     <value>Disabled</value>
   </data>
+  <data name="builtin_main_list_page_searchbar_placeholder" xml:space="preserve">
+    <value>Type here to search commands...</value>
+  </data>
 </root>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Properties/Resources.resx
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Properties/Resources.resx
@@ -228,6 +228,6 @@
     <value>Disabled</value>
   </data>
   <data name="builtin_main_list_page_searchbar_placeholder" xml:space="preserve">
-    <value>Type here to search commands...</value>
+    <value>Search for apps, files and commands...</value>
   </data>
 </root>


### PR DESCRIPTION
## Summary of the Pull Request

Changes the placeholder in the filter box only on the main list page to "Search for apps, files and commands...":
<img width="786" height="473" alt="image" src="https://github.com/user-attachments/assets/844d27ae-61cf-42c9-a7f6-ae78817e928c" />

The default value remains unchanged as "Type here to search..." for all other pages (both built-in and internal), unless the author overrides it:
<img width="786" height="473" alt="image" src="https://github.com/user-attachments/assets/aeb3500b-9e36-4e35-8dd7-3bd226336823" />

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #40763
- [x] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [x] **Localization:** All end-user-facing strings can be localized
- [x] **Dev docs:** Added/updated
- [x] **New binaries:** none
- [x] **Documentation updated:** 

## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed

