### PR TITLE
Bump WindowsAppSDK to 2.0.1

### DIFF
--- a/.pipelines/v2/templates/job-build-project.yml
+++ b/.pipelines/v2/templates/job-build-project.yml
@@ -70,7 +70,7 @@ parameters:
     default: false
   - name: winAppSDKVersionNumber
     type: string
-    default: 1.6
+    default: '2.0'
   - name: useExperimentalVersion
     type: boolean
     default: false

--- a/.pipelines/v2/templates/pipeline-ci-build.yml
+++ b/.pipelines/v2/templates/pipeline-ci-build.yml
@@ -30,7 +30,7 @@ parameters:
     default: false
   - name: winAppSDKVersionNumber
     type: string
-    default: 1.6
+    default: '2.0'
   - name: useExperimentalVersion
     type: boolean
     default: false

--- a/.pipelines/v2/templates/steps-update-winappsdk-and-restore-nuget.yml
+++ b/.pipelines/v2/templates/steps-update-winappsdk-and-restore-nuget.yml
@@ -1,7 +1,7 @@
 parameters:
   - name: versionNumber
     type: string
-    default: 1.6
+    default: '2.0'
   - name: useExperimentalVersion
     type: boolean
     default: false

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -77,10 +77,10 @@
     <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
     <PackageVersion Include="Microsoft.Windows.ImplementationLibrary" Version="1.0.250325.1"/>
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.6901" />
-    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.8.260209005" />
-    <PackageVersion Include="Microsoft.WindowsAppSDK.Foundation" Version="1.8.260203002" />
-    <PackageVersion Include="Microsoft.WindowsAppSDK.AI" Version="1.8.47" />
-    <PackageVersion Include="Microsoft.WindowsAppSDK.Runtime" Version="1.8.260209005" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="2.0.1" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK.Foundation" Version="2.0.20" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK.AI" Version="2.0.185" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK.Runtime" Version="2.0.1" />
     <PackageVersion Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.0.9" />
     <PackageVersion Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.39" />
     <PackageVersion Include="ModernWpfUI" Version="0.9.4" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -63,7 +63,7 @@
     <PackageVersion Include="Microsoft.SemanticKernel.Connectors.MistralAI" Version="1.66.0-alpha" />
     <PackageVersion Include="Microsoft.SemanticKernel.Connectors.Ollama" Version="1.66.0-alpha" />
     <PackageVersion Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.2" />
-    <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.3179.45" />
+    <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.3719.77" />
     <!-- Package Microsoft.Win32.SystemEvents added as a hack for being able to exclude the runtime assets so they don't conflict with 8.0.1. This is a dependency of System.Drawing.Common but the 8.0.1 version wasn't published to nuget. -->
     <PackageVersion Include="Microsoft.Win32.SystemEvents" Version="9.0.10" />
     <PackageVersion Include="Microsoft.WindowsPackageManager.ComInterop" Version="1.10.340" />

--- a/src/modules/cmdpal/ExtensionTemplate/TemplateCmdPalExtension/Directory.Packages.props
+++ b/src/modules/cmdpal/ExtensionTemplate/TemplateCmdPalExtension/Directory.Packages.props
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageVersion Include="Microsoft.CommandPalette.Extensions" Version="0.9.260303001" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0-preview.24508.2" />
-    <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.2903.40" />
+    <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.3719.77" />
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.183" />
     <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.4188" />

--- a/src/modules/cmdpal/ExtensionTemplate/TemplateCmdPalExtension/Directory.Packages.props
+++ b/src/modules/cmdpal/ExtensionTemplate/TemplateCmdPalExtension/Directory.Packages.props
@@ -10,7 +10,7 @@
     <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.4188" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools.MSIX" Version="1.7.20250829.1" />
-    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.8.260209005" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="2.0.1" />
     <PackageVersion Include="Shmuelie.WinRTServer" Version="2.1.1" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <PackageVersion Include="System.Text.Json" Version="9.0.8" />


### PR DESCRIPTION
## Summary of the Pull Request

Bumps `Microsoft.WindowsAppSDK` (and split sub-packages) from **`1.8.260209005`** to public NuGet''s **`2.0.1`** GA, plus the centrally-pinned `Microsoft.Web.WebView2` to **`1.0.3719.77`** to satisfy the new transitive requirement from `Microsoft.WindowsAppSDK.WinUI 2.0.12`.

This is the minimum mechanical version-bump set required for the WinAppSDK 2.0 upgrade — no API migration or behavioral changes. Subsequent commits on this branch will address breaking-change migrations as they surface.

NuGet source-of-truth used to pick sub-package versions: WinAppSDK 2.0.1 catalog `dependencyGroup` (https://api.nuget.org/v3/catalog0/data/2026.04.29.22.25.36/microsoft.windowsappsdk.2.0.1.json).

## PR Checklist

- [ ] Closes: #xxx
- [ ] **Communication:** I''ve discussed this with core contributors already. If the work hasn''t been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places (n/a — version bump only)
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments

### Scope

| File | Change |
|---|---|
| `Directory.Packages.props` | `Microsoft.WindowsAppSDK` `1.8.260209005` → **`2.0.1`** |
| `Directory.Packages.props` | `Microsoft.WindowsAppSDK.Foundation` `1.8.260203002` → **`2.0.20`** |
| `Directory.Packages.props` | `Microsoft.WindowsAppSDK.AI` `1.8.47` → **`2.0.185`** |
| `Directory.Packages.props` | `Microsoft.WindowsAppSDK.Runtime` `1.8.260209005` → **`2.0.1`** |
| `Directory.Packages.props` | `Microsoft.Web.WebView2` `1.0.3179.45` → **`1.0.3719.77`** (required transitive minimum from `Microsoft.WindowsAppSDK.WinUI 2.0.12`) |
| `src/modules/cmdpal/ExtensionTemplate/TemplateCmdPalExtension/Directory.Packages.props` | `Microsoft.WindowsAppSDK` → **`2.0.1`**, `Microsoft.Web.WebView2` → **`1.0.3719.77`** |
| `.pipelines/v2/templates/pipeline-ci-build.yml` | `winAppSDKVersionNumber` default `1.6` → **`2.0`** |
| `.pipelines/v2/templates/job-build-project.yml` | same |
| `.pipelines/v2/templates/steps-update-winappsdk-and-restore-nuget.yml` | same |

### Deliberately not in this PR

- **API breaking-change migrations** (Foundation, AI, ML, WinUI 2.0). Will be follow-up commits.
- **New 2.0 split sub-packages** (`Base`, `InteractiveExperiences`, `WinUI`, `DWrite`, `Widgets`, `ML`). Only Foundation, AI, and Runtime are pinned in `Directory.Packages.props` today; the others flow transitively through the `Microsoft.WindowsAppSDK` meta-package and don''t need explicit central versions unless we start consuming their APIs directly.
- **`Microsoft.Windows.SDK.BuildTools`** version. Left at `10.0.26100.6901` — re-evaluate if 2.0 surfaces a minimum SDK requirement.

### Why this PR is a Draft

`nuget.config` is `<clear/>`-locked to the curated `PowerToysPublicDependencies` Azure DevOps feed (https://pkgs.dev.azure.com/shine-oss/PowerToys/_packaging/PowerToysPublicDependencies). Public `nuget.org` is **not** an acceptable fallback by policy. The curated feed has not yet mirrored the public-NuGet stable releases this PR pins to:

| Package | Pinned | Latest stable in curated feed | Status |
|---|---|---|---|
| `Microsoft.WindowsAppSDK` | `2.0.1` | `1.8.260317003` (newest 2.0.x is `2.0.250930001-experimental1`) | **needs mirror** |
| `Microsoft.WindowsAppSDK.Foundation` | `2.0.20` | `1.8.260222000` (newest 2.0.x is `2.0.250915002-experimental`) | **needs mirror** |
| `Microsoft.WindowsAppSDK.AI` | `2.0.185` | `1.8.53` (newest 2.0.x is `2.0.130-experimental`) | **needs mirror** |
| `Microsoft.WindowsAppSDK.Runtime` | `2.0.1` | `1.8.260317003` (newest 2.0.x is `2.0.250930001-experimental1`) | **needs mirror** |
| `Microsoft.Web.WebView2` | `1.0.3719.77` | `1.0.3405.78` | **needs mirror** |

This Draft will be moved out once **either**:

1. The curated `PowerToysPublicDependencies` feed mirrors the five packages above, **or**
2. CI runs against an explicit pipeline configuration with `useArtifactSource=true` + a corresponding `WindowsAppSDK_Nuget_And_MSIX` artifact, which `UpdateVersions.ps1` injects as a `localpackages` source for the duration of the build.

### Prerequisites

- **#47462** — separate atomic build-script fix for VS 2026 Insiders / `vswhere -prerelease` discovery. Without it, `tools\build\build-common.ps1` lands on VS 2022 BuildTools (no C++ workload) and every native `.vcxproj` errors with `MSB4086 $(PlatformToolsetVersion)` empty — independent of any package change. Confirmed working during local validation.
- **Pre-existing VS 2026 spdlog/fmt v7 workaround.** VS 2026 MSVC 14.51 removed `stdext::checked_array_iterator`, which the vendored `deps/spdlog/include/spdlog/fmt/bundled/format.h` (fmt v7) still references. Reproducible on `main` with VS 2026, **not caused by this bump**. Local fix during validation: add `_SECURE_SCL=0;_ITERATOR_DEBUG_LEVEL=0` to `Cpp.Build.props` `PreprocessorDefinitions` (currently only `_SILENCE_STDEXT_ARR_ITERS_DEPRECATION_WARNING` is set, which silences the warning but does not suppress the deleted symbol). Belongs in its own PR.

## Validation Steps Performed

A throwaway temp branch was used to validate the bump scope **end-to-end** against the curated feed using the **closest-matching experimental package set the feed currently carries** (which shares the same major/minor 2.0.x dependency closure as this PR''s stable target). The temp branch was discarded after capturing results — only the stable-target pins are committed here.

Temp branch composition (uncommitted, validation-only):
- This PR''s commits, with the stable WinAppSDK 2.0.1 / Foundation 2.0.20 / AI 2.0.185 / Runtime 2.0.1 / WebView2 1.0.3719.77 pins **temporarily replaced** by the curated-feed-resident experimental closure (WindowsAppSDK 2.0.250930001-experimental1, Foundation 2.0.250915002-experimental, AI 2.0.3-experimental, Runtime 2.0.250930001-experimental1, WebView2 1.0.3405.78).
- #47462''s two cherry-picks (build-script VS 2026 / `vswhere -prerelease` fix).
- `_SECURE_SCL=0;_ITERATOR_DEBUG_LEVEL=0` added to `Cpp.Build.props` `PreprocessorDefinitions` (spdlog/fmt v7 + MSVC 14.51 workaround).

`tools\build\build-essentials.cmd` results on the temp branch (x64 Debug, VS 2026 Insiders 14.51.36231):

| Stage | Errors | Warnings | Time |
|---|---|---|---|
| `PowerToys.slnx` NuGet restore | **0** | 0 | 1:05 |
| Native C++ `src\runner\runner.vcxproj` | **0** | 0 | 4:08 |
| Managed `src\settings-ui\Settings.UI\PowerToys.Settings.csproj` | **0** | 0 | 3:35 |

Exit code: **0**. The end-to-end `build-essentials` flow passes locally — the WinAppSDK 2.0 upgrade is verified to compile against the runner + Settings.UI projects.

Reproductions captured along the way (independent of this bump):

| Reproduction | Result |
|---|---|
| `build-essentials.cmd` on `main`, fresh PowerShell, no DevShell pre-init | `MSB4086 $(PlatformToolsetVersion)` empty — fixed by #47462 |
| Same temp branch composition **without** the spdlog `_SECURE_SCL=0` patch | 58 native C++ errors in `deps/spdlog/include/spdlog/fmt/bundled/format.h` (`C2653 stdext`, `C2061 checked_array_iterator`, `C7568`, …). Reproducible on `main`. |

**Bottom line:** The mechanical bump scope in this PR (WinAppSDK 2.0.1 + matching sub-packages + WebView2 floor) is verified complete at all three layers (NuGet restore, native C++ link, managed compile) when paired with #47462 and the spdlog workaround. End-to-end CI validation against this PR''s exact stable pins is gated only on the curated-feed mirror landing the five packages flagged above (or a `useArtifactSource` pipeline run).
