### PR TITLE
Fix MSTEST0023/0025/0030/0034: Remaining test diagnostic fixes

### DIFF
--- a/src/modules/MouseUtils/MouseUtils.UITests/FindMyMouseTests.cs
+++ b/src/modules/MouseUtils/MouseUtils.UITests/FindMyMouseTests.cs
@@ -441,7 +441,7 @@ namespace MouseUtils.UITests
                 }
                 else
                 {
-                    Assert.IsTrue(false, "ComboBox is not found in the setting page.");
+                    Assert.Fail("ComboBox is not found in the setting page.");
                 }
             }
             else

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Bookmarks.UnitTests/BookmarkResolverTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Bookmarks.UnitTests/BookmarkResolverTests.cs
@@ -40,7 +40,7 @@ public partial class BookmarkResolverTests
         File.WriteAllText(Path.Combine(_testDirPath, "app.exe"), "This is a test text file.");
     }
 
-    [ClassCleanup]
+    [ClassCleanup(ClassCleanupBehavior.EndOfClass)]
     public static void ClassCleanup()
     {
         if (Directory.Exists(_testDirPath))

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Bookmarks.UnitTests/CommandLineHelperTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Bookmarks.UnitTests/CommandLineHelperTests.cs
@@ -30,7 +30,7 @@ public class CommandLineHelperTests
         File.WriteAllText(_tempTestFile, "test");
     }
 
-    [ClassCleanup]
+    [ClassCleanup(ClassCleanupBehavior.EndOfClass)]
     public static void ClassCleanup()
     {
         // Clean up test directory

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Calc.UnitTests/ExtendedCalculatorParserTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Calc.UnitTests/ExtendedCalculatorParserTests.cs
@@ -23,7 +23,7 @@ public class ExtendedCalculatorParserTests : CommandPaletteUnitTestBase
     public void InputValid_ThrowError_WhenCalledNullOrEmpty(string input)
     {
         // Act
-        Assert.IsTrue(!CalculateHelper.InputValid(input));
+        Assert.IsFalse(CalculateHelper.InputValid(input));
     }
 
     [DataTestMethod]

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Shell.UnitTests/QueryTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Shell.UnitTests/QueryTests.cs
@@ -278,7 +278,7 @@ public class QueryTests : CommandPaletteUnitTestBase
 
         foreach (var item in commandList)
         {
-            Assert.IsTrue(!string.IsNullOrEmpty(item.TextToSuggest));
+            Assert.IsFalse(string.IsNullOrEmpty(item.TextToSuggest));
             Assert.IsFalse(item.TextToSuggest.StartsWith('"'));
         }
     }

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.System.UnitTests/QueryTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.System.UnitTests/QueryTests.cs
@@ -124,7 +124,7 @@ public class QueryTests : CommandPaletteUnitTestBase
             }
         }
 
-        Assert.IsTrue(!findDisconnectedMACResult, "Disconnected MAC address found in the results.");
+        Assert.IsFalse(findDisconnectedMACResult, "Disconnected MAC address found in the results.");
     }
 
     [TestMethod]

--- a/src/modules/fancyzones/FancyZones.UITests/RunFancyZonesTest.cs
+++ b/src/modules/fancyzones/FancyZones.UITests/RunFancyZonesTest.cs
@@ -18,7 +18,7 @@ namespace UITests_FancyZones
             _session = new FancyZonesSession(testContext);
         }
 
-        [ClassCleanup]
+        [ClassCleanup(ClassCleanupBehavior.EndOfClass)]
         public static void ClassCleanup()
         {
             _session?.Close();

--- a/src/modules/imageresizer/tests/Properties/SettingsTests.cs
+++ b/src/modules/imageresizer/tests/Properties/SettingsTests.cs
@@ -382,7 +382,7 @@ namespace ImageResizer.Properties
             Assert.AreEqual("Small-NotDefault", resultWrapper2.Properties.Sizes[0].Name);
         }
 
-        [ClassCleanup]
+        [ClassCleanup(ClassCleanupBehavior.EndOfClass)]
         public static void ClassCleanup()
         {
             _imageResizerApp.Dispose();

--- a/src/modules/imageresizer/tests/Views/TimeRemainingConverterTests.cs
+++ b/src/modules/imageresizer/tests/Views/TimeRemainingConverterTests.cs
@@ -12,6 +12,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace ImageResizer.Views
 {
+    [TestClass]
     public class TimeRemainingConverterTests
     {
         [DataTestMethod]

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Program.UnitTests/Programs/Win32Tests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Program.UnitTests/Programs/Win32Tests.cs
@@ -319,7 +319,7 @@ namespace Microsoft.Plugin.Program.UnitTests.Programs
 
             // Assert
             Assert.AreEqual(1, apps.Count);
-            Assert.IsTrue(!string.IsNullOrEmpty(apps[0].LnkFilePath));
+            Assert.IsFalse(string.IsNullOrEmpty(apps[0].LnkFilePath));
         }
 
         [TestMethod]


### PR DESCRIPTION
Fix 10 remaining MSTEST diagnostics: negated assertions (4 MSTEST0023), Assert.Fail usage (1 MSTEST0025), missing TestClass attribute (1 MSTEST0030), ClassCleanupBehavior.EndOfClass (4 MSTEST0034).