### PR TITLE
Add opus to Peek's allowed file list

### DIFF
--- a/src/modules/peek/Peek.FilePreviewer/Previewers/MediaPreviewer/AudioPreviewer.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/MediaPreviewer/AudioPreviewer.cs
@@ -202,6 +202,7 @@ namespace Peek.FilePreviewer.Previewers.MediaPreviewer
             ".m4a",
             ".mp3",
             ".ogg",
+            ".opus",
             ".wav",
             ".wma",
         };


### PR DESCRIPTION
## Summary of the Pull Request

Adds `.opus` to Peek's supported audio file extensions so `.opus` files are routed through the audio previewer instead of being treated as unsupported up front.

## PR Checklist

- [x] Closes: #42576
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments

Issue #42576 reports that `.opus` files are not currently included in Peek's supported audio extension list.

This PR adds `.opus` to the supported audio file types in `AudioPreviewer`. That allows Peek to attempt the existing audio preview path for `.opus` files and use the current fallback behavior if playback is unsupported in the environment.

This is a small, scoped change and does not add any new strings, binaries, or documentation changes.

## Validation Steps Performed

- Reviewed the existing previewer flow to confirm audio file extensions are routed through `AudioPreviewer`
- Verified that `.opus` was missing from the supported audio extension list
- Confirmed the change is limited to adding `.opus` to that list

I was not able to run a local build in my current environment because the .NET SDK is not installed.
