### PR TITLE
Fix a settings crash due to incompatible property name

### DIFF
--- a/src/settings-ui/Settings.UI.Library/ZoomItProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/ZoomItProperties.cs
@@ -78,6 +78,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 
         public BoolProperty ShowTrayIcon { get; set; }
 
+        [JsonPropertyName("AnimnateZoom")]
         public BoolProperty AnimateZoom { get; set; }
 
         public IntProperty ZoominSliderLevel { get; set; }


### PR DESCRIPTION
This pull request includes a minor change to the `ZoomItProperties` class in the `Settings.UI.Library` project. The change adds a new property with a JSON serialization attribute.

* [`src/settings-ui/Settings.UI.Library/ZoomItProperties.cs`](diffhunk://#diff-2cd3f90110c7ba387a449d246b4949c3f6cf7f746865f327dbb70f01feeb0cf1R81): Added a new property `AnimateZoom` of type `BoolProperty` with a `[JsonPropertyName("AnimnateZoom")]` attribute for JSON serialization.<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] Closes: #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
This pull request introduces a minor update to the `ZoomItProperties` class in the `Settings.UI.Library` project. The change adds a new property, `AnimateZoom`, with a JSON property name annotation.

* [`src/settings-ui/Settings.UI.Library/ZoomItProperties.cs`](diffhunk://#diff-2cd3f90110c7ba387a449d246b4949c3f6cf7f746865f327dbb70f01feeb0cf1R81): Added a new `BoolProperty` named `AnimateZoom` with a `[JsonPropertyName("AnimnateZoom")]` attribute.
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Locally checked, no broken any more
This pull request includes a small change to the `ZoomItProperties` class in `src/settings-ui/Settings.UI.Library/ZoomItProperties.cs`. The change introduces a new `JsonPropertyName` attribute for the `AnimateZoom` property to specify its JSON serialization name as "AnimnateZoom".