### PR TITLE
[FancyZones] Add option to not cycle through the end of the zone list + Maximize/Minimize

### DIFF
--- a/src/modules/fancyzones/FancyZonesLib/Settings.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/Settings.cpp
@@ -20,6 +20,7 @@ namespace NonLocalizable
     const wchar_t MouseMiddleClickSpanningMultipleZonesID[] = L"fancyzones_mouseMiddleClickSpanningMultipleZones";
     const wchar_t OverrideSnapHotKeysID[] = L"fancyzones_overrideSnapHotkeys";
     const wchar_t MoveWindowAcrossMonitorsID[] = L"fancyzones_moveWindowAcrossMonitors";
+    const wchar_t CycleThroughAllZonesID[] = L"fancyzones_cycleThroughAllZones";
     const wchar_t MoveWindowsBasedOnPositionID[] = L"fancyzones_moveWindowsBasedOnPosition";
     const wchar_t OverlappingZonesAlgorithmID[] = L"fancyzones_overlappingZonesAlgorithm";
     const wchar_t DisplayOrWorkAreaChangeMoveWindowsID[] = L"fancyzones_displayOrWorkAreaChange_moveWindows";
@@ -111,6 +112,7 @@ void FancyZonesSettings::LoadSettings()
         SetBoolFlag(values, NonLocalizable::MouseMiddleClickSpanningMultipleZonesID, SettingId::MouseMiddleClickSpanningMultipleZones, m_settings.mouseMiddleClickSpanningMultipleZones);
         SetBoolFlag(values, NonLocalizable::OverrideSnapHotKeysID, SettingId::OverrideSnapHotkeys, m_settings.overrideSnapHotkeys);
         SetBoolFlag(values, NonLocalizable::MoveWindowAcrossMonitorsID, SettingId::MoveWindowAcrossMonitors, m_settings.moveWindowAcrossMonitors);
+        SetBoolFlag(values, NonLocalizable::CycleThroughAllZonesID, SettingId::CycleThroughAllZones, m_settings.cycleThroughAllZones);
         SetBoolFlag(values, NonLocalizable::MoveWindowsBasedOnPositionID, SettingId::MoveWindowsBasedOnPosition, m_settings.moveWindowsBasedOnPosition);
         SetBoolFlag(values, NonLocalizable::DisplayOrWorkAreaChangeMoveWindowsID, SettingId::DisplayOrWorkAreaChangeMoveWindows, m_settings.displayOrWorkAreaChange_moveWindows);
         SetBoolFlag(values, NonLocalizable::ZoneSetChangeMoveWindowsID, SettingId::ZoneSetChangeMoveWindows, m_settings.zoneSetChange_moveWindows);

--- a/src/modules/fancyzones/FancyZonesLib/Settings.h
+++ b/src/modules/fancyzones/FancyZonesLib/Settings.h
@@ -32,6 +32,7 @@ struct Settings
     bool zoneSetChange_moveWindows = false;
     bool overrideSnapHotkeys = false;
     bool moveWindowAcrossMonitors = false;
+    bool cycleThroughAllZones = true;
     bool moveWindowsBasedOnPosition = false;
     bool appLastZone_moveWindows = false;
     bool openWindowOnActiveMonitor = false;

--- a/src/modules/fancyzones/FancyZonesLib/SettingsConstants.h
+++ b/src/modules/fancyzones/FancyZonesLib/SettingsConstants.h
@@ -7,6 +7,7 @@ enum class SettingId
     MouseMiddleClickSpanningMultipleZones,
     OverrideSnapHotkeys,
     MoveWindowAcrossMonitors,
+    CycleThroughAllZones,
     MoveWindowsBasedOnPosition,
     OverlappingZonesAlgorithm,
     DisplayOrWorkAreaChangeMoveWindows,

--- a/src/modules/fancyzones/FancyZonesLib/WindowKeyboardSnap.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WindowKeyboardSnap.cpp
@@ -25,32 +25,46 @@ bool WindowKeyboardSnap::Snap(HWND window, RECT windowRect, HMONITOR monitor, DW
     // clean previous extension data
     m_extendData.Reset();
 
+    bool success = false;
+    bool cycle = FancyZonesSettings::settings().cycleThroughAllZones;
+
     const auto& currentWorkArea = activeWorkAreas.at(monitor);
     if (monitors.size() > 1 && FancyZonesSettings::settings().moveWindowAcrossMonitors)
     {
         // Multi monitor environment.
         // First, try to stay on the same monitor
-        bool success = MoveByDirectionAndPosition(window, windowRect, vkCode, false, currentWorkArea.get());
+        success = MoveByDirectionAndPosition(window, windowRect, vkCode, false, currentWorkArea.get());
         if (success)
         {
             return true;
         }
 
         // Try to snap on another monitor
-        success = SnapBasedOnPositionOnAnotherMonitor(window, windowRect, vkCode, monitor, activeWorkAreas, monitors);
+        success = SnapBasedOnPositionOnAnotherMonitor(window, windowRect, vkCode, cycle, monitor, activeWorkAreas, monitors);
         if (success)
         {
             // Unsnap from previous work area
             currentWorkArea->Unsnap(window);
         }
-
-        return success;
     }
     else
     {
         // Single monitor environment, or combined multi-monitor environment.
-        return MoveByDirectionAndPosition(window, windowRect, vkCode, true, currentWorkArea.get());
+        success = MoveByDirectionAndPosition(window, windowRect, vkCode, cycle, currentWorkArea.get());        
     }
+
+    if (!success && (vkCode == VK_UP || vkCode == VK_DOWN))
+    {
+        WINDOWPLACEMENT placement{};
+        GetWindowPlacement(window, &placement);
+        if (vkCode == VK_UP)
+            placement.showCmd = SW_SHOWMAXIMIZED;
+        else if (vkCode == VK_DOWN)
+            placement.showCmd = SW_SHOWMINIMIZED;
+        success = SetWindowPlacement(window, &placement);
+    }
+
+    return success;
 }
 
 bool WindowKeyboardSnap::Extend(HWND window, RECT windowRect, HMONITOR monitor, DWORD vkCode, const std::unordered_map<HMONITOR, std::unique_ptr<WorkArea>>& activeWorkAreas)
@@ -133,7 +147,7 @@ bool WindowKeyboardSnap::SnapHotkeyBasedOnZoneNumber(HWND window, DWORD vkCode, 
     return false;
 }
 
-bool WindowKeyboardSnap::SnapBasedOnPositionOnAnotherMonitor(HWND window, RECT windowRect, DWORD vkCode, HMONITOR current, const std::unordered_map<HMONITOR, std::unique_ptr<WorkArea>>& activeWorkAreas, const std::vector<std::pair<HMONITOR, RECT>>& monitors)
+bool WindowKeyboardSnap::SnapBasedOnPositionOnAnotherMonitor(HWND window, RECT windowRect, DWORD vkCode, bool cycle, HMONITOR current, const std::unordered_map<HMONITOR, std::unique_ptr<WorkArea>>& activeWorkAreas, const std::vector<std::pair<HMONITOR, RECT>>& monitors)
 {
     // Extract zones from all other monitors and target one of them
     std::vector<RECT> zoneRects;
@@ -192,6 +206,9 @@ bool WindowKeyboardSnap::SnapBasedOnPositionOnAnotherMonitor(HWND window, RECT w
         return snapped;
     }
 
+    if (!cycle)
+        return false;
+    
     // We reached the end of all monitors.
     // Try again, cycling on all monitors.
     // First, add zones from the origin monitor to zoneRects

--- a/src/modules/fancyzones/FancyZonesLib/WindowKeyboardSnap.h
+++ b/src/modules/fancyzones/FancyZonesLib/WindowKeyboardSnap.h
@@ -46,7 +46,7 @@ public:
 	
 private:
     bool SnapHotkeyBasedOnZoneNumber(HWND window, DWORD vkCode, HMONITOR monitor, const std::unordered_map<HMONITOR, std::unique_ptr<WorkArea>>& activeWorkAreas, const std::vector<HMONITOR>& monitors);
-    bool SnapBasedOnPositionOnAnotherMonitor(HWND window, RECT windowRect, DWORD vkCode, HMONITOR monitor, const std::unordered_map<HMONITOR, std::unique_ptr<WorkArea>>& activeWorkAreas, const std::vector<std::pair<HMONITOR, RECT>>& monitors);
+    bool SnapBasedOnPositionOnAnotherMonitor(HWND window, RECT windowRect, DWORD vkCode, bool cycle, HMONITOR monitor, const std::unordered_map<HMONITOR, std::unique_ptr<WorkArea>>& activeWorkAreas, const std::vector<std::pair<HMONITOR, RECT>>& monitors);
     
     bool MoveByDirectionAndIndex(HWND window, DWORD vkCode, bool cycle, WorkArea* const workArea);
     bool MoveByDirectionAndPosition(HWND window, RECT windowRect, DWORD vkCode, bool cycle, WorkArea* const workArea);

--- a/src/modules/fancyzones/FancyZonesLib/trace.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/trace.cpp
@@ -48,6 +48,7 @@
 #define MoveWindowsOnZoneSetChangeKey "MoveWindowsOnZoneSetChange"
 #define OverrideSnapHotKeysKey "OverrideSnapHotKeys"
 #define MoveWindowAcrossMonitorsKey "MoveWindowAcrossMonitors"
+#define CycleThroughAllZonesKey "CycleThroughAllZones"
 #define MoveWindowsBasedOnPositionKey "MoveWindowsBasedOnPosition"
 #define MoveWindowsToLastZoneOnAppOpeningKey "MoveWindowsToLastZoneOnAppOpening"
 #define OpenWindowOnActiveMonitorKey "OpenWindowOnActiveMonitor"
@@ -303,6 +304,7 @@ void Trace::SettingsTelemetry(const Settings& settings) noexcept
         TraceLoggingBoolean(settings.zoneSetChange_moveWindows, MoveWindowsOnZoneSetChangeKey),
         TraceLoggingBoolean(settings.overrideSnapHotkeys, OverrideSnapHotKeysKey),
         TraceLoggingBoolean(settings.moveWindowAcrossMonitors, MoveWindowAcrossMonitorsKey),
+        TraceLoggingBoolean(settings.cycleThroughAllZones, CycleThroughAllZonesKey),
         TraceLoggingBoolean(settings.moveWindowsBasedOnPosition, MoveWindowsBasedOnPositionKey),
         TraceLoggingBoolean(settings.appLastZone_moveWindows, MoveWindowsToLastZoneOnAppOpeningKey),
         TraceLoggingBoolean(settings.openWindowOnActiveMonitor, OpenWindowOnActiveMonitorKey),

--- a/src/modules/fancyzones/FancyZonesTests/UnitTests/FancyZonesSettings.Spec.cpp
+++ b/src/modules/fancyzones/FancyZonesTests/UnitTests/FancyZonesSettings.Spec.cpp
@@ -34,6 +34,7 @@ namespace FancyZonesUnitTests
         Assert::AreEqual(expected.zoneSetChange_moveWindows, actual.zoneSetChange_moveWindows);
         Assert::AreEqual(expected.overrideSnapHotkeys, actual.overrideSnapHotkeys);
         Assert::AreEqual(expected.moveWindowAcrossMonitors, actual.moveWindowAcrossMonitors);
+        Assert::AreEqual(expected.cycleThroughAllZones, actual.cycleThroughAllZones);
         Assert::AreEqual(expected.moveWindowsBasedOnPosition, actual.moveWindowsBasedOnPosition);
         Assert::AreEqual(expected.appLastZone_moveWindows, actual.appLastZone_moveWindows);
         Assert::AreEqual(expected.openWindowOnActiveMonitor, actual.openWindowOnActiveMonitor);
@@ -74,6 +75,7 @@ namespace FancyZonesUnitTests
             values.add_property(L"fancyzones_zoneSetChange_moveWindows", m_defaultSettings.zoneSetChange_moveWindows);
             values.add_property(L"fancyzones_overrideSnapHotkeys", m_defaultSettings.overrideSnapHotkeys);
             values.add_property(L"fancyzones_moveWindowAcrossMonitors", m_defaultSettings.moveWindowAcrossMonitors);
+            values.add_property(L"fancyzones_cycleThroughAllZones", m_defaultSettings.cycleThroughAllZones);
             values.add_property(L"fancyzones_moveWindowsBasedOnPosition", m_defaultSettings.moveWindowsBasedOnPosition);
             values.add_property(L"fancyzones_appLastZone_moveWindows", m_defaultSettings.appLastZone_moveWindows);
             values.add_property(L"fancyzones_openWindowOnActiveMonitor", m_defaultSettings.openWindowOnActiveMonitor);
@@ -117,6 +119,7 @@ namespace FancyZonesUnitTests
             values.add_property(L"fancyzones_zoneSetChange_moveWindows", expected.zoneSetChange_moveWindows);
             values.add_property(L"fancyzones_overrideSnapHotkeys", expected.overrideSnapHotkeys);
             values.add_property(L"fancyzones_moveWindowAcrossMonitors", expected.moveWindowAcrossMonitors);
+            values.add_property(L"fancyzones_cycleThroughAllZones", expected.cycleThroughAllZones);
             values.add_property(L"fancyzones_moveWindowsBasedOnPosition", expected.moveWindowsBasedOnPosition);
             values.add_property(L"fancyzones_appLastZone_moveWindows", expected.appLastZone_moveWindows);
             values.add_property(L"fancyzones_openWindowOnActiveMonitor", expected.openWindowOnActiveMonitor);

--- a/src/settings-ui/Settings.UI.Library/FZConfigProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/FZConfigProperties.cs
@@ -27,6 +27,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             FancyzonesMouseSwitch = new BoolProperty();
             FancyzonesMouseMiddleClickSpanningMultipleZones = new BoolProperty();
             FancyzonesMoveWindowsAcrossMonitors = new BoolProperty();
+            FancyzonesCycleThroughAllZones = new BoolProperty();
             FancyzonesMoveWindowsBasedOnPosition = new BoolProperty();
             FancyzonesOverlappingZonesAlgorithm = new IntProperty();
             FancyzonesDisplayOrWorkAreaChangeMoveWindows = new BoolProperty(ConfigDefaults.DefaultFancyzonesDisplayOrWorkAreaChangeMoveWindows);
@@ -71,6 +72,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 
         [JsonPropertyName("fancyzones_moveWindowAcrossMonitors")]
         public BoolProperty FancyzonesMoveWindowsAcrossMonitors { get; set; }
+
+        [JsonPropertyName("fancyzones_cycleThroughAllZones")]
+        public BoolProperty FancyzonesCycleThroughAllZones { get; set; }
 
         [JsonPropertyName("fancyzones_moveWindowsBasedOnPosition")]
         public BoolProperty FancyzonesMoveWindowsBasedOnPosition { get; set; }

--- a/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/FancyZones.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/FancyZones.cs
@@ -63,6 +63,7 @@ namespace ViewModelTests
             Assert.AreEqual(originalSettings.Properties.FancyzonesMakeDraggedWindowTransparent.Value, viewModel.MakeDraggedWindowsTransparent);
             Assert.AreEqual(originalSettings.Properties.FancyzonesMouseSwitch.Value, viewModel.MouseSwitch);
             Assert.AreEqual(originalSettings.Properties.FancyzonesMoveWindowsAcrossMonitors.Value, viewModel.MoveWindowsAcrossMonitors);
+            Assert.AreEqual(originalSettings.Properties.FancyzonesCycleThroughAllZones.Value, viewModel.CycleThroughAllZones);
             Assert.AreEqual(originalSettings.Properties.FancyzonesMoveWindowsBasedOnPosition.Value, viewModel.MoveWindowsBasedOnPosition);
             Assert.AreEqual(originalSettings.Properties.FancyzonesOpenWindowOnActiveMonitor.Value, viewModel.OpenWindowOnActiveMonitor);
             Assert.AreEqual(originalSettings.Properties.FancyzonesOverrideSnapHotkeys.Value, viewModel.OverrideSnapHotkeys);

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/FancyZonesPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/FancyZonesPage.xaml
@@ -254,6 +254,12 @@
                                 IsEnabled="{x:Bind ViewModel.SnapHotkeysCategoryEnabled, Mode=OneWay}">
                                 <CheckBox x:Uid="FancyZones_MoveWindowsAcrossAllMonitorsCheckBoxControl" IsChecked="{x:Bind ViewModel.MoveWindowsAcrossMonitors, Mode=TwoWay}" />
                             </tkcontrols:SettingsCard>
+                            <tkcontrols:SettingsCard
+                                Name="FancyZonesCycleThroughAllZones"
+                                ContentAlignment="Left"
+                                IsEnabled="{x:Bind ViewModel.SnapHotkeysCategoryEnabled, Mode=OneWay}">
+                                <CheckBox x:Uid="FancyZones_CycleThroughAllZonesCheckBoxControl" IsChecked="{x:Bind ViewModel.CycleThroughAllZones, Mode=TwoWay}" />
+                            </tkcontrols:SettingsCard>
                         </tkcontrols:SettingsExpander.Items>
                     </tkcontrols:SettingsExpander>
                 </controls:SettingsGroup>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -864,6 +864,9 @@ opera.exe</value>
   <data name="FancyZones_MoveWindowsAcrossAllMonitorsCheckBoxControl.Content" xml:space="preserve">
     <value>Move windows between zones across all monitors</value>
   </data>
+  <data name="FancyZones_CycleThroughAllZonesCheckBoxControl.Content" xml:space="preserve">
+    <value>Cycle through all zones</value>
+  </data>
   <data name="FancyZones_OverrideSnapHotkeys.Header" xml:space="preserve">
     <value>Override Windows Snap</value>
   </data>

--- a/src/settings-ui/Settings.UI/ViewModels/FancyZonesViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/FancyZonesViewModel.cs
@@ -70,6 +70,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             _mouseMiddleButtonSpanningMultipleZones = Settings.Properties.FancyzonesMouseMiddleClickSpanningMultipleZones.Value;
             _overrideSnapHotkeys = Settings.Properties.FancyzonesOverrideSnapHotkeys.Value;
             _moveWindowsAcrossMonitors = Settings.Properties.FancyzonesMoveWindowsAcrossMonitors.Value;
+            _cycleThroughAllZones = Settings.Properties.FancyzonesCycleThroughAllZones.Value;
             _moveWindowBehaviour = Settings.Properties.FancyzonesMoveWindowsBasedOnPosition.Value ? MoveWindowBehaviour.MoveWindowBasedOnPosition : MoveWindowBehaviour.MoveWindowBasedOnZoneIndex;
             _overlappingZonesAlgorithm = (OverlappingZonesAlgorithm)Settings.Properties.FancyzonesOverlappingZonesAlgorithm.Value;
             _displayOrWorkAreaChangeMoveWindows = Settings.Properties.FancyzonesDisplayOrWorkAreaChangeMoveWindows.Value;
@@ -155,6 +156,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         private bool _mouseMiddleButtonSpanningMultipleZones;
         private bool _overrideSnapHotkeys;
         private bool _moveWindowsAcrossMonitors;
+        private bool _cycleThroughAllZones;
         private MoveWindowBehaviour _moveWindowBehaviour;
         private OverlappingZonesAlgorithm _overlappingZonesAlgorithm;
         private bool _displayOrWorkAreaChangeMoveWindows;
@@ -337,6 +339,24 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 {
                     _moveWindowsAcrossMonitors = value;
                     Settings.Properties.FancyzonesMoveWindowsAcrossMonitors.Value = value;
+                    NotifyPropertyChanged();
+                }
+            }
+        }
+
+        public bool CycleThroughAllZones
+        {
+            get
+            {
+                return _cycleThroughAllZones;
+            }
+
+            set
+            {
+                if (value != _cycleThroughAllZones)
+                {
+                    _cycleThroughAllZones = value;
+                    Settings.Properties.FancyzonesCycleThroughAllZones.Value = value;
                     NotifyPropertyChanged();
                 }
             }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Add option to FancyZones not cycle through the end of the zone list + Maximize/Minimize

This allows:
- Pressing Win+Up to maximize the window if it is in the upper most zone
- Pressing Win+Down to minimize the window if it is in the bottom most zone
- Pressing Win+some to many times to the Left/Right to ensure window is in the leftmost/rightmost zone without counting to exactly

Solves the base problem of issues #31098, #32069, #21214, #35397 and #18638 .
Does NOT solve the idea in issue #31098 to have an override key to temporarily disable "Override Windows Snap".

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] Closes: maybe #31098  
  (no temporary disable of "Override Window Snap)
- [ ] Closes: #32069  
  (although not with Win+Enter)
- [ ] Closes: #21214 
- [ ] Closes: #35397  
  (although not with Ctrl+Win+Up)
- [ ] Closes: #18638 
- [ ] **Communication:** Asked @quyenvsp who mentioned planning to work on this if that is still the case and he said no and that I can go ahead: (see https://github.com/microsoft/PowerToys/issues/31098#issuecomment-3920925126 and https://github.com/microsoft/PowerToys/issues/31098#issuecomment-3920955341 )
- [ ] **Tests:** Tried to update tests but not even main branch tests work on my machine: **help needed!**
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Please tell me if there are any that needs to be Added/updated
- [ ] **New binaries:** ~Added on the required places:~ no new binaries
   - [ ] ~[JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries~
   - [ ] ~[WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder~
   - [ ] ~[YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects~
   - [ ] ~[YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)~
- [ ] **Documentation updated:** Probably still needs to be done … (If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: )

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
In the code to cycle through the zones I added an early exit if cycle is disabled.
In the calling code I added maximizing/minimizing code when snapping was unsuccessful and the snap was called with VK_UP/VK_DOWN.

Something I also tried to implement but had to discard any attempts:
To add an override to temporarily disable "Override Windows Snap" while CTRL is pressed. But if I understand the code correctly that would already work in the unmodified version if Windows Snap would do anything while CTRL is pressed …

**The Unit Tests don't work on my machine! Not even the ones on main branch.**
But I added similar calls to places where I found "MoveWindowAcrossMonitors".
But for this more help is needed.

Screenshot of the Settings Dialog:
<img width="1013" height="259" alt="image" src="https://github.com/user-attachments/assets/0a6342a4-cf6f-4788-b4b1-48f88ff07ea3" />


<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Modifications done because I was personally annoyed by the old behavior. I am using the modified version (minus the settings) productively since a few weeks. I am switching to the version with the settings today.