### PR TITLE
Add DataTemplateSelector for HeroImage sizing

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Converters/HeroImageDataTemplateSelector.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Converters/HeroImageDataTemplateSelector.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CommandPalette.Extensions.Toolkit;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Microsoft.CmdPal.UI;
+
+/// <summary>
+/// DataTemplateSelector for HeroImage content that chooses between image and icon templates
+/// based on whether the IconInfo contains image data or icon data.
+/// </summary>
+public partial class HeroImageDataTemplateSelector : DataTemplateSelector
+{
+    /// <summary>
+    /// Template used for image content (when IconData has Data property set)
+    /// </summary>
+    public DataTemplate? ImageTemplate { get; set; }
+
+    /// <summary>
+    /// Template used for icon content (when IconData has Icon property set)
+    /// </summary>
+    public DataTemplate? IconTemplate { get; set; }
+
+    protected override DataTemplate? SelectTemplateCore(object item)
+    {
+        if (item is IconInfo iconInfo)
+        {
+            // Check if this is image content by looking at the Light IconData
+            // If Data is not null, it's an image; otherwise it's an icon
+            if (iconInfo.Light?.Data != null)
+            {
+                return ImageTemplate;
+            }
+            else
+            {
+                return IconTemplate;
+            }
+        }
+
+        // Fallback to icon template for unknown types
+        return IconTemplate;
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml
@@ -36,6 +36,11 @@
                 SeparatorTemplate="{StaticResource DetailsSeparatorTemplate}"
                 TagTemplate="{StaticResource DetailsTagsTemplate}" />
 
+            <cmdpalUI:HeroImageDataTemplateSelector
+                x:Key="HeroImageDataTemplateSelector"
+                ImageTemplate="{StaticResource HeroImageTemplate}"
+                IconTemplate="{StaticResource HeroIconTemplate}" />
+
             <converters:BoolToVisibilityConverter
                 x:Key="BoolToInvertedVisibilityConverter"
                 FalseValue="Visible"
@@ -167,6 +172,32 @@
                 x:Key="DefaultMarkdownConfig"
                 ImageProvider="{StaticResource ImageProvider}"
                 Themes="{StaticResource DefaultMarkdownThemeConfig}" />
+
+            <!-- HeroImage Templates -->
+            <DataTemplate x:Key="HeroImageTemplate" x:DataType="Microsoft.CommandPalette.Extensions.Toolkit:IconInfo">
+                <cpcontrols:IconBox
+                    x:Name="HeroImageBorder"
+                    MinWidth="200"
+                    MaxWidth="400"
+                    Height="Auto"
+                    Margin="0,0,16,16"
+                    HorizontalAlignment="Left"
+                    AutomationProperties.AccessibilityView="Raw"
+                    SourceKey="{x:Bind Light, Mode=OneWay}"
+                    SourceRequested="{x:Bind help:IconCacheProvider.SourceRequested}" />
+            </DataTemplate>
+
+            <DataTemplate x:Key="HeroIconTemplate" x:DataType="Microsoft.CommandPalette.Extensions.Toolkit:IconInfo">
+                <cpcontrols:IconBox
+                    x:Name="HeroIconBorder"
+                    Width="64"
+                    Height="64"
+                    Margin="0,0,16,16"
+                    HorizontalAlignment="Left"
+                    AutomationProperties.AccessibilityView="Raw"
+                    SourceKey="{x:Bind Light, Mode=OneWay}"
+                    SourceRequested="{x:Bind help:IconCacheProvider.SourceRequested}" />
+            </DataTemplate>
         </ResourceDictionary>
     </Page.Resources>
 
@@ -421,14 +452,12 @@
                             <RowDefinition Height="*" />
                         </Grid.RowDefinitions>
 
-                        <cpcontrols:IconBox
-                            x:Name="HeroImageBorder"
-                            Width="64"
+                        <ContentPresenter
+                            x:Name="HeroImagePresenter"
                             Margin="0,0,16,16"
                             HorizontalAlignment="Left"
-                            AutomationProperties.AccessibilityView="Raw"
-                            SourceKey="{x:Bind ViewModel.Details.HeroImage, Mode=OneWay}"
-                            SourceRequested="{x:Bind help:IconCacheProvider.SourceRequested}"
+                            Content="{x:Bind ViewModel.Details.HeroImage, Mode=OneWay}"
+                            ContentTemplateSelector="{StaticResource HeroImageDataTemplateSelector}"
                             Visibility="{x:Bind HasHeroImage, Mode=OneWay}" />
 
                         <TextBlock


### PR DESCRIPTION
## Summary
Fixes #41698 by implementing a DataTemplateSelector approach to provide different sizing for image previews vs app icons in Command Palette clipboard history.

## Problem
Image previews in Command Palette clipboard history were too small, while app icons needed to remain at their standard size. Simply changing the IconBox width would affect both images and icons.

## Solution
- **Created `HeroImageDataTemplateSelector`**: Chooses between image and icon templates based on IconInfo content type
- **Added `HeroImageTemplate`**: For image content with larger sizing (MinWidth=200, MaxWidth=400, Height=Auto)
- **Added `HeroIconTemplate`**: For icon content with standard sizing (64x64)
- **Updated ShellPage.xaml**: Replaced hardcoded IconBox with ContentPresenter using DataTemplateSelector

## Technical Details
- Uses `IconData.Data` property to detect image content vs `IconData.Icon` property for icon content
- Maintains backward compatibility with existing icon display
- Follows existing DataTemplateSelector patterns in the codebase
- No changes to core classes required

Fixes #41698