### PR TITLE
fix: pin 5 unpinned action(s),extract 5 unsafe expression(s) to env vars

### DIFF
--- a/.github/workflows/automatic-issue-deduplication.yml
+++ b/.github/workflows/automatic-issue-deduplication.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run Deduplicate Action
-        uses: pelikhan/action-genai-issue-dedup@v0
+        uses: pelikhan/action-genai-issue-dedup@bdb3b5d9451c1090ffcdf123d7447a5e7c7a2528 # v0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           label_as_duplicate: true

--- a/.github/workflows/manual-batch-issue-deduplication.yml
+++ b/.github/workflows/manual-batch-issue-deduplication.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Run GenAI Issue Deduplicator
-        uses: pelikhan/action-genai-issue-dedup@v0
+        uses: pelikhan/action-genai-issue-dedup@bdb3b5d9451c1090ffcdf123d7447a5e7c7a2528 # v0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_issue: ${{ matrix.issue }}

--- a/.github/workflows/msstore-submissions.yml
+++ b/.github/workflows/msstore-submissions.yml
@@ -23,7 +23,7 @@ jobs:
           export $(echo 'anypass_just_to_unlock' | gnome-keyring-daemon --start --components=gpg,pkcs11,secrets,ssh)
 
       - name: Log in to Azure
-        uses: azure/login@v2
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -44,10 +44,10 @@ jobs:
         with:
           dotnet-version: '9.0.x'
 
-      - uses: microsoft/setup-msstore-cli@v1
+      - uses: microsoft/setup-msstore-cli@3b2ec9136230357ce9abc02b9d056626fb248d3f # v1
 
       - name: Fetch Store Credential
-        uses: azure/cli@v2
+        uses: azure/cli@9f7ce6f37c31b777ec6c6b6d1dfe7db79f497956 # v2
         with:
           azcliversion: latest
           inlineScript: |-
@@ -56,11 +56,15 @@ jobs:
 
       - name: Configure Store Credentials
         run: |-
-          msstore reconfigure -cfp cert.pfx -c ${{ secrets.AZURE_CLIENT_ID }} -t ${{ secrets.AZURE_TENANT_ID }} -s ${{ secrets.SELLER_ID }}
+          msstore reconfigure -cfp cert.pfx -c ${AZURE_CLIENT_ID} -t ${AZURE_TENANT_ID} -s ${SELLER_ID}
 
+        env:
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          SELLER_ID: ${{ secrets.SELLER_ID }}
       - name: Update draft submission
         run: |-
-          msstore submission update ${{ secrets.PRODUCT_ID }} '{
+          msstore submission update ${PRODUCT_ID} '{
             "packages":[
                 {
                   "packageUrl":"${{ steps.releaseVars.outputs.powerToysInstallerX64Url }}",
@@ -79,10 +83,14 @@ jobs:
             ]
           }'
 
+        env:
+          PRODUCT_ID: ${{ secrets.PRODUCT_ID }}
       - name: Publish Submission
         run: |-
-          msstore submission publish ${{ secrets.PRODUCT_ID }}
+          msstore submission publish ${PRODUCT_ID}
 
+        env:
+          PRODUCT_ID: ${{ secrets.PRODUCT_ID }}
       - name: Clean up auth certificate
         if: always()
         run: |-


### PR DESCRIPTION
## Fix: CI/CD Security Vulnerabilities in GitHub Actions

Hi! [Runner Guard](https://github.com/Vigilant-LLC/runner-guard), an open-source
CI/CD security scanner by [Vigilant Cyber Security](https://www.vigilantdefense.com),
identified security vulnerabilities in this repository's GitHub Actions workflows.

This PR applies automated fixes where possible and reports additional findings
for your review.

### Fixes applied (in this PR)

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-007 | high | `.github/workflows/automatic-issue-deduplication.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/manual-batch-issue-deduplication.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/msstore-submissions.yml` | Pinned 3 third-party action(s) to commit SHA |
| RGS-002 | high | `.github/workflows/msstore-submissions.yml` | Extracted 5 unsafe expression(s) to env vars |


### Advisory: additional findings (manual review recommended)

| Rule | Severity | File | Description |
| RGS-004 | high | `.github/workflows/spelling2.yml` | Comment-Triggered Workflow Without Author Authorization Check |
| RGS-005 | medium | `.github/workflows/spelling2.yml` | Excessive Permissions on Untrusted Trigger |
| RGS-005 | medium | `.github/workflows/spelling2.yml` | Excessive Permissions on Untrusted Trigger |
| RGS-005 | medium | `.github/workflows/spelling2.yml` | Excessive Permissions on Untrusted Trigger |
| RGS-005 | medium | `.github/workflows/spelling2.yml` | Excessive Permissions on Untrusted Trigger |


### Why this matters

GitHub Actions workflows that use untrusted input in `run:` blocks, expose
secrets inline, or use unpinned third-party actions are vulnerable to
code injection, credential theft, and supply chain attacks. These are the same
vulnerability classes exploited in the [tj-actions/changed-files incident](https://www.vigilantdefense.com/resources/runner-guard)
and subsequent supply chain attacks, which compromised CI secrets across
thousands of repositories.

### How to verify

Review the diff — each change is mechanical and preserves workflow behavior:
- **Expression extraction** (RGS-002/008/014): Moves `${{ }}` expressions from
  `run:` blocks into `env:` mappings, preventing shell injection
- **SHA pinning** (RGS-007): Pins third-party actions to immutable commit SHAs
  (original version tag preserved as comment)
- **Debug env removal** (RGS-015): Removes `ACTIONS_RUNNER_DEBUG`/`ACTIONS_STEP_DEBUG`
  which leak secrets in workflow logs

Run `brew install Vigilant-LLC/tap/runner-guard && runner-guard scan .` or install from the
[repo](https://github.com/Vigilant-LLC/runner-guard) to verify.

---

Found by [Runner Guard](https://github.com/Vigilant-LLC/runner-guard) | Built by [Vigilant Cyber Security](https://www.vigilantdefense.com) | [Learn more](https://www.vigilantdefense.com/resources/runner-guard)

If this PR is not welcome, just close it -- we won't send another.