### PR TITLE
build: remove *tests* and all coverage/DIA DLLs from binskim

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -115,6 +115,7 @@ bigbar
 bigobj
 binlog
 binres
+binskim
 BITMAPFILEHEADER
 bitmapimage
 BITMAPINFO
@@ -255,6 +256,7 @@ Corpor
 cotaskmem
 COULDNOT
 countof
+covrun
 cpcontrols
 cph
 cplusplus
@@ -969,6 +971,7 @@ msc
 mscorlib
 msctls
 msdata
+msdia
 MSDL
 MSGFLT
 MSHCTX

--- a/.pipelines/v2/release.yml
+++ b/.pipelines/v2/release.yml
@@ -92,7 +92,7 @@ extends:
               versionNumber: ${{ parameters.versionNumber }}
               publishArtifacts: false # 1ES PT handles publication for us.
               official: true
-              codeSign: false
+              codeSign: true
               runTests: false
               signingIdentity:
                 serviceName: $(SigningServiceName)

--- a/.pipelines/v2/release.yml
+++ b/.pipelines/v2/release.yml
@@ -67,7 +67,7 @@ extends:
       binskim:
         enabled: true
         # Exclude every dll/exe in tests/*, as well as all msdia*, covrun* and vcruntime*
-        analyzeTargetGlob: +:file|$(Build.ArtifactStagingDirectory)/**/*.dll;+:file|$(Build.ArtifactStagingDirectory)/**/*.exe;-:file|**/*tests/**/*.dll;-:file|**/*tests/**/*.exe;-:file:regex|(covrun.*)\.dll$;-:file:regex|(msdia.*)\.dll$;-:file:regex|(vcruntime.*)\.dll$
+        analyzeTargetGlob: +:file|$(Build.ArtifactStagingDirectory)/**/*.dll;+:file|$(Build.ArtifactStagingDirectory)/**/*.exe;-:file:regex|tests.*\.(dll|exe)$;-:file:regex|(covrun.*)\.dll$;-:file:regex|(msdia.*)\.dll$;-:file:regex|(vcruntime.*)\.dll$
 
     stages:
       - stage: Build

--- a/.pipelines/v2/release.yml
+++ b/.pipelines/v2/release.yml
@@ -67,7 +67,7 @@ extends:
       binskim:
         enabled: true
         # Exclude every dll/exe in tests/*, as well as all msdia*, covrun* and vcruntime*
-        analyzeTargetGlob: +:file|$(Build.ArtifactStagingDirectory)/**/*.dll;+:file|$(Build.ArtifactStagingDirectory)/**/*.exe;-:file|*/*tests/**/*.dll;-:file|*/*tests/**/*.exe;-:file:regex|(covrun.*)\.dll$;-:file:regex|(msdia.*)\.dll$;-:file:regex|(vcruntime.*)\.dll$
+        analyzeTargetGlob: +:file|$(Build.ArtifactStagingDirectory)/**/*.dll;+:file|$(Build.ArtifactStagingDirectory)/**/*.exe;-:file|**/*tests/**/*.dll;-:file|**/*tests/**/*.exe;-:file:regex|(covrun.*)\.dll$;-:file:regex|(msdia.*)\.dll$;-:file:regex|(vcruntime.*)\.dll$
 
     stages:
       - stage: Build

--- a/.pipelines/v2/release.yml
+++ b/.pipelines/v2/release.yml
@@ -64,6 +64,10 @@ extends:
       tsa:
         enabled: true
         configFile: '$(Build.SourcesDirectory)\.pipelines\tsa.json'
+      binskim:
+        enabled: true
+        # Exclude every dll/exe in tests/*, as well as all msdia*, covrun* and vcruntime*
+        analyzeTargetGlob: +:file|**/*.dll;+:file|**/*.exe;-:file|*/*tests/**/*.dll;-:file|*/*tests/**/*.exe;-:file:regex|(covrun.*)\.dll$;-:file:regex|(msdia.*)\.dll$;-:file:regex|(vcruntime.*)\.dll$
 
     stages:
       - stage: Build

--- a/.pipelines/v2/release.yml
+++ b/.pipelines/v2/release.yml
@@ -92,7 +92,7 @@ extends:
               versionNumber: ${{ parameters.versionNumber }}
               publishArtifacts: false # 1ES PT handles publication for us.
               official: true
-              codeSign: true
+              codeSign: false
               runTests: false
               signingIdentity:
                 serviceName: $(SigningServiceName)

--- a/.pipelines/v2/release.yml
+++ b/.pipelines/v2/release.yml
@@ -67,7 +67,7 @@ extends:
       binskim:
         enabled: true
         # Exclude every dll/exe in tests/*, as well as all msdia*, covrun* and vcruntime*
-        analyzeTargetGlob: +:file|**/*.dll;+:file|**/*.exe;-:file|*/*tests/**/*.dll;-:file|*/*tests/**/*.exe;-:file:regex|(covrun.*)\.dll$;-:file:regex|(msdia.*)\.dll$;-:file:regex|(vcruntime.*)\.dll$
+        analyzeTargetGlob: +:file|$(Build.ArtifactStagingDirectory)/**/*.dll;+:file|$(Build.ArtifactStagingDirectory)/**/*.exe;-:file|*/*tests/**/*.dll;-:file|*/*tests/**/*.exe;-:file:regex|(covrun.*)\.dll$;-:file:regex|(msdia.*)\.dll$;-:file:regex|(vcruntime.*)\.dll$
 
     stages:
       - stage: Build


### PR DESCRIPTION
This thing files about 900 bugs a month on us.

Before:

```
Done. 11,036 files scanned.
```

After:

```
Done. 4,753 files scanned.
```