### PR TITLE
CmdPal: Prevent the main window from stealing focus

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml
@@ -31,6 +31,6 @@
             TintIntensity="{x:Bind ViewModel.BackgroundImageTintIntensity, Mode=OneWay}"
             Visibility="{x:Bind ViewModel.ShowBackgroundImage, Mode=OneWay}" />
 
-        <pages:ShellPage />
+        <pages:ShellPage HostWindow="{x:Bind}" />
     </Grid>
 </winuiex:WindowEx>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml.cs
@@ -53,7 +53,8 @@ public sealed partial class MainWindow : WindowEx,
     IRecipient<ErrorOccurredMessage>,
     IRecipient<DragStartedMessage>,
     IRecipient<DragCompletedMessage>,
-    IDisposable
+    IDisposable,
+    IHostWindow
 {
     [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1310:Field names should not contain underscore", Justification = "Stylistically, window messages are WM_")]
     [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1306:Field names should begin with lower-case letter", Justification = "Stylistically, window messages are WM_")]
@@ -88,6 +89,8 @@ public sealed partial class MainWindow : WindowEx,
     private bool _preventHideWhenDeactivated;
 
     private MainWindowViewModel ViewModel { get; }
+
+    public bool IsVisibleToUser { get; private set; } = true;
 
     public MainWindow()
     {
@@ -575,15 +578,12 @@ public sealed partial class MainWindow : WindowEx,
             {
                 Logger.LogWarning($"DWM cloaking of the main window failed. HRESULT: {hr.Value}.");
             }
+            else
+            {
+                IsVisibleToUser = false;
+            }
 
             wasCloaked = hr.Succeeded;
-        }
-
-        if (wasCloaked)
-        {
-            // Because we're only cloaking the window, bury it at the bottom in case something can
-            // see it - e.g. some accessibility helper (note: this also removes the top-most status).
-            PInvoke.SetWindowPos(_hwnd, HWND.HWND_BOTTOM, 0, 0, 0, 0, SET_WINDOW_POS_FLAGS.SWP_NOMOVE | SET_WINDOW_POS_FLAGS.SWP_NOSIZE);
         }
 
         return wasCloaked;
@@ -595,6 +595,7 @@ public sealed partial class MainWindow : WindowEx,
         {
             BOOL value = false;
             PInvoke.DwmSetWindowAttribute(_hwnd, DWMWINDOWATTRIBUTE.DWMWA_CLOAK, &value, (uint)sizeof(BOOL));
+            IsVisibleToUser = true;
         }
     }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
@@ -13,6 +13,7 @@ using Microsoft.CmdPal.Core.ViewModels.Messages;
 using Microsoft.CmdPal.UI.Events;
 using Microsoft.CmdPal.UI.Helpers;
 using Microsoft.CmdPal.UI.Messages;
+using Microsoft.CmdPal.UI.Services;
 using Microsoft.CmdPal.UI.Settings;
 using Microsoft.CmdPal.UI.ViewModels;
 using Microsoft.CommandPalette.Extensions;
@@ -71,6 +72,8 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
     public ShellViewModel ViewModel { get; private set; } = App.Current.Services.GetService<ShellViewModel>()!;
 
     public event PropertyChangedEventHandler? PropertyChanged;
+
+    public IHostWindow? HostWindow { get; set; }
 
     public ShellPage()
     {
@@ -435,7 +438,7 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
 
         if (!RootFrame.CanGoBack)
         {
-            ViewModel.GoHome();
+            ViewModel.GoHome(withAnimation, focusSearch);
         }
 
         if (focusSearch)
@@ -531,6 +534,11 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
 
         if (shouldSearchBoxBeVisible || page is not ContentPage)
         {
+            if (HostWindow?.IsVisibleToUser != true)
+            {
+                return;
+            }
+
             ViewModel.IsSearchBoxVisible = shouldSearchBoxBeVisible;
             SearchBox.Focus(FocusState.Programmatic);
             SearchBox.SelectSearch();
@@ -547,6 +555,11 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
 
                     try
                     {
+                        if (HostWindow?.IsVisibleToUser != true)
+                        {
+                            return;
+                        }
+
                         await page.DispatcherQueue.EnqueueAsync(
                             async () =>
                             {
@@ -555,6 +568,11 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
                                 for (var i = 0; i < 10; i++)
                                 {
                                     token.ThrowIfCancellationRequested();
+
+                                    if (HostWindow?.IsVisibleToUser != true)
+                                    {
+                                        break;
+                                    }
 
                                     if (FocusManager.FindFirstFocusableElement(page) is FrameworkElement frameworkElement)
                                     {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Services/IHostWindow.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Services/IHostWindow.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CmdPal.UI.Services;
+
+/// <summary>
+/// Represents abstract host window functionality.
+/// </summary>
+public interface IHostWindow
+{
+    /// <summary>
+    /// Gets a value indicating whether the window is visible to the user, taking account not only window visibility but also cloaking.
+    /// </summary>
+    bool IsVisibleToUser { get; }
+}


### PR DESCRIPTION
## Summary of the Pull Request

This PR adds two fixes to prevent Command Palette’s main window from stealing focus while or after it is being hidden.

1) GoBack was not forwarding the withAnimation and focusSearch parameters when chaining to GoHome.

2) Page focus after load can be triggered too late—when the window is already hidden—causing CmdPal to regain focus unexpectedly.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #45301
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

