### PR TITLE
CmdPal: Add 'Keep previous query' setting to Command Palette

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsModel.cs
@@ -42,6 +42,8 @@ public partial class SettingsModel : ObservableObject
 
     public bool HighlightSearchOnActivate { get; set; } = true;
 
+    public bool KeepPreviousQuery { get; set; }
+
     public bool ShowSystemTrayIcon { get; set; } = true;
 
     public bool IgnoreShortcutWhenFullscreen { get; set; }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsViewModel.cs
@@ -104,6 +104,16 @@ public partial class SettingsViewModel : INotifyPropertyChanged
         }
     }
 
+    public bool KeepPreviousQuery
+    {
+        get => _settings.KeepPreviousQuery;
+        set
+        {
+            _settings.KeepPreviousQuery = value;
+            Save();
+        }
+    }
+
     public int MonitorPositionIndex
     {
         get => (int)_settings.SummonOn;

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/SearchBar.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/SearchBar.xaml.cs
@@ -421,7 +421,13 @@ public sealed partial class SearchBar : UserControl,
         }
     }
 
-    public void Receive(GoHomeMessage message) => ClearSearch();
+    public void Receive(GoHomeMessage message)
+    {
+        if (!Settings.KeepPreviousQuery)
+        {
+            ClearSearch();
+        }
+    }
 
     public void Receive(FocusSearchBoxMessage message) => FilterBox.Focus(Microsoft.UI.Xaml.FocusState.Programmatic);
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/GeneralPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/GeneralPage.xaml
@@ -68,6 +68,9 @@
                     <controls:SettingsCard x:Uid="Settings_GeneralPage_HighlightSearch_SettingsCard" HeaderIcon="{ui:FontIcon Glyph=&#xE933;}">
                         <ToggleSwitch IsOn="{x:Bind viewModel.HighlightSearchOnActivate, Mode=TwoWay}" />
                     </controls:SettingsCard>
+                    <controls:SettingsCard x:Uid="Settings_GeneralPage_KeepPreviousQuery_SettingsCard" HeaderIcon="{ui:FontIcon Glyph=&#xE81C;}">
+                        <ToggleSwitch IsOn="{x:Bind viewModel.KeepPreviousQuery, Mode=TwoWay}" />
+                    </controls:SettingsCard>
                     <controls:SettingsCard x:Uid="Run_PositionHeader" HeaderIcon="{ui:FontIcon Glyph=&#xe78b;}">
                         <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}" SelectedIndex="{x:Bind viewModel.MonitorPositionIndex, Mode=TwoWay}">
                             <ComboBoxItem x:Uid="Run_Radio_Position_Cursor" />

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Strings/en-us/Resources.resw
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Strings/en-us/Resources.resw
@@ -350,6 +350,12 @@ Right-click to remove the key combination, thereby deactivating the shortcut.</v
   <data name="Settings_GeneralPage_HighlightSearch_SettingsCard.Description" xml:space="preserve">
     <value>Selects the previous search text at launch</value>
   </data>
+  <data name="Settings_GeneralPage_KeepPreviousQuery_SettingsCard.Header" xml:space="preserve">
+    <value>Keep previous query</value>
+  </data>
+  <data name="Settings_GeneralPage_KeepPreviousQuery_SettingsCard.Description" xml:space="preserve">
+    <value>Preserves the last search text when Command Palette is reopened</value>
+  </data>
   <data name="Settings_GeneralPage_ShowAppDetails_SettingsCard.Header" xml:space="preserve">
     <value>Show app details</value>
   </data>


### PR DESCRIPTION
## Summary

Closes #39929
Closes #44826

Adds a new "Keep previous query" toggle to Command Palette settings that preserves the last search text when the palette is reopened after running a command.

## Changes

- **`SettingsModel.cs`** — Added `KeepPreviousQuery` bool property (defaults to `false`)
- **`SettingsViewModel.cs`** — Added property with auto-save on change
- **`GeneralPage.xaml`** — Added toggle switch in the Activation section, below "Highlight search on activate"
- **`Resources.resw`** — Added localized header ("Keep previous query") and description ("Preserves the last search text when Command Palette is reopened")
- **`SearchBar.xaml.cs`** — `Receive(GoHomeMessage)` now checks the setting and skips `ClearSearch()` when enabled

## Behavior

- **Off (default):** No change from current behavior — search text is cleared on dismiss.
- **On:** When a command is run and the palette dismisses, the search text is preserved. On reopen, the previous query is still in the search box. Combined with the existing "Highlight search on activate" setting, the text will be pre-selected so the user can immediately retype or press Enter to re-run.

## Validation

- Setting off: search clears on dismiss (existing behavior unchanged)
- Setting on: search text persists across dismiss/reopen
- Setting serializes/deserializes correctly via existing JSON settings infrastructure
- No impact on page navigation, escape key behavior, or auto-go-home timer