### PR TITLE
Fix MSTEST0039: Use Assert.ThrowsExactly instead of ThrowsException

### DIFF
--- a/src/modules/Hosts/Hosts.Tests/HostsServiceTest.cs
+++ b/src/modules/Hosts/Hosts.Tests/HostsServiceTest.cs
@@ -224,7 +224,7 @@ namespace Hosts.Tests
             elevationHelper.Setup(m => m.IsElevated).Returns(false);
 
             var service = new HostsService(fileSystem, _userSettings.Object, elevationHelper.Object, _backupManager.Object);
-            await Assert.ThrowsExceptionAsync<NotRunningElevatedException>(async () => await service.WriteAsync("# Empty hosts file", Enumerable.Empty<Entry>()));
+            await Assert.ThrowsExactlyAsync<NotRunningElevatedException>(async () => await service.WriteAsync("# Empty hosts file", Enumerable.Empty<Entry>()));
         }
 
         [TestMethod]
@@ -240,7 +240,7 @@ namespace Hosts.Tests
 
             fileSystem.AddFile(service.HostsFilePath, hostsFile);
 
-            await Assert.ThrowsExceptionAsync<ReadOnlyHostsException>(async () => await service.WriteAsync("# Empty hosts file", Enumerable.Empty<Entry>()));
+            await Assert.ThrowsExactlyAsync<ReadOnlyHostsException>(async () => await service.WriteAsync("# Empty hosts file", Enumerable.Empty<Entry>()));
         }
 
         [TestMethod]

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Apps.UnitTests/AllAppsPageTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Apps.UnitTests/AllAppsPageTests.cs
@@ -16,7 +16,7 @@ public class AllAppsPageTests : AppsTestBase
     public void AllAppsPage_Constructor_ThrowsOnNullAppCache()
     {
         // Act & Assert
-        Assert.ThrowsException<ArgumentNullException>(() => new AllAppsPage(null!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => new AllAppsPage(null!));
     }
 
     [TestMethod]

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Bookmarks.UnitTests/PlaceholderInfoNameEqualityComparerTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Bookmarks.UnitTests/PlaceholderInfoNameEqualityComparerTests.cs
@@ -77,7 +77,7 @@ public class PlaceholderInfoNameEqualityComparerTests
     public void GetHashCode_Null_ThrowsArgumentNullException()
     {
         var comparer = PlaceholderInfoNameEqualityComparer.Instance;
-        Assert.ThrowsException<ArgumentNullException>(() => comparer.GetHashCode(null!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => comparer.GetHashCode(null!));
     }
 
     [TestMethod]

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Bookmarks.UnitTests/PlaceholderParserTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Bookmarks.UnitTests/PlaceholderParserTests.cs
@@ -131,7 +131,7 @@ public class PlaceholderParserTests
     [TestMethod]
     public void ParsePlaceholders_NullInput_ThrowsArgumentNullException()
     {
-        Assert.ThrowsException<ArgumentNullException>(() => _parser.ParsePlaceholders(null!, out _, out _));
+        Assert.ThrowsExactly<ArgumentNullException>(() => _parser.ParsePlaceholders(null!, out _, out _));
     }
 
     [TestMethod]
@@ -165,13 +165,13 @@ public class PlaceholderParserTests
     public void Placeholder_Constructor_ThrowsOnNull()
     {
         // Assert
-        Assert.ThrowsException<ArgumentNullException>(() => new PlaceholderInfo(null!, 0));
+        Assert.ThrowsExactly<ArgumentNullException>(() => new PlaceholderInfo(null!, 0));
     }
 
     [TestMethod]
     public void Placeholder_Constructor_ThrowsArgumentOutOfRange()
     {
         // Assert
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => new PlaceholderInfo("Name", -1));
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => new PlaceholderInfo("Name", -1));
     }
 }

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Calc.UnitTests/BaseConverterTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Calc.UnitTests/BaseConverterTests.cs
@@ -140,6 +140,6 @@ public class BaseConverterTests
     [DataRow(-1)]
     public void Convert_ThrowsArgumentOutOfRange_WhenBaseInvalid(int toBase)
     {
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => BaseConverter.Convert(BigInteger.One, toBase));
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => BaseConverter.Convert(BigInteger.One, toBase));
     }
 }

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Calc.UnitTests/NumberTranslatorTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Calc.UnitTests/NumberTranslatorTests.cs
@@ -22,7 +22,7 @@ public class NumberTranslatorTests
         CultureInfo targetCulture = targetCultureName is not null ? new CultureInfo(targetCultureName) : null;
 
         // Act
-        Assert.ThrowsException<ArgumentNullException>(() => NumberTranslator.Create(sourceCulture, targetCulture));
+        Assert.ThrowsExactly<ArgumentNullException>(() => NumberTranslator.Create(sourceCulture, targetCulture));
     }
 
     [DataTestMethod]
@@ -50,7 +50,7 @@ public class NumberTranslatorTests
         var translator = NumberTranslator.Create(new CultureInfo("de-DE", false), new CultureInfo("en-US", false));
 
         // Act
-        Assert.ThrowsException<ArgumentNullException>(() => translator.Translate(input));
+        Assert.ThrowsExactly<ArgumentNullException>(() => translator.Translate(input));
     }
 
     [DataTestMethod]

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.TimeDate.UnitTests/ResultHelperTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.TimeDate.UnitTests/ResultHelperTests.cs
@@ -58,7 +58,7 @@ public class ResultHelperTests
         AvailableResult availableResult = null;
 
         // Act & Assert
-        Assert.ThrowsException<System.NullReferenceException>(() => availableResult.ToListItem());
+        Assert.ThrowsExactly<System.NullReferenceException>(() => availableResult.ToListItem());
     }
 
     [TestMethod]

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/ExtensionTemplateServiceTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/ExtensionTemplateServiceTests.cs
@@ -139,7 +139,7 @@ public class ExtensionTemplateServiceTests
     [TestMethod]
     public void TemplateFileHandling_ThrowsForUnknownExtension()
     {
-        var ex = Assert.ThrowsException<InvalidOperationException>(() => ExtensionTemplateService.GetTemplateFileHandling("template.svg"));
+        var ex = Assert.ThrowsExactly<InvalidOperationException>(() => ExtensionTemplateService.GetTemplateFileHandling("template.svg"));
 
         StringAssert.Contains(ex.Message, ".svg");
     }

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator.UnitTest/ExtendedCalculatorParserTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator.UnitTest/ExtendedCalculatorParserTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
         public void InputValid_ThrowError_WhenCalledNullOrEmpty(string input)
         {
             // Act
-            Assert.ThrowsException<ArgumentNullException>(() => CalculateHelper.InputValid(input));
+            Assert.ThrowsExactly<ArgumentNullException>(() => CalculateHelper.InputValid(input));
         }
 
         [DataTestMethod]
@@ -33,7 +33,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
             var engine = new CalculateEngine();
 
             // Act
-            Assert.ThrowsException<ArgumentNullException>(() => engine.Interpret(input, CultureInfo.CurrentCulture, out _));
+            Assert.ThrowsExactly<ArgumentNullException>(() => engine.Interpret(input, CultureInfo.CurrentCulture, out _));
         }
 
         [DataTestMethod]

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator.UnitTest/NumberTranslatorTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator.UnitTest/NumberTranslatorTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
             CultureInfo targetCulture = targetCultureName != null ? new CultureInfo(targetCultureName) : null;
 
             // Act
-            Assert.ThrowsException<ArgumentNullException>(() => NumberTranslator.Create(sourceCulture, targetCulture));
+            Assert.ThrowsExactly<ArgumentNullException>(() => NumberTranslator.Create(sourceCulture, targetCulture));
         }
 
         [DataTestMethod]
@@ -50,7 +50,7 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
             var translator = NumberTranslator.Create(new CultureInfo("de-DE", false), new CultureInfo("en-US", false));
 
             // Act
-            Assert.ThrowsException<ArgumentNullException>(() => translator.Translate(input));
+            Assert.ThrowsExactly<ArgumentNullException>(() => translator.Translate(input));
         }
 
         [DataTestMethod]

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests/TimeAndDateHelperTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests/TimeAndDateHelperTests.cs
@@ -90,7 +90,7 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests
             // Assert
             if (valueExpected == null)
             {
-                Assert.ThrowsException<ArgumentOutOfRangeException>(() => TimeAndDateHelper.ConvertToOleAutomationFormat(dt, (OADateFormats)type));
+                Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => TimeAndDateHelper.ConvertToOleAutomationFormat(dt, (OADateFormats)type));
             }
             else
             {

--- a/src/modules/launcher/Wox.Test/Plugins/ToolTipDataTest.cs
+++ b/src/modules/launcher/Wox.Test/Plugins/ToolTipDataTest.cs
@@ -20,7 +20,7 @@ namespace Wox.Test.Plugins
             string text = "text";
 
             // Assert
-            var ex = Assert.ThrowsException<ArgumentException>(() => new ToolTipData(title, text));
+            var ex = Assert.ThrowsExactly<ArgumentException>(() => new ToolTipData(title, text));
         }
     }
 }


### PR DESCRIPTION
Replace 18 Assert.ThrowsException calls with Assert.ThrowsExactly for more precise exception type matching.