### PR TITLE
Add telemetry for tray icon

### DIFF
--- a/src/runner/trace.cpp
+++ b/src/runner/trace.cpp
@@ -88,7 +88,7 @@ void Trace::TrayIconLeftClick(bool quickAccessEnabled)
         g_hProvider,
         "TrayIcon_LeftClick",
         TraceLoggingBoolean(quickAccessEnabled, "QuickAccessEnabled"),
-        ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServiceUsage),
+        ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
         TraceLoggingBoolean(TRUE, "UTCReplace_AppSessionGuid"),
         TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));
 }
@@ -99,7 +99,7 @@ void Trace::TrayIconDoubleClick(bool quickAccessEnabled)
         g_hProvider,
         "TrayIcon_DoubleClick",
         TraceLoggingBoolean(quickAccessEnabled, "QuickAccessEnabled"),
-        ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServiceUsage),
+        ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
         TraceLoggingBoolean(TRUE, "UTCReplace_AppSessionGuid"),
         TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));
 }
@@ -110,7 +110,7 @@ void Trace::TrayIconRightClick(bool quickAccessEnabled)
         g_hProvider,
         "TrayIcon_RightClick",
         TraceLoggingBoolean(quickAccessEnabled, "QuickAccessEnabled"),
-        ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServiceUsage),
+        ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
         TraceLoggingBoolean(TRUE, "UTCReplace_AppSessionGuid"),
         TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));
 }

--- a/src/runner/trace.cpp
+++ b/src/runner/trace.cpp
@@ -81,3 +81,36 @@ void Trace::UpdateDownloadCompleted(bool success, const std::wstring& version)
         TraceLoggingBoolean(TRUE, "UTCReplace_AppSessionGuid"),
         TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));
 }
+
+void Trace::TrayIconLeftClick(bool quickAccessEnabled)
+{
+    TraceLoggingWriteWrapper(
+        g_hProvider,
+        "TrayIcon_LeftClick",
+        TraceLoggingBoolean(quickAccessEnabled, "QuickAccessEnabled"),
+        ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServiceUsage),
+        TraceLoggingBoolean(TRUE, "UTCReplace_AppSessionGuid"),
+        TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));
+}
+
+void Trace::TrayIconDoubleClick(bool quickAccessEnabled)
+{
+    TraceLoggingWriteWrapper(
+        g_hProvider,
+        "TrayIcon_DoubleClick",
+        TraceLoggingBoolean(quickAccessEnabled, "QuickAccessEnabled"),
+        ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServiceUsage),
+        TraceLoggingBoolean(TRUE, "UTCReplace_AppSessionGuid"),
+        TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));
+}
+
+void Trace::TrayIconRightClick(bool quickAccessEnabled)
+{
+    TraceLoggingWriteWrapper(
+        g_hProvider,
+        "TrayIcon_RightClick",
+        TraceLoggingBoolean(quickAccessEnabled, "QuickAccessEnabled"),
+        ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServiceUsage),
+        TraceLoggingBoolean(TRUE, "UTCReplace_AppSessionGuid"),
+        TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE));
+}

--- a/src/runner/trace.h
+++ b/src/runner/trace.h
@@ -13,4 +13,9 @@ public:
     // Auto-update telemetry
     static void UpdateCheckCompleted(bool success, bool updateAvailable, const std::wstring& fromVersion, const std::wstring& toVersion);
     static void UpdateDownloadCompleted(bool success, const std::wstring& version);
+
+    // Tray icon interaction telemetry
+    static void TrayIconLeftClick(bool quickAccessEnabled);
+    static void TrayIconDoubleClick(bool quickAccessEnabled);
+    static void TrayIconRightClick(bool quickAccessEnabled);
 };

--- a/src/runner/tray_icon.cpp
+++ b/src/runner/tray_icon.cpp
@@ -7,6 +7,7 @@
 #include "centralized_kb_hook.h"
 #include "quick_access_host.h"
 #include "hotkey_conflict_detector.h"
+#include "trace.h"
 #include <Windows.h>
 
 #include <common/utils/resources.h>
@@ -131,6 +132,9 @@ void click_timer_elapsed()
     double_click_timer_running = false;
     if (!double_clicked)
     {
+        // Log telemetry for single click (confirmed it's not a double click)
+        Trace::TrayIconLeftClick(get_general_settings().enableQuickAccess);
+
         if (get_general_settings().enableQuickAccess)
         {
             open_quick_access_flyout_window();
@@ -197,6 +201,9 @@ LRESULT __stdcall tray_icon_window_proc(HWND window, UINT message, WPARAM wparam
             case WM_CONTEXTMENU:
             {
                 bool quick_access_enabled = get_general_settings().enableQuickAccess;
+
+                // Log telemetry
+                Trace::TrayIconRightClick(quick_access_enabled);
 
                 // Reload menu if Quick Access state has changed or is first time
                 if (h_menu && (!last_quick_access_state.has_value() || quick_access_enabled != last_quick_access_state.value()))
@@ -278,6 +285,9 @@ LRESULT __stdcall tray_icon_window_proc(HWND window, UINT message, WPARAM wparam
             }
             case WM_LBUTTONDBLCLK:
             {
+                // Log telemetry
+                Trace::TrayIconDoubleClick(get_general_settings().enableQuickAccess);
+
                 double_clicked = true;
                 open_settings_window(std::nullopt);
                 break;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This pull request adds telemetry tracking for user interactions with the application's tray icon. Specifically, it introduces new methods for logging `left-click`, `right-click`, and `double-click` events, and integrates these telemetry calls into the tray icon event handling logic.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] Closes: #xxx
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [x] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

