### PR TITLE
CmdPal: Add Acrylic backdrop to the context menu and tweak its style

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml
@@ -41,13 +41,25 @@
                 <Style.Setters>
                     <Setter Property="Margin" Value="0" />
                     <Setter Property="Padding" Value="0" />
+                    <Setter Property="Background" Value="Transparent" />
+                    <Setter Property="BorderBrush" Value="{ThemeResource DividerStrokeColorDefaultBrush}" />
+                    <Setter Property="Transitions">
+                        <Setter.Value>
+                            <TransitionCollection />
+                        </Setter.Value>
+                    </Setter>
                 </Style.Setters>
             </Style>
 
             <Flyout
                 x:Name="ContextMenuFlyout"
                 FlyoutPresenterStyle="{StaticResource ContextMenuFlyoutStyle}"
-                Opened="ContextMenuFlyout_Opened">
+                Opened="ContextMenuFlyout_Opened"
+                ShouldConstrainToRootBounds="False">
+                <Flyout.SystemBackdrop>
+                    <!-- Backdrop requires ShouldConstrainToRootBounds="False" -->
+                    <DesktopAcrylicBackdrop />
+                </Flyout.SystemBackdrop>
                 <cpcontrols:ContextMenu x:Name="ContextControl" />
             </Flyout>
 


### PR DESCRIPTION
## Summary of the Pull Request

- Adds acrylic backdrop to the context menu
- Tweaks border of the context menu to match CmdPal aesthetics
- Acrylic backdrop requires ShouldConstrainToRootBounds="False", otherwise the backdrop is not rendered

After:

<img width="1007" height="1313" alt="image" src="https://github.com/user-attachments/assets/d6a7bd6a-d5d8-4674-9062-91f496f49f0c" />


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #41134
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

