### PR TITLE
[Image Resizer] A11y fixes

### DIFF
--- a/src/modules/imageresizer/ui/ImageResizerXAML/MainWindow.xaml.cs
+++ b/src/modules/imageresizer/ui/ImageResizerXAML/MainWindow.xaml.cs
@@ -3,6 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 // Code forked from Brice Lambson's https://github.com/bricelam/ImageResizer/
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Threading.Tasks;
 using ImageResizer.Helpers;
 using ImageResizer.ViewModels;
 using ImageResizer.Views;
@@ -10,11 +15,6 @@ using ManagedCommon;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Threading.Tasks;
 using Windows.Graphics;
 using Windows.Storage.Pickers;
 using WinUIEx;
@@ -44,7 +44,7 @@ namespace ImageResizer
             SetTitleBar(titleBar);
             this.SetIcon("Assets/ImageResizer/ImageResizer.ico");
 
-            Title = ResourceLoaderInstance.ResourceLoader.GetString("ImageResizer");
+            Title = ResourceLoaderInstance.GetString("ImageResizer");
 
             WindowHelpers.ForceTopBorder1PixelInsetOnWindows10(this.GetWindowHandle());
 

--- a/src/modules/imageresizer/ui/ImageResizerXAML/MainWindow.xaml.cs
+++ b/src/modules/imageresizer/ui/ImageResizerXAML/MainWindow.xaml.cs
@@ -3,17 +3,18 @@
 // See the LICENSE file in the project root for more information.
 
 // Code forked from Brice Lambson's https://github.com/bricelam/ImageResizer/
-using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Threading.Tasks;
+using ImageResizer.Helpers;
 using ImageResizer.ViewModels;
 using ImageResizer.Views;
 using ManagedCommon;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Threading.Tasks;
 using Windows.Graphics;
 using Windows.Storage.Pickers;
 using WinUIEx;
@@ -42,6 +43,8 @@ namespace ImageResizer
             ExtendsContentIntoTitleBar = true;
             SetTitleBar(titleBar);
             this.SetIcon("Assets/ImageResizer/ImageResizer.ico");
+
+            Title = ResourceLoaderInstance.ResourceLoader.GetString("ImageResizer");
 
             WindowHelpers.ForceTopBorder1PixelInsetOnWindows10(this.GetWindowHandle());
 

--- a/src/modules/imageresizer/ui/ImageResizerXAML/Views/InputPage.xaml
+++ b/src/modules/imageresizer/ui/ImageResizerXAML/Views/InputPage.xaml
@@ -318,6 +318,7 @@
             </Button>
 
             <Button
+                x:Uid="Resize_button"
                 Grid.Column="1"
                 MinWidth="{StaticResource ButtonMinWidth}"
                 Command="{x:Bind ViewModel.ResizeCommand}"
@@ -332,6 +333,7 @@
             </Button>
 
             <Button
+                x:Uid="Cancel"
                 Grid.Column="2"
                 MinWidth="{StaticResource ButtonMinWidth}"
                 Margin="8,0,0,0"
@@ -339,7 +341,6 @@
                 <Button.KeyboardAccelerators>
                     <KeyboardAccelerator Key="Escape" />
                 </Button.KeyboardAccelerators>
-                <TextBlock x:Uid="Cancel" />
             </Button>
         </Grid>
     </Grid>

--- a/src/modules/imageresizer/ui/Strings/en-us/Resources.resw
+++ b/src/modules/imageresizer/ui/Strings/en-us/Resources.resw
@@ -121,7 +121,7 @@
     <value>Image Resizer</value>
     <comment>Product name, do not loc</comment>
   </data>
-  <data name="Cancel.Text" xml:space="preserve">
+  <data name="Cancel.Content" xml:space="preserve">
     <value>Cancel</value>
   </data>
   <data name="Height" xml:space="preserve">
@@ -442,5 +442,8 @@
   </data>
   <data name="TitleBarTitle.Title" xml:space="preserve">
     <value>Image Resizer</value>
+  </data>
+  <data name="Resize_button.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Resize</value>
   </data>
 </root>


### PR DESCRIPTION
This PR solves the following issues:

- Narrator announced the Resize button as 'button', now it's 'resize'.
- The app window was still 'WinUI Desktop', it's now 'Image Resizer' 