### PR TITLE
Search UX improvements

### DIFF
--- a/src/settings-ui/Settings.UI/Helpers/NavigatablePage.cs
+++ b/src/settings-ui/Settings.UI/Helpers/NavigatablePage.cs
@@ -10,13 +10,14 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Hosting;
 using Microsoft.UI.Xaml.Media;
+using Windows.UI;
 
 namespace Microsoft.PowerToys.Settings.UI.Helpers;
 
 public abstract partial class NavigatablePage : Page
 {
     private const int ExpandWaitDuration = 500;
-    private const int AnimationDuration = 1000;
+    private const int AnimationDuration = 2000;
 
     private NavigationParams _pendingNavigationParams;
 
@@ -85,15 +86,15 @@ public abstract partial class NavigatablePage : Page
 
         // Create a subtle glow effect using drop shadow
         var dropShadow = compositor.CreateDropShadow();
-        dropShadow.Color = Microsoft.UI.Colors.Gray;
-        dropShadow.BlurRadius = 8f;
+        dropShadow.Color = (Color)Application.Current.Resources["SystemAccentColorLight2"];
+        dropShadow.BlurRadius = 16f;
         dropShadow.Opacity = 0f;
         dropShadow.Offset = new Vector3(0, 0, 0);
 
         var spriteVisual = compositor.CreateSpriteVisual();
-        spriteVisual.Size = new Vector2((float)target.ActualWidth + 16, (float)target.ActualHeight + 16);
+        spriteVisual.Size = new Vector2((float)target.ActualWidth, (float)target.ActualHeight);
         spriteVisual.Shadow = dropShadow;
-        spriteVisual.Offset = new Vector3(-8, -8, 0);
+        spriteVisual.Offset = new Vector3(0, 0, 0);
 
         // Insert the shadow visual behind the target element
         ElementCompositionPreview.SetElementChildVisual(target, spriteVisual);
@@ -106,31 +107,7 @@ public abstract partial class NavigatablePage : Page
         fadeAnimation.Duration = TimeSpan.FromMilliseconds(AnimationDuration);
 
         dropShadow.StartAnimation("Opacity", fadeAnimation);
-
-        if (target is Control ctrl)
-        {
-            // TODO: ability to adjust brush color and animation from settings.
-            var originalBackground = ctrl.Background;
-
-            var highlightBrush = new SolidColorBrush();
-            var grayColor = Microsoft.UI.Colors.Gray;
-            grayColor.A = 50; // Very subtle transparency
-            highlightBrush.Color = grayColor;
-
-            // Apply the highlight
-            ctrl.Background = highlightBrush;
-
-            // Wait for animation to complete
-            await Task.Delay(AnimationDuration);
-
-            // Restore original background
-            ctrl.Background = originalBackground;
-        }
-        else
-        {
-            // For non-control elements, just wait for the glow animation
-            await Task.Delay(AnimationDuration);
-        }
+        await Task.Delay(AnimationDuration);
 
         // Clean up the shadow visual
         ElementCompositionPreview.SetElementChildVisual(target, null);

--- a/src/settings-ui/Settings.UI/Helpers/NavigatablePage.cs
+++ b/src/settings-ui/Settings.UI/Helpers/NavigatablePage.cs
@@ -17,7 +17,7 @@ namespace Microsoft.PowerToys.Settings.UI.Helpers;
 public abstract partial class NavigatablePage : Page
 {
     private const int ExpandWaitDuration = 500;
-    private const int AnimationDuration = 2000;
+    private const int AnimationDuration = 1850;
 
     private NavigationParams _pendingNavigationParams;
 
@@ -92,9 +92,9 @@ public abstract partial class NavigatablePage : Page
         dropShadow.Offset = new Vector3(0, 0, 0);
 
         var spriteVisual = compositor.CreateSpriteVisual();
-        spriteVisual.Size = new Vector2((float)target.ActualWidth, (float)target.ActualHeight);
+        spriteVisual.Size = new Vector2((float)target.ActualWidth + 8, (float)target.ActualHeight + 8);
         spriteVisual.Shadow = dropShadow;
-        spriteVisual.Offset = new Vector3(0, 0, 0);
+        spriteVisual.Offset = new Vector3(-4, -4, 0);
 
         // Insert the shadow visual behind the target element
         ElementCompositionPreview.SetElementChildVisual(target, spriteVisual);

--- a/src/settings-ui/Settings.UI/Helpers/NavigatablePage.cs
+++ b/src/settings-ui/Settings.UI/Helpers/NavigatablePage.cs
@@ -92,15 +92,9 @@ public abstract partial class NavigatablePage : Page
         dropShadow.Offset = new Vector3(0, 0, 0);
 
         var spriteVisual = compositor.CreateSpriteVisual();
-<<<<<<< HEAD
         spriteVisual.Size = new Vector2((float)target.ActualWidth + 8, (float)target.ActualHeight + 8);
         spriteVisual.Shadow = dropShadow;
         spriteVisual.Offset = new Vector3(-4, -4, 0);
-=======
-        spriteVisual.Size = new Vector2((float)target.ActualWidth, (float)target.ActualHeight);
-        spriteVisual.Shadow = dropShadow;
-        spriteVisual.Offset = new Vector3(0, 0, 0);
->>>>>>> origin/main
 
         // Insert the shadow visual behind the target element
         ElementCompositionPreview.SetElementChildVisual(target, spriteVisual);

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/SearchResultsPage.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/SearchResultsPage.xaml.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using CommunityToolkit.WinUI.Controls;
 using Microsoft.PowerToys.Settings.UI.Helpers;
 using Microsoft.PowerToys.Settings.UI.Services;
 using Microsoft.PowerToys.Settings.UI.ViewModels;
@@ -32,7 +33,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             if (e.Parameter is SearchResultsNavigationParams searchParams)
             {
                 ViewModel.SetSearchResults(searchParams.Query, searchParams.Results);
-                PageControl.ModuleDescription = string.Empty;
+                PageControl.ModuleDescription = $"{ResourceLoaderInstance.ResourceLoader.GetString("Search_ResultsFor")} '{searchParams.Query}'";
             }
         }
 
@@ -43,7 +44,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
 
         private void ModuleButton_Click(object sender, RoutedEventArgs e)
         {
-            if (sender is CommunityToolkit.WinUI.Controls.SettingsCard card && card.DataContext is SettingEntry tagEntry)
+            if (sender is SettingsCard card && card.DataContext is SettingEntry tagEntry)
             {
                 NavigateToModule(tagEntry);
             }
@@ -51,7 +52,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
 
         private void SettingButton_Click(object sender, RoutedEventArgs e)
         {
-            if (sender is CommunityToolkit.WinUI.Controls.SettingsCard card && card.DataContext is SettingEntry tagEntry)
+            if (sender is SettingsCard card && card.DataContext is SettingEntry tagEntry)
             {
                 NavigateToSetting(tagEntry);
             }

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/ShellPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/ShellPage.xaml
@@ -65,7 +65,7 @@
             </Grid>
         </DataTemplate>
         <DataTemplate x:Key="ShowAllSearchResultTemplate" x:DataType="models:SuggestionItem">
-            <Grid >
+            <Grid>
                 <Rectangle
                     Height="1"
                     Margin="0,-12,0,0"
@@ -86,7 +86,6 @@
             <ic:InvokeCommandAction Command="{x:Bind ViewModel.LoadedCommand}" />
         </ic:EventTriggerBehavior>
     </i:Interaction.Behaviors>
-
     <Grid x:Name="RootGrid">
         <Grid.RowDefinitions>
             <RowDefinition Height="48" />

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/ShellPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/ShellPage.xaml
@@ -57,12 +57,6 @@
         </DataTemplate>
         <DataTemplate x:Key="NoResultSearchResultTemplate" x:DataType="models:SuggestionItem">
             <Grid>
-                <Rectangle
-                    Height="1"
-                    Margin="0,-4,0,0"
-                    HorizontalAlignment="Stretch"
-                    VerticalAlignment="Top"
-                    Fill="{ThemeResource DividerStrokeColorDefaultBrush}" />
                 <TextBlock
                     Margin="8"
                     HorizontalAlignment="Center"
@@ -71,10 +65,10 @@
             </Grid>
         </DataTemplate>
         <DataTemplate x:Key="ShowAllSearchResultTemplate" x:DataType="models:SuggestionItem">
-            <Grid Padding="16,8">
+            <Grid >
                 <Rectangle
                     Height="1"
-                    Margin="0,-4,0,0"
+                    Margin="0,-12,0,0"
                     HorizontalAlignment="Stretch"
                     VerticalAlignment="Top"
                     Fill="{ThemeResource DividerStrokeColorDefaultBrush}" />

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -2896,20 +2896,19 @@ Right-click to remove the key combination, thereby deactivating the shortcut.</v
   <data name="MouseUtils_GlidingCursor.Description" xml:space="preserve">
     <value>An accessibility feature that lets you control the mouse with a single button using guided horizontal and vertical lines</value>
   </data>
-	<data name="MouseUtils_GlidingCursor_InitialSpeed.Header" xml:space="preserve">
+  <data name="MouseUtils_GlidingCursor_InitialSpeed.Header" xml:space="preserve">
     <value>Initial line speed</value>
   </data>
-	<data name="MouseUtils_GlidingCursor_InitialSpeed.Description" xml:space="preserve">
+  <data name="MouseUtils_GlidingCursor_InitialSpeed.Description" xml:space="preserve">
     <value>Speed of the horizontal or vertical line when it begins moving</value>
   </data>
-	<data name="MouseUtils_GlidingCursor_DelaySpeed.Header" xml:space="preserve">
+  <data name="MouseUtils_GlidingCursor_DelaySpeed.Header" xml:space="preserve">
     <value>Reduced line speed</value>
   </data>
-	<data name="MouseUtils_GlidingCursor_DelaySpeed.Description" xml:space="preserve">
+  <data name="MouseUtils_GlidingCursor_DelaySpeed.Description" xml:space="preserve">
     <value>Speed after slowing down the line with a second shortcut press</value>
   </data>
-
-	<data name="FancyZones_Radio_Custom_Colors.Content" xml:space="preserve">
+  <data name="FancyZones_Radio_Custom_Colors.Content" xml:space="preserve">
     <value>Custom colors</value>
   </data>
   <data name="FancyZones_Radio_Default_Theme.Content" xml:space="preserve">
@@ -5266,7 +5265,7 @@ To record a specific window, enter the hotkey with the Alt key in the opposite m
     <value>All shortcuts function correctly</value>
   </data>
   <data name="ResolveConflicts_Button.Content" xml:space="preserve">
-	<value>Resolve conflicts</value>
+    <value>Resolve conflicts</value>
   </data>
   <data name="ShortcutConflictControl_Title.Text" xml:space="preserve">
     <value>Shortcut conflicts</value>
@@ -5286,5 +5285,9 @@ To record a specific window, enter the hotkey with the Alt key in the opposite m
   </data>
   <data name="Hosts_NoLeadingSpaces.Description" xml:space="preserve">
     <value>Do not prepend spaces to active lines when saving the hosts file</value>
+  </data>
+  <data name="Search_ResultsFor" xml:space="preserve">
+    <value>Results for</value>
+    <comment>Prefix for search string. E.g. "Results for 'shortcut'"</comment>
   </data>
 </root>


### PR DESCRIPTION
### Fixing visual glitch in the 'Show all results' template:

Before
<img width="588" height="103" alt="image" src="https://github.com/user-attachments/assets/00da60ea-d0ab-4ffe-8f69-75be7e537d63" />

After
<img width="598" height="70" alt="image" src="https://github.com/user-attachments/assets/dc859731-8783-494a-b561-ea6396ca69b3" />


### Displaying "Show results for * search term *" on search results page
Before
<img width="716" height="239" alt="image" src="https://github.com/user-attachments/assets/a80e6e58-df88-47b2-85ab-c39cbdc88690" />

After
<img width="349" height="264" alt="image" src="https://github.com/user-attachments/assets/99029ee6-94f7-4454-a443-640c22f9e6f3" />


### Using Accent Color for the search highlight for better visibility and fixing a bug
Before
![highlight-bug](https://github.com/user-attachments/assets/2d4c0f5b-4030-4c10-a4ec-c7c5023034f0)


After

![fix-accent](https://github.com/user-attachments/assets/62a223a9-9360-4297-9127-5aaef82c162f)
