### PR TITLE
Revert "Add Drag and Drop For Environment Variables (#40105)" 

### DIFF
--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml
@@ -466,39 +466,27 @@
                         TextChanged="EditVariableDialogValueTxtBox_TextChanged"
                         TextWrapping="Wrap" />
                     <MenuFlyoutSeparator Visibility="{Binding ShowAsList, Converter={StaticResource BoolToVisibilityConverter}}" />
-                    <ListView
+                    <ItemsControl
                         x:Name="EditVariableValuesList"
                         Margin="0,-8,0,12"
                         HorizontalAlignment="Stretch"
-                        AllowDrop="True"
-                        CanDragItems="True"
-                        CanReorderItems="True"
-                        DragItemsCompleted="EditVariableValuesList_DragItemsCompleted"
                         ItemsSource="{Binding ValuesList, Mode=TwoWay}"
                         Visibility="{Binding ShowAsList, Converter={StaticResource BoolToVisibilityConverter}}">
-                        <ListView.ItemTemplate>
+                        <ItemsControl.ItemTemplate>
                             <DataTemplate>
                                 <Grid>
                                     <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="32" />
                                         <ColumnDefinition Width="*" />
                                         <ColumnDefinition Width="40" />
                                     </Grid.ColumnDefinitions>
-                                    <FontIcon
-                                        Grid.Column="0"
-                                        Margin="0,0,8,0"
-                                        FontSize="16"
-                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                        Glyph="&#xE759;" />
                                     <TextBox
-                                        Grid.Column="1"
                                         Background="Transparent"
                                         BorderBrush="Transparent"
                                         LostFocus="EditVariableValuesListTextBox_LostFocus"
                                         Text="{Binding Text}" />
                                     <Button
                                         x:Uid="More_Options_Button"
-                                        Grid.Column="2"
+                                        Grid.Column="1"
                                         VerticalAlignment="Center"
                                         Content="&#xE712;"
                                         FontFamily="{ThemeResource SymbolThemeFontFamily}"
@@ -535,8 +523,8 @@
                                     </Button>
                                 </Grid>
                             </DataTemplate>
-                        </ListView.ItemTemplate>
-                    </ListView>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
                 </StackPanel>
             </ScrollViewer>
         </ContentDialog>

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -16,8 +16,6 @@ namespace EnvironmentVariablesUILib
 {
     public sealed partial class EnvironmentVariablesMainPage : Page
     {
-        private const string ValueListSeparator = ";";
-
         private sealed class RelayCommandParameter
         {
             public RelayCommandParameter(Variable variable, VariablesSet set)
@@ -442,7 +440,7 @@ namespace EnvironmentVariablesUILib
                 variable.ValuesList.Move(index, index - 1);
             }
 
-            var newValues = string.Join(ValueListSeparator, variable.ValuesList?.Select(x => x.Text).ToArray());
+            var newValues = string.Join(";", variable.ValuesList?.Select(x => x.Text).ToArray());
             EditVariableDialogValueTxtBox.Text = newValues;
         }
 
@@ -463,7 +461,7 @@ namespace EnvironmentVariablesUILib
                 variable.ValuesList.Move(index, index + 1);
             }
 
-            var newValues = string.Join(ValueListSeparator, variable.ValuesList?.Select(x => x.Text).ToArray());
+            var newValues = string.Join(";", variable.ValuesList?.Select(x => x.Text).ToArray());
             EditVariableDialogValueTxtBox.Text = newValues;
         }
 
@@ -478,7 +476,7 @@ namespace EnvironmentVariablesUILib
             var variable = EditVariableDialog.DataContext as Variable;
             variable.ValuesList.Remove(listItem);
 
-            var newValues = string.Join(ValueListSeparator, variable.ValuesList?.Select(x => x.Text).ToArray());
+            var newValues = string.Join(";", variable.ValuesList?.Select(x => x.Text).ToArray());
             EditVariableDialogValueTxtBox.Text = newValues;
         }
 
@@ -494,7 +492,7 @@ namespace EnvironmentVariablesUILib
             var index = variable.ValuesList.IndexOf(listItem);
             variable.ValuesList.Insert(index, new Variable.ValuesListItem { Text = string.Empty });
 
-            var newValues = string.Join(ValueListSeparator, variable.ValuesList?.Select(x => x.Text).ToArray());
+            var newValues = string.Join(";", variable.ValuesList?.Select(x => x.Text).ToArray());
             EditVariableDialogValueTxtBox.TextChanged -= EditVariableDialogValueTxtBox_TextChanged;
             EditVariableDialogValueTxtBox.Text = newValues;
             EditVariableDialogValueTxtBox.TextChanged += EditVariableDialogValueTxtBox_TextChanged;
@@ -512,7 +510,7 @@ namespace EnvironmentVariablesUILib
             var index = variable.ValuesList.IndexOf(listItem);
             variable.ValuesList.Insert(index + 1, new Variable.ValuesListItem { Text = string.Empty });
 
-            var newValues = string.Join(ValueListSeparator, variable.ValuesList?.Select(x => x.Text).ToArray());
+            var newValues = string.Join(";", variable.ValuesList?.Select(x => x.Text).ToArray());
             EditVariableDialogValueTxtBox.TextChanged -= EditVariableDialogValueTxtBox_TextChanged;
             EditVariableDialogValueTxtBox.Text = newValues;
             EditVariableDialogValueTxtBox.TextChanged += EditVariableDialogValueTxtBox_TextChanged;
@@ -534,7 +532,7 @@ namespace EnvironmentVariablesUILib
             listItem.Text = (sender as TextBox)?.Text;
             var variable = EditVariableDialog.DataContext as Variable;
 
-            var newValues = string.Join(ValueListSeparator, variable.ValuesList?.Select(x => x.Text).ToArray());
+            var newValues = string.Join(";", variable.ValuesList?.Select(x => x.Text).ToArray());
             EditVariableDialogValueTxtBox.TextChanged -= EditVariableDialogValueTxtBox_TextChanged;
             EditVariableDialogValueTxtBox.Text = newValues;
             EditVariableDialogValueTxtBox.TextChanged += EditVariableDialogValueTxtBox_TextChanged;
@@ -549,17 +547,6 @@ namespace EnvironmentVariablesUILib
         {
             CancelAddVariable();
             ConfirmAddVariableBtn.IsEnabled = false;
-        }
-
-        private void EditVariableValuesList_DragItemsCompleted(ListViewBase sender, DragItemsCompletedEventArgs args)
-        {
-            if (EditVariableDialog.DataContext is Variable variable && variable.ValuesList != null)
-            {
-                var newValues = string.Join(ValueListSeparator, variable.ValuesList.Select(x => x.Text));
-                EditVariableDialogValueTxtBox.TextChanged -= EditVariableDialogValueTxtBox_TextChanged;
-                EditVariableDialogValueTxtBox.Text = newValues;
-                EditVariableDialogValueTxtBox.TextChanged += EditVariableDialogValueTxtBox_TextChanged;
-            }
         }
     }
 }


### PR DESCRIPTION
This reverts commit 1b6b446915a3dbe7e3240ab1ba2afa48ceca58cd.

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Reverting this PR because WinUI 3 doesn’t support drag operations when running as admin.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] Closes: #xxx
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

