### PR TITLE
fix(runner): detect right Alt key in centralized keyboard hook

### DIFF
--- a/src/runner/centralized_kb_hook.cpp
+++ b/src/runner/centralized_kb_hook.cpp
@@ -147,7 +147,7 @@ namespace CentralizedKeyboardHook
             .win = (GetAsyncKeyState(VK_LWIN) & 0x8000) || (GetAsyncKeyState(VK_RWIN) & 0x8000),
             .ctrl = static_cast<bool>(GetAsyncKeyState(VK_CONTROL) & 0x8000),
             .shift = static_cast<bool>(GetAsyncKeyState(VK_SHIFT) & 0x8000),
-            .alt = static_cast<bool>(GetAsyncKeyState(VK_MENU) & 0x8000),
+            .alt = (GetAsyncKeyState(VK_MENU) & 0x8000) || (GetAsyncKeyState(VK_LMENU) & 0x8000) || (GetAsyncKeyState(VK_RMENU) & 0x8000),
             .key = static_cast<unsigned char>(keyPressInfo.vkCode)
         };
 


### PR DESCRIPTION
## Summary of the Pull Request

Fixes the centralized keyboard hook to properly detect the right Alt key (`VK_RMENU`) in addition to the generic Alt key (`VK_MENU`) and left Alt key (`VK_LMENU`). This resolves an issue where hotkeys configured with right Alt would not trigger correctly.

## PR Checklist

- [x] Closes: #25433
- [x] **Communication:** This is a bug fix for a reported and reproduced issue
- [ ] **Tests:** No automated tests added; this is a low-level keyboard hook change that requires manual validation
- [x] **Localization:** N/A - no user-facing strings changed
- [x] **Dev docs:** N/A - no documentation changes needed

## Detailed Description of the Pull Request / Additional comments

The issue affects any PowerToys feature using the centralized keyboard hook (e.g., Advanced Paste, other hotkey-activated modules). When users configure shortcuts using the right Alt key, the hotkey detection would fail because only `VK_MENU` was being checked.

**Root cause:** In `src/runner/centralized_kb_hook.cpp`, the `.alt` field was only checking `VK_MENU` (generic Alt), but Windows distinguishes between:
- `VK_MENU` (0x12) - generic Alt
- `VK_LMENU` (0xA4) - left Alt  
- `VK_RMENU` (0xA5) - right Alt

**Fix:** Updated the alt key detection to check all three virtual key codes, consistent with how the `.win` field already handles left/right Windows keys.

## Validation Steps Performed

1. Configured Advanced Paste shortcut to `Ctrl + Right Alt + V`
2. Copied formatted text to clipboard
3. Pressed `Ctrl + Right Alt + V` ΓåÆ plain text now pastes correctly
4. Verified `Ctrl + Left Alt + V` still works
5. Verified other Alt-based shortcuts in PowerToys continue to function

Fixes #25433