### PR TITLE
[PowerDisplay] Default-off and confirm dialog for InputSource/ColorTemp/PowerState

### DIFF
--- a/src/modules/powerdisplay/PowerDisplay/ViewModels/MainViewModel.Settings.cs
+++ b/src/modules/powerdisplay/PowerDisplay/ViewModels/MainViewModel.Settings.cs
@@ -415,13 +415,17 @@ public partial class MainViewModel
             SupportsVolume = vm.VcpCapabilitiesInfo?.SupportedVcpCodes.ContainsKey(0x62) ?? false,
             SupportsPowerState = vm.VcpCapabilitiesInfo?.SupportedVcpCodes.ContainsKey(0xD6) ?? false,
 
-            // Default Enable* to match Supports* for new monitors (first-time setup)
-            // ApplyPreservedUserSettings will override these with saved user preferences if they exist
+            // Default Enable* for new monitors (first-time setup):
+            // - Contrast / Volume: enabled if the monitor advertises the VCP code (low-risk features).
+            // - InputSource / ColorTemperature / PowerState: always disabled by default. These can leave
+            //   the monitor in a state recoverable only via physical buttons; users opt in via the
+            //   Settings UI checkbox, which raises a confirmation dialog (HandleDangerousFeatureClickAsync).
+            // ApplyPreservedUserSettings will override these with saved user preferences if they exist.
             EnableContrast = vm.VcpCapabilitiesInfo?.SupportedVcpCodes.ContainsKey(0x12) ?? false,
             EnableVolume = vm.VcpCapabilitiesInfo?.SupportedVcpCodes.ContainsKey(0x62) ?? false,
-            EnableInputSource = vm.VcpCapabilitiesInfo?.SupportedVcpCodes.ContainsKey(0x60) ?? false,
-            EnableColorTemperature = vm.VcpCapabilitiesInfo?.SupportedVcpCodes.ContainsKey(0x14) ?? false,
-            EnablePowerState = vm.VcpCapabilitiesInfo?.SupportedVcpCodes.ContainsKey(0xD6) ?? false,
+            EnableInputSource = false,
+            EnableColorTemperature = false,
+            EnablePowerState = false,
 
             // Monitor number for display name formatting
             MonitorNumber = vm.MonitorNumber,

--- a/src/modules/powerdisplay/PowerDisplay/ViewModels/MainViewModel.Settings.cs
+++ b/src/modules/powerdisplay/PowerDisplay/ViewModels/MainViewModel.Settings.cs
@@ -418,7 +418,7 @@ public partial class MainViewModel
             // Default Enable* for new monitors (first-time setup):
             // - Contrast / Volume: enabled if the monitor advertises the VCP code (low-risk features).
             // - InputSource / ColorTemperature / PowerState: always disabled by default. These can leave
-            //   the monitor in a state recoverable only via physical buttons; users opt in via the
+            //   the monitor in a state recoverable only via physical buttons; users opt-in via the
             //   Settings UI checkbox, which raises a confirmation dialog (HandleDangerousFeatureClickAsync).
             // ApplyPreservedUserSettings will override these with saved user preferences if they exist.
             EnableContrast = vm.VcpCapabilitiesInfo?.SupportedVcpCodes.ContainsKey(0x12) ?? false,

--- a/src/modules/powerdisplay/PowerDisplay/ViewModels/MonitorViewModel.cs
+++ b/src/modules/powerdisplay/PowerDisplay/ViewModels/MonitorViewModel.cs
@@ -215,13 +215,19 @@ public partial class MonitorViewModel : ObservableObject, IDisposable
         // Subscribe to underlying Monitor property changes (e.g., Orientation updates in mirror mode)
         _monitor.PropertyChanged += OnMonitorPropertyChanged;
 
-        // Initialize Show properties based on hardware capabilities
+        // Initialize Show properties for first-time detection. ApplyFeatureVisibility will
+        // override these whenever settings.json has a saved entry for this monitor, so these
+        // values only take effect for brand-new monitors (no persisted preference yet).
+        // Mirror CreateMonitorInfo's defaults to keep the flyout and settings.json in sync:
+        //   - Brightness / Contrast / Volume: enabled if the hardware advertises the VCP code.
+        //   - InputSource / ColorTemperature / PowerState: always disabled by default (dangerous
+        //     features); the user opts in via the Settings UI confirmation dialog.
         ShowBrightness = monitor.SupportsBrightness;
         ShowContrast = monitor.SupportsContrast;
         ShowVolume = monitor.SupportsVolume;
-        ShowInputSource = monitor.SupportsInputSource;
-        _showPowerState = monitor.SupportsPowerState;
-        _showColorTemperature = monitor.SupportsColorTemperature;
+        ShowInputSource = false;
+        _showPowerState = false;
+        _showColorTemperature = false;
 
         // Initialize basic properties from monitor
         _brightness = monitor.CurrentBrightness;

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerDisplayPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerDisplayPage.xaml
@@ -224,7 +224,11 @@
                                                 Tag="{x:Bind}" />
                                         </tkcontrols:SettingsCard>
                                         <tkcontrols:SettingsCard ContentAlignment="Left" IsEnabled="{x:Bind SupportsPowerState, Mode=OneWay}">
-                                            <CheckBox x:Uid="PowerDisplay_Monitor_EnablePowerState" IsChecked="{x:Bind EnablePowerState, Mode=TwoWay}" />
+                                            <CheckBox
+                                                x:Uid="PowerDisplay_Monitor_EnablePowerState"
+                                                Click="EnablePowerState_Click"
+                                                IsChecked="{x:Bind EnablePowerState, Mode=TwoWay}"
+                                                Tag="{x:Bind}" />
                                         </tkcontrols:SettingsCard>
                                         <tkcontrols:SettingsCard ContentAlignment="Left">
                                             <CheckBox x:Uid="PowerDisplay_Monitor_HideMonitor" IsChecked="{x:Bind IsHidden, Mode=TwoWay}" />

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerDisplayPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerDisplayPage.xaml
@@ -211,7 +211,11 @@
                                             <CheckBox x:Uid="PowerDisplay_Monitor_EnableVolume" IsChecked="{x:Bind EnableVolume, Mode=TwoWay}" />
                                         </tkcontrols:SettingsCard>
                                         <tkcontrols:SettingsCard ContentAlignment="Left" IsEnabled="{x:Bind SupportsInputSource, Mode=OneWay}">
-                                            <CheckBox x:Uid="PowerDisplay_Monitor_EnableInputSource" IsChecked="{x:Bind EnableInputSource, Mode=TwoWay}" />
+                                            <CheckBox
+                                                x:Uid="PowerDisplay_Monitor_EnableInputSource"
+                                                Click="EnableInputSource_Click"
+                                                IsChecked="{x:Bind EnableInputSource, Mode=TwoWay}"
+                                                Tag="{x:Bind}" />
                                         </tkcontrols:SettingsCard>
                                         <tkcontrols:SettingsCard ContentAlignment="Left">
                                             <CheckBox x:Uid="PowerDisplay_Monitor_EnableRotation" IsChecked="{x:Bind EnableRotation, Mode=TwoWay}" />

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerDisplayPage.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerDisplayPage.xaml.cs
@@ -229,6 +229,14 @@ namespace Microsoft.PowerToys.Settings.UI.Views
                 (monitor, value) => monitor.EnablePowerState = value);
         }
 
+        private async void EnableInputSource_Click(object sender, RoutedEventArgs e)
+        {
+            await HandleDangerousFeatureClickAsync(
+                sender,
+                "PowerDisplay_InputSource",
+                (monitor, value) => monitor.EnableInputSource = value);
+        }
+
         private async Task HandleDangerousFeatureClickAsync(
             object sender,
             string resourceKeyPrefix,

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerDisplayPage.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerDisplayPage.xaml.cs
@@ -268,7 +268,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
                         },
                     },
                 },
-                PrimaryButtonText = resourceLoader.GetString("PowerDisplay_ColorTemperature_EnableButton"),
+                PrimaryButtonText = resourceLoader.GetString("PowerDisplay_Dialog_Enable"),
                 CloseButtonText = resourceLoader.GetString("PowerDisplay_Dialog_Cancel"),
                 DefaultButton = ContentDialogButton.Close,
             };

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerDisplayPage.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerDisplayPage.xaml.cs
@@ -221,6 +221,14 @@ namespace Microsoft.PowerToys.Settings.UI.Views
                 (monitor, value) => monitor.EnableColorTemperature = value);
         }
 
+        private async void EnablePowerState_Click(object sender, RoutedEventArgs e)
+        {
+            await HandleDangerousFeatureClickAsync(
+                sender,
+                "PowerDisplay_PowerState",
+                (monitor, value) => monitor.EnablePowerState = value);
+        }
+
         private async Task HandleDangerousFeatureClickAsync(
             object sender,
             string resourceKeyPrefix,

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerDisplayPage.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerDisplayPage.xaml.cs
@@ -209,13 +209,24 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             }
         }
 
-        // Flag to prevent reentrant handling during programmatic checkbox changes
-        private bool _isRestoringColorTempCheckbox;
+        // Flag to prevent reentrant Click handling while we programmatically restore
+        // a checkbox after the user cancels a dangerous-feature confirmation dialog.
+        private bool _isRestoringDangerousFeatureCheckbox;
 
         private async void EnableColorTemperature_Click(object sender, RoutedEventArgs e)
         {
-            // Skip if we're programmatically restoring the checkbox state
-            if (_isRestoringColorTempCheckbox)
+            await HandleDangerousFeatureClickAsync(
+                sender,
+                "PowerDisplay_ColorTemperature",
+                (monitor, value) => monitor.EnableColorTemperature = value);
+        }
+
+        private async Task HandleDangerousFeatureClickAsync(
+            object sender,
+            string resourceKeyPrefix,
+            Action<MonitorInfo, bool> setter)
+        {
+            if (_isRestoringDangerousFeatureCheckbox)
             {
                 return;
             }
@@ -225,18 +236,17 @@ namespace Microsoft.PowerToys.Settings.UI.Views
                 return;
             }
 
-            // Only show warning when enabling (checking the box)
+            // Only show the warning when the user is enabling the feature.
             if (checkBox.IsChecked != true)
             {
                 return;
             }
 
-            // Show confirmation dialog with color temperature warning
             var resourceLoader = ResourceLoaderInstance.ResourceLoader;
             var dialog = new ContentDialog
             {
                 XamlRoot = this.XamlRoot,
-                Title = resourceLoader.GetString("PowerDisplay_ColorTemperature_WarningTitle"),
+                Title = resourceLoader.GetString($"{resourceKeyPrefix}_WarningTitle"),
                 Content = new StackPanel
                 {
                     Spacing = 12,
@@ -244,25 +254,25 @@ namespace Microsoft.PowerToys.Settings.UI.Views
                     {
                         new TextBlock
                         {
-                            Text = resourceLoader.GetString("PowerDisplay_ColorTemperature_WarningHeader"),
+                            Text = resourceLoader.GetString($"{resourceKeyPrefix}_WarningHeader"),
                             FontWeight = Microsoft.UI.Text.FontWeights.Bold,
                             Foreground = (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources["SystemFillColorCriticalBrush"],
                             TextWrapping = TextWrapping.Wrap,
                         },
                         new TextBlock
                         {
-                            Text = resourceLoader.GetString("PowerDisplay_ColorTemperature_WarningDescription"),
+                            Text = resourceLoader.GetString($"{resourceKeyPrefix}_WarningDescription"),
                             TextWrapping = TextWrapping.Wrap,
                         },
                         new TextBlock
                         {
-                            Text = resourceLoader.GetString("PowerDisplay_ColorTemperature_WarningList"),
+                            Text = resourceLoader.GetString($"{resourceKeyPrefix}_WarningList"),
                             TextWrapping = TextWrapping.Wrap,
                             Margin = new Thickness(20, 0, 0, 0),
                         },
                         new TextBlock
                         {
-                            Text = resourceLoader.GetString("PowerDisplay_ColorTemperature_WarningConfirm"),
+                            Text = resourceLoader.GetString($"{resourceKeyPrefix}_WarningConfirm"),
                             FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
                             TextWrapping = TextWrapping.Wrap,
                         },
@@ -277,16 +287,16 @@ namespace Microsoft.PowerToys.Settings.UI.Views
 
             if (result != ContentDialogResult.Primary)
             {
-                // User cancelled: revert checkbox to unchecked
-                _isRestoringColorTempCheckbox = true;
+                // User cancelled: revert checkbox to unchecked.
+                _isRestoringDangerousFeatureCheckbox = true;
                 try
                 {
                     checkBox.IsChecked = false;
-                    monitor.EnableColorTemperature = false;
+                    setter(monitor, false);
                 }
                 finally
                 {
-                    _isRestoringColorTempCheckbox = false;
+                    _isRestoringDangerousFeatureCheckbox = false;
                 }
             }
         }

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -5522,7 +5522,7 @@ The break timer font matches the text font.</value>
     <value>Confirm input source control</value>
   </data>
   <data name="PowerDisplay_InputSource_WarningHeader" xml:space="preserve">
-    <value>⚠️ Warning: This is a potentially dangerous operation!</value>
+    <value>⚠️ Warning: This action may be unsafe.</value>
   </data>
   <data name="PowerDisplay_InputSource_WarningDescription" xml:space="preserve">
     <value>Switching input sources may cause unintended results, including:</value>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -5519,7 +5519,7 @@ The break timer font matches the text font.</value>
     <value>Do you want to enable power state control for this monitor?</value>
   </data>
   <data name="PowerDisplay_InputSource_WarningTitle" xml:space="preserve">
-    <value>Confirm Input Source Control</value>
+    <value>Confirm input source control</value>
   </data>
   <data name="PowerDisplay_InputSource_WarningHeader" xml:space="preserve">
     <value>⚠️ Warning: This is a potentially dangerous operation!</value>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -5501,7 +5501,7 @@ The break timer font matches the text font.</value>
   <data name="PowerDisplay_ColorTemperature_WarningConfirm" xml:space="preserve">
     <value>Do you want to enable color temperature control for this monitor?</value>
   </data>
-  <data name="PowerDisplay_ColorTemperature_EnableButton" xml:space="preserve">
+  <data name="PowerDisplay_Dialog_Enable" xml:space="preserve">
     <value>Enable</value>
   </data>
   <data name="PowerDisplay_Dialog_Cancel" xml:space="preserve">

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -5516,7 +5516,7 @@ The break timer font matches the text font.</value>
 • Some monitors may not restore the previous state correctly.</value>
   </data>
   <data name="PowerDisplay_PowerState_WarningConfirm" xml:space="preserve">
-    <value>Do you want to enable power state control for this monitor?</value>
+    <value>Enable power state control for this monitor?</value>
   </data>
   <data name="PowerDisplay_InputSource_WarningTitle" xml:space="preserve">
     <value>Confirm input source control</value>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -5508,7 +5508,7 @@ The break timer font matches the text font.</value>
     <value>⚠️ Warning: This action may be unsafe.</value>
   </data>
   <data name="PowerDisplay_PowerState_WarningDescription" xml:space="preserve">
-    <value>Enabling power state control may cause unintended results, including:</value>
+    <value>Enabling power state control may lead to unexpected behavior, including:</value>
   </data>
   <data name="PowerDisplay_PowerState_WarningList" xml:space="preserve">
     <value>• Monitor entering standby that cannot be woken via software

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -5502,7 +5502,7 @@ The break timer font matches the text font.</value>
     <value>Do you want to enable color temperature control for this monitor?</value>
   </data>
   <data name="PowerDisplay_PowerState_WarningTitle" xml:space="preserve">
-    <value>Confirm Power State Control</value>
+    <value>Confirm power state control</value>
   </data>
   <data name="PowerDisplay_PowerState_WarningHeader" xml:space="preserve">
     <value>⚠️ Warning: This action may be unsafe.</value>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -5533,7 +5533,7 @@ The break timer font matches the text font.</value>
 • Some monitors may not enumerate or expose all input sources reliably</value>
   </data>
   <data name="PowerDisplay_InputSource_WarningConfirm" xml:space="preserve">
-    <value>Do you want to enable input source control for this monitor?</value>
+    <value>Enable input source control for this monitor?</value>
   </data>
   <data name="PowerDisplay_Dialog_Enable" xml:space="preserve">
     <value>Enable</value>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -5511,9 +5511,9 @@ The break timer font matches the text font.</value>
     <value>Enabling power state control may lead to unexpected behavior, including:</value>
   </data>
   <data name="PowerDisplay_PowerState_WarningList" xml:space="preserve">
-    <value>• Monitor entering standby that cannot be woken via software
-• Need to physically press the monitor's power button or unplug and reconnect the signal cable to recover
-• Some monitors may not return to the previous state correctly</value>
+    <value>• Monitor may enter standby and not wake via software.
+• You may need to press the monitor’s power button or reconnect the cable to recover.
+• Some monitors may not restore the previous state correctly.</value>
   </data>
   <data name="PowerDisplay_PowerState_WarningConfirm" xml:space="preserve">
     <value>Do you want to enable power state control for this monitor?</value>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -5501,6 +5501,23 @@ The break timer font matches the text font.</value>
   <data name="PowerDisplay_ColorTemperature_WarningConfirm" xml:space="preserve">
     <value>Do you want to enable color temperature control for this monitor?</value>
   </data>
+  <data name="PowerDisplay_PowerState_WarningTitle" xml:space="preserve">
+    <value>Confirm Power State Control</value>
+  </data>
+  <data name="PowerDisplay_PowerState_WarningHeader" xml:space="preserve">
+    <value>⚠️ Warning: This is a potentially dangerous operation!</value>
+  </data>
+  <data name="PowerDisplay_PowerState_WarningDescription" xml:space="preserve">
+    <value>Enabling power state control may cause unintended results, including:</value>
+  </data>
+  <data name="PowerDisplay_PowerState_WarningList" xml:space="preserve">
+    <value>• Monitor entering standby that cannot be woken via software
+• Need to physically press the monitor's power button or unplug/replug the signal cable to recover
+• Some monitors may not return to the previous state correctly</value>
+  </data>
+  <data name="PowerDisplay_PowerState_WarningConfirm" xml:space="preserve">
+    <value>Do you want to enable power state control for this monitor?</value>
+  </data>
   <data name="PowerDisplay_Dialog_Enable" xml:space="preserve">
     <value>Enable</value>
   </data>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -5505,7 +5505,7 @@ The break timer font matches the text font.</value>
     <value>Confirm Power State Control</value>
   </data>
   <data name="PowerDisplay_PowerState_WarningHeader" xml:space="preserve">
-    <value>⚠️ Warning: This is a potentially dangerous operation!</value>
+    <value>⚠️ Warning: This action may be unsafe.</value>
   </data>
   <data name="PowerDisplay_PowerState_WarningDescription" xml:space="preserve">
     <value>Enabling power state control may cause unintended results, including:</value>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -5518,6 +5518,23 @@ The break timer font matches the text font.</value>
   <data name="PowerDisplay_PowerState_WarningConfirm" xml:space="preserve">
     <value>Do you want to enable power state control for this monitor?</value>
   </data>
+  <data name="PowerDisplay_InputSource_WarningTitle" xml:space="preserve">
+    <value>Confirm Input Source Control</value>
+  </data>
+  <data name="PowerDisplay_InputSource_WarningHeader" xml:space="preserve">
+    <value>⚠️ Warning: This is a potentially dangerous operation!</value>
+  </data>
+  <data name="PowerDisplay_InputSource_WarningDescription" xml:space="preserve">
+    <value>Switching input sources may cause unintended results, including:</value>
+  </data>
+  <data name="PowerDisplay_InputSource_WarningList" xml:space="preserve">
+    <value>• Monitor going black if the new input has no signal
+• Loss of software control until you switch back via the monitor's physical buttons
+• Some monitors may not enumerate or expose all input sources reliably</value>
+  </data>
+  <data name="PowerDisplay_InputSource_WarningConfirm" xml:space="preserve">
+    <value>Do you want to enable input source control for this monitor?</value>
+  </data>
   <data name="PowerDisplay_Dialog_Enable" xml:space="preserve">
     <value>Enable</value>
   </data>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -5528,9 +5528,9 @@ The break timer font matches the text font.</value>
     <value>Switching input sources may cause unintended results, including:</value>
   </data>
   <data name="PowerDisplay_InputSource_WarningList" xml:space="preserve">
-    <value>• Monitor going black if the new input has no signal
-• Loss of software control until you switch back via the monitor's physical buttons
-• Some monitors may not enumerate or expose all input sources reliably</value>
+    <value>• Screen may go black if the selected input has no signal.
+• Software control may be lost until you switch back using the monitor’s physical buttons.
+• Some monitors may not reliably expose all input sources.</value>
   </data>
   <data name="PowerDisplay_InputSource_WarningConfirm" xml:space="preserve">
     <value>Enable input source control for this monitor?</value>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -5512,7 +5512,7 @@ The break timer font matches the text font.</value>
   </data>
   <data name="PowerDisplay_PowerState_WarningList" xml:space="preserve">
     <value>• Monitor entering standby that cannot be woken via software
-• Need to physically press the monitor's power button or unplug/replug the signal cable to recover
+• Need to physically press the monitor's power button or unplug and reconnect the signal cable to recover
 • Some monitors may not return to the previous state correctly</value>
   </data>
   <data name="PowerDisplay_PowerState_WarningConfirm" xml:space="preserve">


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Three per-monitor PowerDisplay features have failure modes recoverable only via physical buttons:

Input Source — switching to an input with no signal goes black; PowerToys can no longer drive a panel that isn't displaying its own signal
Color Temperature — some monitors apply changes that cannot be reset via DDC/CI; OSD reset required
Power State — VCP 0xD6 standby may not respond to subsequent DDC/CI wake commands
This PR:

Defaults all three features off for newly-discovered monitors. Supports* derivation from VCP capabilities is unchanged — unsupported checkboxes are still greyed out.
Pops a confirmation dialog when a user toggles any of them on in Settings, mirroring the existing Color Temperature warning. Cancel reverts the checkbox; Enable keeps it.
Refactors the existing Color Temperature click handler into a shared HandleDangerousFeatureClickAsync(sender, resourceKeyPrefix, setter) helper. All three feature handlers now reuse it.
Renames PowerDisplay_ColorTemperature_EnableButton → PowerDisplay_Dialog_Enable so the three dialogs share one button-text resource (paralleling the existing shared PowerDisplay_Dialog_Cancel)

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] Closes: #xxx
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

