### PR TITLE
CmdPal: Replace localized strings used as setting values in WebSearch extension with literals

### DIFF
--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.WebSearch.UnitTests/MockSettingsInterface.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.WebSearch.UnitTests/MockSettingsInterface.cs
@@ -15,9 +15,9 @@ public class MockSettingsInterface : ISettingsInterface
 
     public bool GlobalIfURI { get; set; }
 
-    public string ShowHistory { get; set; }
+    public uint ShowHistory { get; set; }
 
-    public MockSettingsInterface(string showHistory = "none", bool globalIfUri = true, List<HistoryItem> mockHistory = null)
+    public MockSettingsInterface(uint showHistory = 0, bool globalIfUri = true, List<HistoryItem> mockHistory = null)
     {
         _historyItems = mockHistory ?? new List<HistoryItem>();
         GlobalIfURI = globalIfUri;
@@ -50,9 +50,9 @@ public class MockSettingsInterface : ISettingsInterface
         _historyItems.Add(historyItem);
 
         // Simulate the same logic as SettingsManager
-        if (int.TryParse(ShowHistory, out var maxHistoryItems) && maxHistoryItems > 0)
+        if (ShowHistory > 0)
         {
-            while (_historyItems.Count > maxHistoryItems)
+            while (_historyItems.Count > ShowHistory)
             {
                 _historyItems.RemoveAt(0); // Remove the oldest item
             }

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.WebSearch.UnitTests/MockSettingsInterface.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.WebSearch.UnitTests/MockSettingsInterface.cs
@@ -15,13 +15,13 @@ public class MockSettingsInterface : ISettingsInterface
 
     public bool GlobalIfURI { get; set; }
 
-    public uint ShowHistory { get; set; }
+    public uint HistoryItemCount { get; set; }
 
-    public MockSettingsInterface(uint showHistory = 0, bool globalIfUri = true, List<HistoryItem> mockHistory = null)
+    public MockSettingsInterface(uint historyItemCount = 0, bool globalIfUri = true, List<HistoryItem> mockHistory = null)
     {
         _historyItems = mockHistory ?? new List<HistoryItem>();
         GlobalIfURI = globalIfUri;
-        ShowHistory = showHistory;
+        HistoryItemCount = historyItemCount;
     }
 
     public List<ListItem> LoadHistory()
@@ -50,9 +50,9 @@ public class MockSettingsInterface : ISettingsInterface
         _historyItems.Add(historyItem);
 
         // Simulate the same logic as SettingsManager
-        if (ShowHistory > 0)
+        if (HistoryItemCount > 0)
         {
-            while (_historyItems.Count > ShowHistory)
+            while (_historyItems.Count > HistoryItemCount)
             {
                 _historyItems.RemoveAt(0); // Remove the oldest item
             }

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.WebSearch.UnitTests/QueryTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.WebSearch.UnitTests/QueryTests.cs
@@ -54,7 +54,7 @@ public class QueryTests : CommandPaletteUnitTestBase
             new HistoryItem("another search", DateTime.Parse("2024-01-02 13:00:00", CultureInfo.CurrentCulture)),
         };
 
-        var settings = new MockSettingsInterface(mockHistory: mockHistoryItems, showHistory: 5);
+        var settings = new MockSettingsInterface(mockHistory: mockHistoryItems, historyItemCount: 5);
 
         var page = new WebSearchListPage(settings);
 
@@ -89,7 +89,7 @@ public class QueryTests : CommandPaletteUnitTestBase
             new HistoryItem("another search4", DateTime.Parse("2024-01-05 13:00:00", CultureInfo.CurrentCulture)),
         };
 
-        var settings = new MockSettingsInterface(mockHistory: mockHistoryItems, showHistory: 5);
+        var settings = new MockSettingsInterface(mockHistory: mockHistoryItems, historyItemCount: 5);
 
         var page = new WebSearchListPage(settings);
 
@@ -122,7 +122,7 @@ public class QueryTests : CommandPaletteUnitTestBase
             new HistoryItem("another search5", DateTime.Parse("2024-01-06 13:00:00", CultureInfo.CurrentCulture)),
         };
 
-        var settings = new MockSettingsInterface(mockHistory: mockHistoryItems, showHistory: 0);
+        var settings = new MockSettingsInterface(mockHistory: mockHistoryItems, historyItemCount: 0);
 
         var page = new WebSearchListPage(settings);
 

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.WebSearch.UnitTests/QueryTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.WebSearch.UnitTests/QueryTests.cs
@@ -54,7 +54,7 @@ public class QueryTests : CommandPaletteUnitTestBase
             new HistoryItem("another search", DateTime.Parse("2024-01-02 13:00:00", CultureInfo.CurrentCulture)),
         };
 
-        var settings = new MockSettingsInterface(mockHistory: mockHistoryItems, showHistory: "5");
+        var settings = new MockSettingsInterface(mockHistory: mockHistoryItems, showHistory: 5);
 
         var page = new WebSearchListPage(settings);
 
@@ -89,7 +89,7 @@ public class QueryTests : CommandPaletteUnitTestBase
             new HistoryItem("another search4", DateTime.Parse("2024-01-05 13:00:00", CultureInfo.CurrentCulture)),
         };
 
-        var settings = new MockSettingsInterface(mockHistory: mockHistoryItems, showHistory: "5");
+        var settings = new MockSettingsInterface(mockHistory: mockHistoryItems, showHistory: 5);
 
         var page = new WebSearchListPage(settings);
 
@@ -122,7 +122,7 @@ public class QueryTests : CommandPaletteUnitTestBase
             new HistoryItem("another search5", DateTime.Parse("2024-01-06 13:00:00", CultureInfo.CurrentCulture)),
         };
 
-        var settings = new MockSettingsInterface(mockHistory: mockHistoryItems, showHistory: "None");
+        var settings = new MockSettingsInterface(mockHistory: mockHistoryItems, showHistory: 0);
 
         var page = new WebSearchListPage(settings);
 

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/Commands/SearchWebCommand.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/Commands/SearchWebCommand.cs
@@ -34,7 +34,7 @@ internal sealed partial class SearchWebCommand : InvokableCommand
             return CommandResult.KeepOpen();
         }
 
-        if (_settingsManager.ShowHistory != 0)
+        if (_settingsManager.HistoryItemCount != 0)
         {
             _settingsManager.SaveHistory(new HistoryItem(Arguments, DateTime.Now));
         }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/Commands/SearchWebCommand.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/Commands/SearchWebCommand.cs
@@ -34,7 +34,7 @@ internal sealed partial class SearchWebCommand : InvokableCommand
             return CommandResult.KeepOpen();
         }
 
-        if (_settingsManager.ShowHistory != Resources.history_none)
+        if (_settingsManager.ShowHistory != 0)
         {
             _settingsManager.SaveHistory(new HistoryItem(Arguments, DateTime.Now));
         }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/Helpers/ISettingsInterface.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/Helpers/ISettingsInterface.cs
@@ -11,7 +11,7 @@ public interface ISettingsInterface
 {
     public bool GlobalIfURI { get; }
 
-    public uint ShowHistory { get; }
+    public uint HistoryItemCount { get; }
 
     public List<ListItem> LoadHistory();
 

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/Helpers/ISettingsInterface.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/Helpers/ISettingsInterface.cs
@@ -11,7 +11,7 @@ public interface ISettingsInterface
 {
     public bool GlobalIfURI { get; }
 
-    public string ShowHistory { get; }
+    public uint ShowHistory { get; }
 
     public List<ListItem> LoadHistory();
 

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/Helpers/SettingsManager.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/Helpers/SettingsManager.cs
@@ -37,15 +37,15 @@ public class SettingsManager : JsonSettingsManager, ISettingsInterface
         Resources.plugin_global_if_uri,
         false);
 
-    private readonly ChoiceSetSetting _showHistory = new(
-        Namespaced(nameof(ShowHistory)),
-        Resources.plugin_show_history,
-        Resources.plugin_show_history,
+    private readonly ChoiceSetSetting _historyItemCount = new(
+        Namespaced("ShowHistory"),
+        Resources.plugin_history_item_count,
+        Resources.plugin_history_item_count,
         _choices);
 
     public bool GlobalIfURI => _globalIfURI.Value;
 
-    public uint ShowHistory => uint.TryParse(_showHistory.Value, out var value) ? value : 0;
+    public uint HistoryItemCount => uint.TryParse(_historyItemCount.Value, out var value) ? value : 0;
 
     internal static string SettingsJsonPath()
     {
@@ -90,11 +90,11 @@ public class SettingsManager : JsonSettingsManager, ISettingsInterface
             // Add the new history item
             historyItems.Add(historyItem);
 
-            // Determine the maximum number of items to keep based on ShowHistory
-            if (ShowHistory > 0)
+            // Determine the maximum number of items to keep based on HistoryItemCount
+            if (HistoryItemCount > 0)
             {
                 // Keep only the most recent `maxHistoryItems` items
-                while (historyItems.Count > ShowHistory)
+                while (historyItems.Count > HistoryItemCount)
                 {
                     historyItems.RemoveAt(0); // Remove the oldest item
                 }
@@ -150,7 +150,7 @@ public class SettingsManager : JsonSettingsManager, ISettingsInterface
         _historyPath = HistoryStateJsonPath();
 
         Settings.Add(_globalIfURI);
-        Settings.Add(_showHistory);
+        Settings.Add(_historyItemCount);
 
         // Load settings from file upon initialization
         LoadSettings();
@@ -188,11 +188,11 @@ public class SettingsManager : JsonSettingsManager, ISettingsInterface
         base.SaveSettings();
         try
         {
-            if (ShowHistory == 0)
+            if (HistoryItemCount == 0)
             {
                 ClearHistory();
             }
-            else if (ShowHistory > 0)
+            else if (HistoryItemCount > 0)
             {
                 // Trim the history file if there are more items than the new limit
                 if (File.Exists(_historyPath))
@@ -201,10 +201,10 @@ public class SettingsManager : JsonSettingsManager, ISettingsInterface
                     var historyItems = JsonSerializer.Deserialize<List<HistoryItem>>(existingContent, WebSearchJsonSerializationContext.Default.ListHistoryItem) ?? [];
 
                     // Check if trimming is needed
-                    if (historyItems.Count > ShowHistory)
+                    if (historyItems.Count > HistoryItemCount)
                     {
-                        // Trim the list to keep only the most recent `ShowHistory` items
-                        historyItems = historyItems.Skip(historyItems.Count - (int)ShowHistory).ToList();
+                        // Trim the list to keep only the most recent `HistoryItemCount` items
+                        historyItems = historyItems.Skip((int)(historyItems.Count - HistoryItemCount)).ToList();
 
                         // Save the trimmed history back to the file
                         var trimmedHistoryJson = JsonSerializer.Serialize(historyItems, WebSearchJsonSerializationContext.Default.ListHistoryItem);

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/Helpers/SettingsManager.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/Helpers/SettingsManager.cs
@@ -16,6 +16,7 @@ namespace Microsoft.CmdPal.Ext.WebSearch.Helpers;
 
 public class SettingsManager : JsonSettingsManager, ISettingsInterface
 {
+    private const string HistoryItemCountLegacySettingsKey = "ShowHistory";
     private readonly string _historyPath;
 
     private static readonly string _namespace = "websearch";
@@ -38,7 +39,7 @@ public class SettingsManager : JsonSettingsManager, ISettingsInterface
         false);
 
     private readonly ChoiceSetSetting _historyItemCount = new(
-        Namespaced("ShowHistory"),
+        Namespaced(HistoryItemCountLegacySettingsKey),
         Resources.plugin_history_item_count,
         Resources.plugin_history_item_count,
         _choices);

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/Pages/WebSearchListPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/Pages/WebSearchListPage.cs
@@ -33,7 +33,7 @@ internal sealed partial class WebSearchListPage : DynamicListPage
         _allItems = [];
         Id = "com.microsoft.cmdpal.websearch";
         _settingsManager = settingsManager;
-        _historyItems = _settingsManager.ShowHistory != Resources.history_none ? _settingsManager.LoadHistory() : null;
+        _historyItems = _settingsManager.ShowHistory != 0 ? _settingsManager.LoadHistory() : null;
         if (_historyItems is not null)
         {
             _allItems.AddRange(_historyItems);
@@ -57,7 +57,7 @@ internal sealed partial class WebSearchListPage : DynamicListPage
 
         if (_historyItems is not null)
         {
-            filteredHistoryItems = _settingsManager.ShowHistory != Resources.history_none ? ListHelpers.FilterList(_historyItems, query).OfType<ListItem>() : null;
+            filteredHistoryItems = _settingsManager.ShowHistory != 0 ? ListHelpers.FilterList(_historyItems, query).OfType<ListItem>() : null;
         }
 
         var results = new List<ListItem>();

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/Pages/WebSearchListPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/Pages/WebSearchListPage.cs
@@ -33,7 +33,7 @@ internal sealed partial class WebSearchListPage : DynamicListPage
         _allItems = [];
         Id = "com.microsoft.cmdpal.websearch";
         _settingsManager = settingsManager;
-        _historyItems = _settingsManager.ShowHistory != 0 ? _settingsManager.LoadHistory() : null;
+        _historyItems = _settingsManager.HistoryItemCount != 0 ? _settingsManager.LoadHistory() : null;
         if (_historyItems is not null)
         {
             _allItems.AddRange(_historyItems);
@@ -57,7 +57,7 @@ internal sealed partial class WebSearchListPage : DynamicListPage
 
         if (_historyItems is not null)
         {
-            filteredHistoryItems = _settingsManager.ShowHistory != 0 ? ListHelpers.FilterList(_historyItems, query).OfType<ListItem>() : null;
+            filteredHistoryItems = _settingsManager.HistoryItemCount != 0 ? ListHelpers.FilterList(_historyItems, query).OfType<ListItem>() : null;
         }
 
         var results = new List<ListItem>();

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/Properties/Resources.Designer.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/Properties/Resources.Designer.cs
@@ -169,6 +169,15 @@ namespace Microsoft.CmdPal.Ext.WebSearch.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Determines the number of history items to show from previous searches.
+        /// </summary>
+        public static string plugin_history_item_count {
+            get {
+                return ResourceManager.GetString("plugin_history_item_count", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to In the default browser.
         /// </summary>
         public static string plugin_in_browser {
@@ -228,15 +237,6 @@ namespace Microsoft.CmdPal.Ext.WebSearch.Properties {
         public static string plugin_search_failed {
             get {
                 return ResourceManager.GetString("plugin_search_failed", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Determines the number of history items to show from previous searches.
-        /// </summary>
-        public static string plugin_show_history {
-            get {
-                return ResourceManager.GetString("plugin_show_history", resourceCulture);
             }
         }
         

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/Properties/Resources.resx
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/Properties/Resources.resx
@@ -172,7 +172,7 @@
   <data name="plugin_search_failed" xml:space="preserve">
     <value>Failed to open {0}.</value>
   </data>
-  <data name="plugin_show_history" xml:space="preserve">
+  <data name="plugin_history_item_count" xml:space="preserve">
     <value>Determines the number of history items to show from previous searches</value>
   </data>
   <data name="settings_page_name" xml:space="preserve">


### PR DESCRIPTION
## Summary of the Pull Request

For WebSearch extension:

- Replaces localized string identifiers with invariant literal keys to ensure stable and consistent setting values, avoiding issues when switching cultures or if display strings change.  
- Renames the `ShowHistory` property to `HistoryItemCount`.  
- Changes the type from `string` to `int` and centralizes parsing logic in `SettingsManager`.  
- Retains backward compatibility by preserving the legacy settings key `"ShowHistory"` in `SettingsManager`.  


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #40547 
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** All end-user-facing strings can be localized
- [x] **Dev docs:** none
- [x] **New binaries:** none
- [x] **Documentation updated:** none

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

