### PR TITLE
CmdPal: prevent ctrl+i from inserting a tab

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/SearchBar.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/SearchBar.xaml.cs
@@ -131,6 +131,11 @@ public sealed partial class SearchBar : UserControl,
             WeakReferenceMessenger.Default.Send<OpenContextMenuMessage>(new OpenContextMenuMessage(null, null, null, ContextMenuFilterLocation.Bottom));
             e.Handled = true;
         }
+        else if (ctrlPressed && e.Key == VirtualKey.I)
+        {
+            // Today you learned that Ctrl+I in a TextBox will insert a tab
+            e.Handled = true;
+        }
         else if (e.Key == VirtualKey.Escape)
         {
             if (string.IsNullOrEmpty(FilterBox.Text))


### PR DESCRIPTION
Eat the Ctrl+I, so that it doesn't insert a tab. Why does it insert a tab? Who knows.

closes #41681
