### PR TITLE
fix: default 8 modules to disabled to match EnabledModules.cs

### DIFF
--- a/src/modules/AdvancedPaste/AdvancedPasteModuleInterface/dllmain.cpp
+++ b/src/modules/AdvancedPaste/AdvancedPasteModuleInterface/dllmain.cpp
@@ -910,6 +910,12 @@ public:
         return powertoys_gpo::getConfiguredAdvancedPasteEnabledValue();
     }
 
+    // Returns whether the PowerToys should be enabled by default
+    virtual bool is_enabled_by_default() const override
+    {
+        return false;
+    }
+
     virtual bool get_config(wchar_t* buffer, int* buffer_size) override
     {
         HINSTANCE hinstance = reinterpret_cast<HINSTANCE>(&__ImageBase);

--- a/src/modules/CropAndLock/CropAndLockModuleInterface/dllmain.cpp
+++ b/src/modules/CropAndLock/CropAndLockModuleInterface/dllmain.cpp
@@ -75,6 +75,12 @@ public:
         return powertoys_gpo::getConfiguredCropAndLockEnabledValue();
     }
 
+    // Returns whether the PowerToys should be enabled by default
+    virtual bool is_enabled_by_default() const override
+    {
+        return false;
+    }
+
     // Return JSON with the configuration options.
     // These are the settings shown on the settings page along with their current values.
     virtual bool get_config(wchar_t* buffer, int* buffer_size) override

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesModuleInterface/dllmain.cpp
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesModuleInterface/dllmain.cpp
@@ -226,6 +226,12 @@ public:
         return powertoys_gpo::getConfiguredEnvironmentVariablesEnabledValue();
     }
 
+    // Returns whether the PowerToys should be enabled by default
+    virtual bool is_enabled_by_default() const override
+    {
+        return false;
+    }
+
     virtual bool get_config(wchar_t* /*buffer*/, int* /*buffer_size*/) override
     {
         return false;

--- a/src/modules/Hosts/HostsModuleInterface/dllmain.cpp
+++ b/src/modules/Hosts/HostsModuleInterface/dllmain.cpp
@@ -243,6 +243,12 @@ public:
         return powertoys_gpo::getConfiguredHostsFileEditorEnabledValue();
     }
 
+    // Returns whether the PowerToys should be enabled by default
+    virtual bool is_enabled_by_default() const override
+    {
+        return false;
+    }
+
     virtual bool get_config(wchar_t* /*buffer*/, int* /*buffer_size*/) override
     {
         return false;

--- a/src/modules/Workspaces/WorkspacesModuleInterface/dllmain.cpp
+++ b/src/modules/Workspaces/WorkspacesModuleInterface/dllmain.cpp
@@ -92,6 +92,12 @@ public:
         return powertoys_gpo::getConfiguredWorkspacesEnabledValue();
     }
 
+    // Returns whether the PowerToys should be enabled by default
+    virtual bool is_enabled_by_default() const override
+    {
+        return false;
+    }
+
     // Return JSON with the configuration options.
     // These are the settings shown on the settings page along with their current values.
     virtual bool get_config(_Out_ PWSTR buffer, _Out_ int* buffer_size) override

--- a/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
+++ b/src/modules/launcher/Microsoft.Launcher/dllmain.cpp
@@ -156,6 +156,12 @@ public:
         return powertoys_gpo::getConfiguredPowerLauncherEnabledValue();
     }
 
+    // Returns whether the PowerToys should be enabled by default
+    virtual bool is_enabled_by_default() const override
+    {
+        return false;
+    }
+
     // Return JSON with the configuration options.
     virtual bool get_config(wchar_t* buffer, int* buffer_size) override
     {

--- a/src/modules/powerdisplay/PowerDisplayModuleInterface/dllmain.cpp
+++ b/src/modules/powerdisplay/PowerDisplayModuleInterface/dllmain.cpp
@@ -262,6 +262,12 @@ public:
         return powertoys_gpo::getConfiguredPowerDisplayEnabledValue();
     }
 
+    // Returns whether the PowerToys should be enabled by default
+    virtual bool is_enabled_by_default() const override
+    {
+        return false;
+    }
+
     virtual bool get_config(wchar_t* buffer, int* buffer_size) override
     {
         HINSTANCE hinstance = reinterpret_cast<HINSTANCE>(&__ImageBase);

--- a/src/modules/registrypreview/RegistryPreviewExt/dllmain.cpp
+++ b/src/modules/registrypreview/RegistryPreviewExt/dllmain.cpp
@@ -199,6 +199,12 @@ public:
         return powertoys_gpo::getConfiguredRegistryPreviewEnabledValue();
     }
 
+    // Returns whether the PowerToys should be enabled by default
+    virtual bool is_enabled_by_default() const override
+    {
+        return false;
+    }
+
     // Return JSON with the configuration options.
     virtual bool get_config(wchar_t* buffer, int* buffer_size) override
     {


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Fixes a mismatch where 8 modules inherited the default `is_enabled_by_default() = true` from `PowertoyModuleIface` while `EnabledModules.cs` declared them `false`. On a clean install the Runner would enable these modules on first launch, then Settings UI would flip them back off once it persisted `settings.json` — a one-time visible flicker and a DSC compliance gap.

Adds an explicit `is_enabled_by_default() const override { return false; }` in the following module interfaces so both sides of the default agree:

- `src/modules/launcher/Microsoft.Launcher/dllmain.cpp` (PowerToys Run)
- `src/modules/CropAndLock/CropAndLockModuleInterface/dllmain.cpp`
- `src/modules/AdvancedPaste/AdvancedPasteModuleInterface/dllmain.cpp`
- `src/modules/Hosts/HostsModuleInterface/dllmain.cpp`
- `src/modules/registrypreview/RegistryPreviewExt/dllmain.cpp`
- `src/modules/EnvironmentVariables/EnvironmentVariablesModuleInterface/dllmain.cpp`
- `src/modules/Workspaces/WorkspacesModuleInterface/dllmain.cpp`
- `src/modules/powerdisplay/PowerDisplayModuleInterface/dllmain.cpp`

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] Closes: #xxx
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

