### PR TITLE
Add missing Icelandic character í (VK_I)

### DIFF
--- a/src/modules/poweraccent/PowerAccent.Core/Languages.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/Languages.cs
@@ -376,6 +376,7 @@ namespace PowerAccent.Core
                 LetterKey.VK_A => new[] { "á", "æ" },
                 LetterKey.VK_D => new[] { "ð" },
                 LetterKey.VK_E => new[] { "é" },
+                LetterKey.VK_I => new[] { "í" },
                 LetterKey.VK_O => new[] { "ó", "ö" },
                 LetterKey.VK_U => new[] { "ú" },
                 LetterKey.VK_Y => new[] { "ý" },


### PR DESCRIPTION
## Summary of the Pull Request
The Icelandic language definition was missing `í` entirely. This adds it to `VK_I`.

Closes: Add missing Icelandic character í (VK_I) #46423

## Validation Steps Performed
Code review only. The change is a single line addition to a data-only switch   statement, consistent in structure with all other language entries in the file. No binaries, pipelines, or localization files are affected.
