### PR TITLE
CmdPal: Clean up orphaned hotkeys when extension is uninstalled

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandManager.cs
@@ -374,6 +374,22 @@ public partial class TopLevelCommandManager : ObservableObject,
                     }
                 }
 
+                // Clean up any hotkeys assigned to the removed commands
+                if (commandsToRemove.Count != 0)
+                {
+                    var removedIds = commandsToRemove.Select(c => c.Id).ToHashSet();
+                    var settings = _serviceProvider.GetService<SettingsModel>();
+                    if (settings != null)
+                    {
+                        var originalCount = settings.CommandHotkeys.Count;
+                        settings.CommandHotkeys.RemoveAll(h => removedIds.Contains(h.CommandId));
+                        if (settings.CommandHotkeys.Count != originalCount)
+                        {
+                            SettingsModel.SaveSettings(settings);
+                        }
+                    }
+                }
+
                 // Then back on the UI thread (remember, TopLevelCommands is
                 // Observable, so you can't touch it on the BG thread)...
                 await Task.Factory.StartNew(


### PR DESCRIPTION
## Summary

Fixes #45452

When a user assigns a hotkey to an extension's top-level command and later uninstalls that extension, the hotkey binding remained in `settings.json` under `CommandHotkeys`. CmdPal continued to register and consume that hotkey globally, even though the extension was gone — effectively "eating" the key combination system-wide.

## Root Cause

`ExtensionService_OnExtensionRemoved` in `TopLevelCommandManager.cs` correctly removed the extension's commands from the in-memory `TopLevelCommands` list, but did not clean up the corresponding entries in `SettingsModel.CommandHotkeys`. Since hotkeys are registered from settings on startup and settings reload, the orphaned hotkey kept being registered.

## Fix

When an extension is removed, collect the IDs of all commands being removed, then remove any `CommandHotkeys` entries matching those IDs from settings and persist the change. On the next settings reload, `SetupHotkey` will no longer register those orphaned hotkeys.

## Validation

- Hotkeys for removed extensions are cleaned from settings immediately on uninstall
- No impact on hotkeys for installed extensions
- Settings file is only written if orphaned hotkeys were actually found and removed
