### PR TITLE
Optimize PowerRename logic on memory allocation based on path depth.

### DIFF
--- a/src/modules/powerrename/lib/PowerRenameManager.cpp
+++ b/src/modules/powerrename/lib/PowerRenameManager.cpp
@@ -772,7 +772,8 @@ DWORD WINAPI CPowerRenameManager::s_fileOpWorkerThread(_In_ void* pv)
 
                         // Creating a vector of vectors of items of the same depth
                         // Size by maxDepth+1 (not itemCount) to avoid excessive memory allocation
-                        std::vector<std::vector<UINT>> matrix(maxDepth + 1);
+                        // Cast to size_t before arithmetic to avoid overflow on 32-bit UINT
+                        std::vector<std::vector<UINT>> matrix(static_cast<size_t>(maxDepth) + 1);
 
                         for (UINT u = 0; u < itemCount; u++)
                         {
@@ -859,6 +860,7 @@ DWORD WINAPI CPowerRenameManager::s_fileOpWorkerThread(_In_ void* pv)
                             spFileOp->PerformOperations();
                         }
                     }
+                }
             }
 
             // Send the manager thread the completion message


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This pull request improves the way items are grouped and processed by depth in the `s_fileOpWorkerThread` function of `PowerRenameManager.cpp`. Instead of sizing the depth matrix by the total item count, it now determines the actual maximum depth of items first, resulting in more efficient memory usage and correctness when handling items by their depth.

**Improvements to depth-based processing:**

* Added a first pass to determine the maximum depth among all items before allocating the depth matrix, ensuring the matrix is sized appropriately and not excessively large.
* Updated the logic to iterate from the maximum depth down to zero when adding items, aligning with the new matrix sizing and ensuring correct processing order.