### PR TITLE
fix(MouseHighlighter): cap shape count to prevent memory leak

### DIFF
--- a/src/modules/MouseUtils/MouseHighlighter/MouseHighlighter.cpp
+++ b/src/modules/MouseUtils/MouseHighlighter/MouseHighlighter.cpp
@@ -217,8 +217,12 @@ void Highlighter::AddDrawingPoint(MouseButton button)
 
     m_shape.Shapes().Append(circleShape);
 
-    // TODO: We're leaking shapes for long drawing sessions.
-    // Perhaps add a task to the Dispatcher every X circles to clean up.
+    // Cap the number of shapes to prevent unbounded memory growth in long sessions.
+    constexpr uint32_t maxShapes = 10000;
+    while (m_shape.Shapes().Size() > maxShapes)
+    {
+        m_shape.Shapes().RemoveAt(0);
+    }
 
     // Get back on top in case other Window is now the topmost.
     // HACK: Draw with 1 pixel off. Otherwise, Windows glitches the task bar transparency when a transparent window fill the whole screen.


### PR DESCRIPTION
Shapes were appended to the visual indefinitely during long drawing sessions. There was a TODO in the code acknowledging the leak. Added a 10K shape cap that removes the oldest shapes when exceeded, keeping memory bounded.

Fixes #46964