### PR TITLE
Hosts: add “No leading spaces” option and honor it when saving

### DIFF
--- a/src/modules/Hosts/Hosts/Settings/UserSettings.cs
+++ b/src/modules/Hosts/Hosts/Settings/UserSettings.cs
@@ -26,6 +26,8 @@ namespace Hosts.Settings
 
         private bool _loopbackDuplicates;
 
+        public bool NoLeadingSpaces { get; private set; }
+
         public bool LoopbackDuplicates
         {
             get => _loopbackDuplicates;
@@ -88,6 +90,7 @@ namespace Hosts.Settings
                             AdditionalLinesPosition = (HostsAdditionalLinesPosition)settings.Properties.AdditionalLinesPosition;
                             Encoding = (HostsEncoding)settings.Properties.Encoding;
                             LoopbackDuplicates = settings.Properties.LoopbackDuplicates;
+                            NoLeadingSpaces = settings.Properties.NoLeadingSpaces;
                         }
 
                         retry = false;

--- a/src/modules/Hosts/HostsUILib/Helpers/HostsService.cs
+++ b/src/modules/Hosts/HostsUILib/Helpers/HostsService.cs
@@ -157,7 +157,7 @@ namespace HostsUILib.Helpers
                         {
                             lineBuilder.Append('#').Append(' ');
                         }
-                        else if (anyDisabled)
+                        else if (anyDisabled && !_userSettings.NoLeadingSpaces)
                         {
                             lineBuilder.Append(' ').Append(' ');
                         }

--- a/src/modules/Hosts/HostsUILib/Settings/IUserSettings.cs
+++ b/src/modules/Hosts/HostsUILib/Settings/IUserSettings.cs
@@ -19,5 +19,7 @@ namespace HostsUILib.Settings
         event EventHandler LoopbackDuplicatesChanged;
 
         public delegate void OpenSettingsFunction();
+
+        public bool NoLeadingSpaces { get; }
     }
 }

--- a/src/settings-ui/Settings.UI.Library/HostsProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/HostsProperties.cs
@@ -24,6 +24,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 
         public HostsEncoding Encoding { get; set; }
 
+        [JsonConverter(typeof(BoolPropertyJsonConverter))]
+        public bool NoLeadingSpaces { get; set; }
+
         public HostsProperties()
         {
             ShowStartupWarning = true;
@@ -31,6 +34,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             LoopbackDuplicates = false;
             AdditionalLinesPosition = HostsAdditionalLinesPosition.Top;
             Encoding = HostsEncoding.Utf8;
+            NoLeadingSpaces = false;
         }
     }
 }

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/HostsPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/HostsPage.xaml
@@ -56,6 +56,9 @@
                     <tkcontrols:SettingsCard x:Uid="Hosts_Toggle_LoopbackDuplicates" HeaderIcon="{ui:FontIcon Glyph=&#xEC27;}">
                         <ToggleSwitch x:Uid="ToggleSwitch" IsOn="{x:Bind ViewModel.LoopbackDuplicates, Mode=TwoWay}" />
                     </tkcontrols:SettingsCard>
+                    <tkcontrols:SettingsCard x:Uid="Hosts_NoLeadingSpaces" HeaderIcon="{ui:FontIcon Glyph=&#xE8A5;}">
+                        <ToggleSwitch x:Uid="ToggleSwitch" IsOn="{x:Bind ViewModel.NoLeadingSpaces, Mode=TwoWay}" />
+                    </tkcontrols:SettingsCard>
                     <tkcontrols:SettingsCard x:Uid="Hosts_Encoding">
                         <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}" SelectedIndex="{x:Bind Path=ViewModel.Encoding, Mode=TwoWay}">
                             <ComboBoxItem x:Uid="Hosts_Encoding_Utf8" />

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -5127,4 +5127,10 @@ To record a specific window, enter the hotkey with the Alt key in the opposite m
   <data name="KeyBack" xml:space="preserve">
     <value>Back key</value>
   </data>
+  <data name="Hosts_NoLeadingSpaces.Header" xml:space="preserve">
+    <value>No leading spaces</value>
+  </data>
+  <data name="Hosts_NoLeadingSpaces.Description" xml:space="preserve">
+    <value>Do not prepend spaces to active lines when saving the hosts file</value>
+  </data>
 </root>

--- a/src/settings-ui/Settings.UI/ViewModels/HostsViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/HostsViewModel.cs
@@ -105,6 +105,19 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             }
         }
 
+        public bool NoLeadingSpaces
+        {
+            get => Settings.Properties.NoLeadingSpaces;
+            set
+            {
+                if (value != Settings.Properties.NoLeadingSpaces)
+                {
+                    Settings.Properties.NoLeadingSpaces = value;
+                    NotifyPropertyChanged();
+                }
+            }
+        }
+
         public int AdditionalLinesPosition
         {
             get => (int)Settings.Properties.AdditionalLinesPosition;


### PR DESCRIPTION
## Summary of the Pull Request

Adds a new Hosts File Editor setting “No leading spaces” that prevents prepending spaces to active lines when saving the hosts file (when any entry is disabled). Default is Off to preserve current behavior.



## PR Checklist

- [x] Closes: #36386  

- [ ] Communication: N/A (small, scoped option)

- [x] Tests: Added/updated and all pass

- [x] Localization: New en-US strings added; other locales handled by loc pipeline

- [ ] Dev docs: N/A

- [x] New binaries: None

- [x] Documentation updated: N/A



## Detailed Description of the Pull Request / Additional comments

- Settings surface:

  - `src/settings-ui/Settings.UI.Library/HostsProperties.cs`: add `NoLeadingSpaces`

  - `src/modules/Hosts/HostsUILib/Settings/IUserSettings.cs`: add `NoLeadingSpaces`

  - `src/modules/Hosts/Hosts/Settings/UserSettings.cs`: load/save value from settings.json

  - `src/settings-ui/Settings.UI/ViewModels/HostsViewModel.cs`: expose `NoLeadingSpaces`

  - `src/settings-ui/Settings.UI/SettingsXAML/Views/HostsPage.xaml`: new SettingsCard toggle

  - `src/settings-ui/Settings.UI/Strings/en-us/Resources.resw`: add `Hosts_NoLeadingSpaces.Header/Description`

- Writer change:

  - `src/modules/Hosts/HostsUILib/Helpers/HostsService.cs`: gate indent with `anyDisabled && !_userSettings.NoLeadingSpaces`

- Tests:

  - `src/modules/Hosts/Hosts.Tests/HostsServiceTest.cs`: `NoLeadingSpaces_Disabled_RemovesIndent`



Backward compatibility: default Off, current formatting unchanged unless the user enables the option.



## Validation Steps Performed

- Automated: `HostsEditor.UnitTests` including `NoLeadingSpaces_Disabled_RemovesIndent` passing.

- Manual:

  1. Run PowerToys (runner) as Admin.

  2. Settings → Hosts File Editor → enable “No leading spaces”.

  3. In editor, add active `127.0.0.10 example1` and disabled `127.0.0.11 example2`; Save.

  4. Open `C:\Windows\System32\drivers\etc\hosts` in Notepad.

     - ON: active line starts at column 0; disabled is `# 127...`.

     - OFF: active line begins with two spaces when a disabled entry exists.