### PR TITLE
IconMarginConverter class now partial to resolve AOT warning

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/IconMarginConverter.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/IconMarginConverter.cs
@@ -7,7 +7,7 @@ using Microsoft.UI.Xaml.Data;
 
 namespace Microsoft.CmdPal.UI.Controls;
 
-public sealed class IconMarginConverter : IValueConverter
+public sealed partial class IconMarginConverter : IValueConverter
 {
     public object Convert(object value, Type targetType, object parameter, string language)
     {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This resolves the issue brought up in PR 41851 where the new class generated a warning for AOT builds.

Please see https://github.com/microsoft/PowerToys/pull/41851#issuecomment-3320083888
