### PR TITLE
Bump our telemetry package version

### DIFF
--- a/.pipelines/packages.config
+++ b/.pipelines/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.PowerToys.Telemetry" version="2.0.3" />
+  <package id="Microsoft.PowerToys.Telemetry" version="2.0.4" />
 </packages>


### PR DESCRIPTION
Data collection is still hard.

This just makes it so that the build pipeline uses the updated PowerToys telemetry NuGet package. The updated package switches us over to use a diagnostic data provider group for compliance with some new regulations (i.e. DMA and EU Data Act).