### PR TITLE
Dock: Fix tab focus order for items

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockControl.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockControl.xaml
@@ -29,7 +29,10 @@
             </ItemsPanelTemplate>
 
             <DataTemplate x:Key="DockBandTemplate" x:DataType="dockVm:DockBandViewModel">
-                <ItemsRepeater ItemsSource="{x:Bind Items, Mode=OneWay}" Layout="{StaticResource ItemsOrientationLayout}">
+                <ItemsRepeater
+                    ItemsSource="{x:Bind Items, Mode=OneWay}"
+                    Layout="{StaticResource ItemsOrientationLayout}"
+                    TabFocusNavigation="Local">
                     <ItemsRepeater.Transitions>
                         <TransitionCollection />
                     </ItemsRepeater.Transitions>
@@ -63,10 +66,12 @@
                 <Setter Property="Padding" Value="0" />
                 <Setter Property="IsItemClickEnabled" Value="False" />
                 <Setter Property="SelectionMode" Value="None" />
+                <Setter Property="IsTabStop" Value="False" />
                 <!--  Drag properties controlled by code-behind based on IsEditMode  -->
                 <Setter Property="CanDragItems" Value="False" />
                 <Setter Property="CanReorderItems" Value="False" />
                 <Setter Property="AllowDrop" Value="False" />
+                <Setter Property="TabFocusNavigation" Value="Local" />
             </Style>
 
             <Style x:Key="DockBandListViewItemStyle" TargetType="ListViewItem">
@@ -76,6 +81,7 @@
                 <Setter Property="MinWidth" Value="0" />
                 <Setter Property="HorizontalContentAlignment" Value="Stretch" />
                 <Setter Property="VerticalContentAlignment" Value="Stretch" />
+                <Setter Property="IsTabStop" Value="False" />
             </Style>
 
             <Style
@@ -225,7 +231,8 @@
                         ItemsPanel="{StaticResource HorizontalItemsPanel}"
                         ItemsSource="{x:Bind ViewModel.StartItems, Mode=OneWay}"
                         SelectionMode="None"
-                        Style="{StaticResource DockBandListViewStyle}" />
+                        Style="{StaticResource DockBandListViewStyle}"
+                        TabIndex="0" />
                 </cpcontrols:ScrollContainer.Source>
             </cpcontrols:ScrollContainer>
 
@@ -260,7 +267,8 @@
                         ItemsPanel="{StaticResource HorizontalItemsPanel}"
                         ItemsSource="{x:Bind ViewModel.CenterItems, Mode=OneWay}"
                         SelectionMode="None"
-                        Style="{StaticResource DockBandListViewStyle}" />
+                        Style="{StaticResource DockBandListViewStyle}"
+                        TabIndex="1" />
                 </cpcontrols:ScrollContainer.Source>
             </cpcontrols:ScrollContainer>
 
@@ -294,7 +302,8 @@
                         ItemsPanel="{StaticResource HorizontalItemsPanel}"
                         ItemsSource="{x:Bind ViewModel.EndItems, Mode=OneWay}"
                         SelectionMode="None"
-                        Style="{StaticResource DockBandListViewStyle}">
+                        Style="{StaticResource DockBandListViewStyle}"
+                        TabIndex="2">
                         <ListView.ItemContainerTransitions>
                             <TransitionCollection />
                         </ListView.ItemContainerTransitions>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockItemControl.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockItemControl.xaml
@@ -54,6 +54,9 @@
             <Setter Property="BorderThickness" Value="{ThemeResource ButtonBorderThemeThickness}" />
             <Setter Property="CornerRadius" Value="{StaticResource DockItemCornerRadius}" />
             <Setter Property="TextVisibility" Value="Visible" />
+            <Setter Property="IsTabStop" Value="True" />
+            <Setter Property="UseSystemFocusVisuals" Value="True" />
+            <Setter Property="FocusVisualMargin" Value="-2" />
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="local:DockItemControl">


### PR DESCRIPTION
Now, once the dock has focus, tab will work the way you'd expect.

* re #45584
* re #45595 - if we do add that KB shortcut, well, reasonable tab focus would be expected.
