### PR TITLE
Fix MSTEST0037: Replace Assert.IsTrue with Assert.AreEqual

### DIFF
--- a/src/modules/Hosts/Hosts.UITests/HostModuleTests.cs
+++ b/src/modules/Hosts/Hosts.UITests/HostModuleTests.cs
@@ -137,9 +137,7 @@ namespace Hosts.UITests
                 // Add new URL override and a warning tip should be shown
                 this.AddEntry("192.168.0.1", "localhost", true);
 
-                Assert.IsTrue(
-                    this.FindAll<TextBlock>("The hosts file cannot be saved because the program isn't running as administrator.").Count == 1,
-                    "Should display host-file saving error if not run as administrator");
+                Assert.AreEqual(1, this.FindAll<TextBlock>("The hosts file cannot be saved because the program isn't running as administrator.").Count, "Should display host-file saving error if not run as administrator");
             }
         }
 
@@ -197,7 +195,7 @@ namespace Hosts.UITests
 
             // Open-filter-panel
             this.Find<Button>("Filters").Click();
-            Assert.IsTrue(this.FindAll<Button>("Clear filters").Count == 1, "Filter panel should be opened afer click Filter Button");
+            Assert.AreEqual(1, this.FindAll<Button>("Clear filters").Count, "Filter panel should be opened afer click Filter Button");
 
             var addressFilterCases = new KeyValuePair<string, int>[]
             {
@@ -223,7 +221,7 @@ namespace Hosts.UITests
             foreach (var (addressFilter, expectedCount) in addressFilterCases)
             {
                 this.Find<TextBox>("Address").SetText(addressFilter);
-                Assert.IsTrue(this.Find("Entries").FindAll<Button>("Delete").Count == expectedCount);
+                Assert.AreEqual(expectedCount, this.Find("Entries").FindAll<Button>("Delete").Count);
             }
 
             var hostFilterCases = new KeyValuePair<string, int>[]
@@ -247,12 +245,12 @@ namespace Hosts.UITests
             foreach (var (hostFilterCase, expectedCount) in hostFilterCases)
             {
                 this.Find<TextBox>("Hosts").SetText(hostFilterCase);
-                Assert.IsTrue(this.Find("Entries").FindAll<Button>("Delete").Count == expectedCount);
+                Assert.AreEqual(expectedCount, this.Find("Entries").FindAll<Button>("Delete").Count);
             }
 
             // Close-filter-panel
             this.Find<Button>("Filters").Click();
-            Assert.IsFalse(this.FindAll<Button>("Clear filters").Count == 1, "Filter panel should be closed after clicking Filter Button");
+            Assert.AreNotEqual(1, this.FindAll<Button>("Clear filters").Count, "Filter panel should be closed after clicking Filter Button");
         }
 
         private void AddEntry(string ip, string host, bool active = true, bool clickAddEntryButton = true)
@@ -266,8 +264,8 @@ namespace Hosts.UITests
             // Adding a new host override localhost -> 192.168.0.1
             Assert.IsFalse(this.Find<Button>("Add").Enabled, "Add button should be Disabled by default");
 
-            Assert.IsTrue(this.Find<TextBox>("Address").SetText(ip).Text == ip);
-            Assert.IsTrue(this.Find<TextBox>("Hosts").SetText(host).Text == host);
+            Assert.AreEqual(ip, this.Find<TextBox>("Address").SetText(ip).Text);
+            Assert.AreEqual(host, this.Find<TextBox>("Hosts").SetText(host).Text);
 
             this.Find<ToggleSwitch>("Active").Toggle(active);
 
@@ -301,7 +299,7 @@ namespace Hosts.UITests
             }
 
             // Should have no row left, and no more delete button
-            Assert.IsTrue(this.FindAll<Button>("Delete", 1000).Count == 0);
+            Assert.AreEqual(0, this.FindAll<Button>("Delete", 1000).Count);
         }
     }
 }

--- a/src/modules/Hosts/Hosts.UITests/HostsSettingTests.cs
+++ b/src/modules/Hosts/Hosts.UITests/HostsSettingTests.cs
@@ -80,7 +80,7 @@ namespace Hosts.UITests
             this.LaunchFromSetting(showWarning: false);
 
             // Should NOT show warning dialog
-            Assert.IsTrue(this.FindAll("Warning").Count == 0, "Should NOT show warning dialog");
+            Assert.AreEqual(0, this.FindAll("Warning").Count, "Should NOT show warning dialog");
 
             // Host Editor Window should not be closed
             Assert.IsFalse(this.IsHostsFileEditorClosed(), "Hosts File Editor should NOT be closed");

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Calc.UnitTests/QueryTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Calc.UnitTests/QueryTests.cs
@@ -29,7 +29,7 @@ public class QueryTests : CommandPaletteUnitTestBase
         page.UpdateSearchText(string.Empty, input);
         var result = page.GetItems();
 
-        Assert.IsTrue(result.Length == 1, "Valid input should always return result");
+        Assert.AreEqual(1, result.Length, "Valid input should always return result");
 
         var firstResult = result.FirstOrDefault();
 

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Calc.UnitTests/SettingsManagerTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Calc.UnitTests/SettingsManagerTests.cs
@@ -29,7 +29,7 @@ public class SettingsManagerTests
 
         // Assert
         Assert.IsNotNull(settings);
-        Assert.IsTrue(settings.TrigUnit == CalculateEngine.TrigMode.Radians);
+        Assert.AreEqual(CalculateEngine.TrigMode.Radians, settings.TrigUnit);
         Assert.IsFalse(settings.InputUseEnglishFormat);
         Assert.IsFalse(settings.OutputUseEnglishFormat);
         Assert.IsTrue(settings.CloseOnEnter);

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Registry.UnitTests/RegistryHelperTest.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Registry.UnitTests/RegistryHelperTest.cs
@@ -24,7 +24,7 @@ public class RegistryHelperTest
     {
         var (baseKeyList, _) = RegistryHelper.GetRegistryBaseKey(query);
         Assert.IsNotNull(baseKeyList);
-        Assert.IsTrue(baseKeyList.Count() == 1);
+        Assert.AreEqual(1, baseKeyList.Count());
         Assert.AreEqual(expectedBaseKey, baseKeyList.First().Name);
     }
 

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Shell.UnitTests/QueryTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Shell.UnitTests/QueryTests.cs
@@ -173,7 +173,7 @@ public class QueryTests : CommandPaletteUnitTestBase
         var commandList = page.GetItems();
 
         // Should find only items for what's in c:\
-        Assert.IsTrue(commandList.Length == filesInC.Count());
+        Assert.AreEqual(filesInC.Count(), commandList.Length);
 
         await UpdatePageAndWaitForItems(page, () => { page.SearchText = "c:\\Win"; });
         await UpdatePageAndWaitForItems(page, () => { page.SearchText = "c:\\Windows"; });
@@ -182,7 +182,7 @@ public class QueryTests : CommandPaletteUnitTestBase
         commandList = page.GetItems();
 
         // Should still find everything
-        Assert.IsTrue(commandList.Length == filesInC.Count());
+        Assert.AreEqual(filesInC.Count(), commandList.Length);
 
         await TypeStringIntoPage(page, "c:\\Windows\\Pro");
         await BackspaceSearchText(page, "c:\\Windows\\Pro", 3); // 3 characters for c:\
@@ -190,7 +190,7 @@ public class QueryTests : CommandPaletteUnitTestBase
         commandList = page.GetItems();
 
         // Should still find everything
-        Assert.IsTrue(commandList.Length == filesInC.Count());
+        Assert.AreEqual(filesInC.Count(), commandList.Length);
     }
 
     private async Task TypeStringIntoPage(IDynamicListPage page, string searchText)
@@ -228,7 +228,7 @@ public class QueryTests : CommandPaletteUnitTestBase
         await UpdatePageAndWaitForItems(page, () => { page.SearchText = "c:\\"; });
 
         var commandList = page.GetItems();
-        Assert.IsTrue(commandList.Length == filesInC.Count());
+        Assert.AreEqual(filesInC.Count(), commandList.Length);
 
         // First navigate to c:\Windows. This should match everything that matches "windows" inside of C:\
         await UpdatePageAndWaitForItems(page, () => { page.SearchText = "c:\\Windows"; });
@@ -237,12 +237,12 @@ public class QueryTests : CommandPaletteUnitTestBase
         // Then go into c:\windows\. This will only have the results in c:\windows\
         await UpdatePageAndWaitForItems(page, () => { page.SearchText = "c:\\Windows\\"; });
         var windowsCommands = page.GetItems();
-        Assert.IsTrue(windowsCommands.Length != cWindowsCommandsPre.Length);
+        Assert.AreNotEqual(cWindowsCommandsPre.Length, windowsCommands.Length);
 
         // now go back to c:\windows. This should match the results from the last time we entered this string
         await UpdatePageAndWaitForItems(page, () => { page.SearchText = "c:\\Windows"; });
         var cWindowsCommandsPost = page.GetItems();
-        Assert.IsTrue(cWindowsCommandsPre.Length == cWindowsCommandsPost.Length);
+        Assert.AreEqual(cWindowsCommandsPost.Length, cWindowsCommandsPre.Length);
     }
 
     [TestMethod]
@@ -260,7 +260,7 @@ public class QueryTests : CommandPaletteUnitTestBase
         await UpdatePageAndWaitForItems(page, () => { page.SearchText = "c:\\Program Files\\"; });
 
         var commandList = page.GetItems();
-        Assert.IsTrue(commandList.Length == filesInProgramFiles.Count());
+        Assert.AreEqual(filesInProgramFiles.Count(), commandList.Length);
     }
 
     [TestMethod]

--- a/src/modules/fancyzones/FancyZonesEditor.UITests/CustomLayoutsTests.cs
+++ b/src/modules/fancyzones/FancyZonesEditor.UITests/CustomLayoutsTests.cs
@@ -258,8 +258,8 @@ namespace Microsoft.FancyZonesEditor.UITests
 
             // verify new name
             Session.Find<Button>(ElementName.Cancel).Click();
-            Assert.IsTrue(Session.FindAll<Element>(oldName).Count == 0);
-            Assert.IsTrue(Session.FindAll<Element>(newName).Count != 0);
+            Assert.AreEqual(0, Session.FindAll<Element>(oldName).Count);
+            Assert.AreNotEqual(0, Session.FindAll<Element>(newName).Count);
         }
 
         [TestMethod]

--- a/src/modules/fancyzones/FancyZonesEditor.UITests/DeleteLayoutTests.cs
+++ b/src/modules/fancyzones/FancyZonesEditor.UITests/DeleteLayoutTests.cs
@@ -226,7 +226,7 @@ namespace Microsoft.FancyZonesEditor.UITests
             Session.SendKeySequence(Key.Tab, Key.Enter);
 
             // verify the layout is removed
-            Assert.IsTrue(Session.FindAll<Element>(deletedLayout).Count == 0);
+            Assert.AreEqual(0, Session.FindAll<Element>(deletedLayout).Count);
 
             // check the file
             var customLayouts = new CustomLayouts();
@@ -246,7 +246,7 @@ namespace Microsoft.FancyZonesEditor.UITests
             Session.SendKeySequence(Key.Tab, Key.Enter);
 
             // verify the layout is removed
-            Assert.IsTrue(Session.FindAll<Element>(deletedLayout).Count == 0);
+            Assert.AreEqual(0, Session.FindAll<Element>(deletedLayout).Count);
 
             // verify the empty layout is selected
             Assert.IsTrue(Session.Find<Element>(TestConstants.TemplateLayoutNames[LayoutType.Blank])!.Selected);
@@ -290,7 +290,7 @@ namespace Microsoft.FancyZonesEditor.UITests
             Session.SendKeySequence(Key.Tab, Key.Enter);
 
             // verify the layout is removed
-            Assert.IsTrue(Session.FindAll<Element>(deletedLayout).Count == 0);
+            Assert.AreEqual(0, Session.FindAll<Element>(deletedLayout).Count);
 
             // check the file
             var customLayouts = new CustomLayouts();

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program.UnitTests/Programs/Win32Tests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program.UnitTests/Programs/Win32Tests.cs
@@ -599,8 +599,8 @@ namespace Microsoft.Plugin.Program.UnitTests.Programs
 
             // Assert
             // Using Ordinal since this is used internally
-            Assert.IsTrue(result.Title.Equals(_chrome.Name, StringComparison.Ordinal));
-            Assert.IsFalse(result.Title.Equals(_chrome.Description, StringComparison.Ordinal));
+            Assert.AreEqual(_chrome.Name, result.Title);
+            Assert.AreNotEqual(_chrome.Description, result.Title);
         }
 
         [TestMethod]
@@ -614,8 +614,8 @@ namespace Microsoft.Plugin.Program.UnitTests.Programs
 
             // Assert
             // Using Ordinal since this is used internally
-            Assert.IsTrue(result.Title.Equals(_cmderRunCommand.ExecutableName, StringComparison.Ordinal));
-            Assert.IsFalse(result.Title.Equals(_cmderRunCommand.Description, StringComparison.Ordinal));
+            Assert.AreEqual(_cmderRunCommand.ExecutableName, result.Title);
+            Assert.AreNotEqual(_cmderRunCommand.Description, result.Title);
         }
 
         [DataTestMethod]

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Registry.UnitTest/Helper/RegistryHelperTest.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Registry.UnitTest/Helper/RegistryHelperTest.cs
@@ -24,7 +24,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Registry.UnitTest.Helper
         {
             var (baseKeyList, _) = RegistryHelper.GetRegistryBaseKey(query);
             Assert.IsNotNull(baseKeyList);
-            Assert.IsTrue(baseKeyList.Count() == 1);
+            Assert.AreEqual(1, baseKeyList.Count());
             Assert.AreEqual(expectedBaseKey, baseKeyList.First().Name);
         }
 

--- a/src/modules/launcher/Wox.Test/FuzzyMatcherTest.cs
+++ b/src/modules/launcher/Wox.Test/FuzzyMatcherTest.cs
@@ -75,10 +75,10 @@ namespace Wox.Test
 
             results = results.Where(x => x.Score > 0).OrderByDescending(x => x.Score).ToList();
 
-            Assert.IsTrue(results.Count == 3);
-            Assert.IsTrue(results[0].Title == "Inste");
-            Assert.IsTrue(results[1].Title == "Install Package");
-            Assert.IsTrue(results[2].Title == "file open in browser-test");
+            Assert.AreEqual(3, results.Count);
+            Assert.AreEqual("Inste", results[0].Title);
+            Assert.AreEqual("Install Package", results[1].Title);
+            Assert.AreEqual("file open in browser-test", results[2].Title);
         }
 
         [DataTestMethod]
@@ -89,7 +89,7 @@ namespace Wox.Test
             var matcher = new StringMatcher();
             var scoreResult = matcher.FuzzyMatch(searchString, compareString).RawScore;
 
-            Assert.IsTrue(scoreResult == 0);
+            Assert.AreEqual(0, scoreResult);
         }
 
         [DataTestMethod]

--- a/src/modules/launcher/Wox.Test/Plugins/WindowsIndexerTest.cs
+++ b/src/modules/launcher/Wox.Test/Plugins/WindowsIndexerTest.cs
@@ -187,7 +187,7 @@ namespace Wox.Test.Plugins
             var windowsSearchAPIResults = api.Search("FilePath", mockSearchManager);
 
             // Assert
-            Assert.IsTrue(windowsSearchAPIResults.Count() == 2);
+            Assert.AreEqual(2, windowsSearchAPIResults.Count());
             Assert.IsTrue(windowsSearchAPIResults.Any(x => x.Title == "file1.txt"));
             Assert.IsTrue(windowsSearchAPIResults.Any(x => x.Title == "file2.txt"));
         }
@@ -208,7 +208,7 @@ namespace Wox.Test.Plugins
             var windowsSearchAPIResults = api.Search("FilePath", mockSearchManager);
 
             // Assert
-            Assert.IsTrue(windowsSearchAPIResults.Count() == 1);
+            Assert.AreEqual(1, windowsSearchAPIResults.Count());
             Assert.IsFalse(windowsSearchAPIResults.Any(x => x.Title == "file1.txt"));
             Assert.IsTrue(windowsSearchAPIResults.Any(x => x.Title == "file2.txt"));
         }

--- a/src/modules/launcher/Wox.Test/QueryBuilderTest.cs
+++ b/src/modules/launcher/Wox.Test/QueryBuilderTest.cs
@@ -87,8 +87,8 @@ namespace Wox.Test
 
             // Assert
             // Using Ordinal since this is used internally
-            Assert.IsTrue(firstQuery.Search.Equals(secondQuery.Search, StringComparison.Ordinal));
-            Assert.IsTrue(firstQuery.ActionKeyword.Equals(secondQuery.ActionKeyword, StringComparison.Ordinal));
+            Assert.AreEqual(secondQuery.Search, firstQuery.Search);
+            Assert.AreEqual(secondQuery.ActionKeyword, firstQuery.ActionKeyword);
         }
 
         [TestMethod]
@@ -139,10 +139,10 @@ namespace Wox.Test
 
             // Assert
             // Using Ordinal since this is used internally
-            Assert.IsTrue(builtQuery.Terms.Count == 3
-                && builtQuery.Terms[0].Equals("Test", StringComparison.Ordinal)
-                && builtQuery.Terms[1].Equals("search", StringComparison.Ordinal)
-                && builtQuery.Terms[2].Equals("term", StringComparison.Ordinal));
+            Assert.AreEqual(3, builtQuery.Terms.Count);
+            Assert.AreEqual("Test", builtQuery.Terms[0]);
+            Assert.AreEqual("search", builtQuery.Terms[1]);
+            Assert.AreEqual("term", builtQuery.Terms[2]);
         }
 
         [TestMethod]

--- a/src/modules/powerrename/PowerRenameUITest/BasicRenameTests.cs
+++ b/src/modules/powerrename/PowerRenameUITest/BasicRenameTests.cs
@@ -42,7 +42,7 @@ public class BasicRenameTests : PowerRenameUITestBase
         this.SetSearchBoxText("testCase1");
         this.SetReplaceBoxText("replaced");
 
-        Assert.IsTrue(this.Find<TextBlock>("replaced.txt").Text == "replaced.txt");
+        Assert.AreEqual("replaced.txt", this.Find<TextBlock>("replaced.txt").Text);
     }
 
     [TestMethod]
@@ -57,7 +57,7 @@ public class BasicRenameTests : PowerRenameUITestBase
 
         CheckOriginalOrRenamedCount(2);
 
-        Assert.IsTrue(this.Find<TextBlock>("matched.txt").Text == "matched.txt");
+        Assert.AreEqual("matched.txt", this.Find<TextBlock>("matched.txt").Text);
     }
 
     [TestMethod]
@@ -68,8 +68,8 @@ public class BasicRenameTests : PowerRenameUITestBase
 
         this.SetMatchAllOccurrencesCheckbox(true);
 
-        Assert.IsTrue(this.Find<TextBlock>("fesfCase2.fxf").Text == "fesfCase2.fxf");
-        Assert.IsTrue(this.Find<TextBlock>("fesfCase1.fxf").Text == "fesfCase1.fxf");
+        Assert.AreEqual("fesfCase2.fxf", this.Find<TextBlock>("fesfCase2.fxf").Text);
+        Assert.AreEqual("fesfCase1.fxf", this.Find<TextBlock>("fesfCase1.fxf").Text);
     }
 
     [TestMethod]
@@ -79,7 +79,7 @@ public class BasicRenameTests : PowerRenameUITestBase
         this.SetReplaceBoxText("match1");
 
         CheckOriginalOrRenamedCount(1);
-        Assert.IsTrue(this.Find<TextBlock>("match1.txt").Text == "match1.txt");
+        Assert.AreEqual("match1.txt", this.Find<TextBlock>("match1.txt").Text);
 
         this.SetCaseSensitiveCheckbox(true);
         CheckOriginalOrRenamedCount(0);

--- a/src/modules/powerrename/PowerRenameUITest/PowerRenameUITestBase.cs
+++ b/src/modules/powerrename/PowerRenameUITest/PowerRenameUITestBase.cs
@@ -170,31 +170,31 @@ public class PowerRenameUITestBase : UITestBase
 
     protected void SetSearchBoxText(string text)
     {
-        Assert.IsTrue(this.Find<TextBox>("Search for").SetText(text, true).Text == text);
+        Assert.AreEqual(text, this.Find<TextBox>("Search for").SetText(text, true).Text);
     }
 
     protected void SetReplaceBoxText(string text)
     {
-        Assert.IsTrue(this.Find<TextBox>("Replace with").SetText(text, true).Text == text);
+        Assert.AreEqual(text, this.Find<TextBox>("Replace with").SetText(text, true).Text);
     }
 
     protected void SetRegularExpressionCheckbox(bool flag)
     {
-        Assert.IsTrue(this.Find<CheckBox>("Use regular expressions").SetCheck(flag).IsChecked == flag);
+        Assert.AreEqual(flag, this.Find<CheckBox>("Use regular expressions").SetCheck(flag).IsChecked);
     }
 
     protected void SetMatchAllOccurrencesCheckbox(bool flag)
     {
-        Assert.IsTrue(this.Find<CheckBox>("Match all occurrences").SetCheck(flag).IsChecked == flag);
+        Assert.AreEqual(flag, this.Find<CheckBox>("Match all occurrences").SetCheck(flag).IsChecked);
     }
 
     protected void SetCaseSensitiveCheckbox(bool flag)
     {
-        Assert.IsTrue(this.Find<CheckBox>("Case sensitive").SetCheck(flag).IsChecked == flag);
+        Assert.AreEqual(flag, this.Find<CheckBox>("Case sensitive").SetCheck(flag).IsChecked);
     }
 
     protected void CheckOriginalOrRenamedCount(int count)
     {
-        Assert.IsTrue(this.Find<TextBlock>($"({count})").Text == $"({count})");
+        Assert.AreEqual($"({count})", this.Find<TextBlock>($"({count})").Text);
     }
 }

--- a/src/modules/previewpane/UnitTests-BgcodeThumbnailProvider/BgcodeThumbnailProviderTests.cs
+++ b/src/modules/previewpane/UnitTests-BgcodeThumbnailProvider/BgcodeThumbnailProviderTests.cs
@@ -22,7 +22,7 @@ namespace BgcodeThumbnailProviderUnitTests
 
             Bitmap bitmap = provider.GetThumbnail(256);
 
-            Assert.IsTrue(bitmap != null);
+            Assert.IsNotNull(bitmap);
         }
 
         [TestMethod]
@@ -35,7 +35,7 @@ namespace BgcodeThumbnailProviderUnitTests
 
             Bitmap bitmap = provider.GetThumbnail(0);
 
-            Assert.IsTrue(bitmap == null);
+            Assert.IsNull(bitmap);
         }
 
         [TestMethod]
@@ -48,7 +48,7 @@ namespace BgcodeThumbnailProviderUnitTests
 
             Bitmap bitmap = provider.GetThumbnail(10001);
 
-            Assert.IsTrue(bitmap == null);
+            Assert.IsNull(bitmap);
         }
 
         [TestMethod]
@@ -57,7 +57,7 @@ namespace BgcodeThumbnailProviderUnitTests
             using (var reader = new BinaryReader(new MemoryStream()))
             {
                 Bitmap thumbnail = BgcodeThumbnailProvider.GetThumbnail(reader, 256);
-                Assert.IsTrue(thumbnail == null);
+                Assert.IsNull(thumbnail);
             }
         }
 
@@ -65,7 +65,7 @@ namespace BgcodeThumbnailProviderUnitTests
         public void CheckNoBgcodeNullStringShouldReturnNullBitmap()
         {
             Bitmap thumbnail = BgcodeThumbnailProvider.GetThumbnail(null, 256);
-            Assert.IsTrue(thumbnail == null);
+            Assert.IsNull(thumbnail);
         }
     }
 }

--- a/src/modules/previewpane/UnitTests-GcodeThumbnailProvider/GcodeThumbnailProviderTests.cs
+++ b/src/modules/previewpane/UnitTests-GcodeThumbnailProvider/GcodeThumbnailProviderTests.cs
@@ -24,7 +24,7 @@ namespace GcodeThumbnailProviderUnitTests
 
             Bitmap bitmap = provider.GetThumbnail(256);
 
-            Assert.IsTrue(bitmap != null);
+            Assert.IsNotNull(bitmap);
         }
 
         [TestMethod]
@@ -37,7 +37,7 @@ namespace GcodeThumbnailProviderUnitTests
 
             Bitmap bitmap = provider.GetThumbnail(0);
 
-            Assert.IsTrue(bitmap == null);
+            Assert.IsNull(bitmap);
         }
 
         [TestMethod]
@@ -50,7 +50,7 @@ namespace GcodeThumbnailProviderUnitTests
 
             Bitmap bitmap = provider.GetThumbnail(10001);
 
-            Assert.IsTrue(bitmap == null);
+            Assert.IsNull(bitmap);
         }
 
         [TestMethod]
@@ -59,7 +59,7 @@ namespace GcodeThumbnailProviderUnitTests
             using (var reader = new StringReader(string.Empty))
             {
                 Bitmap thumbnail = GcodeThumbnailProvider.GetThumbnail(reader, 256);
-                Assert.IsTrue(thumbnail == null);
+                Assert.IsNull(thumbnail);
             }
         }
 
@@ -67,7 +67,7 @@ namespace GcodeThumbnailProviderUnitTests
         public void CheckNoGcodeNullStringShouldReturnNullBitmap()
         {
             Bitmap thumbnail = GcodeThumbnailProvider.GetThumbnail(null, 256);
-            Assert.IsTrue(thumbnail == null);
+            Assert.IsNull(thumbnail);
         }
     }
 }

--- a/src/modules/previewpane/UnitTests-PdfThumbnailProvider/PdfThumbnailProviderTests.cs
+++ b/src/modules/previewpane/UnitTests-PdfThumbnailProvider/PdfThumbnailProviderTests.cs
@@ -28,7 +28,7 @@ namespace PdfThumbnailProviderUnitTests
 
             Bitmap bitmap = provider.GetThumbnail(256);
 
-            Assert.IsTrue(bitmap != null);
+            Assert.IsNotNull(bitmap);
         }
 
         [TestMethod]
@@ -41,7 +41,7 @@ namespace PdfThumbnailProviderUnitTests
 
             Bitmap bitmap = provider.GetThumbnail(0);
 
-            Assert.IsTrue(bitmap == null);
+            Assert.IsNull(bitmap);
         }
 
         [TestMethod]
@@ -54,7 +54,7 @@ namespace PdfThumbnailProviderUnitTests
 
             Bitmap bitmap = provider.GetThumbnail(10001);
 
-            Assert.IsTrue(bitmap == null);
+            Assert.IsNull(bitmap);
         }
     }
 }

--- a/src/modules/previewpane/UnitTests-QoiThumbnailProvider/QoiThumbnailProviderTests.cs
+++ b/src/modules/previewpane/UnitTests-QoiThumbnailProvider/QoiThumbnailProviderTests.cs
@@ -22,7 +22,7 @@ namespace QoiThumbnailProviderUnitTests
 
             Bitmap bitmap = provider.GetThumbnail(256);
 
-            Assert.IsTrue(bitmap != null);
+            Assert.IsNotNull(bitmap);
         }
 
         [TestMethod]
@@ -35,7 +35,7 @@ namespace QoiThumbnailProviderUnitTests
 
             Bitmap bitmap = provider.GetThumbnail(0);
 
-            Assert.IsTrue(bitmap == null);
+            Assert.IsNull(bitmap);
         }
 
         [TestMethod]
@@ -48,14 +48,14 @@ namespace QoiThumbnailProviderUnitTests
 
             Bitmap bitmap = provider.GetThumbnail(10001);
 
-            Assert.IsTrue(bitmap == null);
+            Assert.IsNull(bitmap);
         }
 
         [TestMethod]
         public void CheckNoQoiNullStringShouldReturnNullBitmap()
         {
             Bitmap thumbnail = QoiThumbnailProvider.GetThumbnail(null, 256);
-            Assert.IsTrue(thumbnail == null);
+            Assert.IsNull(thumbnail);
         }
     }
 }

--- a/src/modules/previewpane/UnitTests-StlThumbnailProvider/StlThumbnailProviderTests.cs
+++ b/src/modules/previewpane/UnitTests-StlThumbnailProvider/StlThumbnailProviderTests.cs
@@ -23,7 +23,7 @@ namespace StlThumbnailProviderUnitTests
 
             Bitmap bitmap = provider.GetThumbnail(256);
 
-            Assert.IsTrue(bitmap != null);
+            Assert.IsNotNull(bitmap);
         }
 
         [TestMethod]
@@ -36,7 +36,7 @@ namespace StlThumbnailProviderUnitTests
 
             Bitmap bitmap = provider.GetThumbnail(0);
 
-            Assert.IsTrue(bitmap == null);
+            Assert.IsNull(bitmap);
         }
 
         [TestMethod]
@@ -49,7 +49,7 @@ namespace StlThumbnailProviderUnitTests
 
             Bitmap bitmap = provider.GetThumbnail(10001);
 
-            Assert.IsTrue(bitmap == null);
+            Assert.IsNull(bitmap);
         }
 
         [TestMethod]
@@ -58,7 +58,7 @@ namespace StlThumbnailProviderUnitTests
             using (var stream = new MemoryStream())
             {
                 Bitmap thumbnail = StlThumbnailProvider.GetThumbnail(stream, 256);
-                Assert.IsTrue(thumbnail == null);
+                Assert.IsNull(thumbnail);
             }
         }
 
@@ -66,7 +66,7 @@ namespace StlThumbnailProviderUnitTests
         public void CheckNoStlNullStreamShouldReturnNullBitmap()
         {
             Bitmap thumbnail = StlThumbnailProvider.GetThumbnail(null, 256);
-            Assert.IsTrue(thumbnail == null);
+            Assert.IsNull(thumbnail);
         }
     }
 }

--- a/src/modules/previewpane/UnitTests-SvgThumbnailProvider/SvgThumbnailProviderTests.cs
+++ b/src/modules/previewpane/UnitTests-SvgThumbnailProvider/SvgThumbnailProviderTests.cs
@@ -49,7 +49,7 @@ namespace SvgThumbnailProviderUnitTests
             svgThumbnailProvider.SvgContents = svgBuilder.ToString();
             svgThumbnailProvider.SvgContentsReady.Set();
             Bitmap thumbnail = svgThumbnailProvider.GetThumbnail(256);
-            Assert.IsTrue(thumbnail != null);
+            Assert.IsNotNull(thumbnail);
         }
 
         [TestMethod]
@@ -70,7 +70,7 @@ namespace SvgThumbnailProviderUnitTests
 
             svgThumbnailProvider.SvgContentsReady.Set();
             Bitmap thumbnail = svgThumbnailProvider.GetThumbnail(256);
-            Assert.IsTrue(thumbnail != null);
+            Assert.IsNotNull(thumbnail);
         }
 
         [TestMethod]
@@ -92,7 +92,7 @@ namespace SvgThumbnailProviderUnitTests
 
             svgThumbnailProvider.SvgContentsReady.Set();
             Bitmap thumbnail = svgThumbnailProvider.GetThumbnail(256);
-            Assert.IsTrue(thumbnail != null);
+            Assert.IsNotNull(thumbnail);
         }
 
         [TestMethod]
@@ -113,7 +113,7 @@ namespace SvgThumbnailProviderUnitTests
 ";
             svgThumbnailProvider.SvgContentsReady.Set();
             Bitmap thumbnail = svgThumbnailProvider.GetThumbnail(256);
-            Assert.IsTrue(thumbnail != null);
+            Assert.IsNotNull(thumbnail);
         }
 
         [TestMethod]
@@ -126,7 +126,7 @@ namespace SvgThumbnailProviderUnitTests
             svgThumbnailProvider.SvgContents = svgBuilder.ToString();
             svgThumbnailProvider.SvgContentsReady.Set();
             Bitmap thumbnail = svgThumbnailProvider.GetThumbnail(256);
-            Assert.IsTrue(thumbnail == null);
+            Assert.IsNull(thumbnail);
         }
 
         [TestMethod]
@@ -136,7 +136,7 @@ namespace SvgThumbnailProviderUnitTests
             svgThumbnailProvider.SvgContents = string.Empty;
             svgThumbnailProvider.SvgContentsReady.Set();
             Bitmap thumbnail = svgThumbnailProvider.GetThumbnail(256);
-            Assert.IsTrue(thumbnail == null);
+            Assert.IsNull(thumbnail);
         }
 
         [TestMethod]
@@ -147,7 +147,7 @@ namespace SvgThumbnailProviderUnitTests
             svgThumbnailProvider.SvgContentsReady.Set();
 
             Bitmap thumbnail = svgThumbnailProvider.GetThumbnail(256);
-            Assert.IsTrue(thumbnail == null);
+            Assert.IsNull(thumbnail);
         }
 
         [TestMethod]
@@ -158,7 +158,7 @@ namespace SvgThumbnailProviderUnitTests
             svgThumbnailProvider.SvgContents = content;
             svgThumbnailProvider.SvgContentsReady.Set();
             Bitmap thumbnail = svgThumbnailProvider.GetThumbnail(0);
-            Assert.IsTrue(thumbnail == null);
+            Assert.IsNull(thumbnail);
         }
 
         [TestMethod]
@@ -183,7 +183,7 @@ namespace SvgThumbnailProviderUnitTests
             svgThumbnailProvider.SvgContentsReady.Set();
 
             Bitmap thumbnail = svgThumbnailProvider.GetThumbnail(256);
-            Assert.IsTrue(thumbnail != null);
+            Assert.IsNotNull(thumbnail);
         }
 
         [TestMethod]
@@ -195,7 +195,7 @@ namespace SvgThumbnailProviderUnitTests
 
             Bitmap bitmap = svgThumbnailProvider.GetThumbnail(256);
 
-            Assert.IsTrue(bitmap != null);
+            Assert.IsNotNull(bitmap);
         }
 
         [TestMethod]
@@ -207,7 +207,7 @@ namespace SvgThumbnailProviderUnitTests
 
             Bitmap bitmap = svgThumbnailProvider.GetThumbnail(256);
 
-            Assert.IsTrue(bitmap != null);
+            Assert.IsNotNull(bitmap);
         }
 
         [TestMethod]
@@ -219,7 +219,7 @@ namespace SvgThumbnailProviderUnitTests
 
             Bitmap bitmap = svgThumbnailProvider.GetThumbnail(8);
 
-            Assert.IsTrue(bitmap != null);
+            Assert.IsNotNull(bitmap);
         }
     }
 }

--- a/src/settings-ui/Settings.UI.UnitTests/ModelsTests/HelperTest.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ModelsTests/HelperTest.cs
@@ -21,7 +21,7 @@ namespace CommonLibTest
         public static void TestStringsAreEqual(string v1, string v2)
         {
             var res = Helper.CompareVersions(v1, v2);
-            Assert.IsTrue(res == 0);
+            Assert.AreEqual(0, res);
         }
 
         [TestMethod]

--- a/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/PowerLauncherViewModelTest.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/PowerLauncherViewModelTest.cs
@@ -126,8 +126,8 @@ namespace ViewModelTests
             viewModel.SearchTypePreference = "SearchOptionsAreNotValidated";
 
             Assert.AreEqual(sendCallbackMock.TimesSent, 2);
-            Assert.IsTrue(mockSettings.Properties.SearchResultPreference == "SearchOptionsAreNotValidated");
-            Assert.IsTrue(mockSettings.Properties.SearchTypePreference == "SearchOptionsAreNotValidated");
+            Assert.AreEqual("SearchOptionsAreNotValidated", mockSettings.Properties.SearchResultPreference);
+            Assert.AreEqual("SearchOptionsAreNotValidated", mockSettings.Properties.SearchTypePreference);
         }
 
         public static void AssertHotkeySettings(HotkeySettings setting, bool win, bool ctrl, bool alt, bool shift, int code)


### PR DESCRIPTION
Replace ~90 Assert.IsTrue equality checks with proper Assert.AreEqual/AreNotEqual/IsNull/IsNotNull calls for better test failure messages across 23 test files.