### PR TITLE
Light Switch Hotfixes v2

### DIFF
--- a/src/modules/LightSwitch/LightSwitchService/LightSwitchService.cpp
+++ b/src/modules/LightSwitch/LightSwitchService/LightSwitchService.cpp
@@ -243,7 +243,7 @@ DWORD WINAPI ServiceWorkerThread(LPVOID lpParam)
                                     settings.scheduleMode == ScheduleMode::SunsetToSunrise);
         bool coordsChanged = (prevLat != settings.latitude || prevLon != settings.longitude);
 
-        if (modeChangedToSunset || coordsChanged)
+        if ((modeChangedToSunset || coordsChanged) && settings.scheduleMode == ScheduleMode::SunsetToSunrise)
         {
             Logger::info(L"[LightSwitchService] Mode or coordinates changed, recalculating sun times.");
             update_sun_times(settings);


### PR DESCRIPTION
Should fix: #42627
Issue: Suntimes not updating within the day if the mode changes to SunsetToSunrise
Fix: Update suntimes in the service if the mode is changed to Sun mode.

Other: small bug fixes (brackets, etc)