### PR TITLE
Fix out-of-bounds read in Stage 2 WinMain args

### DIFF
--- a/src/Update/PowerToys.Update.cpp
+++ b/src/Update/PowerToys.Update.cpp
@@ -217,6 +217,12 @@ int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int)
     }
     else if (action == UPDATE_NOW_LAUNCH_STAGE2)
     {
+        if (nArgs < 3)
+        {
+            Logger::error("Stage 2 invoked without installer path argument");
+            return 1;
+        }
+
         using namespace std::string_view_literals;
         const bool failed = !InstallNewVersionStage2(args[2]);
         if (failed)


### PR DESCRIPTION
Fix out-of-bounds array read when Stage 2 is invoked without an installer path argument.

`WinMain` only checked `nArgs < 2` but Stage 2 unconditionally accessed `args[2]`.

Found during multi-agent code review of #46889.
