### PR TITLE
fix(Peek): prevent OverflowException in NumberOfDigits

### DIFF
--- a/src/modules/peek/Peek.Common/Helpers/MathHelper.cs
+++ b/src/modules/peek/Peek.Common/Helpers/MathHelper.cs
@@ -16,7 +16,7 @@ namespace Peek.Common.Helpers
 
         public static int NumberOfDigits(int num)
         {
-            return Math.Abs(num).ToString(CultureInfo.InvariantCulture).Length;
+            return Math.Abs((long)num).ToString(CultureInfo.InvariantCulture).Length;
         }
     }
 }


### PR DESCRIPTION
Math.Abs(int.MinValue) throws OverflowException because -2147483648 has no positive int representation. Cast to long before taking the absolute value so it fits.

One-line fix in MathHelper.cs.

Fixes #46960