### PR TITLE
Settings: Fix settings arrow render

### DIFF
--- a/src/common/Common.UI.Controls/Controls/KeyVisual/KeyCharPresenter.xaml
+++ b/src/common/Common.UI.Controls/Controls/KeyVisual/KeyCharPresenter.xaml
@@ -95,6 +95,7 @@
                             <FontIcon
                                 HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                 FontSize="{TemplateBinding FontSize}"
                                 FontWeight="{TemplateBinding FontWeight}"
                                 Glyph="{TemplateBinding Content}" />

--- a/src/common/Common.UI.Controls/Controls/KeyVisual/KeyCharPresenter.xaml
+++ b/src/common/Common.UI.Controls/Controls/KeyVisual/KeyCharPresenter.xaml
@@ -95,7 +95,6 @@
                             <FontIcon
                                 HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                 FontSize="{TemplateBinding FontSize}"
                                 FontWeight="{TemplateBinding FontWeight}"
                                 Glyph="{TemplateBinding Content}" />

--- a/src/common/Common.UI.Controls/Controls/KeyVisual/KeyVisual.xaml.cs
+++ b/src/common/Common.UI.Controls/Controls/KeyVisual/KeyVisual.xaml.cs
@@ -63,9 +63,7 @@ namespace Microsoft.PowerToys.Common.UI.Controls
 
         private static void OnContentChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            var keyVisual = (KeyVisual)d;
-            keyVisual.Update();
-            keyVisual.SetVisualStates();
+            ((KeyVisual)d).SetVisualStates();
         }
 
         private static void OnStateChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -98,14 +96,6 @@ namespace Microsoft.PowerToys.Common.UI.Controls
 
         private void Update()
         {
-            if (_keyPresenter == null)
-            {
-                return;
-            }
-
-            _keyPresenter.Content = Content;
-            _keyPresenter.Style = (Style)Application.Current.Resources["DefaultKeyCharPresenterStyle"];
-
             if (Content == null)
             {
                 return;

--- a/src/common/Common.UI.Controls/Controls/KeyVisual/KeyVisual.xaml.cs
+++ b/src/common/Common.UI.Controls/Controls/KeyVisual/KeyVisual.xaml.cs
@@ -106,19 +106,19 @@ namespace Microsoft.PowerToys.Common.UI.Controls
                 switch (key)
                 {
                     case nameof(VirtualKey.Up):
-                        SetGlyphOrText("\uE0E4", VirtualKey.Up, forceGlyph: true);
+                        SetGlyphOrText("\uE0E4", VirtualKey.Up);
                         break;
 
                     case nameof(VirtualKey.Down):
-                        SetGlyphOrText("\uE0E5", VirtualKey.Down, forceGlyph: true);
+                        SetGlyphOrText("\uE0E5", VirtualKey.Down);
                         break;
 
                     case nameof(VirtualKey.Left):
-                        SetGlyphOrText("\uE0E2", VirtualKey.Left, forceGlyph: true);
+                        SetGlyphOrText("\uE0E2", VirtualKey.Left);
                         break;
 
                     case nameof(VirtualKey.Right):
-                        SetGlyphOrText("\uE0E3", VirtualKey.Right, forceGlyph: true);
+                        SetGlyphOrText("\uE0E3", VirtualKey.Right);
                         break;
 
                     case "Copilot":
@@ -157,19 +157,19 @@ namespace Microsoft.PowerToys.Common.UI.Controls
                         break;
 
                     case VirtualKey.Up:
-                        SetGlyphOrText("\uE0E4", virtualKey, forceGlyph: true);
+                        SetGlyphOrText("\uE0E4", virtualKey);
                         break;
 
                     case VirtualKey.Down:
-                        SetGlyphOrText("\uE0E5", virtualKey, forceGlyph: true);
+                        SetGlyphOrText("\uE0E5", virtualKey);
                         break;
 
                     case VirtualKey.Left:
-                        SetGlyphOrText("\uE0E2", virtualKey, forceGlyph: true);
+                        SetGlyphOrText("\uE0E2", virtualKey);
                         break;
 
                     case VirtualKey.Right:
-                        SetGlyphOrText("\uE0E3", virtualKey, forceGlyph: true);
+                        SetGlyphOrText("\uE0E3", virtualKey);
                         break;
 
                     case VirtualKey.LeftWindows:
@@ -180,9 +180,9 @@ namespace Microsoft.PowerToys.Common.UI.Controls
             }
         }
 
-        private void SetGlyphOrText(string glyph, VirtualKey key, bool forceGlyph = false)
+        private void SetGlyphOrText(string glyph, VirtualKey key)
         {
-            if (RenderKeyAsGlyph || forceGlyph)
+            if (RenderKeyAsGlyph)
             {
                 _keyPresenter.Content = glyph;
                 _keyPresenter.Style = (Style)Application.Current.Resources["GlyphKeyCharPresenterStyle"];

--- a/src/common/Common.UI.Controls/Controls/KeyVisual/KeyVisual.xaml.cs
+++ b/src/common/Common.UI.Controls/Controls/KeyVisual/KeyVisual.xaml.cs
@@ -63,7 +63,9 @@ namespace Microsoft.PowerToys.Common.UI.Controls
 
         private static void OnContentChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
-            ((KeyVisual)d).SetVisualStates();
+            var keyVisual = (KeyVisual)d;
+            keyVisual.Update();
+            keyVisual.SetVisualStates();
         }
 
         private static void OnStateChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
@@ -96,6 +98,14 @@ namespace Microsoft.PowerToys.Common.UI.Controls
 
         private void Update()
         {
+            if (_keyPresenter == null)
+            {
+                return;
+            }
+
+            _keyPresenter.Content = Content;
+            _keyPresenter.Style = (Style)Application.Current.Resources["DefaultKeyCharPresenterStyle"];
+
             if (Content == null)
             {
                 return;
@@ -141,19 +151,19 @@ namespace Microsoft.PowerToys.Common.UI.Controls
                         break;
 
                     case VirtualKey.Up:
-                        _keyPresenter.Content = "\uE0E4";
+                        _keyPresenter.Content = "\u2191";
                         break;
 
                     case VirtualKey.Down:
-                        _keyPresenter.Content = "\uE0E5";
+                        _keyPresenter.Content = "\u2193";
                         break;
 
                     case VirtualKey.Left:
-                        _keyPresenter.Content = "\uE0E2";
+                        _keyPresenter.Content = "\u2190";
                         break;
 
                     case VirtualKey.Right:
-                        _keyPresenter.Content = "\uE0E3";
+                        _keyPresenter.Content = "\u2192";
                         break;
 
                     case VirtualKey.LeftWindows:

--- a/src/common/Common.UI.Controls/Controls/KeyVisual/KeyVisual.xaml.cs
+++ b/src/common/Common.UI.Controls/Controls/KeyVisual/KeyVisual.xaml.cs
@@ -151,19 +151,19 @@ namespace Microsoft.PowerToys.Common.UI.Controls
                         break;
 
                     case VirtualKey.Up:
-                        _keyPresenter.Content = "\u2191";
+                        SetGlyph("\uE0E4");
                         break;
 
                     case VirtualKey.Down:
-                        _keyPresenter.Content = "\u2193";
+                        SetGlyph("\uE0E5");
                         break;
 
                     case VirtualKey.Left:
-                        _keyPresenter.Content = "\u2190";
+                        SetGlyph("\uE0E2");
                         break;
 
                     case VirtualKey.Right:
-                        _keyPresenter.Content = "\u2192";
+                        SetGlyph("\uE0E3");
                         break;
 
                     case VirtualKey.LeftWindows:
@@ -178,14 +178,19 @@ namespace Microsoft.PowerToys.Common.UI.Controls
         {
             if (RenderKeyAsGlyph)
             {
-                _keyPresenter.Content = glyph;
-                _keyPresenter.Style = (Style)Application.Current.Resources["GlyphKeyCharPresenterStyle"];
+                SetGlyph(glyph);
             }
             else
             {
                 _keyPresenter.Content = key.ToString();
                 _keyPresenter.Style = (Style)Application.Current.Resources["DefaultKeyCharPresenterStyle"];
             }
+        }
+
+        private void SetGlyph(string glyph)
+        {
+            _keyPresenter.Content = glyph;
+            _keyPresenter.Style = (Style)Application.Current.Resources["GlyphKeyCharPresenterStyle"];
         }
 
         private void KeyVisual_IsEnabledChanged(object sender, DependencyPropertyChangedEventArgs e)

--- a/src/common/Common.UI.Controls/Controls/KeyVisual/KeyVisual.xaml.cs
+++ b/src/common/Common.UI.Controls/Controls/KeyVisual/KeyVisual.xaml.cs
@@ -141,19 +141,19 @@ namespace Microsoft.PowerToys.Common.UI.Controls
                         break;
 
                     case VirtualKey.Up:
-                        SetGlyph("\uE0E4");
+                        SetGlyphOrText("\uE0E4", virtualKey, forceGlyph: true);
                         break;
 
                     case VirtualKey.Down:
-                        SetGlyph("\uE0E5");
+                        SetGlyphOrText("\uE0E5", virtualKey, forceGlyph: true);
                         break;
 
                     case VirtualKey.Left:
-                        SetGlyph("\uE0E2");
+                        SetGlyphOrText("\uE0E2", virtualKey, forceGlyph: true);
                         break;
 
                     case VirtualKey.Right:
-                        SetGlyph("\uE0E3");
+                        SetGlyphOrText("\uE0E3", virtualKey, forceGlyph: true);
                         break;
 
                     case VirtualKey.LeftWindows:
@@ -164,23 +164,18 @@ namespace Microsoft.PowerToys.Common.UI.Controls
             }
         }
 
-        private void SetGlyphOrText(string glyph, VirtualKey key)
+        private void SetGlyphOrText(string glyph, VirtualKey key, bool forceGlyph = false)
         {
-            if (RenderKeyAsGlyph)
+            if (RenderKeyAsGlyph || forceGlyph)
             {
-                SetGlyph(glyph);
+                _keyPresenter.Content = glyph;
+                _keyPresenter.Style = (Style)Application.Current.Resources["GlyphKeyCharPresenterStyle"];
             }
             else
             {
                 _keyPresenter.Content = key.ToString();
                 _keyPresenter.Style = (Style)Application.Current.Resources["DefaultKeyCharPresenterStyle"];
             }
-        }
-
-        private void SetGlyph(string glyph)
-        {
-            _keyPresenter.Content = glyph;
-            _keyPresenter.Style = (Style)Application.Current.Resources["GlyphKeyCharPresenterStyle"];
         }
 
         private void KeyVisual_IsEnabledChanged(object sender, DependencyPropertyChangedEventArgs e)

--- a/src/common/Common.UI.Controls/Controls/KeyVisual/KeyVisual.xaml.cs
+++ b/src/common/Common.UI.Controls/Controls/KeyVisual/KeyVisual.xaml.cs
@@ -105,6 +105,22 @@ namespace Microsoft.PowerToys.Common.UI.Controls
             {
                 switch (key)
                 {
+                    case nameof(VirtualKey.Up):
+                        SetGlyphOrText("\uE0E4", VirtualKey.Up, forceGlyph: true);
+                        break;
+
+                    case nameof(VirtualKey.Down):
+                        SetGlyphOrText("\uE0E5", VirtualKey.Down, forceGlyph: true);
+                        break;
+
+                    case nameof(VirtualKey.Left):
+                        SetGlyphOrText("\uE0E2", VirtualKey.Left, forceGlyph: true);
+                        break;
+
+                    case nameof(VirtualKey.Right):
+                        SetGlyphOrText("\uE0E3", VirtualKey.Right, forceGlyph: true);
+                        break;
+
                     case "Copilot":
                         _keyPresenter.Style = (Style)Application.Current.Resources["CopilotKeyCharPresenterStyle"];
                         break;

--- a/src/settings-ui/Settings.UI/SettingsXAML/Controls/ShortcutControl/ShortcutControl.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Controls/ShortcutControl/ShortcutControl.xaml
@@ -46,6 +46,7 @@
                                 Content="{Binding}"
                                 CornerRadius="{StaticResource ControlCornerRadius}"
                                 IsTabStop="False"
+                                RenderKeyAsGlyph="True"
                                 State="{Binding ElementName=LayoutRoot, Path=KeyVisualShouldShowConflict, Mode=OneWay, Converter={StaticResource BoolToKeyVisualStateConverter}, ConverterParameter=Warning}"
                                 Style="{StaticResource AccentKeyVisualStyle}" />
                         </DataTemplate>

--- a/src/settings-ui/Settings.UI/SettingsXAML/Controls/ShortcutControl/ShortcutDialogContentControl.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Controls/ShortcutControl/ShortcutDialogContentControl.xaml
@@ -236,6 +236,7 @@
                             FontSize="16"
                             FontWeight="SemiBold"
                             IsTabStop="False"
+                            RenderKeyAsGlyph="True"
                             State="{Binding ElementName=ShortcutContentControl, Path=IsError, Mode=OneWay, Converter={StaticResource BoolToKeyVisualStateConverter}, ConverterParameter=Error}"
                             Style="{StaticResource AccentKeyVisualStyle}" />
                     </DataTemplate>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Existing: 
<img width="1201" height="150" alt="image" src="https://github.com/user-attachments/assets/5e764875-bed8-45b5-97a8-60e5f475c296" />

A box icon for whatever up, down, left, right, they are not treated as Glyph icon rendered, instead as normal text

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] Closes: #xxx
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

<img width="1273" height="714" alt="image" src="https://github.com/user-attachments/assets/4d2ffa92-e0ca-44f4-8eda-9c4a7e05bbde" />

