### PR TITLE
Restore focus to More button after context menu closes via escape button

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml.cs
@@ -134,6 +134,15 @@ public sealed partial class CommandBar : UserControl,
         WeakReferenceMessenger.Default.Send<OpenContextMenuMessage>(new OpenContextMenuMessage(null, null, null, ContextMenuFilterLocation.Bottom));
     }
 
+    /// <summary>
+    /// Sets focus to the "More" button after closing the context menu,
+    /// keeping keyboard navigation intuitive.
+    /// </summary>
+    public void FocusMoreCommandsButton()
+    {
+        MoreCommandsButton?.Focus(FocusState.Programmatic);
+    }
+
     private void ContextMenuFlyout_Opened(object sender, object e)
     {
         // We need to wait until our flyout is opened to try and toss focus

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContextMenu.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContextMenu.xaml
@@ -15,6 +15,7 @@
     xmlns:ui="using:CommunityToolkit.WinUI"
     xmlns:viewModels="using:Microsoft.CmdPal.UI.ViewModels"
     Background="Transparent"
+    PreviewKeyDown="UserControl_PreviewKeyDown"
     mc:Ignorable="d">
 
     <UserControl.Resources>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContextMenu.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContextMenu.xaml.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using CommunityToolkit.Mvvm.Messaging;
+using CommunityToolkit.WinUI;
 using Microsoft.CmdPal.Core.ViewModels;
 using Microsoft.CmdPal.Core.ViewModels.Messages;
 using Microsoft.CmdPal.UI.Messages;
@@ -112,6 +113,24 @@ public sealed partial class ContextMenu : UserControl,
         else if (result == ContextKeybindingResult.Unhandled)
         {
             e.Handled = false;
+        }
+    }
+
+    /// <summary>
+    /// Handles Escape to close the context menu and return focus to the "More" button.
+    /// </summary>
+    private void UserControl_PreviewKeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        if (e.Key == VirtualKey.Escape)
+        {
+            // Close the context menu (if not already handled)
+            WeakReferenceMessenger.Default.Send(new CloseContextMenuMessage());
+
+            // Find the parent CommandBar and set focus to MoreCommandsButton
+            var parent = this.FindParent<CommandBar>();
+            parent?.FocusMoreCommandsButton();
+
+            e.Handled = true;
         }
     }
 


### PR DESCRIPTION
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #41363
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed




https://github.com/user-attachments/assets/374fd1bc-8e62-4117-a613-f0d35678e3ed

