### PR TITLE
feat(Calculator): format large numbers with locale-aware thousands separators

### DIFF
--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Helper/ResultHelper.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Helper/ResultHelper.cs
@@ -30,7 +30,7 @@ public static class ResultHelper
             return null;
         }
 
-        var result = roundedResult?.ToString(outputCulture);
+        var result = FormatWithSeparators(roundedResult.Value, outputCulture);
 
         // Create a SaveCommand and subscribe to the SaveRequested event
         // This can append the result to the history list.
@@ -66,7 +66,7 @@ public static class ResultHelper
             return null;
         }
 
-        var decimalResult = roundedResult?.ToString(outputCulture);
+        var decimalResult = FormatWithSeparators(roundedResult.Value, outputCulture);
         var decimalValue = (decimal)roundedResult;
 
         List<IContextItem> context = [];
@@ -135,5 +135,18 @@ public static class ResultHelper
             TextToSuggest = decimalResult,
             MoreCommands = context.ToArray(),
         };
+    }
+
+    /// <summary>
+    /// Formats a decimal with locale-aware thousands separators while preserving
+    /// the original number of decimal places.
+    /// </summary>
+    private static string FormatWithSeparators(decimal value, CultureInfo culture)
+    {
+        var plain = value.ToString(culture);
+        var sep = culture.NumberFormat.NumberDecimalSeparator;
+        var decIdx = plain.IndexOf(sep, StringComparison.Ordinal);
+        var decimals = decIdx >= 0 ? plain.Length - decIdx - sep.Length : 0;
+        return value.ToString("N" + decimals, culture);
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request

Calculator results for large numbers (e.g. 1000000) now display with thousands separators (e.g. 1,000,000) using the user's locale. Small numbers and decimals keep their existing formatting.

The approach: detect how many decimal places the raw result has, then apply the `N` format specifier with that count. This preserves the original precision while adding separators to the integer part.

Before: `1000000` / `3.14159`
After: `1,000,000` / `3.14159`

## PR Checklist

- [x] Closes: #40203
- [x] **Communication:** Issue is labeled Help Wanted
- [ ] **Tests:** Manually verified with various numbers and locale settings
- [ ] **Localization:** Uses CultureInfo from the existing output locale setting
- [ ] **Dev docs:** N/A
- [ ] **New binaries:** N/A