### PR TITLE
Add Parallel project build

### DIFF
--- a/.pipelines/v2/templates/job-build-project.yml
+++ b/.pipelines/v2/templates/job-build-project.yml
@@ -258,6 +258,7 @@ jobs:
         -restore -graph
         /p:RestorePackagesConfig=true
         /p:CIBuild=true
+        /p:BuildInParallel=true
         /bl:$(LogOutputDirectory)\build-0-main.binlog
         ${{ parameters.additionalBuildOptions }}
         $(MSBuildCacheParameters)
@@ -277,7 +278,7 @@ jobs:
     condition: ne(variables['BuildPlatform'], 'x64')
     inputs:
       solution: src/dsc/v3/PowerToys.DSC/PowerToys.DSC.csproj
-      msbuildArgs: /t:Build /m /restore
+      msbuildArgs: /t:Build /m /restore /p:BuildInParallel=true
       platform: x64
       configuration: $(BuildConfiguration)
       msbuildArchitecture: x64
@@ -323,6 +324,7 @@ jobs:
         -restore -graph
         /p:RestorePackagesConfig=true
         /p:CIBuild=true
+        /p:BuildInParallel=true
         /bl:$(LogOutputDirectory)\build-bug-report.binlog
         ${{ parameters.additionalBuildOptions }}
         $(MSBuildCacheParameters)
@@ -344,6 +346,7 @@ jobs:
         -restore -graph
         /p:RestorePackagesConfig=true
         /p:CIBuild=true
+        /p:BuildInParallel=true
         /bl:$(LogOutputDirectory)\build-styles-report.binlog
         ${{ parameters.additionalBuildOptions }}
         $(MSBuildCacheParameters)
@@ -365,7 +368,7 @@ jobs:
         msbuildArgs: >-
           /target:Publish
           /graph
-          /p:Configuration=$(BuildConfiguration);Platform=$(BuildPlatform);AppxBundle=Never
+          /p:Configuration=$(BuildConfiguration);Platform=$(BuildPlatform);AppxBundle=Never;BuildInParallel=true
           /p:VCRTForwarders-IncludeDebugCRT=false
           /p:PowerToysRoot=$(Build.SourcesDirectory)
           /p:PublishProfile=InstallationPublishProfile.pubxml

--- a/.pipelines/v2/templates/job-build-ui-tests.yml
+++ b/.pipelines/v2/templates/job-build-ui-tests.yml
@@ -90,6 +90,7 @@ jobs:
           /p:RestorePackagesConfig=true
           /p:BuildProjectReferences=true
           /p:CIBuild=true
+          /p:BuildInParallel=true
           /bl:$(LogOutputDirectory)\build-all-uitests.binlog
           $(NUGET_RESTORE_MSBUILD_ARGS)
         platform: $(BuildPlatform)
@@ -111,6 +112,7 @@ jobs:
             /p:RestorePackagesConfig=true
             /p:BuildProjectReferences=true
             /p:CIBuild=true
+            /p:BuildInParallel=true
             /bl:$(LogOutputDirectory)\build-${{ module }}.binlog
             $(NUGET_RESTORE_MSBUILD_ARGS)
           platform: $(BuildPlatform)

--- a/tools/build/build-common.ps1
+++ b/tools/build/build-common.ps1
@@ -52,8 +52,10 @@ function RunMSBuild {
 
     $base = @(
         $Solution
+        "/m"
         "/p:Platform=$Platform"
         "/p:Configuration=$Configuration"
+        "/p:BuildInParallel=true"
         "/verbosity:normal"
         '/clp:Summary;PerformanceSummary;ErrorsOnly;WarningsOnly'
         "/fileLoggerParameters:LogFile=$allLog;Verbosity=detailed"
@@ -92,9 +94,7 @@ function RestoreThenBuild {
     RunMSBuild $Solution $restoreArgs $Platform $Configuration
 
     if (-not $RestoreOnly) {
-        $buildArgs = '/m'
-        if ($ExtraArgs) { $buildArgs = "$buildArgs $ExtraArgs" }
-        RunMSBuild $Solution $buildArgs $Platform $Configuration
+        RunMSBuild $Solution $ExtraArgs $Platform $Configuration
     }
 }
 
@@ -133,9 +133,7 @@ function BuildProjectsInDirectory {
         if ($f.Extension -eq '.sln') {
             RestoreThenBuild $f.FullName $ExtraArgs $Platform $Configuration $RestoreOnly
         } else {
-            $buildArgs = '/m'
-            if ($ExtraArgs) { $buildArgs = "$buildArgs $ExtraArgs" }
-            RunMSBuild $f.FullName $buildArgs $Platform $Configuration
+            RunMSBuild $f.FullName $ExtraArgs $Platform $Configuration
         }
     }
 

--- a/tools/build/generate-dsc-manifests.ps1
+++ b/tools/build/generate-dsc-manifests.ps1
@@ -63,6 +63,7 @@ if ($ForceRebuildExecutable -or -not (Test-Path $exePath)) {
         '/m',
         "/p:Configuration=$BuildConfiguration",
         "/p:Platform=x64",
+        "/p:BuildInParallel=true",
         '/restore'
     )
 


### PR DESCRIPTION
This pull request makes a series of changes to the build pipeline and supporting scripts to consistently enable MSBuild's parallel build feature. The main goal is to improve build performance by ensuring that the `/p:BuildInParallel=true` property is set across all relevant build jobs and scripts. This affects both YAML pipeline templates and PowerShell build scripts.

**Build pipeline improvements:**

* Added `/p:BuildInParallel=true` to MSBuild arguments in multiple pipeline templates (`job-build-project.yml`, `job-build-ui-tests.yml`) to ensure parallel builds are enabled for all major build and test jobs. [[1]](diffhunk://#diff-2a1b06b9419d9ac8a4fc446800d32a657d60c45979e82462df2d6d71a75ba68cR261) [[2]](diffhunk://#diff-2a1b06b9419d9ac8a4fc446800d32a657d60c45979e82462df2d6d71a75ba68cL280-R281) [[3]](diffhunk://#diff-2a1b06b9419d9ac8a4fc446800d32a657d60c45979e82462df2d6d71a75ba68cR327) [[4]](diffhunk://#diff-2a1b06b9419d9ac8a4fc446800d32a657d60c45979e82462df2d6d71a75ba68cR349) [[5]](diffhunk://#diff-2a1b06b9419d9ac8a4fc446800d32a657d60c45979e82462df2d6d71a75ba68cL368-R371) [[6]](diffhunk://#diff-e60463c73b7e15843bce31fefee28b6365f6ec74270e6366e98c72c1a3afa789R93) [[7]](diffhunk://#diff-e60463c73b7e15843bce31fefee28b6365f6ec74270e6366e98c72c1a3afa789R115)

**PowerShell build script enhancements:**

* Updated `build-common.ps1` and `generate-dsc-manifests.ps1` to always include `/m` and `/p:BuildInParallel=true` when invoking MSBuild, ensuring parallelism is enabled regardless of how the scripts are called. [[1]](diffhunk://#diff-43764921d6c830dbb3a15fe875aebfbc46966ae5ff62f3179adb3ff046b47b9dR55-R58) [[2]](diffhunk://#diff-43764921d6c830dbb3a15fe875aebfbc46966ae5ff62f3179adb3ff046b47b9dL95-R97) [[3]](diffhunk://#diff-43764921d6c830dbb3a15fe875aebfbc46966ae5ff62f3179adb3ff046b47b9dL136-R136) [[4]](diffhunk://#diff-0aea601649bf9c7d6fc11f32ab1d36fe672fceb4a0a582c9ee98d2937edc5371R66)

These changes collectively standardize the use of parallel build options, which should help reduce build times across CI and local development.