### PR TITLE
CmdPal: Ensure IconBox uses an initialized scale

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/IconBox.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/IconBox.cs
@@ -18,7 +18,7 @@ public partial class IconBox : ContentControl
 {
     private const double DefaultIconFontSize = 16.0;
 
-    private double _lastScale = 1.0;
+    private double _lastScale;
     private ElementTheme _lastTheme;
     private double _lastFontSize;
 
@@ -262,7 +262,11 @@ public partial class IconBox : ContentControl
                 return;
             }
 
-            var eventArgs = new SourceRequestedEventArgs(sourceKey, iconBox._lastTheme, iconBox._lastScale);
+            var scale = iconBox._lastScale > 0
+                ? iconBox._lastScale
+                : (iconBox.XamlRoot?.RasterizationScale > 0 ? iconBox.XamlRoot.RasterizationScale : 1.0);
+
+            var eventArgs = new SourceRequestedEventArgs(sourceKey, iconBox._lastTheme, scale);
             await iconBoxSourceRequestedHandler.InvokeAsync(iconBox, eventArgs);
 
             // After the await:


### PR DESCRIPTION
## Summary of the Pull Request

This PR makes sure that IconBox is using valid scale to prevent defaulting to 0 and using poorly resizes full-scale image:

<img width="81" height="79" alt="image" src="https://github.com/user-attachments/assets/55bbb08f-6f78-4c19-b7a6-748176dee9c8" />
vs 
<img width="89" height="88" alt="image" src="https://github.com/user-attachments/assets/2dc26863-88c0-4c47-8798-023611d571b5" />


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #45973
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

