### PR TITLE
Bump WindowsAppSDK to 2.0.1

### DIFF
--- a/.pipelines/v2/templates/job-build-project.yml
+++ b/.pipelines/v2/templates/job-build-project.yml
@@ -70,7 +70,7 @@ parameters:
     default: false
   - name: winAppSDKVersionNumber
     type: string
-    default: 1.6
+    default: '2.0'
   - name: useExperimentalVersion
     type: boolean
     default: false

--- a/.pipelines/v2/templates/pipeline-ci-build.yml
+++ b/.pipelines/v2/templates/pipeline-ci-build.yml
@@ -30,7 +30,7 @@ parameters:
     default: false
   - name: winAppSDKVersionNumber
     type: string
-    default: 1.6
+    default: '2.0'
   - name: useExperimentalVersion
     type: boolean
     default: false

--- a/.pipelines/v2/templates/steps-update-winappsdk-and-restore-nuget.yml
+++ b/.pipelines/v2/templates/steps-update-winappsdk-and-restore-nuget.yml
@@ -1,7 +1,7 @@
 parameters:
   - name: versionNumber
     type: string
-    default: 1.6
+    default: '2.0'
   - name: useExperimentalVersion
     type: boolean
     default: false

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -77,10 +77,10 @@
     <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
     <PackageVersion Include="Microsoft.Windows.ImplementationLibrary" Version="1.0.250325.1"/>
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.6901" />
-    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.8.260209005" />
-    <PackageVersion Include="Microsoft.WindowsAppSDK.Foundation" Version="1.8.260203002" />
-    <PackageVersion Include="Microsoft.WindowsAppSDK.AI" Version="1.8.47" />
-    <PackageVersion Include="Microsoft.WindowsAppSDK.Runtime" Version="1.8.260209005" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="2.0.1" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK.Foundation" Version="2.0.20" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK.AI" Version="2.0.185" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK.Runtime" Version="2.0.1" />
     <PackageVersion Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.0.9" />
     <PackageVersion Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.39" />
     <PackageVersion Include="ModernWpfUI" Version="0.9.4" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -63,7 +63,7 @@
     <PackageVersion Include="Microsoft.SemanticKernel.Connectors.MistralAI" Version="1.66.0-alpha" />
     <PackageVersion Include="Microsoft.SemanticKernel.Connectors.Ollama" Version="1.66.0-alpha" />
     <PackageVersion Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.2" />
-    <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.3179.45" />
+    <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.3719.77" />
     <!-- Package Microsoft.Win32.SystemEvents added as a hack for being able to exclude the runtime assets so they don't conflict with 8.0.1. This is a dependency of System.Drawing.Common but the 8.0.1 version wasn't published to nuget. -->
     <PackageVersion Include="Microsoft.Win32.SystemEvents" Version="9.0.10" />
     <PackageVersion Include="Microsoft.WindowsPackageManager.ComInterop" Version="1.10.340" />

--- a/src/modules/cmdpal/ExtensionTemplate/TemplateCmdPalExtension/Directory.Packages.props
+++ b/src/modules/cmdpal/ExtensionTemplate/TemplateCmdPalExtension/Directory.Packages.props
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageVersion Include="Microsoft.CommandPalette.Extensions" Version="0.9.260303001" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0-preview.24508.2" />
-    <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.2903.40" />
+    <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.3719.77" />
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.183" />
     <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.4188" />

--- a/src/modules/cmdpal/ExtensionTemplate/TemplateCmdPalExtension/Directory.Packages.props
+++ b/src/modules/cmdpal/ExtensionTemplate/TemplateCmdPalExtension/Directory.Packages.props
@@ -10,7 +10,7 @@
     <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.4188" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools.MSIX" Version="1.7.20250829.1" />
-    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="1.8.260209005" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="2.0.1" />
     <PackageVersion Include="Shmuelie.WinRTServer" Version="2.1.1" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <PackageVersion Include="System.Text.Json" Version="9.0.8" />


### PR DESCRIPTION
## Summary of the Pull Request

Bumps `Microsoft.WindowsAppSDK` (and split sub-packages) from **`1.8.260209005`** to public NuGet''s **`2.0.1`** GA, plus the centrally-pinned `Microsoft.Web.WebView2` to **`1.0.3719.77`** to satisfy the new transitive requirement from `Microsoft.WindowsAppSDK.WinUI 2.0.12`.

This is the minimum mechanical version-bump set required for the WinAppSDK 2.0 upgrade ΓÇö no API migration or behavioral changes. Subsequent commits on this branch will address breaking-change migrations as they surface.

NuGet source-of-truth used to pick sub-package versions: WinAppSDK 2.0.1 catalog `dependencyGroup` (https://api.nuget.org/v3/catalog0/data/2026.04.29.22.25.36/microsoft.windowsappsdk.2.0.1.json).

## Detailed Description of the Pull Request / Additional comments

### Scope

| Package | Pinned |
|---|---|
| `Microsoft.WindowsAppSDK` | `2.0.1` | 
| `Microsoft.WindowsAppSDK.Foundation` | `2.0.20` | 
| `Microsoft.WindowsAppSDK.AI` | `2.0.185` | 
| `Microsoft.WindowsAppSDK.Runtime` | `2.0.1` | 
| `Microsoft.Web.WebView2` | `1.0.3719.77` | 

## Validation Steps Performed

`tools\build\build-essentials.cmd` results on the temp branch (x64 Debug, VS 2026 Insiders 14.51.36231):

| Stage | Errors | Warnings | Time |
|---|---|---|---|
| `PowerToys.slnx` NuGet restore | **0** | 0 | 1:05 |
| Native C++ `src\runner\runner.vcxproj` | **0** | 0 | 4:08 |
| Managed `src\settings-ui\Settings.UI\PowerToys.Settings.csproj` | **0** | 0 | 3:35 |

Exit code: **0**. The end-to-end `build-essentials` flow passes locally ΓÇö the WinAppSDK 2.0 upgrade is verified to compile against the runner + Settings.UI projects.