### PR TITLE
[release-notes skill] Use local agent for PR summaries; vendor prepare-release-assets.ps1

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -218,6 +218,7 @@ clickable
 clickonce
 clientedge
 clientside
+cliextensions
 CLIPBOARDUPDATE
 CLIPCHILDREN
 CLIPSIBLINGS
@@ -1455,6 +1456,7 @@ ptcontrols
 ptd
 PTOKEN
 ptstr
+ptsym
 pui
 pvct
 PWAs
@@ -1900,6 +1902,7 @@ trx
 tsa
 tskill
 tstoi
+tsv
 tweakable
 TWF
 tymed

--- a/.github/skills/release-note-generation/SKILL.md
+++ b/.github/skills/release-note-generation/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: release-note-generation
-description: Toolkit for generating PowerToys release notes from GitHub milestone PRs or commit ranges. Use when asked to create release notes, summarize milestone PRs, generate changelog, prepare release documentation, request Copilot reviews for PRs, update README for a new release, manage PR milestones, or collect PRs between commits/tags. Supports PR collection by milestone or commit range, milestone assignment, grouping by label, summarization with external contributor attribution, and README version bumping.
+description: Toolkit for generating PowerToys release notes from GitHub milestone PRs or commit ranges. Use when asked to create release notes, summarize milestone PRs, generate changelog, prepare release documentation, generate PR review summaries locally for release notes, update README for a new release, manage PR milestones, collect PRs between commits/tags, or prepare release assets (download installers and compute installer hashes).
 license: Complete terms in LICENSE.txt
 ---
 
 # Release Note Generation Skill
 
-Generate professional release notes for PowerToys milestones by collecting merged PRs, requesting Copilot code reviews, grouping by label, and producing user-facing summaries.
+Generate professional release notes for PowerToys milestones by collecting merged PRs, summarizing each PR with the local CLI agent, grouping by label, and producing user-facing summaries.
 
 ## Output Directory
 
@@ -26,16 +26,17 @@ Generated Files/ReleaseNotes/
 
 - Generate release notes for a milestone
 - Summarize PRs merged in a release
-- Request Copilot reviews for milestone PRs
+- Generate per-PR review summaries locally for release-notes copy
 - Assign milestones to PRs missing them
 - Collect PRs between two commits/tags
 - Update README.md for a new version
+- Prepare GitHub release assets (download installers/symbols + compute hashes)
 
 ## Prerequisites
 
 - **GitHub CLI (`gh`) installed and authenticated** — The collection script uses `gh pr view` and `gh api graphql` to fetch PR metadata and co-author information. Run `gh auth status` to verify; if not logged in, run `gh auth login` first. See [Step 1.0.0](./references/step1-collection.md) for details.
-- MCP Server: github-mcp-server installed
-- GitHub Copilot code review enabled for the org/repo
+- MCP Server: github-mcp-server installed (used to fetch PR diffs/files for the local-agent review step)
+- For [prepare-release-assets.ps1](./scripts/prepare-release-assets.ps1) only: **Azure CLI** authenticated against the Microsoft tenant (`az login`) with the `azure-devops` extension; access to the `microsoft/Dart` ADO project
 
 ## Required Variables
 
@@ -65,12 +66,12 @@ Generated Files/ReleaseNotes/
 └────────────────────────────────┘
               ↓
 ┌────────────────────────────────┐
-│ 3.1 Request Reviews (Copilot)  │
+│ 3.1 Local-agent PR summaries    │
+│ (writes CopilotSummary)         │
 └────────────────────────────────┘
               ↓
 ┌────────────────────────────────┐
-│ 3.2 Refresh PR data             │
-│ (CopilotSummary)                │
+│ 3.2 (Optional) Refresh PR data  │
 └────────────────────────────────┘
               ↓
 ┌────────────────────────────────┐
@@ -93,7 +94,7 @@ Generated Files/ReleaseNotes/
 | 1.1 | Collect PRs | From previous release tag on `stable` branch → `sorted_prs.csv` |
 | 1.2 | Assign Milestones | Ensure all PRs have correct milestone |
 | 2.1–2.4 | Label PRs | Auto-suggest + human label low-confidence |
-| 3.1–3.3 | Reviews & Grouping | Request Copilot reviews → refresh → group by label |
+| 3.1–3.3 | Reviews & Grouping | Local agent summarizes each PR diff into `CopilotSummary` → (optional refresh) → group by label |
 | 4.1–4.2 | Summaries & Final | Generate grouped summaries, then consolidate |
 
 ## Detailed workflow docs
@@ -114,6 +115,7 @@ Do not read all steps at once—only read the step you are executing.
 | [group-prs-by-label.ps1](./scripts/group-prs-by-label.ps1) | Group PRs into CSVs |
 | [collect-or-apply-milestones.ps1](./scripts/collect-or-apply-milestones.ps1) | Assign milestones |
 | [diff_prs.ps1](./scripts/diff_prs.ps1) | Incremental PR diff |
+| [prepare-release-assets.ps1](./scripts/prepare-release-assets.ps1) | Download installers + symbols from an ADO build, compute SHA256, emit the "Installer Hashes" markdown table for the GitHub release page |
 
 ## References
 
@@ -133,5 +135,6 @@ Do not read all steps at once—only read the step you are executing.
 |-------|----------|
 | `gh` command not found | Install GitHub CLI and add to PATH |
 | No PRs returned | Verify milestone title matches exactly |
-| Empty CopilotSummary | Request Copilot reviews first, then re-run dump |
+| Empty `CopilotSummary` for many PRs | Run Step 3.1 (local-agent summaries). Do **not** use `mcp_github_request_copilot_review` from a CLI/coding agent — the GitHub API rejects bot-initiated review requests, so the column will stay empty. |
 | Many unlabeled PRs | Return to labeling step before grouping |
+| `prepare-release-assets.ps1` fails with "Failed to acquire ADO access token" | Run `az login` and ensure you have access to the `microsoft/Dart` ADO project |

--- a/.github/skills/release-note-generation/references/step3-review-grouping.md
+++ b/.github/skills/release-note-generation/references/step3-review-grouping.md
@@ -1,28 +1,48 @@
-# Step 3: Copilot Reviews and Grouping
+# Step 3: Local Agent Reviews and Grouping
 
 ## 3.0 To-do
-- 3.1 Request Copilot Reviews (Agent Mode)
-- 3.2 Refresh PR Data
+- 3.1 Generate PR Summaries with the Local Agent
+- 3.2 (Optional) Refresh PR Data
 - 3.3 Group PRs by Label
 
-## 3.1 Request Copilot Reviews (Agent Mode)
+## 3.1 Generate PR Summaries with the Local Agent
 
-Use MCP tools to request Copilot reviews for all PRs in `Generated Files/ReleaseNotes/sorted_prs.csv`:
+> ⚠️ **Do not use `mcp_github_request_copilot_review` (or any "request Copilot review" tool that calls the GitHub API).**
+> When this skill is driven from a CLI / coding agent, the request is made from a bot identity and the GitHub API rejects it ("Bot reviewers cannot be requested"). The PR ends up with no Copilot review and `CopilotSummary` stays empty.
+>
+> Instead, **the local agent that is running this skill performs the review itself** and writes the summary directly into `sorted_prs.csv`.
 
-- Use `mcp_github_request_copilot_review` for each PR ID
-- Do NOT generate or run scripts for this step
+For every PR listed in `Generated Files/ReleaseNotes/sorted_prs.csv` whose `CopilotSummary` is empty:
+
+1. Fetch the PR diff using a tool that does **not** post anything back to GitHub. Any of these works:
+    - `mcp_github_pull_request_read` with `method: get_diff`
+    - `mcp_github_pull_request_read` with `method: get_files` (when the diff is large)
+    - `gh pr diff <PR_NUMBER> --repo microsoft/PowerToys`
+2. Read the PR title, body, and diff. Produce a 1–3 sentence, user-facing summary in the same style as a Copilot PR review (focus on observable behavior change, not implementation details).
+3. Write the summary into the `CopilotSummary` column for that PR row in `Generated Files/ReleaseNotes/sorted_prs.csv`. Preserve all other columns and the existing row order.
+
+**Batching guidance**
+
+- Process PRs in the order they appear in `sorted_prs.csv`.
+- Generate summaries for **all** PRs in one pass before continuing to Step 3.3, so the human reviewer can validate them together.
+- For very large diffs, summarize from `get_files` (filenames + per-file patches) rather than the full diff.
+- Skip PRs that already have a non-empty `CopilotSummary` (e.g. PRs where a human reviewer already pasted one). Do not overwrite existing summaries.
+
+**Why not post the summary back to the PR?** Posting a comment from the agent's identity would not be picked up by `dump-prs-since-commit.ps1` (which only matches Copilot bot authors), and it adds noise to the PR. Writing straight into the CSV keeps the artifact self-contained.
 
 ---
 
-## 3.2 Refresh PR Data
+## 3.2 (Optional) Refresh PR Data
 
-Re-run the collection script to capture Copilot review summaries into the `CopilotSummary` column:
+Only re-run the collection script if PR metadata on GitHub has changed (new labels, retitled PRs, etc.) since Step 1.1. **Skip this step if you only want to preserve the locally generated `CopilotSummary` values from Step 3.1**, because re-running the dump will overwrite the CSV.
 
 ```powershell
 pwsh ./.github/skills/release-note-generation/scripts/dump-prs-since-commit.ps1 `
     -StartCommit '{{PreviousReleaseTag}}' -Branch 'stable' `
     -OutputDir 'Generated Files/ReleaseNotes'
 ```
+
+If you do refresh, redo Step 3.1 afterwards to repopulate `CopilotSummary`.
 
 ---
 
@@ -35,3 +55,4 @@ pwsh ./.github/skills/release-note-generation/scripts/group-prs-by-label.ps1 -Cs
 Creates `Generated Files/ReleaseNotes/grouped_csv/` with one CSV per label combination.
 
 **Validation:** The `Unlabeled.csv` file should be minimal (ideally empty). If many PRs remain unlabeled, return to Step 2 (see [step2-labeling.md](./step2-labeling.md)).
+

--- a/.github/skills/release-note-generation/scripts/prepare-release-assets.ps1
+++ b/.github/skills/release-note-generation/scripts/prepare-release-assets.ps1
@@ -1,0 +1,252 @@
+<#
+.SYNOPSIS
+    Prepares the binary assets for a PowerToys GitHub release: downloads the
+    four installers (per-user/per-machine x x64/arm64) and the symbol archives
+    from an ADO pipeline build, computes SHA256 hashes, and emits the
+    "Installer Hashes" markdown table.
+
+.DESCRIPTION
+    Given an ADO Dart pipeline build id (e.g. from
+    https://microsoft.visualstudio.com/Dart/_build/results?buildId=NNN),
+    downloads the four installer EXEs and the per-arch symbol zips into a
+    single per-version folder, then writes a hashes.md alongside them with a
+    markdown table ready to paste into the GitHub release notes.
+
+    Requires: az login (Azure CLI authenticated), az devops extension.
+
+.EXAMPLE
+    .\prepare-release-assets.ps1 -BuildId 145505247
+    .\prepare-release-assets.ps1 -BuildId 145505247 -OutputFolder D:\Releases
+#>
+param(
+    [Parameter(Mandatory = $true)]
+    [int]$BuildId,
+
+    [string]$OutputFolder = "$env:USERPROFILE\Downloads",
+
+    [string]$Organization = "https://dev.azure.com/microsoft",
+    [string]$Project = "Dart",
+
+    [string]$GitHubRepo = "microsoft/PowerToys"
+)
+
+$ErrorActionPreference = "Stop"
+$env:AZURE_CORE_NO_PROMPT = "true"
+
+# Work around broken az extensions: if the default extension dir has
+# inaccessible files, redirect to a clean directory.
+$defaultExtDir = "$env:USERPROFILE\.azure\cliextensions"
+if (-not $env:AZURE_EXTENSION_DIR -and (Test-Path $defaultExtDir)) {
+    $broken = Get-ChildItem "$defaultExtDir\*\*.dist-info" -Directory -ErrorAction SilentlyContinue | Where-Object {
+        try { [System.IO.Directory]::GetFiles($_.FullName) | Out-Null; $false } catch { $true }
+    }
+    if ($broken) {
+        $cleanDir = "$env:USERPROFILE\.azure\cliextensions_clean"
+        Write-Host "  Detected broken az extension, redirecting to $cleanDir" -ForegroundColor Yellow
+        $env:AZURE_EXTENSION_DIR = $cleanDir
+        if (-not (Test-Path $cleanDir)) { New-Item -ItemType Directory -Path $cleanDir -Force | Out-Null }
+    }
+}
+
+# Ensure azure-devops extension is installed
+$ext = az extension list --query "[?name=='azure-devops']" -o tsv 2>$null
+if (-not $ext) {
+    Write-Host "Installing azure-devops extension..." -ForegroundColor Yellow
+    az extension add --name azure-devops --yes 2>$null
+}
+
+# Configure az devops defaults
+az devops configure --defaults organization=$Organization project=$Project 2>$null
+
+# --- Step 1: Get build info to determine version ---
+Write-Host "Fetching build $BuildId info..." -ForegroundColor Cyan
+$buildJson = az pipelines build show --id $BuildId --output json 2>$null
+if (-not $buildJson) {
+    Write-Error "Could not fetch build $BuildId. Are you logged in (az login)?"
+    exit 1
+}
+$build = $buildJson | ConvertFrom-Json
+
+$versionParam = $build.templateParameters.VersionNumber
+if (-not $versionParam) {
+    Write-Error "Could not determine version from build $BuildId"
+    exit 1
+}
+Write-Host "  Version: $versionParam" -ForegroundColor DarkGray
+
+# --- Step 2: Get artifact metadata once ---
+Write-Host "Fetching artifact metadata..." -ForegroundColor Cyan
+$artifactsJson = az pipelines runs artifact list --run-id $BuildId --output json 2>$null
+$artifacts = $artifactsJson | ConvertFrom-Json
+
+# --- Step 3: Prepare destination folder ---
+$destFolder = Join-Path $OutputFolder "PowerToys-v$versionParam"
+if (-not (Test-Path $destFolder)) {
+    New-Item -ItemType Directory -Path $destFolder -Force | Out-Null
+}
+Write-Host "  Destination: $destFolder" -ForegroundColor DarkGray
+
+# --- Step 4: Get an ADO access token once ---
+$token = az account get-access-token --resource "499b84ac-1321-427f-aa17-267ca6975798" --query accessToken -o tsv 2>$null
+if (-not $token) {
+    Write-Error "Failed to acquire ADO access token. Run 'az login' first."
+    exit 1
+}
+
+# --- Step 5: Define the four installers to download ---
+$targets = @(
+    [pscustomobject]@{ Description = "Per user - x64";     Scope = "perUser";    Arch = "x64";    Artifact = "build-x64-Release";   FileName = "PowerToysUserSetup-$versionParam-x64.exe";   Ref = "ptUserX64" }
+    [pscustomobject]@{ Description = "Per user - ARM64";   Scope = "perUser";    Arch = "arm64";  Artifact = "build-arm64-Release"; FileName = "PowerToysUserSetup-$versionParam-arm64.exe"; Ref = "ptUserArm64" }
+    [pscustomobject]@{ Description = "Machine wide - x64"; Scope = "perMachine"; Arch = "x64";    Artifact = "build-x64-Release";   FileName = "PowerToysSetup-$versionParam-x64.exe";       Ref = "ptMachineX64" }
+    [pscustomobject]@{ Description = "Machine wide - ARM64"; Scope = "perMachine"; Arch = "arm64"; Artifact = "build-arm64-Release"; FileName = "PowerToysSetup-$versionParam-arm64.exe";    Ref = "ptMachineArm64" }
+)
+
+# --- Step 6: Download each installer (skip if already present) ---
+foreach ($t in $targets) {
+    $destPath = Join-Path $destFolder $t.FileName
+
+    if (Test-Path $destPath) {
+        $sizeMB = [math]::Round((Get-Item $destPath).Length / 1MB, 1)
+        Write-Host "[skip] $($t.FileName) already exists ($sizeMB MB)" -ForegroundColor DarkGray
+        continue
+    }
+
+    $artifact = $artifacts | Where-Object { $_.name -eq $t.Artifact }
+    if (-not $artifact) {
+        Write-Error "Artifact '$($t.Artifact)' not found in build $BuildId. Available: $(($artifacts | ForEach-Object name) -join ', ')"
+        exit 1
+    }
+
+    $baseDownloadUrl = $artifact.resource.downloadUrl
+    $encodedSubPath = [Uri]::EscapeDataString("/$($t.FileName)")
+    $fileUrl = $baseDownloadUrl -replace "format=zip", "format=file&subPath=$encodedSubPath"
+
+    Write-Host "Downloading $($t.FileName) ..." -ForegroundColor Cyan
+    $webClient = New-Object System.Net.WebClient
+    $webClient.Headers.Add("Authorization", "Bearer $token")
+    try {
+        $webClient.DownloadFile($fileUrl, $destPath)
+    }
+    catch {
+        Write-Error "Download failed for $($t.FileName): $_"
+        Write-Host "URL: $fileUrl" -ForegroundColor DarkGray
+        exit 1
+    }
+    finally {
+        $webClient.Dispose()
+    }
+
+    $sizeMB = [math]::Round((Get-Item $destPath).Length / 1MB, 1)
+    Write-Host "  Saved ($sizeMB MB)" -ForegroundColor Green
+}
+
+# --- Step 6b: Download symbols (one zip per arch) ---
+$symbolTargets = @(
+    [pscustomobject]@{ Arch = "x64";   Artifact = "build-x64-Release";   SubPath = "/symbols-x64" }
+    [pscustomobject]@{ Arch = "arm64"; Artifact = "build-arm64-Release"; SubPath = "/symbols-arm64" }
+)
+
+foreach ($s in $symbolTargets) {
+    $finalZip = Join-Path $destFolder "symbols-$($s.Arch).zip"
+    if (Test-Path $finalZip) {
+        $sizeMB = [math]::Round((Get-Item $finalZip).Length / 1MB, 1)
+        Write-Host "[skip] symbols-$($s.Arch).zip already exists ($sizeMB MB)" -ForegroundColor DarkGray
+        continue
+    }
+
+    $artifact = $artifacts | Where-Object { $_.name -eq $s.Artifact }
+    if (-not $artifact) {
+        Write-Error "Artifact '$($s.Artifact)' not found in build $BuildId."
+        exit 1
+    }
+
+    $baseDownloadUrl = $artifact.resource.downloadUrl
+    $encodedSubPath = [Uri]::EscapeDataString($s.SubPath)
+    # Symbols are downloaded as a folder => keep format=zip and append subPath
+    if ($baseDownloadUrl -match "subPath=") {
+        $symbolsUrl = $baseDownloadUrl -replace "subPath=[^&]*", "subPath=$encodedSubPath"
+    }
+    else {
+        $sep = if ($baseDownloadUrl.Contains("?")) { "&" } else { "?" }
+        $symbolsUrl = "$baseDownloadUrl$sep" + "subPath=$encodedSubPath"
+    }
+
+    $tmpZip = Join-Path ([System.IO.Path]::GetTempPath()) ("ptsym-$($s.Arch)-$([Guid]::NewGuid().ToString('N')).zip")
+    $tmpExtract = Join-Path ([System.IO.Path]::GetTempPath()) ("ptsym-$($s.Arch)-$([Guid]::NewGuid().ToString('N'))")
+
+    Write-Host "Downloading symbols-$($s.Arch).zip ..." -ForegroundColor Cyan
+    $webClient = New-Object System.Net.WebClient
+    $webClient.Headers.Add("Authorization", "Bearer $token")
+    try {
+        $webClient.DownloadFile($symbolsUrl, $tmpZip)
+    }
+    catch {
+        Write-Error "Symbols download failed for $($s.Arch): $_"
+        Write-Host "URL: $symbolsUrl" -ForegroundColor DarkGray
+        exit 1
+    }
+    finally {
+        $webClient.Dispose()
+    }
+
+    Write-Host "  Extracting..." -ForegroundColor DarkGray
+    if (Test-Path $tmpExtract) { Remove-Item $tmpExtract -Recurse -Force }
+    Expand-Archive -Path $tmpZip -DestinationPath $tmpExtract -Force
+
+    # Walk down while the current dir holds exactly one subfolder and no files.
+    $current = Get-Item $tmpExtract
+    while ($true) {
+        $children = Get-ChildItem -LiteralPath $current.FullName -Force
+        $subDirs = @($children | Where-Object { $_.PSIsContainer })
+        $files = @($children | Where-Object { -not $_.PSIsContainer })
+        if ($subDirs.Count -eq 1 -and $files.Count -eq 0) {
+            $current = $subDirs[0]
+        }
+        else {
+            break
+        }
+    }
+
+    # Stage to a folder named symbols-<arch> so the zip extracts to that name.
+    $stageRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("ptsym-stage-$([Guid]::NewGuid().ToString('N'))")
+    $stageInner = Join-Path $stageRoot "symbols-$($s.Arch)"
+    New-Item -ItemType Directory -Path $stageInner -Force | Out-Null
+    Get-ChildItem -LiteralPath $current.FullName -Force | ForEach-Object {
+        Copy-Item -LiteralPath $_.FullName -Destination $stageInner -Recurse -Force
+    }
+
+    Write-Host "  Repacking to $finalZip ..." -ForegroundColor DarkGray
+    if (Test-Path $finalZip) { Remove-Item $finalZip -Force }
+    Compress-Archive -Path "$stageInner\*" -DestinationPath $finalZip -CompressionLevel Optimal
+
+    Remove-Item $tmpZip -Force -ErrorAction SilentlyContinue
+    Remove-Item $tmpExtract -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item $stageRoot -Recurse -Force -ErrorAction SilentlyContinue
+
+    $sizeMB = [math]::Round((Get-Item $finalZip).Length / 1MB, 1)
+    Write-Host "  Saved symbols-$($s.Arch).zip ($sizeMB MB)" -ForegroundColor Green
+}
+
+# --- Step 7: Compute SHA256 and build markdown ---
+Write-Host "`nComputing SHA256 hashes..." -ForegroundColor Cyan
+
+$sb = [System.Text.StringBuilder]::new()
+[void]$sb.AppendLine("## Installer Hashes")
+[void]$sb.AppendLine("")
+[void]$sb.AppendLine("|  Description   | Filename | sha256 hash |")
+[void]$sb.AppendLine("|----------------|----------|----------|")
+
+foreach ($t in $targets) {
+    $destPath = Join-Path $destFolder $t.FileName
+    $hash = (Get-FileHash -Path $destPath -Algorithm SHA256).Hash.ToUpper()
+    [void]$sb.AppendLine("| $($t.Description) | $($t.FileName) | $hash |")
+    Write-Host "  $($t.FileName)  $hash" -ForegroundColor DarkGray
+}
+
+$markdown = $sb.ToString()
+$mdPath = Join-Path $destFolder "hashes.md"
+Set-Content -Path $mdPath -Value $markdown -Encoding UTF8
+
+Write-Host "`nMarkdown written to: $mdPath" -ForegroundColor Green
+Write-Host "`n----- Installer Hashes -----`n" -ForegroundColor Yellow
+Write-Host $markdown

--- a/.github/skills/release-note-generation/scripts/prepare-release-assets.ps1
+++ b/.github/skills/release-note-generation/scripts/prepare-release-assets.ps1
@@ -137,7 +137,7 @@ if (-not $ext) {
     Write-Host "Installing azure-devops extension..." -ForegroundColor Yellow
     Invoke-Az extension add --name azure-devops --yes | Out-Null
     if ($LASTEXITCODE -ne 0) {
-        Write-Error "Failed to install azure-devops extension.`naz: $script:LastAzError"
+        Write-Error "Failed to install azure-devops extension. (az: $script:LastAzError)"
         exit 1
     }
 }
@@ -145,7 +145,7 @@ if (-not $ext) {
 # Configure az devops defaults
 Invoke-Az devops configure --defaults organization=$Organization project=$Project | Out-Null
 if ($LASTEXITCODE -ne 0) {
-    Write-Error "Failed to configure az devops defaults.`naz: $script:LastAzError"
+    Write-Error "Failed to configure az devops defaults. (az: $script:LastAzError)"
     exit 1
 }
 
@@ -153,7 +153,7 @@ if ($LASTEXITCODE -ne 0) {
 Write-Host "Fetching build $BuildId info..." -ForegroundColor Cyan
 $buildJson = Invoke-Az pipelines build show --id $BuildId --output json
 if (-not $buildJson) {
-    Write-Error "Could not fetch build $BuildId. Are you logged in (az login)?`naz: $script:LastAzError"
+    Write-Error "Could not fetch build $BuildId. Are you logged in (az login)? (az: $script:LastAzError)"
     exit 1
 }
 $build = $buildJson | ConvertFrom-Json
@@ -169,7 +169,7 @@ Write-Host "  Version: $versionParam" -ForegroundColor DarkGray
 Write-Host "Fetching artifact metadata..." -ForegroundColor Cyan
 $artifactsJson = Invoke-Az pipelines runs artifact list --run-id $BuildId --output json
 if (-not $artifactsJson) {
-    Write-Error "Could not list artifacts for build $BuildId.`naz: $script:LastAzError"
+    Write-Error "Could not list artifacts for build $BuildId. (az: $script:LastAzError)"
     exit 1
 }
 $artifacts = $artifactsJson | ConvertFrom-Json
@@ -184,7 +184,7 @@ Write-Host "  Destination: $destFolder" -ForegroundColor DarkGray
 # --- Step 4: Get an ADO access token once ---
 $token = Invoke-Az account get-access-token --resource "499b84ac-1321-427f-aa17-267ca6975798" --query accessToken -o tsv
 if (-not $token) {
-    Write-Error "Failed to acquire ADO access token. Run 'az login' first.`naz: $script:LastAzError"
+    Write-Error "Failed to acquire ADO access token. Run 'az login' first. (az: $script:LastAzError)"
     exit 1
 }
 

--- a/.github/skills/release-note-generation/scripts/prepare-release-assets.ps1
+++ b/.github/skills/release-note-generation/scripts/prepare-release-assets.ps1
@@ -42,7 +42,12 @@ function Invoke-Az {
     $tmpErr = [System.IO.Path]::GetTempFileName()
     try {
         $output = & az @args 2>$tmpErr
-        $script:LastAzError = (Get-Content $tmpErr -Raw -ErrorAction SilentlyContinue).Trim()
+        # Get-Content -Raw returns $null for an empty file, and calling .Trim()
+        # on $null throws under $ErrorActionPreference = 'Stop' -- which would
+        # turn every successful (no-stderr) az call into a fatal error. Guard
+        # explicitly so $script:LastAzError is always a (possibly empty) string.
+        $rawErr = Get-Content $tmpErr -Raw -ErrorAction SilentlyContinue
+        $script:LastAzError = if ($null -eq $rawErr) { '' } else { $rawErr.Trim() }
         return $output
     }
     finally {

--- a/.github/skills/release-note-generation/scripts/prepare-release-assets.ps1
+++ b/.github/skills/release-note-generation/scripts/prepare-release-assets.ps1
@@ -33,6 +33,84 @@ param(
 $ErrorActionPreference = "Stop"
 $env:AZURE_CORE_NO_PROMPT = "true"
 
+# --- Helpers -----------------------------------------------------------------
+
+# Invoke an `az` CLI command and capture stderr in $script:LastAzError so
+# callers can surface the underlying message (expired login, blocked extension,
+# tenant policy, ...) instead of swallowing it with `2>$null`.
+function Invoke-Az {
+    $tmpErr = [System.IO.Path]::GetTempFileName()
+    try {
+        $output = & az @args 2>$tmpErr
+        $script:LastAzError = (Get-Content $tmpErr -Raw -ErrorAction SilentlyContinue).Trim()
+        return $output
+    }
+    finally {
+        Remove-Item $tmpErr -Force -ErrorAction SilentlyContinue
+    }
+}
+
+# Build an ADO artifact download URL from scratch instead of regex-replacing
+# the URL returned by `az pipelines runs artifact list`. Preserves any other
+# query parameters and only swaps `format` and `subPath`, so we don't break if
+# the upstream URL shape ever changes.
+function Get-ArtifactDownloadUrl {
+    param(
+        [Parameter(Mandatory)][string]$BaseUrl,
+        [Parameter(Mandatory)][string]$SubPath,
+        [Parameter(Mandatory)][ValidateSet('file', 'zip')][string]$Format
+    )
+    $encodedSubPath = [Uri]::EscapeDataString($SubPath)
+    $idx = $BaseUrl.IndexOf('?')
+    if ($idx -lt 0) {
+        return "${BaseUrl}?format=${Format}&subPath=${encodedSubPath}"
+    }
+    $base = $BaseUrl.Substring(0, $idx)
+    $kept = $BaseUrl.Substring($idx + 1) -split '&' | Where-Object {
+        $_ -and -not ($_ -match '^(format|subPath)=')
+    }
+    $kept = @($kept) + @("format=$Format", "subPath=$encodedSubPath")
+    return "${base}?$($kept -join '&')"
+}
+
+# Download a single ADO artifact file with bearer auth and a small retry/backoff
+# loop. A transient network blip on a ~200 MB installer or symbol zip otherwise
+# aborts the entire release-prep run.
+function Invoke-AdoDownload {
+    param(
+        [Parameter(Mandatory)][string]$Url,
+        [Parameter(Mandatory)][string]$DestPath,
+        [Parameter(Mandatory)][string]$Token,
+        [int]$MaxAttempts = 3
+    )
+    $lastError = $null
+    for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+        $webClient = New-Object System.Net.WebClient
+        $webClient.Headers.Add("Authorization", "Bearer $Token")
+        try {
+            $webClient.DownloadFile($Url, $DestPath)
+            return
+        }
+        catch {
+            $lastError = $_
+            if (Test-Path $DestPath) {
+                Remove-Item $DestPath -Force -ErrorAction SilentlyContinue
+            }
+            if ($attempt -lt $MaxAttempts) {
+                $backoffSec = [int][Math]::Pow(2, $attempt)  # 2, 4, 8 ...
+                Write-Host "  Attempt $attempt failed: $($_.Exception.Message). Retrying in ${backoffSec}s..." -ForegroundColor Yellow
+                Start-Sleep -Seconds $backoffSec
+            }
+        }
+        finally {
+            $webClient.Dispose()
+        }
+    }
+    throw "Download failed after $MaxAttempts attempts. Last error: $($lastError.Exception.Message)`nURL: $Url"
+}
+
+# -----------------------------------------------------------------------------
+
 # Work around broken az extensions: if the default extension dir has
 # inaccessible files, redirect to a clean directory.
 $defaultExtDir = "$env:USERPROFILE\.azure\cliextensions"
@@ -49,20 +127,28 @@ if (-not $env:AZURE_EXTENSION_DIR -and (Test-Path $defaultExtDir)) {
 }
 
 # Ensure azure-devops extension is installed
-$ext = az extension list --query "[?name=='azure-devops']" -o tsv 2>$null
+$ext = Invoke-Az extension list --query "[?name=='azure-devops']" -o tsv
 if (-not $ext) {
     Write-Host "Installing azure-devops extension..." -ForegroundColor Yellow
-    az extension add --name azure-devops --yes 2>$null
+    Invoke-Az extension add --name azure-devops --yes | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to install azure-devops extension.`naz: $script:LastAzError"
+        exit 1
+    }
 }
 
 # Configure az devops defaults
-az devops configure --defaults organization=$Organization project=$Project 2>$null
+Invoke-Az devops configure --defaults organization=$Organization project=$Project | Out-Null
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Failed to configure az devops defaults.`naz: $script:LastAzError"
+    exit 1
+}
 
 # --- Step 1: Get build info to determine version ---
 Write-Host "Fetching build $BuildId info..." -ForegroundColor Cyan
-$buildJson = az pipelines build show --id $BuildId --output json 2>$null
+$buildJson = Invoke-Az pipelines build show --id $BuildId --output json
 if (-not $buildJson) {
-    Write-Error "Could not fetch build $BuildId. Are you logged in (az login)?"
+    Write-Error "Could not fetch build $BuildId. Are you logged in (az login)?`naz: $script:LastAzError"
     exit 1
 }
 $build = $buildJson | ConvertFrom-Json
@@ -76,7 +162,11 @@ Write-Host "  Version: $versionParam" -ForegroundColor DarkGray
 
 # --- Step 2: Get artifact metadata once ---
 Write-Host "Fetching artifact metadata..." -ForegroundColor Cyan
-$artifactsJson = az pipelines runs artifact list --run-id $BuildId --output json 2>$null
+$artifactsJson = Invoke-Az pipelines runs artifact list --run-id $BuildId --output json
+if (-not $artifactsJson) {
+    Write-Error "Could not list artifacts for build $BuildId.`naz: $script:LastAzError"
+    exit 1
+}
 $artifacts = $artifactsJson | ConvertFrom-Json
 
 # --- Step 3: Prepare destination folder ---
@@ -87,18 +177,18 @@ if (-not (Test-Path $destFolder)) {
 Write-Host "  Destination: $destFolder" -ForegroundColor DarkGray
 
 # --- Step 4: Get an ADO access token once ---
-$token = az account get-access-token --resource "499b84ac-1321-427f-aa17-267ca6975798" --query accessToken -o tsv 2>$null
+$token = Invoke-Az account get-access-token --resource "499b84ac-1321-427f-aa17-267ca6975798" --query accessToken -o tsv
 if (-not $token) {
-    Write-Error "Failed to acquire ADO access token. Run 'az login' first."
+    Write-Error "Failed to acquire ADO access token. Run 'az login' first.`naz: $script:LastAzError"
     exit 1
 }
 
 # --- Step 5: Define the four installers to download ---
 $targets = @(
-    [pscustomobject]@{ Description = "Per user - x64";     Scope = "perUser";    Arch = "x64";    Artifact = "build-x64-Release";   FileName = "PowerToysUserSetup-$versionParam-x64.exe";   Ref = "ptUserX64" }
-    [pscustomobject]@{ Description = "Per user - ARM64";   Scope = "perUser";    Arch = "arm64";  Artifact = "build-arm64-Release"; FileName = "PowerToysUserSetup-$versionParam-arm64.exe"; Ref = "ptUserArm64" }
-    [pscustomobject]@{ Description = "Machine wide - x64"; Scope = "perMachine"; Arch = "x64";    Artifact = "build-x64-Release";   FileName = "PowerToysSetup-$versionParam-x64.exe";       Ref = "ptMachineX64" }
-    [pscustomobject]@{ Description = "Machine wide - ARM64"; Scope = "perMachine"; Arch = "arm64"; Artifact = "build-arm64-Release"; FileName = "PowerToysSetup-$versionParam-arm64.exe";    Ref = "ptMachineArm64" }
+    [pscustomobject]@{ Description = "Per user - x64";       Scope = "perUser";    Arch = "x64";   Artifact = "build-x64-Release";   FileName = "PowerToysUserSetup-$versionParam-x64.exe" }
+    [pscustomobject]@{ Description = "Per user - ARM64";     Scope = "perUser";    Arch = "arm64"; Artifact = "build-arm64-Release"; FileName = "PowerToysUserSetup-$versionParam-arm64.exe" }
+    [pscustomobject]@{ Description = "Machine wide - x64";   Scope = "perMachine"; Arch = "x64";   Artifact = "build-x64-Release";   FileName = "PowerToysSetup-$versionParam-x64.exe" }
+    [pscustomobject]@{ Description = "Machine wide - ARM64"; Scope = "perMachine"; Arch = "arm64"; Artifact = "build-arm64-Release"; FileName = "PowerToysSetup-$versionParam-arm64.exe" }
 )
 
 # --- Step 6: Download each installer (skip if already present) ---
@@ -117,23 +207,15 @@ foreach ($t in $targets) {
         exit 1
     }
 
-    $baseDownloadUrl = $artifact.resource.downloadUrl
-    $encodedSubPath = [Uri]::EscapeDataString("/$($t.FileName)")
-    $fileUrl = $baseDownloadUrl -replace "format=zip", "format=file&subPath=$encodedSubPath"
+    $fileUrl = Get-ArtifactDownloadUrl -BaseUrl $artifact.resource.downloadUrl -SubPath "/$($t.FileName)" -Format file
 
     Write-Host "Downloading $($t.FileName) ..." -ForegroundColor Cyan
-    $webClient = New-Object System.Net.WebClient
-    $webClient.Headers.Add("Authorization", "Bearer $token")
     try {
-        $webClient.DownloadFile($fileUrl, $destPath)
+        Invoke-AdoDownload -Url $fileUrl -DestPath $destPath -Token $token
     }
     catch {
         Write-Error "Download failed for $($t.FileName): $_"
-        Write-Host "URL: $fileUrl" -ForegroundColor DarkGray
         exit 1
-    }
-    finally {
-        $webClient.Dispose()
     }
 
     $sizeMB = [math]::Round((Get-Item $destPath).Length / 1MB, 1)
@@ -160,71 +242,64 @@ foreach ($s in $symbolTargets) {
         exit 1
     }
 
-    $baseDownloadUrl = $artifact.resource.downloadUrl
-    $encodedSubPath = [Uri]::EscapeDataString($s.SubPath)
     # Symbols are downloaded as a folder => keep format=zip and append subPath
-    if ($baseDownloadUrl -match "subPath=") {
-        $symbolsUrl = $baseDownloadUrl -replace "subPath=[^&]*", "subPath=$encodedSubPath"
-    }
-    else {
-        $sep = if ($baseDownloadUrl.Contains("?")) { "&" } else { "?" }
-        $symbolsUrl = "$baseDownloadUrl$sep" + "subPath=$encodedSubPath"
-    }
+    $symbolsUrl = Get-ArtifactDownloadUrl -BaseUrl $artifact.resource.downloadUrl -SubPath $s.SubPath -Format zip
 
     $tmpZip = Join-Path ([System.IO.Path]::GetTempPath()) ("ptsym-$($s.Arch)-$([Guid]::NewGuid().ToString('N')).zip")
     $tmpExtract = Join-Path ([System.IO.Path]::GetTempPath()) ("ptsym-$($s.Arch)-$([Guid]::NewGuid().ToString('N'))")
+    $stageRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("ptsym-stage-$([Guid]::NewGuid().ToString('N'))")
 
-    Write-Host "Downloading symbols-$($s.Arch).zip ..." -ForegroundColor Cyan
-    $webClient = New-Object System.Net.WebClient
-    $webClient.Headers.Add("Authorization", "Bearer $token")
     try {
-        $webClient.DownloadFile($symbolsUrl, $tmpZip)
+        Write-Host "Downloading symbols-$($s.Arch).zip ..." -ForegroundColor Cyan
+        try {
+            Invoke-AdoDownload -Url $symbolsUrl -DestPath $tmpZip -Token $token
+        }
+        catch {
+            Write-Error "Symbols download failed for $($s.Arch): $_"
+            exit 1
+        }
+
+        Write-Host "  Extracting..." -ForegroundColor DarkGray
+        Expand-Archive -Path $tmpZip -DestinationPath $tmpExtract -Force
+
+        # Walk down while the current dir holds exactly one subfolder and no files.
+        $current = Get-Item $tmpExtract
+        while ($true) {
+            $children = Get-ChildItem -LiteralPath $current.FullName -Force
+            $subDirs = @($children | Where-Object { $_.PSIsContainer })
+            $files = @($children | Where-Object { -not $_.PSIsContainer })
+            if ($subDirs.Count -eq 1 -and $files.Count -eq 0) {
+                $current = $subDirs[0]
+            }
+            else {
+                break
+            }
+        }
+
+        # Stage to a folder named symbols-<arch> so the zip extracts to that name.
+        $stageInner = Join-Path $stageRoot "symbols-$($s.Arch)"
+        New-Item -ItemType Directory -Path $stageInner -Force | Out-Null
+        Get-ChildItem -LiteralPath $current.FullName -Force | ForEach-Object {
+            Copy-Item -LiteralPath $_.FullName -Destination $stageInner -Recurse -Force
+        }
+
+        Write-Host "  Repacking to $finalZip ..." -ForegroundColor DarkGray
+        if (Test-Path $finalZip) { Remove-Item $finalZip -Force }
+        Compress-Archive -Path "$stageInner\*" -DestinationPath $finalZip -CompressionLevel Optimal
+
+        $sizeMB = [math]::Round((Get-Item $finalZip).Length / 1MB, 1)
+        Write-Host "  Saved symbols-$($s.Arch).zip ($sizeMB MB)" -ForegroundColor Green
     }
     catch {
-        Write-Error "Symbols download failed for $($s.Arch): $_"
-        Write-Host "URL: $symbolsUrl" -ForegroundColor DarkGray
-        exit 1
+        # Don't leave a half-built zip behind if anything in the pipeline blew up.
+        if (Test-Path $finalZip) { Remove-Item $finalZip -Force -ErrorAction SilentlyContinue }
+        throw
     }
     finally {
-        $webClient.Dispose()
+        Remove-Item $tmpZip -Force -ErrorAction SilentlyContinue
+        Remove-Item $tmpExtract -Recurse -Force -ErrorAction SilentlyContinue
+        Remove-Item $stageRoot -Recurse -Force -ErrorAction SilentlyContinue
     }
-
-    Write-Host "  Extracting..." -ForegroundColor DarkGray
-    if (Test-Path $tmpExtract) { Remove-Item $tmpExtract -Recurse -Force }
-    Expand-Archive -Path $tmpZip -DestinationPath $tmpExtract -Force
-
-    # Walk down while the current dir holds exactly one subfolder and no files.
-    $current = Get-Item $tmpExtract
-    while ($true) {
-        $children = Get-ChildItem -LiteralPath $current.FullName -Force
-        $subDirs = @($children | Where-Object { $_.PSIsContainer })
-        $files = @($children | Where-Object { -not $_.PSIsContainer })
-        if ($subDirs.Count -eq 1 -and $files.Count -eq 0) {
-            $current = $subDirs[0]
-        }
-        else {
-            break
-        }
-    }
-
-    # Stage to a folder named symbols-<arch> so the zip extracts to that name.
-    $stageRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("ptsym-stage-$([Guid]::NewGuid().ToString('N'))")
-    $stageInner = Join-Path $stageRoot "symbols-$($s.Arch)"
-    New-Item -ItemType Directory -Path $stageInner -Force | Out-Null
-    Get-ChildItem -LiteralPath $current.FullName -Force | ForEach-Object {
-        Copy-Item -LiteralPath $_.FullName -Destination $stageInner -Recurse -Force
-    }
-
-    Write-Host "  Repacking to $finalZip ..." -ForegroundColor DarkGray
-    if (Test-Path $finalZip) { Remove-Item $finalZip -Force }
-    Compress-Archive -Path "$stageInner\*" -DestinationPath $finalZip -CompressionLevel Optimal
-
-    Remove-Item $tmpZip -Force -ErrorAction SilentlyContinue
-    Remove-Item $tmpExtract -Recurse -Force -ErrorAction SilentlyContinue
-    Remove-Item $stageRoot -Recurse -Force -ErrorAction SilentlyContinue
-
-    $sizeMB = [math]::Round((Get-Item $finalZip).Length / 1MB, 1)
-    Write-Host "  Saved symbols-$($s.Arch).zip ($sizeMB MB)" -ForegroundColor Green
 }
 
 # --- Step 7: Compute SHA256 and build markdown ---
@@ -233,8 +308,8 @@ Write-Host "`nComputing SHA256 hashes..." -ForegroundColor Cyan
 $sb = [System.Text.StringBuilder]::new()
 [void]$sb.AppendLine("## Installer Hashes")
 [void]$sb.AppendLine("")
-[void]$sb.AppendLine("|  Description   | Filename | sha256 hash |")
-[void]$sb.AppendLine("|----------------|----------|----------|")
+[void]$sb.AppendLine("| Description | Filename | sha256 hash |")
+[void]$sb.AppendLine("| --- | --- | --- |")
 
 foreach ($t in $targets) {
     $destPath = Join-Path $destFolder $t.FileName
@@ -250,3 +325,5 @@ Set-Content -Path $mdPath -Value $markdown -Encoding UTF8
 Write-Host "`nMarkdown written to: $mdPath" -ForegroundColor Green
 Write-Host "`n----- Installer Hashes -----`n" -ForegroundColor Yellow
 Write-Host $markdown
+
+Write-Host "Draft a new GitHub release at: https://github.com/$GitHubRepo/releases/new?tag=v$versionParam" -ForegroundColor Green


### PR DESCRIPTION
## Summary

Two related changes to the `release-note-generation` agent skill:

### 1. Step 3 reviews: use the local agent instead of `mcp_github_request_copilot_review`

Step 3.1 previously instructed the agent to call `mcp_github_request_copilot_review` for every milestone PR so that the `CopilotSummary` column in `sorted_prs.csv` would be populated by the GitHub-side Copilot bot.

When this skill is driven from a CLI / coding agent, that request comes from a bot identity, and the GitHub API rejects it (`Bot reviewers cannot be requested`). The PR ends up with no Copilot review and `CopilotSummary` stays empty.

`references/step3-review-grouping.md` has been rewritten to instead have **the local agent** that is running the skill perform the review itself:

- Fetch each PR's diff with a non-mutating tool (`mcp_github_pull_request_read` `get_diff` / `get_files`, or `gh pr diff`).
- Produce a 1-3 sentence user-facing summary in the same style as a Copilot PR review.
- Write the summary directly into the `CopilotSummary` column of `Generated Files/ReleaseNotes/sorted_prs.csv`, preserving row order and skipping rows that already have a non-empty summary.

Step 3.2 (re-run `dump-prs-since-commit.ps1`) is demoted to optional, with a note that re-running the dump will overwrite the locally-generated summaries.

`SKILL.md` was updated to match: front-matter description, "When to Use", workflow diagram, the 3.1-3.3 row in the summary table, prerequisites (no longer requires "GitHub Copilot code review enabled for the org/repo"; mentions MCP for fetching diffs), and the troubleshooting row for empty `CopilotSummary` now points at Step 3.1 with the bot-rejection caveat.

### 2. Vendor `prepare-release-assets.ps1` into the skill

Added `scripts/prepare-release-assets.ps1` -- previously kept in OneDrive at `Tools/prepare-release.ps1`. Renamed because the script does more than download installers: it also pulls per-arch symbol archives, computes SHA256, and emits the **Installer Hashes** markdown table for the GitHub release page. "Release assets" captures all of that.

Header `.SYNOPSIS` / `.DESCRIPTION` / `.EXAMPLE` blocks were updated to reflect the new filename and the symbol-archive behavior (the original synopsis only mentioned installers).

`SKILL.md` registers the new script in the "Available Scripts" table, lists Azure CLI + the `azure-devops` extension as a prerequisite (only when running this script), adds a "Prepare GitHub release assets" entry to "When to Use", and adds a troubleshooting row for the most common failure (`Failed to acquire ADO access token` -> `az login`).

## Files changed

| File | Change |
|------|--------|
| `.github/skills/release-note-generation/SKILL.md` | Updated description, prerequisites, workflow, scripts table, troubleshooting |
| `.github/skills/release-note-generation/references/step3-review-grouping.md` | Rewritten to use local-agent review; demoted refresh step |
| `.github/skills/release-note-generation/scripts/prepare-release-assets.ps1` | New (vendored from OneDrive) |

## Validation

- PowerShell parser ([`Parser]::ParseFile`) reports no errors on the new script.
- Documentation-only / scripts-only change -- no product code touched, so the standard PowerToys build / test gates do not apply.
- The change preserves the existing CSV schema (`Id, Title, Labels, Author, Url, Body, CopilotSummary, NeedThanks`), so downstream Step 3.3 (`group-prs-by-label.ps1`) and Step 4 summarization continue to work without modification.
