### PR TITLE
[OOBE] Ensure the Settings button on the SCOOBE page opens Home, not a blank page

### DIFF
--- a/src/settings-ui/Settings.UI/SettingsXAML/ScoobeWindow.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/ScoobeWindow.xaml.cs
@@ -209,7 +209,7 @@ namespace Microsoft.PowerToys.Settings.UI
 
         private void OpenSettingsItem_Tapped(object sender, Microsoft.UI.Xaml.Input.TappedRoutedEventArgs e)
         {
-            App.OpenSettingsWindow();
+            App.OpenSettingsWindow(ensurePageIsSelected: true);
         }
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request
This PR fixes an issue where selecting the **Settings** button on the What's New page for a new or upgraded installation of PowerToys would show the Settings application but with a blank contents page instead of the Home page.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #46202
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
When the current version of PowerToys doesn't match the `last_version_run`, the What's New (SCOOBE) page is displayed. The Settings page is loaded at the same time in a hidden state.

If the user selects the Settings button in the bottom-left of the What's New page, `OpenSettingsItem_Tapped()` is called, which calls:

```csharp
App.OpenSettingsWindow();
```

This unhides the Settings window, but Settings has not navigated to an initial page, resulting in a blank display.

The solution is to instead call:

```csharp
App.OpenSettingsWindow(ensurePageIsSelected: true);
```

## Validation Steps Performed

Manual tests, following the instructions given in the original issue, i.e. setting the `last_version_run` JSON manually and retrying to simulate the upgrade/new install.