### PR TITLE
Remove debug dialog

### DIFF
--- a/src/settings-ui/Settings.UI/SettingsXAML/App.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/App.xaml.cs
@@ -320,38 +320,12 @@ namespace Microsoft.PowerToys.Settings.UI
                 WindowHelpers.ForceTopBorder1PixelInsetOnWindows10(WindowNative.GetWindowHandle(settingsWindow));
                 settingsWindow.Activate();
                 settingsWindow.NavigateToSection(StartupPage);
-                ShowMessageDialog("The application is running in Debug mode.", "DEBUG");
 #else
                 /* If we try to run Settings as a standalone app, it will start PowerToys.exe if not running and open Settings again through it in the Dashboard page. */
                 Common.UI.SettingsDeepLink.OpenSettings(Common.UI.SettingsDeepLink.SettingsWindow.Dashboard, true);
                 Exit();
 #endif
             }
-        }
-
-#if !DEBUG
-        private async void ShowMessageDialogAndExit(string content, string title = null)
-#else
-        private async void ShowMessageDialog(string content, string title = null)
-#endif
-        {
-            await ShowDialogAsync(content, title);
-#if !DEBUG
-            this.Exit();
-#endif
-        }
-
-        public static Task<IUICommand> ShowDialogAsync(string content, string title = null)
-        {
-            var dialog = new MessageDialog(content, title ?? string.Empty);
-            var handle = NativeMethods.GetActiveWindow();
-            if (handle == IntPtr.Zero)
-            {
-                throw new InvalidOperationException();
-            }
-
-            InitializeWithWindow.Initialize(dialog, handle);
-            return dialog.ShowAsync().AsTask<IUICommand>();
         }
 
         public static TwoWayPipeMessageIPCManaged GetTwoWayIPCManager()


### PR DESCRIPTION
Quality of life improvement for the dev loop: removing the dialog in Settings, since we have a DEBUG header in the titlebar anyways.