### PR TITLE
CmdPal: Guard against null DockSettings in ThemeService.Reload

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Services/ThemeService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Services/ThemeService.cs
@@ -149,8 +149,10 @@ internal sealed partial class ThemeService : IThemeService, IDisposable
         // Atomic swap
         Interlocked.Exchange(ref _currentState, newState);
 
-        // Compute DockThemeSnapshot from DockSettings
-        var dockSettings = _settingsService.Settings.DockSettings;
+        // Compute DockThemeSnapshot from DockSettings. Defend against a null
+        // DockSettings on a settings.json that predates the dock-settings
+        // change — otherwise Initialize() throws here on first activation.
+        var dockSettings = _settingsService.Settings.DockSettings ?? new DockSettings();
         var dockIntensity = Math.Clamp(dockSettings.CustomThemeColorIntensity, 0, 100);
         IThemeProvider dockProvider = dockIntensity > 0 && dockSettings.ColorizationMode is ColorizationMode.CustomColor or ColorizationMode.WindowsAccentColor or ColorizationMode.Image
                 ? _colorfulThemeProvider


### PR DESCRIPTION
## Summary
Defensive fix for a `NullReferenceException` thrown on Command Palette startup during `ThemeService.Initialize()`.

## Symptoms
On first window activation, the log shows:
```
[Error] MainWindow.xaml.cs::MainWindow_Activated::1003
    Failed to initialize ThemeService
System.NullReferenceException
   at Microsoft.CmdPal.UI.Services.ThemeService.Reload() + 0x364
   at Microsoft.CmdPal.UI.MainWindow.MainWindow_Activated + 0x3c
```
This NRE is currently swallowed by `MainWindow_Activated`, so it does not crash the app on its own — but it does mean theme initialization is skipped on every startup for affected users (observed in a CmdPal v0.99.0.0 / Windows 10.0.26100 / de-DE bug report). It also shares the root cause with the fatal builtin-load NRE addressed in the companion PR #47251.

## Root cause
`ThemeService.Reload()` reads `_settingsService.Settings.DockSettings.X` to compute the dock theme snapshot. `SettingsModel.DockSettings` is an init-only property on a record:
```csharp
public DockSettings DockSettings { get; init; } = new();
```
When `System.Text.Json` deserializes a `settings.json` that contains `"DockSettings": null` (or that was produced by a CmdPal version older than the dock-settings change in #45824 and then re-serialized through an intermediate path), the `= new()` default initializer is **silently overridden by null**. The first `dockSettings.X` access in `Reload()` then NREs.

### Why it started firing now
- PR #45824 ("CmdPal: Add a dock") introduced the `DockSettings` property on `SettingsModel`.
- PR #46451 (commit `4337f8e5ff`, "CmdPal: Make settings and app state immutable") converted `SettingsModel` to an immutable record with init-only properties; this is the form where the deserializer-overrides-default-with-null pitfall applies.

Users upgrading in-place from a CmdPal version older than #45824 (e.g. 0.97.x → 0.99.0) are the most likely to hit this.

## Fix
Coalesce `_settingsService.Settings.DockSettings` against `new DockSettings()` in `Reload()`. Adds a brief comment explaining why.

```csharp
// Compute DockThemeSnapshot from DockSettings. Defend against a null
// DockSettings on a settings.json that predates the dock-settings
// change — otherwise Initialize() throws here on first activation.
var dockSettings = _settingsService.Settings.DockSettings ?? new DockSettings();
```

## Validation
- One-line defensive null-coalesce; behavior is unchanged when `DockSettings` is non-null (the common, healthy case).
- Same defensive pattern applied to `CommandProviderWrapper.InitializeCommands` in the companion PR #47251.

## Related
- Companion PR: #47251 ("CmdPal: Fix NullReferenceException on startup loading built-in providers") — fixes the fatal startup crash that shares this root cause.
- Regression source: PR #46451 (commit `4337f8e5ff`).
- Contributing factor: PR #45824 (introduced `DockSettings`).
