### PR TITLE
CmdPal: Add null check before caching view model for item

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ListViewModel.cs
@@ -228,32 +228,44 @@ public partial class ListViewModel : PageViewModel, IDisposable
             var reused = 0;
             foreach (var item in newItems)
             {
-                // Check for cancellation during item processing
-                if (cancellationToken.IsCancellationRequested)
+                try
                 {
-                    return;
+                    if (item is null)
+                    {
+                        continue;
+                    }
+
+                    // Check for cancellation during item processing
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        return;
+                    }
+
+                    if (_vmCache.TryGetValue(item, out var existing))
+                    {
+                        existing.LayoutShowsTitle = showsTitle;
+                        existing.LayoutShowsSubtitle = showsSubtitle;
+                        newViewModels.Add(existing);
+                        reused++;
+                        continue;
+                    }
+
+                    var viewModel = new ListItemViewModel(item, new(this), _contextMenuFactory);
+
+                    // If an item fails to load, silently ignore it.
+                    if (viewModel.SafeFastInit())
+                    {
+                        viewModel.LayoutShowsTitle = showsTitle;
+                        viewModel.LayoutShowsSubtitle = showsSubtitle;
+
+                        _vmCache[item] = viewModel;
+                        newViewModels.Add(viewModel);
+                        created++;
+                    }
                 }
-
-                if (_vmCache.TryGetValue(item, out var existing))
+                catch (Exception ex)
                 {
-                    existing.LayoutShowsTitle = showsTitle;
-                    existing.LayoutShowsSubtitle = showsSubtitle;
-                    newViewModels.Add(existing);
-                    reused++;
-                    continue;
-                }
-
-                var viewModel = new ListItemViewModel(item, new(this), _contextMenuFactory);
-
-                // If an item fails to load, silently ignore it.
-                if (viewModel.SafeFastInit())
-                {
-                    viewModel.LayoutShowsTitle = showsTitle;
-                    viewModel.LayoutShowsSubtitle = showsSubtitle;
-
-                    _vmCache[item] = viewModel;
-                    newViewModels.Add(viewModel);
-                    created++;
+                    CoreLogger.LogError("Failed to load item:\n", ex + ToString());
                 }
             }
 


### PR DESCRIPTION
## Summary of the Pull Request

Ensures the item is not null before adding its view model it to the cache to prevent potential null being used as a key in a dictionary

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #45814
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

