### PR TITLE
feat(EnvironmentVariables): add helper for removing duplicate PATH entries

### DIFF
--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/Variable.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/Variable.cs
@@ -109,6 +109,24 @@ namespace EnvironmentVariablesUILib.Models
             return new ObservableCollection<ValuesListItem>(values.Split(';').Select(x => new ValuesListItem { Text = x }));
         }
 
+        /// <summary>
+        /// Removes duplicate entries from a semicolon-separated values string (case-insensitive).
+        /// Preserves the first occurrence of each entry and maintains original order.
+        /// </summary>
+        internal static string RemoveDuplicateValues(string values)
+        {
+            if (string.IsNullOrEmpty(values))
+            {
+                return values;
+            }
+
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var unique = values.Split(';')
+                               .Where(entry => !string.IsNullOrWhiteSpace(entry) && seen.Add(entry.Trim()))
+                               .ToList();
+            return string.Join(";", unique);
+        }
+
         internal Task Update(Variable edited, bool propagateChange, ProfileVariablesSet parentProfile)
         {
             bool nameChanged = Name != edited.Name;


### PR DESCRIPTION
Adds a RemoveDuplicateValues helper method to the Variable model that deduplicates semicolon-separated entries (case-insensitive, preserves first occurrence and original order). This is the logic piece for adding a "Remove Duplicates" button to the PATH editor.

The UI button integration can follow in a separate PR once this logic is reviewed and agreed on.

Refs #40402