### PR TITLE
Correct StringFormat initialization in test code

### DIFF
--- a/tools/FancyZones_DrawLayoutTest/FancyZones_DrawLayoutTest.cpp
+++ b/tools/FancyZones_DrawLayoutTest/FancyZones_DrawLayoutTest.cpp
@@ -333,7 +333,8 @@ void DrawIndex(HDC hdc, const RECT& rect, size_t index)
     std::wstring text = std::to_wstring(index);
 
     g.SetTextRenderingHint(Gdiplus::TextRenderingHintAntiAlias);
-    Gdiplus::StringFormat stringFormat = new Gdiplus::StringFormat();
+
+    Gdiplus::StringFormat stringFormat;
     stringFormat.SetAlignment(Gdiplus::StringAlignmentCenter);
     stringFormat.SetLineAlignment(Gdiplus::StringAlignmentCenter);
 
@@ -345,6 +346,7 @@ void DrawIndex(HDC hdc, const RECT& rect, size_t index)
 
     g.DrawString(text.c_str(), -1, &font, gdiRect, &stringFormat, &solidBrush);
 }
+
 
 void DrawZone(HDC hdc, const ColorSetting& colorSetting, const RECT& rect, size_t index)
 {


### PR DESCRIPTION

This PR fixes a memory leak in the DrawIndex function where a Gdiplus::StringFormat object was allocated on the heap using new but never released. Each call to DrawIndex leaked one StringFormat instance, which could accumulate over time and degrade performance.

Changes
Replaced heap allocation (new Gdiplus::StringFormat()) with stack allocation (Gdiplus::StringFormat stringFormat;).

Ensured StringFormat is properly destroyed when DrawIndex returns, eliminating the leak.

No functional changes to rendering behavior text alignment and line alignment remain identical.

Impact
Bug fix: Prevents memory leaks during repeated calls to DrawIndex.

Performance improvement: Reduces unnecessary memory consumption in scenarios where indexes are drawn frequently.

Code quality: Aligns with RAII best practices in C++ by avoiding manual memory management.

Testing
Verified that text rendering output remains unchanged.

Confirmed via runtime checks that no additional allocations persist after DrawIndex completes.