### PR TITLE
[Light Switch] Fix Light Switch start up logic

### DIFF
--- a/src/modules/LightSwitch/LightSwitchService/LightSwitchService.cpp
+++ b/src/modules/LightSwitch/LightSwitchService/LightSwitchService.cpp
@@ -250,7 +250,6 @@ DWORD WINAPI ServiceWorkerThread(LPVOID lpParam)
 
     Logger::info(L"[LightSwitchService] Initialized at {:02d}:{:02d}.", st.wHour, st.wMinute);
     stateManager.SyncInitialThemeState();
-    stateManager.OnTick(nowMinutes);
 
     // ────────────────────────────────────────────────────────────────
     // Worker Loop
@@ -281,7 +280,7 @@ DWORD WINAPI ServiceWorkerThread(LPVOID lpParam)
             GetLocalTime(&st);
             nowMinutes = st.wHour * 60 + st.wMinute;
             DetectAndHandleExternalThemeChange(stateManager);
-            stateManager.OnTick(nowMinutes);
+            stateManager.OnTick();
             continue;
         }
 

--- a/src/modules/LightSwitch/LightSwitchService/LightSwitchStateManager.cpp
+++ b/src/modules/LightSwitch/LightSwitchService/LightSwitchStateManager.cpp
@@ -28,7 +28,7 @@ void LightSwitchStateManager::OnSettingsChanged()
 }
 
 // Called once per minute
-void LightSwitchStateManager::OnTick(int currentMinutes)
+void LightSwitchStateManager::OnTick()
 {
     std::lock_guard<std::mutex> lock(_stateMutex);
     if (_state.lastAppliedMode != ScheduleMode::FollowNightLight)
@@ -109,10 +109,14 @@ void LightSwitchStateManager::SyncInitialThemeState()
     std::lock_guard<std::mutex> lock(_stateMutex);
     _state.isSystemLightActive = GetCurrentSystemTheme();
     _state.isAppsLightActive = GetCurrentAppsTheme();
+    _state.isNightLightActive = IsNightLightEnabled();
     Logger::debug(L"[LightSwitchStateManager] Synced initial state to current system theme ({})",
                   _state.isSystemLightActive ? L"light" : L"dark");
     Logger::debug(L"[LightSwitchStateManager] Synced initial state to current apps theme ({})",
                   _state.isAppsLightActive ? L"light" : L"dark");
+    
+    // This will ensure that the theme is applied according to current settings at startup
+    EvaluateAndApplyIfNeeded();
 }
 
 static std::pair<int, int> update_sun_times(auto& settings)

--- a/src/modules/LightSwitch/LightSwitchService/LightSwitchStateManager.h
+++ b/src/modules/LightSwitch/LightSwitchService/LightSwitchStateManager.h
@@ -28,7 +28,7 @@ public:
     void OnSettingsChanged();
 
     // Called every minute (from service worker tick).
-    void OnTick(int currentMinutes);
+    void OnTick();
 
     // Called when manual override is toggled (via shortcut or system change).
     void OnManualOverride();


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Title

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: https://github.com/microsoft/PowerToys/issues/45291
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [x] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Before, there was a function that initialized some variables about the current system state that were later used to check against if that state needed to change in a different function. That caused from some issues because I was reusing the function for a double purpose. Now the `SyncInitialThemeState()` function in the State Manager will sync those initial variables and apply the correct theme if needed.

I also removed an unnecessary parameter from `onTick`

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manual testing
