### PR TITLE
CmdPal: Ensure CommandItemViewModel reacts to changes of replaced Command

### DIFF
--- a/src/modules/cmdpal/Core/Microsoft.CmdPal.Core.ViewModels/CommandItemViewModel.cs
+++ b/src/modules/cmdpal/Core/Microsoft.CmdPal.Core.ViewModels/CommandItemViewModel.cs
@@ -306,6 +306,7 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel, ICommandBa
                 Command.PropertyChanged -= Command_PropertyChanged;
                 Command = new(model.Command, PageContext);
                 Command.InitializeProperties();
+                Command.PropertyChanged += Command_PropertyChanged;
 
                 // Extensions based on Command Palette SDK < 0.3 CommandItem class won't notify when Title changes because Command
                 // or Command.Name change. This is a workaround to ensure that the Title is always up-to-date for extensions with old SDK.

--- a/src/modules/cmdpal/ext/SamplePagesExtension/Pages/SampleListPage.cs
+++ b/src/modules/cmdpal/ext/SamplePagesExtension/Pages/SampleListPage.cs
@@ -190,7 +190,11 @@ internal sealed partial class SampleListPage : ListPage
                     new CommandContextItem(new EverChangingCommand("Faces", "😁", "🥺", "😍")),
                     new CommandContextItem(new EverChangingCommand("Hearts", "♥️", "💚", "💜", "🧡", "💛", "💙")),
                 ],
-            }
+            },
+            new ListItemChangingCommandInTime()
+            {
+                Title = "I'm a list item that changes entire command in time",
+            },
         ];
     }
 
@@ -248,6 +252,11 @@ internal sealed partial class SampleListPage : ListPage
         private int _currentIndex;
 
         public EverChangingCommand(string name, params string[] icons)
+            : this(name, TimeSpan.FromSeconds(5), icons)
+        {
+        }
+
+        public EverChangingCommand(string name, TimeSpan interval, params string[] icons)
         {
             _icons = icons ?? throw new ArgumentNullException(nameof(icons));
             if (_icons.Length == 0)
@@ -260,7 +269,7 @@ internal sealed partial class SampleListPage : ListPage
             Icon = new IconInfo(_icons[_currentIndex]);
 
             // Start timer to change icon and name every 5 seconds
-            _timer = new Timer(OnTimerElapsed, null, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(5));
+            _timer = new Timer(OnTimerElapsed, null, interval, interval);
         }
 
         private void OnTimerElapsed(object state)
@@ -280,6 +289,31 @@ internal sealed partial class SampleListPage : ListPage
         public void Dispose()
         {
             _timer?.Dispose();
+        }
+    }
+
+    internal sealed partial class ListItemChangingCommandInTime : ListItem
+    {
+        private readonly EverChangingCommand[] _commands =
+        [
+            new("Water", TimeSpan.FromSeconds(2), "🐬", "🐳", "🐟", "🦈"),
+            new("Faces", TimeSpan.FromSeconds(2), "😁", "🥺", "😍"),
+            new("Hearts", TimeSpan.FromSeconds(2), "♥️", "💚", "💜", "🧡", "💛", "💙"),
+        ];
+
+        private int _state;
+
+        public ListItemChangingCommandInTime()
+        {
+            Subtitle = "I change my command every 10 seconds, and the command changes it's icon every 2 seconds";
+            var timer = new Timer(OnTimerElapsed, null, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10));
+            this.Command = _commands[0];
+        }
+
+        private void OnTimerElapsed(object state)
+        {
+            _state = (_state + 1) % _commands.Length;
+            this.Command = _commands[_state];
         }
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request

This PR resolves the issue with CommandItemViewModel's subscription to changes in the associated Command when it gets replaced by another Command. The current implementation removes the handler from the old command but fails to attach a new one.

## Change log one-liner


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #42981 
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

