### PR TITLE
CmdPal: Agile will rule the World and maybe fix WinGet

### DIFF
--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WinGet/Pages/WinGetExtensionPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WinGet/Pages/WinGetExtensionPage.cs
@@ -16,6 +16,7 @@ using Microsoft.CmdPal.Ext.WinGet.Pages;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 using Microsoft.Management.Deployment;
+using WinRT;
 
 namespace Microsoft.CmdPal.Ext.WinGet;
 
@@ -235,8 +236,8 @@ internal sealed partial class WinGetExtensionPage : DynamicListPage, IDisposable
 
             // BODGY, re: microsoft/winget-cli#5151
             // FindPackagesAsync isn't actually async.
-            Task<FindPackagesResult> internalSearchTask = Task.Run(() => catalog.FindPackages(opts), ct);
-            FindPackagesResult searchResults = await internalSearchTask;
+            Task<AgileReference<FindPackagesResult>> internalSearchTask = Task.Run(() => catalog.FindPackages(opts).AsAgile(), ct);
+            FindPackagesResult searchResults = (await internalSearchTask).Get();
 
             // TODO more error handling like this:
             if (searchResults.Status != FindPackagesResultStatus.Ok)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This might fix the winget. Don't assume it's correct. Just that it works (on my machine).

I didn't test this properly yet 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] Closes: #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

## AI Summary
This pull request updates the WinGet extension page to improve compatibility with WinRT and address issues with asynchronous package search. The main changes focus on using WinRT's `AgileReference` to properly handle async results from the WinGet catalog search.

WinRT compatibility and async handling:

* Added a `using WinRT;` directive to enable usage of WinRT types and helpers in `WinGetExtensionPage.cs`.
* Updated the package search logic in `DoSearchAsync` to wrap the result of `catalog.FindPackages(opts)` in an `AgileReference` using `.AsAgile()`, and retrieve the actual result with `.Get()`. This change helps resolve issues with WinRT object threading and async handling.

Why this helps AOT:

* COM/WinRT Threading: In .NET Native/AOT scenarios, COM and WinRT objects often have strict rules: they can only be used on the thread where they were created, unless they're "agile." If you marshal a WinRT object across threads without using an agile reference, you can get runtime errors in AOT environments.
* AgileReference: The .AsAgile() method wraps the WinRT object (FindPackagesResult) in an AgileReference, allowing you to safely access it from any thread, even after running it on a background thread. When you call .Get(), you're marshaling the object back to the current thread in a safe way.
* AOT Safety: JIT environments (like regular .NET) are more lenient, but AOT environments (like .NET Native for UWP apps, or apps that use WinRT projections) strictly enforce these rules. Using AgileReference prevents hard-to-debug crashes or access violations in AOT scenarios.
