### PR TITLE
CmdPal: Free the fallbacks (ranking)

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
@@ -345,8 +345,8 @@ public partial class MainListPage : DynamicListPage,
                 return;
             }
 
-            // Defaulting scored to 1 but we'll eventually use user rankings
-            _fallbackItems = [.. newFallbacks.Select(f => new Scored<IListItem> { Item = f, Score = 1 })];
+            List<Scored<IListItem>> scoredFallbacks = [.. ListHelpers.FilterListWithScores<IListItem>(newFallbacks ?? [], SearchText, ScoreFallbackItem)];
+            _fallbackItems = [.. scoredFallbacks.OrderByDescending(o => o.Score)];
 
             if (token.IsCancellationRequested)
             {
@@ -506,6 +506,19 @@ public partial class MainListPage : DynamicListPage,
             var recentWeightBoost = history.GetCommandHistoryWeight(id);
             finalScore += recentWeightBoost;
         }
+
+        return (int)finalScore;
+    }
+
+    private int ScoreFallbackItem(string query, IListItem topLevelOrAppItem)
+    {
+        var id = IdForTopLevelOrAppItem(topLevelOrAppItem);
+
+        var topLevelVM = topLevelOrAppItem as TopLevelViewModel;
+
+        var fallbackRankings = topLevelVM!.WeightBoost;
+
+        var finalScore = fallbackRankings + 1;
 
         return (int)finalScore;
     }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Properties/Resources.Designer.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Properties/Resources.Designer.cs
@@ -401,5 +401,23 @@ namespace Microsoft.CmdPal.UI.ViewModels.Properties {
                 return ResourceManager.GetString("builtin_reload_subtitle", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use a higher number to have this fallback&apos;s result show higher in the list of fallback commands. Default is 0..
+        /// </summary>
+        public static string fallback_weight_boost_description {
+            get {
+                return ResourceManager.GetString("fallback_weight_boost_description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Global sort order score modifier.
+        /// </summary>
+        public static string fallback_weight_boost_title {
+            get {
+                return ResourceManager.GetString("fallback_weight_boost_title", resourceCulture);
+            }
+        }
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Properties/Resources.resx
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Properties/Resources.resx
@@ -233,4 +233,10 @@
   <data name="builtin_main_list_page_searchbar_placeholder" xml:space="preserve">
     <value>Search for apps, files and commands...</value>
   </data>
+  <data name="fallback_weight_boost_description" xml:space="preserve">
+    <value>Use a higher number to have this fallback's result show higher in the list of fallback commands. Default is 0.</value>
+  </data>
+  <data name="fallback_weight_boost_title" xml:space="preserve">
+    <value>Global sort order score modifier</value>
+  </data>
 </root>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ProviderSettings.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ProviderSettings.cs
@@ -10,7 +10,7 @@ public class ProviderSettings
 {
     public bool IsEnabled { get; set; } = true;
 
-    public Dictionary<string, bool> FallbackCommands { get; set; } = [];
+    public Dictionary<string, FallbackSettings> FallbackCommands { get; set; } = [];
 
     [JsonIgnore]
     public string ProviderDisplayName { get; set; } = string.Empty;
@@ -47,11 +47,40 @@ public class ProviderSettings
 
     public bool IsFallbackEnabled(TopLevelViewModel command)
     {
-        return FallbackCommands.TryGetValue(command.Id, out var enabled) ? enabled : true;
+        return FallbackCommands.TryGetValue(command.Id, out var settings) ? settings.IsEnabled : true;
+    }
+
+    public int FallbackWeightBoost(TopLevelViewModel command)
+    {
+        return FallbackCommands.TryGetValue(command.Id, out var settings) ? settings.WeightBoost : 0;
     }
 
     public void SetFallbackEnabled(TopLevelViewModel command, bool enabled)
     {
-        FallbackCommands[command.Id] = enabled;
+        var existingSettings = FallbackCommands.TryGetValue(command.Id, out var settings) ? settings : new FallbackSettings(true, 0);
+        existingSettings.IsEnabled = enabled;
+        FallbackCommands[command.Id] = existingSettings;
+    }
+
+    public void SetFallbackWeightBoost(TopLevelViewModel command, int weightBoost)
+    {
+        var existingSettings = FallbackCommands.TryGetValue(command.Id, out var settings) ? settings : new FallbackSettings(true, 0);
+        existingSettings.WeightBoost = weightBoost;
+        FallbackCommands[command.Id] = existingSettings;
     }
 }
+
+#pragma warning disable SA1402 // File may only contain a single type
+public sealed class FallbackSettings
+{
+    public bool IsEnabled { get; set; } = true;
+
+    public int WeightBoost { get; set; }
+
+    public FallbackSettings(bool isEnabled, int weightBoost)
+    {
+        IsEnabled = isEnabled;
+        WeightBoost = weightBoost;
+    }
+}
+#pragma warning restore SA1402 // File may only contain a single type

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ProviderSettingsViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ProviderSettingsViewModel.cs
@@ -32,6 +32,10 @@ public partial class ProviderSettingsViewModel(
             $"{ExtensionName}, {TopLevelCommands.Count} commands" :
         Resources.builtin_disabled_extension;
 
+    public string FallbackSortHeader => Resources.fallback_weight_boost_title;
+
+    public string FallbackSortDescription => Resources.fallback_weight_boost_description;
+
     [MemberNotNullWhen(true, nameof(Extension))]
     public bool IsFromExtension => _provider.Extension is not null;
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelViewModel.cs
@@ -170,6 +170,20 @@ public sealed partial class TopLevelViewModel : ObservableObject, IListItem
         }
     }
 
+    public int WeightBoost
+    {
+        get => _providerSettings.FallbackWeightBoost(this);
+        set
+        {
+            if (value != WeightBoost)
+            {
+                _providerSettings.SetFallbackWeightBoost(this, value);
+                Save();
+                WeakReferenceMessenger.Default.Send<ReloadCommandsMessage>(new());
+            }
+        }
+    }
+
     public TopLevelViewModel(
         CommandItemViewModel item,
         bool isFallback,

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/ExtensionPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/ExtensionPage.xaml
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Page
     x:Class="Microsoft.CmdPal.UI.Settings.ExtensionPage"
+    x:Name="RootPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:cmdpalUI="using:Microsoft.CmdPal.UI"
@@ -117,8 +118,8 @@
                                     Visibility="{x:Bind ViewModel.HasFallbackCommands}">
                                     <ItemsRepeater.ItemTemplate>
                                         <DataTemplate x:DataType="viewModels:TopLevelViewModel">
-                                            <controls:SettingsCard DataContext="{x:Bind}" Header="{x:Bind DisplayTitle, Mode=OneWay}">
-                                                <controls:SettingsCard.HeaderIcon>
+                                            <controls:SettingsExpander Description="{x:Bind DisplayTitle}" Header="{x:Bind Title}">
+                                                <controls:SettingsExpander.HeaderIcon>
                                                     <cpcontrols:ContentIcon>
                                                         <cpcontrols:ContentIcon.Content>
                                                             <cpcontrols:IconBox
@@ -129,13 +130,28 @@
                                                                 SourceRequested="{x:Bind helpers:IconCacheProvider.SourceRequested}" />
                                                         </cpcontrols:ContentIcon.Content>
                                                     </cpcontrols:ContentIcon>
-                                                </controls:SettingsCard.HeaderIcon>
-
-                                                <!--  Content goes here  -->
-                                                <ToggleSwitch IsOn="{x:Bind IsEnabled, Mode=TwoWay}" />
-
-
-                                            </controls:SettingsCard>
+                                                </controls:SettingsExpander.HeaderIcon>
+                                                <StackPanel Orientation="Horizontal" Spacing="16">
+                                                    <ToggleSwitch IsOn="{x:Bind IsEnabled, Mode=TwoWay}" />
+                                                </StackPanel>
+                                                <controls:SettingsExpander.Items>
+                                                    <controls:SettingsCard
+                                                        Margin="-32,0,0,0"
+                                                        Description="{Binding ViewModel.FallbackSortDescription, ElementName=RootPage}"
+                                                        Header="{Binding ViewModel.FallbackSortHeader, ElementName=RootPage}"
+                                                        HeaderIcon="{ui:FontIcon Glyph=&#xE8CB;}"
+                                                        IsEnabled="{x:Bind IsEnabled, Mode=OneWay}">
+                                                        <NumberBox
+                                                            MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                                            LargeChange="50"
+                                                            Maximum="1000"
+                                                            Minimum="-1000"
+                                                            SmallChange="10"
+                                                            SpinButtonPlacementMode="Compact"
+                                                            Value="{x:Bind WeightBoost, Mode=TwoWay}" />
+                                                    </controls:SettingsCard>
+                                                </controls:SettingsExpander.Items>
+                                            </controls:SettingsExpander>
                                         </DataTemplate>
                                     </ItemsRepeater.ItemTemplate>
                                 </ItemsRepeater>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/SettingsWindow.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/SettingsWindow.xaml.cs
@@ -10,7 +10,6 @@ using Microsoft.CmdPal.UI.ViewModels;
 using Microsoft.CmdPal.UI.ViewModels.Messages;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
 using WinUIEx;
 using RS_ = Microsoft.CmdPal.UI.Helpers.ResourceLoaderInstance;


### PR DESCRIPTION
My fellow countrymen of code! For too long, we've had our fallbacks managed for us - ranked by rigid rules, buried beneath commands we never chose. But no more!

Today, we rise.

With this change to the Command Palette, PowerToys grants you the freedom to weight your fallbacks. To shape your own command destiny. To lift your most trusted tools to the top, and cast the irrelevant into the shadows.

You may rank them. You may reorder them. You may forge a palette that answers to you—and not the other way around.
They may take our defaults... but they'll never take our preferences!

https://github.com/user-attachments/assets/d71462b1-a29a-4c79-b588-5d3573b88e83

Closes #38288