### PR TITLE
Add AppUserModel_ID awareness to FancyZones

### DIFF
--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesData/AppZoneHistory.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesData/AppZoneHistory.cpp
@@ -324,7 +324,6 @@ void AppZoneHistory::AdjustWorkAreaIds(const std::vector<FancyZonesDataTypes::Mo
     }
 }
 
-
 std::wstring AppZoneHistory::GetProcessPathWithAUMID(HWND window) noexcept
 {
     auto processPath = get_process_path_waiting_uwp(window);
@@ -340,7 +339,7 @@ std::wstring AppZoneHistory::GetProcessPathWithAUMID(HWND window) noexcept
             processPath.append(L"?").append(pv.pwszVal);
         }
     }
-    
+
     return processPath;
 }
 

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesData/AppZoneHistory.h
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesData/AppZoneHistory.h
@@ -52,6 +52,7 @@ public:
     void SaveData();
     void AdjustWorkAreaIds(const std::vector<FancyZonesDataTypes::MonitorId>& ids);
 
+    static std::wstring GetProcessPathWithAUMID(HWND window) noexcept;
     bool SetAppLastZones(HWND window, const FancyZonesDataTypes::WorkAreaId& workAreaId, const GUID& layoutId, const ZoneIndexSet& zoneIndexSet);
     bool RemoveAppLastZone(HWND window, const FancyZonesDataTypes::WorkAreaId& workAreaId, const GUID& layoutId);
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This change allows FancyZones to distinguish between logically distinct windows of the same executable like browser profiles, progressive web apps and others where the shell normally gives them separate taskbar icons.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #34713
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Applications that set their shell `AppUserModel_ID` (mostly browsers) will need to be repositioned once immediately after updating to a version that includes this. 

To remain backward compatible for all other applications, the json variable remains "app-path" even though the conditionally appended "?&lt;AppUserModel_ID&gt;" for some windows means it is no longer always a valid path. It is never actually *used* as a path, however. It is merely a key for the Map. The '?' separator, being illegal in a filename on Windows, makes it easy to strip off if anyone ever needs to do so in future. I similarly left the internal variable name as `processPath`, mostly just to minimize the size of the diff.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
The build succeeds on my Windows 11 system and I've been running with it on my daily driver for two days with heavy use of PWAs and profiles on Chrome, Edge and Brave. I don't have a Windows 10 system or image to make a VM but I don't see any changes in the shell API that's used here. Firefox doesn't implement the necessary shell integration natively so its behavior doesn't change but the native helper for the third party PWA extension might.