### PR TITLE
Tests: do not use *relative drive letter*

### DIFF
--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Bookmarks.UnitTests/BookmarkResolverTests.Common.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Bookmarks.UnitTests/BookmarkResolverTests.Common.cs
@@ -110,7 +110,7 @@ public partial class BookmarkResolverTests
                 [
                     new PlaceholderClassificationCase(
                         Name: "Drive",
-                        Input: "C:",
+                        Input: "C:\\.",
                         ExpectSuccess: true,
                         ExpectedKind: CommandKind.Directory,
                         ExpectedTarget: "C:\\",


### PR DESCRIPTION
Since we switched to running the build on C:\, this test started failing. C: means "current directory on the C drive"!