### PR TITLE
Fix: used wrong preview resize event from another handler

### DIFF
--- a/src/modules/previewpane/BgcodePreviewHandler/Program.cs
+++ b/src/modules/previewpane/BgcodePreviewHandler/Program.cs
@@ -49,7 +49,7 @@ namespace Microsoft.PowerToys.PreviewHandler.Bgcode
                     _previewHandlerControl.DoPreview(filePath);
 
                     NativeEventWaiter.WaitForEventLoop(
-                        Constants.GcodePreviewResizeEvent(),
+                        Constants.BgcodePreviewResizeEvent(),
                         () =>
                         {
                             Rectangle s = default;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Bug: Was using GcodePreviewResizeEvent, which will never work — switched to use Bgcode's own event

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] Closes: #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

## AI Summary
This pull request makes a minor update to the event handling in the preview pane module. The change updates the event constant used for resizing the preview from `GcodePreviewResizeEvent` to `BgcodePreviewResizeEvent`, likely to improve naming consistency or to support a new event type.
