### PR TITLE
CmdPal: Remove deadlock bait from AppListItem

### DIFF
--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/AppListItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/AppListItem.cs
@@ -17,12 +17,25 @@ public sealed partial class AppListItem : ListItem
 {
     private readonly AppCommand _appCommand;
     private readonly AppItem _app;
-    private readonly Lazy<Details> _details;
     private readonly Lazy<Task<IconInfo?>> _iconLoadTask;
+    private readonly Lazy<Task<Details>> _detailsLoadTask;
 
     private InterlockedBoolean _isLoadingIcon;
+    private InterlockedBoolean _isLoadingDetails;
 
-    public override IDetails? Details { get => _details.Value; set => base.Details = value; }
+    public override IDetails? Details
+    {
+        get
+        {
+            if (_isLoadingDetails.Set())
+            {
+                _ = LoadDetailsAsync();
+            }
+
+            return base.Details;
+        }
+        set => base.Details = value;
+    }
 
     public override IIconInfo? Icon
     {
@@ -52,14 +65,20 @@ public sealed partial class AppListItem : ListItem
 
         MoreCommands = AddPinCommands(_app.Commands!, isPinned);
 
-        _details = new Lazy<Details>(() =>
-        {
-            var t = BuildDetails();
-            t.Wait();
-            return t.Result;
-        });
-
+        _detailsLoadTask = new Lazy<Task<Details>>(BuildDetails);
         _iconLoadTask = new Lazy<Task<IconInfo?>>(async () => await FetchIcon(useThumbnails));
+    }
+
+    private async Task LoadDetailsAsync()
+    {
+        try
+        {
+            Details = await _detailsLoadTask.Value;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning($"Failed to load details for {AppIdentifier}\n{ex}");
+        }
     }
 
     private async Task LoadIconAsync()


### PR DESCRIPTION
## Summary of the Pull Request

This PR removes a Task.Wait() call from lazy-loading AppListItem details that could be invoked on the UI thread and lead to a deadlock.

It now follows the same pattern previously used for loading icons in the same class, which has proven to work well.

Prevents #44938 from stepping on this landmine.

Cherry-picked from #44973.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #45074 
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

