### PR TITLE
CmdPal: Fix CmdPal command bar not refreshing on back navigation

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml.cs
@@ -106,6 +106,9 @@ public sealed partial class ListPage : Page,
                         }
                     }
                 }
+
+                // Ensure the command bar refreshes with the restored page's commands.
+                PushSelectionToVm();
             });
         }
 


### PR DESCRIPTION
## Summary

Fixes #46810 — When navigating backward in CmdPal (Esc/Backspace), the bottom command bar retained stale commands from the previous page until the user changed selection.

## Root Cause

In `ListPage.xaml.cs` `OnNavigatedTo()`, the back-navigation path sets selection using `SuppressSelectionChangedScope()`, which prevents `Items_SelectionChanged` from firing. This means `PushSelectionToVm()` is never called, so `UpdateCommandBarMessage` is never sent to `CommandBarViewModel`, and the command bar displays stale state.

## Fix

Added `PushSelectionToVm()` after the selection restoration block inside the back-navigation dispatcher callback. This is safe because:
- `PushSelectionToVm()` is idempotent (guards with `ReferenceEquals(_lastPushedToVm, li)`)
- Handles both selected items (pushes to VM) and no selection (sends null)
- Triggers `UpdateCommandBarMessage` which refreshes the command bar

## Validation

### Manual Test Steps

| Scenario | Expected |
|----------|----------|
| **Esc navigation** — Navigate into nested page, press Esc | Bottom bar commands update immediately to parent page |
| **Backspace navigation** — Navigate into nested page, press Backspace | Bottom bar commands update immediately to parent page |
| **Forward navigation** — Navigate forward into a page | Commands update (no regression) |
| **Selection change** — Change selection on any page | Commands update (no regression) |
| **No flicker** — Navigate back and observe command bar | Single clean update, no double-fire |
| **Empty page** — Navigate back to page with no selectable items | Graceful handling, no crash |
