### PR TITLE
CmdPal: Make sure fallback items have icons visible in Settings window

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelViewModel.cs
@@ -32,6 +32,7 @@ public sealed partial class TopLevelViewModel : ObservableObject, IListItem
     private string _generatedId = string.Empty;
 
     private HotkeySettings? _hotkey;
+    private IIconInfo? _initialIcon;
 
     private CommandAlias? Alias { get; set; }
 
@@ -56,6 +57,8 @@ public sealed partial class TopLevelViewModel : ObservableObject, IListItem
     public string Subtitle => _commandItemViewModel.Subtitle;
 
     public IIconInfo Icon => _commandItemViewModel.Icon;
+
+    public IIconInfo InitialIcon => _initialIcon ?? _commandItemViewModel.Icon;
 
     ICommand? ICommandItem.Command => _commandItemViewModel.Command.Model.Unsafe;
 
@@ -205,6 +208,8 @@ public sealed partial class TopLevelViewModel : ObservableObject, IListItem
             {
                 DisplayTitle = fallback.DisplayTitle;
             }
+
+            UpdateInitialIcon(false);
         }
     }
 
@@ -221,7 +226,31 @@ public sealed partial class TopLevelViewModel : ObservableObject, IListItem
                 FetchAliasFromAliasManager();
                 UpdateHotkey();
                 UpdateTags();
+                UpdateInitialIcon();
             }
+            else if (e.PropertyName == nameof(CommandItem.Icon))
+            {
+                UpdateInitialIcon();
+            }
+        }
+    }
+
+    private void UpdateInitialIcon(bool raiseNotification = true)
+    {
+        if (_initialIcon != null || !_commandItemViewModel.Icon.IsSet)
+        {
+            return;
+        }
+
+        _initialIcon = _commandItemViewModel.Icon;
+
+        if (raiseNotification)
+        {
+            DoOnUiThread(
+                () =>
+                {
+                    PropChanged?.Invoke(this, new PropChangedEventArgs(nameof(InitialIcon)));
+                });
         }
     }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/ExtensionPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/ExtensionPage.xaml
@@ -125,7 +125,7 @@
                                                                 Width="20"
                                                                 Height="20"
                                                                 AutomationProperties.AccessibilityView="Raw"
-                                                                SourceKey="{x:Bind Icon, Mode=OneWay}"
+                                                                SourceKey="{x:Bind InitialIcon, Mode=OneWay}"
                                                                 SourceRequested="{x:Bind helpers:IconCacheProvider.SourceRequested}" />
                                                         </cpcontrols:ContentIcon.Content>
                                                     </cpcontrols:ContentIcon>

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.System/FallbackSystemCommandItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.System/FallbackSystemCommandItem.cs
@@ -17,6 +17,7 @@ internal sealed partial class FallbackSystemCommandItem : FallbackCommandItem
     {
         Title = string.Empty;
         Subtitle = string.Empty;
+        Icon = Icons.LockIcon;
 
         var isBootedInUefiMode = settings.GetSystemFirmwareType() == FirmwareType.Uefi;
         var hideEmptyRB = settings.HideEmptyRecycleBin();

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/FallbackTimeDateItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/FallbackTimeDateItem.cs
@@ -22,6 +22,7 @@ internal sealed partial class FallbackTimeDateItem : FallbackCommandItem
     {
         Title = string.Empty;
         Subtitle = string.Empty;
+        Icon = Icons.TimeDateIcon;
         _settingsManager = settings;
         _timestamp = timestamp;
 

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/Pages/FallbackWindowsSettingsItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/Pages/FallbackWindowsSettingsItem.cs
@@ -33,7 +33,6 @@ internal sealed partial class FallbackWindowsSettingsItem : FallbackCommandItem
         Command = new NoOpCommand();
         Title = string.Empty;
         Subtitle = string.Empty;
-        Icon = null;
         MoreCommands = null;
 
         if (string.IsNullOrWhiteSpace(query) ||
@@ -59,7 +58,6 @@ internal sealed partial class FallbackWindowsSettingsItem : FallbackCommandItem
 
             Title = setting.Name;
             Subtitle = setting.JoinedFullSettingsPath;
-            Icon = Icons.WindowsSettingsIcon;
             Command = new OpenSettingsCommand(setting)
             {
                 Icon = Icons.WindowsSettingsIcon,
@@ -80,10 +78,7 @@ internal sealed partial class FallbackWindowsSettingsItem : FallbackCommandItem
         // us to the Windows Settings search page, prepopulated with this search.
         var settingsPage = new WindowsSettingsListPage(_windowsSettings, query);
         Title = string.Format(CultureInfo.CurrentCulture, _title, query);
-        Icon = Icons.WindowsSettingsIcon;
         Subtitle = _subtitle;
         Command = settingsPage;
-
-        return;
     }
 }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/Pages/FallbackWindowsSettingsItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/Pages/FallbackWindowsSettingsItem.cs
@@ -33,6 +33,7 @@ internal sealed partial class FallbackWindowsSettingsItem : FallbackCommandItem
         Command = new NoOpCommand();
         Title = string.Empty;
         Subtitle = string.Empty;
+        Icon = null;
         MoreCommands = null;
 
         if (string.IsNullOrWhiteSpace(query) ||
@@ -58,6 +59,7 @@ internal sealed partial class FallbackWindowsSettingsItem : FallbackCommandItem
 
             Title = setting.Name;
             Subtitle = setting.JoinedFullSettingsPath;
+            Icon = Icons.WindowsSettingsIcon;
             Command = new OpenSettingsCommand(setting)
             {
                 Icon = Icons.WindowsSettingsIcon,
@@ -78,7 +80,10 @@ internal sealed partial class FallbackWindowsSettingsItem : FallbackCommandItem
         // us to the Windows Settings search page, prepopulated with this search.
         var settingsPage = new WindowsSettingsListPage(_windowsSettings, query);
         Title = string.Format(CultureInfo.CurrentCulture, _title, query);
+        Icon = Icons.WindowsSettingsIcon;
         Subtitle = _subtitle;
         Command = settingsPage;
+
+        return;
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request

This PR ensures that fallback items consistently display an icon in Settings window:

- Adds a new `InitialIcon` property to `TopLevelViewModel` to store the first non-empty icon received.  
- Uses `InitialIcon` in the extension settings page when listing fallback items belonging to an extension.  
- Sets initial icons in the constructor for fallback items that were not previously initialized:  
  - Date & Time extension  
  - System Commands extension
- The Windows Settings extension had its icon initially set, but it was cleared when the item was updated for an empty search query. By persisting the initial icon, subsequent updates no longer affect how the fallback item is represented in Settings.

This change is considered a hotfix for the current state.  
The ideal long-term solution would be to declare the `DisplayIcon` on fallback item explicitly, similar to `DisplayTitle`.
 
Pictures!

Date and Time:
<img width="495" height="218" alt="image" src="https://github.com/user-attachments/assets/0f5815ed-62ce-4479-9bb9-692a1b8dbaa6" />

Windows Settings extension:
<img width="429" height="209" alt="image" src="https://github.com/user-attachments/assets/03b5bc6e-6ef0-4f0f-8d9f-d71c0df1f49d" />

System Commands extension
<img width="632" height="426" alt="image" src="https://github.com/user-attachments/assets/63ae2486-8e60-462c-84c6-ad914826efec" />


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #41404
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

- Verified that icons are correctly displayed for all built-in extensions.  
- Confirmed correct behavior with third-party extensions (e.g., Colors for Command Palette).  
- Tested in Release configuration with AOT enabled.