### PR TITLE
Fix SA1622: Add text to empty generic type parameter documentation

### DIFF
--- a/src/dsc/v3/PowerToys.DSC.UnitTests/BaseDscTest.cs
+++ b/src/dsc/v3/PowerToys.DSC.UnitTests/BaseDscTest.cs
@@ -35,7 +35,7 @@ public class BaseDscTest
     /// <summary>
     /// Execute a dsc command with the provided arguments.
     /// </summary>
-    /// <typeparam name="T"></typeparam>
+    /// <typeparam name="T">The type of the DSC command to execute.</typeparam>
     /// <param name="args"></param>
     /// <returns></returns>
     protected DscExecuteResult ExecuteDscCommand<T>(params string[] args)


### PR DESCRIPTION
Add meaningful description to 1 empty typeparam XML doc tag in BaseDscTest.cs.