### PR TITLE
Fix SA1623: Fix property documentation summaries

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.Common/Helpers/InterlockedBoolean.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Common/Helpers/InterlockedBoolean.cs
@@ -12,7 +12,7 @@ public struct InterlockedBoolean(bool initialValue = false)
     private int _value = initialValue ? 1 : 0;
 
     /// <summary>
-    /// Gets or sets the boolean value atomically
+    /// Gets or sets a value indicating whether the atomic boolean is true.
     /// </summary>
     public bool Value
     {

--- a/src/modules/cmdpal/Microsoft.CmdPal.Common/Text/PinyinFuzzyMatcherOptions.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Common/Text/PinyinFuzzyMatcherOptions.cs
@@ -8,6 +8,6 @@ public sealed class PinyinFuzzyMatcherOptions
 {
     public PinyinMode Mode { get; init; } = PinyinMode.AutoSimplifiedChineseUi;
 
-    /// <summary>Remove IME syllable separators (') for query secondary variant.</summary>
+    /// <summary>Gets a value indicating whether IME syllable separators (') are removed for query secondary variant.</summary>
     public bool RemoveApostrophesForQuery { get; init; } = true;
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AppearanceSettingsViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AppearanceSettingsViewModel.cs
@@ -341,25 +341,25 @@ public sealed partial class AppearanceSettingsViewModel : ObservableObject, IDis
     }
 
     /// <summary>
-    /// Gets whether the backdrop opacity slider should be visible.
+    /// Gets a value indicating whether the backdrop opacity slider should be visible.
     /// </summary>
     public bool IsBackdropOpacityVisible =>
         BackdropStyles.Get(_settingsService.Settings.BackdropStyle).SupportsOpacity;
 
     /// <summary>
-    /// Gets whether the backdrop description (for styles without options) should be visible.
+    /// Gets a value indicating whether the backdrop description (for styles without options) should be visible.
     /// </summary>
     public bool IsMicaBackdropDescriptionVisible =>
         !BackdropStyles.Get(_settingsService.Settings.BackdropStyle).SupportsOpacity;
 
     /// <summary>
-    /// Gets whether background/colorization settings are available.
+    /// Gets a value indicating whether background/colorization settings are available.
     /// </summary>
     public bool IsBackgroundSettingsEnabled =>
         BackdropStyles.Get(_settingsService.Settings.BackdropStyle).SupportsColorization;
 
     /// <summary>
-    /// Gets whether the "not available" message should be shown (inverse of IsBackgroundSettingsEnabled).
+    /// Gets a value indicating whether the "not available" message should be shown (inverse of IsBackgroundSettingsEnabled).
     /// </summary>
     public bool IsBackgroundNotAvailableVisible =>
         !BackdropStyles.Get(_settingsService.Settings.BackdropStyle).SupportsColorization;

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/BackdropStyleConfig.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/BackdropStyleConfig.cs
@@ -36,17 +36,17 @@ public sealed record BackdropStyleConfig
     public float FixedOpacity { get; init; }
 
     /// <summary>
-    /// Gets whether this backdrop style supports custom colorization (tint colors).
+    /// Gets a value indicating whether this backdrop style supports custom colorization (tint colors).
     /// </summary>
     public bool SupportsColorization { get; init; } = true;
 
     /// <summary>
-    /// Gets whether this backdrop style supports custom background images.
+    /// Gets a value indicating whether this backdrop style supports custom background images.
     /// </summary>
     public bool SupportsBackgroundImage { get; init; } = true;
 
     /// <summary>
-    /// Gets whether this backdrop style supports opacity adjustment.
+    /// Gets a value indicating whether this backdrop style supports opacity adjustment.
     /// </summary>
     public bool SupportsOpacity { get; init; } = true;
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/ThemeSnapshot.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/ThemeSnapshot.cs
@@ -67,7 +67,7 @@ public sealed class ThemeSnapshot
     public required float BackgroundBrightness { get; init; }
 
     /// <summary>
-    /// Gets whether colorization is active (accent color, custom color, or image mode).
+    /// Gets a value indicating whether colorization is active (accent color, custom color, or image mode).
     /// </summary>
     public required bool HasColorization { get; init; }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Settings/DockSettings.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Settings/DockSettings.cs
@@ -93,19 +93,19 @@ public record DockBandSettings
     public required string CommandId { get; init; }
 
     /// <summary>
-    /// Gets or sets whether titles are shown for items in this band.
+    /// Gets whether titles are shown for items in this band.
     /// If null, falls back to dock-wide ShowLabels setting.
     /// </summary>
     public bool? ShowTitles { get; init; }
 
     /// <summary>
-    /// Gets or sets whether subtitles are shown for items in this band.
+    /// Gets whether subtitles are shown for items in this band.
     /// If null, falls back to dock-wide ShowLabels setting.
     /// </summary>
     public bool? ShowSubtitles { get; init; }
 
     /// <summary>
-    /// Gets or sets a value for backward compatibility. Maps to ShowTitles.
+    /// Gets a value for backward compatibility. Maps to ShowTitles.
     /// </summary>
     [System.Text.Json.Serialization.JsonIgnore]
     public bool? ShowLabels

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/WindowPosition.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/WindowPosition.cs
@@ -9,37 +9,37 @@ namespace Microsoft.CmdPal.UI.ViewModels;
 public sealed class WindowPosition
 {
     /// <summary>
-    /// Gets or sets left position in device pixels.
+    /// Gets the left position in device pixels.
     /// </summary>
     public int X { get; init; }
 
     /// <summary>
-    /// Gets or sets top position in device pixels.
+    /// Gets the top position in device pixels.
     /// </summary>
     public int Y { get; init; }
 
     /// <summary>
-    /// Gets or sets width in device pixels.
+    /// Gets the width in device pixels.
     /// </summary>
     public int Width { get; init; }
 
     /// <summary>
-    /// Gets or sets height in device pixels.
+    /// Gets the height in device pixels.
     /// </summary>
     public int Height { get; init; }
 
     /// <summary>
-    /// Gets or sets width of the screen in device pixels where the window is located.
+    /// Gets the width of the screen in device pixels where the window is located.
     /// </summary>
     public int ScreenWidth { get; init; }
 
     /// <summary>
-    /// Gets or sets height of the screen in device pixels where the window is located.
+    /// Gets the height of the screen in device pixels where the window is located.
     /// </summary>
     public int ScreenHeight { get; init; }
 
     /// <summary>
-    /// Gets or sets DPI (dots per inch) of the display where the window is located.
+    /// Gets the DPI (dots per inch) of the display where the window is located.
     /// </summary>
     public int Dpi { get; init; }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Events/CmdPalDockConfiguration.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Events/CmdPalDockConfiguration.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CmdPal.UI.Events;
 public class CmdPalDockConfiguration : EventBase, IEvent
 {
     /// <summary>
-    /// Gets or sets whether the dock is enabled.
+    /// Gets or sets a value indicating whether the dock is enabled.
     /// </summary>
     public bool IsDockEnabled { get; set; }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Events/CmdPalExtensionInvoked.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Events/CmdPalExtensionInvoked.cs
@@ -33,7 +33,7 @@ public class CmdPalExtensionInvoked : EventBase, IEvent
     public string CommandName { get; set; }
 
     /// <summary>
-    /// Gets or sets whether the command executed successfully.
+    /// Gets or sets a value indicating whether the command executed successfully.
     /// </summary>
     public bool Success { get; set; }
 

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/AllAppsSettings.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/AllAppsSettings.cs
@@ -76,7 +76,7 @@ public class AllAppsSettings : JsonSettingsManager, ISettingsInterface
     };
 
     /// <summary>
-    /// Parsed search result limit. Returns <see langword="null"/> when the caller should
+    /// Gets the parsed search result limit. Returns <see langword="null"/> when the caller should
     /// use its own default (unrecognized value, empty, or old stored "0").
     /// </summary>
     public int? SearchResultLimit

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/ShellHelpers.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/ShellHelpers.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CommandPalette.Extensions.Toolkit;
 public static class ShellHelpers
 {
     /// <summary>
-    /// These are the executable file extensions that Windows Shell recognizes. Unlike CMD/PowerShell,
+    /// Gets the executable file extensions that Windows Shell recognizes. Unlike CMD/PowerShell,
     /// Shell does not use PATHEXT, but has a magic fixed list.
     /// </summary>
     public static string[] ExecutableExtensions { get; } = [".PIF", ".COM", ".EXE", ".BAT", ".CMD"];

--- a/src/modules/powerdisplay/PowerDisplay.Lib/Utils/VcpNames.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Lib/Utils/VcpNames.cs
@@ -17,7 +17,7 @@ namespace PowerDisplay.Common.Utils
     public static class VcpNames
     {
         /// <summary>
-        /// Optional delegate to provide localized VCP code names.
+        /// Gets or sets the optional delegate to provide localized VCP code names.
         /// Set this at application startup to enable localization.
         /// The delegate receives a VCP code and should return the localized name, or null to use the default.
         /// </summary>

--- a/src/settings-ui/Settings.UI.Library/PowerDisplayProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/PowerDisplayProperties.cs
@@ -48,7 +48,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         public bool ShowSystemTrayIcon { get; set; }
 
         /// <summary>
-        /// Gets or sets whether to show the profile switcher button in the flyout UI.
+        /// Gets or sets a value indicating whether to show the profile switcher button in the flyout UI.
         /// Default is true. When false, the profile switcher is hidden (but profiles still work via Settings).
         /// Note: Also hidden when no profiles exist.
         /// </summary>
@@ -56,7 +56,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         public bool ShowProfileSwitcher { get; set; }
 
         /// <summary>
-        /// Gets or sets whether to show the identify monitors button in the flyout UI.
+        /// Gets or sets a value indicating whether to show the identify monitors button in the flyout UI.
         /// Default is true.
         /// </summary>
         [JsonPropertyName("show_identify_monitors_button")]

--- a/src/settings-ui/Settings.UI/ViewModels/PowerDisplayViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/PowerDisplayViewModel.cs
@@ -465,7 +465,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         public ObservableCollection<CustomVcpValueMapping> CustomVcpMappings => _customVcpMappings;
 
         /// <summary>
-        /// Gets whether there are any custom VCP mappings (for UI binding)
+        /// Gets a value indicating whether there are any custom VCP mappings (for UI binding).
         /// </summary>
         public bool HasCustomVcpMappings => _customVcpMappings?.Count > 0;
 
@@ -475,7 +475,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         public ObservableCollection<PowerDisplayProfile> Profiles => _profiles;
 
         /// <summary>
-        /// Gets whether there are any profiles (for UI binding)
+        /// Gets a value indicating whether there are any profiles (for UI binding).
         /// </summary>
         public bool HasProfiles => _profiles?.Count > 0;
 


### PR DESCRIPTION
Update 29 property XML doc summaries to begin with Gets, Gets or sets, or Gets a value indicating whether as required by StyleCop SA1623.