### PR TITLE
Make the ZoomIt AAC audio track depend on system audio or audio input

### DIFF
--- a/src/modules/ZoomIt/ZoomIt/VideoRecordingSession.cpp
+++ b/src/modules/ZoomIt/ZoomIt/VideoRecordingSession.cpp
@@ -1215,14 +1215,8 @@ void VideoRecordingSession::OnMediaStreamSourceSampleRequested(
     {
         try
         {
-            if (auto sample = m_audioGenerator->TryGetNextSample())
-            {
-                request.Sample(sample.value());
-            }
-            else
-            {
-                request.Sample(nullptr);
-            }
+            auto sample = m_audioGenerator ? m_audioGenerator->TryGetNextSample() : std::optional<winrt::MediaStreamSample>{};
+            request.Sample(sample.has_value() ? sample.value() : nullptr);
         }
         catch (winrt::hresult_error const& error)
         {


### PR DESCRIPTION
When neither option is selected, then the resulting .mp4 container won't have an audio track added to it.
This is due to the recent audio input addition. As a result, all .mp4 recordings now have an audio track, even if empty. Restoring the prior functionality, where just the h264 video is present on no audio.

## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] Closes: #xxx
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

