### PR TITLE
fix(LightSwitch): notify observers on profile setting changes

### DIFF
--- a/src/modules/LightSwitch/LightSwitchService/LightSwitchSettings.cpp
+++ b/src/modules/LightSwitch/LightSwitchService/LightSwitchSettings.cpp
@@ -255,6 +255,7 @@ void LightSwitchSettings::LoadSettings()
             if (m_settings.enableDarkModeProfile != val)
             {
                 m_settings.enableDarkModeProfile = val;
+                NotifyObservers(SettingId::EnableDarkModeProfile);
             }
         }
 
@@ -265,6 +266,7 @@ void LightSwitchSettings::LoadSettings()
             if (m_settings.enableLightModeProfile != val)
             {
                 m_settings.enableLightModeProfile = val;
+                NotifyObservers(SettingId::EnableLightModeProfile);
             }
         }
 
@@ -275,6 +277,7 @@ void LightSwitchSettings::LoadSettings()
             if (m_settings.darkModeProfile != val)
             {
                 m_settings.darkModeProfile = val;
+                NotifyObservers(SettingId::DarkModeProfile);
             }
         }
 
@@ -285,6 +288,7 @@ void LightSwitchSettings::LoadSettings()
             if (m_settings.lightModeProfile != val)
             {
                 m_settings.lightModeProfile = val;
+                NotifyObservers(SettingId::LightModeProfile);
             }
         }
 

--- a/src/modules/LightSwitch/LightSwitchService/SettingsConstants.h
+++ b/src/modules/LightSwitch/LightSwitchService/SettingsConstants.h
@@ -10,5 +10,9 @@ enum class SettingId
     Sunrise_Offset,
     Sunset_Offset,
     ChangeSystem,
-    ChangeApps
+    ChangeApps,
+    EnableDarkModeProfile,
+    EnableLightModeProfile,
+    DarkModeProfile,
+    LightModeProfile
 };


### PR DESCRIPTION
The four profile settings (enableDarkModeProfile, enableLightModeProfile, darkModeProfile, lightModeProfile) were loaded and stored but never sent observer notifications. Components watching for these changes never got told about them.

Added the missing SettingId enum entries and NotifyObservers calls in the setting update paths.

Fixes #46956