### PR TITLE
fix(settings-ui): Get rid of build warning - change binding mode to OneTime for update controls

### DIFF
--- a/src/settings-ui/Settings.UI/SettingsXAML/Controls/Dashboard/CheckUpdateControl.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Controls/Dashboard/CheckUpdateControl.xaml
@@ -12,7 +12,7 @@
         <Button
             Click="SWVersionButtonClicked"
             Style="{StaticResource SubtleButtonStyle}"
-            Visibility="{x:Bind UpdateAvailable, Mode=OneWay}">
+            Visibility="{x:Bind UpdateAvailable, Mode=OneTime}">
             <Grid ColumnSpacing="16">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" />
@@ -38,7 +38,7 @@
                     <TextBlock x:Uid="UpdateAvailableTextBlock" FontWeight="SemiBold" />
                     <TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}" Style="{StaticResource CaptionTextBlockStyle}">
                         <Run x:Uid="GeneralVersion" />
-                        <Run Text="{x:Bind UpdateSettingsConfig.NewVersion, Mode=OneWay}" />
+                        <Run Text="{x:Bind UpdateSettingsConfig.NewVersion, Mode=OneTime}" />
                     </TextBlock>
                 </StackPanel>
             </Grid>
@@ -47,7 +47,7 @@
             Padding="0,0,4,0"
             VerticalAlignment="Center"
             ColumnSpacing="16"
-            Visibility="{x:Bind UpdateAvailable, Converter={StaticResource ReverseBoolToVisibilityConverter}, Mode=OneWay}">
+            Visibility="{x:Bind UpdateAvailable, Converter={StaticResource ReverseBoolToVisibilityConverter}, Mode=OneTime}">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="*" />
@@ -72,7 +72,7 @@
                 <TextBlock x:Uid="YoureUpToDate" FontWeight="SemiBold" />
                 <TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}" Style="{StaticResource CaptionTextBlockStyle}">
                     <Run x:Uid="General_VersionLastChecked" />
-                    <Run Text="{x:Bind UpdateSettingsConfig.LastCheckedDateLocalized, Mode=OneWay}" />
+                        <Run Text="{x:Bind UpdateSettingsConfig.LastCheckedDateLocalized, Mode=OneTime}" />
                 </TextBlock>
             </StackPanel>
         </Grid>

--- a/src/settings-ui/Settings.UI/SettingsXAML/Controls/Dashboard/CheckUpdateControl.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Controls/Dashboard/CheckUpdateControl.xaml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8" ?>
 <UserControl
     x:Class="Microsoft.PowerToys.Settings.UI.Controls.CheckUpdateControl"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
@@ -72,7 +72,7 @@
                 <TextBlock x:Uid="YoureUpToDate" FontWeight="SemiBold" />
                 <TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}" Style="{StaticResource CaptionTextBlockStyle}">
                     <Run x:Uid="General_VersionLastChecked" />
-                        <Run Text="{x:Bind UpdateSettingsConfig.LastCheckedDateLocalized, Mode=OneTime}" />
+                    <Run Text="{x:Bind UpdateSettingsConfig.LastCheckedDateLocalized, Mode=OneTime}" />
                 </TextBlock>
             </StackPanel>
         </Grid>

--- a/src/settings-ui/Settings.UI/SettingsXAML/Controls/Dashboard/ShortcutConflictWindow.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Controls/Dashboard/ShortcutConflictWindow.xaml
@@ -105,14 +105,14 @@
                                         HorizontalAlignment="Right"
                                         VerticalAlignment="Center"
                                         Click="OnIgnoreConflictClicked"
-                                        IsChecked="{x:Bind ConflictIgnored, Mode=OneWay}" />
+                                        IsChecked="{x:Bind ConflictIgnored, Mode=OneTime}" />
                                 </Grid>
 
                                 <!--  PowerToys Module Cards  -->
                                 <ItemsControl
                                     Grid.Row="1"
-                                    IsEnabled="{x:Bind ConflictVisible, Mode=OneWay}"
-                                    ItemsSource="{x:Bind Modules, Mode=OneWay}">
+                                    IsEnabled="{x:Bind ConflictVisible, Mode=OneTime}"
+                                    ItemsSource="{x:Bind Modules, Mode=OneTime}">
                                     <ItemsControl.ItemTemplate>
                                         <DataTemplate x:DataType="hotkeyConflicts:ModuleHotkeyData">
                                             <tkcontrols:SettingsCard
@@ -147,7 +147,7 @@
                                     Background="Transparent"
                                     BorderThickness="0,1,0,0"
                                     CornerRadius="0"
-                                    IsEnabled="{x:Bind ShouldShowSysConflict, Mode=OneWay}">
+                                    IsEnabled="{x:Bind ShouldShowSysConflict, Mode=OneTime}">
                                     <tkcontrols:SettingsCard.HeaderIcon>
                                         <PathIcon Data="M9 20H0V11H9V20ZM20 20H11V11H20V20ZM9 9H0V0H9V9ZM20 9H11V0H20V9Z" Foreground="{ThemeResource WindowsLogoGradient}" />
                                     </tkcontrols:SettingsCard.HeaderIcon>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Change the binding mode to `OneTime` for various update controls in the settings UI to improve performance and reduce unnecessary updates.

Without the change, beside the functionality/performance issue, there are list of build warning like:
src\settings-ui\Settings.UI\SettingsXAML\Controls\Dashboard\CheckUpdateControl.xaml(15,13): XamlCompiler warning **WMC1506**: OneWay bindings require at least one of their steps to support raising notifications when their value changes 

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Updated the binding mode for controls in `CheckUpdateControl.xaml` and `ShortcutConflictWindow.xaml` to `OneTime` to enhance efficiency.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manually tested the settings UI to ensure that the controls behave as expected without unnecessary updates.
```

