### PR TITLE
dock: shift around the padding for fitts law

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockControl.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockControl.xaml
@@ -334,12 +334,16 @@
                     <VisualState.StateTriggers>
                         <ui:IsEqualStateTrigger Value="{x:Bind DockSide, Mode=OneWay}" To="Top" />
                     </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="ContentGrid.Margin" Value="4,0,4,4" />
+                    </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="DockOnBottom">
                     <VisualState.StateTriggers>
                         <ui:IsEqualStateTrigger Value="{x:Bind DockSide, Mode=OneWay}" To="Bottom" />
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
+                        <Setter Target="ContentGrid.Margin" Value="4,4,4,0" />
                         <Setter Target="RootGrid.BorderThickness" Value="0,1,0,0" />
                     </VisualState.Setters>
                 </VisualState>
@@ -373,7 +377,8 @@
                         <Setter Target="EndScroller.(Grid.ColumnSpan)" Value="3" />
                         <Setter Target="EndScroller.HorizontalAlignment" Value="Stretch" />
                         <Setter Target="EndScroller.VerticalAlignment" Value="Bottom" />
-                        <Setter Target="ContentGrid.Padding" Value="4,8,4,8" />
+                        <Setter Target="ContentGrid.Margin" Value="0,4,4,4" />
+                        <Setter Target="ContentGrid.Padding" Value="0,8,4,8" />
                         <Setter Target="RootGrid.BorderThickness" Value="0,0,1,0" />
 
                         <Setter Target="StartListView.ItemsPanel" Value="{StaticResource VerticalItemsPanel}" />
@@ -411,7 +416,8 @@
                         <Setter Target="EndScroller.(Grid.ColumnSpan)" Value="3" />
                         <Setter Target="EndScroller.HorizontalAlignment" Value="Stretch" />
                         <Setter Target="EndScroller.VerticalAlignment" Value="Bottom" />
-                        <Setter Target="ContentGrid.Padding" Value="4,8,4,8" />
+                        <Setter Target="ContentGrid.Margin" Value="4,4,0,4" />
+                        <Setter Target="ContentGrid.Padding" Value="4,8,0,8" />
                         <Setter Target="RootGrid.BorderThickness" Value="1,0,0,0" />
 
                         <Setter Target="StartListView.ItemsPanel" Value="{StaticResource VerticalItemsPanel}" />

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockControl.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockControl.xaml
@@ -182,7 +182,7 @@
         <Grid
             x:Name="ContentGrid"
             Margin="4"
-            Padding="4,0,4,0"
+            Padding="0,0,0,0"
             Background="Transparent"
             RightTapped="RootGrid_RightTapped">
             <Grid.ColumnDefinitions>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockItemControl.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockItemControl.xaml
@@ -75,48 +75,48 @@
                                     AutomationProperties.Name="{TemplateBinding Title}"
                                     Background="Transparent"
                                     ColumnSpacing="8">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="Auto" />
-                                </Grid.ColumnDefinitions>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
 
-                                <!--  Icon  -->
-                                <ContentPresenter
-                                    x:Name="IconPresenter"
-                                    VerticalAlignment="Center"
-                                    Content="{TemplateBinding Icon}" />
+                                    <!--  Icon  -->
+                                    <ContentPresenter
+                                        x:Name="IconPresenter"
+                                        VerticalAlignment="Center"
+                                        Content="{TemplateBinding Icon}" />
 
-                                <!--  Text (Title + Subtitle)  -->
-                                <StackPanel
-                                    x:Name="TextPanel"
-                                    Grid.Column="1"
-                                    VerticalAlignment="Center"
-                                    Visibility="{TemplateBinding TextVisibility}">
-                                    <TextBlock
-                                        x:Name="TitleText"
-                                        MinWidth="24"
-                                        MaxWidth="100"
-                                        HorizontalAlignment="Left"
+                                    <!--  Text (Title + Subtitle)  -->
+                                    <StackPanel
+                                        x:Name="TextPanel"
+                                        Grid.Column="1"
                                         VerticalAlignment="Center"
-                                        FontFamily="Segoe UI"
-                                        FontSize="12"
-                                        Text="{TemplateBinding Title}"
-                                        TextAlignment="Left"
-                                        TextTrimming="CharacterEllipsis"
-                                        TextWrapping="NoWrap" />
-                                    <TextBlock
-                                        x:Name="SubtitleText"
-                                        MaxWidth="100"
-                                        Margin="0,-4,0,0"
-                                        HorizontalAlignment="Left"
-                                        VerticalAlignment="Center"
-                                        FontFamily="Segoe UI"
-                                        FontSize="10"
-                                        Foreground="{ThemeResource TextFillColorTertiary}"
-                                        Text="{TemplateBinding Subtitle}"
-                                        TextAlignment="Center"
-                                        TextTrimming="CharacterEllipsis"
-                                        TextWrapping="NoWrap" />
+                                        Visibility="{TemplateBinding TextVisibility}">
+                                        <TextBlock
+                                            x:Name="TitleText"
+                                            MinWidth="24"
+                                            MaxWidth="100"
+                                            HorizontalAlignment="Left"
+                                            VerticalAlignment="Center"
+                                            FontFamily="Segoe UI"
+                                            FontSize="12"
+                                            Text="{TemplateBinding Title}"
+                                            TextAlignment="Left"
+                                            TextTrimming="CharacterEllipsis"
+                                            TextWrapping="NoWrap" />
+                                        <TextBlock
+                                            x:Name="SubtitleText"
+                                            MaxWidth="100"
+                                            Margin="0,-4,0,0"
+                                            HorizontalAlignment="Left"
+                                            VerticalAlignment="Center"
+                                            FontFamily="Segoe UI"
+                                            FontSize="10"
+                                            Foreground="{ThemeResource TextFillColorTertiary}"
+                                            Text="{TemplateBinding Subtitle}"
+                                            TextAlignment="Center"
+                                            TextTrimming="CharacterEllipsis"
+                                            TextWrapping="NoWrap" />
                                     </StackPanel>
                                 </Grid>
                             </Grid>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockItemControl.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockItemControl.xaml
@@ -58,19 +58,23 @@
                 <Setter.Value>
                     <ControlTemplate TargetType="local:DockItemControl">
                         <Grid
-                            x:Name="PART_RootGrid"
-                            Padding="{TemplateBinding Padding}"
-                            VerticalAlignment="Stretch"
-                            Background="{TemplateBinding Background}"
-                            BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}"
-                            CornerRadius="{TemplateBinding CornerRadius}"
+                            x:Name="PART_HitTestGrid"
+                            Background="Transparent"
                             ToolTipService.ToolTip="{TemplateBinding ToolTip}">
                             <Grid
-                                x:Name="ContentGrid"
-                                AutomationProperties.Name="{TemplateBinding Title}"
-                                Background="Transparent"
-                                ColumnSpacing="8">
+                                x:Name="PART_RootGrid"
+                                Margin="{TemplateBinding InnerMargin}"
+                                Padding="{TemplateBinding Padding}"
+                                VerticalAlignment="Stretch"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                CornerRadius="{TemplateBinding CornerRadius}">
+                                <Grid
+                                    x:Name="ContentGrid"
+                                    AutomationProperties.Name="{TemplateBinding Title}"
+                                    Background="Transparent"
+                                    ColumnSpacing="8">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="Auto" />
                                     <ColumnDefinition Width="Auto" />
@@ -113,7 +117,8 @@
                                         TextAlignment="Center"
                                         TextTrimming="CharacterEllipsis"
                                         TextWrapping="NoWrap" />
-                                </StackPanel>
+                                    </StackPanel>
+                                </Grid>
                             </Grid>
                             <VisualStateManager.VisualStateGroups>
                                 <VisualStateGroup x:Name="CommonStates">


### PR DESCRIPTION
This makes the buttons hitbox extend all the way to the edges of the dock, but the visual presentation of these buttons is unchanged.

This lets us adhere to fitts law appropriately.

Closes #45596
Closes #45590
