### PR TITLE
Chore: Fix broken links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ winget install --scope machine Microsoft.PowerToys -s winget
 <details>
 <summary><strong>Other methods</strong></summary>
 <br/>
-There are <a href="./doc/unofficialInstallMethods.md">community driven install methods</a> such as Chocolatey and Scoop. If these are your preferred install solutions, you can find the install instructions there.
+There are <a href="https://learn.microsoft.com/windows/powertoys/install#community-driven-install-tools">community driven install methods</a> such as Chocolatey and Scoop. If these are your preferred install solutions, you can find the install instructions there.
 </details>
 
 ## ✨ What's new


### PR DESCRIPTION
The repository README.md has several formatting issues in [Installation section](https://github.com/microsoft/PowerToys#-installation), resulting in invalid link references. It's mainly because Markdown references won't be rendered in HTML blocks.

This trivial PR just fixes that, nothing fancy. Have a nice day!