### PR TITLE
feat(CmdPal): increase hero image size for clipboard history previews

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml
@@ -445,7 +445,8 @@
 
                         <cpcontrols:IconBox
                             x:Name="HeroImageBorder"
-                            Width="64"
+                            MaxWidth="320"
+                            MaxHeight="240"
                             Margin="0,0,16,16"
                             HorizontalAlignment="Left"
                             AutomationProperties.AccessibilityView="Raw"


### PR DESCRIPTION
## Summary of the Pull Request

The hero image in the CmdPal details pane was fixed at 64px wide, making clipboard image previews essentially useless for anything other than icons. Replaced the fixed Width="64" with MaxWidth="320" and MaxHeight="240" so images scale up to a readable size while staying bounded within the details pane. Small images like icons still display at their natural size since there's no minimum constraint.

## PR Checklist

- [x] Closes: #41698
- [ ] **Tests:** Verified visually with clipboard image entries of various sizes (screenshots, photos, small icons)
- [ ] **Localization:** N/A
- [ ] **Dev docs:** N/A
- [ ] **New binaries:** N/A