### PR TITLE
CmdPal: Remove constrain that keeps the context menu flyout in the bounds of the window

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml
@@ -47,7 +47,8 @@
             <Flyout
                 x:Name="ContextMenuFlyout"
                 FlyoutPresenterStyle="{StaticResource ContextMenuFlyoutStyle}"
-                Opened="ContextMenuFlyout_Opened">
+                Opened="ContextMenuFlyout_Opened"
+                ShouldConstrainToRootBounds="False">
                 <cpcontrols:ContextMenu x:Name="ContextControl" />
             </Flyout>
 


### PR DESCRIPTION
## Summary of the Pull Request

Added `ShouldConstrainToRootBounds="False"` to the Flyout element, allowing it to extend beyond the bounds of its parent container. This allows the menu to always open with top-left corner at the cursor position as is common for the context menus.

This affects the menu only when opened as a context menu on the list item (e.g. mouse right-click), not when opened from the Command Bar (that opens same as before).

After screenshot:

<img width="834" height="589" alt="image" src="https://github.com/user-attachments/assets/acb40e08-074e-4bae-afe7-87c6a73a6581" />


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #41131 
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

