### PR TITLE
[GPO]Bump en-US ADML revision to 1.20 to match ADMX (fixes #47645)

### DIFF
--- a/src/gpo/assets/en-US/PowerToys.adml
+++ b/src/gpo/assets/en-US/PowerToys.adml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) Microsoft Corporation.
      Licensed under the MIT License. -->
-<policyDefinitionResources xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.19" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
+<policyDefinitionResources xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.20" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
   <displayName>PowerToys</displayName>
   <description>PowerToys</description>
   <resources>


### PR DESCRIPTION
## Summary

Fixes #47645.

The ADMX policy definition (`src/gpo/assets/PowerToys.admx`) declares `revision="1.20"` and `<resources minRequiredRevision="1.20"/>`, but the en-US ADML language resource (`src/gpo/assets/en-US/PowerToys.adml`) was still at `revision="1.19"`. Group Policy Editor refuses to load the PowerToys template because the language resource does not meet the minimum required revision, producing the error reported in the issue.

## Change

Bump `revision` on the `policyDefinitionResources` root element of `PowerToys.adml` from `1.19` to `1.20` so it matches the ADMX `minRequiredRevision`.

## Validation

- Diffed against `src/gpo/assets/PowerToys.admx` to confirm the revisions now align (both `1.20`).
- Documentation/asset-only change; no code build required.

## PR Checklist

- [x] Closes #47645
- [x] Tests added/passed — N/A (asset-only revision bump)
- [x] Requires documentation to be updated — No
- [x] I know how to test these changes — Open `gpedit.msc` and confirm PowerToys policies load without the resource-version error.
