### PR TITLE
docs(paste): add AI data handling privacy notice

### DIFF
--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/AdvancedPastePage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/AdvancedPastePage.xaml
@@ -81,6 +81,19 @@
                             </InfoBar.IconSource>
                         </InfoBar>
 
+                        <InfoBar
+                            x:Uid="AdvancedPaste_AIPrivacyNotice"
+                            IsClosable="True"
+                            IsOpen="{x:Bind ViewModel.IsAIEnabled, Mode=OneWay}"
+                            IsTabStop="{x:Bind ViewModel.IsAIEnabled, Mode=OneWay}"
+                            Severity="Informational">
+                            <InfoBar.ActionButton>
+                                <HyperlinkButton
+                                    x:Uid="AdvancedPaste_AIPrivacyNotice_LearnMore"
+                                    NavigateUri="https://learn.microsoft.com/windows/powertoys/advanced-paste#privacy-and-data-handling" />
+                            </InfoBar.ActionButton>
+                        </InfoBar>
+
                         <!--  Paste with AI  -->
                         <tkcontrols:SettingsExpander
                             Name="AdvancedPasteEnableAISettingsCard"

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -717,6 +717,18 @@ Please review the placeholder content that represents the final terms and usage 
   <data name="AdvancedPaste_Ollama_PrivacyLabel" xml:space="preserve">
     <value>Ollama Privacy Policy</value>
   </data>
+  <data name="AdvancedPaste_AIPrivacyNotice.Title" xml:space="preserve">
+    <value>Data Handling Notice</value>
+    <comment>InfoBar title for AI privacy notice</comment>
+  </data>
+  <data name="AdvancedPaste_AIPrivacyNotice.Message" xml:space="preserve">
+    <value>When using AI features, your clipboard content is sent to AI services for processing. Per the provider's API privacy policy, this data is typically not used for model training but may be retained for a limited time for abuse detection. Review your provider's privacy policy for details.</value>
+    <comment>InfoBar message explaining AI data handling</comment>
+  </data>
+  <data name="AdvancedPaste_AIPrivacyNotice_LearnMore.Content" xml:space="preserve">
+    <value>Learn more</value>
+    <comment>Link text for AI privacy documentation</comment>
+  </data>
   <data name="RemapKeysList.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Current key remappings</value>
   </data>


### PR DESCRIPTION
docs(paste): add AI data handling privacy notice

```markdown
## Summary of the Pull Request

Adds a privacy notice InfoBar to the Advanced Paste settings page informing users that clipboard content is sent to AI services when using AI features. This addresses user concerns about what happens to sensitive data (passwords, keys, personal info) when using "Paste with AI".

## PR Checklist

- [x] Closes: #32948
- [x] **Communication:** Addressing a user-reported documentation gap about AI data handling
- [ ] **Tests:** N/A - UI string and XAML layout changes only; no logic changes requiring automated tests
- [x] **Localization:** All end-user-facing strings can be localized (added to `Resources.resw`)
- [ ] **Dev docs:** N/A - This is end-user facing UI change
- [ ] **New binaries:** N/A - No new binaries added
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments

### Changes

- **`src/settings-ui/Settings.UI/SettingsXAML/Views/AdvancedPastePage.xaml`**: Added an informational `InfoBar` that displays when AI features are enabled, warning users about data handling
- **`src/settings-ui/Settings.UI/Strings/en-us/Resources.resw`**: Added three new localized strings:
  - `AdvancedPaste_AIPrivacyNotice.Title`: "Data Handling Notice"
  - `AdvancedPaste_AIPrivacyNotice.Message`: Explains that clipboard content is sent to AI services and refers users to provider privacy policies
  - `AdvancedPaste_AIPrivacyNotice_LearnMore.Content`: "Learn more" link text

### Behavior

- The InfoBar is visible when `ViewModel.IsAIEnabled` is `true`
- Users can dismiss the notice (closable)
- Includes a "Learn more" hyperlink pointing to the Advanced Paste documentation privacy section

Fixes #32948

## Validation Steps Performed

- Verified XAML compiles without errors
- Confirmed string resources are properly formatted in `Resources.resw`
- Manual verification: InfoBar displays correctly when AI features are enabled in Settings UI
```