### PR TITLE
Sync breadcrumbs bar width and padding with settings pages, keeping them always aligned with each other

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/SettingsWindow.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/SettingsWindow.xaml
@@ -65,26 +65,27 @@
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="*" />
                 </Grid.RowDefinitions>
-                <BreadcrumbBar
-                    x:Name="NavigationBreadcrumbBar"
-                    MaxWidth="1000"
-                    Margin="16,0,0,0"
-                    ItemClicked="NavigationBreadcrumbBar_ItemClicked"
-                    ItemsSource="{x:Bind BreadCrumbs, Mode=OneWay}">
-                    <BreadcrumbBar.ItemTemplate>
-                        <DataTemplate x:DataType="local:Crumb">
-                            <TextBlock Text="{x:Bind Label, Mode=OneWay}" />
-                        </DataTemplate>
-                    </BreadcrumbBar.ItemTemplate>
-                    <BreadcrumbBar.Resources>
-                        <ResourceDictionary>
-                            <x:Double x:Key="BreadcrumbBarItemThemeFontSize">28</x:Double>
-                            <Thickness x:Key="BreadcrumbBarChevronPadding">7,4,8,0</Thickness>
-                            <FontWeight x:Key="BreadcrumbBarItemFontWeight">SemiBold</FontWeight>
-                            <x:Double x:Key="BreadcrumbBarChevronFontSize">16</x:Double>
-                        </ResourceDictionary>
-                    </BreadcrumbBar.Resources>
-                </BreadcrumbBar>
+                <Grid Padding="16,0">
+                    <BreadcrumbBar
+                        x:Name="NavigationBreadcrumbBar"
+                        MaxWidth="1000"
+                        ItemClicked="NavigationBreadcrumbBar_ItemClicked"
+                        ItemsSource="{x:Bind BreadCrumbs, Mode=OneWay}">
+                        <BreadcrumbBar.ItemTemplate>
+                            <DataTemplate x:DataType="local:Crumb">
+                                <TextBlock Text="{x:Bind Label, Mode=OneWay}" />
+                            </DataTemplate>
+                        </BreadcrumbBar.ItemTemplate>
+                        <BreadcrumbBar.Resources>
+                            <ResourceDictionary>
+                                <x:Double x:Key="BreadcrumbBarItemThemeFontSize">28</x:Double>
+                                <Thickness x:Key="BreadcrumbBarChevronPadding">7,4,8,0</Thickness>
+                                <FontWeight x:Key="BreadcrumbBarItemFontWeight">SemiBold</FontWeight>
+                                <x:Double x:Key="BreadcrumbBarChevronFontSize">16</x:Double>
+                            </ResourceDictionary>
+                        </BreadcrumbBar.Resources>
+                    </BreadcrumbBar>
+                </Grid>
                 <Frame x:Name="NavFrame" Grid.Row="1" />
             </Grid>
         </NavigationView>


### PR DESCRIPTION
## Summary of the Pull Request

Sync breadcrumbs bar width and padding with settings pages, keeping them always aligned with each other

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] Closes: #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

