### PR TITLE
powerrename: fix union usage

### DIFF
--- a/src/modules/powerrename/lib/PowerRenameRegEx.cpp
+++ b/src/modules/powerrename/lib/PowerRenameRegEx.cpp
@@ -298,19 +298,13 @@ IFACEMETHODIMP CPowerRenameRegEx::PutFlags(_In_ DWORD flags)
 
 IFACEMETHODIMP CPowerRenameRegEx::PutFileTime(_In_ SYSTEMTIME fileTime)
 {
-    union timeunion
-    {
-        FILETIME fileTime;
-        ULARGE_INTEGER ul;
-    };
+    FILETIME ft1;
+    FILETIME ft2;
 
-    timeunion ft1;
-    timeunion ft2;
+    SystemTimeToFileTime(&m_fileTime, &ft1);
+    SystemTimeToFileTime(&fileTime, &ft2);
 
-    SystemTimeToFileTime(&m_fileTime, &ft1.fileTime);
-    SystemTimeToFileTime(&fileTime, &ft2.fileTime);
-
-    if (ft2.ul.QuadPart != ft1.ul.QuadPart)
+    if (ft2.dwLowDateTime != ft1.dwLowDateTime || ft2.dwHighDateTime != ft1.dwHighDateTime)
     {
         m_fileTime = fileTime;
         m_useFileTime = true;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #42843
- [x] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
fix undefined behavior when using union in the `IFACEMETHODIMP CPowerRenameRegEx::PutFileTime(_In_ SYSTEMTIME fileTime)` function
https://github.com/microsoft/PowerToys/blob/a69f7fa806539e0de6e9e901b4f651c512fdd54f/src/modules/powerrename/lib/PowerRenameRegEx.cpp#L299

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

