### PR TITLE
[Updater] Open PowerToys handle before WM_CLOSE to avoid PID-recycle race

### DIFF
--- a/src/Update/PowerToys.Update.cpp
+++ b/src/Update/PowerToys.Update.cpp
@@ -21,6 +21,8 @@
 #include <common/utils/resources.h>
 #include <common/utils/timeutil.h>
 
+#include <wil/resource.h>
+
 #include <common/SettingsAPI/settings_helpers.h>
 
 #include <common/logger/logger.h>
@@ -116,7 +118,22 @@ bool InstallNewVersionStage1(fs::path installer)
 
         if (pt_main_window != nullptr)
         {
+            // Get the process that owns the tray window so we can wait for it to exit
+            DWORD ptProcessId = 0;
+            GetWindowThreadProcessId(pt_main_window, &ptProcessId);
+
             SendMessageW(pt_main_window, WM_CLOSE, 0, 0);
+
+            // Wait for PT to actually exit before launching installer.
+            // Without this, the installer may find PT files locked.
+            if (ptProcessId != 0)
+            {
+                wil::unique_handle ptProcess{ OpenProcess(SYNCHRONIZE, FALSE, ptProcessId) };
+                if (ptProcess)
+                {
+                    WaitForSingleObject(ptProcess.get(), 10000); // 10 second timeout
+                }
+            }
         }
 
         std::wstring arguments{ UPDATE_NOW_LAUNCH_STAGE2 };

--- a/src/Update/PowerToys.Update.cpp
+++ b/src/Update/PowerToys.Update.cpp
@@ -190,9 +190,17 @@ bool InstallNewVersionStage1(fs::path installer)
 
         if (pt_main_window != nullptr)
         {
-            // Get the process that owns the tray window so we can wait for it to exit
+            // Get the process that owns the tray window so we can wait for it to exit.
             DWORD ptProcessId = 0;
             GetWindowThreadProcessId(pt_main_window, &ptProcessId);
+
+            // Open the process handle BEFORE sending WM_CLOSE. PowerToys can exit
+            // inside its own WM_CLOSE handler, and once it does the OS is free to
+            // recycle its PID -- opening by PID afterwards could then fail or, worse,
+            // attach to an unrelated process that reused the PID. Holding the handle
+            // anchors the kernel object to the original process, so reuse is
+            // impossible while we wait on it.
+            wil::unique_handle ptProcess{ ptProcessId != 0 ? OpenProcess(SYNCHRONIZE, FALSE, ptProcessId) : nullptr };
 
             // Use SendMessageTimeoutW to avoid blocking indefinitely if the
             // tray window thread is hung or unresponsive.
@@ -201,13 +209,9 @@ bool InstallNewVersionStage1(fs::path installer)
 
             // Wait for PT to actually exit before launching installer.
             // Without this, the installer may find PT files locked.
-            if (ptProcessId != 0)
+            if (ptProcess)
             {
-                wil::unique_handle ptProcess{ OpenProcess(SYNCHRONIZE, FALSE, ptProcessId) };
-                if (ptProcess)
-                {
-                    WaitForSingleObject(ptProcess.get(), 10000); // 10 second timeout
-                }
+                WaitForSingleObject(ptProcess.get(), 10000); // 10 second timeout
             }
         }
 


### PR DESCRIPTION
Narrows this PR to @yeelam-gordon's review feedback.

The wait-for-exit before launching the installer is **already in `main`** (landed separately), so the original change here is now redundant. What's **not** in main is the PID-recycle hazard Gordon flagged, so this PR applies just that fix:

Open the PowerToys process handle **before** sending `WM_CLOSE`. PowerToys can exit inside its own `WM_CLOSE` handler, after which the OS may recycle its PID — opening by PID afterwards could then fail or attach to an unrelated process that reused it, and `WaitForSingleObject` would wait on the wrong thing. Holding the handle first anchors the kernel object to the original process, so PID reuse is impossible while we wait on it.

Rebased onto latest `main` (resolves the previous merge conflict).

Originally fixes #46966.
