### PR TITLE
[ZoomIt] Add datetime suffix to screenshots

### DIFF
--- a/src/modules/ZoomIt/ZoomIt/Zoomit.cpp
+++ b/src/modules/ZoomIt/ZoomIt/Zoomit.cpp
@@ -5511,8 +5511,10 @@ auto GetUniqueRecordingFilename()
 //
 // GetUniqueScreenshotFilename
 //
-// Gets a unique file name for screenshots based on the current date and time.
-// Consistent with the naming scheme used by the Snipping Tool.
+// Gets a unique file name for screenshot saves, using the current date and
+// time as a suffix. This reduces the chance that the user could overwrite an
+// existing file if they are saving multiple captures in the same folder, and
+// also ensures that ordering is correct when sorted by name.
 //
 //----------------------------------------------------------------------------
 auto GetUniqueScreenshotFilename()


### PR DESCRIPTION
This pull request introduces an improvement to how screenshot filenames are generated in `ZoomIt`. The main change is to ensure that each screenshot is saved with a unique, timestamped filename, which helps prevent accidental overwrites and keeps files sorted chronologically.

**Enhancement to screenshot filename generation:**

* Added a new implementation for `GetUniqueScreenshotFilename()` in `Zoomit.cpp` to generate screenshot filenames using the current date and time, following the format `"ZoomIt YYYY-MM-DD HHMMSS.png"`. This reduces the risk of overwriting existing files and improves file organization.<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR:

Includes an update to create unique screenshot filenames, saving the user from having to manually type a new filename each time they save a new screenshot in the same location.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #43158
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

## Unique filename issue

The PR fixes the user's complaint about the screenshots always being called "zoomit" by adding a `GetUniqueScreenshotFilename()` method which creates a unique filename based on the current date and time, e.g. `ZoomIt 2025-11-01 004723.png`. This is consistent with other tools like the Windows Snipping Tool and provides files which sort correctly when ordered by name, which is not the case for files with simple numeric suffixes.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Tested on a local build.