### PR TITLE
fix(settings-ui): enable language list wrapping in Quick Accent

### DIFF
--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerAccentPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerAccentPage.xaml
@@ -70,7 +70,7 @@
                             IsThreeState="True"
                             Unchecked="QuickAccent_SelectedLanguage_UnselectAll" />
                         <tkcontrols:SettingsExpander.Items>
-                            <tkcontrols:SettingsCard>
+                            <tkcontrols:SettingsCard HorizontalContentAlignment="Stretch" ContentAlignment="Vertical">
                                 <ListView
                                     x:Name="QuickAccent_Language_Select"
                                     MinWidth="{StaticResource SettingActionControlMinWidth}"


### PR DESCRIPTION
## Summary of the Pull Request

Fixes the Quick Accent language selection list to properly wrap within the available width instead of overflowing horizontally.

## PR Checklist
- [x] Closes: #40255
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

## Detailed Description of the Pull Request

Added HorizontalContentAlignment="Stretch" and ContentAlignment="Vertical" to the SettingsCard containing the language ListView in PowerAccentPage.xaml.

## Validation Steps Performed

1. Open PowerToys Settings → Quick Accent
2. Expand "Selected Language" section
3. Verify language items wrap to multiple rows instead of overflowing horizontally