### PR TITLE
[KBM] Fixing text replacement bug

### DIFF
--- a/src/modules/keyboardmanager/common/Helpers.cpp
+++ b/src/modules/keyboardmanager/common/Helpers.cpp
@@ -497,47 +497,56 @@ namespace Helpers
         }
     }
 
-    // Function to send text via clipboard paste (Ctrl+V).
-    // Saves the previous clipboard content and restores it asynchronously.
-    bool SendTextViaClipboard(const std::wstring& text)
+    // Inner implementation that may throw C++ exceptions.
+    static bool SendTextViaClipboardImpl(const std::wstring& text)
     {
-        try
-        {
-            // Lazily start the worker on first use.
-            std::call_once(s_workerInitFlag, [] {
-                s_workerThread = std::thread(ClipboardWorkerLoop);
-                std::atexit([] {
-                    {
-                        std::lock_guard<std::mutex> lock(s_queueMutex);
-                        s_shutdown.store(true);
-                    }
-                    s_queueCV.notify_one();
-                    if (s_workerThread.joinable())
-                    {
-                        s_workerThread.join();
-                    }
-                });
-            });
-
-            // Enqueue the text and return immediately so we never block the
-            // low-level keyboard hook (WH_KEYBOARD_LL).
-            {
-                std::lock_guard<std::mutex> lock(s_queueMutex);
-                if (!s_clipboardQueue.empty())
+        // Lazily start the worker on first use.
+        std::call_once(s_workerInitFlag, [] {
+            s_workerThread = std::thread(ClipboardWorkerLoop);
+            std::atexit([] {
                 {
-                    return true;
+                    std::lock_guard<std::mutex> lock(s_queueMutex);
+                    s_shutdown.store(true);
                 }
-                s_clipboardQueue.push(text);
-            }
-            s_queueCV.notify_one();
-        }
-        catch (...)
+                s_queueCV.notify_one();
+                if (s_workerThread.joinable())
+                {
+                    s_workerThread.join();
+                }
+            });
+        });
+
+        // Enqueue the text and return immediately so we never block the
+        // low-level keyboard hook (WH_KEYBOARD_LL).
         {
-            OutputDebugStringA("KBM SendTextViaClipboard exception caught\n");
-            return false;
+            std::lock_guard<std::mutex> lock(s_queueMutex);
+            if (!s_clipboardQueue.empty())
+            {
+                return true;
+            }
+            s_clipboardQueue.push(text);
         }
+        s_queueCV.notify_one();
 
         return true;
+    }
+
+    // Function to send text via clipboard paste (Ctrl+V).
+    // Saves the previous clipboard content and restores it asynchronously.
+    // This function MUST NOT throw — it's called from noexcept hook handlers.
+    // We use __try/__except (SEH) because C++ try/catch may be optimized away
+    // in Release builds when the caller is noexcept.
+    bool SendTextViaClipboard(const std::wstring& text) noexcept
+    {
+        __try
+        {
+            return SendTextViaClipboardImpl(text);
+        }
+        __except (EXCEPTION_EXECUTE_HANDLER)
+        {
+            OutputDebugStringA("KBM SendTextViaClipboard SEH exception caught\n");
+            return false;
+        }
     }
 
     // Function to filter the key codes for artificial key codes

--- a/src/modules/keyboardmanager/common/Helpers.h
+++ b/src/modules/keyboardmanager/common/Helpers.h
@@ -42,7 +42,7 @@ namespace Helpers
     void SetTextKeyEvents(std::vector<INPUT>& keyEventArray, const std::wstring& remapping);
 
     // Function to send text via clipboard paste (Ctrl+V). Saves and restores previous clipboard content.
-    bool SendTextViaClipboard(const std::wstring& text);
+    bool SendTextViaClipboard(const std::wstring& text) noexcept;
 
     // Function to return window handle for a full screen UWP app
     HWND GetFullscreenUWPWindowHandle();


### PR DESCRIPTION
There is a bug now where text replacement is causing the app to crash. Wrapping those blocks in try catch so the worker stays alive.