### PR TITLE
Add Windows 10 context menu entry back on Windows 11

### DIFF
--- a/src/modules/FileLocksmith/FileLocksmithExt/PowerToysModule.cpp
+++ b/src/modules/FileLocksmith/FileLocksmithExt/PowerToysModule.cpp
@@ -88,12 +88,9 @@ public:
                 package::RegisterSparsePackage(path, packageUri);
             }
         }
-        else
-        {
 #if defined(ENABLE_REGISTRATION) || defined(NDEBUG)
-            FileLocksmithRuntimeRegistration::EnsureRegistered();
+        FileLocksmithRuntimeRegistration::EnsureRegistered();
 #endif
-        }
 
         m_enabled = true;
     }
@@ -101,13 +98,10 @@ public:
     virtual void disable() override
     {
         Logger::info(L"File Locksmith disabled");
-        if (!package::IsWin11OrGreater())
-        {
 #if defined(ENABLE_REGISTRATION) || defined(NDEBUG)
-            FileLocksmithRuntimeRegistration::Unregister();
-            Logger::info(L"File Locksmith context menu unregistered (Win10)");
+        FileLocksmithRuntimeRegistration::Unregister();
+        Logger::info(L"File Locksmith context menu unregistered (Win10)");
 #endif
-        }
         m_enabled = false;
     }
 

--- a/src/modules/imageresizer/dll/dllmain.cpp
+++ b/src/modules/imageresizer/dll/dllmain.cpp
@@ -112,12 +112,9 @@ public:
                 package::RegisterSparsePackage(path, packageUri);
             }
         }
-        else
-        {
 #if defined(ENABLE_REGISTRATION) || defined(NDEBUG)
-            ImageResizerRuntimeRegistration::EnsureRegistered();
+        ImageResizerRuntimeRegistration::EnsureRegistered();
 #endif
-        }
 
         Trace::EnableImageResizer(m_enabled);
     }
@@ -127,13 +124,10 @@ public:
     {
         m_enabled = false;
         Trace::EnableImageResizer(m_enabled);
-        if (!package::IsWin11OrGreater())
-        {
 #if defined(ENABLE_REGISTRATION) || defined(NDEBUG)
-            ImageResizerRuntimeRegistration::Unregister();
-            Logger::info(L"ImageResizer context menu unregistered (Win10)");
+        ImageResizerRuntimeRegistration::Unregister();
+        Logger::info(L"ImageResizer context menu unregistered (Win10)");
 #endif
-        }
     }
 
     // Returns if the powertoys is enabled

--- a/src/modules/powerrename/dll/dllmain.cpp
+++ b/src/modules/powerrename/dll/dllmain.cpp
@@ -202,12 +202,9 @@ public:
                 package::RegisterSparsePackage(path, packageUri);
             }
         }
-        else
-        {
 #if defined(ENABLE_REGISTRATION) || defined(NDEBUG)
-            PowerRenameRuntimeRegistration::EnsureRegistered();
+        PowerRenameRuntimeRegistration::EnsureRegistered();
 #endif
-        }
     }
 
     // Disable the powertoy
@@ -215,13 +212,10 @@ public:
     {
         m_enabled = false;
         Logger::info(L"PowerRename disabled");
-        if (!package::IsWin11OrGreater())
-        {
 #if defined(ENABLE_REGISTRATION) || defined(NDEBUG)
-            PowerRenameRuntimeRegistration::Unregister();
-            Logger::info(L"PowerRename context menu unregistered (Win10)");
+        PowerRenameRuntimeRegistration::Unregister();
+        Logger::info(L"PowerRename context menu unregistered (Win10)");
 #endif
-        }
     }
 
     // Returns if the powertoy is enabled


### PR DESCRIPTION
## Summary of the Pull Request
Ensure Windows 11 adds the registry entries for the old context menu so that "Show more options"/classic menu always includes them.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] Closes: #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

