### PR TITLE
[PD] Fix thread safety, color temperature guard, and log accuracy

### DIFF
--- a/src/modules/powerdisplay/PowerDisplay.Lib/Services/MonitorStateManager.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Lib/Services/MonitorStateManager.cs
@@ -26,8 +26,8 @@ namespace PowerDisplay.Common.Services
         private readonly ConcurrentDictionary<string, MonitorState> _states = new();
         private readonly SimpleDebouncer _saveDebouncer;
 
-        private bool _disposed;
-        private bool _isDirty; // Track pending changes for flush on dispose
+        private volatile bool _disposed;
+        private volatile bool _isDirty; // Track pending changes for flush on dispose
         private const int SaveDebounceMs = 2000; // Save 2 seconds after last update
 
         /// <summary>

--- a/src/modules/powerdisplay/PowerDisplay/ViewModels/MainViewModel.Settings.cs
+++ b/src/modules/powerdisplay/PowerDisplay/ViewModels/MainViewModel.Settings.cs
@@ -233,7 +233,8 @@ public partial class MainViewModel
             }
 
             // Apply color temperature if included in profile
-            if (setting.ColorTemperatureVcp.HasValue && setting.ColorTemperatureVcp.Value > 0)
+            if (setting.ColorTemperatureVcp.HasValue && setting.ColorTemperatureVcp.Value > 0 &&
+                monitorVm.ShowColorTemperature)
             {
                 updateTasks.Add(monitorVm.SetColorTemperatureAsync(setting.ColorTemperatureVcp.Value));
             }
@@ -273,7 +274,8 @@ public partial class MainViewModel
                 }
 
                 // Restore color temperature if different from current
-                if (savedState.Value.ColorTemperatureVcp > 0 &&
+                if (monitorVm.ShowColorTemperature &&
+                    savedState.Value.ColorTemperatureVcp > 0 &&
                     savedState.Value.ColorTemperatureVcp != monitorVm.ColorTemperature)
                 {
                     updateTasks.Add(monitorVm.SetColorTemperatureAsync(savedState.Value.ColorTemperatureVcp));

--- a/src/settings-ui/Settings.UI/ViewModels/PowerDisplayViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/PowerDisplayViewModel.cs
@@ -562,7 +562,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
 
                 SendConfigMSG(JsonSerializer.Serialize(actionMessage, SettingsSerializationContext.Default.PowerDisplayActionMessage));
 
-                Logger.LogInfo($"Profile '{profile.Name}' applied successfully");
+                Logger.LogInfo($"Profile '{profile.Name}' apply request sent via IPC");
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Mark _disposed and _isDirty as volatile for correct cross-thread visibility. Guard color temperature apply/restore behind ShowColorTemperature to avoid writing unsupported VCP codes. Fix misleading log message in Settings UI profile apply path.

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] Closes: #xxx
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

