### PR TITLE
feat(WindowWalker): support compound app+title search queries

### DIFF
--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowWalker/Pages/WindowWalkerListPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowWalker/Pages/WindowWalkerListPage.cs
@@ -77,8 +77,26 @@ internal sealed partial class WindowWalkerListPage : DynamicListPage, IDisposabl
     private static int ScoreFunction(string q, Window window)
     {
         var titleScore = FuzzyStringMatcher.ScoreFuzzy(q, window.Title);
-        var processNameScore = FuzzyStringMatcher.ScoreFuzzy(q, window.Process.Name ?? string.Empty);
-        return Math.Max(titleScore, processNameScore);
+        var processName = window.Process.Name ?? string.Empty;
+        var processNameScore = FuzzyStringMatcher.ScoreFuzzy(q, processName);
+
+        // Support compound queries like "word budget" where "word" matches the
+        // process name and "budget" matches something in the window title.
+        var combinedScore = 0;
+        var parts = q.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length >= 2)
+        {
+            var appPart = parts[0];
+            var titlePart = string.Join(" ", parts[1..]);
+            var appScore = FuzzyStringMatcher.ScoreFuzzy(appPart, processName);
+            var restScore = FuzzyStringMatcher.ScoreFuzzy(titlePart, window.Title);
+            if (appScore > 0 && restScore > 0)
+            {
+                combinedScore = appScore + restScore;
+            }
+        }
+
+        return Math.Max(Math.Max(titleScore, processNameScore), combinedScore);
     }
 
     public override IListItem[] GetItems() => Query(SearchText);


### PR DESCRIPTION
## Summary of the Pull Request

Window Walker currently matches search text against either the window title or the process name separately. This adds compound query support so typing "word budget" matches a Microsoft Word window with "budget" in the title.

The first word is matched against the process name and the remaining words against the window title. Both parts need to score above zero for the combined score to count. Existing single-word search behavior is completely unchanged since the combined score is only considered when the query has 2+ words.

## PR Checklist

- [x] Closes: #40910
- [ ] **Tests:** Manually tested with multiple Word/Chrome/VS Code windows open, verified compound queries rank the right window first
- [ ] **Localization:** N/A (no user-facing strings)
- [ ] **Dev docs:** N/A
- [ ] **New binaries:** N/A