### PR TITLE
feat(AdvancedPaste): Add paste as plain text (trimmed) option

### DIFF
--- a/src/common/interop/Constants.cpp
+++ b/src/common/interop/Constants.cpp
@@ -67,6 +67,10 @@ namespace winrt::PowerToys::Interop::implementation
     {
         return CommonSharedConstants::ADVANCED_PASTE_JSON_MESSAGE;
     }
+    hstring Constants::AdvancedPastePlainTextTrimmedMessage()
+    {
+        return CommonSharedConstants::ADVANCED_PASTE_PLAIN_TEXT_TRIMMED_MESSAGE;
+    }
     hstring Constants::AdvancedPasteAdditionalActionMessage()
     {
         return CommonSharedConstants::ADVANCED_PASTE_ADDITIONAL_ACTION_MESSAGE;

--- a/src/common/interop/Constants.h
+++ b/src/common/interop/Constants.h
@@ -20,6 +20,7 @@ namespace winrt::PowerToys::Interop::implementation
         static hstring AdvancedPasteShowUIMessage();
         static hstring AdvancedPasteMarkdownMessage();
         static hstring AdvancedPasteJsonMessage();
+        static hstring AdvancedPastePlainTextTrimmedMessage();
         static hstring AdvancedPasteAdditionalActionMessage();
         static hstring AdvancedPasteCustomActionMessage();
         static hstring AdvancedPasteTerminateAppMessage();

--- a/src/common/interop/Constants.idl
+++ b/src/common/interop/Constants.idl
@@ -17,6 +17,7 @@ namespace PowerToys
             static String AdvancedPasteShowUIMessage();
             static String AdvancedPasteMarkdownMessage();
             static String AdvancedPasteJsonMessage();
+            static String AdvancedPastePlainTextTrimmedMessage();
             static String AdvancedPasteAdditionalActionMessage();
             static String AdvancedPasteCustomActionMessage();
             static String AdvancedPasteTerminateAppMessage();

--- a/src/common/interop/shared_constants.h
+++ b/src/common/interop/shared_constants.h
@@ -35,6 +35,8 @@ namespace CommonSharedConstants
 
     const wchar_t ADVANCED_PASTE_JSON_MESSAGE[] = L"PasteJson";
 
+    const wchar_t ADVANCED_PASTE_PLAIN_TEXT_TRIMMED_MESSAGE[] = L"PastePlainTextTrimmed";
+
     const wchar_t ADVANCED_PASTE_ADDITIONAL_ACTION_MESSAGE[] = L"AdditionalAction";
     
     const wchar_t ADVANCED_PASTE_CUSTOM_ACTION_MESSAGE[] = L"CustomAction";

--- a/src/modules/AdvancedPaste/AdvancedPaste/AdvancedPasteXAML/App.xaml.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/AdvancedPasteXAML/App.xaml.cs
@@ -160,6 +160,10 @@ namespace AdvancedPaste
             {
                 await viewModel.ExecutePasteFormatAsync(PasteFormats.Json, PasteActionSource.GlobalKeyboardShortcut);
             }
+            else if (messageType == PowerToys.Interop.Constants.AdvancedPastePlainTextTrimmedMessage())
+            {
+                await viewModel.ExecutePasteFormatAsync(PasteFormats.PlainTextTrimmed, PasteActionSource.GlobalKeyboardShortcut);
+            }
             else if (messageType == PowerToys.Interop.Constants.AdvancedPasteAdditionalActionMessage())
             {
                 await OnAdvancedPasteAdditionalActionHotkey(messageParts);

--- a/src/modules/AdvancedPaste/AdvancedPaste/Helpers/TransformHelpers.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/Helpers/TransformHelpers.cs
@@ -23,6 +23,7 @@ public static class TransformHelpers
         return format switch
         {
             PasteFormats.PlainText => await ToPlainTextAsync(clipboardData),
+            PasteFormats.PlainTextTrimmed => await ToTrimmedPlainTextAsync(clipboardData),
             PasteFormats.Markdown => await ToMarkdownAsync(clipboardData),
             PasteFormats.Json => await ToJsonAsync(clipboardData),
             PasteFormats.ImageToText => await ImageToTextAsync(clipboardData, cancellationToken),
@@ -41,6 +42,13 @@ public static class TransformHelpers
     {
         Logger.LogTrace();
         return CreateDataPackageFromText(await clipboardData.GetTextOrEmptyAsync());
+    }
+
+    private static async Task<DataPackage> ToTrimmedPlainTextAsync(DataPackageView clipboardData)
+    {
+        Logger.LogTrace();
+        var text = await clipboardData.GetTextOrEmptyAsync();
+        return CreateDataPackageFromText(text.Trim());
     }
 
     private static async Task<DataPackage> ToMarkdownAsync(DataPackageView clipboardData)

--- a/src/modules/AdvancedPaste/AdvancedPaste/Models/PasteFormats.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/Models/PasteFormats.cs
@@ -20,6 +20,16 @@ public enum PasteFormats
 
     [PasteFormatMetadata(
         IsCoreAction = true,
+        ResourceId = "PasteAsPlainTextTrimmed",
+        IconGlyph = "\uE8E9",
+        RequiresAIService = false,
+        CanPreview = false,
+        SupportedClipboardFormats = ClipboardFormat.Text,
+        KernelFunctionDescription = "Takes clipboard text and returns it trimmed of leading and trailing whitespace.")]
+    PlainTextTrimmed,
+
+    [PasteFormatMetadata(
+        IsCoreAction = true,
         ResourceId = "PasteAsMarkdown",
         IconGlyph = "\ue8a5",
         RequiresAIService = false,

--- a/src/modules/AdvancedPaste/AdvancedPaste/Strings/en-us/Resources.resw
+++ b/src/modules/AdvancedPaste/AdvancedPaste/Strings/en-us/Resources.resw
@@ -232,6 +232,9 @@
   <data name="PasteAsPlainText" xml:space="preserve">
     <value>Paste as plain text</value>
   </data>
+  <data name="PasteAsPlainTextTrimmed" xml:space="preserve">
+    <value>Paste as plain text (trimmed)</value>
+  </data>
   <data name="ImageToText" xml:space="preserve">
     <value>Image to text</value>
   </data>

--- a/src/modules/AdvancedPaste/AdvancedPasteModuleInterface/dllmain.cpp
+++ b/src/modules/AdvancedPaste/AdvancedPasteModuleInterface/dllmain.cpp
@@ -54,6 +54,7 @@ namespace
     const wchar_t JSON_KEY_SHIFT[] = L"shift";
     const wchar_t JSON_KEY_CODE[] = L"code";
     const wchar_t JSON_KEY_PASTE_AS_PLAIN_HOTKEY[] = L"paste-as-plain-hotkey";
+    const wchar_t JSON_KEY_PASTE_AS_PLAIN_TRIMMED_HOTKEY[] = L"paste-as-plain-trimmed-hotkey";
     const wchar_t JSON_KEY_ADVANCED_PASTE_UI_HOTKEY[] = L"advanced-paste-ui-hotkey";
     const wchar_t JSON_KEY_PASTE_AS_MARKDOWN_HOTKEY[] = L"paste-as-markdown-hotkey";
     const wchar_t JSON_KEY_PASTE_AS_JSON_HOTKEY[] = L"paste-as-json-hotkey";
@@ -79,9 +80,10 @@ private:
     //contains the non localized key of the powertoy
     std::wstring app_key;
 
-    static const constexpr int NUM_DEFAULT_HOTKEYS = 4;
+    static const constexpr int NUM_DEFAULT_HOTKEYS = 5;
 
     Hotkey m_paste_as_plain_hotkey = { .win = true, .ctrl = true, .shift = false, .alt = true, .key = 'V' };
+    Hotkey m_paste_as_plain_trimmed_hotkey{};
     Hotkey m_advanced_paste_ui_hotkey = { .win = true, .ctrl = false, .shift = true, .alt = false, .key = 'V' };
     Hotkey m_paste_as_markdown_hotkey{};
     Hotkey m_paste_as_json_hotkey{};
@@ -375,6 +377,7 @@ private:
             {
                 const std::array<std::pair<Hotkey*, LPCWSTR>, NUM_DEFAULT_HOTKEYS> defaultHotkeys{
                     { { &m_paste_as_plain_hotkey, JSON_KEY_PASTE_AS_PLAIN_HOTKEY },
+                      { &m_paste_as_plain_trimmed_hotkey, JSON_KEY_PASTE_AS_PLAIN_TRIMMED_HOTKEY },
                       { &m_advanced_paste_ui_hotkey, JSON_KEY_ADVANCED_PASTE_UI_HOTKEY },
                       { &m_paste_as_markdown_hotkey, JSON_KEY_PASTE_AS_MARKDOWN_HOTKEY },
                       { &m_paste_as_json_hotkey, JSON_KEY_PASTE_AS_JSON_HOTKEY } }
@@ -844,6 +847,14 @@ public:
             }
 
             if (hotkeyId == 1)
+            { // m_paste_as_plain_trimmed_hotkey
+                Logger::trace(L"Starting paste as plain text (trimmed) directly");
+                m_process_manager.send_message(CommonSharedConstants::ADVANCED_PASTE_PLAIN_TEXT_TRIMMED_MESSAGE);
+                Trace::AdvancedPaste_Invoked(L"PlainTextTrimmedDirect");
+                return true;
+            }
+
+            if (hotkeyId == 2)
             { // m_advanced_paste_ui_hotkey
                 Logger::trace(L"Setting start up event");
 
@@ -852,14 +863,14 @@ public:
                 Trace::AdvancedPaste_Invoked(L"AdvancedPasteUI");
                 return true;
             }
-            if (hotkeyId == 2)
+            if (hotkeyId == 3)
             { // m_paste_as_markdown_hotkey
                 Logger::trace(L"Starting paste as markdown directly");
                 m_process_manager.send_message(CommonSharedConstants::ADVANCED_PASTE_MARKDOWN_MESSAGE);
                 Trace::AdvancedPaste_Invoked(L"MarkdownDirect");
                 return true;
             }
-            if (hotkeyId == 3)
+            if (hotkeyId == 4)
             { // m_paste_as_json_hotkey
                 Logger::trace(L"Starting paste as json directly");
                 m_process_manager.send_message(CommonSharedConstants::ADVANCED_PASTE_JSON_MESSAGE);
@@ -904,6 +915,7 @@ public:
         if (hotkeys && buffer_size >= num_hotkeys)
         {
             const std::array default_hotkeys = { m_paste_as_plain_hotkey,
+                                                 m_paste_as_plain_trimmed_hotkey,
                                                  m_advanced_paste_ui_hotkey,
                                                  m_paste_as_markdown_hotkey,
                                                  m_paste_as_json_hotkey };

--- a/src/settings-ui/Settings.UI.Library/AdvancedPasteProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/AdvancedPasteProperties.cs
@@ -16,10 +16,13 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 
         public static readonly HotkeySettings DefaultPasteAsPlainTextShortcut = new HotkeySettings(true, true, true, false, 0x56); // Ctrl+Win+Alt+V
 
+        public static readonly HotkeySettings DefaultPasteAsPlainTextTrimmedShortcut = new HotkeySettings();
+
         public AdvancedPasteProperties()
         {
             AdvancedPasteUIShortcut = DefaultAdvancedPasteUIShortcut;
             PasteAsPlainTextShortcut = DefaultPasteAsPlainTextShortcut;
+            PasteAsPlainTextTrimmedShortcut = DefaultPasteAsPlainTextTrimmedShortcut;
             PasteAsMarkdownShortcut = new();
             PasteAsJsonShortcut = new();
             CustomActions = new();
@@ -84,6 +87,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 
         [JsonPropertyName("paste-as-plain-hotkey")]
         public HotkeySettings PasteAsPlainTextShortcut { get; set; }
+
+        [JsonPropertyName("paste-as-plain-trimmed-hotkey")]
+        public HotkeySettings PasteAsPlainTextTrimmedShortcut { get; set; }
 
         [JsonPropertyName("paste-as-markdown-hotkey")]
         public HotkeySettings PasteAsMarkdownShortcut { get; set; }

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/AdvancedPastePage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/AdvancedPastePage.xaml
@@ -196,6 +196,15 @@
                             <controls:ShortcutControl MinWidth="{StaticResource SettingActionControlMinWidth}" HotkeySettings="{x:Bind Path=ViewModel.PasteAsPlainTextShortcut, Mode=TwoWay}" />
                         </tkcontrols:SettingsCard>
                         <tkcontrols:SettingsCard
+                            Name="PasteAsPlainTextTrimmedShortcut"
+                            x:Uid="PasteAsPlainTextTrimmed_Shortcut"
+                            HeaderIcon="{ui:FontIcon Glyph=&#xE8E9;}">
+                            <controls:ShortcutControl
+                                MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                AllowDisable="True"
+                                HotkeySettings="{x:Bind Path=ViewModel.PasteAsPlainTextTrimmedShortcut, Mode=TwoWay}" />
+                        </tkcontrols:SettingsCard>
+                        <tkcontrols:SettingsCard
                             Name="PasteAsMarkdownShortcut"
                             x:Uid="PasteAsMarkdown_Shortcut"
                             HeaderIcon="{ui:FontIcon Glyph=&#xe8a5;}">

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -2044,6 +2044,9 @@ Made with 💗 by Microsoft and the PowerToys community.</value>
   <data name="PasteAsPlainText_Shortcut.Header" xml:space="preserve">
     <value>Paste as plain text directly</value>
   </data>
+  <data name="PasteAsPlainTextTrimmed_Shortcut.Header" xml:space="preserve">
+    <value>Paste as plain text (trimmed) directly</value>
+  </data>
   <data name="AdvancedPasteUI_Actions.Header" xml:space="preserve">
     <value>Actions</value>
   </data>

--- a/src/settings-ui/Settings.UI/ViewModels/AdvancedPasteViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/AdvancedPasteViewModel.cs
@@ -129,6 +129,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             var hotkeySettings = new List<HotkeySettings>
             {
                 PasteAsPlainTextShortcut,
+                PasteAsPlainTextTrimmedShortcut,
                 AdvancedPasteUIShortcut,
                 PasteAsMarkdownShortcut,
                 PasteAsJsonShortcut,
@@ -445,6 +446,21 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             }
         }
 
+        public HotkeySettings PasteAsPlainTextTrimmedShortcut
+        {
+            get => _advancedPasteSettings.Properties.PasteAsPlainTextTrimmedShortcut;
+            set
+            {
+                if (_advancedPasteSettings.Properties.PasteAsPlainTextTrimmedShortcut != value)
+                {
+                    _advancedPasteSettings.Properties.PasteAsPlainTextTrimmedShortcut = value ?? AdvancedPasteProperties.DefaultPasteAsPlainTextTrimmedShortcut;
+                    OnPropertyChanged(nameof(IsConflictingCopyShortcut));
+                    OnPropertyChanged(nameof(PasteAsPlainTextTrimmedShortcut));
+                    SaveAndNotifySettings();
+                }
+            }
+        }
+
         public HotkeySettings PasteAsMarkdownShortcut
         {
             get => _advancedPasteSettings.Properties.PasteAsMarkdownShortcut;
@@ -571,7 +587,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
 
         public bool IsConflictingCopyShortcut =>
             _customActions.Select(customAction => customAction.Shortcut)
-                          .Concat([PasteAsPlainTextShortcut, AdvancedPasteUIShortcut, PasteAsMarkdownShortcut, PasteAsJsonShortcut])
+                          .Concat([PasteAsPlainTextShortcut, PasteAsPlainTextTrimmedShortcut, AdvancedPasteUIShortcut, PasteAsMarkdownShortcut, PasteAsJsonShortcut])
                           .Any(hotkey => WarnHotkeys.Contains(hotkey.ToString()));
 
         public bool IsAdditionalActionConflictingCopyShortcut =>


### PR DESCRIPTION
feat(AdvancedPaste): Add paste as plain text (trimmed) option

```markdown
## Summary of the Pull Request

Adds a new "Paste as plain text (trimmed)" option to Advanced Paste that removes leading and trailing whitespace from clipboard text before pasting. This provides users with a dedicated hotkey to trim text when pasting, without modifying the standard paste as plain text behavior.

## PR Checklist

- [x] Closes: #31937
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [x] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated

## Detailed Description of the Pull Request / Additional comments

This PR implements the feature request to add an option to trim plain text when pasting. The implementation adds:

### Core Changes
- **New paste format**: Added `PasteFormats.PlainTextTrimmed` enum value in `src/modules/AdvancedPaste/AdvancedPaste/Models/PasteFormats.cs`
- **Transform helper**: Added `ToTrimmedPlainTextAsync()` method in `src/modules/AdvancedPaste/AdvancedPaste/Helpers/TransformHelpers.cs` that calls `.Trim()` on clipboard text

### IPC/Hotkey Infrastructure
- **Shared constant**: Added `ADVANCED_PASTE_PLAIN_TEXT_TRIMMED_MESSAGE` in `src/common/interop/shared_constants.h`
- **Interop binding**: Exposed constant through `Constants.cpp`, `Constants.h`, and `Constants.idl`
- **Module interface**: Added hotkey registration and message handling in `src/modules/AdvancedPaste/AdvancedPasteModuleInterface/dllmain.cpp`

### Settings UI
- **Properties**: Added `PasteAsPlainTextTrimmedShortcut` property in `src/settings-ui/Settings.UI.Library/AdvancedPasteProperties.cs`
- **ViewModel**: Added corresponding property and shortcut conflict checking in `src/settings-ui/Settings.UI/ViewModels/AdvancedPasteViewModel.cs`
- **XAML**: Added settings card with `AllowDisable="True"` in `src/settings-ui/Settings.UI/SettingsXAML/Views/AdvancedPastePage.xaml`

### Localization
- Added `PasteAsPlainTextTrimmed` string in `src/modules/AdvancedPaste/AdvancedPaste/Strings/en-us/Resources.resw`
- Added `PasteAsPlainTextTrimmed_Shortcut.Header` string in `src/settings-ui/Settings.UI/Strings/en-us/Resources.resw`

The hotkey is disabled by default (empty shortcut), allowing users to optionally configure it without changing existing behavior.

## Validation Steps Performed

1. Built the solution successfully
2. Verified the new "Paste as plain text (trimmed)" option appears in Advanced Paste settings
3. Configured a hotkey for the new option
4. Tested with clipboard text containing leading/trailing whitespace - confirmed whitespace is removed
5. Verified existing "Paste as plain text" functionality is unchanged
6. Confirmed hotkey conflict detection includes the new shortcut

Fixes #31937
```