### PR TITLE
zoomit bug fixes

### DIFF
--- a/src/modules/ZoomIt/ZoomIt/Zoomit.cpp
+++ b/src/modules/ZoomIt/ZoomIt/Zoomit.cpp
@@ -4024,6 +4024,7 @@ LRESULT APIENTRY MainWndProc(
             // Now copy crop or copy+save
             if( LOWORD( wParam ) == SNIP_SAVE_HOTKEY )
             {
+                // Hide cursor for screen capture
                 ShowCursor(false);
                 SendMessage( hWnd, WM_COMMAND, IDC_SAVE_CROP, ( zoomed ? 0 : SHALLOW_ZOOM ) );
                 ShowCursor(true);
@@ -5782,6 +5783,7 @@ LRESULT APIENTRY MainWndProc(
 
             if( !g_DrawingShape ) {
 
+                // If the point has changed, draw a line to it
                 if (prevPt.x != LOWORD(lParam) || prevPt.y != HIWORD(lParam)) {
                     Gdiplus::Graphics	dstGraphics(hdcScreenCompat);
                     if ((GetWindowLong(g_hWndMain, GWL_EXSTYLE) & WS_EX_LAYERED) == 0)
@@ -5795,6 +5797,7 @@ LRESULT APIENTRY MainWndProc(
                     path.AddLine(prevPt.x, prevPt.y, LOWORD(lParam), HIWORD(lParam));
                     dstGraphics.DrawPath(&pen, &path);
                 }
+                // Draw a dot at the current point, if the point hasn't changed
                 else {
                     MoveToEx(hdcScreenCompat, prevPt.x, prevPt.y, NULL);
                     LineTo(hdcScreenCompat, LOWORD(lParam), HIWORD(lParam));

--- a/src/modules/ZoomIt/ZoomIt/Zoomit.cpp
+++ b/src/modules/ZoomIt/ZoomIt/Zoomit.cpp
@@ -3525,6 +3525,10 @@ winrt::fire_and_forget StartRecordingAsync( HWND hWnd, LPRECT rcCrop, HWND hWndR
         }
         if( destFile == nullptr ) {
 
+            if (stream) {
+                stream.Close();
+                stream = nullptr;
+            }
             co_await file.DeleteAsync();
         }
         else {
@@ -3544,6 +3548,10 @@ winrt::fire_and_forget StartRecordingAsync( HWND hWnd, LPRECT rcCrop, HWND hWndR
     }
     else {
 
+        if (stream) {
+            stream.Close();
+            stream = nullptr;
+        }
         co_await file.DeleteAsync();
         g_RecordingSession = nullptr;
     }

--- a/src/modules/ZoomIt/ZoomIt/Zoomit.cpp
+++ b/src/modules/ZoomIt/ZoomIt/Zoomit.cpp
@@ -4016,7 +4016,9 @@ LRESULT APIENTRY MainWndProc(
             // Now copy crop or copy+save
             if( LOWORD( wParam ) == SNIP_SAVE_HOTKEY )
             {
+                ShowCursor(false);
                 SendMessage( hWnd, WM_COMMAND, IDC_SAVE_CROP, ( zoomed ? 0 : SHALLOW_ZOOM ) );
+                ShowCursor(true);
             }
             else
             {
@@ -4047,12 +4049,6 @@ LRESULT APIENTRY MainWndProc(
                 {
                     OutputDebug( L"Exiting liveDraw after snip\n" );
                     SendMessage( hWnd, WM_KEYDOWN, VK_ESCAPE, 0 );
-                }
-                else
-                {
-                    // Set wparam to 1 to exit without animation
-                    OutputDebug(L"Exiting zoom after snip\n" );
-                    SendMessage( hWnd, WM_HOTKEY, ZOOM_HOTKEY, SHALLOW_DESTROY );
                 }
             }
             break;

--- a/src/modules/ZoomIt/ZoomIt/Zoomit.cpp
+++ b/src/modules/ZoomIt/ZoomIt/Zoomit.cpp
@@ -5774,17 +5774,24 @@ LRESULT APIENTRY MainWndProc(
 
             if( !g_DrawingShape ) {
 
-                Gdiplus::Graphics	dstGraphics(hdcScreenCompat);
-                if( ( GetWindowLong( g_hWndMain, GWL_EXSTYLE ) & WS_EX_LAYERED ) == 0 )
-                {
-                    dstGraphics.SetSmoothingMode(Gdiplus::SmoothingModeAntiAlias);
+                if (prevPt.x != LOWORD(lParam) || prevPt.y != HIWORD(lParam)) {
+                    Gdiplus::Graphics	dstGraphics(hdcScreenCompat);
+                    if ((GetWindowLong(g_hWndMain, GWL_EXSTYLE) & WS_EX_LAYERED) == 0)
+                    {
+                        dstGraphics.SetSmoothingMode(Gdiplus::SmoothingModeAntiAlias);
+                    }
+                    Gdiplus::Color	color = ColorFromColorRef(g_PenColor);
+                    Gdiplus::Pen pen(color, static_cast<Gdiplus::REAL>(g_PenWidth));
+                    Gdiplus::GraphicsPath path;
+                    pen.SetLineJoin(Gdiplus::LineJoinRound);
+                    path.AddLine(prevPt.x, prevPt.y, LOWORD(lParam), HIWORD(lParam));
+                    dstGraphics.DrawPath(&pen, &path);
                 }
-                Gdiplus::Color	color = ColorFromColorRef(g_PenColor);
-                Gdiplus::Pen pen(color, static_cast<Gdiplus::REAL>(g_PenWidth));
-                Gdiplus::GraphicsPath path;
-                pen.SetLineJoin(Gdiplus::LineJoinRound);
-                path.AddLine(prevPt.x, prevPt.y, LOWORD(lParam), HIWORD(lParam));
-                dstGraphics.DrawPath(&pen, &path);
+                else {
+                    MoveToEx(hdcScreenCompat, prevPt.x, prevPt.y, NULL);
+                    LineTo(hdcScreenCompat, LOWORD(lParam), HIWORD(lParam));
+                    InvalidateRect(hWnd, NULL, FALSE);
+                }
 
                 prevPt.x = LOWORD( lParam );
                 prevPt.y = HIWORD( lParam );


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] Closes: #41040, #41041, #41043
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Manually tested and ensured that the issues are resolved.
- [ ] **Localization:** N/A
- [ ] **Dev docs:** N/A
- [ ] **New binaries:** No new binaries added
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
This PR includes code-changes to restore some of the features of ZoomIt that existed in older versions and lost in later versions, such as when in Draw mode, after drawing, if an area is snipped, it doesn't clear the drawing immediately, giving the user an option to cancel snip and update the drawing. Also, in draw mode, when left mouse is clicked, it results in a dot, as it was in previous versions. This PR also addresses some race conditions during Recording that results in error when the Recording is saved.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manually tested and validated the draw and snip modes. 

