### PR TITLE
[Light Switch] Fixed issue where Light switch could be toggled from the dashboard while GPO settings are active

### DIFF
--- a/src/settings-ui/QuickAccess.UI/Helpers/ModuleGpoHelper.cs
+++ b/src/settings-ui/QuickAccess.UI/Helpers/ModuleGpoHelper.cs
@@ -28,6 +28,7 @@ internal static class ModuleGpoHelper
             ModuleType.Hosts => GPOWrapper.GetConfiguredHostsFileEditorEnabledValue(),
             ModuleType.ImageResizer => GPOWrapper.GetConfiguredImageResizerEnabledValue(),
             ModuleType.KeyboardManager => GPOWrapper.GetConfiguredKeyboardManagerEnabledValue(),
+            ModuleType.LightSwitch => GPOWrapper.GetConfiguredLightSwitchEnabledValue(),
             ModuleType.MouseHighlighter => GPOWrapper.GetConfiguredMouseHighlighterEnabledValue(),
             ModuleType.MouseJump => GPOWrapper.GetConfiguredMouseJumpEnabledValue(),
             ModuleType.MousePointerCrosshairs => GPOWrapper.GetConfiguredMousePointerCrosshairsEnabledValue(),

--- a/src/settings-ui/QuickAccess.UI/ViewModels/LauncherViewModel.cs
+++ b/src/settings-ui/QuickAccess.UI/ViewModels/LauncherViewModel.cs
@@ -40,6 +40,7 @@ public sealed class LauncherViewModel : Observable
             _settingsRepository,
             new Microsoft.PowerToys.QuickAccess.Services.QuickAccessLauncher(_coordinator),
             moduleType => Helpers.ModuleGpoHelper.GetModuleGpoConfiguration(moduleType) == GpoRuleConfigured.Disabled,
+            moduleType => Helpers.ModuleGpoHelper.GetModuleGpoConfiguration(moduleType) == GpoRuleConfigured.Enabled,
             _resourceLoader);
         var updatingSettings = UpdatingSettings.LoadSettings() ?? new UpdatingSettings();
         IsUpdateAvailable = updatingSettings.State is UpdatingSettings.UpdatingState.ReadyToInstall or UpdatingSettings.UpdatingState.ReadyToDownload;

--- a/src/settings-ui/Settings.UI.Controls/QuickAccess/QuickAccessViewModel.cs
+++ b/src/settings-ui/Settings.UI.Controls/QuickAccess/QuickAccessViewModel.cs
@@ -19,6 +19,7 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
         private readonly ISettingsRepository<GeneralSettings> _settingsRepository;
         private readonly IQuickAccessLauncher _launcher;
         private readonly Func<ModuleType, bool> _isModuleGpoDisabled;
+        private readonly Func<ModuleType, bool> _isModuleGpoEnabled;
         private readonly ResourceLoader _resourceLoader;
         private readonly DispatcherQueue _dispatcherQueue;
         private GeneralSettings _generalSettings;
@@ -29,11 +30,13 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
             ISettingsRepository<GeneralSettings> settingsRepository,
             IQuickAccessLauncher launcher,
             Func<ModuleType, bool> isModuleGpoDisabled,
+            Func<ModuleType, bool> isModuleGpoEnabled,
             ResourceLoader resourceLoader)
         {
             _settingsRepository = settingsRepository;
             _launcher = launcher;
             _isModuleGpoDisabled = isModuleGpoDisabled;
+            _isModuleGpoEnabled = isModuleGpoEnabled;
             _resourceLoader = resourceLoader;
             _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
 
@@ -85,7 +88,7 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
             {
                 Title = _resourceLoader.GetString(Microsoft.PowerToys.Settings.UI.Library.Helpers.ModuleHelper.GetModuleLabelResourceName(moduleType)),
                 Tag = moduleType,
-                Visible = Microsoft.PowerToys.Settings.UI.Library.Helpers.ModuleHelper.GetIsModuleEnabled(_generalSettings, moduleType),
+                Visible = _isModuleGpoEnabled(moduleType) || Microsoft.PowerToys.Settings.UI.Library.Helpers.ModuleHelper.GetIsModuleEnabled(_generalSettings, moduleType),
                 Description = GetModuleToolTip(moduleType),
                 Icon = Microsoft.PowerToys.Settings.UI.Library.Helpers.ModuleHelper.GetModuleTypeFluentIconName(moduleType),
                 Command = new RelayCommand(() => _launcher.Launch(moduleType)),
@@ -111,7 +114,7 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
             {
                 if (item.Tag is ModuleType moduleType)
                 {
-                    item.Visible = Microsoft.PowerToys.Settings.UI.Library.Helpers.ModuleHelper.GetIsModuleEnabled(_generalSettings, moduleType);
+                    item.Visible = _isModuleGpoEnabled(moduleType) || Microsoft.PowerToys.Settings.UI.Library.Helpers.ModuleHelper.GetIsModuleEnabled(_generalSettings, moduleType);
                 }
             }
         }

--- a/src/settings-ui/Settings.UI/Helpers/ModuleGpoHelper.cs
+++ b/src/settings-ui/Settings.UI/Helpers/ModuleGpoHelper.cs
@@ -30,6 +30,7 @@ namespace Microsoft.PowerToys.Settings.UI.Helpers
                 case ModuleType.Hosts: return GPOWrapper.GetConfiguredHostsFileEditorEnabledValue();
                 case ModuleType.ImageResizer: return GPOWrapper.GetConfiguredImageResizerEnabledValue();
                 case ModuleType.KeyboardManager: return GPOWrapper.GetConfiguredKeyboardManagerEnabledValue();
+                case ModuleType.LightSwitch: return GPOWrapper.GetConfiguredLightSwitchEnabledValue();
                 case ModuleType.MouseHighlighter: return GPOWrapper.GetConfiguredMouseHighlighterEnabledValue();
                 case ModuleType.MouseJump: return GPOWrapper.GetConfiguredMouseJumpEnabledValue();
                 case ModuleType.MousePointerCrosshairs: return GPOWrapper.GetConfiguredMousePointerCrosshairsEnabledValue();

--- a/src/settings-ui/Settings.UI/ViewModels/DashboardViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/DashboardViewModel.cs
@@ -124,6 +124,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 _settingsRepository,
                 new Microsoft.PowerToys.Settings.UI.Controls.QuickAccessLauncher(App.IsElevated),
                 moduleType => Helpers.ModuleGpoHelper.GetModuleGpoConfiguration(moduleType) == global::PowerToys.GPOWrapper.GpoRuleConfigured.Disabled,
+                moduleType => Helpers.ModuleGpoHelper.GetModuleGpoConfiguration(moduleType) == global::PowerToys.GPOWrapper.GpoRuleConfigured.Enabled,
                 resourceLoader);
 
             BuildModuleList();


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Current behavior is that GPO policies are enforced on the Light Switch settings page but not on the dashboard or quick access menu's. This allows the user to still toggle Light Switch settings in scenarios where GPO is either forcing it to be enabled or disabled. This PR addresses that issue.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #43754
## Additional notes
This PR only addresses issues on the dashboard page and in the quick access menu as described by https://github.com/microsoft/PowerToys/issues/43754. 

This PR also fixed an issue where modules were not showing in the Quick access menu when GPO is set to "Enabled" until you visited the module specific page. When modules are forced enabled, they should appear in Quick Access upon launch if they have a quick access entry. 

This issue does not address issue https://github.com/microsoft/PowerToys/issues/42484 which was fixed with the PR https://github.com/microsoft/PowerToys/pull/44567

## Validation Steps Performed
Tested locally, photos below
Not configured:
<img width="1371" height="964" alt="image" src="https://github.com/user-attachments/assets/50ee579d-8ffb-44fd-92a9-e191b61c0318" />
Enabled:
<img width="1183" height="988" alt="image" src="https://github.com/user-attachments/assets/789abf28-d140-4d93-8934-48b3ac92be2e" />
Disabled:
<img width="1282" height="965" alt="image" src="https://github.com/user-attachments/assets/17ec915a-29d9-42fb-a58e-4b769a728e6a" />

We can observe the option being locked on the quick toggles and not present in the quick access menu when disabled.
