### PR TITLE
feat(CmdPal): replace input with result when query ends with '='

### DIFF
--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Pages/CalculatorListPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Pages/CalculatorListPage.cs
@@ -70,10 +70,21 @@ public sealed partial class CalculatorListPage : DynamicListPage
 
         skipQuerySearchText = string.Empty;
 
-        _emptyItem.Subtitle = newSearch;
+        // Check if query ends with '=' (Replace input feature - Issue #43460)
+        bool replaceInputOnEquals = newSearch.EndsWith('=');
+        string queryToProcess = replaceInputOnEquals ? newSearch.TrimEnd('=') : newSearch;
 
-        var result = QueryHelper.Query(newSearch, _settingsManager, false, HandleSave);
+        _emptyItem.Subtitle = queryToProcess;
+
+        var result = QueryHelper.Query(queryToProcess, _settingsManager, false, HandleSave);
         UpdateResult(result);
+
+        // If query ended with '=', replace input with result
+        if (replaceInputOnEquals && result is not null && !string.IsNullOrEmpty(result.Title))
+        {
+            skipQuerySearchText = result.Title;
+            SearchText = result.Title;
+        }
     }
 
     private void UpdateResult(ListItem result)


### PR DESCRIPTION
## Summary
Implements #43460 - Adds the "Replace input if query ends with =" feature to the Command Palette Calculator extension.

## Problem
The PowerToys Run Calculator has this feature, but the new Command Palette Calculator was missing it.

## Solution
When users type an expression ending with `=` (e.g., `2+2=`), the input is automatically replaced with the calculated result (e.g., `4`).

## Changes
- Detect if query ends with `=`
- Process expression without trailing `=`
- Replace `SearchText` with result on success

## Testing
Manual testing performed with expressions like:
- `2+2=` → `4`
- `10*5=` → `50`

Fixes #43460