### PR TITLE
fix(paste): correct GPO info bar placement for clipboard history setting

### DIFF
--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/AdvancedPastePage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/AdvancedPastePage.xaml
@@ -155,28 +155,18 @@
                             HeaderIcon="{ui:FontIcon Glyph=&#xEDA7;}"
                             IsExpanded="True">
                             <controls:ShortcutControl MinWidth="{StaticResource SettingActionControlMinWidth}" HotkeySettings="{x:Bind Path=ViewModel.AdvancedPasteUIShortcut, Mode=TwoWay}" />
-                            <tkcontrols:SettingsExpander.ItemsHeader>
-                                <InfoBar
-                                    x:Uid="GPO_SettingIsManaged"
-                                    IsClosable="False"
-                                    IsOpen="{x:Bind ViewModel.ShowClipboardHistoryIsGpoConfiguredInfoBar, Mode=OneWay}"
-                                    IsTabStop="{x:Bind ViewModel.ShowClipboardHistoryIsGpoConfiguredInfoBar, Mode=OneWay}"
-                                    Severity="Informational">
-                                    <InfoBar.IconSource>
-                                        <FontIconSource FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE72E;" />
-                                    </InfoBar.IconSource>
-                                </InfoBar>
-                            </tkcontrols:SettingsExpander.ItemsHeader>
                             <tkcontrols:SettingsExpander.Items>
                                 <tkcontrols:SettingsCard Name="AdvancedPasteEnableClipboardPreview" ContentAlignment="Left">
                                     <controls:CheckBoxWithDescriptionControl x:Uid="AdvancedPaste_EnableClipboardPreview" IsChecked="{x:Bind ViewModel.EnableClipboardPreview, Mode=TwoWay}" />
                                 </tkcontrols:SettingsCard>
-                                <tkcontrols:SettingsCard
-                                    Name="AdvancedPasteClipboardHistoryEnabledSettingsCard"
-                                    ContentAlignment="Left"
-                                    IsEnabled="{x:Bind ViewModel.ClipboardHistoryEnabled, Mode=OneWay}">
-                                    <controls:CheckBoxWithDescriptionControl x:Uid="AdvancedPaste_Clipboard_History_Enabled_SettingsCard" IsChecked="{x:Bind ViewModel.ClipboardHistoryEnabled, Mode=TwoWay}" />
-                                </tkcontrols:SettingsCard>
+                                <controls:GPOInfoControl ShowWarning="{x:Bind ViewModel.ShowClipboardHistoryIsGpoConfiguredInfoBar, Mode=OneWay}">
+                                    <tkcontrols:SettingsCard
+                                        Name="AdvancedPasteClipboardHistoryEnabledSettingsCard"
+                                        ContentAlignment="Left"
+                                        IsEnabled="{x:Bind ViewModel.ClipboardHistoryEnabled, Mode=OneWay}">
+                                        <controls:CheckBoxWithDescriptionControl x:Uid="AdvancedPaste_Clipboard_History_Enabled_SettingsCard" IsChecked="{x:Bind ViewModel.ClipboardHistoryEnabled, Mode=TwoWay}" />
+                                    </tkcontrols:SettingsCard>
+                                </controls:GPOInfoControl>
                                 <tkcontrols:SettingsCard Name="AdvancedPasteCloseAfterLosingFocus" ContentAlignment="Left">
                                     <CheckBox x:Uid="AdvancedPaste_CloseAfterLosingFocus" IsChecked="{x:Bind ViewModel.CloseAfterLosingFocus, Mode=TwoWay}" />
                                 </tkcontrols:SettingsCard>


### PR DESCRIPTION
## Summary of the Pull Request

Fixes the incorrect placement of the GPO (Group Policy Object) info bar for the clipboard history setting on the Advanced Paste settings page. Previously, the info bar was displayed at the top of the expander's items header, applying to all settings. Now it correctly wraps only the specific `AdvancedPasteClipboardHistoryEnabledSettingsCard` using the `GPOInfoControl` control.

## PR Checklist

- [x] Closes: #45029
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [x] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated ΓÇö N/A, no documentation changes needed
- [ ] **New binaries:** Added on the required places ΓÇö N/A, no new binaries

## Detailed Description of the Pull Request / Additional comments

**Problem:** The GPO info bar was incorrectly placed in the `SettingsExpander.ItemsHeader`, causing it to appear at the top of all clipboard-related settings. This provided misleading information, implying that all settings were GPO-managed when only the clipboard history setting is affected.

**Solution:** 
- Removed the `InfoBar` from `SettingsExpander.ItemsHeader`
- Wrapped the `AdvancedPasteClipboardHistoryEnabledSettingsCard` with `controls:GPOInfoControl`, which correctly positions the GPO warning directly adjacent to the specific setting it applies to

**File changed:** `src/settings-ui/Settings.UI/SettingsXAML/Views/AdvancedPastePage.xaml`

## Validation Steps Performed

- Manual validation: Opened Settings UI ΓåÆ Advanced Paste page and verified the GPO info bar now appears only next to the "Clipboard History" setting when GPO-configured, rather than at the top of the entire settings section.
- No automated tests required: This is a XAML layout change with no behavior modification; the `GPOInfoControl` already handles the visibility logic via the existing `ShowClipboardHistoryIsGpoConfiguredInfoBar` binding.

Fixes #45029