### PR TITLE
Reinstate ZoomIt branding

### DIFF
--- a/src/modules/ZoomIt/ZoomIt/ZoomIt.rc
+++ b/src/modules/ZoomIt/ZoomIt/ZoomIt.rc
@@ -2,6 +2,13 @@
 //
 #include "resource.h"
 
+// version.h and branding.h are different in the Sysinternals repository,
+// keep the includes as such, here.
+// From $(MSBuildThisFileDirectory)..\..\..\common\version
+#include "version.h"
+// From $(MSBuildThisFileDirectory)PowerToys
+#include "branding.h"
+
 #define APSTUDIO_READONLY_SYMBOLS
 /////////////////////////////////////////////////////////////////////////////
 //
@@ -68,8 +75,8 @@ APPICON                 ICON                    "appicon.ico"
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 9,10,0,0
- PRODUCTVERSION 9,10,0,0
+ FILEVERSION FILE_VERSION
+ PRODUCTVERSION PRODUCT_VERSION
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -84,14 +91,14 @@ BEGIN
     BEGIN
         BLOCK "040904b0"
         BEGIN
-            VALUE "CompanyName", "Microsoft Corporation"
-            VALUE "FileDescription", "Sysinternals Screen Magnifier"
-            VALUE "FileVersion", "9.10"
-            VALUE "InternalName", "ZoomIt"
-            VALUE "LegalCopyright", "Copyright (C) Microsoft Corporation. All rights reserved."
-            VALUE "OriginalFilename", "PowerToys.ZoomIt.exe"
-            VALUE "ProductName", "PowerToys Sysinternals ZoomIt"
-            VALUE "ProductVersion", "9.10"
+            VALUE "CompanyName", COMPANY_NAME
+            VALUE "FileDescription", FILE_DESCRIPTION
+            VALUE "FileVersion", FILE_VERSION_STRING
+            VALUE "InternalName", INTERNAL_NAME
+            VALUE "LegalCopyright", COPYRIGHT_NOTE
+            VALUE "OriginalFilename", ORIGINAL_FILENAME
+            VALUE "ProductName", ZOOMIT_PRODUCT_NAME
+            VALUE "ProductVersion", PRODUCT_VERSION_STRING
         END
     END
     BLOCK "VarFileInfo"
@@ -114,8 +121,8 @@ FONT 8, "MS Shell Dlg", 0, 0, 0x0
 BEGIN
     DEFPUSHBUTTON   "OK",IDOK,166,306,50,14
     PUSHBUTTON      "Cancel",IDCANCEL,223,306,50,14
-    LTEXT           "ZoomIt v9.01",IDC_VERSION,42,7,73,10
-    LTEXT           "Copyright ï¿½ 2006-2025 Mark Russinovich",IDC_COPYRIGHT,42,17,231,8
+    LTEXT           "ZoomIt v9.10",IDC_VERSION,42,7,73,10
+    LTEXT           "Copyright © 2006-2025 Mark Russinovich",IDC_COPYRIGHT,42,17,231,8
     CONTROL         "<a HREF=""https://www.sysinternals.com"">Sysinternals - www.sysinternals.com</a>",IDC_LINK,
                     "SysLink",WS_TABSTOP,42,26,150,9
     ICON            "APPICON",IDC_STATIC,12,9,20,20


### PR DESCRIPTION
This pull request restores dynamic branding and versioning for the ZoomIt subproject.

## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] Closes: #xxx
- [x] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
It was deleted by mistake in the previous commit.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

What was broken and this PR changes:
<img width="736" height="709" alt="image" src="https://github.com/user-attachments/assets/803b0051-cf5b-4e81-a7e9-f562295896ea" />


Fixed behavior now, in PowerToys (official version up, with the changes this commit overrides down):
<img width="1159" height="1345" alt="image" src="https://github.com/user-attachments/assets/cf4d0c81-2d97-4ef5-a179-8f423dfe9739" />

Fixed behavior now, standalone:
<img width="1617" height="968" alt="image" src="https://github.com/user-attachments/assets/467ffccd-f3d2-4543-bec3-1186941084c5" />
