### PR TITLE
CmdPal: Add keyboard shortcut (Ctrl+,) to open Settings

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
@@ -591,24 +591,31 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
                          InputKeyboardSource.GetKeyStateForCurrentThread(VirtualKey.RightWindows).HasFlag(CoreVirtualKeyStates.Down);
 
         var onlyAlt = altPressed && !ctrlPressed && !shiftPressed && !winPressed;
-        if (e.Key == VirtualKey.Left && onlyAlt)
+        var onlyCtrl = !altPressed && ctrlPressed && !shiftPressed && !winPressed;
+        switch (e.Key)
         {
-            WeakReferenceMessenger.Default.Send<NavigateBackMessage>(new());
-            e.Handled = true;
-        }
-        else if (e.Key == VirtualKey.Home && onlyAlt)
-        {
-            WeakReferenceMessenger.Default.Send<GoHomeMessage>(new(WithAnimation: false));
-            e.Handled = true;
-        }
-        else
-        {
-            // The CommandBar is responsible for handling all the item keybindings,
-            // since the bound context item may need to then show another
-            // context menu
-            TryCommandKeybindingMessage msg = new(ctrlPressed, altPressed, shiftPressed, winPressed, e.Key);
-            WeakReferenceMessenger.Default.Send(msg);
-            e.Handled = msg.Handled;
+            case VirtualKey.Left when onlyAlt: // Alt+Left arrow
+                WeakReferenceMessenger.Default.Send<NavigateBackMessage>(new());
+                e.Handled = true;
+                break;
+            case VirtualKey.Home when onlyAlt: // Alt+Home
+                WeakReferenceMessenger.Default.Send<GoHomeMessage>(new(WithAnimation: false));
+                e.Handled = true;
+                break;
+            case (VirtualKey)188 when onlyCtrl: // Ctrl+,
+                WeakReferenceMessenger.Default.Send<OpenSettingsMessage>(new());
+                e.Handled = true;
+                break;
+            default:
+            {
+                // The CommandBar is responsible for handling all the item keybindings,
+                // since the bound context item may need to then show another
+                // context menu
+                TryCommandKeybindingMessage msg = new(ctrlPressed, altPressed, shiftPressed, winPressed, e.Key);
+                WeakReferenceMessenger.Default.Send(msg);
+                e.Handled = msg.Handled;
+                break;
+            }
         }
     }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Strings/en-us/Resources.resw
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Strings/en-us/Resources.resw
@@ -471,4 +471,7 @@ Right-click to remove the key combination, thereby deactivating the shortcut.</v
   <data name="ScreenReader_Announcement_NavigatedToPage0" xml:space="preserve">
     <value>Navigated to {0} page</value>
   </data>
+  <data name="SettingsButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Settings (Ctrl+,)</value>
+  </data>
 </root>


### PR DESCRIPTION
## Summary of the Pull Request

This PR introduces a new keyboard shortcut `Ctrl + ,` that opens the Settings window directly.


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #42785 
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

