### PR TITLE
Added open tag to default expand open

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Before you begin, make sure your device meets the system requirements:
 
 Choose one of the installation methods below:
 
-<details>
+<details open>
 <summary>Download .exe from GitHub</summary>
 
 Go to the [PowerToys GitHub releases][github-release-link], click Assets to reveal the downloads, and choose the installer that matches your architecture and install scope. For most devices, that's the x64 per-user installer.


### PR DESCRIPTION
By default, none of the 4 methods are expanded. this will expand the top item by default for users.

<img width="974" height="414" alt="image" src="https://github.com/user-attachments/assets/f328dee6-9206-47a1-b45f-1f951142eef4" />
