### PR TITLE
Zoomit: Fix a issue that after trim, the video can't be saved and we can't start a new recording session

### DIFF
--- a/src/modules/ZoomIt/ZoomIt/Zoomit.cpp
+++ b/src/modules/ZoomIt/ZoomIt/Zoomit.cpp
@@ -5679,6 +5679,16 @@ winrt::fire_and_forget StartRecordingAsync( HWND hWnd, LPRECT rcCrop, HWND hWndR
     // Recording completed (closed via hotkey or item close). Proceed to save/trim workflow.
     OutputDebugStringW(L"[Recording] StartAsync completed, entering save workflow\n");
 
+    // Release the writer stream and session objects before trim/save. Keeping the temp file
+    // open here can cause trimming and later MoveAndReplaceAsync calls to fail on the same file.
+    if (stream)
+    {
+        stream.Close();
+        stream = nullptr;
+    }
+    g_RecordingSession = nullptr;
+    g_GifRecordingSession = nullptr;
+
     // Resume on the UI thread for the save dialog
     co_await uiThread;
     OutputDebugStringW(L"[Recording] Resumed on UI thread\n");


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

The bug was caused by a resource lifetime issue between the recording phase and the save/trim phase. After a recording stopped, StartRecordingAsync moved directly into the save workflow while it was still holding the temporary recording stream and the active recording session objects, later file operations in the save flow could fail against that same file. Once that happened, ZoomIt could end up stuck in a bad state where the first save did not complete cleanly and subsequent recording attempts would no longer start until ZoomIt was restarted.



<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
As title
- [ ] Closes: #46006
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Validated locally recording works fine when trimmed
