### PR TITLE
Fix NullReferenceException crash in Settings Frame_NavigationFailed handler

### DIFF
--- a/src/settings-ui/Settings.UI/ViewModels/ShellViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/ShellViewModel.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
 
+using ManagedCommon;
 using Microsoft.PowerToys.Settings.UI.Helpers;
 using Microsoft.PowerToys.Settings.UI.Library;
 using Microsoft.PowerToys.Settings.UI.Library.Helpers;
@@ -135,7 +136,8 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
 
         private void Frame_NavigationFailed(object sender, NavigationFailedEventArgs e)
         {
-            throw e.Exception;
+            e.Handled = true;
+            Logger.LogError($"Failed to navigate to page {e.SourcePageType?.FullName ?? "(unknown)"}", e.Exception);
         }
 
         private void Frame_Navigated(object sender, NavigationEventArgs e)


### PR DESCRIPTION
The Frame_NavigationFailed handler in ShellViewModel was using 'throw e.Exception'
which throws a NullReferenceException when e.Exception is null (C# 'throw null'
semantics). Even when e.Exception is non-null, re-throwing it this way creates an
unhandled exception that escalates through WinUI to FailFastWithStowedExceptions,
terminating the entire Settings process.

This was observed in crash dumps where a search query triggered navigation to
SearchResultsPage which failed, invoking Frame_NavigationFailed. The crash bucket
is STOWED_EXCEPTION_System.NullReferenceException_80004003_PowerToys.Settings.dll
with failure hash {73484fc9-e7b8-14e8-7bfe-53de191a166d}.

The fix:
- Sets e.Handled = true to prevent the exception from propagating to WinUI
- Logs the navigation failure using the existing Logger infrastructure
- Uses null-safe access on e.SourcePageType and e.Exception

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ no logged bugs, I found this issue on my machine] Closes: #xxx
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [No ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ N/A] **Localization:** All end-user-facing strings can be localized
- [ N/A] **Dev docs:** Added/updated
- [ N/A] **New binaries:** Added on the required places
   - [N/A ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [N/A ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ N/A] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ N/A] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ N/A] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- There were no tests that covered this before, I'm just adding better error handling rather than crash. I have not verified as I haven't been able to repro the crash state.

