### PR TITLE
Fix SYSLIB1096: Convert ComImport to GeneratedComInterface

### DIFF
--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Bookmark/Helpers/CommandLauncher.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Bookmark/Helpers/CommandLauncher.cs
@@ -4,11 +4,12 @@
 
 using System.ComponentModel;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using ManagedCommon;
 
 namespace Microsoft.CmdPal.Ext.Bookmarks.Helpers;
 
-internal static class CommandLauncher
+internal static partial class CommandLauncher
 {
     /// <summary>
     ///     Launches the classified item.
@@ -83,10 +84,10 @@ internal static class CommandLauncher
         [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "Private class")]
         private class _ApplicationActivationManager;
 
-        [ComImport]
+        [GeneratedComInterface]
         [Guid("2E941141-7F97-4756-BA1D-9DECDE894A3D")]
         [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-        private interface IApplicationActivationManager
+        private partial interface IApplicationActivationManager
         {
             int ActivateApplication(
                 [MarshalAs(UnmanagedType.LPWStr)] string appUserModelId,

--- a/src/modules/imageresizer/ui/Services/WinAiSuperResolutionService.cs
+++ b/src/modules/imageresizer/ui/Services/WinAiSuperResolutionService.cs
@@ -11,7 +11,7 @@ using Windows.Graphics.Imaging;
 
 namespace ImageResizer.Services
 {
-    public sealed class WinAiSuperResolutionService : IAISuperResolutionService
+    public sealed partial class WinAiSuperResolutionService : IAISuperResolutionService
     {
         private readonly ImageScaler _imageScaler;
         private readonly object _usageLock = new object();

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/IApplicationActivationManager.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program/Programs/IApplicationActivationManager.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 namespace Microsoft.Plugin.Program.Programs.ApplicationActivationHelper
 {
@@ -18,10 +19,10 @@ namespace Microsoft.Plugin.Program.Programs.ApplicationActivationHelper
     }
 
     // ApplicationActivationManager
-    [ComImport]
+    [GeneratedComInterface]
     [Guid("2e941141-7f97-4756-ba1d-9decde894a3d")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    public interface IApplicationActivationManager
+    public partial interface IApplicationActivationManager
     {
         IntPtr ActivateApplication([In] string appUserModelId, [In] string arguments, [In] ActivateOptions options, [Out] out uint processId);
 

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsTerminal/Helpers/IApplicationActivationManager.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsTerminal/Helpers/IApplicationActivationManager.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 namespace Microsoft.PowerToys.Run.Plugin.WindowsTerminal.Helpers
 {
@@ -18,10 +19,10 @@ namespace Microsoft.PowerToys.Run.Plugin.WindowsTerminal.Helpers
     }
 
     // ApplicationActivationManager
-    [ComImport]
+    [GeneratedComInterface]
     [Guid("2e941141-7f97-4756-ba1d-9decde894a3d")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    public interface IApplicationActivationManager
+    public partial interface IApplicationActivationManager
     {
         IntPtr ActivateApplication([In] string appUserModelId, [In] string arguments, [In] ActivateOptions options, [Out] out uint processId);
 

--- a/src/modules/launcher/Wox.Infrastructure/Image/IShellItem.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Image/IShellItem.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 namespace Wox.Infrastructure.Image
 {
@@ -19,10 +20,10 @@ namespace Wox.Infrastructure.Image
         URL = 0x80068000,
     }
 
-    [ComImport]
+    [GeneratedComInterface]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [Guid("43826d1e-e718-42ee-bc55-a1e261c37bfe")]
-    internal interface IShellItem
+    internal partial interface IShellItem
     {
         void BindToHandler(
             IntPtr pbc,

--- a/src/modules/launcher/Wox.Infrastructure/Image/WindowsThumbnailProvider.cs
+++ b/src/modules/launcher/Wox.Infrastructure/Image/WindowsThumbnailProvider.cs
@@ -6,6 +6,7 @@ using System;
 using System.IO.Abstractions;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 using System.Windows;
 using System.Windows.Interop;
 using System.Windows.Media.Imaging;
@@ -26,7 +27,7 @@ namespace Wox.Infrastructure.Image
         InCacheOnly = 0x10,
     }
 
-    public static class WindowsThumbnailProvider
+    public static partial class WindowsThumbnailProvider
     {
         private static readonly IFileSystem FileSystem = new FileSystem();
         private static readonly IPath Path = FileSystem.Path;
@@ -52,10 +53,10 @@ namespace Wox.Infrastructure.Image
             AccessDenied = unchecked((int)0x80030005),
         }
 
-        [ComImport]
+        [GeneratedComInterface]
         [Guid("bcc18b79-ba16-442f-80c4-8a59c30c463b")]
         [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-        internal interface IShellItemImageFactory
+        internal partial interface IShellItemImageFactory
         {
             [PreserveSig]
             HResult GetImage(

--- a/src/modules/launcher/Wox.Plugin/Common/Interfaces/IShellItem.cs
+++ b/src/modules/launcher/Wox.Plugin/Common/Interfaces/IShellItem.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 using Wox.Plugin.Common.Win32;
 
@@ -25,10 +26,10 @@ namespace Wox.Plugin.Common.Interfaces
         URL = 0x80068000,
     }
 
-    [ComImport]
+    [GeneratedComInterface]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [Guid("43826d1e-e718-42ee-bc55-a1e261c37bfe")]
-    public interface IShellItem
+    public partial interface IShellItem
     {
         void BindToHandler(
             IntPtr pbc,

--- a/src/modules/launcher/Wox.Plugin/Common/VirtualDesktop/IVirtualDesktopManager.cs
+++ b/src/modules/launcher/Wox.Plugin/Common/VirtualDesktop/IVirtualDesktopManager.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 namespace Wox.Plugin.Common.VirtualDesktop.Interop
 {
@@ -11,11 +12,10 @@ namespace Wox.Plugin.Common.VirtualDesktop.Interop
     /// Interface for accessing Virtual Desktop Manager.
     /// Code used from <see href="https://learn.microsoft.com/archive/blogs/winsdk/virtual-desktop-switching-in-windows-10"./>
     /// </summary>
-    [ComImport]
+    [GeneratedComInterface]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [Guid("a5cd92ff-29be-454c-8d04-d82879fb3f1b")]
-    [System.Security.SuppressUnmanagedCodeSecurity]
-    internal interface IVirtualDesktopManager
+    internal partial interface IVirtualDesktopManager
     {
         [PreserveSig]
         int IsWindowOnCurrentVirtualDesktop([In] IntPtr hTopLevelWindow, [Out] out int onCurrentDesktop);

--- a/src/modules/peek/Peek.Common/Models/Win32/IEnumIDList.cs
+++ b/src/modules/peek/Peek.Common/Models/Win32/IEnumIDList.cs
@@ -4,13 +4,14 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 namespace Peek.Common.Models
 {
-    [ComImport]
+    [GeneratedComInterface]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [Guid("000214F2-0000-0000-C000-000000000046")]
-    public interface IEnumIDList
+    public partial interface IEnumIDList
     {
         [PreserveSig]
 #pragma warning disable CA1716

--- a/src/modules/peek/Peek.Common/Models/Win32/IFolderView.cs
+++ b/src/modules/peek/Peek.Common/Models/Win32/IFolderView.cs
@@ -5,15 +5,14 @@
 using System;
 using System.Drawing;
 using System.Runtime.InteropServices;
-using System.Security;
+using System.Runtime.InteropServices.Marshalling;
 
 namespace Peek.Common.Models
 {
-    [ComImport]
+    [GeneratedComInterface]
     [Guid("cde725b0-ccc9-4519-917e-325d72fab4ce")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    [SuppressUnmanagedCodeSecurity]
-    public interface IFolderView
+    public partial interface IFolderView
     {
         void GetCurrentViewMode([Out] out uint pViewMode);
 

--- a/src/modules/peek/Peek.Common/Models/Win32/IPropertyStore.cs
+++ b/src/modules/peek/Peek.Common/Models/Win32/IPropertyStore.cs
@@ -4,15 +4,16 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 using static Peek.Common.Helpers.PropertyStoreHelper;
 
 namespace Peek.Common.Models
 {
-    [ComImport]
+    [GeneratedComInterface]
     [Guid("886D8EEB-8CF2-4446-8D02-CDBA1DBDCF99")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    public interface IPropertyStore
+    public partial interface IPropertyStore
     {
         void GetCount(out uint propertyCount);
 

--- a/src/modules/peek/Peek.Common/Models/Win32/IShellFolder2.cs
+++ b/src/modules/peek/Peek.Common/Models/Win32/IShellFolder2.cs
@@ -4,15 +4,16 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 using Windows.Win32.UI.Shell;
 
 namespace Peek.Common.Models
 {
-    [ComImport]
+    [GeneratedComInterface]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [Guid("93F2F68C-1D1B-11D3-A30E-00C04F79ABD1")]
-    public interface IShellFolder2
+    public partial interface IShellFolder2
     {
         [PreserveSig]
         int ParseDisplayName(IntPtr hwnd, IntPtr pbc, [MarshalAs(UnmanagedType.LPWStr)] string pszDisplayName, ref int pchEaten, out IntPtr ppidl, ref int pdwAttributes);

--- a/src/modules/peek/Peek.Common/Models/Win32/IShellItem.cs
+++ b/src/modules/peek/Peek.Common/Models/Win32/IShellItem.cs
@@ -4,15 +4,16 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 using Windows.Win32.UI.Shell;
 
 namespace Peek.Common.Models
 {
-    [ComImport]
+    [GeneratedComInterface]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [Guid("43826d1e-e718-42ee-bc55-a1e261c37bfe")]
-    public interface IShellItem
+    public partial interface IShellItem
     {
         void BindToHandler(
             IntPtr pbc,

--- a/src/modules/peek/Peek.Common/Models/Win32/IShellItemArray.cs
+++ b/src/modules/peek/Peek.Common/Models/Win32/IShellItemArray.cs
@@ -3,37 +3,30 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 using Windows.Win32.UI.Shell;
 
 namespace Peek.Common.Models
 {
-    [ComImport]
+    [GeneratedComInterface]
     [Guid("B63EA76D-1F85-456F-A19C-48159EFA858B")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    public interface IShellItemArray
+    public partial interface IShellItemArray
     {
-        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         void BindToHandler([In, MarshalAs(UnmanagedType.Interface)] IntPtr pbc, [In] ref Guid rbhid, [In] ref Guid riid, out IntPtr ppvOut);
 
-        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         void GetPropertyStore([In] int flags, [In] ref Guid riid, out IntPtr ppv);
 
-        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         void GetPropertyDescriptionList([In] ref PropertyKey keyType, [In] ref Guid riid, out IntPtr ppv);
 
-        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         void GetAttributes([In] SIATTRIBFLAGS dwAttribFlags, [In] uint sfgaoMask, out uint psfgaoAttribs);
 
-        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         int GetCount();
 
-        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         Common.Models.IShellItem GetItemAt(int dwIndex);
 
-        [MethodImpl(MethodImplOptions.InternalCall, MethodCodeType = MethodCodeType.Runtime)]
         void EnumItems([MarshalAs(UnmanagedType.Interface)] out IntPtr ppenumShellItems);
     }
 }

--- a/src/modules/peek/Peek.Common/Models/Win32/IShellItemImageFactory.cs
+++ b/src/modules/peek/Peek.Common/Models/Win32/IShellItemImageFactory.cs
@@ -4,13 +4,14 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 namespace Peek.Common.Models
 {
-    [ComImport]
+    [GeneratedComInterface]
     [Guid("bcc18b79-ba16-442f-80c4-8a59c30c463b")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    public interface IShellItemImageFactory
+    public partial interface IShellItemImageFactory
     {
         [PreserveSig]
         HResult GetImage(

--- a/src/modules/peek/Peek.Common/Models/Win32/IShellView.cs
+++ b/src/modules/peek/Peek.Common/Models/Win32/IShellView.cs
@@ -4,15 +4,14 @@
 
 using System;
 using System.Runtime.InteropServices;
-using System.Security;
+using System.Runtime.InteropServices.Marshalling;
 
 namespace Peek.Common.Models
 {
-    [ComImport]
+    [GeneratedComInterface]
     [Guid("000214E3-0000-0000-C000-000000000046")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    [SuppressUnmanagedCodeSecurity]
-    public interface IShellView
+    public partial interface IShellView
     {
     }
 }

--- a/src/modules/peek/Peek.Common/WIC/IWICBitmapDecoder.cs
+++ b/src/modules/peek/Peek.Common/WIC/IWICBitmapDecoder.cs
@@ -4,13 +4,14 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 namespace Peek.Common.WIC
 {
-    [ComImport]
+    [GeneratedComInterface]
     [Guid(IID.IWICBitmapDecoder)]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    public interface IWICBitmapDecoder
+    public partial interface IWICBitmapDecoder
     {
         [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "Implements COM Interface")]
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Implements COM Interface")]

--- a/src/modules/peek/Peek.Common/WIC/IWICBitmapFrameDecode.cs
+++ b/src/modules/peek/Peek.Common/WIC/IWICBitmapFrameDecode.cs
@@ -4,13 +4,14 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 namespace Peek.Common.WIC
 {
-    [ComImport]
+    [GeneratedComInterface]
     [Guid(IID.IWICBitmapFrameDecode)]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    public interface IWICBitmapFrameDecode : IWICBitmapSource
+    public partial interface IWICBitmapFrameDecode : IWICBitmapSource
     {
         new void GetSize([Out] out int puiWidth, [Out] out int puiHeight);
     }

--- a/src/modules/peek/Peek.Common/WIC/IWICBitmapSource.cs
+++ b/src/modules/peek/Peek.Common/WIC/IWICBitmapSource.cs
@@ -4,13 +4,14 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 namespace Peek.Common.WIC
 {
-    [ComImport]
+    [GeneratedComInterface]
     [Guid(IID.IWICBitmapSource)]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    public interface IWICBitmapSource
+    public partial interface IWICBitmapSource
     {
         void GetSize([Out] out int puiWidth, [Out] out int puiHeight);
     }

--- a/src/modules/peek/Peek.Common/WIC/IWICImagingFactory.cs
+++ b/src/modules/peek/Peek.Common/WIC/IWICImagingFactory.cs
@@ -4,13 +4,14 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 namespace Peek.Common.WIC
 {
-    [ComImport]
+    [GeneratedComInterface]
     [Guid(IID.IWICImagingFactory)]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    public interface IWICImagingFactory
+    public partial interface IWICImagingFactory
     {
         IWICBitmapDecoder CreateDecoderFromFilename(
             [In, MarshalAs(UnmanagedType.LPWStr)] string wzFilename,

--- a/src/modules/previewpane/common/cominterop/IInitializeWithFile.cs
+++ b/src/modules/previewpane/common/cominterop/IInitializeWithFile.cs
@@ -4,16 +4,17 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 namespace Common.Cominterop
 {
     /// <summary>
     /// Exposes a method to initialize a handler, such as a property handler, thumbnail handler, or preview handler, with a file path.
     /// </summary>
-    [ComImport]
+    [GeneratedComInterface]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [Guid("b7d14566-0509-4cce-a71f-0a554233bd9b")]
-    public interface IInitializeWithFile
+    public partial interface IInitializeWithFile
     {
         /// <summary>
         /// Initializes a handler with a file path.

--- a/src/modules/previewpane/common/cominterop/IInitializeWithStream.cs
+++ b/src/modules/previewpane/common/cominterop/IInitializeWithStream.cs
@@ -5,16 +5,17 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
+using System.Runtime.InteropServices.Marshalling;
 
 namespace Common.ComInterlop
 {
     /// <summary>
     /// Exposes a method that initializes a handler, such as a property handler, thumbnail handler, or preview handler, with a stream.
     /// </summary>
-    [ComImport]
+    [GeneratedComInterface]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [Guid("b824b49d-22ac-4161-ac8a-9916e8fa3f7f")]
-    public interface IInitializeWithStream
+    public partial interface IInitializeWithStream
     {
         /// <summary>
         /// Initializes a handler with a stream.

--- a/src/modules/previewpane/common/cominterop/IOleWindow.cs
+++ b/src/modules/previewpane/common/cominterop/IOleWindow.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 namespace Common.ComInterlop
 {
@@ -11,10 +12,10 @@ namespace Common.ComInterlop
     /// The IOleWindow interface provides methods that allow an application to obtain the handle to the various windows that participate
     /// in in-place activation, and also to enter and exit context-sensitive help mode.
     /// </summary>
-    [ComImport]
+    [GeneratedComInterface]
     [Guid("00000114-0000-0000-C000-000000000046")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    public interface IOleWindow
+    public partial interface IOleWindow
     {
         /// <summary>
         /// Retrieves a handle to one of the windows participating in in-place activation (frame, document, parent, or in-place object window).

--- a/src/modules/previewpane/common/cominterop/IPreviewHandler.cs
+++ b/src/modules/previewpane/common/cominterop/IPreviewHandler.cs
@@ -4,16 +4,17 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 namespace Common.ComInterlop
 {
     /// <summary>
     /// Exposes methods for the display of rich previews.
     /// </summary>
-    [ComImport]
+    [GeneratedComInterface]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [Guid("8895b1c6-b41f-4c1c-a562-0d564250836f")]
-    public interface IPreviewHandler
+    public partial interface IPreviewHandler
     {
         /// <summary>
         /// Sets the parent window of the previewer window, as well as the area within the parent to be used for the previewer window.

--- a/src/modules/previewpane/common/cominterop/IPreviewHandlerFrame.cs
+++ b/src/modules/previewpane/common/cominterop/IPreviewHandlerFrame.cs
@@ -4,16 +4,17 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 namespace Common.ComInterlop
 {
     /// <summary>
     /// Enables preview handlers to pass keyboard shortcuts to the host. This interface retrieves a list of keyboard shortcuts and directs the host to handle a keyboard shortcut.
     /// </summary>
-    [ComImport]
+    [GeneratedComInterface]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [Guid("fec87aaf-35f9-447a-adb7-20234491401a")]
-    public interface IPreviewHandlerFrame
+    public partial interface IPreviewHandlerFrame
     {
         /// <summary>
         /// Gets a list of the keyboard shortcuts for the preview host.

--- a/src/modules/previewpane/common/cominterop/IPreviewHandlerVisuals.cs
+++ b/src/modules/previewpane/common/cominterop/IPreviewHandlerVisuals.cs
@@ -4,16 +4,17 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 namespace Common.ComInterlop
 {
     /// <summary>
     /// Exposes methods for applying color and font information to preview handlers.
     /// </summary>
-    [ComImport]
+    [GeneratedComInterface]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
     [Guid("8327b13c-b63f-4b24-9b8a-d010dcc3f599")]
-    public interface IPreviewHandlerVisuals
+    public partial interface IPreviewHandlerVisuals
     {
         /// <summary>
         /// Sets the background color of the preview handler.

--- a/src/modules/previewpane/common/cominterop/IThumbnailProvider.cs
+++ b/src/modules/previewpane/common/cominterop/IThumbnailProvider.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 namespace Common.ComInterlop
 {
@@ -31,10 +32,10 @@ namespace Common.ComInterlop
     /// <summary>
     /// Exposes methods for thumbnail provider.
     /// </summary>
-    [ComImport]
+    [GeneratedComInterface]
     [Guid("e357fccd-a995-4576-b01f-234630154e96")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    public interface IThumbnailProvider
+    public partial interface IThumbnailProvider
     {
         /// <summary>
         /// Gets a thumbnail image and alpha type.

--- a/src/modules/previewpane/common/cominterop/IViewObject.cs
+++ b/src/modules/previewpane/common/cominterop/IViewObject.cs
@@ -4,16 +4,17 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 namespace Common.ComInterlop
 {
     /// <summary>
     /// Enables an object to display itself directly without passing a data object to the caller.
     /// </summary>
-    [ComImport]
+    [GeneratedComInterface]
     [Guid("0000010D-0000-0000-C000-000000000046")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    public interface IViewObject
+    public partial interface IViewObject
     {
         /// <summary>
         /// Draws a representation of an object onto the specified device context.


### PR DESCRIPTION
Convert 28 COM interface declarations from [ComImport] to [GeneratedComInterface] for compile-time COM marshalling code generation across Peek, PreviewPane, Launcher, CmdPal, and ImageResizer modules.