### PR TITLE
Update CursorWrap settings

### DIFF
--- a/src/modules/MouseUtils/CursorWrap/dllmain.cpp
+++ b/src/modules/MouseUtils/CursorWrap/dllmain.cpp
@@ -196,10 +196,10 @@ public:
         m_enabled = true;
         Trace::EnableCursorWrap(true);
         
-        if (m_autoActivate)
-        {
-            StartMouseHook();
-        }
+        // Always start the mouse hook when the module is enabled
+        // This ensures cursor wrapping is active immediately after enabling
+        StartMouseHook();
+        Logger::info("CursorWrap enabled - mouse hook started");
     }
 
     // Disable the powertoy
@@ -208,6 +208,7 @@ public:
         m_enabled = false;
         Trace::EnableCursorWrap(false);
         StopMouseHook();
+        Logger::info("CursorWrap disabled - mouse hook stopped");
     }
 
     // Returns if the powertoys is enabled

--- a/src/settings-ui/Settings.UI/ViewModels/MouseUtilsViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/MouseUtilsViewModel.cs
@@ -1000,6 +1000,13 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                     GeneralSettingsConfig.Enabled.CursorWrap = value;
                     OnPropertyChanged(nameof(IsCursorWrapEnabled));
 
+                    // Auto-enable the AutoActivate setting when CursorWrap is enabled
+                    // This ensures cursor wrapping is active immediately after enabling
+                    if (value && !_cursorWrapAutoActivate)
+                    {
+                        CursorWrapAutoActivate = true;
+                    }
+
                     OutGoingGeneralSettings outgoing = new OutGoingGeneralSettings(GeneralSettingsConfig);
                     SendConfigMSG(outgoing.ToString());
 


### PR DESCRIPTION
## Summary of the Pull Request
Modify CursorWrap settings so that 'Activate on Startup' is enabled when CursorWrap is enabled. Disabling CursorWrap doesn't change the 'Activate on Startup' toggle, this will need to be manually disabled, CursorWrap is active when enabled, the hotkey can be used to temporarily disable the CursorWrap functionality.

## PR Checklist

- [ ] Closes: #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

## Validation Steps Performed
Manual validation performed on desktop PC and Surface Laptop.
