### PR TITLE
loc: move build to windows-latest; 2019 is d e a d

### DIFF
--- a/.pipelines/loc/loc.yml
+++ b/.pipelines/loc/loc.yml
@@ -9,7 +9,7 @@ schedules:
     always: false # only run if there's code changes!
 
 pool:
-  vmImage: windows-2019
+  vmImage: windows-latest
 
 resources:
   repositories:


### PR DESCRIPTION
When Azure DevOps says "no image found," well... he's dead, Jim.