### PR TITLE
[Quick Accent] Fix issue where default "All available" setting is not parsed correctly

### DIFF
--- a/src/modules/poweraccent/PowerAccent.Core/Languages.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/Languages.cs
@@ -744,6 +744,7 @@ namespace PowerAccent.Core
                 LetterKey.VK_I => new[] { "í" },
                 LetterKey.VK_O => new[] { "ó", "ő", "ö" },
                 LetterKey.VK_U => new[] { "ú", "ű", "ü" },
+                LetterKey.VK_Y => new[] { "ÿ", "ý" },
                 LetterKey.VK_COMMA => new[] { "„", "”", "»", "«" },
                 _ => Array.Empty<string>(),
             };

--- a/src/modules/poweraccent/PowerAccent.Core/Services/SettingsService.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/Services/SettingsService.cs
@@ -61,10 +61,30 @@ public class SettingsService
                         ExcludedApps = settings.Properties.ExcludedApps.Value;
                         _keyboardListener.UpdateExcludedApps(ExcludedApps);
 
-                        SelectedLang = settings.Properties.SelectedLang.Value
+                        var selectedLangEntries = settings.Properties.SelectedLang.Value
                             .Split(',', StringSplitOptions.RemoveEmptyEntries)
-                            .Select(lang => Enum.TryParse(lang, out Language selectedLangValue) ? selectedLangValue : Language.SPECIAL)
+                            .Select(lang => lang.Trim())
                             .ToArray();
+
+                        // Either select all languages if "ALL" is specified, or parse
+                        // the specified languages while ignoring unrecognised values.
+                        SelectedLang = selectedLangEntries.Any(lang => lang.Equals("ALL", StringComparison.OrdinalIgnoreCase))
+                            ? Enum.GetValues<Language>()
+                            : selectedLangEntries
+                                .Select(lang =>
+                                {
+                                    if (Enum.TryParse(lang, ignoreCase: true, out Language parsedLang))
+                                    {
+                                        return (Language?)parsedLang;
+                                    }
+
+                                    // Skip unrecognised values.
+                                    Logger.LogWarning($"Unknown language value '{lang}' in settings, skipping.");
+                                    return null;
+                                })
+                                .Where(lang => lang.HasValue)
+                                .Select(lang => lang!.Value)
+                                .ToArray();
 
                         switch (settings.Properties.ToolbarPosition.Value)
                         {

--- a/src/modules/poweraccent/PowerAccent.Core/Services/SettingsService.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/Services/SettingsService.cs
@@ -67,8 +67,10 @@ public class SettingsService
                             .ToArray();
 
                         // Either select all languages if "ALL" is specified, or parse
-                        // the specified languages while ignoring unrecognised values.
-                        SelectedLang = selectedLangEntries.Any(lang => lang.Equals("ALL", StringComparison.OrdinalIgnoreCase))
+                        // the specified languages while ignoring unrecognized values.
+                        bool isAllSelected = selectedLangEntries.Any(lang =>
+                            lang.Equals("ALL", StringComparison.OrdinalIgnoreCase));
+                        SelectedLang = isAllSelected
                             ? Enum.GetValues<Language>()
                             : selectedLangEntries
                                 .Select(lang =>
@@ -78,13 +80,16 @@ public class SettingsService
                                         return (Language?)parsedLang;
                                     }
 
-                                    // Skip unrecognised values.
+                                    // Skip unrecognized values.
                                     Logger.LogWarning($"Unknown language value '{lang}' in settings, skipping.");
                                     return null;
                                 })
                                 .Where(lang => lang.HasValue)
                                 .Select(lang => lang!.Value)
                                 .ToArray();
+
+                        Logger.LogInfo(
+                            $"Languages selected: {(isAllSelected ? "ALL" : string.Join(", ", SelectedLang))}");
 
                         switch (settings.Properties.ToolbarPosition.Value)
                         {

--- a/src/settings-ui/Settings.UI/ViewModels/PowerAccentViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/PowerAccentViewModel.cs
@@ -126,7 +126,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             {
                 SelectedLanguageOptions = selectedLangEntries
                     .Select(l => Languages.Find(lang => lang.LanguageCode.Equals(l, StringComparison.OrdinalIgnoreCase)))
-                    .Where(l => l != null) // Unrecognised language codes (e.g. manual edits, removed languages) are skipped.
+                    .Where(l => l != null) // Unrecognized language codes (e.g. manual edits, removed languages) are skipped.
                     .ToArray();
             }
             else

--- a/src/settings-ui/Settings.UI/ViewModels/PowerAccentViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/PowerAccentViewModel.cs
@@ -113,20 +113,25 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
 
             _excludedApps = _powerAccentSettings.Properties.ExcludedApps.Value;
 
-            if (!string.IsNullOrWhiteSpace(_powerAccentSettings.Properties.SelectedLang.Value) && !_powerAccentSettings.Properties.SelectedLang.Value.Contains("ALL"))
-            {
-                SelectedLanguageOptions = _powerAccentSettings.Properties.SelectedLang.Value.Split(',')
-                   .Select(l => Languages.Find(lang => lang.LanguageCode == l))
-                   .Where(l => l != null) // Wrongly typed languages will appear as null after find. We want to remove those to avoid crashes.
-                   .ToArray();
-            }
-            else if (_powerAccentSettings.Properties.SelectedLang.Value.Contains("ALL"))
+            var selectedLangEntries = _powerAccentSettings.Properties.SelectedLang.Value
+                .Split(',', StringSplitOptions.RemoveEmptyEntries)
+                .Select(l => l.Trim())
+                .ToArray();
+
+            if (selectedLangEntries.Any(l => l.Equals("ALL", StringComparison.OrdinalIgnoreCase)))
             {
                 SelectedLanguageOptions = Languages.ToArray();
             }
+            else if (selectedLangEntries.Length > 0)
+            {
+                SelectedLanguageOptions = selectedLangEntries
+                    .Select(l => Languages.Find(lang => lang.LanguageCode.Equals(l, StringComparison.OrdinalIgnoreCase)))
+                    .Where(l => l != null) // Unrecognised language codes (e.g. manual edits, removed languages) are skipped.
+                    .ToArray();
+            }
             else
             {
-                SelectedLanguageOptions = Array.Empty<PowerAccentLanguageModel>();
+                SelectedLanguageOptions = [];
             }
 
             _toolbarPositionIndex = Array.IndexOf(_toolbarOptions, _powerAccentSettings.Properties.ToolbarPosition.Value);


### PR DESCRIPTION
## Summary of the Pull Request
When first enabled in the Settings application, Quick Accent defaults to **All available** character sets, but the persisted "ALL" option in the settings.json file is not understood by the application itself. This leads to the fallback SPECIAL character set being selected - unbeknownst to the user - which only contains a small subset of the available mappings.

This PR also adds two new characters to the Hungarian language, as requested under #47085.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #47113
- [x] Closes: #47085
- [x] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

The cause of the issue is:

1. The default `SelectedLang` value for a new Quick Accent settings file is "ALL", set in `PowerAccentProperties.cs`:
 
https://github.com/microsoft/PowerToys/blob/5520ae4cfa59f53f4bd4cffc7a9c3d20c98250ed/src/settings-ui/Settings.UI.Library/PowerAccentProperties.cs#L46

2. The Settings application understands the "ALL" setting, _but Quick Accent itself does not_.
3. There is an existing fallback in Quick Accent for when the language cannot be parsed, which is to select the "SPECIAL" language instead. This is a grab-bag of mappings for non-language-specific entries such as cross-cultural punctuation, IPA, currency etc.

The effect is that new users will see that All available character sets have been selected in the Settings application by default, but that only a small number of the available mappings will be shown when they trigger Quick Accent. De-selecting and re-selecting All available will fix the issue, but a new user is unlikely to do this. This leads to issues being logged such as #47085, where missing characters are reported, but they actually are present in the underlying mappings for the language(s).

There is also another issue with `SelectedLang` parsing, in that entries are compared against the in-built language codes in a case-sensitive non-trimmed manner. This means that entries such as "FR", "fr" and " FR" are all distinct. Although this isn't an issue at the moment, it means that adding new languages or editing the settings file manually is prone to triggering fall-throughs and the selection of the SPECIAL language without the user knowing.

The fix here is to:

1. Pre-parse the SelectedLang entries to trim them and remove any empty values.
2. Do an explicit (case-insensitive) check for "ALL"; if present, all languages are immediately selected.
3. If "ALL" is not present in the list, do a case-insensitive check for each entry against the in-built language codes.
4. Reject any non-matches and log a warning. Do not fall through to auto-select the SPECIAL character set. This respects the principle of least surprise, and means that the user is never given character options that they did not explicitly select.

Changes to the Quick Accent application are in `ReadSettings()` in SettingsService.cs. I have also made the Settings application parsing more robust, so both it and Quick Accent should be able to correctly parse entries like "SP,    INVALID, EST".

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Follow the manual steps below:

1. Close the Quick Accent process if it is currently running
6. Edit the settings.json file for Quick Accent, and set the "selected_lang" value to "all" (this setting is no longer case-sensitive).
7. (Re)start Quick Accent by starting `PowerToys.PowerAccent.exe`.
8. Trigger Quick Accent for the E key and observe the selection dialog that opens. It should contain E mappings for every language:

<img width="3371" height="155" alt="image" src="https://github.com/user-attachments/assets/84d709ea-fdcc-4430-8d22-f9732969a20a" />

9. Trigger Quick Accent for the Y key and observe the selection dialog that opens. It should contain Y mappings for every language, including the Y-With-Diaresis character originally reported as missing:

<img width="1264" height="149" alt="image" src="https://github.com/user-attachments/assets/ecea3734-e58c-4da6-896b-2e58a9fd05e8" />

10. Back in the settings file, change "selected_lang" value to "HR" for Croatian. Save the file.
11. Trigger Quick Accent for the C key and observe that only the following mappings are shown:

<img width="1055" height="146" alt="image" src="https://github.com/user-attachments/assets/69764145-0836-4dfb-8655-3a8a3be7f561" />

12. Again, in settings, change the "selected_lang" value to "". Save the file.
13. Confirm that triggering Quick Accent does not result in an error and simply does not show the dialog.
14. In settings again, change the "selected_lang" value to "FR, INVALID, DE" and save.
15. Trigger Quick Accent and confirm that entries for French and German are available in the dialog.
16. Check the logs and confirm that a warning is present about "INVALID" not being a valid language and being skipped.

Separately, for the Settings application:

1. Close the PowerToys Runner and ensure Quick Accent and Settings are not present in the Processes list.
2. Edit the settings.json file for Quick Accent, changing the "selected_lang" value to "FR, INVALID,      DE" and save.
3. Run PowerToys and open the Settings application.
4. On the Quick Accent settings page, ensure that French and German languages are selected. (Previously, parsing would fail after FR.)