### PR TITLE
cmdpal: fix our settings load crash

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AppStateModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AppStateModel.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
+using System.Text.Json.Serialization;
 
 namespace Microsoft.CmdPal.UI.ViewModels;
 
@@ -11,9 +12,21 @@ public record AppStateModel
     ///////////////////////////////////////////////////////////////////////////
     // STATE HERE
     // Make sure that any new types you add are added to JsonSerializationContext!
-    public RecentCommandsManager RecentCommands { get; init; } = new();
+    private RecentCommandsManager? _recentCommands = new();
 
-    public ImmutableList<string> RunHistory { get; init; } = ImmutableList<string>.Empty;
+    public RecentCommandsManager RecentCommands
+    {
+        get => _recentCommands ?? new();
+        init => _recentCommands = value;
+    }
+
+    private ImmutableList<string>? _runHistory = ImmutableList<string>.Empty;
+
+    public ImmutableList<string> RunHistory
+    {
+        get => _runHistory ?? ImmutableList<string>.Empty;
+        init => _runHistory = value;
+    }
 
     // END SETTINGS
     ///////////////////////////////////////////////////////////////////////////

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandProviderWrapper.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandProviderWrapper.cs
@@ -400,11 +400,6 @@ public sealed class CommandProviderWrapper : ICommandProviderContext
 
     private ICommandItem[] LoadPinnedCommands(ICommandProvider4 model, ProviderSettings providerSettings)
     {
-        if (providerSettings is null || providerSettings.PinnedCommandIds is null)
-        {
-            return [];
-        }
-
         var pinnedItems = new List<ICommandItem>();
 
         foreach (var pinnedId in providerSettings.PinnedCommandIds)
@@ -448,7 +443,7 @@ public sealed class CommandProviderWrapper : ICommandProviderContext
         var settingsService = serviceProvider.GetRequiredService<ISettingsService>();
         var providerSettings = GetProviderSettings(settingsService.Settings);
 
-        if (providerSettings.PinnedCommandIds is null || !providerSettings.PinnedCommandIds.Contains(commandId))
+        if (!providerSettings.PinnedCommandIds.Contains(commandId))
         {
             settingsService.UpdateSettings(
                 s =>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandProviderWrapper.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandProviderWrapper.cs
@@ -400,6 +400,11 @@ public sealed class CommandProviderWrapper : ICommandProviderContext
 
     private ICommandItem[] LoadPinnedCommands(ICommandProvider4 model, ProviderSettings providerSettings)
     {
+        if (providerSettings is null || providerSettings.PinnedCommandIds is null)
+        {
+            return [];
+        }
+
         var pinnedItems = new List<ICommandItem>();
 
         foreach (var pinnedId in providerSettings.PinnedCommandIds)
@@ -443,7 +448,7 @@ public sealed class CommandProviderWrapper : ICommandProviderContext
         var settingsService = serviceProvider.GetRequiredService<ISettingsService>();
         var providerSettings = GetProviderSettings(settingsService.Settings);
 
-        if (!providerSettings.PinnedCommandIds.Contains(commandId))
+        if (providerSettings.PinnedCommandIds is null || !providerSettings.PinnedCommandIds.Contains(commandId))
         {
             settingsService.UpdateSettings(
                 s =>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ProviderSettings.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ProviderSettings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation
+// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -18,11 +18,23 @@ public record ProviderSettings
 
     public bool IsEnabled { get; init; } = true;
 
-    public ImmutableDictionary<string, FallbackSettings> FallbackCommands { get; init; }
+    private ImmutableDictionary<string, FallbackSettings>? _fallbackCommands
         = ImmutableDictionary<string, FallbackSettings>.Empty;
 
-    public ImmutableList<string> PinnedCommandIds { get; init; }
+    public ImmutableDictionary<string, FallbackSettings> FallbackCommands
+    {
+        get => _fallbackCommands ?? ImmutableDictionary<string, FallbackSettings>.Empty;
+        init => _fallbackCommands = value;
+    }
+
+    private ImmutableList<string>? _pinnedCommandIds
         = ImmutableList<string>.Empty;
+
+    public ImmutableList<string> PinnedCommandIds
+    {
+        get => _pinnedCommandIds ?? ImmutableList<string>.Empty;
+        init => _pinnedCommandIds = value;
+    }
 
     [JsonIgnore]
     public string ProviderId { get; init; } = string.Empty;
@@ -37,7 +49,6 @@ public record ProviderSettings
     {
     }
 
-    [JsonConstructor]
     public ProviderSettings(bool isEnabled)
     {
         IsEnabled = isEnabled;

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/RecentCommandsManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/RecentCommandsManager.cs
@@ -1,16 +1,20 @@
-﻿// Copyright (c) Microsoft Corporation
+// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
-using System.Text.Json.Serialization;
 
 namespace Microsoft.CmdPal.UI.ViewModels;
 
 public record RecentCommandsManager : IRecentCommandsManager
 {
-    [JsonInclude]
-    internal ImmutableList<HistoryItem> History { get; init; } = ImmutableList<HistoryItem>.Empty;
+    private ImmutableList<HistoryItem>? _history = ImmutableList<HistoryItem>.Empty;
+
+    internal ImmutableList<HistoryItem> History
+    {
+        get => _history ?? ImmutableList<HistoryItem>.Empty;
+        init => _history = value;
+    }
 
     public RecentCommandsManager()
     {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Settings/DockSettings.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Settings/DockSettings.cs
@@ -45,7 +45,7 @@ public record DockSettings
     public string? BackgroundImagePath { get; init; }
 
     // </Theme settings>
-    public ImmutableList<DockBandSettings> StartBands { get; init; } = ImmutableList.Create(
+    private ImmutableList<DockBandSettings>? _startBands = ImmutableList.Create(
         new DockBandSettings
         {
             ProviderId = "com.microsoft.cmdpal.builtin.core",
@@ -58,9 +58,21 @@ public record DockSettings
             ShowLabels = false,
         });
 
-    public ImmutableList<DockBandSettings> CenterBands { get; init; } = ImmutableList<DockBandSettings>.Empty;
+    public ImmutableList<DockBandSettings> StartBands
+    {
+        get => _startBands ?? ImmutableList<DockBandSettings>.Empty;
+        init => _startBands = value;
+    }
 
-    public ImmutableList<DockBandSettings> EndBands { get; init; } = ImmutableList.Create(
+    private ImmutableList<DockBandSettings>? _centerBands = ImmutableList<DockBandSettings>.Empty;
+
+    public ImmutableList<DockBandSettings> CenterBands
+    {
+        get => _centerBands ?? ImmutableList<DockBandSettings>.Empty;
+        init => _centerBands = value;
+    }
+
+    private ImmutableList<DockBandSettings>? _endBands = ImmutableList.Create(
         new DockBandSettings
         {
             ProviderId = "PerformanceMonitor",
@@ -71,6 +83,12 @@ public record DockSettings
             ProviderId = "com.microsoft.cmdpal.builtin.datetime",
             CommandId = "com.microsoft.cmdpal.timedate.dockBand",
         });
+
+    public ImmutableList<DockBandSettings> EndBands
+    {
+        get => _endBands ?? ImmutableList<DockBandSettings>.Empty;
+        init => _endBands = value;
+    }
 
     public bool ShowLabels { get; init; } = true;
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Settings/HotkeySettings.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Settings/HotkeySettings.cs
@@ -55,8 +55,14 @@ public record HotkeySettings// : ICmdLineRepresentable
 
     // This is currently needed for FancyZones, we need to unify these two objects
     // see src\common\settings_objects.h
+    private string? _key = string.Empty;
+
     [JsonPropertyName("key")]
-    public string Key { get; init; } = string.Empty;
+    public string Key
+    {
+        get => _key ?? string.Empty;
+        init => _key = value;
+    }
 
     public override string ToString()
     {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsModel.cs
@@ -39,16 +39,40 @@ public record SettingsModel
 
     public bool AllowExternalReload { get; init; }
 
-    public ImmutableDictionary<string, ProviderSettings> ProviderSettings { get; init; }
+    private ImmutableDictionary<string, ProviderSettings>? _providerSettings
         = ImmutableDictionary<string, ProviderSettings>.Empty;
 
-    public string[] FallbackRanks { get; init; } = [];
+    public ImmutableDictionary<string, ProviderSettings> ProviderSettings
+    {
+        get => _providerSettings ?? ImmutableDictionary<string, ProviderSettings>.Empty;
+        init => _providerSettings = value;
+    }
 
-    public ImmutableDictionary<string, CommandAlias> Aliases { get; init; }
+    private string[]? _fallbackRanks = [];
+
+    public string[] FallbackRanks
+    {
+        get => _fallbackRanks ?? [];
+        init => _fallbackRanks = value;
+    }
+
+    private ImmutableDictionary<string, CommandAlias>? _aliases
         = ImmutableDictionary<string, CommandAlias>.Empty;
 
-    public ImmutableList<TopLevelHotkey> CommandHotkeys { get; init; }
+    public ImmutableDictionary<string, CommandAlias> Aliases
+    {
+        get => _aliases ?? ImmutableDictionary<string, CommandAlias>.Empty;
+        init => _aliases = value;
+    }
+
+    private ImmutableList<TopLevelHotkey>? _commandHotkeys
         = ImmutableList<TopLevelHotkey>.Empty;
+
+    public ImmutableList<TopLevelHotkey> CommandHotkeys
+    {
+        get => _commandHotkeys ?? ImmutableList<TopLevelHotkey>.Empty;
+        init => _commandHotkeys = value;
+    }
 
     public MonitorBehavior SummonOn { get; init; } = MonitorBehavior.ToMouse;
 
@@ -62,7 +86,13 @@ public record SettingsModel
 
     public bool EnableDock { get; init; }
 
-    public DockSettings DockSettings { get; init; } = new();
+    private DockSettings? _dockSettings = new();
+
+    public DockSettings DockSettings
+    {
+        get => _dockSettings ?? new();
+        init => _dockSettings = value;
+    }
 
     // Theme settings
     public UserTheme Theme { get; init; } = UserTheme.Default;


### PR DESCRIPTION
Fixes a category of crashes in CmdPal, related to our settings parsing. 

It would seem that I don't understand JSON parsing all that well in C#. 

Basically, we've got a bunch of places where we have
 
```c#
class Foo
{
  public Bar MySetting {get;init;} = new()
}
```

but when we JSON deserialize the settings, if there wasn't a `"MySetting"` key, then the deserializer deserializes to `null`, not `new()`. but since `Foo.MySetting` isn't a `Bar?`, then the compiler can't check the fact that json _gets special rules to write a null to it????_

Closes #47249

tested with the settings.json from that thread.