### PR TITLE
CmdPal: Adding prop to cmdpal.ui.csproj to enable telem in AOT builds

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Microsoft.CmdPal.UI.csproj
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Microsoft.CmdPal.UI.csproj
@@ -38,6 +38,11 @@
 	  <DefineConstants>$(DefineConstants)</DefineConstants>
   </PropertyGroup>
 
+  <!-- Added to ensure telemetry events are triggered from AOT build -->
+  <PropertyGroup>
+    <EventSourceSupport>true</EventSourceSupport>
+  </PropertyGroup>
+
   <!-- For debugging purposes, uncomment this block to enable AOT builds -->
 	<!-- <PropertyGroup>
     <EnableCmdPalAOT>true</EnableCmdPalAOT>


### PR DESCRIPTION
This pull request makes a configuration change to the `Microsoft.CmdPal.UI.csproj` project file to improve telemetry support for AOT (Ahead-Of-Time) builds.

Project configuration:

* Added the `EventSourceSupport` property and set it to `true` to ensure telemetry events are triggered correctly when building with AOT.