### PR TITLE
[QuickAccent] Add capitalization for Superscript Latin Small Letter N

### DIFF
--- a/src/modules/poweraccent/PowerAccent.Core/PowerAccent.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/PowerAccent.cs
@@ -368,6 +368,7 @@ public partial class PowerAccent : IDisposable
                 case "ı\u0307\u0304": result.Add("İ\u0304"); break;
                 case "ı": result.Add("İ"); break;
                 case "ᵛ": result.Add("ⱽ"); break;
+                case "ⁿ": result.Add("ᴺ"); break;
                 case "ϑ": break;
                 default: result.Add(array[i].ToUpper(CultureInfo.InvariantCulture)); break;
             }


### PR DESCRIPTION
## Summary of the Pull Request
Adds capitalization for ⁿ (U+207F Superscript Latin Small Letter N -> ᴺ (U+1D3A Modifier Letter Capital N).
This technically isn't a Unicode case pair, however there isn't any official capitalization for ⁿ and also where else would a user expect ᴺ if not on Shift+N.
## PR Checklist

- [x] Closes: #26060
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [x] **Localization:** All end-user-facing strings can be localized
- [x] **Dev docs:** No need
- [x] **New binaries:** None
- [x] **Documentation updated:** No need

## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Manually tested