### PR TITLE
Light Switch: Fix spellcheck and add version info

### DIFF
--- a/src/modules/LightSwitch/LightSwitchModuleInterface/LightSwitchModuleInterface.rc
+++ b/src/modules/LightSwitch/LightSwitchModuleInterface/LightSwitchModuleInterface.rc
@@ -1,32 +1,36 @@
+#include <windows.h>
+#include "resource.h"
+#include "../../../common/version/version.h"
+
 1 VERSIONINFO
- FILEVERSION 0,1,0,0
- PRODUCTVERSION 0,1,0,0
- FILEFLAGSMASK 0x3fL
+FILEVERSION FILE_VERSION
+PRODUCTVERSION PRODUCT_VERSION
+FILEFLAGSMASK VS_FFI_FILEFLAGSMASK
 #ifdef _DEBUG
- FILEFLAGS 0x1L
+FILEFLAGS VS_FF_DEBUG
 #else
- FILEFLAGS 0x0L
+FILEFLAGS 0x0L
 #endif
- FILEOS 0x40004L
- FILETYPE 0x2L
- FILESUBTYPE 0x0L
+FILEOS VOS_NT_WINDOWS32
+FILETYPE VFT_DLL
+FILESUBTYPE VFT2_UNKNOWN 
 BEGIN
     BLOCK "StringFileInfo"
     BEGIN
-        BLOCK "040904b0"
+        BLOCK "040904b0" // US English (0x0409), Unicode (0x04B0) charset
         BEGIN
-            VALUE "CompanyName", "Company Name"
-            VALUE "FileDescription", "Light Switch Module"
-            VALUE "FileVersion", "0.1.0.0"
-            VALUE "InternalName", "Light Switch"
-            VALUE "LegalCopyright", "Copyright (C) 2019 Company Name"
-            VALUE "OriginalFilename", "PowerToys.LightSwitchModuleInterface.dll"
-            VALUE "ProductName", "Light Switch"
-            VALUE "ProductVersion", "0.1.0.0"
+            VALUE "CompanyName", COMPANY_NAME
+            VALUE "FileDescription", FILE_DESCRIPTION
+            VALUE "FileVersion", FILE_VERSION_STRING
+            VALUE "InternalName", INTERNAL_NAME
+            VALUE "LegalCopyright", COPYRIGHT_NOTE
+            VALUE "OriginalFilename", ORIGINAL_FILENAME
+            VALUE "ProductName", PRODUCT_NAME
+            VALUE "ProductVersion", PRODUCT_VERSION_STRING
         END
     END
     BLOCK "VarFileInfo"
     BEGIN
-        VALUE "Translation", 0x409, 1200
+        VALUE "Translation", 0x409, 1200 // US English (0x0409), Unicode (1200) charset
     END
 END

--- a/src/modules/LightSwitch/LightSwitchModuleInterface/dllmain.cpp
+++ b/src/modules/LightSwitch/LightSwitchModuleInterface/dllmain.cpp
@@ -460,7 +460,7 @@ public:
             }
             else if (hotkeyId == 0)
             {
-                // get current will return true if in light mode, otherwise false
+                // get current will return true if in light mode; otherwise false
                 Logger::info(L"[Light Switch] Hotkey triggered: Toggle Theme");
                 if (g_settings.m_changeSystem)
                 {

--- a/src/modules/LightSwitch/LightSwitchModuleInterface/resource.h
+++ b/src/modules/LightSwitch/LightSwitchModuleInterface/resource.h
@@ -1,0 +1,13 @@
+//{{NO_DEPENDENCIES}}
+// Microsoft Visual C++ generated include file.
+// Used by CalculatorEngineCommon.rc
+
+//////////////////////////////
+// Non-localizable
+
+#define FILE_DESCRIPTION "Light Switch Module"
+#define INTERNAL_NAME "Light Switch"
+#define ORIGINAL_FILENAME "PowerToys.LightSwitchModuleInterface.dll"
+
+// Non-localizable
+//////////////////////////////


### PR DESCRIPTION
## Summary of the Pull Request

This PR addresses spellchecking issues in Light Switch module:

- Resolves the forbidden pattern “`, otherwise`” by rewriting it as “`; otherwise`”.
- Updates `resource.h`, which was previously empty and therefore treated as a binary file by the spellchecker.  
  The file now includes standard version information consistent with other projects, ensuring it is properly recognized and that the correct version information is included in `PowerToys.LightSwitchModuleInterface.dll`.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] Closes: #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

