### PR TITLE
Enable only ci-nightly build will update Build Cache for ci build

### DIFF
--- a/.pipelines/v2/ci-nightly.yml
+++ b/.pipelines/v2/ci-nightly.yml
@@ -4,7 +4,7 @@
 trigger: none
 pr: none
 
-# 02:00 SGT daily (18:00 UTC previous day) — adjust as you like
+# (18:00 UTC) — adjust as you like
 schedules:
   - cron: "0 18 * * *"   # UTC
     displayName: Nightly pre-warm (main)

--- a/.pipelines/v2/ci-nightly.yml
+++ b/.pipelines/v2/ci-nightly.yml
@@ -25,9 +25,14 @@ parameters:
     type: boolean
     displayName: "Enable MSBuild Caching"
     default: true
+  - name: msBuildCacheIsReadOnly
+    type: boolean
+    displayName: "MSBuild Cache Read Only"
+    default: false
 
 extends:
   template: templates/pipeline-ci-build.yml
   parameters:
     buildPlatforms: ${{ parameters.buildPlatforms }}
     enableMsBuildCaching: ${{ parameters.enableMsBuildCaching }}
+    msBuildCacheIsReadOnly: ${{ parameters.msBuildCacheIsReadOnly }}

--- a/.pipelines/v2/ci-nightly.yml
+++ b/.pipelines/v2/ci-nightly.yml
@@ -1,0 +1,33 @@
+# .pipelines/v2/nightly-prewarm.yml
+# Nightly pre-warm that reuses your existing ci.yml as-is
+
+trigger: none
+pr: none
+
+# 02:00 SGT daily (18:00 UTC previous day) — adjust as you like
+schedules:
+  - cron: "0 18 * * *"   # UTC
+    displayName: Nightly pre-warm (main)
+    branches:
+      include:
+        - main
+    always: true
+
+name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
+
+parameters:
+  - name: buildPlatforms
+    type: object
+    default:
+      - x64
+      - arm64
+  - name: enableMsBuildCaching
+    type: boolean
+    displayName: "Enable MSBuild Caching"
+    default: true
+
+extends:
+  template: templates/pipeline-ci-build.yml
+  parameters:
+    buildPlatforms: ${{ parameters.buildPlatforms }}
+    enableMsBuildCaching: ${{ parameters.enableMsBuildCaching }}

--- a/.pipelines/v2/ci.yml
+++ b/.pipelines/v2/ci.yml
@@ -32,7 +32,7 @@ parameters:
   - name: enableMsBuildCaching
     type: boolean
     displayName: "Enable MSBuild Caching"
-    default: true
+    default: false
   - name: runTests
     type: boolean
     displayName: "Run Tests"

--- a/.pipelines/v2/templates/job-build-project.yml
+++ b/.pipelines/v2/templates/job-build-project.yml
@@ -50,6 +50,9 @@ parameters:
   - name: enableMsBuildCaching
     type: boolean
     default: false
+  - name: msBuildCacheIsReadOnly
+    type: boolean
+    default: true
   - name: runTests
     type: boolean
     default: true
@@ -154,15 +157,9 @@ jobs:
         $MSBuildCacheParameters += " -reportfileaccesses"
         $MSBuildCacheParameters += " -p:MSBuildCacheEnabled=true"
         $MSBuildCacheParameters += " -p:MSBuildCacheLogDirectory=$(LogOutputDirectory)\MSBuildCacheLogs"
-        # Branch-based cache policy:
-        # Always use a stable universe name (main). Make non-main branches read-only so they don't poison cache.
-        $sourceBranch = "$env:BUILD_SOURCEBRANCH"  # e.g. refs/heads/main or refs/pull/123/merge
-        $isMain = $false
-        if ($sourceBranch -match "refs/heads/main$") { $isMain = $true }
-        if ($isMain) {
-          $MSBuildCacheParameters += " /p:MSBuildCacheRemoteCacheIsReadOnly=false"
-        }
-        else {
+        # Cache read-only policy controlled by parameter
+        $cacheIsReadOnly = "${{ parameters.msBuildCacheIsReadOnly }}"
+        if ($cacheIsReadOnly -eq "True") {
           $MSBuildCacheParameters += " /p:MSBuildCacheRemoteCacheIsReadOnly=true"
         }
         Write-Host "MSBuildCacheParameters: $MSBuildCacheParameters"

--- a/.pipelines/v2/templates/job-build-project.yml
+++ b/.pipelines/v2/templates/job-build-project.yml
@@ -154,6 +154,17 @@ jobs:
         $MSBuildCacheParameters += " -reportfileaccesses"
         $MSBuildCacheParameters += " -p:MSBuildCacheEnabled=true"
         $MSBuildCacheParameters += " -p:MSBuildCacheLogDirectory=$(LogOutputDirectory)\MSBuildCacheLogs"
+        # Branch-based cache policy:
+        # Always use a stable universe name (main). Make non-main branches read-only so they don't poison cache.
+        $sourceBranch = "$env:BUILD_SOURCEBRANCH"  # e.g. refs/heads/main or refs/pull/123/merge
+        $isMain = $false
+        if ($sourceBranch -match "refs/heads/main$") { $isMain = $true }
+        if ($isMain) {
+          $MSBuildCacheParameters += " /p:MSBuildCacheRemoteCacheIsReadOnly=false"
+        }
+        else {
+          $MSBuildCacheParameters += " /p:MSBuildCacheRemoteCacheIsReadOnly=true"
+        }
         Write-Host "MSBuildCacheParameters: $MSBuildCacheParameters"
         Write-Host "##vso[task.setvariable variable=MSBuildCacheParameters]$MSBuildCacheParameters"
       displayName: Prepare MSBuildCache variables
@@ -418,7 +429,7 @@ jobs:
       }
       
       if ($Packages.Count -gt 0) {
-          # Priority: Look for platform-specific MSIX (x64/arm64) first, then fall back to any
+          # Priority: Look for platform-specific MSIX (x64/arm64) first, then fallback to any
           $PlatformPackage = $Packages | Where-Object { $_.Name -match "Microsoft\.CmdPal\.UI_.*_(x64|arm64)\.msix$" } | Select-Object -First 1
           if ($PlatformPackage) {
               $Package = $PlatformPackage

--- a/.pipelines/v2/templates/pipeline-ci-build.yml
+++ b/.pipelines/v2/templates/pipeline-ci-build.yml
@@ -13,6 +13,9 @@ parameters:
   - name: enableMsBuildCaching
     type: boolean
     default: false
+  - name: msBuildCacheIsReadOnly
+    type: boolean
+    default: true
   - name: runTests
     type: boolean
     default: true
@@ -52,6 +55,7 @@ stages:
             buildConfigurations: [Release]
             enablePackageCaching: true
             enableMsBuildCaching: ${{ parameters.enableMsBuildCaching }}
+            msBuildCacheIsReadOnly: ${{ parameters.msBuildCacheIsReadOnly }}
             runTests: ${{ parameters.runTests }}
             useVSPreview: ${{ parameters.useVSPreview }}
             useLatestWinAppSDK: ${{ parameters.useLatestWinAppSDK }}


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This pull request introduces a new nightly pre-warm pipeline and adds configurability for MSBuild cache read-only behavior across the CI pipeline templates. The main goals are to enable scheduled nightly builds that pre-warm caches and to provide more granular control over MSBuild cache policies through pipeline parameters.

Pipeline enhancements:

* Added a new `.pipelines/v2/nightly-prewarm.yml` pipeline that schedules a nightly pre-warm build for the `main` branch, reusing the existing CI template and supporting both `x64` and `arm64` platforms.
* Introduced a `msBuildCacheIsReadOnly` parameter (defaulting to `true`) in both `pipeline-ci-build.yml` and `job-build-project.yml` templates, allowing control over whether the MSBuild remote cache is used in read-only mode. [[1]](diffhunk://#diff-95896d25119462fea5ce61f0f72a43862ff3020d2e1cce8bd1f2d5d943dafae8R16-R18) [[2]](diffhunk://#diff-2a1b06b9419d9ac8a4fc446800d32a657d60c45979e82462df2d6d71a75ba68cR53-R55)