### PR TITLE
docs(paste): add AI preview credit documentation

### DIFF
--- a/doc/devdocs/modules/advancedpaste.md
+++ b/doc/devdocs/modules/advancedpaste.md
@@ -29,7 +29,7 @@ The implementation flow:
 4. If preview is enabled, the cached result is displayed in the preview UI
 5. User can paste the cached result without any additional API calls
 
-See `OptionsViewModel.cs` lines 702-717 for the implementation.
+See the `ExecutePasteFormatAsync(PasteFormat, PasteActionSource)` method in `OptionsViewModel.cs` for the implementation.
 
 ## Debugging
 

--- a/doc/devdocs/modules/advancedpaste.md
+++ b/doc/devdocs/modules/advancedpaste.md
@@ -18,13 +18,28 @@ Advanced Paste is a PowerToys module that provides enhanced clipboard pasting wi
 
 TODO: Add implementation details
 
+### Paste with AI Preview
+
+The "Show preview" setting (`ShowCustomPreview`) controls whether AI-generated results are displayed in a preview window before pasting. **The preview feature does not consume additional AI credits**—the preview displays the same AI response that was already generated, cached locally from a single API call.
+
+The implementation flow:
+1. User initiates "Paste with AI" action
+2. A single AI API call is made via `ExecutePasteFormatAsync`
+3. The result is cached in `GeneratedResponses`
+4. If preview is enabled, the cached result is displayed in the preview UI
+5. User can paste the cached result without any additional API calls
+
+See `OptionsViewModel.cs` lines 702-717 for the implementation.
+
 ## Debugging
 
 TODO: Add debugging information
 
 ## Settings
 
-TODO: Add settings documentation
+| Setting | Description |
+|---------|-------------|
+| `ShowCustomPreview` | When enabled, shows AI-generated results in a preview window before pasting. Does not affect AI credit consumption. |
 
 ## Future Improvements
 


### PR DESCRIPTION
docs(paste): add AI preview credit documentation

```markdown
## Summary of the Pull Request

Adds documentation clarifying that the "Show preview" setting for Paste with AI does not consume additional AI credits. The preview displays the same AI response that was already generated from a single API call, cached locally.

## PR Checklist

- [x] Closes: #32950
- [x] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass - N/A (documentation only)
- [ ] **Localization:** All end-user-facing strings can be localized - N/A (dev docs only)
- [x] **Dev docs:** Added/updated
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments

This PR addresses the question raised in issue #32950 about whether enabling preview for Paste with AI costs extra AI quota.

Changes to `doc/devdocs/modules/advancedpaste.md`:
- Added new "Paste with AI Preview" section explaining:
  - The `ShowCustomPreview` setting behavior
  - Confirmation that preview does **not** consume additional AI credits
  - The implementation flow showing a single API call with local caching
  - Reference to `OptionsViewModel.cs` lines 702-717
- Added settings documentation table for `ShowCustomPreview`

Fixes #32950

## Validation Steps Performed

- Verified documentation renders correctly in Markdown preview
- Confirmed technical accuracy by referencing `OptionsViewModel.cs` implementation
```