### PR TITLE
[Cmdpal] Use DynamicDependency to preserve trimmed Adaptive Card action types

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentFormViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentFormViewModel.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using AdaptiveCards.ObjectModel.WinUI3;
 using AdaptiveCards.Templating;
@@ -96,6 +97,9 @@ public partial class ContentFormViewModel(IFormContent _form, WeakReference<IPag
         UpdateProperty(nameof(Card));
     }
 
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(AdaptiveOpenUrlAction))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(AdaptiveSubmitAction))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(AdaptiveSubmitAction))]
     public void HandleSubmit(IAdaptiveActionElement action, JsonObject inputs)
     {
         if (action is AdaptiveOpenUrlAction openUrlAction)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentFormViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentFormViewModel.cs
@@ -99,7 +99,7 @@ public partial class ContentFormViewModel(IFormContent _form, WeakReference<IPag
 
     [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(AdaptiveOpenUrlAction))]
     [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(AdaptiveSubmitAction))]
-    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(AdaptiveSubmitAction))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(AdaptiveExecuteAction))]
     public void HandleSubmit(IAdaptiveActionElement action, JsonObject inputs)
     {
         if (action is AdaptiveOpenUrlAction openUrlAction)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentFormViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentFormViewModel.cs
@@ -98,107 +98,35 @@ public partial class ContentFormViewModel(IFormContent _form, WeakReference<IPag
 
     public void HandleSubmit(IAdaptiveActionElement action, JsonObject inputs)
     {
-        // BODGY circa GH #40979
-        // Usually, you're supposed to try to cast the action to a specific
-        // type, and use those objects to get the data you need.
-        // However, there's something weird with AdaptiveCards and the way it
-        // works when we consume it when built in Release, with AOT (and
-        // trimming) enabled. Any sort of `action.As<IAdaptiveSubmitAction>()`
-        // or similar will throw a System.InvalidCastException.
-        //
-        // Instead we have this horror show.
-        //
-        // The `action.ToJson()` blob ACTUALLY CONTAINS THE `type` field, which
-        // we can use to determine what kind of action it is. Then we can parse
-        // the JSON manually based on the type.
-        var actionJson = action.ToJson();
-
-        if (actionJson.TryGetValue("type", out var actionTypeValue))
+        if (action is AdaptiveOpenUrlAction openUrlAction)
         {
-            var actionTypeString = actionTypeValue.GetString();
-            Logger.LogTrace($"atString={actionTypeString}");
-
-            var actionType = actionTypeString switch
-            {
-                "Action.Submit" => ActionType.Submit,
-                "Action.Execute" => ActionType.Execute,
-                "Action.OpenUrl" => ActionType.OpenUrl,
-                _ => ActionType.Unsupported,
-            };
-
-            Logger.LogDebug($"{actionTypeString}->{actionType}");
-
-            switch (actionType)
-            {
-                case ActionType.OpenUrl:
-                    {
-                        HandleOpenUrlAction(action, actionJson);
-                    }
-
-                    break;
-                case ActionType.Submit:
-                case ActionType.Execute:
-                    {
-                        HandleSubmitAction(action, actionJson, inputs);
-                    }
-
-                    break;
-                default:
-                    Logger.LogError($"{actionType} was an unexpected action `type`");
-                    break;
-            }
-        }
-        else
-        {
-            Logger.LogError($"actionJson.TryGetValue(type) failed");
-        }
-    }
-
-    private void HandleOpenUrlAction(IAdaptiveActionElement action, JsonObject actionJson)
-    {
-        if (actionJson.TryGetValue("url", out var actionUrlValue))
-        {
-            var actionUrl = actionUrlValue.GetString() ?? string.Empty;
-            if (Uri.TryCreate(actionUrl, default(UriCreationOptions), out var uri))
-            {
-                WeakReferenceMessenger.Default.Send<LaunchUriMessage>(new(uri));
-            }
-            else
-            {
-                Logger.LogError($"Failed to produce URI for {actionUrlValue}");
-            }
-        }
-    }
-
-    private void HandleSubmitAction(
-        IAdaptiveActionElement action,
-        JsonObject actionJson,
-        JsonObject inputs)
-    {
-        var dataString = string.Empty;
-        if (actionJson.TryGetValue("data", out var actionDataValue))
-        {
-            dataString = actionDataValue.Stringify() ?? string.Empty;
+            WeakReferenceMessenger.Default.Send<LaunchUriMessage>(new(openUrlAction.Url));
+            return;
         }
 
-        var inputString = inputs.Stringify();
-        _ = Task.Run(() =>
+        if (action is AdaptiveSubmitAction or AdaptiveExecuteAction)
         {
-            try
+            // Get the data and inputs
+            var dataString = (action as AdaptiveSubmitAction)?.DataJson.Stringify() ?? string.Empty;
+            var inputString = inputs.Stringify();
+
+            _ = Task.Run(() =>
             {
-                var model = _formModel.Unsafe!;
-                if (model != null)
+                try
                 {
-                    var result = model.SubmitForm(inputString, dataString);
-                    Logger.LogDebug($"SubmitForm() returned {result}");
-                    WeakReferenceMessenger.Default.Send<HandleCommandResultMessage>(new(new(result)));
+                    var model = _formModel.Unsafe!;
+                    if (model != null)
+                    {
+                        var result = model.SubmitForm(inputString, dataString);
+                        WeakReferenceMessenger.Default.Send<HandleCommandResultMessage>(new(new(result)));
+                    }
                 }
-            }
-            catch (Exception ex)
-            {
-                ShowException(ex);
-            }
-        });
+                catch (Exception ex)
+                {
+                    ShowException(ex);
+                }
+            });
+        }
     }
 
     private static readonly string ErrorCardJson = """

--- a/src/modules/cmdpal/ext/SamplePagesExtension/Pages/SampleContentPage.cs
+++ b/src/modules/cmdpal/ext/SamplePagesExtension/Pages/SampleContentPage.cs
@@ -225,11 +225,6 @@ internal sealed partial class SampleContentForm : FormContent
                     }
                 ]
             }
-        },
-        {
-            "type": "Action.OpenUrl",
-            "title": "Action.OpenUrl",
-            "url": "https://adaptivecards.microsoft.com/"
         }
     ]
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
1. Preserve Adaptive Card action types during trimming using DynamicDependency
2. Revert PR https://github.com/microsoft/PowerToys/pull/41010

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #40979
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

