### PR TITLE
Add /need-monitor-info command

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -236,6 +236,28 @@ configuration:
     - if:
       - payloadType: Issue_Comment
       - commentContains:
+          pattern: '\/need-monitor-info'
+          isRegex: True
+      - or:
+        - activitySenderHasAssociation:
+            association: Owner
+        - activitySenderHasAssociation:
+            association: Member
+        - activitySenderHasAssociation:
+            association: Collaborator
+      then:
+      - removeLabel:
+          label: Needs-Triage
+      - removeLabel:
+          label: Needs-Team-Response
+      - addLabel:
+          label: Needs-Author-Feedback
+      - addReply:
+          reply: "To help debug your layout, please run [this script](https://github.com/microsoft/PowerToys/blob/main/src/modules/MouseUtils/CursorWrap/CursorWrapTests/Capture-MonitorLayout.ps1) and attach the generated JSON output to this thread.\n\nThis allows us to better understand the issue and investigate potential fixes."
+      description: 
+    - if:
+      - payloadType: Issue_Comment
+      - commentContains:
           pattern: "I(( would|'d) (like|love|be happy)| want) (to help|helping|to contribute|contributing|to implement|implementing|to fix|fixing)"
           isRegex: True
       then:

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -238,6 +238,8 @@ configuration:
       - commentContains:
           pattern: '\/need-monitor-info'
           isRegex: True
+      - hasLabel:
+          label: Product-Cursor Wrap
       - or:
         - activitySenderHasAssociation:
             association: Owner


### PR DESCRIPTION
## Summary of the Pull Request

Adds a `/need-monitor-info` bot command to `resourceManagement.yml` that allows owners, members, and collaborators to request monitor layout information from issue reporters. The command only triggers when the issue has the `Product-Cursor Wrap` label applied, ensuring it is scoped to Cursor Wrap issues.

## PR Checklist

- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments

When a team member comments `/need-monitor-info` on a `Product-Cursor Wrap` issue, the bot will:
- Remove the `Needs-Triage` and `Needs-Team-Response` labels
- Add the `Needs-Author-Feedback` label
- Post a reply directing the author to run the [Capture-MonitorLayout.ps1](https://github.com/microsoft/PowerToys/blob/main/src/modules/MouseUtils/CursorWrap/CursorWrapTests/Capture-MonitorLayout.ps1) script and attach the generated JSON output to the thread

The `hasLabel: Product-Cursor Wrap` condition ensures the command is scoped exclusively to Cursor Wrap issues and will not trigger on unrelated issues.

## Validation Steps Performed

- Manually reviewed the updated `resourceManagement.yml` policy to confirm correct YAML structure and placement of the new `hasLabel` condition.