### PR TITLE
[CmdPal Settings] Improved NavView behavior

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/SettingsWindow.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/SettingsWindow.xaml
@@ -24,10 +24,11 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <TitleBar x:Name="TitleBar">
+        <TitleBar x:Name="AppTitleBar" PaneToggleRequested="AppTitleBar_PaneToggleRequested">
             <!--  This is a workaround for https://github.com/microsoft/microsoft-ui-xaml/issues/10374, once fixed we should just be using IconSource  -->
             <TitleBar.LeftHeader>
                 <ImageIcon
+                    x:Name="WorkAroundIcon"
                     Height="16"
                     Margin="16,0,0,0"
                     Source="ms-appx:///Assets/icon.svg" />
@@ -36,8 +37,11 @@
         <NavigationView
             x:Name="NavView"
             Grid.Row="1"
+            CompactModeThresholdWidth="1007"
             DisplayModeChanged="NavView_DisplayModeChanged"
+            ExpandedModeThresholdWidth="1007"
             IsBackButtonVisible="Collapsed"
+            IsPaneToggleButtonVisible="False"
             IsSettingsVisible="False"
             ItemInvoked="NavView_ItemInvoked"
             Loaded="NavView_Loaded"
@@ -47,7 +51,6 @@
                 <SolidColorBrush x:Key="NavigationViewContentGridBorderBrush" Color="Transparent" />
                 <Thickness x:Key="NavigationViewHeaderMargin">15,0,0,0</Thickness>
             </NavigationView.Resources>
-
             <NavigationView.MenuItems>
                 <NavigationViewItem
                     x:Uid="Settings_GeneralPage_NavigationViewItem_General"
@@ -58,17 +61,15 @@
                     Icon="{ui:FontIcon Glyph=&#xEA86;}"
                     Tag="Extensions" />
             </NavigationView.MenuItems>
-
             <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="*" />
                 </Grid.RowDefinitions>
-
                 <BreadcrumbBar
                     x:Name="NavigationBreadcrumbBar"
-                    Grid.Row="0"
                     MaxWidth="1000"
+                    Margin="16,0,0,0"
                     ItemClicked="NavigationBreadcrumbBar_ItemClicked"
                     ItemsSource="{x:Bind BreadCrumbs, Mode=OneWay}">
                     <BreadcrumbBar.ItemTemplate>
@@ -85,7 +86,6 @@
                         </ResourceDictionary>
                     </BreadcrumbBar.Resources>
                 </BreadcrumbBar>
-
                 <Frame x:Name="NavFrame" Grid.Row="1" />
             </Grid>
         </NavigationView>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/SettingsWindow.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/SettingsWindow.xaml.cs
@@ -34,7 +34,7 @@ public sealed partial class SettingsWindow : WindowEx,
         var title = RS_.GetString("SettingsWindowTitle");
         this.AppWindow.Title = title;
         this.AppWindow.TitleBar.PreferredHeightOption = TitleBarHeightOption.Tall;
-        this.TitleBar.Title = title;
+        this.AppTitleBar.Title = title;
         PositionCentered();
 
         WeakReferenceMessenger.Default.Register<NavigateToExtensionSettingsMessage>(this);
@@ -142,11 +142,13 @@ public sealed partial class SettingsWindow : WindowEx,
     {
         if (args.DisplayMode == NavigationViewDisplayMode.Compact || args.DisplayMode == NavigationViewDisplayMode.Minimal)
         {
-            NavView.IsPaneToggleButtonVisible = false;
+            AppTitleBar.IsPaneToggleButtonVisible = true;
+            WorkAroundIcon.Margin = new Thickness(8, 0, 16, 0); // Required for workaround, see XAML comment
         }
         else
         {
-            NavView.IsPaneToggleButtonVisible = true;
+            AppTitleBar.IsPaneToggleButtonVisible = false;
+            WorkAroundIcon.Margin = new Thickness(16, 0, 0, 0); // Required for workaround, see XAML comment
         }
     }
 
@@ -154,6 +156,11 @@ public sealed partial class SettingsWindow : WindowEx,
     {
         // This might come in on a background thread
         DispatcherQueue.TryEnqueue(() => Close());
+    }
+
+    private void AppTitleBar_PaneToggleRequested(TitleBar sender, object args)
+    {
+        NavView.IsPaneOpen = !NavView.IsPaneOpen;
     }
 }
 


### PR DESCRIPTION
## Summary of the Pull Request

The NavView behavior (e.g. when showing the panebutton, collapsing the menu etc.) was inconsistent with other Settings experiences (like PT Settings and W11 Settings).

## PR Checklist

- [ ] Closes: #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

