### PR TITLE
CmdPal: Allow any image format as icon for protocol bookmarks

### DIFF
--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/ThumbnailHelper.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/ThumbnailHelper.cs
@@ -242,8 +242,8 @@ public static class ThumbnailHelper
             }
         }
 
-        // 2) Handle .png files returned by store apps
-        if (iconRef.EndsWith(".png", StringComparison.OrdinalIgnoreCase))
+        // 2) Handle image files from a store app
+        if (File.Exists(iconRef))
         {
             try
             {


### PR DESCRIPTION
## Summary of the Pull Request

This change attempts to load any supported image format as a protocol bookmark icon, instead of restricting it to PNG only. The original implementation handled only PNG (which are common), but the manifest also supports JPG/JPEG extensions.

Reference: [UWP manifest schema – uap:VisualElements](https://learn.microsoft.com/en-us/uwp/schemas/appxpackage/uapmanifestschema/element-uap-visualelements)


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #42144 
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

