### PR TITLE
Fix MVVMTK0051: Set LangVersion=preview for MVVM Toolkit AOT compat

### DIFF
--- a/src/modules/AdvancedPaste/AdvancedPaste/AdvancedPaste.csproj
+++ b/src/modules/AdvancedPaste/AdvancedPaste/AdvancedPaste.csproj
@@ -4,6 +4,7 @@
   <Import Project="$(RepoRoot)src\Common.SelfContained.props" />
 
   <PropertyGroup>
+    <LangVersion>preview</LangVersion>
     <OutputType>WinExe</OutputType>
     <OutputPath>$(RepoRoot)$(Platform)\$(Configuration)\WinUI3Apps</OutputPath>
     <UseWinUI>true</UseWinUI>

--- a/src/modules/AdvancedPaste/AdvancedPaste/ViewModels/OptionsViewModel.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/ViewModels/OptionsViewModel.cs
@@ -53,7 +53,7 @@ namespace AdvancedPaste.ViewModels
         public DataPackageView ClipboardData { get; set; }
 
         [ObservableProperty]
-        private ClipboardItem _currentClipboardItem;
+        public partial ClipboardItem CurrentClipboardItem { get; set; }
 
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(IsCustomAIAvailable))]
@@ -61,11 +61,11 @@ namespace AdvancedPaste.ViewModels
         [NotifyPropertyChangedFor(nameof(ClipboardHasDataForCustomAI))]
         [NotifyPropertyChangedFor(nameof(InputTxtBoxPlaceholderText))]
         [NotifyPropertyChangedFor(nameof(CustomAIUnavailableErrorText))]
-        private ClipboardFormat _availableClipboardFormats;
+        public partial ClipboardFormat AvailableClipboardFormats { get; set; }
 
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(ShowClipboardHistoryButton))]
-        private bool _clipboardHistoryEnabled;
+        public partial bool ClipboardHistoryEnabled { get; set; }
 
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(CustomAIUnavailableErrorText))]
@@ -79,22 +79,22 @@ namespace AdvancedPaste.ViewModels
         [NotifyPropertyChangedFor(nameof(HasTermsLink))]
         [NotifyPropertyChangedFor(nameof(HasPrivacyLink))]
         [NotifyPropertyChangedFor(nameof(HasLegalLinks))]
-        private bool _isAllowedByGPO;
+        public partial bool IsAllowedByGPO { get; set; }
 
         [ObservableProperty]
-        private PasteActionError _pasteActionError = PasteActionError.None;
+        public partial PasteActionError PasteActionError { get; set; } = PasteActionError.None;
 
         [ObservableProperty]
-        private string _query = string.Empty;
+        public partial string Query { get; set; } = string.Empty;
 
         private bool _pasteFormatsDirty;
 
         [ObservableProperty]
-        private bool _isBusy;
+        public partial bool IsBusy { get; set; }
 
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(HasIndeterminateTransformProgress))]
-        private double _transformProgress = double.NaN;
+        public partial double TransformProgress { get; set; } = double.NaN;
 
         public ObservableCollection<PasteFormat> StandardPasteFormats { get; } = [];
 
@@ -614,7 +614,7 @@ namespace AdvancedPaste.ViewModels
         }
 
         [ObservableProperty]
-        private string _customFormatResult;
+        public partial string CustomFormatResult { get; set; }
 
         [RelayCommand]
         public async Task PasteCustomAsync()

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesUILib.csproj
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesUILib.csproj
@@ -3,6 +3,7 @@
   <Import Project="$(RepoRoot)src\Common.Dotnet.CsWinRT.props" />
 
   <PropertyGroup>
+    <LangVersion>preview</LangVersion>
     <OutputType>Library</OutputType>
     <RootNamespace>EnvironmentVariablesUILib</RootNamespace>
     <UseWinUI>true</UseWinUI>

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/ProfileVariablesSet.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/ProfileVariablesSet.cs
@@ -14,7 +14,7 @@ namespace EnvironmentVariablesUILib.Models
     public partial class ProfileVariablesSet : VariablesSet
     {
         [ObservableProperty]
-        private bool _isEnabled;
+        public partial bool IsEnabled { get; set; }
 
         public ProfileVariablesSet()
             : base()

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/Variable.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/Variable.cs
@@ -29,7 +29,6 @@ namespace EnvironmentVariablesUILib.Models
         public partial bool ApplyToSystem { get; set; }
 
         [JsonIgnore]
-        [property: JsonIgnore]
         [ObservableProperty]
         public partial bool IsAppliedFromProfile { get; set; } // Used to mark that a variable in a default set is applied by a profile. Used to disable editing / mark it in the UI.
 
@@ -52,7 +51,6 @@ namespace EnvironmentVariablesUILib.Models
         }
 
         [ObservableProperty]
-        [JsonIgnore]
         [JsonIgnore]
         public partial ObservableCollection<ValuesListItem> ValuesList { get; set; }
 

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/Variable.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/Variable.cs
@@ -20,18 +20,18 @@ namespace EnvironmentVariablesUILib.Models
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(Valid))]
         [NotifyPropertyChangedFor(nameof(ShowAsList))]
-        private string _name;
+        public partial string Name { get; set; }
 
         [ObservableProperty]
-        private string _values;
+        public partial string Values { get; set; }
 
         [ObservableProperty]
-        private bool _applyToSystem;
+        public partial bool ApplyToSystem { get; set; }
 
         [JsonIgnore]
         [property: JsonIgnore]
         [ObservableProperty]
-        private bool _isAppliedFromProfile; // Used to mark that a variable in a default set is applied by a profile. Used to disable editing / mark it in the UI.
+        public partial bool IsAppliedFromProfile { get; set; } // Used to mark that a variable in a default set is applied by a profile. Used to disable editing / mark it in the UI.
 
         [JsonIgnore]
         public bool IsEditable
@@ -52,9 +52,9 @@ namespace EnvironmentVariablesUILib.Models
         }
 
         [ObservableProperty]
-        [property: JsonIgnore]
         [JsonIgnore]
-        private ObservableCollection<ValuesListItem> _valuesList;
+        [JsonIgnore]
+        public partial ObservableCollection<ValuesListItem> ValuesList { get; set; }
 
         [JsonIgnore]
         public bool Valid => Validate();

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/VariablesSet.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/VariablesSet.cs
@@ -25,7 +25,7 @@ namespace EnvironmentVariablesUILib.Models
 
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(Valid))]
-        private string _name;
+        public partial string Name { get; set; }
 
         [JsonIgnore]
         public VariablesSetType Type { get; set; }
@@ -34,7 +34,7 @@ namespace EnvironmentVariablesUILib.Models
         public string IconPath { get; set; }
 
         [ObservableProperty]
-        private ObservableCollection<Variable> _variables;
+        public partial ObservableCollection<Variable> Variables { get; set; }
 
         public bool Valid => Validate();
 

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
@@ -31,17 +31,17 @@ namespace EnvironmentVariablesUILib.ViewModels
         public VariablesSet DefaultVariables { get; private set; } = new DefaultVariablesSet(Guid.NewGuid(), "DefaultVariables", VariablesSetType.User);
 
         [ObservableProperty]
-        private ObservableCollection<ProfileVariablesSet> _profiles;
+        public partial ObservableCollection<ProfileVariablesSet> Profiles { get; set; }
 
         [ObservableProperty]
-        private ObservableCollection<Variable> _appliedVariables = new ObservableCollection<Variable>();
+        public partial ObservableCollection<Variable> AppliedVariables { get; set; } = new ObservableCollection<Variable>();
 
         [ObservableProperty]
-        private bool _isElevated;
+        public partial bool IsElevated { get; set; }
 
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(IsInfoBarButtonVisible))]
-        private EnvironmentState _environmentState;
+        public partial EnvironmentState EnvironmentState { get; set; }
 
         public bool IsInfoBarButtonVisible => EnvironmentState == EnvironmentState.EnvironmentMessageReceived;
 

--- a/src/modules/Hosts/HostsUILib/HostsUILib.csproj
+++ b/src/modules/Hosts/HostsUILib/HostsUILib.csproj
@@ -4,6 +4,7 @@
   <Import Project="$(RepoRoot)src\Common.Dotnet.AotCompatibility.props" />
 
   <PropertyGroup>
+    <LangVersion>preview</LangVersion>
     <OutputType>Library</OutputType>
     <RootNamespace>HostsUILib</RootNamespace>
     <UseWinUI>true</UseWinUI>

--- a/src/modules/Hosts/HostsUILib/Models/Entry.cs
+++ b/src/modules/Hosts/HostsUILib/Models/Entry.cs
@@ -21,7 +21,7 @@ namespace HostsUILib.Models
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(Valid))]
         [NotifyPropertyChangedFor(nameof(IsAddressValid))]
-        private string _address;
+        public partial string Address { get; set; }
 
         partial void OnAddressChanged(string value)
         {
@@ -42,7 +42,7 @@ namespace HostsUILib.Models
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(Valid))]
         [NotifyPropertyChangedFor(nameof(IsHostsValid))]
-        private string _hosts;
+        public partial string Hosts { get; set; }
 
         partial void OnHostsChanged(string value)
         {
@@ -51,19 +51,19 @@ namespace HostsUILib.Models
 
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(Valid))]
-        private string _comment;
+        public partial string Comment { get; set; }
 
         [ObservableProperty]
-        private bool _active;
+        public partial bool Active { get; set; }
 
         [ObservableProperty]
-        private bool? _ping;
+        public partial bool? Ping { get; set; }
 
         [ObservableProperty]
-        private bool _pinging;
+        public partial bool Pinging { get; set; }
 
         [ObservableProperty]
-        private bool _duplicate;
+        public partial bool Duplicate { get; set; }
 
         public bool Valid => Validate(true);
 

--- a/src/modules/Hosts/HostsUILib/ViewModels/MainViewModel.cs
+++ b/src/modules/Hosts/HostsUILib/ViewModels/MainViewModel.cs
@@ -34,43 +34,43 @@ namespace HostsUILib.ViewModels
         private bool _readingHosts;
 
         [ObservableProperty]
-        private Entry _selected;
+        public partial Entry Selected { get; set; }
 
         [ObservableProperty]
-        private bool _error;
+        public partial bool Error { get; set; }
 
         [ObservableProperty]
-        private string _errorMessage;
+        public partial string ErrorMessage { get; set; }
 
         [ObservableProperty]
-        private bool _isReadOnly;
+        public partial bool IsReadOnly { get; set; }
 
         [ObservableProperty]
-        private bool _fileChanged;
+        public partial bool FileChanged { get; set; }
 
         [ObservableProperty]
-        private string _addressFilter;
+        public partial string AddressFilter { get; set; }
 
         [ObservableProperty]
-        private string _hostsFilter;
+        public partial string HostsFilter { get; set; }
 
         [ObservableProperty]
-        private string _commentFilter;
+        public partial string CommentFilter { get; set; }
 
         [ObservableProperty]
-        private string _additionalLines;
+        public partial string AdditionalLines { get; set; }
 
         [ObservableProperty]
-        private bool _isLoading;
+        public partial bool IsLoading { get; set; }
 
         [ObservableProperty]
-        private bool _filtered;
+        public partial bool Filtered { get; set; }
 
         [ObservableProperty]
-        private bool _showOnlyDuplicates;
+        public partial bool ShowOnlyDuplicates { get; set; }
 
         [ObservableProperty]
-        private bool _showSplittedEntriesTooltip;
+        public partial bool ShowSplittedEntriesTooltip { get; set; }
 
         partial void OnShowOnlyDuplicatesChanged(bool value)
         {

--- a/src/modules/peek/Peek.FilePreviewer/Controls/DriveControl.xaml.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Controls/DriveControl.xaml.cs
@@ -17,7 +17,7 @@ namespace Peek.FilePreviewer.Controls
     public sealed partial class DriveControl : UserControl
     {
         [ObservableProperty]
-        private Rect _spaceBarClip;
+        public partial Rect SpaceBarClip { get; set; }
 
         public static readonly DependencyProperty SourceProperty = DependencyProperty.Register(
             nameof(Source),

--- a/src/modules/peek/Peek.FilePreviewer/Controls/ShellPreviewHandlerControl.xaml.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Controls/ShellPreviewHandlerControl.xaml.cs
@@ -27,7 +27,7 @@ namespace Peek.FilePreviewer.Controls
         private static readonly HBRUSH DarkThemeBgBrush = PInvoke_FilePreviewer.CreateSolidBrush(DarkThemeBgColor);
 
         [ObservableProperty]
-        private IPreviewHandler? source;
+        public partial IPreviewHandler? Source { get; set; }
 
         private HWND containerHwnd;
         private WNDPROC containerWndProc;

--- a/src/modules/peek/Peek.FilePreviewer/FilePreview.xaml.cs
+++ b/src/modules/peek/Peek.FilePreviewer/FilePreview.xaml.cs
@@ -49,7 +49,7 @@ namespace Peek.FilePreviewer
                 new PropertyMetadata(false, async (d, e) => await ((FilePreview)d).OnScalingFactorPropertyChanged()));
 
         [ObservableProperty]
-        private int numberOfFiles;
+        public partial int NumberOfFiles { get; set; }
 
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(ImagePreviewer))]
@@ -61,13 +61,13 @@ namespace Peek.FilePreviewer
         [NotifyPropertyChangedFor(nameof(DrivePreviewer))]
         [NotifyPropertyChangedFor(nameof(SpecialFolderPreviewer))]
         [NotifyPropertyChangedFor(nameof(UnsupportedFilePreviewer))]
-        private IPreviewer? previewer;
+        public partial IPreviewer? Previewer { get; set; }
 
         [ObservableProperty]
-        private string infoTooltip = ResourceLoaderInstance.ResourceLoader.GetString("PreviewTooltip_Blank");
+        public partial string InfoTooltip { get; set; } = ResourceLoaderInstance.ResourceLoader.GetString("PreviewTooltip_Blank");
 
         [ObservableProperty]
-        private string noMoreFilesText = ResourceLoaderInstance.ResourceLoader.GetString("NoMoreFiles");
+        public partial string NoMoreFilesText { get; set; } = ResourceLoaderInstance.ResourceLoader.GetString("NoMoreFiles");
 
         private CancellationTokenSource _cancellationTokenSource = new();
 

--- a/src/modules/peek/Peek.FilePreviewer/Models/SpecialFolderPreviewData.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Models/SpecialFolderPreviewData.cs
@@ -10,17 +10,17 @@ namespace Peek.FilePreviewer.Models;
 public partial class SpecialFolderPreviewData : ObservableObject
 {
     [ObservableProperty]
-    private ImageSource? iconPreview;
+    public partial ImageSource? IconPreview { get; set; }
 
     [ObservableProperty]
-    private string? fileName;
+    public partial string? FileName { get; set; }
 
     [ObservableProperty]
-    private string? fileType;
+    public partial string? FileType { get; set; }
 
     [ObservableProperty]
-    private string? fileSize;
+    public partial string? FileSize { get; set; }
 
     [ObservableProperty]
-    private string? dateModified;
+    public partial string? DateModified { get; set; }
 }

--- a/src/modules/peek/Peek.FilePreviewer/Models/UnsupportedFilePreviewData.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Models/UnsupportedFilePreviewData.cs
@@ -10,18 +10,18 @@ namespace Peek.FilePreviewer.Models
     public partial class UnsupportedFilePreviewData : ObservableObject
     {
         [ObservableProperty]
-        private ImageSource? iconPreview;
+        public partial ImageSource? IconPreview { get; set; }
 
         [ObservableProperty]
-        private string? fileName;
+        public partial string? FileName { get; set; }
 
         [ObservableProperty]
-        private string? fileType;
+        public partial string? FileType { get; set; }
 
         [ObservableProperty]
-        private string? fileSize;
+        public partial string? FileSize { get; set; }
 
         [ObservableProperty]
-        private string? dateModified;
+        public partial string? DateModified { get; set; }
     }
 }

--- a/src/modules/peek/Peek.FilePreviewer/Peek.FilePreviewer.csproj
+++ b/src/modules/peek/Peek.FilePreviewer/Peek.FilePreviewer.csproj
@@ -3,6 +3,7 @@
   <Import Project="$(RepoRoot)src\Common.Dotnet.CsWinRT.props" />
 
   <PropertyGroup>
+    <LangVersion>preview</LangVersion>
     <RootNamespace>Peek.FilePreviewer</RootNamespace>
     <UseWinUI>true</UseWinUI>
     <Nullable>enable</Nullable>

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/Archives/ArchivePreviewer.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/Archives/ArchivePreviewer.cs
@@ -37,16 +37,16 @@ namespace Peek.FilePreviewer.Previewers.Archives
         private ulong _extractedSize;
 
         [ObservableProperty]
-        private PreviewState state;
+        public partial PreviewState State { get; set; }
 
         [ObservableProperty]
-        private string? _directoryCountText;
+        public partial string? DirectoryCountText { get; set; }
 
         [ObservableProperty]
-        private string? _fileCountText;
+        public partial string? FileCountText { get; set; }
 
         [ObservableProperty]
-        private string? _sizeText;
+        public partial string? SizeText { get; set; }
 
         private IFileSystemItem Item { get; }
 

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/Archives/Models/ArchiveItem.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/Archives/Models/ArchiveItem.cs
@@ -12,19 +12,19 @@ namespace Peek.FilePreviewer.Previewers.Archives.Models
     public partial class ArchiveItem : ObservableObject
     {
         [ObservableProperty]
-        private string _name;
+        public partial string Name { get; set; }
 
         [ObservableProperty]
-        private ArchiveItemType _type;
+        public partial ArchiveItemType Type { get; set; }
 
         [ObservableProperty]
-        private ImageSource? _icon;
+        public partial ImageSource? Icon { get; set; }
 
         [ObservableProperty]
-        private ulong _size;
+        public partial ulong Size { get; set; }
 
         [ObservableProperty]
-        private bool _isExpanded;
+        public partial bool IsExpanded { get; set; }
 
         public ObservableCollection<ArchiveItem> Children { get; }
 

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/Drive/DrivePreviewer.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/Drive/DrivePreviewer.cs
@@ -23,10 +23,10 @@ namespace Peek.FilePreviewer.Previewers.Drive
     public partial class DrivePreviewer : ObservableObject, IDrivePreviewer
     {
         [ObservableProperty]
-        private PreviewState _state;
+        public partial PreviewState State { get; set; }
 
         [ObservableProperty]
-        private DrivePreviewData? _preview;
+        public partial DrivePreviewData? Preview { get; set; }
 
         private IFileSystemItem Item { get; }
 

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/Drive/Models/DrivePreviewData.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/Drive/Models/DrivePreviewData.cs
@@ -10,31 +10,31 @@ namespace Peek.FilePreviewer.Previewers.Drive.Models
     public partial class DrivePreviewData : ObservableObject
     {
         [ObservableProperty]
-        private ImageSource? iconPreview;
+        public partial ImageSource? IconPreview { get; set; }
 
         [ObservableProperty]
-        private string _name;
+        public partial string Name { get; set; }
 
         [ObservableProperty]
-        private string _type;
+        public partial string Type { get; set; }
 
         [ObservableProperty]
-        private string _fileSystem;
+        public partial string FileSystem { get; set; }
 
         [ObservableProperty]
-        private ulong _capacity;
+        public partial ulong Capacity { get; set; }
 
         [ObservableProperty]
-        private ulong _usedSpace;
+        public partial ulong UsedSpace { get; set; }
 
         [ObservableProperty]
-        private ulong _freeSpace;
+        public partial ulong FreeSpace { get; set; }
 
         /// <summary>
         /// Represents the usage percentage of the drive, ranging from 0 to 1
         /// </summary>
         [ObservableProperty]
-        private double _percentageUsage;
+        public partial double PercentageUsage { get; set; }
 
         public DrivePreviewData()
         {

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/MediaPreviewer/AudioPreviewer.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/MediaPreviewer/AudioPreviewer.cs
@@ -29,10 +29,10 @@ namespace Peek.FilePreviewer.Previewers.MediaPreviewer
         private MediaSource? _mediaSource;
 
         [ObservableProperty]
-        private PreviewState _state;
+        public partial PreviewState State { get; set; }
 
         [ObservableProperty]
-        private AudioPreviewData? _preview;
+        public partial AudioPreviewData? Preview { get; set; }
 
         private IFileSystemItem Item { get; }
 

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/MediaPreviewer/ImagePreviewer.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/MediaPreviewer/ImagePreviewer.cs
@@ -30,19 +30,19 @@ namespace Peek.FilePreviewer.Previewers
     public partial class ImagePreviewer : ObservableObject, IImagePreviewer
     {
         [ObservableProperty]
-        private ImageSource? preview;
+        public partial ImageSource? Preview { get; set; }
 
         [ObservableProperty]
-        private PreviewState state;
+        public partial PreviewState State { get; set; }
 
         [ObservableProperty]
-        private Size? imageSize;
+        public partial Size? ImageSize { get; set; }
 
         [ObservableProperty]
-        private Size maxImageSize;
+        public partial Size MaxImageSize { get; set; }
 
         [ObservableProperty]
-        private double scalingFactor;
+        public partial double ScalingFactor { get; set; }
 
         public ImagePreviewer(IFileSystemItem file)
         {

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/MediaPreviewer/Models/AudioPreviewData.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/MediaPreviewer/Models/AudioPreviewData.cs
@@ -11,22 +11,22 @@ namespace Peek.FilePreviewer.Previewers.MediaPreviewer.Models
     public partial class AudioPreviewData : ObservableObject
     {
         [ObservableProperty]
-        private MediaSource? _mediaSource;
+        public partial MediaSource? MediaSource { get; set; }
 
         [ObservableProperty]
-        private ImageSource? _thumbnail;
+        public partial ImageSource? Thumbnail { get; set; }
 
         [ObservableProperty]
-        private string _title;
+        public partial string Title { get; set; }
 
         [ObservableProperty]
-        private string _artist;
+        public partial string Artist { get; set; }
 
         [ObservableProperty]
-        private string _album;
+        public partial string Album { get; set; }
 
         [ObservableProperty]
-        private string _length;
+        public partial string Length { get; set; }
 
         public AudioPreviewData()
         {

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/MediaPreviewer/VideoPreviewer.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/MediaPreviewer/VideoPreviewer.cs
@@ -28,16 +28,16 @@ namespace Peek.FilePreviewer.Previewers
         private MediaSource? _mediaSource;
 
         [ObservableProperty]
-        private MediaSource? preview;
+        public partial MediaSource? Preview { get; set; }
 
         [ObservableProperty]
-        private PreviewState state;
+        public partial PreviewState State { get; set; }
 
         [ObservableProperty]
-        private Size videoSize;
+        public partial Size VideoSize { get; set; }
 
         [ObservableProperty]
-        private string? missingCodecName;
+        public partial string? MissingCodecName { get; set; }
 
         public VideoPreviewer(IFileSystemItem file)
         {

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/ShellPreviewHandlerPreviewer/ShellPreviewHandlerPreviewer.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/ShellPreviewHandlerPreviewer/ShellPreviewHandlerPreviewer.cs
@@ -32,10 +32,10 @@ namespace Peek.FilePreviewer.Previewers
         private static readonly ConcurrentDictionary<Guid, IClassFactory> HandlerFactories = new();
 
         [ObservableProperty]
-        private IPreviewHandler? preview;
+        public partial IPreviewHandler? Preview { get; set; }
 
         [ObservableProperty]
-        private PreviewState state;
+        public partial PreviewState State { get; set; }
 
         private Stream? fileStream;
 

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/SpecialFolderPreviewer/SpecialFolderPreviewer.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/SpecialFolderPreviewer/SpecialFolderPreviewer.cs
@@ -31,10 +31,10 @@ public partial class SpecialFolderPreviewer : ObservableObject, ISpecialFolderPr
     private DateTime? _dateModified;
 
     [ObservableProperty]
-    private SpecialFolderPreviewData preview = new();
+    public partial SpecialFolderPreviewData Preview { get; set; } = new();
 
     [ObservableProperty]
-    private PreviewState state;
+    public partial PreviewState State { get; set; }
 
     public SpecialFolderPreviewer(IFileSystemItem file)
     {

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/UnsupportedFilePreviewer/UnsupportedFilePreviewer.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/UnsupportedFilePreviewer/UnsupportedFilePreviewer.cs
@@ -45,10 +45,10 @@ namespace Peek.FilePreviewer.Previewers
         private static readonly EnumerationOptions FolderEnumerationOptions;
 
         [ObservableProperty]
-        private UnsupportedFilePreviewData preview = new();
+        public partial UnsupportedFilePreviewData Preview { get; set; } = new();
 
         [ObservableProperty]
-        private PreviewState state;
+        public partial PreviewState State { get; set; }
 
         static UnsupportedFilePreviewer()
         {

--- a/src/modules/peek/Peek.FilePreviewer/Previewers/WebBrowserPreviewer/WebBrowserPreviewer.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/WebBrowserPreviewer/WebBrowserPreviewer.cs
@@ -40,16 +40,16 @@ namespace Peek.FilePreviewer.Previewers
         };
 
         [ObservableProperty]
-        private Uri? preview;
+        public partial Uri? Preview { get; set; }
 
         [ObservableProperty]
-        private PreviewState state;
+        public partial PreviewState State { get; set; }
 
         [ObservableProperty]
-        private bool isDevFilePreview;
+        public partial bool IsDevFilePreview { get; set; }
 
         [ObservableProperty]
-        private bool customContextMenu;
+        public partial bool CustomContextMenu { get; set; }
 
         private bool disposed;
 

--- a/src/modules/peek/Peek.UI/MainWindowViewModel.cs
+++ b/src/modules/peek/Peek.UI/MainWindowViewModel.cs
@@ -45,7 +45,7 @@ namespace Peek.UI
 
         /// <summary>
         /// The actual index of the current item in the items array. Does not necessarily
-        /// correspond to <see cref="_displayIndex"/> if one or more files have been deleted.
+        /// correspond to <see cref="DisplayIndex"/> if one or more files have been deleted.
         /// </summary>
         private int _currentIndex;
 
@@ -53,14 +53,14 @@ namespace Peek.UI
         /// The item index to display in the titlebar.
         /// </summary>
         [ObservableProperty]
-        private int _displayIndex;
+        public partial int DisplayIndex { get; set; }
 
         /// <summary>
         /// The item to be displayed by a matching previewer. May be null if the user has deleted
         /// all items.
         /// </summary>
         [ObservableProperty]
-        private IFileSystemItem? _currentItem;
+        public partial IFileSystemItem? CurrentItem { get; set; }
 
         /// <summary>
         /// Work around missing navigation when peeking from CLI.
@@ -76,11 +76,11 @@ namespace Peek.UI
         }
 
         [ObservableProperty]
-        private string _windowTitle;
+        public partial string WindowTitle { get; set; }
 
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(DisplayItemCount))]
-        private NeighboringItems? _items;
+        public partial NeighboringItems? Items { get; set; }
 
         /// <summary>
         /// The number of items selected and available to preview. Decreases as the user deletes
@@ -102,13 +102,13 @@ namespace Peek.UI
         }
 
         [ObservableProperty]
-        private double _scalingFactor = 1.0;
+        public partial double ScalingFactor { get; set; } = 1.0;
 
         [ObservableProperty]
-        private string _errorMessage = string.Empty;
+        public partial string ErrorMessage { get; set; } = string.Empty;
 
         [ObservableProperty]
-        private bool _isErrorVisible = false;
+        public partial bool IsErrorVisible { get; set; } = false;
 
         private enum NavigationDirection
         {

--- a/src/modules/peek/Peek.UI/Peek.UI.csproj
+++ b/src/modules/peek/Peek.UI/Peek.UI.csproj
@@ -5,6 +5,7 @@
   <Import Project="$(RepoRoot)src\Common.Dotnet.AotCompatibility.props" />
 
   <PropertyGroup>
+    <LangVersion>preview</LangVersion>
     <AssemblyName>PowerToys.Peek.UI</AssemblyName>
     <AssemblyTitle>PowerToys.Peek.UI</AssemblyTitle>
     <AssemblyDescription>PowerToys Peek UI</AssemblyDescription>

--- a/src/modules/peek/Peek.UI/PeekXAML/Views/TitleBar.xaml.cs
+++ b/src/modules/peek/Peek.UI/PeekXAML/Views/TitleBar.xaml.cs
@@ -58,22 +58,22 @@ namespace Peek.UI.Views
                new PropertyMetadata(null, (d, e) => ((TitleBar)d).OnNumberOfFilesPropertyChanged()));
 
         [ObservableProperty]
-        private string openWithAppText = ResourceLoaderInstance.ResourceLoader.GetString("LaunchAppButton_OpenWith_Text");
+        public partial string OpenWithAppText { get; set; } = ResourceLoaderInstance.ResourceLoader.GetString("LaunchAppButton_OpenWith_Text");
 
         [ObservableProperty]
-        private string openWithAppToolTip = ResourceLoaderInstance.ResourceLoader.GetString("LaunchAppButton_OpenWith_ToolTip");
+        public partial string OpenWithAppToolTip { get; set; } = ResourceLoaderInstance.ResourceLoader.GetString("LaunchAppButton_OpenWith_ToolTip");
 
         [ObservableProperty]
-        private string? fileCountText;
+        public partial string? FileCountText { get; set; }
 
         [ObservableProperty]
-        private string fileName = string.Empty;
+        public partial string FileName { get; set; } = string.Empty;
 
         [ObservableProperty]
-        private string defaultAppName = string.Empty;
+        public partial string DefaultAppName { get; set; } = string.Empty;
 
         [ObservableProperty]
-        private bool pinned = false;
+        public partial bool Pinned { get; set; } = false;
 
         public TitleBar()
         {

--- a/src/modules/peek/Peek.UI/Services/NeighboringItemsQuery.cs
+++ b/src/modules/peek/Peek.UI/Services/NeighboringItemsQuery.cs
@@ -11,7 +11,7 @@ namespace Peek.UI
     public partial class NeighboringItemsQuery : ObservableObject
     {
         [ObservableProperty]
-        private bool isMultipleFilesActivation;
+        public partial bool IsMultipleFilesActivation { get; set; }
 
         public NeighboringItems? GetNeighboringItems(Windows.Win32.Foundation.HWND foregroundWindowHandle)
         {

--- a/src/modules/registrypreview/RegistryPreviewUILib/Controls/MonacoEditor/MonacoEditorControl.xaml.cs
+++ b/src/modules/registrypreview/RegistryPreviewUILib/Controls/MonacoEditor/MonacoEditorControl.xaml.cs
@@ -28,7 +28,7 @@ namespace RegistryPreviewUILib
         public string Text { get; private set; }
 
         [ObservableProperty]
-        private bool _isLoading;
+        public partial bool IsLoading { get; set; }
 
         public event EventHandler TextChanged;
 

--- a/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewUILib.csproj
+++ b/src/modules/registrypreview/RegistryPreviewUILib/RegistryPreviewUILib.csproj
@@ -4,6 +4,7 @@
   <Import Project="$(RepoRoot)src\Monaco.props" />
 
   <PropertyGroup>
+    <LangVersion>preview</LangVersion>
     <OutputType>Library</OutputType>
     <RootNamespace>RegistryPreviewUILib</RootNamespace>
     <UseWinUI>true</UseWinUI>


### PR DESCRIPTION
Add LangVersion=preview to 6 projects (AdvancedPaste, EnvironmentVariablesUILib, HostsUILib, Peek.FilePreviewer, Peek.UI, RegistryPreviewUILib) to enable MVVM Toolkit partial property support for WinRT AOT compatibility.