### PR TITLE
[Settings] Format last update check date with friendly relative dates

### DIFF
--- a/src/settings-ui/Settings.UI.Library/UpdatingSettings.cs
+++ b/src/settings-ui/Settings.UI.Library/UpdatingSettings.cs
@@ -68,22 +68,32 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         {
             get
             {
+                var dt = LastCheckedDateTime;
+                return dt?.ToString(CultureInfo.CurrentCulture) ?? string.Empty;
+            }
+        }
+
+        [JsonIgnore]
+        public DateTime? LastCheckedDateTime
+        {
+            get
+            {
                 try
                 {
                     if (LastCheckedDate == null)
                     {
-                        return string.Empty;
+                        return null;
                     }
 
                     long seconds = long.Parse(LastCheckedDate, CultureInfo.CurrentCulture);
                     var date = DateTimeOffset.FromUnixTimeSeconds(seconds).UtcDateTime;
-                    return date.ToLocalTime().ToString(CultureInfo.CurrentCulture);
+                    return date.ToLocalTime();
                 }
                 catch (Exception)
                 {
                 }
 
-                return string.Empty;
+                return null;
             }
         }
 

--- a/src/settings-ui/Settings.UI/Helpers/FriendlyDateHelper.cs
+++ b/src/settings-ui/Settings.UI/Helpers/FriendlyDateHelper.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Globalization;
+
+namespace Microsoft.PowerToys.Settings.UI.Helpers;
+
+public static class FriendlyDateHelper
+{
+    /// <summary>
+    /// Formats a <see cref="DateTime"/> as a friendly relative string.
+    /// Today → "Today at 1:22 PM", Yesterday → "Yesterday at 3:45 PM",
+    /// older dates fall back to the full culture-specific date/time format.
+    /// </summary>
+    public static string Format(DateTime? dateTime)
+    {
+        if (dateTime is not DateTime dt)
+        {
+            return string.Empty;
+        }
+
+        var resourceLoader = ResourceLoaderInstance.ResourceLoader;
+        var today = DateTime.Now.Date;
+        var time = dt.ToString("t", CultureInfo.CurrentCulture);
+
+        if (dt.Date == today)
+        {
+            var fmt = resourceLoader.GetString("General_LastCheckedDate_TodayAt");
+            if (!string.IsNullOrEmpty(fmt))
+            {
+                return string.Format(CultureInfo.CurrentCulture, fmt, time);
+            }
+        }
+
+        if (dt.Date == today.AddDays(-1))
+        {
+            var fmt = resourceLoader.GetString("General_LastCheckedDate_YesterdayAt");
+            if (!string.IsNullOrEmpty(fmt))
+            {
+                return string.Format(CultureInfo.CurrentCulture, fmt, time);
+            }
+        }
+
+        return dt.ToString(CultureInfo.CurrentCulture);
+    }
+}

--- a/src/settings-ui/Settings.UI/SettingsXAML/Controls/Dashboard/CheckUpdateControl.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Controls/Dashboard/CheckUpdateControl.xaml
@@ -72,7 +72,7 @@
                 <TextBlock x:Uid="YoureUpToDate" FontWeight="SemiBold" />
                 <TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}" Style="{StaticResource CaptionTextBlockStyle}">
                     <Run x:Uid="General_VersionLastChecked" />
-                    <Run Text="{x:Bind UpdateSettingsConfig.LastCheckedDateLocalized, Mode=OneTime}" />
+                    <Run Text="{x:Bind LastCheckedDateFriendly, Mode=OneTime}" />
                 </TextBlock>
             </StackPanel>
         </Grid>

--- a/src/settings-ui/Settings.UI/SettingsXAML/Controls/Dashboard/CheckUpdateControl.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Controls/Dashboard/CheckUpdateControl.xaml.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.PowerToys.Settings.UI.Helpers;
 using Microsoft.PowerToys.Settings.UI.Library;
 using Microsoft.PowerToys.Settings.UI.Services;
 using Microsoft.PowerToys.Settings.UI.Views;
@@ -15,11 +16,14 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
 
         public UpdatingSettings UpdateSettingsConfig { get; set; }
 
+        public string LastCheckedDateFriendly { get; set; }
+
         public CheckUpdateControl()
         {
             InitializeComponent();
             UpdateSettingsConfig = UpdatingSettings.LoadSettings();
             UpdateAvailable = UpdateSettingsConfig != null && (UpdateSettingsConfig.State == UpdatingSettings.UpdatingState.ReadyToInstall || UpdateSettingsConfig.State == UpdatingSettings.UpdatingState.ReadyToDownload);
+            LastCheckedDateFriendly = FriendlyDateHelper.Format(UpdateSettingsConfig?.LastCheckedDateTime);
         }
 
         private void SWVersionButtonClicked(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -1377,6 +1377,14 @@ opera.exe</value>
   <data name="General_VersionLastChecked.Text" xml:space="preserve">
     <value>Last checked: </value>
   </data>
+  <data name="General_LastCheckedDate_TodayAt" xml:space="preserve">
+    <value>Today at {0}</value>
+    <comment>Friendly date format when the last update check was today. {0} is the localized short time, e.g. "Today at 1:22 PM".</comment>
+  </data>
+  <data name="General_LastCheckedDate_YesterdayAt" xml:space="preserve">
+    <value>Yesterday at {0}</value>
+    <comment>Friendly date format when the last update check was yesterday. {0} is the localized short time, e.g. "Yesterday at 3:45 PM".</comment>
+  </data>
   <data name="General_SettingsBackupInfo_DateHeader.Text" xml:space="preserve">
     <value>Created at:</value>
   </data>

--- a/src/settings-ui/Settings.UI/ViewModels/GeneralViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/GeneralViewModel.cs
@@ -188,7 +188,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             _updatingState = UpdatingSettingsConfig.State;
             _newAvailableVersion = UpdatingSettingsConfig.NewVersion;
             _newAvailableVersionLink = UpdatingSettingsConfig.ReleasePageLink;
-            _updateCheckedDate = UpdatingSettingsConfig.LastCheckedDateLocalized;
+            _updateCheckedDate = FriendlyDateHelper.Format(UpdatingSettingsConfig.LastCheckedDateTime);
 
             _newUpdatesToastIsGpoDisabled = GPOWrapper.GetDisableNewUpdateToastValue() == GpoRuleConfigured.Enabled;
             _autoDownloadUpdatesIsGpoDisabled = GPOWrapper.GetDisableAutomaticUpdateDownloadValue() == GpoRuleConfigured.Enabled;
@@ -1383,7 +1383,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 }
                 else
                 {
-                    bool dateChanged = UpdateCheckedDate == UpdatingSettingsConfig.LastCheckedDateLocalized;
+                    bool dateChanged = UpdateCheckedDate == FriendlyDateHelper.Format(UpdatingSettingsConfig.LastCheckedDateTime);
                     bool fileDownloaded = string.IsNullOrEmpty(UpdatingSettingsConfig.DownloadedInstallerFilename);
                     IsNewVersionDownloading = !(dateChanged || fileDownloaded);
                 }
@@ -1391,7 +1391,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 PowerToysUpdatingState = UpdatingSettingsConfig.State;
                 PowerToysNewAvailableVersion = UpdatingSettingsConfig.NewVersion;
                 PowerToysNewAvailableVersionLink = UpdatingSettingsConfig.ReleasePageLink;
-                UpdateCheckedDate = UpdatingSettingsConfig.LastCheckedDateLocalized;
+                UpdateCheckedDate = FriendlyDateHelper.Format(UpdatingSettingsConfig.LastCheckedDateTime);
 
                 _isNoNetwork = PowerToysUpdatingState == UpdatingSettings.UpdatingState.NetworkError;
                 NotifyPropertyChanged(nameof(IsNoNetwork));


### PR DESCRIPTION
## Summary

Formats the Last checked date on the General and Dashboard pages with friendly relative strings instead of raw date/time output.

**Before:** Last checked: 4/12/2026 1:22:00 PM
**After:** Last checked: Today at 1:22 PM / Yesterday at 3:45 PM

### Changes

- Add LastCheckedDateTime property to UpdatingSettings exposing the parsed DateTime
- Create FriendlyDateHelper in Settings.UI that formats Today/Yesterday with localized resource strings, falling back to the full culture-specific format for older dates
- Update GeneralViewModel and CheckUpdateControl to use the friendly format
- Add localized resource strings General_LastCheckedDate_TodayAt and General_LastCheckedDate_YesterdayAt