### PR TITLE
CmdPal: Fix starting new web URI for default browser that doesn't support exe arguments

### DIFF
--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/Helpers/Browser/BrowserInfoServiceExtensions.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/Helpers/Browser/BrowserInfoServiceExtensions.cs
@@ -2,6 +2,8 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using ManagedCommon;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 
 namespace Microsoft.CmdPal.Ext.WebSearch.Helpers.Browser;
@@ -26,6 +28,22 @@ internal static class BrowserInfoServiceExtensions
     /// </remarks>
     public static bool Open(this IBrowserInfoService browserInfoService, string url)
     {
+        // If the URL is a valid URI, attempt to open it with the default browser by invoking it through the shell.
+        if (Uri.TryCreate(url, UriKind.Absolute, out _))
+        {
+            try
+            {
+                ShellHelpers.OpenInShell(url);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogDebug($"Failed to launch the URI {url}: {ex}");
+            }
+        }
+
+        // Use legacy method to open the URL if it's not a well-formed URI or if the shell launch fails.
+        // This may handle cases where the URL is a search query or a custom URI scheme.
         var defaultBrowser = browserInfoService.GetDefaultBrowser();
         return defaultBrowser != null && ShellHelpers.OpenCommandInShell(defaultBrowser.Path, defaultBrowser.ArgumentsPattern, url);
     }


### PR DESCRIPTION
## Summary of the Pull Request

This PR changes the way the Web Search built-in extension handles full URIs: it bypasses default browser discovery and asks the shell to open the URI directly. The original execution path remains as a fallback and for simple queries (when a custom search engine is not set).

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #45610
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

