### PR TITLE
[Awake] Exit the application when --use-parent-pid is used and the parent PID cannot be found

### DIFF
--- a/src/modules/awake/Awake/Program.cs
+++ b/src/modules/awake/Awake/Program.cs
@@ -335,7 +335,7 @@ namespace Awake
         {
             int targetPid = 0;
 
-            // We prioritise a user-provided PID over the parent PID. If both are given on the
+            // We prioritize a user-provided PID over the parent PID. If both are given on the
             // command line, the --pid value will be used.
             if (pid != 0)
             {

--- a/src/modules/awake/Awake/Properties/Resources.Designer.cs
+++ b/src/modules/awake/Awake/Properties/Resources.Designer.cs
@@ -151,6 +151,15 @@ namespace Awake.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Exiting because the parent process ID could not be found..
+        /// </summary>
+        internal static string AWAKE_EXIT_PARENT_BINDING_FAILURE_MESSAGE {
+            get {
+                return ResourceManager.GetString("AWAKE_EXIT_PARENT_BINDING_FAILURE_MESSAGE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Received a signal to end the process. Making sure we quit....
         /// </summary>
         internal static string AWAKE_EXIT_SIGNAL_MESSAGE {

--- a/src/modules/awake/Awake/Properties/Resources.resx
+++ b/src/modules/awake/Awake/Properties/Resources.resx
@@ -226,4 +226,7 @@
   <data name="AWAKE_SCREEN_OFF" xml:space="preserve">
     <value>Off</value>
   </data>
+  <data name="AWAKE_EXIT_PARENT_BINDING_FAILURE_MESSAGE" xml:space="preserve">
+    <value>Exiting because the parent process ID could not be found.</value>
+  </data>
 </root>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
If a user starts Awake with the `--use-parent-pid` parameter and the parent process ID cannot be found (or an error occurs during its lookup) then Awake will currently enter an unresponsive state without setting a keep-awake mode. The user may be unaware this has happened because Awake's system tray icon will be present.

This fixes the issue by exiting the application if there was an issue obtaining the parent process ID.

It also includes a small refactor by extracting the "PID-binding" logic into a separate method.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #41709
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
This is a small targeted update which adds a comment and `Exit`, and also improves the clarity of the error log message:

```csharp
    if (targetPid == 0)
    {
        // The parent process could not be identified.
        Logger.LogError("Failed to identify a parent process for binding.");
        Exit(Resources.AWAKE_EXIT_PARENT_BINDING_FAILURE_MESSAGE, 1);
    }
```

(The new resource is currently set to "Exiting because the parent process ID could not be found.")

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
A failure state is challenging to trigger, so I hardcoded `GetParentProcess()` to return `null` then confirmed that running Awake with the `--use-parent-pid` option exited cleanly, logging the error appropriately.

I confirmed that the parent-tracking functionality worked by restoring the `GetParentProcess()` code and using `--use-parent-pid` when running Awake via PowerShell. Closing the PowerShell window also closed Awake, as expected.