### PR TITLE
Peek: Show error message when activated in unsupported virtual folders

### DIFF
--- a/src/modules/peek/Peek.UI/MainWindowViewModel.cs
+++ b/src/modules/peek/Peek.UI/MainWindowViewModel.cs
@@ -388,6 +388,13 @@ namespace Peek.UI
             IsErrorVisible = true;
         }
 
+        public void ShowError(string message)
+        {
+            IsErrorVisible = false;
+            ErrorMessage = message;
+            IsErrorVisible = true;
+        }
+
         private void NavigationThrottleTimer_Tick(object? sender, object e)
         {
             if (sender == null)

--- a/src/modules/peek/Peek.UI/PeekXAML/MainWindow.xaml
+++ b/src/modules/peek/Peek.UI/PeekXAML/MainWindow.xaml
@@ -50,7 +50,8 @@
             Item="{x:Bind ViewModel.CurrentItem, Mode=OneWay}"
             NumberOfFiles="{x:Bind ViewModel.DisplayItemCount, Mode=OneWay}"
             PreviewSizeChanged="FilePreviewer_PreviewSizeChanged"
-            ScalingFactor="{x:Bind ViewModel.ScalingFactor, Mode=OneWay}" />
+            ScalingFactor="{x:Bind ViewModel.ScalingFactor, Mode=OneWay}"
+            Visibility="{x:Bind ContentVisibility(ViewModel.IsErrorVisible), Mode=OneWay}" />
 
         <InfoBar
             x:Name="ErrorInfoBar"
@@ -59,6 +60,7 @@
             Grid.RowSpan="2"
             Margin="4,0,4,6"
             VerticalAlignment="Bottom"
+            Closed="ErrorInfoBar_Closed"
             IsOpen="{x:Bind ViewModel.IsErrorVisible, Mode=TwoWay}"
             Message="{x:Bind ViewModel.ErrorMessage, Mode=OneWay}"
             Severity="Error" />

--- a/src/modules/peek/Peek.UI/PeekXAML/MainWindow.xaml.cs
+++ b/src/modules/peek/Peek.UI/PeekXAML/MainWindow.xaml.cs
@@ -14,6 +14,7 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Peek.Common.Constants;
 using Peek.Common.Extensions;
+using Peek.Common.Helpers;
 using Peek.FilePreviewer.Models;
 using Peek.FilePreviewer.Previewers;
 using Peek.UI.Extensions;
@@ -195,6 +196,20 @@ namespace Peek.UI
             bootTime.Start();
 
             ViewModel.Initialize(selectedItem);
+
+            // If no files were found (e.g., in virtual folders like Home/Recent), show an error
+            if (ViewModel.CurrentItem == null)
+            {
+                Logger.LogInfo("Peek: No files found to preview, showing error.");
+                var errorMessage = ResourceLoaderInstance.ResourceLoader.GetString("NoFilesSelected");
+                ViewModel.ShowError(errorMessage);
+
+                // Still show the window so user can see the warning
+                this.Show();
+                WindowHelpers.BringToForeground(this.GetWindowHandle());
+                return;
+            }
+
             ViewModel.ScalingFactor = this.GetMonitorScale();
             this.Content.KeyUp += Content_KeyUp;
 
@@ -301,6 +316,25 @@ namespace Peek.UI
         public void Dispose()
         {
             themeListener?.Dispose();
+        }
+
+        /// <summary>
+        /// Returns Visibility.Visible if error is not showing, otherwise Collapsed.
+        /// </summary>
+        public Visibility ContentVisibility(bool isErrorVisible)
+        {
+            return isErrorVisible ? Visibility.Collapsed : Visibility.Visible;
+        }
+
+        /// <summary>
+        /// Handle InfoBar closed - if there's no current item, close the window.
+        /// </summary>
+        private void ErrorInfoBar_Closed(InfoBar sender, InfoBarClosedEventArgs args)
+        {
+            if (ViewModel.CurrentItem == null)
+            {
+                Uninitialize();
+            }
         }
     }
 }

--- a/src/modules/peek/Peek.UI/PeekXAML/MainWindow.xaml.cs
+++ b/src/modules/peek/Peek.UI/PeekXAML/MainWindow.xaml.cs
@@ -319,7 +319,7 @@ namespace Peek.UI
         }
 
         /// <summary>
-        /// Returns Visibility.Visible if error is not showing, otherwise Collapsed.
+        /// Returns Visibility.Collapsed when error is showing, Visibility.Visible when not.
         /// </summary>
         public Visibility ContentVisibility(bool isErrorVisible)
         {

--- a/src/modules/peek/Peek.UI/Strings/en-us/Resources.resw
+++ b/src/modules/peek/Peek.UI/Strings/en-us/Resources.resw
@@ -341,6 +341,10 @@
     <value>No more files to preview.</value>
     <comment>The message to show when there are no files remaining to preview.</comment>
   </data>
+  <data name="NoFilesSelected" xml:space="preserve">
+    <value>No files selected or this folder is not supported for preview.</value>
+    <comment>Displayed when Peek is activated in a virtual folder (like Home or Recent) where file selection cannot be retrieved.</comment>
+  </data>
   <data name="DeleteFileError_NotFound" xml:space="preserve">
     <value>The file cannot be found. Please check if the file has been moved, renamed, or deleted.</value>
     <comment>Displayed if the file or path was not found</comment>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

When Peek is activated in virtual folders like Home or Recent, it now displays a clear error message instead of showing a stuck loading state or "Search in Microsoft Store" link.

### Problem
When users activate Peek (press the hotkey) in Windows virtual folders such as Home or Recent, the Shell API (SVGIO_SELECTION) returns 0 items because these folders don't support the standard file selection retrieval mechanism. Previously, this caused:

- The Peek window to appear stuck in a loading state
- The "Search in Microsoft Store" fallback UI to display incorrectly
- Subsequent Peek activations to fail until the window was manually closed
<img width="2550" height="1310" alt="image" src="https://github.com/user-attachments/assets/fd657e46-97f8-4042-bf43-971055f74700" />

### Solution

- Added a check in `Initialize()` to detect when no files are found after querying the Shell
- Display an error InfoBar with a user-friendly message: "No files selected or this folder is not supported for preview."
- Hide the `FilePreview` control when the error is shown to prevent displaying irrelevant fallback UI
- Close the window automatically when the user dismisses the InfoBar (clicks X)

<img width="1790" height="1193" alt="image" src="https://github.com/user-attachments/assets/4a5c9bfa-1996-487a-86d3-5458431b14cb" />

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #44576
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

