### PR TITLE
fix(AlwaysOnTop): fix HexToRGB null termination and default color mismatch

### DIFF
--- a/src/settings-ui/Settings.UI.Library/AlwaysOnTopProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/AlwaysOnTopProperties.cs
@@ -16,7 +16,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         public const bool DefaultFrameEnabled = true;
         public const bool DefaultShowInSystemMenu = false;
         public const int DefaultFrameThickness = 15;
-        public const string DefaultFrameColor = "#0099cc";
+        public const string DefaultFrameColor = "#00ADEF";
         public const bool DefaultFrameAccentColor = true;
         public const int DefaultFrameOpacity = 100;
         public const bool DefaultSoundEnabled = true;

--- a/src/settings-ui/Settings.UI.Library/Utilities/GetSettingCommandLineCommand.cs
+++ b/src/settings-ui/Settings.UI.Library/Utilities/GetSettingCommandLineCommand.cs
@@ -28,7 +28,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library;
 /// {
 ///   "AlwaysOnTop": {
 ///     "FrameEnabled": true,
-///     "FrameAccentColor": "#0099cc"
+///     "FrameAccentColor": "#00ADEF"
 ///   },
 ///   "FancyZones": {
 ///     "FancyzonesShiftDrag": true,


### PR DESCRIPTION
Two fixes in AlwaysOnTop:

1. HexToRGB passed string_view.data() to stoll, but string_view isn't guaranteed null-terminated. Constructed a wstring from the view first. (#46962)

2. Default frame color was #0099cc in C# settings but RGB(0,173,239) = #00ADEF in the C++ backend. Aligned the C# constant to match. (#46961)

Fixes #46962, #46961