### PR TITLE
Add function to get Win32 path from file handle

### DIFF
--- a/src/modules/FileLocksmith/FileLocksmithLibInterop/FileLocksmith.cpp
+++ b/src/modules/FileLocksmith/FileLocksmithLibInterop/FileLocksmith.cpp
@@ -29,7 +29,7 @@ std::vector<ProcessResult> find_processes_recursive(const std::vector<std::wstri
 
     for (const auto& path : paths)
     {
-        auto kernel_path = nt_ext.path_to_kernel_name(path.c_str());
+        auto kernel_path = nt_ext.path_to_canonical_name(path.c_str());
         if (!kernel_path.empty())
         {
             (is_directory(path) ? kernel_names_dirs : kernel_names_files)[kernel_path] = path;
@@ -68,7 +68,7 @@ std::vector<ProcessResult> find_processes_recursive(const std::vector<std::wstri
     {
         if (handle_info.type_name == L"File")
         {
-            auto path = kernel_paths_contain(handle_info.kernel_file_name);
+            auto path = kernel_paths_contain(handle_info.file_path);
             if (!path.empty())
             {
                 pid_files[handle_info.pid].insert(std::move(path));
@@ -83,7 +83,7 @@ std::vector<ProcessResult> find_processes_recursive(const std::vector<std::wstri
     {
         for (const auto& path : process.modules)
         {
-            auto kernel_name = nt_ext.path_to_kernel_name(path.c_str());
+            auto kernel_name = nt_ext.path_to_canonical_name(path.c_str());
 
             auto found_path = kernel_paths_contain(kernel_name);
             if (!found_path.empty())

--- a/src/modules/FileLocksmith/FileLocksmithLibInterop/NtdllExtensions.cpp
+++ b/src/modules/FileLocksmith/FileLocksmithLibInterop/NtdllExtensions.cpp
@@ -139,17 +139,58 @@ std::wstring NtdllExtensions::file_handle_to_kernel_name(HANDLE file_handle)
     return file_handle_to_kernel_name(file_handle, buffer);
 }
 
-std::wstring NtdllExtensions::path_to_kernel_name(LPCWSTR path)
+std::wstring NtdllExtensions::file_handle_to_path(HANDLE file_handle, std::vector<BYTE>& buffer)
 {
-    HANDLE file_handle = CreateFileW(path, 0, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
+    if (file_handle == nullptr || file_handle == INVALID_HANDLE_VALUE)
+    {
+        return L"";
+    }
+
+    if (GetFileType(file_handle) != FILE_TYPE_DISK)
+    {
+        return L"";
+    }
+
+    // Try to get the friendly DOS path first.
+    DWORD dw_chars_required = GetFinalPathNameByHandleW(file_handle, nullptr, 0, VOLUME_NAME_DOS);
+    if (dw_chars_required > 0)
+    {
+        std::wstring path_buffer;
+        path_buffer.resize(dw_chars_required);
+
+        DWORD dw_result = GetFinalPathNameByHandleW(file_handle, path_buffer.data(), dw_chars_required, VOLUME_NAME_DOS);
+
+        // Ensure success and that we actually got the string.
+        if (dw_result > 0 && dw_result < dw_chars_required)
+        {
+            path_buffer.resize(dw_result);
+
+            // Handle UNC paths.
+            if (path_buffer.compare(4, 4, L"UNC\\") == 0)
+            {
+                return L"\\\\" + path_buffer.substr(8);
+            }
+
+            return path_buffer.substr(4);
+        }
+    }
+
+    // Fallback to kernel name if DOS path retrieval failed.
+    return file_handle_to_kernel_name(file_handle, buffer);
+}
+
+std::wstring NtdllExtensions::path_to_canonical_name(LPCWSTR path)
+{
+    HANDLE file_handle = CreateFileW(path, 0, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, nullptr, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, nullptr);
     if (file_handle == INVALID_HANDLE_VALUE)
     {
         return {};
     }
 
-    auto kernel_name = file_handle_to_kernel_name(file_handle);
+    std::vector<BYTE> buffer(DefaultResultBufferSize);
+    auto canonical_name = file_handle_to_path(file_handle, buffer);
     CloseHandle(file_handle);
-    return kernel_name;
+    return canonical_name;
 }
 
 std::vector<NtdllExtensions::HandleInfo> NtdllExtensions::handles() noexcept
@@ -240,8 +281,12 @@ std::vector<NtdllExtensions::HandleInfo> NtdllExtensions::handles() noexcept
 
                 if (type_name == L"File")
                 {
-                    file_name = file_handle_to_kernel_name(handle_copy, object_info_buffer);
-                    result.push_back(HandleInfo{ pid, handle_info->HandleValue, type_name, file_name });
+                    file_name = file_handle_to_path(handle_copy, object_info_buffer);
+
+                    if (!file_name.empty())
+                    {
+                        result.push_back(HandleInfo{ pid, handle_info->HandleValue, type_name, file_name });
+                    }
                 }
 
                 CloseHandle(handle_copy);

--- a/src/modules/FileLocksmith/FileLocksmithLibInterop/NtdllExtensions.h
+++ b/src/modules/FileLocksmith/FileLocksmithLibInterop/NtdllExtensions.h
@@ -24,6 +24,9 @@ private:
 
     std::wstring file_handle_to_kernel_name(HANDLE file_handle, std::vector<BYTE>& buffer);
 
+    // Converts a file handle to a friendly DOS path, falling back to kernel name if needed.
+    std::wstring file_handle_to_path(HANDLE file_handle, std::vector<BYTE>& buffer);
+
 public:
     struct ProcessInfo
     {
@@ -38,12 +41,12 @@ public:
         ULONG_PTR pid;
         ULONG_PTR handle;
         std::wstring type_name;
-        std::wstring kernel_file_name;
+        std::wstring file_path;
     };
 
     std::wstring file_handle_to_kernel_name(HANDLE file_handle);
 
-    std::wstring path_to_kernel_name(LPCWSTR path);
+    std::wstring path_to_canonical_name(LPCWSTR path);
 
     // Gives the user name of the account running this process
     std::wstring pid_to_user(DWORD pid);


### PR DESCRIPTION
## Summary of the Pull Request
This PR improves how File Locksmith resolves file handles to paths by using `GetFinalPathNameByHandleW()` instead of manual string-based translation.

Previously, path resolution relied on manually manipulating NT kernel path strings to derive a usable path. `GetFinalPathNameByHandleW()` does this work canonically at the API level, making resolution more robust for long paths and complex mount points, where manual string translation was more likely to fall short.


- Added a helper function get_win32_path_from_handle inside the anonymous namespace.
- Implemented a two-stage buffer allocation to safely handle paths of any length.
- Added sanitization logic to strip the \\?\ prefix and correctly format \\?\UNC\ paths for user display.

Important: I have intentionally preserved the internal variable name kernel_file_name within the handles() loop and the associated HandleInfo struct fields.

While these variables now store resolved Win32 paths, keeping the original names ensures binary and source compatibility with other modules and the UI layer that consume this data. This avoids a large-scale refactoring and ensures this PR remains focused solely on fixing the path resolution bug.


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #31385
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [x] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
