### PR TITLE
fix(cmdpal): handle unavailable extension packages during loading

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Models/ExtensionService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Models/ExtensionService.cs
@@ -199,8 +199,15 @@ public partial class ExtensionService : IExtensionService, IDisposable
                 var extensions = await GetInstalledAppExtensionsAsync();
                 foreach (var extension in extensions)
                 {
-                    var wrappers = await CreateWrappersForExtension(extension);
-                    UpdateExtensionsListsFromWrappers(wrappers);
+                    try
+                    {
+                        var wrappers = await CreateWrappersForExtension(extension);
+                        UpdateExtensionsListsFromWrappers(wrappers);
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.LogError($"Failed to load extension '{extension.DisplayName}': {ex.Message}");
+                    }
                 }
             }
 
@@ -245,8 +252,15 @@ public partial class ExtensionService : IExtensionService, IDisposable
         List<ExtensionWrapper> wrappers = [];
         foreach (var classId in classIds)
         {
-            var extensionWrapper = CreateExtensionWrapper(extension, cmdPalProvider, classId);
-            wrappers.Add(extensionWrapper);
+            try
+            {
+                var extensionWrapper = CreateExtensionWrapper(extension, cmdPalProvider, classId);
+                wrappers.Add(extensionWrapper);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError($"Failed to create wrapper for extension '{extension.DisplayName}' classId '{classId}': {ex.Message}");
+            }
         }
 
         return wrappers;


### PR DESCRIPTION
## Summary of the Pull Request

Fixes a Watson crash where \AppExtension.Package\ throws a COM/HRESULT exception when the underlying package is in a bad state (being updated, partially installed, recently uninstalled, or corrupted). Previously, one bad extension killed the entire extension-loading loop, preventing **all** extensions from loading.

This adds try-catch guards in \ExtensionService\ at two levels so a single failing extension is logged and skipped rather than aborting the enumeration.

## PR Checklist

- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [x] **Tests:** This is a defensive resilience fix with no behavior change for the happy path; existing tests still pass
- [ ] **Localization:** N/A — no end-user-facing strings changed (log messages are developer-facing)
- [ ] **Dev docs:** N/A — no new APIs or features
- [ ] **New binaries:** N/A — no new binaries

## Detailed Description of the Pull Request / Additional comments

**File changed:** \src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Models/ExtensionService.cs\

Two try-catch blocks added:

1. **\GetInstalledExtensionsAsync\** — wraps the per-extension loop body (lines 200–211) so that if \CreateWrappersForExtension\ or any property access on \AppExtension\ throws, the loop continues to the next extension.

2. **\CreateWrappersForExtension\** — wraps the per-classId wrapper creation (lines 252–264) so that if the \ExtensionWrapper\ constructor throws (e.g. \ppExtension.Package\ is unavailable), remaining class IDs in the same extension still get processed.

Both catch blocks log via \Logger.LogError\ with the extension display name and error message.

The \InstallPackageUnderLock\ code path also calls \CreateWrappersForExtension\ and inherits the inner protection automatically.

## Validation Steps Performed

- Built \Microsoft.CmdPal.UI.ViewModels\ with \	ools/build/build.cmd\ — exit code 0, no warnings or errors
- Verified no existing tests are broken by the change
