### PR TITLE
Adding additional descriptions for all apps settings

### DIFF
--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/AllAppsSettings.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/AllAppsSettings.cs
@@ -44,25 +44,25 @@ public class AllAppsSettings : JsonSettingsManager
     private readonly ToggleSetting _enableStartMenuSource = new(
         Namespaced(nameof(EnableStartMenuSource)),
         Resources.enable_start_menu_source,
-        Resources.enable_start_menu_source,
+        Resources.enable_start_menu_source_description,
         true);
 
     private readonly ToggleSetting _enableDesktopSource = new(
         Namespaced(nameof(EnableDesktopSource)),
         Resources.enable_desktop_source,
-        Resources.enable_desktop_source,
+        Resources.enable_desktop_source_description,
         true);
 
     private readonly ToggleSetting _enableRegistrySource = new(
         Namespaced(nameof(EnableRegistrySource)),
         Resources.enable_registry_source,
-        Resources.enable_registry_source,
+        Resources.enable_registry_source_description,
         false); // This one is very noisy
 
     private readonly ToggleSetting _enablePathEnvironmentVariableSource = new(
         Namespaced(nameof(EnablePathEnvironmentVariableSource)),
         Resources.enable_path_environment_variable_source,
-        Resources.enable_path_environment_variable_source,
+        Resources.enable_path_environment_variable_source_description,
         false); // this one is very VERY noisy
 
     public double MinScoreThreshold { get; set; } = 0.75;

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Properties/Resources.Designer.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Properties/Resources.Designer.cs
@@ -106,7 +106,7 @@ namespace Microsoft.CmdPal.Ext.Apps.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Include apps found on the desktop.
+        ///   Looks up a localized string similar to Include Desktop apps.
         /// </summary>
         internal static string enable_desktop_source {
             get {
@@ -115,7 +115,16 @@ namespace Microsoft.CmdPal.Ext.Apps.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Include apps anywhere on the %PATH%.
+        ///   Looks up a localized string similar to Should apps found on the Desktop be included in search results?.
+        /// </summary>
+        internal static string enable_desktop_source_description {
+            get {
+                return ResourceManager.GetString("enable_desktop_source_description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Include %PATH% apps.
         /// </summary>
         internal static string enable_path_environment_variable_source {
             get {
@@ -124,7 +133,16 @@ namespace Microsoft.CmdPal.Ext.Apps.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Include apps registered in the Registry.
+        ///   Looks up a localized string similar to Should apps found on the %PATH% be included in search results?.
+        /// </summary>
+        internal static string enable_path_environment_variable_source_description {
+            get {
+                return ResourceManager.GetString("enable_path_environment_variable_source_description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Include Registry apps.
         /// </summary>
         internal static string enable_registry_source {
             get {
@@ -133,11 +151,29 @@ namespace Microsoft.CmdPal.Ext.Apps.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Include apps found in the Start Menu.
+        ///   Looks up a localized string similar to Should apps registered in the Windows Registry be included in search results?.
+        /// </summary>
+        internal static string enable_registry_source_description {
+            get {
+                return ResourceManager.GetString("enable_registry_source_description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Include Start Menu apps.
         /// </summary>
         internal static string enable_start_menu_source {
             get {
                 return ResourceManager.GetString("enable_start_menu_source", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Should apps found in the Start Menu be included in search results?.
+        /// </summary>
+        internal static string enable_start_menu_source_description {
+            get {
+                return ResourceManager.GetString("enable_start_menu_source_description", resourceCulture);
             }
         }
         

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Properties/Resources.resx
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Properties/Resources.resx
@@ -180,16 +180,16 @@
     <value>Copied to clipboard!</value>
   </data>
   <data name="enable_start_menu_source" xml:space="preserve">
-    <value>Include apps found in the Start Menu</value>
+    <value>Include Start Menu apps</value>
   </data>
   <data name="enable_desktop_source" xml:space="preserve">
-    <value>Include apps found on the desktop</value>
+    <value>Include Desktop apps</value>
   </data>
   <data name="enable_registry_source" xml:space="preserve">
-    <value>Include apps registered in the Registry</value>
+    <value>Include Registry apps</value>
   </data>
   <data name="enable_path_environment_variable_source" xml:space="preserve">
-    <value>Include apps anywhere on the %PATH%</value>
+    <value>Include %PATH% apps</value>
   </data>
   <data name="use_thumbnails_setting_label" xml:space="preserve">
     <value>Use thumbnails for apps</value>
@@ -204,5 +204,17 @@
   </data>
   <data name="unpin_app" xml:space="preserve">
     <value>Unpin</value>
+  </data>
+  <data name="enable_desktop_source_description" xml:space="preserve">
+    <value>Should apps found on the Desktop be included in search results?</value>
+  </data>
+  <data name="enable_path_environment_variable_source_description" xml:space="preserve">
+    <value>Should apps found on the %PATH% be included in search results?</value>
+  </data>
+  <data name="enable_registry_source_description" xml:space="preserve">
+    <value>Should apps registered in the Windows Registry be included in search results?</value>
+  </data>
+  <data name="enable_start_menu_source_description" xml:space="preserve">
+    <value>Should apps found in the Start Menu be included in search results?</value>
   </data>
 </root>


### PR DESCRIPTION
Closes #38351

Adding some descriptions for all apps extension settings.

<img width="725" height="470" alt="image" src="https://github.com/user-attachments/assets/9fb06105-80a3-4c78-b10d-241164fead11" />
