### PR TITLE
[CmdPal] Rename DockSettings.DockSize to BandSize for safe upgrade

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Settings/DockSettings.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Settings/DockSettings.cs
@@ -18,7 +18,7 @@ public record DockSettings
 {
     public DockSide Side { get; init; } = DockSide.Top;
 
-    public DockSize DockSize { get; init; } = DockSize.Default;
+    public DockSize BandSize { get; init; } = DockSize.Default;
 
     public bool AlwaysOnTop { get; set; } = true;
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsViewModel.cs
@@ -201,10 +201,10 @@ public partial class SettingsViewModel : INotifyPropertyChanged
 
     public DockSize Dock_DockSize
     {
-        get => _settingsService.Settings.DockSettings.DockSize;
+        get => _settingsService.Settings.DockSettings.BandSize;
         set
         {
-            _settingsService.UpdateSettings(s => s with { DockSettings = s.DockSettings with { DockSize = value } });
+            _settingsService.UpdateSettings(s => s with { DockSettings = s.DockSettings with { BandSize = value } });
         }
     }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockControl.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockControl.xaml.cs
@@ -245,7 +245,7 @@ public sealed partial class DockControl : UserControl, IRecipient<CloseContextMe
 
         // Compact mode is only supported for Top/Bottom positions
         var isHorizontal = settings.Side == DockSide.Top || settings.Side == DockSide.Bottom;
-        var effectiveSize = isHorizontal ? settings.DockSize : DockSize.Default;
+        var effectiveSize = isHorizontal ? settings.BandSize : DockSize.Default;
         DockSize = effectiveSize;
 
         ItemsOrientation = isHorizontal ? Orientation.Horizontal : Orientation.Vertical;

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockWindow.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockWindow.xaml.cs
@@ -449,7 +449,7 @@ public sealed partial class DockWindow : WindowEx,
     private static DockSize EffectiveDockSize(DockSettings settings)
     {
         var isHorizontal = settings.Side == DockSide.Top || settings.Side == DockSide.Bottom;
-        return isHorizontal ? settings.DockSize : DockSize.Default;
+        return isHorizontal ? settings.BandSize : DockSize.Default;
     }
 
     private void UpdateAppBarDataForEdge(DockSide side, DockSize size, double scaleFactor)


### PR DESCRIPTION
### ⚠️ REVIEWERS TO DECIDE. MERGE THIS PR OR GO FOR: #47212 ⚠️

## Summary

The Compact Mode PR (#46699) replaced the `DockSize` enum (`Small`/`Medium`/`Large`) with a new one (`Default`/`Compact`). Users who upgrade from an earlier build have a legacy `"DockSize": "Small"` value in `settings.json` that the source-generated `EnumConverter` cannot parse, which causes the entire settings file to fail loading:

```
PersistenceService.cs::Load::46
Failed to load settings from ...\settings.json:
System.Text.Json.JsonException: The JSON value could not be converted to
Microsoft.CmdPal.UI.ViewModels.Settings.DockSettings. Path: $.DockSettings.DockSize
```

## Fix

Rename the persisted property `DockSettings.DockSize` -> `DockSettings.BandSize`.

The old `DockSize` key becomes an unknown property (silently ignored by `System.Text.Json`), and the new `BandSize` property starts at its default (`DockSize.Default`), preserving the user's existing visual experience after upgrading. On the next save, the stale key is dropped.

## Files changed

- `Microsoft.CmdPal.UI.ViewModels/Settings/DockSettings.cs` - rename property
- `Microsoft.CmdPal.UI.ViewModels/SettingsViewModel.cs` - update `Dock_DockSize` getter/setter
- `Microsoft.CmdPal.UI/Dock/DockControl.xaml.cs` - read `settings.BandSize`
- `Microsoft.CmdPal.UI/Dock/DockWindow.xaml.cs` - read `settings.BandSize`

The `DockControl.DockSize` DependencyProperty and `DockItemControl` references are intentionally left alone -- they're runtime/XAML bindings, not persisted.
