### PR TITLE
[ZoomIt] Remove stale WIL package import from ZoomItBreak.vcxproj

### DIFF
--- a/src/modules/ZoomIt/ZoomItBreak/ZoomItBreak.vcxproj
+++ b/src/modules/ZoomIt/ZoomItBreak/ZoomItBreak.vcxproj
@@ -220,11 +220,4 @@
     <ClInclude Include="BreakTimer.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.231216.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.231216.1\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
-  </Target>
-  <Import Project="..\..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.231216.1\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.231216.1\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
 </Project>


### PR DESCRIPTION
## Summary of the Pull Request
ZoomItBreak.vcxproj contained a leftover Import of Microsoft.Windows.ImplementationLibrary.targets pinned to version 1.0.231216.1, plus the matching EnsureNuGetPackageBuildImports guard. The project has no packages.config and its source files (BreakTimer.cpp/.h, ZoomItBreakScr.cpp) include no wil headers, so the import was dead code copy-pasted from ZoomIt.vcxproj when the screensaver project was introduced in #46506.

Until PR #41280 (.NET 10 upgrade), the sibling ZoomIt project restored WIL 1.0.231216.1 via its own packages.config, so the folder coincidentally existed and the stale Import silently succeeded. PR #41280 bumped that dependency to 1.0.260126.7, leaving nothing in the repo that requests the old version. NuGet no longer creates the 1.0.231216.1 folder, the EnsureNuGetPackage target fires, and the official build fails with:

  ZoomItBreak.vcxproj(227,5): Error : This project references
  NuGet package(s) that are missing on this computer ...
  Microsoft.Windows.ImplementationLibrary.1.0.231216.1\...targets

Fix: drop the unused import and guard target. Verified by clean rebuild of x64 Release and ARM64 Release; ZoomItBreak64.scr / ZoomItBreak64a.scr produced with empty error logs.