### PR TITLE
Adding app icon to run context menu item in all apps ext

### DIFF
--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/AppCommand.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/AppCommand.cs
@@ -26,6 +26,11 @@ public sealed partial class AppCommand : InvokableCommand
 
         Name = Resources.run_command_action;
         Id = GenerateId();
+
+        if (!string.IsNullOrEmpty(app.IcoPath))
+        {
+            Icon = new(app.IcoPath);
+        }
     }
 
     internal static async Task StartApp(string aumid)


### PR DESCRIPTION
Closes #40978

All apps extension's "Run" command now has the apps icon if available.

<img width="1197" height="741" alt="image" src="https://github.com/user-attachments/assets/96ce75cb-cc6e-4176-bf4f-c92c2842b258" />



