### PR TITLE
Fix VS Code Workspaces shared storage lookup

### DIFF
--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/VSCodeHelper/VSCodeInstance.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/VSCodeHelper/VSCodeInstance.cs
@@ -22,6 +22,8 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.VSCodeHelper
 
         public string AppData { get; set; } = string.Empty;
 
+        public string SharedStorageDbPath { get; set; } = string.Empty;
+
         public ImageSource WorkspaceIcon() => WorkspaceIconBitMap;
 
         public ImageSource RemoteIcon() => RemoteIconBitMap;

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/VSCodeHelper/VSCodeInstances.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/VSCodeHelper/VSCodeInstances.cs
@@ -16,6 +16,7 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.VSCodeHelper
     public static class VSCodeInstances
     {
         private static readonly string _userAppDataPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+        private static readonly string _userProfilePath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
 
         public static List<VSCodeInstance> Instances { get; set; } = new List<VSCodeInstance>();
 
@@ -129,6 +130,7 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.VSCodeHelper
 
                 var portableData = Path.Join(iconPath, "data");
                 instance.AppData = Directory.Exists(portableData) ? Path.Join(portableData, "user-data") : Path.Combine(_userAppDataPath, version);
+                instance.SharedStorageDbPath = GetSharedStorageDbPath(version, iconPath, Directory.Exists(portableData));
                 var vsCodeIconPath = Path.Join(iconPath, $"{version}.exe");
                 if (!File.Exists(vsCodeIconPath))
                 {
@@ -156,6 +158,31 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.VSCodeHelper
 
                 Instances.Add(instance);
             }
+        }
+
+        private static string GetSharedStorageDbPath(string version, string iconPath, bool isPortable)
+        {
+            if (isPortable)
+            {
+                return Path.Join(iconPath, "data-shared", "sharedStorage", "state.vscdb");
+            }
+
+            var sharedStorageDirectory = version switch
+            {
+                "Code" => ".vscode-shared",
+                "Code - Insiders" => ".vscode-insiders-shared",
+                "Code - Exploration" => ".vscode-exploration-shared",
+                "VSCodium" => ".vscodium-shared",
+                "VSCodium - Insiders" => ".vscodium-insiders-shared",
+                _ => string.Empty,
+            };
+
+            if (string.IsNullOrEmpty(sharedStorageDirectory))
+            {
+                return string.Empty;
+            }
+
+            return Path.Combine(_userProfilePath, sharedStorageDirectory, "sharedStorage", "state.vscdb");
         }
     }
 }

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/WorkspacesHelper/VSCodeWorkspacesApi.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/WorkspacesHelper/VSCodeWorkspacesApi.cs
@@ -97,6 +97,7 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.WorkspacesHelper
 
                     // User/globalStorage/state.vscdb - history.recentlyOpenedPathsList - vscode v1.64 or later
                     var vscode_storage_db = Path.Combine(vscodeInstance.AppData, "User/globalStorage/state.vscdb");
+                    var vscode_shared_storage_db = vscodeInstance.SharedStorageDbPath;
 
                     if (File.Exists(vscode_storage))
                     {
@@ -104,15 +105,35 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.WorkspacesHelper
                         results.AddRange(storageResults);
                     }
 
-                    if (File.Exists(vscode_storage_db))
+                    var storageDbPaths = new[] { vscode_storage_db, vscode_shared_storage_db }
+                        .Where(filePath => !string.IsNullOrEmpty(filePath))
+                        .Distinct(StringComparer.OrdinalIgnoreCase);
+
+                    foreach (var storageDbPath in storageDbPaths)
                     {
-                        var storageDbResults = GetWorkspacesInVscdb(vscodeInstance, vscode_storage_db);
-                        results.AddRange(storageDbResults);
+                        if (File.Exists(storageDbPath))
+                        {
+                            var storageDbResults = GetWorkspacesInVscdb(vscodeInstance, storageDbPath);
+                            results.AddRange(storageDbResults);
+                        }
                     }
                 }
 
-                return results;
+                return results
+                    .Where(workspace => workspace != null)
+                    .GroupBy(GetWorkspaceKey, StringComparer.OrdinalIgnoreCase)
+                    .Select(workspaceGroup => workspaceGroup.First())
+                    .ToList();
             }
+        }
+
+        private static string GetWorkspaceKey(VSCodeWorkspace workspace)
+        {
+            return string.Join(
+                "|",
+                workspace.VSCodeInstance?.ExecutablePath ?? string.Empty,
+                workspace.WorkspaceType,
+                workspace.Path ?? string.Empty);
         }
 
         private List<VSCodeWorkspace> GetWorkspacesInJson(VSCodeInstance vscodeInstance, string filePath)


### PR DESCRIPTION
## Summary

Fixes VS Code Workspaces recent entries discovery after VS Code 1.118 moved `history.recentlyOpenedPathsList` to the shared application storage database.

The plugin now probes both the legacy `User/globalStorage/state.vscdb` database and the new shared storage database for VS Code Stable, Insiders, Exploration, VSCodium, VSCodium Insiders, and portable installs.

It also deduplicates results that may appear in both locations.

Fixes #47445

## Validation

- Reviewed the change against the issue's documented VS Code 1.118 storage paths.
- Attempted local focused build from `src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces` with `tools/build/build.cmd -Platform x64 -Configuration Debug`.
- Build was blocked by local environment/tooling issues unrelated to this C# change: missing/invalid VC tooling/Windows SDK.
