### PR TITLE
CmdPal: Add option to Clipboard History extension to keep item after pasting

### DIFF
--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/ClipboardHistoryCommandsProvider.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/ClipboardHistoryCommandsProvider.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.CmdPal.Ext.ClipboardHistory.Helpers;
 using Microsoft.CmdPal.Ext.ClipboardHistory.Pages;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
@@ -11,14 +12,18 @@ namespace Microsoft.CmdPal.Ext.ClipboardHistory;
 public partial class ClipboardHistoryCommandsProvider : CommandProvider
 {
     private readonly ListItem _clipboardHistoryListItem;
+    private readonly SettingsManager _settingsManager = new();
 
     public ClipboardHistoryCommandsProvider()
     {
-        _clipboardHistoryListItem = new ListItem(new ClipboardHistoryListPage())
+        _clipboardHistoryListItem = new ListItem(new ClipboardHistoryListPage(_settingsManager))
         {
             Title = Properties.Resources.list_item_title,
             Subtitle = Properties.Resources.list_item_subtitle,
             Icon = Icons.ClipboardListIcon,
+            MoreCommands = [
+                new CommandContextItem(_settingsManager.Settings.SettingsPage),
+            ],
         };
 
         DisplayName = Properties.Resources.provider_display_name;

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Commands/DeleteItemCommand.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Commands/DeleteItemCommand.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CmdPal.Ext.ClipboardHistory.Models;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+using Windows.ApplicationModel.DataTransfer;
+
+namespace Microsoft.CmdPal.Ext.ClipboardHistory.Commands;
+
+internal sealed partial class DeleteItemCommand : InvokableCommand
+{
+    private readonly ClipboardItem _clipboardItem;
+
+    internal DeleteItemCommand(ClipboardItem clipboardItem)
+    {
+        _clipboardItem = clipboardItem;
+        Name = Properties.Resources.delete_command_name;
+        Icon = Icons.DeleteIcon;
+    }
+
+    public override CommandResult Invoke()
+    {
+        Clipboard.DeleteItemFromHistory(_clipboardItem.Item);
+        return CommandResult.ShowToast(Properties.Resources.delete_toast_text);
+    }
+}

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Commands/PasteCommand.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Commands/PasteCommand.cs
@@ -4,6 +4,7 @@
 
 using CommunityToolkit.Mvvm.Messaging;
 using Microsoft.CmdPal.Common.Messages;
+using Microsoft.CmdPal.Ext.ClipboardHistory.Helpers;
 using Microsoft.CmdPal.Ext.ClipboardHistory.Models;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 using Windows.ApplicationModel.DataTransfer;
@@ -14,11 +15,13 @@ internal sealed partial class PasteCommand : InvokableCommand
 {
     private readonly ClipboardItem _clipboardItem;
     private readonly ClipboardFormat _clipboardFormat;
+    private readonly ISettingOptions _settings;
 
-    internal PasteCommand(ClipboardItem clipboardItem, ClipboardFormat clipboardFormat)
+    internal PasteCommand(ClipboardItem clipboardItem, ClipboardFormat clipboardFormat, ISettingOptions settings)
     {
         _clipboardItem = clipboardItem;
         _clipboardFormat = clipboardFormat;
+        _settings = settings;
         Name = Properties.Resources.paste_command_name;
         Icon = Icons.PasteIcon;
     }
@@ -39,7 +42,11 @@ internal sealed partial class PasteCommand : InvokableCommand
 
         ClipboardHelper.SendPasteKeyCombination();
 
-        Clipboard.DeleteItemFromHistory(_clipboardItem.Item);
+        if (!_settings.KeepAfterPaste)
+        {
+            Clipboard.DeleteItemFromHistory(_clipboardItem.Item);
+        }
+
         return CommandResult.ShowToast(Properties.Resources.paste_toast_text);
     }
 }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Helpers/ISettingOptions.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Helpers/ISettingOptions.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CmdPal.Ext.ClipboardHistory.Helpers;
+
+public interface ISettingOptions
+{
+    bool KeepAfterPaste { get; }
+}

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Helpers/SettingsManager.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Helpers/SettingsManager.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using Microsoft.CmdPal.Ext.ClipboardHistory.Properties;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+
+namespace Microsoft.CmdPal.Ext.ClipboardHistory.Helpers;
+
+public class SettingsManager : JsonSettingsManager, ISettingOptions
+{
+    private const string Namespace = "clipboardmanager";
+
+    private static string Namespaced(string propertyName) => $"{Namespace}.{propertyName}";
+
+    private readonly ToggleSetting _keepAfterPaste = new(
+        Namespaced(nameof(KeepAfterPaste)),
+        Resources.settings_keepafterpaste_title!,
+        Resources.settings_keepafterpaste_description!,
+        false);
+
+    public bool KeepAfterPaste => _keepAfterPaste.Value;
+
+    private static string SettingsJsonPath()
+    {
+        var directory = Utilities.BaseSettingsPath("Microsoft.CmdPal");
+        Directory.CreateDirectory(directory);
+
+        // now, the state is just next to the exe
+        return Path.Combine(directory, "settings.json");
+    }
+
+    public SettingsManager()
+    {
+        FilePath = SettingsJsonPath();
+
+        Settings.Add(_keepAfterPaste);
+
+        // Load settings from file upon initialization
+        LoadSettings();
+
+        Settings.SettingsChanged += (_, _) => SaveSettings();
+    }
+}

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Icons.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Icons.cs
@@ -14,5 +14,7 @@ internal sealed class Icons
 
     internal static IconInfo PasteIcon { get; } = new("\uE77F");
 
+    internal static IconInfo DeleteIcon { get; } = new("\uE74D");
+
     internal static IconInfo ClipboardListIcon { get; } = IconHelpers.FromRelativePath("Assets\\ClipboardHistory.svg");
 }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/KeyChords.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/KeyChords.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+using Windows.System;
+
+namespace Microsoft.CmdPal.Ext.ClipboardHistory;
+
+internal static class KeyChords
+{
+    internal static KeyChord DeleteEntry { get; } = KeyChordHelpers.FromModifiers(ctrl: true, shift: true, vkey: VirtualKey.Delete);
+}

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Models/ClipboardItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Models/ClipboardItem.cs
@@ -8,6 +8,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using Microsoft.CmdPal.Ext.ClipboardHistory.Commands;
+using Microsoft.CmdPal.Ext.ClipboardHistory.Helpers;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.Storage.Streams;
@@ -16,9 +17,11 @@ namespace Microsoft.CmdPal.Ext.ClipboardHistory.Models;
 
 public class ClipboardItem
 {
-    public string? Content { get; set; }
+    public string? Content { get; init; }
 
-    public required ClipboardHistoryItem Item { get; set; }
+    public required ClipboardHistoryItem Item { get; init; }
+
+    public required ISettingOptions Settings { get; init; }
 
     public DateTimeOffset Timestamp => Item?.Timestamp ?? DateTimeOffset.MinValue;
 
@@ -103,7 +106,9 @@ public class ClipboardItem
                     Metadata = metadata.ToArray(),
                 },
                 MoreCommands = [
-                    new CommandContextItem(new PasteCommand(this, ClipboardFormat.Image))
+                    new CommandContextItem(new PasteCommand(this, ClipboardFormat.Image, Settings)),
+                    new Separator(),
+                    new CommandContextItem(new DeleteItemCommand(this)) { IsCritical = true, RequestedShortcut = KeyChords.DeleteEntry },
                 ],
             };
         }
@@ -126,7 +131,9 @@ public class ClipboardItem
                     Metadata = metadata.ToArray(),
                 },
                 MoreCommands = [
-                                new CommandContextItem(new PasteCommand(this, ClipboardFormat.Text)),
+                                new CommandContextItem(new PasteCommand(this, ClipboardFormat.Text, Settings)),
+                                new Separator(),
+                                new CommandContextItem(new DeleteItemCommand(this)) { IsCritical = true, RequestedShortcut = KeyChords.DeleteEntry },
                             ],
             };
         }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Pages/ClipboardHistoryListPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Pages/ClipboardHistoryListPage.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CmdPal.Ext.ClipboardHistory.Helpers;
 using Microsoft.CmdPal.Ext.ClipboardHistory.Models;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
@@ -17,11 +18,15 @@ namespace Microsoft.CmdPal.Ext.ClipboardHistory.Pages;
 
 internal sealed partial class ClipboardHistoryListPage : ListPage
 {
+    private readonly SettingsManager _settingsManager;
     private readonly ObservableCollection<ClipboardItem> clipboardHistory;
     private readonly string _defaultIconPath;
 
-    public ClipboardHistoryListPage()
+    public ClipboardHistoryListPage(SettingsManager settingsManager)
     {
+        ArgumentNullException.ThrowIfNull(settingsManager);
+
+        _settingsManager = settingsManager;
         clipboardHistory = [];
         _defaultIconPath = string.Empty;
         Icon = Icons.ClipboardListIcon;
@@ -84,11 +89,11 @@ internal sealed partial class ClipboardHistoryListPage : ListPage
                 if (item.Content.Contains(StandardDataFormats.Text))
                 {
                     var text = await item.Content.GetTextAsync();
-                    items.Add(new ClipboardItem { Content = text, Item = item });
+                    items.Add(new ClipboardItem { Settings = _settingsManager, Content = text, Item = item });
                 }
                 else if (item.Content.Contains(StandardDataFormats.Bitmap))
                 {
-                    items.Add(new ClipboardItem { Item = item });
+                    items.Add(new ClipboardItem { Settings = _settingsManager, Item = item });
                 }
             }
 

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Properties/Resources.Designer.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Properties/Resources.Designer.cs
@@ -97,6 +97,24 @@ namespace Microsoft.CmdPal.Ext.ClipboardHistory.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Delete.
+        /// </summary>
+        public static string delete_command_name {
+            get {
+                return ResourceManager.GetString("delete_command_name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Deleted from clipboard history.
+        /// </summary>
+        public static string delete_toast_text {
+            get {
+                return ResourceManager.GetString("delete_toast_text", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Copy, paste, and search items on the clipboard.
         /// </summary>
         public static string list_item_subtitle {
@@ -138,6 +156,24 @@ namespace Microsoft.CmdPal.Ext.ClipboardHistory.Properties {
         public static string provider_display_name {
             get {
                 return ResourceManager.GetString("provider_display_name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Keep items in clipboard history even after you paste them..
+        /// </summary>
+        public static string settings_keepafterpaste_description {
+            get {
+                return ResourceManager.GetString("settings_keepafterpaste_description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Keep after pasting.
+        /// </summary>
+        public static string settings_keepafterpaste_title {
+            get {
+                return ResourceManager.GetString("settings_keepafterpaste_title", resourceCulture);
             }
         }
     }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Properties/Resources.resx
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.ClipboardHistory/Properties/Resources.resx
@@ -144,4 +144,16 @@
   <data name="clipboard_failed_to_load" xml:space="preserve">
     <value>Loading clipboard history failed</value>
   </data>
+  <data name="delete_command_name" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="delete_toast_text" xml:space="preserve">
+    <value>Deleted from clipboard history</value>
+  </data>
+  <data name="settings_keepafterpaste_title" xml:space="preserve">
+    <value>Keep after pasting</value>
+  </data>
+  <data name="settings_keepafterpaste_description" xml:space="preserve">
+    <value>Keep items in clipboard history even after you paste them.</value>
+  </data>
 </root>


### PR DESCRIPTION

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Introduces a new toggle in the Clipboard History extension settings that allows items to remain in history after being pasted into another application. Also adds a separate menu item to remove items from history manually.


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #41433
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

