### PR TITLE
CmdPal: init Details in a slow pass; add more winget logs

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/CommandItemViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/CommandItemViewModel.cs
@@ -160,7 +160,7 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel, ICommandBa
         Initialized |= InitializedState.Initialized;
     }
 
-    public void SlowInitializeProperties()
+    public virtual void SlowInitializeProperties()
     {
         if (IsSelectedInitialized)
         {

--- a/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/ListItemViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/ListItemViewModel.cs
@@ -47,9 +47,21 @@ public partial class ListItemViewModel(IListItem model, WeakReference<IPageConte
 
         UpdateTags(li.Tags);
 
-        TextToSuggest = li.TextToSuggest;
         Section = li.Section ?? string.Empty;
-        var extensionDetails = li.Details;
+
+        UpdateProperty(nameof(Section));
+    }
+
+    public override void SlowInitializeProperties()
+    {
+        base.SlowInitializeProperties();
+        var model = Model.Unsafe;
+        if (model is null)
+        {
+            return;
+        }
+
+        var extensionDetails = model.Details;
         if (extensionDetails is not null)
         {
             Details = new(extensionDetails, PageContext);
@@ -58,8 +70,8 @@ public partial class ListItemViewModel(IListItem model, WeakReference<IPageConte
             UpdateProperty(nameof(HasDetails));
         }
 
+        TextToSuggest = model.TextToSuggest;
         UpdateProperty(nameof(TextToSuggest));
-        UpdateProperty(nameof(Section));
     }
 
     protected override void FetchProperty(string propertyName)


### PR DESCRIPTION
Related to #41384

We should load the `IDetails` from a `IListItem` in the slow pass, instead of immediately when we load the list of items.

see also #39215

Also adds a lot of logging on our side, which helped ID that it isn't our fault that the winget APIs are returning slowly. That's tracked upstream (somewhere)