### PR TITLE
Light Switch is not clearing manual override if the boundary happens while offline

### DIFF
--- a/src/modules/LightSwitch/LightSwitchService/LightSwitchService.cpp
+++ b/src/modules/LightSwitch/LightSwitchService/LightSwitchService.cpp
@@ -19,6 +19,7 @@ HANDLE g_ServiceStopEvent = nullptr;
 extern int g_lastUpdatedDay = -1;
 static ScheduleMode prevMode = ScheduleMode::Off;
 static std::wstring prevLat, prevLon;
+static int prevMinutes = -1;
 
 VOID WINAPI ServiceMain(DWORD argc, LPTSTR* argv);
 VOID WINAPI ServiceCtrlHandler(DWORD dwCtrl);
@@ -149,7 +150,6 @@ static void update_sun_times(auto& settings)
         std::wstring wmsg(e.what(), e.what() + strlen(e.what()));
         Logger::error(L"[LightSwitchService] Exception during sun time update: {}", wmsg);
     }
-    
 }
 
 DWORD WINAPI ServiceWorkerThread(LPVOID lpParam)
@@ -379,6 +379,7 @@ DWORD WINAPI ServiceWorkerThread(LPVOID lpParam)
             {
                 update_sun_times(settings);
                 g_lastUpdatedDay = st.wDay;
+                prevMinutes = -1;
                 Logger::info(L"[LightSwitchService] Recalculated sun times at new day boundary.");
             }
 
@@ -403,11 +404,36 @@ DWORD WINAPI ServiceWorkerThread(LPVOID lpParam)
 
             if (manualOverrideActive)
             {
-                if (nowMinutes == (currentSettings.lightTime + currentSettings.sunrise_offset) % 1440 ||
-                    nowMinutes == (currentSettings.darkTime + currentSettings.sunset_offset) % 1440)
+                int lightBoundary = (currentSettings.lightTime + currentSettings.sunrise_offset) % 1440;
+                int darkBoundary = (currentSettings.darkTime + currentSettings.sunset_offset) % 1440;
+
+                bool crossedLight = false;
+                bool crossedDark = false;
+
+                if (prevMinutes != -1)
+                {
+                    if (nowMinutes < prevMinutes)
+                    {
+                        crossedLight = (prevMinutes <= lightBoundary || nowMinutes >= lightBoundary);
+                        crossedDark = (prevMinutes <= darkBoundary || nowMinutes >= darkBoundary);
+                    }
+                    else
+                    {
+                        crossedLight = (prevMinutes < lightBoundary && nowMinutes >= lightBoundary);
+                        crossedDark = (prevMinutes < darkBoundary && nowMinutes >= darkBoundary);
+                    }
+                }
+
+                Logger::debug(L"[LightSwitchService] prevMinutes={} nowMinutes={} light={} dark={}",
+                              prevMinutes,
+                              nowMinutes,
+                              lightBoundary,
+                              darkBoundary);
+
+                if (crossedLight || crossedDark)
                 {
                     ResetEvent(hManualOverride);
-                    Logger::info(L"[LightSwitchService] Manual override cleared at boundary");
+                    Logger::info(L"[LightSwitchService] Manual override cleared after crossing schedule boundary.");
                 }
                 else
                 {
@@ -429,6 +455,8 @@ DWORD WINAPI ServiceWorkerThread(LPVOID lpParam)
         int msToNextMinute = (60 - st.wSecond) * 1000 - st.wMilliseconds;
         if (msToNextMinute < 50)
             msToNextMinute = 50;
+
+       prevMinutes = nowMinutes;
 
         DWORD wait = WaitForMultipleObjects(count, waits, FALSE, msToNextMinute);
         if (wait == WAIT_OBJECT_0)


### PR DESCRIPTION
Bug: If light switch is transitioning while the computer is offline, Light Switch will not clear the manual override at the boundary.
Fix: Ensure the "Clear override" logic checks if we are at or past a boundary point.