### PR TITLE
fix(PowerAccent): return true from OnKeyUp after emitting accented char

### DIFF
--- a/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.cpp
+++ b/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.cpp
@@ -282,6 +282,7 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
                 m_hideToolbarCb(InputType::Char);
 
                 m_toolbarVisible = false;
+                return true;
             }
         }
 


### PR DESCRIPTION
After selecting an accented character and hiding the toolbar, OnKeyUp was returning false. This let the original letter key-up event pass through to the focused app, so you'd get the accented character plus the original letter.

One-line fix: return true after the char emission path so the key-up gets swallowed.

Fixes #46963