### PR TITLE
CmdPal: Null pattern matching based on `is` expression rather than overridable operators

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.Common/Helpers/ExtensionHostInstance.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Common/Helpers/ExtensionHostInstance.cs
@@ -24,7 +24,7 @@ public partial class ExtensionHostInstance
     /// <param name="message">The log message to send</param>
     public void LogMessage(ILogMessage message)
     {
-        if (Host != null)
+        if (Host is not null)
         {
             _ = Task.Run(async () =>
             {
@@ -47,7 +47,7 @@ public partial class ExtensionHostInstance
 
     public void ShowStatus(IStatusMessage message, StatusContext context)
     {
-        if (Host != null)
+        if (Host is not null)
         {
             _ = Task.Run(async () =>
             {
@@ -64,7 +64,7 @@ public partial class ExtensionHostInstance
 
     public void HideStatus(IStatusMessage message)
     {
-        if (Host != null)
+        if (Host is not null)
         {
             _ = Task.Run(async () =>
             {

--- a/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/AppExtensionHost.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/AppExtensionHost.cs
@@ -36,7 +36,7 @@ public abstract partial class AppExtensionHost : IExtensionHost
 
     public IAsyncAction HideStatus(IStatusMessage? message)
     {
-        if (message == null)
+        if (message is null)
         {
             return Task.CompletedTask.AsAsyncAction();
         }
@@ -55,7 +55,7 @@ public abstract partial class AppExtensionHost : IExtensionHost
 
     public IAsyncAction LogMessage(ILogMessage? message)
     {
-        if (message == null)
+        if (message is null)
         {
             return Task.CompletedTask.AsAsyncAction();
         }
@@ -80,7 +80,7 @@ public abstract partial class AppExtensionHost : IExtensionHost
                 try
                 {
                     var vm = StatusMessages.Where(messageVM => messageVM.Model.Unsafe == message).FirstOrDefault();
-                    if (vm != null)
+                    if (vm is not null)
                     {
                         StatusMessages.Remove(vm);
                     }
@@ -113,7 +113,7 @@ public abstract partial class AppExtensionHost : IExtensionHost
     {
         // If this message is already in the list of messages, just bring it to the top
         var oldVm = StatusMessages.Where(messageVM => messageVM.Model.Unsafe == message).FirstOrDefault();
-        if (oldVm != null)
+        if (oldVm is not null)
         {
             Task.Factory.StartNew(
                 () =>
@@ -142,7 +142,7 @@ public abstract partial class AppExtensionHost : IExtensionHost
 
     public IAsyncAction ShowStatus(IStatusMessage? message, StatusContext context)
     {
-        if (message == null)
+        if (message is null)
         {
             return Task.CompletedTask.AsAsyncAction();
         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/CommandBarViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/CommandBarViewModel.cs
@@ -2,7 +2,6 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Messaging;
 using Microsoft.CmdPal.Core.ViewModels.Messages;
@@ -35,13 +34,13 @@ public partial class CommandBarViewModel : ObservableObject,
     [NotifyPropertyChangedFor(nameof(HasPrimaryCommand))]
     public partial CommandItemViewModel? PrimaryCommand { get; set; }
 
-    public bool HasPrimaryCommand => PrimaryCommand != null && PrimaryCommand.ShouldBeVisible;
+    public bool HasPrimaryCommand => PrimaryCommand is not null && PrimaryCommand.ShouldBeVisible;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(HasSecondaryCommand))]
     public partial CommandItemViewModel? SecondaryCommand { get; set; }
 
-    public bool HasSecondaryCommand => SecondaryCommand != null;
+    public bool HasSecondaryCommand => SecondaryCommand is not null;
 
     [ObservableProperty]
     public partial bool ShouldShowContextMenu { get; set; } = false;
@@ -58,14 +57,14 @@ public partial class CommandBarViewModel : ObservableObject,
 
     private void SetSelectedItem(ICommandBarContext? value)
     {
-        if (value != null)
+        if (value is not null)
         {
             PrimaryCommand = value.PrimaryCommand;
             value.PropertyChanged += SelectedItemPropertyChanged;
         }
         else
         {
-            if (SelectedItem != null)
+            if (SelectedItem is not null)
             {
                 SelectedItem.PropertyChanged -= SelectedItemPropertyChanged;
             }
@@ -88,7 +87,7 @@ public partial class CommandBarViewModel : ObservableObject,
 
     private void UpdateContextItems()
     {
-        if (SelectedItem == null)
+        if (SelectedItem is null)
         {
             SecondaryCommand = null;
             ShouldShowContextMenu = false;
@@ -127,13 +126,13 @@ public partial class CommandBarViewModel : ObservableObject,
     public ContextKeybindingResult CheckKeybinding(bool ctrl, bool alt, bool shift, bool win, VirtualKey key)
     {
         var keybindings = SelectedItem?.Keybindings();
-        if (keybindings != null)
+        if (keybindings is not null)
         {
             // Does the pressed key match any of the keybindings?
             var pressedKeyChord = KeyChordHelpers.FromModifiers(ctrl, alt, shift, win, key, 0);
             if (keybindings.TryGetValue(pressedKeyChord, out var matchedItem))
             {
-                return matchedItem != null ? PerformCommand(matchedItem) : ContextKeybindingResult.Unhandled;
+                return matchedItem is not null ? PerformCommand(matchedItem) : ContextKeybindingResult.Unhandled;
             }
         }
 
@@ -142,7 +141,7 @@ public partial class CommandBarViewModel : ObservableObject,
 
     private ContextKeybindingResult PerformCommand(CommandItemViewModel? command)
     {
-        if (command == null)
+        if (command is null)
         {
             return ContextKeybindingResult.Unhandled;
         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/CommandContextItemViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/CommandContextItemViewModel.cs
@@ -17,7 +17,7 @@ public partial class CommandContextItemViewModel(ICommandContextItem contextItem
 
     public KeyChord? RequestedShortcut { get; private set; }
 
-    public bool HasRequestedShortcut => RequestedShortcut != null && (RequestedShortcut.Value != nullKeyChord);
+    public bool HasRequestedShortcut => RequestedShortcut is not null && (RequestedShortcut.Value != nullKeyChord);
 
     public override void InitializeProperties()
     {
@@ -29,7 +29,7 @@ public partial class CommandContextItemViewModel(ICommandContextItem contextItem
         base.InitializeProperties();
 
         var contextItem = Model.Unsafe;
-        if (contextItem == null)
+        if (contextItem is null)
         {
             return; // throw?
         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/CommandItemViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/CommandItemViewModel.cs
@@ -66,7 +66,7 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel, ICommandBa
     {
         get
         {
-            List<IContextItemViewModel> l = _defaultCommandContextItem == null ?
+            List<IContextItemViewModel> l = _defaultCommandContextItem is null ?
                 new() :
                 [_defaultCommandContextItem];
 
@@ -98,7 +98,7 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel, ICommandBa
         }
 
         var model = _commandItemModel.Unsafe;
-        if (model == null)
+        if (model is null)
         {
             return;
         }
@@ -126,7 +126,7 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel, ICommandBa
         }
 
         var model = _commandItemModel.Unsafe;
-        if (model == null)
+        if (model is null)
         {
             return;
         }
@@ -134,7 +134,7 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel, ICommandBa
         Command.InitializeProperties();
 
         var listIcon = model.Icon;
-        if (listIcon != null)
+        if (listIcon is not null)
         {
             _listItemIcon = new(listIcon);
             _listItemIcon.InitializeProperties();
@@ -170,13 +170,13 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel, ICommandBa
         }
 
         var model = _commandItemModel.Unsafe;
-        if (model == null)
+        if (model is null)
         {
             return;
         }
 
         var more = model.MoreCommands;
-        if (more != null)
+        if (more is not null)
         {
             MoreCommands = more
                 .Select(item =>
@@ -298,7 +298,7 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel, ICommandBa
     protected virtual void FetchProperty(string propertyName)
     {
         var model = this._commandItemModel.Unsafe;
-        if (model == null)
+        if (model is null)
         {
             return; // throw?
         }
@@ -306,7 +306,7 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel, ICommandBa
         switch (propertyName)
         {
             case nameof(Command):
-                if (Command != null)
+                if (Command is not null)
                 {
                     Command.PropertyChanged -= Command_PropertyChanged;
                 }
@@ -337,7 +337,7 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel, ICommandBa
 
             case nameof(model.MoreCommands):
                 var more = model.MoreCommands;
-                if (more != null)
+                if (more is not null)
                 {
                     var newContextMenu = more
                         .Select(item =>
@@ -392,7 +392,7 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel, ICommandBa
                 // Extensions based on Command Palette SDK < 0.3 CommandItem class won't notify when Title changes because Command
                 // or Command.Name change. This is a workaround to ensure that the Title is always up-to-date for extensions with old SDK.
                 var model = _commandItemModel.Unsafe;
-                if (model != null)
+                if (model is not null)
                 {
                     _itemTitle = model.Title;
                 }
@@ -428,7 +428,7 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel, ICommandBa
         Command.SafeCleanup();
 
         var model = _commandItemModel.Unsafe;
-        if (model != null)
+        if (model is not null)
         {
             model.PropChanged -= Model_PropChanged;
         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/CommandViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/CommandViewModel.cs
@@ -44,7 +44,7 @@ public partial class CommandViewModel : ExtensionObjectViewModel
         }
 
         var model = Model.Unsafe;
-        if (model == null)
+        if (model is null)
         {
             return;
         }
@@ -67,13 +67,13 @@ public partial class CommandViewModel : ExtensionObjectViewModel
         }
 
         var model = Model.Unsafe;
-        if (model == null)
+        if (model is null)
         {
             return;
         }
 
         var ico = model.Icon;
-        if (ico != null)
+        if (ico is not null)
         {
             Icon = new(ico);
             Icon.InitializeProperties();
@@ -98,7 +98,7 @@ public partial class CommandViewModel : ExtensionObjectViewModel
     protected void FetchProperty(string propertyName)
     {
         var model = Model.Unsafe;
-        if (model == null)
+        if (model is null)
         {
             return; // throw?
         }
@@ -125,7 +125,7 @@ public partial class CommandViewModel : ExtensionObjectViewModel
         Icon = new(null); // necessary?
 
         var model = Model.Unsafe;
-        if (model != null)
+        if (model is not null)
         {
             model.PropChanged -= Model_PropChanged;
         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/ConfirmResultViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/ConfirmResultViewModel.cs
@@ -25,7 +25,7 @@ public partial class ConfirmResultViewModel(IConfirmationArgs _args, WeakReferen
     public override void InitializeProperties()
     {
         var model = Model.Unsafe;
-        if (model == null)
+        if (model is null)
         {
             return;
         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/ContentPageViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/ContentPageViewModel.cs
@@ -28,7 +28,7 @@ public abstract partial class ContentPageViewModel : PageViewModel, ICommandBarC
     public DetailsViewModel? Details { get; private set; }
 
     [MemberNotNullWhen(true, nameof(Details))]
-    public bool HasDetails => Details != null;
+    public bool HasDetails => Details is not null;
 
     /////// ICommandBarContext ///////
     public IEnumerable<IContextItemViewModel> MoreCommands => Commands.Skip(1);
@@ -67,7 +67,7 @@ public abstract partial class ContentPageViewModel : PageViewModel, ICommandBarC
             foreach (var item in newItems)
             {
                 var viewModel = ViewModelFromContent(item, PageContext);
-                if (viewModel != null)
+                if (viewModel is not null)
                 {
                     viewModel.InitializeProperties();
                     newContent.Add(viewModel);
@@ -104,7 +104,7 @@ public abstract partial class ContentPageViewModel : PageViewModel, ICommandBarC
         base.InitializeProperties();
 
         var model = _model.Unsafe;
-        if (model == null)
+        if (model is null)
         {
             return; // throw?
         }
@@ -133,7 +133,7 @@ public abstract partial class ContentPageViewModel : PageViewModel, ICommandBarC
             });
 
         var extensionDetails = model.Details;
-        if (extensionDetails != null)
+        if (extensionDetails is not null)
         {
             Details = new(extensionDetails, PageContext);
             Details.InitializeProperties();
@@ -156,7 +156,7 @@ public abstract partial class ContentPageViewModel : PageViewModel, ICommandBarC
         base.FetchProperty(propertyName);
 
         var model = this._model.Unsafe;
-        if (model == null)
+        if (model is null)
         {
             return; // throw?
         }
@@ -166,7 +166,7 @@ public abstract partial class ContentPageViewModel : PageViewModel, ICommandBarC
             case nameof(Commands):
 
                 var more = model.Commands;
-                if (more != null)
+                if (more is not null)
                 {
                     var newContextMenu = more
                             .ToList()
@@ -216,7 +216,7 @@ public abstract partial class ContentPageViewModel : PageViewModel, ICommandBarC
                 break;
             case nameof(Details):
                 var extensionDetails = model.Details;
-                Details = extensionDetails != null ? new(extensionDetails, PageContext) : null;
+                Details = extensionDetails is not null ? new(extensionDetails, PageContext) : null;
                 UpdateDetails();
                 break;
         }
@@ -248,7 +248,7 @@ public abstract partial class ContentPageViewModel : PageViewModel, ICommandBarC
     [RelayCommand]
     private void InvokePrimaryCommand(ContentPageViewModel page)
     {
-        if (PrimaryCommand != null)
+        if (PrimaryCommand is not null)
         {
             WeakReferenceMessenger.Default.Send<PerformCommandMessage>(new(PrimaryCommand.Command.Model, PrimaryCommand.Model));
         }
@@ -258,7 +258,7 @@ public abstract partial class ContentPageViewModel : PageViewModel, ICommandBarC
     [RelayCommand]
     private void InvokeSecondaryCommand(ContentPageViewModel page)
     {
-        if (SecondaryCommand != null)
+        if (SecondaryCommand is not null)
         {
             WeakReferenceMessenger.Default.Send<PerformCommandMessage>(new(SecondaryCommand.Command.Model, SecondaryCommand.Model));
         }
@@ -285,7 +285,7 @@ public abstract partial class ContentPageViewModel : PageViewModel, ICommandBarC
         Content.Clear();
 
         var model = _model.Unsafe;
-        if (model != null)
+        if (model is not null)
         {
             model.ItemsChanged -= Model_ItemsChanged;
         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/ContextMenuViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/ContextMenuViewModel.cs
@@ -8,7 +8,6 @@ using CommunityToolkit.Mvvm.Messaging;
 using Microsoft.CmdPal.Core.ViewModels.Messages;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
-using Microsoft.Diagnostics.Utilities;
 using Windows.System;
 
 namespace Microsoft.CmdPal.Core.ViewModels;
@@ -51,7 +50,7 @@ public partial class ContextMenuViewModel : ObservableObject,
 
     public void UpdateContextItems()
     {
-        if (SelectedItem != null)
+        if (SelectedItem is not null)
         {
             if (SelectedItem.MoreCommands.Count() > 1)
             {
@@ -68,14 +67,14 @@ public partial class ContextMenuViewModel : ObservableObject,
             return;
         }
 
-        if (SelectedItem == null)
+        if (SelectedItem is null)
         {
             return;
         }
 
         _lastSearchText = searchText;
 
-        if (CurrentContextMenu == null)
+        if (CurrentContextMenu is null)
         {
             ListHelpers.InPlaceUpdateList(FilteredItems, []);
             return;
@@ -124,7 +123,7 @@ public partial class ContextMenuViewModel : ObservableObject,
     /// that have a shortcut key set.</returns>
     public Dictionary<KeyChord, CommandContextItemViewModel> Keybindings()
     {
-        if (CurrentContextMenu == null)
+        if (CurrentContextMenu is null)
         {
             return [];
         }
@@ -140,7 +139,7 @@ public partial class ContextMenuViewModel : ObservableObject,
     public ContextKeybindingResult? CheckKeybinding(bool ctrl, bool alt, bool shift, bool win, VirtualKey key)
     {
         var keybindings = Keybindings();
-        if (keybindings != null)
+        if (keybindings is not null)
         {
             // Does the pressed key match any of the keybindings?
             var pressedKeyChord = KeyChordHelpers.FromModifiers(ctrl, alt, shift, win, key, 0);
@@ -190,7 +189,7 @@ public partial class ContextMenuViewModel : ObservableObject,
         OnPropertyChanging(nameof(CurrentContextMenu));
         OnPropertyChanged(nameof(CurrentContextMenu));
 
-        if (CurrentContextMenu != null)
+        if (CurrentContextMenu is not null)
         {
             ListHelpers.InPlaceUpdateList(FilteredItems, [.. CurrentContextMenu!]);
         }
@@ -198,7 +197,7 @@ public partial class ContextMenuViewModel : ObservableObject,
 
     public ContextKeybindingResult InvokeCommand(CommandItemViewModel? command)
     {
-        if (command == null)
+        if (command is null)
         {
             return ContextKeybindingResult.Unhandled;
         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/DetailsCommandsViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/DetailsCommandsViewModel.cs
@@ -22,7 +22,7 @@ public partial class DetailsCommandsViewModel(
     {
         base.InitializeProperties();
         var model = _dataModel.Unsafe;
-        if (model == null)
+        if (model is null)
         {
             return;
         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/DetailsElementViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/DetailsElementViewModel.cs
@@ -16,7 +16,7 @@ public abstract partial class DetailsElementViewModel(IDetailsElement _detailsEl
     public override void InitializeProperties()
     {
         var model = _model.Unsafe;
-        if (model == null)
+        if (model is null)
         {
             return;
         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/DetailsLinkViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/DetailsLinkViewModel.cs
@@ -18,7 +18,7 @@ public partial class DetailsLinkViewModel(
 
     public Uri? Link { get; private set; }
 
-    public bool IsLink => Link != null;
+    public bool IsLink => Link is not null;
 
     public bool IsText => !IsLink;
 
@@ -26,14 +26,14 @@ public partial class DetailsLinkViewModel(
     {
         base.InitializeProperties();
         var model = _dataModel.Unsafe;
-        if (model == null)
+        if (model is null)
         {
             return;
         }
 
         Text = model.Text ?? string.Empty;
         Link = model.Link;
-        if (string.IsNullOrEmpty(Text) && Link != null)
+        if (string.IsNullOrEmpty(Text) && Link is not null)
         {
             Text = Link.ToString();
         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/DetailsTagsViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/DetailsTagsViewModel.cs
@@ -22,7 +22,7 @@ public partial class DetailsTagsViewModel(
     {
         base.InitializeProperties();
         var model = _dataModel.Unsafe;
-        if (model == null)
+        if (model is null)
         {
             return;
         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/DetailsViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/DetailsViewModel.cs
@@ -26,7 +26,7 @@ public partial class DetailsViewModel(IDetails _details, WeakReference<IPageCont
     public override void InitializeProperties()
     {
         var model = _detailsModel.Unsafe;
-        if (model == null)
+        if (model is null)
         {
             return;
         }
@@ -41,7 +41,7 @@ public partial class DetailsViewModel(IDetails _details, WeakReference<IPageCont
         UpdateProperty(nameof(HeroImage));
 
         var meta = model.Metadata;
-        if (meta != null)
+        if (meta is not null)
         {
             foreach (var element in meta)
             {
@@ -53,7 +53,7 @@ public partial class DetailsViewModel(IDetails _details, WeakReference<IPageCont
                     IDetailsTags => new DetailsTagsViewModel(element, this.PageContext),
                     _ => null,
                 };
-                if (vm != null)
+                if (vm is not null)
                 {
                     vm.InitializeProperties();
                     Metadata.Add(vm);

--- a/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/IconDataViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/IconDataViewModel.cs
@@ -16,7 +16,7 @@ public partial class IconDataViewModel : ObservableObject, IIconData
     // If the extension previously gave us a Data, then died, the data will
     // throw if we actually try to read it, but the pointer itself won't be
     // null, so this is relatively safe.
-    public bool HasIcon => !string.IsNullOrEmpty(Icon) || Data.Unsafe != null;
+    public bool HasIcon => !string.IsNullOrEmpty(Icon) || Data.Unsafe is not null;
 
     // Locally cached properties from IIconData.
     public string Icon { get; private set; } = string.Empty;
@@ -36,7 +36,7 @@ public partial class IconDataViewModel : ObservableObject, IIconData
     public void InitializeProperties()
     {
         var model = _model.Unsafe;
-        if (model == null)
+        if (model is null)
         {
             return;
         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/IconInfoViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/IconInfoViewModel.cs
@@ -26,7 +26,7 @@ public partial class IconInfoViewModel : ObservableObject, IIconInfo
 
     public bool HasIcon(bool light) => IconForTheme(light).HasIcon;
 
-    public bool IsSet => _model.Unsafe != null;
+    public bool IsSet => _model.Unsafe is not null;
 
     IIconData? IIconInfo.Dark => Dark;
 
@@ -43,7 +43,7 @@ public partial class IconInfoViewModel : ObservableObject, IIconInfo
     public void InitializeProperties()
     {
         var model = _model.Unsafe;
-        if (model == null)
+        if (model is null)
         {
             return;
         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/ListItemViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/ListItemViewModel.cs
@@ -27,7 +27,7 @@ public partial class ListItemViewModel(IListItem model, WeakReference<IPageConte
     public DetailsViewModel? Details { get; private set; }
 
     [MemberNotNullWhen(true, nameof(Details))]
-    public bool HasDetails => Details != null;
+    public bool HasDetails => Details is not null;
 
     public override void InitializeProperties()
     {
@@ -40,7 +40,7 @@ public partial class ListItemViewModel(IListItem model, WeakReference<IPageConte
         base.InitializeProperties();
 
         var li = Model.Unsafe;
-        if (li == null)
+        if (li is null)
         {
             return; // throw?
         }
@@ -50,7 +50,7 @@ public partial class ListItemViewModel(IListItem model, WeakReference<IPageConte
         TextToSuggest = li.TextToSuggest;
         Section = li.Section ?? string.Empty;
         var extensionDetails = li.Details;
-        if (extensionDetails != null)
+        if (extensionDetails is not null)
         {
             Details = new(extensionDetails, PageContext);
             Details.InitializeProperties();
@@ -67,7 +67,7 @@ public partial class ListItemViewModel(IListItem model, WeakReference<IPageConte
         base.FetchProperty(propertyName);
 
         var model = this.Model.Unsafe;
-        if (model == null)
+        if (model is null)
         {
             return; // throw?
         }
@@ -85,7 +85,7 @@ public partial class ListItemViewModel(IListItem model, WeakReference<IPageConte
                 break;
             case nameof(Details):
                 var extensionDetails = model.Details;
-                Details = extensionDetails != null ? new(extensionDetails, PageContext) : null;
+                Details = extensionDetails is not null ? new(extensionDetails, PageContext) : null;
                 Details?.InitializeProperties();
                 UpdateProperty(nameof(Details));
                 UpdateProperty(nameof(HasDetails));
@@ -136,7 +136,7 @@ public partial class ListItemViewModel(IListItem model, WeakReference<IPageConte
         Details?.SafeCleanup();
 
         var model = Model.Unsafe;
-        if (model != null)
+        if (model is not null)
         {
             // We don't need to revoke the PropChanged event handler here,
             // because we are just overriding CommandItem's FetchProperty and

--- a/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/ListViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/ListViewModel.cs
@@ -298,11 +298,11 @@ public partial class ListViewModel : PageViewModel, IDisposable
     [RelayCommand]
     private void InvokeItem(ListItemViewModel? item)
     {
-        if (item != null)
+        if (item is not null)
         {
             WeakReferenceMessenger.Default.Send<PerformCommandMessage>(new(item.Command.Model, item.Model));
         }
-        else if (ShowEmptyContent && EmptyContent.PrimaryCommand?.Model.Unsafe != null)
+        else if (ShowEmptyContent && EmptyContent.PrimaryCommand?.Model.Unsafe is not null)
         {
             WeakReferenceMessenger.Default.Send<PerformCommandMessage>(new(
                 EmptyContent.PrimaryCommand.Command.Model,
@@ -314,14 +314,14 @@ public partial class ListViewModel : PageViewModel, IDisposable
     [RelayCommand]
     private void InvokeSecondaryCommand(ListItemViewModel? item)
     {
-        if (item != null)
+        if (item is not null)
         {
-            if (item.SecondaryCommand != null)
+            if (item.SecondaryCommand is not null)
             {
                 WeakReferenceMessenger.Default.Send<PerformCommandMessage>(new(item.SecondaryCommand.Command.Model, item.Model));
             }
         }
-        else if (ShowEmptyContent && EmptyContent.SecondaryCommand?.Model.Unsafe != null)
+        else if (ShowEmptyContent && EmptyContent.SecondaryCommand?.Model.Unsafe is not null)
         {
             WeakReferenceMessenger.Default.Send<PerformCommandMessage>(new(
                 EmptyContent.SecondaryCommand.Command.Model,
@@ -332,12 +332,12 @@ public partial class ListViewModel : PageViewModel, IDisposable
     [RelayCommand]
     private void UpdateSelectedItem(ListItemViewModel? item)
     {
-        if (_lastSelectedItem != null)
+        if (_lastSelectedItem is not null)
         {
             _lastSelectedItem.PropertyChanged -= SelectedItemPropertyChanged;
         }
 
-        if (item != null)
+        if (item is not null)
         {
             SetSelectedItem(item);
         }
@@ -383,7 +383,7 @@ public partial class ListViewModel : PageViewModel, IDisposable
     private void SelectedItemPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
     {
         var item = _lastSelectedItem;
-        if (item == null)
+        if (item is null)
         {
             return;
         }
@@ -438,7 +438,7 @@ public partial class ListViewModel : PageViewModel, IDisposable
         base.InitializeProperties();
 
         var model = _model.Unsafe;
-        if (model == null)
+        if (model is null)
         {
             return; // throw?
         }
@@ -465,7 +465,7 @@ public partial class ListViewModel : PageViewModel, IDisposable
     public void LoadMoreIfNeeded()
     {
         var model = this._model.Unsafe;
-        if (model == null)
+        if (model is null)
         {
             return;
         }
@@ -509,7 +509,7 @@ public partial class ListViewModel : PageViewModel, IDisposable
         base.FetchProperty(propertyName);
 
         var model = this._model.Unsafe;
-        if (model == null)
+        if (model is null)
         {
             return; // throw?
         }
@@ -540,7 +540,7 @@ public partial class ListViewModel : PageViewModel, IDisposable
     private void UpdateEmptyContent()
     {
         UpdateProperty(nameof(ShowEmptyContent));
-        if (!ShowEmptyContent || EmptyContent.Model.Unsafe == null)
+        if (!ShowEmptyContent || EmptyContent.Model.Unsafe is null)
         {
             return;
         }
@@ -588,7 +588,7 @@ public partial class ListViewModel : PageViewModel, IDisposable
         }
 
         var model = _model.Unsafe;
-        if (model != null)
+        if (model is not null)
         {
             model.ItemsChanged -= Model_ItemsChanged;
         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/LogMessageViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/LogMessageViewModel.cs
@@ -22,7 +22,7 @@ public partial class LogMessageViewModel : ExtensionObjectViewModel
     public override void InitializeProperties()
     {
         var model = _model.Unsafe;
-        if (model == null)
+        if (model is null)
         {
             return; // throw?
         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/PageViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/PageViewModel.cs
@@ -45,7 +45,7 @@ public partial class PageViewModel : ExtensionObjectViewModel, IPageContext
     [ObservableProperty]
     public partial AppExtensionHost ExtensionHost { get; private set; }
 
-    public bool HasStatusMessage => MostRecentStatusMessage != null;
+    public bool HasStatusMessage => MostRecentStatusMessage is not null;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(HasStatusMessage))]
@@ -132,7 +132,7 @@ public partial class PageViewModel : ExtensionObjectViewModel, IPageContext
     public override void InitializeProperties()
     {
         var page = _pageModel.Unsafe;
-        if (page == null)
+        if (page is null)
         {
             return; // throw?
         }
@@ -177,7 +177,7 @@ public partial class PageViewModel : ExtensionObjectViewModel, IPageContext
     protected virtual void FetchProperty(string propertyName)
     {
         var model = this._pageModel.Unsafe;
-        if (model == null)
+        if (model is null)
         {
             return; // throw?
         }
@@ -240,7 +240,7 @@ public partial class PageViewModel : ExtensionObjectViewModel, IPageContext
         ExtensionHost.StatusMessages.CollectionChanged -= StatusMessages_CollectionChanged;
 
         var model = _pageModel.Unsafe;
-        if (model != null)
+        if (model is not null)
         {
             model.PropChanged -= Model_PropChanged;
         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/ProgressViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/ProgressViewModel.cs
@@ -24,7 +24,7 @@ public partial class ProgressViewModel : ExtensionObjectViewModel
     public override void InitializeProperties()
     {
         var model = Model.Unsafe;
-        if (model == null)
+        if (model is null)
         {
             return; // throw?
         }
@@ -50,7 +50,7 @@ public partial class ProgressViewModel : ExtensionObjectViewModel
     protected virtual void FetchProperty(string propertyName)
     {
         var model = this.Model.Unsafe;
-        if (model == null)
+        if (model is null)
         {
             return; // throw?
         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/ShellViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/ShellViewModel.cs
@@ -120,7 +120,7 @@ public partial class ShellViewModel : ObservableObject,
 
         ////LoadedState = ViewModelLoadedState.Loading;
         if (!viewModel.IsInitialized
-            && viewModel.InitializeCommand != null)
+            && viewModel.InitializeCommand is not null)
         {
             _ = Task.Run(async () =>
             {
@@ -185,7 +185,7 @@ public partial class ShellViewModel : ObservableObject,
     private void PerformCommand(PerformCommandMessage message)
     {
         var command = message.Command.Unsafe;
-        if (command == null)
+        if (command is null)
         {
             return;
         }
@@ -205,7 +205,7 @@ public partial class ShellViewModel : ObservableObject,
 
                 // Construct our ViewModel of the appropriate type and pass it the UI Thread context.
                 var pageViewModel = _pageViewModelFactory.TryCreatePageViewModel(page, _isNested, host);
-                if (pageViewModel == null)
+                if (pageViewModel is null)
                 {
                     Logger.LogError($"Failed to create ViewModel for page {page.GetType().Name}");
                     throw new NotSupportedException();
@@ -240,7 +240,7 @@ public partial class ShellViewModel : ObservableObject,
         // TODO GH #525 This needs more better locking.
         lock (_invokeLock)
         {
-            if (_handleInvokeTask != null)
+            if (_handleInvokeTask is not null)
             {
                 // do nothing - a command is already doing a thing
             }
@@ -280,7 +280,7 @@ public partial class ShellViewModel : ObservableObject,
 
     private void UnsafeHandleCommandResult(ICommandResult? result)
     {
-        if (result == null)
+        if (result is null)
         {
             // No result, nothing to do.
             return;

--- a/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/StatusMessageViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/StatusMessageViewModel.cs
@@ -17,7 +17,7 @@ public partial class StatusMessageViewModel : ExtensionObjectViewModel
 
     public ProgressViewModel? Progress { get; private set; }
 
-    public bool HasProgress => Progress != null;
+    public bool HasProgress => Progress is not null;
 
     public StatusMessageViewModel(IStatusMessage message, WeakReference<IPageContext> context)
         : base(context)
@@ -28,7 +28,7 @@ public partial class StatusMessageViewModel : ExtensionObjectViewModel
     public override void InitializeProperties()
     {
         var model = Model.Unsafe;
-        if (model == null)
+        if (model is null)
         {
             return; // throw?
         }
@@ -36,7 +36,7 @@ public partial class StatusMessageViewModel : ExtensionObjectViewModel
         Message = model.Message;
         State = model.State;
         var modelProgress = model.Progress;
-        if (modelProgress != null)
+        if (modelProgress is not null)
         {
             Progress = new(modelProgress, this.PageContext);
             Progress.InitializeProperties();
@@ -61,7 +61,7 @@ public partial class StatusMessageViewModel : ExtensionObjectViewModel
     protected virtual void FetchProperty(string propertyName)
     {
         var model = this.Model.Unsafe;
-        if (model == null)
+        if (model is null)
         {
             return; // throw?
         }
@@ -76,7 +76,7 @@ public partial class StatusMessageViewModel : ExtensionObjectViewModel
                 break;
             case nameof(Progress):
                 var modelProgress = model.Progress;
-                if (modelProgress != null)
+                if (modelProgress is not null)
                 {
                     Progress = new(modelProgress, this.PageContext);
                     Progress.InitializeProperties();

--- a/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/TagViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/TagViewModel.cs
@@ -28,7 +28,7 @@ public partial class TagViewModel(ITag _tag, WeakReference<IPageContext> context
     public override void InitializeProperties()
     {
         var model = _tagModel.Unsafe;
-        if (model == null)
+        if (model is null)
         {
             return;
         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AliasManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AliasManager.cs
@@ -35,7 +35,7 @@ public partial class AliasManager : ObservableObject
             try
             {
                 var topLevelCommand = _topLevelCommandManager.LookupCommand(alias.CommandId);
-                if (topLevelCommand != null)
+                if (topLevelCommand is not null)
                 {
                     WeakReferenceMessenger.Default.Send<ClearSearchMessage>();
 
@@ -88,7 +88,7 @@ public partial class AliasManager : ObservableObject
         }
 
         // If we already have _this exact alias_, do nothing
-        if (newAlias != null &&
+        if (newAlias is not null &&
             _aliases.TryGetValue(newAlias.SearchPrefix, out var existingAlias))
         {
             if (existingAlias.CommandId == commandId)
@@ -113,7 +113,7 @@ public partial class AliasManager : ObservableObject
             _aliases.Remove(alias.SearchPrefix);
         }
 
-        if (newAlias != null)
+        if (newAlias is not null)
         {
             AddAlias(newAlias);
         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AppStateModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AppStateModel.cs
@@ -55,7 +55,7 @@ public partial class AppStateModel : ObservableObject
 
             var loaded = JsonSerializer.Deserialize<AppStateModel>(jsonContent, JsonSerializationContext.Default.AppStateModel);
 
-            Debug.WriteLine(loaded != null ? "Loaded settings file" : "Failed to parse");
+            Debug.WriteLine(loaded is not null ? "Loaded settings file" : "Failed to parse");
 
             return loaded ?? new();
         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandProviderWrapper.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandProviderWrapper.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CmdPal.UI.ViewModels;
 
 public sealed class CommandProviderWrapper
 {
-    public bool IsExtension => Extension != null;
+    public bool IsExtension => Extension is not null;
 
     private readonly bool isValid;
 
@@ -188,14 +188,14 @@ public sealed class CommandProviderWrapper
 
             return topLevelViewModel;
         };
-        if (commands != null)
+        if (commands is not null)
         {
             TopLevelItems = commands
                 .Select(c => makeAndAdd(c, false))
                 .ToArray();
         }
 
-        if (fallbacks != null)
+        if (fallbacks is not null)
         {
             FallbackItems = fallbacks
                 .Select(c => makeAndAdd(c, true))

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandSettingsViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandSettingsViewModel.cs
@@ -18,18 +18,18 @@ public partial class CommandSettingsViewModel(ICommandSettings? _unsafeSettings,
     public bool Initialized { get; private set; }
 
     public bool HasSettings =>
-        _model.Unsafe != null && // We have a settings model AND
-        (!Initialized || SettingsPage != null); // we weren't initialized, OR we were, and we do have a settings page
+        _model.Unsafe is not null && // We have a settings model AND
+        (!Initialized || SettingsPage is not null); // we weren't initialized, OR we were, and we do have a settings page
 
     private void UnsafeInitializeProperties()
     {
         var model = _model.Unsafe;
-        if (model == null)
+        if (model is null)
         {
             return;
         }
 
-        if (model.SettingsPage != null)
+        if (model.SettingsPage is not null)
         {
             SettingsPage = new CommandPaletteContentPageViewModel(model.SettingsPage, mainThread, provider.ExtensionHost);
             SettingsPage.InitializeProperties();

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/CreatedExtensionForm.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/CreatedExtensionForm.cs
@@ -30,7 +30,7 @@ internal sealed partial class CreatedExtensionForm : NewExtensionFormBase
     public override ICommandResult SubmitForm(string inputs, string data)
     {
         var dataInput = JsonNode.Parse(data)?.AsObject();
-        if (dataInput == null)
+        if (dataInput is null)
         {
             return CommandResult.KeepOpen();
         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/LogMessagesPage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/LogMessagesPage.cs
@@ -23,7 +23,7 @@ public partial class LogMessagesPage : ListPage
 
     private void LogMessages_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
-        if (e.Action == NotifyCollectionChangedAction.Add && e.NewItems != null)
+        if (e.Action == NotifyCollectionChangedAction.Add && e.NewItems is not null)
         {
             foreach (var item in e.NewItems)
             {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
@@ -158,7 +158,7 @@ public partial class MainListPage : DynamicListPage,
 
             // If we don't have any previous filter results to work with, start
             // with a list of all our commands & apps.
-            if (_filteredItems == null)
+            if (_filteredItems is null)
             {
                 _filteredItems = commands;
                 _filteredItemsIncludesApps = _includeApps;

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/NewExtensionForm.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/NewExtensionForm.cs
@@ -98,7 +98,7 @@ internal sealed partial class NewExtensionForm : NewExtensionFormBase
     public override CommandResult SubmitForm(string payload)
     {
         var formInput = JsonNode.Parse(payload)?.AsObject();
-        if (formInput == null)
+        if (formInput is null)
         {
             return CommandResult.KeepOpen();
         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/NewExtensionPage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/NewExtensionPage.cs
@@ -14,7 +14,7 @@ public partial class NewExtensionPage : ContentPage
 
     public override IContent[] GetContent()
     {
-        return _resultForm != null ? [_resultForm] : [_inputForm];
+        return _resultForm is not null ? [_resultForm] : [_inputForm];
     }
 
     public NewExtensionPage()
@@ -28,13 +28,13 @@ public partial class NewExtensionPage : ContentPage
 
     private void FormSubmitted(NewExtensionFormBase sender, NewExtensionFormBase? args)
     {
-        if (_resultForm != null)
+        if (_resultForm is not null)
         {
             _resultForm.FormSubmitted -= FormSubmitted;
         }
 
         _resultForm = args;
-        if (_resultForm != null)
+        if (_resultForm is not null)
         {
             _resultForm.FormSubmitted += FormSubmitted;
         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentFormViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentFormViewModel.cs
@@ -115,7 +115,7 @@ public partial class ContentFormViewModel(IFormContent _form, WeakReference<IPag
                 try
                 {
                     var model = _formModel.Unsafe!;
-                    if (model != null)
+                    if (model is not null)
                     {
                         var result = model.SubmitForm(inputString, dataString);
                         WeakReferenceMessenger.Default.Send<HandleCommandResultMessage>(new(new(result)));

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentMarkdownViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentMarkdownViewModel.cs
@@ -20,7 +20,7 @@ public partial class ContentMarkdownViewModel(IMarkdownContent _markdown, WeakRe
     public override void InitializeProperties()
     {
         var model = Model.Unsafe;
-        if (model == null)
+        if (model is null)
         {
             return;
         }
@@ -47,7 +47,7 @@ public partial class ContentMarkdownViewModel(IMarkdownContent _markdown, WeakRe
     protected void FetchProperty(string propertyName)
     {
         var model = Model.Unsafe;
-        if (model == null)
+        if (model is null)
         {
             return; // throw?
         }
@@ -66,7 +66,7 @@ public partial class ContentMarkdownViewModel(IMarkdownContent _markdown, WeakRe
     {
         base.UnsafeCleanup();
         var model = Model.Unsafe;
-        if (model != null)
+        if (model is not null)
         {
             model.PropChanged -= Model_PropChanged;
         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentTreeViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentTreeViewModel.cs
@@ -30,13 +30,13 @@ public partial class ContentTreeViewModel(ITreeContent _tree, WeakReference<IPag
     public override void InitializeProperties()
     {
         var model = Model.Unsafe;
-        if (model == null)
+        if (model is null)
         {
             return;
         }
 
         var root = model.RootContent;
-        if (root != null)
+        if (root is not null)
         {
             RootContent = ViewModelFromContent(root, PageContext);
             RootContent?.InitializeProperties();
@@ -82,7 +82,7 @@ public partial class ContentTreeViewModel(ITreeContent _tree, WeakReference<IPag
     protected void FetchProperty(string propertyName)
     {
         var model = Model.Unsafe;
-        if (model == null)
+        if (model is null)
         {
             return; // throw?
         }
@@ -91,7 +91,7 @@ public partial class ContentTreeViewModel(ITreeContent _tree, WeakReference<IPag
         {
             case nameof(RootContent):
                 var root = model.RootContent;
-                if (root != null)
+                if (root is not null)
                 {
                     RootContent = ViewModelFromContent(root, PageContext);
                 }
@@ -119,7 +119,7 @@ public partial class ContentTreeViewModel(ITreeContent _tree, WeakReference<IPag
             foreach (var item in newItems)
             {
                 var viewModel = ViewModelFromContent(item, PageContext);
-                if (viewModel != null)
+                if (viewModel is not null)
                 {
                     viewModel.InitializeProperties();
                     newContent.Add(viewModel);
@@ -153,7 +153,7 @@ public partial class ContentTreeViewModel(ITreeContent _tree, WeakReference<IPag
 
         Children.Clear();
         var model = Model.Unsafe;
-        if (model != null)
+        if (model is not null)
         {
             model.PropChanged -= Model_PropChanged;
             model.ItemsChanged -= Model_ItemsChanged;

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/HotkeyManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/HotkeyManager.cs
@@ -29,7 +29,7 @@ public partial class HotkeyManager : ObservableObject
             }
         }
 
-        _commandHotkeys.RemoveAll(item => item.Hotkey == null);
+        _commandHotkeys.RemoveAll(item => item.Hotkey is null);
 
         foreach (var item in _commandHotkeys)
         {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Models/ExtensionService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Models/ExtensionService.cs
@@ -90,7 +90,7 @@ public partial class ExtensionService : IExtensionService, IDisposable
         }).Result;
         var isExtension = isCmdPalExtensionResult.IsExtension;
         var extension = isCmdPalExtensionResult.Extension;
-        if (isExtension && extension != null)
+        if (isExtension && extension is not null)
         {
             CommandPaletteHost.Instance.DebugLog($"Installed new extension app {extension.DisplayName}");
 
@@ -152,7 +152,7 @@ public partial class ExtensionService : IExtensionService, IDisposable
             {
                 var (cmdPalProvider, classId) = await GetCmdPalExtensionPropertiesAsync(extension);
 
-                return new(cmdPalProvider != null && classId.Count != 0, extension);
+                return new(cmdPalProvider is not null && classId.Count != 0, extension);
             }
         }
 
@@ -237,7 +237,7 @@ public partial class ExtensionService : IExtensionService, IDisposable
     {
         var (cmdPalProvider, classIds) = await GetCmdPalExtensionPropertiesAsync(extension);
 
-        if (cmdPalProvider == null || classIds.Count == 0)
+        if (cmdPalProvider is null || classIds.Count == 0)
         {
             return [];
         }
@@ -352,12 +352,12 @@ public partial class ExtensionService : IExtensionService, IDisposable
     {
         var propSetList = new List<string>();
         var singlePropertySet = GetSubPropertySet(activationPropSet, CreateInstanceProperty);
-        if (singlePropertySet != null)
+        if (singlePropertySet is not null)
         {
             var classId = GetProperty(singlePropertySet, ClassIdProperty);
 
             // If the instance has a classId as a single string, then it's only supporting a single instance.
-            if (classId != null)
+            if (classId is not null)
             {
                 propSetList.Add(classId);
             }
@@ -365,7 +365,7 @@ public partial class ExtensionService : IExtensionService, IDisposable
         else
         {
             var propertySetArray = GetSubPropertySetArray(activationPropSet, CreateInstanceProperty);
-            if (propertySetArray != null)
+            if (propertySetArray is not null)
             {
                 foreach (var prop in propertySetArray)
                 {
@@ -375,7 +375,7 @@ public partial class ExtensionService : IExtensionService, IDisposable
                     }
 
                     var classId = GetProperty(propertySet, ClassIdProperty);
-                    if (classId != null)
+                    if (classId is not null)
                     {
                         propSetList.Add(classId);
                     }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ProviderSettings.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ProviderSettings.cs
@@ -35,7 +35,7 @@ public class ProviderSettings
     public void Connect(CommandProviderWrapper wrapper)
     {
         ProviderId = wrapper.ProviderId;
-        IsBuiltin = wrapper.Extension == null;
+        IsBuiltin = wrapper.Extension is null;
 
         ProviderDisplayName = wrapper.DisplayName;
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ProviderSettingsViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ProviderSettingsViewModel.cs
@@ -33,7 +33,7 @@ public partial class ProviderSettingsViewModel(
         Resources.builtin_disabled_extension;
 
     [MemberNotNullWhen(true, nameof(Extension))]
-    public bool IsFromExtension => _provider.Extension != null;
+    public bool IsFromExtension => _provider.Extension is not null;
 
     public IExtensionWrapper? Extension => _provider.Extension;
 
@@ -76,7 +76,7 @@ public partial class ProviderSettingsViewModel(
     {
         get
         {
-            if (_provider.Settings == null)
+            if (_provider.Settings is null)
             {
                 return false;
             }
@@ -100,7 +100,7 @@ public partial class ProviderSettingsViewModel(
     {
         get
         {
-            if (_provider.Settings == null)
+            if (_provider.Settings is null)
             {
                 return null;
             }
@@ -126,7 +126,7 @@ public partial class ProviderSettingsViewModel(
     {
         get
         {
-            if (field == null)
+            if (field is null)
             {
                 field = BuildTopLevelViewModels();
             }
@@ -149,7 +149,7 @@ public partial class ProviderSettingsViewModel(
     {
         get
         {
-            if (field == null)
+            if (field is null)
             {
                 field = BuildFallbackViewModels();
             }
@@ -173,7 +173,7 @@ public partial class ProviderSettingsViewModel(
 
     private void InitializeSettingsPage()
     {
-        if (_provider.Settings == null)
+        if (_provider.Settings is null)
         {
             return;
         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/RecentCommandsManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/RecentCommandsManager.cs
@@ -30,7 +30,7 @@ public partial class RecentCommandsManager : ObservableObject
             // These numbers are vaguely scaled so that "VS" will make "Visual Studio" the
             // match after one use.
             // Usually it has a weight of 84, compared to 109 for the VS cmd prompt
-            if (entry.Item != null)
+            if (entry.Item is not null)
             {
                 var index = entry.Index;
 
@@ -61,7 +61,7 @@ public partial class RecentCommandsManager : ObservableObject
             var entry = History
             .Where(item => item.CommandId == commandId)
             .FirstOrDefault();
-            if (entry == null)
+            if (entry is null)
             {
                 var newitem = new HistoryItem() { CommandId = commandId, Uses = 1 };
                 History.Insert(0, newitem);

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsModel.cs
@@ -95,7 +95,7 @@ public partial class SettingsModel : ObservableObject
 
             var loaded = JsonSerializer.Deserialize<SettingsModel>(jsonContent, JsonSerializationContext.Default.SettingsModel);
 
-            Debug.WriteLine(loaded != null ? "Loaded settings file" : "Failed to parse");
+            Debug.WriteLine(loaded is not null ? "Loaded settings file" : "Failed to parse");
 
             return loaded ?? new();
         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandManager.cs
@@ -151,7 +151,7 @@ public partial class TopLevelCommandManager : ObservableObject,
         WeakReference<IPageContext> weakSelf = new(this);
         await sender.LoadTopLevelCommands(_serviceProvider, weakSelf);
 
-        List<TopLevelViewModel> newItems = [..sender.TopLevelItems];
+        List<TopLevelViewModel> newItems = [.. sender.TopLevelItems];
         foreach (var i in sender.FallbackItems)
         {
             if (i.IsEnabled)
@@ -241,7 +241,7 @@ public partial class TopLevelCommandManager : ObservableObject,
             _extensionCommandProviders.Clear();
         }
 
-        if (extensions != null)
+        if (extensions is not null)
         {
             await StartExtensionsAndGetCommands(extensions);
         }
@@ -275,7 +275,7 @@ public partial class TopLevelCommandManager : ObservableObject,
         var startTasks = extensions.Select(StartExtensionWithTimeoutAsync);
 
         // Wait for all extensions to start
-        var wrappers = (await Task.WhenAll(startTasks)).Where(wrapper => wrapper != null).Select(w => w!).ToList();
+        var wrappers = (await Task.WhenAll(startTasks)).Where(wrapper => wrapper is not null).Select(w => w!).ToList();
 
         lock (_commandProvidersLock)
         {
@@ -285,7 +285,7 @@ public partial class TopLevelCommandManager : ObservableObject,
         // Load the commands from the providers in parallel
         var loadTasks = wrappers.Select(LoadCommandsWithTimeoutAsync);
 
-        var commandSets = (await Task.WhenAll(loadTasks)).Where(results => results != null).Select(r => r!).ToList();
+        var commandSets = (await Task.WhenAll(loadTasks)).Where(results => results is not null).Select(r => r!).ToList();
 
         lock (TopLevelCommands)
         {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelViewModel.cs
@@ -239,7 +239,7 @@ public sealed partial class TopLevelViewModel : ObservableObject, IListItem
     private void FetchAliasFromAliasManager()
     {
         var am = _serviceProvider.GetService<AliasManager>();
-        if (am != null)
+        if (am is not null)
         {
             var commandAlias = am.AliasFromId(Id);
             if (commandAlias is not null)
@@ -253,7 +253,7 @@ public sealed partial class TopLevelViewModel : ObservableObject, IListItem
     private void UpdateHotkey()
     {
         var hotkey = _settings.CommandHotkeys.Where(hk => hk.CommandId == Id).FirstOrDefault();
-        if (hotkey != null)
+        if (hotkey is not null)
         {
             _hotkey = hotkey.Hotkey;
         }
@@ -263,12 +263,12 @@ public sealed partial class TopLevelViewModel : ObservableObject, IListItem
     {
         List<Tag> tags = [];
 
-        if (Hotkey != null)
+        if (Hotkey is not null)
         {
             tags.Add(new Tag() { Text = Hotkey.ToString() });
         }
 
-        if (Alias != null)
+        if (Alias is not null)
         {
             tags.Add(new Tag() { Text = Alias.SearchPrefix });
         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml.cs
@@ -10,7 +10,6 @@ using Microsoft.CmdPal.UI.Views;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
-using Microsoft.UI.Xaml.Input;
 using Windows.System;
 
 namespace Microsoft.CmdPal.UI.Controls;
@@ -50,7 +49,7 @@ public sealed partial class CommandBar : UserControl,
             return;
         }
 
-        if (message.Element == null)
+        if (message.Element is null)
         {
             _ = DispatcherQueue.TryEnqueue(
                 () =>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContentFormControl.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContentFormControl.xaml.cs
@@ -44,7 +44,7 @@ public sealed partial class ContentFormControl : UserControl
         // 5% BODGY: if we set this multiple times over the lifetime of the app,
         // then the second call will explode, because "CardOverrideStyles is already the child of another element".
         // SO only set this once.
-        if (_renderer.OverrideStyles == null)
+        if (_renderer.OverrideStyles is null)
         {
             _renderer.OverrideStyles = CardOverrideStyles;
         }
@@ -55,19 +55,19 @@ public sealed partial class ContentFormControl : UserControl
 
     private void AttachViewModel(ContentFormViewModel? vm)
     {
-        if (_viewModel != null)
+        if (_viewModel is not null)
         {
             _viewModel.PropertyChanged -= ViewModel_PropertyChanged;
         }
 
         _viewModel = vm;
 
-        if (_viewModel != null)
+        if (_viewModel is not null)
         {
             _viewModel.PropertyChanged += ViewModel_PropertyChanged;
 
             var c = _viewModel.Card;
-            if (c != null)
+            if (c is not null)
             {
                 DisplayCard(c);
             }
@@ -76,7 +76,7 @@ public sealed partial class ContentFormControl : UserControl
 
     private void ViewModel_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
     {
-        if (ViewModel == null)
+        if (ViewModel is null)
         {
             return;
         }
@@ -84,7 +84,7 @@ public sealed partial class ContentFormControl : UserControl
         if (e.PropertyName == nameof(ViewModel.Card))
         {
             var c = ViewModel.Card;
-            if (c != null)
+            if (c is not null)
             {
                 DisplayCard(c);
             }
@@ -95,7 +95,7 @@ public sealed partial class ContentFormControl : UserControl
     {
         _renderedCard = _renderer.RenderAdaptiveCard(result.AdaptiveCard);
         ContentGrid.Children.Clear();
-        if (_renderedCard.FrameworkElement != null)
+        if (_renderedCard.FrameworkElement is not null)
         {
             ContentGrid.Children.Add(_renderedCard.FrameworkElement);
 
@@ -148,7 +148,7 @@ public sealed partial class ContentFormControl : UserControl
 
             // Recursively check children
             var result = FindFirstFocusableElement(child);
-            if (result != null)
+            if (result is not null)
             {
                 return result;
             }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContextMenu.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContextMenu.xaml.cs
@@ -31,7 +31,7 @@ public sealed partial class ContextMenu : UserControl,
         WeakReferenceMessenger.Default.Register<UpdateCommandBarMessage>(this);
         WeakReferenceMessenger.Default.Register<TryCommandKeybindingMessage>(this);
 
-        if (ViewModel != null)
+        if (ViewModel is not null)
         {
             ViewModel.PropertyChanged += ViewModel_PropertyChanged;
         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/IconBox.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/IconBox.cs
@@ -91,7 +91,7 @@ public partial class IconBox : ContentControl
     {
         if (d is IconBox @this)
         {
-            if (e.NewValue == null)
+            if (e.NewValue is null)
             {
                 @this.Source = null;
             }
@@ -104,7 +104,7 @@ public partial class IconBox : ContentControl
                     var requestedTheme = @this.ActualTheme;
                     var eventArgs = new SourceRequestedEventArgs(e.NewValue, requestedTheme);
 
-                    if (@this.SourceRequested != null)
+                    if (@this.SourceRequested is not null)
                     {
                         await @this.SourceRequested.InvokeAsync(@this, eventArgs);
 
@@ -142,7 +142,7 @@ public partial class IconBox : ContentControl
                             iconData = requestedTheme == ElementTheme.Light ? info.Light : info.Dark;
                         }
 
-                        if (iconData != null &&
+                        if (iconData is not null &&
                             @this.Source is FontIconSource)
                         {
                             if (!string.IsNullOrEmpty(iconData.Icon) && iconData.Icon.Length <= 2)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/KeyVisual/KeyVisual.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/KeyVisual/KeyVisual.cs
@@ -2,7 +2,6 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.CmdPal.UI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Markup;
@@ -80,12 +79,12 @@ public sealed partial class KeyVisual : Control
 
     private void Update()
     {
-        if (_keyVisual == null)
+        if (_keyVisual is null)
         {
             return;
         }
 
-        if (_keyVisual.Content != null)
+        if (_keyVisual.Content is not null)
         {
             if (_keyVisual.Content.GetType() == typeof(string))
             {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/SearchBar.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/SearchBar.xaml.cs
@@ -51,13 +51,13 @@ public sealed partial class SearchBar : UserControl,
         //// TODO: If the Debounce timer hasn't fired, we may want to store the current Filter in the OldValue/prior VM, but we don't want that to go actually do work...
         var @this = (SearchBar)d;
 
-        if (@this != null
+        if (@this is not null
             && e.OldValue is PageViewModel old)
         {
             old.PropertyChanged -= @this.Page_PropertyChanged;
         }
 
-        if (@this != null
+        if (@this is not null
             && e.NewValue is PageViewModel page)
         {
             // TODO: In some cases we probably want commands to clear a filter
@@ -85,7 +85,7 @@ public sealed partial class SearchBar : UserControl,
         {
             this.FilterBox.Text = string.Empty;
 
-            if (CurrentPageViewModel != null)
+            if (CurrentPageViewModel is not null)
             {
                 CurrentPageViewModel.Filter = string.Empty;
             }
@@ -143,7 +143,7 @@ public sealed partial class SearchBar : UserControl,
                 FilterBox.Text = string.Empty;
 
                 // hack TODO GH #245
-                if (CurrentPageViewModel != null)
+                if (CurrentPageViewModel is not null)
                 {
                     CurrentPageViewModel.Filter = FilterBox.Text;
                 }
@@ -154,7 +154,7 @@ public sealed partial class SearchBar : UserControl,
         else if (e.Key == VirtualKey.Back)
         {
             // hack TODO GH #245
-            if (CurrentPageViewModel != null)
+            if (CurrentPageViewModel is not null)
             {
                 CurrentPageViewModel.Filter = FilterBox.Text;
             }
@@ -318,7 +318,7 @@ public sealed partial class SearchBar : UserControl,
         }
 
         // Actually plumb Filtering to the view model
-        if (CurrentPageViewModel != null)
+        if (CurrentPageViewModel is not null)
         {
             CurrentPageViewModel.Filter = FilterBox.Text;
         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ShortcutControl/ShortcutControl.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ShortcutControl/ShortcutControl.xaml.cs
@@ -39,13 +39,13 @@ public sealed partial class ShortcutControl : UserControl, IDisposable, IRecipie
     private static void OnAllowDisableChanged(DependencyObject d, DependencyPropertyChangedEventArgs? e)
     {
         var me = d as ShortcutControl;
-        if (me == null)
+        if (me is null)
         {
             return;
         }
 
         var description = me.c?.FindDescendant<TextBlock>();
-        if (description == null)
+        if (description is null)
         {
             return;
         }
@@ -431,7 +431,7 @@ public sealed partial class ShortcutControl : UserControl, IDisposable, IRecipie
 
     private void ShortcutDialog_PrimaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
     {
-        if (lastValidSettings != null && ComboIsValid(lastValidSettings))
+        if (lastValidSettings is not null && ComboIsValid(lastValidSettings))
         {
             HotkeySettings = lastValidSettings with { };
         }
@@ -458,7 +458,7 @@ public sealed partial class ShortcutControl : UserControl, IDisposable, IRecipie
 
     private static bool ComboIsValid(HotkeySettings? settings)
     {
-        return settings != null && (settings.IsValid() || settings.IsEmpty());
+        return settings is not null && (settings.IsValid() || settings.IsEmpty());
     }
 
     public void Receive(WindowActivatedEventArgs message) => DoWindowActivated(message);
@@ -466,12 +466,12 @@ public sealed partial class ShortcutControl : UserControl, IDisposable, IRecipie
     private void DoWindowActivated(WindowActivatedEventArgs args)
     {
         args.Handled = true;
-        if (args.WindowActivationState != WindowActivationState.Deactivated && (hook == null || hook.GetDisposedState() == true))
+        if (args.WindowActivationState != WindowActivationState.Deactivated && (hook is null || hook.GetDisposedState() == true))
         {
             // If the PT settings window gets focussed/activated again, we enable the keyboard hook to catch the keyboard input.
             hook = new HotkeySettingsControlHook(Hotkey_KeyDown, Hotkey_KeyUp, Hotkey_IsActive, FilterAccessibleKeyboardEvents);
         }
-        else if (args.WindowActivationState == WindowActivationState.Deactivated && hook != null && hook.GetDisposedState() == false)
+        else if (args.WindowActivationState == WindowActivationState.Deactivated && hook is not null && hook.GetDisposedState() == false)
         {
             // If the PT settings window lost focus/activation, we disable the keyboard hook to allow keyboard input on other windows.
             hook.Dispose();
@@ -490,7 +490,7 @@ public sealed partial class ShortcutControl : UserControl, IDisposable, IRecipie
         {
             if (disposing)
             {
-                if (hook != null)
+                if (hook is not null)
                 {
                     hook.Dispose();
                 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/Tag.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/Tag.xaml.cs
@@ -84,7 +84,7 @@ public partial class Tag : Control
             return;
         }
 
-        if (tag.ForegroundColor != null &&
+        if (tag.ForegroundColor is not null &&
             OptionalColorBrushCacheProvider.Convert(tag.ForegroundColor.Value) is SolidColorBrush brush)
         {
             tag.Foreground = brush;
@@ -114,7 +114,7 @@ public partial class Tag : Control
             return;
         }
 
-        if (tag.BackgroundColor != null &&
+        if (tag.BackgroundColor is not null &&
             OptionalColorBrushCacheProvider.Convert(tag.BackgroundColor.Value) is SolidColorBrush brush)
         {
             tag.Background = brush;

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml.cs
@@ -74,7 +74,7 @@ public sealed partial class ListPage : Page,
         WeakReferenceMessenger.Default.Unregister<ActivateSelectedListItemMessage>(this);
         WeakReferenceMessenger.Default.Unregister<ActivateSecondaryCommandMessage>(this);
 
-        if (ViewModel != null)
+        if (ViewModel is not null)
         {
             ViewModel.PropertyChanged -= ViewModel_PropertyChanged;
             ViewModel.ItemsUpdated -= Page_ItemsUpdated;
@@ -142,13 +142,13 @@ public sealed partial class ListPage : Page,
         // here, then in Page_ItemsUpdated trying to select that cached item if
         // it's in the list (otherwise, clear the cache), but that seems
         // aggressively BODGY for something that mostly just works today.
-        if (ItemsList.SelectedItem != null)
+        if (ItemsList.SelectedItem is not null)
         {
             ItemsList.ScrollIntoView(ItemsList.SelectedItem);
 
             // Automation notification for screen readers
             var listViewPeer = Microsoft.UI.Xaml.Automation.Peers.ListViewAutomationPeer.CreatePeerForElement(ItemsList);
-            if (listViewPeer != null && li != null)
+            if (listViewPeer is not null && li is not null)
             {
                 var notificationText = li.Title;
                 listViewPeer.RaiseNotificationEvent(
@@ -165,7 +165,7 @@ public sealed partial class ListPage : Page,
         // Find the ScrollViewer in the ListView
         var listViewScrollViewer = FindScrollViewer(this.ItemsList);
 
-        if (listViewScrollViewer != null)
+        if (listViewScrollViewer is not null)
         {
             listViewScrollViewer.ViewChanged += ListViewScrollViewer_ViewChanged;
         }
@@ -174,7 +174,7 @@ public sealed partial class ListPage : Page,
     private void ListViewScrollViewer_ViewChanged(object? sender, ScrollViewerViewChangedEventArgs e)
     {
         var scrollView = sender as ScrollViewer;
-        if (scrollView == null)
+        if (scrollView is null)
         {
             return;
         }
@@ -256,7 +256,7 @@ public sealed partial class ListPage : Page,
                 page.PropertyChanged += @this.ViewModel_PropertyChanged;
                 page.ItemsUpdated += @this.Page_ItemsUpdated;
             }
-            else if (e.NewValue == null)
+            else if (e.NewValue is null)
             {
                 Logger.LogDebug("cleared view model");
             }
@@ -274,7 +274,7 @@ public sealed partial class ListPage : Page,
         // ItemsList_SelectionChanged again to give us another chance to change
         // the selection from null -> something. Better to just update the
         // selection once, at the end of all the updating.
-        if (ItemsList.SelectedItem == null)
+        if (ItemsList.SelectedItem is null)
         {
             ItemsList.SelectedIndex = 0;
         }
@@ -307,7 +307,7 @@ public sealed partial class ListPage : Page,
         {
             var child = VisualTreeHelper.GetChild(parent, i);
             var result = FindScrollViewer(child);
-            if (result != null)
+            if (result is not null)
             {
                 return result;
             }
@@ -329,7 +329,7 @@ public sealed partial class ListPage : Page,
             _ => (null, null),
         };
 
-        if (item == null || element == null)
+        if (item is null || element is null)
         {
             return;
         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/GpoValueChecker.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/GpoValueChecker.cs
@@ -2,13 +2,6 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CmdPal.Ext.Bookmarks;
-using Microsoft.UI.Xaml.Documents;
 using Microsoft.Win32;
 
 namespace Microsoft.CmdPal.UI.Helpers;
@@ -63,7 +56,7 @@ internal static class GpoValueChecker
     {
         using (RegistryKey? key = rootKey.OpenSubKey(subKeyPath, false))
         {
-            if (key == null)
+            if (key is null)
             {
                 return null;
             }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/IconCacheProvider.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/IconCacheProvider.cs
@@ -4,7 +4,6 @@
 
 using Microsoft.CmdPal.Core.ViewModels;
 using Microsoft.CmdPal.UI.Controls;
-using Microsoft.CmdPal.UI.Helpers;
 
 namespace Microsoft.CmdPal.UI.Helpers;
 
@@ -19,7 +18,7 @@ public static partial class IconCacheProvider
     public static async void SourceRequested(IconBox sender, SourceRequestedEventArgs args)
 #pragma warning restore IDE0060 // Remove unused parameter
     {
-        if (args.Key == null)
+        if (args.Key is null)
         {
             return;
         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/IconCacheService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/IconCacheService.cs
@@ -28,7 +28,7 @@ public sealed class IconCacheService(DispatcherQueue dispatcherQueue)
                 var source = IconPathConverter.IconSourceMUX(icon.Icon, false);
                 return source;
             }
-            else if (icon.Data != null)
+            else if (icon.Data is not null)
             {
                 try
                 {
@@ -49,7 +49,7 @@ public sealed class IconCacheService(DispatcherQueue dispatcherQueue)
 
     private async Task<IconSource?> StreamToIconSource(IRandomAccessStreamReference iconStreamRef)
     {
-        if (iconStreamRef == null)
+        if (iconStreamRef is null)
         {
             return null;
         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/TrayIconService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/TrayIconService.cs
@@ -49,7 +49,7 @@ internal sealed partial class TrayIconService
     {
         if (showSystemTrayIcon ?? _settingsModel.ShowSystemTrayIcon)
         {
-            if (_window == null)
+            if (_window is null)
             {
                 _window = new Window();
                 _hwnd = new HWND(WindowNative.GetWindowHandle(_window));
@@ -63,7 +63,7 @@ internal sealed partial class TrayIconService
                 _originalWndProc = Marshal.GetDelegateForFunctionPointer<WNDPROC>(PInvoke.SetWindowLongPtr(_hwnd, WINDOW_LONG_PTR_INDEX.GWL_WNDPROC, hotKeyPrcPointer));
             }
 
-            if (_trayIconData == null)
+            if (_trayIconData is null)
             {
                 // We need to stash this handle, so it doesn't clean itself up. If
                 // explorer restarts, we'll come back through here, and we don't
@@ -87,7 +87,7 @@ internal sealed partial class TrayIconService
             // Add the notification icon
             PInvoke.Shell_NotifyIcon(NOTIFY_ICON_MESSAGE.NIM_ADD, in d);
 
-            if (_popupMenu == null)
+            if (_popupMenu is null)
             {
                 _popupMenu = PInvoke.CreatePopupMenu_SafeHandle();
                 PInvoke.InsertMenu(_popupMenu, 0, MENU_ITEM_FLAGS.MF_BYPOSITION | MENU_ITEM_FLAGS.MF_STRING, PInvoke.WM_USER + 1, RS_.GetString("TrayMenu_Settings"));
@@ -102,7 +102,7 @@ internal sealed partial class TrayIconService
 
     public void Destroy()
     {
-        if (_trayIconData != null)
+        if (_trayIconData is not null)
         {
             var d = (NOTIFYICONDATAW)_trayIconData;
             if (PInvoke.Shell_NotifyIcon(NOTIFY_ICON_MESSAGE.NIM_DELETE, in d))
@@ -111,19 +111,19 @@ internal sealed partial class TrayIconService
             }
         }
 
-        if (_popupMenu != null)
+        if (_popupMenu is not null)
         {
             _popupMenu.Close();
             _popupMenu = null;
         }
 
-        if (_largeIcon != null)
+        if (_largeIcon is not null)
         {
             _largeIcon.Close();
             _largeIcon = null;
         }
 
-        if (_window != null)
+        if (_window is not null)
         {
             _window.Close();
             _window = null;
@@ -166,7 +166,7 @@ internal sealed partial class TrayIconService
             // WM_WINDOWPOSCHANGING which is always received on explorer startup sequence.
             case PInvoke.WM_WINDOWPOSCHANGING:
                 {
-                    if (_trayIconData == null)
+                    if (_trayIconData is null)
                     {
                         SetupTrayIcon();
                     }
@@ -188,7 +188,7 @@ internal sealed partial class TrayIconService
                     {
                         case PInvoke.WM_RBUTTONUP:
                             {
-                                if (_popupMenu != null)
+                                if (_popupMenu is not null)
                                 {
                                     PInvoke.GetCursorPos(out var cursorPos);
                                     PInvoke.SetForegroundWindow(_hwnd);

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/TypedEventHandlerExtensions.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/TypedEventHandlerExtensions.cs
@@ -46,7 +46,7 @@ public static class TypedEventHandlerExtensions
 #pragma warning restore CA1715 // Identifiers should have correct prefix
         where R : DeferredEventArgs
     {
-        if (eventHandler == null)
+        if (eventHandler is null)
         {
             return Task.CompletedTask;
         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/WindowHelper.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/WindowHelper.cs
@@ -13,7 +13,7 @@ internal sealed partial class WindowHelper
         UserNotificationState state;
 
         // https://learn.microsoft.com/en-us/windows/win32/api/shellapi/ne-shellapi-query_user_notification_state
-        if (Marshal.GetExceptionForHR(NativeMethods.SHQueryUserNotificationState(out state)) == null)
+        if (Marshal.GetExceptionForHR(NativeMethods.SHQueryUserNotificationState(out state)) is null)
         {
             if (state == UserNotificationState.QUNS_RUNNING_D3D_FULL_SCREEN ||
                 state == UserNotificationState.QUNS_BUSY ||

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml.cs
@@ -10,7 +10,6 @@ using ManagedCommon;
 using Microsoft.CmdPal.Common.Helpers;
 using Microsoft.CmdPal.Common.Messages;
 using Microsoft.CmdPal.Common.Services;
-using Microsoft.CmdPal.Core.ViewModels;
 using Microsoft.CmdPal.Core.ViewModels.Messages;
 using Microsoft.CmdPal.UI.Events;
 using Microsoft.CmdPal.UI.Helpers;
@@ -379,7 +378,7 @@ public sealed partial class MainWindow : WindowEx,
 
     private void DisposeAcrylic()
     {
-        if (_acrylicController != null)
+        if (_acrylicController is not null)
         {
             _acrylicController.Dispose();
             _acrylicController = null!;
@@ -454,7 +453,7 @@ public sealed partial class MainWindow : WindowEx,
             PowerToysTelemetry.Log.WriteEvent(new CmdPalDismissedOnLostFocus());
         }
 
-        if (_configurationSource != null)
+        if (_configurationSource is not null)
         {
             _configurationSource.IsInputActive = args.WindowActivationState != WindowActivationState.Deactivated;
         }
@@ -462,7 +461,7 @@ public sealed partial class MainWindow : WindowEx,
 
     public void HandleLaunch(AppActivationArguments? activatedEventArgs)
     {
-        if (activatedEventArgs == null)
+        if (activatedEventArgs is null)
         {
             Summon(string.Empty);
             return;
@@ -530,7 +529,7 @@ public sealed partial class MainWindow : WindowEx,
         UnregisterHotkeys();
 
         var globalHotkey = settings.Hotkey;
-        if (globalHotkey != null)
+        if (globalHotkey is not null)
         {
             if (settings.UseLowLevelGlobalHotkey)
             {
@@ -560,7 +559,7 @@ public sealed partial class MainWindow : WindowEx,
         {
             var key = commandHotkey.Hotkey;
 
-            if (key != null)
+            if (key is not null)
             {
                 if (settings.UseLowLevelGlobalHotkey)
                 {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/LoadingPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/LoadingPage.xaml.cs
@@ -24,7 +24,7 @@ public sealed partial class LoadingPage : Page
     protected override void OnNavigatedTo(NavigationEventArgs e)
     {
         if (e.Parameter is ShellViewModel shellVM
-            && shellVM.LoadCommand != null)
+            && shellVM.LoadCommand is not null)
         {
             // This will load the built-in commands, then navigate to the main page.
             // Once the mainpage loads, we'll start loading extensions.

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
@@ -17,7 +17,6 @@ using Microsoft.PowerToys.Telemetry;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Input;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media.Animation;
 using DispatcherQueue = Microsoft.UI.Dispatching.DispatcherQueue;
@@ -171,7 +170,7 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
     // This gets called from the UI thread
     private async Task HandleConfirmArgsOnUiThread(IConfirmationArgs? args)
     {
-        if (args == null)
+        if (args is null)
         {
             return;
         }
@@ -236,7 +235,7 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
 
     public void OpenSettings()
     {
-        if (_settingsWindow == null)
+        if (_settingsWindow is null)
         {
             _settingsWindow = new SettingsWindow();
         }
@@ -323,7 +322,7 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
                 // command from our list of toplevel commands.
                 var tlcManager = App.Current.Services.GetService<TopLevelCommandManager>()!;
                 var topLevelCommand = tlcManager.LookupCommand(commandId);
-                if (topLevelCommand != null)
+                if (topLevelCommand is not null)
                 {
                     var command = topLevelCommand.CommandViewModel.Model.Unsafe;
                     var isPage = command is not IInvokableCommand;

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/PowerToysRootPageService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/PowerToysRootPageService.cs
@@ -100,7 +100,7 @@ internal sealed class PowerToysRootPageService : IRootPageService
             _activeExtension = extension;
 
             var extensionWinRtObject = _activeExtension?.GetExtensionObject();
-            if (extensionWinRtObject != null)
+            if (extensionWinRtObject is not null)
             {
                 try
                 {

--- a/src/modules/cmdpal/Microsoft.Terminal.UI/IconPathConverter.cpp
+++ b/src/modules/cmdpal/Microsoft.Terminal.UI/IconPathConverter.cpp
@@ -331,7 +331,7 @@ namespace winrt::Microsoft::Terminal::UI::implementation
         // * C:\Program Files\PowerShell\7\pwsh.exe, 0
 
         const auto swBitmap{ _getBitmapFromIconFileAsync(winrt::hstring{ iconPathWithoutIndex }, index, targetSize) };
-        if (swBitmap == nullptr)
+        if (swBitmap is nullptr)
         {
             return nullptr;
         }

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Calc.UnitTests/NumberTranslatorTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Calc.UnitTests/NumberTranslatorTests.cs
@@ -18,8 +18,8 @@ public class NumberTranslatorTests
     public void Create_ThrowError_WhenCalledNullOrEmpty(string sourceCultureName, string targetCultureName)
     {
         // Arrange
-        CultureInfo sourceCulture = sourceCultureName != null ? new CultureInfo(sourceCultureName) : null;
-        CultureInfo targetCulture = targetCultureName != null ? new CultureInfo(targetCultureName) : null;
+        CultureInfo sourceCulture = sourceCultureName is not null ? new CultureInfo(sourceCultureName) : null;
+        CultureInfo targetCulture = targetCultureName is not null ? new CultureInfo(targetCultureName) : null;
 
         // Act
         Assert.ThrowsException<ArgumentNullException>(() => NumberTranslator.Create(sourceCulture, targetCulture));

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.TimeDate.UnitTests/TimeAndDateHelperTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.TimeDate.UnitTests/TimeAndDateHelperTests.cs
@@ -45,7 +45,7 @@ public class TimeAndDateHelperTests
         var result = TimeAndDateHelper.GetCalendarWeekRule(setting);
 
         // Assert
-        if (valueExpected == null)
+        if (valueExpected is null)
         {
             // falls back to system setting.
             Assert.AreEqual(DateTimeFormatInfo.CurrentInfo.CalendarWeekRule, result);
@@ -72,7 +72,7 @@ public class TimeAndDateHelperTests
         var result = TimeAndDateHelper.GetFirstDayOfWeek(setting);
 
         // Assert
-        if (valueExpected == null)
+        if (valueExpected is null)
         {
             // falls back to system setting.
             Assert.AreEqual(DateTimeFormatInfo.CurrentInfo.FirstDayOfWeek, result);

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/AllAppsPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/AllAppsPage.cs
@@ -2,16 +2,12 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Numerics;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using ManagedCommon;
-using Microsoft.CmdPal.Ext.Apps.Commands;
 using Microsoft.CmdPal.Ext.Apps.Programs;
 using Microsoft.CmdPal.Ext.Apps.Properties;
 using Microsoft.CmdPal.Ext.Apps.State;
@@ -145,7 +141,7 @@ public sealed partial class AllAppsPage : ListPage
         */
         var existingAppItem = allApps.FirstOrDefault(f => f.AppIdentifier == e.AppIdentifier);
 
-        if (existingAppItem != null)
+        if (existingAppItem is not null)
         {
             var appListItem = new AppListItem(existingAppItem, true, e.IsPinned);
 

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/AppCache.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/AppCache.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CmdPal.Ext.Apps.Programs;
@@ -66,7 +65,7 @@ public sealed partial class AppCache : IDisposable
 
     private void UpdateUWPIconPath(Theme theme)
     {
-        if (_packageRepository != null)
+        if (_packageRepository is not null)
         {
             foreach (UWPApplication app in _packageRepository)
             {

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/AppListItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/AppListItem.cs
@@ -72,7 +72,7 @@ internal sealed partial class AppListItem : ListItem
             try
             {
                 var stream = await ThumbnailHelper.GetThumbnail(_app.ExePath, true);
-                if (stream != null)
+                if (stream is not null)
                 {
                     heroImage = IconInfo.FromStream(stream);
                 }
@@ -106,7 +106,7 @@ internal sealed partial class AppListItem : ListItem
             try
             {
                 var stream = await ThumbnailHelper.GetThumbnail(_app.ExePath);
-                if (stream != null)
+                if (stream is not null)
                 {
                     var data = new IconData(RandomAccessStreamReference.CreateFromStream(stream));
                     icon = new IconInfo(data, data);

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Programs/AppxPackageHelper.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Programs/AppxPackageHelper.cs
@@ -6,9 +6,7 @@ using System;
 using System.Collections.Generic;
 using ManagedCommon;
 using Microsoft.CmdPal.Ext.Apps.Utils;
-using Microsoft.UI.Xaml.Controls;
 using Windows.Win32;
-using Windows.Win32.Foundation;
 using Windows.Win32.Storage.Packaging.Appx;
 using Windows.Win32.System.Com;
 
@@ -51,14 +49,14 @@ public static class AppxPackageHelper
                 {
                     result.Add((IntPtr)manifestApp);
                 }
-                else if (manifestApp != null)
+                else if (manifestApp is not null)
                 {
                     manifestApp->Release();
                 }
             }
             catch (Exception ex)
             {
-                if (manifestApp != null)
+                if (manifestApp is not null)
                 {
                     manifestApp->Release();
                 }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Programs/PackageManagerWrapper.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Programs/PackageManagerWrapper.cs
@@ -22,11 +22,11 @@ public class PackageManagerWrapper : IPackageManager
     {
         var user = WindowsIdentity.GetCurrent().User;
 
-        if (user != null)
+        if (user is not null)
         {
             var pkgs = _packageManager.FindPackagesForUser(user.Value);
 
-            return pkgs.Select(PackageWrapper.GetWrapperFromPackage).Where(package => package != null);
+            return pkgs.Select(PackageWrapper.GetWrapperFromPackage).Where(package => package is not null);
         }
 
         return Enumerable.Empty<IPackage>();

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Programs/UWP.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Programs/UWP.cs
@@ -11,9 +11,7 @@ using System.Threading.Tasks;
 using System.Xml.Linq;
 using ManagedCommon;
 using Microsoft.CmdPal.Ext.Apps.Utils;
-using Microsoft.CommandPalette.Extensions.Toolkit;
 using Windows.Win32;
-using Windows.Win32.Foundation;
 using Windows.Win32.Storage.Packaging.Appx;
 using Windows.Win32.System.Com;
 
@@ -99,7 +97,7 @@ public partial class UWP
     private static string[] XmlNamespaces(string path)
     {
         var z = XDocument.Load(path);
-        if (z.Root != null)
+        if (z.Root is not null)
         {
             var namespaces = z.Root.Attributes().
                 Where(a => a.IsNamespaceDeclaration).

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Programs/UWPApplication.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Programs/UWPApplication.cs
@@ -308,7 +308,7 @@ public class UWPApplication : IProgram
     private bool SetScaleIcons(string path, string colorscheme, bool highContrast = false)
     {
         var extension = Path.GetExtension(path);
-        if (extension != null)
+        if (extension is not null)
         {
             var end = path.Length - extension.Length;
             var prefix = path.Substring(0, end);
@@ -363,7 +363,7 @@ public class UWPApplication : IProgram
     private bool SetTargetSizeIcon(string path, string colorscheme, bool highContrast = false)
     {
         var extension = Path.GetExtension(path);
-        if (extension != null)
+        if (extension is not null)
         {
             var end = path.Length - extension.Length;
             var prefix = path.Substring(0, end);
@@ -576,7 +576,7 @@ public class UWPApplication : IProgram
 
             var group = new DrawingGroup();
             var converted = ColorConverter.ConvertFromString(currentBackgroundColor);
-            if (converted != null)
+            if (converted is not null)
             {
                 var color = (Color)converted;
                 var brush = new SolidColorBrush(color);

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Programs/Win32Program.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Programs/Win32Program.cs
@@ -170,7 +170,7 @@ public class Win32Program : IProgram
 
     public bool QueryEqualsNameForRunCommands(string query)
     {
-        if (query != null && AppType == ApplicationType.RunCommand)
+        if (query is not null && AppType == ApplicationType.RunCommand)
         {
             // Using OrdinalIgnoreCase since this is used internally
             if (!query.Equals(Name, StringComparison.OrdinalIgnoreCase) && !query.Equals(ExecutableName, StringComparison.OrdinalIgnoreCase))
@@ -667,7 +667,7 @@ public class Win32Program : IProgram
         var paths = new List<string>();
         using (var root = Registry.LocalMachine.OpenSubKey(appPaths))
         {
-            if (root != null)
+            if (root is not null)
             {
                 paths.AddRange(GetPathsFromRegistry(root));
             }
@@ -675,7 +675,7 @@ public class Win32Program : IProgram
 
         using (var root = Registry.CurrentUser.OpenSubKey(appPaths))
         {
-            if (root != null)
+            if (root is not null)
             {
                 paths.AddRange(GetPathsFromRegistry(root));
             }
@@ -700,7 +700,7 @@ public class Win32Program : IProgram
         {
             using (var key = root.OpenSubKey(subkey))
             {
-                if (key == null)
+                if (key is null)
                 {
                     return string.Empty;
                 }
@@ -742,13 +742,13 @@ public class Win32Program : IProgram
 
         public bool Equals(Win32Program? app1, Win32Program? app2)
         {
-            if (app1 == null && app2 == null)
+            if (app1 is null && app2 is null)
             {
                 return true;
             }
 
-            return app1 != null
-                    && app2 != null
+            return app1 is not null
+                    && app2 is not null
                     && (app1.Name?.ToUpperInvariant(), app1.ExecutableName?.ToUpperInvariant(), app1.FullPath?.ToUpperInvariant())
                     .Equals((app2.Name?.ToUpperInvariant(), app2.ExecutableName?.ToUpperInvariant(), app2.FullPath?.ToUpperInvariant()));
         }
@@ -908,7 +908,7 @@ public class Win32Program : IProgram
             Parallel.ForEach(paths, source =>
             {
                 var program = GetProgramFromPath(source);
-                if (program != null)
+                if (program is not null)
                 {
                     programsList.Add(program);
                 }
@@ -918,7 +918,7 @@ public class Win32Program : IProgram
             Parallel.ForEach(runCommandPaths, source =>
             {
                 var program = GetRunCommandProgramFromPath(source);
-                if (program != null)
+                if (program is not null)
                 {
                     runCommandProgramsList.Add(program);
                 }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Storage/FileSystemWatcherWrapper.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Storage/FileSystemWatcherWrapper.cs
@@ -19,7 +19,7 @@ public sealed partial class FileSystemWatcherWrapper : FileSystemWatcher, IFileS
         get => this.Filters;
         set
         {
-            if (value != null)
+            if (value is not null)
             {
                 foreach (var filter in value)
                 {

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Storage/Win32ProgramRepository.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Storage/Win32ProgramRepository.cs
@@ -10,7 +10,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Threading.Tasks;
 using ManagedCommon;
-using Microsoft.CmdPal.Ext.Apps.Programs;
 using Win32Program = Microsoft.CmdPal.Ext.Apps.Programs.Win32Program;
 
 namespace Microsoft.CmdPal.Ext.Apps.Storage;
@@ -53,7 +52,7 @@ internal sealed partial class Win32ProgramRepository : ListRepository<Programs.W
                 if (!string.IsNullOrEmpty(appPath))
                 {
                     Win32Program? app = Win32Program.GetAppFromPath(appPath);
-                    if (app != null)
+                    if (app is not null)
                     {
                         Add(app);
                         _isDirty = true;
@@ -137,7 +136,7 @@ internal sealed partial class Win32ProgramRepository : ListRepository<Programs.W
         }
 
         // To remove the old app which has been renamed and to add the new application.
-        if (oldApp != null)
+        if (oldApp is not null)
         {
             if (string.IsNullOrWhiteSpace(oldApp.Name) || string.IsNullOrWhiteSpace(oldApp.ExecutableName) || string.IsNullOrWhiteSpace(oldApp.FullPath))
             {
@@ -149,7 +148,7 @@ internal sealed partial class Win32ProgramRepository : ListRepository<Programs.W
             }
         }
 
-        if (newApp != null)
+        if (newApp is not null)
         {
             Add(newApp);
             _isDirty = true;
@@ -177,7 +176,7 @@ internal sealed partial class Win32ProgramRepository : ListRepository<Programs.W
             if (extension.Equals(LnkExtension, StringComparison.OrdinalIgnoreCase))
             {
                 app = GetAppWithSameLnkFilePath(path);
-                if (app == null)
+                if (app is null)
                 {
                     // Cancelled links won't have a resolved path.
                     app = GetAppWithSameNameAndExecutable(Path.GetFileNameWithoutExtension(path), Path.GetFileName(path));
@@ -197,7 +196,7 @@ internal sealed partial class Win32ProgramRepository : ListRepository<Programs.W
             Logger.LogError(ex.Message);
         }
 
-        if (app != null)
+        if (app is not null)
         {
             Remove(app);
             _isDirty = true;
@@ -244,7 +243,7 @@ internal sealed partial class Win32ProgramRepository : ListRepository<Programs.W
         if (!Path.GetExtension(path).Equals(UrlExtension, StringComparison.OrdinalIgnoreCase) && !Path.GetExtension(path).Equals(LnkExtension, StringComparison.OrdinalIgnoreCase))
         {
             Programs.Win32Program? app = Programs.Win32Program.GetAppFromPath(path);
-            if (app != null)
+            if (app is not null)
             {
                 Add(app);
                 _isDirty = true;

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Utils/ComFreeHelper.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Utils/ComFreeHelper.cs
@@ -2,7 +2,6 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Windows.Win32;
 using Windows.Win32.Foundation;
 using Windows.Win32.System.Com;
@@ -27,7 +26,7 @@ public static class ComFreeHelper
     public static unsafe void ComObjectRelease<T>(T* comPtr)
         where T : unmanaged
     {
-        if (comPtr != null)
+        if (comPtr is not null)
         {
             ((IUnknown*)comPtr)->Release();
         }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Utils/ShellLinkHelper.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Utils/ShellLinkHelper.cs
@@ -3,8 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Text;
-using ManagedCommon;
 using Windows.Win32;
 using Windows.Win32.Foundation;
 using Windows.Win32.System.Com;
@@ -37,7 +35,7 @@ public class ShellLinkHelper : IShellLinkHelper
         IPersistFile* persistFile = null;
         Guid iid = typeof(IPersistFile).GUID;
         ((IUnknown*)link)->QueryInterface(&iid, (void**)&persistFile);
-        if (persistFile != null)
+        if (persistFile is not null)
         {
             using var persistFileHandle = new SafeComHandle((IntPtr)persistFile);
             try

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Utils/ShellLocalization.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Utils/ShellLocalization.cs
@@ -45,7 +45,7 @@ public class ShellLocalization
 
             var filename = ComFreeHelper.GetStringAndFree(hr, filenamePtr);
 
-            if (filename == null)
+            if (filename is null)
             {
                 return string.Empty;
             }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Utils/ThemeHelper.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Utils/ThemeHelper.cs
@@ -32,7 +32,7 @@ public static class ThemeHelper
 
         // Retrieve the registry value, which is a DWORD (0 or 1)
         var registryValueObj = Registry.GetValue(registryKey, registryValue, null);
-        if (registryValueObj != null)
+        if (registryValueObj is not null)
         {
             // 0 = Dark mode, 1 = Light mode
             var isLightMode = Convert.ToBoolean((int)registryValueObj, CultureInfo.InvariantCulture);

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Bookmark/AddBookmarkForm.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Bookmark/AddBookmarkForm.cs
@@ -63,7 +63,7 @@ internal sealed partial class AddBookmarkForm : FormContent
     public override CommandResult SubmitForm(string payload)
     {
         var formInput = JsonNode.Parse(payload);
-        if (formInput == null)
+        if (formInput is null)
         {
             return CommandResult.GoHome();
         }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Bookmark/BookmarkPlaceholderForm.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Bookmark/BookmarkPlaceholderForm.cs
@@ -73,7 +73,7 @@ internal sealed partial class BookmarkPlaceholderForm : FormContent
         // parse the submitted JSON and then open the link
         var formInput = JsonNode.Parse(payload);
         var formObject = formInput?.AsObject();
-        if (formObject == null)
+        if (formObject is null)
         {
             return CommandResult.GoHome();
         }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Bookmark/BookmarksCommandProvider.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Bookmark/BookmarksCommandProvider.cs
@@ -49,7 +49,7 @@ public partial class BookmarksCommandProvider : CommandProvider
 
     private void SaveAndUpdateCommands()
     {
-        if (_bookmarks != null)
+        if (_bookmarks is not null)
         {
             var jsonPath = BookmarksCommandProvider.StateJsonPath();
             Bookmarks.WriteToFile(jsonPath, _bookmarks);
@@ -64,12 +64,12 @@ public partial class BookmarksCommandProvider : CommandProvider
         List<CommandItem> collected = [];
         collected.Add(new CommandItem(_addNewCommand));
 
-        if (_bookmarks == null)
+        if (_bookmarks is null)
         {
             LoadBookmarksFromFile();
         }
 
-        if (_bookmarks != null)
+        if (_bookmarks is not null)
         {
             collected.AddRange(_bookmarks.Data.Select(BookmarkToCommandItem));
         }
@@ -93,7 +93,7 @@ public partial class BookmarksCommandProvider : CommandProvider
             Logger.LogError(ex.Message);
         }
 
-        if (_bookmarks == null)
+        if (_bookmarks is null)
         {
             _bookmarks = new();
         }
@@ -134,7 +134,7 @@ public partial class BookmarksCommandProvider : CommandProvider
             name: Resources.bookmarks_delete_name,
             action: () =>
             {
-                if (_bookmarks != null)
+                if (_bookmarks is not null)
                 {
                     ExtensionHost.LogMessage($"Deleting bookmark ({bookmark.Name},{bookmark.Bookmark})");
 

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Bookmark/UrlCommand.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Bookmark/UrlCommand.cs
@@ -73,7 +73,7 @@ public partial class UrlCommand : InvokableCommand
         if (string.IsNullOrEmpty(args))
         {
             var uri = GetUri(exe);
-            if (uri != null)
+            if (uri is not null)
             {
                 _ = Launcher.LaunchUriAsync(uri);
             }
@@ -109,7 +109,7 @@ public partial class UrlCommand : InvokableCommand
         // First, try to get the icon from the thumbnail helper
         // This works for local files and folders
         icon = await MaybeGetIconForPath(target);
-        if (icon != null)
+        if (icon is not null)
         {
             return icon;
         }
@@ -142,7 +142,7 @@ public partial class UrlCommand : InvokableCommand
         {
             // If the executable exists, try to get the icon from the file
             icon = await MaybeGetIconForPath(fullExePath);
-            if (icon != null)
+            if (icon is not null)
             {
                 return icon;
             }
@@ -154,7 +154,7 @@ public partial class UrlCommand : InvokableCommand
         try
         {
             var uri = GetUri(baseString);
-            if (uri != null)
+            if (uri is not null)
             {
                 var hostname = uri.Host;
                 var faviconUrl = $"{uri.Scheme}://{hostname}/favicon.ico";
@@ -176,7 +176,7 @@ public partial class UrlCommand : InvokableCommand
         try
         {
             var stream = await ThumbnailHelper.GetThumbnail(target);
-            if (stream != null)
+            if (stream is not null)
             {
                 var data = new IconData(RandomAccessStreamReference.CreateFromStream(stream));
                 return new IconInfo(data, data);

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Helper/NumberTranslator.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Helper/NumberTranslator.cs
@@ -107,7 +107,7 @@ public class NumberTranslator
             // Currently, we only convert base literals (hexadecimal, binary, octal) to decimal.
             var converted = ConvertBaseLiteral(token, cultureTo);
 
-            if (converted != null)
+            if (converted is not null)
             {
                 outputBuilder.Append(converted);
                 continue;

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Helper/ResultHelper.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Helper/ResultHelper.cs
@@ -16,7 +16,7 @@ public static class ResultHelper
     public static ListItem CreateResult(decimal? roundedResult, CultureInfo inputCulture, CultureInfo outputCulture, string query, SettingsManager settings, TypedEventHandler<object, object> handleSave)
     {
         // Return null when the expression is not a valid calculator query.
-        if (roundedResult == null)
+        if (roundedResult is null)
         {
             return null;
         }
@@ -48,7 +48,7 @@ public static class ResultHelper
     public static ListItem CreateResult(decimal? roundedResult, CultureInfo inputCulture, CultureInfo outputCulture, string query)
     {
         // Return null when the expression is not a valid calculator query.
-        if (roundedResult == null)
+        if (roundedResult is null)
         {
             return null;
         }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Pages/CalculatorListPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Pages/CalculatorListPage.cs
@@ -82,7 +82,7 @@ public sealed partial class CalculatorListPage : DynamicListPage
         {
             this._items.Clear();
 
-            if (result != null)
+            if (result is not null)
             {
                 this._items.Add(result);
             }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Pages/FallbackCalculatorItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Pages/FallbackCalculatorItem.cs
@@ -28,7 +28,7 @@ public sealed partial class FallbackCalculatorItem : FallbackCommandItem
     {
         var result = QueryHelper.Query(query, _settings, true, null);
 
-        if (result == null)
+        if (result is null)
         {
             _copyCommand.Text = string.Empty;
             _copyCommand.Name = string.Empty;

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Helpers/ClipboardHelper.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Helpers/ClipboardHelper.cs
@@ -139,7 +139,7 @@ internal static class ClipboardHelper
         switch (clipboardFormat)
         {
             case ClipboardFormat.Text:
-                if (clipboardItem.Content == null)
+                if (clipboardItem.Content is null)
                 {
                     ExtensionHost.LogMessage(new LogMessage() { Message = "No valid clipboard content" });
                     return;
@@ -152,7 +152,7 @@ internal static class ClipboardHelper
                 break;
 
             case ClipboardFormat.Image:
-                if (clipboardItem.ImageData == null)
+                if (clipboardItem.ImageData is null)
                 {
                     ExtensionHost.LogMessage(new LogMessage() { Message = "No valid clipboard content" });
                     return;
@@ -240,7 +240,7 @@ internal static class ClipboardHelper
     internal static async Task<SoftwareBitmap?> GetClipboardImageContentAsync(DataPackageView clipboardData)
     {
         using var stream = await GetClipboardImageStreamAsync(clipboardData);
-        if (stream != null)
+        if (stream is not null)
         {
             var decoder = await BitmapDecoder.CreateAsync(stream);
             return await decoder.GetSoftwareBitmapAsync();
@@ -255,7 +255,7 @@ internal static class ClipboardHelper
         {
             var storageItems = await clipboardData.GetStorageItemsAsync();
             var file = storageItems.Count == 1 ? storageItems[0] as StorageFile : null;
-            if (file != null)
+            if (file is not null)
             {
                 return await file.OpenReadAsync();
             }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Models/ClipboardItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Models/ClipboardItem.cs
@@ -37,7 +37,7 @@ public class ClipboardItem
     }
 
     [MemberNotNullWhen(true, nameof(ImageData))]
-    private bool IsImage => ImageData != null;
+    private bool IsImage => ImageData is not null;
 
     [MemberNotNullWhen(true, nameof(Content))]
     private bool IsText => !string.IsNullOrEmpty(Content);

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Pages/ClipboardHistoryListPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Pages/ClipboardHistoryListPage.cs
@@ -54,7 +54,7 @@ internal sealed partial class ClipboardHistoryListPage : ListPage
         try
         {
             var allowClipboardHistory = Registry.GetValue(registryKey, "AllowClipboardHistory", null);
-            return allowClipboardHistory != null ? (int)allowClipboardHistory == 0 : false;
+            return allowClipboardHistory is not null ? (int)allowClipboardHistory == 0 : false;
         }
         catch (Exception)
         {
@@ -100,7 +100,7 @@ internal sealed partial class ClipboardHistoryListPage : ListPage
                 {
                     var imageReceived = await item.Item.Content.GetBitmapAsync();
 
-                    if (imageReceived != null)
+                    if (imageReceived is not null)
                     {
                         item.ImageData = imageReceived;
                     }
@@ -141,7 +141,7 @@ internal sealed partial class ClipboardHistoryListPage : ListPage
         for (var i = 0; i < clipboardHistory.Count; i++)
         {
             var item = clipboardHistory[i];
-            if (item != null)
+            if (item is not null)
             {
                 listItems.Add(item.ToListItem());
             }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Indexer/FallbackOpenFileItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Indexer/FallbackOpenFileItem.cs
@@ -46,7 +46,7 @@ internal sealed partial class FallbackOpenFileItem : FallbackCommandItem, System
             return;
         }
 
-        if (_suppressCallback != null && _suppressCallback(query))
+        if (_suppressCallback is not null && _suppressCallback(query))
         {
             Command = new NoOpCommand();
             Title = string.Empty;
@@ -71,7 +71,7 @@ internal sealed partial class FallbackOpenFileItem : FallbackCommandItem, System
             try
             {
                 var stream = ThumbnailHelper.GetThumbnail(item.FullPath).Result;
-                if (stream != null)
+                if (stream is not null)
                 {
                     var data = new IconData(RandomAccessStreamReference.CreateFromStream(stream));
                     Icon = new IconInfo(data, data);
@@ -92,7 +92,7 @@ internal sealed partial class FallbackOpenFileItem : FallbackCommandItem, System
                 _searchEngine.Query(query, _queryCookie);
                 var results = _searchEngine.FetchItems(0, 20, _queryCookie, out var _);
 
-                if (results.Count == 0 || ((results[0] as IndexerListItem) == null))
+                if (results.Count == 0 || ((results[0] as IndexerListItem) is null))
                 {
                     // Exit 2: We searched for the file, and found nothing. Oh well.
                     // Hide ourselves.

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Indexer/Indexer/DataSourceManager.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Indexer/Indexer/DataSourceManager.cs
@@ -16,7 +16,7 @@ internal static class DataSourceManager
 
     public static IDBInitialize GetDataSource()
     {
-        if (_dataSource == null)
+        if (_dataSource is null)
         {
             InitializeDataSource();
         }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Indexer/Indexer/SearchQuery.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Indexer/Indexer/SearchQuery.cs
@@ -12,7 +12,6 @@ using ManagedCsWin32;
 using Microsoft.CmdPal.Ext.Indexer.Indexer.OleDB;
 using Microsoft.CmdPal.Ext.Indexer.Indexer.SystemSearch;
 using Microsoft.CmdPal.Ext.Indexer.Indexer.Utils;
-using static Microsoft.CmdPal.Ext.Indexer.Indexer.Utils.NativeHelpers;
 
 namespace Microsoft.CmdPal.Ext.Indexer.Indexer;
 
@@ -54,14 +53,14 @@ internal sealed partial class SearchQuery : IDisposable
         try
         {
             queryTpTimer = new Timer(QueryTimerCallback, this, Timeout.Infinite, Timeout.Infinite);
-            if (queryTpTimer == null)
+            if (queryTpTimer is null)
             {
                 Logger.LogError("Failed to create query timer");
                 return;
             }
 
             queryCompletedEvent = new EventWaitHandle(false, EventResetMode.ManualReset);
-            if (queryCompletedEvent == null)
+            if (queryCompletedEvent is null)
             {
                 Logger.LogError("Failed to create query completed event");
                 return;
@@ -85,7 +84,7 @@ internal sealed partial class SearchQuery : IDisposable
         // Are we currently doing work? If so, let's cancel
         lock (_lockObject)
         {
-            if (queryTpTimer != null)
+            if (queryTpTimer is not null)
             {
                 queryTpTimer.Change(Timeout.Infinite, Timeout.Infinite);
                 queryTpTimer.Dispose();
@@ -117,7 +116,7 @@ internal sealed partial class SearchQuery : IDisposable
             try
             {
                 // We need to generate a search query string with the search text the user entered above
-                if (currentRowset != null)
+                if (currentRowset is not null)
                 {
                     // We have a previous rowset, this means the user is typing and we should store this
                     // recapture the where ID from this so the next ExecuteSync call will be faster
@@ -146,14 +145,14 @@ internal sealed partial class SearchQuery : IDisposable
         {
             getRow.GetRowFromHROW(null, rowHandle, ref Unsafe.AsRef(in IID.IPropertyStore), out var propertyStore);
 
-            if (propertyStore == null)
+            if (propertyStore is null)
             {
                 Logger.LogError("Failed to get IPropertyStore interface");
                 return false;
             }
 
             var searchResult = SearchResult.Create(propertyStore);
-            if (searchResult == null)
+            if (searchResult is null)
             {
                 Logger.LogError("Failed to create search result");
                 return false;
@@ -171,7 +170,7 @@ internal sealed partial class SearchQuery : IDisposable
 
     public bool FetchRows(int offset, int limit)
     {
-        if (currentRowset == null)
+        if (currentRowset is null)
         {
             Logger.LogError("No rowset to fetch rows from");
             return false;
@@ -241,7 +240,7 @@ internal sealed partial class SearchQuery : IDisposable
     {
         var queryStr = QueryStringBuilder.GeneratePrimingQuery();
         var rowset = ExecuteCommand(queryStr);
-        if (rowset != null)
+        if (rowset is not null)
         {
             reuseRowset = rowset;
             reuseWhereID = GetReuseWhereId(reuseRowset);
@@ -261,7 +260,7 @@ internal sealed partial class SearchQuery : IDisposable
             var guid = typeof(IDBCreateCommand).GUID;
             session.CreateSession(IntPtr.Zero, ref guid, out var ppDBSession);
 
-            if (ppDBSession == null)
+            if (ppDBSession is null)
             {
                 Logger.LogError("CreateSession failed");
                 return null;
@@ -271,7 +270,7 @@ internal sealed partial class SearchQuery : IDisposable
             guid = typeof(ICommandText).GUID;
             createCommand.CreateCommand(IntPtr.Zero, ref guid, out ICommandText commandText);
 
-            if (commandText == null)
+            if (commandText is null)
             {
                 Logger.LogError("Failed to get ICommandText interface");
                 return null;
@@ -342,13 +341,13 @@ internal sealed partial class SearchQuery : IDisposable
     {
         var rowsetInfo = (IRowsetInfo)rowset;
 
-        if (rowsetInfo == null)
+        if (rowsetInfo is null)
         {
             return 0;
         }
 
         var prop = GetPropset(rowsetInfo);
-        if (prop == null)
+        if (prop is null)
         {
             return 0;
         }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Indexer/Indexer/SearchResult.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Indexer/Indexer/SearchResult.cs
@@ -26,7 +26,7 @@ internal sealed class SearchResult
         ItemUrl = url;
         IsFolder = isFolder;
 
-        if (LaunchUri == null || LaunchUri.Length == 0)
+        if (LaunchUri is null || LaunchUri.Length == 0)
         {
             // Launch the file with the default app, so use the file path
             LaunchUri = filePath;

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Indexer/Indexer/Utils/QueryStringBuilder.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Indexer/Indexer/Utils/QueryStringBuilder.cs
@@ -5,8 +5,6 @@
 using System;
 using System.Globalization;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.Marshalling;
 using ManagedCommon;
 using ManagedCsWin32;
 using Microsoft.CmdPal.Ext.Indexer.Indexer.SystemSearch;
@@ -28,7 +26,7 @@ internal sealed partial class QueryStringBuilder
 
     public static string GenerateQuery(string searchText, uint whereId)
     {
-        if (queryHelper == null)
+        if (queryHelper is null)
         {
             ISearchManager searchManager;
 
@@ -43,13 +41,13 @@ internal sealed partial class QueryStringBuilder
             }
 
             ISearchCatalogManager catalogManager = searchManager.GetCatalog(SystemIndex);
-            if (catalogManager == null)
+            if (catalogManager is null)
             {
                 throw new ArgumentException($"Failed to get catalog manager for {SystemIndex}");
             }
 
             queryHelper = catalogManager.GetQueryHelper();
-            if (queryHelper == null)
+            if (queryHelper is null)
             {
                 throw new ArgumentException("Failed to get query helper from catalog manager");
             }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Indexer/Pages/ActionsListContextItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Indexer/Pages/ActionsListContextItem.cs
@@ -44,12 +44,12 @@ internal sealed partial class ActionsListContextItem : CommandContextItem, IDisp
     {
         lock (UpdateMoreCommandsLock)
         {
-            if (actionRuntime == null)
+            if (actionRuntime is null)
             {
                 actionRuntime = ActionRuntimeManager.InstanceAsync.GetAwaiter().GetResult();
             }
 
-            if (actionRuntime == null)
+            if (actionRuntime is null)
             {
                 return;
             }
@@ -62,7 +62,7 @@ internal sealed partial class ActionsListContextItem : CommandContextItem, IDisp
         {
             var extension = System.IO.Path.GetExtension(fullPath).ToLower(CultureInfo.InvariantCulture);
             ActionEntity entity = null;
-            if (extension != null)
+            if (extension is not null)
             {
                 if (extension == ".jpg" || extension == ".jpeg" || extension == ".png")
                 {
@@ -74,7 +74,7 @@ internal sealed partial class ActionsListContextItem : CommandContextItem, IDisp
                 }
             }
 
-            if (entity == null)
+            if (entity is null)
             {
                 entity = actionRuntime.EntityFactory.CreateFileEntity(fullPath);
             }
@@ -100,7 +100,7 @@ internal sealed partial class ActionsListContextItem : CommandContextItem, IDisp
     {
         lock (UpdateMoreCommandsLock)
         {
-            if (actionRuntime != null)
+            if (actionRuntime is not null)
             {
                 actionRuntime.ActionCatalog.Changed -= ActionCatalog_Changed;
             }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Indexer/Pages/DirectoryExplorePage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Indexer/Pages/DirectoryExplorePage.cs
@@ -35,14 +35,14 @@ public sealed partial class DirectoryExplorePage : DynamicListPage
 
     public override void UpdateSearchText(string oldSearch, string newSearch)
     {
-        if (_directoryContents == null)
+        if (_directoryContents is null)
         {
             return;
         }
 
         if (string.IsNullOrEmpty(newSearch))
         {
-            if (_filteredContents != null)
+            if (_filteredContents is not null)
             {
                 _filteredContents = null;
                 RaiseItemsChanged(-1);
@@ -58,7 +58,7 @@ public sealed partial class DirectoryExplorePage : DynamicListPage
             newSearch,
             (s, i) => ListHelpers.ScoreListItem(s, i));
 
-        if (_filteredContents != null)
+        if (_filteredContents is not null)
         {
             lock (_filteredContents)
             {
@@ -75,12 +75,12 @@ public sealed partial class DirectoryExplorePage : DynamicListPage
 
     public override IListItem[] GetItems()
     {
-        if (_filteredContents != null)
+        if (_filteredContents is not null)
         {
             return _filteredContents.ToArray();
         }
 
-        if (_directoryContents != null)
+        if (_directoryContents is not null)
         {
             return _directoryContents.ToArray();
         }
@@ -120,7 +120,7 @@ public sealed partial class DirectoryExplorePage : DynamicListPage
                 try
                 {
                     var stream = ThumbnailHelper.GetThumbnail(item.FilePath).Result;
-                    if (stream != null)
+                    if (stream is not null)
                     {
                         var data = new IconData(RandomAccessStreamReference.CreateFromStream(stream));
                         icon = new IconInfo(data, data);

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Indexer/Pages/DirectoryPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Indexer/Pages/DirectoryPage.cs
@@ -31,7 +31,7 @@ public sealed partial class DirectoryPage : ListPage
 
     public override IListItem[] GetItems()
     {
-        if (_directoryContents != null)
+        if (_directoryContents is not null)
         {
             return _directoryContents.ToArray();
         }
@@ -86,7 +86,7 @@ public sealed partial class DirectoryPage : ListPage
                 try
                 {
                     var stream = ThumbnailHelper.GetThumbnail(item.FilePath).Result;
-                    if (stream != null)
+                    if (stream is not null)
                     {
                         var data = new IconData(RandomAccessStreamReference.CreateFromStream(stream));
                         icon = new IconInfo(data, data);

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Indexer/SearchEngine.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Indexer/SearchEngine.cs
@@ -42,7 +42,7 @@ public sealed partial class SearchEngine : IDisposable
     {
         hasMore = false;
         var results = new List<IListItem>();
-        if (_searchQuery != null)
+        if (_searchQuery is not null)
         {
             var cookie = _searchQuery.Cookie;
             if (cookie == queryCookie)
@@ -59,7 +59,7 @@ public sealed partial class SearchEngine : IDisposable
                     try
                     {
                         var stream = ThumbnailHelper.GetThumbnail(result.LaunchUri).Result;
-                        if (stream != null)
+                        if (stream is not null)
                         {
                             var data = new IconData(RandomAccessStreamReference.CreateFromStream(stream));
                             icon = new IconInfo(data, data);

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Registry/Helpers/RegistryHelper.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Registry/Helpers/RegistryHelper.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Linq;
-using ManagedCommon;
 using Microsoft.CmdPal.Ext.Registry.Classes;
 using Microsoft.CmdPal.Ext.Registry.Constants;
 using Microsoft.CmdPal.Ext.Registry.Properties;
@@ -118,7 +117,7 @@ internal static class RegistryHelper
                 subKey = result.First().Key;
             }
 
-            if (result.Count > 1 || subKey == null)
+            if (result.Count > 1 || subKey is null)
             {
                 break;
             }
@@ -183,7 +182,7 @@ internal static class RegistryHelper
                 if (string.Equals(subKey, searchSubKey, StringComparison.OrdinalIgnoreCase))
                 {
                     var key = parentKey.OpenSubKey(subKey, RegistryKeyPermissionCheck.ReadSubTree);
-                    if (key != null)
+                    if (key is not null)
                     {
                         list.Add(new RegistryEntry(key));
                     }
@@ -194,7 +193,7 @@ internal static class RegistryHelper
                 try
                 {
                     var key = parentKey.OpenSubKey(subKey, RegistryKeyPermissionCheck.ReadSubTree);
-                    if (key != null)
+                    if (key is not null)
                     {
                         list.Add(new RegistryEntry(key));
                     }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Registry/Helpers/ResultHelper.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Registry/Helpers/ResultHelper.cs
@@ -88,7 +88,7 @@ internal static class ResultHelper
                 foreach (var valueName in valueNames)
                 {
                     var value = key.GetValue(valueName);
-                    if (value != null)
+                    if (value is not null)
                     {
                         valueList.Add(KeyValuePair.Create(valueName, value));
                     }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Registry/Helpers/ValueHelper.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Registry/Helpers/ValueHelper.cs
@@ -26,7 +26,7 @@ internal static class ValueHelper
     {
         var unformattedValue = key.GetValue(valueName);
 
-        if (unformattedValue == null)
+        if (unformattedValue is null)
         {
             throw new InvalidOperationException($"Cannot proceed when {nameof(unformattedValue)} is null.");
         }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Shell/Commands/ExecuteItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Shell/Commands/ExecuteItem.cs
@@ -46,7 +46,7 @@ internal sealed partial class ExecuteItem : InvokableCommand
 
     private void Execute(Func<ProcessStartInfo, Process?> startProcess, ProcessStartInfo info)
     {
-        if (startProcess == null)
+        if (startProcess is null)
         {
             return;
         }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Shell/Helpers/ShellListPageHelpers.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Shell/Helpers/ShellListPageHelpers.cs
@@ -126,7 +126,7 @@ public class ShellListPageHelpers
             return null;
         }
 
-        if (li != null)
+        if (li is not null)
         {
             li.TextToSuggest = searchText;
         }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Shell/Pages/RunExeItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Shell/Pages/RunExeItem.cs
@@ -78,7 +78,7 @@ internal sealed partial class RunExeItem : ListItem
         try
         {
             var stream = await ThumbnailHelper.GetThumbnail(FullExePath);
-            if (stream != null)
+            if (stream is not null)
             {
                 var data = new IconData(RandomAccessStreamReference.CreateFromStream(stream));
                 icon = new IconInfo(data, data);

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Shell/Pages/ShellListPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Shell/Pages/ShellListPage.cs
@@ -245,14 +245,14 @@ internal sealed partial class ShellListPage : DynamicListPage, IDisposable
         var histItemsNotInSearch =
             _historyItems
                 .Where(kv => !kv.Key.Equals(newSearch, StringComparison.OrdinalIgnoreCase));
-        if (_exeItem != null)
+        if (_exeItem is not null)
         {
             // If we have an exe item, we want to remove it from the history items
             histItemsNotInSearch = histItemsNotInSearch
                 .Where(kv => !kv.Value.Title.Equals(_exeItem.Title, StringComparison.OrdinalIgnoreCase));
         }
 
-        if (_uriItem != null)
+        if (_uriItem is not null)
         {
             // If we have an uri item, we want to remove it from the history items
             histItemsNotInSearch = histItemsNotInSearch
@@ -307,8 +307,8 @@ internal sealed partial class ShellListPage : DynamicListPage, IDisposable
         }
 
         var filteredTopLevel = ListHelpers.FilterList(_topLevelItems, SearchText);
-        List<ListItem> uriItems = _uriItem != null ? [_uriItem] : [];
-        List<ListItem> exeItems = _exeItem != null ? [_exeItem] : [];
+        List<ListItem> uriItems = _uriItem is not null ? [_uriItem] : [];
+        List<ListItem> exeItems = _exeItem is not null ? [_exeItem] : [];
 
         return
             exeItems
@@ -459,7 +459,7 @@ internal sealed partial class ShellListPage : DynamicListPage, IDisposable
         var hist = _historyService.GetRunHistory();
         var histItems = hist
             .Select(h => (h, ShellListPageHelpers.ListItemForCommandString(h, AddToHistory)))
-            .Where(tuple => tuple.Item2 != null)
+            .Where(tuple => tuple.Item2 is not null)
             .Select(tuple => (tuple.h, tuple.Item2!))
             .ToList();
         _historyItems.Clear();

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Shell/PathListItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Shell/PathListItem.cs
@@ -72,7 +72,7 @@ internal sealed partial class PathListItem : ListItem
         _icon = new Lazy<IconInfo>(() =>
         {
             var iconStream = ThumbnailHelper.GetThumbnail(path).Result;
-            var icon = iconStream != null ? IconInfo.FromStream(iconStream) :
+            var icon = iconStream is not null ? IconInfo.FromStream(iconStream) :
              _isDirectory ? Icons.FolderIcon : Icons.RunV2Icon;
             return icon;
         });

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.System/FallbackSystemCommandItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.System/FallbackSystemCommandItem.cs
@@ -57,7 +57,7 @@ internal sealed partial class FallbackSystemCommandItem : FallbackCommandItem
             }
         }
 
-        if (result == null)
+        if (result is null)
         {
             Command = null;
             Title = string.Empty;

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.System/Helpers/NetworkConnectionProperties.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.System/Helpers/NetworkConnectionProperties.cs
@@ -155,7 +155,7 @@ internal sealed class NetworkConnectionProperties
     internal static List<NetworkConnectionProperties> GetList()
     {
         var interfaces = NetworkInterface.GetAllNetworkInterfaces()
-                                         .Where(x => x.NetworkInterfaceType != NetworkInterfaceType.Loopback && x.GetPhysicalAddress() != null)
+                                         .Where(x => x.NetworkInterfaceType != NetworkInterfaceType.Loopback && x.GetPhysicalAddress() is not null)
                                          .Select(i => new NetworkConnectionProperties(i))
                                          .OrderByDescending(i => i.IPv4) // list IPv4 first
                                          .ThenBy(i => i.IPv6Primary) // then IPv6
@@ -195,9 +195,9 @@ internal sealed class NetworkConnectionProperties
             CreateIpInfoForDetailsText($"**{Resources.Microsoft_plugin_sys_Ip6Site}:**\n\n* ", IPv6SiteLocal) +
             CreateIpInfoForDetailsText($"**{Resources.Microsoft_plugin_sys_Ip6Unique}:**\n\n* ", IPv6UniqueLocal) +
             CreateIpInfoForDetailsText($"**{Resources.Microsoft_plugin_sys_Gateways}:**\n\n* ", Gateways) +
-            CreateIpInfoForDetailsText($"**{Resources.Microsoft_plugin_sys_Dhcp}:**\n\n* ", DhcpServers == null ? string.Empty : DhcpServers) +
-            CreateIpInfoForDetailsText($"**{Resources.Microsoft_plugin_sys_Dns}:**\n\n* ", DnsServers == null ? string.Empty : DnsServers) +
-            CreateIpInfoForDetailsText($"**{Resources.Microsoft_plugin_sys_Wins}:**\n\n* ", WinsServers == null ? string.Empty : WinsServers) +
+            CreateIpInfoForDetailsText($"**{Resources.Microsoft_plugin_sys_Dhcp}:**\n\n* ", DhcpServers is null ? string.Empty : DhcpServers) +
+            CreateIpInfoForDetailsText($"**{Resources.Microsoft_plugin_sys_Dns}:**\n\n* ", DnsServers is null ? string.Empty : DnsServers) +
+            CreateIpInfoForDetailsText($"**{Resources.Microsoft_plugin_sys_Wins}:**\n\n* ", WinsServers is null ? string.Empty : WinsServers) +
             $"\n\n**{Resources.Microsoft_plugin_sys_AdapterName}:** {Adapter}" +
             $"\n\n**{Resources.Microsoft_plugin_sys_PhysicalAddress}:** {PhysicalAddress}" +
             $"\n\n**{Resources.Microsoft_plugin_sys_Speed}:** {GetFormattedSpeedValue(Speed)}";

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/FallbackTimeDateItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/FallbackTimeDateItem.cs
@@ -4,11 +4,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Globalization;
 using System.Linq;
 using Microsoft.CmdPal.Ext.TimeDate.Helpers;
-using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 
 namespace Microsoft.CmdPal.Ext.TimeDate;
@@ -66,7 +64,7 @@ internal sealed partial class FallbackTimeDateItem : FallbackCommandItem
             }
         }
 
-        if (result != null)
+        if (result is not null)
         {
             Title = result.Title;
             Subtitle = result.Subtitle;
@@ -90,7 +88,7 @@ internal sealed partial class FallbackTimeDateItem : FallbackCommandItem
 
         foreach (var option in _validOptions)
         {
-            if (option == null)
+            if (option is null)
             {
                 continue;
             }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Helpers/AvailableResultsList.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Helpers/AvailableResultsList.cs
@@ -29,7 +29,7 @@ internal static class AvailableResultsList
 
         var timeExtended = timeLongFormat ?? settings.TimeWithSecond;
         var dateExtended = dateLongFormat ?? settings.DateWithWeekday;
-        var isSystemDateTime = timestamp == null;
+        var isSystemDateTime = timestamp is null;
         var dateTimeNow = timestamp ?? DateTime.Now;
         var dateTimeNowUtc = dateTimeNow.ToUniversalTime();
         var firstWeekRule = firstWeekOfYear ?? TimeAndDateHelper.GetCalendarWeekRule(settings.FirstWeekOfYear);

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Helpers/SettingsManager.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Helpers/SettingsManager.cs
@@ -103,7 +103,7 @@ public class SettingsManager : JsonSettingsManager
     {
         get
         {
-            if (_firstWeekOfYear.Value == null || string.IsNullOrEmpty(_firstWeekOfYear.Value))
+            if (_firstWeekOfYear.Value is null || string.IsNullOrEmpty(_firstWeekOfYear.Value))
             {
                 return -1;
             }
@@ -123,7 +123,7 @@ public class SettingsManager : JsonSettingsManager
     {
         get
         {
-            if (_firstDayOfWeek.Value == null || string.IsNullOrEmpty(_firstDayOfWeek.Value))
+            if (_firstDayOfWeek.Value is null || string.IsNullOrEmpty(_firstDayOfWeek.Value))
             {
                 return -1;
             }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/Helpers/DefaultBrowserInfo.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/Helpers/DefaultBrowserInfo.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using ManagedCommon;
@@ -87,7 +86,7 @@ public static class DefaultBrowserInfo
                 var appName = GetRegistryValue($@"HKEY_CLASSES_ROOT\{progId}\Application", "ApplicationName")
                     ?? GetRegistryValue($@"HKEY_CLASSES_ROOT\{progId}", "FriendlyTypeName");
 
-                if (appName != null)
+                if (appName is not null)
                 {
                     // Handle indirect strings:
                     if (appName.StartsWith('@'))

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/Helpers/SettingsManager.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/Helpers/SettingsManager.cs
@@ -67,7 +67,7 @@ public class SettingsManager : JsonSettingsManager
 
     public void SaveHistory(HistoryItem historyItem)
     {
-        if (historyItem == null)
+        if (historyItem is null)
         {
             return;
         }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/Pages/WebSearchListPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/Pages/WebSearchListPage.cs
@@ -34,7 +34,7 @@ internal sealed partial class WebSearchListPage : DynamicListPage
         Id = "com.microsoft.cmdpal.websearch";
         _settingsManager = settingsManager;
         _historyItems = _settingsManager.ShowHistory != Resources.history_none ? _settingsManager.LoadHistory() : null;
-        if (_historyItems != null)
+        if (_historyItems is not null)
         {
             _allItems.AddRange(_historyItems);
         }
@@ -55,7 +55,7 @@ internal sealed partial class WebSearchListPage : DynamicListPage
         ArgumentNullException.ThrowIfNull(query);
         IEnumerable<ListItem>? filteredHistoryItems = null;
 
-        if (_historyItems != null)
+        if (_historyItems is not null)
         {
             filteredHistoryItems = _settingsManager.ShowHistory != Resources.history_none ? ListHelpers.FilterList(_historyItems, query).OfType<ListItem>() : null;
         }
@@ -74,7 +74,7 @@ internal sealed partial class WebSearchListPage : DynamicListPage
             results.Add(result);
         }
 
-        if (filteredHistoryItems != null)
+        if (filteredHistoryItems is not null)
         {
             results.AddRange(filteredHistoryItems);
         }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WinGet/Pages/InstallPackageCommand.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WinGet/Pages/InstallPackageCommand.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Globalization;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
@@ -79,7 +78,7 @@ public partial class InstallPackageCommand : InvokableCommand
     {
         // TODO: LOCK in here, so this can only be invoked once until the
         // install / uninstall is done. Just use like, an atomic
-        if (_installTask != null)
+        if (_installTask is not null)
         {
             return CommandResult.KeepOpen();
         }
@@ -143,7 +142,7 @@ public partial class InstallPackageCommand : InvokableCommand
             {
                 await Task.Delay(2500).ConfigureAwait(false);
 
-                if (_installTask == null)
+                if (_installTask is null)
                 {
                     WinGetExtensionHost.Instance.HideStatus(_installBanner);
                 }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WinGet/Pages/InstallPackageListItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WinGet/Pages/InstallPackageListItem.cs
@@ -34,7 +34,7 @@ public partial class InstallPackageListItem : ListItem
 
         var version = _package.DefaultInstallVersion ?? _package.InstalledVersion;
         var versionTagText = "Unknown";
-        if (version != null)
+        if (version is not null)
         {
             versionTagText = version.Version == "Unknown" && version.PackageCatalog.Info.Id == "StoreEdgeFD" ? "msstore" : version.Version;
         }
@@ -60,11 +60,11 @@ public partial class InstallPackageListItem : ListItem
             Logger.LogWarning($"{ex.ErrorCode}");
         }
 
-        if (metadata != null)
+        if (metadata is not null)
         {
             if (metadata.Tags.Where(t => t.Equals(WinGetExtensionPage.ExtensionsTag, StringComparison.OrdinalIgnoreCase)).Any())
             {
-                if (_installCommand != null)
+                if (_installCommand is not null)
                 {
                     _installCommand.SkipDependencies = true;
                 }
@@ -172,7 +172,7 @@ public partial class InstallPackageListItem : ListItem
             return;
         }
 
-        var isInstalled = _package.InstalledVersion != null;
+        var isInstalled = _package.InstalledVersion is not null;
 
         var installedState = isInstalled ?
             (_package.IsUpdateAvailable ?
@@ -193,11 +193,11 @@ public partial class InstallPackageListItem : ListItem
                 Icon = Icons.DeleteIcon,
             };
 
-            if (WinGetStatics.AppSearchCallback != null)
+            if (WinGetStatics.AppSearchCallback is not null)
             {
                 var callback = WinGetStatics.AppSearchCallback;
-                var installedApp = callback(_package.DefaultInstallVersion == null ? _package.Name : _package.DefaultInstallVersion.DisplayName);
-                if (installedApp != null)
+                var installedApp = callback(_package.DefaultInstallVersion is null ? _package.Name : _package.DefaultInstallVersion.DisplayName);
+                if (installedApp is not null)
                 {
                     this.Command = installedApp.Command;
                     contextMenu = [.. installedApp.MoreCommands];

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WinGet/Pages/WinGetExtensionPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WinGet/Pages/WinGetExtensionPage.cs
@@ -53,7 +53,7 @@ internal sealed partial class WinGetExtensionPage : DynamicListPage, IDisposable
         {
             // emptySearchForTag ===
             // we don't have results yet, we haven't typed anything, and we're searching for a tag
-            var emptySearchForTag = _results == null &&
+            var emptySearchForTag = _results is null &&
                 string.IsNullOrEmpty(SearchText) &&
                 HasTag;
 
@@ -64,7 +64,7 @@ internal sealed partial class WinGetExtensionPage : DynamicListPage, IDisposable
                 return items;
             }
 
-            if (_results != null && _results.Any())
+            if (_results is not null && _results.Any())
             {
                 ListItem[] results = _results.Select(PackageToListItem).ToArray();
                 IsLoading = false;
@@ -100,7 +100,7 @@ internal sealed partial class WinGetExtensionPage : DynamicListPage, IDisposable
     private void DoUpdateSearchText(string newSearch)
     {
         // Cancel any ongoing search
-        if (_cancellationTokenSource != null)
+        if (_cancellationTokenSource is not null)
         {
             Logger.LogDebug("Cancelling old search", memberName: nameof(DoUpdateSearchText));
             _cancellationTokenSource.Cancel();
@@ -221,7 +221,7 @@ internal sealed partial class WinGetExtensionPage : DynamicListPage, IDisposable
         // WinGetStatics static ctor when we were created.
         PackageCatalog catalog = await catalogTask.Value;
 
-        if (catalog == null)
+        if (catalog is null)
         {
             // This error should have already been displayed by WinGetStatics
             return [];

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowWalker/Commands/SwitchToWindowCommand.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowWalker/Commands/SwitchToWindowCommand.cs
@@ -18,10 +18,10 @@ internal sealed partial class SwitchToWindowCommand : InvokableCommand
     {
         Name = Resources.switch_to_command_title;
         _window = window;
-        if (_window != null)
+        if (_window is not null)
         {
             var p = Process.GetProcessById((int)_window.Process.ProcessID);
-            if (p != null)
+            if (p is not null)
             {
                 try
                 {

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowWalker/Components/ResultHelper.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowWalker/Components/ResultHelper.cs
@@ -23,7 +23,7 @@ internal static class ResultHelper
     /// <returns>List of results</returns>
     internal static List<WindowWalkerListItem> GetResultList(List<SearchResult> searchControllerResults, bool isKeywordSearch)
     {
-        if (searchControllerResults == null || searchControllerResults.Count == 0)
+        if (searchControllerResults is null || searchControllerResults.Count == 0)
         {
             return [];
         }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowWalker/Helpers/VirtualDesktopHelper.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowWalker/Helpers/VirtualDesktopHelper.cs
@@ -83,7 +83,7 @@ public class VirtualDesktopHelper
     /// <summary>
     /// Gets a value indicating whether the Virtual Desktop Manager is initialized successfully
     /// </summary>
-    public bool VirtualDesktopManagerInitialized => _virtualDesktopManager != null;
+    public bool VirtualDesktopManagerInitialized => _virtualDesktopManager is not null;
 
     /// <summary>
     /// Method to update the list of Virtual Desktops from Registry
@@ -98,10 +98,10 @@ public class VirtualDesktopHelper
 
         // List of all desktops
         using RegistryKey? virtualDesktopKey = Registry.CurrentUser.OpenSubKey(registryExplorerVirtualDesktops, false);
-        if (virtualDesktopKey != null)
+        if (virtualDesktopKey is not null)
         {
             var allDeskValue = (byte[]?)virtualDesktopKey.GetValue("VirtualDesktopIDs", null) ?? Array.Empty<byte>();
-            if (allDeskValue != null)
+            if (allDeskValue is not null)
             {
                 // We clear only, if we can read from registry. Otherwise, we keep the existing values.
                 _availableDesktops.Clear();
@@ -124,10 +124,10 @@ public class VirtualDesktopHelper
         // Guid for current desktop
         var virtualDesktopsKeyName = _isWindowsEleven ? registryExplorerVirtualDesktops : registrySessionVirtualDesktops;
         using RegistryKey? virtualDesktopsKey = Registry.CurrentUser.OpenSubKey(virtualDesktopsKeyName, false);
-        if (virtualDesktopsKey != null)
+        if (virtualDesktopsKey is not null)
         {
             var currentVirtualDesktopValue = virtualDesktopsKey.GetValue("CurrentVirtualDesktop", null);
-            if (currentVirtualDesktopValue != null)
+            if (currentVirtualDesktopValue is not null)
             {
                 _currentDesktop = new Guid((byte[])currentVirtualDesktopValue);
             }
@@ -268,7 +268,7 @@ public class VirtualDesktopHelper
         using RegistryKey? deskSubKey = Registry.CurrentUser.OpenSubKey(registryPath, false);
         var desktopName = deskSubKey?.GetValue("Name");
 
-        return (desktopName != null) ? (string)desktopName : defaultName;
+        return (desktopName is not null) ? (string)desktopName : defaultName;
     }
 
     /// <summary>
@@ -313,7 +313,7 @@ public class VirtualDesktopHelper
     /// <returns>HResult of the called method as integer.</returns>
     public int GetWindowDesktopId(IntPtr hWindow, out Guid desktopId)
     {
-        if (_virtualDesktopManager == null)
+        if (_virtualDesktopManager is null)
         {
             ExtensionHost.LogMessage(new LogMessage() { Message = "VirtualDesktopHelper.GetWindowDesktopId() failed: The instance of <IVirtualDesktopHelper> isn't available." });
             desktopId = Guid.Empty;
@@ -330,7 +330,7 @@ public class VirtualDesktopHelper
     /// <returns>An instance of <see cref="VDesktop"/> for the desktop where the window is assigned to, or an empty instance of <see cref="VDesktop"/> on failure.</returns>
     public VDesktop GetWindowDesktop(IntPtr hWindow)
     {
-        if (_virtualDesktopManager == null)
+        if (_virtualDesktopManager is null)
         {
             ExtensionHost.LogMessage(new LogMessage() { Message = "VirtualDesktopHelper.GetWindowDesktop() failed: The instance of <IVirtualDesktopHelper> isn't available." });
             return CreateVDesktopInstance(Guid.Empty);
@@ -348,7 +348,7 @@ public class VirtualDesktopHelper
     /// <returns>Type of <see cref="VirtualDesktopAssignmentType"/>.</returns>
     public VirtualDesktopAssignmentType GetWindowDesktopAssignmentType(IntPtr hWindow, Guid? desktop = null)
     {
-        if (_virtualDesktopManager == null)
+        if (_virtualDesktopManager is null)
         {
             ExtensionHost.LogMessage(new LogMessage() { Message = "VirtualDesktopHelper.GetWindowDesktopAssignmentType() failed: The instance of <IVirtualDesktopHelper> isn't available." });
             return VirtualDesktopAssignmentType.Unknown;
@@ -415,7 +415,7 @@ public class VirtualDesktopHelper
     /// <returns><see langword="True"/> on success and <see langword="false"/> on failure.</returns>
     public bool MoveWindowToDesktop(IntPtr hWindow, ref Guid desktopId)
     {
-        if (_virtualDesktopManager == null)
+        if (_virtualDesktopManager is null)
         {
             ExtensionHost.LogMessage(new LogMessage() { Message = "VirtualDesktopHelper.MoveWindowToDesktop() failed: The instance of <IVirtualDesktopHelper> isn't available." });
             return false;

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsServices/Helpers/ServiceHelper.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsServices/Helpers/ServiceHelper.cs
@@ -47,7 +47,7 @@ public static class ServiceHelper
         var result = serviceList.Select(s =>
         {
             var serviceResult = ServiceResult.CreateServiceController(s);
-            if (serviceResult == null)
+            if (serviceResult is null)
             {
                 return null;
             }
@@ -98,7 +98,7 @@ public static class ServiceHelper
                 // ToolTipData = new ToolTipData(serviceResult.DisplayName, serviceResult.ServiceName),
                 // IcoPath = icoPath,
             };
-        }).Where(s => s != null);
+        }).Where(s => s is not null);
 
         return result;
     }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/Helpers/UnsupportedSettingsHelper.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/Helpers/UnsupportedSettingsHelper.cs
@@ -49,8 +49,8 @@ internal static class UnsupportedSettingsHelper
             : currentBuildNumber;
 
         var filteredSettingsList = windowsSettings.Settings.Where(found
-            => (found.DeprecatedInBuild == null || currentWindowsBuild < found.DeprecatedInBuild)
-            && (found.IntroducedInBuild == null || currentWindowsBuild >= found.IntroducedInBuild));
+            => (found.DeprecatedInBuild is null || currentWindowsBuild < found.DeprecatedInBuild)
+            && (found.IntroducedInBuild is null || currentWindowsBuild >= found.IntroducedInBuild));
 
         filteredSettingsList = filteredSettingsList.OrderBy(found => found.Name);
 

--- a/src/modules/cmdpal/ext/SamplePagesExtension/Pages/SampleContentPage.cs
+++ b/src/modules/cmdpal/ext/SamplePagesExtension/Pages/SampleContentPage.cs
@@ -304,7 +304,7 @@ internal sealed partial class SampleContentForm : FormContent
     public override CommandResult SubmitForm(string payload)
     {
         var formInput = JsonNode.Parse(payload)?.AsObject();
-        if (formInput == null)
+        if (formInput is null)
         {
             return CommandResult.GoHome();
         }

--- a/src/modules/cmdpal/ext/SamplePagesExtension/SampleUpdatingItemsPage.cs
+++ b/src/modules/cmdpal/ext/SamplePagesExtension/SampleUpdatingItemsPage.cs
@@ -24,7 +24,7 @@ public partial class SampleUpdatingItemsPage : ListPage
 
     public override IListItem[] GetItems()
     {
-        if (timer == null)
+        if (timer is null)
         {
             timer = new Timer(500);
             timer.Elapsed += (object source, ElapsedEventArgs e) =>

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/AnonymousCommand.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/AnonymousCommand.cs
@@ -18,7 +18,7 @@ public sealed partial class AnonymousCommand : InvokableCommand
 
     public override ICommandResult Invoke()
     {
-        if (_action != null)
+        if (_action is not null)
         {
             _action();
         }

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/ChoiceSetSetting.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/ChoiceSetSetting.cs
@@ -65,7 +65,7 @@ public sealed class ChoiceSetSetting : Setting<string>
     public override void Update(JsonObject payload)
     {
         // If the key doesn't exist in the payload, don't do anything
-        if (payload[Key] != null)
+        if (payload[Key] is not null)
         {
             Value = payload[Key]?.GetValue<string>();
         }

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/ClipboardHelper.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/ClipboardHelper.cs
@@ -2,10 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Diagnostics;
 using System.Runtime.InteropServices;
-using System.Threading;
 
 namespace Microsoft.CommandPalette.Extensions.Toolkit;
 
@@ -293,7 +290,7 @@ public static partial class ClipboardHelper
         thread.Start();
         thread.Join();
 
-        if (exception != null)
+        if (exception is not null)
         {
             throw exception;
         }

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/CommandContextItem.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/CommandContextItem.cs
@@ -28,7 +28,7 @@ public partial class CommandContextItem : CommandItem, ICommandContextItem
             c.Name = name;
         }
 
-        if (result != null)
+        if (result is not null)
         {
             c.Result = result;
         }

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/CommandItem.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/CommandItem.cs
@@ -48,7 +48,7 @@ public partial class CommandItem : BaseObservable, ICommandItem
         get => _command;
         set
         {
-            if (_commandListener != null)
+            if (_commandListener is not null)
             {
                 _commandListener.Detach();
                 _commandListener = null;
@@ -56,7 +56,7 @@ public partial class CommandItem : BaseObservable, ICommandItem
 
             _command = value;
 
-            if (value != null)
+            if (value is not null)
             {
                 _commandListener = new(this, OnCommandPropertyChanged, listener => value.PropChanged -= listener.OnEvent);
                 value.PropChanged += _commandListener.OnEvent;
@@ -123,7 +123,7 @@ public partial class CommandItem : BaseObservable, ICommandItem
             c.Name = name;
         }
 
-        if (result != null)
+        if (result is not null)
         {
             c.Result = result;
         }

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/ExtensionHost.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/ExtensionHost.cs
@@ -19,7 +19,7 @@ public partial class ExtensionHost
     /// <param name="message">The log message to send</param>
     public static void LogMessage(ILogMessage message)
     {
-        if (Host != null)
+        if (Host is not null)
         {
             _ = Task.Run(async () =>
             {
@@ -42,7 +42,7 @@ public partial class ExtensionHost
 
     public static void ShowStatus(IStatusMessage message, StatusContext context)
     {
-        if (Host != null)
+        if (Host is not null)
         {
             _ = Task.Run(async () =>
             {
@@ -59,7 +59,7 @@ public partial class ExtensionHost
 
     public static void HideStatus(IStatusMessage message)
     {
-        if (Host != null)
+        if (Host is not null)
         {
             _ = Task.Run(async () =>
             {

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/ExtensionInstanceManager`1.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/ExtensionInstanceManager`1.cs
@@ -55,7 +55,7 @@ internal sealed partial class ExtensionInstanceManager : IClassFactory
 
         ppvObject = IntPtr.Zero;
 
-        if (pUnkOuter != null)
+        if (pUnkOuter is not null)
         {
             Marshal.ThrowExceptionForHR(CLASS_E_NOAGGREGATION);
         }

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/JsonSettingsManager.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/JsonSettingsManager.cs
@@ -76,7 +76,7 @@ public abstract class JsonSettingsManager
                 {
                     foreach (var item in newSettings)
                     {
-                        savedSettings[item.Key] = item.Value != null ? item.Value.DeepClone() : null;
+                        savedSettings[item.Key] = item.Value is not null ? item.Value.DeepClone() : null;
                     }
 
                     var serialized = savedSettings.ToJsonString(_serializerOptions);

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/Settings.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/Settings.cs
@@ -41,7 +41,7 @@ public sealed partial class Settings : ICommandSettings
             .Values
             .Where(s => s is ISettingsForm)
             .Select(s => s as ISettingsForm)
-            .Where(s => s != null)
+            .Where(s => s is not null)
             .Select(s => s!);
 
         var bodies = string.Join(",", settings
@@ -77,7 +77,7 @@ public sealed partial class Settings : ICommandSettings
             .Values
             .Where(s => s is ISettingsForm)
             .Select(s => s as ISettingsForm)
-            .Where(s => s != null)
+            .Where(s => s is not null)
             .Select(s => s!);
         var content = string.Join(",\n", settings.Select(s => s.ToState()));
         return $"{{\n{content}\n}}";
@@ -86,7 +86,7 @@ public sealed partial class Settings : ICommandSettings
     public void Update(string data)
     {
         var formInput = JsonNode.Parse(data)?.AsObject();
-        if (formInput == null)
+        if (formInput is null)
         {
             return;
         }

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/SettingsForm.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/SettingsForm.cs
@@ -19,7 +19,7 @@ public partial class SettingsForm : FormContent
     public override ICommandResult SubmitForm(string inputs, string data)
     {
         var formInput = JsonNode.Parse(inputs)?.AsObject();
-        if (formInput == null)
+        if (formInput is null)
         {
             return CommandResult.KeepOpen();
         }

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/ShellHelpers.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/ShellHelpers.cs
@@ -125,7 +125,7 @@ public static class ShellHelpers
         else
         {
             var values = Environment.GetEnvironmentVariable("PATH");
-            if (values != null)
+            if (values is not null)
             {
                 foreach (var path in values.Split(';'))
                 {

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/StringMatcher.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/StringMatcher.cs
@@ -93,7 +93,7 @@ public partial class StringMatcher
 
         query = query.Trim();
 
-        // if (_alphabet != null)
+        // if (_alphabet is not null)
         // {
         //    query = _alphabet.Translate(query);
         //    stringToCompare = _alphabet.Translate(stringToCompare);

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/TextSetting.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/TextSetting.cs
@@ -50,7 +50,7 @@ public partial class TextSetting : Setting<string>
     public override void Update(JsonObject payload)
     {
         // If the key doesn't exist in the payload, don't do anything
-        if (payload[Key] != null)
+        if (payload[Key] is not null)
         {
             Value = payload[Key]?.GetValue<string>();
         }

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/ToggleSetting.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/ToggleSetting.cs
@@ -43,7 +43,7 @@ public sealed class ToggleSetting : Setting<bool>
     public override void Update(JsonObject payload)
     {
         // If the key doesn't exist in the payload, don't do anything
-        if (payload[Key] != null)
+        if (payload[Key] is not null)
         {
             // Adaptive cards returns boolean values as a string "true"/"false", cause of course.
             var strFromJson = payload[Key]?.GetValue<string>() ?? string.Empty;


### PR DESCRIPTION
What the title says. 😄 

Rather than relying on the potentially overloaded `!=` or `==` operators when checking for null, now we'll use the `is` expression (possibly combined with the `not` operator) to ensure correct checking. Probably overkill for many of these classes, but decided to err on the side of consistency. Would matter more on classes that may be inherited or extended.

Using `is` and `is not` will provide us a guarantee that no user-overloaded equality operators (`==`/`!=`) is invoked when a `expression is null` is evaluated.

In code form, changed all instances of:

```c#
something != null

something == null
```

to:

```c#
something is not null

something is null
```

The one exception was checking null on a `KeyChord`. `KeyChord` is a struct which is never null so VS will raise an error when trying this versus just providing a warning when using `keyChord != null`. In reality, we shouldn't do this check because it can't ever be null. In the case of a `KeyChord` it **would** be a `KeyChord` equivalent to:

```c#
KeyChord keyChord = new ()
{
    Modifiers = 0,
    Vkey = 0,
    ScanCode = 0
};
```