### PR TITLE
Update default module states

### DIFF
--- a/src/settings-ui/Settings.UI.Library/EnabledModules.cs
+++ b/src/settings-ui/Settings.UI.Library/EnabledModules.cs
@@ -119,7 +119,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             }
         }
 
-        private bool powerLauncher = true;
+        private bool powerLauncher; // defaulting to off
 
         [JsonPropertyName("PowerToys Run")]
         public bool PowerLauncher
@@ -153,7 +153,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             }
         }
 
-        private bool cropAndLock = true;
+        private bool cropAndLock; // defaulting to off
 
         [JsonPropertyName("CropAndLock")]
         public bool CropAndLock
@@ -315,7 +315,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             }
         }
 
-        private bool advancedPaste = true;
+        private bool advancedPaste; // defaulting to off
 
         [JsonPropertyName("AdvancedPaste")]
         public bool AdvancedPaste
@@ -349,7 +349,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             }
         }
 
-        private bool hosts = true;
+        private bool hosts; // defaulting to off
 
         [JsonPropertyName("Hosts")]
         public bool Hosts
@@ -398,7 +398,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             }
         }
 
-        private bool registryPreview = true;
+        private bool registryPreview; // defaulting to off
 
         [JsonPropertyName("RegistryPreview")]
         public bool RegistryPreview
@@ -431,7 +431,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             }
         }
 
-        private bool environmentVariables = true;
+        private bool environmentVariables; // defaulting to off
 
         [JsonPropertyName("EnvironmentVariables")]
         public bool EnvironmentVariables
@@ -463,7 +463,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             }
         }
 
-        private bool workspaces = true;
+        private bool workspaces; // defaulting to off
 
         [JsonPropertyName("Workspaces")]
         public bool Workspaces

--- a/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/General.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/General.cs
@@ -351,7 +351,7 @@ namespace ViewModelTests
             Assert.IsTrue(modules.PowerPreview);
             Assert.IsTrue(modules.ShortcutGuide);
             Assert.IsTrue(modules.PowerRename);
-            Assert.IsTrue(modules.PowerLauncher);
+            Assert.IsFalse(modules.PowerLauncher);
             Assert.IsTrue(modules.ColorPicker);
         }
     }


### PR DESCRIPTION
## Summary

- **Disable 7 modules by default** for new users: PowerToys Run, Crop and Lock, Advanced Paste, Hosts File Editor, Registry Preview, Environment Variables, Workspaces
- **Swap default hotkeys**: Command Palette now defaults to \Alt+Space\, PowerToys Run now defaults to \Win+Alt+Space\
- Update unit test to reflect PowerLauncher default-off state

## Changes

| File | Change |
|------|--------|
| \EnabledModules.cs\ | Set 7 module defaults to off |
| \PowerLauncherProperties.cs\ | Default hotkey → \Win+Alt+Space\ |
| \SettingsModel.cs\ (CmdPal) | Default hotkey → \Alt+Space\ |
| \General.cs\ (test) | Assert PowerLauncher is false |

## Validation

- Existing unit test updated to match new defaults
- No ABI or IPC contract changes