### PR TITLE
Revert "Pin check-spelling action to v0.0.26 (a35147f)"

### DIFF
--- a/.github/workflows/spelling2.yml
+++ b/.github/workflows/spelling2.yml
@@ -93,7 +93,7 @@ jobs:
     steps:
       - name: check-spelling
         id: spelling
-        uses: check-spelling/check-spelling@a35147f799f30f8739c33f92222c847214e82e67 # v0.0.26
+        uses: check-spelling/check-spelling@c635c2f3f714eec2fcf27b643a1919b9a811ef2e # v0.0.25
         with:
           config: .github/actions/spell-check
           suppress_push_for_open_pull_request: ${{ github.actor != 'dependabot[bot]' && 1 }}
@@ -147,7 +147,7 @@ jobs:
     if: (success() || failure()) && needs.spelling.outputs.followup && github.event_name == 'push'
     steps:
       - name: comment
-        uses: check-spelling/check-spelling@a35147f799f30f8739c33f92222c847214e82e67 # v0.0.26
+        uses: check-spelling/check-spelling@c635c2f3f714eec2fcf27b643a1919b9a811ef2e # v0.0.25
         with:
           config: .github/actions/spell-check
           checkout: true
@@ -166,7 +166,7 @@ jobs:
     if: (success() || failure()) && needs.spelling.outputs.followup && contains(github.event_name, 'pull_request')
     steps:
       - name: comment
-        uses: check-spelling/check-spelling@a35147f799f30f8739c33f92222c847214e82e67 # v0.0.26
+        uses: check-spelling/check-spelling@c635c2f3f714eec2fcf27b643a1919b9a811ef2e # v0.0.25
         with:
           config: .github/actions/spell-check
           checkout: true
@@ -193,7 +193,7 @@ jobs:
       cancel-in-progress: false
     steps:
       - name: apply spelling updates
-        uses: check-spelling/check-spelling@a35147f799f30f8739c33f92222c847214e82e67 # v0.0.26
+        uses: check-spelling/check-spelling@c635c2f3f714eec2fcf27b643a1919b9a811ef2e # v0.0.25
         with:
           experimental_apply_changes_via_bot: ${{ github.repository_owner != 'microsoft' && 1 }}
           checkout: true


### PR DESCRIPTION
Reverts microsoft/PowerToys#46746

ok, gordon said this change is unrelated to the pipeline,  revert it.