### PR TITLE
CmdPal: Properly quote arguments when rebuilding normalized path

### DIFF
--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Shell.UnitTests/NormalizeCommandLineTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Shell.UnitTests/NormalizeCommandLineTests.cs
@@ -23,6 +23,7 @@ public class NormalizeCommandLineTests : CommandPaletteUnitTestBase
     [DataRow("ping bing.com", "c:\\Windows\\system32\\ping.exe", "bing.com")]
     [DataRow("curl bing.com", "c:\\Windows\\system32\\curl.exe", "bing.com")]
     [DataRow("ipconfig /all", "c:\\Windows\\system32\\ipconfig.exe", "/all")]
+    [DataRow("ipconfig a b \"c d\"", "c:\\Windows\\system32\\ipconfig.exe", "a b \"c d\"")]
     public void NormalizeCommandLineSimple(string input, string expectedExe, string expectedArgs = "")
     {
         NormalizeTestCore(input, expectedExe, expectedArgs);
@@ -46,7 +47,7 @@ public class NormalizeCommandLineTests : CommandPaletteUnitTestBase
     [TestMethod]
     [DataRow("cmd --run --test", "C:\\Windows\\System32\\cmd.exe", "--run --test")]
     [DataRow("cmd    --run   --test  ", "C:\\Windows\\System32\\cmd.exe", "--run --test")]
-    [DataRow("cmd \"--run --test\" --pass", "C:\\Windows\\System32\\cmd.exe", "--run --test --pass")]
+    [DataRow("cmd \"--run --test\" --pass", "C:\\Windows\\System32\\cmd.exe", "\"--run --test\" --pass")]
     public void NormalizeArgsWithSpaces(string input, string expectedExe, string expectedArgs = "")
     {
         NormalizeTestCore(input, expectedExe, expectedArgs);

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Shell/Helpers/ShellListPageHelpers.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Shell/Helpers/ShellListPageHelpers.cs
@@ -157,7 +157,98 @@ public class ShellListPageHelpers
         executable = segments[0];
         if (segments.Length > 1)
         {
-            arguments = string.Join(' ', segments[1..]);
+            arguments = ArgumentBuilder.BuildArguments(segments[1..]);
+        }
+    }
+
+    private static class ArgumentBuilder
+    {
+        internal static string BuildArguments(string[] arguments)
+        {
+            if (arguments.Length <= 0)
+            {
+                return string.Empty;
+            }
+
+            var stringBuilder = new StringBuilder();
+            foreach (var argument in arguments)
+            {
+                AppendArgument(stringBuilder, argument);
+            }
+
+            return stringBuilder.ToString();
+        }
+
+        private static void AppendArgument(StringBuilder stringBuilder, string argument)
+        {
+            if (stringBuilder.Length > 0)
+            {
+                stringBuilder.Append(' ');
+            }
+
+            if (argument.Length == 0 || ShouldBeQuoted(argument))
+            {
+                stringBuilder.Append('\"');
+                var index = 0;
+                while (index < argument.Length)
+                {
+                    var c = argument[index++];
+                    if (c == '\\')
+                    {
+                        var numBackSlash = 1;
+                        while (index < argument.Length && argument[index] == '\\')
+                        {
+                            index++;
+                            numBackSlash++;
+                        }
+
+                        if (index == argument.Length)
+                        {
+                            stringBuilder.Append('\\', numBackSlash * 2);
+                        }
+                        else if (argument[index] == '\"')
+                        {
+                            stringBuilder.Append('\\', (numBackSlash * 2) + 1);
+                            stringBuilder.Append('\"');
+                            index++;
+                        }
+                        else
+                        {
+                            stringBuilder.Append('\\', numBackSlash);
+                        }
+
+                        continue;
+                    }
+
+                    if (c == '\"')
+                    {
+                        stringBuilder.Append('\\');
+                        stringBuilder.Append('\"');
+                        continue;
+                    }
+
+                    stringBuilder.Append(c);
+                }
+
+                stringBuilder.Append('\"');
+            }
+            else
+            {
+                stringBuilder.Append(argument);
+            }
+        }
+
+        private static bool ShouldBeQuoted(string s)
+        {
+            foreach (var c in s)
+            {
+                if (char.IsWhiteSpace(c) || c == '\"')
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request

This PR ensures proper quoting of arguments after normalization. When joining arguments back into a single string, any argument containing whitespace or double quotes must be quoted (because parsing unquoted them). Adjusts unit tests to reflect the correct expected results.

Ref: 42016

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] Closes: #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

