### PR TITLE
[CmdPal] Enhance ToggleSetting's Label and Description layout

### DIFF
--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/JsonSerializationContext.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/JsonSerializationContext.cs
@@ -15,6 +15,7 @@ namespace Microsoft.CommandPalette.Extensions.Toolkit;
 [JsonSerializable(typeof(List<Choice>))]
 [JsonSerializable(typeof(List<ChoiceSetSetting>))]
 [JsonSerializable(typeof(Dictionary<string, object>), TypeInfoPropertyName = "Dictionary")]
+[JsonSerializable(typeof(List<Dictionary<string, object>>))]
 [JsonSourceGenerationOptions(UseStringEnumConverter = true, WriteIndented = true)]
 internal sealed partial class JsonSerializationContext : JsonSerializerContext
 {

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/ToggleSetting.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/ToggleSetting.cs
@@ -26,15 +26,69 @@ public sealed class ToggleSetting : Setting<bool>
 
     public override Dictionary<string, object> ToDictionary()
     {
-        return new Dictionary<string, object>
+        var items = new List<Dictionary<string, object>>();
+
+        if (!string.IsNullOrEmpty(Label))
         {
-            { "type", "Input.Toggle" },
-            { "title", Label },
-            { "id", Key },
-            { "label", Description },
-            { "value", JsonSerializer.Serialize(Value, JsonSerializationContext.Default.Boolean) },
-            { "isRequired", IsRequired },
-            { "errorMessage", ErrorMessage },
+            items.Add(
+                new()
+                {
+                    { "type", "TextBlock" },
+                    { "text", Label },
+                    { "wrap", true },
+                });
+        }
+
+        if (!(string.IsNullOrEmpty(Description) || string.Equals(Description, Label, StringComparison.OrdinalIgnoreCase)))
+        {
+            items.Add(
+                new()
+                {
+                    { "type", "TextBlock" },
+                    { "text", Description },
+                    { "isSubtle", true },
+                    { "size", "Small" },
+                    { "spacing", "Small" },
+                    { "wrap", true },
+                });
+        }
+
+        return new()
+        {
+            { "type", "ColumnSet" },
+            {
+                "columns", new List<Dictionary<string, object>>
+                {
+                    new()
+                    {
+                        { "type", "Column" },
+                        { "width", "20px" },
+                        {
+                            "items", new List<Dictionary<string, object>>
+                            {
+                                new()
+                                {
+                                    { "type", "Input.Toggle" },
+                                    { "title", " " },
+                                    { "id", Key },
+                                    { "value", JsonSerializer.Serialize(Value, JsonSerializationContext.Default.Boolean) },
+                                    { "isRequired", IsRequired },
+                                    { "errorMessage", ErrorMessage },
+                                },
+                            }
+                        },
+                        { "verticalContentAlignment", "Center" },
+                    },
+                    new()
+                    {
+                        { "type", "Column" },
+                        { "width", "stretch" },
+                        { "items", items },
+                        { "verticalContentAlignment", "Center" },
+                    },
+                }
+            },
+            { "spacing", "Medium" },
         };
     }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR changes the positioning of Label and Description from ToggleSetting, making it more similar to `CheckBoxWithDescriptionControl` used in Settings.
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] Closes: #39283 
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
I initially tried solving this by using a Regex on the card JSON to replace all `Input.Toggle` elements with the new `ColumnSet` structure. However, since `ToggleSetting.cs` already serves as a wrapper for creating an Input.Toggle, I decided it was more effective to update the declaration inside the `ToDictionary()` method directly.

### This is the result:

<img width="797" height="531" alt="Screenshot 2025-11-11 120426" src="https://github.com/user-attachments/assets/2ae5d15d-699e-45ef-ab52-afd653d82111" />


<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

