### PR TITLE
CmdPal: Fix fallback command disable toggle using interface type check

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelViewModel.cs
@@ -225,7 +225,7 @@ public sealed partial class TopLevelViewModel : ObservableObject, IListItem, IEx
         IsFallback = topLevelType == TopLevelType.Fallback;
         IsDockBand = topLevelType == TopLevelType.DockBand;
         ExtensionHost = extensionHost;
-        if (IsFallback && commandItem is FallbackCommandItem fallback)
+        if (IsFallback && commandItem is IFallbackCommandItem2 fallback)
         {
             _fallbackId = fallback.Id;
         }


### PR DESCRIPTION
## Summary

One-line fix for [#46928](https://github.com/microsoft/PowerToys/issues/46928) — unable to disable built-in and third-party extension fallback commands in Command Palette.

## Problem

In `TopLevelViewModel.cs`, the constructor checked:
```csharp
if (IsFallback && commandItem is FallbackCommandItem fallback)
```

This uses the **concrete toolkit class** `FallbackCommandItem`. However, extensions loaded out-of-process via WinRT/COM only expose **interface proxies** — they never match the concrete class. As a result, `_fallbackId` was never set, and the settings toggle to disable a fallback command had no effect.

## Fix

Changed the type check to use the `IFallbackCommandItem2` WinRT interface (which defines the `Id` property):

```csharp
if (IsFallback && commandItem is IFallbackCommandItem2 fallback)
```

The `IFallbackCommandItem2` interface is already defined in the Extensions IDL and implemented by `FallbackCommandItem` in the toolkit. This correctly matches both in-process and out-of-process extension objects.

## Validation

- [x] Build clean (`Microsoft.CmdPal.UI.ViewModels` — exit code 0)
- [x] No ABI or schema changes
- [x] Single file changed, single line modified

Fixes #46928