### PR TITLE
fix(cmdpal): refresh dock settings on pin/unpin (#47155)

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Dock/DockViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Dock/DockViewModel.cs
@@ -61,6 +61,11 @@ public sealed partial class DockViewModel
         }
 
         Logger.LogDebug("Starting DockBands_CollectionChanged");
+
+        // Refresh settings so newly pinned/unpinned bands are visible.
+        // Pin/unpin operations save with hotReload:false (to avoid
+        // double-updates), so _settings can be stale here.
+        _settings = _settingsService.Settings.DockSettings;
         SetupBands();
         Logger.LogDebug("Ended DockBands_CollectionChanged");
     }


### PR DESCRIPTION
## Summary of the Pull Request

Fixes the CmdPal Dock not refreshing when a command is pinned or unpinned. The dock now immediately reflects pin/unpin changes without requiring a CmdPal restart.

**Root cause:** `DockViewModel._settings` was cached at construction and only refreshed via the `SettingsChanged` event. However, pin/unpin operations in `CommandProviderWrapper.PinDockBand()` / `UnpinDockBand()` intentionally save with `hotReload: false` (to avoid double-updates), so `SettingsChanged` never fires. When `DockBands_CollectionChanged` called `SetupBands()`, it iterated over the stale `_settings` which didn't include the newly pinned band.

**Fix:** Re-read `DockSettings` from the settings service at the top of `DockBands_CollectionChanged`, ensuring `SetupBands()` always sees the latest persisted state.

## PR Checklist

- [x] Closes: #47155
- [x] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [x] **Localization:** All end-user-facing strings can be localized — N/A (no UI string changes)
- [ ] **Dev docs:** Added/updated — N/A (no public API or behavior doc changes)

## Detailed Description of the Pull Request / Additional comments

Single-line change in `src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Dock/DockViewModel.cs`:

```csharp
_settings = _settingsService.Settings.DockSettings;
```

Added before the existing `SetupBands()` call inside `DockBands_CollectionChanged`. The edit-mode guard (`_isEditing`) is already checked earlier in the method, so drag/drop operations are unaffected.

This fix covers both pin and unpin flows since both use the same `hotReload: false` → `CommandsChanged` → `DockBands_CollectionChanged` code path.

## Validation Steps Performed

- Built `Microsoft.CmdPal.UI.ViewModels.csproj` — exit code 0, no warnings related to change
- Verified unpin flow uses the same code path and benefits from the fix
- Manual verification: pin a command via CmdPal → dock updates immediately without restart
