### PR TITLE
Fix CA1816: Remove GC.SuppressFinalize from overridden Dispose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -368,3 +368,8 @@ installer/*/*.wxs.bk
 .squad/
 .squad-workstream
 .github/agents/
+nuget.exe
+format_report.json
+build_output*.log
+dotnet_format_output.log
+*.binlog

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceMonitorCommandsProvider.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceMonitorCommandsProvider.cs
@@ -94,7 +94,6 @@ public partial class PerformanceMonitorCommandsProvider : CommandProvider
             DisposeActivePages();
         }
 
-        GC.SuppressFinalize(this);
         base.Dispose();
     }
 

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/WebSearchCommandsProvider.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/WebSearchCommandsProvider.cs
@@ -52,6 +52,5 @@ public sealed partial class WebSearchCommandsProvider : CommandProvider
         _webSearchTopLevelItem?.Dispose();
 
         base.Dispose();
-        GC.SuppressFinalize(this);
     }
 }


### PR DESCRIPTION
Remove GC.SuppressFinalize(this) from 2 overridden Dispose() methods in CmdPal extensions. The base CommandProvider class handles finalization suppression.