### PR TITLE
Fix MSTEST0017: Correct assertion argument order

### DIFF
--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UITests/BasicTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UITests/BasicTests.cs
@@ -22,7 +22,7 @@ public class BasicTests : CommandPaletteTestBase
         SetSearchBox("files");
 
         var searchFileItem = this.Find<NavigationViewItem>("Search files");
-        Assert.AreEqual(searchFileItem.Name, "Search files");
+        Assert.AreEqual("Search files", searchFileItem.Name);
         searchFileItem.DoubleClick();
 
         SetFilesExtensionSearchBox("AppData");
@@ -36,7 +36,7 @@ public class BasicTests : CommandPaletteTestBase
         SetSearchBox("calculator");
 
         var searchFileItem = this.Find<NavigationViewItem>("Calculator");
-        Assert.AreEqual(searchFileItem.Name, "Calculator");
+        Assert.AreEqual("Calculator", searchFileItem.Name);
         searchFileItem.DoubleClick();
 
         SetCalculatorExtensionSearchBox("1+2");
@@ -50,7 +50,7 @@ public class BasicTests : CommandPaletteTestBase
         SetSearchBox("time and date");
 
         var searchFileItem = this.Find<NavigationViewItem>("Time and date");
-        Assert.AreEqual(searchFileItem.Name, "Time and date");
+        Assert.AreEqual("Time and date", searchFileItem.Name);
         searchFileItem.DoubleClick();
 
         SetTimeAndDaterExtensionSearchBox("year");
@@ -64,7 +64,7 @@ public class BasicTests : CommandPaletteTestBase
         SetSearchBox("Windows Terminal");
 
         var searchFileItem = this.Find<NavigationViewItem>("Open Windows Terminal profiles");
-        Assert.AreEqual(searchFileItem.Name, "Open Windows Terminal profiles");
+        Assert.AreEqual("Open Windows Terminal profiles", searchFileItem.Name);
         searchFileItem.DoubleClick();
 
         // SetSearchBox("PowerShell");
@@ -77,7 +77,7 @@ public class BasicTests : CommandPaletteTestBase
         SetSearchBox("Windows settings");
 
         var searchFileItem = this.Find<NavigationViewItem>("Windows settings");
-        Assert.AreEqual(searchFileItem.Name, "Windows settings");
+        Assert.AreEqual("Windows settings", searchFileItem.Name);
         searchFileItem.DoubleClick();
 
         SetSearchBox("power");
@@ -91,7 +91,7 @@ public class BasicTests : CommandPaletteTestBase
         SetSearchBox("Registry");
 
         var searchFileItem = this.Find<NavigationViewItem>("Registry");
-        Assert.AreEqual(searchFileItem.Name, "Registry");
+        Assert.AreEqual("Registry", searchFileItem.Name);
         searchFileItem.DoubleClick();
 
         // Type the string will cause strange behavior.so comment it out for now.
@@ -105,7 +105,7 @@ public class BasicTests : CommandPaletteTestBase
         SetSearchBox("Windows Services");
 
         var searchFileItem = this.Find<NavigationViewItem>("Windows Services");
-        Assert.AreEqual(searchFileItem.Name, "Windows Services");
+        Assert.AreEqual("Windows Services", searchFileItem.Name);
         searchFileItem.DoubleClick();
 
         SetSearchBox("hyper-v");
@@ -119,7 +119,7 @@ public class BasicTests : CommandPaletteTestBase
         SetSearchBox("Windows System Commands");
 
         var searchFileItem = this.Find<NavigationViewItem>("Windows System Commands");
-        Assert.AreEqual(searchFileItem.Name, "Windows System Commands");
+        Assert.AreEqual("Windows System Commands", searchFileItem.Name);
         searchFileItem.DoubleClick();
 
         SetSearchBox("Sleep");

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UITests/IndexerTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UITests/IndexerTests.cs
@@ -45,7 +45,7 @@ public class IndexerTests : CommandPaletteTestBase
         SetSearchBox("files");
 
         var searchFileItem = this.Find<NavigationViewItem>("Search files");
-        Assert.AreEqual(searchFileItem.Name, "Search files");
+        Assert.AreEqual("Search files", searchFileItem.Name);
         searchFileItem.DoubleClick();
     }
 

--- a/src/modules/colorPicker/ColorPickerUI.UnitTests/Helpers/ColorRepresentationHelperTest.cs
+++ b/src/modules/colorPicker/ColorPickerUI.UnitTests/Helpers/ColorRepresentationHelperTest.cs
@@ -34,7 +34,7 @@ namespace ColorPicker.Helpers
         public void GetStringRepresentationTest(string type, string expected)
         {
             var result = ColorRepresentationHelper.GetStringRepresentation(Color.Black, type, ColorFormatHelper.GetDefaultFormat(type));
-            Assert.AreEqual(result, expected);
+            Assert.AreEqual(expected, result);
         }
     }
 }

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator.UnitTest/QueryTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator.UnitTest/QueryTests.cs
@@ -76,7 +76,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
             var result = _main.Object.Query(expectedQuery).Count;
 
             // Assert
-            Assert.AreEqual(result, 0);
+            Assert.AreEqual(0, result);
         }
 
         [DataTestMethod]
@@ -101,12 +101,12 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
             var resultWithKeyword = _main.Object.Query(expectedQueryWithKeyword).Count;
 
             // Assert
-            Assert.AreEqual(result, 0);
-            Assert.AreEqual(resultWithKeyword, 0);
+            Assert.AreEqual(0, result);
+            Assert.AreEqual(0, resultWithKeyword);
         }
 
         [DataTestMethod]
-        [DataRow("10+(8*9)/0,5")] // German decimal digit separator
+        [DataRow("10+(8*9)/0,5")]// German decimal digit separator
         [DataRow("10+(8*9)/0.5")]
         [DataRow("10+(8*9)/1,5")] // German decimal digit separator
         [DataRow("10+(8*9)/1.5")]
@@ -121,8 +121,8 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
             var resultWithKeyword = _main.Object.Query(expectedQueryWithKeyword).FirstOrDefault().SubTitle;
 
             // Assert
-            Assert.AreEqual(result, "Copy this number to the clipboard");
-            Assert.AreEqual(resultWithKeyword, "Copy this number to the clipboard");
+            Assert.AreEqual("Copy this number to the clipboard", result);
+            Assert.AreEqual("Copy this number to the clipboard", resultWithKeyword);
         }
 
         [DataTestMethod]

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsTerminal.UnitTests/TerminalHelperTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.WindowsTerminal.UnitTests/TerminalHelperTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Plugin.WindowsTerminal.UnitTests
         public void ArgumentsTest(string profile, bool openNewTab, bool openQuake, string expectedArguments)
         {
             var arguments = TerminalHelper.GetArguments(profile, openNewTab, openQuake);
-            Assert.AreEqual(arguments, expectedArguments);
+            Assert.AreEqual(expectedArguments, arguments);
         }
 
         [DataTestMethod]
@@ -37,7 +37,7 @@ namespace Microsoft.Plugin.WindowsTerminal.UnitTests
             var settings = File.ReadAllText(settingsPath);
             var profiles = TerminalHelper.ParseSettings(terminal, settings);
 
-            Assert.AreEqual(profiles.Count, 4);
+            Assert.AreEqual(4, profiles.Count);
         }
 
         [DataTestMethod]
@@ -59,7 +59,7 @@ namespace Microsoft.Plugin.WindowsTerminal.UnitTests
 
             var expectedIdentifier = identifier != null ? new Guid(identifier) : null as Guid?;
             Assert.AreEqual(profile.Terminal, terminal);
-            Assert.AreEqual(profile.Identifier, expectedIdentifier);
+            Assert.AreEqual(expectedIdentifier, profile.Identifier);
             Assert.AreEqual(profile.Name, name);
             Assert.AreEqual(profile.Hidden, hidden);
         }

--- a/src/modules/previewpane/UnitTests-PreviewHandlerCommon/StreamWrapperTests.cs
+++ b/src/modules/previewpane/UnitTests-PreviewHandlerCommon/StreamWrapperTests.cs
@@ -208,7 +208,7 @@ namespace PreviewHandlerCommonUnitTests
                 var actualPosition = streamWrapper.Seek(0, SeekOrigin.Begin);
 
                 // Assert
-                Assert.AreEqual(actualPosition, position);
+                Assert.AreEqual(position, actualPosition);
             }
         }
 

--- a/src/settings-ui/Settings.UI.UnitTests/ModelsTests/SettingsUtilsTests.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ModelsTests/SettingsUtilsTests.cs
@@ -100,8 +100,8 @@ namespace CommonLibTest
             TestClass settings = mockSettingsUtils.GetSettingsOrDefault<TestClass>(string.Empty);
 
             // Assert
-            Assert.AreEqual(settings.TestInt, 100);
-            Assert.AreEqual(settings.TestString, "test");
+            Assert.AreEqual(100, settings.TestInt);
+            Assert.AreEqual("test", settings.TestString);
         }
 
         public static string RandomString()

--- a/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/PowerLauncherViewModelTest.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/PowerLauncherViewModelTest.cs
@@ -125,7 +125,7 @@ namespace ViewModelTests
             viewModel.SearchResultPreference = "SearchOptionsAreNotValidated";
             viewModel.SearchTypePreference = "SearchOptionsAreNotValidated";
 
-            Assert.AreEqual(sendCallbackMock.TimesSent, 2);
+            Assert.AreEqual(2, sendCallbackMock.TimesSent);
             Assert.IsTrue(mockSettings.Properties.SearchResultPreference == "SearchOptionsAreNotValidated");
             Assert.IsTrue(mockSettings.Properties.SearchTypePreference == "SearchOptionsAreNotValidated");
         }


### PR DESCRIPTION
Swap expected/actual arguments in 22 Assert calls to follow the correct MSTest convention of Assert.AreEqual(expected, actual).