### PR TITLE
CmdPal: Bind FilterDropDown selection to the current filter and ensure notifications are raised on UI thread

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/ExtensionObjectViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/ExtensionObjectViewModel.cs
@@ -51,6 +51,36 @@ public abstract partial class ExtensionObjectViewModel : ObservableObject
         DoOnUiThread(() => OnPropertyChanged(propertyName));
     }
 
+    protected void UpdateProperty(string propertyName1, string propertyName2)
+    {
+        DoOnUiThread(() =>
+        {
+            OnPropertyChanged(propertyName1);
+            OnPropertyChanged(propertyName2);
+        });
+    }
+
+    protected void UpdateProperty(string propertyName1, string propertyName2, string propertyName3)
+    {
+        DoOnUiThread(() =>
+        {
+            OnPropertyChanged(propertyName1);
+            OnPropertyChanged(propertyName2);
+            OnPropertyChanged(propertyName3);
+        });
+    }
+
+    protected void UpdateProperty(params string[] propertyNames)
+    {
+        DoOnUiThread(() =>
+        {
+            foreach (var propertyName in propertyNames)
+            {
+                OnPropertyChanged(propertyName);
+            }
+        });
+    }
+
     protected void ShowException(Exception ex, string? extensionHint = null)
     {
         if (PageContext.TryGetTarget(out var pageContext))

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/FiltersDropDown.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/FiltersDropDown.xaml
@@ -74,6 +74,8 @@
         PlaceholderText="Filters"
         PreviewKeyDown="FiltersComboBox_PreviewKeyDown"
         SelectionChanged="FiltersComboBox_SelectionChanged"
+        SelectedValue="{x:Bind ViewModel.CurrentFilterId, Mode=OneWay}"
+        SelectedValuePath="Id"
         Style="{StaticResource ComboBoxStyle}"
         Visibility="{x:Bind ViewModel.ShouldShowFilters, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
         <ComboBox.ItemContainerStyle>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/FiltersDropDown.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/FiltersDropDown.xaml
@@ -73,9 +73,9 @@
         ItemsSource="{x:Bind ViewModel.Filters, Mode=OneWay}"
         PlaceholderText="Filters"
         PreviewKeyDown="FiltersComboBox_PreviewKeyDown"
-        SelectionChanged="FiltersComboBox_SelectionChanged"
         SelectedValue="{x:Bind ViewModel.CurrentFilterId, Mode=OneWay}"
         SelectedValuePath="Id"
+        SelectionChanged="FiltersComboBox_SelectionChanged"
         Style="{StaticResource ComboBoxStyle}"
         Visibility="{x:Bind ViewModel.ShouldShowFilters, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
         <ComboBox.ItemContainerStyle>


### PR DESCRIPTION
## Summary of the Pull Request

This PR declaratively binds FilterDropDown.SelectedValue to CurrentFilterId (one-way only; updates in the opposite direction are handled within the drop-down’s code). It also removes observable properties and reverts to the UpdateProperty style to ensure property change notifications are raised on the UI thread, aligning the handling style with other classes.

## Impact
- Fixed a crash that could occur on pages with filters
- The filter drop-down now correctly syncs with the initially selected filter when loading a page

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #41578
- [x] Closes: #41649
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

