### PR TITLE
CmdPal: combo fix content panel and zombie apocalypse

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ContentPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ContentPage.xaml.cs
@@ -34,8 +34,14 @@ public sealed partial class ContentPage : Page,
     public ContentPage()
     {
         this.InitializeComponent();
-        WeakReferenceMessenger.Default.Register<ActivateSelectedListItemMessage>(this);
-        WeakReferenceMessenger.Default.Register<ActivateSecondaryCommandMessage>(this);
+        this.Unloaded += OnUnloaded;
+    }
+
+    private void OnUnloaded(object sender, RoutedEventArgs e)
+    {
+        // Unhook from everything to ensure nothing can reach us
+        // between this point and our complete and utter destruction.
+        WeakReferenceMessenger.Default.UnregisterAll(this);
     }
 
     protected override void OnNavigatedTo(NavigationEventArgs e)
@@ -44,6 +50,9 @@ public sealed partial class ContentPage : Page,
         {
             ViewModel = vm;
         }
+
+        WeakReferenceMessenger.Default.Register<ActivateSelectedListItemMessage>(this);
+        WeakReferenceMessenger.Default.Register<ActivateSecondaryCommandMessage>(this);
 
         base.OnNavigatedTo(e);
     }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/SettingsWindow.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/SettingsWindow.xaml.cs
@@ -104,6 +104,8 @@ public sealed partial class SettingsWindow : WindowEx,
     private void Window_Closed(object sender, WindowEventArgs args)
     {
         WeakReferenceMessenger.Default.Send<SettingsWindowClosedMessage>();
+
+        WeakReferenceMessenger.Default.UnregisterAll(this);
     }
 
     private void PaneToggleBtn_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary of the Pull Request

Changes the timing of when `ContentPage` registers to messages from the Toolkit Messenger so it happens only when navigated to, mirroring the unregister on navigation from. Also unregisters from all messages when unloaded.

Proactively unregisters the Settings window from all messages on close instead of relying on the GC’s nondeterministic cleanup. Since the Settings window is newly created each time, old instances can still react to messages even after their time is over, merely waiting for GC to collect them.

## PR Checklist

- [x] Closes: #40846 
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

