### PR TITLE
CmdPal: adjust frecency weighting

### DIFF
--- a/PowerToys.sln
+++ b/PowerToys.sln
@@ -825,6 +825,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LightSwitch.UITests", "src\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.CmdPal.Ext.ClipboardHistory.UnitTests", "src\modules\cmdpal\Tests\Microsoft.CmdPal.Ext.ClipboardHistory.UnitTests\Microsoft.CmdPal.Ext.ClipboardHistory.UnitTests.csproj", "{4E0FCF69-B06B-D272-76BF-ED3A559B4EDA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.CmdPal.UI.ViewModels.UnitTests", "src\modules\cmdpal\Tests\Microsoft.CmdPal.UI.ViewModels.UnitTests\Microsoft.CmdPal.UI.ViewModels.UnitTests.csproj", "{A66E9270-5D93-EC9C-F06E-CE7295BB9A6C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM64 = Debug|ARM64
@@ -2995,6 +2997,14 @@ Global
 		{4E0FCF69-B06B-D272-76BF-ED3A559B4EDA}.Release|ARM64.Build.0 = Release|ARM64
 		{4E0FCF69-B06B-D272-76BF-ED3A559B4EDA}.Release|x64.ActiveCfg = Release|x64
 		{4E0FCF69-B06B-D272-76BF-ED3A559B4EDA}.Release|x64.Build.0 = Release|x64
+		{A66E9270-5D93-EC9C-F06E-CE7295BB9A6C}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{A66E9270-5D93-EC9C-F06E-CE7295BB9A6C}.Debug|ARM64.Build.0 = Debug|ARM64
+		{A66E9270-5D93-EC9C-F06E-CE7295BB9A6C}.Debug|x64.ActiveCfg = Debug|x64
+		{A66E9270-5D93-EC9C-F06E-CE7295BB9A6C}.Debug|x64.Build.0 = Debug|x64
+		{A66E9270-5D93-EC9C-F06E-CE7295BB9A6C}.Release|ARM64.ActiveCfg = Release|ARM64
+		{A66E9270-5D93-EC9C-F06E-CE7295BB9A6C}.Release|ARM64.Build.0 = Release|ARM64
+		{A66E9270-5D93-EC9C-F06E-CE7295BB9A6C}.Release|x64.ActiveCfg = Release|x64
+		{A66E9270-5D93-EC9C-F06E-CE7295BB9A6C}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -3323,6 +3333,7 @@ Global
 		{3DCCD936-D085-4869-A1DE-CA6A64152C94} = {5B201255-53C8-490B-A34F-01F05D48A477}
 		{F5333ED7-06D8-4AB3-953A-36D63F08CB6F} = {3DCCD936-D085-4869-A1DE-CA6A64152C94}
 		{4E0FCF69-B06B-D272-76BF-ED3A559B4EDA} = {8EF25507-2575-4ADE-BF7E-D23376903AB8}
+		{A66E9270-5D93-EC9C-F06E-CE7295BB9A6C} = {8EF25507-2575-4ADE-BF7E-D23376903AB8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C3A2F9D1-7930-4EF4-A6FC-7EE0A99821D0}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
@@ -428,7 +428,7 @@ public partial class MainListPage : DynamicListPage,
     // Almost verbatim ListHelpers.ScoreListItem, but also accounting for the
     // fact that we want fallback handlers down-weighted, so that they don't
     // _always_ show up first.
-    private static int ScoreTopLevelItem(string query, IListItem topLevelOrAppItem, IRecentCommandsManager history)
+    internal static int ScoreTopLevelItem(string query, IListItem topLevelOrAppItem, IRecentCommandsManager history)
     {
         var title = topLevelOrAppItem.Title;
         if (string.IsNullOrWhiteSpace(title))

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
@@ -504,7 +504,7 @@ public partial class MainListPage : DynamicListPage,
         // here we add the recent command weight boost
         //
         // Otherwise something like `x` will still match everything you've run before
-        var finalScore = matchSomething;
+        var finalScore = matchSomething * 10;
         if (matchSomething > 0)
         {
             var recentWeightBoost = history.GetCommandHistoryWeight(id);

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Properties/AssemblyInfo.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Properties/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Microsoft.CmdPal.UI.ViewModels.UnitTests")]

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/RecentCommandsManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/RecentCommandsManager.cs
@@ -7,7 +7,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace Microsoft.CmdPal.UI.ViewModels;
 
-public partial class RecentCommandsManager : ObservableObject
+public partial class RecentCommandsManager : ObservableObject, IRecentCommandsManager
 {
     [JsonInclude]
     internal List<HistoryItem> History { get; set; } = [];
@@ -79,4 +79,11 @@ public partial class RecentCommandsManager : ObservableObject
             }
         }
     }
+}
+
+public interface IRecentCommandsManager
+{
+    int GetCommandHistoryWeight(string commandId);
+
+    void AddHistoryItem(string commandId);
 }

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/Microsoft.CmdPal.UI.ViewModels.UnitTests.csproj
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/Microsoft.CmdPal.UI.ViewModels.UnitTests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!-- Look at Directory.Build.props in root for common stuff as well -->
+  <Import Project="..\..\..\..\Common.Dotnet.CsWinRT.props" />
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <RootNamespace>Microsoft.CmdPal.UI.ViewModels.UnitTests</RootNamespace>
+    <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\WinUI3Apps\CmdPal\tests\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Moq" />
+    <PackageReference Include="MSTest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Microsoft.CmdPal.UI.ViewModels\Microsoft.CmdPal.UI.ViewModels.csproj" />
+    <ProjectReference Include="..\Microsoft.CmdPal.Ext.UnitTestsBase\Microsoft.CmdPal.Ext.UnitTestBase.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/Microsoft.CmdPal.UI.ViewModels.UnitTests.csproj
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/Microsoft.CmdPal.UI.ViewModels.UnitTests.csproj
@@ -9,11 +9,13 @@
     <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\WinUI3Apps\CmdPal\tests\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Moq" />
     <PackageReference Include="MSTest" />
+    <PackageReference Include="WyHash" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/RecentCommandsTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/RecentCommandsTests.cs
@@ -5,13 +5,14 @@
 using System.Collections.Generic;
 using Microsoft.CmdPal.Ext.UnitTestBase;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WyHash;
 
 namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
 
 [TestClass]
 public class RecentCommandsTests : CommandPaletteUnitTestBase
 {
-    private static RecentCommandsManager CreateHistory(IList<string> commandIds = null)
+    private static RecentCommandsManager CreateHistory(IList<string>? commandIds = null)
     {
         var history = new RecentCommandsManager();
         if (commandIds != null)
@@ -50,5 +51,85 @@ public class RecentCommandsTests : CommandPaletteUnitTestBase
 
         // Assert
         Assert.IsTrue(history.GetCommandHistoryWeight("com.microsoft.cmdpal.shell") > 0);
+    }
+
+    [TestMethod]
+    public void ValidateHistoryWeighting()
+    {
+        // Setup
+        var history = CreateMockHistoryServiceWithCommonCommands();
+
+        // Act
+        var shellWeight = history.GetCommandHistoryWeight("com.microsoft.cmdpal.shell");
+        var windowWalkerWeight = history.GetCommandHistoryWeight("com.microsoft.cmdpal.windowwalker");
+        var vsWeight = history.GetCommandHistoryWeight("Visual Studio 2022 Preview_6533433915015224980");
+        var reloadWeight = history.GetCommandHistoryWeight("com.microsoft.cmdpal.reload");
+        var nonExistentWeight = history.GetCommandHistoryWeight("non.existent.command");
+
+        // Assert
+        Assert.IsTrue(shellWeight > windowWalkerWeight, "Shell should be weighted higher than Window Walker, more uses");
+        Assert.IsTrue(vsWeight > windowWalkerWeight, "Visual Studio should be weighted higher than Window Walker, because recency");
+        Assert.AreEqual(reloadWeight, vsWeight, "both reload and VS were used in the last three commands, same weight");
+        Assert.IsTrue(shellWeight > vsWeight, "VS and run were both used in the last 3, but shell has 2 more frequency");
+        Assert.AreEqual(0, nonExistentWeight, "Non-existent command should have zero weight");
+    }
+
+    private sealed record ListItemMock(
+        string Title,
+        string? Subtitle = "",
+        string? GivenId = "",
+        string? ProviderId = "")
+    {
+        public string Id => string.IsNullOrEmpty(GivenId) ? GenerateId() : GivenId;
+
+        private string GenerateId()
+        {
+            // Use WyHash64 to generate stable ID hashes.
+            // manually seeding with 0, so that the hash is stable across launches
+            var result = WyHash64.ComputeHash64(ProviderId + Title + Subtitle, seed: 0);
+            return $"{ProviderId}{result}";
+        }
+    }
+
+    private static RecentCommandsManager CreateHistory(IList<ListItemMock> items)
+    {
+        var history = new RecentCommandsManager();
+        foreach (var item in items)
+        {
+            history.AddHistoryItem(item.Id);
+        }
+
+        return history;
+    }
+
+    [TestMethod]
+    public void ValidateMocksWork()
+    {
+        // Setup
+        var items = new List<ListItemMock>
+        {
+            new("Command A", "Subtitle A", "idA", "providerA"),
+            new("Command B", "Subtitle B", GivenId: "idB"),
+            new("Command C", "Subtitle C", ProviderId: "providerC"),
+            new("Command A", "Subtitle A", "idA", "providerA"), // Duplicate to test incrementing uses
+        };
+
+        // Act
+        var history = CreateHistory(items);
+
+        // Assert
+        foreach (var item in items)
+        {
+            var weight = history.GetCommandHistoryWeight(item.Id);
+            Assert.IsTrue(weight > 0, $"Item {item.Title} should have a weight greater than zero.");
+        }
+
+        // Check that the duplicate item has a higher weight due to increased uses
+        var weightA = history.GetCommandHistoryWeight("idA");
+        var weightB = history.GetCommandHistoryWeight("idB");
+        var weightC = history.GetCommandHistoryWeight(items[2].Id); // providerC generated ID
+        Assert.IsTrue(weightA > weightB, "Item A should have a higher weight than Item B due to more uses.");
+        Assert.IsTrue(weightA > weightC, "Item A should have a higher weight than Item C due to more uses.");
+        Assert.AreEqual(weightC, weightB, "Item C and Item B were used in the last 3 commands");
     }
 }

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/RecentCommandsTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/RecentCommandsTests.cs
@@ -357,19 +357,17 @@ public partial class RecentCommandsTests : CommandPaletteUnitTestBase
         }
 
         var unweightedMatches = GetMatches(items, unweightedScores).ToList();
-        Assert.AreEqual(4, unweightedMatches.Count, "There should be three matching items");
+        Assert.AreEqual(4, unweightedMatches.Count);
         Assert.AreEqual("Command Prompt", unweightedMatches[0].Title, "Command Prompt should be the top match");
         Assert.AreEqual("Visual Studio Code", unweightedMatches[1].Title, "Visual Studio Code should be the second match");
         Assert.AreEqual("Terminal Canary", unweightedMatches[2].Title);
         Assert.AreEqual("Run commands", unweightedMatches[3].Title);
 
-        // After weighting for usage, Visual Studio Code should be the top match
-        // because it's been used more recently than Command Prompt (code is in
-        // bucket 0, cmd is in bucket 1)
+        // Even after weighting for 1 use, Command Prompt should still be the top match.
         var weightedMatches = GetMatches(items, weightedScores).ToList();
-        Assert.AreEqual(4, weightedMatches.Count, "There should be three matching items");
-        Assert.AreEqual("Visual Studio Code", weightedMatches[0].Title, "Visual Studio should be the top match");
-        Assert.AreEqual("Command Prompt", weightedMatches[1].Title, "Command Prompt should be the second match");
+        Assert.AreEqual(4, weightedMatches.Count);
+        Assert.AreEqual("Command Prompt", weightedMatches[0].Title);
+        Assert.AreEqual("Visual Studio Code", weightedMatches[1].Title);
         Assert.AreEqual("Terminal Canary", weightedMatches[2].Title);
         Assert.AreEqual("Run commands", weightedMatches[3].Title);
     }

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/RecentCommandsTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/RecentCommandsTests.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Microsoft.CmdPal.Ext.UnitTestBase;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
+
+[TestClass]
+public class RecentCommandsTests : CommandPaletteUnitTestBase
+{
+    private static RecentCommandsManager CreateHistory(IList<string> commandIds = null)
+    {
+        var history = new RecentCommandsManager();
+        if (commandIds != null)
+        {
+            foreach (var item in commandIds)
+            {
+                history.AddHistoryItem(item);
+            }
+        }
+
+        return history;
+    }
+
+    private static RecentCommandsManager CreateMockHistoryServiceWithCommonCommands()
+    {
+        var commonCommands = new List<string>
+        {
+            "com.microsoft.cmdpal.shell",
+            "com.microsoft.cmdpal.windowwalker",
+            "Visual Studio 2022 Preview_6533433915015224980",
+            "com.microsoft.cmdpal.reload",
+            "com.microsoft.cmdpal.shell",
+        };
+
+        return CreateHistory(commonCommands);
+    }
+
+    [TestMethod]
+    public void ValidateHistoryFunctionality()
+    {
+        // Setup
+        var history = CreateHistory();
+
+        // Act
+        history.AddHistoryItem("com.microsoft.cmdpal.shell");
+
+        // Assert
+        Assert.IsTrue(history.GetCommandHistoryWeight("com.microsoft.cmdpal.shell") > 0);
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/RecentCommandsTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/RecentCommandsTests.cs
@@ -77,7 +77,7 @@ public partial class RecentCommandsTests : CommandPaletteUnitTestBase
         Assert.IsTrue(vsWeight > windowWalkerWeight, "Visual Studio should be weighted higher than Window Walker, because recency");
         Assert.AreEqual(reloadWeight, vsWeight, "both reload and VS were used in the last three commands, same weight");
         Assert.IsTrue(shellWeight > vsWeight, "VS and run were both used in the last 3, but shell has 2 more frequency");
-        Assert.AreEqual(0, nonExistentWeight, "Non-existent command should have zero weight");
+        Assert.AreEqual(0, nonExistentWeight, "Nonexistent command should have zero weight");
     }
 
     private sealed partial record ListItemMock(

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/RecentCommandsTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/RecentCommandsTests.cs
@@ -320,5 +320,18 @@ public partial class RecentCommandsTests : CommandPaletteUnitTestBase
                 Assert.AreEqual(unweighted, weighted);
             }
         }
+
+        var matches = items.Join(
+            weightedScores,
+            item => item.Id,
+            score => items[weightedScores.IndexOf(score)].Id,
+            (item, score) => new { item.Title, Score = score })
+            .Where(x => x.Score > 0)
+            .OrderByDescending(x => x.Score)
+            .ToList();
+        Assert.AreEqual(3, matches.Count, "There should be three matching items");
+        Assert.AreEqual("Command Prompt", matches[0].Title, "Command Prompt should be the top match");
+        Assert.AreEqual("Visual Studio Code", matches[1].Title, "Visual Studio Code should be the second match");
+        Assert.AreEqual("Run commands", matches[2].Title, "Run commands should be the third match");
     }
 }

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/RecentCommandsTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/RecentCommandsTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.CmdPal.Ext.UnitTestBase;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using WyHash;
@@ -131,5 +132,99 @@ public class RecentCommandsTests : CommandPaletteUnitTestBase
         Assert.IsTrue(weightA > weightB, "Item A should have a higher weight than Item B due to more uses.");
         Assert.IsTrue(weightA > weightC, "Item A should have a higher weight than Item C due to more uses.");
         Assert.AreEqual(weightC, weightB, "Item C and Item B were used in the last 3 commands");
+    }
+
+    [TestMethod]
+    public void ValidateHistoryBuckets()
+    {
+        // Setup
+        // (these will be checked in reverse order, so that A is the most recent)
+        var items = new List<ListItemMock>
+        {
+            new("Command A", "Subtitle A", GivenId: "idA"), // #0  -> bucket 0
+            new("Command B", "Subtitle B", GivenId: "idB"), // #1  -> bucket 0
+            new("Command C", "Subtitle C", GivenId: "idC"), // #2  -> bucket 0
+            new("Command D", "Subtitle D", GivenId: "idD"), // #3  -> bucket 1
+            new("Command E", "Subtitle E", GivenId: "idE"), // #4  -> bucket 1
+            new("Command F", "Subtitle F", GivenId: "idF"), // #5  -> bucket 1
+            new("Command G", "Subtitle G", GivenId: "idG"), // #6  -> bucket 1
+            new("Command H", "Subtitle H", GivenId: "idH"), // #7  -> bucket 1
+            new("Command I", "Subtitle I", GivenId: "idI"), // #8  -> bucket 1
+            new("Command J", "Subtitle J", GivenId: "idJ"), // #9  -> bucket 1
+            new("Command K", "Subtitle K", GivenId: "idK"), // #10 -> bucket 1
+            new("Command L", "Subtitle L", GivenId: "idL"), // #11 -> bucket 2
+            new("Command M", "Subtitle M", GivenId: "idM"), // #12 -> bucket 2
+            new("Command N", "Subtitle N", GivenId: "idN"), // #13 -> bucket 2
+            new("Command O", "Subtitle O", GivenId: "idO"), // #14 -> bucket 2
+        };
+
+        for (var i = items.Count; i <= 50; i++)
+        {
+            items.Add(new ListItemMock($"Command #{i}", GivenId: $"id{i}"));
+        }
+
+        // Act
+        var history = CreateHistory(items.Reverse<ListItemMock>().ToList());
+
+        // Assert
+        // First three items should be in the top bucket
+        var weightA = history.GetCommandHistoryWeight("idA");
+        var weightB = history.GetCommandHistoryWeight("idB");
+        var weightC = history.GetCommandHistoryWeight("idC");
+
+        Assert.AreEqual(weightA, weightB, "Items A and B were used in the last 3 commands");
+        Assert.AreEqual(weightB, weightC, "Items B and C were used in the last 3 commands");
+
+        // Next eight items (3-10 inclusive) should be in the second bucket
+        var weightD = history.GetCommandHistoryWeight("idD");
+        var weightE = history.GetCommandHistoryWeight("idE");
+        var weightF = history.GetCommandHistoryWeight("idF");
+        var weightG = history.GetCommandHistoryWeight("idG");
+        var weightH = history.GetCommandHistoryWeight("idH");
+        var weightI = history.GetCommandHistoryWeight("idI");
+        var weightJ = history.GetCommandHistoryWeight("idJ");
+        var weightK = history.GetCommandHistoryWeight("idK");
+
+        Assert.AreEqual(weightD, weightE, "Items D and E were used in the last 10 commands");
+        Assert.AreEqual(weightE, weightF, "Items E and F were used in the last 10 commands");
+        Assert.AreEqual(weightF, weightG, "Items F and G were used in the last 10 commands");
+        Assert.AreEqual(weightG, weightH, "Items G and H were used in the last 10 commands");
+        Assert.AreEqual(weightH, weightI, "Items H and I were used in the last 10 commands");
+        Assert.AreEqual(weightI, weightJ, "Items I and J were used in the last 10 commands");
+        Assert.AreEqual(weightJ, weightK, "Items J and K were used in the last 10 commands");
+
+        // Items up to the 15th should be in the third bucket
+        var weightL = history.GetCommandHistoryWeight("idL");
+        var weightM = history.GetCommandHistoryWeight("idM");
+        var weightN = history.GetCommandHistoryWeight("idN");
+        var weightO = history.GetCommandHistoryWeight("idO");
+        var weight15 = history.GetCommandHistoryWeight("id15");
+        Assert.AreEqual(weightL, weightM, "Items L and M were used in the last 15 commands");
+        Assert.AreEqual(weightM, weightN, "Items M and N were used in the last 15 commands");
+        Assert.AreEqual(weightN, weightO, "Items N and O were used in the last 15 commands");
+        Assert.AreEqual(weightO, weight15, "Items O and 15 were used in the last 15 commands");
+
+        // Items after that should be in the lowest buckets
+        var weight0 = history.GetCommandHistoryWeight(items[0].Id);
+        var weight3 = history.GetCommandHistoryWeight(items[3].Id);
+        var weight11 = history.GetCommandHistoryWeight(items[11].Id);
+        var weight16 = history.GetCommandHistoryWeight("id16");
+        var weight20 = history.GetCommandHistoryWeight("id20");
+        var weight30 = history.GetCommandHistoryWeight("id30");
+        var weight40 = history.GetCommandHistoryWeight("id40");
+        var weight49 = history.GetCommandHistoryWeight("id49");
+
+        Assert.IsTrue(weight0 > weight3);
+        Assert.IsTrue(weight3 > weight11);
+        Assert.IsTrue(weight11 > weight16);
+
+        Assert.AreEqual(weight16, weight20);
+        Assert.AreEqual(weight20, weight30);
+        Assert.IsTrue(weight30 > weight40);
+        Assert.AreEqual(weight40, weight49);
+
+        // The 50th item has fallen out of the list now
+        var weight50 = history.GetCommandHistoryWeight("id50");
+        Assert.AreEqual(0, weight50, "Item 50 should have fallen out of the history list");
     }
 }


### PR DESCRIPTION
In #41959 we changed the string matcher's weighting. It ended up giving us lower scores than before. 

That meant that the weighting from recent commands was far too heavy, and it was polluting the results. Basically any command that you'd run would be like, 30 characters of weight heavier than anything you haven't.  


This increases the weight of all string matches by 10x. That means something like 
`Command Prompt` will get a string matched weight of `100` instead of `10`. This balances better with the weighting from frecency (where the MRU command gets +35, then `+min(5*uses,35)`, for up to 70 points of weight)

It also adds a bunch of tests here, to try and catch this again in the future.

Closes #42158