### PR TITLE
[CmdPal] Fix Window Walker 'Not Responding' tag illegible in dark mode

### DIFF
--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowWalker/Components/ResultHelper.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowWalker/Components/ResultHelper.cs
@@ -108,7 +108,6 @@ internal static class ResultHelper
             tags.Add(new Tag
             {
                 Text = Resources.windowwalker_NotResponding,
-                Foreground = ColorHelpers.FromRgb(220, 20, 60),
             });
         }
 


### PR DESCRIPTION
## Summary

The 'Not Responding' tag in Window Walker used a hardcoded crimson foreground color (rgb 220,20,60) that was illegible against the dark tag background in dark mode.

**Fix:** Remove the hardcoded color override so the tag uses the default theme-aware TagForeground brush, which is legible in both light and dark modes.

Closes #40219