### PR TITLE
feat(quick-accent): add diameter ⌀ symbol for Shift+O #41954

### DIFF
--- a/src/modules/poweraccent/PowerAccent.Core/Languages.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/Languages.cs
@@ -212,7 +212,7 @@ namespace PowerAccent.Core
                 LetterKey.VK_L => new[] { "ļ", "₺" }, // ₺ is in VK_T for other languages, but not VK_L, so we add it here.
                 LetterKey.VK_M => new[] { "ṁ" },
                 LetterKey.VK_N => new[] { "ņ", "ṅ", "ⁿ", "ℕ", "№" },
-                LetterKey.VK_O => new[] { "ȯ", "∅" },
+                LetterKey.VK_O => new[] { "ȯ", "∅", "⌀" },
                 LetterKey.VK_P => new[] { "ṗ", "℗", "∏", "¶" },
                 LetterKey.VK_Q => new[] { "ℚ" },
                 LetterKey.VK_R => new[] { "ṙ", "®", "ℝ" },


### PR DESCRIPTION
## Summary of the Pull Request
- Adds support for the diameter symbol (⌀, U+2300) in Quick Accent. 
- When holding Shift+O with the Special Characters language enabled.

## Implementation
- Updated GetDefaultLetterKeySPECIAL(LetterKey.VK_O) to include ⌀.
- No impact on other existing functionalities.

## Issue
Closes  #41954