### PR TITLE
Revert "[Peek] Use WebView2 for SVG preview to improve compatibility (#44209)"

### DIFF
--- a/src/modules/peek/Peek.FilePreviewer/Previewers/WebBrowserPreviewer/WebBrowserPreviewer.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/WebBrowserPreviewer/WebBrowserPreviewer.cs
@@ -33,10 +33,6 @@ namespace Peek.FilePreviewer.Previewers
 
             // Markdown
             ".md",
-
-            // SVG - using WebView2 for better compatibility with complex SVGs
-            // (e.g., from Adobe Illustrator, Inkscape)
-            ".svg",
         };
 
         [ObservableProperty]
@@ -115,10 +111,9 @@ namespace Peek.FilePreviewer.Previewers
                 {
                     bool isHtml = File.Extension == ".html" || File.Extension == ".htm";
                     bool isMarkdown = File.Extension == ".md";
-                    bool isSvg = File.Extension == ".svg";
 
                     bool supportedByMonaco = MonacoHelper.SupportedMonacoFileTypes.Contains(File.Extension);
-                    bool useMonaco = supportedByMonaco && !isHtml && !isMarkdown && !isSvg;
+                    bool useMonaco = supportedByMonaco && !isHtml && !isMarkdown;
 
                     IsDevFilePreview = supportedByMonaco;
                     CustomContextMenu = useMonaco;
@@ -132,13 +127,6 @@ namespace Peek.FilePreviewer.Previewers
                     {
                         var raw = await ReadHelper.Read(File.Path.ToString());
                         Preview = new Uri(MarkdownHelper.PreviewTempFile(raw, File.Path, TempFolderPath.Path));
-                    }
-                    else if (isSvg)
-                    {
-                        // SVG files are rendered directly by WebView2 for better compatibility
-                        // with complex SVGs from Adobe Illustrator, Inkscape, etc.
-                        IsDevFilePreview = false;
-                        Preview = new Uri(File.Path);
                     }
                     else
                     {


### PR DESCRIPTION
This reverts commit d32ea86314ee1f5bdd995d39aa482cd44783faa5.

this may cause the icm PowerToys - RemoteCodeExecution - Stored Cross-Site Scripting (XSS) in Peek allowing Local File Inclusion (LFI) and RCE

We will look into implementing a more secure approach.

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] Closes: #xxx
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

