### PR TITLE
CmdPal: Remove support for "selection" TextToSuggest

### DIFF
--- a/src/common/UITestAutomation/UITestAutomation.csproj
+++ b/src/common/UITestAutomation/UITestAutomation.csproj
@@ -17,8 +17,6 @@
     <PackageReference Include="Appium.WebDriver" />
     <PackageReference Include="MSTest" />
     <PackageReference Include="System.IO.Abstractions" />
-    <PackageReference Include="System.Net.Http" />
-    <PackageReference Include="System.Private.Uri" />
     <PackageReference Include="System.Text.RegularExpressions" />
     <PackageReference Include="CoenM.ImageSharp.ImageHash" />
   </ItemGroup>

--- a/src/modules/cmdpal/Microsoft.CmdPal.Common/Microsoft.CmdPal.Common.csproj
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Common/Microsoft.CmdPal.Common.csproj
@@ -16,7 +16,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" />
-    <PackageReference Include="System.Text.Json" />
 
     <PackageReference Include="Microsoft.Windows.CsWin32">
       <PrivateAssets>all</PrivateAssets>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentTreeViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentTreeViewModel.cs
@@ -25,7 +25,7 @@ public partial class ContentTreeViewModel(ITreeContent _tree, WeakReference<IPag
 
     // This is the content that's actually bound in XAML. We needed a
     // collection, even if the collection is just a single item.
-    public ObservableCollection<ContentViewModel> Root => [RootContent];
+    public ObservableCollection<ContentViewModel> Root => RootContent is not null ? [RootContent] : [];
 
     public override void InitializeProperties()
     {
@@ -122,7 +122,7 @@ public partial class ContentTreeViewModel(ITreeContent _tree, WeakReference<IPag
                 if (viewModel is not null)
                 {
                     viewModel.InitializeProperties();
-                    newContent.Add(viewModel);
+                    newContent.Add((ContentViewModel)viewModel);
                 }
             }
         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/SearchBar.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/SearchBar.xaml.cs
@@ -32,9 +32,21 @@ public sealed partial class SearchBar : UserControl,
     private readonly DispatcherQueueTimer _debounceTimer = DispatcherQueue.GetForCurrentThread().CreateTimer();
     private bool _isBackspaceHeld;
 
+    // Inline text suggestions
+    // In 0.4-0.5 we would replace the text of the search box with the TextToSuggest
+    // This was really cool for navigating paths in run and pretty much nowhere else.
+    // We'll have to try another approach, but for now, the code is still testable.
+    // You can test this by setting the CMDPAL_ENABLE_SUGGESTION_SELECTION env var to 1
     private bool _inSuggestion;
+
+    private bool InSuggestion => _inSuggestion && IsTextToSuggestEnabled;
+
     private string? _lastText;
+
     private string? _deletedSuggestion;
+
+    // 0.6+ suggestions
+    private string? _textToSuggest;
 
     public PageViewModel? CurrentPageViewModel
     {
@@ -194,7 +206,23 @@ public sealed partial class SearchBar : UserControl,
         }
         else if (e.Key == VirtualKey.Right)
         {
-            if (_inSuggestion)
+            // Check if the "replace search text with suggestion" feature from 0.4-0.5 is enabled.
+            // If it isn't, then only use the suggestion when the caret is at the end of the input.
+            if (!IsTextToSuggestEnabled)
+            {
+                if (_textToSuggest != null &&
+                    FilterBox.SelectionStart == FilterBox.Text.Length)
+                {
+                    FilterBox.Text = _textToSuggest;
+                    FilterBox.Select(_textToSuggest.Length, 0);
+                    e.Handled = true;
+                }
+
+                return;
+            }
+
+            // Here, we're using the "replace search text with suggestion" feature.
+            if (InSuggestion)
             {
                 _inSuggestion = false;
                 _lastText = null;
@@ -208,7 +236,7 @@ public sealed partial class SearchBar : UserControl,
             e.Handled = true;
         }
 
-        if (_inSuggestion)
+        if (InSuggestion)
         {
             if (
                  e.Key == VirtualKey.Back ||
@@ -294,7 +322,7 @@ public sealed partial class SearchBar : UserControl,
             return;
         }
 
-        if (_inSuggestion)
+        if (InSuggestion)
         {
             // Logger.LogInfo($"-- skipping, in suggestion --");
             return;
@@ -316,7 +344,7 @@ public sealed partial class SearchBar : UserControl,
 
     private void DoFilterBoxUpdate()
     {
-        if (_inSuggestion)
+        if (InSuggestion)
         {
             // Logger.LogInfo($"--- skipping ---");
             return;
@@ -368,6 +396,12 @@ public sealed partial class SearchBar : UserControl,
 
     public void Receive(UpdateSuggestionMessage message)
     {
+        if (!IsTextToSuggestEnabled)
+        {
+            _textToSuggest = message.TextToSuggest;
+            return;
+        }
+
         var suggestion = message.TextToSuggest;
 
         _queue.TryEnqueue(new(() =>
@@ -456,5 +490,16 @@ public sealed partial class SearchBar : UserControl,
                 FilterBox.Select(matchedChars, suggestion.Length - matchedChars);
             }
         }));
+    }
+
+    private static bool IsTextToSuggestEnabled => _textToSuggestEnabled.Value;
+
+    private static Lazy<bool> _textToSuggestEnabled = new(() => QueryTextToSuggestEnabled());
+
+    private static bool QueryTextToSuggestEnabled()
+    {
+        var env = System.Environment.GetEnvironmentVariable("CMDPAL_ENABLE_SUGGESTION_SELECTION");
+        return !string.IsNullOrEmpty(env) &&
+           (env == "1" || env.Equals("true", System.StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Microsoft.CmdPal.UI.csproj
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Microsoft.CmdPal.UI.csproj
@@ -99,13 +99,6 @@
     </PackageReference>
 
     <PackageReference Include="Microsoft.Extensions.Hosting" />
-
-    <PackageReference Include="System.Net.Http" />
-
-    <PackageReference Include="System.Private.Uri" />
-    <PackageReference Include="System.Text.Json" />
-
-    <PackageReference Include="System.Text.RegularExpressions" />
   </ItemGroup>
 
   <!--


### PR DESCRIPTION
`TextToSuggest` has been nothing but pain. We need another approach.
I'm leaving the code, but just disabled behind an env flag. Same as actions.

Closes #41659
