### PR TITLE
CmdPal: Add the pdb's for `.Extensions` too

### DIFF
--- a/src/modules/cmdpal/extensionsdk/nuget/Microsoft.CommandPalette.Extensions.SDK.nuspec
+++ b/src/modules/cmdpal/extensionsdk/nuget/Microsoft.CommandPalette.Extensions.SDK.nuspec
@@ -34,6 +34,7 @@
     <file src="..\Microsoft.CommandPalette.Extensions\x64\release\Microsoft.CommandPalette.Extensions\Microsoft.CommandPalette.Extensions.dll" target="runtimes\win-x64\native\"/>
     <file src="..\Microsoft.CommandPalette.Extensions\x64\release\Microsoft.CommandPalette.Extensions\Microsoft.CommandPalette.Extensions.pdb" target="runtimes\win-x64\native\"/>
     <file src="..\Microsoft.CommandPalette.Extensions\arm64\release\Microsoft.CommandPalette.Extensions\Microsoft.CommandPalette.Extensions.dll" target="runtimes\win-arm64\native\"/>
+    <file src="..\Microsoft.CommandPalette.Extensions\arm64\release\Microsoft.CommandPalette.Extensions\Microsoft.CommandPalette.Extensions.pdb" target="runtimes\win-arm64\native\"/>
 
     <!-- Not putting the following into the lib folder because we don't want plugin project to directly reference the winmd -->
     <file src="..\Microsoft.CommandPalette.Extensions\x64\release\Microsoft.CommandPalette.Extensions\Microsoft.CommandPalette.Extensions.winmd" target="winmd\"/>


### PR DESCRIPTION
* The _toolkit_ is AnyCPU.
* the extensions interface itself `Microsoft.CommandPalette.Extensions` is c++, so it needs both ARM and x64

Technically I'm not sure there's anything of real value in just `.Extensions`, since that project is just there to build the winmd (we don't have any runtimeclasses), so not having the symbols for that shouldn't be the end of the world
