### PR TITLE
Preview Pane (Monaco): Experimental Fix Attempt for Ctrl+C Copy Failure (#36474)

### DIFF
--- a/src/modules/peek/Peek.FilePreviewer/Controls/BrowserControl.xaml.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Controls/BrowserControl.xaml.cs
@@ -192,7 +192,6 @@ namespace Peek.FilePreviewer.Controls
                 PreviewBrowser.CoreWebView2.DOMContentLoaded += CoreWebView2_DOMContentLoaded;
                 PreviewBrowser.CoreWebView2.NewWindowRequested += CoreWebView2_NewWindowRequested;
                 PreviewBrowser.CoreWebView2.ContextMenuRequested += CoreWebView2_ContextMenuRequested;
-                PreviewBrowser.KeyboardAccelerators.Add(GetCtrlCAccelerator());
             }
             catch (Exception ex)
             {
@@ -200,27 +199,6 @@ namespace Peek.FilePreviewer.Controls
             }
 
             Navigate();
-        }
-
-        private KeyboardAccelerator GetCtrlCAccelerator()
-        {
-            var ctrlCAccelerator = new KeyboardAccelerator
-            {
-                Key = VirtualKey.C,
-                Modifiers = VirtualKeyModifiers.Control,
-            };
-
-            // Handle Ctrl+C to copy selected text from WebView2
-            ctrlCAccelerator.Invoked += async (s, e) =>
-            {
-                if (PreviewBrowser.CoreWebView2 != null)
-                {
-                    await PreviewBrowser.CoreWebView2.ExecuteScriptAsync("runCopyCommand()");
-                    e.Handled = true;
-                }
-            };
-
-            return ctrlCAccelerator;
         }
 
         private List<Control> GetContextMenuItems(CoreWebView2 sender, CoreWebView2ContextMenuRequestedEventArgs args)


### PR DESCRIPTION
## Summary of the Pull Request

This PR introduces an experimental fix attempt for **clipboard copy (Ctrl + C) not working in Monaco-based File Explorer Preview** (Issue #36474).  
Our team investigated the interaction between **Monaco Editor**, **WebView2**, and the **WinForms hosting layer** used in PowerToys Preview Handlers. We identified that clipboard hotkeys were not propagated correctly from WebView2 to Monaco, resulting in Office reporting: **"Clipboard item not collected: Format not supported by Office Clipboard."**

As a mitigation attempt, we added a **WebView2 KeyDown handler** that explicitly forwards `Ctrl+C` to Monaco via a JavaScript `runCopyCommand()` call.

Although the fix passed existing tests, it caused Monaco-based previews to stop working on our local development environment. Even after restoring to a clean installation of PowerToys, Monaco previews remained unresponsive.  
Because of that, **this PR is not a final fix**, but instead contributes investigation results, hypotheses, and a minimal reproducible implementation that future contributors can build on.

We hope that this work will accelerate root-cause diagnosis by maintainers familiar with the Monaco/WebView2 integration layer.

---

## PR Checklist

- [ ] Closes: #36474  
- [x] **Communication:** Shared approach and findings in the issue discussion.
- [x] **Tests:** Existing tests pass; no new tests added due to non-final nature of the fix.
- [x] **Localization:** No user-facing strings changed.
- [ ] **Dev docs:** Not updated (pending final resolution)
- [ ] **New binaries:** Not applicable
- [ ] **Documentation updated:** N/A

---

## Detailed Description of the Pull Request / Additional comments

### Root Cause Investigation

Based on our testing and review of the following PowerToys documentation:

- `FilePreviewCommon.md` architecture (Preview Handler pipeline)
- Monaco Editor integration through WebView2 (`monaco-editor.md`)

We believe the problem occurs in the boundary between **WinForms → WebView2 → Monaco Editor**.

Our primary hypotheses:

1. **Monaco Editor loses input focus** inside WebView2, resulting in Monaco not receiving Ctrl + C at all.  
2. **Key event suppression** (`e.Handled = true`) in WinForms or WebView2 may prevent normal copy event propagation.  
3. Monaco *does* execute the copy command, but the resulting clipboard data is written in an **unsupported or corrupted format**, which aligns with the Office Clipboard error reported in #36474.

### Code Changes Introduced

To test hypothesis #1 and #2, we added a fallback override that captures Ctrl + C at the WebView2 layer and explicitly executes Monaco’s internal copy command via injected JavaScript:

```csharp
_webView.KeyDown += WebView2_KeyDown;
_webView.BringToFront();

private async void WebView2_KeyDown(object sender, System.Windows.Forms.KeyEventArgs e)
{
    // Check for Ctrl+C
    if (e.Control && e.KeyCode == Keys.C)
    {
        if (_webView.CoreWebView2 != null)
        {
            await _webView.CoreWebView2.ExecuteScriptAsync("runCopyCommand()");
        }

        e.Handled = true;
    }
}
```
---
### Results

* All existing tests passed.
* However, Monaco-based previews stopped functioning on our development machine after applying this code.
* Full cleanup (removing build outputs, reinstalling stable PowerToys) **did not restore preview functionality**, suggesting the attempted fix may have triggered a deeper side effect in Monaco or WebView2 integration into File Explorer.

Because of these unintended consequences, this PR is **not intended to be merged as-is** but as a **contribution of debugging context** and a minimal code example for further investigation by maintainers.

---

## Validation Steps Performed

1. Manual testing across several text and source-code file types.
2. Verified that existing automated tests still pass.
3. Observed preview handler failure after applying patch, even after environment cleanup.

---

## Additional Notes

We encourage deeper investigation from contributors familiar with:

* PowerToys ↔ WebView2 lifetime and focus management
* Monaco integration patterns (especially clipboard fallback hooks)
* Clipboard format negotiation when interacting with Office Clipboard

We hope this contribution accelerates root cause analysis for #36474.