### PR TITLE
[PowerDisplay] Fix brightness/contrast/volume on monitors with native max != 100

### DIFF
--- a/src/modules/powerdisplay/PowerDisplay.Lib.UnitTests/VcpFeatureValueTests.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Lib.UnitTests/VcpFeatureValueTests.cs
@@ -1,0 +1,104 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PowerDisplay.Common.Models;
+
+namespace PowerDisplay.UnitTests;
+
+[TestClass]
+public class VcpFeatureValueTests
+{
+    [TestMethod]
+    public void ToPercentage_StandardRange_MapsCurrentToPercent()
+    {
+        var value = new VcpFeatureValue(current: 75, minimum: 0, maximum: 100);
+        Assert.AreEqual(75, value.ToPercentage());
+    }
+
+    [TestMethod]
+    public void ToPercentage_SamsungHalfRange_MapsCurrentToPercent()
+    {
+        // Samsung S27DG602SN style: native max=50.
+        var value = new VcpFeatureValue(current: 25, minimum: 0, maximum: 50);
+        Assert.AreEqual(50, value.ToPercentage());
+    }
+
+    [TestMethod]
+    public void ToPercentage_DegenerateRange_ReturnsZero()
+    {
+        var value = new VcpFeatureValue(current: 10, minimum: 5, maximum: 5);
+        Assert.AreEqual(0, value.ToPercentage());
+    }
+
+    [TestMethod]
+    public void ToPercentage_Invalid_ReturnsZero()
+    {
+        Assert.AreEqual(0, VcpFeatureValue.Invalid.ToPercentage());
+    }
+
+    [TestMethod]
+    public void FromPercentage_StandardRange_IsIdentity()
+    {
+        Assert.AreEqual(0, VcpFeatureValue.FromPercentage(0, maximum: 100));
+        Assert.AreEqual(50, VcpFeatureValue.FromPercentage(50, maximum: 100));
+        Assert.AreEqual(100, VcpFeatureValue.FromPercentage(100, maximum: 100));
+    }
+
+    [TestMethod]
+    public void FromPercentage_SamsungHalfRange_ScalesToHalf()
+    {
+        // The bug: with native max=50, slider 80% must produce raw 40, not 80.
+        Assert.AreEqual(0, VcpFeatureValue.FromPercentage(0, maximum: 50));
+        Assert.AreEqual(25, VcpFeatureValue.FromPercentage(50, maximum: 50));
+        Assert.AreEqual(40, VcpFeatureValue.FromPercentage(80, maximum: 50));
+        Assert.AreEqual(50, VcpFeatureValue.FromPercentage(100, maximum: 50));
+    }
+
+    [TestMethod]
+    public void FromPercentage_OversizedRange_ScalesProportionally()
+    {
+        // Some high-end displays advertise max=255.
+        Assert.AreEqual(0, VcpFeatureValue.FromPercentage(0, maximum: 255));
+        Assert.AreEqual(128, VcpFeatureValue.FromPercentage(50, maximum: 255));
+        Assert.AreEqual(255, VcpFeatureValue.FromPercentage(100, maximum: 255));
+    }
+
+    [TestMethod]
+    public void FromPercentage_NonZeroMinimum_OffsetsResult()
+    {
+        Assert.AreEqual(10, VcpFeatureValue.FromPercentage(0, maximum: 60, minimum: 10));
+        Assert.AreEqual(35, VcpFeatureValue.FromPercentage(50, maximum: 60, minimum: 10));
+        Assert.AreEqual(60, VcpFeatureValue.FromPercentage(100, maximum: 60, minimum: 10));
+    }
+
+    [TestMethod]
+    public void FromPercentage_OutOfRangePercent_IsClamped()
+    {
+        Assert.AreEqual(0, VcpFeatureValue.FromPercentage(-50, maximum: 100));
+        Assert.AreEqual(100, VcpFeatureValue.FromPercentage(250, maximum: 100));
+    }
+
+    [TestMethod]
+    public void FromPercentage_DegenerateRange_ReturnsMinimum()
+    {
+        Assert.AreEqual(0, VcpFeatureValue.FromPercentage(75, maximum: 0));
+        Assert.AreEqual(7, VcpFeatureValue.FromPercentage(75, maximum: 7, minimum: 7));
+    }
+
+    [TestMethod]
+    public void RoundTrip_IsApproximatelyStable()
+    {
+        // ToPercentage and FromPercentage are inverses up to integer rounding error.
+        const int max = 50;
+        for (int raw = 0; raw <= max; raw++)
+        {
+            var pct = new VcpFeatureValue(raw, 0, max).ToPercentage();
+            var roundTripped = VcpFeatureValue.FromPercentage(pct, max);
+            Assert.IsTrue(
+                System.Math.Abs(roundTripped - raw) <= 1,
+                $"raw={raw} → pct={pct} → roundTripped={roundTripped} (drift > 1)");
+        }
+    }
+}

--- a/src/modules/powerdisplay/PowerDisplay.Lib/Drivers/DDC/DdcCiController.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Lib/Drivers/DDC/DdcCiController.cs
@@ -95,32 +95,50 @@ namespace PowerDisplay.Common.Drivers.DDC
 
         public string Name => "DDC/CI Monitor Controller";
 
-        /// <summary>
-        /// Get monitor brightness using VCP code 0x10
-        /// </summary>
+        /// <inheritdoc />
         public async Task<VcpFeatureValue> GetBrightnessAsync(Monitor monitor, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(monitor);
             return await GetVcpFeatureAsync(monitor, VcpCodeBrightness, cancellationToken);
         }
 
-        /// <summary>
-        /// Set monitor brightness using VCP code 0x10
-        /// </summary>
+        /// <inheritdoc />
         public Task<MonitorOperationResult> SetBrightnessAsync(Monitor monitor, int brightness, CancellationToken cancellationToken = default)
-            => SetVcpFeatureAsync(monitor, NativeConstants.VcpCodeBrightness, brightness, cancellationToken);
+        {
+            ArgumentNullException.ThrowIfNull(monitor);
+            var raw = VcpFeatureValue.FromPercentage(brightness, monitor.BrightnessVcpMax);
+            return SetVcpFeatureAsync(monitor, NativeConstants.VcpCodeBrightness, raw, cancellationToken);
+        }
 
-        /// <summary>
-        /// Set monitor contrast
-        /// </summary>
+        /// <inheritdoc />
+        public async Task<VcpFeatureValue> GetContrastAsync(Monitor monitor, CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(monitor);
+            return await GetVcpFeatureAsync(monitor, VcpCodeContrast, cancellationToken);
+        }
+
+        /// <inheritdoc />
         public Task<MonitorOperationResult> SetContrastAsync(Monitor monitor, int contrast, CancellationToken cancellationToken = default)
-            => SetVcpFeatureAsync(monitor, NativeConstants.VcpCodeContrast, contrast, cancellationToken);
+        {
+            ArgumentNullException.ThrowIfNull(monitor);
+            var raw = VcpFeatureValue.FromPercentage(contrast, monitor.ContrastVcpMax);
+            return SetVcpFeatureAsync(monitor, NativeConstants.VcpCodeContrast, raw, cancellationToken);
+        }
 
-        /// <summary>
-        /// Set monitor volume
-        /// </summary>
+        /// <inheritdoc />
+        public async Task<VcpFeatureValue> GetVolumeAsync(Monitor monitor, CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(monitor);
+            return await GetVcpFeatureAsync(monitor, VcpCodeVolume, cancellationToken);
+        }
+
+        /// <inheritdoc />
         public Task<MonitorOperationResult> SetVolumeAsync(Monitor monitor, int volume, CancellationToken cancellationToken = default)
-            => SetVcpFeatureAsync(monitor, NativeConstants.VcpCodeVolume, volume, cancellationToken);
+        {
+            ArgumentNullException.ThrowIfNull(monitor);
+            var raw = VcpFeatureValue.FromPercentage(volume, monitor.VolumeVcpMax);
+            return SetVcpFeatureAsync(monitor, NativeConstants.VcpCodeVolume, raw, cancellationToken);
+        }
 
         /// <summary>
         /// Get monitor color temperature using VCP code 0x14 (Select Color Preset)
@@ -528,11 +546,13 @@ namespace PowerDisplay.Common.Drivers.DDC
 
         /// <summary>
         /// Initialize brightness value for a monitor using VCP 0x10.
+        /// Persists the device-reported raw maximum so subsequent writes can scale percent → raw.
         /// </summary>
         private static void InitializeBrightness(Monitor monitor, IntPtr handle)
         {
             if (TryGetVcpFeature(handle, VcpCodeBrightness, monitor.Id, out uint current, out uint max))
             {
+                monitor.BrightnessVcpMax = (int)max;
                 var brightnessInfo = new VcpFeatureValue((int)current, 0, (int)max);
                 monitor.CurrentBrightness = brightnessInfo.ToPercentage();
             }
@@ -540,11 +560,13 @@ namespace PowerDisplay.Common.Drivers.DDC
 
         /// <summary>
         /// Initialize contrast value for a monitor using VCP 0x12.
+        /// Persists the device-reported raw maximum so subsequent writes can scale percent → raw.
         /// </summary>
         private static void InitializeContrast(Monitor monitor, IntPtr handle)
         {
             if (TryGetVcpFeature(handle, VcpCodeContrast, monitor.Id, out uint current, out uint max))
             {
+                monitor.ContrastVcpMax = (int)max;
                 var contrastInfo = new VcpFeatureValue((int)current, 0, (int)max);
                 monitor.CurrentContrast = contrastInfo.ToPercentage();
             }
@@ -552,11 +574,13 @@ namespace PowerDisplay.Common.Drivers.DDC
 
         /// <summary>
         /// Initialize volume value for a monitor using VCP 0x62.
+        /// Persists the device-reported raw maximum so subsequent writes can scale percent → raw.
         /// </summary>
         private static void InitializeVolume(Monitor monitor, IntPtr handle)
         {
             if (TryGetVcpFeature(handle, VcpCodeVolume, monitor.Id, out uint current, out uint max))
             {
+                monitor.VolumeVcpMax = (int)max;
                 var volumeInfo = new VcpFeatureValue((int)current, 0, (int)max);
                 monitor.CurrentVolume = volumeInfo.ToPercentage();
             }

--- a/src/modules/powerdisplay/PowerDisplay.Lib/Drivers/DDC/MonitorDiscoveryHelper.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Lib/Drivers/DDC/MonitorDiscoveryHelper.cs
@@ -124,9 +124,6 @@ namespace PowerDisplay.Common.Drivers.DDC
                     Id = monitorId,
                     Name = name.Trim(),
                     CurrentBrightness = 50, // Default value, will be updated by MonitorManager after discovery
-                    MinBrightness = 0,
-                    MaxBrightness = 100,
-                    IsAvailable = true,
                     Handle = physicalMonitor.HPhysicalMonitor,
                     Capabilities = MonitorCapabilities.DdcCi,
                     CommunicationMethod = "DDC/CI",

--- a/src/modules/powerdisplay/PowerDisplay.Lib/Drivers/WMI/WmiController.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Lib/Drivers/WMI/WmiController.cs
@@ -301,9 +301,6 @@ namespace PowerDisplay.Common.Drivers.WMI
                                 Id = uniqueId,
                                 Name = string.Empty,
                                 CurrentBrightness = currentBrightness,
-                                MinBrightness = 0,
-                                MaxBrightness = 100,
-                                IsAvailable = true,
                                 InstanceName = instanceName,
                                 Capabilities = MonitorCapabilities.Brightness | MonitorCapabilities.Wmi,
                                 CommunicationMethod = "WMI",
@@ -334,10 +331,20 @@ namespace PowerDisplay.Common.Drivers.WMI
                 cancellationToken);
         }
 
-        // Extended features not supported by WMI
+        // Extended features not supported by WMI (internal laptop displays expose only brightness via WMI).
+        public Task<VcpFeatureValue> GetContrastAsync(Monitor monitor, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(VcpFeatureValue.Invalid);
+        }
+
         public Task<MonitorOperationResult> SetContrastAsync(Monitor monitor, int contrast, CancellationToken cancellationToken = default)
         {
             return Task.FromResult(MonitorOperationResult.Failure("Contrast control not supported via WMI"));
+        }
+
+        public Task<VcpFeatureValue> GetVolumeAsync(Monitor monitor, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(VcpFeatureValue.Invalid);
         }
 
         public Task<MonitorOperationResult> SetVolumeAsync(Monitor monitor, int volume, CancellationToken cancellationToken = default)

--- a/src/modules/powerdisplay/PowerDisplay.Lib/Interfaces/IMonitorController.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Lib/Interfaces/IMonitorController.cs
@@ -12,8 +12,20 @@ using Monitor = PowerDisplay.Common.Models.Monitor;
 namespace PowerDisplay.Common.Interfaces
 {
     /// <summary>
-    /// Monitor controller interface
+    /// Monitor controller interface.
     /// </summary>
+    /// <remarks>
+    /// <para><b>Continuous-range VCPs (Brightness 0x10, Contrast 0x12, Volume 0x62)</b>:</para>
+    /// <list type="bullet">
+    /// <item><description><c>Get*Async</c> returns a <see cref="VcpFeatureValue"/> with <b>raw VCP</b> <c>Current</c> and <c>Maximum</c>.
+    ///   Most monitors report <c>Maximum</c>=100, but some (e.g. Samsung) report 50. Callers must use
+    ///   <see cref="VcpFeatureValue.ToPercentage"/> to obtain a 0-100 percentage rather than treating <c>Current</c> as a percent.</description></item>
+    /// <item><description><c>Set*Async</c> takes a <b>percentage 0-100</b>. The implementation scales it to the device's
+    ///   raw VCP range using the per-monitor max captured at discovery (<c>Monitor.BrightnessVcpMax</c> etc.).</description></item>
+    /// </list>
+    /// <para><b>Discrete VCPs (ColorTemperature 0x14, InputSource 0x60, PowerState 0xD6)</b>: values are raw VCP enum codes
+    /// (e.g. <c>0x05</c> = 6500K, <c>0x11</c> = HDMI-1, <c>0x01</c> = Power On). No percentage semantics — pass values through verbatim.</para>
+    /// </remarks>
     public interface IMonitorController
     {
         /// <summary>
@@ -22,18 +34,22 @@ namespace PowerDisplay.Common.Interfaces
         string Name { get; }
 
         /// <summary>
-        /// Gets monitor brightness
+        /// Reads the monitor's current brightness directly from hardware (VCP 0x10).
         /// </summary>
         /// <param name="monitor">Monitor object</param>
         /// <param name="cancellationToken">Cancellation token</param>
-        /// <returns>Brightness information</returns>
+        /// <returns>
+        /// <see cref="VcpFeatureValue"/> with raw VCP <c>Current</c> and <c>Maximum</c>.
+        /// Call <see cref="VcpFeatureValue.ToPercentage"/> to obtain a 0-100 percent value.
+        /// </returns>
         Task<VcpFeatureValue> GetBrightnessAsync(Monitor monitor, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Sets monitor brightness
+        /// Sets the monitor brightness (VCP 0x10) from a percentage. The implementation scales
+        /// 0-100 to the device's raw VCP range before issuing the DDC/CI write.
         /// </summary>
         /// <param name="monitor">Monitor object</param>
-        /// <param name="brightness">Brightness value (0-100)</param>
+        /// <param name="brightness">Brightness percentage (0-100)</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Operation result</returns>
         Task<MonitorOperationResult> SetBrightnessAsync(Monitor monitor, int brightness, CancellationToken cancellationToken = default);
@@ -46,19 +62,43 @@ namespace PowerDisplay.Common.Interfaces
         Task<IEnumerable<Monitor>> DiscoverMonitorsAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Sets monitor contrast
+        /// Reads the monitor's current contrast directly from hardware (VCP 0x12).
         /// </summary>
         /// <param name="monitor">Monitor object</param>
-        /// <param name="contrast">Contrast value (0-100)</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>
+        /// <see cref="VcpFeatureValue"/> with raw VCP <c>Current</c> and <c>Maximum</c>.
+        /// Call <see cref="VcpFeatureValue.ToPercentage"/> to obtain a 0-100 percent value.
+        /// </returns>
+        Task<VcpFeatureValue> GetContrastAsync(Monitor monitor, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Sets the monitor contrast (VCP 0x12) from a percentage. The implementation scales
+        /// 0-100 to the device's raw VCP range before issuing the DDC/CI write.
+        /// </summary>
+        /// <param name="monitor">Monitor object</param>
+        /// <param name="contrast">Contrast percentage (0-100)</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Operation result</returns>
         Task<MonitorOperationResult> SetContrastAsync(Monitor monitor, int contrast, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Sets monitor volume
+        /// Reads the monitor's current volume directly from hardware (VCP 0x62).
         /// </summary>
         /// <param name="monitor">Monitor object</param>
-        /// <param name="volume">Volume value (0-100)</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>
+        /// <see cref="VcpFeatureValue"/> with raw VCP <c>Current</c> and <c>Maximum</c>.
+        /// Call <see cref="VcpFeatureValue.ToPercentage"/> to obtain a 0-100 percent value.
+        /// </returns>
+        Task<VcpFeatureValue> GetVolumeAsync(Monitor monitor, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Sets the monitor volume (VCP 0x62) from a percentage. The implementation scales
+        /// 0-100 to the device's raw VCP range before issuing the DDC/CI write.
+        /// </summary>
+        /// <param name="monitor">Monitor object</param>
+        /// <param name="volume">Volume percentage (0-100)</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Operation result</returns>
         Task<MonitorOperationResult> SetVolumeAsync(Monitor monitor, int volume, CancellationToken cancellationToken = default);

--- a/src/modules/powerdisplay/PowerDisplay.Lib/Models/Monitor.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Lib/Models/Monitor.cs
@@ -24,7 +24,6 @@ namespace PowerDisplay.Common.Models
         private int _currentColorTemperature = 0x05; // Default to 6500K preset (VCP 0x14 value)
         private int _currentInputSource; // VCP 0x60 value
         private int _currentPowerState = 0x01; // Default to On (VCP 0xD6 value)
-        private bool _isAvailable = true;
         private int _orientation;
 
         /// <summary>
@@ -43,14 +42,14 @@ namespace PowerDisplay.Common.Models
         public string Name { get; set; } = string.Empty;
 
         /// <summary>
-        /// Gets or sets current brightness (0-100)
+        /// Gets or sets current brightness as a percentage (0-100).
         /// </summary>
         public int CurrentBrightness
         {
             get => _currentBrightness;
             set
             {
-                var clamped = Math.Clamp(value, MinBrightness, MaxBrightness);
+                var clamped = Math.Clamp(value, 0, 100);
                 if (_currentBrightness != clamped)
                 {
                     _currentBrightness = clamped;
@@ -60,14 +59,15 @@ namespace PowerDisplay.Common.Models
         }
 
         /// <summary>
-        /// Gets or sets minimum brightness value
+        /// Gets or sets the device-reported raw VCP maximum for brightness (VCP 0x10).
         /// </summary>
-        public int MinBrightness { get; set; }
-
-        /// <summary>
-        /// Gets or sets maximum brightness value
-        /// </summary>
-        public int MaxBrightness { get; set; } = 100;
+        /// <remarks>
+        /// <para>This is the value returned in the "max" out-parameter of <c>GetVCPFeatureAndVCPFeatureReply</c>.
+        /// Most monitors report 100, but some (e.g. several Samsung models) report 50 — for those, writing
+        /// the slider percentage as the raw VCP value lops off the upper half of the range. Writers must scale
+        /// percent → raw using this field; readers use it via <see cref="VcpFeatureValue.ToPercentage"/>.</para>
+        /// </remarks>
+        public int BrightnessVcpMax { get; set; } = 100;
 
         /// <summary>
         /// Gets or sets current color temperature VCP preset value (from VCP code 0x14).
@@ -184,14 +184,14 @@ namespace PowerDisplay.Common.Models
         private int _currentVolume = 50;
 
         /// <summary>
-        /// Gets or sets current contrast (0-100)
+        /// Gets or sets current contrast as a percentage (0-100).
         /// </summary>
         public int CurrentContrast
         {
             get => _currentContrast;
             set
             {
-                var clamped = Math.Clamp(value, MinContrast, MaxContrast);
+                var clamped = Math.Clamp(value, 0, 100);
                 if (_currentContrast != clamped)
                 {
                     _currentContrast = clamped;
@@ -201,24 +201,20 @@ namespace PowerDisplay.Common.Models
         }
 
         /// <summary>
-        /// Gets or sets minimum contrast value
+        /// Gets or sets the device-reported raw VCP maximum for contrast (VCP 0x12).
+        /// See <see cref="BrightnessVcpMax"/> for semantics — same story applies to contrast.
         /// </summary>
-        public int MinContrast { get; set; }
+        public int ContrastVcpMax { get; set; } = 100;
 
         /// <summary>
-        /// Gets or sets maximum contrast value
-        /// </summary>
-        public int MaxContrast { get; set; } = 100;
-
-        /// <summary>
-        /// Gets or sets current volume (0-100)
+        /// Gets or sets current volume as a percentage (0-100).
         /// </summary>
         public int CurrentVolume
         {
             get => _currentVolume;
             set
             {
-                var clamped = Math.Clamp(value, MinVolume, MaxVolume);
+                var clamped = Math.Clamp(value, 0, 100);
                 if (_currentVolume != clamped)
                 {
                     _currentVolume = clamped;
@@ -228,30 +224,10 @@ namespace PowerDisplay.Common.Models
         }
 
         /// <summary>
-        /// Gets or sets minimum volume value
+        /// Gets or sets the device-reported raw VCP maximum for volume (VCP 0x62).
+        /// See <see cref="BrightnessVcpMax"/> for semantics — same story applies to volume.
         /// </summary>
-        public int MinVolume { get; set; }
-
-        /// <summary>
-        /// Gets or sets maximum volume value
-        /// </summary>
-        public int MaxVolume { get; set; } = 100;
-
-        /// <summary>
-        /// Gets or sets a value indicating whether the monitor is available/online
-        /// </summary>
-        public bool IsAvailable
-        {
-            get => _isAvailable;
-            set
-            {
-                if (_isAvailable != value)
-                {
-                    _isAvailable = value;
-                    OnPropertyChanged();
-                }
-            }
-        }
+        public int VolumeVcpMax { get; set; } = 100;
 
         /// <summary>
         /// Gets or sets physical monitor handle (for DDC/CI)
@@ -283,11 +259,6 @@ namespace PowerDisplay.Common.Models
         /// </summary>
         public VcpCapabilities? VcpCapabilitiesInfo { get; set; }
 
-        /// <summary>
-        /// Gets or sets last update time
-        /// </summary>
-        public DateTime LastUpdate { get; set; } = DateTime.Now;
-
         public event PropertyChangedEventHandler? PropertyChanged;
 
         protected virtual void OnPropertyChanged([CallerMemberName] string? propertyName = null)
@@ -298,19 +269,6 @@ namespace PowerDisplay.Common.Models
         public override string ToString()
         {
             return $"{Name} ({CommunicationMethod}) - {CurrentBrightness}%";
-        }
-
-        /// <summary>
-        /// Update monitor status
-        /// </summary>
-        public void UpdateStatus(int brightness, bool isAvailable = true)
-        {
-            IsAvailable = isAvailable;
-            if (isAvailable)
-            {
-                CurrentBrightness = brightness;
-                LastUpdate = DateTime.Now;
-            }
         }
 
         /// <inheritdoc />

--- a/src/modules/powerdisplay/PowerDisplay.Lib/Models/VcpFeatureValue.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Lib/Models/VcpFeatureValue.cs
@@ -69,6 +69,27 @@ namespace PowerDisplay.Common.Models
             return (int)Math.Round((double)(Current - Minimum) * 100 / (Maximum - Minimum));
         }
 
+        /// <summary>
+        /// Converts a percentage (0-100) to a raw VCP value within [<paramref name="minimum"/>, <paramref name="maximum"/>].
+        /// Symmetric inverse of <see cref="ToPercentage"/>: writers convert the slider percentage to a
+        /// device-native value before calling SetVCPFeature, so monitors whose native range isn't 0-100
+        /// (e.g. some Samsung displays advertise max=50 for brightness/contrast) receive a value they accept.
+        /// </summary>
+        /// <param name="percent">Percentage in [0, 100]; values outside the range are clamped.</param>
+        /// <param name="maximum">Device-reported maximum raw VCP value.</param>
+        /// <param name="minimum">Device-reported minimum raw VCP value (defaults to 0).</param>
+        /// <returns>Raw VCP value mapped from the percentage; returns <paramref name="minimum"/> if the range is degenerate.</returns>
+        public static int FromPercentage(int percent, int maximum, int minimum = 0)
+        {
+            if (maximum <= minimum)
+            {
+                return minimum;
+            }
+
+            percent = Math.Clamp(percent, 0, 100);
+            return minimum + (int)Math.Round(percent * (double)(maximum - minimum) / 100);
+        }
+
         public override string ToString()
         {
             return IsValid ? $"{Current}/{Maximum} ({ToPercentage()}%)" : "Invalid";

--- a/src/modules/powerdisplay/PowerDisplay/Helpers/MonitorManager.cs
+++ b/src/modules/powerdisplay/PowerDisplay/Helpers/MonitorManager.cs
@@ -152,7 +152,7 @@ namespace PowerDisplay.Helpers
                 monitorId,
                 brightness,
                 (ctrl, mon, val, ct) => ctrl.SetBrightnessAsync(mon, val, ct),
-                (mon, val) => mon.UpdateStatus(val, true),
+                (mon, val) => mon.CurrentBrightness = val,
                 cancellationToken);
 
         /// <summary>
@@ -202,14 +202,13 @@ namespace PowerDisplay.Helpers
         /// <summary>
         /// Set power state for a monitor using VCP 0xD6.
         /// Note: Setting any state other than On (0x01) will turn off the display.
-        /// We don't update monitor state since the display will be off.
         /// </summary>
         public Task<MonitorOperationResult> SetPowerStateAsync(string monitorId, int powerState, CancellationToken cancellationToken = default)
             => ExecuteMonitorOperationAsync(
                 monitorId,
                 powerState,
                 (ctrl, mon, val, ct) => ctrl.SetPowerStateAsync(mon, val, ct),
-                (mon, val) => { }, // No state update - display will be off for non-On values
+                (mon, val) => mon.CurrentPowerState = val,
                 cancellationToken);
 
         /// <summary>
@@ -267,7 +266,6 @@ namespace PowerDisplay.Helpers
                 if (currentOrientation >= 0 && currentOrientation != monitor.Orientation)
                 {
                     monitor.Orientation = currentOrientation;
-                    monitor.LastUpdate = DateTime.Now;
                 }
             }
         }
@@ -326,18 +324,12 @@ namespace PowerDisplay.Helpers
                 if (result.IsSuccess)
                 {
                     onSuccess(monitor, value);
-                    monitor.LastUpdate = DateTime.Now;
-                }
-                else
-                {
-                    monitor.IsAvailable = false;
                 }
 
                 return result;
             }
             catch (Exception ex)
             {
-                monitor.IsAvailable = false;
                 Logger.LogError($"[MonitorManager] Operation failed for {monitorId}: {ex.Message}");
                 return MonitorOperationResult.Failure($"Exception: {ex.Message}");
             }

--- a/src/modules/powerdisplay/PowerDisplay/PowerDisplayXAML/MainWindow.xaml
+++ b/src/modules/powerdisplay/PowerDisplay/PowerDisplayXAML/MainWindow.xaml
@@ -324,8 +324,8 @@
                                                         IsEnabled="{x:Bind IsInteractionEnabled, Mode=OneWay}"
                                                         IsTabStop="True"
                                                         KeyUp="{x:Bind HandleBrightnessKeyUp}"
-                                                        Maximum="{x:Bind MaxBrightness, Mode=OneWay}"
-                                                        Minimum="{x:Bind MinBrightness, Mode=OneWay}"
+                                                        Maximum="100"
+                                                        Minimum="0"
                                                         PointerCaptureLost="{x:Bind HandleBrightnessPointerCaptureLost}"
                                                         Value="{x:Bind Brightness, Mode=OneWay}" />
                                                 </Grid>
@@ -356,8 +356,9 @@
                                                         IsTabStop="True"
                                                         KeyUp="{x:Bind HandleContrastKeyUp}"
                                                         Maximum="100"
+                                                        Minimum="0"
                                                         PointerCaptureLost="{x:Bind HandleContrastPointerCaptureLost}"
-                                                        Value="{x:Bind ContrastPercent, Mode=OneWay}" />
+                                                        Value="{x:Bind Contrast, Mode=OneWay}" />
                                                 </Grid>
 
                                                 <!--  Volume Control  -->
@@ -384,8 +385,8 @@
                                                         IsEnabled="{x:Bind IsInteractionEnabled, Mode=OneWay}"
                                                         IsTabStop="True"
                                                         KeyUp="{x:Bind HandleVolumeKeyUp}"
-                                                        Maximum="{x:Bind MaxVolume, Mode=OneWay}"
-                                                        Minimum="{x:Bind MinVolume, Mode=OneWay}"
+                                                        Maximum="100"
+                                                        Minimum="0"
                                                         PointerCaptureLost="{x:Bind HandleVolumePointerCaptureLost}"
                                                         Value="{x:Bind Volume, Mode=OneWay}" />
                                                 </Grid>

--- a/src/modules/powerdisplay/PowerDisplay/ViewModels/MonitorViewModel.cs
+++ b/src/modules/powerdisplay/PowerDisplay/ViewModels/MonitorViewModel.cs
@@ -37,9 +37,6 @@ public partial class MonitorViewModel : ObservableObject, IDisposable
     private int _contrast;
     private int _volume;
 
-    [ObservableProperty]
-    public partial bool IsAvailable { get; set; }
-
     // Visibility settings (controlled by Settings UI)
     [ObservableProperty]
     public partial bool ShowBrightness { get; set; }
@@ -68,7 +65,7 @@ public partial class MonitorViewModel : ObservableObject, IDisposable
     /// <param name="brightness">Brightness value (0-100)</param>
     public async Task SetBrightnessAsync(int brightness)
     {
-        brightness = Math.Clamp(brightness, MinBrightness, MaxBrightness);
+        brightness = Math.Clamp(brightness, 0, 100);
 
         // Update UI state immediately
         if (_brightness != brightness)
@@ -86,13 +83,12 @@ public partial class MonitorViewModel : ObservableObject, IDisposable
     /// </summary>
     public async Task SetContrastAsync(int contrast)
     {
-        contrast = Math.Clamp(contrast, MinContrast, MaxContrast);
+        contrast = Math.Clamp(contrast, 0, 100);
 
         if (_contrast != contrast)
         {
             _contrast = contrast;
             OnPropertyChanged(nameof(Contrast));
-            OnPropertyChanged(nameof(ContrastPercent));
         }
 
         await ApplyPropertyToHardwareAsync(nameof(Contrast), contrast, _monitorManager.SetContrastAsync);
@@ -103,7 +99,7 @@ public partial class MonitorViewModel : ObservableObject, IDisposable
     /// </summary>
     public async Task SetVolumeAsync(int volume)
     {
-        volume = Math.Clamp(volume, MinVolume, MaxVolume);
+        volume = Math.Clamp(volume, 0, 100);
 
         if (_volume != volume)
         {
@@ -233,7 +229,6 @@ public partial class MonitorViewModel : ObservableObject, IDisposable
         _brightness = monitor.CurrentBrightness;
         _contrast = monitor.CurrentContrast;
         _volume = monitor.CurrentVolume;
-        IsAvailable = monitor.IsAvailable;
     }
 
     public string Id => _monitor.Id;
@@ -282,19 +277,6 @@ public partial class MonitorViewModel : ObservableObject, IDisposable
     public string MonitorIconGlyph => _monitor.CommunicationMethod?.Contains("WMI", StringComparison.OrdinalIgnoreCase) == true
         ? AppConstants.UI.InternalMonitorGlyph // Laptop icon for WMI
         : AppConstants.UI.ExternalMonitorGlyph; // External monitor icon for DDC/CI and others
-
-    // Monitor property ranges
-    public int MinBrightness => _monitor.MinBrightness;
-
-    public int MaxBrightness => _monitor.MaxBrightness;
-
-    public int MinContrast => _monitor.MinContrast;
-
-    public int MaxContrast => _monitor.MaxContrast;
-
-    public int MinVolume => _monitor.MinVolume;
-
-    public int MaxVolume => _monitor.MaxVolume;
 
     // Advanced control display logic
     public bool HasAdvancedControls => ShowContrast || ShowVolume;
@@ -780,38 +762,6 @@ public partial class MonitorViewModel : ObservableObject, IDisposable
         }
     }
 
-    public int ContrastPercent
-    {
-        get => MapToPercent(_contrast, MinContrast, MaxContrast);
-        set
-        {
-            var actualValue = MapFromPercent(value, MinContrast, MaxContrast);
-            Contrast = actualValue;
-        }
-    }
-
-    // Mapping functions for percentage conversion
-    private int MapToPercent(int value, int min, int max)
-    {
-        if (max <= min)
-        {
-            return 0;
-        }
-
-        return (int)Math.Round((value - min) * 100.0 / (max - min));
-    }
-
-    private int MapFromPercent(int percent, int min, int max)
-    {
-        if (max <= min)
-        {
-            return min;
-        }
-
-        percent = Math.Clamp(percent, 0, 100);
-        return min + (int)Math.Round(percent * (max - min) / 100.0);
-    }
-
     private void OnMainViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
         if (e.PropertyName == nameof(MainViewModel.IsInteractionEnabled))
@@ -862,7 +812,7 @@ public partial class MonitorViewModel : ObservableObject, IDisposable
     {
         if (sender is Slider slider)
         {
-            ContrastPercent = (int)slider.Value;
+            Contrast = (int)slider.Value;
         }
     }
 
@@ -870,7 +820,7 @@ public partial class MonitorViewModel : ObservableObject, IDisposable
     {
         if (IsArrowKey(e.Key) && sender is Slider slider)
         {
-            ContrastPercent = (int)slider.Value;
+            Contrast = (int)slider.Value;
         }
     }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Fixes #47458 — on monitors that advertise a non-100 raw VCP maximum (e.g. Samsung S27DG602SN reports 50), the DDC controller was writing the slider's 0–100 percentage directly as the raw VCP value. Anything above the device's max was silently clamped, so only the bottom half of the brightness / contrast / volume sliders had any visible effect.

The same root cause affects all three continuous-range VCPs (0x10 brightness, 0x12 contrast, 0x62 volume).

- Capture the device-reported `max` at discovery into new
  `Monitor.{Brightness,Contrast,Volume}VcpMax` fields.
- Add `VcpFeatureValue.FromPercentage(percent, max, min)` as the
  symmetric inverse of the existing `ToPercentage()`.
- Scale percent → raw inside `DdcCiController.Set{Brightness,Contrast,
  Volume}Async` before each `SetVCPFeature` call.
- WMI is unaffected — Windows already standardises WMI brightness to
  0–100.

The whole stack above the controller (ViewModel, MonitorManager, slider, settings persistence, IPC) stays in the percent domain. The only place percent ↔ raw conversion happens is the controller boundary.

#47458

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [x] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

