### PR TITLE
[PT Run][Time and Date] Add friendly date/time result (#16809)

### DIFF
--- a/doc/devdocs/modules/launcher/plugins/timedate.md
+++ b/doc/devdocs/modules/launcher/plugins/timedate.md
@@ -36,6 +36,7 @@ The following formats are currently available:
 | Now | 3/5/2022 5:10 PM | x | x | |
 | Time UTC | 4:10 PM | x | x | |
 | Now UTC | 3/5/2022 4:10 PM | x | x | |
+| Friendly | Yesterday | x | | |
 | Unix Timestamp | 1646496622 | x | x | |
 | Unix Timestamp in milliseconds | 1646496622500 | x | x | |
 | Hour | 10 | x | | |

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests/ImageTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests/ImageTests.cs
@@ -62,6 +62,7 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests
         [DataRow("iso zone", "ISO 8601 with time zone - ", "Images\\timeDate.dark.png")]
         [DataRow("iso utc zone", "ISO 8601 UTC with time zone - ", "Images\\timeDate.dark.png")]
         [DataRow("rfc", "RFC1123 -", "Images\\timeDate.dark.png")]
+        [DataRow("friendly", "Friendly -", "Images\\timeDate.dark.png")]
         [DataRow("compatible", "Date and time in filename-compatible format", "Images\\timeDate.dark.png")]
         public void IconThemeDarkTest(string typedString, string subTitleMatch, string expectedResult)
         {
@@ -109,6 +110,7 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests
         [DataRow("iso zone", "ISO 8601 with time zone - ", "Images\\timeDate.light.png")]
         [DataRow("iso utc zone", "ISO 8601 UTC with time zone - ", "Images\\timeDate.light.png")]
         [DataRow("rfc", "RFC1123 -", "Images\\timeDate.light.png")]
+        [DataRow("friendly", "Friendly -", "Images\\timeDate.light.png")]
         [DataRow("compatible", "Date and time in filename-compatible format", "Images\\timeDate.light.png")]
         public void IconThemeLightTest(string typedString, string subTitleMatch, string expectedResult)
         {

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests/QueryTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests/QueryTests.cs
@@ -56,9 +56,9 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests
         [DataRow("(time", 18)]
         [DataRow("(date", 28)]
         [DataRow("(year", 8)]
-        [DataRow("(now", 34)]
-        [DataRow("(current", 34)]
-        [DataRow("(", 34)]
+        [DataRow("(now", 35)]
+        [DataRow("(current", 35)]
+        [DataRow("(", 35)]
         [DataRow("(now::10:10:10", 1)] // Windows file time
         [DataRow("(current::10:10:10", 0)]
         public void CountWithPluginKeyword(string typedString, int expectedResultCount)

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests/TimeAndDateHelperTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests/TimeAndDateHelperTests.cs
@@ -166,6 +166,22 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests
             Assert.AreEqual(result, week);
         }
 
+        [DataTestMethod]
+        [DataRow("2026-04-07T12:00:00", "2026-04-07T08:00:00", "4 hours ago")]
+        [DataRow("2026-04-07T12:00:00", "2026-04-07T15:00:00", "in 3 hours")]
+        [DataRow("2026-04-07T12:00:00", "2026-04-07T12:00:05", "Today")]
+        [DataRow("2026-04-07T12:00:00", "2026-04-06T12:00:00", "Yesterday")]
+        [DataRow("2026-04-07T12:00:00", "2026-04-08T12:00:00", "Tomorrow")]
+        public void FriendlyDateTimeFormats(string now, string target, string expected)
+        {
+            DateTime referenceNow = DateTime.Parse(now, CultureInfo.InvariantCulture);
+            DateTime targetTime = DateTime.Parse(target, CultureInfo.InvariantCulture);
+
+            var result = TimeAndDateHelper.GetFriendlyDateTime(targetTime, referenceNow);
+
+            Assert.AreEqual(expected, result);
+        }
+
         [TestCleanup]
         public void CleanUp()
         {

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests/TimeDateResultTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests/TimeDateResultTests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests
         public void LocalFormatsWithShortTimeAndShortDate(string formatLabel, string expectedResult)
         {
             // Setup
-            var helperResults = AvailableResultsList.GetList(true, false, false, GetDateTimeForTest(), CalendarWeekRule.FirstDay, DayOfWeek.Sunday);
+            var helperResults = AvailableResultsList.GetList(true, false, false, GetDateTimeForTest(), now: null, CalendarWeekRule.FirstDay, DayOfWeek.Sunday);
 
             // Act
             var result = helperResults.FirstOrDefault(x => x.Label.Equals(formatLabel, StringComparison.OrdinalIgnoreCase));
@@ -101,7 +101,7 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests
         public void LocalFormatsWithShortTimeAndLongDate(string formatLabel, string expectedResult)
         {
             // Setup
-            var helperResults = AvailableResultsList.GetList(true, false, true, GetDateTimeForTest(), CalendarWeekRule.FirstDay, DayOfWeek.Sunday);
+            var helperResults = AvailableResultsList.GetList(true, false, true, GetDateTimeForTest(), now: null, CalendarWeekRule.FirstDay, DayOfWeek.Sunday);
 
             // Act
             var result = helperResults.FirstOrDefault(x => x.Label.Equals(formatLabel, StringComparison.OrdinalIgnoreCase));
@@ -136,7 +136,7 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests
         public void LocalFormatsWithLongTimeAndShortDate(string formatLabel, string expectedResult)
         {
             // Setup
-            var helperResults = AvailableResultsList.GetList(true, true, false, GetDateTimeForTest(), CalendarWeekRule.FirstDay, DayOfWeek.Sunday);
+            var helperResults = AvailableResultsList.GetList(true, true, false, GetDateTimeForTest(), now: null, CalendarWeekRule.FirstDay, DayOfWeek.Sunday);
 
             // Act
             var result = helperResults.FirstOrDefault(x => x.Label.Equals(formatLabel, StringComparison.OrdinalIgnoreCase));
@@ -171,7 +171,7 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests
         public void LocalFormatsWithLongTimeAndLongDate(string formatLabel, string expectedResult)
         {
             // Setup
-            var helperResults = AvailableResultsList.GetList(true, true, true, GetDateTimeForTest(), CalendarWeekRule.FirstDay, DayOfWeek.Sunday);
+            var helperResults = AvailableResultsList.GetList(true, true, true, GetDateTimeForTest(), now: null, CalendarWeekRule.FirstDay, DayOfWeek.Sunday);
 
             // Act
             var result = helperResults.FirstOrDefault(x => x.Label.Equals(formatLabel, StringComparison.OrdinalIgnoreCase));
@@ -190,7 +190,7 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests
         public void UtcFormatsWithShortTimeAndShortDate(string formatLabel, string expectedFormat)
         {
             // Setup
-            var helperResults = AvailableResultsList.GetList(true, false, false, GetDateTimeForTest(true), CalendarWeekRule.FirstDay, DayOfWeek.Sunday);
+            var helperResults = AvailableResultsList.GetList(true, false, false, GetDateTimeForTest(true), now: null, CalendarWeekRule.FirstDay, DayOfWeek.Sunday);
             var expectedResult = GetDateTimeForTest().ToString(expectedFormat, CultureInfo.CurrentCulture);
 
             // Act
@@ -210,7 +210,7 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests
         public void UtcFormatsWithShortTimeAndLongDate(string formatLabel, string expectedFormat)
         {
             // Setup
-            var helperResults = AvailableResultsList.GetList(true, false, true, GetDateTimeForTest(true), CalendarWeekRule.FirstDay, DayOfWeek.Sunday);
+            var helperResults = AvailableResultsList.GetList(true, false, true, GetDateTimeForTest(true), now: null, CalendarWeekRule.FirstDay, DayOfWeek.Sunday);
             var expectedResult = GetDateTimeForTest().ToString(expectedFormat, CultureInfo.CurrentCulture);
 
             // Act
@@ -230,7 +230,7 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests
         public void UtcFormatsWithLongTimeAndShortDate(string formatLabel, string expectedFormat)
         {
             // Setup
-            var helperResults = AvailableResultsList.GetList(true, true, false, GetDateTimeForTest(true), CalendarWeekRule.FirstDay, DayOfWeek.Sunday);
+            var helperResults = AvailableResultsList.GetList(true, true, false, GetDateTimeForTest(true), now: null, CalendarWeekRule.FirstDay, DayOfWeek.Sunday);
             var expectedResult = GetDateTimeForTest().ToString(expectedFormat, CultureInfo.CurrentCulture);
 
             // Act
@@ -250,7 +250,7 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests
         public void UtcFormatsWithLongTimeAndLongDate(string formatLabel, string expectedFormat)
         {
             // Setup
-            var helperResults = AvailableResultsList.GetList(true, true, true, GetDateTimeForTest(true), CalendarWeekRule.FirstDay, DayOfWeek.Sunday);
+            var helperResults = AvailableResultsList.GetList(true, true, true, GetDateTimeForTest(true), now: null, CalendarWeekRule.FirstDay, DayOfWeek.Sunday);
             var expectedResult = GetDateTimeForTest().ToString(expectedFormat, CultureInfo.CurrentCulture);
 
             // Act
@@ -266,7 +266,7 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests
             // Setup
             string formatLabel = "Unix epoch time";
             DateTime timeValue = DateTime.Now.ToUniversalTime();
-            var helperResults = AvailableResultsList.GetList(true, false, false, timeValue, CalendarWeekRule.FirstDay, DayOfWeek.Sunday);
+            var helperResults = AvailableResultsList.GetList(true, false, false, timeValue, now: null, CalendarWeekRule.FirstDay, DayOfWeek.Sunday);
             var expectedResult = (long)timeValue.Subtract(new DateTime(1970, 1, 1)).TotalSeconds;
 
             // Act
@@ -282,7 +282,7 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests
             // Setup
             string formatLabel = "Unix epoch time in milliseconds";
             DateTime timeValue = DateTime.Now.ToUniversalTime();
-            var helperResults = AvailableResultsList.GetList(true, false, false, timeValue, CalendarWeekRule.FirstDay, DayOfWeek.Sunday);
+            var helperResults = AvailableResultsList.GetList(true, false, false, timeValue, now: null, CalendarWeekRule.FirstDay, DayOfWeek.Sunday);
             var expectedResult = (long)timeValue.Subtract(new DateTime(1970, 1, 1)).TotalMilliseconds;
 
             // Act
@@ -298,7 +298,7 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests
             // Setup
             string formatLabel = "Windows file time (Int64 number)";
             DateTime timeValue = DateTime.Now;
-            var helperResults = AvailableResultsList.GetList(true, false, false, timeValue, CalendarWeekRule.FirstDay, DayOfWeek.Sunday);
+            var helperResults = AvailableResultsList.GetList(true, false, false, timeValue, now: null, CalendarWeekRule.FirstDay, DayOfWeek.Sunday);
             var expectedResult = timeValue.ToFileTime().ToString(CultureInfo.CurrentCulture);
 
             // Act
@@ -314,7 +314,7 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests
             // Setup
             string formatLabel = "Era";
             DateTime timeValue = DateTime.Now;
-            var helperResults = AvailableResultsList.GetList(true, false, false, timeValue, CalendarWeekRule.FirstDay, DayOfWeek.Sunday);
+            var helperResults = AvailableResultsList.GetList(true, false, false, timeValue, now: null, CalendarWeekRule.FirstDay, DayOfWeek.Sunday);
             var expectedResult = DateTimeFormatInfo.CurrentInfo.GetEraName(CultureInfo.CurrentCulture.Calendar.GetEra(timeValue));
 
             // Act
@@ -330,7 +330,7 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests
             // Setup
             string formatLabel = "Era abbreviation";
             DateTime timeValue = DateTime.Now;
-            var helperResults = AvailableResultsList.GetList(true, false, false, timeValue, CalendarWeekRule.FirstDay, DayOfWeek.Sunday);
+            var helperResults = AvailableResultsList.GetList(true, false, false, timeValue, now: null, CalendarWeekRule.FirstDay, DayOfWeek.Sunday);
             var expectedResult = DateTimeFormatInfo.CurrentInfo.GetAbbreviatedEraName(CultureInfo.CurrentCulture.Calendar.GetEra(timeValue));
 
             // Act
@@ -348,7 +348,7 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests
         {
             // Setup
             DateTime timeValue = new DateTime(2021, 1, 12);
-            var helperResults = AvailableResultsList.GetList(true, false, false, timeValue, weekRule, DayOfWeek.Sunday);
+            var helperResults = AvailableResultsList.GetList(true, false, false, timeValue, now: null, weekRule, DayOfWeek.Sunday);
 
             // Act
             var resultWeekOfYear = helperResults.FirstOrDefault(x => x.Label.Equals("week of the year (calendar week, week number)", StringComparison.OrdinalIgnoreCase));
@@ -369,7 +369,7 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests
         {
             // Setup
             DateTime timeValue = new DateTime(2024, 1, 12); // Friday
-            var helperResults = AvailableResultsList.GetList(true, false, false, timeValue, CalendarWeekRule.FirstDay, dayOfWeek);
+            var helperResults = AvailableResultsList.GetList(true, false, false, timeValue, now: null, CalendarWeekRule.FirstDay, dayOfWeek);
 
             // Act
             var resultWeekOfYear = helperResults.FirstOrDefault(x => x.Label.Equals("week of the year (calendar week, week number)", StringComparison.OrdinalIgnoreCase));

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate/Components/AvailableResultsList.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate/Components/AvailableResultsList.cs
@@ -20,10 +20,11 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.Components
         /// <param name="timeLongFormat">Required for UnitTest: Show time in long format</param>
         /// <param name="dateLongFormat">Required for UnitTest: Show date in long format</param>
         /// <param name="timestamp">Use custom <see cref="DateTime"/> object to calculate results instead of the system date/time</param>
+        /// <param name="now">Required for UnitTest: Reference "now" time used for relative/friendly formatting</param>
         /// <param name="firstWeekOfYear">Required for UnitTest: Use custom first week of the year instead of the plugin setting.</param>
         /// <param name="firstDayOfWeek">Required for UnitTest: Use custom first day of the week instead the plugin setting.</param>
         /// <returns>List of results</returns>
-        internal static List<AvailableResult> GetList(bool isKeywordSearch, bool? timeLongFormat = null, bool? dateLongFormat = null, DateTime? timestamp = null, CalendarWeekRule? firstWeekOfYear = null, DayOfWeek? firstDayOfWeek = null)
+        internal static List<AvailableResult> GetList(bool isKeywordSearch, bool? timeLongFormat = null, bool? dateLongFormat = null, DateTime? timestamp = null, DateTime? now = null, CalendarWeekRule? firstWeekOfYear = null, DayOfWeek? firstDayOfWeek = null)
         {
             List<AvailableResult> results = new List<AvailableResult>();
             Calendar calendar = CultureInfo.CurrentCulture.Calendar;
@@ -32,6 +33,7 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.Components
             bool dateExtended = dateLongFormat ?? TimeDateSettings.Instance.DateWithWeekday;
             bool isSystemDateTime = timestamp == null;
             DateTime dateTimeNow = timestamp ?? DateTime.Now;
+            DateTime dateTimeReferenceNow = now ?? DateTime.Now;
             DateTime dateTimeNowUtc = dateTimeNow.ToUniversalTime();
             CalendarWeekRule firstWeekRule = firstWeekOfYear ?? TimeAndDateHelper.GetCalendarWeekRule(TimeDateSettings.Instance.CalendarFirstWeekRule);
             DayOfWeek firstDayOfTheWeek = firstDayOfWeek ?? TimeAndDateHelper.GetFirstDayOfWeek(TimeDateSettings.Instance.FirstDayOfWeek);
@@ -71,6 +73,14 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.Components
                 int weekOfYear = calendar.GetWeekOfYear(dateTimeNow, firstWeekRule, firstDayOfTheWeek);
                 string era = DateTimeFormatInfo.CurrentInfo.GetEraName(calendar.GetEra(dateTimeNow));
                 string eraShort = DateTimeFormatInfo.CurrentInfo.GetAbbreviatedEraName(calendar.GetEra(dateTimeNow));
+
+                results.Add(new AvailableResult()
+                {
+                    Value = TimeAndDateHelper.GetFriendlyDateTime(dateTimeNow, dateTimeReferenceNow),
+                    Label = Resources.Microsoft_plugin_timedate_Friendly,
+                    AlternativeSearchTag = ResultHelper.SelectStringFromResources(isSystemDateTime, "Microsoft_plugin_timedate_SearchTagFriendly"),
+                    IconType = ResultIconType.DateTime,
+                });
 
                 // Custom formats
                 foreach (string f in TimeDateSettings.Instance.CustomFormats)

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate/Components/TimeAndDateHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate/Components/TimeAndDateHelper.cs
@@ -417,6 +417,72 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.Components
                     return DateTimeFormatInfo.CurrentInfo.FirstDayOfWeek;
             }
         }
+
+        /// <summary>
+        /// Returns a friendly human-readable representation of a timestamp relative to a reference "now".
+        /// Uses local date boundaries for Today / Yesterday / Tomorrow.
+        /// </summary>
+        internal static string GetFriendlyDateTime(DateTime target, DateTime referenceNow)
+        {
+            // Use local date boundaries. If the input carries UTC kind, convert for comparison/display purposes.
+            DateTime localTarget = target.Kind == DateTimeKind.Utc ? target.ToLocalTime() : target;
+            DateTime localNow = referenceNow.Kind == DateTimeKind.Utc ? referenceNow.ToLocalTime() : referenceNow;
+
+            int dayDiff = (localTarget.Date - localNow.Date).Days;
+            if (dayDiff == 0)
+            {
+                return Resources.Microsoft_plugin_timedate_Friendly_Today;
+            }
+
+            if (dayDiff == -1)
+            {
+                return Resources.Microsoft_plugin_timedate_Friendly_Yesterday;
+            }
+
+            if (dayDiff == 1)
+            {
+                return Resources.Microsoft_plugin_timedate_Friendly_Tomorrow;
+            }
+
+            TimeSpan span = localTarget - localNow;
+            bool isFuture = span.Ticks > 0;
+            TimeSpan abs = span.Duration();
+
+            if (abs.TotalSeconds < 10)
+            {
+                return Resources.Microsoft_plugin_timedate_Friendly_JustNow;
+            }
+
+            if (abs.TotalMinutes < 60)
+            {
+                int minutes = (int)Math.Round(abs.TotalMinutes, MidpointRounding.AwayFromZero);
+                if (minutes <= 1)
+                {
+                    return isFuture ? Resources.Microsoft_plugin_timedate_Friendly_InMinute : Resources.Microsoft_plugin_timedate_Friendly_MinuteAgo;
+                }
+
+                return string.Format(CultureInfo.CurrentCulture, isFuture ? Resources.Microsoft_plugin_timedate_Friendly_InMinutes : Resources.Microsoft_plugin_timedate_Friendly_MinutesAgo, minutes);
+            }
+
+            if (abs.TotalHours < 24)
+            {
+                int hours = (int)Math.Round(abs.TotalHours, MidpointRounding.AwayFromZero);
+                if (hours <= 1)
+                {
+                    return isFuture ? Resources.Microsoft_plugin_timedate_Friendly_InHour : Resources.Microsoft_plugin_timedate_Friendly_HourAgo;
+                }
+
+                return string.Format(CultureInfo.CurrentCulture, isFuture ? Resources.Microsoft_plugin_timedate_Friendly_InHours : Resources.Microsoft_plugin_timedate_Friendly_HoursAgo, hours);
+            }
+
+            int days = (int)Math.Round(abs.TotalDays, MidpointRounding.AwayFromZero);
+            if (days <= 1)
+            {
+                return isFuture ? Resources.Microsoft_plugin_timedate_Friendly_InDay : Resources.Microsoft_plugin_timedate_Friendly_DayAgo;
+            }
+
+            return string.Format(CultureInfo.CurrentCulture, isFuture ? Resources.Microsoft_plugin_timedate_Friendly_InDays : Resources.Microsoft_plugin_timedate_Friendly_DaysAgo, days);
+        }
     }
 
     /// <summary>

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate/Properties/Resources.Designer.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate/Properties/Resources.Designer.cs
@@ -122,6 +122,159 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.Properties {
                 return ResourceManager.GetString("Microsoft_plugin_timedate_DayMonth", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Friendly.
+        /// </summary>
+        internal static string Microsoft_plugin_timedate_Friendly {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_timedate_Friendly", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to 1 day ago.
+        /// </summary>
+        internal static string Microsoft_plugin_timedate_Friendly_DayAgo {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_timedate_Friendly_DayAgo", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to {0} days ago.
+        /// </summary>
+        internal static string Microsoft_plugin_timedate_Friendly_DaysAgo {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_timedate_Friendly_DaysAgo", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to 1 hour ago.
+        /// </summary>
+        internal static string Microsoft_plugin_timedate_Friendly_HourAgo {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_timedate_Friendly_HourAgo", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to {0} hours ago.
+        /// </summary>
+        internal static string Microsoft_plugin_timedate_Friendly_HoursAgo {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_timedate_Friendly_HoursAgo", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to in 1 day.
+        /// </summary>
+        internal static string Microsoft_plugin_timedate_Friendly_InDay {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_timedate_Friendly_InDay", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to in {0} days.
+        /// </summary>
+        internal static string Microsoft_plugin_timedate_Friendly_InDays {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_timedate_Friendly_InDays", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to in 1 hour.
+        /// </summary>
+        internal static string Microsoft_plugin_timedate_Friendly_InHour {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_timedate_Friendly_InHour", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to in {0} hours.
+        /// </summary>
+        internal static string Microsoft_plugin_timedate_Friendly_InHours {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_timedate_Friendly_InHours", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to in 1 minute.
+        /// </summary>
+        internal static string Microsoft_plugin_timedate_Friendly_InMinute {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_timedate_Friendly_InMinute", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to in {0} minutes.
+        /// </summary>
+        internal static string Microsoft_plugin_timedate_Friendly_InMinutes {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_timedate_Friendly_InMinutes", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to just now.
+        /// </summary>
+        internal static string Microsoft_plugin_timedate_Friendly_JustNow {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_timedate_Friendly_JustNow", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to 1 minute ago.
+        /// </summary>
+        internal static string Microsoft_plugin_timedate_Friendly_MinuteAgo {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_timedate_Friendly_MinuteAgo", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to {0} minutes ago.
+        /// </summary>
+        internal static string Microsoft_plugin_timedate_Friendly_MinutesAgo {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_timedate_Friendly_MinutesAgo", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Today.
+        /// </summary>
+        internal static string Microsoft_plugin_timedate_Friendly_Today {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_timedate_Friendly_Today", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Tomorrow.
+        /// </summary>
+        internal static string Microsoft_plugin_timedate_Friendly_Tomorrow {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_timedate_Friendly_Tomorrow", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Yesterday.
+        /// </summary>
+        internal static string Microsoft_plugin_timedate_Friendly_Yesterday {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_timedate_Friendly_Yesterday", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Day of the month.
@@ -552,6 +705,15 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.Properties {
         internal static string Microsoft_plugin_timedate_SearchTagFormat {
             get {
                 return ResourceManager.GetString("Microsoft_plugin_timedate_SearchTagFormat", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to friendly; relative; ago; yesterday; today; tomorrow.
+        /// </summary>
+        internal static string Microsoft_plugin_timedate_SearchTagFriendly {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_timedate_SearchTagFriendly", resourceCulture);
             }
         }
         

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate/Properties/Resources.resx
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate/Properties/Resources.resx
@@ -140,6 +140,57 @@
   <data name="Microsoft_plugin_timedate_DayMonth" xml:space="preserve">
     <value>Month and day</value>
   </data>
+  <data name="Microsoft_plugin_timedate_Friendly" xml:space="preserve">
+    <value>Friendly</value>
+  </data>
+  <data name="Microsoft_plugin_timedate_Friendly_Today" xml:space="preserve">
+    <value>Today</value>
+  </data>
+  <data name="Microsoft_plugin_timedate_Friendly_Yesterday" xml:space="preserve">
+    <value>Yesterday</value>
+  </data>
+  <data name="Microsoft_plugin_timedate_Friendly_Tomorrow" xml:space="preserve">
+    <value>Tomorrow</value>
+  </data>
+  <data name="Microsoft_plugin_timedate_Friendly_JustNow" xml:space="preserve">
+    <value>just now</value>
+  </data>
+  <data name="Microsoft_plugin_timedate_Friendly_MinuteAgo" xml:space="preserve">
+    <value>1 minute ago</value>
+  </data>
+  <data name="Microsoft_plugin_timedate_Friendly_MinutesAgo" xml:space="preserve">
+    <value>{0} minutes ago</value>
+  </data>
+  <data name="Microsoft_plugin_timedate_Friendly_InMinute" xml:space="preserve">
+    <value>in 1 minute</value>
+  </data>
+  <data name="Microsoft_plugin_timedate_Friendly_InMinutes" xml:space="preserve">
+    <value>in {0} minutes</value>
+  </data>
+  <data name="Microsoft_plugin_timedate_Friendly_HourAgo" xml:space="preserve">
+    <value>1 hour ago</value>
+  </data>
+  <data name="Microsoft_plugin_timedate_Friendly_HoursAgo" xml:space="preserve">
+    <value>{0} hours ago</value>
+  </data>
+  <data name="Microsoft_plugin_timedate_Friendly_InHour" xml:space="preserve">
+    <value>in 1 hour</value>
+  </data>
+  <data name="Microsoft_plugin_timedate_Friendly_InHours" xml:space="preserve">
+    <value>in {0} hours</value>
+  </data>
+  <data name="Microsoft_plugin_timedate_Friendly_DayAgo" xml:space="preserve">
+    <value>1 day ago</value>
+  </data>
+  <data name="Microsoft_plugin_timedate_Friendly_DaysAgo" xml:space="preserve">
+    <value>{0} days ago</value>
+  </data>
+  <data name="Microsoft_plugin_timedate_Friendly_InDay" xml:space="preserve">
+    <value>in 1 day</value>
+  </data>
+  <data name="Microsoft_plugin_timedate_Friendly_InDays" xml:space="preserve">
+    <value>in {0} days</value>
+  </data>
   <data name="Microsoft_plugin_timedate_DayOfMonth" xml:space="preserve">
     <value>Day of the month</value>
   </data>
@@ -244,6 +295,10 @@
   </data>
   <data name="Microsoft_plugin_timedate_SearchTagFormat" xml:space="preserve">
     <value>Date and time; Time and Date</value>
+    <comment>Don't change order</comment>
+  </data>
+  <data name="Microsoft_plugin_timedate_SearchTagFriendly" xml:space="preserve">
+    <value>friendly; relative; ago; yesterday; today; tomorrow</value>
     <comment>Don't change order</comment>
   </data>
   <data name="Microsoft_plugin_timedate_SearchTagCustom" xml:space="preserve">


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This PR adds a **Friendly** date/time result to the Time and Date PT Run plugin.  
The plugin now shows a human-readable representation (e.g. “Today”, “Yesterday”, “in 3 hours”, “4 hours ago”) alongside the existing formats when the user queries the current system time or a specific timestamp. The change is localized, documented, and covered by unit tests in the TimeDate plugin test project.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #16809
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [x] **Communication:** I've added a comment for this on the issue and the contributors issue as well.
- [x] **Tests:** Added unit testing and other test cases to verify correct functionality.
- [x] **Localization:** All end-user-facing strings can be localized
- [x] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

- **New Friendly result**
  - Added a predefined `Friendly` result in `AvailableResultsList.GetList` that is shown together with the existing formats (Time, Date, Now, Unix, ISO 8601, etc.) when returning the full result list.
  - The result value is computed via a new helper `TimeAndDateHelper.GetFriendlyDateTime(DateTime target, DateTime referenceNow)`, which:
    - Uses local date boundaries to return **Today**, **Yesterday**, or **Tomorrow** when appropriate.
    - Otherwise returns relative phrases such as **“just now”**, **“1 minute ago / in 1 minute”**, **“{N} minutes/hours ago / in {N} minutes/hours”**, or **“{N} days ago / in {N} days”**.
    - Supports both past and future timestamps and respects `DateTimeKind` (UTC values are converted to local for comparison).
  - The result uses the existing DateTime icon and a new search-tag resource so it can be discovered with terms like “friendly”, “relative”, “yesterday”, “today”, “tomorrow”, or “ago”.

- **Integration and localization**
  - `AvailableResultsList.GetList` gained an optional `now` parameter so tests can inject a stable reference time; callers in production continue to use current system time when `now` is not specified.
  - All new user-facing text (Friendly label, Today/Yesterday/Tomorrow, relative phrases and tags) is stored in `Resources.resx` with corresponding properties in `Resources.Designer.cs`.

- **Tests and docs**
  - **Unit tests**
    - `TimeAndDateHelperTests`: added a data-driven test that verifies typical Friendly outputs (e.g. “4 hours ago”, “in 3 hours”, “Today”, “Yesterday”, “Tomorrow”) for a fixed `now` and different targets.
    - `TimeDateResultTests`: updated to call the new `GetList` signature and to ensure existing format values remain unchanged.
    - `ImageTests`: extended to assert that the Friendly result uses the expected DateTime icon in both dark and light themes.
    - `QueryTests`: adjusted expected counts for keyword queries that now include the Friendly result, and confirmed that Friendly participates in the same matching logic as other formats.
  - **Dev docs**
    - `doc/devdocs/modules/launcher/plugins/timedate.md`: added the Friendly format to the “List of available formats” table with an example like “Yesterday”.

**Note on tests:** due to tooling constraints on my current machine (Visual Studio workloads / Windows SDK installation blocked by disk space), I was not able to run the TimeDate test project end-to-end locally. The changes are intentionally scoped to the TimeDate plugin and its tests, and I would appreciate CI and at least one local maintainer run of `Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests` before merge.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Automated (intended):
- `dotnet test src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests/Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests.csproj -c Release`  
  _(I could not complete this locally due to missing VS workloads / SDK; please run in CI or on a fully provisioned dev machine.)_

Suggested manual validation:
1. **System time query**
   - Invoke PT Run and the Time and Date plugin.
   - Type the plugin keyword + `now` (or just the keyword, depending on configuration).
   - Confirm that:
     - A **Friendly** result appears alongside existing formats.
     - Its value is a reasonable description of the current time (e.g. “Today”, “just now”).
2. **Relative past/future**
   - Query a timestamp a few hours in the past and future (e.g. `10:00` vs an assumed `13:00` now, or specific dates).
   - Confirm Friendly shows “N hours ago” or “in N hours” as expected.
3. **Date boundaries**
   - Query dates of “yesterday”, “today”, and “tomorrow” relative to the current date.
   - Confirm the Friendly result reads exactly “Yesterday”, “Today”, or “Tomorrow”.
4. **Search and icons**
   - With the plugin keyword, type partial terms like `friendly`, `relative`, `yesterday`.
   - Confirm the Friendly result is returned and uses the same DateTime icon as the existing Date+Time results for both dark and light themes.