### PR TITLE
Add back build cache, which will use the nightly build one

### DIFF
--- a/.pipelines/v2/ci.yml
+++ b/.pipelines/v2/ci.yml
@@ -32,7 +32,7 @@ parameters:
   - name: enableMsBuildCaching
     type: boolean
     displayName: "Enable MSBuild Caching"
-    default: false
+    default: true
   - name: runTests
     type: boolean
     displayName: "Run Tests"


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Related to this PR https://github.com/microsoft/PowerToys/pull/41968.
Now, we can enabled back the ci build with the nightly build cache (Just kick off one today, and it will run periodically daily).