### PR TITLE
Add edge delay before wrapping to another edge/display

### DIFF
--- a/src/modules/MouseUtils/CursorWrap/CursorWrapCore.h
+++ b/src/modules/MouseUtils/CursorWrap/CursorWrapCore.h
@@ -6,6 +6,7 @@
 #include <windows.h>
 #include <vector>
 #include <string>
+#include <functional>
 #include "MonitorTopology.h"
 
 // Core cursor wrapping engine
@@ -13,6 +14,7 @@ class CursorWrapCore
 {
 public:
     CursorWrapCore();
+    ~CursorWrapCore();
 
     void UpdateMonitorInfo();
     
@@ -23,8 +25,13 @@ public:
     // wrapMode: 0=Both, 1=VerticalOnly, 2=HorizontalOnly
     // stickyEdgeEnabled: if true, cursor must stay at edge for stickyDelayMs before wrapping
     // stickyEdgeDelayMs: delay in milliseconds before wrap occurs when sticky edge is enabled
+    // Returns: new position (same as currentPos if no wrap, or wrapped position)
+    // Note: When sticky edge timer fires, the wrap is performed via callback
     POINT HandleMouseMove(const POINT& currentPos, bool disableWrapDuringDrag, int wrapMode, 
                           bool stickyEdgeEnabled, int stickyEdgeDelayMs);
+    
+    // Set callback to be invoked when sticky edge timer fires and wrap should occur
+    void SetStickyEdgeWrapCallback(std::function<void(POINT)> callback);
 
     const std::vector<MonitorInfo>& GetMonitors() const { return m_monitors; }
     const MonitorTopology& GetTopology() const { return m_topology; }
@@ -34,13 +41,20 @@ private:
     std::wstring GenerateTopologyJSON() const;
 #endif
 
+    void StartStickyEdgeTimer(int delayMs);
+    void CancelStickyEdgeTimer();
+    static void CALLBACK StickyEdgeTimerCallback(PTP_CALLBACK_INSTANCE instance, PVOID context, PTP_TIMER timer);
+    void OnStickyEdgeTimerFired();
+
     std::vector<MonitorInfo> m_monitors;
     MonitorTopology m_topology;
     
     // Sticky edge state
     bool m_stickyEdgeActive = false;         // True when cursor is at a wrappable edge waiting to wrap
-    ULONGLONG m_stickyEdgeStartTime = 0;     // Tick count when cursor first hit the edge
     POINT m_stickyEdgePosition = {0, 0};     // Position when sticky edge was triggered
     EdgeType m_stickyEdgeType = EdgeType::Left; // Which edge type triggered sticky state
     HMONITOR m_stickyEdgeMonitor = nullptr;  // Monitor where sticky edge was triggered
+    PTP_TIMER m_stickyEdgeTimer = nullptr;   // Threadpool timer for sticky edge delay
+    std::function<void(POINT)> m_wrapCallback; // Callback to perform wrap when timer fires
+    int m_currentWrapMode = 0;               // Cached wrap mode for timer callback
 };

--- a/src/modules/MouseUtils/CursorWrap/CursorWrapCore.h
+++ b/src/modules/MouseUtils/CursorWrap/CursorWrapCore.h
@@ -16,9 +16,15 @@ public:
 
     void UpdateMonitorInfo();
     
-    // Handle mouse move with wrap mode filtering
+    // Reset sticky edge state (call when settings change or wrap is disabled)
+    void ResetStickyEdgeState();
+    
+    // Handle mouse move with wrap mode filtering and sticky edge support
     // wrapMode: 0=Both, 1=VerticalOnly, 2=HorizontalOnly
-    POINT HandleMouseMove(const POINT& currentPos, bool disableWrapDuringDrag, int wrapMode);
+    // stickyEdgeEnabled: if true, cursor must stay at edge for stickyDelayMs before wrapping
+    // stickyEdgeDelayMs: delay in milliseconds before wrap occurs when sticky edge is enabled
+    POINT HandleMouseMove(const POINT& currentPos, bool disableWrapDuringDrag, int wrapMode, 
+                          bool stickyEdgeEnabled, int stickyEdgeDelayMs);
 
     const std::vector<MonitorInfo>& GetMonitors() const { return m_monitors; }
     const MonitorTopology& GetTopology() const { return m_topology; }
@@ -30,4 +36,11 @@ private:
 
     std::vector<MonitorInfo> m_monitors;
     MonitorTopology m_topology;
+    
+    // Sticky edge state
+    bool m_stickyEdgeActive = false;         // True when cursor is at a wrappable edge waiting to wrap
+    ULONGLONG m_stickyEdgeStartTime = 0;     // Tick count when cursor first hit the edge
+    POINT m_stickyEdgePosition = {0, 0};     // Position when sticky edge was triggered
+    EdgeType m_stickyEdgeType = EdgeType::Left; // Which edge type triggered sticky state
+    HMONITOR m_stickyEdgeMonitor = nullptr;  // Monitor where sticky edge was triggered
 };

--- a/src/modules/MouseUtils/CursorWrap/dllmain.cpp
+++ b/src/modules/MouseUtils/CursorWrap/dllmain.cpp
@@ -477,6 +477,12 @@ private:
         // Refresh monitor info before starting hook
         m_core.UpdateMonitorInfo();
         
+        // Set up the callback for sticky edge timer-based wrapping
+        m_core.SetStickyEdgeWrapCallback([](POINT newPos) {
+            Logger::info(L"CursorWrap: Sticky edge callback - setting cursor to ({}, {})", newPos.x, newPos.y);
+            SetCursorPos(newPos.x, newPos.y);
+        });
+        
         m_mouseHook = SetWindowsHookEx(WH_MOUSE_LL, MouseHookProc, GetModuleHandle(nullptr), 0);
         if (m_mouseHook)
         {

--- a/src/settings-ui/Settings.UI.Library/CursorWrapProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/CursorWrapProperties.cs
@@ -25,12 +25,20 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         [JsonPropertyName("wrap_mode")]
         public IntProperty WrapMode { get; set; }
 
+        [JsonPropertyName("sticky_edge_enabled")]
+        public BoolProperty StickyEdgeEnabled { get; set; }
+
+        [JsonPropertyName("sticky_edge_delay_ms")]
+        public IntProperty StickyEdgeDelayMs { get; set; }
+
         public CursorWrapProperties()
         {
             ActivationShortcut = DefaultActivationShortcut;
             AutoActivate = new BoolProperty(false);
             DisableWrapDuringDrag = new BoolProperty(true);
             WrapMode = new IntProperty(0); // 0=Both (default), 1=VerticalOnly, 2=HorizontalOnly
+            StickyEdgeEnabled = new BoolProperty(false); // Default to disabled
+            StickyEdgeDelayMs = new IntProperty(250); // Default to 0.25 seconds
         }
     }
 }

--- a/src/settings-ui/Settings.UI.Library/CursorWrapSettings.cs
+++ b/src/settings-ui/Settings.UI.Library/CursorWrapSettings.cs
@@ -56,6 +56,20 @@ namespace Microsoft.PowerToys.Settings.UI.Library
                 settingsUpgraded = true;
             }
 
+            // Add StickyEdgeEnabled property if it doesn't exist (for users upgrading from older versions)
+            if (Properties.StickyEdgeEnabled == null)
+            {
+                Properties.StickyEdgeEnabled = new BoolProperty(false); // Default to disabled
+                settingsUpgraded = true;
+            }
+
+            // Add StickyEdgeDelayMs property if it doesn't exist (for users upgrading from older versions)
+            if (Properties.StickyEdgeDelayMs == null)
+            {
+                Properties.StickyEdgeDelayMs = new IntProperty(250); // Default to 0.25 seconds
+                settingsUpgraded = true;
+            }
+
             return settingsUpgraded;
         }
     }

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/MouseUtilsPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/MouseUtilsPage.xaml
@@ -54,6 +54,22 @@
                                     <ComboBoxItem x:Uid="MouseUtils_CursorWrap_WrapMode_HorizontalOnly" />
                                 </ComboBox>
                             </tkcontrols:SettingsCard>
+                            <tkcontrols:SettingsCard ContentAlignment="Left" IsEnabled="{x:Bind ViewModel.IsCursorWrapEnabled, Mode=OneWay}">
+                                <CheckBox x:Uid="MouseUtils_CursorWrap_StickyEdge" IsChecked="{x:Bind ViewModel.CursorWrapStickyEdgeEnabled, Mode=TwoWay}" />
+                            </tkcontrols:SettingsCard>
+                            <tkcontrols:SettingsCard
+                                Name="MouseUtilsCursorWrapStickyEdgeDelay"
+                                x:Uid="MouseUtils_CursorWrap_StickyEdgeDelay"
+                                IsEnabled="{x:Bind ViewModel.CursorWrapStickyEdgeEnabled, Mode=OneWay}">
+                                <NumberBox
+                                    MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                    LargeChange="250"
+                                    Maximum="1000"
+                                    Minimum="250"
+                                    SmallChange="50"
+                                    SpinButtonPlacementMode="Compact"
+                                    Value="{x:Bind Path=ViewModel.CursorWrapStickyEdgeDelayMs, Mode=TwoWay}" />
+                            </tkcontrols:SettingsCard>
                         </tkcontrols:SettingsExpander.Items>
                     </tkcontrols:SettingsExpander>
                 </controls:SettingsGroup>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -2744,7 +2744,19 @@ From there, simply click on one of the supported files in the File Explorer and 
   <data name="MouseUtils_CursorWrap_WrapMode_Both.Content" xml:space="preserve">
     <value>Vertical and horizontal</value>
   </data>
-  <data name="Oobe_MouseUtils_MousePointerCrosshairs.Text" xml:space="preserve">
+	<data name="MouseUtils_CursorWrap_StickyEdge.Content" xml:space="preserve">
+  <value>Enable sticky edge</value>
+  <comment>Checkbox to enable sticky edge behavior - cursor must stay at edge before wrapping</comment>
+  </data>
+    <data name="MouseUtils_CursorWrap_StickyEdgeDelay.Header" xml:space="preserve">
+    <value>Sticky edge delay (ms)</value>
+    <comment>Header for the sticky edge delay setting</comment>
+  </data>
+  <data name="MouseUtils_CursorWrap_StickyEdgeDelay.Description" xml:space="preserve">
+    <value>Time in milliseconds the cursor must stay at the edge before wrapping (250-1000)</value>
+    <comment>Description for the sticky edge delay setting</comment>
+  </data>
+	<data name="Oobe_MouseUtils_MousePointerCrosshairs.Text" xml:space="preserve">
     <value>Mouse Pointer Crosshairs</value>
     <comment>Mouse as in the hardware peripheral.</comment>
   </data>

--- a/src/settings-ui/Settings.UI/ViewModels/MouseUtilsViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/MouseUtilsViewModel.cs
@@ -116,6 +116,12 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             // Null-safe access in case property wasn't upgraded yet - default to 0 (Both)
             _cursorWrapWrapMode = CursorWrapSettingsConfig.Properties.WrapMode?.Value ?? 0;
 
+            // Null-safe access in case property wasn't upgraded yet - default to false
+            _cursorWrapStickyEdgeEnabled = CursorWrapSettingsConfig.Properties.StickyEdgeEnabled?.Value ?? false;
+
+            // Null-safe access in case property wasn't upgraded yet - default to 250ms
+            _cursorWrapStickyEdgeDelayMs = CursorWrapSettingsConfig.Properties.StickyEdgeDelayMs?.Value ?? 250;
+
             int isEnabled = 0;
 
             Utilities.NativeMethods.SystemParametersInfo(Utilities.NativeMethods.SPI_GETCLIENTAREAANIMATION, 0, ref isEnabled, 0);
@@ -1114,6 +1120,62 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             }
         }
 
+        public bool CursorWrapStickyEdgeEnabled
+        {
+            get
+            {
+                return _cursorWrapStickyEdgeEnabled;
+            }
+
+            set
+            {
+                if (value != _cursorWrapStickyEdgeEnabled)
+                {
+                    _cursorWrapStickyEdgeEnabled = value;
+
+                    // Ensure the property exists before setting value
+                    if (CursorWrapSettingsConfig.Properties.StickyEdgeEnabled == null)
+                    {
+                        CursorWrapSettingsConfig.Properties.StickyEdgeEnabled = new BoolProperty(value);
+                    }
+                    else
+                    {
+                        CursorWrapSettingsConfig.Properties.StickyEdgeEnabled.Value = value;
+                    }
+
+                    NotifyCursorWrapPropertyChanged();
+                }
+            }
+        }
+
+        public int CursorWrapStickyEdgeDelayMs
+        {
+            get
+            {
+                return _cursorWrapStickyEdgeDelayMs;
+            }
+
+            set
+            {
+                if (value != _cursorWrapStickyEdgeDelayMs)
+                {
+                    _cursorWrapStickyEdgeDelayMs = value;
+
+                    // Ensure the property exists before setting value
+                    if (CursorWrapSettingsConfig.Properties.StickyEdgeDelayMs == null)
+                    {
+                        CursorWrapSettingsConfig.Properties.StickyEdgeDelayMs = new IntProperty(value);
+                    }
+                    else
+                    {
+                        CursorWrapSettingsConfig.Properties.StickyEdgeDelayMs.Value = value;
+                    }
+
+                    NotifyCursorWrapPropertyChanged();
+                }
+            }
+        }
+
         public void NotifyCursorWrapPropertyChanged([CallerMemberName] string propertyName = null)
         {
             OnPropertyChanged(propertyName);
@@ -1186,5 +1248,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         private bool _cursorWrapAutoActivate;
         private bool _cursorWrapDisableWrapDuringDrag; // Will be initialized in constructor from settings
         private int _cursorWrapWrapMode; // 0=Both, 1=VerticalOnly, 2=HorizontalOnly
+        private bool _cursorWrapStickyEdgeEnabled; // Enable sticky edge behavior
+        private int _cursorWrapStickyEdgeDelayMs; // Delay in milliseconds before wrap
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request
This PR adds a new option for a delay before wrapping to another monitor edge, this feature can be enabled/disabled, and supports delays of 250ms to 1000ms.

## PR Checklist

- [ ] Closes: #44855 
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments
Adds a delay before transitioning to another display, this allows the user to 'bump' the edge of the display when aiming for an applications system menu, browser tabs, close button, system tray, etc... default delay is 250 ms - if the user moves the mouse during the delay period then the timeout is cancelled.

## Validation Steps Performed
Confirmed behavior on Surface Laptop 7 Pro with USB-C external monitor.
