### PR TITLE
fix(Screen Ruler): edge detection at pixel 0 and SAD truncation

### DIFF
--- a/src/modules/MeasureTool/MeasureToolCore/BGRATextureView.h
+++ b/src/modules/MeasureTool/MeasureToolCore/BGRATextureView.h
@@ -118,7 +118,7 @@ struct BGRATextureView
         else
         {
             // Method 2: Test whether sum of all channel differences is smaller than tolerance
-            const int32_t score = _mm_cvtsi128_si32(_mm_sad_epu8(distances, _mm_setzero_si128())) & std::numeric_limits<uint8_t>::max();
+            const int32_t score = _mm_cvtsi128_si32(_mm_sad_epu8(distances, _mm_setzero_si128())) & std::numeric_limits<uint16_t>::max();
             return score <= tolerance;
         }
     }

--- a/src/modules/MeasureTool/MeasureToolCore/EdgeDetection.cpp
+++ b/src/modules/MeasureTool/MeasureToolCore/EdgeDetection.cpp
@@ -29,8 +29,9 @@ inline long FindEdge(const BGRATextureView& texture, const POINT centerPoint, co
             }
             else
             {
-                if (--x == 0)
+                if (x == 0)
                     break;
+                --x;
             }
         }
         else
@@ -42,8 +43,9 @@ inline long FindEdge(const BGRATextureView& texture, const POINT centerPoint, co
             }
             else
             {
-                if (--y == 0)
+                if (y == 0)
                     break;
+                --y;
             }
         }
 


### PR DESCRIPTION
Two small fixes in Screen Ruler:

1. FindEdge skipped the pixel at row/column 0 because it pre-decremented then checked == 0. Now checks before decrementing so the boundary pixel gets tested. (#46947)

2. PixelsClose total mode masked the SAD result with 0xFF, wrapping any diff above 255 back to a small number. A white-vs-black comparison (SAD=765) would wrap to 253 and pass a tolerance of 254. Changed to 0xFFFF since the max possible SAD across 4 channels is 1020. (#46946)

Fixes #46947, #46946