### PR TITLE
CmdPal: Add CmdPalLogger, Provider, and extension method

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.Common/Logging/CmdPalLogger.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Common/Logging/CmdPalLogger.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.Logging;
+using MEL = Microsoft.Extensions.Logging;
+
+namespace Microsoft.CmdPal.Common.Logging;
+
+/// <summary>
+/// An <see cref="ILogger"/> implementation that delegates to <see cref="ManagedCommon.Logger"/>.
+/// Instances are created by <see cref="CmdPalLoggerProvider"/>.
+/// </summary>
+public sealed class CmdPalLogger(string categoryName) : MEL.ILogger
+{
+    public IDisposable? BeginScope<TState>(TState state)
+        where TState : notnull => null;
+
+    public bool IsEnabled(LogLevel logLevel) => logLevel != LogLevel.None;
+
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        if (!IsEnabled(logLevel))
+        {
+            return;
+        }
+
+        ArgumentNullException.ThrowIfNull(formatter);
+
+        var message = $"[{categoryName}] {formatter(state, exception)}";
+
+        switch (logLevel)
+        {
+            case LogLevel.Trace:
+                ManagedCommon.Logger.LogTrace(message);
+                break;
+            case LogLevel.Debug:
+                ManagedCommon.Logger.LogDebug(message);
+                break;
+            case LogLevel.Information:
+                ManagedCommon.Logger.LogInfo(message);
+                break;
+            case LogLevel.Warning:
+                ManagedCommon.Logger.LogWarning(message);
+                break;
+            case LogLevel.Error:
+            case LogLevel.Critical:
+                if (exception is not null)
+                {
+                    ManagedCommon.Logger.LogError(message, exception);
+                }
+                else
+                {
+                    ManagedCommon.Logger.LogError(message);
+                }
+
+                break;
+            case LogLevel.None:
+            default:
+                break;
+        }
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.Common/Logging/CmdPalLoggerProvider.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Common/Logging/CmdPalLoggerProvider.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Concurrent;
+
+using MEL = Microsoft.Extensions.Logging;
+
+namespace Microsoft.CmdPal.Common.Logging;
+
+/// <summary>
+/// An <see cref="MEL.ILoggerProvider"/> that creates <see cref="CmdPalLogger"/> instances
+/// backed by the <see cref="ManagedCommon.Logger"/> infrastructure.
+/// Register via <see cref="CmdPalLoggingExtensions.AddCmdPalLogging"/>.
+/// </summary>
+public sealed partial class CmdPalLoggerProvider : MEL.ILoggerProvider
+{
+    private readonly ConcurrentDictionary<string, CmdPalLogger> _loggers = new(StringComparer.OrdinalIgnoreCase);
+
+    public MEL.ILogger CreateLogger(string categoryName) =>
+        _loggers.GetOrAdd(categoryName, name => new CmdPalLogger(name));
+
+    public void Dispose() => _loggers.Clear();
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.Common/Logging/CmdPalLoggingExtensions.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Common/Logging/CmdPalLoggingExtensions.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+
+using MEL = Microsoft.Extensions.Logging;
+
+namespace Microsoft.CmdPal.Common.Logging;
+
+public static class CmdPalLoggingExtensions
+{
+    /// <summary>
+    /// Registers the Microsoft.Extensions.Logging infrastructure and adds a
+    /// <see cref="CmdPalLoggerProvider"/> that routes all <see cref="MEL.ILogger"/>
+    /// output to <see cref="ManagedCommon.Logger"/>.
+    /// </summary>
+    public static IServiceCollection AddCmdPalLogging(this IServiceCollection services)
+    {
+        services.AddLogging(builder =>
+        {
+            builder.ClearProviders();
+            builder.Services.TryAddEnumerable(
+                ServiceDescriptor.Singleton<MEL.ILoggerProvider, CmdPalLoggerProvider>());
+        });
+
+        return services;
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.Common/Microsoft.CmdPal.Common.csproj
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Common/Microsoft.CmdPal.Common.csproj
@@ -26,6 +26,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\extensionsdk\Microsoft.CommandPalette.Extensions.Toolkit\Microsoft.CommandPalette.Extensions.Toolkit.csproj" />
+    <ProjectReference Include="..\..\..\common\ManagedCommon\ManagedCommon.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -58,6 +59,10 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
       <_Parameter1>$(AssemblyName).UnitTests</_Parameter1>
     </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Logging\" />
   </ItemGroup>
 
 </Project>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/App.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/App.xaml.cs
@@ -5,6 +5,7 @@
 using ManagedCommon;
 using Microsoft.CmdPal.Common;
 using Microsoft.CmdPal.Common.Helpers;
+using Microsoft.CmdPal.Common.Logging;
 using Microsoft.CmdPal.Common.Services;
 using Microsoft.CmdPal.Common.Text;
 using Microsoft.CmdPal.Ext.Apps;
@@ -124,6 +125,8 @@ public partial class App : Application, IDisposable
         // Root services
         services.AddSingleton(TaskScheduler.FromCurrentSynchronizationContext());
         var dispatcherQueue = DispatcherQueue.GetForCurrentThread();
+
+        services.AddCmdPalLogging();
 
         AddBuiltInCommands(services, appInfoService.ConfigDirectory);
 


### PR DESCRIPTION
This pull request introduces a new logging infrastructure for the CmdPal module by integrating the Microsoft.Extensions.Logging (MEL) abstraction and routing all log output through the existing `ManagedCommon.Logger`. The changes add a custom logger, logger provider, and extension method for easy registration, and update dependencies and service configuration to enable the new logging system.

> This logging is not in use currently, but will be in a future PR.

**Logging Infrastructure Integration:**

* Added a new `CmdPalLogger` class implementing `ILogger`, which delegates logging calls to `ManagedCommon.Logger` to centralize and standardize log output.
* Implemented `CmdPalLoggerProvider` to create and manage `CmdPalLogger` instances, allowing MEL-based logging throughout the application.
* Introduced `CmdPalLoggingExtensions.AddCmdPalLogging` for registering the logger provider via dependency injection, ensuring all MEL logging is routed appropriately.
* Updated `App.xaml.cs` to register the new logging system with `services.AddCmdPalLogging()`, enabling the infrastructure at application startup. [[1]](diffhunk://#diff-84386fa8a23e7058525bd269788bbf9e352b1f49d08e5f877059386ba3b83222R8) [[2]](diffhunk://#diff-84386fa8a23e7058525bd269788bbf9e352b1f49d08e5f877059386ba3b83222R129-R130)

**Project and Dependency Updates:**

* Updated the project file `Microsoft.CmdPal.Common.csproj` to reference the `ManagedCommon` project and to include a folder for the new logging code. [[1]](diffhunk://#diff-affab7e2df96d3b8073ab649e4ef5a34d459cd69e525573fd6426d698efec18fR29) [[2]](diffhunk://#diff-affab7e2df96d3b8073ab649e4ef5a34d459cd69e525573fd6426d698efec18fR64-R67)