### PR TITLE
Override Win+Number to snap window to FancyZones zone by index

### DIFF
--- a/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
@@ -491,6 +491,20 @@ FancyZones::OnKeyDown(PKBDLLHOOKSTRUCT info) noexcept
         }
     }
 
+    // Win+Number (0-9): snap window to zone by global index across monitors
+    if (win && !shift && !ctrl && !alt)
+    {
+        if (info->vkCode >= '0' && info->vkCode <= '9')
+        {
+            if (ShouldProcessSnapHotkey(info->vkCode))
+            {
+                Trace::FancyZones::OnKeyDown(info->vkCode, win, ctrl, false /*inMoveSize*/);
+                PostMessageW(m_window, WM_PRIV_SNAP_HOTKEY, 0, info->vkCode);
+                return true;
+            }
+        }
+    }
+
     if (FancyZonesSettings::settings().quickLayoutSwitch)
     {
         int digitPressed = -1;
@@ -635,7 +649,14 @@ LRESULT FancyZones::WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lpa
                 monitor = MonitorFromWindow(foregroundWindow, MONITOR_DEFAULTTONULL);
             }
 
-            if (FancyZonesSettings::settings().moveWindowsBasedOnPosition)
+            DWORD vkCode = static_cast<DWORD>(lparam);
+
+            // Win+Number: snap to zone by global index across monitors
+            if (vkCode >= '0' && vkCode <= '9')
+            {
+                m_windowKeyboardSnapper.SnapToZoneByNumber(foregroundWindow, monitor, vkCode, m_workAreaConfiguration.GetAllWorkAreas(), FancyZonesUtils::GetMonitorsOrdered());
+            }
+            else if (FancyZonesSettings::settings().moveWindowsBasedOnPosition)
             {
                 auto monitors = FancyZonesUtils::GetAllMonitorRects<&MONITORINFOEX::rcWork>();
                 RECT windowRect;
@@ -644,11 +665,11 @@ LRESULT FancyZones::WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lpa
                     // Check whether Alt is used in the shortcut key combination
                     if (GetAsyncKeyState(VK_MENU) & 0x8000)
                     {
-                        m_windowKeyboardSnapper.Extend(foregroundWindow, windowRect, monitor, static_cast<DWORD>(lparam), m_workAreaConfiguration.GetAllWorkAreas());
+                        m_windowKeyboardSnapper.Extend(foregroundWindow, windowRect, monitor, vkCode, m_workAreaConfiguration.GetAllWorkAreas());
                     }
                     else
                     {
-                        m_windowKeyboardSnapper.Snap(foregroundWindow, windowRect, monitor, static_cast<DWORD>(lparam), m_workAreaConfiguration.GetAllWorkAreas(), monitors);
+                        m_windowKeyboardSnapper.Snap(foregroundWindow, windowRect, monitor, vkCode, m_workAreaConfiguration.GetAllWorkAreas(), monitors);
                     }
                 }
                 else
@@ -658,7 +679,7 @@ LRESULT FancyZones::WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lpa
             }
             else
             {
-                m_windowKeyboardSnapper.Snap(foregroundWindow, monitor, static_cast<DWORD>(lparam), m_workAreaConfiguration.GetAllWorkAreas(), FancyZonesUtils::GetMonitorsOrdered());
+                m_windowKeyboardSnapper.Snap(foregroundWindow, monitor, vkCode, m_workAreaConfiguration.GetAllWorkAreas(), FancyZonesUtils::GetMonitorsOrdered());
             }
         }
         else if (message == WM_PRIV_INIT)
@@ -1124,6 +1145,11 @@ bool FancyZones::ShouldProcessSnapHotkey(DWORD vkCode) noexcept
         if (vkCode == VK_UP || vkCode == VK_DOWN)
         {
             return FancyZonesSettings::settings().moveWindowsBasedOnPosition;
+        }
+        else if (vkCode >= '0' && vkCode <= '9')
+        {
+            // Win+Number: snap to zone by index - always allowed when zones exist
+            return true;
         }
         else
         {

--- a/src/modules/fancyzones/FancyZonesLib/WindowKeyboardSnap.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WindowKeyboardSnap.cpp
@@ -15,6 +15,93 @@ bool WindowKeyboardSnap::Snap(HWND window, HMONITOR monitor, DWORD vkCode, const
     return (vkCode == VK_LEFT || vkCode == VK_RIGHT) && SnapHotkeyBasedOnZoneNumber(window, vkCode, monitor, activeWorkAreas, monitors);
 }
 
+bool WindowKeyboardSnap::SnapToZoneByNumber(HWND window, HMONITOR /*activeMonitor*/, DWORD vkCode, const std::unordered_map<HMONITOR, std::unique_ptr<WorkArea>>& activeWorkAreas, const std::vector<HMONITOR>& monitors)
+{
+    // Map vkCode '0'-'9' to zone index. '1' = zone 0, '2' = zone 1, ..., '0' = zone 9
+    ZoneIndex targetGlobalIndex;
+    if (vkCode == '0')
+    {
+        targetGlobalIndex = 9;
+    }
+    else
+    {
+        targetGlobalIndex = static_cast<ZoneIndex>(vkCode - '1');
+    }
+
+    // clean previous extension data
+    m_extendData.Reset();
+
+    // Build a flat list of zones across all monitors in monitor order.
+    // Each entry: cumulative offset of zone indices per monitor.
+    ZoneIndex offset = 0;
+    for (HMONITOR monitor : monitors)
+    {
+        if (!activeWorkAreas.contains(monitor))
+        {
+            continue;
+        }
+
+        const auto& workArea = activeWorkAreas.at(monitor);
+        if (!workArea)
+        {
+            continue;
+        }
+
+        const auto& layout = workArea->GetLayout();
+        if (!layout)
+        {
+            continue;
+        }
+
+        auto numZones = static_cast<ZoneIndex>(layout->Zones().size());
+        if (targetGlobalIndex >= offset && targetGlobalIndex < offset + numZones)
+        {
+            // Found the work area containing the target zone
+            ZoneIndex localIndex = targetGlobalIndex - offset;
+            bool snapped = workArea->Snap(window, { localIndex });
+
+            if (snapped)
+            {
+                // Unsnap from all other work areas
+                for (const auto& [otherMonitor, otherWorkArea] : activeWorkAreas)
+                {
+                    if (otherWorkArea && otherWorkArea.get() != workArea.get())
+                    {
+                        otherWorkArea->Unsnap(window);
+                    }
+                }
+
+                Trace::FancyZones::KeyboardSnapWindowToZone(workArea->GetLayout().get(), workArea->GetLayoutWindows());
+            }
+
+            return snapped;
+        }
+
+        offset += numZones;
+    }
+
+    // For span-zones-across-monitors mode (single NULL monitor key)
+    if (monitors.empty() && activeWorkAreas.contains(nullptr))
+    {
+        const auto& workArea = activeWorkAreas.at(nullptr);
+        if (workArea)
+        {
+            const auto& layout = workArea->GetLayout();
+            if (layout && targetGlobalIndex < static_cast<ZoneIndex>(layout->Zones().size()))
+            {
+                bool snapped = workArea->Snap(window, { targetGlobalIndex });
+                if (snapped)
+                {
+                    Trace::FancyZones::KeyboardSnapWindowToZone(workArea->GetLayout().get(), workArea->GetLayoutWindows());
+                }
+                return snapped;
+            }
+        }
+    }
+
+    return false;
+}
+
 bool WindowKeyboardSnap::Snap(HWND window, RECT windowRect, HMONITOR monitor, DWORD vkCode, const std::unordered_map<HMONITOR, std::unique_ptr<WorkArea>>& activeWorkAreas, const std::vector<std::pair<HMONITOR, RECT>>& monitors)
 {
     if (!activeWorkAreas.contains(monitor))

--- a/src/modules/fancyzones/FancyZonesLib/WindowKeyboardSnap.h
+++ b/src/modules/fancyzones/FancyZonesLib/WindowKeyboardSnap.h
@@ -36,13 +36,16 @@ public:
     WindowKeyboardSnap() = default;
     ~WindowKeyboardSnap() = default;
 
-    bool Snap(HWND window, HMONITOR activeMonitor, DWORD vkCode, 
-        const std::unordered_map<HMONITOR, std::unique_ptr<WorkArea>>& activeWorkAreas, 
+    bool Snap(HWND window, HMONITOR activeMonitor, DWORD vkCode,
+        const std::unordered_map<HMONITOR, std::unique_ptr<WorkArea>>& activeWorkAreas,
         const std::vector<HMONITOR>& monitors);
-    bool Snap(HWND window, RECT windowRect, HMONITOR activeMonitor, DWORD vkCode, 
-        const std::unordered_map<HMONITOR, std::unique_ptr<WorkArea>>& activeWorkAreas, 
+    bool Snap(HWND window, RECT windowRect, HMONITOR activeMonitor, DWORD vkCode,
+        const std::unordered_map<HMONITOR, std::unique_ptr<WorkArea>>& activeWorkAreas,
         const std::vector<std::pair<HMONITOR, RECT>>& monitors);
     bool Extend(HWND window, RECT windowRect, HMONITOR monitor, DWORD vkCode, const std::unordered_map<HMONITOR, std::unique_ptr<WorkArea>>& activeWorkAreas);
+    bool SnapToZoneByNumber(HWND window, HMONITOR activeMonitor, DWORD vkCode,
+        const std::unordered_map<HMONITOR, std::unique_ptr<WorkArea>>& activeWorkAreas,
+        const std::vector<HMONITOR>& monitors);
 	
 private:
     bool SnapHotkeyBasedOnZoneNumber(HWND window, DWORD vkCode, HMONITOR monitor, const std::unordered_map<HMONITOR, std::unique_ptr<WorkArea>>& activeWorkAreas, const std::vector<HMONITOR>& monitors);


### PR DESCRIPTION
Add Win+Number (1-9, 0) shortcut to snap the active window to a specific zone by global index across all monitors. Zones are numbered sequentially across monitors in display order, so if monitor 1 has 3 zones and monitor 2 has 3 zones, Win+1-3 targets monitor 1 and Win+4-6 targets monitor 2.
