### PR TITLE
Fixed manual override event

### DIFF
--- a/src/modules/LightSwitch/LightSwitchModuleInterface/dllmain.cpp
+++ b/src/modules/LightSwitch/LightSwitchModuleInterface/dllmain.cpp
@@ -108,7 +108,7 @@ public:
 
         m_force_light_event_handle = CreateDefaultEvent(L"POWERTOYS_LIGHTSWITCH_FORCE_LIGHT");
         m_force_dark_event_handle = CreateDefaultEvent(L"POWERTOYS_LIGHTSWITCH_FORCE_DARK");
-        m_manual_override_event_handle = CreateDefaultEvent(L"POWERTOYS_LIGHTSWITCH_MANUAL_OVERRIDE");
+        m_manual_override_event_handle = CreateEventW(nullptr, TRUE, FALSE, L"POWERTOYS_LIGHTSWITCH_MANUAL_OVERRIDE");
 
         init_settings();
     };


### PR DESCRIPTION
Issue: When using the shortcut to switch modes manually, the service would try to correct the theme to the expected mode.
Problem: Event resetting between each loop.
Fix: Set the event to be manually reset only so that the event isn't resetting between each loop. The rest of the code was already written to expect this behavior so no other changes should be necessary. 