### PR TITLE
CmdPal: Prevent some SearchText bouncing.

### DIFF
--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/DynamicListPage.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/DynamicListPage.cs
@@ -12,7 +12,7 @@ public abstract class DynamicListPage : ListPage, IDynamicListPage
         set
         {
             var oldSearch = base.SearchText;
-            base.SearchText = value;
+            SetSearchNoUpdate(value);
             UpdateSearchText(oldSearch, value);
         }
     }

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/ListPage.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/ListPage.cs
@@ -105,4 +105,9 @@ public partial class ListPage : Page, IListPage
         {
         }
     }
+
+    protected void SetSearchNoUpdate(string newSearchText)
+    {
+        _searchText = newSearchText;
+    }
 }


### PR DESCRIPTION
This stops us from raising a PropChanged(SearchText) in DynamicListPage when we're the ones to set it.

When we'd raise the PropChanged in response to a `set`, it could cause a race between CmdPal and the extension. It was totally possible that CmdPal could call

```
SearchText="foo";
SearchText="fool";
```

and in the extension, we'd raise the PropChanged for each of those, but then have CmdPal handle those events out-of-order.

This seems to entirely remove all the "jiggling" that I'd notice in the evil samples from #41158

Closes #38190


