### PR TITLE
CmdPal: Linq clean-up (All Apps)

### DIFF
--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/AllAppsCommandProvider.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/AllAppsCommandProvider.cs
@@ -102,7 +102,7 @@ public partial class AllAppsCommandProvider : CommandProvider
         }
 
         // ... Now, combine those two
-        List<ICommandItem> both = [bestAppMatch, .. nameMatches];
+        List<ICommandItem> both = bestAppMatch is null ? nameMatches : [.. nameMatches, bestAppMatch];
 
         if (both.Count == 1)
         {

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/AllAppsCommandProvider.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/AllAppsCommandProvider.cs
@@ -71,25 +71,27 @@ public partial class AllAppsCommandProvider : CommandProvider
     {
         var items = _page.GetItems();
 
-        // We're going to do this search in two directions:
-        // First, is this name a substring of any app...
         var nameMatches = new List<ICommandItem>();
-        foreach (var item in items)
-        {
-            if (item.Title is not null && item.Title.Contains(displayName))
-            {
-                nameMatches.Add(item);
-            }
-        }
-
-        // ... Then, does any app have this name as a substring ...
-        // Only get one of these - "Terminal Preview" contains both "Terminal" and "Terminal Preview", so just take the best one
         ICommandItem? bestAppMatch = null;
         var bestLength = -1;
 
         foreach (var item in items)
         {
-            if (item.Title is not null && displayName.Contains(item.Title))
+            if (item.Title is null)
+            {
+                continue;
+            }
+
+            // We're going to do this search in two directions:
+            // First, is this name a substring of any app...
+            if (item.Title.Contains(displayName))
+            {
+                nameMatches.Add(item);
+            }
+
+            // ... Then, does any app have this name as a substring ...
+            // Only get one of these - "Terminal Preview" contains both "Terminal" and "Terminal Preview", so just take the best one
+            if (displayName.Contains(item.Title))
             {
                 if (item.Title.Length > bestLength)
                 {

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/AppCache.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/AppCache.cs
@@ -31,11 +31,7 @@ public sealed partial class AppCache : IAppCache, IDisposable
     {
         _win32ProgramRepositoryHelper = new Win32ProgramFileSystemWatchers();
 
-        var watchers = new List<IFileSystemWatcherWrapper>();
-        foreach (var watcher in _win32ProgramRepositoryHelper.FileSystemWatchers)
-        {
-            watchers.Add(watcher);
-        }
+        var watchers = new List<IFileSystemWatcherWrapper>(_win32ProgramRepositoryHelper.FileSystemWatchers);
 
         _win32ProgramRepository = new Win32ProgramRepository(watchers, AllAppsSettings.Instance, _win32ProgramRepositoryHelper.PathsToWatch);
 

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/AppCache.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/AppCache.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CmdPal.Ext.Apps.Programs;
 using Microsoft.CmdPal.Ext.Apps.Storage;
@@ -31,7 +30,14 @@ public sealed partial class AppCache : IAppCache, IDisposable
     public AppCache()
     {
         _win32ProgramRepositoryHelper = new Win32ProgramFileSystemWatchers();
-        _win32ProgramRepository = new Win32ProgramRepository(_win32ProgramRepositoryHelper.FileSystemWatchers.Cast<IFileSystemWatcherWrapper>().ToList(), AllAppsSettings.Instance, _win32ProgramRepositoryHelper.PathsToWatch);
+
+        var watchers = new List<IFileSystemWatcherWrapper>();
+        foreach (var watcher in _win32ProgramRepositoryHelper.FileSystemWatchers)
+        {
+            watchers.Add(watcher);
+        }
+
+        _win32ProgramRepository = new Win32ProgramRepository(watchers, AllAppsSettings.Instance, _win32ProgramRepositoryHelper.PathsToWatch);
 
         _packageRepository = new PackageRepository(new PackageCatalogWrapper());
 

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/IAppCache.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/IAppCache.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using Microsoft.CmdPal.Ext.Apps.Programs;
 
 namespace Microsoft.CmdPal.Ext.Apps;

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/JsonSerializationContext.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/JsonSerializationContext.cs
@@ -2,12 +2,8 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Text.Json.Serialization;
-using System.Threading.Tasks;
 using Microsoft.CmdPal.Ext.Apps.State;
 
 namespace Microsoft.CmdPal.Ext.Apps;

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Programs/PackageManagerWrapper.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Programs/PackageManagerWrapper.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Linq;
 using System.Security.Principal;
 using Windows.Management.Deployment;
 
@@ -26,9 +25,19 @@ public class PackageManagerWrapper : IPackageManager
         {
             var pkgs = _packageManager.FindPackagesForUser(user.Value);
 
-            return pkgs.Select(PackageWrapper.GetWrapperFromPackage).Where(package => package is not null);
+            ICollection<IPackage> packages = [];
+
+            foreach (var package in pkgs)
+            {
+                if (package is not null)
+                {
+                    packages.Add(PackageWrapper.GetWrapperFromPackage(package));
+                }
+            }
+
+            return packages;
         }
 
-        return Enumerable.Empty<IPackage>();
+        return [];
     }
 }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Programs/UWP.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Programs/UWP.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO.Abstractions;
-using System.Linq;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using ManagedCommon;
@@ -72,18 +71,20 @@ public partial class UWP
             PInvoke.SHCreateStreamOnFileEx(path, STGMREAD, noAttribute, false, null, &stream).ThrowOnFailure();
             using var streamHandle = new SafeComHandle((IntPtr)stream);
 
-            Apps = AppxPackageHelper.GetAppsFromManifest(stream).Select(appInManifest =>
+            var appsInManifest = AppxPackageHelper.GetAppsFromManifest(stream);
+
+            foreach (var appInManifest in appsInManifest)
             {
                 using var appHandle = new SafeComHandle(appInManifest);
-                return new UWPApplication((IAppxManifestApplication*)appInManifest, this);
-            }).Where(a =>
-            {
-                var valid =
-                    !string.IsNullOrEmpty(a.UserModelId) &&
-                    !string.IsNullOrEmpty(a.DisplayName) &&
-                    a.AppListEntry != "none";
-                return valid;
-            }).ToList();
+                var uwpApp = new UWPApplication((IAppxManifestApplication*)appInManifest, this);
+
+                if (!string.IsNullOrEmpty(uwpApp.UserModelId) &&
+                    !string.IsNullOrEmpty(uwpApp.DisplayName) &&
+                    uwpApp.AppListEntry != "none")
+                {
+                    Apps.Add(uwpApp);
+                }
+            }
         }
         catch (Exception ex)
         {
@@ -93,19 +94,43 @@ public partial class UWP
         }
     }
 
-    // http://www.hanselman.com/blog/GetNamespacesFromAnXMLDocumentWithXPathDocumentAndLINQToXML.aspx
     private static string[] XmlNamespaces(string path)
     {
         var z = XDocument.Load(path);
         if (z.Root is not null)
         {
-            var namespaces = z.Root.Attributes().
-                Where(a => a.IsNamespaceDeclaration).
-                GroupBy(
-                    a => a.Name.Namespace == XNamespace.None ? string.Empty : a.Name.LocalName,
-                    a => XNamespace.Get(a.Value)).Select(
-                    g => g.First().ToString()).ToArray();
-            return namespaces;
+            var namespaces = new List<string>();
+
+            var attributes = z.Root.Attributes();
+            foreach (var attribute in attributes)
+            {
+                if (attribute.IsNamespaceDeclaration)
+                {
+                    // Extract namespace
+                    var key = attribute.Name.Namespace == XNamespace.None ? string.Empty : attribute.Name.LocalName;
+                    XNamespace ns = XNamespace.Get(attribute.Value);
+
+                    // Check if we already have a namespace with this key
+                    var alreadyExists = false;
+                    foreach (var existingNs in namespaces)
+                    {
+                        // If we find the namespace value already in our list, skip adding it again
+                        if (existingNs == ns.ToString())
+                        {
+                            alreadyExists = true;
+                            break;
+                        }
+                    }
+
+                    // Add the first namespace found for each key (equivalent to .GroupBy().Select(g => g.First()))
+                    if (!alreadyExists)
+                    {
+                        namespaces.Add(ns.ToString());
+                    }
+                }
+            }
+
+            return namespaces.ToArray();
         }
         else
         {
@@ -115,10 +140,13 @@ public partial class UWP
 
     private void InitPackageVersion(string[] namespaces)
     {
-        foreach (var n in _versionFromNamespace.Keys.Where(namespaces.Contains))
+        foreach (var n in _versionFromNamespace.Keys)
         {
-            Version = _versionFromNamespace[n];
-            return;
+            if (Array.IndexOf(namespaces, n) >= 0)
+            {
+                Version = _versionFromNamespace[n];
+                return;
+            }
         }
 
         Version = PackageVersion.Unknown;
@@ -137,7 +165,18 @@ public partial class UWP
 
                 foreach (var app in u.Apps)
                 {
-                    if (AllAppsSettings.Instance.DisabledProgramSources.All(x => x.UniqueIdentifier != app.UniqueIdentifier))
+                    var isDisabled = false;
+
+                    foreach (var disabled in AllAppsSettings.Instance.DisabledProgramSources)
+                    {
+                        if (disabled.UniqueIdentifier == app.UniqueIdentifier)
+                        {
+                            isDisabled = true;
+                            break;
+                        }
+                    }
+
+                    if (!isDisabled)
                     {
                         appsBag.Add(app);
                     }
@@ -154,20 +193,28 @@ public partial class UWP
 
     private static IEnumerable<IPackage> CurrentUserPackages()
     {
-        return PackageManagerWrapper.FindPackagesForCurrentUser().Where(p =>
+        var currentUsersPackages = PackageManagerWrapper.FindPackagesForCurrentUser();
+        ICollection<IPackage> packagesToReturn = [];
+
+        foreach (var pkg in currentUsersPackages)
         {
             try
             {
-                var f = p.IsFramework;
-                var path = p.InstalledLocation;
-                return !f && !string.IsNullOrEmpty(path);
+                var f = pkg.IsFramework;
+                var path = pkg.InstalledLocation;
+
+                if (!f && !string.IsNullOrEmpty(path))
+                {
+                    packagesToReturn.Add(pkg);
+                }
             }
             catch (Exception ex)
             {
                 Logger.LogError(ex.Message);
-                return false;
             }
-        });
+        }
+
+        return packagesToReturn;
     }
 
     public override string ToString()

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Programs/UWP.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Programs/UWP.cs
@@ -99,7 +99,7 @@ public partial class UWP
         var z = XDocument.Load(path);
         if (z.Root is not null)
         {
-            var namespaces = new List<string>();
+            var namespaces = new HashSet<string>();
 
             var attributes = z.Root.Attributes();
             foreach (var attribute in attributes)
@@ -109,28 +109,16 @@ public partial class UWP
                     // Extract namespace
                     var key = attribute.Name.Namespace == XNamespace.None ? string.Empty : attribute.Name.LocalName;
                     XNamespace ns = XNamespace.Get(attribute.Value);
+                    var nsString = ns.ToString();
 
-                    // Check if we already have a namespace with this key
-                    var alreadyExists = false;
-                    foreach (var existingNs in namespaces)
-                    {
-                        // If we find the namespace value already in our list, skip adding it again
-                        if (existingNs == ns.ToString())
-                        {
-                            alreadyExists = true;
-                            break;
-                        }
-                    }
-
-                    // Add the first namespace found for each key (equivalent to .GroupBy().Select(g => g.First()))
-                    if (!alreadyExists)
-                    {
-                        namespaces.Add(ns.ToString());
-                    }
+                    // Use HashSet to check for duplicates
+                    namespaces.Add(nsString);
                 }
             }
 
-            return namespaces.ToArray();
+            var uniqueNamespaces = new string[namespaces.Count];
+            namespaces.CopyTo(uniqueNamespaces);
+            return uniqueNamespaces;
         }
         else
         {

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Programs/UWPApplication.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Programs/UWPApplication.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO.Abstractions;
-using System.Linq;
 using System.Xml;
 using ManagedCommon;
 using Microsoft.CmdPal.Ext.Apps.Commands;
@@ -340,20 +339,22 @@ public class UWPApplication : IUWPApplication
             //
             // FirstOrDefault would result in us using the 1x scaled icon
             // always, which is usually too small for our needs.
-            var selectedIconPath = paths.LastOrDefault(File.Exists);
-            if (!string.IsNullOrEmpty(selectedIconPath))
+            for (var i = paths.Count - 1; i >= 0; i--)
             {
-                LogoPath = selectedIconPath;
-                if (highContrast)
+                if (File.Exists(paths[i]))
                 {
-                    LogoType = LogoType.HighContrast;
-                }
-                else
-                {
-                    LogoType = LogoType.Colored;
-                }
+                    LogoPath = paths[i];
+                    if (highContrast)
+                    {
+                        LogoType = LogoType.HighContrast;
+                    }
+                    else
+                    {
+                        LogoType = LogoType.Colored;
+                    }
 
-                return true;
+                    return true;
+                }
             }
         }
 
@@ -394,7 +395,23 @@ public class UWPApplication : IUWPApplication
                 }
             }
 
-            var selectedIconPath = paths.OrderBy(x => Math.Abs(pathFactorPairs.GetValueOrDefault(x) - appIconSize)).FirstOrDefault(File.Exists);
+            // Sort paths by distance to desired app icon size
+            var selectedIconPath = string.Empty;
+            var closestDistance = int.MaxValue;
+
+            foreach (var p in paths)
+            {
+                if (File.Exists(p) && pathFactorPairs.TryGetValue(p, out var factor))
+                {
+                    var distance = Math.Abs(factor - appIconSize);
+                    if (distance < closestDistance)
+                    {
+                        closestDistance = distance;
+                        selectedIconPath = p;
+                    }
+                }
+            }
+
             if (!string.IsNullOrEmpty(selectedIconPath))
             {
                 LogoPath = selectedIconPath;

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Programs/Win32Program.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Programs/Win32Program.cs
@@ -7,7 +7,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions;
-using System.Linq;
 using System.Security;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -606,9 +605,24 @@ public class Win32Program : IProgram
     }
 
     private static IEnumerable<string> CustomProgramPaths(IEnumerable<ProgramSource> sources, IList<string> suffixes)
-        => sources?.Where(programSource => Directory.Exists(programSource.Location) && programSource.Enabled)
-            .SelectMany(programSource => ProgramPaths(programSource.Location, suffixes))
-            .ToList() ?? Enumerable.Empty<string>();
+    {
+        if (sources is not null)
+        {
+            var paths = new List<string>();
+
+            foreach (var programSource in sources)
+            {
+                if (Directory.Exists(programSource.Location) && programSource.Enabled)
+                {
+                    paths.AddRange(ProgramPaths(programSource.Location, suffixes));
+                }
+            }
+
+            return paths;
+        }
+
+        return [];
+    }
 
     // Function to obtain the list of applications, the locations of which have been added to the env variable PATH
     private static List<string> PathEnvironmentProgramPaths(IList<string> suffixes)
@@ -637,9 +651,15 @@ public class Win32Program : IProgram
     }
 
     private static List<string> IndexPath(IList<string> suffixes, List<string> indexLocations)
-            => indexLocations
-            .SelectMany(indexLocation => ProgramPaths(indexLocation, suffixes))
-            .ToList();
+    {
+        var paths = new List<string>();
+        foreach (var indexLocation in indexLocations)
+        {
+            paths.AddRange(ProgramPaths(indexLocation, suffixes));
+        }
+
+        return paths;
+    }
 
     private static List<string> StartMenuProgramPaths(IList<string> suffixes)
     {
@@ -681,17 +701,51 @@ public class Win32Program : IProgram
             }
         }
 
-        return paths
-            .Where(path => suffixes.Any(suffix => path.EndsWith(suffix, StringComparison.InvariantCultureIgnoreCase)))
-            .Select(ExpandEnvironmentVariables)
-            .Where(path => path is not null)
-            .ToList();
+        var returnedPaths = new List<string>();
+        foreach (var path in paths)
+        {
+            var matchesSuffix = false;
+            foreach (var suffix in suffixes)
+            {
+                if (path.EndsWith(suffix, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    matchesSuffix = true;
+                    break;
+                }
+            }
+
+            if (matchesSuffix)
+            {
+                var expandedPath = ExpandEnvironmentVariables(path);
+                if (expandedPath is not null)
+                {
+                    returnedPaths.Add(expandedPath);
+                }
+            }
+        }
+
+        return returnedPaths;
     }
 
     private static IEnumerable<string> GetPathsFromRegistry(RegistryKey root)
-        => root
-            .GetSubKeyNames()
-            .Select(x => GetPathFromRegistrySubkey(root, x));
+    {
+        var result = new List<string>();
+
+        // Get all subkey names
+        var subKeyNames = root.GetSubKeyNames();
+
+        // Process each subkey to extract the path
+        foreach (var subkeyName in subKeyNames)
+        {
+            var path = GetPathFromRegistrySubkey(root, subkeyName);
+            if (!string.IsNullOrEmpty(path))
+            {
+                result.Add(path);
+            }
+        }
+
+        return result;
+    }
 
     private static string GetPathFromRegistrySubkey(RegistryKey root, string subkey)
     {
@@ -758,7 +812,28 @@ public class Win32Program : IProgram
     }
 
     public static List<Win32Program> DeduplicatePrograms(IEnumerable<Win32Program> programs)
-        => new HashSet<Win32Program>(programs, Win32ProgramEqualityComparer.Default).ToList();
+    {
+        // Create a HashSet with the custom equality comparer to automatically deduplicate programs
+        var uniquePrograms = new HashSet<Win32Program>(Win32ProgramEqualityComparer.Default);
+
+        // Filter out invalid programs and add valid ones to the HashSet
+        foreach (var program in programs)
+        {
+            if (program?.Valid == true)
+            {
+                uniquePrograms.Add(program);
+            }
+        }
+
+        // Convert the HashSet to a List for return
+        var result = new List<Win32Program>(uniquePrograms.Count);
+        foreach (var program in uniquePrograms)
+        {
+            result.Add(program);
+        }
+
+        return result;
+    }
 
     private static Win32Program GetProgramFromPath(string path)
     {
@@ -874,8 +949,22 @@ public class Win32Program : IProgram
 
                 foreach (var path in source.GetPaths())
                 {
-                    if (disabledProgramsList.All(x => x.UniqueIdentifier != path) &&
-                        !ExecutableApplicationExtensions.Contains(Extension(path)))
+                    if (ExecutableApplicationExtensions.Contains(Extension(path)))
+                    {
+                        continue;
+                    }
+
+                    var isDisabled = false;
+                    foreach (var disabledProgram in disabledProgramsList)
+                    {
+                        if (disabledProgram.UniqueIdentifier == path)
+                        {
+                            isDisabled = true;
+                            break;
+                        }
+                    }
+
+                    if (!isDisabled)
                     {
                         pathBag.Add(path);
                     }
@@ -895,7 +984,17 @@ public class Win32Program : IProgram
 
                 foreach (var path in source.GetPaths())
                 {
-                    if (disabledProgramsList.All(x => x.UniqueIdentifier != path))
+                    var isDisabled = false;
+                    foreach (var disabledProgram in disabledProgramsList)
+                    {
+                        if (disabledProgram.UniqueIdentifier == path)
+                        {
+                            isDisabled = true;
+                            break;
+                        }
+                    }
+
+                    if (!isDisabled)
                     {
                         runCommandPathBag.Add(path);
                     }
@@ -924,10 +1023,21 @@ public class Win32Program : IProgram
                 }
             });
 
-            var programs = programsList.ToList();
-            var runCommandPrograms = runCommandProgramsList.ToList();
+            var allPrograms = new List<Win32Program>();
 
-            return DeduplicatePrograms(programs.Concat(runCommandPrograms).Where(program => program?.Valid == true));
+            var programs = new List<Win32Program>();
+            foreach (var program in programsList)
+            {
+                allPrograms.Add(program);
+            }
+
+            var runCommandPrograms = new List<Win32Program>();
+            foreach (var program in runCommandProgramsList)
+            {
+                allPrograms.Add(program);
+            }
+
+            return DeduplicatePrograms(allPrograms);
         }
         catch (Exception e)
         {

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Programs/Win32Program.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Programs/Win32Program.cs
@@ -1033,20 +1033,7 @@ public class Win32Program : IProgram
                 }
             });
 
-            var allPrograms = new List<Win32Program>();
-
-            var programs = new List<Win32Program>();
-            foreach (var program in programsList)
-            {
-                allPrograms.Add(program);
-            }
-
-            var runCommandPrograms = new List<Win32Program>();
-            foreach (var program in runCommandProgramsList)
-            {
-                allPrograms.Add(program);
-            }
-
+            List<Win32Program> allPrograms = [.. programsList, .. runCommandProgramsList];
             return DeduplicatePrograms(allPrograms);
         }
         catch (Exception e)

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/State/PinStateChangedEventArgs.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/State/PinStateChangedEventArgs.cs
@@ -3,10 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Microsoft.CmdPal.Ext.Apps.State;
 

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/State/PinnedAppsManager.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/State/PinnedAppsManager.cs
@@ -3,9 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Linq;
 using ManagedCommon;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 
@@ -31,7 +29,7 @@ public sealed class PinnedAppsManager
 
     public bool IsAppPinned(string appIdentifier)
     {
-        return _pinnedApps.PinnedAppIdentifiers.Contains(appIdentifier, StringComparer.OrdinalIgnoreCase);
+        return _pinnedApps.PinnedAppIdentifiers.IndexOf(appIdentifier) >= 0;
     }
 
     public void PinApp(string appIdentifier)

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Storage/ListRepository`1.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Storage/ListRepository`1.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 using ManagedCommon;
 
 namespace Microsoft.CmdPal.Ext.Apps.Storage;
@@ -20,7 +19,16 @@ public class ListRepository<T> : IRepository<T>, IEnumerable<T>
 {
     public IList<T> Items
     {
-        get { return _items.Values.ToList(); }
+        get
+        {
+            var items = new List<T>();
+            foreach (var item in _items.Values)
+            {
+                items.Add(item);
+            }
+
+            return items;
+        }
     }
 
     private ConcurrentDictionary<int, T> _items = new ConcurrentDictionary<int, T>();
@@ -34,9 +42,16 @@ public class ListRepository<T> : IRepository<T>, IEnumerable<T>
         // enforce that internal representation
         try
         {
+            var result = new ConcurrentDictionary<int, T>();
+
+            foreach (var item in list)
+            {
 #pragma warning disable CS8602 // Dereference of a possibly null reference.
-            _items = new ConcurrentDictionary<int, T>(list.ToDictionary(i => i.GetHashCode()));
+                result.TryAdd(item.GetHashCode(), item);
 #pragma warning restore CS8602 // Dereference of a possibly null reference.
+            }
+
+            _items = result;
         }
         catch (ArgumentException ex)
         {

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Storage/ListRepository`1.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Storage/ListRepository`1.cs
@@ -21,7 +21,7 @@ public class ListRepository<T> : IRepository<T>, IEnumerable<T>
     {
         get
         {
-            var items = new List<T>();
+            var items = new List<T>(_items.Count);
             foreach (var item in _items.Values)
             {
                 items.Add(item);

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Storage/PackageRepository.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Storage/PackageRepository.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Linq;
 using ManagedCommon;
 using Microsoft.CmdPal.Ext.Apps.Programs;
 using Microsoft.CmdPal.Ext.Apps.Utils;
@@ -104,10 +103,14 @@ internal sealed partial class PackageRepository : ListRepository<IUWPApplication
         // find apps associated with this package.
         var packageWrapper = PackageWrapper.GetWrapperFromPackage(package);
         var uwp = new UWP(packageWrapper);
-        var apps = Items.Where(a => a.Package.Equals(uwp)).ToArray();
 
-        foreach (var app in apps)
+        foreach (var app in Items)
         {
+            if (!app.Package.Equals(uwp))
+            {
+                continue;
+            }
+
             Remove(app);
             _isDirty = true;
         }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Storage/Win32ProgramFileSystemWatchers.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Storage/Win32ProgramFileSystemWatchers.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using ManagedCommon;
 
 namespace Microsoft.CmdPal.Ext.Apps.Storage;
@@ -55,7 +54,16 @@ internal sealed partial class Win32ProgramFileSystemWatchers : IDisposable
             }
         }
 
-        return paths.Except(invalidPaths).ToArray();
+        var validPaths = new List<string>();
+        foreach (var path in paths)
+        {
+            if (!invalidPaths.Contains(path))
+            {
+                validPaths.Add(path);
+            }
+        }
+
+        return validPaths.ToArray();
     }
 
     public void Dispose()

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Utils/ShellCommand.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Utils/ShellCommand.cs
@@ -2,10 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Diagnostics;
-using System.Text;
-using System.Threading;
 
 namespace Microsoft.CmdPal.Ext.Apps.Utils;
 

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Utils/Theme.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Utils/Theme.cs
@@ -2,12 +2,6 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Microsoft.CmdPal.Ext.Apps.Utils;
 
 public enum Theme

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Utils/ThemeHelper.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Utils/ThemeHelper.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Globalization;
-using System.Linq;
 
 using Microsoft.Win32;
 
@@ -56,15 +55,25 @@ public static class ThemeHelper
             return Theme.Light; // Default to light theme if missing
         }
 
-        var theme = themePath.Split('\\').Last().Split('.').First().ToLowerInvariant();
-
-        return theme switch
+        var splitThemePath = themePath.Split('\\');
+        if (splitThemePath.Length > 0)
         {
-            "hc1" => Theme.HighContrastOne,
-            "hc2" => Theme.HighContrastTwo,
-            "hcwhite" => Theme.HighContrastWhite,
-            "hcblack" => Theme.HighContrastBlack,
-            _ => Theme.Light,
-        };
+            var lastSegment = splitThemePath[splitThemePath.Length - 1];
+            var splitSegment = lastSegment.Split('.');
+            if (splitSegment.Length > 0)
+            {
+                var themeVariant = splitSegment[0].ToLowerInvariant();
+                return themeVariant switch
+                {
+                    "hc1" => Theme.HighContrastOne,
+                    "hc2" => Theme.HighContrastTwo,
+                    "hcwhite" => Theme.HighContrastWhite,
+                    "hcblack" => Theme.HighContrastBlack,
+                    _ => Theme.Light,
+                };
+            }
+        }
+
+        return Theme.Light;
     }
 }


### PR DESCRIPTION
Beginning the process of removing System.Linq from CmdPal. This PR removes it from the All Apps extension.