### PR TITLE
CmdPal: Make sure to include apps in the ctor

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
@@ -60,6 +60,7 @@ public partial class MainListPage : DynamicListPage,
         var settings = _serviceProvider.GetService<SettingsModel>()!;
         settings.SettingsChanged += SettingsChangedHandler;
         HotReloadSettings(settings);
+        _includeApps = _tlcManager.IsProviderActive(AllAppsCommandProvider.WellKnownId);
 
         IsLoading = true;
     }


### PR DESCRIPTION
A regression from #40132 

We need to set the value of `_includeApps` in the `MainListPage` ctor. Without it, if the user doesn't have any extensions installed, the value is never updated.