### PR TITLE
Fix crash in ObtainInstaller when GitHub API is unreachable

### DIFF
--- a/src/Update/PowerToys.Update.cpp
+++ b/src/Update/PowerToys.Update.cpp
@@ -58,6 +58,16 @@ std::optional<fs::path> ObtainInstaller(bool& isUpToDate)
     auto state = UpdateState::read();
 
     const auto new_version_info = std::move(get_github_version_info_async()).get();
+
+    // Check for error BEFORE dereferencing. The previous code crashed here
+    // when GitHub API was unreachable because it dereferenced the expected
+    // value via std::holds_alternative before checking for the error state.
+    if (!new_version_info)
+    {
+        Logger::error(L"Couldn't obtain github version info: {}", new_version_info.error());
+        return std::nullopt;
+    }
+
     if (std::holds_alternative<version_up_to_date>(*new_version_info))
     {
         isUpToDate = true;
@@ -67,12 +77,6 @@ std::optional<fs::path> ObtainInstaller(bool& isUpToDate)
 
     if (state.state == UpdateState::readyToDownload || state.state == UpdateState::errorDownloading)
     {
-        if (!new_version_info)
-        {
-            Logger::error(L"Couldn't obtain github version info: {}", new_version_info.error());
-            return std::nullopt;
-        }
-
         // Cleanup old updates before downloading the latest
         updating::cleanup_updates();
 


### PR DESCRIPTION
Fix crash in ObtainInstaller when GitHub API is unreachable.

`*new_version_info` was dereferenced via `std::holds_alternative` before checking for error state. Crashes PowerToys.Update.exe when network is down, DNS fails, or GitHub rate-limits.

Found during multi-agent code review of #46889.
