### PR TITLE
Fix Common.Interop.UnitTests.TestSend infinite hang on CI

### DIFF
--- a/src/common/interop/interop-tests/InteropTests.cs
+++ b/src/common/interop/interop-tests/InteropTests.cs
@@ -13,8 +13,15 @@ namespace Microsoft.Interop.Tests
     [TestClass]
     public class InteropTests : IDisposable
     {
-        private const string ServerSidePipe = "\\\\.\\pipe\\serverside";
-        private const string ClientSidePipe = "\\\\.\\pipe\\clientside";
+        // Pipe names are machine-global, so two concurrent test runs on the same CI agent
+        // (or a leaked handle from a prior run) would deadlock if we used a shared constant.
+        // Suffix with process id + a GUID so every test run gets its own pair.
+        private const string PipePrefix = @"\\.\pipe\";
+        private static readonly string PipeSuffix = $"{Environment.ProcessId}_{Guid.NewGuid():N}";
+        private static readonly string ServerSidePipe = $"{PipePrefix}serverside_{PipeSuffix}";
+        private static readonly string ClientSidePipe = $"{PipePrefix}clientside_{PipeSuffix}";
+
+        private static readonly TimeSpan MessageWaitTimeout = TimeSpan.FromSeconds(30);
 
         internal TwoWayPipeMessageIPCManaged ClientPipe { get; set; }
 
@@ -54,7 +61,11 @@ namespace Microsoft.Interop.Tests
                     Thread.Sleep(100);
 
                     ClientPipe.Send(testString);
-                    reset.WaitOne();
+
+                    // Bounded wait so a broken pipe handshake fails the test quickly
+                    // instead of hanging the CI agent until the job-level timeout.
+                    var timeoutMessage = $"Pipe callback was not invoked within {MessageWaitTimeout.TotalSeconds}s. Server='{ServerSidePipe}' Client='{ClientSidePipe}'.";
+                    Assert.IsTrue(reset.WaitOne(MessageWaitTimeout), timeoutMessage);
 
                     serverPipe.End();
                 }


### PR DESCRIPTION
## Summary

Fixes an infinite hang in Common.Interop.UnitTests.TestSend that caused the x64 CI job to time out at 80 minutes on retried runs (originally observed on #47106, but the race is latent in any run that shares a CI agent with a previous run).

## Root cause

The test used two machine-global named pipes (\\.\pipe\serverside and \\.\pipe\clientside) as fixed constants, and waited for the pipe callback with an **unbounded** eset.WaitOne().

If a prior test run on the same CI agent left a pipe handle alive (e.g. after a job cancellation or a flaky cleanup), the next run's TwoWayPipeMessageIPCManaged handshake would silently never complete, and `WaitOne()` would block until the pipeline's job-level timeout (~80 minutes) killed the agent.

## Fix

Two small, orthogonal changes in `InteropTests.cs`:

1. **Unique pipe names per run** — suffix the pipe paths with `Environment.ProcessId` + a fresh `Guid`, so runs on the same agent can never collide.
2. **Bounded wait** — `reset.WaitOne(TimeSpan.FromSeconds(30))` wrapped in `Assert.IsTrue` with a diagnostic message identifying the pipes. A broken handshake now fails the test in 30 s with a clear error, instead of hanging the CI job.

The inner `Assert.AreEqual(testString, msg)` — the actual correctness check — is unchanged. On the happy path the callback fires in milliseconds and the test behaves identically to before.

## Verification

Built and ran locally with VS2026 MSBuild (x64 Release): `TestSend` passes in ~139 ms.

## Follow-up (not in this PR)

`TwoWayPipeMessageIPC.cpp` still relies on a `Thread.Sleep(100)` race workaround (comment in the test) for server-ready timing. A proper handshake there would let us drop the sleep; out of scope here.
