### PR TITLE
Add additional build and sign step for SilentFilesInUseBAFunction

### DIFF
--- a/.pipelines/v2/templates/steps-build-installer-vnext.yml
+++ b/.pipelines/v2/templates/steps-build-installer-vnext.yml
@@ -144,7 +144,7 @@ steps:
         /p:RunBuildEvents=true;PerUser=${{parameters.buildUserInstaller}};RestorePackagesConfig=true;CIBuild=true
         /p:InstallerSuffix=${{ parameters.installerSuffix }}
         -restore -graph
-        /bl:$(LogOutputDirectory)\installer-$(InstallerBuildSlug)-silentfilesinusebafunction.binlog
+        /bl:$(LogOutputDirectory)\installer-$(InstallerBuildSlug)-SilentFilesInUseBAFunction.binlog
         ${{ parameters.additionalBuildOptions }}
       platform: $(BuildPlatform)
       configuration: $(BuildConfiguration)

--- a/.pipelines/v2/templates/steps-build-installer-vnext.yml
+++ b/.pipelines/v2/templates/steps-build-installer-vnext.yml
@@ -163,6 +163,7 @@ steps:
           batchSignPolicyFile: '$(build.sourcesdirectory)\.pipelines\ESRPSigning_installer.json'
           ciPolicyFile: '$(build.sourcesdirectory)\.pipelines\CIPolicy.xml'
 
+  #### END BUILDING AND SIGNING SilentFilesInUseBAFunction DLL
   
   #### BOOTSTRAP BUILDING AND SIGNING
   - task: VSBuild@1

--- a/.pipelines/v2/templates/steps-build-installer-vnext.yml
+++ b/.pipelines/v2/templates/steps-build-installer-vnext.yml
@@ -148,7 +148,7 @@ steps:
         ${{ parameters.additionalBuildOptions }}
       platform: $(BuildPlatform)
       configuration: $(BuildConfiguration)
-      clean: true
+      clean: false # don't undo our hard work above by deleting the msi
       msbuildArchitecture: x64
       maximumCpuCount: true
 

--- a/.pipelines/v2/templates/steps-build-installer-vnext.yml
+++ b/.pipelines/v2/templates/steps-build-installer-vnext.yml
@@ -132,6 +132,38 @@ steps:
           ciPolicyFile: '$(build.sourcesdirectory)\.pipelines\CIPolicy.xml'
 
   #### END MSI
+  
+  #### BUILDING AND SIGNING SilentFilesInUseBAFunction DLL
+  - task: VSBuild@1
+    displayName: ${{replace(replace(parameters.buildUserInstaller,'True','👤'),'False','💻')}} Build SilentFilesInUseBAFunction
+    inputs:
+      solution: "**/installer/PowerToysSetup.sln"
+      vsVersion: 17.0
+      msbuildArgs: >-
+        /t:SilentFilesInUseBAFunction
+        /p:RunBuildEvents=true;PerUser=${{parameters.buildUserInstaller}};RestorePackagesConfig=true;CIBuild=true
+        /p:InstallerSuffix=${{ parameters.installerSuffix }}
+        -restore -graph
+        /bl:$(LogOutputDirectory)\installer-$(InstallerBuildSlug)-silentfilesinusebafunction.binlog
+        ${{ parameters.additionalBuildOptions }}
+      platform: $(BuildPlatform)
+      configuration: $(BuildConfiguration)
+      clean: true
+      msbuildArchitecture: x64
+      maximumCpuCount: true
+
+  - ${{ if eq(parameters.codeSign, true) }}:
+    - template: steps-esrp-signing.yml
+      parameters:
+        displayName: ${{replace(replace(parameters.buildUserInstaller,'True','👤'),'False','💻')}} Sign SilentFilesInUseBAFunction
+        signingIdentity: ${{ parameters.signingIdentity }}
+        inputs:
+          FolderPath: 'installer/$(BuildPlatform)/$(BuildConfiguration)'
+          signType: batchSigning
+          batchSignPolicyFile: '$(build.sourcesdirectory)\.pipelines\ESRPSigning_installer.json'
+          ciPolicyFile: '$(build.sourcesdirectory)\.pipelines\CIPolicy.xml'
+
+  
   #### BOOTSTRAP BUILDING AND SIGNING
   - task: VSBuild@1
     displayName: ${{replace(replace(parameters.buildUserInstaller,'True','👤'),'False','💻')}} Build VNext Bootstrapper
@@ -148,7 +180,7 @@ steps:
         ${{ parameters.additionalBuildOptions }}
       platform: $(BuildPlatform)
       configuration: $(BuildConfiguration)
-      clean: false # don't undo our hard work above by deleting the MSI
+      clean: false # don't undo our hard work above by deleting the MSI nor SilentFilesInUseBAFunction
       msbuildArchitecture: x64
       maximumCpuCount: true
 

--- a/installer/PowerToysSetupVNext/SilentFilesInUseBA/SilentFilesInUseBAFunction.vcxproj
+++ b/installer/PowerToysSetupVNext/SilentFilesInUseBA/SilentFilesInUseBAFunction.vcxproj
@@ -26,6 +26,7 @@
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <TargetName>SilentFilesInUseBAFunction</TargetName>
+    <ProjectName>PowerToysSetupCustomActionsVNext</ProjectName>
     <ProjectModuleDefinitionFile>bafunctions.def</ProjectModuleDefinitionFile>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>

--- a/installer/PowerToysSetupVNext/SilentFilesInUseBA/SilentFilesInUseBAFunction.vcxproj
+++ b/installer/PowerToysSetupVNext/SilentFilesInUseBA/SilentFilesInUseBAFunction.vcxproj
@@ -92,5 +92,31 @@
     </Link>
   </ItemDefinitionGroup>
 
+  <!-- C++ source compile-specific things for Debug/Release configurations -->
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
+    <ClCompile>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Optimization>Disabled</Optimization>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
+    <ClCompile>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Optimization>MaxSpeed</Optimization>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
 </Project>


### PR DESCRIPTION

This pull request adds a new build and signing step for the `SilentFilesInUseBAFunction` DLL in the installer pipeline and makes a minor project configuration update. The main goal is to ensure that this DLL is built and signed as part of the CI process, and that its output is preserved during subsequent build steps.

**Pipeline changes:**

* Added a new build step in `.pipelines/v2/templates/steps-build-installer-vnext.yml` to compile the `SilentFilesInUseBAFunction` target from the `PowerToysSetup.sln` solution, with appropriate MSBuild arguments and logging.
* Introduced a conditional code-signing step for the `SilentFilesInUseBAFunction` DLL, using the existing ESRP signing template and policies.
* Updated the comment for the main installer build step to clarify that it now preserves both the MSI and `SilentFilesInUseBAFunction` outputs.

**Project configuration:**

* Set the `ProjectName` property to `PowerToysSetupCustomActionsVNext` in `SilentFilesInUseBAFunction.vcxproj` for clearer project identification.