### PR TITLE
Fix WMC1506 XAML compiler warnings in AdvancedPaste

### DIFF
--- a/src/modules/AdvancedPaste/AdvancedPaste/AdvancedPasteXAML/Controls/ClipboardHistoryItemPreviewControl.xaml
+++ b/src/modules/AdvancedPaste/AdvancedPaste/AdvancedPasteXAML/Controls/ClipboardHistoryItemPreviewControl.xaml
@@ -70,12 +70,12 @@
             Spacing="2">
             <TextBlock
                 Style="{StaticResource BodyTextBlockStyle}"
-                Text="{x:Bind Header, Mode=OneWay}"
+                Text="{x:Bind Header, Mode=OneTime}"
                 TextWrapping="NoWrap" />
             <TextBlock
                 Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                 Style="{StaticResource CaptionTextBlockStyle}"
-                Text="{x:Bind Timestamp, Converter={StaticResource DateTimeToFriendlyStringConverter}, Mode=OneWay}" />
+                Text="{x:Bind Timestamp, Converter={StaticResource DateTimeToFriendlyStringConverter}, Mode=OneTime}" />
         </StackPanel>
     </Grid>
 </UserControl>

--- a/src/modules/AdvancedPaste/AdvancedPaste/AdvancedPasteXAML/Pages/MainPage.xaml
+++ b/src/modules/AdvancedPaste/AdvancedPaste/AdvancedPasteXAML/Pages/MainPage.xaml
@@ -29,31 +29,31 @@
                         Padding="-9,0,0,0"
                         HorizontalAlignment="Stretch"
                         VerticalAlignment="Stretch"
-                        AutomationProperties.AcceleratorKey="{x:Bind ShortcutText, Mode=OneWay}"
+                        AutomationProperties.AcceleratorKey="{x:Bind ShortcutText, Mode=OneTime}"
                         AutomationProperties.AutomationControlType="ListItem"
-                        AutomationProperties.FullDescription="{x:Bind ToolTip, Mode=OneWay}"
-                        AutomationProperties.HelpText="{x:Bind Name, Mode=OneWay}"
-                        AutomationProperties.Name="{x:Bind AccessibleName, Mode=OneWay}">
+                        AutomationProperties.FullDescription="{x:Bind ToolTip, Mode=OneTime}"
+                        AutomationProperties.HelpText="{x:Bind Name, Mode=OneTime}"
+                        AutomationProperties.Name="{x:Bind AccessibleName, Mode=OneTime}">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="48" />
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
                         <ToolTipService.ToolTip>
-                            <TextBlock Text="{x:Bind ToolTip, Mode=OneWay}" />
+                            <TextBlock Text="{x:Bind ToolTip, Mode=OneTime}" />
                         </ToolTipService.ToolTip>
                         <FontIcon
                             Margin="0,0,0,0"
                             VerticalAlignment="Center"
                             AutomationProperties.AccessibilityView="Raw"
                             FontSize="16"
-                            Glyph="{x:Bind IconGlyph, Mode=OneWay}" />
+                            Glyph="{x:Bind IconGlyph, Mode=OneTime}" />
                         <TextBlock
                             Grid.Column="1"
                             VerticalAlignment="Center"
                             x:Phase="1"
                             Style="{StaticResource CaptionTextBlockStyle}"
-                            Text="{x:Bind Name, Mode=OneWay}" />
+                            Text="{x:Bind Name, Mode=OneTime}" />
                         <TextBlock
                             Grid.Column="2"
                             Margin="0,0,8,0"
@@ -61,7 +61,7 @@
                             VerticalAlignment="Center"
                             Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                             Style="{StaticResource CaptionTextBlockStyle}"
-                            Text="{x:Bind ShortcutText, Mode=OneWay}" />
+                            Text="{x:Bind ShortcutText, Mode=OneTime}" />
                     </Grid>
                 </DataTemplate>
             </controls:PasteFormatTemplateSelector.ItemTemplate>
@@ -83,13 +83,13 @@
                             Margin="0,0,0,0"
                             VerticalAlignment="Center"
                             FontSize="16"
-                            Glyph="{x:Bind IconGlyph, Mode=OneWay}" />
+                            Glyph="{x:Bind IconGlyph, Mode=OneTime}" />
                         <TextBlock
                             Grid.Column="1"
                             VerticalAlignment="Center"
                             x:Phase="1"
                             Style="{StaticResource CaptionTextBlockStyle}"
-                            Text="{x:Bind Name, Mode=OneWay}" />
+                            Text="{x:Bind Name, Mode=OneTime}" />
                     </Grid>
                 </DataTemplate>
             </controls:PasteFormatTemplateSelector.ItemTemplateDisabled>
@@ -198,7 +198,7 @@
                             <ItemsView.ItemTemplate>
                                 <DataTemplate x:DataType="local:ClipboardItem">
                                     <ItemContainer
-                                        AutomationProperties.Name="{x:Bind Description, Mode=OneWay}"
+                                        AutomationProperties.Name="{x:Bind Description, Mode=OneTime}"
                                         CornerRadius="16"
                                         ToolTipService.ToolTip="{x:Bind Content}">
                                         <Grid


### PR DESCRIPTION
## Summary

Fixes all 13 **WMC1506** XAML compiler warnings ("OneWay bindings require at least one of their steps to support raising notifications when their value changes") by changing \Mode=OneWay\ to \Mode=OneTime\ on \x:Bind\ expressions bound to non-observable properties.

## Details

**Root cause:** \PasteFormat\ (plain sealed class) and \ClipboardItem\ (plain class) do not implement \INotifyPropertyChanged\. Using \Mode=OneWay\ on their properties creates subscriptions that will never fire, generating WMC1506 warnings.

**Fix:** Changed to \Mode=OneTime\ which is semantically correct — these properties are set once and never change after construction.

**Files changed:**
- \ClipboardHistoryItemPreviewControl.xaml\ — 2 bindings (\Header\, \Timestamp\)
- \MainPage.xaml\ — 11 bindings across \PasteFormat\ and \ClipboardItem\ DataTemplates

**Note on ClipboardHistoryItemPreviewControl:** Its computed properties (\Header\, \Timestamp\) are refreshed via \Bindings.Update()\ when the \ClipboardItem\ DependencyProperty changes. \Bindings.Update()\ forces re-evaluation of all \x:Bind\ bindings regardless of mode, so \OneTime\ works correctly here.

## Validation

- [x] Full solution build passes (exit code 0)
- [x] Zero WMC1506 warnings after changes (was 13 before)
- [x] No behavioral changes — only binding mode optimization