### PR TITLE
DevDocs: Add prerequisites to enable long paths in Windows

### DIFF
--- a/doc/devdocs/readme.md
+++ b/doc/devdocs/readme.md
@@ -76,6 +76,7 @@ Once you've discussed your proposed feature/fix/etc. with a team member, and an 
 1. Windows 10 April 2018 Update (version 1803) or newer
 1. Visual Studio Community/Professional/Enterprise 2022 17.4 or newer
 1. A local clone of the PowerToys repository
+1. Enable long paths in Windows (see [Enable Long Paths](https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation#enabling-long-paths-in-windows-10-version-1607-and-later) for details)
 
 ### Install Visual Studio dependencies
 

--- a/doc/devdocs/readme.md
+++ b/doc/devdocs/readme.md
@@ -76,7 +76,7 @@ Once you've discussed your proposed feature/fix/etc. with a team member, and an 
 1. Windows 10 April 2018 Update (version 1803) or newer
 1. Visual Studio Community/Professional/Enterprise 2022 17.4 or newer
 1. A local clone of the PowerToys repository
-1. Enable long paths in Windows (see [Enable Long Paths](https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation#enabling-long-paths-in-windows-10-version-1607-and-later) for details)
+1. Enable long paths in Windows (see [Enable Long Paths](https://docs.microsoft.com/windows/win32/fileio/maximum-file-path-limitation#enabling-long-paths-in-windows-10-version-1607-and-later) for details)
 
 ### Install Visual Studio dependencies
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Added the "long paths" to the prerequisites in the DevDocs

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [x] **Dev docs:** Added/updated

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
While setting up the PowerToys solution, I ran into repeated issues where files or SDKs could not be found when loading the solution. After a full evening of debugging, the root cause turned out to be Windows’ default path length limitation.

Even with a repository path like C:/Users/Micha/Development/PowerToys (which is not unusually long by itself), the combination of folder structure and file names exceeded the maximum allowed path length and caused the build problems.