### PR TITLE
Adding sort to DateTime extension results

### DIFF
--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Helpers/TimeDateCalculator.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Helpers/TimeDateCalculator.cs
@@ -79,16 +79,22 @@ public sealed partial class TimeDateCalculator
         }
         else
         {
+            List<(int Score, AvailableResult Item)> itemScores = [];
+
             // Generate filtered list of results
             foreach (var f in availableFormats)
             {
                 var score = f.Score(query, f.Label, f.AlternativeSearchTag);
-
                 if (score > 0)
                 {
-                    results.Add(f.ToListItem());
+                    itemScores.Add((score, f));
                 }
             }
+
+            results = itemScores
+                        .OrderByDescending(s => s.Score)
+                        .Select(s => s.Item.ToListItem())
+                        .ToList();
         }
 
         if (results.Count == 0)


### PR DESCRIPTION
Closes #41385

Adds a sort to the DateTime extension results.

<img width="1001" height="602" alt="image" src="https://github.com/user-attachments/assets/ccccae6a-c4a4-460f-a6d3-3325ecfc53da" />

<img width="992" height="606" alt="image" src="https://github.com/user-attachments/assets/b8af51bd-cbd0-4341-ac46-0fb3e97ec2ac" />
