### PR TITLE
[QuickAccent] Add vowels with acute, grave, and dieresis to Welsh

### DIFF
--- a/src/modules/poweraccent/PowerAccent.Core/Languages.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/Languages.cs
@@ -781,14 +781,14 @@ namespace PowerAccent.Core
         {
             return letter switch
             {
-                LetterKey.VK_A => new[] { "â" },
-                LetterKey.VK_E => new[] { "ê" },
-                LetterKey.VK_I => new[] { "î" },
-                LetterKey.VK_O => new[] { "ô" },
+                LetterKey.VK_A => new[] { "â", "ä", "à", "á" },
+                LetterKey.VK_E => new[] { "ê", "ë", "è", "é" },
+                LetterKey.VK_I => new[] { "î", "ï", "ì", "í" },
+                LetterKey.VK_O => new[] { "ô", "ö", "ò", "ó" },
                 LetterKey.VK_P => new[] { "£" },
-                LetterKey.VK_U => new[] { "û" },
-                LetterKey.VK_Y => new[] { "ŷ" },
-                LetterKey.VK_W => new[] { "ŵ" },
+                LetterKey.VK_U => new[] { "û", "ü", "ù", "ú" },
+                LetterKey.VK_Y => new[] { "ŷ", "ÿ", "ỳ", "ý" },
+                LetterKey.VK_W => new[] { "ŵ", "ẅ", "ẁ", "ẃ" },
                 _ => Array.Empty<string>(),
             };
         }


### PR DESCRIPTION
## Summary of the Pull Request
Extends the Welsh character set by vowels with acute, grave, and dieresis accents. Order is now circumflex, dieresis, grave, acute for all letters. Decision based on the last paragraph of [wikipedia's diacritics section](https://en.wikipedia.org/wiki/Welsh_orthography#Diacritics).
See original issue for sources.
## PR Checklist
- [x] Closes: #41155
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [x] **Localization:** All end-user-facing strings can be localized
- [x] **Dev docs:** No need
- [x] **New binaries:** None
- [x] **Documentation updated:** No need
## Detailed Description of the Pull Request / Additional comments
## Validation Steps Performed
Tested manually