### PR TITLE
[Light Switch] Dedupe sun time updates on start up

### DIFF
--- a/src/modules/LightSwitch/LightSwitchService/LightSwitchService.cpp
+++ b/src/modules/LightSwitch/LightSwitchService/LightSwitchService.cpp
@@ -216,6 +216,10 @@ DWORD WINAPI ServiceWorkerThread(LPVOID lpParam)
     LightSwitchSettings::instance().LoadSettings();
     auto& settings = LightSwitchSettings::instance().settings();
 
+    prevMode = settings.scheduleMode;
+    prevLat = settings.latitude;
+    prevLon = settings.longitude;
+
     // --- Initial theme application (if schedule enabled) ---
     if (settings.scheduleMode != ScheduleMode::Off)
     {
@@ -241,7 +245,9 @@ DWORD WINAPI ServiceWorkerThread(LPVOID lpParam)
         // Check for changes in schedule mode or coordinates
         bool modeChangedToSunset = (prevMode != settings.scheduleMode &&
                                     settings.scheduleMode == ScheduleMode::SunsetToSunrise);
-        bool coordsChanged = (prevLat != settings.latitude || prevLon != settings.longitude);
+
+        // ensures that coordsChanged is false on first run (since we already did this work below)
+        bool coordsChanged = (g_lastUpdatedDay != -1) && (prevLat != settings.latitude || prevLon != settings.longitude);
 
         if ((modeChangedToSunset || coordsChanged) && settings.scheduleMode == ScheduleMode::SunsetToSunrise)
         {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
**Issue**: Currently we are doing the same work twice on first start up of Powertoys. 
1. We check if today = the last updated day and if not we update the sun times. 
2. We also then check if any settings have changed and if so, we update sun times. 

If this is a fresh start, the service will have no values to compare to so it will hit point 1 because it will always appear to be a new day if the service just started and also point 2 since there is no "prev" values to compare to.

**Fix**: added a guard to skip point 2 on a fresh start (ie: `g_lastUpdatedDay == -1`) which allows the start-up logic to handle this update while still allowing for an update in settings to trigger a sun times update later in the life cycle if needed.
