### PR TITLE
Add custom name feature to Keyboard Manager

### DIFF
--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Controls/UnifiedMappingControl.xaml
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Controls/UnifiedMappingControl.xaml
@@ -137,6 +137,15 @@
                 BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}"
                 GotFocus="AppNameTextBox_GotFocus"
                 Visibility="Collapsed" />
+            <TextBlock
+                x:Uid="NameLabel"
+                Margin="0,16,0,4"
+                FontWeight="SemiBold" />
+            <TextBox
+                x:Name="NameTextBox"
+                x:Uid="NameTextBox"
+                Background="{ThemeResource TextControlBackgroundFocused}"
+                BorderBrush="{ThemeResource ControlStrokeColorDefaultBrush}" />
         </StackPanel>
         <!--  Arrow Separator  -->
         <Grid

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Controls/UnifiedMappingControl.xaml.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Controls/UnifiedMappingControl.xaml.cs
@@ -546,6 +546,11 @@ namespace KeyboardManagerEditorUI.Controls
         /// </summary>
         public ProgramAlreadyRunningAction GetIfRunningAction() => (ProgramAlreadyRunningAction)(IfRunningComboBox?.SelectedIndex ?? 0);
 
+        /// <summary>
+        /// Gets the custom name for the mapping.
+        /// </summary>
+        public string GetName() => NameTextBox?.Text ?? string.Empty;
+
         #endregion
 
         #region Public API - Validation
@@ -731,6 +736,17 @@ namespace KeyboardManagerEditorUI.Controls
             }
         }
 
+        /// <summary>
+        /// Sets the custom name for the mapping.
+        /// </summary>
+        public void SetName(string name)
+        {
+            if (NameTextBox != null)
+            {
+                NameTextBox.Text = name;
+            }
+        }
+
         #endregion
 
         #region Helper Methods
@@ -865,6 +881,11 @@ namespace KeyboardManagerEditorUI.Controls
             {
                 AppNameTextBox.Text = string.Empty;
                 AppNameTextBox.Visibility = Visibility.Collapsed;
+            }
+
+            if (NameTextBox != null)
+            {
+                NameTextBox.Text = string.Empty;
             }
 
             // Reset checkboxes

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/IToggleableShortcut.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/IToggleableShortcut.cs
@@ -19,5 +19,7 @@ namespace KeyboardManagerEditorUI.Helpers
         string Id { get; set; }
 
         string AppName { get; set; }
+
+        string Name { get; set; }
     }
 }

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/ProgramShortcut.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/ProgramShortcut.cs
@@ -27,6 +27,8 @@ namespace KeyboardManagerEditorUI.Helpers
 
         public string AppName { get; set; } = string.Empty;
 
+        public string Name { get; set; } = string.Empty;
+
         public string StartInDirectory { get; set; } = string.Empty;
 
         public string Elevation { get; set; } = string.Empty;

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/Remapping.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/Remapping.cs
@@ -22,6 +22,8 @@ namespace KeyboardManagerEditorUI.Helpers
 
         public string AppName { get; set; } = string.Empty;
 
+        public string Name { get; set; } = string.Empty;
+
         private bool IsEnabledValue { get; set; } = true;
 
         public string Id { get; set; } = string.Empty;

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/TextMapping.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/TextMapping.cs
@@ -20,6 +20,8 @@ namespace KeyboardManagerEditorUI.Helpers
 
         public string AppName { get; set; } = string.Empty;
 
+        public string Name { get; set; } = string.Empty;
+
         public bool IsActive { get; set; } = true;
 
         public string Id { get; set; } = string.Empty;

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/URLShortcut.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/URLShortcut.cs
@@ -23,5 +23,7 @@ namespace KeyboardManagerEditorUI.Helpers
         public bool IsAllApps { get; set; } = true;
 
         public string AppName { get; set; } = string.Empty;
+
+        public string Name { get; set; } = string.Empty;
     }
 }

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/MainPage.xaml
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/MainPage.xaml
@@ -189,7 +189,21 @@
                                                                 x:Uid="InText"
                                                                 VerticalAlignment="Center"
                                                                 Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                                                            <controls:IconLabelControl ActionType="Program" Label="{x:Bind AppName}" />
+                                                        <controls:IconLabelControl ActionType="Program" Label="{x:Bind AppName}" />
+                                                        </StackPanel>
+                                                        <StackPanel
+                                                            Orientation="Horizontal"
+                                                            Spacing="8"
+                                                            Visibility="{x:Bind Name, Converter={StaticResource StringVisibilityConverter}}">
+                                                            <TextBlock
+                                                                x:Uid="NameText"
+                                                                VerticalAlignment="Center"
+                                                                Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" />
+                                                            <TextBlock
+                                                                Text="{x:Bind Name}"
+                                                                VerticalAlignment="Center"
+                                                                FontWeight="SemiBold"
+                                                                Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" />
                                                         </StackPanel>
                                                     </StackPanel>
                                                     <StackPanel
@@ -223,7 +237,7 @@
                                     </ListView>
                                 </StackPanel>
 
-                                <!--  Text Section  -->
+                                <!--  Text Section -->
                                 <StackPanel Orientation="Vertical" Visibility="{x:Bind TextMappings.Count, Mode=OneWay, Converter={StaticResource CountToVisibilityConverter}}">
                                     <TextBlock
                                         x:Uid="TextMappingsHeader"
@@ -278,6 +292,20 @@
                                                                 VerticalAlignment="Center"
                                                                 Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                                                             <controls:IconLabelControl ActionType="Program" Label="{x:Bind AppName}" />
+                                                        </StackPanel>
+                                                        <StackPanel
+                                                            Orientation="Horizontal"
+                                                            Spacing="8"
+                                                            Visibility="{x:Bind Name, Converter={StaticResource StringVisibilityConverter}}">
+                                                            <TextBlock
+                                                                x:Uid="NameText"
+                                                                VerticalAlignment="Center"
+                                                                Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" />
+                                                            <TextBlock
+                                                                Text="{x:Bind Name}"
+                                                                VerticalAlignment="Center"
+                                                                FontWeight="SemiBold"
+                                                                Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" />
                                                         </StackPanel>
                                                     </StackPanel>
                                                     <StackPanel
@@ -396,6 +424,20 @@
                                                                 Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                                                             <controls:IconLabelControl ActionType="Program" Label="{x:Bind AppName}" />
                                                         </StackPanel>
+                                                        <StackPanel
+                                                            Orientation="Horizontal"
+                                                            Spacing="8"
+                                                            Visibility="{x:Bind Name, Converter={StaticResource StringVisibilityConverter}}">
+                                                            <TextBlock
+                                                                x:Uid="NameText"
+                                                                VerticalAlignment="Center"
+                                                                Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" />
+                                                            <TextBlock
+                                                                Text="{x:Bind Name}"
+                                                                VerticalAlignment="Center"
+                                                                FontWeight="SemiBold"
+                                                                Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" />
+                                                        </StackPanel>
                                                     </StackPanel>
                                                     <StackPanel
                                                         Grid.Column="1"
@@ -484,6 +526,20 @@
                                                                 VerticalAlignment="Center"
                                                                 Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                                                             <controls:IconLabelControl ActionType="Program" Label="{x:Bind AppName}" />
+                                                        </StackPanel>
+                                                        <StackPanel
+                                                            Orientation="Horizontal"
+                                                            Spacing="8"
+                                                            Visibility="{x:Bind Name, Converter={StaticResource StringVisibilityConverter}}">
+                                                            <TextBlock
+                                                                x:Uid="NameText"
+                                                                VerticalAlignment="Center"
+                                                                Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" />
+                                                            <TextBlock
+                                                                Text="{x:Bind Name}"
+                                                                VerticalAlignment="Center"
+                                                                FontWeight="SemiBold"
+                                                                Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" />
                                                         </StackPanel>
                                                     </StackPanel>
                                                     <StackPanel

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/MainPage.xaml.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/MainPage.xaml.cs
@@ -132,6 +132,7 @@ namespace KeyboardManagerEditorUI.Pages
             UnifiedMappingControl.SetActionType(UnifiedMappingControl.ActionType.KeyOrShortcut);
             UnifiedMappingControl.SetActionKeys(remapping.RemappedKeys.ToList());
             UnifiedMappingControl.SetAppSpecific(!remapping.IsAllApps, remapping.AppName);
+            UnifiedMappingControl.SetName(remapping.Name);
             RemappingDialog.Title = "Edit remapping";
             await ShowRemappingDialog();
         }
@@ -158,6 +159,7 @@ namespace KeyboardManagerEditorUI.Pages
             UnifiedMappingControl.SetActionType(UnifiedMappingControl.ActionType.Text);
             UnifiedMappingControl.SetTextContent(textMapping.Text);
             UnifiedMappingControl.SetAppSpecific(!textMapping.IsAllApps, textMapping.AppName);
+            UnifiedMappingControl.SetName(textMapping.Name);
             RemappingDialog.Title = "Edit remapping";
             await ShowRemappingDialog();
         }
@@ -196,6 +198,7 @@ namespace KeyboardManagerEditorUI.Pages
             }
 
             UnifiedMappingControl.SetAppSpecific(!programShortcut.IsAllApps, programShortcut.AppName);
+            UnifiedMappingControl.SetName(programShortcut.Name);
             RemappingDialog.Title = "Edit remapping";
             await ShowRemappingDialog();
         }
@@ -222,6 +225,7 @@ namespace KeyboardManagerEditorUI.Pages
             UnifiedMappingControl.SetActionType(UnifiedMappingControl.ActionType.OpenUrl);
             UnifiedMappingControl.SetUrl(urlShortcut.URL);
             UnifiedMappingControl.SetAppSpecific(!urlShortcut.IsAllApps, urlShortcut.AppName);
+            UnifiedMappingControl.SetName(urlShortcut.Name);
             RemappingDialog.Title = "Edit remapping";
             await ShowRemappingDialog();
         }
@@ -466,7 +470,8 @@ namespace KeyboardManagerEditorUI.Pages
             if (saved)
             {
                 _mappingService.SaveSettings();
-                SettingsManager.AddShortcutKeyMappingToSettings(shortcutKeyMapping);
+                string name = UnifiedMappingControl.GetName();
+                SettingsManager.AddShortcutKeyMappingToSettings(shortcutKeyMapping, name);
             }
 
             return saved;
@@ -492,7 +497,8 @@ namespace KeyboardManagerEditorUI.Pages
             if (saved)
             {
                 _mappingService.SaveSettings();
-                SettingsManager.AddShortcutKeyMappingToSettings(shortcutKeyMapping);
+                string name = UnifiedMappingControl.GetName();
+                SettingsManager.AddShortcutKeyMappingToSettings(shortcutKeyMapping, name);
             }
 
             return saved;
@@ -521,7 +527,8 @@ namespace KeyboardManagerEditorUI.Pages
             if (saved)
             {
                 _mappingService.SaveSettings();
-                SettingsManager.AddShortcutKeyMappingToSettings(shortcutKeyMapping);
+                string name = UnifiedMappingControl.GetName();
+                SettingsManager.AddShortcutKeyMappingToSettings(shortcutKeyMapping, name);
             }
 
             return saved;
@@ -555,7 +562,8 @@ namespace KeyboardManagerEditorUI.Pages
             if (saved)
             {
                 _mappingService.SaveSettings();
-                SettingsManager.AddShortcutKeyMappingToSettings(shortcutKeyMapping);
+                string name = UnifiedMappingControl.GetName();
+                SettingsManager.AddShortcutKeyMappingToSettings(shortcutKeyMapping, name);
             }
 
             return saved;
@@ -761,6 +769,7 @@ namespace KeyboardManagerEditorUI.Pages
                     AppName = mapping.TargetApp ?? string.Empty,
                     Id = shortcutSettings.Id,
                     IsActive = shortcutSettings.IsActive,
+                    Name = shortcutSettings.Name,
                 });
             }
         }
@@ -790,6 +799,7 @@ namespace KeyboardManagerEditorUI.Pages
                     AppName = mapping.TargetApp ?? string.Empty,
                     Id = shortcutSettings.Id,
                     IsActive = shortcutSettings.IsActive,
+                    Name = shortcutSettings.Name,
                 });
             }
         }
@@ -820,6 +830,7 @@ namespace KeyboardManagerEditorUI.Pages
                     Id = shortcutSettings.Id,
                     IsAllApps = string.IsNullOrEmpty(mapping.TargetApp),
                     AppName = mapping.TargetApp ?? string.Empty,
+                    Name = shortcutSettings.Name,
                     StartInDirectory = mapping.StartInDirectory,
                     Elevation = mapping.Elevation.ToString(),
                     IfRunningAction = mapping.IfRunningAction.ToString(),
@@ -853,6 +864,7 @@ namespace KeyboardManagerEditorUI.Pages
                     IsActive = shortcutSettings.IsActive,
                     IsAllApps = string.IsNullOrEmpty(mapping.TargetApp),
                     AppName = mapping.TargetApp ?? string.Empty,
+                    Name = shortcutSettings.Name,
                 });
             }
         }

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Settings/SettingsManager.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Settings/SettingsManager.cs
@@ -183,9 +183,9 @@ namespace KeyboardManagerEditorUI.Settings
             }
         }
 
-        public static void AddShortcutKeyMappingToSettings(ShortcutKeyMapping shortcutKeyMapping)
+        public static void AddShortcutKeyMappingToSettings(ShortcutKeyMapping shortcutKeyMapping, string name = "")
         {
-            AddShortcutMapping(EditorSettings, shortcutKeyMapping);
+            AddShortcutMapping(EditorSettings, shortcutKeyMapping, name);
             WriteSettings();
         }
 
@@ -211,13 +211,14 @@ namespace KeyboardManagerEditorUI.Settings
             }
         }
 
-        private static void AddShortcutMapping(EditorSettings settings, ShortcutKeyMapping mapping)
+        private static void AddShortcutMapping(EditorSettings settings, ShortcutKeyMapping mapping, string name = "")
         {
             string guid = Guid.NewGuid().ToString();
             var shortcutSettings = new ShortcutSettings
             {
                 Id = guid,
                 Shortcut = mapping,
+                Name = name,
                 IsActive = true,
             };
 

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Settings/ShortcutSettings.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Settings/ShortcutSettings.cs
@@ -17,6 +17,8 @@ namespace KeyboardManagerEditorUI.Settings
 
         public ShortcutKeyMapping Shortcut { get; set; } = new ShortcutKeyMapping();
 
+        public string Name { get; set; } = string.Empty;
+
         public List<string> Profiles { get; set; } = new List<string>();
 
         public bool IsActive { get; set; } = true;

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Strings/en-US/Resources.resw
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Strings/en-US/Resources.resw
@@ -292,4 +292,16 @@
   <data name="MouseClickPlaceholder.Text" xml:space="preserve">
     <value>Mouse click action - coming soon</value>
   </data>
+  <data name="NameLabel.Text" xml:space="preserve">
+    <value>Name (optional)</value>
+  </data>
+  <data name="NameTextBox.Header" xml:space="preserve">
+    <value>Name (optional)</value>
+  </data>
+  <data name="NameTextBox.PlaceholderText" xml:space="preserve">
+    <value>Enter a name for this shortcut</value>
+  </data>
+  <data name="NameText.Text" xml:space="preserve">
+    <value>Name:</value>
+  </data>
 </root>


### PR DESCRIPTION
Add support for assigning custom names to keyboard shortcuts in Keyboard Manager, allowing users to easily identify remappings.

### Changes
- Added `Name` property to `ShortcutSettings` data model
- Added `Name` property to helper classes: `Remapping`, `TextMapping`, `ProgramShortcut`, `URLShortcut`
- Added `Name` field to `IToggleableShortcut` interface
- Updated `SettingsManager` to persist custom names
- Added name input field in `UnifiedMappingControl`
- Displayed custom names in remappings list view
- Added localized strings for new UI elements

Fixes #46561

## Summary of the Pull Request
This PR adds support for custom naming of keyboard shortcuts in Keyboard Manager. Users can now assign and edit names for remappings, improving usability and making it easier to identify shortcuts in the list view.

## PR Checklist

- [x] Closes: #46561
- [ ] **Communication:** I've discussed this with core contributors already
- [ ] **Tests:** Added/updated and all pass
- [x] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
- [ ] **Documentation updated:** N/A

## Detailed Description of the Pull Request / Additional comments

This feature improves usability of Keyboard Manager by allowing users to assign meaningful names to their remapped shortcuts. This is especially useful when multiple remappings are configured, as users no longer need to remember the original shortcut behavior.

The implementation ensures that custom names are persisted and displayed consistently across all remapping types.

## Validation Steps Performed

- Created new remappings and assigned custom names
- Edited existing remappings and updated names
- Verified names persist after restart
- Tested across all remapping types:
  - Key remapping
  - Text insertion
  - Program launching
  - URL opening
- Confirmed names are displayed correctly in list view