### PR TITLE
CmdPal: Fix RDP extension rejecting host:port connections

### DIFF
--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.RemoteDesktop.UnitTests/FallbackRemoteDesktopItemTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.RemoteDesktop.UnitTests/FallbackRemoteDesktopItemTests.cs
@@ -98,6 +98,48 @@ public class FallbackRemoteDesktopItemTests
         Assert.IsNull(command);
     }
 
+    [TestMethod]
+    public void UpdateQuery_WhenQueryIsHostnameWithPort_UsesFullHostPort()
+    {
+        // Arrange
+        var setup = CreateFallback();
+        var fallback = setup.Fallback;
+        const string hostPort = "localhost:3389";
+
+        // Act
+        fallback.UpdateQuery(hostPort);
+
+        // Assert
+        var expectedTitle = string.Format(CultureInfo.CurrentCulture, OpenHostCompositeFormat, hostPort);
+        Assert.AreEqual(expectedTitle, fallback.Title);
+        Assert.AreEqual(Resources.remotedesktop_title, fallback.Subtitle);
+
+        var command = fallback.Command as OpenRemoteDesktopCommand;
+        Assert.IsNotNull(command);
+        Assert.AreEqual(hostPort, GetCommandHost(command));
+    }
+
+    [TestMethod]
+    public void UpdateQuery_WhenQueryIsIPWithPort_UsesFullHostPort()
+    {
+        // Arrange
+        var setup = CreateFallback();
+        var fallback = setup.Fallback;
+        const string hostPort = "192.168.1.100:3390";
+
+        // Act
+        fallback.UpdateQuery(hostPort);
+
+        // Assert
+        var expectedTitle = string.Format(CultureInfo.CurrentCulture, OpenHostCompositeFormat, hostPort);
+        Assert.AreEqual(expectedTitle, fallback.Title);
+        Assert.AreEqual(Resources.remotedesktop_title, fallback.Subtitle);
+
+        var command = fallback.Command as OpenRemoteDesktopCommand;
+        Assert.IsNotNull(command);
+        Assert.AreEqual(hostPort, GetCommandHost(command));
+    }
+
     private static string GetCommandHost(OpenRemoteDesktopCommand command)
     {
         var field = typeof(OpenRemoteDesktopCommand).GetField("_rdpHost", BindingFlags.NonPublic | BindingFlags.Instance);


### PR DESCRIPTION
 ## Summary

Fixes #45100

Uri.CheckHostName does not accept host:port strings (e.g. localhost:3389), returning UriHostNameType.Unknown. This causes the RDP extension to show an invalid hostname error when connecting to a local forwarded port.

## Changes

- OpenRemoteDesktopCommand.cs - Strip port suffix before Uri.CheckHostName validation. The full host:port is still passed to mstsc /v:.
- FallbackRemoteDesktopItem.cs - Same port-aware validation so the fallback correctly recognizes host:port queries and displays them in the title.
- FallbackRemoteDesktopItemTests.cs - Added tests for localhost:3389 and 192.168.1.100:3390 inputs.

## Validation

Port detection uses LastIndexOf(':') + ushort.TryParse to safely identify a trailing port number without affecting IPv6 addresses or plain hostnames.