### PR TITLE
CmdPal: immediately move to page, while loading

### DIFF
--- a/src/modules/cmdpal/Core/Microsoft.CmdPal.Core.ViewModels/ShellViewModel.cs
+++ b/src/modules/cmdpal/Core/Microsoft.CmdPal.Core.ViewModels/ShellViewModel.cs
@@ -206,10 +206,13 @@ public partial class ShellViewModel : ObservableObject,
                     .ContinueWith(
                         (Task t) =>
                         {
+                            // When we're done loading the page, then update the command bar to match
                             OnUIThread(() => { WeakReferenceMessenger.Default.Send<UpdateCommandBarMessage>(new(null)); });
-                            WeakReferenceMessenger.Default.Send<NavigateToPageMessage>(new(pageViewModel, message.WithAnimation));
                         },
                         _scheduler);
+
+                // While we're loading in the background, immediately move to the next page.
+                WeakReferenceMessenger.Default.Send<NavigateToPageMessage>(new(pageViewModel, message.WithAnimation));
 
                 // Note: Originally we set our page back in the ViewModel here, but that now happens in response to the Frame navigating triggered from the above
                 // See RootFrame_Navigated event handler.


### PR DESCRIPTION
Regressed in #41358

We're synchronously waiting for the first FetchItems to return before actually navigating to the page. Yikes.

Closes #42157

drive-by:
Closes #42231
Closes #42156
