### PR TITLE
Fix Calculator plugin: numpad decimal key ignored in non-English locales

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/Main.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator/Main.cs
@@ -101,8 +101,20 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator
                 return new List<Result>();
             }
 
+            // Fix: The numpad decimal key always sends '.' regardless of system locale.
+            // When the input culture uses ',' as decimal separator (e.g. es-AR, de-DE, it-IT),
+            // replace '.' with ',' so the expression is parsed correctly.
+            // This matches the behavior of Excel and Windows Calculator.
+            var rawSearch = query.Search;
+            if (!_inputUseEnglishFormat
+                && inputCulture.NumberFormat.NumberDecimalSeparator == ","
+                && rawSearch.Contains('.'))
+            {
+                rawSearch = rawSearch.Replace('.', ',');
+            }
+
             NumberTranslator translator = NumberTranslator.Create(inputCulture, new CultureInfo("en-US"));
-            var input = translator.Translate(query.Search.Normalize(NormalizationForm.FormKC));
+            var input = translator.Translate(rawSearch.Normalize(NormalizationForm.FormKC));
 
             if (replaceInput)
             {


### PR DESCRIPTION
## Summary

- The numpad decimal key always sends `.` regardless of system locale. In cultures that use `,` as decimal separator (es-AR, de-DE, it-IT, fr-FR, pt-BR, etc.), this `.` was being interpreted as a group separator or ignored entirely, producing wrong results (e.g. `25.3*2.2 = 5566` instead of `55.66`).
- This fix replaces `.` with the locale's decimal separator before passing the input to `NumberTranslator`, matching the behavior of Excel and the Windows Calculator app.
- The fix only applies when the user has **not** enabled "Input use English format" and the current culture uses `,` as decimal separator.

Fixes #40879

## Test plan

- [ ] Set system locale to a culture that uses `,` as decimal separator (e.g. es-AR, de-DE, it-IT)
- [ ] Ensure "Input use English format" is **disabled** in PowerToys Run Calculator settings
- [ ] Open PowerToys Run and type `25.3*2.2` using the **numpad** decimal key
- [ ] Verify result is `55,66` (not `5566`)
- [ ] Type `3.14*2` using the numpad decimal key → verify result is `6,28`
- [ ] Switch to a locale that uses `.` as decimal separator (e.g. en-US) and verify normal behavior is unaffected
- [ ] Enable "Input use English format" and verify `.` is accepted as-is regardless of locale