### PR TITLE
Awake: Add "Keep awake when lid closed" option.

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -750,6 +750,7 @@ LEVELID
 LExit
 lhwnd
 LIBID
+LIDCLOSE
 LIMITSIZE
 LIMITTEXT
 lindex
@@ -1160,6 +1161,8 @@ POWERRENAMETEST
 POWERTOYNAME
 powertoyssetup
 powertoysusersetup
+Powr
+powrprof
 Powrprof
 ppenum
 ppidl

--- a/src/modules/awake/Awake/Core/LidOverrideManager.cs
+++ b/src/modules/awake/Awake/Core/LidOverrideManager.cs
@@ -1,0 +1,408 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using Awake.Core.Models;
+using Awake.Core.Native;
+using ManagedCommon;
+
+namespace Awake.Core
+{
+    /// <summary>
+    /// Manager for handling lid close action override to prevent sleep when laptop lid is closed.
+    /// </summary>
+    internal static class LidOverrideManager
+    {
+        // Crash-recovery state has different lifecycle requirements than user settings:
+        // it must survive abnormal termination and is deleted on successful restore.
+        // Using a direct path rather than SettingsUtils for this reason.
+        // NOTE: Not managed by SettingsUtils — must be explicitly cleaned up on module uninstall.
+        private static readonly string StateFilePath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "Microsoft",
+            "PowerToys",
+            "Awake",
+            "LidOverrideState.json");
+
+        private static readonly object _lock = new();
+        private static LidOverrideState? _currentState;
+        private static bool _isInitialized;
+        private static bool _lidPresent;
+
+        // Mutable copies of the constant GUIDs — required because P/Invoke takes ref Guid.
+        private static Guid _subGroupGuid = Native.Constants.GUID_SYSTEM_BUTTON_SUBGROUP;
+        private static Guid _lidCloseGuid = Native.Constants.GUID_LIDCLOSE_ACTION;
+
+        /// <summary>
+        /// Gets a value indicating whether the lid override is currently active.
+        /// </summary>
+        internal static bool IsOverrideActive
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _currentState?.IsOverrideActive ?? false;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Initializes the lid override manager. Checks for and recovers from previous crashes.
+        /// </summary>
+        /// <param name="lidPresent">Whether a lid is present on the device.</param>
+        internal static void Initialize(bool lidPresent)
+        {
+            lock (_lock)
+            {
+                if (_isInitialized)
+                {
+                    return;
+                }
+
+                _isInitialized = true;
+                _lidPresent = lidPresent;
+
+                if (!lidPresent)
+                {
+                    Logger.LogInfo("Lid not present on device. LidOverrideManager will be inactive.");
+                    return;
+                }
+
+                try
+                {
+                    // Check for orphaned state from previous crash
+                    if (File.Exists(StateFilePath))
+                    {
+                        Logger.LogInfo("Found existing lid override state file. Checking for crash recovery...");
+                        string json = File.ReadAllText(StateFilePath);
+                        var savedState = JsonSerializer.Deserialize<LidOverrideState>(json);
+
+                        // Validate the deserialized state.
+                        // Valid lid close actions: 0=DoNothing, 1=Sleep, 2=Hibernate, 3=Shutdown.
+                        // Bounds check also serves as defense against tampered state files.
+                        if (savedState?.IsOverrideActive == true &&
+                            savedState.SchemeGuid != Guid.Empty &&
+                            savedState.OriginalAcValue <= 3 &&
+                            savedState.OriginalDcValue <= 3)
+                        {
+                            Logger.LogInfo("Detected orphaned lid override from previous session. Restoring original settings...");
+                            _currentState = savedState;
+                            RestoreLidSettingsInternal();
+                        }
+                        else
+                        {
+                            // Invalid or inactive state file, clean it up
+                            TryDeleteStateFile();
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogError($"Error during LidOverrideManager initialization: {ex.Message}");
+
+                    // Clean up potentially corrupt state file
+                    TryDeleteStateFile();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Applies the lid override to prevent sleep when the lid is closed.
+        /// </summary>
+        /// <returns>True if successful, false otherwise.</returns>
+        internal static bool ApplyLidOverride()
+        {
+            lock (_lock)
+            {
+                return ApplyLidOverrideInternal();
+            }
+        }
+
+        /// <summary>
+        /// Re-applies the lid override after a power event (e.g., resume from suspend).
+        /// Only re-writes the "Do nothing" values; does not update saved original values.
+        /// </summary>
+        internal static void ReapplyLidOverride()
+        {
+            lock (_lock)
+            {
+                if (_currentState == null || !_currentState.IsOverrideActive)
+                {
+                    return;
+                }
+
+                try
+                {
+                    if (!TryGetActiveSchemeGuid(out Guid schemeGuid))
+                    {
+                        return;
+                    }
+
+                    WriteLidCloseAction(ref schemeGuid, Native.Constants.LID_ACTION_DO_NOTHING, Native.Constants.LID_ACTION_DO_NOTHING);
+
+                    Logger.LogInfo("Lid override reapplied after power event.");
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogError($"Failed to reapply lid override: {ex.Message}");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Restores the original lid close settings.
+        /// </summary>
+        /// <returns>True if successful, false otherwise.</returns>
+        internal static bool RestoreLidSettings()
+        {
+            lock (_lock)
+            {
+                return RestoreLidSettingsInternal();
+            }
+        }
+
+        /// <summary>
+        /// Retrieves the active power scheme GUID via the Win32 API.
+        /// Handles allocation, marshaling, and cleanup of the native pointer.
+        /// </summary>
+        private static bool TryGetActiveSchemeGuid(out Guid schemeGuid)
+        {
+            schemeGuid = Guid.Empty;
+
+            uint result = Bridge.PowerGetActiveScheme(IntPtr.Zero, out IntPtr activePolicyGuid);
+            if (result != Native.Constants.ERROR_SUCCESS)
+            {
+                if (activePolicyGuid != IntPtr.Zero)
+                {
+                    Bridge.LocalFree(activePolicyGuid);
+                }
+
+                Logger.LogError($"Failed to get active power scheme. Error code: {result}");
+                return false;
+            }
+
+            if (activePolicyGuid == IntPtr.Zero)
+            {
+                Logger.LogError("PowerGetActiveScheme succeeded but returned null pointer.");
+                return false;
+            }
+
+            schemeGuid = Marshal.PtrToStructure<Guid>(activePolicyGuid);
+            Bridge.LocalFree(activePolicyGuid);
+            return true;
+        }
+
+        /// <summary>
+        /// Writes AC and DC lid close action values and activates the power scheme.
+        /// Logs errors but does not throw. Returns true only if all three writes succeed.
+        /// </summary>
+        private static bool WriteLidCloseAction(ref Guid schemeGuid, uint acValue, uint dcValue)
+        {
+            bool allSucceeded = true;
+
+            uint result = Bridge.PowerWriteACValueIndex(
+                IntPtr.Zero, ref schemeGuid, ref _subGroupGuid, ref _lidCloseGuid, acValue);
+            if (result != Native.Constants.ERROR_SUCCESS)
+            {
+                Logger.LogError($"Failed to write AC lid close value. Error code: {result}");
+                allSucceeded = false;
+            }
+
+            result = Bridge.PowerWriteDCValueIndex(
+                IntPtr.Zero, ref schemeGuid, ref _subGroupGuid, ref _lidCloseGuid, dcValue);
+            if (result != Native.Constants.ERROR_SUCCESS)
+            {
+                Logger.LogError($"Failed to write DC lid close value. Error code: {result}");
+                allSucceeded = false;
+            }
+
+            result = Bridge.PowerSetActiveScheme(IntPtr.Zero, ref schemeGuid);
+            if (result != Native.Constants.ERROR_SUCCESS)
+            {
+                Logger.LogError($"Failed to apply power scheme changes. Error code: {result}");
+                allSucceeded = false;
+            }
+
+            return allSucceeded;
+        }
+
+        private static bool ApplyLidOverrideInternal()
+        {
+            if (!_isInitialized || !_lidPresent)
+            {
+                Logger.LogInfo("LidOverrideManager not initialized or no lid present. Skipping apply.");
+                return false;
+            }
+
+            try
+            {
+                if (!TryGetActiveSchemeGuid(out Guid schemeGuid))
+                {
+                    return false;
+                }
+
+                // Read current AC and DC values
+                uint result = Bridge.PowerReadACValueIndex(
+                    IntPtr.Zero,
+                    ref schemeGuid,
+                    ref _subGroupGuid,
+                    ref _lidCloseGuid,
+                    out uint originalAcValue);
+
+                if (result != Native.Constants.ERROR_SUCCESS)
+                {
+                    Logger.LogError($"Failed to read AC lid close value. Error code: {result}");
+                    return false;
+                }
+
+                result = Bridge.PowerReadDCValueIndex(
+                    IntPtr.Zero,
+                    ref schemeGuid,
+                    ref _subGroupGuid,
+                    ref _lidCloseGuid,
+                    out uint originalDcValue);
+
+                if (result != Native.Constants.ERROR_SUCCESS)
+                {
+                    Logger.LogError($"Failed to read DC lid close value. Error code: {result}");
+                    return false;
+                }
+
+                // Set lid close action to "Do nothing" for both AC and DC
+                if (!WriteLidCloseAction(ref schemeGuid, Native.Constants.LID_ACTION_DO_NOTHING, Native.Constants.LID_ACTION_DO_NOTHING))
+                {
+                    // Rollback: restore original values on failure
+                    if (!WriteLidCloseAction(ref schemeGuid, originalAcValue, originalDcValue))
+                    {
+                        Logger.LogError("Rollback of lid override also failed. Power plan lid settings may be inconsistent.");
+                    }
+
+                    return false;
+                }
+
+                // Only save state AFTER all writes succeed
+                _currentState = new LidOverrideState
+                {
+                    IsOverrideActive = true,
+                    OriginalAcValue = originalAcValue,
+                    OriginalDcValue = originalDcValue,
+                    SchemeGuid = schemeGuid,
+                };
+
+                SaveState();
+
+                Logger.LogInfo($"Lid override applied successfully. Original AC: {originalAcValue}, DC: {originalDcValue}");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError($"Exception applying lid override: {ex.Message}");
+                return false;
+            }
+        }
+
+        private static bool RestoreLidSettingsInternal()
+        {
+            if (_currentState == null || !_currentState.IsOverrideActive)
+            {
+                Logger.LogInfo("No active lid override to restore.");
+                TryDeleteStateFile();
+                return true;
+            }
+
+            try
+            {
+                Guid savedSchemeGuid = _currentState.SchemeGuid;
+                if (savedSchemeGuid == Guid.Empty)
+                {
+                    Logger.LogError("Empty scheme GUID in state.");
+                    TryDeleteStateFile();
+                    _currentState = null;
+                    return false;
+                }
+
+                // Determine which scheme to restore to. If the user changed their power plan
+                // while the override was active, restore to the currently active scheme instead
+                // of the saved one, since the saved scheme may no longer be active.
+                Guid schemeGuid = savedSchemeGuid;
+                if (TryGetActiveSchemeGuid(out Guid activeSchemeGuid))
+                {
+                    if (activeSchemeGuid != savedSchemeGuid)
+                    {
+                        Logger.LogInfo($"Active power scheme ({activeSchemeGuid}) differs from saved scheme ({savedSchemeGuid}). Restoring to active scheme.");
+                        schemeGuid = activeSchemeGuid;
+                    }
+                }
+                else
+                {
+                    Logger.LogError("Failed to get active power scheme during restore. Falling back to saved scheme.");
+                }
+
+                bool allSucceeded = WriteLidCloseAction(ref schemeGuid, _currentState.OriginalAcValue, _currentState.OriginalDcValue);
+
+
+                if (allSucceeded)
+                {
+                    Logger.LogInfo($"Lid settings restored. AC: {_currentState.OriginalAcValue}, DC: {_currentState.OriginalDcValue}");
+                    _currentState = null;
+                    TryDeleteStateFile();
+                }
+                else
+                {
+                    Logger.LogError("Partial failure restoring lid settings. State file preserved for retry on next launch.");
+
+                    // Mark override as inactive but preserve original values for potential
+                    // in-session retry. Setting _currentState = null would cause the next
+                    // ApplyLidOverride to read partially-restored values as "originals."
+                    _currentState.IsOverrideActive = false;
+                }
+
+                return allSucceeded;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError($"Exception restoring lid settings: {ex.Message}. State file preserved for retry on next launch.");
+                return false;
+            }
+        }
+
+        private static void SaveState()
+        {
+            try
+            {
+                string? directory = Path.GetDirectoryName(StateFilePath);
+                if (!string.IsNullOrEmpty(directory))
+                {
+                    Directory.CreateDirectory(directory);
+                }
+
+                string tempPath = StateFilePath + ".tmp";
+                string json = JsonSerializer.Serialize(_currentState);
+                File.WriteAllText(tempPath, json);
+                File.Move(tempPath, StateFilePath, overwrite: true);
+                Logger.LogInfo("Lid override state saved.");
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError($"Failed to save lid override state: {ex.Message}");
+            }
+        }
+
+        private static void TryDeleteStateFile()
+        {
+            try
+            {
+                File.Delete(StateFilePath);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError($"Failed to delete lid override state file: {ex.Message}");
+            }
+        }
+    }
+}

--- a/src/modules/awake/Awake/Core/Manager.cs
+++ b/src/modules/awake/Awake/Core/Manager.cs
@@ -157,6 +157,10 @@ namespace Awake.Core
 
             Logger.LogInfo($"Power event received. Reapplying awake state for mode: {CurrentOperatingMode}");
             _stateQueue.Add(ComputeAwakeState(IsDisplayOn));
+
+            // Re-apply lid override if active, in case Windows reset power plan settings.
+            // ReapplyLidOverride has its own internal early-out check.
+            LidOverrideManager.ReapplyLidOverride();
         }
 
         internal static void CancelExistingThread()
@@ -391,6 +395,11 @@ namespace Awake.Core
             Logger.LogInfo($"Completed {timerType} keep-awake.");
             CancelExistingThread();
 
+            // Restore lid settings directly rather than relying on the FileSystemWatcher
+            // round-trip through ProcessSettings, which is non-deterministic.
+            // RestoreLidSettings is a no-op when no override is active.
+            LidOverrideManager.RestoreLidSettings();
+
             if (IsUsingPowerToysConfig)
             {
                 // If running under PowerToys settings, just revert to the default Passive state.
@@ -411,6 +420,10 @@ namespace Awake.Core
         internal static void CompleteExit(int exitCode)
         {
             SetPassiveKeepAwake(updateSettings: false);
+
+            // Safe to call unconditionally: RestoreLidSettings is a no-op when _currentState is null
+            // (which is the case when Initialize was called with lidPresent=false or no override was applied).
+            LidOverrideManager.RestoreLidSettings();
 
             // Stop the monitor thread gracefully
             StopMonitor();
@@ -519,6 +532,99 @@ namespace Awake.Core
             CurrentOperatingMode = AwakeMode.PASSIVE;
 
             SetModeShellIcon();
+        }
+
+        /// <summary>
+        /// Sets the lid override setting.
+        /// </summary>
+        internal static void SetLidOverride([CallerMemberName] string callerName = "")
+        {
+            Logger.LogInfo($"Setting lid override configuration from settings. Invoked by {callerName}.");
+            if (IsUsingPowerToysConfig)
+            {
+                try
+                {
+                    AwakeSettings currentSettings = ModuleSettings!.GetSettings<AwakeSettings>(Constants.AppName) ?? new AwakeSettings();
+                    currentSettings.Properties.KeepAwakeOnLidClose = !currentSettings.Properties.KeepAwakeOnLidClose;
+
+                    // For TIMED mode: apply lid override directly without restarting the timer.
+                    // Saving settings triggers ProcessSettings via FileSystemWatcher, which would
+                    // call SetTimedKeepAwake and reset the countdown. Mirror the SetDisplay pattern.
+                    // Safe to use CurrentOperatingMode here: SetLidOverride is only called from
+                    // the tray WndProc (single-threaded), so no FileSystemWatcher reentrancy concern.
+                    if (CurrentOperatingMode == AwakeMode.TIMED && TimeRemaining > 0)
+                    {
+                        if (!ApplyLidOverrideIfNeeded(CurrentOperatingMode, currentSettings.Properties.KeepAwakeOnLidClose))
+                        {
+                            Logger.LogError("Lid override failed in TIMED mode. Setting not saved.");
+                            return;
+                        }
+
+                        ModuleSettings!.SaveSettings(JsonSerializer.Serialize(currentSettings), Constants.AppName);
+                        return;
+                    }
+
+                    ModuleSettings!.SaveSettings(JsonSerializer.Serialize(currentSettings), Constants.AppName);
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogError($"Failed to handle lid override setting command: {ex.Message}");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Applies or removes lid override based on the given mode and settings.
+        /// </summary>
+        /// <param name="mode">The awake mode to evaluate against. Passed explicitly to avoid
+        /// reading stale <see cref="CurrentOperatingMode"/> during FileSystemWatcher reentrancy.</param>
+        /// <param name="keepAwakeOnLidClose">Whether to keep awake when lid is closed.</param>
+        /// <returns>True if the operation succeeded, false if a power API call failed.</returns>
+        internal static bool ApplyLidOverrideIfNeeded(AwakeMode mode, bool keepAwakeOnLidClose)
+        {
+            if (mode == AwakeMode.PASSIVE)
+            {
+                // In passive mode, always restore original lid settings
+                if (LidOverrideManager.IsOverrideActive)
+                {
+                    Logger.LogInfo("Restoring lid settings due to passive mode.");
+                    if (!LidOverrideManager.RestoreLidSettings())
+                    {
+                        Logger.LogError("Failed to restore lid settings during passive transition.");
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            // In active modes (INDEFINITE, TIMED, EXPIRABLE)
+            if (keepAwakeOnLidClose)
+            {
+                if (!LidOverrideManager.IsOverrideActive)
+                {
+                    Logger.LogInfo("Applying lid override for active mode.");
+                    if (!LidOverrideManager.ApplyLidOverride())
+                    {
+                        Logger.LogError("Failed to apply lid override.");
+                        return false;
+                    }
+                }
+            }
+            else
+            {
+                if (LidOverrideManager.IsOverrideActive)
+                {
+                    Logger.LogInfo("Removing lid override (setting disabled).");
+                    if (!LidOverrideManager.RestoreLidSettings())
+                    {
+                        Logger.LogError("Failed to remove lid override.");
+                        return false;
+                    }
+                }
+            }
+
+            return true;
         }
 
         /// <summary>

--- a/src/modules/awake/Awake/Core/Models/LidOverrideState.cs
+++ b/src/modules/awake/Awake/Core/Models/LidOverrideState.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Text.Json.Serialization;
+
+namespace Awake.Core.Models
+{
+    /// <summary>
+    /// Model for tracking the original lid settings and override state.
+    /// Used for crash recovery to restore original settings if Awake exits unexpectedly.
+    /// </summary>
+    internal sealed class LidOverrideState
+    {
+        [JsonPropertyName("isOverrideActive")]
+        public bool IsOverrideActive { get; set; }
+
+        [JsonPropertyName("originalAcValue")]
+        public uint OriginalAcValue { get; set; }
+
+        [JsonPropertyName("originalDcValue")]
+        public uint OriginalDcValue { get; set; }
+
+        [JsonPropertyName("schemeGuid")]
+        public Guid SchemeGuid { get; set; }
+    }
+}

--- a/src/modules/awake/Awake/Core/Models/TrayCommands.cs
+++ b/src/modules/awake/Awake/Core/Models/TrayCommands.cs
@@ -10,6 +10,7 @@ namespace Awake.Core.Models
         TC_MODE_PASSIVE = Native.Constants.WM_USER + 0x3,
         TC_MODE_INDEFINITE = Native.Constants.WM_USER + 0x4,
         TC_MODE_EXPIRABLE = Native.Constants.WM_USER + 0x5,
+        TC_LID_SETTING = Native.Constants.WM_USER + 0x6,
         TC_EXIT = Native.Constants.WM_USER + 0x64,
         TC_TIME = Native.Constants.WM_USER + 0x65,
     }

--- a/src/modules/awake/Awake/Core/Native/Bridge.cs
+++ b/src/modules/awake/Awake/Core/Native/Bridge.cs
@@ -113,5 +113,46 @@ namespace Awake.Core.Native
 
         [DllImport("user32.dll", CharSet = CharSet.Unicode)]
         internal static extern int RegisterWindowMessage(string lpString);
+
+        [DllImport("powrprof.dll", SetLastError = true)]
+        internal static extern uint PowerGetActiveScheme(IntPtr userRootPowerKey, out IntPtr activePolicyGuid);
+
+        [DllImport("powrprof.dll", SetLastError = true)]
+        internal static extern uint PowerReadACValueIndex(
+            IntPtr rootPowerKey,
+            ref Guid schemeGuid,
+            ref Guid subGroupOfPowerSettingsGuid,
+            ref Guid powerSettingGuid,
+            out uint acValueIndex);
+
+        [DllImport("powrprof.dll", SetLastError = true)]
+        internal static extern uint PowerReadDCValueIndex(
+            IntPtr rootPowerKey,
+            ref Guid schemeGuid,
+            ref Guid subGroupOfPowerSettingsGuid,
+            ref Guid powerSettingGuid,
+            out uint dcValueIndex);
+
+        [DllImport("powrprof.dll", SetLastError = true)]
+        internal static extern uint PowerWriteACValueIndex(
+            IntPtr rootPowerKey,
+            ref Guid schemeGuid,
+            ref Guid subGroupOfPowerSettingsGuid,
+            ref Guid powerSettingGuid,
+            uint acValueIndex);
+
+        [DllImport("powrprof.dll", SetLastError = true)]
+        internal static extern uint PowerWriteDCValueIndex(
+            IntPtr rootPowerKey,
+            ref Guid schemeGuid,
+            ref Guid subGroupOfPowerSettingsGuid,
+            ref Guid powerSettingGuid,
+            uint dcValueIndex);
+
+        [DllImport("powrprof.dll", SetLastError = true)]
+        internal static extern uint PowerSetActiveScheme(IntPtr userRootPowerKey, ref Guid schemeGuid);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        internal static extern IntPtr LocalFree(IntPtr hMem);
     }
 }

--- a/src/modules/awake/Awake/Core/Native/Constants.cs
+++ b/src/modules/awake/Awake/Core/Native/Constants.cs
@@ -2,6 +2,8 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+
 namespace Awake.Core.Native
 {
     [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1310:Field names should not contain underscore", Justification = "Win32 API convention.")]
@@ -58,5 +60,18 @@ namespace Awake.Core.Native
 
         // Attach Console
         internal const int ATTACH_PARENT_PROCESS = -1;
+
+        // Power Settings GUIDs for lid close action
+        // GUID_LIDCLOSE_ACTION: {5CA83367-6E45-459F-A27B-476B1D01C936}
+        internal static readonly Guid GUID_LIDCLOSE_ACTION = new("5CA83367-6E45-459F-A27B-476B1D01C936");
+
+        // GUID_SYSTEM_BUTTON_SUBGROUP: {4F971E89-EEBD-4455-A8DE-9E59040E7347}
+        internal static readonly Guid GUID_SYSTEM_BUTTON_SUBGROUP = new("4F971E89-EEBD-4455-A8DE-9E59040E7347");
+
+        // Lid close action value
+        internal const uint LID_ACTION_DO_NOTHING = 0;
+
+        // Power API error code
+        internal const uint ERROR_SUCCESS = 0;
     }
 }

--- a/src/modules/awake/Awake/Core/TrayHelper.cs
+++ b/src/modules/awake/Awake/Core/TrayHelper.cs
@@ -339,6 +339,12 @@ namespace Awake.Core
                                 break;
                             }
 
+                        case (uint)TrayCommands.TC_LID_SETTING:
+                            {
+                                Manager.SetLidOverride();
+                                break;
+                            }
+
                         case (uint)TrayCommands.TC_MODE_INDEFINITE:
                             {
                                 AwakeSettings settings = Manager.ModuleSettings!.GetSettings<AwakeSettings>(Constants.AppName) ?? new AwakeSettings();
@@ -424,19 +430,21 @@ namespace Awake.Core
                 null);
         }
 
-        internal static void SetTray(AwakeSettings settings, bool startedFromPowerToys)
+        internal static void SetTray(AwakeSettings settings, bool startedFromPowerToys, bool lidPresent = false)
         {
             SetTray(
                 settings.Properties.KeepDisplayOn,
+                settings.Properties.KeepAwakeOnLidClose,
                 settings.Properties.Mode,
                 settings.Properties.CustomTrayTimes,
-                startedFromPowerToys);
+                startedFromPowerToys,
+                lidPresent);
         }
 
-        public static void SetTray(bool keepDisplayOn, AwakeMode mode, Dictionary<string, uint> trayTimeShortcuts, bool startedFromPowerToys)
+        public static void SetTray(bool keepDisplayOn, bool keepAwakeOnLidClose, AwakeMode mode, Dictionary<string, uint> trayTimeShortcuts, bool startedFromPowerToys, bool lidPresent = false)
         {
             ClearExistingTrayMenu();
-            CreateNewTrayMenu(startedFromPowerToys, keepDisplayOn, mode);
+            CreateNewTrayMenu(startedFromPowerToys, keepDisplayOn, keepAwakeOnLidClose, mode, lidPresent);
 
             InsertAwakeModeMenuItems(mode);
 
@@ -453,7 +461,7 @@ namespace Awake.Core
             }
         }
 
-        private static void CreateNewTrayMenu(bool startedFromPowerToys, bool keepDisplayOn, AwakeMode mode)
+        private static void CreateNewTrayMenu(bool startedFromPowerToys, bool keepDisplayOn, bool keepAwakeOnLidClose, AwakeMode mode, bool lidPresent)
         {
             TrayMenu = Bridge.CreatePopupMenu();
 
@@ -467,11 +475,17 @@ namespace Awake.Core
                 InsertMenuItem(0, TrayCommands.TC_EXIT, Resources.AWAKE_EXIT);
             }
 
+            // Add lid close option only if a lid is present
+            if (lidPresent)
+            {
+                InsertMenuItem(0, TrayCommands.TC_LID_SETTING, Resources.AWAKE_KEEP_AWAKE_LID_CLOSED, keepAwakeOnLidClose, mode == AwakeMode.PASSIVE);
+            }
+
             InsertMenuItem(0, TrayCommands.TC_DISPLAY_SETTING, Resources.AWAKE_KEEP_SCREEN_ON, keepDisplayOn, mode == AwakeMode.PASSIVE);
 
             if (!startedFromPowerToys)
             {
-                InsertSeparator(1);
+                InsertSeparator(lidPresent ? 2 : 1);
             }
         }
 

--- a/src/modules/awake/Awake/Program.cs
+++ b/src/modules/awake/Awake/Program.cs
@@ -125,6 +125,9 @@ namespace Awake
                     Bridge.GetPwrCapabilities(out _powerCapabilities);
                     Logger.LogInfo(JsonSerializer.Serialize(_powerCapabilities, _serializerOptions));
 
+                    // Initialize the lid override manager (checks for crash recovery)
+                    LidOverrideManager.Initialize(_powerCapabilities.LidPresent);
+
                     return await rootCommand.InvokeAsync(args);
                 }
             }
@@ -502,7 +505,7 @@ namespace Awake
         private static void InitializeSettings()
         {
             AwakeSettings settings = Manager.ModuleSettings?.GetSettings<AwakeSettings>(Core.Constants.AppName) ?? new AwakeSettings();
-            TrayHelper.SetTray(settings, _startedFromPowerToys);
+            TrayHelper.SetTray(settings, _startedFromPowerToys, _powerCapabilities.LidPresent);
         }
 
         private static void HandleAwakeConfigChange(FileSystemEventArgs fileEvent)
@@ -564,7 +567,19 @@ namespace Awake
                         break;
                 }
 
-                TrayHelper.SetTray(settings, _startedFromPowerToys);
+                // Apply or remove lid override based on current mode and settings.
+                // Pass the mode explicitly to avoid reading stale CurrentOperatingMode
+                // during FileSystemWatcher reentrancy (mode setters may save settings and
+                // return before updating the static property).
+                if (_powerCapabilities.LidPresent)
+                {
+                    if (!Manager.ApplyLidOverrideIfNeeded(settings.Properties.Mode, settings.Properties.KeepAwakeOnLidClose))
+                    {
+                        Logger.LogError("Lid override application failed during settings processing.");
+                    }
+                }
+
+                TrayHelper.SetTray(settings, _startedFromPowerToys, _powerCapabilities.LidPresent);
             }
             catch (Exception ex)
             {

--- a/src/modules/awake/Awake/Properties/Resources.Designer.cs
+++ b/src/modules/awake/Awake/Properties/Resources.Designer.cs
@@ -221,7 +221,16 @@ namespace Awake.Properties {
                 return ResourceManager.GetString("AWAKE_KEEP_SCREEN_ON", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Keep awake when lid closed.
+        /// </summary>
+        internal static string AWAKE_KEEP_AWAKE_LID_CLOSED {
+            get {
+                return ResourceManager.GetString("AWAKE_KEEP_AWAKE_LID_CLOSED", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Keep awake until expiration date and time.
         /// </summary>

--- a/src/modules/awake/Awake/Properties/Resources.resx
+++ b/src/modules/awake/Awake/Properties/Resources.resx
@@ -139,6 +139,10 @@
   <data name="AWAKE_KEEP_SCREEN_ON" xml:space="preserve">
     <value>Keep screen on</value>
   </data>
+  <data name="AWAKE_KEEP_AWAKE_LID_CLOSED" xml:space="preserve">
+    <value>Keep awake when lid closed</value>
+    <comment>Menu option to prevent system sleep when laptop lid is closed while Awake is active</comment>
+  </data>
   <data name="AWAKE_KEEP_UNTIL_EXPIRATION" xml:space="preserve">
     <value>Keep awake until expiration date and time</value>
     <comment>Keep the system awake until expiration date and time</comment>

--- a/src/settings-ui/Settings.UI.Library/AwakeProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/AwakeProperties.cs
@@ -15,6 +15,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         public AwakeProperties()
         {
             KeepDisplayOn = false;
+            KeepAwakeOnLidClose = false;
             Mode = AwakeMode.PASSIVE;
             IntervalHours = 0;
             IntervalMinutes = 1;
@@ -24,6 +25,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 
         [JsonPropertyName("keepDisplayOn")]
         public bool KeepDisplayOn { get; set; }
+
+        [JsonPropertyName("keepAwakeOnLidClose")]
+        public bool KeepAwakeOnLidClose { get; set; }
 
         [JsonPropertyName("mode")]
         public AwakeMode Mode { get; set; }

--- a/src/settings-ui/Settings.UI.Library/AwakeSettings.cs
+++ b/src/settings-ui/Settings.UI.Library/AwakeSettings.cs
@@ -36,6 +36,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
                     CustomTrayTimes = Properties.CustomTrayTimes.ToDictionary(entry => entry.Key, entry => entry.Value),
                     Mode = Properties.Mode,
                     KeepDisplayOn = Properties.KeepDisplayOn,
+                    KeepAwakeOnLidClose = Properties.KeepAwakeOnLidClose,
                     IntervalMinutes = Properties.IntervalMinutes,
                     IntervalHours = Properties.IntervalHours,
 

--- a/src/settings-ui/Settings.UI.UnitTests/ModelsTests/AwakeSettingsCloneTests.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ModelsTests/AwakeSettingsCloneTests.cs
@@ -1,0 +1,125 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+using Microsoft.PowerToys.Settings.UI.Library;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CommonLibTest
+{
+    [TestClass]
+    public class AwakeSettingsCloneTests
+    {
+        /// <summary>
+        /// Verify Clone() copies all AwakeProperties fields, not just the defaults.
+        /// Set every property to a non-default value, clone, and compare.
+        /// </summary>
+        [TestMethod]
+        public void Clone_CopiesAllProperties()
+        {
+            var original = new AwakeSettings
+            {
+                Properties = new AwakeProperties
+                {
+                    KeepDisplayOn = true,
+                    KeepAwakeOnLidClose = true,
+                    Mode = AwakeMode.INDEFINITE,
+                    IntervalHours = 5,
+                    IntervalMinutes = 30,
+                    ExpirationDateTime = new DateTimeOffset(2030, 6, 15, 12, 0, 0, TimeSpan.Zero),
+                    CustomTrayTimes = new Dictionary<string, uint>
+                    {
+                        { "15 minutes", 15 },
+                        { "1 hour", 60 },
+                    },
+                },
+            };
+
+            var clone = (AwakeSettings)original.Clone();
+
+            Assert.AreEqual(original.Properties.KeepDisplayOn, clone.Properties.KeepDisplayOn);
+            Assert.AreEqual(original.Properties.KeepAwakeOnLidClose, clone.Properties.KeepAwakeOnLidClose);
+            Assert.AreEqual(original.Properties.Mode, clone.Properties.Mode);
+            Assert.AreEqual(original.Properties.IntervalHours, clone.Properties.IntervalHours);
+            Assert.AreEqual(original.Properties.IntervalMinutes, clone.Properties.IntervalMinutes);
+            Assert.AreEqual(original.Properties.ExpirationDateTime, clone.Properties.ExpirationDateTime);
+            CollectionAssert.AreEqual(
+                original.Properties.CustomTrayTimes.OrderBy(kv => kv.Key).ToList(),
+                clone.Properties.CustomTrayTimes.OrderBy(kv => kv.Key).ToList());
+        }
+
+        /// <summary>
+        /// Verify Clone() produces a deep copy: mutating the clone does not affect the original.
+        /// </summary>
+        [TestMethod]
+        public void Clone_ProducesDeepCopy()
+        {
+            var original = new AwakeSettings
+            {
+                Properties = new AwakeProperties
+                {
+                    KeepDisplayOn = true,
+                    KeepAwakeOnLidClose = true,
+                    Mode = AwakeMode.TIMED,
+                    IntervalHours = 2,
+                    IntervalMinutes = 15,
+                    CustomTrayTimes = new Dictionary<string, uint> { { "30 minutes", 30 } },
+                },
+            };
+
+            var clone = (AwakeSettings)original.Clone();
+
+            // Mutate clone
+            clone.Properties.KeepDisplayOn = false;
+            clone.Properties.KeepAwakeOnLidClose = false;
+            clone.Properties.Mode = AwakeMode.PASSIVE;
+            clone.Properties.IntervalHours = 0;
+            clone.Properties.IntervalMinutes = 0;
+            clone.Properties.CustomTrayTimes["new entry"] = 99;
+
+            // Original unchanged
+            Assert.IsTrue(original.Properties.KeepDisplayOn);
+            Assert.IsTrue(original.Properties.KeepAwakeOnLidClose);
+            Assert.AreEqual(AwakeMode.TIMED, original.Properties.Mode);
+            Assert.AreEqual(2u, original.Properties.IntervalHours);
+            Assert.AreEqual(15u, original.Properties.IntervalMinutes);
+            Assert.IsFalse(original.Properties.CustomTrayTimes.ContainsKey("new entry"));
+        }
+
+        /// <summary>
+        /// Guard against future properties being added to AwakeProperties without
+        /// updating Clone(). Compares the set of public instance properties on
+        /// AwakeProperties against a known list. If this test fails, a new property
+        /// was added — update Clone() and this test's expected list.
+        /// </summary>
+        [TestMethod]
+        public void Clone_CoversAllAwakeProperties()
+        {
+            var propertyNames = typeof(AwakeProperties)
+                .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Select(p => p.Name)
+                .OrderBy(n => n)
+                .ToList();
+
+            var expected = new List<string>
+            {
+                "CustomTrayTimes",
+                "ExpirationDateTime",
+                "IntervalHours",
+                "IntervalMinutes",
+                "KeepAwakeOnLidClose",
+                "KeepDisplayOn",
+                "Mode",
+            };
+
+            var message = "AwakeProperties has properties not covered by this test. " +
+                "If you added a new property, update AwakeSettings.Clone() and this expected list.";
+            CollectionAssert.AreEqual(expected, propertyNames, message);
+        }
+    }
+}

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/AwakePage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/AwakePage.xaml
@@ -99,6 +99,14 @@
                         IsEnabled="{x:Bind ViewModel.IsScreenConfigurationPossibleEnabled, Mode=OneWay}">
                         <ToggleSwitch IsOn="{x:Bind ViewModel.KeepDisplayOn, Mode=TwoWay}" />
                     </tkcontrols:SettingsCard>
+
+                    <tkcontrols:SettingsCard
+                        x:Uid="Awake_LidSettingsCard"
+                        HeaderIcon="{ui:FontIcon Glyph=&#xE7F7;}"
+                        IsEnabled="{x:Bind ViewModel.IsLidConfigurationPossibleEnabled, Mode=OneWay}"
+                        Visibility="{x:Bind ViewModel.IsLidPresentOnDevice, Mode=OneWay}">
+                        <ToggleSwitch IsOn="{x:Bind ViewModel.KeepAwakeOnLidClose, Mode=TwoWay}" />
+                    </tkcontrols:SettingsCard>
                 </controls:SettingsGroup>
             </StackPanel>
         </controls:SettingsPageControl.ModuleContent>

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/AwakePage.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/AwakePage.xaml.cs
@@ -5,6 +5,7 @@
 using System;
 using System.IO;
 using System.IO.Abstractions;
+using System.Runtime.InteropServices;
 using ManagedCommon;
 using Microsoft.PowerToys.Settings.UI.Helpers;
 using Microsoft.PowerToys.Settings.UI.Library;
@@ -17,6 +18,30 @@ namespace Microsoft.PowerToys.Settings.UI.Views
 {
     public sealed partial class AwakePage : NavigablePage, IRefreshablePage
     {
+        [DllImport("powrprof.dll", SetLastError = true)]
+        private static extern bool GetPwrCapabilities(out SystemPowerCapabilities lpSystemPowerCapabilities);
+
+        // Partial definition of Win32 SYSTEM_POWER_CAPABILITIES. Only the first three
+        // fields are needed; the rest are absorbed into Remainder to satisfy the marshaler.
+        // The full struct is 112 bytes (see PowrProf.h). The three leading bool fields
+        // marshal as 1 byte each (UnmanagedType.U1), so Remainder = 112 - 3 = 109 bytes.
+        // See also: Awake.Core.Models.SystemPowerCapabilities for the canonical full definition.
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
+        private struct SystemPowerCapabilities
+        {
+            [MarshalAs(UnmanagedType.U1)]
+            public bool PowerButtonPresent;
+
+            [MarshalAs(UnmanagedType.U1)]
+            public bool SleepButtonPresent;
+
+            [MarshalAs(UnmanagedType.U1)]
+            public bool LidPresent;
+
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 109)]
+            public byte[] Remainder;
+        }
+
         private readonly string _appName = "Awake";
         private readonly SettingsUtils _settingsUtils;
 
@@ -47,6 +72,12 @@ namespace Microsoft.PowerToys.Settings.UI.Views
 
             // We load the view model settings first.
             LoadSettings(_generalSettingsRepository, _moduleSettingsRepository);
+
+            // Detect if the device has a lid
+            if (GetPwrCapabilities(out SystemPowerCapabilities capabilities))
+            {
+                ViewModel.SetLidPresent(capabilities.LidPresent);
+            }
 
             DataContext = ViewModel;
 

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -2274,6 +2274,12 @@ From there, simply click on one of the supported files in the File Explorer and 
   <data name="Awake_DisplaySettingsCard.Description" xml:space="preserve">
     <value>This setting is only available when keeping the PC awake</value>
   </data>
+  <data name="Awake_LidSettingsCard.Header" xml:space="preserve">
+    <value>Keep awake when lid closed</value>
+  </data>
+  <data name="Awake_LidSettingsCard.Description" xml:space="preserve">
+    <value>Prevents sleep when the laptop lid is closed while keeping the PC awake</value>
+  </data>
   <data name="Awake_ExpirationSettingsExpander.Description" xml:space="preserve">
     <value>Keep custom awake state until a specific date and time</value>
   </data>

--- a/src/settings-ui/Settings.UI/ViewModels/AwakeViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/AwakeViewModel.cs
@@ -96,6 +96,27 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
 
         public bool IsScreenConfigurationPossibleEnabled => ModuleSettings.Properties.Mode != AwakeMode.PASSIVE && IsEnabled;
 
+        public bool IsLidConfigurationPossibleEnabled => ModuleSettings.Properties.Mode != AwakeMode.PASSIVE && IsEnabled && IsLidPresentOnDevice;
+
+        public bool IsLidPresentOnDevice
+        {
+            get => _isLidPresentOnDevice;
+            private set
+            {
+                if (_isLidPresentOnDevice != value)
+                {
+                    _isLidPresentOnDevice = value;
+                    OnPropertyChanged(nameof(IsLidPresentOnDevice));
+                    OnPropertyChanged(nameof(IsLidConfigurationPossibleEnabled));
+                }
+            }
+        }
+
+        public void SetLidPresent(bool lidPresent)
+        {
+            IsLidPresentOnDevice = lidPresent;
+        }
+
         public AwakeMode Mode
         {
             get => ModuleSettings.Properties.Mode;
@@ -128,6 +149,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                     OnPropertyChanged(nameof(IsTimeConfigurationEnabled));
                     OnPropertyChanged(nameof(IsScreenConfigurationPossibleEnabled));
                     OnPropertyChanged(nameof(IsExpirationConfigurationEnabled));
+                    OnPropertyChanged(nameof(IsLidConfigurationPossibleEnabled));
 
                     NotifyPropertyChanged();
                 }
@@ -142,6 +164,19 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 if (ModuleSettings.Properties.KeepDisplayOn != value)
                 {
                     ModuleSettings.Properties.KeepDisplayOn = value;
+                    NotifyPropertyChanged();
+                }
+            }
+        }
+
+        public bool KeepAwakeOnLidClose
+        {
+            get => ModuleSettings.Properties.KeepAwakeOnLidClose;
+            set
+            {
+                if (ModuleSettings.Properties.KeepAwakeOnLidClose != value)
+                {
+                    ModuleSettings.Properties.KeepAwakeOnLidClose = value;
                     NotifyPropertyChanged();
                 }
             }
@@ -210,12 +245,14 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             OnPropertyChanged(nameof(IsTimeConfigurationEnabled));
             OnPropertyChanged(nameof(IsScreenConfigurationPossibleEnabled));
             OnPropertyChanged(nameof(IsExpirationConfigurationEnabled));
+            OnPropertyChanged(nameof(IsLidConfigurationPossibleEnabled));
         }
 
         public void RefreshModuleSettings()
         {
             OnPropertyChanged(nameof(Mode));
             OnPropertyChanged(nameof(KeepDisplayOn));
+            OnPropertyChanged(nameof(KeepAwakeOnLidClose));
             OnPropertyChanged(nameof(IntervalHours));
             OnPropertyChanged(nameof(IntervalMinutes));
             OnPropertyChanged(nameof(ExpirationDateTime));
@@ -225,5 +262,6 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         private bool _enabledGPOConfiguration;
         private AwakeSettings _moduleSettings;
         private bool _isEnabled;
+        private bool _isLidPresentOnDevice;
     }
 }


### PR DESCRIPTION
### Summary

Laptops running Awake in INDEFINITE or TIMED mode still go to sleep when the lid is closed, because Windows applies the power plan's lid close action regardless of `SetThreadExecutionState`. This adds a toggle that overrides the lid close action to "Do nothing" in the active power scheme while Awake is in a non-passive mode. The toggle defaults to off, so existing behavior is unchanged for users who want sleep-on-close.

The core of the change is `LidOverrideManager`, a new static class that wraps the Win32 `PowerWriteACValueIndex`/`PowerWriteDCValueIndex` APIs to temporarily set the lid close action to "Do nothing" (for both AC and DC power), then restore the original values when the override is removed. It persists a JSON state file alongside the normal settings so that if Awake crashes or gets killed, the next launch detects the orphaned override and restores the original lid settings before doing anything else.

```mermaid
stateDiagram-v2
    [*] --> Passive
    Passive --> Active: Mode set to INDEFINITE/TIMED/EXPIRABLE<br/>+ keepAwakeOnLidClose=true
    Active --> Passive: Mode set to PASSIVE<br/>or timer expires
    Active --> Active: Power event (resume)<br/>→ reapply override
    Active --> CrashRecovery: Process killed
    CrashRecovery --> Passive: Next launch reads state file<br/>→ restores original values

    state Active {
        [*] --> OverrideApplied: WriteLidCloseAction(DoNothing)
        OverrideApplied --> OverrideRemoved: RestoreLidSettings()
        OverrideRemoved --> [*]
    }
```

Key design decisions the diff won't immediately convey:

- **Mode parameter passed explicitly** to `ApplyLidOverrideIfNeeded` rather than reading `CurrentOperatingMode` — the mode setters save settings and return *before* updating the static property, so the FileSystemWatcher can re-trigger `ProcessSettings` with a stale value.
- **TIMED mode short-circuit** in `SetLidOverride` mirrors the existing `SetDisplay` pattern — toggling the lid setting directly without saving first avoids restarting the countdown timer.
- **State file uses a direct path** rather than `SettingsUtils` because crash-recovery state has a delete-on-restore lifecycle that doesn't fit the settings framework.
- The Settings UI detects lid presence via its own minimal `SystemPowerCapabilities` P/Invoke since it runs in a separate process from the Awake module.

Relates to #34479 (and the issues consolidated there: #16422, #41095, #35051, #13785, #13622, #34903).

### Testing

- Manual: toggled the setting on/off across all four modes (PASSIVE, INDEFINITE, TIMED, EXPIRABLE) on a laptop with a lid. Verified via `powercfg /q` that the lid close action changes to 0 when enabled and restores to 1 (Sleep) when disabled.
- Crash recovery: applied override, killed Awake via Task Manager, relaunched — confirmed original settings restored and state file cleaned up.
- No-lid device: verified on a desktop that the toggle is hidden and `LidOverrideManager.Initialize` returns early.
- Unit tests added for `AwakeSettings.Clone()` to guard against future property omissions (reflection-based property list assertion).
- Not tested: power scheme switching while override is active (the code handles it by detecting the active scheme at restore time).

### Trade-offs and Alternatives

The override modifies the system-wide power plan, not just the Awake process. This is unavoidable — there is no per-process lid close action API. The risk is mitigated by crash recovery and by restoring settings on every exit path.

An alternative would be registering for `WM_POWERBROADCAST` / `PBT_APMSUSPEND` and calling `SetSuspendState(FALSE)` to cancel the suspend, but this is fragile (the cancel can be overridden by the kernel) and doesn't work for hibernate or shutdown lid actions.
