### PR TITLE
[QuickAccent] Add en-dash to VK_MINUS for SPECIAL language

### DIFF
--- a/src/modules/poweraccent/PowerAccent.Core/Languages.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/Languages.cs
@@ -227,7 +227,7 @@ namespace PowerAccent.Core
                 LetterKey.VK_Z => new[] { "ʒ", "ǯ", "ℤ", "ᶻ" },
                 LetterKey.VK_COMMA => new[] { "∙", "₋", "⁻", "–", "√", "‟", "《", "》", "‛", "〈", "〉", "″", "‴", "⁗" }, // – is in VK_MINUS for other languages, but not VK_COMMA, so we add it here.
                 LetterKey.VK_PERIOD => new[] { "…", "⁝", "\u0300", "\u0301", "\u0302", "\u0303", "\u0304", "\u0308", "\u030B", "\u030C" },
-                LetterKey.VK_MINUS => new[] { "~", "‐", "‑", "‒", "—", "―", "⁓", "−", "⸺", "⸻", "∓", "₋", "⁻" },
+                LetterKey.VK_MINUS => new[] { "~", "‐", "‑", "‒", "–", "—", "―", "⁓", "−", "⸺", "⸻", "∓", "₋", "⁻" },
                 LetterKey.VK_SLASH_ => new[] { "÷", "√" },
                 LetterKey.VK_DIVIDE_ => new[] { "÷", "√" },
                 LetterKey.VK_MULTIPLY_ => new[] { "×", "⋅", "ˣ", "ₓ" },


### PR DESCRIPTION
## Summary of the Pull Request
Add en-dash to the existing dash characters available under the minus key for the Special Characters set.

This PR re-creates #45965 by @daverayment because that PR's pipeline appears to have been corrupted. All credit for the change belongs to @daverayment — the commit on this branch preserves their original authorship.

## PR Checklist

- [x] Closes: #44030
- [x] Closes: #36805

## Detailed Description of the Pull Request / Additional comments

This PR adds the en-dash '–' character to the VK_MINUS key under the Special Characters character set, positioned before the em-dash character.

Although the character is available under VK_COMMA, it should be present under VK_MINUS, along with the other dash characters.

Previously, en-dash was available for VK_MINUS under the Hebrew language, so users who selected **All available** character sets (or who specifically selected Hebrew as a workaround) had access to en-dash via the minus key. However, this was seen as a duplication of the VK_COMMA functionality and the character was removed for the Hebrew character set in #43504. Although this is technically correct, this has understandably caused confusion for users who relied on the prior behaviour.

The comment on the VK_COMMA for the Special Characters declaration previously read:

`csharp
// – is in VK_MINUS for other languages, but not VK_COMMA, so we add it here.
`

That ""for other languages"" is telling. The Hebrew en-dash entry was removed, and the en-dash mapping for the minus key is not present for any other language, orphaning the functionality.

## Validation Steps Performed

Original author @daverayment built and ran the updated Quick Accent code and confirmed that the character was available when only the Special character set was selected, and that it was absent when that set was deselected. Confirmed that the character was available under both comma and minus keys.
