### PR TITLE
feat(Peek): add .opus audio file support

### DIFF
--- a/src/modules/peek/Peek.FilePreviewer/Previewers/MediaPreviewer/AudioPreviewer.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/MediaPreviewer/AudioPreviewer.cs
@@ -202,6 +202,7 @@ namespace Peek.FilePreviewer.Previewers.MediaPreviewer
             ".m4a",
             ".mp3",
             ".ogg",
+            ".opus",
             ".wav",
             ".wma",
         };


### PR DESCRIPTION
Adds .opus to the supported audio extensions in Peek's AudioPreviewer. Opus is widely used (Discord, WhatsApp, WebRTC all use it) and Windows can play it with the Web Media Extensions installed.

One line added to the extensions array.

Closes #42576