### PR TITLE
[PowerRename] Fix named pipe detection

### DIFF
--- a/src/modules/powerrename/PowerRenameUILib/PowerRenameXAML/App.xaml.cpp
+++ b/src/modules/powerrename/PowerRenameUILib/PowerRenameXAML/App.xaml.cpp
@@ -127,28 +127,13 @@ void App::OnLaunched(LaunchActivatedEventArgs const&)
 
     auto args = std::wstring{ GetCommandLine() };
     
-    // Try to parse command line arguments first
-    std::vector<std::wstring> cmdLineFiles = ParseCommandLineArgs(args);
-    
-    if (!cmdLineFiles.empty())
-    {
-        // Use command line arguments for UI testing
-        for (const auto& filePath : cmdLineFiles)
-        {
-            g_files.push_back(filePath);
-        }
-        Logger::debug(L"Starting PowerRename with {} files from command line", g_files.size());
-    }
-    else
-    {
-        // Use original pipe/stdin logic for normal operation
-        size_t pos{ args.rfind(L"\\\\.\\pipe\\") };
+    // Check if the command line arguments contains a pipe name first
+    size_t pos{ args.rfind(L"\\\\.\\pipe\\") };
 
-        std::wstring pipe_name;
-        if (pos != std::wstring::npos)
-        {
-            pipe_name = args.substr(pos);
-        }
+    std::wstring pipe_name;
+    if (pos != std::wstring::npos)
+    {
+        pipe_name = args.substr(pos);
 
         HANDLE hStdin;
 
@@ -266,6 +251,21 @@ void App::OnLaunched(LaunchActivatedEventArgs const&)
         CloseHandle(hStdin);
 #endif
         Logger::debug(L"Starting PowerRename with {} files from pipe/stdin", g_files.size());
+    }
+    else
+    {
+        // Try to parse command files from command line arguments
+        std::vector<std::wstring> cmdLineFiles = ParseCommandLineArgs(args);
+
+        if (!cmdLineFiles.empty())
+        {
+            // Use command line arguments for UI testing
+            for (const auto& filePath : cmdLineFiles)
+            {
+                g_files.push_back(filePath);
+            }
+            Logger::debug(L"Starting PowerRename with {} files from command line", g_files.size());
+        }
     }
 
     window = make<MainWindow>();

--- a/src/modules/powerrename/PowerRenameUILib/PowerRenameXAML/App.xaml.cpp
+++ b/src/modules/powerrename/PowerRenameUILib/PowerRenameXAML/App.xaml.cpp
@@ -126,14 +126,28 @@ void App::OnLaunched(LaunchActivatedEventArgs const&)
     }
 
     auto args = std::wstring{ GetCommandLine() };
-    
-    // Check if the command line arguments contains a pipe name first
-    size_t pos{ args.rfind(L"\\\\.\\pipe\\") };
+    size_t pipePos{ args.rfind(L"\\\\.\\pipe\\") };
 
-    std::wstring pipe_name;
-    if (pos != std::wstring::npos)
+    // Try to parse command line arguments first
+    std::vector<std::wstring> cmdLineFiles = ParseCommandLineArgs(args);
+    
+    if (pipePos == std::wstring::npos && !cmdLineFiles.empty())
     {
-        pipe_name = args.substr(pos);
+        // Use command line arguments for UI testing
+        for (const auto& filePath : cmdLineFiles)
+        {
+            g_files.push_back(filePath);
+        }
+        Logger::debug(L"Starting PowerRename with {} files from command line", g_files.size());
+    }
+    else
+    {
+        // Use original pipe/stdin logic for normal operation
+        std::wstring pipe_name;
+        if (pipePos != std::wstring::npos)
+        {
+            pipe_name = args.substr(pipePos);
+        }
 
         HANDLE hStdin;
 
@@ -251,21 +265,6 @@ void App::OnLaunched(LaunchActivatedEventArgs const&)
         CloseHandle(hStdin);
 #endif
         Logger::debug(L"Starting PowerRename with {} files from pipe/stdin", g_files.size());
-    }
-    else
-    {
-        // Try to parse command files from command line arguments
-        std::vector<std::wstring> cmdLineFiles = ParseCommandLineArgs(args);
-
-        if (!cmdLineFiles.empty())
-        {
-            // Use command line arguments for UI testing
-            for (const auto& filePath : cmdLineFiles)
-            {
-                g_files.push_back(filePath);
-            }
-            Logger::debug(L"Starting PowerRename with {} files from command line", g_files.size());
-        }
     }
 
     window = make<MainWindow>();


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

Fix a regression present on master where PowerRename is activated with empty file list where invoked Explorer context menu.
Regression was caused by https://github.com/microsoft/PowerToys/pull/40393

- [ ] Closes: #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Verified that PowerRename shows file list when activated:
- From Windows 11 Explorer context menu
- From Legacy Explorer context menu
- From command line passing some file paths

## AI Summary
This pull request updates the logic in the `App::OnLaunched` method in `App.xaml.cpp` to improve how command line arguments and named pipe inputs are handled. The main change is to ensure that command line arguments are only used for UI testing if a named pipe is not present, and to streamline the handling of the pipe name variable.

Argument and pipe handling improvements:

* Added a single computation of `pipePos` (the position of the named pipe in the command line) and used it consistently to determine whether to use command line arguments or named pipe logic.
* Updated the pipe name extraction logic to use the precomputed `pipePos` variable, removing redundant code and improving clarity.