### PR TITLE
Workspace: Fix an overlay issue for workspace snapshot draw

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -1022,6 +1022,7 @@ MERGECOPY
 MERGEPAINT
 metadatamatters
 Metadatas
+Metacharacter
 metafile
 mfc
 Mgmt

--- a/src/modules/Workspaces/WorkspacesEditor/OverlayWindow.xaml.cs
+++ b/src/modules/Workspaces/WorkspacesEditor/OverlayWindow.xaml.cs
@@ -2,7 +2,10 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Windows;
+
+using WorkspacesEditor.Utils;
 
 namespace WorkspacesEditor
 {
@@ -11,9 +14,40 @@ namespace WorkspacesEditor
     /// </summary>
     public partial class OverlayWindow : Window
     {
+        private int _targetX;
+        private int _targetY;
+        private int _targetWidth;
+        private int _targetHeight;
+
         public OverlayWindow()
         {
             InitializeComponent();
+            SourceInitialized += OnWindowSourceInitialized;
+        }
+
+        /// <summary>
+        /// Sets the target bounds for the overlay window.
+        /// The window will be positioned using DPI-unaware context after initialization.
+        /// </summary>
+        public void SetTargetBounds(int x, int y, int width, int height)
+        {
+            _targetX = x;
+            _targetY = y;
+            _targetWidth = width;
+            _targetHeight = height;
+
+            // Set initial WPF properties (will be corrected after HWND creation)
+            Left = x;
+            Top = y;
+            Width = width;
+            Height = height;
+        }
+
+        private void OnWindowSourceInitialized(object sender, EventArgs e)
+        {
+            // Reposition window using DPI-unaware context to match the virtual coordinates.
+            // This fixes overlay positioning on mixed-DPI multi-monitor setups.
+            NativeMethods.SetWindowPositionDpiUnaware(this, _targetX, _targetY, _targetWidth, _targetHeight);
         }
     }
 }

--- a/src/modules/Workspaces/WorkspacesEditor/ViewModels/MainViewModel.cs
+++ b/src/modules/Workspaces/WorkspacesEditor/ViewModels/MainViewModel.cs
@@ -495,10 +495,10 @@ namespace WorkspacesEditor.ViewModels
             {
                 var bounds = screen.Bounds;
                 OverlayWindow overlayWindow = new OverlayWindow();
-                overlayWindow.Top = bounds.Top;
-                overlayWindow.Left = bounds.Left;
-                overlayWindow.Width = bounds.Width;
-                overlayWindow.Height = bounds.Height;
+
+                // Use DPI-unaware positioning to fix overlay on mixed-DPI multi-monitor setups
+                overlayWindow.SetTargetBounds(bounds.Left, bounds.Top, bounds.Width, bounds.Height);
+
                 overlayWindow.ShowActivated = true;
                 overlayWindow.Topmost = true;
                 overlayWindow.Show();


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Root cause: Workspaces uses DPI-unaware coordinates (via GetDpiUnawareScreens()
which runs in a temporary DPI-unaware thread) to store/match window positions
across different DPI settings. However, WorkspacesEditor itself uses PerMonitorV2
DPI awareness for UI clarity. When assigning these DPI-unaware coordinates directly
to WPF window properties, WPF automatically scaled them again based on current DPI,
causing incorrect overlay positioning.

Fix: Use SetWindowPositionDpiUnaware() to bypass WPF's automatic DPI scaling
by temporarily switching to DPI-unaware context when calling Win32 SetWindowPos.

Fix #45174

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] Closes: #45174
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Verified in local build vs production build, and the problem fixed in local build.
