### PR TITLE
Fix/quick accent italian e characters

### DIFF
--- a/src/modules/poweraccent/PowerAccent.Core/Languages.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/Languages.cs
@@ -769,7 +769,7 @@ namespace PowerAccent.Core
             return letter switch
             {
                 LetterKey.VK_A => new[] { "à" },
-                LetterKey.VK_E => new[] { "è", "é", "ə", "€" },
+                LetterKey.VK_E => new[] { "è", "é" },
                 LetterKey.VK_I => new[] { "ì", "í" },
                 LetterKey.VK_O => new[] { "ò", "ó" },
                 LetterKey.VK_U => new[] { "ù", "ú" },


### PR DESCRIPTION

## Summary

The Italian (IT) Quick Accent set for the `e` key incorrectly included two characters:
- `ə` (schwa) — an IPA phonetic symbol, already present in the IPA language set
- `€` (Euro sign) — a currency symbol, not an accented letter

Standard Italian only uses `è` and `é` as accented forms of the letter *e*.

## Changes
- `Languages.cs`: removed `"ə"` and `"€"` from `GetDefaultLetterKeyIT` `VK_E` case

## Issues Fixed
Fixes #46857