### PR TITLE
[Settings] Fix Dashboard toggle glitches and sorting UI

### DIFF
--- a/src/settings-ui/Settings.UI/ViewModels/DashboardViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/DashboardViewModel.cs
@@ -198,7 +198,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 }
             }
 
-            // Notify that DashboardSortOrder changed to update menu checkmarks.
+            // Notify that DashboardSortOrder changed so the menu updates its checked state.
             OnPropertyChanged(nameof(DashboardSortOrder));
         }
 


### PR DESCRIPTION
## Summary of the Pull Request
Fixes two UI bugs in the Settings Dashboard: module list glitching when toggling modules, and incorrect sort menu checkmarks.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #43624 
- [x] Closes: #43625
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

### User-Facing Fixes

#### 1. Module list glitching when toggling enabled state
When enabling or disabling a module from the "Utilities" list, the entire list would flicker and redraw, causing other toggles to glitch. This made it appear as if multiple modules were being affected by a single change.

**Root cause**
The `AllModules` ObservableCollection was being completely cleared and re-populated on every change, forcing the UI to destroy and recreate all list items.

**Fix**
Refactored collection updates to modify items in-place:
- Introduced `_moduleItems` master list, built once during initialization.
- `RefreshModuleList()` now updates properties without clearing collections
- `SortModuleList()` uses `ObservableCollection.Move()` instead of `Clear()`/`Add()`

#### 2. Incorrect sort menu checkmark behaviour
The checkmark in the "Sort by" menu would not update correctly when changing sort order, sometimes showing the incorrect item checked, or even both at once.

**Root cause**
The `IsChecked` prop on the `ToggleMenuFlyoutItem` is bound to `DashboardSortOrder`, but the binding was not updating because the ViewModel didn't raise a property change notification when the sort order was changed.

**Fix**
Added `OnPropertyChanged(nameof(DashboardSortOrder))` in `SortModuleList()`.

### Code quality improvements

1. Renamed `GetShortcutModules()` to `RefreshShortcutModules()`. The original name implied a getter, but the routine actually affects state by rebuilding the shortcut and action lists, violating the Command-Query Separation principle.
2. Added an `_isUpdatingFromUI` flag as a defensive measure against circular updates when a UI toggle is changed.
3. Separation of concerns for operations on the modules list. Building, sorting and refreshing it are separated.
4. Added comments and XML doc headers for new methods. Included brief description of GPO locking behaviour.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Verified that toggling modules in the list no longer causes the list to flicker or for other toggles to glitch.
- Confirmed that the sort order checkmarks update correctly and reflect the current sort order.
- Tested GPO policy settings are still queried as before.
- Checked sort behaviour is unaffected.

## Videos

*Sorting UI*
https://github.com/user-attachments/assets/3484bf63-2946-4460-83a5-361fa7e41c82

*Toggle behaviour*
https://github.com/user-attachments/assets/1fae5429-6fa3-4431-80f3-0907dab4f326


