### PR TITLE
Fix MSTEST0016: Fix test class declarations

### DIFF
--- a/src/common/UITestAutomation/UITestBase.cs
+++ b/src/common/UITestAutomation/UITestBase.cs
@@ -15,7 +15,6 @@ namespace Microsoft.PowerToys.UITest
     /// <summary>
     /// Base class that should be inherited by all Test Classes.
     /// </summary>
-    [TestClass]
     public class UITestBase : IDisposable
     {
         public required TestContext TestContext { get; set; }

--- a/src/modules/MouseUtils/MouseJump.Common.UnitTests/Helpers/DrawingHelperTests.cs
+++ b/src/modules/MouseUtils/MouseJump.Common.UnitTests/Helpers/DrawingHelperTests.cs
@@ -13,7 +13,6 @@ using MouseJump.Common.Models.Styles;
 
 namespace MouseJump.Common.UnitTests.Helpers;
 
-[TestClass]
 public static class DrawingHelperTests
 {
     [TestClass]

--- a/src/modules/MouseUtils/MouseJump.Common.UnitTests/Helpers/LayoutHelperTests.cs
+++ b/src/modules/MouseUtils/MouseJump.Common.UnitTests/Helpers/LayoutHelperTests.cs
@@ -12,7 +12,6 @@ using MouseJump.Common.Models.Styles;
 
 namespace MouseJump.Common.UnitTests.Helpers;
 
-[TestClass]
 public static class LayoutHelperTests
 {
     /*

--- a/src/modules/MouseUtils/MouseJump.Common.UnitTests/Helpers/MouseHelperTests.cs
+++ b/src/modules/MouseUtils/MouseJump.Common.UnitTests/Helpers/MouseHelperTests.cs
@@ -8,7 +8,6 @@ using MouseJump.Common.Models.Drawing;
 
 namespace MouseJump.Common.UnitTests.Helpers;
 
-[TestClass]
 public static class MouseHelperTests
 {
     [TestClass]

--- a/src/modules/MouseUtils/MouseJump.Common.UnitTests/Models/Drawing/RectangleInfoTests.cs
+++ b/src/modules/MouseUtils/MouseJump.Common.UnitTests/Models/Drawing/RectangleInfoTests.cs
@@ -7,7 +7,6 @@ using MouseJump.Common.Models.Drawing;
 
 namespace MouseJump.Common.UnitTests.Models.Drawing;
 
-[TestClass]
 public static class RectangleInfoTests
 {
     [TestClass]

--- a/src/modules/MouseUtils/MouseJump.Common.UnitTests/Models/Drawing/SizeInfoTests.cs
+++ b/src/modules/MouseUtils/MouseJump.Common.UnitTests/Models/Drawing/SizeInfoTests.cs
@@ -7,7 +7,6 @@ using MouseJump.Common.Models.Drawing;
 
 namespace MouseJump.Common.UnitTests.Models.Drawing;
 
-[TestClass]
 public static class SizeInfoTests
 {
     [TestClass]

--- a/src/modules/fancyzones/FancyZones.UITests/Init.cs
+++ b/src/modules/fancyzones/FancyZones.UITests/Init.cs
@@ -9,7 +9,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.FancyZonesEditor.UITests
 {
     [TestClass]
-    public class Init
+    public static class Init
     {
         private static Process? appDriver;
 

--- a/src/modules/fancyzones/FancyZonesEditor.UITests/Init.cs
+++ b/src/modules/fancyzones/FancyZonesEditor.UITests/Init.cs
@@ -9,7 +9,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.FancyZonesEditor.UITests
 {
     [TestClass]
-    public class Init
+    public static class Init
     {
         private static Process? appDriver;
 

--- a/src/modules/fancyzones/FancyZonesEditor.UITests/NewFancyZonesEditorTest.cs
+++ b/src/modules/fancyzones/FancyZonesEditor.UITests/NewFancyZonesEditorTest.cs
@@ -14,7 +14,6 @@ using static FancyZonesEditorCommon.Data.EditorParameters;
 
 namespace Microsoft.FancyZonesEditor.UITests
 {
-    [TestClass]
     public class NewFancyZonesEditorTest
     {
         public NewFancyZonesEditorTest()

--- a/src/modules/powerrename/PowerRenameUITest/PowerRenameUITestBase.cs
+++ b/src/modules/powerrename/PowerRenameUITest/PowerRenameUITestBase.cs
@@ -11,7 +11,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace PowerRename.UITests;
 
-[TestClass]
 public class PowerRenameUITestBase : UITestBase
 {
     private static readonly string[] OriginalTestFilePaths = new string[]


### PR DESCRIPTION
Fix 10 test classes by removing [TestClass] from base/outer classes and making assembly init/cleanup classes static.