### PR TITLE
Emulate ZoomIt _mm_cvtsi128_si64 with _mm_storel_epi64 for x86

### DIFF
--- a/src/modules/ZoomIt/ZoomIt/PanoramaCapture.cpp
+++ b/src/modules/ZoomIt/ZoomIt/PanoramaCapture.cpp
@@ -118,6 +118,16 @@
 #include <commctrl.h>
 #if defined(_M_X64) || defined(_M_IX86)
 #include <emmintrin.h>
+#if defined(_M_IX86)
+// _mm_cvtsi128_si64 is unavailable on 32-bit x86; emulate via _mm_storel_epi64.
+inline __int64 _mm_cvtsi128_si64_compat( __m128i v )
+{
+    __int64 r;
+    _mm_storel_epi64( reinterpret_cast<__m128i*>( &r ), v );
+    return r;
+}
+#define _mm_cvtsi128_si64 _mm_cvtsi128_si64_compat
+#endif
 #elif defined(_M_ARM64)
 #include <arm_neon.h>
 #endif

--- a/src/modules/ZoomIt/ZoomIt/ZoomIt.rc
+++ b/src/modules/ZoomIt/ZoomIt/ZoomIt.rc
@@ -121,7 +121,7 @@ FONT 8, "MS Shell Dlg", 0, 0, 0x0
 BEGIN
     DEFPUSHBUTTON   "OK",IDOK,184,308,50,14
     PUSHBUTTON      "Cancel",IDCANCEL,241,308,50,14
-    LTEXT           "ZoomIt v10.1",IDC_VERSION,42,7,73,10
+    LTEXT           "ZoomIt v11.0",IDC_VERSION,42,7,73,10
     LTEXT           "Copyright \251 2006-2026 Mark Russinovich",IDC_COPYRIGHT,42,17,251,8
     CONTROL         "<a HREF=""https://www.sysinternals.com"">Sysinternals - www.sysinternals.com</a>",IDC_LINK,
                     "SysLink",WS_TABSTOP,42,26,150,9


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Added this to ensure that ZoomIt can still build for 32 bit, even though PowerToys doesn't ship such binaries.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] Closes: #xxx
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Ensured that the ZoomIt subproject compiles fine for 32 bit, this inside the Sysinternals build process, also tested that the panoramic screenshot functionality works. This change is isolated through the preprocessor for AMD64 and ARM64.