### PR TITLE
CmdPal: Ensuring alias changes are propagated to related TopLevelViewModels

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AliasManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AliasManager.cs
@@ -106,7 +106,7 @@ public partial class AliasManager : ObservableObject
                 toRemove.Add(kv.Value);
             }
 
-            // Look for the the alias belonging to another command, and remove it
+            // Look for the alias belonging to another command, and remove it
             if (newAlias is not null && kv.Value.Alias == newAlias.Alias)
             {
                 toRemove.Add(kv.Value);

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AliasManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AliasManager.cs
@@ -97,13 +97,26 @@ public partial class AliasManager : ObservableObject
             }
         }
 
-        // Look for the old alias, and remove it
         List<CommandAlias> toRemove = [];
         foreach (var kv in _aliases)
         {
+            // Look for the old aliases for the command, and remove it
             if (kv.Value.CommandId == commandId)
             {
                 toRemove.Add(kv.Value);
+            }
+
+            // Look for the the alias belonging to another command, and remove it
+            if (newAlias is not null && kv.Value.Alias == newAlias.Alias)
+            {
+                toRemove.Add(kv.Value);
+
+                // Remove alias from other TopLevelViewModels it may be assigned to
+                var topLevelCommand = _topLevelCommandManager.LookupCommand(kv.Value.CommandId);
+                if (topLevelCommand is not null)
+                {
+                    topLevelCommand.AliasText = string.Empty;
+                }
             }
         }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelViewModel.cs
@@ -109,6 +109,8 @@ public sealed partial class TopLevelViewModel : ObservableObject, IListItem
         get => Alias?.Alias ?? string.Empty;
         set
         {
+            var previousAlias = Alias?.Alias ?? string.Empty;
+
             if (string.IsNullOrEmpty(value))
             {
                 Alias = null;
@@ -125,9 +127,13 @@ public sealed partial class TopLevelViewModel : ObservableObject, IListItem
                 }
             }
 
-            HandleChangeAlias();
-            OnPropertyChanged(nameof(AliasText));
-            OnPropertyChanged(nameof(IsDirectAlias));
+            // Only call HandleChangeAlias if there was an actual change.
+            if (previousAlias != Alias?.Alias)
+            {
+                HandleChangeAlias();
+                OnPropertyChanged(nameof(AliasText));
+                OnPropertyChanged(nameof(IsDirectAlias));
+            }
         }
     }
 


### PR DESCRIPTION
Closes #39709

- Only updating aliases when the alias has changed
- When an alias is used that is already in use, remove the alias from the previous TopLevelViewModel
- Don't crash if the previous TopLevelViewModel doesn't exist (e.g. it was uninstalled)