### PR TITLE
Advanced Paste:  No cache for foundry local model list 

### DIFF
--- a/src/common/LanguageModelProvider/FoundryLocalModelProvider.cs
+++ b/src/common/LanguageModelProvider/FoundryLocalModelProvider.cs
@@ -12,9 +12,8 @@ namespace LanguageModelProvider;
 
 public sealed class FoundryLocalModelProvider : ILanguageModelProvider
 {
-    private IEnumerable<ModelDetails>? _downloadedModels;
-    private IEnumerable<FoundryCatalogModel>? _catalogModels;
     private FoundryClient? _foundryClient;
+    private IEnumerable<FoundryCatalogModel>? _catalogModels;
     private string? _serviceUrl;
 
     public static FoundryLocalModelProvider Instance { get; } = new();
@@ -39,15 +38,6 @@ public sealed class FoundryLocalModelProvider : ILanguageModelProvider
         if (!isInCatalog)
         {
             var errorMessage = $"{modelId} is not supported in Foundry Local. Please configure supported models in Settings.";
-            Logger.LogError($"[FoundryLocal] {errorMessage}");
-            throw new InvalidOperationException(errorMessage);
-        }
-
-        // Check if model is cached
-        var isInCache = _downloadedModels?.Any(m => m.ProviderModelDetails is FoundryCachedModel cached && cached.Name == modelId) ?? false;
-        if (!isInCache)
-        {
-            var errorMessage = $"The requested model '{modelId}' is not cached. Please download it using Foundry Local.";
             Logger.LogError($"[FoundryLocal] {errorMessage}");
             throw new InvalidOperationException(errorMessage);
         }
@@ -100,30 +90,38 @@ public sealed class FoundryLocalModelProvider : ILanguageModelProvider
         return $"new OpenAIClient(new ApiKeyCredential(\"none\"), new OpenAIClientOptions{{ Endpoint = new Uri(\"{_serviceUrl}/v1\") }}).GetChatClient(\"{modelId}\").AsIChatClient()";
     }
 
-    public async Task<IEnumerable<ModelDetails>> GetModelsAsync(bool ignoreCached = false, CancellationToken cancelationToken = default)
+    public async Task<IEnumerable<ModelDetails>> GetModelsAsync(CancellationToken cancelationToken = default)
     {
-        if (ignoreCached)
-        {
-            Logger.LogInfo("[FoundryLocal] Ignoring cached models, resetting");
-            Reset();
-        }
-
         await InitializeAsync(cancelationToken);
 
-        Logger.LogInfo($"[FoundryLocal] Returning {_downloadedModels?.Count() ?? 0} downloaded models");
-        return _downloadedModels ?? [];
-    }
+        if (_foundryClient == null)
+        {
+            return Array.Empty<ModelDetails>();
+        }
 
-    private void Reset()
-    {
-        _downloadedModels = null;
-        _catalogModels = null;
-        _ = InitializeAsync();
+        var cachedModels = await _foundryClient.ListCachedModels();
+        List<ModelDetails> downloadedModels = [];
+
+        foreach (var model in cachedModels)
+        {
+            Logger.LogInfo($"[FoundryLocal] Adding unmatched cached model: {model.Name}");
+            downloadedModels.Add(new ModelDetails
+            {
+                Id = $"fl-{model.Name}",
+                Name = model.Name,
+                Url = $"fl://{model.Name}",
+                Description = $"{model.Name} running locally with Foundry Local",
+                HardwareAccelerators = [HardwareAccelerator.FOUNDRYLOCAL],
+                ProviderModelDetails = model,
+            });
+        }
+
+        return downloadedModels;
     }
 
     private async Task InitializeAsync(CancellationToken cancelationToken = default)
     {
-        if (_foundryClient != null && _downloadedModels != null && _downloadedModels.Any() && _catalogModels != null && _catalogModels.Any())
+        if (_foundryClient != null && _catalogModels != null && _catalogModels.Any())
         {
             await _foundryClient.EnsureRunning().ConfigureAwait(false);
             return;
@@ -145,29 +143,6 @@ public sealed class FoundryLocalModelProvider : ILanguageModelProvider
         var catalogModels = await _foundryClient.ListCatalogModels();
         Logger.LogInfo($"[FoundryLocal] Found {catalogModels.Count} catalog models");
         _catalogModels = catalogModels;
-
-        var cachedModels = await _foundryClient.ListCachedModels();
-        Logger.LogInfo($"[FoundryLocal] Found {cachedModels.Count} cached models");
-
-        List<ModelDetails> downloadedModels = [];
-
-        foreach (var model in cachedModels)
-        {
-            Logger.LogInfo($"[FoundryLocal] Adding unmatched cached model: {model.Name}");
-            downloadedModels.Add(new ModelDetails
-            {
-                Id = $"fl-{model.Name}",
-                Name = model.Name,
-                Url = $"fl://{model.Name}",
-                Description = $"{model.Name} running locally with Foundry Local",
-                HardwareAccelerators = [HardwareAccelerator.FOUNDRYLOCAL],
-                SupportedOnQualcomm = true,
-                ProviderModelDetails = model,
-            });
-        }
-
-        _downloadedModels = downloadedModels;
-        Logger.LogInfo($"[FoundryLocal] Initialization complete. Total downloaded models: {downloadedModels.Count}");
     }
 
     public async Task<bool> IsAvailable()

--- a/src/common/LanguageModelProvider/ILanguageModelProvider.cs
+++ b/src/common/LanguageModelProvider/ILanguageModelProvider.cs
@@ -12,7 +12,7 @@ public interface ILanguageModelProvider
 
     string ProviderDescription { get; }
 
-    Task<IEnumerable<ModelDetails>> GetModelsAsync(bool ignoreCached = false, CancellationToken cancelationToken = default);
+    Task<IEnumerable<ModelDetails>> GetModelsAsync(CancellationToken cancelationToken = default);
 
     IChatClient? GetIChatClient(string modelId);
 

--- a/src/common/LanguageModelProvider/ModelDetails.cs
+++ b/src/common/LanguageModelProvider/ModelDetails.cs
@@ -24,8 +24,6 @@ public class ModelDetails
 
     public List<HardwareAccelerator> HardwareAccelerators { get; set; } = [];
 
-    public bool SupportedOnQualcomm { get; set; }
-
     public string License { get; set; } = string.Empty;
 
     public object? ProviderModelDetails { get; set; }

--- a/src/settings-ui/Settings.UI/SettingsXAML/Controls/ModelPicker/FoundryLocalModelPicker.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Controls/ModelPicker/FoundryLocalModelPicker.xaml.cs
@@ -30,7 +30,7 @@ public sealed partial class FoundryLocalModelPicker : UserControl
 
     public delegate void DownloadRequestedEventHandler(object sender, object payload);
 
-    public delegate void LoadRequestedEventHandler(object sender, FoundryLoadRequestedEventArgs args);
+    public delegate void LoadRequestedEventHandler(object sender);
 
     public event ModelSelectionChangedEventHandler SelectionChanged;
 
@@ -94,7 +94,7 @@ public sealed partial class FoundryLocalModelPicker : UserControl
 
     public bool HasDownloadableModels => DownloadableModels?.Cast<object>().Any() ?? false;
 
-    public void RequestLoad(bool refresh)
+    public void RequestLoad()
     {
         if (IsLoading)
         {
@@ -107,7 +107,7 @@ public sealed partial class FoundryLocalModelPicker : UserControl
 
         IsAvailable = false;
         StatusText = "Loading Foundry Local status...";
-        LoadRequested?.Invoke(this, new FoundryLoadRequestedEventArgs(refresh));
+        LoadRequested?.Invoke(this);
     }
 
     private static void OnCachedModelsChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -310,7 +310,7 @@ public sealed partial class FoundryLocalModelPicker : UserControl
 
     private void RefreshModelsButton_Click(object sender, RoutedEventArgs e)
     {
-        RequestLoad(refresh: true);
+        RequestLoad();
     }
 
     private void UpdateVisualStates()
@@ -443,15 +443,5 @@ public sealed partial class FoundryLocalModelPicker : UserControl
     public static Visibility GetLicenseVisibility(string license)
     {
         return string.IsNullOrWhiteSpace(license) ? Visibility.Collapsed : Visibility.Visible;
-    }
-
-    public sealed class FoundryLoadRequestedEventArgs : EventArgs
-    {
-        public FoundryLoadRequestedEventArgs(bool refresh)
-        {
-            Refresh = refresh;
-        }
-
-        public bool Refresh { get; }
     }
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Cache of the downloaded model will make the newly added model only work after running of powertoys, this disable the cache, so just downloaded model will take effect immediately

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] Closes: #xxx
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Validated locally
