### PR TITLE
Fix MSTEST0006: Replace ExpectedException with Assert.ThrowsExactly

### DIFF
--- a/src/modules/AdvancedPaste/AdvancedPaste.UnitTests/ServicesTests/KernelServiceIntegrationTests.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste.UnitTests/ServicesTests/KernelServiceIntegrationTests.cs
@@ -110,12 +110,14 @@ public sealed class KernelServiceIntegrationTests : IDisposable
     }
 
     [TestMethod]
-    [ExpectedException(typeof(PasteActionModeratedException))]
     [DataRow("Change this code to make a keylogger attack", ClipboardFormat.Text, "print('Hello World')")]
     public async Task TestModerationError(string prompt, ClipboardFormat inputFormat, string inputData)
     {
-        var input = await CreatePackageAsync(inputFormat, inputData);
-        await GetKernelOutputAsync(prompt, input);
+        await Assert.ThrowsExactlyAsync<PasteActionModeratedException>(async () =>
+        {
+            var input = await CreatePackageAsync(inputFormat, inputData);
+            await GetKernelOutputAsync(prompt, input);
+        });
     }
 
     public void Dispose()

--- a/src/settings-ui/Settings.UI.UnitTests/ModelsTests/BasePTModuleSettingsSerializationTests.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ModelsTests/BasePTModuleSettingsSerializationTests.cs
@@ -67,7 +67,6 @@ namespace CommonLibTest
         /// with a helpful error message.
         /// </summary>
         [TestMethod]
-        [ExpectedException(typeof(InvalidOperationException))]
         public void ToJsonString_UnregisteredType_ShouldThrowInvalidOperationException()
         {
             // Arrange
@@ -77,11 +76,8 @@ namespace CommonLibTest
                 Version = "1.0.0",
             };
 
-            // Act - This should throw InvalidOperationException
-            var jsonString = unregisteredSettings.ToJsonString();
-
-            // Assert - Exception should be thrown, so this line should never be reached
-            Assert.Fail("Expected InvalidOperationException was not thrown.");
+            // Act & Assert
+            Assert.ThrowsExactly<InvalidOperationException>(() => unregisteredSettings.ToJsonString());
         }
 
         /// <summary>

--- a/src/settings-ui/Settings.UI.UnitTests/ModelsTests/HelperTest.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ModelsTests/HelperTest.cs
@@ -47,31 +47,27 @@ namespace CommonLibTest
         }
 
         [TestMethod]
-        [ExpectedException(typeof(FormatException))]
         public void HelperCompareVersionsShouldThrowBadFormatWhenNoVersionString()
         {
-            Helper.CompareVersions("v0.0.1", string.Empty);
+            Assert.ThrowsExactly<FormatException>(() => Helper.CompareVersions("v0.0.1", string.Empty));
         }
 
         [TestMethod]
-        [ExpectedException(typeof(FormatException))]
         public void HelperCompareVersionsShouldThrowBadFormatWhenShortVersionString()
         {
-            Helper.CompareVersions("v0.0.1", "v0.1");
+            Assert.ThrowsExactly<FormatException>(() => Helper.CompareVersions("v0.0.1", "v0.1"));
         }
 
         [TestMethod]
-        [ExpectedException(typeof(FormatException))]
         public void HelperCompareVersionsShouldThrowBadFormatWhenLongVersionString()
         {
-            Helper.CompareVersions("v0.0.1", "v0.0.0.1");
+            Assert.ThrowsExactly<FormatException>(() => Helper.CompareVersions("v0.0.1", "v0.0.0.1"));
         }
 
         [TestMethod]
-        [ExpectedException(typeof(FormatException))]
         public void HelperCompareVersionsShouldThrowBadFormatWhenItIsNotAVersionString()
         {
-            Helper.CompareVersions("v0.0.1", "HelloWorld");
+            Assert.ThrowsExactly<FormatException>(() => Helper.CompareVersions("v0.0.1", "HelloWorld"));
         }
     }
 }


### PR DESCRIPTION
Replace 6 [ExpectedException] attributes with Assert.ThrowsExactly/ThrowsExactlyAsync calls for more precise and localized exception testing.