### PR TITLE
feat(settings-ui): crash fix - add back the missing default language option to resources

### DIFF
--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -4772,6 +4772,9 @@ The break timer font matches the text font.</value>
   <data name="LanguageRestartInfoButton.Content" xml:space="preserve">
     <value>Restart</value>
   </data>
+  <data name="Default_language" xml:space="preserve">
+    <value>Windows default</value>
+  </data>
   <data name="Arabic_Saudi_Arabia_Language" xml:space="preserve">
     <value>Arabic (Saudi Arabia)</value>
   </data>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -4772,7 +4772,7 @@ The break timer font matches the text font.</value>
   <data name="LanguageRestartInfoButton.Content" xml:space="preserve">
     <value>Restart</value>
   </data>
-  <data name="Default_language" xml:space="preserve">
+  <data name="Default_Language" xml:space="preserve">
     <value>Windows default</value>
   </data>
   <data name="Arabic_Saudi_Arabia_Language" xml:space="preserve">

--- a/src/settings-ui/Settings.UI/ViewModels/GeneralViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/GeneralViewModel.cs
@@ -226,7 +226,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         // Supported languages. Taken from Resources.wxs + default + en-US
         private Dictionary<string, string> langTagsAndIds = new Dictionary<string, string>
         {
-            { string.Empty, "Default_language" },
+            { string.Empty, "Default_Language" },
             { "ar-SA", "Arabic_Saudi_Arabia_Language" },
             { "cs-CZ", "Czech_Language" },
             { "de-DE", "German_Language" },


### PR DESCRIPTION
Add back the default language option to the resources for better localization support. This change is fixing a regression:
 Two bugs here:
  1. The original commit by Stefan had a case mismatch (Default_language vs Default_Language) — latent bug
  2. Niels's PR used Copilot CLI to find dead strings, which incorrectly removed a live resource due to the case
  mismatch