### PR TITLE
CmdPal: Localize additional UI strings in Registry and Services commands

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Properties/Resources.Designer.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Properties/Resources.Designer.cs
@@ -286,6 +286,42 @@ namespace Microsoft.CmdPal.UI.ViewModels.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Built-in.
+        /// </summary>
+        public static string builtin_extension_name {
+            get {
+                return ResourceManager.GetString("builtin_extension_name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0}, {1} commands.
+        /// </summary>
+        public static string builtin_extension_subtext {
+            get {
+                return ResourceManager.GetString("builtin_extension_subtext", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0}, {1}.
+        /// </summary>
+        public static string builtin_extension_subtext_disabled {
+            get {
+                return ResourceManager.GetString("builtin_extension_subtext_disabled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0}, {1} commands, {2} fallback commands.
+        /// </summary>
+        public static string builtin_extension_subtext_with_fallback {
+            get {
+                return ResourceManager.GetString("builtin_extension_subtext_with_fallback", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Home.
         /// </summary>
         public static string builtin_home_name {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Properties/Resources.resx
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Properties/Resources.resx
@@ -126,6 +126,21 @@
   <data name="builtin_display_name" xml:space="preserve">
     <value>Built-in commands</value>
   </data>
+  <data name="builtin_extension_name" xml:space="preserve">
+    <value>Built-in</value>
+  </data>
+  <data name="builtin_extension_subtext" xml:space="preserve">
+    <value>{0}, {1} commands</value>
+    <comment>{0}=extension name, {1}=number of commands</comment>
+  </data>
+  <data name="builtin_extension_subtext_with_fallback" xml:space="preserve">
+    <value>{0}, {1} commands, {2} fallback commands</value>
+    <comment>{0}=extension name, {1}=number of commands, {2} number of fallback commands</comment>
+  </data>
+  <data name="builtin_extension_subtext_disabled" xml:space="preserve">
+    <value>{0}, {1}</value>
+    <comment>{0}=extension name, {1}=message</comment>
+  </data>
   <data name="builtin_log_subtitle" xml:space="preserve">
     <value>View log messages</value>
   </data>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ProviderSettingsViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ProviderSettingsViewModel.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Text;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Messaging;
 using Microsoft.CmdPal.Core.Common.Services;
@@ -15,6 +17,9 @@ namespace Microsoft.CmdPal.UI.ViewModels;
 public partial class ProviderSettingsViewModel : ObservableObject
 {
     private static readonly IconInfoViewModel EmptyIcon = new(null);
+    private static readonly CompositeFormat ExtensionSubtextFormat = CompositeFormat.Parse(Resources.builtin_extension_subtext);
+    private static readonly CompositeFormat ExtensionSubtextWithFallbackFormat = CompositeFormat.Parse(Resources.builtin_extension_subtext_with_fallback);
+    private static readonly CompositeFormat ExtensionSubtextDisabledFormat = CompositeFormat.Parse(Resources.builtin_extension_subtext_disabled);
 
     private readonly CommandProviderWrapper _provider;
     private readonly ProviderSettings _providerSettings;
@@ -39,13 +44,13 @@ public partial class ProviderSettingsViewModel : ObservableObject
 
     public string DisplayName => _provider.DisplayName;
 
-    public string ExtensionName => _provider.Extension?.ExtensionDisplayName ?? "Built-in";
+    public string ExtensionName => _provider.Extension?.ExtensionDisplayName ?? Resources.builtin_extension_name;
 
     public string ExtensionSubtext => IsEnabled ?
         HasFallbackCommands ?
-            $"{ExtensionName}, {TopLevelCommands.Count} commands, {_provider.FallbackItems?.Length} fallback commands" :
-            $"{ExtensionName}, {TopLevelCommands.Count} commands" :
-        $"{ExtensionName}, {Resources.builtin_disabled_extension}";
+            string.Format(CultureInfo.CurrentCulture, ExtensionSubtextWithFallbackFormat, ExtensionName, TopLevelCommands.Count, _provider.FallbackItems?.Length ?? 0) :
+            string.Format(CultureInfo.CurrentCulture, ExtensionSubtextFormat, ExtensionName, TopLevelCommands.Count) :
+        string.Format(CultureInfo.CurrentCulture, ExtensionSubtextDisabledFormat, ExtensionName, Resources.builtin_disabled_extension);
 
     [MemberNotNullWhen(true, nameof(Extension))]
     public bool IsFromExtension => _provider.Extension is not null;

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Registry/Properties/Resources.Designer.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Registry/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CmdPal.Ext.Registry.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -174,6 +174,15 @@ namespace Microsoft.CmdPal.Ext.Registry.Properties {
         internal static string RegistryKey {
             get {
                 return ResourceManager.GetString("RegistryKey", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Browse the Windows registry.
+        /// </summary>
+        internal static string RegistryProvider_BrowseTitle {
+            get {
+                return ResourceManager.GetString("RegistryProvider_BrowseTitle", resourceCulture);
             }
         }
         

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Registry/Properties/Resources.resx
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Registry/Properties/Resources.resx
@@ -188,4 +188,7 @@
   <data name="RegistryProvider_DisplayName" xml:space="preserve">
     <value>Windows Registry</value>
   </data>
+  <data name="RegistryProvider_BrowseTitle" xml:space="preserve">
+    <value>Browse the Windows registry</value>
+  </data>
 </root>

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Registry/RegistryCommandsProvider.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Registry/RegistryCommandsProvider.cs
@@ -25,7 +25,7 @@ public partial class RegistryCommandsProvider : CommandProvider
         return [
             new CommandItem(new RegistryListPage(_settingsManager))
             {
-                Title = "Browse the Windows registry",
+                Title = Resources.RegistryProvider_BrowseTitle,
             }
         ];
     }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsServices/Commands/ServiceCommand.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsServices/Commands/ServiceCommand.cs
@@ -3,16 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Resources;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.CmdPal.Ext.WindowsServices.Helpers;
-using Microsoft.CommandPalette.Extensions;
+using Microsoft.CmdPal.Ext.WindowsServices.Properties;
 using Microsoft.CommandPalette.Extensions.Toolkit;
-using Windows.UI;
 
 namespace Microsoft.CmdPal.Ext.WindowsServices.Commands;
 
@@ -25,15 +19,15 @@ internal sealed partial class ServiceCommand : InvokableCommand
     {
         _serviceResult = serviceResult;
         _action = action;
-        Name = action.ToString();
-        if (serviceResult.IsRunning)
+        Name = action switch
         {
-            Icon = Icons.StopIcon;
-        }
-        else
-        {
-            Icon = Icons.PlayIcon;
-        }
+            Action.Start => Resources.wox_plugin_service_start,
+            Action.Stop => Resources.wox_plugin_service_stop,
+            Action.Restart => Resources.wox_plugin_service_restart,
+            _ => throw new ArgumentOutOfRangeException(nameof(action), action, null),
+        };
+
+        Icon = serviceResult.IsRunning ? Icons.StopIcon : Icons.PlayIcon;
     }
 
     public override CommandResult Invoke()

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsServices/Pages/ServiceFilters.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsServices/Pages/ServiceFilters.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.CmdPal.Ext.WindowsServices;
+using Microsoft.CmdPal.Ext.WindowsServices.Properties;
 
 namespace Microsoft.CommandPalette.Extensions.Toolkit;
 
@@ -16,11 +17,11 @@ public partial class ServiceFilters : Filters
     public override IFilterItem[] GetFilters()
     {
         return [
-            new Filter() { Id = "all", Name = "All Services" },
+            new Filter() { Id = "all", Name = Resources.Filters_All_Name },
             new Separator(),
-            new Filter() { Id = "running", Name = "Running", Icon = Icons.PlayIcon },
-            new Filter() { Id = "stopped", Name = "Stopped", Icon = Icons.StopIcon },
-            new Filter() { Id = "paused", Name = "Paused", Icon = Icons.PauseIcon },
+            new Filter() { Id = "running", Name = Resources.Filters_Running_Name, Icon = Icons.PlayIcon },
+            new Filter() { Id = "stopped", Name = Resources.Filters_Stopped_Name, Icon = Icons.StopIcon },
+            new Filter() { Id = "paused", Name = Resources.Filters_Paused_Name, Icon = Icons.PauseIcon },
         ];
     }
 }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsServices/Pages/ServicesListPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsServices/Pages/ServicesListPage.cs
@@ -3,8 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
 using Microsoft.CmdPal.Ext.WindowsServices.Helpers;
+using Microsoft.CmdPal.Ext.WindowsServices.Properties;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 
@@ -15,7 +15,7 @@ internal sealed partial class ServicesListPage : DynamicListPage
     public ServicesListPage()
     {
         Icon = Icons.ServicesIcon;
-        Name = "Windows Services";
+        Name = Resources.ServicesListPage_Name;
 
         var filters = new ServiceFilters();
         filters.PropChanged += Filters_PropChanged;

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsServices/Properties/Resources.Designer.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsServices/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CmdPal.Ext.WindowsServices.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -57,6 +57,60 @@ namespace Microsoft.CmdPal.Ext.WindowsServices.Properties {
             }
             set {
                 resourceCulture = value;
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to All Services.
+        /// </summary>
+        internal static string Filters_All_Name {
+            get {
+                return ResourceManager.GetString("Filters_All_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Paused.
+        /// </summary>
+        internal static string Filters_Paused_Name {
+            get {
+                return ResourceManager.GetString("Filters_Paused_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Running.
+        /// </summary>
+        internal static string Filters_Running_Name {
+            get {
+                return ResourceManager.GetString("Filters_Running_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Stopped.
+        /// </summary>
+        internal static string Filters_Stopped_Name {
+            get {
+                return ResourceManager.GetString("Filters_Stopped_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Manage Windows services.
+        /// </summary>
+        internal static string ManageWindowsServicesCommand_Title {
+            get {
+                return ResourceManager.GetString("ManageWindowsServicesCommand_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Windows Services.
+        /// </summary>
+        internal static string ServicesListPage_Name {
+            get {
+                return ResourceManager.GetString("ServicesListPage_Name", resourceCulture);
             }
         }
         
@@ -169,7 +223,7 @@ namespace Microsoft.CmdPal.Ext.WindowsServices.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Start (Enter).
+        ///   Looks up a localized string similar to Start.
         /// </summary>
         internal static string wox_plugin_service_start {
             get {
@@ -286,7 +340,7 @@ namespace Microsoft.CmdPal.Ext.WindowsServices.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Stop (Enter).
+        ///   Looks up a localized string similar to Stop.
         /// </summary>
         internal static string wox_plugin_service_stop {
             get {

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsServices/Properties/Resources.resx
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsServices/Properties/Resources.resx
@@ -117,17 +117,37 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="Filters_All_Name" xml:space="preserve">
+    <value>All Services</value>
+  </data>
+  <data name="Filters_Paused_Name" xml:space="preserve">
+    <value>Paused</value>
+  </data>
+  <data name="Filters_Running_Name" xml:space="preserve">
+    <value>Running</value>
+  </data>
+  <data name="Filters_Stopped_Name" xml:space="preserve">
+    <value>Stopped</value>
+  </data>
+  <data name="ManageWindowsServicesCommand_Title" xml:space="preserve">
+    <value>Manage Windows services</value>
+  </data>
+  <data name="ServicesListPage_Name" xml:space="preserve">
+    <value>Windows Services</value>
+  </data>
   <data name="WindowsServicesProvider_DisplayName" xml:space="preserve">
     <value>Windows Services</value>
   </data>
   <data name="wox_plugin_service_continue_pending" xml:space="preserve">
     <value>Continue</value>
+    <comment>Verb, stop selected service</comment>
   </data>
   <data name="wox_plugin_service_name" xml:space="preserve">
     <value>Name</value>
   </data>
   <data name="wox_plugin_service_open_services" xml:space="preserve">
     <value>Open services</value>
+    <comment>Verb (to open Windows Services MSC)</comment>
   </data>
   <data name="wox_plugin_service_paused" xml:space="preserve">
     <value>Paused</value>
@@ -143,6 +163,7 @@
   </data>
   <data name="wox_plugin_service_restart" xml:space="preserve">
     <value>Restart</value>
+    <comment>Verb, restart selected service</comment>
   </data>
   <data name="wox_plugin_service_restarted_notification" xml:space="preserve">
     <value>The service has been restarted</value>
@@ -154,7 +175,8 @@
     <value>Running</value>
   </data>
   <data name="wox_plugin_service_start" xml:space="preserve">
-    <value>Start (Enter)</value>
+    <value>Start</value>
+    <comment>Verb, start selected service</comment>
   </data>
   <data name="wox_plugin_service_started" xml:space="preserve">
     <value>Started</value>
@@ -193,7 +215,8 @@
     <value>Status</value>
   </data>
   <data name="wox_plugin_service_stop" xml:space="preserve">
-    <value>Stop (Enter)</value>
+    <value>Stop</value>
+    <comment>Verb, stop selected service</comment>
   </data>
   <data name="wox_plugin_service_stopped" xml:space="preserve">
     <value>Stopped</value>

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsServices/WindowsServicesCommandsProvider.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsServices/WindowsServicesCommandsProvider.cs
@@ -23,7 +23,7 @@ public partial class WindowsServicesCommandsProvider : CommandProvider
         return [
             new CommandItem(new ServicesListPage())
             {
-                Title = "Manage Windows services",
+                Title = Resources.ManageWindowsServicesCommand_Title,
             }
         ];
     }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsTerminal/Properties/Resources.Designer.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsTerminal/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CmdPal.Ext.WindowsTerminal.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsTerminal/Properties/Resources.resx
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsTerminal/Properties/Resources.resx
@@ -157,6 +157,7 @@
   </data>
   <data name="list_item_title" xml:space="preserve">
     <value>Open Windows Terminal profiles</value>
+    <comment>Verb: leads to a list of Terminal profiles to open</comment>
   </data>
   <data name="preferred_channel" xml:space="preserve">
     <value>Preferred channel</value>


### PR DESCRIPTION
## Summary of the Pull Request

This PR
- Makes the "Browse the Windows registry" text for the Registry extension command localizable
- Makes the "Manage Windows Services" text for the Windows services command localizable
- Makes the Windows services filters ("all", "running", "paused", "stopped") localizable
- Makes the Windows service primary command strings ("Start", "Stop", "Resume") localizable
- Adds comment to "Open Windows Terminal profiles" resource

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] Closes: #xxx
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

