### PR TITLE
CmdPal: Add setting to hide app descriptions in All Apps

### DIFF
--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Apps.UnitTests/AllAppsPageTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Apps.UnitTests/AllAppsPageTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.CmdPal.Ext.Apps.Programs;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.CmdPal.Ext.Apps.UnitTests;
@@ -72,5 +73,63 @@ public class AllAppsPageTests : AppsTestBase
         // we need to loop the items to ensure we got the correct ones
         Assert.IsTrue(items.Any(i => i.Title == "Notepad"));
         Assert.IsTrue(items.Any(i => i.Title == "Calculator"));
+    }
+
+    [TestMethod]
+    public async Task AllAppsPage_GetItems_HidesSubtitlesWhenSettingEnabled()
+    {
+        // Arrange
+        var mockCache = new MockAppCache();
+        var win32App = TestDataHelper.CreateTestWin32Program("Notepad", "C:\\Windows\\System32\\notepad.exe");
+        mockCache.AddWin32Program(win32App);
+
+        try
+        {
+            AllAppsSettings.Instance.Settings.Update("{\"apps.HideAppDescriptions\": \"true\"}");
+
+            var page = new AllAppsPage(mockCache);
+            await Task.Delay(100);
+
+            // Act
+            var items = page.GetItems();
+
+            // Assert
+            Assert.AreEqual(1, items.Length);
+            var appItem = items.OfType<AppListItem>().Single();
+            Assert.AreEqual(string.Empty, appItem.Subtitle);
+        }
+        finally
+        {
+            AllAppsSettings.Instance.Settings.Update("{\"apps.HideAppDescriptions\": \"false\"}");
+        }
+    }
+
+    [TestMethod]
+    public async Task AllAppsPage_GetItems_ShowsSubtitlesWhenSettingDisabled()
+    {
+        // Arrange
+        var mockCache = new MockAppCache();
+        var win32App = TestDataHelper.CreateTestWin32Program("Notepad", "C:\\Windows\\System32\\notepad.exe");
+        mockCache.AddWin32Program(win32App);
+
+        try
+        {
+            AllAppsSettings.Instance.Settings.Update("{\"apps.HideAppDescriptions\": \"false\"}");
+
+            var page = new AllAppsPage(mockCache);
+            await Task.Delay(100);
+
+            // Act
+            var items = page.GetItems();
+
+            // Assert
+            Assert.AreEqual(1, items.Length);
+            var appItem = items.OfType<AppListItem>().Single();
+            Assert.IsFalse(string.IsNullOrEmpty(appItem.Subtitle));
+        }
+        finally
+        {
+            AllAppsSettings.Instance.Settings.Update("{\"apps.HideAppDescriptions\": \"false\"}");
+        }
     }
 }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/AllAppsPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/AllAppsPage.cs
@@ -98,6 +98,14 @@ public sealed partial class AllAppsPage : ListPage
 
         items.Sort((a, b) => string.Compare(a.Title, b.Title, StringComparison.Ordinal));
 
+        if (AllAppsSettings.Instance.HideAppDescriptions)
+        {
+            foreach (var item in items)
+            {
+                item.Subtitle = string.Empty;
+            }
+        }
+
         return [.. items];
     }
 }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/AllAppsSettings.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/AllAppsSettings.cs
@@ -66,6 +66,8 @@ public class AllAppsSettings : JsonSettingsManager, ISettingsInterface
 
     public bool IncludeNonAppsInStartMenu => _includeNonAppsInStartMenu.Value;
 
+    public bool HideAppDescriptions => _hideAppDescriptions.Value;
+
     private readonly ChoiceSetSetting _searchResultLimitSource = new(
         Namespaced(nameof(SearchResultLimit)),
         Resources.limit_fallback_results_source,
@@ -137,6 +139,12 @@ public class AllAppsSettings : JsonSettingsManager, ISettingsInterface
         string.Empty,
         true);
 
+    private readonly ToggleSetting _hideAppDescriptions = new(
+        Namespaced(nameof(HideAppDescriptions)),
+        Resources.hide_app_descriptions,
+        Resources.hide_app_descriptions_description,
+        false);
+
     public double MinScoreThreshold { get; set; } = 0.75;
 
     internal const char SuffixSeparator = ';';
@@ -160,6 +168,7 @@ public class AllAppsSettings : JsonSettingsManager, ISettingsInterface
         Settings.Add(_enableRegistrySource);
         Settings.Add(_enablePathEnvironmentVariableSource);
         Settings.Add(_searchResultLimitSource);
+        Settings.Add(_hideAppDescriptions);
 
         LoadSettings();
 

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Properties/Resources.Designer.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Properties/Resources.Designer.cs
@@ -142,6 +142,24 @@ namespace Microsoft.CmdPal.Ext.Apps.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Hide app description in search results.
+        /// </summary>
+        internal static string hide_app_descriptions {
+            get {
+                return ResourceManager.GetString("hide_app_descriptions", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Hide description text next to app results for a cleaner look.
+        /// </summary>
+        internal static string hide_app_descriptions_description {
+            get {
+                return ResourceManager.GetString("hide_app_descriptions_description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Also include non-app shortcuts from the Start menu.
         /// </summary>
         internal static string include_non_apps_in_start_menu {

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Properties/Resources.resx
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/Properties/Resources.resx
@@ -244,4 +244,10 @@
   <data name="include_non_apps_in_start_menu" xml:space="preserve">
     <value>Also include non-app shortcuts from the Start menu</value>
   </data>
+  <data name="hide_app_descriptions" xml:space="preserve">
+    <value>Hide app description in search results</value>
+  </data>
+  <data name="hide_app_descriptions_description" xml:space="preserve">
+    <value>Hide description text next to app results for a cleaner look</value>
+  </data>
 </root>


### PR DESCRIPTION
## Summary

Adds a **Hide app descriptions** toggle setting to the Command Palette All Apps extension. When enabled, the descriptive subtitle text next to app results is hidden for a cleaner look.

### Changes

| File | Change |
|------|--------|
| `AllAppsSettings.cs` | New `HideAppDescriptions` `ToggleSetting` (default: `false`), following the existing `EnableStartMenuSource` pattern |
| `AllAppsPage.cs` | Conditionally clears `Subtitle` on each `AppListItem` in `GetPrograms()` when setting is enabled |
| `Resources.resx` / `Resources.Designer.cs` | Resource strings for the setting label and description |
| `AllAppsPageTests.cs` | Two new tests verifying subtitle visibility with setting on/off |

### Validation

- [x] Build clean (exit code 0)
- [x] All 14 unit tests pass (including 2 new tests)
- [x] Setting defaults to `false` (preserves current behavior)
- [x] Empty subtitle renders gracefully (no placeholder shown)
- [x] No ABI breaks — all changes scoped to All Apps extension

Closes #46634