### PR TITLE
CmdPal's search bar now accepts page up/down keyboard strokes.

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/Messages/NavigatePageDownCommand.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/Messages/NavigatePageDownCommand.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CmdPal.Core.ViewModels.Messages;
+
+/// <summary>
+/// Used to navigate down one page in the page when pressing the PageDown key in the SearchBox.
+/// </summary>
+public record NavigatePageDownCommand { }

--- a/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/Messages/NavigatePageUpCommand.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Core.ViewModels/Messages/NavigatePageUpCommand.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CmdPal.Core.ViewModels.Messages;
+
+/// <summary>
+/// Used to navigate up one page in the page when pressing the PageUp key in the SearchBox.
+/// </summary>
+public record NavigatePageUpCommand { }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/SearchBar.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/SearchBar.xaml.cs
@@ -207,6 +207,16 @@ public sealed partial class SearchBar : UserControl,
 
             e.Handled = true;
         }
+        else if (e.Key == VirtualKey.PageDown)
+        {
+            WeakReferenceMessenger.Default.Send<NavigatePageDownCommand>();
+            e.Handled = true;
+        }
+        else if (e.Key == VirtualKey.PageUp)
+        {
+            WeakReferenceMessenger.Default.Send<NavigatePageUpCommand>();
+            e.Handled = true;
+        }
 
         if (_inSuggestion)
         {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml.cs
@@ -18,12 +18,15 @@ using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Navigation;
 using Windows.System;
+using Windows.Foundation;
 
 namespace Microsoft.CmdPal.UI;
 
 public sealed partial class ListPage : Page,
     IRecipient<NavigateNextCommand>,
     IRecipient<NavigatePreviousCommand>,
+    IRecipient<NavigatePageDownCommand>,
+    IRecipient<NavigatePageUpCommand>,
     IRecipient<ActivateSelectedListItemMessage>,
     IRecipient<ActivateSecondaryCommandMessage>
 {
@@ -74,6 +77,8 @@ public sealed partial class ListPage : Page,
         // RegisterAll isn't AOT compatible
         WeakReferenceMessenger.Default.Register<NavigateNextCommand>(this);
         WeakReferenceMessenger.Default.Register<NavigatePreviousCommand>(this);
+        WeakReferenceMessenger.Default.Register<NavigatePageDownCommand>(this);
+        WeakReferenceMessenger.Default.Register<NavigatePageUpCommand>(this);
         WeakReferenceMessenger.Default.Register<ActivateSelectedListItemMessage>(this);
         WeakReferenceMessenger.Default.Register<ActivateSecondaryCommandMessage>(this);
 
@@ -86,6 +91,8 @@ public sealed partial class ListPage : Page,
 
         WeakReferenceMessenger.Default.Unregister<NavigateNextCommand>(this);
         WeakReferenceMessenger.Default.Unregister<NavigatePreviousCommand>(this);
+        WeakReferenceMessenger.Default.Unregister<NavigatePageDownCommand>(this);
+        WeakReferenceMessenger.Default.Unregister<NavigatePageUpCommand>(this);
         WeakReferenceMessenger.Default.Unregister<ActivateSelectedListItemMessage>(this);
         WeakReferenceMessenger.Default.Unregister<ActivateSecondaryCommandMessage>(this);
 
@@ -285,6 +292,91 @@ public sealed partial class ListPage : Page,
         else if (ItemView.SelectedItem is ListItemViewModel item)
         {
             ViewModel?.InvokeSecondaryCommandCommand.Execute(item);
+        }
+    }
+
+    public void Receive(NavigatePageDownCommand message)
+    {
+        var scroll = FindScrollViewer(ItemView);
+        if ( scroll is null )
+        {
+            return;
+        }
+
+        var viewportHeight = scroll.ViewportHeight;
+        if ( viewportHeight <= 0 )
+        {
+            return;
+        }
+
+        var currentIndex = ItemView.SelectedIndex >= 0 ? ItemView.SelectedIndex : 0;
+        var itemCount = ItemView.Items.Count;
+
+        // Estimate items per page using the first available container height
+        double itemHeight = 0;
+        for ( var i = currentIndex; i < itemCount; i++ )
+        {
+            if ( ItemView.ContainerFromIndex(i) is FrameworkElement { ActualHeight: > 0 } c )
+            {
+                itemHeight = c.ActualHeight;
+                break;
+            }
+        }
+
+        if ( itemHeight <= 0 )
+        {
+            // fallback to 1 item if we can't measure
+            itemHeight = 1;
+        }
+
+        var itemsPerPage = Math.Max(1, (int)Math.Floor(viewportHeight / itemHeight));
+        var targetIndex = Math.Min(itemCount - 1, currentIndex + itemsPerPage);
+
+        if ( targetIndex != currentIndex )
+        {
+            ItemView.SelectedIndex = targetIndex;
+            ItemView.ScrollIntoView(ItemView.SelectedItem);
+        }
+    }
+
+    public void Receive(NavigatePageUpCommand message)
+    {
+        var scroll = FindScrollViewer(ItemView);
+        if ( scroll is null )
+        {
+            return;
+        }
+
+        var viewportHeight = scroll.ViewportHeight;
+        if ( viewportHeight <= 0 )
+        {
+            return;
+        }
+
+        var currentIndex = ItemView.SelectedIndex >= 0 ? ItemView.SelectedIndex : 0;
+
+        double itemHeight = 0;
+        for ( var i = currentIndex; i >= 0; i-- )
+        {
+            if ( ItemView.ContainerFromIndex(i) is FrameworkElement { ActualHeight: > 0 } c )
+            {
+                itemHeight = c.ActualHeight;
+                break;
+            }
+        }
+
+        if ( itemHeight <= 0 )
+        {
+            itemHeight = 1;
+        }
+
+        var itemsPerPage = Math.Max(1, (int)Math.Floor(viewportHeight / itemHeight));
+        var targetIndex = Math.Max(0, currentIndex - itemsPerPage);
+
+        if ( targetIndex != currentIndex )
+        {
+            ItemView.SelectedIndex = targetIndex;
+            ItemView.ScrollIntoView(ItemView.SelectedItem);
         }
     }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
The page up/down keys now function while the search box is focused.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ X ] Closes: #41877
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Previously, the page up/down keys only performed any action while an item in the list was focused. The page up/down keys did not have any effect while the search box was focused, however the up/down arrows do have effect. This PR enables the page up/down keys while the search box is focused.

There is a caveat here. The page up/down behavior is not consistent. I do not see a way to tell the ListView to perform its native page up/down function. Instead, I manually calculate roughly which item to scroll-to. Because of this, the amount of scroll between when the search box is focused and when an item in the ListView is focused is not consistent.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

![pageupdown](https://github.com/user-attachments/assets/b30f6e4e-03de-45bd-8570-0b06850bef24)
In this GIF:
1. CmdPal appears
2. SearchBar focused, down/up arrow keys.
3. SearchBar focused, page down/up keys.
4. Tab to item in ListView
5. ListView item focused down/up arrow keys.
6. ListView item focused page down/up keys.
7. SearchBar focused
8. Filter "abc"
9. SearchBar focused page down/up keys.