### PR TITLE
CmdPal: Fix calculator appending extra zeros on non-en-US locales

### DIFF
--- a/src/common/CalculatorEngineCommon/ExprtkEvaluator.cpp
+++ b/src/common/CalculatorEngineCommon/ExprtkEvaluator.cpp
@@ -28,6 +28,7 @@ namespace ExprtkCalculator::internal
     std::wstring ToWStringFullPrecision(double value)
     {
         std::wostringstream oss;
+        oss.imbue(std::locale::classic());
         oss << std::fixed << std::setprecision(15) << value;
         return oss.str();
     }


### PR DESCRIPTION
## Summary

Fixes #45624

The C++ expression engine (`ExprtkEvaluator.cpp`) formatted calculation results using the system locale via `std::wostringstream`. On systems where the locale uses a comma as the decimal separator (e.g. many European locales), a result like `8.0` was formatted as `"8,000000000000000"`.

The C# side then parsed this string with en-US culture, which interpreted the commas as **thousands separators**, turning `8` into `8,000,000,000,000,000` — hence the "extra trillion zeros" reported in the issue.

## Fix

One-line change: imbue the classic (C) locale on the output stream to always use a dot decimal separator, regardless of the system locale.

## Why switching Degrees to Radians "fixed" it for the reporter

The trig mode setting changes the code path through `UpdateTrigFunctions` which wraps expressions with conversion factors like `(pi / 180) *`. This changes the expression structure enough that the engine may produce results through a different formatting path, masking the locale issue in some cases.

## Validation

- The fix ensures consistent behavior across all system locales
- No functional change for en-US systems (dot is already the decimal separator in the C locale)
