### PR TITLE
[Settings] Fix Dashboard layout and 1px alignment offset

### DIFF
--- a/src/settings-ui/Settings.UI/SettingsXAML/Controls/Dashboard/ShortcutConflictControl.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Controls/Dashboard/ShortcutConflictControl.xaml
@@ -23,7 +23,10 @@
                     AutomationProperties.AccessibilityView="Raw"
                     FontSize="20"
                     Glyph="&#xEDA7;" />
-                <StackPanel Grid.Column="1" Orientation="Vertical">
+                <StackPanel
+                    Grid.Column="1"
+                    Orientation="Vertical"
+                    Spacing="1">
                     <TextBlock x:Uid="ShortcutConflictControl_Title" FontWeight="SemiBold" />
                     <TextBlock
                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/DashboardPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/DashboardPage.xaml
@@ -148,7 +148,7 @@
                 <!--  This grid is required to ensure that the content is horizontally aligned  -->
                 <Grid
                     MaxWidth="{StaticResource PageMaxWidth}"
-                    Padding="0,0,20,48"
+                    Padding="0,0,20,16"
                     ColumnSpacing="16"
                     RowSpacing="16">
                     <Grid.ColumnDefinitions>
@@ -158,76 +158,74 @@
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="*" />
-                        <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
-                    <controls:Card x:Uid="QuickAccessTitle" VerticalAlignment="Top">
-                        <Grid>
-                            <controls:QuickAccessList
-                                x:Name="QuickAccessItemsControl"
-                                Margin="8,0,12,12"
-                                ItemsSource="{x:Bind ViewModel.QuickAccessItems, Mode=OneWay}"
-                                Visibility="{x:Bind ViewModel.QuickAccessItems.Count, Mode=OneWay, Converter={StaticResource DoubleToVisibilityConverter}}" />
-                            <TextBlock
-                                x:Uid="NoActionsToShow"
-                                Margin="12"
-                                HorizontalAlignment="Left"
-                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                Visibility="{x:Bind ViewModel.QuickAccessItems.Count, Mode=OneWay, Converter={StaticResource DoubleToInvertedVisibilityConverter}}" />
-                        </Grid>
-                    </controls:Card>
+                    <StackPanel Orientation="Vertical" Spacing="16">
+                        <controls:Card x:Uid="QuickAccessTitle" VerticalAlignment="Top">
+                            <Grid>
+                                <controls:QuickAccessList
+                                    x:Name="QuickAccessItemsControl"
+                                    Margin="8,0,12,12"
+                                    ItemsSource="{x:Bind ViewModel.QuickAccessItems, Mode=OneWay}"
+                                    Visibility="{x:Bind ViewModel.QuickAccessItems.Count, Mode=OneWay, Converter={StaticResource DoubleToVisibilityConverter}}" />
+                                <TextBlock
+                                    x:Uid="NoActionsToShow"
+                                    Margin="12"
+                                    HorizontalAlignment="Left"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    Visibility="{x:Bind ViewModel.QuickAccessItems.Count, Mode=OneWay, Converter={StaticResource DoubleToInvertedVisibilityConverter}}" />
+                            </Grid>
+                        </controls:Card>
+                        <controls:Card x:Uid="ShortcutsOverview" VerticalAlignment="Top">
+                            <Grid>
+                                <ItemsRepeater
+                                    Grid.Row="2"
+                                    Margin="8,0,0,0"
+                                    ItemsSource="{x:Bind ViewModel.ShortcutModules, Mode=OneWay}">
+                                    <ItemsRepeater.Layout>
+                                        <StackLayout Orientation="Vertical" Spacing="0" />
+                                    </ItemsRepeater.Layout>
+                                    <ItemsRepeater.ItemTemplate>
+                                        <DataTemplate x:DataType="viewmodels:DashboardListItem">
+                                            <Grid>
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="32" />
+                                                    <ColumnDefinition Width="*" />
+                                                </Grid.ColumnDefinitions>
+                                                <Image
+                                                    Width="16"
+                                                    Margin="0,10,0,0"
+                                                    HorizontalAlignment="Left"
+                                                    VerticalAlignment="Top"
+                                                    AutomationProperties.AccessibilityView="Raw"
+                                                    Source="{x:Bind Icon, Mode=OneWay}"
+                                                    ToolTipService.ToolTip="{x:Bind Label}" />
+                                                <ItemsControl
+                                                    Grid.Column="1"
+                                                    IsTabStop="False"
+                                                    ItemTemplateSelector="{StaticResource ModuleItemTemplateSelector}"
+                                                    ItemsSource="{x:Bind DashboardModuleItems, Mode=OneWay}">
+                                                    <ItemsControl.ItemsPanel>
+                                                        <ItemsPanelTemplate>
+                                                            <StackPanel Spacing="0" />
+                                                        </ItemsPanelTemplate>
+                                                    </ItemsControl.ItemsPanel>
+                                                </ItemsControl>
+                                            </Grid>
+                                        </DataTemplate>
+                                    </ItemsRepeater.ItemTemplate>
+                                </ItemsRepeater>
+                                <TextBlock
+                                    x:Uid="NoShortcutsToShow"
+                                    Margin="12"
+                                    HorizontalAlignment="Left"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    Visibility="{x:Bind ViewModel.ShortcutModules.Count, Mode=OneWay, Converter={StaticResource DoubleToInvertedVisibilityConverter}}" />
+                            </Grid>
+                        </controls:Card>
+                    </StackPanel>
                     <controls:Card
-                        x:Uid="ShortcutsOverview"
-                        Grid.Row="1"
-                        VerticalAlignment="Top">
-                        <Grid>
-                            <ItemsRepeater
-                                Grid.Row="2"
-                                Margin="8,0,0,0"
-                                ItemsSource="{x:Bind ViewModel.ShortcutModules, Mode=OneWay}">
-                                <ItemsRepeater.Layout>
-                                    <StackLayout Orientation="Vertical" Spacing="0" />
-                                </ItemsRepeater.Layout>
-                                <ItemsRepeater.ItemTemplate>
-                                    <DataTemplate x:DataType="viewmodels:DashboardListItem">
-                                        <Grid>
-                                            <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="32" />
-                                                <ColumnDefinition Width="*" />
-                                            </Grid.ColumnDefinitions>
-                                            <Image
-                                                Width="16"
-                                                Margin="0,10,0,0"
-                                                HorizontalAlignment="Left"
-                                                VerticalAlignment="Top"
-                                                AutomationProperties.AccessibilityView="Raw"
-                                                Source="{x:Bind Icon, Mode=OneWay}"
-                                                ToolTipService.ToolTip="{x:Bind Label}" />
-                                            <ItemsControl
-                                                Grid.Column="1"
-                                                IsTabStop="False"
-                                                ItemTemplateSelector="{StaticResource ModuleItemTemplateSelector}"
-                                                ItemsSource="{x:Bind DashboardModuleItems, Mode=OneWay}">
-                                                <ItemsControl.ItemsPanel>
-                                                    <ItemsPanelTemplate>
-                                                        <StackPanel Spacing="0" />
-                                                    </ItemsPanelTemplate>
-                                                </ItemsControl.ItemsPanel>
-                                            </ItemsControl>
-                                        </Grid>
-                                    </DataTemplate>
-                                </ItemsRepeater.ItemTemplate>
-                            </ItemsRepeater>
-                            <TextBlock
-                                x:Uid="NoShortcutsToShow"
-                                Margin="12"
-                                HorizontalAlignment="Left"
-                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                Visibility="{x:Bind ViewModel.ShortcutModules.Count, Mode=OneWay, Converter={StaticResource DoubleToInvertedVisibilityConverter}}" />
-                        </Grid>
-                    </controls:Card>
-                    <controls:Card
+                        x:Name="UtilitiesCard"
                         x:Uid="UtilitiesHeader"
-                        Grid.RowSpan="2"
                         Grid.Column="1"
                         MinWidth="400"
                         Padding="0"
@@ -283,8 +281,8 @@
                         <Setter Target="TopButtonPanel.(Grid.Row)" Value="1" />
                         <Setter Target="TopButtonPanel.Margin" Value="0,16,0,0" />
                         <Setter Target="TopButtonPanel.(Grid.Column)" Value="0" />
-                        <Setter Target="ModulesCard.(Grid.Column)" Value="0" />
-                        <Setter Target="ModulesCard.(Grid.Row)" Value="2" />
+                        <Setter Target="UtilitiesCard.(Grid.Column)" Value="0" />
+                        <Setter Target="UtilitiesCard.(Grid.Row)" Value="1" />
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>


### PR DESCRIPTION
## Summary

Fixes layout issues on the Settings Dashboard page:

- **Scroll area fix**: The scroll area on the Home page extended far beyond the content, leaving a large empty space below the modules list. (By wrapping the quick launch / shortcuts cards into a `StackPanel` vs separate `Grid.Rows`
- **Resizing fix**: On main, resizing states are not applied when making the window smaller. This is now fixed.
- **1px alignment fix**: Fixed a 1-pixel vertical alignment mismatch on the Dashboard shortcut conflict control.

Closes #45925
Closes #41523