### PR TITLE
New+: Fixed issue with files and folders containing only numbers

### DIFF
--- a/src/modules/NewPlus/NewShellExtensionContextMenu/helpers_filesystem.h
+++ b/src/modules/NewPlus/NewShellExtensionContextMenu/helpers_filesystem.h
@@ -4,22 +4,6 @@
 
 namespace newplus::helpers::filesystem
 {
-    namespace constants::non_localizable
-    {
-        constexpr WCHAR desktop_ini_filename[] = L"desktop.ini";
-    }
-
-    inline bool is_hidden(const std::filesystem::path path)
-    {
-        const std::filesystem::path::string_type name = path.filename();
-        if (name == constants::non_localizable::desktop_ini_filename)
-        {
-            return true;
-        }
-
-        return false;
-    }
-
     inline bool is_directory(const std::filesystem::path path)
     {
         const auto entry = std::filesystem::directory_entry(path);

--- a/src/modules/NewPlus/NewShellExtensionContextMenu/helpers_variables.h
+++ b/src/modules/NewPlus/NewShellExtensionContextMenu/helpers_variables.h
@@ -129,6 +129,18 @@ namespace newplus::helpers::variables
         return result;
     }
 
+    static bool exclude_item(const std::filesystem::path& path)
+    {
+        DWORD attrs = GetFileAttributesW(path.c_str());
+        if (attrs == INVALID_FILE_ATTRIBUTES)
+        {
+            return false;
+        }
+
+        // Exclude if hidden or system
+        return (attrs & (FILE_ATTRIBUTE_HIDDEN | FILE_ATTRIBUTE_SYSTEM)) != 0;
+    }
+
     inline void resolve_variables_in_filename_and_rename_files(const std::filesystem::path& path, const bool do_rename = true)
     {
         // Depth first recursion, so that we start renaming the leaves, and avoid having to rescan
@@ -143,7 +155,7 @@ namespace newplus::helpers::variables
         // Perform the actual rename
         for (const auto& current : std::filesystem::directory_iterator(path))
         {
-            if (!newplus::helpers::filesystem::is_hidden(current))
+            if (!exclude_item(current))
             {
                 const std::filesystem::path resolved_path = resolve_variables_in_path(current.path());
 

--- a/src/modules/NewPlus/NewShellExtensionContextMenu/template_folder.cpp
+++ b/src/modules/NewPlus/NewShellExtensionContextMenu/template_folder.cpp
@@ -35,7 +35,7 @@ void template_folder::rescan_template_folder()
         }
         else
         {
-            if (!helpers::filesystem::is_hidden(entry.path()))
+            if (!newplus::helpers::variables::exclude_item(entry.path()))
             {
                 files.push_back({ entry.path().wstring(), new template_item(entry) });
             }


### PR DESCRIPTION
## Summary of the Pull Request
Supersedes https://github.com/microsoft/PowerToys/pull/41465

1) Fix for where template file or folder only contained numbers
2) Fix for where hidden files are shown in the list of templates

## PR Checklist
- [x] Closes: #36216
- [x] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [n/a] **Tests:** Added/updated and all pass
- [n/a] **Localization:** All end-user-facing strings can be localized
- [n/a] **Dev docs:** Added/updated
- [n/a] **New binaries:** Added on the required places
   - [n/a] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [n/a] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [n/a] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [n/a] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [n/a] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments
1) Fix for where template file or folder only contained numbers
    // Filename cases to support
    // type      | filename                             | result
    // [file]    | 01. First entry.txt                  | First entry.txt
    // [folder]  | 02. Second entry                     | Second entry
    // [folder]  | 03 Third entry                       | Third entry
    // [file]    | 04 Fourth entry.txt                  | Fourth entry.txt
    // [file]    | 05.Fifth entry.txt                   | Fifth entry.txt
    // [folder]  | 001231                               | 001231
    // [file]    | 001231.txt                           | 001231.txt
    // [file]    | 13. 0123456789012345.txt             | 0123456789012345.txt

2) Fix for where hidden files are shown in the list of templates
Instead of excluding based on filename (desktop.ini) exclude based on hidden and system attribute being set

## Validation Steps Performed
### Before fix
Notice
	1) Folders with numbers only aren't displayed on the context menu
	2) Files with extension with numbers only show extension on the context menu
	3) Some hidden files are shown
<img width="1893" height="786" alt="image" src="https://github.com/user-attachments/assets/3845a541-499f-47a7-ae99-a92886f74214" />



### After fixes
#### Scenario 1
New+ Setting: Hide leading digits…: Yes
New+ Setting: Hide file extension: Yes
New+ Setting: Replace variables: No
<img width="1816" height="1185" alt="image" src="https://github.com/user-attachments/assets/5ed2c205-d5ce-4366-90d9-c08ef4d2881f" />


#### Scenario 2
New+ Setting: Hide leading digits…: No
New+ Setting: Hide file extension: No
New+ Setting: Replace variables: No
<img width="1819" height="1197" alt="image" src="https://github.com/user-attachments/assets/710265d5-94e9-4fee-9a47-a7bbb78b45bd" />


#### Scenario 3
New+ Setting: Hide leading digits…: Yes
New+ Setting: Hide file extension: Yes
New+ Setting: Replace variables: Yes


<img width="1816" height="1197" alt="image" src="https://github.com/user-attachments/assets/45a90cdd-ec21-4425-9de0-c323ec90f149" />




