### PR TITLE
CmdPal: Fix NullReferenceException on startup loading built-in providers

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -1224,6 +1224,7 @@ NPH
 npmjs
 NPU
 NResize
+NREs
 NTAPI
 ntdll
 ntfs

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandProviderWrapper.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandProviderWrapper.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Immutable;
 using ManagedCommon;
 using Microsoft.CmdPal.Common.Services;
 using Microsoft.CmdPal.UI.ViewModels.Models;
@@ -127,7 +128,8 @@ public sealed class CommandProviderWrapper : ICommandProviderContext
 
     private ProviderSettings GetProviderSettings(SettingsModel settings)
     {
-        if (!settings.ProviderSettings.TryGetValue(ProviderId, out var ps))
+        var providerSettings = settings.ProviderSettings;
+        if (providerSettings is null || !providerSettings.TryGetValue(ProviderId, out var ps))
         {
             ps = new ProviderSettings();
         }
@@ -151,7 +153,8 @@ public sealed class CommandProviderWrapper : ICommandProviderContext
         settingsService.UpdateSettings(
             s =>
             {
-                if (!s.ProviderSettings.TryGetValue(ProviderId, out var ps))
+                var providerSettings = s.ProviderSettings ?? ImmutableDictionary<string, ProviderSettings>.Empty;
+                if (!providerSettings.TryGetValue(ProviderId, out var ps))
                 {
                     ps = new ProviderSettings();
                 }
@@ -160,7 +163,7 @@ public sealed class CommandProviderWrapper : ICommandProviderContext
 
                 return s with
                 {
-                    ProviderSettings = s.ProviderSettings.SetItem(ProviderId, newPs),
+                    ProviderSettings = providerSettings.SetItem(ProviderId, newPs),
                 };
             },
             hotReload: false);
@@ -238,7 +241,11 @@ public sealed class CommandProviderWrapper : ICommandProviderContext
         }
         catch (Exception e)
         {
-            Logger.LogError($"Failed to load commands from extension {Extension!.PackageFamilyName}", e);
+            // Note: Extension is null for in-proc built-in providers, so this
+            // log line MUST stay null-safe. Otherwise the catch itself NREs and
+            // takes down LoadBuiltinsAsync / shell startup.
+            var providerLabel = Extension?.PackageFamilyName ?? ProviderId;
+            Logger.LogError($"Failed to load commands from {providerLabel}", e);
 
             if (!displayInfoInitialized)
             {
@@ -320,7 +327,11 @@ public sealed class CommandProviderWrapper : ICommandProviderContext
             }
         }
 
-        var dockSettings = settings.DockSettings;
+        // DockSettings can be null when loading a settings.json that was
+        // produced by a CmdPal version older than the dock-settings change
+        // (e.g. an in-place upgrade from 0.97.x). Fall back to defaults so
+        // built-in providers can still load instead of NRE-ing on startup.
+        var dockSettings = settings.DockSettings ?? new DockSettings();
         var allPinnedCommands = dockSettings.AllPinnedCommands;
         var pinnedBandsForThisProvider = allPinnedCommands.Where(c => c.ProviderId == ProviderId);
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandProviderWrapper.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandProviderWrapper.cs
@@ -153,8 +153,8 @@ public sealed class CommandProviderWrapper : ICommandProviderContext
         settingsService.UpdateSettings(
             s =>
             {
-                var providerSettings = s.ProviderSettings ?? ImmutableDictionary<string, ProviderSettings>.Empty;
-                if (!providerSettings.TryGetValue(ProviderId, out var ps))
+                var allProviderSettings = s.ProviderSettings ?? ImmutableDictionary<string, ProviderSettings>.Empty;
+                if (!allProviderSettings.TryGetValue(ProviderId, out var ps))
                 {
                     ps = new ProviderSettings();
                 }
@@ -163,7 +163,7 @@ public sealed class CommandProviderWrapper : ICommandProviderContext
 
                 return s with
                 {
-                    ProviderSettings = providerSettings.SetItem(ProviderId, newPs),
+                    ProviderSettings = allProviderSettings.SetItem(ProviderId, newPs),
                 };
             },
             hotReload: false);
@@ -242,8 +242,8 @@ public sealed class CommandProviderWrapper : ICommandProviderContext
         catch (Exception e)
         {
             // Note: Extension is null for in-proc built-in providers, so this
-            // log line MUST stay null-safe. Otherwise the catch itself NREs and
-            // takes down LoadBuiltinsAsync / shell startup.
+            // log line MUST stay null-safe; otherwise the catch itself NREs
+            // and takes down LoadBuiltinsAsync / shell startup.
             var providerLabel = Extension?.PackageFamilyName ?? ProviderId;
             Logger.LogError($"Failed to load commands from {providerLabel}", e);
 


### PR DESCRIPTION
## Summary
Fix a `NullReferenceException` on Command Palette startup that prevents the shell from loading any built-in providers.

Closes: #47249

## Symptoms
On startup CmdPal crashes with:
```
System.NullReferenceException
   at Microsoft.CmdPal.UI.ViewModels.CommandProviderWrapper.LoadTopLevelCommands+0xa36
   at TopLevelCommandManager.LoadTopLevelCommandsFromProvider+0x5e
   at TopLevelCommandManager.LoadBuiltinsAsync+0x19c
   at PowerToysRootPageService.PreLoadAsync+0x51
   at ShellViewModel.LoadAsync+0x55
```
Reproduced on a user bug report (CmdPal v0.99.0.0, Windows 10.0.26100, de-DE) where every startup attempt produces an `CmdPal_ErrorReport_*.log` with this stack and no commands ever appear.

## Root cause
`CommandProviderWrapper.LoadTopLevelCommands` had a `catch` handler that dereferenced `Extension!.PackageFamilyName`:
```csharp
catch (Exception e)
{
    Logger.LogError($"Failed to load commands from extension {Extension!.PackageFamilyName}", e);
    ...
}
```
But `Extension` is **null** for built-in providers, which use the in-proc `(ICommandProvider, TaskScheduler)` constructor that never assigns it. `LoadBuiltinsAsync` only ever calls this for built-ins. So whenever any exception was thrown inside the try block:
1. The catch fires.
2. `Extension!.PackageFamilyName` itself NREs.
3. That second NRE escapes the catch, masks the original exception, and aborts the entire builtin load (and shell startup).

### Why it started firing now
Two changes from #46451 ("CmdPal: Make settings and app state immutable", commit `4337f8e5ff`) made it easy to throw inside the try block on a stale `settings.json`:
- A new `settingsService.UpdateSettings(...)` lambda was added at the very top of `LoadTopLevelCommands` (before `displayInfoInitialized` can be set). Its body calls `s.ProviderSettings.TryGetValue(...)`.
- `SettingsModel.ProviderSettings` and `SettingsModel.DockSettings` became init-only `ImmutableDictionary` / record properties. The `= ImmutableDictionary<...>.Empty` / `= new()` defaults are silently **overridden by null** when an older `settings.json` (from before these properties existed, or from a prior schema) is deserialized via `System.Text.Json`. That null then NREs at `s.ProviderSettings.TryGetValue` or `settings.DockSettings.AllPinnedCommands` (line 324 in `InitializeCommands`).

Either of those NREs alone would have been logged and recovered from. Together with the buggy catch handler, they take down startup.

`DockSettings` itself was added by #45824 ("CmdPal: Add a dock"), so users who upgrade in-place from a CmdPal version older than that (e.g. 0.97.x → 0.99.0, as in the bug report) are the most likely to hit this.

## Fix
Three surgical changes in `src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandProviderWrapper.cs`:

1. **Null-safe catch handler** — log `Extension?.PackageFamilyName ?? ProviderId` so the real exception is recorded for built-in providers instead of being shadowed by a second NRE.
2. **Defensive `ProviderSettings` access** — coalesce against `ImmutableDictionary<string, ProviderSettings>.Empty` in `GetProviderSettings` and in the new `UpdateSettings` lambda introduced by #46451.
3. **Defensive `DockSettings` access** — coalesce against `new DockSettings()` in `InitializeCommands` so a stale `settings.json` cannot NRE the dock-band lookup.

A companion PR will apply the same defensive coalesce in `ThemeService.Reload()`, which exhibits the same `NullReferenceException` pattern at startup ("Failed to initialize ThemeService") for the same root cause.

## Validation
- Built `Microsoft.CmdPal.UI.ViewModels` (x64/Debug) successfully.
- No behavior change for healthy settings; only adds null guards on the exact members that can come back null after JSON deserialization, and stops the catch handler from masking the real exception.

## Out of scope
- Repairing or migrating bad on-disk `settings.json` (separate concern; addressed by the defensive defaults above).
- Issue #47145 — search-time native crash (different bug, different stack).

## Related
- Regression source: PR #46451 (commit `4337f8e5ff`, "CmdPal: Make settings and app state immutable").
- Contributing factor: PR #45824 ("CmdPal: Add a dock") introduced the `DockSettings` property.
