### PR TITLE
CmdPal: Hotfix flaky query test in Shell extension tests

### DIFF
--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Shell.UnitTests/QueryTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Shell.UnitTests/QueryTests.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -16,6 +17,8 @@ namespace Microsoft.CmdPal.Ext.Shell.UnitTests;
 [TestClass]
 public class QueryTests : CommandPaletteUnitTestBase
 {
+    private static readonly TimeSpan WaitForAsyncUpdate = TimeSpan.FromSeconds(5);
+
     private static Mock<IRunHistoryService> CreateMockHistoryService(IList<string> historyItems = null)
     {
         var mockHistoryService = new Mock<IRunHistoryService>();
@@ -84,8 +87,8 @@ public class QueryTests : CommandPaletteUnitTestBase
 
         pages.UpdateSearchText(string.Empty, command);
 
-        // wait for about 1s.
-        await Task.Delay(1000);
+        // wait for update to complete
+        await Task.Delay(WaitForAsyncUpdate);
 
         var commandList = pages.GetItems();
 
@@ -112,7 +115,8 @@ public class QueryTests : CommandPaletteUnitTestBase
         // Test: Search for a command that exists in history
         pages.UpdateSearchText(string.Empty, command);
 
-        await Task.Delay(1000);
+        // wait for update to complete
+        await Task.Delay(WaitForAsyncUpdate);
 
         var commandList = pages.GetItems();
 
@@ -136,7 +140,8 @@ public class QueryTests : CommandPaletteUnitTestBase
 
         pages.UpdateSearchText("abcdefg", string.Empty);
 
-        await Task.Delay(1000);
+        // wait for update to complete
+        await Task.Delay(WaitForAsyncUpdate);
 
         var commandList = pages.GetItems();
 


### PR DESCRIPTION
## Summary of the Pull Request

This PR increases the waiting time between updating the query and retrieving results in Shell extension query tests. This should help stabilize the tests by reducing the chance of incomplete updates affecting the results.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] Closes: #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

