### PR TITLE
Fix calculator comma decimal parsing

### DIFF
--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Calc.UnitTests/NumberTranslatorTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Calc.UnitTests/NumberTranslatorTests.cs
@@ -134,6 +134,23 @@ public class NumberTranslatorTests
     }
 
     [DataTestMethod]
+    [DataRow("1,5+1,5", "1.5+1.5")]
+    [DataRow("-1,5+2", "-1.5+2")]
+    [DataRow("1,000+2", "1000+2")]
+    public void Translate_ParsesUngroupedCommaAsDecimal_WhenSourceCultureUsesDotDecimal(string input, string expectedResult)
+    {
+        // Arrange
+        var translator = NumberTranslator.Create(new CultureInfo("en-US", false), new CultureInfo("en-US", false));
+
+        // Act
+        var result = translator.Translate(input);
+
+        // Assert
+        Assert.IsNotNull(result);
+        Assert.AreEqual(expectedResult, result);
+    }
+
+    [DataTestMethod]
     [DataRow("de-DE", "12,0004", "12.0004")]
     [DataRow("de-DE", "0xF000", "61440")]
     [DataRow("de-DE", "0", "0")]

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Calc.UnitTests/QueryTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Calc.UnitTests/QueryTests.cs
@@ -60,6 +60,19 @@ public class QueryTests : CommandPaletteUnitTestBase
     }
 
     [TestMethod]
+    public void TopLevelPageQuery_AcceptsCommaDecimalSeparator()
+    {
+        var settings = new Settings(outputUseEnglishFormat: true);
+        var page = new CalculatorListPage(settings);
+
+        page.UpdateSearchText(string.Empty, "1,5+1,5");
+        var result = page.GetItems().FirstOrDefault();
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual("3", result.Title);
+    }
+
+    [TestMethod]
     public void EmptyQueryTest()
     {
         var settings = new Settings();

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Helper/NumberTranslator.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Helper/NumberTranslator.cs
@@ -137,13 +137,69 @@ public class NumberTranslator
                 decimal number;
 
                 outputBuilder.Append(
-                    decimal.TryParse(inner, NumberStyles.Number, cultureFrom, out number)
+                    TryParseNumber(inner, cultureFrom, out number)
                     ? (new string('0', leadingZeroCount) + number.ToString(cultureTo))
                     : inner.Replace(cultureFrom.TextInfo.ListSeparator, cultureTo.TextInfo.ListSeparator));
             }
         }
 
         return outputBuilder.ToString();
+    }
+
+    private static bool TryParseNumber(string input, CultureInfo culture, out decimal number)
+    {
+        if (TryParseCommaDecimal(input, culture, out number))
+        {
+            return true;
+        }
+
+        return decimal.TryParse(input, NumberStyles.Number, culture, out number);
+    }
+
+    private static bool TryParseCommaDecimal(string input, CultureInfo culture, out decimal number)
+    {
+        number = default;
+
+        if (culture.NumberFormat.NumberDecimalSeparator == ",")
+        {
+            return false;
+        }
+
+        var commaIndex = input.IndexOf(',');
+        if (commaIndex <= 0 || commaIndex != input.LastIndexOf(',') || commaIndex == input.Length - 1)
+        {
+            return false;
+        }
+
+        var integerStart = input[0] is '+' or '-' ? 1 : 0;
+        if (commaIndex == integerStart)
+        {
+            return false;
+        }
+
+        for (var i = integerStart; i < commaIndex; i++)
+        {
+            if (!char.IsDigit(input[i]))
+            {
+                return false;
+            }
+        }
+
+        for (var i = commaIndex + 1; i < input.Length; i++)
+        {
+            if (!char.IsDigit(input[i]))
+            {
+                return false;
+            }
+        }
+
+        if (input.Length - commaIndex - 1 == 3)
+        {
+            return false;
+        }
+
+        var normalized = input.Replace(",", culture.NumberFormat.NumberDecimalSeparator, StringComparison.Ordinal);
+        return decimal.TryParse(normalized, NumberStyles.Number, culture, out number);
     }
 
     private static Regex GetSplitRegex(CultureInfo culture)

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator.UnitTest/ExtendedCalculatorParserTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator.UnitTest/ExtendedCalculatorParserTests.cs
@@ -192,6 +192,8 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
         [DataRow("cos", false)]
         [DataRow("abs", false)]
         [DataRow("1+1.1e3", true)]
+        [DataRow(".76*2.4", true)]
+        [DataRow("-.5*2", true)]
         [DataRow("randi(8)", true)]
         [DataRow("randi()", false)]
         [DataRow("randi(0.5)", true)]
@@ -237,6 +239,8 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
                new object[] { "0+(1*2)/(0+1)", 2M }, // Validate that division by "(0+1)" is not interpret as division by zero.
                new object[] { "0+(1*2)/0.5", 4M }, // Validate that division by number with decimal digits is not interpret as division by zero.
                new object[] { "0+(1*2)/0o004", 0.5M }, // Validate that division by an octal number with zeroes is not treated as division by zero.
+               new object[] { ".76*2.4", 1.824M },
+               new object[] { "-.5*2", -1M },
            };
 
         [DataTestMethod]

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator.UnitTest/QueryTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.Calculator.UnitTest/QueryTests.cs
@@ -229,6 +229,8 @@ namespace Microsoft.PowerToys.Run.Plugin.Calculator.UnitTests
         [DataRow("(1+1)(3+2)", 10)]
         [DataRow("(1+1)cos(pi)", -2)]
         [DataRow("log(100)cos(pi)", -2)]
+        [DataRow(".76*2.4", 1.824)]
+        [DataRow("-.5*2", -1)]
         public void RightAnswerForHumanMultiplicationExpressions(string typedString, double answer)
         {
             // Setup


### PR DESCRIPTION
## Summary of the Pull Request

Fixes Command Palette Calculator handling for comma decimal input such as `1,5+1,5`, so it evaluates as `3` instead of treating each value as `15`.

Also adds explicit regression coverage for PowerToys Run Calculator inputs without leading zeroes, such as `.76*2.4` and `-.5*2`.

## PR Checklist

- [x] Closes: #39231
- [x] Closes: #16287
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments

Command Palette Calculator translated comma-separated numbers using the current culture parsing rules. In cultures where `.` is the decimal separator and `,` is the group separator, input like `1,5+1,5` could be interpreted as `15+15`, returning `30`.

This PR adds a narrow fallback in the CmdPal calculator number translator:
- `1,5+1,5` is translated as `1.5+1.5`.
- `-1,5+2` is translated as `-1.5+2`.
- Valid grouped numbers like `1,000+2` continue to be treated as thousands and translate to `1000+2`.

This also adds regression tests for PowerToys Run Calculator inputs without leading zeroes:
- `.76*2.4`
- `-.5*2`

## Validation Steps Performed

- Built CmdPal Calc unit tests:
  - `tools\build\build.cmd -Path src\modules\cmdpal\Tests\Microsoft.CmdPal.Ext.Calc.UnitTests`
- Ran CmdPal Calc unit tests:
  - `321/321` passed
- Built PowerToys Run Calculator unit tests:
  - `tools\build\build.cmd -Path src\modules\launcher\Plugins\Microsoft.PowerToys.Run.Plugin.Calculator.UnitTest`
- Ran PowerToys Run Calculator unit tests:
  - `366/366` passed
- Ran build essentials:
  - `tools\build\build-essentials.cmd`
