### PR TITLE
Use shape icons for Command Palette Windows Service state.

### DIFF
--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsServices/Helpers/ServiceHelper.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsServices/Helpers/ServiceHelper.cs
@@ -88,11 +88,11 @@ public static class ServiceHelper
                 ];
             }
 
-            IconInfo icon = Icons.GreenCircleIcon;
+            IconInfo icon = Icons.PlayIcon;
             switch (s.Status)
             {
                 case ServiceControllerStatus.Stopped:
-                    icon = Icons.RedCircleIcon;
+                    icon = Icons.StopIcon;
                     break;
                 case ServiceControllerStatus.Running:
                     break;

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsServices/Icons.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsServices/Icons.cs
@@ -18,9 +18,5 @@ internal sealed class Icons
 
     internal static IconInfo OpenIcon { get; } = new IconInfo("\xE8A7"); // OpenInNewWindow icon
 
-    internal static IconInfo GreenCircleIcon { get; } = new("\U0001f7e2"); // unicode LARGE GREEN CIRCLE
-
-    internal static IconInfo RedCircleIcon { get; } = new("\U0001F534"); // unicode LARGE RED CIRCLE
-
     internal static IconInfo PauseIcon { get; } = new("\u23F8"); // unicode DOUBLE VERTICAL BAR, aka, "Pause"
 }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsServices/Pages/ServiceFilters.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsServices/Pages/ServiceFilters.cs
@@ -18,8 +18,8 @@ public partial class ServiceFilters : Filters
         return [
             new Filter() { Id = "all", Name = "All Services" },
             new Separator(),
-            new Filter() { Id = "running", Name = "Running", Icon = Icons.GreenCircleIcon },
-            new Filter() { Id = "stopped", Name = "Stopped", Icon = Icons.RedCircleIcon },
+            new Filter() { Id = "running", Name = "Running", Icon = Icons.PlayIcon },
+            new Filter() { Id = "stopped", Name = "Stopped", Icon = Icons.StopIcon },
             new Filter() { Id = "paused", Name = "Paused", Icon = Icons.PauseIcon },
         ];
     }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary
Resolves #41653 by using play/pause/stop icons for Windows Service state in the Command Palette utility. Prior to this green/red circles were used. New icons provide an improved user experience, especially for color-blind users. The new icons are consistent with the UI in the native Windows Services management console utility (services.msc).

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ X ] Closes: #41653
- [ X ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Windows service states display new icons:
<img width="901" height="549" alt="image" src="https://github.com/user-attachments/assets/3265ff3c-b5ab-4c58-9922-1b7fc0e7c76d" />
<img width="894" height="594" alt="image" src="https://github.com/user-attachments/assets/cffad0b4-5c31-4e63-afe0-630a94ed8379" />

Here is an image of how the icons currently appear prior to working on this PR.
<img width="871" height="596" alt="image" src="https://github.com/user-attachments/assets/e7a6ca81-5dc5-413d-b9d2-055c00c77ad3" />


