### PR TITLE
CmdPal: Fix race condition in SupersedingAsyncGate cancellation handling [MSH]

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.Common/Helpers/SupersedingAsyncGate.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Common/Helpers/SupersedingAsyncGate.cs
@@ -89,7 +89,7 @@ public class SupersedingAsyncGate : IDisposable
                 }
                 catch (OperationCanceledException)
                 {
-                    CompleteIfCurrent(currentTcs, currentCallId, tcs => tcs.SetCanceled(currentCts.Token));
+                    CompleteIfCurrent(currentTcs, currentCallId, tcs => tcs.TrySetCanceled(currentCts.Token));
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
## Summary of the Pull Request

Change SetCanceled to TrySetCanceled in OperationCanceledException handler to prevent InvalidOperationException when external and internal cancellation tokens complete the TaskCompletionSource simultaneously.


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #40982
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** none
- [ ] **Localization:** nope
- [ ] **Dev docs:** none
- [ ] **New binaries:** none
- [ ] **Documentation updated:** none

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

