### PR TITLE
Remove unused UPDATE_STAGE2 constants from UpdateUtils.h

### DIFF
--- a/src/runner/UpdateUtils.h
+++ b/src/runner/UpdateUtils.h
@@ -11,10 +11,7 @@ namespace cmdArg
     // restarting it from there, so it doesn't interfere with the installation process.
     const inline wchar_t* UPDATE_NOW_LAUNCH_STAGE1 = L"-update_now";
     // Stage 2 consists of starting the installer and optionally launching newly installed PowerToys binary.
-    // That's indicated by the following 2 flags.
     const inline wchar_t* UPDATE_NOW_LAUNCH_STAGE2 = L"-update_now_stage_2";
-    const inline wchar_t* UPDATE_STAGE2_RESTART_PT = L"restart";
-    const inline wchar_t* UPDATE_STAGE2_DONT_START_PT = L"dont_start";
 
     const inline wchar_t* UPDATE_REPORT_SUCCESS = L"-report_update_success";
 }


### PR DESCRIPTION
Remove `UPDATE_STAGE2_RESTART_PT` and `UPDATE_STAGE2_DONT_START_PT` constants from `UpdateUtils.h`. Never referenced anywhere in the codebase.

Fixes #46968. Found during multi-agent code review of #46889.
