### PR TITLE
CmdPal: Removing app tag from apps

### DIFF
--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/AppListItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/AppListItem.cs
@@ -15,8 +15,6 @@ namespace Microsoft.CmdPal.Ext.Apps.Programs;
 
 public sealed partial class AppListItem : ListItem
 {
-    private static readonly Tag _appTag = new("App");
-
     private readonly AppCommand _appCommand;
     private readonly AppItem _app;
     private readonly Lazy<Details> _details;
@@ -48,7 +46,6 @@ public sealed partial class AppListItem : ListItem
         _app = app;
         Title = app.Name;
         Subtitle = app.Subtitle;
-        Tags = [_appTag];
         Icon = Icons.GenericAppIcon;
 
         MoreCommands = AddPinCommands(_app.Commands!, isPinned);


### PR DESCRIPTION
The "App" tag is pretty redundant and is adding a lot of visual noise. Closes #38968 

New:
![image](https://github.com/user-attachments/assets/5eff195c-5aaf-477a-b988-4b3b14583569)
