### PR TITLE
2 fixes in 97

### DIFF
--- a/installer/PowerToysSetupCustomActionsVNext/CustomAction.cpp
+++ b/installer/PowerToysSetupCustomActionsVNext/CustomAction.cpp
@@ -1549,7 +1549,7 @@ UINT __stdcall TerminateProcessesCA(MSIHANDLE hInstall)
     }
     processes.resize(bytes / sizeof(processes[0]));
 
-    std::array<std::wstring_view, 42> processesToTerminate = {
+    std::array<std::wstring_view, 44> processesToTerminate = {
         L"PowerToys.PowerLauncher.exe",
         L"PowerToys.Settings.exe",
         L"PowerToys.AdvancedPaste.exe",
@@ -1584,12 +1584,14 @@ UINT __stdcall TerminateProcessesCA(MSIHANDLE hInstall)
         L"PowerToys.MouseWithoutBordersService.exe",
         L"PowerToys.CropAndLock.exe",
         L"PowerToys.EnvironmentVariables.exe",
+        L"PowerToys.QuickAccess.exe",
         L"PowerToys.WorkspacesSnapshotTool.exe",
         L"PowerToys.WorkspacesLauncher.exe",
         L"PowerToys.WorkspacesLauncherUI.exe",
         L"PowerToys.WorkspacesEditor.exe",
         L"PowerToys.WorkspacesWindowArranger.exe",
         L"Microsoft.CmdPal.UI.exe",
+        L"Microsoft.CmdPal.Ext.PowerToys.exe",
         L"PowerToys.ZoomIt.exe",
         L"PowerToys.exe",
     };

--- a/src/modules/Workspaces/WorkspacesCsharpLibrary/Data/ApplicationWrapper.cs
+++ b/src/modules/Workspaces/WorkspacesCsharpLibrary/Data/ApplicationWrapper.cs
@@ -10,10 +10,10 @@ public struct ApplicationWrapper
 {
     public struct WindowPositionWrapper
     {
-        [JsonPropertyName("x")]
+        [JsonPropertyName("X")]
         public int X { get; set; }
 
-        [JsonPropertyName("y")]
+        [JsonPropertyName("Y")]
         public int Y { get; set; }
 
         [JsonPropertyName("width")]


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
1. Should stop new executable when uninstall
2. Fix a workspaces editor deserialization issue


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] Closes: #xxx
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
It's a regression introduced when implementing the cmdpal workspaces extension
Before fix:
<img width="235" height="135" alt="image" src="https://github.com/user-attachments/assets/74bbf3ba-72cb-4a43-bba6-8eb96423f045" />

After fix:
<img width="341" height="294" alt="image" src="https://github.com/user-attachments/assets/ce2236b8-c762-4bbf-85af-6a83a3987492" />