### PR TITLE
Replay both key down and up for Win in GrabAndMove

### DIFF
--- a/src/modules/GrabAndMove/GrabAndMove/main.cpp
+++ b/src/modules/GrabAndMove/GrabAndMove/main.cpp
@@ -579,14 +579,16 @@ static void StopResizing()
     HideOverlay();
 }
 
-static void ReplayAbsorbedAlt()
+static void ReplayAbsorbedModifier(bool alsoKeyUp)
 {
-    INPUT keyboardInput = {};
-    keyboardInput.type = INPUT_KEYBOARD;
-    keyboardInput.ki.wVk = static_cast<WORD>(g_absorbedVk);
-    keyboardInput.ki.wScan = static_cast<WORD>(g_absorbedScanCode);
-    keyboardInput.ki.dwFlags = (g_absorbedFlags & LLKHF_EXTENDED) ? KEYEVENTF_EXTENDEDKEY : 0;
-    SendInput(1, &keyboardInput, sizeof(INPUT));
+    INPUT inputs[2] = {};
+    inputs[0].type = INPUT_KEYBOARD;
+    inputs[0].ki.wVk = static_cast<WORD>(g_absorbedVk);
+    inputs[0].ki.wScan = static_cast<WORD>(g_absorbedScanCode);
+    inputs[0].ki.dwFlags = (g_absorbedFlags & LLKHF_EXTENDED) ? KEYEVENTF_EXTENDEDKEY : 0;
+    inputs[1] = inputs[0];
+    inputs[1].ki.dwFlags |= KEYEVENTF_KEYUP;
+    SendInput(alsoKeyUp ? 2 : 1, inputs, sizeof(INPUT));
 }
 
 // ---------------------------------------------------------------------------
@@ -735,8 +737,9 @@ static LRESULT CALLBACK KeyboardProc(int nCode, WPARAM wParam, LPARAM lParam)
                         g_dragConsumedAlt = false;
                         return 1;
                     }
-                    // No drag happened; replay the keydown, then let keyup through
-                    ReplayAbsorbedAlt();
+                    // No drag happened; replay the keydown, THEN the keyup
+                    ReplayAbsorbedModifier(true);
+                    return 1; // swallow this keyup since the replay already sent one
                 }
             }
             goto forward; // let Win keyup pass through
@@ -793,7 +796,7 @@ static LRESULT CALLBACK KeyboardProc(int nCode, WPARAM wParam, LPARAM lParam)
                             return 1;
                         }
                         // No drag happened; replay the keydown, then let keyup through
-                        ReplayAbsorbedAlt();
+                        ReplayAbsorbedModifier(false);
                     }
                 }
             }
@@ -804,7 +807,7 @@ static LRESULT CALLBACK KeyboardProc(int nCode, WPARAM wParam, LPARAM lParam)
                 {
                     g_altAbsorbed = false;
                     g_altPressed = false;
-                    ReplayAbsorbedAlt();
+                    ReplayAbsorbedModifier(false);
                 }
             }
         }
@@ -814,7 +817,7 @@ static LRESULT CALLBACK KeyboardProc(int nCode, WPARAM wParam, LPARAM lParam)
         {
             g_winAbsorbed = false;
             g_winPressed = false;
-            ReplayAbsorbedAlt();
+            ReplayAbsorbedModifier(false);
         }
 
         // Track held non-modifier keys (used to suppress GrabAndMove when the modifier


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
The code for keyup on the `Win` key would replay the previously absorbed keydown event and just leave this keyup to propagate normally, thus leading to a race condition between `CallNextHookEx` and `SendInput`. This resulted in almost guaranteed out-of-order event (`Win` up, followed by `Win` down) in the case of `Win+G` (the Xbox Game bar shortcut).

Fixed by also absorbing the keyup for `Win`, but calling `SendInput` for both keydown and keyup.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #47293 
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [x] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

