### PR TITLE
Add .opus audio format support to Peek

### DIFF
--- a/src/modules/peek/Peek.FilePreviewer/Previewers/MediaPreviewer/AudioPreviewer.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/MediaPreviewer/AudioPreviewer.cs
@@ -202,6 +202,7 @@ namespace Peek.FilePreviewer.Previewers.MediaPreviewer
             ".m4a",
             ".mp3",
             ".ogg",
+            ".opus",
             ".wav",
             ".wma",
         };


### PR DESCRIPTION
Closes #42576

Adds .opus to the list of supported audio file types in AudioPreviewer, allowing Peek to preview Opus audio files.

With [Web Media Extensions](https://www.microsoft.com/en-us/p/web-media-extensions/9n5tdp8vcmhs) installed, playback works. Without it, users will see the standard "Unsupported Video Type or Invalid File Path" message.