### PR TITLE
Settings: Fix settings process shutdown when closing secondary windows

### DIFF
--- a/src/settings-ui/Settings.UI/SettingsXAML/App.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/App.xaml.cs
@@ -356,6 +356,7 @@ namespace Microsoft.PowerToys.Settings.UI
                 scoobeWindow.Closed += (_, _) =>
                 {
                     scoobeWindow = null;
+                    settingsWindow?.CloseHiddenWindow();
                 };
 
                 scoobeWindow.Activate();
@@ -377,6 +378,7 @@ namespace Microsoft.PowerToys.Settings.UI
                 oobeWindow.Closed += (_, _) =>
                 {
                     oobeWindow = null;
+                    settingsWindow?.CloseHiddenWindow();
                 };
 
                 oobeWindow.Activate();
@@ -396,6 +398,7 @@ namespace Microsoft.PowerToys.Settings.UI
                 shortcutConflictWindow.Closed += (_, _) =>
                 {
                     shortcutConflictWindow = null;
+                    settingsWindow?.CloseHiddenWindow();
                 };
 
                 shortcutConflictWindow.Activate();


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] Closes: #45549 
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

When no window alive, the settings exe should also be gone