### PR TITLE
Mouse Without Borders: A conflict machine Id will make connection fail

### DIFF
--- a/src/modules/MouseWithoutBorders/App/Class/Setting.cs
+++ b/src/modules/MouseWithoutBorders/App/Class/Setting.cs
@@ -1187,4 +1187,3 @@ namespace MouseWithoutBorders.Class
         internal static Settings Values = new Settings();
     }
 }
-


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR fixes a critical issue in Mouse Without Borders where conflicting machine IDs would cause connection failures. The changes ensure that when machine IDs are generated or updated, the settings are immediately persisted to prevent loss of the new ID and maintain proper synchronization between the property and backing field.

Key changes:

* Immediate settings persistence when a new machine ID is generated (unless instant saving is paused)
* Proper synchronization of the machineId field when the MachineId property is set
* Addition of settings saving logic in both getter and setter scenarios


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] Closes: #42084
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
* Do a release bundle build and install new bundle with this fix on both two machines
* Manually change two pc's machine ID to the same value
* Make sure they can connect
* Verify there is log entrance indicating that there is conflict for machineID
* Close MWB, make sure next launch still connect
