### PR TITLE
Tests(CmdPal/Calc): verify CloseOnEnter swaps primary Copy/Save

### DIFF
--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Calc.UnitTests/CloseOnEnterTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Calc.UnitTests/CloseOnEnterTests.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using System.Linq;
+using Microsoft.CmdPal.Ext.Calc.Helper;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.Foundation;
+
+namespace Microsoft.CmdPal.Ext.Calc.UnitTests;
+
+[TestClass]
+public class CloseOnEnterTests
+{
+    [TestMethod]
+    public void PrimaryIsCopy_WhenCloseOnEnterTrue()
+    {
+        var settings = new Settings(closeOnEnter: true);
+        TypedEventHandler<object, object> handleSave = (s, e) => { };
+
+        var item = ResultHelper.CreateResult(
+            4m,
+            CultureInfo.CurrentCulture,
+            CultureInfo.CurrentCulture,
+            "2+2",
+            settings,
+            handleSave);
+
+        Assert.IsNotNull(item);
+        Assert.IsInstanceOfType(item.Command, typeof(CopyTextCommand));
+
+        var firstMore = item.MoreCommands.First();
+        Assert.IsInstanceOfType(firstMore, typeof(CommandContextItem));
+        Assert.IsInstanceOfType(((CommandItem)firstMore).Command, typeof(SaveCommand));
+    }
+
+    [TestMethod]
+    public void PrimaryIsSave_WhenCloseOnEnterFalse()
+    {
+        var settings = new Settings(closeOnEnter: false);
+        TypedEventHandler<object, object> handleSave = (s, e) => { };
+
+        var item = ResultHelper.CreateResult(
+            4m,
+            CultureInfo.CurrentCulture,
+            CultureInfo.CurrentCulture,
+            "2+2",
+            settings,
+            handleSave);
+
+        Assert.IsNotNull(item);
+        Assert.IsInstanceOfType(item.Command, typeof(SaveCommand));
+
+        var firstMore = item.MoreCommands.First();
+        Assert.IsInstanceOfType(firstMore, typeof(CommandContextItem));
+        Assert.IsInstanceOfType(((CommandItem)firstMore).Command, typeof(CopyTextCommand));
+    }
+}


### PR DESCRIPTION
## Summary of the Pull Request
Add two unit tests for CmdPal Calculator to guard the “Close on Enter” behavior. Tests assert that:
- CloseOnEnter = true → primary is Copy, first More is Save.
- CloseOnEnter = false → primary is Save, first More is Copy.

Relates to #40262. Follow-up tests for [CmdPal][Calc] “Close on Enter” feature (see PR #40398).

## PR Checklist
- [ ] Closes: N/A
- [ ] **Communication:** N/A (tests-only follow-up)
- [x] **Tests:** Added/updated and all pass
- [ ] **Localization:** N/A (no user-facing strings)
- [ ] **Dev docs:** N/A
- [ ] **New binaries:** None
- [ ] **Documentation updated:** N/A

## Detailed Description of the Pull Request / Additional comments
Added:
- `src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Calc.UnitTests/CloseOnEnterTests.cs`

Implementation notes:
- Uses existing `Settings` test helper to toggle `CloseOnEnter`.
- Calls `ResultHelper.CreateResult(...)`, then asserts:
  - `ListItem.Command` type is `CopyTextCommand` or `SaveCommand` per setting.
  - First entry in `MoreCommands` (cast to `CommandItem`) is the opposite command.

## Validation Steps Performed
- Local test run:
  - VS Test Explorer: `CloseOnEnterTests` → Passed (2).
  - CLI:  
    `dotnet test src\modules\cmdpal\Tests\Microsoft.CmdPal.Ext.Calc.UnitTests\Microsoft.CmdPal.Ext.Calc.UnitTests.csproj -c Debug -p:Platform=x64 --filter FullyQualifiedName~CloseOnEnterTests`
- Manual sanity check:
  - Open CmdPal (Win+Alt+Space), Calculator provider, toggle “Close on Enter,” verify Enter closes (Copy primary) vs keeps open (Save primary).


Also relates to #40398 #40262 