### PR TITLE
CmdPal: when a band item updates, update the tooltip too

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Dock/DockBandViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Dock/DockBandViewModel.cs
@@ -327,6 +327,13 @@ public partial class DockItemViewModel : CommandItemViewModel
     {
         _showTitle = showTitle;
         _showSubtitle = showSubtitle;
+        PropertyChanged += (s, e) =>
+        {
+            if (e.PropertyName is nameof(Title) or nameof(Subtitle))
+            {
+                UpdateProperty(nameof(Tooltip));
+            }
+        };
     }
 }
 


### PR DESCRIPTION
Binding is hard.

The tooltip is bound to `.Tooltip`. But we forgot to raise a property changed event for `Tooltip` when title or subtitle change.

Closes: issue filed on teams
