### PR TITLE
Enable "Space" only to activate Peek

### DIFF
--- a/src/common/ManagedCommon/Logger.cs
+++ b/src/common/ManagedCommon/Logger.cs
@@ -151,7 +151,9 @@ namespace ManagedCommon
 
         public static void LogDebug(string message, [System.Runtime.CompilerServices.CallerMemberName] string memberName = "", [System.Runtime.CompilerServices.CallerFilePath] string sourceFilePath = "", [System.Runtime.CompilerServices.CallerLineNumber] int sourceLineNumber = 0)
         {
+#if DEBUG
             Log(message, Debug, memberName, sourceFilePath, sourceLineNumber);
+#endif
         }
 
         public static void LogTrace([System.Runtime.CompilerServices.CallerMemberName] string memberName = "", [System.Runtime.CompilerServices.CallerFilePath] string sourceFilePath = "", [System.Runtime.CompilerServices.CallerLineNumber] int sourceLineNumber = 0)

--- a/src/common/ManagedCommon/Logger.cs
+++ b/src/common/ManagedCommon/Logger.cs
@@ -19,7 +19,9 @@ namespace ManagedCommon
         private static readonly string Error = "Error";
         private static readonly string Warning = "Warning";
         private static readonly string Info = "Info";
+#if DEBUG
         private static readonly string Debug = "Debug";
+#endif
         private static readonly string TraceFlag = "Trace";
 
         private static readonly string Version = Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version ?? "Unknown";

--- a/src/modules/peek/Peek.UI/Helpers/FileExplorerHelper.cs
+++ b/src/modules/peek/Peek.UI/Helpers/FileExplorerHelper.cs
@@ -157,7 +157,7 @@ namespace Peek.UI.Helpers
                     }
                     else
                     {
-                        ManagedCommon.Logger.LogInfo($"Peek suppression: focus class{focusClass}");
+                        ManagedCommon.Logger.LogDebug($"Peek suppression: focus class{focusClass}");
                     }
                 }
             }

--- a/src/modules/peek/peek/dllmain.cpp
+++ b/src/modules/peek/peek/dllmain.cpp
@@ -168,8 +168,15 @@ private:
         }
         else
         {
-            Logger::info("Peek settings are empty");
-            set_default_key_settings();
+            // First-run (no existing settings file or empty JSON): default to Space-only activation
+            Logger::info("Peek settings are empty - initializing first-run defaults (Space activation)");
+            m_enableSpaceToActivate = true;
+            m_hotkey.win = false;
+            m_hotkey.alt = false;
+            m_hotkey.shift = false;
+            m_hotkey.ctrl = false;
+            m_hotkey.key = ' ';
+            Trace::SpaceModeEnabled(true);
         }
     }
 

--- a/src/modules/peek/peek/dllmain.cpp
+++ b/src/modules/peek/peek/dllmain.cpp
@@ -649,7 +649,16 @@ public:
                 SetEvent(m_hInvokeEvent);
 
                 Trace::PeekInvoked();
-                return true;
+
+
+                if (spaceMode)
+                {
+                    return false;
+                }
+                else
+                {
+                    return true;
+                }
             }
         }
 

--- a/src/modules/peek/peek/dllmain.cpp
+++ b/src/modules/peek/peek/dllmain.cpp
@@ -77,7 +77,6 @@ private:
     // If we should always try to run Peek non-elevated.
     bool m_alwaysRunNotElevated = true;
     bool m_enableSpaceToActivate = false; // toggle from settings
-    Hotkey m_previousHotkey{}; // stored previous shortcut when forcing space
 
     HANDLE m_hProcess = 0;
     DWORD m_processPid = 0;
@@ -148,7 +147,6 @@ private:
                 }
                 else
                 {
-                    m_previousHotkey = m_hotkey; // stash existing
                     m_hotkey.win = false;
                     m_hotkey.alt = false;
                     m_hotkey.shift = false;
@@ -223,7 +221,7 @@ private:
             if (g_foregroundDebounceTimer)
             {
                 // Best effort: cancel previous pending timer; ignore failure.
-                DeleteTimerQueueTimer(nullptr, g_foregroundDebounceTimer, nullptr);
+                DeleteTimerQueueTimer(nullptr, g_foregroundDebounceTimer, INVALID_HANDLE_VALUE);
                 g_foregroundDebounceTimer = nullptr;
             }
             if (CreateTimerQueueTimer(&g_foregroundDebounceTimer, nullptr, ForegroundDebounceTimerProc, nullptr, FOREGROUND_DEBOUNCE_MS, 0, WT_EXECUTEDEFAULT))
@@ -269,7 +267,7 @@ private:
         }
         if (g_foregroundDebounceTimer)
         {
-            DeleteTimerQueueTimer(nullptr, g_foregroundDebounceTimer, nullptr);
+            DeleteTimerQueueTimer(nullptr, g_foregroundDebounceTimer, INVALID_HANDLE_VALUE);
             g_foregroundDebounceTimer = nullptr;
         }
         g_foregroundLastScheduleTick.store(0, std::memory_order_relaxed);

--- a/src/modules/peek/peek/dllmain.cpp
+++ b/src/modules/peek/peek/dllmain.cpp
@@ -481,7 +481,6 @@ public:
     Peek()
     {
         LoggerHelpers::init_logger(MODULE_NAME, L"ModuleInterface", "Peek");
-        g_instance = this;
         init_settings();
 
         m_hInvokeEvent = CreateDefaultEvent(CommonSharedConstants::SHOW_PEEK_SHARED_EVENT);
@@ -495,10 +494,6 @@ public:
         }
         m_enabled = false;
         uninstall_foreground_hook();
-        if (g_instance == this)
-        {
-            g_instance = nullptr;
-        }
     };
 
     // Destroy the powertoy and free memory

--- a/src/modules/peek/peek/trace.cpp
+++ b/src/modules/peek/peek/trace.cpp
@@ -48,3 +48,22 @@ void Trace::SettingsTelemetry(PowertoyModuleIface::Hotkey& hotkey) noexcept
         TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE),
         TraceLoggingWideString(hotKeyStr.c_str(), "HotKey"));
 }
+
+void Trace::SpaceModeEnabled(bool enabled) noexcept
+{
+    TraceLoggingWriteWrapper(
+        g_hProvider,
+        "Peek_SpaceModeEnabled",
+        ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
+        TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE),
+        TraceLoggingBoolean(enabled, "Enabled"));
+}
+
+void Trace::SpaceModeRejected() noexcept
+{
+    TraceLoggingWriteWrapper(
+        g_hProvider,
+        "Peek_SpaceModeRejected",
+        ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
+        TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));
+}

--- a/src/modules/peek/peek/trace.cpp
+++ b/src/modules/peek/peek/trace.cpp
@@ -58,12 +58,3 @@ void Trace::SpaceModeEnabled(bool enabled) noexcept
         TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE),
         TraceLoggingBoolean(enabled, "Enabled"));
 }
-
-void Trace::SpaceModeRejected() noexcept
-{
-    TraceLoggingWriteWrapper(
-        g_hProvider,
-        "Peek_SpaceModeRejected",
-        ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
-        TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));
-}

--- a/src/modules/peek/peek/trace.h
+++ b/src/modules/peek/peek/trace.h
@@ -13,12 +13,9 @@ public:
     static void PeekInvoked() noexcept;
 
     // Event to send settings telemetry.
-    static void SettingsTelemetry(PowertoyModuleIface::Hotkey& hotkey) noexcept;
+    static void Trace::SettingsTelemetry(PowertoyModuleIface::Hotkey& hotkey) noexcept;
 
-    // Log when space mode toggle state changes.
+    // Space mode telemetry (single-key activation toggle)
     static void SpaceModeEnabled(bool enabled) noexcept;
-
-    // Log a rejection in space mode due to ineligible foreground (debounced fast exit).
-    static void SpaceModeRejected() noexcept;
 
 };

--- a/src/modules/peek/peek/trace.h
+++ b/src/modules/peek/peek/trace.h
@@ -13,6 +13,12 @@ public:
     static void PeekInvoked() noexcept;
 
     // Event to send settings telemetry.
-    static void Trace::SettingsTelemetry(PowertoyModuleIface::Hotkey& hotkey) noexcept;
+    static void SettingsTelemetry(PowertoyModuleIface::Hotkey& hotkey) noexcept;
+
+    // Log when space mode toggle state changes.
+    static void SpaceModeEnabled(bool enabled) noexcept;
+
+    // Log a rejection in space mode due to ineligible foreground (debounced fast exit).
+    static void SpaceModeRejected() noexcept;
 
 };

--- a/src/settings-ui/Settings.UI.Library/PeekProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/PeekProperties.cs
@@ -19,7 +19,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             AlwaysRunNotElevated = new BoolProperty(true);
             CloseAfterLosingFocus = new BoolProperty(false);
             ConfirmFileDelete = new BoolProperty(true);
-            EnableSpaceToActivate = new BoolProperty(false);
+            EnableSpaceToActivate = new BoolProperty(true); // Toggle is ON by default for new users. No impact on existing users.
         }
 
         public HotkeySettings ActivationShortcut { get; set; }
@@ -30,7 +30,6 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 
         public BoolProperty ConfirmFileDelete { get; set; }
 
-        // Opt-in single-space activation toggle; when true activation shortcut is forced to space.
         public BoolProperty EnableSpaceToActivate { get; set; }
 
         public override string ToString() => JsonSerializer.Serialize(this);

--- a/src/settings-ui/Settings.UI.Library/PeekProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/PeekProperties.cs
@@ -19,6 +19,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             AlwaysRunNotElevated = new BoolProperty(true);
             CloseAfterLosingFocus = new BoolProperty(false);
             ConfirmFileDelete = new BoolProperty(true);
+            EnableSpaceToActivate = new BoolProperty(false);
         }
 
         public HotkeySettings ActivationShortcut { get; set; }
@@ -28,6 +29,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         public BoolProperty CloseAfterLosingFocus { get; set; }
 
         public BoolProperty ConfirmFileDelete { get; set; }
+
+        // Opt-in single-space activation toggle; when true activation shortcut is forced to space.
+        public BoolProperty EnableSpaceToActivate { get; set; }
 
         public override string ToString() => JsonSerializer.Serialize(this);
     }

--- a/src/settings-ui/Settings.UI.Library/PeekSettings.cs
+++ b/src/settings-ui/Settings.UI.Library/PeekSettings.cs
@@ -15,7 +15,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library
     public class PeekSettings : BasePTModuleSettings, ISettingsConfig, IHotkeyConfig
     {
         public const string ModuleName = "Peek";
-        public const string ModuleVersion = "0.0.1";
+        public const string InitialModuleVersion = "0.0.1";
+        public const string SpaceActivationIntroducedVersion = "0.0.2";
+        public const string CurrentModuleVersion = SpaceActivationIntroducedVersion;
 
         private static readonly JsonSerializerOptions _serializerOptions = new JsonSerializerOptions
         {
@@ -28,7 +30,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         public PeekSettings()
         {
             Name = ModuleName;
-            Version = ModuleVersion;
+            Version = CurrentModuleVersion;
             Properties = new PeekProperties();
         }
 
@@ -54,6 +56,14 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 
         public bool UpgradeSettingsConfiguration()
         {
+            if (string.IsNullOrEmpty(Version) ||
+                Version.Equals(InitialModuleVersion, StringComparison.OrdinalIgnoreCase))
+            {
+                Version = CurrentModuleVersion;
+                Properties.EnableSpaceToActivate.Value = false;
+                return true;
+            }
+
             return false;
         }
 

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/PeekPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/PeekPage.xaml
@@ -24,24 +24,18 @@
                 </controls:GPOInfoControl>
 
                 <controls:SettingsGroup x:Uid="Peek_Activation_GroupSettings" IsEnabled="{x:Bind ViewModel.IsEnabled, Mode=OneWay}">
-                    <tkcontrols:SettingsCard
-                        Name="EnableSpaceMode"
-                        x:Uid="Peek_EnableSpaceMode"
-                        HeaderIcon="{ui:FontIcon Glyph=&#xECA5;}">
-                        <ToggleSwitch IsOn="{x:Bind ViewModel.EnableSpaceToActivate, Mode=TwoWay}" />
+                    <tkcontrols:SettingsCard x:Uid="Peek_ActivationMethod">
+                        <ComboBox SelectedIndex="{x:Bind ViewModel.EnableSpaceToActivate, Mode=TwoWay, Converter={StaticResource BoolToComboBoxIndexConverter}}">
+                            <ComboBoxItem x:Uid="Peek_ActivationMethod_CustomizedShortcut" />
+                            <ComboBoxItem x:Uid="Peek_ActivationMethod_SpaceBar" />
+                        </ComboBox>
                     </tkcontrols:SettingsCard>
                     <tkcontrols:SettingsCard
                         Name="ActivationShortcut"
                         x:Uid="Activation_Shortcut"
-                        HeaderIcon="{ui:FontIcon Glyph=&#xEDA7;}">
-                        <controls:ShortcutControl
-                            MinWidth="{StaticResource SettingActionControlMinWidth}"
-                            HotkeySettings="{x:Bind Path=ViewModel.ActivationShortcut, Mode=TwoWay}"
-                            IsEnabled="{x:Bind ViewModel.IsActivationShortcutLocked, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}">
-                            <ToolTipService.ToolTip>
-                                <ToolTip x:Uid="Peek_SpaceShortcutLocked" />
-                            </ToolTipService.ToolTip>
-                        </controls:ShortcutControl>
+                        HeaderIcon="{ui:FontIcon Glyph=&#xEDA7;}"
+                        Visibility="{x:Bind ViewModel.EnableSpaceToActivate, Mode=OneWay, Converter={StaticResource ReverseBoolToVisibilityConverter}}">
+                        <controls:ShortcutControl MinWidth="{StaticResource SettingActionControlMinWidth}" HotkeySettings="{x:Bind Path=ViewModel.ActivationShortcut, Mode=TwoWay}" />
                     </tkcontrols:SettingsCard>
                 </controls:SettingsGroup>
                 <controls:SettingsGroup x:Uid="Peek_BehaviorHeader" IsEnabled="{x:Bind ViewModel.IsEnabled, Mode=OneWay}">

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/PeekPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/PeekPage.xaml
@@ -24,10 +24,22 @@
                 </controls:GPOInfoControl>
                 <controls:SettingsGroup x:Uid="Peek_Activation_GroupSettings" IsEnabled="{x:Bind ViewModel.IsEnabled, Mode=OneWay}">
                     <tkcontrols:SettingsCard
+                        Name="EnableSpaceMode"
+                        x:Uid="Peek_EnableSpaceMode"
+                        HeaderIcon="{ui:FontIcon Glyph=&#xECA5;}">
+                        <ToggleSwitch IsOn="{x:Bind ViewModel.EnableSpaceToActivate, Mode=TwoWay}" />
+                    </tkcontrols:SettingsCard>
+                    <tkcontrols:SettingsCard
                         Name="ActivationShortcut"
                         x:Uid="Activation_Shortcut"
                         HeaderIcon="{ui:FontIcon Glyph=&#xEDA7;}">
-                        <controls:ShortcutControl MinWidth="{StaticResource SettingActionControlMinWidth}" HotkeySettings="{x:Bind Path=ViewModel.ActivationShortcut, Mode=TwoWay}" />
+                        <controls:ShortcutControl MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                                   HotkeySettings="{x:Bind Path=ViewModel.ActivationShortcut, Mode=TwoWay}"
+                                                   IsEnabled="{x:Bind ViewModel.IsActivationShortcutLocked, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}">
+                            <ToolTipService.ToolTip>
+                                <ToolTip x:Uid="Peek_SpaceShortcutLocked" />
+                            </ToolTipService.ToolTip>
+                        </controls:ShortcutControl>
                     </tkcontrols:SettingsCard>
                 </controls:SettingsGroup>
                 <controls:SettingsGroup x:Uid="Peek_BehaviorHeader" IsEnabled="{x:Bind ViewModel.IsEnabled, Mode=OneWay}">

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/PeekPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/PeekPage.xaml
@@ -14,22 +14,14 @@
     <controls:SettingsPageControl x:Uid="Peek" ModuleImageSource="ms-appx:///Assets/Settings/Modules/Peek.png">
         <controls:SettingsPageControl.ModuleContent>
             <StackPanel Orientation="Vertical">
-                <tkcontrols:SettingsCard
-                    Name="PeekEnablePeek"
-                    x:Uid="Peek_EnablePeek"
-                    HeaderIcon="{ui:BitmapIcon Source=/Assets/Settings/Icons/Peek.png}"
-                    IsEnabled="{x:Bind ViewModel.IsEnabledGpoConfigured, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}">
-                    <ToggleSwitch IsOn="{x:Bind ViewModel.IsEnabled, Mode=TwoWay}" />
-                </tkcontrols:SettingsCard>
-                <InfoBar
-                    x:Uid="GPO_SettingIsManaged"
-                    IsClosable="False"
-                    IsTabStop="{x:Bind ViewModel.IsEnabledGpoConfigured, Mode=OneWay}"
-                    Severity="Informational">
-                    <InfoBar.IconSource>
-                        <FontIconSource FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE72E;" />
-                    </InfoBar.IconSource>
-                </InfoBar>
+                <controls:GPOInfoControl ShowWarning="{x:Bind ViewModel.IsEnabledGpoConfigured, Mode=OneWay}">
+                    <tkcontrols:SettingsCard
+                        Name="PeekEnablePeek"
+                        x:Uid="Peek_EnablePeek"
+                        HeaderIcon="{ui:BitmapIcon Source=/Assets/Settings/Icons/Peek.png}">
+                        <ToggleSwitch IsOn="{x:Bind ViewModel.IsEnabled, Mode=TwoWay}" />
+                    </tkcontrols:SettingsCard>
+                </controls:GPOInfoControl>
 
                 <controls:SettingsGroup x:Uid="Peek_Activation_GroupSettings" IsEnabled="{x:Bind ViewModel.IsEnabled, Mode=OneWay}">
                     <tkcontrols:SettingsCard

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/PeekPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/PeekPage.xaml
@@ -42,9 +42,10 @@
                         Name="ActivationShortcut"
                         x:Uid="Activation_Shortcut"
                         HeaderIcon="{ui:FontIcon Glyph=&#xEDA7;}">
-                        <controls:ShortcutControl MinWidth="{StaticResource SettingActionControlMinWidth}"
-                                                   HotkeySettings="{x:Bind Path=ViewModel.ActivationShortcut, Mode=TwoWay}"
-                                                   IsEnabled="{x:Bind ViewModel.IsActivationShortcutLocked, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}">
+                        <controls:ShortcutControl
+                            MinWidth="{StaticResource SettingActionControlMinWidth}"
+                            HotkeySettings="{x:Bind Path=ViewModel.ActivationShortcut, Mode=TwoWay}"
+                            IsEnabled="{x:Bind ViewModel.IsActivationShortcutLocked, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}">
                             <ToolTipService.ToolTip>
                                 <ToolTip x:Uid="Peek_SpaceShortcutLocked" />
                             </ToolTipService.ToolTip>

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/PeekPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/PeekPage.xaml
@@ -14,14 +14,23 @@
     <controls:SettingsPageControl x:Uid="Peek" ModuleImageSource="ms-appx:///Assets/Settings/Modules/Peek.png">
         <controls:SettingsPageControl.ModuleContent>
             <StackPanel Orientation="Vertical">
-                <controls:GPOInfoControl ShowWarning="{x:Bind ViewModel.IsEnabledGpoConfigured, Mode=OneWay}">
-                    <tkcontrols:SettingsCard
-                        Name="PeekEnablePeek"
-                        x:Uid="Peek_EnablePeek"
-                        HeaderIcon="{ui:BitmapIcon Source=/Assets/Settings/Icons/Peek.png}">
-                        <ToggleSwitch IsOn="{x:Bind ViewModel.IsEnabled, Mode=TwoWay}" />
-                    </tkcontrols:SettingsCard>
-                </controls:GPOInfoControl>
+                <tkcontrols:SettingsCard
+                    Name="PeekEnablePeek"
+                    x:Uid="Peek_EnablePeek"
+                    HeaderIcon="{ui:BitmapIcon Source=/Assets/Settings/Icons/Peek.png}"
+                    IsEnabled="{x:Bind ViewModel.IsEnabledGpoConfigured, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}">
+                    <ToggleSwitch IsOn="{x:Bind ViewModel.IsEnabled, Mode=TwoWay}" />
+                </tkcontrols:SettingsCard>
+                <InfoBar
+                    x:Uid="GPO_SettingIsManaged"
+                    IsClosable="False"
+                    IsTabStop="{x:Bind ViewModel.IsEnabledGpoConfigured, Mode=OneWay}"
+                    Severity="Informational">
+                    <InfoBar.IconSource>
+                        <FontIconSource FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE72E;" />
+                    </InfoBar.IconSource>
+                </InfoBar>
+
                 <controls:SettingsGroup x:Uid="Peek_Activation_GroupSettings" IsEnabled="{x:Bind ViewModel.IsEnabled, Mode=OneWay}">
                     <tkcontrols:SettingsCard
                         Name="EnableSpaceMode"

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -639,17 +639,17 @@ opera.exe</value>
     <value>Additional actions</value>
   </data>
   <data name="RemapKeysList.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Current key remappings</value>
+    <value>Current Key Remappings</value>
   </data>
   <data name="RemapShortcutsList.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Current shortcut remappings</value>
+    <value>Current Shortcut Remappings</value>
   </data>
   <data name="KeyboardManager_RemappedKeysListItem.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Key remapping</value>
+    <value>Key Remapping</value>
     <comment>key as in keyboard key</comment>
   </data>
   <data name="KeyboardManager_RemappedShortcutsListItem.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Shortcut remapping</value>
+    <value>Shortcut Remapping</value>
   </data>
   <data name="KeyboardManager_RemappedTo.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Remapped to</value>
@@ -658,7 +658,7 @@ opera.exe</value>
     <value>Remapped to</value>
   </data>
   <data name="KeyboardManager_TargetApp.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>For target application</value>
+    <value>For Target Application</value>
     <comment>What computer application would this be for</comment>
   </data>
   <data name="KeyboardManager_Image.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
@@ -3154,15 +3154,14 @@ Right-click to remove the key combination, thereby deactivating the shortcut.</v
   </data>
   <data name="Peek_EnableSpaceMode.Header" xml:space="preserve">
     <value>Enable single Space key activation</value>
-    <comment>Header for toggle that forces activation shortcut to Space</comment>
+    <comment>Toggle to force activation shortcut to Space key only</comment>
   </data>
   <data name="Peek_EnableSpaceMode.Description" xml:space="preserve">
-    <value>Use the Space key alone to activate Peek when File Explorer or Desktop is focused. Other contexts are ignored.</value>
-    <comment>Describes scope limitation of Space-only activation for Peek</comment>
+    <value>Use only the Space key to open Peek when File Explorer or the Desktop is focused. Other apps are ignored.</value>
   </data>
-  <data name="Peek_SpaceShortcutLocked.Description" xml:space="preserve">
-    <value>Shortcut locked to Space while single key activation is enabled</value>
-    <comment>Tooltip shown when activation shortcut control is disabled due to Space mode</comment>
+  <data name="Peek_SpaceShortcutLocked.Content" xml:space="preserve">
+    <value>Shortcut locked while single Space activation is enabled</value>
+    <comment>Tooltip shown for disabled activation shortcut control</comment>
   </data>
   <data name="FancyZones_DisableRoundCornersOnWindowSnap.Content" xml:space="preserve">
     <value>Disable rounded corners when a window is snapped</value>
@@ -4417,7 +4416,7 @@ Activate by holding the key for the character you want to add an accent to, then
     <value>Show minimap</value>
   </data>
   <data name="PrivacyLink.Text" xml:space="preserve">
-    <value>OpenAI privacy</value>
+    <value>OpenAI Privacy</value>
   </data>
   <data name="TermsLink.Text" xml:space="preserve">
     <value>OpenAI Terms</value>
@@ -4638,7 +4637,7 @@ Activate by holding the key for the character you want to add an accent to, then
 Copy a zoomed screen with Ctrl+C or save it by typing Ctrl+S. Crop the copy or save region by entering Ctrl+Shift instead of Ctrl.</value>
   </data>
   <data name="ZoomIt_Zoom_Shortcut.Header" xml:space="preserve">
-    <value>Zoom hotkey</value>
+    <value>Zoom Toggle Hotkey</value>
   </data>
   <data name="ZoomIt_Toggle_AnimateZoom.Header" xml:space="preserve">
     <value>Animate zoom in and zoom out</value>
@@ -4659,7 +4658,7 @@ Use LiveDraw to draw and annotate the live desktop. To activate LiveDraw, enter 
 To enter and exit LiveZoom, enter the hotkey specified below.</value>
   </data>
   <data name="ZoomIt_LiveZoom_Shortcut.Header" xml:space="preserve">
-    <value>Live Zoom hotkey</value>
+    <value>Live Zoom Toggle Hotkey</value>
   </data>
   <data name="ZoomIt_DrawGroup.Header" xml:space="preserve">
     <value>Draw</value>
@@ -4678,7 +4677,7 @@ Shapes - Draw a line by holding down the Shift key, a rectangle with the Ctrl ke
 Screen - Clear the screen for a sketch pad by pressing W (white) or K (black). Copy a zoomed screen with Ctrl+C or save it by typing Ctrl+S. Crop the copy or save region by entering Ctrl+Shift instead of Ctrl.</value>
   </data>
   <data name="ZoomIt_Draw_Shortcut.Header" xml:space="preserve">
-    <value>Draw without zoom hotkey</value>
+    <value>Draw without Zoom Hotkey</value>
   </data>
   <data name="ZoomIt_TypeGroup.Header" xml:space="preserve">
     <value>Type</value>
@@ -4692,11 +4691,11 @@ The text color is the current drawing color.</value>
     <value>Text font</value>
   </data>
   <data name="ZoomIt_Type_Font_Button.Content" xml:space="preserve">
-    <value>Choose font</value>
+    <value>Choose Font</value>
     <comment>Font refers to text font</comment>
   </data>
   <data name="ZoomIt_DemoTypeGroup.Header" xml:space="preserve">
-    <value>DemoType</value>
+    <value>Demo Type</value>
   </data>
   <data name="ZoomIt_DemoTypeGroup.Description" xml:space="preserve">
     <value>Use DemoType to have ZoomIt type text specified in the input file when you enter the DemoType toggle. You can also pull input from the clipboard if it is prefixed with the [start] keyword.
@@ -4710,7 +4709,7 @@ When driving input, hit the space bar to unblock keyboard input at the end of a 
 When you reach the end of the file, ZoomIt will reload the file and start at the beginning. Enter the hotkey with the Shift key in the opposite mode to step back to the last [end].</value>
   </data>
   <data name="ZoomIt_DemoType_Shortcut.Header" xml:space="preserve">
-    <value>DemoType toggle hotkey</value>
+    <value>Demo Type Toggle Hotkey</value>
   </data>
   <data name="ZoomIt_DemoType_File.Header" xml:space="preserve">
     <value>Input file</value>
@@ -4719,7 +4718,7 @@ When you reach the end of the file, ZoomIt will reload the file and start at the
     <value>Browse</value>
   </data>
   <data name="ZoomIt_DemoType_File_Picker_Dialog_Title" xml:space="preserve">
-    <value>Specify DemoType file..</value>
+    <value>Specify DemoType file...</value>
   </data>
   <data name="FilePicker_AllFilesFilter" xml:space="preserve">
     <value>All Files</value>
@@ -4742,19 +4741,19 @@ When you reach the end of the file, ZoomIt will reload the file and start at the
 Change the break timer color using the same keys that the drawing color. The break timer font is the same as text font.</value>
   </data>
   <data name="ZoomIt_Break_Shortcut.Header" xml:space="preserve">
-    <value>Start break timer hotkey</value>
+    <value>Start Break Timer Hotkey</value>
   </data>
   <data name="ZoomIt_Break_Timeout.Header" xml:space="preserve">
     <value>Timer (minutes)</value>
   </data>
   <data name="ZoomIt_Break_ShowExpiredTime.Header" xml:space="preserve">
-    <value>Show time elapsed after expiration</value>
+    <value>Show Time Elapsed After Expiration</value>
   </data>
   <data name="ZoomIt_Break_PlaySoundsFile.Header" xml:space="preserve">
-    <value>Play sound on expiration</value>
+    <value>Play Sound on Expiration</value>
   </data>
   <data name="ZoomIt_Break_SoundFile.Header" xml:space="preserve">
-    <value>Alarm sound file</value>
+    <value>Alarm Sound File</value>
   </data>
   <data name="ZoomIt_Break_SoundFile_BrowseButton.Content" xml:space="preserve">
     <value>Browse</value>
@@ -4766,7 +4765,7 @@ Change the break timer color using the same keys that the drawing color. The bre
     <value>Sounds</value>
   </data>
   <data name="ZoomIt_Break_TimerOpacity.Header" xml:space="preserve">
-    <value>Timer opacity</value>
+    <value>Timer Opacity</value>
   </data>
   <data name="ZoomIt_Break_TimerOpacity_10Percent.Content" xml:space="preserve">
     <value>10%</value>
@@ -4799,7 +4798,7 @@ Change the break timer color using the same keys that the drawing color. The bre
     <value>100%</value>
   </data>
   <data name="ZoomIt_Break_TimerPosition.Header" xml:space="preserve">
-    <value>Timer position</value>
+    <value>Timer Position</value>
   </data>
   <data name="ZoomIt_Break_TimerPosition_TopLeftCorner.Content" xml:space="preserve">
     <value>Top left corner</value>
@@ -4829,7 +4828,7 @@ Change the break timer color using the same keys that the drawing color. The bre
     <value>Bottom right corner</value>
   </data>
   <data name="ZoomIt_Break_ShowBackgroundBitmap.Header" xml:space="preserve">
-    <value>Show background bitmap</value>
+    <value>Show Background Bitmap</value>
   </data>
   <data name="ZoomIt_Break_ShowFadedDesktop.Content" xml:space="preserve">
     <value>Use faded desktop as background</value>
@@ -4838,7 +4837,7 @@ Change the break timer color using the same keys that the drawing color. The bre
     <value>Use image file as background</value>
   </data>
   <data name="ZoomIt_Break_BackgroundFile.Header" xml:space="preserve">
-    <value>Background image file</value>
+    <value>Background Image File</value>
   </data>
   <data name="ZoomIt_Break_BackgroundFile_BrowseButton.Content" xml:space="preserve">
     <value>Browse</value>
@@ -4859,14 +4858,14 @@ Change the break timer color using the same keys that the drawing color. The bre
     <value>Record</value>
   </data>
   <data name="ZoomIt_RecordGroup.Description" xml:space="preserve">
-    <value>Record video of the unzoomed live screen or a static zoomed session by entering the recording hotkey and finish the recording by entering it again.
+    <value>Record video of the unzoomed live screen or a static zoomed session by entering the recording hot key and finish the recording by entering it again.
 
 To crop the portion of the screen that will be recorded, enter the hotkey with the Shift key in the opposite mode.
 
 To record a specific window, enter the hotkey with the Alt key in the opposite mode.</value>
   </data>
   <data name="ZoomIt_Record_Shortcut.Header" xml:space="preserve">
-    <value>Record hotkey</value>
+    <value>Record Toggle Hotkey</value>
   </data>
   <data name="ZoomIt_Record_Scaling.Header" xml:space="preserve">
     <value>Scaling</value>
@@ -4887,7 +4886,7 @@ To record a specific window, enter the hotkey with the Alt key in the opposite m
     <value>Copy a region of the screen to the clipboard or enter the hotkey with the Shift key in the opposite mode to save it to a file.</value>
   </data>
   <data name="ZoomIt_Snip_Shortcut.Header" xml:space="preserve">
-    <value>Snip hotkey</value>
+    <value>Snip Toggle Hotkey</value>
   </data>
   <data name="Oobe_ZoomIt.Description" xml:space="preserve">
     <value>ZoomIt is a screen zoom, annotation, and recording tool for technical presentations and demos. You can also use ZoomIt to snip screenshots to the clipboard or to a file.</value>
@@ -5004,7 +5003,7 @@ To record a specific window, enter the hotkey with the Alt key in the opposite m
     <value>File Management</value>
   </data>
   <data name="Shell_TopLevelInputOutput.Content" xml:space="preserve">
-    <value>Input &amp; Output</value>
+    <value>Input / Output</value>
   </data>
   <data name="Shell_TopLevelWindowsAndLayouts.Content" xml:space="preserve">
     <value>Windowing &amp; Layouts</value>
@@ -5157,7 +5156,7 @@ To record a specific window, enter the hotkey with the Alt key in the opposite m
     <value>Quick access</value>
   </data>
   <data name="ShortcutsOverview.Title" xml:space="preserve">
-    <value>Shortcuts</value>
+    <value>Shortcuts overview</value>
   </data>
   <data name="NoActionsToShow.Text" xml:space="preserve">
     <value>No actions to show..</value>
@@ -5307,8 +5306,5 @@ To record a specific window, enter the hotkey with the Alt key in the opposite m
   <data name="Search_ResultsFor" xml:space="preserve">
     <value>Results for</value>
     <comment>Prefix for search string. E.g. "Results for 'shortcut'"</comment>
-  </data>
-  <data name="UtilitiesHeader.Title" xml:space="preserve">
-    <value>Utilities</value>
   </data>
 </root>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -639,17 +639,17 @@ opera.exe</value>
     <value>Additional actions</value>
   </data>
   <data name="RemapKeysList.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Current Key Remappings</value>
+    <value>Current key remappings</value>
   </data>
   <data name="RemapShortcutsList.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Current Shortcut Remappings</value>
+    <value>Current shortcut remappings</value>
   </data>
   <data name="KeyboardManager_RemappedKeysListItem.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Key Remapping</value>
+    <value>Key remapping</value>
     <comment>key as in keyboard key</comment>
   </data>
   <data name="KeyboardManager_RemappedShortcutsListItem.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Shortcut Remapping</value>
+    <value>Shortcut remapping</value>
   </data>
   <data name="KeyboardManager_RemappedTo.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Remapped to</value>
@@ -658,7 +658,7 @@ opera.exe</value>
     <value>Remapped to</value>
   </data>
   <data name="KeyboardManager_TargetApp.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>For Target Application</value>
+    <value>For target application</value>
     <comment>What computer application would this be for</comment>
   </data>
   <data name="KeyboardManager_Image.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
@@ -4416,7 +4416,7 @@ Activate by holding the key for the character you want to add an accent to, then
     <value>Show minimap</value>
   </data>
   <data name="PrivacyLink.Text" xml:space="preserve">
-    <value>OpenAI Privacy</value>
+    <value>OpenAI privacy</value>
   </data>
   <data name="TermsLink.Text" xml:space="preserve">
     <value>OpenAI Terms</value>
@@ -4637,7 +4637,7 @@ Activate by holding the key for the character you want to add an accent to, then
 Copy a zoomed screen with Ctrl+C or save it by typing Ctrl+S. Crop the copy or save region by entering Ctrl+Shift instead of Ctrl.</value>
   </data>
   <data name="ZoomIt_Zoom_Shortcut.Header" xml:space="preserve">
-    <value>Zoom Toggle Hotkey</value>
+    <value>Zoom hotkey</value>
   </data>
   <data name="ZoomIt_Toggle_AnimateZoom.Header" xml:space="preserve">
     <value>Animate zoom in and zoom out</value>
@@ -4658,7 +4658,7 @@ Use LiveDraw to draw and annotate the live desktop. To activate LiveDraw, enter 
 To enter and exit LiveZoom, enter the hotkey specified below.</value>
   </data>
   <data name="ZoomIt_LiveZoom_Shortcut.Header" xml:space="preserve">
-    <value>Live Zoom Toggle Hotkey</value>
+    <value>Live Zoom hotkey</value>
   </data>
   <data name="ZoomIt_DrawGroup.Header" xml:space="preserve">
     <value>Draw</value>
@@ -4677,7 +4677,7 @@ Shapes - Draw a line by holding down the Shift key, a rectangle with the Ctrl ke
 Screen - Clear the screen for a sketch pad by pressing W (white) or K (black). Copy a zoomed screen with Ctrl+C or save it by typing Ctrl+S. Crop the copy or save region by entering Ctrl+Shift instead of Ctrl.</value>
   </data>
   <data name="ZoomIt_Draw_Shortcut.Header" xml:space="preserve">
-    <value>Draw without Zoom Hotkey</value>
+    <value>Draw without zoom hotkey</value>
   </data>
   <data name="ZoomIt_TypeGroup.Header" xml:space="preserve">
     <value>Type</value>
@@ -4691,11 +4691,11 @@ The text color is the current drawing color.</value>
     <value>Text font</value>
   </data>
   <data name="ZoomIt_Type_Font_Button.Content" xml:space="preserve">
-    <value>Choose Font</value>
+    <value>Choose font</value>
     <comment>Font refers to text font</comment>
   </data>
   <data name="ZoomIt_DemoTypeGroup.Header" xml:space="preserve">
-    <value>Demo Type</value>
+    <value>DemoType</value>
   </data>
   <data name="ZoomIt_DemoTypeGroup.Description" xml:space="preserve">
     <value>Use DemoType to have ZoomIt type text specified in the input file when you enter the DemoType toggle. You can also pull input from the clipboard if it is prefixed with the [start] keyword.
@@ -4709,7 +4709,7 @@ When driving input, hit the space bar to unblock keyboard input at the end of a 
 When you reach the end of the file, ZoomIt will reload the file and start at the beginning. Enter the hotkey with the Shift key in the opposite mode to step back to the last [end].</value>
   </data>
   <data name="ZoomIt_DemoType_Shortcut.Header" xml:space="preserve">
-    <value>Demo Type Toggle Hotkey</value>
+    <value>DemoType toggle hotkey</value>
   </data>
   <data name="ZoomIt_DemoType_File.Header" xml:space="preserve">
     <value>Input file</value>
@@ -4718,7 +4718,7 @@ When you reach the end of the file, ZoomIt will reload the file and start at the
     <value>Browse</value>
   </data>
   <data name="ZoomIt_DemoType_File_Picker_Dialog_Title" xml:space="preserve">
-    <value>Specify DemoType file...</value>
+    <value>Specify DemoType file..</value>
   </data>
   <data name="FilePicker_AllFilesFilter" xml:space="preserve">
     <value>All Files</value>
@@ -4741,19 +4741,19 @@ When you reach the end of the file, ZoomIt will reload the file and start at the
 Change the break timer color using the same keys that the drawing color. The break timer font is the same as text font.</value>
   </data>
   <data name="ZoomIt_Break_Shortcut.Header" xml:space="preserve">
-    <value>Start Break Timer Hotkey</value>
+    <value>Start break timer hotkey</value>
   </data>
   <data name="ZoomIt_Break_Timeout.Header" xml:space="preserve">
     <value>Timer (minutes)</value>
   </data>
   <data name="ZoomIt_Break_ShowExpiredTime.Header" xml:space="preserve">
-    <value>Show Time Elapsed After Expiration</value>
+    <value>Show time elapsed after expiration</value>
   </data>
   <data name="ZoomIt_Break_PlaySoundsFile.Header" xml:space="preserve">
-    <value>Play Sound on Expiration</value>
+    <value>Play sound on expiration</value>
   </data>
   <data name="ZoomIt_Break_SoundFile.Header" xml:space="preserve">
-    <value>Alarm Sound File</value>
+    <value>Alarm sound file</value>
   </data>
   <data name="ZoomIt_Break_SoundFile_BrowseButton.Content" xml:space="preserve">
     <value>Browse</value>
@@ -4765,7 +4765,7 @@ Change the break timer color using the same keys that the drawing color. The bre
     <value>Sounds</value>
   </data>
   <data name="ZoomIt_Break_TimerOpacity.Header" xml:space="preserve">
-    <value>Timer Opacity</value>
+    <value>Timer opacity</value>
   </data>
   <data name="ZoomIt_Break_TimerOpacity_10Percent.Content" xml:space="preserve">
     <value>10%</value>
@@ -4798,7 +4798,7 @@ Change the break timer color using the same keys that the drawing color. The bre
     <value>100%</value>
   </data>
   <data name="ZoomIt_Break_TimerPosition.Header" xml:space="preserve">
-    <value>Timer Position</value>
+    <value>Timer position</value>
   </data>
   <data name="ZoomIt_Break_TimerPosition_TopLeftCorner.Content" xml:space="preserve">
     <value>Top left corner</value>
@@ -4828,7 +4828,7 @@ Change the break timer color using the same keys that the drawing color. The bre
     <value>Bottom right corner</value>
   </data>
   <data name="ZoomIt_Break_ShowBackgroundBitmap.Header" xml:space="preserve">
-    <value>Show Background Bitmap</value>
+    <value>Show background bitmap</value>
   </data>
   <data name="ZoomIt_Break_ShowFadedDesktop.Content" xml:space="preserve">
     <value>Use faded desktop as background</value>
@@ -4837,7 +4837,7 @@ Change the break timer color using the same keys that the drawing color. The bre
     <value>Use image file as background</value>
   </data>
   <data name="ZoomIt_Break_BackgroundFile.Header" xml:space="preserve">
-    <value>Background Image File</value>
+    <value>Background image file</value>
   </data>
   <data name="ZoomIt_Break_BackgroundFile_BrowseButton.Content" xml:space="preserve">
     <value>Browse</value>
@@ -4858,14 +4858,14 @@ Change the break timer color using the same keys that the drawing color. The bre
     <value>Record</value>
   </data>
   <data name="ZoomIt_RecordGroup.Description" xml:space="preserve">
-    <value>Record video of the unzoomed live screen or a static zoomed session by entering the recording hot key and finish the recording by entering it again.
+    <value>Record video of the unzoomed live screen or a static zoomed session by entering the recording hotkey and finish the recording by entering it again.
 
 To crop the portion of the screen that will be recorded, enter the hotkey with the Shift key in the opposite mode.
 
 To record a specific window, enter the hotkey with the Alt key in the opposite mode.</value>
   </data>
   <data name="ZoomIt_Record_Shortcut.Header" xml:space="preserve">
-    <value>Record Toggle Hotkey</value>
+    <value>Record hotkey</value>
   </data>
   <data name="ZoomIt_Record_Scaling.Header" xml:space="preserve">
     <value>Scaling</value>
@@ -4886,7 +4886,7 @@ To record a specific window, enter the hotkey with the Alt key in the opposite m
     <value>Copy a region of the screen to the clipboard or enter the hotkey with the Shift key in the opposite mode to save it to a file.</value>
   </data>
   <data name="ZoomIt_Snip_Shortcut.Header" xml:space="preserve">
-    <value>Snip Toggle Hotkey</value>
+    <value>Snip hotkey</value>
   </data>
   <data name="Oobe_ZoomIt.Description" xml:space="preserve">
     <value>ZoomIt is a screen zoom, annotation, and recording tool for technical presentations and demos. You can also use ZoomIt to snip screenshots to the clipboard or to a file.</value>
@@ -5003,7 +5003,7 @@ To record a specific window, enter the hotkey with the Alt key in the opposite m
     <value>File Management</value>
   </data>
   <data name="Shell_TopLevelInputOutput.Content" xml:space="preserve">
-    <value>Input / Output</value>
+    <value>Input &amp; Output</value>
   </data>
   <data name="Shell_TopLevelWindowsAndLayouts.Content" xml:space="preserve">
     <value>Windowing &amp; Layouts</value>
@@ -5156,7 +5156,7 @@ To record a specific window, enter the hotkey with the Alt key in the opposite m
     <value>Quick access</value>
   </data>
   <data name="ShortcutsOverview.Title" xml:space="preserve">
-    <value>Shortcuts overview</value>
+    <value>Shortcuts</value>
   </data>
   <data name="NoActionsToShow.Text" xml:space="preserve">
     <value>No actions to show..</value>
@@ -5306,5 +5306,8 @@ To record a specific window, enter the hotkey with the Alt key in the opposite m
   <data name="Search_ResultsFor" xml:space="preserve">
     <value>Results for</value>
     <comment>Prefix for search string. E.g. "Results for 'shortcut'"</comment>
+  </data>
+  <data name="UtilitiesHeader.Title" xml:space="preserve">
+    <value>Utilities</value>
   </data>
 </root>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -3152,17 +3152,19 @@ Right-click to remove the key combination, thereby deactivating the shortcut.</v
   <data name="Peek_ConfirmFileDelete.Description" xml:space="preserve">
     <value>You'll be asked to confirm before files are moved to the Recycle Bin</value>
   </data>
-  <data name="Peek_EnableSpaceMode.Header" xml:space="preserve">
-    <value>Enable single Space key activation</value>
-    <comment>Toggle to force activation shortcut to Space key only</comment>
+	<data name="Peek_ActivationMethod.Header" xml:space="preserve">
+    <value>Activation method</value>
   </data>
-  <data name="Peek_EnableSpaceMode.Description" xml:space="preserve">
-    <value>Use only the Space key to open Peek when File Explorer or the Desktop is focused. Other apps are ignored.</value>
+	<data name="Peek_ActivationMethod.Description" xml:space="preserve">
+    <value>Use a shortcut or press the Spacebar when a file is selected</value>
+	<comment>Spacebar is a physical keyboard key</comment>
   </data>
-  <data name="Peek_SpaceShortcutLocked.Content" xml:space="preserve">
-    <value>Shortcut locked while single Space activation is enabled</value>
-    <comment>Tooltip shown for disabled activation shortcut control</comment>
+	<data name="Peek_ActivationMethod_CustomizedShortcut.Content" xml:space="preserve">
+    <value>Custom shortcut</value>
   </data>
+	<data name="Peek_ActivationMethod_SpaceBar.Content" xml:space="preserve">
+    <value>Spacebar</value>
+  </data>	
   <data name="FancyZones_DisableRoundCornersOnWindowSnap.Content" xml:space="preserve">
     <value>Disable rounded corners when a window is snapped</value>
   </data>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -3152,6 +3152,18 @@ Right-click to remove the key combination, thereby deactivating the shortcut.</v
   <data name="Peek_ConfirmFileDelete.Description" xml:space="preserve">
     <value>You'll be asked to confirm before files are moved to the Recycle Bin</value>
   </data>
+  <data name="Peek_EnableSpaceMode.Header" xml:space="preserve">
+    <value>Enable single Space key activation</value>
+    <comment>Header for toggle that forces activation shortcut to Space</comment>
+  </data>
+  <data name="Peek_EnableSpaceMode.Description" xml:space="preserve">
+    <value>Use the Space key alone to activate Peek when File Explorer or Desktop is focused. Other contexts are ignored.</value>
+    <comment>Describes scope limitation of Space-only activation for Peek</comment>
+  </data>
+  <data name="Peek_SpaceShortcutLocked.Description" xml:space="preserve">
+    <value>Shortcut locked to Space while single key activation is enabled</value>
+    <comment>Tooltip shown when activation shortcut control is disabled due to Space mode</comment>
+  </data>
   <data name="FancyZones_DisableRoundCornersOnWindowSnap.Content" xml:space="preserve">
     <value>Disable rounded corners when a window is snapped</value>
   </data>

--- a/src/settings-ui/Settings.UI/ViewModels/PeekViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/PeekViewModel.cs
@@ -170,6 +170,12 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             {
                 if (_peekSettings.Properties.ActivationShortcut != value)
                 {
+                    // If space mode toggle is on, ignore external attempts to change (UI will be disabled, but defensive).
+                    if (EnableSpaceToActivate)
+                    {
+                        return;
+                    }
+
                     _peekSettings.Properties.ActivationShortcut = value ?? _peekSettings.Properties.DefaultActivationShortcut;
                     OnPropertyChanged(nameof(ActivationShortcut));
                     NotifySettingsChanged();
@@ -218,6 +224,36 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 }
             }
         }
+
+        public bool EnableSpaceToActivate
+        {
+            get => _peekSettings.Properties.EnableSpaceToActivate.Value;
+            set
+            {
+                if (_peekSettings.Properties.EnableSpaceToActivate.Value != value)
+                {
+                    _peekSettings.Properties.EnableSpaceToActivate.Value = value;
+
+                    if (value)
+                    {
+                        // Force single space (0x20) without modifiers.
+                        _peekSettings.Properties.ActivationShortcut = new HotkeySettings(false, false, false, false, 0x20);
+                    }
+                    else
+                    {
+                        // Revert to default (design simplification, not restoring previous custom combo).
+                        _peekSettings.Properties.ActivationShortcut = _peekSettings.Properties.DefaultActivationShortcut;
+                    }
+
+                    OnPropertyChanged(nameof(EnableSpaceToActivate));
+                    OnPropertyChanged(nameof(ActivationShortcut));
+                    OnPropertyChanged(nameof(IsActivationShortcutLocked));
+                    NotifySettingsChanged();
+                }
+            }
+        }
+
+        public bool IsActivationShortcutLocked => EnableSpaceToActivate;
 
         public bool SourceCodeWrapText
         {

--- a/src/settings-ui/Settings.UI/ViewModels/PeekViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/PeekViewModel.cs
@@ -247,13 +247,10 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
 
                     OnPropertyChanged(nameof(EnableSpaceToActivate));
                     OnPropertyChanged(nameof(ActivationShortcut));
-                    OnPropertyChanged(nameof(IsActivationShortcutLocked));
                     NotifySettingsChanged();
                 }
             }
         }
-
-        public bool IsActivationShortcutLocked => EnableSpaceToActivate;
 
         public bool SourceCodeWrapText
         {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Closes: #26143

This pull request introduces a new "single Space key activation" mode for the Peek PowerToy, allowing users to open Peek with just the Space key when File Explorer or the Desktop is focused. The implementation includes settings UI changes, backend logic to enforce and manage this mode, eligibility checks for activation, and telemetry. It also enhances the user experience by disabling the activation shortcut control when space mode is enabled and providing appropriate tooltips and localization.

**Key changes:**

### Feature: Single Space Key Activation Mode

* Added a new setting (`EnableSpaceToActivate`) to allow users to enable Peek activation using only the Space key, restricted to File Explorer or Desktop focus. When enabled, the activation shortcut is forced to bare Space and the previous shortcut is stashed (not restored on toggle-off for simplicity). (`src/modules/peek/peek/dllmain.cpp`, `src/settings-ui/Settings.UI.Library/PeekProperties.cs`, `src/settings-ui/Settings.UI/ViewModels/PeekViewModel.cs`, `src/settings-ui/Settings.UI/SettingsXAML/Views/PeekPage.xaml`, `src/settings-ui/Settings.UI/Strings/en-us/Resources.resw`) [[1]](diffhunk://#diff-ac3987a14b7c287a047f57613d97a78265f0dcef56084fb5361021953328b039R132-R169) [[2]](diffhunk://#diff-ac3987a14b7c287a047f57613d97a78265f0dcef56084fb5361021953328b039R79-R80) [[3]](diffhunk://#diff-d482fce7c2d0abbe2b307351ef7588378ddf34d47b31ebf71411f264dcce07faR22) [[4]](diffhunk://#diff-d482fce7c2d0abbe2b307351ef7588378ddf34d47b31ebf71411f264dcce07faR33-R35) [[5]](diffhunk://#diff-3fb87fad8b86d17fa39d2319425f78d3029e3de89e88f4040d449d6a16d9d240R228-R257) [[6]](diffhunk://#diff-f474be48688a195b3cce5b395ea6c0cbc93d7a76d228dcb5dc4fc33f36f2ce83L17-R51) [[7]](diffhunk://#diff-dada9baae540a067141b033257982d33df5a6a504e1a1d492fa2961bd04b6a03R3155-R3165)

<img width="1018" height="197" alt="image" src="https://github.com/user-attachments/assets/6f9eec4a-2583-41e5-92e9-9dfbc186728a" />

* UI will hide the activation shortcut control. Attempts to change the shortcut programmatically are ignored while in this mode. (`src/settings-ui/Settings.UI/SettingsXAML/Views/PeekPage.xaml`, `src/settings-ui/Settings.UI/ViewModels/PeekViewModel.cs`, `src/settings-ui/Settings.UI/Strings/en-us/Resources.resw`) [[1]](diffhunk://#diff-f474be48688a195b3cce5b395ea6c0cbc93d7a76d228dcb5dc4fc33f36f2ce83L17-R51) [[2]](diffhunk://#diff-3fb87fad8b86d17fa39d2319425f78d3029e3de89e88f4040d449d6a16d9d240R173-R178) [[3]](diffhunk://#diff-3fb87fad8b86d17fa39d2319425f78d3029e3de89e88f4040d449d6a16d9d240R228-R257) [[4]](diffhunk://#diff-dada9baae540a067141b033257982d33df5a6a504e1a1d492fa2961bd04b6a03R3155-R3165)

<img width="1014" height="116" alt="image" src="https://github.com/user-attachments/assets/d1513101-a859-4b06-9252-2e707bce6689" />

### Activation Logic & Eligibility

* Implemented a foreground window hook and debounce logic to determine if Peek can be activated by Space (only when File Explorer, Desktop, or Peek itself is focused). This minimizes CPU overhead when user repeatedly presses Space but not for Peek . (`src/modules/peek/peek/dllmain.cpp`) [[1]](diffhunk://#diff-ac3987a14b7c287a047f57613d97a78265f0dcef56084fb5361021953328b039R50-R60) [[2]](diffhunk://#diff-ac3987a14b7c287a047f57613d97a78265f0dcef56084fb5361021953328b039R188-R292) [[3]](diffhunk://#diff-ac3987a14b7c287a047f57613d97a78265f0dcef56084fb5361021953328b039L457-R637)

* Managed hook installation and cleanup based on Peek's enabled state and the space mode toggle. (`src/modules/peek/peek/dllmain.cpp`) [[1]](diffhunk://#diff-ac3987a14b7c287a047f57613d97a78265f0dcef56084fb5361021953328b039R188-R292) [[2]](diffhunk://#diff-ac3987a14b7c287a047f57613d97a78265f0dcef56084fb5361021953328b039R562) [[3]](diffhunk://#diff-ac3987a14b7c287a047f57613d97a78265f0dcef56084fb5361021953328b039R593) [[4]](diffhunk://#diff-ac3987a14b7c287a047f57613d97a78265f0dcef56084fb5361021953328b039R496)

### Settings & Telemetry

* Added the new toggle to the settings serialization and XAML UI, with localization and descriptions. (`src/modules/peek/peek/dllmain.cpp`, `src/settings-ui/Settings.UI/SettingsXAML/Views/PeekPage.xaml`, `src/settings-ui/Settings.UI/Strings/en-us/Resources.resw`) [[1]](diffhunk://#diff-ac3987a14b7c287a047f57613d97a78265f0dcef56084fb5361021953328b039R530) [[2]](diffhunk://#diff-f474be48688a195b3cce5b395ea6c0cbc93d7a76d228dcb5dc4fc33f36f2ce83L17-R51) [[3]](diffhunk://#diff-dada9baae540a067141b033257982d33df5a6a504e1a1d492fa2961bd04b6a03R3155-R3165)

* Added telemetry event for enabling/disabling space mode. (`src/modules/peek/peek/trace.cpp`, `src/modules/peek/peek/trace.h`) [[1]](diffhunk://#diff-db76a3e6fa1cc19889492b72d0c063835bdc8f67909cb9d91c9e7e47e248a87aR51-R60) [[2]](diffhunk://#diff-8f824b0a7dd76f7fcd4a15b7885233b5b3212403a56c4efd67b83c4c2d02e486R18-R20)

### Code Quality

* Refactored includes and initialization logic for clarity and maintainability. (`src/modules/peek/peek/dllmain.cpp`) [[1]](diffhunk://#diff-ac3987a14b7c287a047f57613d97a78265f0dcef56084fb5361021953328b039L2-R14) [[2]](diffhunk://#diff-ac3987a14b7c287a047f57613d97a78265f0dcef56084fb5361021953328b039R37-R39) [[3]](diffhunk://#diff-ac3987a14b7c287a047f57613d97a78265f0dcef56084fb5361021953328b039R483)

These changes collectively provide a safer, more accessible, and user-friendly way to activate Peek with a single key, while ensuring users are clearly informed and accidental activations are minimized.
<!-- Please review the items on the PR checklist before submitting-->