### PR TITLE
Improve Command Palette settings card layout

### DIFF
--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/Setting`1.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/Setting`1.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 
@@ -49,29 +50,124 @@ public abstract class Setting<T> : ISettingsForm
 
     public string ToForm()
     {
-        var bodyJson = JsonSerializer.Serialize(ToDictionary(), JsonSerializationContext.Default.Dictionary);
-        var dataJson = $"\"{Key}\": \"{Key}\"";
+        var controlElement = ToDictionary();
 
-        var json = $$"""
-{
-  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
-  "type": "AdaptiveCard",
-  "version": "1.5",
-  "body": [
-      {{bodyJson}}
-  ],
-  "actions": [
-    {
-      "type": "Action.Submit",
-      "title": "Save",
-      "data": {
-        {{dataJson}}
-      }
-    }
-  ]
-}
-""";
-        return json;
+        var labelText = Label;
+        var descriptionText = Description;
+
+        if (controlElement.TryGetValue("label", out var existingLabel) && string.IsNullOrWhiteSpace(labelText) && existingLabel is string existingLabelText)
+        {
+            labelText = existingLabelText;
+        }
+
+        if (controlElement.TryGetValue("title", out var existingTitle) && string.IsNullOrWhiteSpace(labelText) && existingTitle is string existingTitleText)
+        {
+            labelText = existingTitleText;
+        }
+
+        if (controlElement.TryGetValue("label", out var controlDescription) && string.IsNullOrWhiteSpace(descriptionText) && controlDescription is string descriptionFromControl)
+        {
+            descriptionText = descriptionFromControl;
+        }
+
+        if (!string.IsNullOrWhiteSpace(labelText))
+        {
+            controlElement["label"] = labelText;
+            controlElement["labelPosition"] = "hidden";
+        }
+
+        var labelElements = new List<Dictionary<string, object>>();
+        if (!string.IsNullOrWhiteSpace(labelText))
+        {
+            labelElements.Add(new()
+            {
+                { "type", "TextBlock" },
+                { "text", labelText },
+                { "weight", "Bolder" },
+                { "wrap", true }
+            });
+        }
+
+        if (!string.IsNullOrWhiteSpace(descriptionText))
+        {
+            labelElements.Add(new()
+            {
+                { "type", "TextBlock" },
+                { "text", descriptionText },
+                { "isSubtle", true },
+                { "wrap", true },
+                { "spacing", "None" }
+            });
+        }
+
+        var bodyElements = new List<object>();
+
+        if (controlElement.TryGetValue("type", out var typeValue) && typeValue is string typeString && typeString.Equals("Input.Toggle", StringComparison.OrdinalIgnoreCase))
+        {
+            controlElement["title"] = string.Empty;
+
+            if (labelElements.Count == 0)
+            {
+                bodyElements.Add(controlElement);
+            }
+            else
+            {
+                bodyElements.Add(new Dictionary<string, object>
+                {
+                    { "type", "ColumnSet" },
+                    { "columns", new List<object>
+                        {
+                            new Dictionary<string, object>
+                            {
+                                { "type", "Column" },
+                                { "width", "auto" },
+                                { "verticalContentAlignment", "Center" },
+                                { "items", new List<object> { controlElement } }
+                            },
+                            new Dictionary<string, object>
+                            {
+                                { "type", "Column" },
+                                { "width", "stretch" },
+                                { "items", labelElements }
+                            }
+                        }
+                    }
+                });
+            }
+        }
+        else
+        {
+            bodyElements.AddRange(labelElements);
+            bodyElements.Add(controlElement);
+        }
+
+        var card = new Dictionary<string, object>
+        {
+            { "$schema", "http://adaptivecards.io/schemas/adaptive-card.json" },
+            { "type", "AdaptiveCard" },
+            { "version", "1.5" },
+            { "body", bodyElements },
+            {
+                "actions",
+                new List<object>
+                {
+                    new Dictionary<string, object>
+                    {
+                        { "type", "Action.Submit" },
+                        { "title", "Save" },
+                        {
+                            "data",
+                            new Dictionary<string, object>
+                            {
+                                { Key, Key }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        return JsonSerializer.Serialize(card, _jsonSerializerOptions);
     }
 
     public abstract void Update(JsonObject payload);


### PR DESCRIPTION
## Summary
- restructure the Adaptive Card generated for settings so labels and descriptions are rendered in dedicated text blocks ahead of each control
- special-case toggles by wrapping them in a two-column layout, keeping the checkbox aligned with the new text blocks
- fall back to control-provided label/description values when needed and keep labels accessible by hiding the on-control label

## Testing
- not run (PowerToys build/tests require a full Windows environment)

Fixes #39283
