### PR TITLE
[Mouse Without Borders] Adding Horizontal Scrolling Support

### DIFF
--- a/src/modules/MouseWithoutBorders/App/Class/Common.VK.cs
+++ b/src/modules/MouseWithoutBorders/App/Class/Common.VK.cs
@@ -112,6 +112,7 @@ namespace MouseWithoutBorders
         internal const int WM_RBUTTONDBLCLK = 0x206;
         internal const int WM_MBUTTONDBLCLK = 0x209;
         internal const int WM_MOUSEWHEEL = 0x020A;
+        internal const int WM_MOUSEHWHEEL = 0x020E;
 
         internal const int WM_KEYDOWN = 0x100;
         internal const int WM_KEYUP = 0x101;

--- a/src/modules/MouseWithoutBorders/App/Class/InputSimulation.cs
+++ b/src/modules/MouseWithoutBorders/App/Class/InputSimulation.cs
@@ -204,6 +204,9 @@ namespace MouseWithoutBorders.Class
                 case Common.WM_MOUSEWHEEL:
                     mouse_input.mi.dwFlags |= (int)NativeMethods.MOUSEEVENTF.WHEEL;
                     break;
+                case Common.WM_MOUSEHWHEEL:
+                    mouse_input.mi.dwFlags |= (int)NativeMethods.MOUSEEVENTF.HWHEEL;
+                    break;
                 case Common.WM_XBUTTONUP:
                     mouse_input.mi.dwFlags |= (int)NativeMethods.MOUSEEVENTF.XUP;
                     break;

--- a/src/modules/MouseWithoutBorders/App/Class/NativeMethods.cs
+++ b/src/modules/MouseWithoutBorders/App/Class/NativeMethods.cs
@@ -556,6 +556,7 @@ namespace MouseWithoutBorders.Class
             XDOWN = 0x0080,
             XUP = 0x0100,
             WHEEL = 0x0800,
+            HWHEEL = 0x01000,
             VIRTUALDESK = 0x4000,
             ABSOLUTE = 0x8000,
         }


### PR DESCRIPTION
## Summary of the Pull Request
Added support for horizontal scrolling to Mouse Without Borders, instead of being a no-op.

## PR Checklist

- [x] Closes: #37037
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments
Works in a backward compatible fashion, continuing to be a no-op when forwarded to an older version, but works once both devices are updated. 

## Validation Steps Performed
Built on two separate devices that are paired with each other. First tested with one device updated and one on the old code, confirming backwards compatibility support. Second tested both devices updated, confirming horizontal scroll is now working on remote device. 
