### PR TITLE
Update Image Resizer percent presets to use localized header

### DIFF
--- a/src/settings-ui/Settings.UI.Library/ImageSize.cs
+++ b/src/settings-ui/Settings.UI.Library/ImageSize.cs
@@ -65,6 +65,17 @@ public partial class ImageSize : INotifyPropertyChanged, IHasId
         get => !(Unit == ResizeUnit.Percent && Fit != ResizeFit.Stretch);
     }
 
+    /// <summary>
+    /// Gets the localized header text for the Width field. When in Percent mode (non-stretch),
+    /// returns "Percent" since the value represents a scale factor for both dimensions.
+    /// Otherwise returns "Width".
+    /// </summary>
+    [JsonIgnore]
+    public string WidthHeader
+    {
+        get => !IsHeightUsed ? ResourceLoader.GetString("ImageResizer_Sizes_Units_Percent") : ResourceLoader.GetString("ImageResizer_Width");
+    }
+
     [JsonPropertyName("name")]
     public string Name
     {
@@ -81,6 +92,7 @@ public partial class ImageSize : INotifyPropertyChanged, IHasId
             if (SetProperty(ref _fit, value))
             {
                 PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsHeightUsed)));
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(WidthHeader)));
             }
         }
     }
@@ -105,9 +117,18 @@ public partial class ImageSize : INotifyPropertyChanged, IHasId
         get => _unit;
         set
         {
+            var previousUnit = _unit;
             if (SetProperty(ref _unit, value))
             {
                 PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsHeightUsed)));
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(WidthHeader)));
+
+                // When switching to Percent unit, reset width and height to 100%
+                if (value == ResizeUnit.Percent && previousUnit != ResizeUnit.Percent)
+                {
+                    Width = 100;
+                    Height = 100;
+                }
             }
         }
     }

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/ImageResizerPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/ImageResizerPage.xaml
@@ -134,8 +134,8 @@
 
                                                         <StackPanel Orientation="Horizontal" Spacing="8">
                                                             <controls:ImageResizerDimensionsNumberBox
-                                                                x:Uid="ImageResizer_Width"
                                                                 Width="116"
+                                                                Header="{x:Bind WidthHeader, Mode=OneWay}"
                                                                 Minimum="0"
                                                                 SpinButtonPlacementMode="Compact"
                                                                 Value="{x:Bind Width, Mode=TwoWay, Converter={StaticResource ImageResizerNumberBoxValueConverter}}" />


### PR DESCRIPTION
## Summary of the Pull Request
- Show the localized `Percent` header in the Image Resizer preset editor when percent scaling is active.
- Keep the header aligned with fit/unit changes by emitting `PropertyChanged` for `WidthHeader`.
- Reset percent-based presets to 100×100 when switching units to avoid stale pixel values.
- Touched paths: `src/settings-ui/Settings.UI.Library/ImageSize.cs`, `src/settings-ui/Settings.UI/SettingsXAML/Views/ImageResizerPage.xaml`.

## PR Checklist
- [ ] Closes: #xxx
- [x] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [x] **Localization:** All end-user-facing strings can be localized

## Detailed Description of the Pull Request / Additional comments
- Added `WidthHeader` computed property so the number box header reflects percent scaling without introducing new resources.
- Triggered `WidthHeader` updates when `Fit` or `Unit` change to keep the UI responsive to user selections.
- Ensured percent mode starts from a neutral 100% scale by resetting width/height values when switching units.

## Validation Steps Performed
- Tests not run; UI-only change pending manual validation of preset editing scenarios.