### PR TITLE
Upgrade Microsoft.SemanticKernel packages from 1.66.0 to 1.74.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -85,6 +85,14 @@
     <ForceImportBeforeCppProps>$(RepoRoot)Cpp.Build.props</ForceImportBeforeCppProps>
   </PropertyGroup>
 
+  <!-- Force all C# projects to reference these packages from NuGet so their 10.x versions
+       take precedence over the 9.x versions bundled in the .NET 9 runtime. Without this,
+       projects that don't transitively depend on these packages would get the runtime 9.x
+       version, causing deps.json version conflicts with projects that do. -->
+  <ItemGroup Condition="'$(MSBuildProjectExtension)' == '.csproj'">
+    <PackageReference Include="System.Diagnostics.EventLog" />
+    <PackageReference Include="System.Threading.Channels" />
+  </ItemGroup>
 
   <ItemGroup Condition="'$(MSBuildProjectExtension)' == '.csproj' and '$(_IsSkippedTestProject)' != 'true'">
     <PackageReference Include="StyleCop.Analyzers">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -113,7 +113,8 @@
     <PackageVersion Include="System.Data.OleDb" Version="9.0.10" />
     <!-- Package System.Data.SqlClient added to force it as a dependency of Microsoft.Windows.Compatibility to the latest version available at this time. -->
     <PackageVersion Include="System.Data.SqlClient" Version="4.9.0" />
-    <!-- Package System.Diagnostics.EventLog added as a hack for being able to exclude the runtime assets so they don't conflict with 8.0.1. This is a dependency of System.Data.OleDb but the 8.0.1 version wasn't published to nuget. -->
+    <!-- Package System.Diagnostics.EventLog force-pinned to 10.x to match other Microsoft.Extensions packages;
+         referenced by all C# projects (via Directory.Build.props) to override the 9.x version from the .NET runtime. -->
     <PackageVersion Include="System.Diagnostics.EventLog" Version="10.0.5" />
     <!-- Package System.Diagnostics.PerformanceCounter added as a hack for being able to exclude the runtime assets so they don't conflict with 8.0.11. -->
     <PackageVersion Include="System.Diagnostics.PerformanceCounter" Version="9.0.10" />
@@ -124,6 +125,9 @@
     <PackageVersion Include="System.Management" Version="9.0.10" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Numerics.Tensors" Version="10.0.4" />
+    <!-- Including System.Threading.Channels to force version across all projects;
+         referenced by all C# projects (via Directory.Build.props) to override the 9.x version from the .NET runtime. -->
+    <PackageVersion Include="System.Threading.Channels" Version="10.0.4" />
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
     <PackageVersion Include="System.Reactive" Version="6.0.1" />
     <PackageVersion Include="System.Runtime.Caching" Version="9.0.10" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -56,12 +56,12 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.10" />
     <PackageVersion Include="Microsoft.AI.Foundry.Local" Version="0.3.0" />
-    <PackageVersion Include="Microsoft.SemanticKernel" Version="1.66.0" />
-    <PackageVersion Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.66.0" />
-    <PackageVersion Include="Microsoft.SemanticKernel.Connectors.AzureAIInference" Version="1.66.0-beta" />
-    <PackageVersion Include="Microsoft.SemanticKernel.Connectors.Google" Version="1.66.0-alpha" />
-    <PackageVersion Include="Microsoft.SemanticKernel.Connectors.MistralAI" Version="1.66.0-alpha" />
-    <PackageVersion Include="Microsoft.SemanticKernel.Connectors.Ollama" Version="1.66.0-alpha" />
+    <PackageVersion Include="Microsoft.SemanticKernel" Version="1.74.0" />
+    <PackageVersion Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.74.0" />
+    <PackageVersion Include="Microsoft.SemanticKernel.Connectors.AzureAIInference" Version="1.74.0-beta" />
+    <PackageVersion Include="Microsoft.SemanticKernel.Connectors.Google" Version="1.74.0-alpha" />
+    <PackageVersion Include="Microsoft.SemanticKernel.Connectors.MistralAI" Version="1.74.0-alpha" />
+    <PackageVersion Include="Microsoft.SemanticKernel.Connectors.Ollama" Version="1.74.0-alpha" />
     <PackageVersion Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.2" />
     <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.3179.45" />
     <!-- Package Microsoft.Win32.SystemEvents added as a hack for being able to exclude the runtime assets so they don't conflict with 8.0.1. This is a dependency of System.Drawing.Common but the 8.0.1 version wasn't published to nuget. -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -42,19 +42,19 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="9.0.10" />
     <!-- Including Microsoft.Bcl.AsyncInterfaces to force version, since it's used by Microsoft.SemanticKernel. -->
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.10" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Graphics.Win2D" Version="1.3.2" />
     <PackageVersion Include="Microsoft.Windows.CppWinRT" Version="2.0.250303.1" />
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.16" />
-    <PackageVersion Include="Microsoft.Extensions.AI" Version="9.9.1" />
-    <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="9.9.1-preview.1.25474.6" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.AI" Version="10.4.1" />
+    <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="10.4.1" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.5" />
     <PackageVersion Include="Microsoft.AI.Foundry.Local" Version="0.3.0" />
     <PackageVersion Include="Microsoft.SemanticKernel" Version="1.74.0" />
     <PackageVersion Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.74.0" />
@@ -89,11 +89,11 @@
     <PackageVersion Include="MSTest" Version="$(MSTestVersion)" />
     <PackageVersion Include="MSTest.TestFramework" Version="$(MSTestVersion)" />
     <PackageVersion Include="NJsonSchema" Version="11.4.0" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="NLog" Version="5.2.8" />
     <PackageVersion Include="NLog.Extensions.Logging" Version="5.3.8" />
     <PackageVersion Include="NLog.Schema" Version="5.2.8" />
-    <PackageVersion Include="OpenAI" Version="2.5.0" />
+    <PackageVersion Include="OpenAI" Version="2.9.1" />
     <PackageVersion Include="Polly.Core" Version="8.6.5" />
     <PackageVersion Include="ReverseMarkdown" Version="4.1.0" />
     <PackageVersion Include="RtfPipe" Version="2.0.7677.4303" />
@@ -114,22 +114,22 @@
     <!-- Package System.Data.SqlClient added to force it as a dependency of Microsoft.Windows.Compatibility to the latest version available at this time. -->
     <PackageVersion Include="System.Data.SqlClient" Version="4.9.0" />
     <!-- Package System.Diagnostics.EventLog added as a hack for being able to exclude the runtime assets so they don't conflict with 8.0.1. This is a dependency of System.Data.OleDb but the 8.0.1 version wasn't published to nuget. -->
-    <PackageVersion Include="System.Diagnostics.EventLog" Version="9.0.10" />
+    <PackageVersion Include="System.Diagnostics.EventLog" Version="10.0.5" />
     <!-- Package System.Diagnostics.PerformanceCounter added as a hack for being able to exclude the runtime assets so they don't conflict with 8.0.11. -->
     <PackageVersion Include="System.Diagnostics.PerformanceCounter" Version="9.0.10" />
-    <PackageVersion Include="System.ClientModel" Version="1.7.0" />
+    <PackageVersion Include="System.ClientModel" Version="1.9.0" />
     <PackageVersion Include="System.Drawing.Common" Version="9.0.10" />
     <PackageVersion Include="System.IO.Abstractions" Version="22.0.13" />
     <PackageVersion Include="System.IO.Abstractions.TestingHelpers" Version="22.0.13" />
     <PackageVersion Include="System.Management" Version="9.0.10" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
-    <PackageVersion Include="System.Numerics.Tensors" Version="9.0.11" />
+    <PackageVersion Include="System.Numerics.Tensors" Version="10.0.4" />
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
     <PackageVersion Include="System.Reactive" Version="6.0.1" />
     <PackageVersion Include="System.Runtime.Caching" Version="9.0.10" />
-    <PackageVersion Include="System.ServiceProcess.ServiceController" Version="9.0.10" />
+    <PackageVersion Include="System.ServiceProcess.ServiceController" Version="10.0.5" />
     <PackageVersion Include="System.Text.Encoding.CodePages" Version="9.0.10" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.10" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.5" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageVersion Include="ToolGood.Words.Pinyin" Version="3.1.0.3" />
     <PackageVersion Include="UnicodeInformation" Version="2.6.0" />

--- a/src/modules/Hosts/Hosts.Tests/HostsEditor.UnitTests.csproj
+++ b/src/modules/Hosts/Hosts.Tests/HostsEditor.UnitTests.csproj
@@ -17,10 +17,7 @@
     <PackageReference Include="MSTest" />
     <PackageReference Include="System.IO.Abstractions" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" />
-    <PackageReference Include="System.Diagnostics.EventLog">
-      <!-- This package is a dependency of Microsoft.Extensions.Logging.EventLog, but we need to set it here so we can exclude the assets, so it doesn't conflict with the 8.0.1 dll coming from .NET SDK. -->
-      <ExcludeAssets>runtime</ExcludeAssets> <!-- Should already be present on .net sdk runtime, so we avoid the conflicting runtime version from nuget -->
-    </PackageReference>
+    <!-- System.Diagnostics.EventLog is now provided to all C# projects via Directory.Build.props -->
     <!-- HACK: CmdPal uses CommunityToolkit.Common directly. Align the version. -->
     <PackageReference Include="CommunityToolkit.Common" />
   </ItemGroup>

--- a/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Microsoft.Plugin.Indexer.csproj
+++ b/src/modules/launcher/Plugins/Microsoft.Plugin.Indexer/Microsoft.Plugin.Indexer.csproj
@@ -20,9 +20,7 @@
     <PackageReference Include="System.Configuration.ConfigurationManager">
       <ExcludeAssets>runtime</ExcludeAssets> <!-- Should already be present on .net sdk runtime, so we avoid the conflicting runtime version from nuget -->
     </PackageReference>
-    <PackageReference Include="System.Diagnostics.EventLog">
-      <ExcludeAssets>runtime</ExcludeAssets> <!-- Should already be present on .net sdk runtime, so we avoid the conflicting runtime version from nuget -->
-    </PackageReference>
+    <!-- System.Diagnostics.EventLog is now provided to all C# projects via Directory.Build.props -->
     <PackageReference Include="System.Diagnostics.PerformanceCounter">
       <ExcludeAssets>runtime</ExcludeAssets> <!-- Should already be present on .net sdk runtime, so we avoid the conflicting runtime version from nuget -->
     </PackageReference>

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.History/Microsoft.PowerToys.Run.Plugin.History.csproj
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.History/Microsoft.PowerToys.Run.Plugin.History.csproj
@@ -42,9 +42,7 @@
     <PackageReference Include="System.Configuration.ConfigurationManager">
       <ExcludeAssets>runtime</ExcludeAssets> <!-- Should already be present on .net sdk runtime, so we avoid the conflicting runtime version from nuget -->
     </PackageReference>
-    <PackageReference Include="System.Diagnostics.EventLog">
-      <ExcludeAssets>runtime</ExcludeAssets> <!-- Should already be present on .net sdk runtime, so we avoid the conflicting runtime version from nuget -->
-    </PackageReference>
+    <!-- System.Diagnostics.EventLog is now provided to all C# projects via Directory.Build.props -->
     <PackageReference Include="System.Diagnostics.PerformanceCounter">
       <ExcludeAssets>runtime</ExcludeAssets> <!-- Should already be present on .net sdk runtime, so we avoid the conflicting runtime version from nuget -->
     </PackageReference>

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Service/Microsoft.PowerToys.Run.Plugin.Service.csproj
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Service/Microsoft.PowerToys.Run.Plugin.Service.csproj
@@ -20,9 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.ServiceProcess.ServiceController" />
-    <PackageReference Include="System.Diagnostics.EventLog">
-      <ExcludeAssets>runtime</ExcludeAssets> <!-- Should already be present on .net sdk runtime, so we avoid the conflicting runtime version from nuget -->
-    </PackageReference>
+    <!-- System.Diagnostics.EventLog is now provided to all C# projects via Directory.Build.props -->
   </ItemGroup>
 
   <ItemGroup>

--- a/src/modules/launcher/Wox.Test/Wox.Test.csproj
+++ b/src/modules/launcher/Wox.Test/Wox.Test.csproj
@@ -35,9 +35,7 @@
     <PackageReference Include="System.Configuration.ConfigurationManager">
       <ExcludeAssets>runtime</ExcludeAssets> <!-- Should already be present on .net sdk runtime, so we avoid the conflicting runtime version from nuget -->
     </PackageReference>
-    <PackageReference Include="System.Diagnostics.EventLog">
-      <ExcludeAssets>runtime</ExcludeAssets> <!-- Should already be present on .net sdk runtime, so we avoid the conflicting runtime version from nuget -->
-    </PackageReference>
+    <!-- System.Diagnostics.EventLog is now provided to all C# projects via Directory.Build.props -->
     <PackageReference Include="System.Diagnostics.PerformanceCounter">
       <ExcludeAssets>runtime</ExcludeAssets> <!-- Should already be present on .net sdk runtime, so we avoid the conflicting runtime version from nuget -->
     </PackageReference>

--- a/src/modules/powerdisplay/PowerDisplay.Lib.UnitTests/PowerDisplay.Lib.UnitTests.csproj
+++ b/src/modules/powerdisplay/PowerDisplay.Lib.UnitTests/PowerDisplay.Lib.UnitTests.csproj
@@ -28,11 +28,7 @@
            so it doesn't conflict with the dll coming from .NET SDK. -->
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Diagnostics.EventLog">
-      <!-- This package is a transitive dependency, but we need to set it here so we can exclude the assets,
-           so it doesn't conflict with the dll coming from .NET SDK. -->
-      <ExcludeAssets>runtime</ExcludeAssets>
-    </PackageReference>
+    <!-- System.Diagnostics.EventLog is now provided to all C# projects via Directory.Build.props -->
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary of the Pull Request
Upgrades Microsoft.SemanticKernel and all connectors from 1.66.0 to 1.74.0, along with all required transitive dependency bumps.

**SemanticKernel packages (1.66.0 → 1.74.0):**
- Microsoft.SemanticKernel
- Microsoft.SemanticKernel.Connectors.OpenAI
- Microsoft.SemanticKernel.Connectors.AzureAIInference (beta)
- Microsoft.SemanticKernel.Connectors.Google (alpha)
- Microsoft.SemanticKernel.Connectors.MistralAI (alpha)
- Microsoft.SemanticKernel.Connectors.Ollama (alpha)

**Transitive dependency upgrades required by SK 1.74.0:**
- Microsoft.Extensions.AI: 9.9.1 → 10.4.1
- Microsoft.Extensions.AI.OpenAI: 9.9.1-preview → 10.4.1
- Microsoft.Extensions.Caching.Abstractions: 9.0.10 → 10.0.5
- Microsoft.Extensions.Caching.Memory: 9.0.10 → 10.0.5
- Microsoft.Extensions.DependencyInjection: 9.0.10 → 10.0.5
- Microsoft.Extensions.Logging: 9.0.10 → 10.0.5
- Microsoft.Extensions.Logging.Abstractions: 9.0.10 → 10.0.5
- Microsoft.Extensions.Hosting: 9.0.10 → 10.0.5
- Microsoft.Extensions.Hosting.WindowsServices: 9.0.10 → 10.0.5
- Microsoft.Bcl.AsyncInterfaces: 9.0.10 → 10.0.5
- Newtonsoft.Json: 13.0.3 → 13.0.4
- OpenAI: 2.5.0 → 2.9.1
- System.ClientModel: 1.7.0 → 1.9.0
- System.Diagnostics.EventLog: 9.0.10 → 10.0.5
- System.Numerics.Tensors: 9.0.11 → 10.0.4
- System.ServiceProcess.ServiceController: 9.0.10 → 10.0.5
- System.Text.Json: 9.0.10 → 10.0.5

## PR Checklist
- [x] **Communication:** I've discussed this with core contributors already.
- [x] **Tests:** Full solution builds successfully (MSBuild Release x64)

## Validation Steps Performed
- Full solution restore (\dotnet restore PowerToys.slnx\) — no NU errors
- Full solution build (\MSBuild PowerToys.slnx /p:Configuration=Release /p:Platform=x64\) — exit code 0, no compilation errors
