### PR TITLE
CmdPal: Fix search box text selection in ShellPage.GoHome

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
@@ -451,7 +451,15 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
     {
         while (RootFrame.CanGoBack)
         {
-            GoBack(withAnimation, focusSearch);
+            // don't focus on each step, just at the end
+            GoBack(withAnimation, focusSearch: false);
+        }
+
+        // focus search box, even if we were already home
+        if (focusSearch)
+        {
+            SearchBox.Focus(Microsoft.UI.Xaml.FocusState.Programmatic);
+            SearchBox.SelectSearch();
         }
     }
 


### PR DESCRIPTION
## Summary of the Pull Request

This PR fixes an issue where `ShellPage.GoHome` wouldn’t select the search box text when the current page was already the home page.

In that case, the navigation stack was empty, and no code was executed because focusing the text had been delegated to the `GoBack` operation.

## Change log one-liner

Ensured search text is selected when Go home when activated and Highlight search on activate are both enabled.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #42443
- [x] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** All end-user-facing strings can be localized
- [x] **Dev docs:** Added/updated
- [x] **New binaries:** Added on the required places
- [x] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

