### PR TITLE
AI made, no need review yet

### DIFF
--- a/src/common/SettingsAPI/FileWatcher.cpp
+++ b/src/common/SettingsAPI/FileWatcher.cpp
@@ -22,6 +22,7 @@ std::optional<FILETIME> FileWatcher::MyFileTime()
 
 FileWatcher::FileWatcher(const std::wstring& path, std::function<void()> callback) :
     m_path(path),
+    m_lastWrite(MyFileTime()),
     m_callback(callback)
 {
     std::filesystem::path fsPath(path);
@@ -35,14 +36,20 @@ FileWatcher::FileWatcher(const std::wstring& path, std::function<void()> callbac
             std::wstring lowerFileName(fileName);
             std::transform(lowerFileName.begin(), lowerFileName.end(), lowerFileName.begin(), ::towlower);
 
-            if (m_file_name.compare(fileName) == 0)
+            if (m_file_name.compare(lowerFileName) == 0)
             {
                 auto lastWrite = MyFileTime();
-                if (!m_lastWrite.has_value())
+
+                if (!lastWrite.has_value())
+                {
+                    m_lastWrite.reset();
+                }
+                else if (!m_lastWrite.has_value())
                 {
                     m_lastWrite = lastWrite;
+                    m_callback();
                 }
-                else if (lastWrite.has_value())
+                else
                 {
                     if (m_lastWrite->dwHighDateTime != lastWrite->dwHighDateTime ||
                         m_lastWrite->dwLowDateTime != lastWrite->dwLowDateTime)

--- a/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.cpp
+++ b/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.cpp
@@ -23,6 +23,8 @@ namespace NonLocalizable
     const static wchar_t* WINDOW_IS_PINNED_PROP = L"AlwaysOnTop_Pinned";
     constexpr UINT SYSTEM_MENU_TOGGLE_ALWAYS_ON_TOP_COMMAND = 0xEFE0;
     constexpr ULONG_PTR SYSTEM_MENU_TOGGLE_ALWAYS_ON_TOP_COMMAND_OWNER_TAG = 0x414F5450;
+    constexpr DWORD SYSTEM_EVENT_MENU_START = EVENT_SYSTEM_MENUSTART;
+    constexpr DWORD SYSTEM_EVENT_MENU_END = EVENT_SYSTEM_MENUEND;
     constexpr DWORD SYSTEM_EVENT_MENU_POPUP_START = 0x0006;
     constexpr DWORD SYSTEM_EVENT_MENU_POPUP_END = 0x0007;
 }
@@ -63,6 +65,30 @@ namespace
                                 FALSE,
                                 &menuItemInfo) &&
                menuItemInfo.dwItemData == NonLocalizable::SYSTEM_MENU_TOGGLE_ALWAYS_ON_TOP_COMMAND_OWNER_TAG;
+    }
+
+    constexpr bool IsMenuEventObject(LONG objectId) noexcept
+    {
+        return objectId == OBJID_MENU || objectId == OBJID_SYSMENU || objectId == OBJID_WINDOW;
+    }
+
+    HWND ResolveSystemMenuWindow(HWND eventWindow) noexcept
+    {
+        const auto tryResolveWindow = [](HWND candidate) noexcept -> HWND {
+            if (!candidate || !IsWindow(candidate))
+            {
+                return nullptr;
+            }
+
+            return GetSystemMenu(candidate, false) ? candidate : nullptr;
+        };
+
+        if (HWND resolvedWindow = tryResolveWindow(eventWindow))
+        {
+            return resolvedWindow;
+        }
+
+        return tryResolveWindow(GetForegroundWindow());
     }
 }
 
@@ -147,6 +173,8 @@ bool AlwaysOnTop::InitMainWindow()
 
 void AlwaysOnTop::SettingsUpdate(SettingId id)
 {
+    Logger::debug(L"Applying Always On Top setting update: {}", SettingIdToString(id));
+
     switch (id)
     {
     case SettingId::Hotkey:
@@ -230,6 +258,7 @@ LRESULT AlwaysOnTop::WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lp
     }
     else if (message == WM_PRIV_SETTINGS_CHANGED)
     {
+        Logger::debug(L"Always On Top received settings reload message.");
         AlwaysOnTopSettings::instance().LoadSettings();
     }
     
@@ -482,7 +511,9 @@ void AlwaysOnTop::SubscribeToEvents()
 
 void AlwaysOnTop::UpdateSystemMenuEventHooks(bool enable)
 {
-    constexpr std::array<DWORD, 3> menu_events_to_subscribe = {
+    constexpr std::array<DWORD, 5> menu_events_to_subscribe = {
+        NonLocalizable::SYSTEM_EVENT_MENU_START,
+        NonLocalizable::SYSTEM_EVENT_MENU_END,
         NonLocalizable::SYSTEM_EVENT_MENU_POPUP_START,
         NonLocalizable::SYSTEM_EVENT_MENU_POPUP_END,
         EVENT_OBJECT_INVOKED,
@@ -492,6 +523,7 @@ void AlwaysOnTop::UpdateSystemMenuEventHooks(bool enable)
     {
         if (m_systemMenuWinEventHooks.size() == menu_events_to_subscribe.size())
         {
+            Logger::debug(L"Always On Top system menu hooks already enabled.");
             return;
         }
 
@@ -510,10 +542,13 @@ void AlwaysOnTop::UpdateSystemMenuEventHooks(bool enable)
                 Logger::error(L"Failed to set system menu win event hook");
             }
         }
+
+        Logger::debug(L"Always On Top system menu hooks enabled. Registered {} hooks.", m_systemMenuWinEventHooks.size());
     }
     else
     {
         UnsubscribeEvents(m_systemMenuWinEventHooks);
+        Logger::debug(L"Always On Top system menu hooks disabled.");
     }
 }
 
@@ -527,6 +562,7 @@ void AlwaysOnTop::UpdateSystemMenuItem(HWND window) const noexcept
     const auto systemMenu = GetSystemMenu(window, false);
     if (!systemMenu)
     {
+        Logger::debug(L"Skipping Always On Top system menu update because the window has no system menu.");
         return;
     }
 
@@ -536,6 +572,7 @@ void AlwaysOnTop::UpdateSystemMenuItem(HWND window) const noexcept
         if (IsAlwaysOnTopMenuCommand(systemMenu))
         {
             RemoveMenu(systemMenu, NonLocalizable::SYSTEM_MENU_TOGGLE_ALWAYS_ON_TOP_COMMAND, MF_BYCOMMAND);
+            Logger::debug(L"Removed Always On Top entry from the system menu.");
         }
         return;
     }
@@ -552,11 +589,13 @@ void AlwaysOnTop::UpdateSystemMenuItem(HWND window) const noexcept
     if (!HasMenuCommand(systemMenu, NonLocalizable::SYSTEM_MENU_TOGGLE_ALWAYS_ON_TOP_COMMAND))
     {
         InsertMenuItemW(systemMenu, SC_CLOSE, FALSE, &menuItemInfo);
+        Logger::debug(L"Inserted Always On Top entry into the system menu. Pinned={}", IsPinned(window));
     }
     else if (IsAlwaysOnTopMenuCommand(systemMenu))
     {
         menuItemInfo.fMask = MIIM_STATE | MIIM_STRING;
         SetMenuItemInfoW(systemMenu, NonLocalizable::SYSTEM_MENU_TOGGLE_ALWAYS_ON_TOP_COMMAND, FALSE, &menuItemInfo);
+        Logger::debug(L"Updated Always On Top entry in the system menu. Pinned={}", IsPinned(window));
     }
     else
     {
@@ -646,19 +685,26 @@ void AlwaysOnTop::HandleWinHookEvent(WinHookEvent* data) noexcept
 {
     switch (data->event)
     {
+    case NonLocalizable::SYSTEM_EVENT_MENU_START:
     case NonLocalizable::SYSTEM_EVENT_MENU_POPUP_START:
     {
-        if (data->idObject == OBJID_SYSMENU && data->hwnd)
+        if (IsMenuEventObject(data->idObject))
         {
-            m_lastSystemMenuWindow = AlwaysOnTopSettings::settings()->showInSystemMenu ? data->hwnd : nullptr;
-            UpdateSystemMenuItem(data->hwnd);
+            if (HWND targetWindow = ResolveSystemMenuWindow(data->hwnd))
+            {
+                m_lastSystemMenuWindow = AlwaysOnTopSettings::settings()->showInSystemMenu ? targetWindow : nullptr;
+                Logger::debug(L"Always On Top menu start event received. EventObject={}, TargetWindow={:p}", data->idObject, static_cast<void*>(targetWindow));
+                UpdateSystemMenuItem(targetWindow);
+            }
         }
     }
     return;
+    case NonLocalizable::SYSTEM_EVENT_MENU_END:
     case NonLocalizable::SYSTEM_EVENT_MENU_POPUP_END:
     {
-        if (data->idObject == OBJID_SYSMENU && data->hwnd == m_lastSystemMenuWindow)
+        if (IsMenuEventObject(data->idObject))
         {
+            Logger::debug(L"Always On Top menu end event received. Clearing tracked menu window.");
             m_lastSystemMenuWindow = nullptr;
         }
     }

--- a/src/modules/alwaysontop/AlwaysOnTop/Settings.cpp
+++ b/src/modules/alwaysontop/AlwaysOnTop/Settings.cpp
@@ -68,6 +68,7 @@ void AlwaysOnTopSettings::InitFileWatcher()
 {
     const std::wstring& settingsFileName = GetSettingsFileName();
     m_settingsFileWatcher = std::make_unique<FileWatcher>(settingsFileName, [&]() {
+        Logger::debug(L"Always On Top settings file changed. Scheduling reload.");
         PostMessageW(HWND_BROADCAST, WM_PRIV_SETTINGS_CHANGED, NULL, NULL);
     });
 }
@@ -230,6 +231,7 @@ void AlwaysOnTopSettings::LoadSettings()
             m_settings.store(std::shared_ptr<const Settings>(updatedSettings), std::memory_order_release);
             for (const auto changedSetting : changedSettings)
             {
+                Logger::debug(L"Always On Top setting changed: {}", SettingIdToString(changedSetting));
                 NotifyObservers(changedSetting);
             }
         }

--- a/src/modules/alwaysontop/AlwaysOnTop/SettingsConstants.h
+++ b/src/modules/alwaysontop/AlwaysOnTop/SettingsConstants.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string_view>
+
 enum class SettingId
 {
     Hotkey = 0,
@@ -14,3 +16,34 @@ enum class SettingId
     FrameAccentColor,
     RoundCornersEnabled
 };
+
+inline constexpr std::wstring_view SettingIdToString(SettingId id) noexcept
+{
+    switch (id)
+    {
+    case SettingId::Hotkey:
+        return L"Hotkey";
+    case SettingId::SoundEnabled:
+        return L"SoundEnabled";
+    case SettingId::ShowInSystemMenu:
+        return L"ShowInSystemMenu";
+    case SettingId::FrameEnabled:
+        return L"FrameEnabled";
+    case SettingId::FrameThickness:
+        return L"FrameThickness";
+    case SettingId::FrameColor:
+        return L"FrameColor";
+    case SettingId::FrameOpacity:
+        return L"FrameOpacity";
+    case SettingId::BlockInGameMode:
+        return L"BlockInGameMode";
+    case SettingId::ExcludeApps:
+        return L"ExcludeApps";
+    case SettingId::FrameAccentColor:
+        return L"FrameAccentColor";
+    case SettingId::RoundCornersEnabled:
+        return L"RoundCornersEnabled";
+    default:
+        return L"Unknown";
+    }
+}

--- a/src/modules/alwaysontop/AlwaysOnTop/WindowBorder.cpp
+++ b/src/modules/alwaysontop/AlwaysOnTop/WindowBorder.cpp
@@ -280,6 +280,8 @@ void WindowBorder::SettingsUpdate(SettingId id)
         return;
     }
 
+    Logger::debug(L"Refreshing Always On Top border after setting update: {}", SettingIdToString(id));
+
     switch (id)
     {
     case SettingId::FrameThickness:


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
AI MADE IT, NOT TESTED YET

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] Closes: #xxx
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
• This PR fixes two Always On Top runtime issues around
  settings and the title-bar context menu.

First, it fixes a settings propagation bug where the first settings.json change after startup could be missed, so toggling an Always On Top setting did not always take effect immediately. The shared file watcher now establishes an initial timestamp baseline and correctly triggers on the first real write.

Second, it fixes the title-bar context-menu injection path for newly opened windows. The previous implementation depended on a narrow set of accessibility menu events, so some windows would not get the “Always On Top” menu entry until the shortcut was used once. The PR broadens the accepted menu event types, listens to both menu start and popup start/end events, resolves the correct top-level target window, and updates that window’s system menu reliably.

It also adds debug logging along the settings reload and system-menu update path so future reports can be traced
  end to end.
<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

