### PR TITLE
feat(CmdPal): add .vsconfig to extension template

### DIFF
--- a/src/modules/cmdpal/ExtensionTemplate/TemplateCmdPalExtension/.vsconfig
+++ b/src/modules/cmdpal/ExtensionTemplate/TemplateCmdPalExtension/.vsconfig
@@ -1,0 +1,11 @@
+{
+  "version": "1.0",
+  "components": [
+    "Microsoft.VisualStudio.Workload.ManagedDesktop",
+    "Microsoft.VisualStudio.Workload.NetCrossPlat",
+    "Microsoft.Net.Component.4.8.SDK",
+    "Microsoft.NetCore.Component.Runtime.9.0",
+    "Microsoft.NetCore.Component.SDK",
+    "Microsoft.VisualStudio.Component.Windows11SDK.26100"
+  ]
+}


### PR DESCRIPTION
## Summary of the Pull Request

When opening the CmdPal extension template solution, Visual Studio doesn't prompt to install required workloads. Adding a .vsconfig file makes VS detect missing components and offer to install them.

Includes: .NET desktop workload, .NET 9 SDK/runtime, and Windows 11 SDK (26100), matching what the template project requires.

## PR Checklist

- [x] Closes: #39114
- [x] **Communication:** Issue is labeled Help Wanted
- [ ] **Tests:** Verified the .vsconfig triggers the VS installer prompt when a component is missing
- [ ] **Localization:** N/A
- [ ] **Dev docs:** N/A
- [ ] **New binaries:** N/A