### PR TITLE
build: switch Touchdown to Federated Identity

### DIFF
--- a/.pipelines/loc/loc.yml
+++ b/.pipelines/loc/loc.yml
@@ -29,8 +29,8 @@ steps:
   displayName: 'Touchdown Build - 37400, PRODEXT'
   inputs:
     teamId: 37400
-    TDBuildServiceConnection: $(TouchdownServiceConnection)
-    authType: SubjectNameIssuer
+    FederatedIdentityTDBuildServiceConnection: $(TouchdownServiceConnection)
+    authType: FederatedIdentityTDBuild
     resourceFilePath: |
      src\**\Resources.resx
      src\**\Resource.resx

--- a/.pipelines/v2/templates/steps-fetch-and-prepare-localizations.yml
+++ b/.pipelines/v2/templates/steps-fetch-and-prepare-localizations.yml
@@ -8,8 +8,8 @@ steps:
     displayName: 'Download Localization Files -- PowerToys 37400'
     inputs:
       teamId: 37400
-      TDBuildServiceConnection: $(TouchdownServiceConnection)
-      authType: SubjectNameIssuer
+      FederatedIdentityTDBuildServiceConnection: $(TouchdownServiceConnection)
+      authType: FederatedIdentityTDBuild
       resourceFilePath: |
        **\Resources.resx
        **\Resource.resx


### PR DESCRIPTION
This is required as part of offboarding our non-user service account.