### PR TITLE
CmdPal: Fix paths to dirs on the Run fallback

### DIFF
--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Shell/FallbackExecuteItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Shell/FallbackExecuteItem.cs
@@ -154,11 +154,11 @@ internal sealed partial class FallbackExecuteItem : FallbackCommandItem, IDispos
         else if (pathIsDir)
         {
             var pathItem = new PathListItem(exe, query, _addToHistory);
+            Command = pathItem.Command;
+            MoreCommands = pathItem.MoreCommands;
             Title = pathItem.Title;
             Subtitle = pathItem.Subtitle;
             Icon = pathItem.Icon;
-            Command = pathItem.Command;
-            MoreCommands = pathItem.MoreCommands;
         }
         else if (System.Uri.TryCreate(searchText, UriKind.Absolute, out var uri))
         {

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Shell/Pages/ShellListPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Shell/Pages/ShellListPage.cs
@@ -367,7 +367,7 @@ internal sealed partial class ShellListPage : DynamicListPage, IDisposable
         }
 
         // Easiest case: text is literally already a full directory
-        else if (Directory.Exists(trimmed))
+        else if (Directory.Exists(trimmed) && trimmed.EndsWith('\\'))
         {
             directoryPath = trimmed;
             searchPattern = $"*";

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Shell/PathListItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Shell/PathListItem.cs
@@ -20,15 +20,27 @@ internal sealed partial class PathListItem : ListItem
         : base(new OpenUrlWithHistoryCommand(path, addToHistory))
     {
         var fileName = Path.GetFileName(path);
+        if (string.IsNullOrEmpty(fileName))
+        {
+            fileName = Path.GetFileName(Path.GetDirectoryName(path)) ?? string.Empty;
+        }
+
         _isDirectory = Directory.Exists(path);
         if (_isDirectory)
         {
-            path = path + "\\";
-            fileName = fileName + "\\";
+            if (!path.EndsWith('\\'))
+            {
+                path = path + "\\";
+            }
+
+            if (!fileName.EndsWith('\\'))
+            {
+                fileName = fileName + "\\";
+            }
         }
 
-        Title = fileName;
-        Subtitle = path;
+        Title = fileName; // Just the name of the file is the Title
+        Subtitle = path; // What the user typed is the subtitle
 
         // NOTE ME:
         // If there are spaces on originalDir, trim them off, BEFORE combining originalDir and fileName.


### PR DESCRIPTION

We were being too clever with `\`; and yet simultaneously not clever enough. 
* When we saw `c:\users`, we'd treat that as a path with a Title `users\`
* but when we saw `c:\users\`, we'd fail to find a file name, and the just treat the name as `\`. That was dumb.
* And we'd add trailing `\`'s even if there already was one.
* But then if the user typed `c:\users`, we would immediately start enumerating children of that dir, which didn't really feel right

This PR fixes all of that.

Closes #40797