### PR TITLE
Update VSCode task for streamline build + fix prompts syntax error

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -48,9 +48,9 @@ This is the top-level guide for AI changes. Keep edits small, follow existing pa
 - `doc/devdocs/modules/readme.md`
 
 # Language style rules
-- Always enforce repo analyzers: root `.editorconfig` plus any `stylecop.json`.
+- Always enforce repo analyzers: `src/.editorconfig` plus any `stylecop.json`.
 - C# code follows StyleCop.Analyzers and Microsoft.CodeAnalysis.NetAnalyzers.
-- C++ code honors `.clang-format` plus `.clang-tidy` (modernize/cppcoreguidelines/readability).
+- C++ code honors `src/.clang-format` for formatting.
 - Markdown files wrap at 80 characters and use ATX headers with fenced code blocks that include language tags.
 - YAML files indent two spaces and add comments for complex settings while keeping keys clear.
 - PowerShell scripts use Verb-Noun names and prefer single-quoted literals while documenting parameters and satisfying PSScriptAnalyzer.

--- a/.github/prompts/create-commit-title.prompt.md
+++ b/.github/prompts/create-commit-title.prompt.md
@@ -1,6 +1,5 @@
----
-mode: 'agent'
-model: Claude Sonnet 4.5
+agent: 'agent'
+model: GPT-5.1-Codex-Max
 description: 'Generate an 80-character git commit title for the local diff.'
 ---
 

--- a/.github/prompts/create-pr-summary.prompt.md
+++ b/.github/prompts/create-pr-summary.prompt.md
@@ -1,6 +1,5 @@
----
-mode: 'agent'
-model: Claude Sonnet 4.5
+agent: 'agent'
+model: GPT-5.1-Codex-Max
 description: 'Generate a PowerToys-ready pull request description from the local diff.'
 ---
 

--- a/.github/prompts/fix-issue.prompt.md
+++ b/.github/prompts/fix-issue.prompt.md
@@ -1,7 +1,6 @@
----
-mode: 'agent'
-model: GPT-5-Codex (Preview)
-description: "  Execute the fix for a GitHub issue using the previously generated implementation plan. Apply code & tests directly in the repo. Output only a PR description (and optional manual steps)."
+agent: 'agent'
+model: GPT-5.1-Codex-Max
+description: "Execute the fix for a GitHub issue using the previously generated implementation plan. Apply code & tests directly in the repo. Output only a PR description (and optional manual steps)."
 ---
 
 # DEPENDENCY

--- a/.github/prompts/fix-spelling.prompt.md
+++ b/.github/prompts/fix-spelling.prompt.md
@@ -1,6 +1,5 @@
----
-mode: 'agent'
-model: GPT-5-Codex (Preview)
+agent: 'agent'
+model: GPT-5.1-Codex-Max
 description: 'Resolve Code scanning / check-spelling comments on the active PR.'
 ---
 

--- a/.github/prompts/review-issue.prompt.md
+++ b/.github/prompts/review-issue.prompt.md
@@ -1,7 +1,6 @@
----
-mode: 'agent'
-model: Claude Sonnet 4.5
-description: "You are github issue review and planning expertise, Score (0–100) and write one Implementation Plan. Outputs: overview.md, implementation-plan.md."
+agent: 'agent'
+model: GPT-5.1-Codex-Max
+description: "You are a GitHub issue review and planning expert; score (0-100) and write one implementation plan. Outputs: overview.md, implementation-plan.md."
 ---
 
 # GOAL
@@ -10,11 +9,11 @@ For **#{{issue_number}}** produce:
 2) `Generated Files/issueReview/{{issue_number}}/implementation-plan.md`
 
 ## Inputs
-  figure out from the prompt on the 
+Figure out required inputs {{issue_number}} from the invocation context; if anything is missing, ask for the value or note it as a gap.
 
 # CONTEXT (brief)
-Ground evidence using `gh issue view {{issue_number}} --json number,title,body,author,createdAt,updatedAt,state,labels,milestone,reactions,comments,linkedPullRequests`, and download the image for understand the context of the issue more.
-Locate source code in current workspace, but also free feel to use via `rg`/`git grep`. Link related issues/PRs.
+Ground evidence using `gh issue view {{issue_number}} --json number,title,body,author,createdAt,updatedAt,state,labels,milestone,reactions,comments,linkedPullRequests`, and download images to better understand the issue context.
+Locate source code in the current workspace; feel free to use `rg`/`git grep`. Link related issues and PRs.
 
 # OVERVIEW.MD
 ## Summary

--- a/.github/prompts/review-pr.prompt.md
+++ b/.github/prompts/review-pr.prompt.md
@@ -1,6 +1,5 @@
----
-mode: 'agent'
-model: Claude Sonnet 4.5
+agent: 'agent'
+model: GPT-5.1-Codex-Max
 description: "gh-driven PR review; per-step Markdown + machine-readable outputs"
 ---
 

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,106 @@
+{
+  "version": "2.0.0",
+  "windows": {
+    "options": {
+      "shell": {
+        "executable": "cmd.exe",
+        "args": ["/d", "/c"]
+      }
+    }
+  },
+
+  "inputs": [
+    {
+      "id": "config",
+      "type": "pickString",
+      "description": "Configuration",
+      "options": ["Debug", "Release"],
+      "default": "Debug"
+    },
+    {
+      "id": "platform",
+      "type": "pickString",
+      "description": "Platform (leave empty to auto-detect host platform)",
+      "options": ["", "X64", "ARM64"],
+      "default": "X64"
+    },
+    {
+      "id": "msbuildExtra",
+      "type": "promptString",
+      "description": "Extra MSBuild args (optional). Example: /p:CIBuild=true /m",
+      "default": ""
+    }
+  ],
+
+  "tasks": [
+    {
+      "label": "PT: Build (quick)",
+      "type": "shell",
+      "command": "\"${workspaceFolder}\\tools\\build\\build.cmd\"",
+      "args": [
+        "-Path",
+        "${fileDirname}"
+      ],
+      "group": { "kind": "build", "isDefault": true },
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated",
+        "clear": true
+      },
+      "problemMatcher": "$msCompile"
+    },
+
+    {
+      "label": "PT: Build (with options)",
+      "type": "shell",
+      "command": "\"${workspaceFolder}\\tools\\build\\build.cmd\"",
+      "args": [
+        "-Path",
+        "${fileDirname}",
+        "-Platform",
+        "${input:platform}",
+        "-Configuration",
+        "${input:config}",
+        "${input:msbuildExtra}"
+      ],
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated",
+        "clear": true
+      },
+      "problemMatcher": "$msCompile"
+    },
+
+    {
+      "label": "PT: Build Essentials (quick)",
+      "type": "shell",
+      "command": "\"${workspaceFolder}\\tools\\build\\build-essentials.cmd\"",
+      "args": [],
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated",
+        "clear": true
+      },
+      "problemMatcher": "$msCompile"
+    },
+
+    {
+      "label": "PT: Build Essentials (with options)",
+      "type": "shell",
+      "command": "\"${workspaceFolder}\\tools\\build\\build-essentials.cmd\"",
+      "args": [
+        "-Platform",
+        "${input:platform}",
+        "-Configuration",
+        "${input:config}",
+        "${input:msbuildExtra}"
+      ],
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated",
+        "clear": true
+      },
+      "problemMatcher": "$msCompile"
+    }
+  ]
+}

--- a/tools/build/build.ps1
+++ b/tools/build/build.ps1
@@ -11,6 +11,9 @@ Target platform (e.g., 'x64', 'arm64'). If omitted the script will try to detect
 .PARAMETER Configuration
 Build configuration (e.g., 'Debug', 'Release'). Default: 'Debug'.
 
+.PARAMETER Path
+Optional directory path containing projects to build. If not specified, uses the current working directory.
+
 .PARAMETER RestoreOnly
 If specified, only perform package restore for local projects and skip the build steps for a solution file (i.e. .sln).
 
@@ -20,6 +23,10 @@ Any remaining, positional arguments passed to the script are forwarded to MSBuil
 .EXAMPLE
 .\tools\build\build.ps1
 Builds any .sln/.csproj/.vcxproj in the current working directory (auto-detects Platform).
+
+.EXAMPLE
+.\tools\build\build.ps1 -Platform x64 -Configuration Release -Path "C:\MyProject\src"
+Builds local projects in the specified directory for x64 Release.
 
 .EXAMPLE
 .\tools\build\build.ps1 -Platform x64 -Configuration Release
@@ -41,6 +48,7 @@ Only restores packages for local projects; ExtraArgs still forwarded to msbuild'
 param (
     [string]$Platform = '',
     [string]$Configuration = 'Debug',
+    [string]$Path = '',
     [switch]$RestoreOnly,
     [Parameter(ValueFromRemainingArguments=$true)]
     [string[]]$ExtraArgs
@@ -78,7 +86,11 @@ if (-not $Platform -or $Platform -eq '') {
     }
 }
 
-$cwd = (Get-Location).ProviderPath
+$cwd = if ($Path) {
+    (Resolve-Path $Path).ProviderPath
+} else {
+    (Get-Location).ProviderPath
+}
 $extraArgsString = $null
 if ($ExtraArgs -and $ExtraArgs.Count -gt 0) { $extraArgsString = ($ExtraArgs -join ' ') }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This pull request introduces several improvements and updates across the repository, focusing on build tooling, prompt configuration for AI agents, and documentation clarity. The most significant changes include the addition of new VSCode build tasks, updates to prompt files to use a newer AI model, enhancements to the build script for flexibility, and refinements to documentation and style rules.

### Enabled scenario
* On any active files in VSCode, do "Ctrl + Shift + B" just build correctly for you.
* The Run Task (no matter from Terminal or Ctrl + Shift + P), we can see the build option:
<img width="1210" height="253" alt="image" src="https://github.com/user-attachments/assets/09fbef16-55ce-42d5-a9ec-74111be83472" />

**Build tooling and automation:**

* Added a new `.vscode/tasks.json` file with configurable build tasks for PowerToys, supporting quick and customizable builds with platform and configuration selection.
* Enhanced `tools/build/build.ps1` to support an optional `-Path` parameter for building projects in a specified directory, updated parameter documentation, and improved logic to resolve the working directory. [[1]](diffhunk://#diff-7a444242b2a6d9c642341bd2ef45f51ba5698ad7827e5136e85eb483863967a7R14-R16) [[2]](diffhunk://#diff-7a444242b2a6d9c642341bd2ef45f51ba5698ad7827e5136e85eb483863967a7R27-R30) [[3]](diffhunk://#diff-7a444242b2a6d9c642341bd2ef45f51ba5698ad7827e5136e85eb483863967a7R51) [[4]](diffhunk://#diff-7a444242b2a6d9c642341bd2ef45f51ba5698ad7827e5136e85eb483863967a7L81-R93)


**AI agent prompt configuration:**

* Updated all prompt files in `.github/prompts/` to use the `GPT-5.1-Codex-Max` model instead of older models, and standardized the agent field format. [[1]](diffhunk://#diff-7a5c9b18594ff83fda2c191fd5a401ca01b74451e8949dc09e14eabee15de165L1-R2) [[2]](diffhunk://#diff-f48674f7557a6c623bb48120c41b4546b20b32f741cc13d82076b0f4b2375d98L1-R2) [[3]](diffhunk://#diff-a6831d9c98a26487c89c39532ec54d26f8987a8bdc88c5becb9368e9d7e589b9L1-R2) [[4]](diffhunk://#diff-60e145ef3296b0cb4bec35363cc8afbfe0b6b7bd0c7785fe16a11d98e38c6f29L1-R2) [[5]](diffhunk://#diff-6a7664740d6984e73a33254333a302a7e258c638a17134921c53967b4965a304L1-R3) [[6]](diffhunk://#diff-7b246ee6421c503c22d7994406b822ede18d7d0c791b7667a55fcd50524fb0b0L1-R2)
* Improved clarity and consistency in the description and instructions within the `review-issue.prompt.md` file.

**Documentation and style rules:**

* Updated `.github/copilot-instructions.md` to clarify that C++ and C# style analyzers and formatters are now enforced from the `src/` directory, not the repo root, and made the C++ formatting rule more precise.

## PR Checklist
- [N/A] Closes: #xxx
- [N/A] **Tests:** Added/updated and all pass

## Validation Steps Performed
- Not run (config/docs/build-script changes only).