### PR TITLE
feat(CmdPal): add SettingsManager to extension template

### DIFF
--- a/src/modules/cmdpal/ExtensionTemplate/TemplateCmdPalExtension/TemplateCmdPalExtension/SettingsManager.cs
+++ b/src/modules/cmdpal/ExtensionTemplate/TemplateCmdPalExtension/TemplateCmdPalExtension/SettingsManager.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CommandPalette.Extensions.Toolkit;
+
+namespace TemplateCmdPalExtension;
+
+/// <summary>
+/// Manages extension settings using the JsonSettingsManager base class.
+/// Add your own settings as ToggleSetting, TextSetting, or ChoiceSetSetting
+/// fields, register them in the constructor, and they'll automatically
+/// persist to disk and appear in the extension's settings page.
+/// </summary>
+public class SettingsManager : JsonSettingsManager
+{
+    private static readonly string _namespace = "template-extension";
+
+    private static string Namespaced(string propertyName) => $"{_namespace}.{propertyName}";
+
+    // Example toggle setting. Replace or add your own settings here.
+    private readonly ToggleSetting _exampleToggle = new(
+        Namespaced(nameof(ExampleEnabled)),
+        "Example feature",
+        "Enable or disable the example feature",
+        true);
+
+    public bool ExampleEnabled => _exampleToggle.Value;
+
+    public SettingsPage Settings { get; }
+
+    public SettingsManager()
+    {
+        Settings = new SettingsPage(
+            "template-extension-settings",
+            "Extension Settings",
+            [_exampleToggle]);
+
+        LoadSettings();
+        Settings.SettingsChanged += (s, a) => SaveSettings();
+    }
+}


### PR DESCRIPTION
## Summary of the Pull Request

The CmdPal extension template didn't include a settings example, so new extension authors had to figure out the JsonSettingsManager pattern by reading other extensions' code. Added a minimal SettingsManager.cs that demonstrates a toggle setting with auto-save and a settings page.

Extension authors can replace the example toggle with their own settings and they'll automatically persist to disk and show up in the extension's settings page.

## PR Checklist

- [x] Closes: #39274
- [ ] **Tests:** N/A (template code, not runtime code)
- [ ] **Localization:** N/A
- [ ] **Dev docs:** The SettingsManager itself serves as documentation via comments
- [ ] **New binaries:** N/A