### PR TITLE
Fix CsWinRT1028: Add partial to WinRT interface classes

### DIFF
--- a/src/modules/AdvancedPaste/AdvancedPaste.UnitTests/ServicesTests/KernelServiceIntegrationTests.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste.UnitTests/ServicesTests/KernelServiceIntegrationTests.cs
@@ -26,7 +26,7 @@ namespace AdvancedPaste.UnitTests.ServicesTests;
 [TestClass]
 
 /// <summary>Integration tests for the Kernel service; connects to OpenAI and uses full AdvancedPaste action catalog.</summary>
-public sealed class KernelServiceIntegrationTests : IDisposable
+public sealed partial class KernelServiceIntegrationTests : IDisposable
 {
     private const string StandardImageFile = "image_with_text_example.png";
     private IKernelService _kernelService;

--- a/src/modules/AdvancedPaste/AdvancedPaste.UnitTests/Utils/AdvancedPasteEventListener.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste.UnitTests/Utils/AdvancedPasteEventListener.cs
@@ -12,7 +12,7 @@ using Microsoft.PowerToys.Telemetry;
 
 namespace AdvancedPaste.UnitTests.Utils;
 
-internal sealed class AdvancedPasteEventListener : EventListener
+internal sealed partial class AdvancedPasteEventListener : EventListener
 {
     private readonly List<AdvancedPasteGenerateCustomFormatEvent> _customFormatEvents = [];
     private readonly List<AdvancedPasteSemanticKernelFormatEvent> _semanticKernelEvents = [];

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
@@ -13,7 +13,7 @@ using EnvironmentVariablesUILib.Models;
 
 namespace EnvironmentVariablesUILib.Helpers
 {
-    public sealed class EnvironmentVariablesService : IEnvironmentVariablesService
+    public sealed partial class EnvironmentVariablesService : IEnvironmentVariablesService
     {
         private const string ProfilesJsonFileSubPath = "Microsoft\\PowerToys\\EnvironmentVariables\\";
 

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/DefaultVariablesSet.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/DefaultVariablesSet.cs
@@ -6,7 +6,7 @@ using System;
 
 namespace EnvironmentVariablesUILib.Models
 {
-    public class DefaultVariablesSet : VariablesSet
+    public partial class DefaultVariablesSet : VariablesSet
     {
         public DefaultVariablesSet(Guid id, string name, VariablesSetType type)
             : base(id, name, type)

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Apps.UnitTests/MockAppCache.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Apps.UnitTests/MockAppCache.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CmdPal.Ext.Apps.UnitTests;
 /// <summary>
 /// Mock implementation of IAppCache for unit testing.
 /// </summary>
-public class MockAppCache : IAppCache
+public partial class MockAppCache : IAppCache
 {
     private readonly List<Win32Program> _win32s = new();
     private readonly List<IUWPApplication> _uwps = new();

--- a/src/modules/imageresizer/tests/Models/ResizeOperationTests.cs
+++ b/src/modules/imageresizer/tests/Models/ResizeOperationTests.cs
@@ -16,7 +16,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace ImageResizer.Models
 {
     [TestClass]
-    public class ResizeOperationTests : IDisposable
+    public partial class ResizeOperationTests : IDisposable
     {
         // Known legacy container format GUID for PNG, used as FallbackEncoder value in settings JSON
         private static readonly Guid PngContainerFormatGuid = new Guid("1b7cfaf4-713f-473c-bbcd-6137425faeaf");

--- a/src/modules/imageresizer/tests/Test/TestDirectory.cs
+++ b/src/modules/imageresizer/tests/Test/TestDirectory.cs
@@ -15,7 +15,7 @@ using IOPath = System.IO.Path;
 
 namespace ImageResizer
 {
-    public class TestDirectory : IDisposable
+    public partial class TestDirectory : IDisposable
     {
         private readonly string _path;
         private bool disposedValue;

--- a/src/modules/imageresizer/ui/Cli/Commands/ImageResizerRootCommand.cs
+++ b/src/modules/imageresizer/ui/Cli/Commands/ImageResizerRootCommand.cs
@@ -11,7 +11,7 @@ namespace ImageResizer.Cli.Commands
     /// <summary>
     /// Root command for the ImageResizer CLI.
     /// </summary>
-    public sealed class ImageResizerRootCommand : RootCommand
+    public sealed partial class ImageResizerRootCommand : RootCommand
     {
         public ImageResizerRootCommand()
             : base("PowerToys Image Resizer - Resize images from command line")

--- a/src/modules/imageresizer/ui/Models/CustomSize.cs
+++ b/src/modules/imageresizer/ui/Models/CustomSize.cs
@@ -9,7 +9,7 @@ using ImageResizer.Helpers;
 
 namespace ImageResizer.Models
 {
-    public class CustomSize : ResizeSize
+    public partial class CustomSize : ResizeSize
     {
         [JsonIgnore]
         public override string Name

--- a/src/modules/imageresizer/ui/Properties/Settings.cs
+++ b/src/modules/imageresizer/ui/Properties/Settings.cs
@@ -184,7 +184,7 @@ namespace ImageResizer.Properties
             }
         }
 
-        private class AllSizesCollection : IEnumerable<ResizeSize>, INotifyCollectionChanged, INotifyPropertyChanged
+        private partial class AllSizesCollection : IEnumerable<ResizeSize>, INotifyCollectionChanged, INotifyPropertyChanged
         {
             private readonly Settings _settings;
             private ObservableCollection<ResizeSize> _sizes;
@@ -270,7 +270,7 @@ namespace ImageResizer.Properties
             IEnumerator IEnumerable.GetEnumerator()
                 => GetEnumerator();
 
-            private class AllSizesEnumerator : IEnumerator<ResizeSize>
+            private partial class AllSizesEnumerator : IEnumerator<ResizeSize>
             {
                 private readonly AllSizesCollection _list;
                 private int _index = -1;

--- a/src/modules/imageresizer/ui/Services/NoOpAiSuperResolutionService.cs
+++ b/src/modules/imageresizer/ui/Services/NoOpAiSuperResolutionService.cs
@@ -6,7 +6,7 @@ using Windows.Graphics.Imaging;
 
 namespace ImageResizer.Services
 {
-    public sealed class NoOpAiSuperResolutionService : IAISuperResolutionService
+    public sealed partial class NoOpAiSuperResolutionService : IAISuperResolutionService
     {
         public static NoOpAiSuperResolutionService Instance { get; } = new NoOpAiSuperResolutionService();
 

--- a/src/modules/imageresizer/ui/Services/WinAiSuperResolutionService.cs
+++ b/src/modules/imageresizer/ui/Services/WinAiSuperResolutionService.cs
@@ -11,7 +11,7 @@ using Windows.Graphics.Imaging;
 
 namespace ImageResizer.Services
 {
-    public sealed class WinAiSuperResolutionService : IAISuperResolutionService
+    public sealed partial class WinAiSuperResolutionService : IAISuperResolutionService
     {
         private readonly ImageScaler _imageScaler;
         private readonly object _usageLock = new object();

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/KeyboardHookHelper.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/KeyboardHookHelper.cs
@@ -13,7 +13,7 @@ using Windows.System;
 
 namespace KeyboardManagerEditorUI.Helpers
 {
-    public class KeyboardHookHelper : IDisposable
+    public partial class KeyboardHookHelper : IDisposable
     {
         private static KeyboardHookHelper? _instance;
 

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Interop/KeyboardMappingService.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Interop/KeyboardMappingService.cs
@@ -12,7 +12,7 @@ using ManagedCommon;
 
 namespace KeyboardManagerEditorUI.Interop
 {
-    public class KeyboardMappingService : IDisposable
+    public partial class KeyboardMappingService : IDisposable
     {
         private IntPtr _configHandle;
         private bool _disposed;

--- a/src/modules/peek/Peek.Common/Extensions/DisposablePropertyStore.cs
+++ b/src/modules/peek/Peek.Common/Extensions/DisposablePropertyStore.cs
@@ -10,7 +10,7 @@ using Peek.Common.Models;
 
 namespace Peek.Common.Extensions
 {
-    public sealed class DisposablePropertyStore : IDisposable
+    public sealed partial class DisposablePropertyStore : IDisposable
     {
         private readonly IPropertyStore _propertyStore;
 

--- a/src/settings-ui/QuickAccess.UI/Services/QuickAccessCoordinator.cs
+++ b/src/settings-ui/QuickAccess.UI/Services/QuickAccessCoordinator.cs
@@ -13,7 +13,7 @@ using PowerToys.Interop;
 
 namespace Microsoft.PowerToys.QuickAccess.Services;
 
-internal sealed class QuickAccessCoordinator : IQuickAccessCoordinator, IDisposable
+internal sealed partial class QuickAccessCoordinator : IQuickAccessCoordinator, IDisposable
 {
     private readonly MainWindow _window;
     private readonly QuickAccessLaunchContext _launchContext;

--- a/src/settings-ui/QuickAccess.UI/ViewModels/AllAppsViewModel.cs
+++ b/src/settings-ui/QuickAccess.UI/ViewModels/AllAppsViewModel.cs
@@ -20,7 +20,7 @@ using Microsoft.Windows.ApplicationModel.Resources;
 
 namespace Microsoft.PowerToys.QuickAccess.ViewModels;
 
-public sealed class AllAppsViewModel : Observable
+public sealed partial class AllAppsViewModel : Observable
 {
     private readonly object _sortLock = new object();
     private readonly IQuickAccessCoordinator _coordinator;

--- a/src/settings-ui/QuickAccess.UI/ViewModels/FlyoutMenuItem.cs
+++ b/src/settings-ui/QuickAccess.UI/ViewModels/FlyoutMenuItem.cs
@@ -10,7 +10,7 @@ using Microsoft.PowerToys.Settings.UI.Controls;
 
 namespace Microsoft.PowerToys.QuickAccess.ViewModels;
 
-public sealed class FlyoutMenuItem : ModuleListItem
+public sealed partial class FlyoutMenuItem : ModuleListItem
 {
     private bool _visible;
 

--- a/src/settings-ui/QuickAccess.UI/ViewModels/LauncherViewModel.cs
+++ b/src/settings-ui/QuickAccess.UI/ViewModels/LauncherViewModel.cs
@@ -15,7 +15,7 @@ using Microsoft.Windows.ApplicationModel.Resources;
 
 namespace Microsoft.PowerToys.QuickAccess.ViewModels;
 
-public sealed class LauncherViewModel : Observable
+public sealed partial class LauncherViewModel : Observable
 {
     private readonly IQuickAccessCoordinator _coordinator;
     private readonly ISettingsRepository<GeneralSettings> _settingsRepository;

--- a/src/settings-ui/Settings.UI.Controls/ModuleList/ModuleListItem.cs
+++ b/src/settings-ui/Settings.UI.Controls/ModuleList/ModuleListItem.cs
@@ -9,7 +9,7 @@ using System.Windows.Input;
 
 namespace Microsoft.PowerToys.Settings.UI.Controls
 {
-    public class ModuleListItem : INotifyPropertyChanged
+    public partial class ModuleListItem : INotifyPropertyChanged
     {
         private bool _isEnabled;
         private string _label = string.Empty;

--- a/src/settings-ui/Settings.UI.Controls/QuickAccess/QuickAccessItem.cs
+++ b/src/settings-ui/Settings.UI.Controls/QuickAccess/QuickAccessItem.cs
@@ -8,7 +8,7 @@ using Microsoft.UI.Xaml;
 
 namespace Microsoft.PowerToys.Settings.UI.Controls
 {
-    public sealed class QuickAccessItem : Observable
+    public sealed partial class QuickAccessItem : Observable
     {
         private string _title = string.Empty;
 

--- a/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/General.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/General.cs
@@ -16,7 +16,7 @@ using JsonSerializer = System.Text.Json.JsonSerializer;
 namespace ViewModelTests
 {
     [TestClass]
-    public class General
+    public partial class General
     {
         public const string GeneralSettingsFileName = "Test\\GeneralSettings";
 
@@ -28,7 +28,7 @@ namespace ViewModelTests
             mockGeneralSettingsUtils = ISettingsUtilsMocks.GetStubSettingsUtils<GeneralSettings>();
         }
 
-        private sealed class TestGeneralViewModel : GeneralViewModel
+        private sealed partial class TestGeneralViewModel : GeneralViewModel
         {
             public TestGeneralViewModel(
                 Microsoft.PowerToys.Settings.UI.Library.Interfaces.ISettingsRepository<GeneralSettings> settingsRepository,

--- a/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/PowerLauncherViewModelTest.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/PowerLauncherViewModelTest.cs
@@ -13,7 +13,7 @@ using Moq;
 namespace ViewModelTests
 {
     [TestClass]
-    public class PowerLauncherViewModelTest : IDisposable
+    public partial class PowerLauncherViewModelTest : IDisposable
     {
         private sealed class SendCallbackMock
         {

--- a/src/settings-ui/Settings.UI/Helpers/StoreExtensionHelper.cs
+++ b/src/settings-ui/Settings.UI/Helpers/StoreExtensionHelper.cs
@@ -16,7 +16,7 @@ namespace Microsoft.PowerToys.Settings.UI.Helpers
     /// <summary>
     /// Helper class to manage installation status and installation command for a Microsoft Store extension.
     /// </summary>
-    public class StoreExtensionHelper : INotifyPropertyChanged
+    public partial class StoreExtensionHelper : INotifyPropertyChanged
     {
         private readonly string _packageFamilyName;
         private readonly string _storeUri;

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/AdvancedPastePage.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/AdvancedPastePage.xaml.cs
@@ -681,7 +681,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             await LoadFoundryLocalModelsAsync();
         }
 
-        private sealed class FoundryDownloadableModel : INotifyPropertyChanged
+        private sealed partial class FoundryDownloadableModel : INotifyPropertyChanged
         {
             private readonly List<string> _deviceTags;
             private double _progress;

--- a/src/settings-ui/Settings.UI/ViewModels/CmdPalViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/CmdPalViewModel.cs
@@ -23,7 +23,7 @@ using Windows.Management.Deployment;
 
 namespace Microsoft.PowerToys.Settings.UI.ViewModels
 {
-    public class CmdPalViewModel : PageViewModelBase
+    public partial class CmdPalViewModel : PageViewModelBase
     {
         protected override string ModuleName => "CmdPal";
 

--- a/src/settings-ui/Settings.UI/ViewModels/MonitorSelectionItem.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/MonitorSelectionItem.cs
@@ -13,7 +13,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
     /// <summary>
     /// ViewModel for monitor selection in profile editor
     /// </summary>
-    public class MonitorSelectionItem : INotifyPropertyChanged
+    public partial class MonitorSelectionItem : INotifyPropertyChanged
     {
         private bool _isSelected;
         private int _brightness = 100;

--- a/src/settings-ui/Settings.UI/ViewModels/PeekViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/PeekViewModel.cs
@@ -21,7 +21,7 @@ using Settings.UI.Library;
 
 namespace Microsoft.PowerToys.Settings.UI.ViewModels
 {
-    public class PeekViewModel : PageViewModelBase
+    public partial class PeekViewModel : PageViewModelBase
     {
         protected override string ModuleName => PeekSettings.ModuleName;
 

--- a/src/settings-ui/Settings.UI/ViewModels/ProfileEditorViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/ProfileEditorViewModel.cs
@@ -16,7 +16,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
     /// <summary>
     /// ViewModel for Profile Editor Dialog
     /// </summary>
-    public class ProfileEditorViewModel : INotifyPropertyChanged
+    public partial class ProfileEditorViewModel : INotifyPropertyChanged
     {
         private string _profileName = string.Empty;
         private ObservableCollection<MonitorSelectionItem> _monitors;

--- a/src/settings-ui/Settings.UI/ViewModels/SearchResultsViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/SearchResultsViewModel.cs
@@ -12,7 +12,7 @@ using Settings.UI.Library;
 
 namespace Microsoft.PowerToys.Settings.UI.ViewModels
 {
-    public class SearchResultsViewModel : INotifyPropertyChanged
+    public partial class SearchResultsViewModel : INotifyPropertyChanged
     {
         private ObservableCollection<SettingEntry> _moduleResults = new();
         private ObservableCollection<SettingsGroup> _groupedSettingsResults = new();
@@ -97,7 +97,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
     }
 
 #pragma warning disable SA1402 // File may only contain a single type
-    public class SettingsGroup : INotifyPropertyChanged
+    public partial class SettingsGroup : INotifyPropertyChanged
 #pragma warning restore SA1402 // File may only contain a single type
     {
         private string _groupName;

--- a/src/settings-ui/Settings.UI/ViewModels/ShortcutConflictViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/ShortcutConflictViewModel.cs
@@ -25,7 +25,7 @@ using Microsoft.Windows.ApplicationModel.Resources;
 
 namespace Microsoft.PowerToys.Settings.UI.ViewModels
 {
-    public class ShortcutConflictViewModel : PageViewModelBase
+    public partial class ShortcutConflictViewModel : PageViewModelBase
     {
         private readonly SettingsFactory _settingsFactory;
         private readonly Func<string, int> _ipcMSGCallBackFunc;

--- a/src/settings-ui/Settings.UI/ViewModels/ZoomItViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/ZoomItViewModel.cs
@@ -22,7 +22,7 @@ using Windows.Devices.Enumeration;
 
 namespace Microsoft.PowerToys.Settings.UI.ViewModels
 {
-    public class ZoomItViewModel : Observable
+    public partial class ZoomItViewModel : Observable
     {
         private const string FormatGif = "GIF";
         private const string FormatMp4 = "MP4";


### PR DESCRIPTION
Add partial keyword to 44 classes implementing WinRT interfaces for trimming and AOT compatibility across 41 files.