### PR TITLE
Add low memory mode for supported utilities

### DIFF
--- a/src/common/SettingsAPI/settings_helpers.cpp
+++ b/src/common/SettingsAPI/settings_helpers.cpp
@@ -1,6 +1,9 @@
 #include "pch.h"
 #include "settings_helpers.h"
 
+#include <algorithm>
+#include <mutex>
+
 namespace PTSettingsHelper
 {
     constexpr inline const wchar_t* settings_filename = L"\\settings.json";
@@ -10,6 +13,28 @@ namespace PTSettingsHelper
     constexpr inline const wchar_t* last_version_json_field_name = L"last_version";
     constexpr inline const wchar_t* DataDiagnosticsRegKey = L"Software\\Classes\\PowerToys";
     constexpr inline const wchar_t* DataDiagnosticsRegValueName = L"AllowDataDiagnostics";
+
+    namespace
+    {
+        std::mutex low_memory_settings_mutex;
+        json::JsonObject low_memory_settings_cache;
+        bool low_memory_settings_cache_initialized = false;
+
+        json::JsonObject get_low_memory_settings_from_general_settings(const json::JsonObject& general_settings)
+        {
+            auto low_memory_settings = json::has(general_settings, low_memory_modules_json_field_name, json::JsonValueType::Object) ?
+                                           general_settings.GetNamedObject(low_memory_modules_json_field_name) :
+                                           create_default_low_memory_module_settings();
+            ensure_low_memory_settings_shape(low_memory_settings);
+            return low_memory_settings;
+        }
+
+        json::JsonObject get_cached_low_memory_settings()
+        {
+            std::lock_guard lock{ low_memory_settings_mutex };
+            return low_memory_settings_cache_initialized ? low_memory_settings_cache : create_default_low_memory_module_settings();
+        }
+    }
 
     std::wstring get_root_save_folder_location()
     {
@@ -97,6 +122,81 @@ namespace PTSettingsHelper
         std::filesystem::path result(PTSettingsHelper::get_root_save_folder_location());
         result = result.append(log_settings_filename);
         return result.wstring();
+    }
+
+    json::JsonObject create_default_low_memory_module_settings()
+    {
+        json::JsonObject obj;
+        ensure_low_memory_settings_shape(obj);
+        return obj;
+    }
+
+    void refresh_low_memory_settings_cache()
+    {
+        try
+        {
+            refresh_low_memory_settings_cache(load_general_settings());
+        }
+        catch (...)
+        {
+            std::lock_guard lock{ low_memory_settings_mutex };
+            if (!low_memory_settings_cache_initialized)
+            {
+                low_memory_settings_cache = create_default_low_memory_module_settings();
+                low_memory_settings_cache_initialized = true;
+            }
+        }
+    }
+
+    void refresh_low_memory_settings_cache(const json::JsonObject& general_settings)
+    {
+        auto low_memory_settings = get_low_memory_settings_from_general_settings(general_settings);
+
+        std::lock_guard lock{ low_memory_settings_mutex };
+        low_memory_settings_cache = low_memory_settings;
+        low_memory_settings_cache_initialized = true;
+    }
+
+    void ensure_low_memory_settings_shape(json::JsonObject& obj)
+    {
+        for (const auto module_key : supported_low_memory_modules)
+        {
+            if (!json::has(obj, module_key, json::JsonValueType::Boolean))
+            {
+                obj.SetNamedValue(module_key, json::value(false));
+            }
+        }
+    }
+
+    bool is_any_low_memory_module_enabled(const json::JsonObject& low_memory_settings)
+    {
+        for (const auto module_key : supported_low_memory_modules)
+        {
+            if (low_memory_settings.GetNamedBoolean(module_key, false))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    bool is_low_memory_module(std::wstring_view module_key)
+    {
+        return std::find(supported_low_memory_modules.begin(), supported_low_memory_modules.end(), module_key) != supported_low_memory_modules.end();
+    }
+
+    bool is_low_memory_mode_enabled(std::wstring_view powertoy_key, bool default_value)
+    {
+        try
+        {
+            auto low_memory_modules = get_cached_low_memory_settings();
+            return low_memory_modules.GetNamedBoolean(std::wstring{ powertoy_key }, default_value);
+        }
+        catch (...)
+        {
+            return default_value;
+        }
     }
 
     bool get_oobe_opened_state()

--- a/src/common/SettingsAPI/settings_helpers.h
+++ b/src/common/SettingsAPI/settings_helpers.h
@@ -1,5 +1,7 @@
 #pragma once
+#include <array>
 #include <string>
+#include <string_view>
 #include <Shlobj.h>
 
 #include "../utils/json.h"
@@ -7,6 +9,13 @@
 namespace PTSettingsHelper
 {
     constexpr inline const wchar_t* log_settings_filename = L"log_settings.json";
+    constexpr inline const wchar_t* low_memory_modules_json_field_name = L"low_memory_modules";
+    constexpr inline std::array supported_low_memory_modules{
+        std::wstring_view{ L"TextExtractor" },
+        std::wstring_view{ L"ColorPicker" },
+        std::wstring_view{ L"AdvancedPaste" },
+        std::wstring_view{ L"Peek" },
+    };
 
     std::wstring get_powertoys_general_save_file_location();
     std::wstring get_module_save_file_location(std::wstring_view powertoy_key);
@@ -19,6 +28,14 @@ namespace PTSettingsHelper
     void save_general_settings(const json::JsonObject& settings);
     json::JsonObject load_general_settings();
     std::wstring get_log_settings_file_location();
+
+    json::JsonObject create_default_low_memory_module_settings();
+    void refresh_low_memory_settings_cache();
+    void refresh_low_memory_settings_cache(const json::JsonObject& general_settings);
+    void ensure_low_memory_settings_shape(json::JsonObject& obj);
+    bool is_any_low_memory_module_enabled(const json::JsonObject& low_memory_settings);
+    bool is_low_memory_module(std::wstring_view module_key);
+    bool is_low_memory_mode_enabled(std::wstring_view powertoy_key, bool default_value = false);
 
     bool get_oobe_opened_state();
     void save_oobe_opened_state();

--- a/src/modules/AdvancedPaste/AdvancedPaste/AdvancedPasteXAML/App.xaml.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/AdvancedPasteXAML/App.xaml.cs
@@ -38,6 +38,8 @@ namespace AdvancedPaste
     /// </summary>
     public partial class App : Application, IDisposable
     {
+        private const string ExitAfterUseArgument = "--exit-after-use";
+
         public IHost Host { get; private set; }
 
         public ETWTrace EtwTrace { get; private set; } = new ETWTrace();
@@ -57,6 +59,7 @@ namespace AdvancedPaste
         private nint windowHwnd;
 
         private bool disposedValue;
+        private bool exitAfterUse;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="App"/> class.
@@ -97,6 +100,19 @@ namespace AdvancedPaste
             return window;
         }
 
+        internal bool ExitAfterUse => exitAfterUse;
+
+        internal void ExitAfterUseIfEnabled()
+        {
+            if (!ExitAfterUse)
+            {
+                return;
+            }
+
+            Dispose();
+            Environment.Exit(0);
+        }
+
         public static T GetService<T>()
             where T : class
         {
@@ -115,6 +131,8 @@ namespace AdvancedPaste
         protected override void OnLaunched(LaunchActivatedEventArgs args)
         {
             var cmdArgs = Environment.GetCommandLineArgs();
+            exitAfterUse = cmdArgs?.Contains(ExitAfterUseArgument, StringComparer.OrdinalIgnoreCase) == true;
+
             if (cmdArgs?.Length > 1)
             {
                 if (int.TryParse(cmdArgs[1], out int powerToysRunnerPid))
@@ -155,10 +173,12 @@ namespace AdvancedPaste
             else if (messageType == PowerToys.Interop.Constants.AdvancedPasteMarkdownMessage())
             {
                 await viewModel.ExecutePasteFormatAsync(PasteFormats.Markdown, PasteActionSource.GlobalKeyboardShortcut);
+                ExitAfterUseIfEnabled();
             }
             else if (messageType == PowerToys.Interop.Constants.AdvancedPasteJsonMessage())
             {
                 await viewModel.ExecutePasteFormatAsync(PasteFormats.Json, PasteActionSource.GlobalKeyboardShortcut);
+                ExitAfterUseIfEnabled();
             }
             else if (messageType == PowerToys.Interop.Constants.AdvancedPasteAdditionalActionMessage())
             {
@@ -196,6 +216,7 @@ namespace AdvancedPaste
                 {
                     await ShowWindow();
                     await viewModel.ExecutePasteFormatAsync(pasteFormat, PasteActionSource.GlobalKeyboardShortcut);
+                    ExitAfterUseIfEnabled();
                 }
             }
         }
@@ -216,6 +237,7 @@ namespace AdvancedPaste
                 {
                     await ShowWindow();
                     await viewModel.ExecuteCustomActionAsync(customActionId, PasteActionSource.GlobalKeyboardShortcut);
+                    ExitAfterUseIfEnabled();
                 }
             }
         }

--- a/src/modules/AdvancedPaste/AdvancedPaste/AdvancedPasteXAML/MainWindow.xaml.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/AdvancedPasteXAML/MainWindow.xaml.cs
@@ -90,6 +90,7 @@ namespace AdvancedPaste
             if (_userSettings.CloseAfterLosingFocus && args.WindowActivationState == WindowActivationState.Deactivated)
             {
                 Hide();
+                (Application.Current as App)?.ExitAfterUseIfEnabled();
             }
         }
 
@@ -116,6 +117,7 @@ namespace AdvancedPaste
             await _optionsViewModel.CancelPasteActionAsync();
             Hide();
             args.Handled = true;
+            (Application.Current as App)?.ExitAfterUseIfEnabled();
         }
 
         private void Hide()

--- a/src/modules/AdvancedPaste/AdvancedPaste/ViewModels/OptionsViewModel.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/ViewModels/OptionsViewModel.cs
@@ -635,6 +635,8 @@ namespace AdvancedPaste.ViewModels
             // Delete any temp files created. A delay is needed to ensure the file is not in use by the target application -
             // for example, when pasting onto File Explorer, the paste operation will trigger a file copy.
             _ = Task.Run(() => package.GetView().TryCleanupAfterDelayAsync(TimeSpan.FromSeconds(30)));
+
+            (Application.Current as global::AdvancedPaste.App)?.ExitAfterUseIfEnabled();
         }
 
         // Command to select the previous custom format

--- a/src/modules/AdvancedPaste/AdvancedPasteModuleInterface/AdvancedPasteProcessManager.cpp
+++ b/src/modules/AdvancedPaste/AdvancedPasteModuleInterface/AdvancedPasteProcessManager.cpp
@@ -32,15 +32,17 @@ namespace
     }
 }
 
-void AdvancedPasteProcessManager::start()
+void AdvancedPasteProcessManager::start(bool exit_after_use)
 {
     m_enabled = true;
+    m_exit_after_use = exit_after_use;
     submit_task([this]() { refresh(); });
 }
 
 void AdvancedPasteProcessManager::stop()
 {
     m_enabled = false;
+    m_exit_after_use = false;
     submit_task([this]() { refresh(); });
 }
 
@@ -100,7 +102,11 @@ HRESULT AdvancedPasteProcessManager::start_process(const std::wstring& pipe_name
 {
     const unsigned long powertoys_pid = GetCurrentProcessId();
 
-    const auto executable_args = std::format(L"{} {}", std::to_wstring(powertoys_pid), pipe_name);
+    std::wstring executable_args = std::format(L"{} {}", std::to_wstring(powertoys_pid), pipe_name);
+    if (m_exit_after_use)
+    {
+        executable_args.append(L" --exit-after-use");
+    }
 
     SHELLEXECUTEINFOW sei{ sizeof(sei) };
     sei.fMask = { SEE_MASK_NOCLOSEPROCESS | SEE_MASK_FLAG_NO_UI };
@@ -109,7 +115,6 @@ HRESULT AdvancedPasteProcessManager::start_process(const std::wstring& pipe_name
     sei.lpParameters = executable_args.data();
     if (ShellExecuteExW(&sei))
     {
-        Logger::trace("Successfully started Advanced Paste process");
         terminate_process();
         m_hProcess = sei.hProcess;
         return S_OK;

--- a/src/modules/AdvancedPaste/AdvancedPasteModuleInterface/AdvancedPasteProcessManager.h
+++ b/src/modules/AdvancedPaste/AdvancedPasteModuleInterface/AdvancedPasteProcessManager.h
@@ -15,7 +15,7 @@ public:
     AdvancedPasteProcessManager(const AdvancedPasteProcessManager&) = delete;
     AdvancedPasteProcessManager& operator=(const AdvancedPasteProcessManager&) = delete;
 
-    void start();
+    void start(bool exit_after_use = false);
     void stop();
     void send_message(const std::wstring& message_type, const std::wstring& message_arg = L"");
     void bring_to_front();
@@ -31,6 +31,7 @@ private:
 
     OnThreadExecutor m_thread_executor; // all internal operations are done on background thread with task queue
     std::atomic<bool> m_enabled = false; // written on main thread, read on background thread
+    std::atomic<bool> m_exit_after_use = false; // written on main thread, read on background thread
     HANDLE m_hProcess = 0;
     std::unique_ptr<CAtlFile> m_write_pipe;
 };

--- a/src/modules/AdvancedPaste/AdvancedPasteModuleInterface/dllmain.cpp
+++ b/src/modules/AdvancedPaste/AdvancedPasteModuleInterface/dllmain.cpp
@@ -975,14 +975,19 @@ public:
         Logger::trace("AdvancedPaste::enable()");
         Trace::AdvancedPaste_Enable(true);
         m_enabled = true;
-        m_process_manager.start();
+        PTSettingsHelper::refresh_low_memory_settings_cache();
+        if (!PTSettingsHelper::is_low_memory_mode_enabled(get_key()))
+        {
+            m_process_manager.start(false);
+        }
 
         // Start listening for external trigger event so we can invoke the same logic as the hotkey.
         // Note: Use start() directly instead of constructor + move assignment to avoid dangling this pointer in the thread.
         m_triggerEventWaiter.start(CommonSharedConstants::ADVANCED_PASTE_SHOW_UI_EVENT, [this](DWORD) {
             // Same logic as hotkeyId == 1 (m_advanced_paste_ui_hotkey)
             Logger::trace(L"AdvancedPaste ShowUI event triggered");
-            m_process_manager.start();
+            const bool exit_after_use = PTSettingsHelper::is_low_memory_mode_enabled(get_key());
+            m_process_manager.start(exit_after_use);
             m_process_manager.bring_to_front();
             m_process_manager.send_message(CommonSharedConstants::ADVANCED_PASTE_SHOW_UI_MESSAGE);
             Trace::AdvancedPaste_Invoked(L"AdvancedPasteUIEvent");
@@ -1041,8 +1046,6 @@ public:
                 }
             }
 
-            m_process_manager.start();
-
             // hotkeyId in same order as set by get_hotkeys
             if (hotkeyId == 0)
             { // m_paste_as_plain_hotkey
@@ -1057,6 +1060,9 @@ public:
                 Trace::AdvancedPaste_Invoked(L"PastePlainTextDirect");
                 return true;
             }
+
+            const bool exit_after_use = PTSettingsHelper::is_low_memory_mode_enabled(get_key());
+            m_process_manager.start(exit_after_use);
 
             if (hotkeyId == 1)
             { // m_advanced_paste_ui_hotkey

--- a/src/modules/PowerOCR/PowerOCR/App.xaml.cs
+++ b/src/modules/PowerOCR/PowerOCR/App.xaml.cs
@@ -25,6 +25,10 @@ public partial class App : Application, IDisposable
     private Mutex? _instanceMutex;
     private int _powerToysRunnerPid;
     private ETWTrace etwTrace = new ETWTrace();
+    private const string ActivateOnStartupArgument = "--activate";
+    private const string ExitAfterCloseArgument = "--exit-after-close";
+
+    internal static bool ExitAfterClose { get; private set; }
 
     private CancellationTokenSource NativeThreadCTS { get; set; }
 
@@ -49,7 +53,7 @@ public partial class App : Application, IDisposable
 
         NativeEventWaiter.WaitForEventLoop(
             Constants.TerminatePowerOCRSharedEvent(),
-            this.Shutdown,
+            RequestShutdown,
             this.Dispatcher,
             NativeThreadCTS.Token);
     }
@@ -57,8 +61,23 @@ public partial class App : Application, IDisposable
     public void Dispose()
     {
         GC.SuppressFinalize(this);
+        NativeThreadCTS.Cancel();
+        NativeThreadCTS.Dispose();
         keyboardMonitor?.Dispose();
         etwTrace?.Dispose();
+    }
+
+    internal void RequestShutdown()
+    {
+        NativeThreadCTS.Cancel();
+        if (Dispatcher.CheckAccess())
+        {
+            Shutdown();
+        }
+        else
+        {
+            Dispatcher.BeginInvoke(new Action(Shutdown));
+        }
     }
 
     private void Application_Startup(object sender, StartupEventArgs e)
@@ -66,7 +85,7 @@ public partial class App : Application, IDisposable
         if (PowerToys.GPOWrapperProjection.GPOWrapper.GetConfiguredTextExtractorEnabledValue() == PowerToys.GPOWrapperProjection.GpoRuleConfigured.Disabled)
         {
             Logger.LogWarning("Tried to start with a GPO policy setting the utility to always be disabled. Please contact your systems administrator.");
-            Shutdown();
+            RequestShutdown();
             return;
         }
 
@@ -76,7 +95,7 @@ public partial class App : Application, IDisposable
         {
             Logger.LogWarning("Another running TextExtractor instance was detected. Exiting TextExtractor");
             _instanceMutex = null;
-            Shutdown();
+            RequestShutdown();
             return;
         }
 
@@ -85,16 +104,34 @@ public partial class App : Application, IDisposable
             try
             {
                 _ = int.TryParse(e.Args[0], out _powerToysRunnerPid);
-                Logger.LogInfo($"TextExtractor started from the PowerToys Runner. Runner pid={_powerToysRunnerPid}");
+                bool activateOnStartup = Array.Exists(e.Args, arg => string.Equals(arg, ActivateOnStartupArgument, StringComparison.OrdinalIgnoreCase));
+                ExitAfterClose = Array.Exists(e.Args, arg => string.Equals(arg, ExitAfterCloseArgument, StringComparison.OrdinalIgnoreCase));
 
                 RunnerHelper.WaitForPowerToysRunner(_powerToysRunnerPid, () =>
                 {
                     Logger.LogInfo("PowerToys Runner exited. Exiting TextExtractor");
-                    NativeThreadCTS.Cancel();
-                    Current.Dispatcher.Invoke(() => Shutdown());
+                    RequestShutdown();
                 });
                 var userSettings = new UserSettings(new Helpers.ThrottledActionInvoker());
                 eventMonitor = new EventMonitor(Current.Dispatcher, NativeThreadCTS.Token);
+                if (activateOnStartup)
+                {
+                    Current.Dispatcher.BeginInvoke(new Action(() =>
+                    {
+                        try
+                        {
+                            eventMonitor.StartOCRSession();
+                        }
+                        catch (Exception ex)
+                        {
+                            Logger.LogError($"TextExtractor startup activation failed: {ex}");
+                            if (ExitAfterClose)
+                            {
+                                RequestShutdown();
+                            }
+                        }
+                    }));
+                }
             }
             catch (Exception ex)
             {
@@ -113,6 +150,7 @@ public partial class App : Application, IDisposable
 
     protected override void OnExit(ExitEventArgs e)
     {
+        NativeThreadCTS.Cancel();
         _instanceMutex?.ReleaseMutex();
         base.OnExit(e);
     }

--- a/src/modules/PowerOCR/PowerOCR/Helpers/WindowUtilities.cs
+++ b/src/modules/PowerOCR/PowerOCR/Helpers/WindowUtilities.cs
@@ -22,7 +22,6 @@ public static class WindowUtilities
             return;
         }
 
-        Logger.LogInfo($"Adding Overlays for each screen");
         foreach (Screen screen in Screen.AllScreens)
         {
             DpiScale dpiScale = screen.GetDpi();
@@ -65,8 +64,10 @@ public static class WindowUtilities
 
         GC.Collect();
 
-        // TODO: Decide when to close the process
-        // System.Windows.Application.Current.Shutdown();
+        if (App.ExitAfterClose)
+        {
+            (System.Windows.Application.Current as App)?.RequestShutdown();
+        }
     }
 
     public static void ActivateWindow(Window window)

--- a/src/modules/PowerOCR/PowerOCRModuleInterface/dllmain.cpp
+++ b/src/modules/PowerOCR/PowerOCRModuleInterface/dllmain.cpp
@@ -5,6 +5,7 @@
 #include "trace.h"
 #include "Generated Files/resource.h"
 #include <common/logger/logger.h>
+#include <common/SettingsAPI/settings_helpers.h>
 #include <common/SettingsAPI/settings_objects.h>
 #include <common/utils/resources.h>
 
@@ -60,7 +61,7 @@ private:
     //contains the non localized key of the powertoy
     std::wstring app_key;
 
-    HANDLE m_hProcess;
+    HANDLE m_hProcess = nullptr;
 
     // Time to wait for process to close after sending WM_CLOSE signal
     static const int MAX_WAIT_MILLISEC = 10000;
@@ -109,16 +110,39 @@ private:
 
     bool is_process_running()
     {
+        if (m_hProcess == nullptr)
+        {
+            return false;
+        }
+
         return WaitForSingleObject(m_hProcess, 0) == WAIT_TIMEOUT;
     }
 
-    void launch_process()
+    void launch_process(bool activate_on_startup = false, bool exit_after_close = false)
     {
-        Logger::trace(L"Starting TextExtractor process");
+        if (is_process_running())
+        {
+            return;
+        }
+
+        if (m_hProcess != nullptr)
+        {
+            CloseHandle(m_hProcess);
+            m_hProcess = nullptr;
+        }
+
         unsigned long powertoys_pid = GetCurrentProcessId();
 
-        std::wstring executable_args = L"";
-        executable_args.append(std::to_wstring(powertoys_pid));
+        std::wstring executable_args = std::to_wstring(powertoys_pid);
+        if (activate_on_startup)
+        {
+            executable_args.append(L" --activate");
+        }
+
+        if (exit_after_close)
+        {
+            executable_args.append(L" --exit-after-close");
+        }
 
         SHELLEXECUTEINFOW sei{ sizeof(sei) };
         sei.fMask = { SEE_MASK_NOCLOSEPROCESS | SEE_MASK_FLAG_NO_UI };
@@ -127,14 +151,12 @@ private:
         sei.lpParameters = executable_args.data();
         if (ShellExecuteExW(&sei))
         {
-            Logger::trace("Successfully started the TextExtractor process");
+            m_hProcess = sei.hProcess;
         }
         else
         {
             Logger::error(L"TextExtractor failed to start. {}", get_last_error_or_default(GetLastError()));
         }
-
-        m_hProcess = sei.hProcess;
     }
 
     // Load the settings file.
@@ -241,7 +263,14 @@ public:
     {
         Logger::trace("TextExtractor::enable()");
         ResetEvent(m_hInvokeEvent);
-        launch_process();
+        ResetEvent(m_hTerminateEvent);
+        PTSettingsHelper::refresh_low_memory_settings_cache();
+        const bool low_memory_mode = PTSettingsHelper::is_low_memory_mode_enabled(get_key());
+        if (!low_memory_mode)
+        {
+            launch_process();
+        }
+
         m_enabled = true;
         Trace::EnablePowerOCR(true);
     };
@@ -252,9 +281,17 @@ public:
         if (m_enabled)
         {
             ResetEvent(m_hInvokeEvent);
-            SetEvent(m_hTerminateEvent);
-            WaitForSingleObject(m_hProcess, 1500);
-            TerminateProcess(m_hProcess, 1);
+            if (m_hProcess != nullptr)
+            {
+                SetEvent(m_hTerminateEvent);
+                if (WaitForSingleObject(m_hProcess, 1500) == WAIT_TIMEOUT)
+                {
+                    TerminateProcess(m_hProcess, 1);
+                }
+
+                CloseHandle(m_hProcess);
+                m_hProcess = nullptr;
+            }
         }
 
         m_enabled = false;
@@ -268,10 +305,16 @@ public:
             Logger::trace(L"TextExtractor hotkey pressed");
             if (!is_process_running())
             {
-                launch_process();
+                const bool low_memory_mode = PTSettingsHelper::is_low_memory_mode_enabled(get_key());
+                launch_process(true, low_memory_mode);
+                return true;
             }
 
-            SetEvent(m_hInvokeEvent);
+            if (!SetEvent(m_hInvokeEvent))
+            {
+                Logger::error(L"TextExtractor failed to signal invoke event. {}", get_last_error_or_default(GetLastError()));
+            }
+
             return true;
         }
 

--- a/src/modules/colorPicker/ColorPicker/dllmain.cpp
+++ b/src/modules/colorPicker/ColorPicker/dllmain.cpp
@@ -5,6 +5,7 @@
 #include "trace.h"
 #include "Generated Files/resource.h"
 #include <common/logger/logger.h>
+#include <common/SettingsAPI/settings_helpers.h>
 #include <common/SettingsAPI/settings_objects.h>
 #include <common/utils/resources.h>
 
@@ -55,7 +56,7 @@ private:
     //contains the non localized key of the powertoy
     std::wstring app_key;
 
-    HANDLE m_hProcess;
+    HANDLE m_hProcess = nullptr;
 
     // Time to wait for process to close after sending WM_CLOSE signal
     static const int MAX_WAIT_MILLISEC = 10000;
@@ -106,16 +107,34 @@ private:
 
     bool is_process_running()
     {
+        if (m_hProcess == nullptr)
+        {
+            return false;
+        }
+
         return WaitForSingleObject(m_hProcess, 0) == WAIT_TIMEOUT;
     }
 
-    void launch_process()
+    void launch_process(bool exit_after_close = false)
     {
-        Logger::trace(L"Starting ColorPicker process");
+        if (is_process_running())
+        {
+            return;
+        }
+
+        if (m_hProcess != nullptr)
+        {
+            CloseHandle(m_hProcess);
+            m_hProcess = nullptr;
+        }
+
         unsigned long powertoys_pid = GetCurrentProcessId();
 
-        std::wstring executable_args = L"";
-        executable_args.append(std::to_wstring(powertoys_pid));
+        std::wstring executable_args = std::to_wstring(powertoys_pid);
+        if (exit_after_close)
+        {
+            executable_args.append(L" --exit-after-close");
+        }
 
         SHELLEXECUTEINFOW sei{ sizeof(sei) };
         sei.fMask = { SEE_MASK_NOCLOSEPROCESS | SEE_MASK_FLAG_NO_UI };
@@ -124,14 +143,12 @@ private:
         sei.lpParameters = executable_args.data();
         if (ShellExecuteExW(&sei))
         {
-            Logger::trace("Successfully started the Color Picker process");
+            m_hProcess = sei.hProcess;
         }
         else
         {
             Logger::error(L"ColorPicker failed to start. {}", get_last_error_or_default(GetLastError()));
         }
-
-        m_hProcess = sei.hProcess;
     }
 
     // Load the settings file.
@@ -240,7 +257,13 @@ public:
         Logger::trace("ColorPicker::enable()");
         ResetEvent(send_telemetry_event);
         ResetEvent(m_hInvokeEvent);
-        launch_process();
+        ResetEvent(m_hAppTerminateEvent);
+        PTSettingsHelper::refresh_low_memory_settings_cache();
+        if (!PTSettingsHelper::is_low_memory_mode_enabled(get_key()))
+        {
+            launch_process();
+        }
+
         m_enabled = true;
         Trace::EnableColorPicker(true);
     };
@@ -253,10 +276,17 @@ public:
             ResetEvent(send_telemetry_event);
             ResetEvent(m_hInvokeEvent);
 
-            SetEvent(m_hAppTerminateEvent);
-            WaitForSingleObject(m_hProcess, 1500);
+            if (m_hProcess != nullptr)
+            {
+                SetEvent(m_hAppTerminateEvent);
+                if (WaitForSingleObject(m_hProcess, 1500) == WAIT_TIMEOUT)
+                {
+                    TerminateProcess(m_hProcess, 1);
+                }
 
-            TerminateProcess(m_hProcess, 1);
+                CloseHandle(m_hProcess);
+                m_hProcess = nullptr;
+            }
         }
 
         m_enabled = false;
@@ -270,7 +300,7 @@ public:
             Logger::trace(L"ColorPicker hotkey pressed");
             if (!is_process_running())
             {
-                launch_process();
+                launch_process(PTSettingsHelper::is_low_memory_mode_enabled(get_key()));
             }
 
             SetEvent(m_hInvokeEvent);

--- a/src/modules/colorPicker/ColorPickerUI/App.xaml.cs
+++ b/src/modules/colorPicker/ColorPickerUI/App.xaml.cs
@@ -25,6 +25,9 @@ namespace ColorPickerUI
         private static string[] _args;
         private int _powerToysRunnerPid;
         private bool disposedValue;
+        private const string ExitAfterCloseArgument = "--exit-after-close";
+
+        internal bool ExitAfterClose { get; private set; }
 
         private CancellationTokenSource NativeThreadCTS { get; set; }
 
@@ -64,8 +67,8 @@ namespace ColorPickerUI
             if (_args?.Length > 0)
             {
                 _ = int.TryParse(_args[0], out _powerToysRunnerPid);
+                ExitAfterClose = Array.Exists(_args, arg => string.Equals(arg, ExitAfterCloseArgument, StringComparison.OrdinalIgnoreCase));
 
-                Logger.LogInfo($"Color Picker started from the PowerToys Runner. Runner pid={_powerToysRunnerPid}");
                 RunnerHelper.WaitForPowerToysRunner(_powerToysRunnerPid, () =>
                 {
                     Logger.LogInfo("PowerToys Runner exited. Exiting ColorPicker");
@@ -81,14 +84,29 @@ namespace ColorPickerUI
             base.OnStartup(e);
         }
 
+        internal void RequestShutdown()
+        {
+            NativeThreadCTS?.Cancel();
+            if (Dispatcher.CheckAccess())
+            {
+                Shutdown();
+            }
+            else
+            {
+                Dispatcher.Invoke(Shutdown);
+            }
+        }
+
         protected override void OnExit(ExitEventArgs e)
         {
+            NativeThreadCTS?.Cancel();
             if (_instanceMutex != null)
             {
                 _instanceMutex.ReleaseMutex();
             }
 
             CursorManager.RestoreOriginalCursors();
+            Dispose();
             base.OnExit(e);
         }
 
@@ -98,6 +116,8 @@ namespace ColorPickerUI
             {
                 if (disposing)
                 {
+                    NativeThreadCTS?.Cancel();
+                    NativeThreadCTS?.Dispose();
                     _instanceMutex?.Dispose();
                     EtwTrace?.Dispose();
                 }

--- a/src/modules/colorPicker/ColorPickerUI/Helpers/AppStateHandler.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/AppStateHandler.cs
@@ -84,6 +84,7 @@ namespace ColorPicker.Helpers
             {
                 if (IsColorPickerEditorVisible() || _colorPickerShown)
                 {
+                    bool isRunningDetached = (System.Windows.Application.Current as ColorPickerUI.App).IsRunningDetachedFromPowerToys();
                     if (IsColorPickerEditorVisible())
                     {
                         HideColorPickerEditor();
@@ -93,12 +94,17 @@ namespace ColorPicker.Helpers
                         HideColorPicker();
                     }
 
-                    if (!(System.Windows.Application.Current as ColorPickerUI.App).IsRunningDetachedFromPowerToys())
+                    if (!isRunningDetached)
                     {
                         UserSessionEnded?.Invoke(this, EventArgs.Empty);
                     }
 
                     SessionEventHelper.End();
+
+                    if (!isRunningDetached && (System.Windows.Application.Current as ColorPickerUI.App).ExitAfterClose)
+                    {
+                        (System.Windows.Application.Current as ColorPickerUI.App)?.RequestShutdown();
+                    }
 
                     return true;
                 }

--- a/src/modules/colorPicker/ColorPickerUI/ViewModels/MainViewModel.cs
+++ b/src/modules/colorPicker/ColorPickerUI/ViewModels/MainViewModel.cs
@@ -60,7 +60,7 @@ namespace ColorPicker.ViewModels
 
             NativeEventWaiter.WaitForEventLoop(
                 Constants.TerminateColorPickerSharedEvent(),
-                Application.Current.Shutdown,
+                () => (Application.Current as ColorPickerUI.App)?.RequestShutdown(),
                 Application.Current.Dispatcher,
                 exitToken);
 

--- a/src/modules/peek/Peek.UI/PeekXAML/App.xaml.cs
+++ b/src/modules/peek/Peek.UI/PeekXAML/App.xaml.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using ManagedCommon;
 using Microsoft.Extensions.DependencyInjection;
@@ -42,6 +43,7 @@ namespace Peek.UI
         private bool _disposed;
         private SelectedItem? _selectedItem;
         private bool _launchedFromCli;
+        private bool _exitAfterClose;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="App"/> class.
@@ -104,6 +106,7 @@ namespace Peek.UI
             }
 
             var cmdArgs = Environment.GetCommandLineArgs();
+            _exitAfterClose = cmdArgs.Contains("--exit-after-close", StringComparer.OrdinalIgnoreCase);
             if (cmdArgs?.Length > 1)
             {
                 // Check if the last argument is a PowerToys Runner PID
@@ -169,7 +172,7 @@ namespace Peek.UI
                 Window = new MainWindow();
             }
 
-            Window.Toggle(firstActivation, _selectedItem, _launchedFromCli);
+            Window.Toggle(firstActivation, _selectedItem, _launchedFromCli || _exitAfterClose);
             _launchedFromCli = false;
             _selectedItem = null;
         }

--- a/src/modules/peek/peek/dllmain.cpp
+++ b/src/modules/peek/peek/dllmain.cpp
@@ -5,6 +5,7 @@
 #include <comdef.h>
 #include <common/interop/shared_constants.h>
 #include <common/logger/logger.h>
+#include <common/SettingsAPI/settings_helpers.h>
 #include <common/SettingsAPI/settings_objects.h>
 #include <common/utils/elevation.h>
 #include <common/utils/logger_helper.h>
@@ -434,11 +435,23 @@ private:
 
     void launch_process()
     {
+        if (is_viewer_running())
+        {
+            return;
+        }
+
+        if (m_hProcess != 0)
+        {
+            CloseHandle(m_hProcess);
+            m_hProcess = 0;
+            m_processPid = 0;
+        }
+
         Logger::trace(L"Starting Peek.UI process");
 
         unsigned long powertoys_pid = GetCurrentProcessId();
 
-        std::wstring executable_args = L"";
+        std::wstring executable_args = PTSettingsHelper::is_low_memory_mode_enabled(get_key()) ? L"--exit-after-close " : L"";
         executable_args.append(std::to_wstring(powertoys_pid));
 
         if (m_alwaysRunNotElevated && is_process_elevated(false))
@@ -561,7 +574,13 @@ public:
     {
         Logger::trace("Peek::enable()");
         ResetEvent(m_hInvokeEvent);
-        launch_process();
+        ResetEvent(m_hTerminateEvent);
+        PTSettingsHelper::refresh_low_memory_settings_cache();
+        if (!PTSettingsHelper::is_low_memory_mode_enabled(get_key()))
+        {
+            launch_process();
+        }
+
         m_enabled = true;
         Trace::EnablePeek(true);
         manage_space_mode_hook();
@@ -574,23 +593,23 @@ public:
         if (m_enabled)
         {
             ResetEvent(m_hInvokeEvent);
-            SetEvent(m_hTerminateEvent);
-
-            HANDLE hProcess = OpenProcess(SYNCHRONIZE | PROCESS_TERMINATE, FALSE, m_processPid);
-            if (WaitForSingleObject(hProcess, 1500) == WAIT_TIMEOUT)
+            if (m_hProcess != 0)
             {
-                auto result = TerminateProcess(hProcess, 1);
-                if (result == 0)
+                SetEvent(m_hTerminateEvent);
+                if (WaitForSingleObject(m_hProcess, 1500) == WAIT_TIMEOUT)
                 {
-                    int error = GetLastError();
-                    Logger::trace("Couldn't terminate the process. Last error: {}", error);
+                    auto result = TerminateProcess(m_hProcess, 1);
+                    if (result == 0)
+                    {
+                        int error = GetLastError();
+                        Logger::trace("Couldn't terminate the process. Last error: {}", error);
+                    }
                 }
-            }
 
-            CloseHandle(hProcess);
-            CloseHandle(m_hProcess);
-            m_hProcess = 0;
-            m_processPid = 0;
+                CloseHandle(m_hProcess);
+                m_hProcess = 0;
+                m_processPid = 0;
+            }
         }
 
         m_enabled = false;

--- a/src/runner/general_settings.cpp
+++ b/src/runner/general_settings.cpp
@@ -16,6 +16,8 @@
 #include <common/version/version.h>
 #include <common/utils/resources.h>
 
+#include <algorithm>
+
 namespace
 {
     json::JsonValue create_empty_shortcut_array_value()
@@ -62,6 +64,28 @@ namespace
 
         return fallback;
     }
+
+    bool has_low_memory_modules_setting_changed(const json::JsonObject& old_low_memory_settings, const json::JsonObject& new_low_memory_settings, std::wstring_view module_key)
+    {
+        return old_low_memory_settings.GetNamedBoolean(module_key, false) != new_low_memory_settings.GetNamedBoolean(module_key, false);
+    }
+
+    void reapply_low_memory_policy_to_enabled_modules(const json::JsonObject& old_low_memory_settings, const json::JsonObject& new_low_memory_settings)
+    {
+        auto& hkmng = HotkeyConflictDetector::HotkeyConflictManager::GetInstance();
+        for (auto& [name, powertoy] : modules())
+        {
+            if (!PTSettingsHelper::is_low_memory_module(name) || !powertoy->is_enabled() || !has_low_memory_modules_setting_changed(old_low_memory_settings, new_low_memory_settings, name))
+            {
+                continue;
+            }
+
+            powertoy->disable();
+            powertoy->enable();
+            hkmng.EnableHotkeyByModule(name);
+            powertoy.UpdateHotkeyEx();
+        }
+    }
 }
 
 // TODO: would be nice to get rid of these globals, since they're basically cached json settings
@@ -75,6 +99,7 @@ static bool show_whats_new_after_updates = true;
 static bool enable_experimentation = true;
 static bool enable_warnings_elevated_apps = true;
 static bool enable_quick_access = true;
+static json::JsonObject low_memory_modules = PTSettingsHelper::create_default_low_memory_module_settings();
 static PowerToysSettings::HotkeyObject quick_access_shortcut;
 static DashboardSortOrder dashboard_sort_order = DashboardSortOrder::Alphabetical;
 static json::JsonObject ignored_conflict_properties = create_default_ignored_conflict_properties();
@@ -85,6 +110,8 @@ json::JsonObject GeneralSettings::to_json()
 
     auto ignoredProps = ignoredConflictProperties;
     ensure_ignored_conflict_properties_shape(ignoredProps);
+    auto lowMemoryModuleSettings = lowMemoryModules;
+    PTSettingsHelper::ensure_low_memory_settings_shape(lowMemoryModuleSettings);
 
     result.SetNamedValue(L"startup", json::value(isStartupEnabled));
     if (!startupDisabledReason.empty())
@@ -111,6 +138,8 @@ json::JsonObject GeneralSettings::to_json()
     result.SetNamedValue(L"is_admin", json::value(isAdmin));
     result.SetNamedValue(L"enable_warnings_elevated_apps", json::value(enableWarningsElevatedApps));
     result.SetNamedValue(L"enable_quick_access", json::value(enableQuickAccess));
+    result.SetNamedValue(L"low_memory_mode", json::value(lowMemoryMode));
+    result.SetNamedValue(L"low_memory_modules", json::value(lowMemoryModuleSettings));
     result.SetNamedValue(L"quick_access_shortcut", quickAccessShortcut.get_json());
     result.SetNamedValue(L"theme", json::value(theme));
     result.SetNamedValue(L"system_theme", json::value(systemTheme));
@@ -137,6 +166,17 @@ json::JsonObject load_general_settings()
     enable_experimentation = loaded.GetNamedBoolean(L"enable_experimentation", true);
     enable_warnings_elevated_apps = loaded.GetNamedBoolean(L"enable_warnings_elevated_apps", true);
     enable_quick_access = loaded.GetNamedBoolean(L"enable_quick_access", true);
+    if (json::has(loaded, L"low_memory_modules", json::JsonValueType::Object))
+    {
+        low_memory_modules = loaded.GetNamedObject(L"low_memory_modules");
+    }
+    else
+    {
+        low_memory_modules = PTSettingsHelper::create_default_low_memory_module_settings();
+    }
+
+    PTSettingsHelper::ensure_low_memory_settings_shape(low_memory_modules);
+    PTSettingsHelper::refresh_low_memory_settings_cache(loaded);
     if (json::has(loaded, L"quick_access_shortcut", json::JsonValueType::Object))
     {
         quick_access_shortcut = PowerToysSettings::HotkeyObject::from_json(loaded.GetNamedObject(L"quick_access_shortcut"));
@@ -169,12 +209,14 @@ GeneralSettings get_general_settings()
         .isAdmin = is_user_admin,
         .enableWarningsElevatedApps = enable_warnings_elevated_apps,
         .enableQuickAccess = enable_quick_access,
+        .lowMemoryMode = PTSettingsHelper::is_any_low_memory_module_enabled(low_memory_modules),
+        .lowMemoryModules = low_memory_modules,
         .quickAccessShortcut = quick_access_shortcut,
         .showNewUpdatesToastNotification = show_new_updates_toast_notification,
         .downloadUpdatesAutomatically = download_updates_automatically && is_user_admin,
         .showWhatsNewAfterUpdates = show_whats_new_after_updates,
         .enableExperimentation = enable_experimentation,
-    .dashboardSortOrder = dashboard_sort_order,
+        .dashboardSortOrder = dashboard_sort_order,
         .theme = settings_theme,
         .systemTheme = WindowsColors::is_dark_mode() ? L"dark" : L"light",
         .powerToysVersion = get_product_version(),
@@ -297,6 +339,9 @@ void apply_general_settings(const json::JsonObject& general_configs, bool save)
         old_settings_json_string = get_general_settings().to_json().Stringify().c_str();
     }
 
+    auto old_low_memory_modules = low_memory_modules;
+    PTSettingsHelper::ensure_low_memory_settings_shape(old_low_memory_modules);
+
     Logger::info(L"apply_general_settings: {}", std::wstring{ general_configs.ToString() });
     run_as_elevated = general_configs.GetNamedBoolean(L"run_elevated", false);
 
@@ -331,6 +376,19 @@ void apply_general_settings(const json::JsonObject& general_configs, bool save)
         }
         update_quick_access_hotkey(enable_quick_access, quick_access_shortcut);
     }
+
+    if (json::has(general_configs, L"low_memory_modules", json::JsonValueType::Object))
+    {
+        low_memory_modules = general_configs.GetNamedObject(L"low_memory_modules");
+    }
+    else
+    {
+        low_memory_modules = PTSettingsHelper::create_default_low_memory_module_settings();
+    }
+
+    PTSettingsHelper::ensure_low_memory_settings_shape(low_memory_modules);
+    PTSettingsHelper::refresh_low_memory_settings_cache(general_configs);
+    const bool low_memory_policy_changed = old_low_memory_modules.Stringify() != low_memory_modules.Stringify();
 
     show_new_updates_toast_notification = general_configs.GetNamedBoolean(L"show_new_updates_toast_notification", true);
 
@@ -494,6 +552,11 @@ void apply_general_settings(const json::JsonObject& general_configs, bool save)
         {
             PTSettingsHelper::save_general_settings(save_settings.to_json());
             Trace::SettingsChanged(save_settings);
+        }
+
+        if (low_memory_policy_changed)
+        {
+            reapply_low_memory_policy_to_enabled_modules(old_low_memory_modules, low_memory_modules);
         }
     }
 }

--- a/src/runner/general_settings.h
+++ b/src/runner/general_settings.h
@@ -21,6 +21,8 @@ struct GeneralSettings
     bool isAdmin;
     bool enableWarningsElevatedApps;
     bool enableQuickAccess;
+    bool lowMemoryMode;
+    json::JsonObject lowMemoryModules;
     PowerToysSettings::HotkeyObject quickAccessShortcut;
     bool showNewUpdatesToastNotification;
     bool downloadUpdatesAutomatically;

--- a/src/settings-ui/Settings.UI.Library/GeneralSettings.cs
+++ b/src/settings-ui/Settings.UI.Library/GeneralSettings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation
+// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -57,6 +57,13 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         [JsonPropertyName("enable_quick_access")]
         public bool EnableQuickAccess { get; set; }
 
+        // Gets or sets a derived value indicating whether any supported utility uses low memory mode.
+        [JsonPropertyName("low_memory_mode")]
+        public bool LowMemoryMode { get; set; }
+
+        [JsonPropertyName("low_memory_modules")]
+        public LowMemoryModuleSettings LowMemoryModules { get; set; }
+
         // Gets or sets Quick Access shortcut.
         [JsonPropertyName("quick_access_shortcut")]
         public HotkeySettings QuickAccessShortcut { get; set; }
@@ -108,6 +115,8 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             IsAdmin = false;
             EnableWarningsElevatedApps = true;
             EnableQuickAccess = true;
+            LowMemoryMode = false;
+            LowMemoryModules = new LowMemoryModuleSettings();
             QuickAccessShortcut = new HotkeySettings();
             IsElevated = false;
             ShowNewUpdatesToastNotification = true;

--- a/src/settings-ui/Settings.UI.Library/Helpers/ModuleHelper.cs
+++ b/src/settings-ui/Settings.UI.Library/Helpers/ModuleHelper.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using ManagedCommon;
 
 namespace Microsoft.PowerToys.Settings.UI.Library.Helpers
@@ -120,6 +121,62 @@ namespace Microsoft.PowerToys.Settings.UI.Library.Helpers
                 case ModuleType.ZoomIt: generalSettingsConfig.Enabled.ZoomIt = isEnabled; break;
                 case ModuleType.GeneralSettings: generalSettingsConfig.EnableQuickAccess = isEnabled; break;
             }
+        }
+
+        public static IReadOnlyDictionary<ModuleType, string> LowMemoryModuleKeys { get; } = new Dictionary<ModuleType, string>
+        {
+            { ModuleType.PowerOCR, PowerOcrSettings.ModuleName },
+            { ModuleType.ColorPicker, ColorPickerSettings.ModuleName },
+            { ModuleType.AdvancedPaste, AdvancedPasteSettings.ModuleName },
+            { ModuleType.Peek, PeekSettings.ModuleName },
+        };
+
+        public static void EnsureLowMemoryModuleSettings(GeneralSettings generalSettingsConfig)
+        {
+            generalSettingsConfig.LowMemoryModules ??= new LowMemoryModuleSettings();
+            foreach (var moduleKey in LowMemoryModuleKeys.Values)
+            {
+                generalSettingsConfig.LowMemoryModules.EnsureValue(moduleKey);
+            }
+        }
+
+        public static bool GetLowMemoryMode(GeneralSettings generalSettingsConfig, ModuleType moduleType)
+        {
+            EnsureLowMemoryModuleSettings(generalSettingsConfig);
+            return LowMemoryModuleKeys.TryGetValue(moduleType, out string moduleKey) && generalSettingsConfig.LowMemoryModules.GetValue(moduleKey);
+        }
+
+        public static bool SetLowMemoryMode(GeneralSettings generalSettingsConfig, ModuleType moduleType, bool lowMemoryMode)
+        {
+            EnsureLowMemoryModuleSettings(generalSettingsConfig);
+            return LowMemoryModuleKeys.TryGetValue(moduleType, out string moduleKey) && generalSettingsConfig.LowMemoryModules.SetValue(moduleKey, lowMemoryMode);
+        }
+
+        public static bool AnyLowMemoryModeEnabled(GeneralSettings generalSettingsConfig)
+        {
+            EnsureLowMemoryModuleSettings(generalSettingsConfig);
+            foreach (var moduleKey in LowMemoryModuleKeys.Values)
+            {
+                if (generalSettingsConfig.LowMemoryModules.GetValue(moduleKey))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public static bool SetLowMemoryModeForAll(GeneralSettings generalSettingsConfig, bool lowMemoryMode)
+        {
+            bool changed = false;
+            foreach (var moduleType in LowMemoryModuleKeys.Keys)
+            {
+                changed |= SetLowMemoryMode(generalSettingsConfig, moduleType, lowMemoryMode);
+            }
+
+            bool oldLowMemoryMode = generalSettingsConfig.LowMemoryMode;
+            generalSettingsConfig.LowMemoryMode = AnyLowMemoryModeEnabled(generalSettingsConfig);
+            return changed || oldLowMemoryMode != generalSettingsConfig.LowMemoryMode;
         }
 
         /// <summary>

--- a/src/settings-ui/Settings.UI.Library/LowMemoryModuleSettings.cs
+++ b/src/settings-ui/Settings.UI.Library/LowMemoryModuleSettings.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.PowerToys.Settings.UI.Library
+{
+    public class LowMemoryModuleSettings
+    {
+        [JsonPropertyName("TextExtractor")]
+        public bool TextExtractor { get; set; }
+
+        [JsonPropertyName("ColorPicker")]
+        public bool ColorPicker { get; set; }
+
+        [JsonPropertyName("AdvancedPaste")]
+        public bool AdvancedPaste { get; set; }
+
+        [JsonPropertyName("Peek")]
+        public bool Peek { get; set; }
+
+        [JsonExtensionData]
+        public IDictionary<string, JsonElement> AdditionalModules { get; set; } = new Dictionary<string, JsonElement>(StringComparer.Ordinal);
+
+        public bool GetValue(string moduleKey, bool defaultValue = false)
+        {
+            return moduleKey switch
+            {
+                "TextExtractor" => TextExtractor,
+                "ColorPicker" => ColorPicker,
+                "AdvancedPaste" => AdvancedPaste,
+                "Peek" => Peek,
+                _ => AdditionalModules.TryGetValue(moduleKey, out var value) && value.ValueKind is JsonValueKind.True or JsonValueKind.False ? value.GetBoolean() : defaultValue,
+            };
+        }
+
+        public bool SetValue(string moduleKey, bool value)
+        {
+            bool oldValue = GetValue(moduleKey);
+            switch (moduleKey)
+            {
+                case "TextExtractor": TextExtractor = value; break;
+                case "ColorPicker": ColorPicker = value; break;
+                case "AdvancedPaste": AdvancedPaste = value; break;
+                case "Peek": Peek = value; break;
+                default: AdditionalModules[moduleKey] = JsonSerializer.SerializeToElement(value); break;
+            }
+
+            return oldValue != value;
+        }
+
+        public void EnsureValue(string moduleKey, bool defaultValue = false)
+        {
+            if (GetValue(moduleKey, defaultValue) != defaultValue || IsKnownModule(moduleKey) || AdditionalModules.ContainsKey(moduleKey))
+            {
+                return;
+            }
+
+            AdditionalModules[moduleKey] = JsonSerializer.SerializeToElement(defaultValue);
+        }
+
+        private static bool IsKnownModule(string moduleKey) => moduleKey is "TextExtractor" or "ColorPicker" or "AdvancedPaste" or "Peek";
+    }
+}

--- a/src/settings-ui/Settings.UI.Library/SettingsSerializationContext.cs
+++ b/src/settings-ui/Settings.UI.Library/SettingsSerializationContext.cs
@@ -127,6 +127,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 
     // Helper and Utility Types
     [JsonSerializable(typeof(HotkeySettings))]
+    [JsonSerializable(typeof(LowMemoryModuleSettings))]
     [JsonSerializable(typeof(ColorFormatModel))]
     [JsonSerializable(typeof(ImageSize))]
     [JsonSerializable(typeof(KeysDataModel))]

--- a/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/General.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/General.cs
@@ -1,9 +1,8 @@
-﻿// Copyright (c) Microsoft Corporation
+// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;
-
 using Microsoft.PowerToys.Settings.UI.Library;
 using Microsoft.PowerToys.Settings.UI.UnitTests.BackwardsCompatibility;
 using Microsoft.PowerToys.Settings.UI.UnitTests.Mocks;
@@ -48,6 +47,23 @@ namespace ViewModelTests
             {
                 return null;
             }
+        }
+
+        private static void AssertLowMemoryModules(LowMemoryModuleSettings modules, bool textExtractor, bool colorPicker, bool advancedPaste, bool peek)
+        {
+            Assert.IsNotNull(modules);
+            Assert.AreEqual(textExtractor, modules.TextExtractor);
+            Assert.AreEqual(colorPicker, modules.ColorPicker);
+            Assert.AreEqual(advancedPaste, modules.AdvancedPaste);
+            Assert.AreEqual(peek, modules.Peek);
+        }
+
+        private static void AssertLowMemoryModules(GeneralViewModel viewModel, bool textExtractor, bool colorPicker, bool advancedPaste, bool peek)
+        {
+            Assert.AreEqual(textExtractor, viewModel.LowMemoryTextExtractor);
+            Assert.AreEqual(colorPicker, viewModel.LowMemoryColorPicker);
+            Assert.AreEqual(advancedPaste, viewModel.LowMemoryAdvancedPaste);
+            Assert.AreEqual(peek, viewModel.LowMemoryPeek);
         }
 
         [TestMethod]
@@ -337,6 +353,91 @@ namespace ViewModelTests
             // Act
             viewModel.ShowSysTrayIcon = false;
             Assert.IsTrue(sawExpectedIpcPayload);
+        }
+
+        [TestMethod]
+        public void LowMemoryModeShouldBeDisabledByDefault()
+        {
+            GeneralSettings settings = new GeneralSettings();
+
+            Assert.IsFalse(settings.LowMemoryMode);
+            AssertLowMemoryModules(settings.LowMemoryModules, false, false, false, false);
+        }
+
+        [TestMethod]
+        public void LowMemorySettingsShouldRoundTripInOutgoingGeneralSettings()
+        {
+            GeneralSettings settings = new GeneralSettings
+            {
+                LowMemoryMode = true,
+            };
+            settings.LowMemoryModules.TextExtractor = true;
+
+            string outgoingSettings = new OutGoingGeneralSettings(settings).ToString();
+            OutGoingGeneralSettings deserializedSettings = JsonSerializer.Deserialize<OutGoingGeneralSettings>(outgoingSettings);
+
+            Assert.IsNotNull(deserializedSettings.GeneralSettings);
+            Assert.IsTrue(deserializedSettings.GeneralSettings.LowMemoryMode);
+            AssertLowMemoryModules(deserializedSettings.GeneralSettings.LowMemoryModules, true, false, false, false);
+        }
+
+        [TestMethod]
+        public void LowMemoryModuleSettingsShouldRoundTripAdditionalModuleKeys()
+        {
+            GeneralSettings settings = new GeneralSettings();
+            settings.LowMemoryModules.SetValue("FutureUtility", true);
+
+            string outgoingSettings = new OutGoingGeneralSettings(settings).ToString();
+            OutGoingGeneralSettings deserializedSettings = JsonSerializer.Deserialize<OutGoingGeneralSettings>(outgoingSettings);
+
+            Assert.IsNotNull(deserializedSettings.GeneralSettings);
+            Assert.IsNotNull(deserializedSettings.GeneralSettings.LowMemoryModules);
+            Assert.IsTrue(deserializedSettings.GeneralSettings.LowMemoryModules.GetValue("FutureUtility"));
+        }
+
+        [TestMethod]
+        public void LowMemoryBulkCommandsShouldNotRunWhenIndividualOverrideChanges()
+        {
+            int ipcMessageCount = 0;
+            Func<string, int> sendMockIPCConfigMSG = msg =>
+            {
+                ipcMessageCount++;
+                return 0;
+            };
+            Func<string, int> sendRestartAdminIPCMessage = msg => 0;
+            Func<string, int> sendCheckForUpdatesIPCMessage = msg => 0;
+            GeneralViewModel viewModel = new TestGeneralViewModel(
+                settingsRepository: SettingsRepository<GeneralSettings>.GetInstance(mockGeneralSettingsUtils.Object),
+                "GeneralSettings_RunningAsAdminText",
+                "GeneralSettings_RunningAsUserText",
+                false,
+                false,
+                sendMockIPCConfigMSG,
+                sendRestartAdminIPCMessage,
+                sendCheckForUpdatesIPCMessage,
+                GeneralSettingsFileName);
+
+            Assert.IsFalse(viewModel.LowMemoryMode);
+
+            viewModel.LowMemoryTextExtractor = true;
+            Assert.AreEqual(1, ipcMessageCount);
+            Assert.IsTrue(viewModel.LowMemoryMode);
+            AssertLowMemoryModules(viewModel, true, false, false, false);
+
+            viewModel.EnableAllLowMemoryModeCommand.Execute(null);
+            Assert.AreEqual(2, ipcMessageCount);
+            Assert.IsTrue(viewModel.LowMemoryMode);
+            AssertLowMemoryModules(viewModel, true, true, true, true);
+
+            viewModel.LowMemoryPeek = false;
+            Assert.AreEqual(3, ipcMessageCount);
+            Assert.IsTrue(viewModel.LowMemoryMode);
+            AssertLowMemoryModules(viewModel, true, true, true, false);
+
+            viewModel.DisableAllLowMemoryModeCommand.Execute(null);
+            Assert.AreEqual(4, ipcMessageCount);
+            Assert.IsFalse(viewModel.LowMemoryMode);
+            AssertLowMemoryModules(viewModel, false, false, false, false);
         }
 
         [TestMethod]

--- a/src/settings-ui/Settings.UI/Helpers/FriendlyDateHelper.cs
+++ b/src/settings-ui/Settings.UI/Helpers/FriendlyDateHelper.cs
@@ -14,14 +14,14 @@ public static class FriendlyDateHelper
     /// Today → "Today at 1:22 PM", Yesterday → "Yesterday at 3:45 PM",
     /// older dates fall back to the full culture-specific date/time format.
     /// </summary>
-    public static string Format(DateTime? dateTime)
+    public static string Format(DateTime? dateTime, Windows.ApplicationModel.Resources.ResourceLoader resourceLoader = null)
     {
         if (dateTime is not DateTime dt)
         {
             return string.Empty;
         }
 
-        var resourceLoader = ResourceLoaderInstance.ResourceLoader;
+        resourceLoader ??= ResourceLoaderInstance.ResourceLoader;
         var today = DateTime.Now.Date;
         var time = dt.ToString("t", CultureInfo.CurrentCulture);
 

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/AdvancedPastePage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/AdvancedPastePage.xaml
@@ -1,4 +1,4 @@
-﻿<local:NavigablePage
+<local:NavigablePage
     x:Class="Microsoft.PowerToys.Settings.UI.Views.AdvancedPastePage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -67,6 +67,15 @@
                             <ToggleSwitch x:Uid="ToggleSwitch" IsOn="{x:Bind ViewModel.IsEnabled, Mode=TwoWay}" />
                         </tkcontrols:SettingsCard>
                     </controls:GPOInfoControl>
+                    <tkcontrols:SettingsCard
+                        Name="AdvancedPasteLowMemoryMode"
+                        x:Uid="CloseAppWhenInactive"
+                        HeaderIcon="{ui:FontIcon Glyph=&#xE8BE;}">
+                        <ToggleSwitch
+                            x:Uid="ToggleSwitch"
+                            AutomationProperties.Name="{Binding ElementName=AdvancedPasteLowMemoryMode, Path=Header}"
+                            IsOn="{x:Bind ViewModel.UseLowMemoryMode, Mode=TwoWay}" />
+                    </tkcontrols:SettingsCard>
                     <controls:SettingsGroup x:Uid="AdvancedPaste_EnableAISettingsGroup" IsEnabled="{x:Bind ViewModel.IsEnabled, Mode=OneWay}">
                         <InfoBar
                             x:Uid="GPO_AdvancedPasteAi_SettingIsManaged"

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/ColorPickerPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/ColorPickerPage.xaml
@@ -1,4 +1,4 @@
-﻿<local:NavigablePage
+<local:NavigablePage
     x:Class="Microsoft.PowerToys.Settings.UI.Views.ColorPickerPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -26,6 +26,15 @@
                         <ToggleSwitch x:Uid="ToggleSwitch" IsOn="{x:Bind ViewModel.IsEnabled, Mode=TwoWay}" />
                     </tkcontrols:SettingsCard>
                 </controls:GPOInfoControl>
+                <tkcontrols:SettingsCard
+                    Name="ColorPickerLowMemoryMode"
+                    x:Uid="CloseAppWhenInactive"
+                    HeaderIcon="{ui:FontIcon Glyph=&#xE8BE;}">
+                    <ToggleSwitch
+                        x:Uid="ToggleSwitch"
+                        AutomationProperties.Name="{Binding ElementName=ColorPickerLowMemoryMode, Path=Header}"
+                        IsOn="{x:Bind ViewModel.UseLowMemoryMode, Mode=TwoWay}" />
+                </tkcontrols:SettingsCard>
 
                 <controls:SettingsGroup x:Uid="Shortcut" IsEnabled="{x:Bind ViewModel.IsEnabled, Mode=OneWay}">
                     <tkcontrols:SettingsCard

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/GeneralPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/GeneralPage.xaml
@@ -1,4 +1,4 @@
-﻿<local:NavigablePage
+<local:NavigablePage
     x:Class="Microsoft.PowerToys.Settings.UI.Views.GeneralPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -321,6 +321,64 @@
                                 <controls:ShortcutControl HotkeySettings="{x:Bind ViewModel.QuickAccessShortcut, Mode=TwoWay}" />
                             </tkcontrols:SettingsCard>
                             <tkcontrols:SettingsCard Visibility="Collapsed" />
+                        </tkcontrols:SettingsExpander.Items>
+                    </tkcontrols:SettingsExpander>
+
+                    <tkcontrols:SettingsExpander
+                        Name="GeneralPageLowMemoryMode"
+                        x:Uid="GeneralPage_LowMemoryMode"
+                        HeaderIcon="{ui:FontIcon Glyph=&#xE8BE;}">
+                        <tkcontrols:SettingsExpander.Items>
+                            <tkcontrols:SettingsCard
+                                Name="GeneralPageLowMemoryModeAllSupported"
+                                x:Uid="GeneralPage_LowMemoryModeAllSupported">
+                                <StackPanel
+                                    Orientation="Horizontal"
+                                    Spacing="12">
+                                    <Button
+                                        x:Uid="GeneralPage_LowMemoryModeEnableAll"
+                                        Command="{Binding EnableAllLowMemoryModeCommand}" />
+                                    <Button
+                                        x:Uid="GeneralPage_LowMemoryModeDisableAll"
+                                        Command="{Binding DisableAllLowMemoryModeCommand}" />
+                                </StackPanel>
+                            </tkcontrols:SettingsCard>
+                            <tkcontrols:SettingsCard
+                                Name="GeneralPageLowMemoryTextExtractor"
+                                x:Uid="GeneralPage_LowMemoryTextExtractor"
+                                HeaderIcon="{ui:BitmapIcon Source=/Assets/Settings/Icons/TextExtractor.png}">
+                                <ToggleSwitch
+                                    x:Uid="ToggleSwitch"
+                                    AutomationProperties.Name="{Binding ElementName=GeneralPageLowMemoryTextExtractor, Path=Header}"
+                                    IsOn="{x:Bind ViewModel.LowMemoryTextExtractor, Mode=TwoWay}" />
+                            </tkcontrols:SettingsCard>
+                            <tkcontrols:SettingsCard
+                                Name="GeneralPageLowMemoryColorPicker"
+                                x:Uid="GeneralPage_LowMemoryColorPicker"
+                                HeaderIcon="{ui:BitmapIcon Source=/Assets/Settings/Icons/ColorPicker.png}">
+                                <ToggleSwitch
+                                    x:Uid="ToggleSwitch"
+                                    AutomationProperties.Name="{Binding ElementName=GeneralPageLowMemoryColorPicker, Path=Header}"
+                                    IsOn="{x:Bind ViewModel.LowMemoryColorPicker, Mode=TwoWay}" />
+                            </tkcontrols:SettingsCard>
+                            <tkcontrols:SettingsCard
+                                Name="GeneralPageLowMemoryAdvancedPaste"
+                                x:Uid="GeneralPage_LowMemoryAdvancedPaste"
+                                HeaderIcon="{ui:BitmapIcon Source=/Assets/Settings/Icons/AdvancedPaste.png}">
+                                <ToggleSwitch
+                                    x:Uid="ToggleSwitch"
+                                    AutomationProperties.Name="{Binding ElementName=GeneralPageLowMemoryAdvancedPaste, Path=Header}"
+                                    IsOn="{x:Bind ViewModel.LowMemoryAdvancedPaste, Mode=TwoWay}" />
+                            </tkcontrols:SettingsCard>
+                            <tkcontrols:SettingsCard
+                                Name="GeneralPageLowMemoryPeek"
+                                x:Uid="GeneralPage_LowMemoryPeek"
+                                HeaderIcon="{ui:BitmapIcon Source=/Assets/Settings/Icons/Peek.png}">
+                                <ToggleSwitch
+                                    x:Uid="ToggleSwitch"
+                                    AutomationProperties.Name="{Binding ElementName=GeneralPageLowMemoryPeek, Path=Header}"
+                                    IsOn="{x:Bind ViewModel.LowMemoryPeek, Mode=TwoWay}" />
+                            </tkcontrols:SettingsCard>
                         </tkcontrols:SettingsExpander.Items>
                     </tkcontrols:SettingsExpander>
                 </controls:SettingsGroup>

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/GeneralPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/GeneralPage.xaml
@@ -1,4 +1,4 @@
-<local:NavigablePage
+﻿<local:NavigablePage
     x:Class="Microsoft.PowerToys.Settings.UI.Views.GeneralPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -329,18 +329,10 @@
                         x:Uid="GeneralPage_LowMemoryMode"
                         HeaderIcon="{ui:FontIcon Glyph=&#xE8BE;}">
                         <tkcontrols:SettingsExpander.Items>
-                            <tkcontrols:SettingsCard
-                                Name="GeneralPageLowMemoryModeAllSupported"
-                                x:Uid="GeneralPage_LowMemoryModeAllSupported">
-                                <StackPanel
-                                    Orientation="Horizontal"
-                                    Spacing="12">
-                                    <Button
-                                        x:Uid="GeneralPage_LowMemoryModeEnableAll"
-                                        Command="{Binding EnableAllLowMemoryModeCommand}" />
-                                    <Button
-                                        x:Uid="GeneralPage_LowMemoryModeDisableAll"
-                                        Command="{Binding DisableAllLowMemoryModeCommand}" />
+                            <tkcontrols:SettingsCard Name="GeneralPageLowMemoryModeAllSupported" x:Uid="GeneralPage_LowMemoryModeAllSupported">
+                                <StackPanel Orientation="Horizontal" Spacing="12">
+                                    <Button x:Uid="GeneralPage_LowMemoryModeEnableAll" Command="{Binding EnableAllLowMemoryModeCommand}" />
+                                    <Button x:Uid="GeneralPage_LowMemoryModeDisableAll" Command="{Binding DisableAllLowMemoryModeCommand}" />
                                 </StackPanel>
                             </tkcontrols:SettingsCard>
                             <tkcontrols:SettingsCard

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/PeekPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/PeekPage.xaml
@@ -1,4 +1,4 @@
-﻿<local:NavigablePage
+<local:NavigablePage
     x:Class="Microsoft.PowerToys.Settings.UI.Views.PeekPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -23,6 +23,15 @@
                         <ToggleSwitch IsOn="{x:Bind ViewModel.IsEnabled, Mode=TwoWay}" />
                     </tkcontrols:SettingsCard>
                 </controls:GPOInfoControl>
+                <tkcontrols:SettingsCard
+                    Name="PeekLowMemoryMode"
+                    x:Uid="CloseAppWhenInactive"
+                    HeaderIcon="{ui:FontIcon Glyph=&#xE8BE;}">
+                    <ToggleSwitch
+                        x:Uid="ToggleSwitch"
+                        AutomationProperties.Name="{Binding ElementName=PeekLowMemoryMode, Path=Header}"
+                        IsOn="{x:Bind ViewModel.UseLowMemoryMode, Mode=TwoWay}" />
+                </tkcontrols:SettingsCard>
 
                 <controls:SettingsGroup x:Uid="Peek_Activation_GroupSettings" IsEnabled="{x:Bind ViewModel.IsEnabled, Mode=OneWay}">
                     <tkcontrols:SettingsCard x:Uid="Peek_ActivationMethod">

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerOcrPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerOcrPage.xaml
@@ -1,4 +1,4 @@
-﻿<local:NavigablePage
+<local:NavigablePage
     x:Class="Microsoft.PowerToys.Settings.UI.Views.PowerOcrPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -35,6 +35,15 @@
                             IsOn="{x:Bind ViewModel.IsEnabled, Mode=TwoWay}" />
                     </tkcontrols:SettingsCard>
                 </controls:GPOInfoControl>
+                <tkcontrols:SettingsCard
+                    Name="TextExtractorLowMemoryMode"
+                    x:Uid="CloseAppWhenInactive"
+                    HeaderIcon="{ui:FontIcon Glyph=&#xE8BE;}">
+                    <ToggleSwitch
+                        x:Uid="ToggleSwitch"
+                        AutomationProperties.Name="{Binding ElementName=TextExtractorLowMemoryMode, Path=Header}"
+                        IsOn="{x:Bind ViewModel.UseLowMemoryMode, Mode=TwoWay}" />
+                </tkcontrols:SettingsCard>
                 <InfoBar
                     x:Uid="TextExtractor_SupportedLanguages"
                     IsClosable="False"

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -6026,6 +6026,42 @@ Text uses the current drawing color.</value>
   </data>
   <data name="GeneralPage_QuickAccessShortcut.Header" xml:space="preserve">
     <value>Activation shortcut</value>
+  </data>
+  <data name="GeneralPage_LowMemoryMode.Header" xml:space="preserve">
+    <value>Close apps when inactive</value>
+  </data>
+  <data name="GeneralPage_LowMemoryMode.Description" xml:space="preserve">
+    <value>Select apps that close when not in use to save memory. They may open slower.</value>
+  </data>
+  <data name="GeneralPage_LowMemoryModeAllSupported.Header" xml:space="preserve">
+    <value>All apps</value>
+  </data>
+  <data name="GeneralPage_LowMemoryModeAllSupported.Description" xml:space="preserve">
+    <value>Apply this behavior to every app in this list.</value>
+  </data>
+  <data name="GeneralPage_LowMemoryModeEnableAll.Content" xml:space="preserve">
+    <value>Enable all</value>
+  </data>
+  <data name="GeneralPage_LowMemoryModeDisableAll.Content" xml:space="preserve">
+    <value>Disable all</value>
+  </data>
+  <data name="GeneralPage_LowMemoryTextExtractor.Header" xml:space="preserve">
+    <value>Text Extractor</value>
+  </data>
+  <data name="GeneralPage_LowMemoryColorPicker.Header" xml:space="preserve">
+    <value>Color Picker</value>
+  </data>
+  <data name="GeneralPage_LowMemoryAdvancedPaste.Header" xml:space="preserve">
+    <value>Advanced Paste</value>
+  </data>
+  <data name="GeneralPage_LowMemoryPeek.Header" xml:space="preserve">
+    <value>Peek</value>
+  </data>
+  <data name="CloseAppWhenInactive.Header" xml:space="preserve">
+    <value>Close app when inactive</value>
+  </data>
+  <data name="CloseAppWhenInactive.Description" xml:space="preserve">
+    <value>Closes the app when not in use to save memory. It may open slower.</value>
   </data>
   <data name="LightSwitch_ModeFollowNightLight.Content" xml:space="preserve">
     <value>Follow Night Light</value>

--- a/src/settings-ui/Settings.UI/ViewModels/AdvancedPasteViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/AdvancedPasteViewModel.cs
@@ -14,6 +14,7 @@ using System.Runtime.Versioning;
 using System.Text.Json;
 
 using global::PowerToys.GPOWrapper;
+using ManagedCommon;
 using Microsoft.PowerToys.Settings.UI.Helpers;
 using Microsoft.PowerToys.Settings.UI.Library;
 using Microsoft.PowerToys.Settings.UI.Library.Helpers;
@@ -99,6 +100,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
 
             // set the callback functions value to handle outgoing IPC message.
             SendConfigMSG = ipcMSGCallBackFunc;
+            InitializeLowMemorySettings(GeneralSettingsConfig, SendConfigMSG, ModuleType.AdvancedPaste);
 
             _additionalActions = _advancedPasteSettings.Properties.AdditionalActions;
             _customActions = _advancedPasteSettings.Properties.CustomActions.Value ?? new ObservableCollection<AdvancedPasteCustomAction>();

--- a/src/settings-ui/Settings.UI/ViewModels/ColorPickerViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/ColorPickerViewModel.cs
@@ -65,6 +65,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
 
             // set the callback functions value to handle outgoing IPC message.
             SendConfigMSG = ipcMSGCallBackFunc;
+            InitializeLowMemorySettings(GeneralSettingsConfig, SendConfigMSG, ModuleType.ColorPicker);
 
             _delayedTimer = new Timer();
             _delayedTimer.Interval = SaveSettingsDelayInMs;

--- a/src/settings-ui/Settings.UI/ViewModels/GeneralViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/GeneralViewModel.cs
@@ -51,6 +51,57 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
 
         private GeneralSettings GeneralSettingsConfig { get; set; }
 
+        private static readonly string[] LowMemoryModulePropertyNames =
+        {
+            nameof(LowMemoryTextExtractor),
+            nameof(LowMemoryColorPicker),
+            nameof(LowMemoryAdvancedPaste),
+            nameof(LowMemoryPeek),
+        };
+
+        private bool GetLowMemoryMode(ModuleType moduleType) => ModuleHelper.GetLowMemoryMode(GeneralSettingsConfig, moduleType);
+
+        private void SetLowMemoryModeFromModule(ModuleType moduleType, bool value, [CallerMemberName] string propertyName = null)
+        {
+            if (!ModuleHelper.SetLowMemoryMode(GeneralSettingsConfig, moduleType, value))
+            {
+                return;
+            }
+
+            RefreshLowMemoryModeSummary();
+            OnPropertyChanged(nameof(LowMemoryMode));
+            NotifyPropertyChanged(propertyName);
+        }
+
+        private void RefreshLowMemoryModeSummary()
+        {
+            GeneralSettingsConfig.LowMemoryMode = ModuleHelper.AnyLowMemoryModeEnabled(GeneralSettingsConfig);
+        }
+
+        private void NotifyLowMemoryModePropertiesChanged()
+        {
+            NotifyLowMemoryModeModulePropertiesChanged();
+            NotifyPropertyChanged(nameof(LowMemoryMode));
+        }
+
+        private void NotifyLowMemoryModeModulePropertiesChanged()
+        {
+            foreach (var propertyName in LowMemoryModulePropertyNames)
+            {
+                OnPropertyChanged(propertyName);
+            }
+        }
+
+        private string FormatUpdateCheckedDate(DateTime? dateTime)
+        {
+            if (ResourceLoader != null)
+            {
+                return FriendlyDateHelper.Format(dateTime, ResourceLoader);
+            }
+
+            return dateTime?.ToString(CultureInfo.CurrentCulture) ?? string.Empty;
+        }
+
         private UpdatingSettings UpdatingSettingsConfig { get; set; }
 
         public ButtonClickCommand CheckForUpdatesEventHandler { get; set; }
@@ -72,6 +123,10 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         public ButtonClickCommand RestartElevatedButtonEventHandler { get; set; }
 
         public ButtonClickCommand UpdateNowButtonEventHandler { get; set; }
+
+        public ButtonClickCommand EnableAllLowMemoryModeCommand { get; set; }
+
+        public ButtonClickCommand DisableAllLowMemoryModeCommand { get; set; }
 
         public Func<string, int> SendConfigMSG { get; }
 
@@ -105,6 +160,8 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             SelectSettingBackupDirEventHandler = new ButtonClickCommand(SelectSettingBackupDir);
             RestoreConfigsEventHandler = new ButtonClickCommand(RestoreConfigsClick);
             RefreshBackupStatusEventHandler = new ButtonClickCommand(RefreshBackupStatusEventHandlerClick);
+            EnableAllLowMemoryModeCommand = new ButtonClickCommand(() => SetLowMemoryModeForAll(true));
+            DisableAllLowMemoryModeCommand = new ButtonClickCommand(() => SetLowMemoryModeForAll(false));
             HideBackupAndRestoreMessageAreaAction = hideBackupAndRestoreMessageAreaAction;
             DoBackupAndRestoreDryRun = doBackupAndRestoreDryRun;
             PickSingleFolderDialog = pickSingleFolderDialog;
@@ -174,6 +231,8 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             _runElevated = GeneralSettingsConfig.RunElevated;
             _enableWarningsElevatedApps = GeneralSettingsConfig.EnableWarningsElevatedApps;
             _enableQuickAccess = GeneralSettingsConfig.EnableQuickAccess;
+            ModuleHelper.EnsureLowMemoryModuleSettings(GeneralSettingsConfig);
+            RefreshLowMemoryModeSummary();
             _quickAccessShortcut = GeneralSettingsConfig.QuickAccessShortcut;
             if (_quickAccessShortcut != null)
             {
@@ -188,7 +247,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             _updatingState = UpdatingSettingsConfig.State;
             _newAvailableVersion = UpdatingSettingsConfig.NewVersion;
             _newAvailableVersionLink = UpdatingSettingsConfig.ReleasePageLink;
-            _updateCheckedDate = FriendlyDateHelper.Format(UpdatingSettingsConfig.LastCheckedDateTime);
+            _updateCheckedDate = FormatUpdateCheckedDate(UpdatingSettingsConfig.LastCheckedDateTime);
 
             _newUpdatesToastIsGpoDisabled = GPOWrapper.GetDisableNewUpdateToastValue() == GpoRuleConfigured.Enabled;
             _autoDownloadUpdatesIsGpoDisabled = GPOWrapper.GetDisableAutomaticUpdateDownloadValue() == GpoRuleConfigured.Enabled;
@@ -542,6 +601,29 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 }
             }
         }
+
+        public bool LowMemoryMode
+        {
+            get => GeneralSettingsConfig.LowMemoryMode;
+            set => SetLowMemoryModeForAll(value);
+        }
+
+        public void SetLowMemoryModeForAll(bool value)
+        {
+            if (ModuleHelper.SetLowMemoryModeForAll(GeneralSettingsConfig, value))
+            {
+                RefreshLowMemoryModeSummary();
+                NotifyLowMemoryModePropertiesChanged();
+            }
+        }
+
+        public bool LowMemoryTextExtractor { get => GetLowMemoryMode(ModuleType.PowerOCR); set => SetLowMemoryModeFromModule(ModuleType.PowerOCR, value); }
+
+        public bool LowMemoryColorPicker { get => GetLowMemoryMode(ModuleType.ColorPicker); set => SetLowMemoryModeFromModule(ModuleType.ColorPicker, value); }
+
+        public bool LowMemoryAdvancedPaste { get => GetLowMemoryMode(ModuleType.AdvancedPaste); set => SetLowMemoryModeFromModule(ModuleType.AdvancedPaste, value); }
+
+        public bool LowMemoryPeek { get => GetLowMemoryMode(ModuleType.Peek); set => SetLowMemoryModeFromModule(ModuleType.Peek, value); }
 
         public HotkeySettings QuickAccessShortcut
         {
@@ -1383,7 +1465,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 }
                 else
                 {
-                    bool dateChanged = UpdateCheckedDate == FriendlyDateHelper.Format(UpdatingSettingsConfig.LastCheckedDateTime);
+                    bool dateChanged = UpdateCheckedDate == FormatUpdateCheckedDate(UpdatingSettingsConfig.LastCheckedDateTime);
                     bool fileDownloaded = string.IsNullOrEmpty(UpdatingSettingsConfig.DownloadedInstallerFilename);
                     IsNewVersionDownloading = !(dateChanged || fileDownloaded);
                 }
@@ -1391,7 +1473,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 PowerToysUpdatingState = UpdatingSettingsConfig.State;
                 PowerToysNewAvailableVersion = UpdatingSettingsConfig.NewVersion;
                 PowerToysNewAvailableVersionLink = UpdatingSettingsConfig.ReleasePageLink;
-                UpdateCheckedDate = FriendlyDateHelper.Format(UpdatingSettingsConfig.LastCheckedDateTime);
+                UpdateCheckedDate = FormatUpdateCheckedDate(UpdatingSettingsConfig.LastCheckedDateTime);
 
                 _isNoNetwork = PowerToysUpdatingState == UpdatingSettings.UpdatingState.NetworkError;
                 NotifyPropertyChanged(nameof(IsNoNetwork));
@@ -1535,6 +1617,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         {
             _dispatcherQueue?.TryEnqueue(() =>
             {
+                ModuleHelper.EnsureLowMemoryModuleSettings(newSettings);
                 GeneralSettingsConfig = newSettings;
 
                 if (_enableQuickAccess != newSettings.EnableQuickAccess)
@@ -1542,6 +1625,10 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                     _enableQuickAccess = newSettings.EnableQuickAccess;
                     OnPropertyChanged(nameof(EnableQuickAccess));
                 }
+
+                RefreshLowMemoryModeSummary();
+                OnPropertyChanged(nameof(LowMemoryMode));
+                NotifyLowMemoryModeModulePropertiesChanged();
             });
         }
 

--- a/src/settings-ui/Settings.UI/ViewModels/PageViewModelBase.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/PageViewModelBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation
+// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
+using ManagedCommon;
 using Microsoft.PowerToys.Settings.UI.Helpers;
 using Microsoft.PowerToys.Settings.UI.Library;
 using Microsoft.PowerToys.Settings.UI.Library.Helpers;
@@ -20,6 +21,9 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         private readonly Dictionary<string, bool> _hotkeyConflictStatus = new Dictionary<string, bool>();
         private readonly Dictionary<string, string> _hotkeyConflictTooltips = new Dictionary<string, string>();
         private bool _disposed;
+        private GeneralSettings _lowMemoryGeneralSettings;
+        private Func<string, int> _lowMemorySettingsCallback;
+        private ModuleType? _lowMemoryModuleType;
 
         protected abstract string ModuleName { get; }
 
@@ -31,9 +35,37 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             }
         }
 
+        public bool UseLowMemoryMode
+        {
+            get => _lowMemoryGeneralSettings != null && _lowMemoryModuleType.HasValue && ModuleHelper.GetLowMemoryMode(_lowMemoryGeneralSettings, _lowMemoryModuleType.Value);
+            set
+            {
+                if (_lowMemoryGeneralSettings == null || !_lowMemoryModuleType.HasValue)
+                {
+                    return;
+                }
+
+                if (ModuleHelper.SetLowMemoryMode(_lowMemoryGeneralSettings, _lowMemoryModuleType.Value, value))
+                {
+                    _lowMemoryGeneralSettings.LowMemoryMode = ModuleHelper.AnyLowMemoryModeEnabled(_lowMemoryGeneralSettings);
+                    OnPropertyChanged(nameof(UseLowMemoryMode));
+                    _lowMemorySettingsCallback?.Invoke(new OutGoingGeneralSettings(_lowMemoryGeneralSettings).ToString());
+                }
+            }
+        }
+
+        protected void InitializeLowMemorySettings(GeneralSettings generalSettings, Func<string, int> sendConfigMessage, ModuleType moduleType)
+        {
+            _lowMemoryGeneralSettings = generalSettings;
+            _lowMemorySettingsCallback = sendConfigMessage;
+            _lowMemoryModuleType = moduleType;
+            ModuleHelper.EnsureLowMemoryModuleSettings(_lowMemoryGeneralSettings);
+        }
+
         public virtual void OnPageLoaded()
         {
             Debug.WriteLine($"=== PAGE LOADED: {ModuleName} ===");
+            OnPropertyChanged(nameof(UseLowMemoryMode));
             GlobalHotkeyConflictManager.Instance?.RequestAllConflicts();
         }
 

--- a/src/settings-ui/Settings.UI/ViewModels/PeekViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/PeekViewModel.cs
@@ -70,6 +70,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             InitializeEnabledValue();
 
             SendConfigMSG = ipcMSGCallBackFunc;
+            InitializeLowMemorySettings(GeneralSettingsConfig, SendConfigMSG, ModuleType.Peek);
         }
 
         /// <summary>

--- a/src/settings-ui/Settings.UI/ViewModels/PowerOcrViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/PowerOcrViewModel.cs
@@ -95,6 +95,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
 
             // set the callback functions value to handle outgoing IPC message.
             SendConfigMSG = ipcMSGCallBackFunc;
+            InitializeLowMemorySettings(GeneralSettingsConfig, SendConfigMSG, ModuleType.PowerOCR);
 
             _delayedTimer = new Timer();
             _delayedTimer.Interval = SaveSettingsDelayInMs;


### PR DESCRIPTION
## Summary of the Pull Request

Adds option to close app when inactive (low memory mode) for supported utilities, so PowerToys can reduce idle memory usage by closing helper/UI processes when they are not in use.
<img width="788" height="516" alt="image" src="https://github.com/user-attachments/assets/1621e04e-3580-427c-957e-8b9bbd9c2103" />
<img width="770" height="420" alt="image" src="https://github.com/user-attachments/assets/df8bf26e-0d62-4a8b-b9e6-bdc9c54aa7fc" />

This currently covers:

- Text Extractor
- Color Picker
- Advanced Paste
- Peek

The change keeps the current warm-process behavior as the default and adds per-utility low memory toggles plus enable-all/disable-all helpers in General settings.

Links:

- Tracks https://github.com/microsoft/PowerToys/issues/47518
- Also addresses https://github.com/microsoft/PowerToys/issues/10357
- Contribution intent comment: https://github.com/microsoft/PowerToys/issues/28769#issuecomment-4327246436
- Development guidelines reviewed: https://github.com/microsoft/PowerToys/blob/main/doc/devdocs/readme.md and https://github.com/microsoft/PowerToys/blob/main/doc/devdocs/development/guidelines.md

## PR Checklist

- [x] Closes: #47518
- [x] Addresses: #10357
- [x] **Communication:**  Posted proposed scope in the contribution thread; awaiting maintainer confirmation on whether
  the broader scope is acceptable
- [x] **Tests:** Added/updated tests; relevant builds pass locally
- [x] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Not applicable
- [ ] **New binaries:** Not applicable
   - [ ] JSON for signing for new binaries
   - [ ] WXS for installer for new binaries and localization folder
   - [ ] YML for CI pipeline for new test projects
   - [ ] YML for signed pipeline
- [ ] **Documentation updated:** Not applicable

## Detailed Description of the Pull Request / Additional comments

This adds a shared `low_memory_modules` settings map and helper APIs so supported utilities can opt into idle-close behavior without adding a new schema field per module. Each supported utility defaults to `false`, preserving the existing warm-process behavior unless the user enables low memory mode.

The runner refreshes the cached low-memory settings and reapplies the policy by restarting only affected enabled modules when a supported utility's low memory setting changes. Supported module interfaces use `PTSettingsHelper::is_low_memory_mode_enabled(...)` to decide whether to keep the app process warm or launch with exit-after-use behavior.

The Settings UI exposes the behavior in General settings as a status-like group of per-utility toggles, with enable-all/disable-all actions, and also adds each utility-specific toggle to the individual supported module pages.

## Validation Steps Performed

- Built `src/runner` ARM64 Release successfully.
- Built `src/settings-ui/Settings.UI` ARM64 Release successfully.
- Built `src/settings-ui/Settings.UI.UnitTests` ARM64 Release successfully.
- Ran focused `Settings.UI.UnitTests` filter for `ViewModelTests.General`; 16 tests passed.
- Manually installed and tested the ARM64 build locally: Settings opens, low memory UI renders, toggles work, supported processes close while idle and relaunch from hotkeys.
- Verified no versioning/build metadata, signing, installer, pipeline, or dependency files are changed.