### PR TITLE
[Peek] Fix Space key triggering during file rename (#44845)

### DIFF
--- a/src/modules/peek/Peek.UI/PeekXAML/MainWindow.xaml.cs
+++ b/src/modules/peek/Peek.UI/PeekXAML/MainWindow.xaml.cs
@@ -197,16 +197,10 @@ namespace Peek.UI
 
             ViewModel.Initialize(selectedItem);
 
-            // If no files were found (e.g., in virtual folders like Home/Recent), show an error
+            // If no files were found (e.g., user is typing in rename/search box, or in virtual folders),
+            // don't show anything - just return silently to avoid stealing focus
             if (ViewModel.CurrentItem == null)
             {
-                Logger.LogInfo("Peek: No files found to preview, showing error.");
-                var errorMessage = ResourceLoaderInstance.ResourceLoader.GetString("NoFilesSelected");
-                ViewModel.ShowError(errorMessage);
-
-                // Still show the window so user can see the warning
-                this.Show();
-                WindowHelpers.BringToForeground(this.GetWindowHandle());
                 return;
             }
 


### PR DESCRIPTION
Don't show error window when CurrentItem is null - just return silently. This restores the original behavior where CaretVisible() detection in GetSelectedItems() would suppress Peek by returning null, and no window would be shown.

PR #44703 added an error window for virtual folders (Home/Recent), but this also triggered when user was typing (rename, search, address bar), stealing focus and cancelling the operation.

Fixes #44845

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
