### PR TITLE
Add VS 2026 Preview support to setup-dev-environment.ps1

### DIFF
--- a/tools/build/setup-dev-environment.ps1
+++ b/tools/build/setup-dev-environment.ps1
@@ -165,11 +165,12 @@ if (-not $SkipVSComponents) {
         $vsWhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
 
         if (-not $VSInstallPath -and (Test-Path $vsWhere)) {
-            $VSInstallPath = & $vsWhere -latest -property installationPath 2>$null
+            $VSInstallPath = & $vsWhere -latest -prerelease -property installationPath 2>$null
         }
 
         if (-not $VSInstallPath) {
             $commonPaths = @(
+                "${env:ProgramFiles}\Microsoft Visual Studio\18\Preview",
                 "${env:ProgramFiles}\Microsoft Visual Studio\18\Enterprise",
                 "${env:ProgramFiles}\Microsoft Visual Studio\18\Professional",
                 "${env:ProgramFiles}\Microsoft Visual Studio\18\Community",


### PR DESCRIPTION
Fixes #45811

The setup-dev-environment.ps1 script did not support Visual Studio 2026 Preview because vswhere was called without the -prerelease flag and the Preview path was not in the common paths list.

This fix:
1. Adds -prerelease flag to vswhere command to discover preview versions
2. Adds VS 2026 Preview path to the common paths fallback list