### PR TITLE
ci: disable building of draft pull requests

### DIFF
--- a/.pipelines/v2/ci.yml
+++ b/.pipelines/v2/ci.yml
@@ -16,6 +16,7 @@ pr:
     include:
       - main
       - stable
+  drafts: false
 #  paths:
 #    exclude:
 #      - '**.md'


### PR DESCRIPTION
The influx of Copilot-originated pull requests has made it impossible for our CI to keep up; this is in part because for some reason Copilot is treated as a team member and therefore automatically scheduled for CI on the build pool.