### PR TITLE
CmdPal: Fix a bug where dock label settings wouldn't save

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Dock/DockBandSettingsViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Dock/DockBandSettingsViewModel.cs
@@ -46,45 +46,6 @@ public partial class DockBandSettingsViewModel : ObservableObject
 
     public IconInfoViewModel Icon => _adapter.IconViewModel;
 
-    private ShowLabelsOption _showLabels;
-
-    public ShowLabelsOption ShowLabels
-    {
-        get => _showLabels;
-        set
-        {
-            if (value != _showLabels)
-            {
-                _showLabels = value;
-                var newShowTitles = value switch
-                {
-                    ShowLabelsOption.Default => (bool?)null,
-                    ShowLabelsOption.ShowLabels => true,
-                    ShowLabelsOption.HideLabels => false,
-                    _ => null,
-                };
-                UpdateModel(_dockSettingsModel with { ShowTitles = newShowTitles });
-            }
-        }
-    }
-
-    private ShowLabelsOption FetchShowLabels()
-    {
-        if (_dockSettingsModel.ShowLabels == null)
-        {
-            return ShowLabelsOption.Default;
-        }
-
-        return _dockSettingsModel.ShowLabels.Value ? ShowLabelsOption.ShowLabels : ShowLabelsOption.HideLabels;
-    }
-
-    // used to map to ComboBox selection
-    public int ShowLabelsIndex
-    {
-        get => (int)ShowLabels;
-        set => ShowLabels = (ShowLabelsOption)value;
-    }
-
     private DockPinSide PinSide
     {
         get => _pinSide;
@@ -138,7 +99,6 @@ public partial class DockBandSettingsViewModel : ObservableObject
         _bandViewModel = bandViewModel;
         _settingsService = settingsService;
         _pinSide = FetchPinSide();
-        _showLabels = FetchShowLabels();
     }
 
     private DockPinSide FetchPinSide()

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Dock/DockViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Dock/DockViewModel.cs
@@ -559,7 +559,7 @@ public sealed partial class DockViewModel
         }
 
         // Create settings for the new band
-        var bandSettings = new DockBandSettings { ProviderId = topLevel.CommandProviderId, CommandId = bandId, ShowLabels = null };
+        var bandSettings = new DockBandSettings { ProviderId = topLevel.CommandProviderId, CommandId = bandId };
         var dockSettings = _settings;
 
         // Create the band view model

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Settings/DockSettings.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Settings/DockSettings.cs
@@ -55,7 +55,7 @@ public record DockSettings
         {
             ProviderId = "WinGet",
             CommandId = "com.microsoft.cmdpal.winget",
-            ShowLabels = false,
+            ShowTitles = false,
         });
 
     public ImmutableList<DockBandSettings> StartBands
@@ -120,16 +120,6 @@ public record DockBandSettings
     /// If null, falls back to dock-wide ShowLabels setting.
     /// </summary>
     public bool? ShowSubtitles { get; init; }
-
-    /// <summary>
-    /// Gets a value for backward compatibility. Maps to ShowTitles.
-    /// </summary>
-    [System.Text.Json.Serialization.JsonIgnore]
-    public bool? ShowLabels
-    {
-        get => ShowTitles;
-        init => ShowTitles = value;
-    }
 
     /// <summary>
     /// Resolves the effective value of <see cref="ShowTitles"/> for this band.

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelViewModel.cs
@@ -196,7 +196,7 @@ public sealed partial class TopLevelViewModel : ObservableObject, IListItem, IEx
                 {
                     ProviderId = this.CommandProviderId,
                     CommandId = this.Id,
-                    ShowLabels = true,
+                    ShowTitles = true,
                 };
             }
 


### PR DESCRIPTION
This setting is totally vestigial, from the 0.9 dev cycle. 

Unfortunately, the JSON parser would see that it wasn't in the settings.json, then it would write `null` to it. But `ShowLabels` was just a thin alias for `ShowTitles`, so we'd end up parsing totally sane JSON settings into having `null` for `ShowTitle`. 

This fixes that. You can hide your titles again folks. 

