### PR TITLE
Allow PowerToys to launch (without error) in Debug mode without requiring a full build of all modules

### DIFF
--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -190,10 +190,19 @@ int runner(bool isProcessElevated, bool openSettings, std::string settingsWindow
             {
                 std::wstring errorMessage = POWER_TOYS_MODULE_LOAD_FAIL;
                 errorMessage += moduleSubdir;
+                
+#ifdef _DEBUG
+                // In debug mode, simply log the warning and continue execution.
+                // This contrasts with the past approach where developers had to build all modules
+                // without errors before debugging—slowing down quick clone-and-fix iterations.
+                Logger::warn(L"Debug mode: {}", errorMessage);
+#else
+                // In release mode, show error dialog as before
                 MessageBoxW(NULL,
                             errorMessage.c_str(),
                             L"PowerToys",
                             MB_OK | MB_ICONERROR);
+#endif
             }
         }
         // Start initial powertoys


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This pull request updates the error handling logic when a module fails to load in the `runner` function. 
**In debug mode ONLY**, the code now logs a warning instead of showing an error dialog, making it easier for developers to iterate quickly without being blocked by missing modules.

Without these fixes, a long list of errors appears if not all modules are built. Here is just one example:
<img width="642" height="361" alt="image" src="https://github.com/user-attachments/assets/ee01e47a-73d6-47a0-a3ee-eb532c5bfcda" />


Error handling improvements:

* In `src/runner/main.cpp`, the error handling for module load failures now logs a warning in debug mode instead of displaying a blocking error dialog, streamlining the developer experience during debugging. In release mode, the error dialog is still shown as before.