### PR TITLE
CmdPal: Fix first-open top-level context menus for slow providers

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandItemViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandItemViewModel.cs
@@ -86,7 +86,14 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel, ICommandBa
 
     public CommandItemViewModel? SecondaryCommand => _secondaryMoreCommand;
 
-    public bool CanOpenContextMenu => AllCommands.Any(item => item is CommandItemViewModel command && command.ShouldBeVisible);
+    public bool CanOpenContextMenu =>
+
+        // BEAR LOADING: A visible synthetic primary command makes the item
+        // context-openable immediately, even if out-of-proc MoreCommands are still
+        // hydrating. Without this fast path, the first open request can race slow
+        // menu initialization and get dropped.
+        _defaultCommandContextItemViewModel?.ShouldBeVisible == true ||
+        _moreCommandsSnapshot.Any(item => item is CommandItemViewModel command && command.ShouldBeVisible);
 
     public bool ShouldBeVisible => !string.IsNullOrEmpty(Name);
 
@@ -132,13 +139,15 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel, ICommandBa
             return;
         }
 
-        Command = new(model.Command, PageContext);
+        var command = model.Command;
+        Command = new(command, PageContext);
         Command.FastInitializeProperties();
 
         _itemTitle = model.Title;
         Subtitle = model.Subtitle;
         _titleCache.Invalidate();
         _subtitleCache.Invalidate();
+        TryCreateDefaultCommandContextItem(command);
 
         Initialized |= InitializedState.FastInitialized;
     }
@@ -215,7 +224,7 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel, ICommandBa
 
         BuildAndInitMoreCommands();
 
-        TryCreateDefaultCommandContextItem(model);
+        TryCreateDefaultCommandContextItem(model.Command);
 
         lock (_moreCommandsLock)
         {
@@ -316,7 +325,8 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel, ICommandBa
         {
             case nameof(Command):
                 Command.PropertyChanged -= Command_PropertyChanged;
-                Command = new(model.Command, PageContext);
+                var command = model.Command;
+                Command = new(command, PageContext);
                 Command.InitializeProperties();
                 Command.PropertyChanged += Command_PropertyChanged;
 
@@ -332,7 +342,7 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel, ICommandBa
                 }
                 else
                 {
-                    TryCreateDefaultCommandContextItem(model);
+                    TryCreateDefaultCommandContextItem(command);
                 }
 
                 UpdateProperty(nameof(Name));
@@ -407,7 +417,7 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel, ICommandBa
                 }
                 else
                 {
-                    TryCreateDefaultCommandContextItem(model);
+                    TryCreateDefaultCommandContextItem(model.Command);
                 }
 
                 break;
@@ -427,19 +437,22 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel, ICommandBa
     /// When a new instance is created, the snapshot is refreshed and
     /// <see cref="AllCommands"/> is notified.
     /// </summary>
-    private void TryCreateDefaultCommandContextItem(ICommandItem model)
+    private void TryCreateDefaultCommandContextItem(ICommand? commandModel)
     {
         if (_defaultCommandContextItemViewModel is not null)
         {
             return;
         }
 
-        if (string.IsNullOrEmpty(model.Command?.Name))
+        // We only synthesize the primary entry when the command is already
+        // usable; a null/empty primary must still fall back to late
+        // MoreCommands-based opening.
+        if (string.IsNullOrEmpty(Command.Name) || commandModel is null)
         {
             return;
         }
 
-        _defaultCommandContextItemViewModel = new CommandContextItemViewModel(new CommandContextItem(model.Command!), PageContext)
+        _defaultCommandContextItemViewModel = new CommandContextItemViewModel(new CommandContextItem(commandModel), PageContext)
         {
             _itemTitle = Name,
             Subtitle = Subtitle,

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml.cs
@@ -43,6 +43,8 @@ public sealed partial class ListPage : Page,
 
     private ListItemViewModel? _stickySelectedItem;
     private ListItemViewModel? _lastPushedToVm;
+    private long _pendingContextMenuOpenRequestId;
+    private Action? _cancelPendingContextMenuOpen;
 
     // A single search-text change can produce multiple ItemsUpdated calls
     // dispatched as separate UI-thread callbacks. A later "soft" update
@@ -123,6 +125,8 @@ public sealed partial class ListPage : Page,
     protected override void OnNavigatingFrom(NavigatingCancelEventArgs e)
     {
         base.OnNavigatingFrom(e);
+
+        CancelPendingContextMenuOpen();
 
         WeakReferenceMessenger.Default.Unregister<NavigateNextCommand>(this);
         WeakReferenceMessenger.Default.Unregister<NavigatePreviousCommand>(this);
@@ -283,17 +287,7 @@ public sealed partial class ListPage : Page,
             ViewModel?.UpdateSelectedItemCommand.Execute(item);
 
             var pos = e.GetPosition(element);
-
-            _ = DispatcherQueue.TryEnqueue(
-                () =>
-                {
-                    WeakReferenceMessenger.Default.Send<OpenContextMenuMessage>(
-                        new OpenContextMenuMessage(
-                            element,
-                            FlyoutPlacementMode.BottomEdgeAlignedLeft,
-                            pos,
-                            ContextMenuFilterLocation.Top));
-                });
+            RequestContextMenuOpen(item, element, pos);
         }
     }
 
@@ -1014,21 +1008,14 @@ public sealed partial class ListPage : Page,
             pos = new(0, element.ActualHeight);
         }
 
-        _ = DispatcherQueue.TryEnqueue(
-            () =>
-            {
-                WeakReferenceMessenger.Default.Send<OpenContextMenuMessage>(
-                    new OpenContextMenuMessage(
-                        element,
-                        FlyoutPlacementMode.BottomEdgeAlignedLeft,
-                        pos,
-                        ContextMenuFilterLocation.Top));
-            });
+        ViewModel?.UpdateSelectedItemCommand.Execute(item);
+        RequestContextMenuOpen(item, element, pos);
         e.Handled = true;
     }
 
     private void Items_OnContextCanceled(UIElement sender, RoutedEventArgs e)
     {
+        CancelPendingContextMenuOpen();
         _ = DispatcherQueue.TryEnqueue(() => WeakReferenceMessenger.Default.Send<CloseContextMenuMessage>());
     }
 
@@ -1208,6 +1195,87 @@ public sealed partial class ListPage : Page,
 
         // disableAnimation: true prevents a visible jump animation
         scroll.ChangeView(horizontalOffset: null, verticalOffset: 0, zoomFactor: null, disableAnimation: true);
+    }
+
+    private void RequestContextMenuOpen(ListItemViewModel item, FrameworkElement element, Point pos)
+    {
+        // BEAR LOADING: Right-click can arrive before the selected item's slow
+        // context-menu hydration completes, especially for out-of-proc
+        // providers. Keep this exact open request alive until the same
+        // selected item becomes context-openable instead of dropping the first
+        // click.
+        CancelPendingContextMenuOpen();
+        var requestId = Interlocked.Increment(ref _pendingContextMenuOpenRequestId);
+
+        System.ComponentModel.PropertyChangedEventHandler? onItemChanged = null;
+        Action? detach = null;
+        detach = () =>
+        {
+            if (onItemChanged is not null)
+            {
+                item.PropertyChanged -= onItemChanged;
+            }
+
+            if (ReferenceEquals(_cancelPendingContextMenuOpen, detach))
+            {
+                _cancelPendingContextMenuOpen = null;
+            }
+        };
+
+        onItemChanged = (_, args) =>
+        {
+            if (args.PropertyName is nameof(ListItemViewModel.CanOpenContextMenu) or nameof(ListItemViewModel.AllCommands) &&
+                TryOpenContextMenuIfReady(item, element, pos, requestId))
+            {
+                detach();
+            }
+        };
+
+        item.PropertyChanged += onItemChanged;
+        _cancelPendingContextMenuOpen = detach;
+
+        if (TryOpenContextMenuIfReady(item, element, pos, requestId))
+        {
+            detach();
+        }
+    }
+
+    private bool TryOpenContextMenuIfReady(ListItemViewModel item, FrameworkElement element, Point pos, long requestId)
+    {
+        // Ignore stale requests so rapid selection changes or cancelled opens
+        // can't resurrect an old context menu on the wrong item.
+        if (requestId != Volatile.Read(ref _pendingContextMenuOpenRequestId) ||
+            !ReferenceEquals(ItemView.SelectedItem, item) ||
+            !item.CanOpenContextMenu)
+        {
+            return false;
+        }
+
+        _ = DispatcherQueue.TryEnqueue(
+            () =>
+            {
+                if (requestId != Volatile.Read(ref _pendingContextMenuOpenRequestId) ||
+                    !ReferenceEquals(ItemView.SelectedItem, item))
+                {
+                    return;
+                }
+
+                WeakReferenceMessenger.Default.Send<OpenContextMenuMessage>(
+                    new OpenContextMenuMessage(
+                        element,
+                        FlyoutPlacementMode.BottomEdgeAlignedLeft,
+                        pos,
+                        ContextMenuFilterLocation.Top));
+            });
+
+        return true;
+    }
+
+    private void CancelPendingContextMenuOpen()
+    {
+        Interlocked.Increment(ref _pendingContextMenuOpenRequestId);
+        _cancelPendingContextMenuOpen?.Invoke();
+        _cancelPendingContextMenuOpen = null;
     }
 
     private IDisposable SuppressSelectionChangedScope()

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/CommandItemViewModelTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/CommandItemViewModelTests.cs
@@ -79,6 +79,25 @@ public class CommandItemViewModelTests
     }
 
     [TestMethod]
+    public void FastInitializeProperties_CreatesPrimaryContextItem()
+    {
+        // Context menus are opened from fast-initialized list items before slow init completes.
+        // The synthetic primary command must already exist so the first right-click can open the menu.
+        var pageContext = new TestPageContext();
+        var item = new CommandItem(new NoOpCommand { Name = "Primary" })
+        {
+            Title = "Primary",
+        };
+
+        var viewModel = new CommandItemViewModel(new(item), new(pageContext), DefaultContextMenuFactory.Instance);
+        viewModel.FastInitializeProperties();
+
+        Assert.AreEqual(1, viewModel.AllCommands.Count);
+        Assert.IsTrue(viewModel.CanOpenContextMenu);
+        Assert.AreEqual("Primary", ((CommandContextItemViewModel)viewModel.AllCommands[0]).Name);
+    }
+
+    [TestMethod]
     public void LatePrimaryCommandCreation_AddsPrimaryToAllCommands()
     {
         // Reproduces issue where SlowInitializeProperties runs before a real primary command exists.


### PR DESCRIPTION
## Summary of the Pull Request

This PR fixes opening of the list item context menu through right-click, which affected mainly 3rd party out-of-process extensions.

- Keeps the first context-menu request alive when a top-level item is selected but its out-of-proc MoreCommands are still hydrating.
- Short-circuits CanOpenContextMenu when a valid synthetic primary command is already available, so items with a usable primary action can open immediately without waiting for late menu hydration.


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #46625
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

