### PR TITLE
[Settings] Make GrabAndMove strings modifier-agnostic

### DIFF
--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -5975,7 +5975,7 @@ Text uses the current drawing color.</value>
     <comment>The Alt key on the keyboard</comment>
   </data>
   <data name="GrabAndMove_ModifierKey_Win.Content" xml:space="preserve">
-    <value>Win</value>
+    <value>Windows key</value>
     <comment>The Windows key on the keyboard</comment>
   </data>
   <data name="GrabAndMove_ShouldAbsorbAlt.Header" xml:space="preserve">

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -5928,7 +5928,7 @@ Text uses the current drawing color.</value>
     <value>Sample</value>
   </data>
   <data name="GrabAndMove.ModuleDescription" xml:space="preserve">
-    <value>Move and resize windows with Alt+Drag. Left-click to move, right-click to resize.</value>
+    <value>Move and resize windows by holding a modifier key and dragging. Left-click to move, right-click to resize.</value>
     <comment>"Grab And Move" is the name of the utility</comment>
   </data>
   <data name="GrabAndMove.ModuleTitle" xml:space="preserve">
@@ -5956,7 +5956,7 @@ Text uses the current drawing color.</value>
     <comment>"Grab And Move" is the name of the utility</comment>
   </data>
   <data name="Oobe_GrabAndMove_HowToUse.Text" xml:space="preserve">
-    <value>Hold **Alt** and **left-click drag** anywhere inside a window to move it. Hold **Alt** and **right-click drag** to resize it from the nearest edge or corner.</value>
+    <value>Hold the **activation modifier key** and **left-click drag** anywhere inside a window to move it. Hold the **activation modifier key** and **right-click drag** to resize it from the nearest edge or corner.</value>
     <comment>"Grab And Move" is the name of the utility</comment>
   </data>
   <data name="Oobe_GrabAndMove_TipsAndTricks.Text" xml:space="preserve">
@@ -5997,17 +5997,17 @@ Text uses the current drawing color.</value>
     <value>Display the window position and size on the overlay during drag and resize operations</value>
   </data>
   <data name="GrabAndMove_UseAltResize.Header" xml:space="preserve">
-    <value>Enable Alt + Right-click to resize</value>
-    <comment>When enabled, holding Alt and right-clicking allows resizing windows by dragging from the closest edge or corner.</comment>
+    <value>Enable modifier + right-click to resize</value>
+    <comment>When enabled, holding the activation modifier key and right-clicking allows resizing windows by dragging from the closest edge or corner.</comment>
   </data>
   <data name="GrabAndMove_UseAltResize.Description" xml:space="preserve">
-    <value>Hold Alt and right-click to resize a window by dragging from the nearest edge or corner</value>
+    <value>Hold the activation modifier key and right-click to resize a window by dragging from the nearest edge or corner</value>
   </data>
   <data name="GrabAndMove_ExcludeApps.Header" xml:space="preserve">
     <value>Excluded apps</value>
   </data>
   <data name="GrabAndMove_ExcludeApps.Description" xml:space="preserve">
-    <value>Excludes an application from being moved or resized with Alt+Drag - add one application name per line</value>
+    <value>Excludes an application from being moved or resized by Grab And Move - add one application name per line</value>
   </data>
   <data name="GrabAndMove_ExcludeApps_TextBoxControl.PlaceholderText" xml:space="preserve">
     <value>Example: outlook.exe</value>


### PR DESCRIPTION
## Summary of the Pull Request

[PR #47052](https://github.com/microsoft/PowerToys/pull/47052) introduced a **Win** option alongside **Alt** for the GrabAndMove activation modifier (`GrabAndMove_ModifierKey` dropdown, `Alt` / `Win`). However several user-facing strings in Settings still hardcode `Alt`, which now misrepresents the feature when a user has selected `Win` as the modifier.

This PR updates the wording of those strings to be modifier-agnostic.

### Strings changed (en-us)

| Key | Before | After |
|---|---|---|
| `GrabAndMove.ModuleDescription` | Move and resize windows with **Alt+Drag**. Left-click to move, right-click to resize. | Move and resize windows by holding **a modifier key** and dragging. Left-click to move, right-click to resize. |
| `Oobe_GrabAndMove_HowToUse.Text` | Hold **Alt** and left-click drag... Hold **Alt** and right-click drag... | Hold the **activation modifier key** and left-click drag... Hold the **activation modifier key** and right-click drag... |
| `GrabAndMove_UseAltResize.Header` | Enable **Alt + Right-click** to resize | Enable **modifier + right-click** to resize |
| `GrabAndMove_UseAltResize.Description` | Hold **Alt** and right-click to resize... | Hold the **activation modifier key** and right-click to resize... |
| `GrabAndMove_ExcludeApps.Description` | Excludes an application from being moved or resized **with Alt+Drag** - add one application name per line | Excludes an application from being moved or resized **by Grab And Move** - add one application name per line |

`GrabAndMove_ShouldAbsorbAlt` strings are intentionally left unchanged ΓÇö that toggle is genuinely Alt-specific (it suppresses the window-menu activation triggered by Alt).

## PR Checklist

- [x] **Closes:** follow-up to #47052
- [x] **Communication:** no additional comms needed
- [x] **Tests:** N/A (en-us resource strings only)
- [x] **Manual Tests:** Launched Settings UI, verified the GrabAndMove page renders the new strings correctly (module description, `Enable modifier + right-click` toggle header/description, excluded-apps description). Verified OOBE `How to use` text renders with the updated phrasing.
- [x] **Localization:** Only `en-us/Resources.resw` updated; other locales will pick up the new English strings via the standard localization pipeline.
- [x] **No dev docs required**

## Detailed Description of the Pull Request / Additional comments

- Scope is deliberately kept to wording only ΓÇö no logic, IPC, or XAML bindings touched. Resource keys are preserved, so nothing else needs to change.
- CC @GordonLamMSFT as the GrabAndMove / #47052 author.
