### PR TITLE
Fancyzones: Fix a custom layout not work in fancyzone and powertoys extension

### DIFF
--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PowerToys/Commands/FancyZones/FancyZonesMonitorListItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PowerToys/Commands/FancyZones/FancyZonesMonitorListItem.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using Microsoft.CommandPalette.Extensions;
@@ -41,15 +42,19 @@ internal sealed partial class FancyZonesMonitorListItem : ListItem
     public static Details BuildMonitorDetails(FancyZonesMonitorDescriptor monitor)
     {
         var currentVirtualDesktop = FancyZonesVirtualDesktop.GetCurrentVirtualDesktopIdString();
+
+        // Calculate physical resolution from logical pixels and DPI
+        var scaleFactor = monitor.Data.Dpi > 0 ? monitor.Data.Dpi / 96.0 : 1.0;
+        var physicalWidth = (int)Math.Round(monitor.Data.MonitorWidth * scaleFactor);
+        var physicalHeight = (int)Math.Round(monitor.Data.MonitorHeight * scaleFactor);
+        var resolution = $"{physicalWidth}\u00D7{physicalHeight}";
+
         var tags = new List<IDetailsElement>
         {
             DetailTag(Resources.FancyZones_Monitor, monitor.Data.Monitor),
-            DetailTag(Resources.FancyZones_Instance, monitor.Data.MonitorInstanceId),
-            DetailTag(Resources.FancyZones_Serial, monitor.Data.MonitorSerialNumber),
             DetailTag(Resources.FancyZones_Number, monitor.Data.MonitorNumber.ToString(CultureInfo.InvariantCulture)),
             DetailTag(Resources.FancyZones_VirtualDesktop, currentVirtualDesktop),
-            DetailTag(Resources.FancyZones_WorkArea, $"{monitor.Data.LeftCoordinate},{monitor.Data.TopCoordinate}  {monitor.Data.WorkAreaWidth}\u00D7{monitor.Data.WorkAreaHeight}"),
-            DetailTag(Resources.FancyZones_Resolution, $"{monitor.Data.MonitorWidth}\u00D7{monitor.Data.MonitorHeight}"),
+            DetailTag(Resources.FancyZones_Resolution, resolution),
             DetailTag(Resources.FancyZones_DPI, monitor.Data.Dpi.ToString(CultureInfo.InvariantCulture)),
         };
 

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PowerToys/Helpers/FancyZonesMonitorDescriptor.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PowerToys/Helpers/FancyZonesMonitorDescriptor.cs
@@ -19,8 +19,12 @@ internal readonly record struct FancyZonesMonitorDescriptor(
     {
         get
         {
-            var size = $"{Data.MonitorWidth}×{Data.MonitorHeight}";
-            var scaling = Data.Dpi > 0 ? string.Format(CultureInfo.InvariantCulture, "{0}%", (int)Math.Round(Data.Dpi * 100 / 96.0)) : "n/a";
+            // MonitorWidth/Height are logical (DPI-scaled) pixels, calculate physical resolution
+            var scaleFactor = Data.Dpi > 0 ? Data.Dpi / 96.0 : 1.0;
+            var physicalWidth = (int)Math.Round(Data.MonitorWidth * scaleFactor);
+            var physicalHeight = (int)Math.Round(Data.MonitorHeight * scaleFactor);
+            var size = $"{physicalWidth}×{physicalHeight}";
+            var scaling = Data.Dpi > 0 ? string.Format(CultureInfo.InvariantCulture, "{0}%", (int)Math.Round(scaleFactor * 100)) : "n/a";
             return $"{size} \u2022 {scaling}";
         }
     }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PowerToys/Helpers/FancyZonesThumbnailRenderer.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PowerToys/Helpers/FancyZonesThumbnailRenderer.cs
@@ -485,12 +485,21 @@ internal static class FancyZonesThumbnailRenderer
 
     private static List<NormalizedRect> GetFocusRects(int zoneCount)
     {
+        // Focus layout parameters from FancyZonesEditor CanvasLayoutModel:
+        // - DefaultOffset = 100px from top-left (normalized: ~0.05 for typical screen)
+        // - OffsetShift = 50px per zone (normalized: ~0.025)
+        // - ZoneSizeMultiplier = 0.4 (zones are 40% of screen)
         zoneCount = Math.Clamp(zoneCount, 1, 8);
         var rects = new List<NormalizedRect>(zoneCount);
+
+        const float defaultOffset = 0.05f;  // ~100px on 1920px screen
+        const float offsetShift = 0.025f;   // ~50px on 1920px screen
+        const float zoneSize = 0.4f;        // 40% of screen
+
         for (var i = 0; i < zoneCount; i++)
         {
-            var offset = i * 0.06f;
-            rects.Add(new NormalizedRect(0.1f + offset, 0.1f + offset, 0.8f, 0.8f));
+            var offset = i * offsetShift;
+            rects.Add(new NormalizedRect(defaultOffset + offset, defaultOffset + offset, zoneSize, zoneSize));
         }
 
         return rects;

--- a/src/modules/fancyzones/FancyZonesEditorCommon/Data/CustomLayouts.cs
+++ b/src/modules/fancyzones/FancyZonesEditorCommon/Data/CustomLayouts.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 using static FancyZonesEditorCommon.Data.CustomLayouts;
 
@@ -23,8 +24,10 @@ namespace FancyZonesEditorCommon.Data
         {
             public struct CanvasZoneWrapper
             {
+                [JsonPropertyName("X")]
                 public int X { get; set; }
 
+                [JsonPropertyName("Y")]
                 public int Y { get; set; }
 
                 public int Width { get; set; }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
1. Fix a issue that fancyzone custom layouts be able to work
2. Fix monitor info build and the icon render

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] Closes: #xxx
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
<img width="1172" height="701" alt="image" src="https://github.com/user-attachments/assets/0cfa71d9-8ce2-4d27-8995-c797f40f927f" />
