### PR TITLE
[QuickAccent] Update Topmost logic to attempt to fix hybrid graphics issues

### DIFF
--- a/src/modules/poweraccent/PowerAccent.UI/Selector.xaml.cs
+++ b/src/modules/poweraccent/PowerAccent.UI/Selector.xaml.cs
@@ -63,6 +63,7 @@ public partial class Selector : FluentWindow, IDisposable, INotifyPropertyChange
 
     private void PowerAccent_OnChangeDisplay(bool isActive, string[] chars)
     {
+        // Topmost is conditionally set here to address hybrid graphics issues on laptops with Optimus technology.
         this.Topmost = isActive;
 
         CharacterNameVisibility = _powerAccent.ShowUnicodeDescription ? Visibility.Visible : Visibility.Collapsed;

--- a/src/modules/poweraccent/PowerAccent.UI/Selector.xaml.cs
+++ b/src/modules/poweraccent/PowerAccent.UI/Selector.xaml.cs
@@ -63,7 +63,7 @@ public partial class Selector : FluentWindow, IDisposable, INotifyPropertyChange
 
     private void PowerAccent_OnChangeDisplay(bool isActive, string[] chars)
     {
-        // Topmost is conditionally set here to address hybrid graphics issues on laptops with Optimus technology.
+        // Topmost is conditionally set here to address hybrid graphics issues on laptops.
         this.Topmost = isActive;
 
         CharacterNameVisibility = _powerAccent.ShowUnicodeDescription ? Visibility.Visible : Visibility.Collapsed;

--- a/src/modules/poweraccent/PowerAccent.UI/Selector.xaml.cs
+++ b/src/modules/poweraccent/PowerAccent.UI/Selector.xaml.cs
@@ -44,7 +44,6 @@ public partial class Selector : FluentWindow, IDisposable, INotifyPropertyChange
         Wpf.Ui.Appearance.SystemThemeWatcher.Watch(this);
 
         Application.Current.MainWindow.ShowActivated = false;
-        Application.Current.MainWindow.Topmost = true;
     }
 
     protected override void OnSourceInitialized(EventArgs e)
@@ -64,6 +63,8 @@ public partial class Selector : FluentWindow, IDisposable, INotifyPropertyChange
 
     private void PowerAccent_OnChangeDisplay(bool isActive, string[] chars)
     {
+        this.Topmost = isActive;
+
         CharacterNameVisibility = _powerAccent.ShowUnicodeDescription ? Visibility.Visible : Visibility.Collapsed;
 
         if (isActive)


### PR DESCRIPTION
An attempt to fix a Quick Accent issue affecting laptops with 'Optimus' hybrid graphics modes, where the utility locks the machine into discrete graphics mode permanently.

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This PR changes the Topmost behaviour for Quick Accent from always true to only being true when the selection window is displayed.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #34849 (NB: requires testing on laptop with hybrid graphics)
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

Topmost was set to `true` for the main application window on start, which persisted for the lifetime of the application. This PR change removes that, and instead dynamically toggles Topmost for the selection window as it is activated/deactivated. The assumption is that the FluentWindow-derived window is retaining graphics resources and presenting as an active GPU consumer because of the main application window's Topmost status, even if the selection window is hidden.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

I've confirmed with manual tests that the existing QuickAccent functionality appears to function identically with this change. However, I do not own a laptop with a hybrid graphics capability, so am unable to test whether this fixes the underlying problem. I will keep my fingers crossed though 🤞😊