### PR TITLE
[PowerDisplay] Debounced + wheel-scrollable brightness/contrast/volume sliders

### DIFF
--- a/src/modules/powerdisplay/PowerDisplay/Configuration/AppConstants.cs
+++ b/src/modules/powerdisplay/PowerDisplay/Configuration/AppConstants.cs
@@ -43,6 +43,13 @@ namespace PowerDisplay.Configuration
             /// Icon glyph for external monitors (DDC/CI)
             /// </summary>
             public const string ExternalMonitorGlyph = "\uE7F4";
+
+            /// <summary>
+            /// Debounce delay for committing slider changes (brightness, contrast, volume)
+            /// to hardware. Restarts on every value change so a drag/keyboard repeat fires
+            /// a single DDC/CI write once the user stops moving.
+            /// </summary>
+            public const int SliderCommitDebounceMs = 200;
         }
     }
 }

--- a/src/modules/powerdisplay/PowerDisplay/Helpers/SliderExtensions.cs
+++ b/src/modules/powerdisplay/PowerDisplay/Helpers/SliderExtensions.cs
@@ -1,0 +1,132 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Input;
+
+namespace PowerDisplay.Helpers
+{
+    /// <summary>
+    /// Provides attached dependency properties and methods for the <see cref="Slider"/> control.
+    /// </summary>
+    public static class SliderExtensions
+    {
+        /// <summary>
+        /// Attached <see cref="DependencyProperty"/> that, when <c>true</c>, lets the
+        /// <see cref="Slider"/> respond to mouse-wheel input by adjusting its
+        /// <see cref="RangeBase.Value"/> by <see cref="MouseWheelChangeProperty"/>
+        /// per notch. The wheel event is marked handled so an enclosing
+        /// <see cref="ScrollViewer"/> does not also scroll.
+        /// </summary>
+        public static readonly DependencyProperty IsMouseWheelEnabledProperty =
+            DependencyProperty.RegisterAttached(
+                "IsMouseWheelEnabled",
+                typeof(bool),
+                typeof(SliderExtensions),
+                new PropertyMetadata(false, OnIsMouseWheelEnabledChanged));
+
+        /// <summary>
+        /// Attached <see cref="DependencyProperty"/> for the value added to or subtracted
+        /// from <see cref="RangeBase.Value"/> per mouse-wheel notch. Defaults to
+        /// <see cref="double.NaN"/>, which means "use the slider's own
+        /// <see cref="Slider.SmallChange"/>".
+        /// </summary>
+        public static readonly DependencyProperty MouseWheelChangeProperty =
+            DependencyProperty.RegisterAttached(
+                "MouseWheelChange",
+                typeof(double),
+                typeof(SliderExtensions),
+                new PropertyMetadata(double.NaN));
+
+        /// <summary>
+        /// Gets the value of the <see cref="IsMouseWheelEnabledProperty"/> attached property.
+        /// </summary>
+        /// <param name="obj">The <see cref="Slider"/> to read the value from.</param>
+        /// <returns><c>true</c> if mouse-wheel scrolling is enabled on the slider; otherwise <c>false</c>.</returns>
+        public static bool GetIsMouseWheelEnabled(Slider obj)
+        {
+            return (bool)obj.GetValue(IsMouseWheelEnabledProperty);
+        }
+
+        /// <summary>
+        /// Sets the value of the <see cref="IsMouseWheelEnabledProperty"/> attached property.
+        /// </summary>
+        /// <param name="obj">The <see cref="Slider"/> to set the value on.</param>
+        /// <param name="value"><c>true</c> to enable mouse-wheel scrolling on the slider; otherwise <c>false</c>.</param>
+        public static void SetIsMouseWheelEnabled(Slider obj, bool value)
+        {
+            obj.SetValue(IsMouseWheelEnabledProperty, value);
+        }
+
+        /// <summary>
+        /// Gets the value of the <see cref="MouseWheelChangeProperty"/> attached property.
+        /// </summary>
+        /// <param name="obj">The <see cref="Slider"/> to read the value from.</param>
+        /// <returns>The per-notch delta, or <see cref="double.NaN"/> to inherit from <see cref="Slider.SmallChange"/>.</returns>
+        public static double GetMouseWheelChange(Slider obj)
+        {
+            return (double)obj.GetValue(MouseWheelChangeProperty);
+        }
+
+        /// <summary>
+        /// Sets the value of the <see cref="MouseWheelChangeProperty"/> attached property.
+        /// </summary>
+        /// <param name="obj">The <see cref="Slider"/> to set the value on.</param>
+        /// <param name="value">The per-notch delta to apply to <see cref="RangeBase.Value"/>.</param>
+        public static void SetMouseWheelChange(Slider obj, double value)
+        {
+            obj.SetValue(MouseWheelChangeProperty, value);
+        }
+
+        private static void OnIsMouseWheelEnabledChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (d is not Slider slider)
+            {
+                return;
+            }
+
+            slider.PointerWheelChanged -= OnPointerWheelChanged;
+
+            if (e.NewValue is true)
+            {
+                slider.PointerWheelChanged += OnPointerWheelChanged;
+            }
+        }
+
+        private static void OnPointerWheelChanged(object sender, PointerRoutedEventArgs e)
+        {
+            if (sender is not Slider slider)
+            {
+                return;
+            }
+
+            int delta = e.GetCurrentPoint(slider).Properties.MouseWheelDelta;
+            if (delta == 0)
+            {
+                return;
+            }
+
+            double step = GetMouseWheelChange(slider);
+            if (double.IsNaN(step) || step <= 0)
+            {
+                step = slider.SmallChange;
+            }
+
+            double notches = delta / 120.0;
+            double newValue = Math.Clamp(slider.Value + (notches * step), slider.Minimum, slider.Maximum);
+
+            if (newValue != slider.Value)
+            {
+                slider.Value = newValue;
+            }
+
+            // Claim the gesture so an enclosing ScrollViewer does not also scroll.
+            e.Handled = true;
+        }
+    }
+}

--- a/src/modules/powerdisplay/PowerDisplay/Helpers/SliderExtensions.cs
+++ b/src/modules/powerdisplay/PowerDisplay/Helpers/SliderExtensions.cs
@@ -25,7 +25,7 @@ namespace PowerDisplay.Helpers
         /// </summary>
         public static readonly DependencyProperty IsMouseWheelEnabledProperty =
             DependencyProperty.RegisterAttached(
-                "IsMouseWheelEnabled",
+                nameof(GetIsMouseWheelEnabled)[3..],
                 typeof(bool),
                 typeof(SliderExtensions),
                 new PropertyMetadata(false, OnIsMouseWheelEnabledChanged));
@@ -38,7 +38,7 @@ namespace PowerDisplay.Helpers
         /// </summary>
         public static readonly DependencyProperty MouseWheelChangeProperty =
             DependencyProperty.RegisterAttached(
-                "MouseWheelChange",
+                nameof(GetMouseWheelChange)[3..],
                 typeof(double),
                 typeof(SliderExtensions),
                 new PropertyMetadata(double.NaN));

--- a/src/modules/powerdisplay/PowerDisplay/PowerDisplayXAML/MainWindow.xaml
+++ b/src/modules/powerdisplay/PowerDisplay/PowerDisplayXAML/MainWindow.xaml
@@ -1,4 +1,4 @@
-﻿<winuiex:WindowEx
+<winuiex:WindowEx
     x:Class="PowerDisplay.MainWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -321,6 +321,8 @@
                                                         x:Uid="BrightnessAutomation"
                                                         Grid.Column="1"
                                                         VerticalAlignment="Center"
+                                                        helpers:SliderExtensions.IsMouseWheelEnabled="True"
+                                                        helpers:SliderExtensions.MouseWheelChange="5"
                                                         IsEnabled="{x:Bind IsInteractionEnabled, Mode=OneWay}"
                                                         IsTabStop="True"
                                                         Maximum="100"
@@ -350,6 +352,8 @@
                                                         x:Uid="ContrastAutomation"
                                                         Grid.Column="1"
                                                         VerticalAlignment="Center"
+                                                        helpers:SliderExtensions.IsMouseWheelEnabled="True"
+                                                        helpers:SliderExtensions.MouseWheelChange="5"
                                                         IsEnabled="{x:Bind IsInteractionEnabled, Mode=OneWay}"
                                                         IsTabStop="True"
                                                         Maximum="100"
@@ -378,6 +382,8 @@
                                                         x:Uid="VolumeAutomation"
                                                         Grid.Column="1"
                                                         VerticalAlignment="Center"
+                                                        helpers:SliderExtensions.IsMouseWheelEnabled="True"
+                                                        helpers:SliderExtensions.MouseWheelChange="5"
                                                         IsEnabled="{x:Bind IsInteractionEnabled, Mode=OneWay}"
                                                         IsTabStop="True"
                                                         Maximum="100"

--- a/src/modules/powerdisplay/PowerDisplay/PowerDisplayXAML/MainWindow.xaml
+++ b/src/modules/powerdisplay/PowerDisplay/PowerDisplayXAML/MainWindow.xaml
@@ -323,11 +323,9 @@
                                                         VerticalAlignment="Center"
                                                         IsEnabled="{x:Bind IsInteractionEnabled, Mode=OneWay}"
                                                         IsTabStop="True"
-                                                        KeyUp="{x:Bind HandleBrightnessKeyUp}"
                                                         Maximum="100"
                                                         Minimum="0"
-                                                        PointerCaptureLost="{x:Bind HandleBrightnessPointerCaptureLost}"
-                                                        Value="{x:Bind Brightness, Mode=OneWay}" />
+                                                        Value="{x:Bind Brightness, Mode=TwoWay}" />
                                                 </Grid>
 
                                                 <!--  Contrast Control  -->
@@ -354,11 +352,9 @@
                                                         VerticalAlignment="Center"
                                                         IsEnabled="{x:Bind IsInteractionEnabled, Mode=OneWay}"
                                                         IsTabStop="True"
-                                                        KeyUp="{x:Bind HandleContrastKeyUp}"
                                                         Maximum="100"
                                                         Minimum="0"
-                                                        PointerCaptureLost="{x:Bind HandleContrastPointerCaptureLost}"
-                                                        Value="{x:Bind Contrast, Mode=OneWay}" />
+                                                        Value="{x:Bind Contrast, Mode=TwoWay}" />
                                                 </Grid>
 
                                                 <!--  Volume Control  -->
@@ -384,11 +380,9 @@
                                                         VerticalAlignment="Center"
                                                         IsEnabled="{x:Bind IsInteractionEnabled, Mode=OneWay}"
                                                         IsTabStop="True"
-                                                        KeyUp="{x:Bind HandleVolumeKeyUp}"
                                                         Maximum="100"
                                                         Minimum="0"
-                                                        PointerCaptureLost="{x:Bind HandleVolumePointerCaptureLost}"
-                                                        Value="{x:Bind Volume, Mode=OneWay}" />
+                                                        Value="{x:Bind Volume, Mode=TwoWay}" />
                                                 </Grid>
 
                                                 <!--  Rotation Controls  -->

--- a/src/modules/powerdisplay/PowerDisplay/ViewModels/MonitorViewModel.cs
+++ b/src/modules/powerdisplay/PowerDisplay/ViewModels/MonitorViewModel.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using ManagedCommon;
+using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
@@ -20,6 +21,8 @@ using PowerDisplay.Configuration;
 using PowerDisplay.Helpers;
 using PowerDisplay.Models;
 using Windows.System;
+using DispatcherQueue = Microsoft.UI.Dispatching.DispatcherQueue;
+using DispatcherQueueTimer = Microsoft.UI.Dispatching.DispatcherQueueTimer;
 using Monitor = PowerDisplay.Common.Models.Monitor;
 
 namespace PowerDisplay.ViewModels;
@@ -36,6 +39,14 @@ public partial class MonitorViewModel : ObservableObject, IDisposable
     private int _brightness;
     private int _contrast;
     private int _volume;
+
+    // Debounce timers — each user-driven setter restarts the matching timer so a drag
+    // or held arrow key collapses into a single DDC/CI write once the user stops moving.
+    // External / programmatic apply paths (SetBrightnessAsync etc.) bypass the setters
+    // and therefore never schedule a debounced commit.
+    private DispatcherQueueTimer? _brightnessCommitTimer;
+    private DispatcherQueueTimer? _contrastCommitTimer;
+    private DispatcherQueueTimer? _volumeCommitTimer;
 
     // Visibility settings (controlled by Settings UI)
     [ObservableProperty]
@@ -408,7 +419,9 @@ public partial class MonitorViewModel : ObservableObject, IDisposable
         {
             if (_brightness != value)
             {
-                _ = SetBrightnessAsync(value);
+                _brightness = value;
+                OnPropertyChanged();
+                ScheduleCommit(ref _brightnessCommitTimer, () => SetBrightnessAsync(_brightness));
             }
         }
     }
@@ -718,7 +731,9 @@ public partial class MonitorViewModel : ObservableObject, IDisposable
         {
             if (_contrast != value)
             {
-                _ = SetContrastAsync(value);
+                _contrast = value;
+                OnPropertyChanged();
+                ScheduleCommit(ref _contrastCommitTimer, () => SetContrastAsync(_contrast));
             }
         }
     }
@@ -730,7 +745,9 @@ public partial class MonitorViewModel : ObservableObject, IDisposable
         {
             if (_volume != value)
             {
-                _ = SetVolumeAsync(value);
+                _volume = value;
+                OnPropertyChanged();
+                ScheduleCommit(ref _volumeCommitTimer, () => SetVolumeAsync(_volume));
             }
         }
     }
@@ -791,58 +808,23 @@ public partial class MonitorViewModel : ObservableObject, IDisposable
         }
     }
 
-    // Slider commit handlers — fire hardware update only on pointer release or arrow key up
-    public void HandleBrightnessPointerCaptureLost(object sender, PointerRoutedEventArgs e)
+    // Slider commit handlers — debounced via ScheduleCommit. The setters store the
+    // value, raise PropertyChanged, and (re)start a per-metric DispatcherQueueTimer
+    // that fires the hardware write once the user stops moving. The commit closure
+    // reads the latest field at fire-time so intermediate values are coalesced.
+    private void ScheduleCommit(ref DispatcherQueueTimer? timer, Func<Task> commit)
     {
-        if (sender is Slider slider)
+        if (timer == null)
         {
-            Brightness = (int)slider.Value;
+            timer = DispatcherQueue.GetForCurrentThread().CreateTimer();
+            timer.IsRepeating = false;
+            timer.Interval = TimeSpan.FromMilliseconds(AppConstants.UI.SliderCommitDebounceMs);
+            timer.Tick += (_, _) => _ = commit();
         }
-    }
 
-    public void HandleBrightnessKeyUp(object sender, KeyRoutedEventArgs e)
-    {
-        if (IsArrowKey(e.Key) && sender is Slider slider)
-        {
-            Brightness = (int)slider.Value;
-        }
+        timer.Stop();
+        timer.Start();
     }
-
-    public void HandleContrastPointerCaptureLost(object sender, PointerRoutedEventArgs e)
-    {
-        if (sender is Slider slider)
-        {
-            Contrast = (int)slider.Value;
-        }
-    }
-
-    public void HandleContrastKeyUp(object sender, KeyRoutedEventArgs e)
-    {
-        if (IsArrowKey(e.Key) && sender is Slider slider)
-        {
-            Contrast = (int)slider.Value;
-        }
-    }
-
-    public void HandleVolumePointerCaptureLost(object sender, PointerRoutedEventArgs e)
-    {
-        if (sender is Slider slider)
-        {
-            Volume = (int)slider.Value;
-        }
-    }
-
-    public void HandleVolumeKeyUp(object sender, KeyRoutedEventArgs e)
-    {
-        if (IsArrowKey(e.Key) && sender is Slider slider)
-        {
-            Volume = (int)slider.Value;
-        }
-    }
-
-    private static bool IsArrowKey(VirtualKey key) =>
-        key == VirtualKey.Left || key == VirtualKey.Right ||
-        key == VirtualKey.Up || key == VirtualKey.Down;
 
     // Rotation button handlers — one per orientation to avoid Tag string parsing
     public async void HandleRotation0Click(object sender, RoutedEventArgs e) => await CommitRotationClickAsync(0);
@@ -908,6 +890,13 @@ public partial class MonitorViewModel : ObservableObject, IDisposable
 
     public void Dispose()
     {
+        // Drop any pending debounced commits — if we're being disposed the monitor is
+        // gone (unplug/refresh) or the app is shutting down, so a hardware write would
+        // race a half-torn-down MonitorManager.
+        _brightnessCommitTimer?.Stop();
+        _contrastCommitTimer?.Stop();
+        _volumeCommitTimer?.Stop();
+
         // Unsubscribe from MainViewModel events
         if (_mainViewModel != null)
         {


### PR DESCRIPTION
## Summary of the Pull Request

The brightness / contrast / volume sliders in the PowerDisplay flyout previously committed to hardware (DDC/CI) only on `PointerCaptureLost` plus arrow-key `KeyUp`. That doesn't work reliably on touchscreens — tap-on-track issues no pointer capture, and the Slider / Thumb doesn't always bubble `PointerCaptureLost` on touch — so the value the user dialed in never reached the monitor.

This PR replaces that wiring with the simpler approach we actually wanted: a TwoWay `Value` binding plus a debounced commit in the view-model. `ValueChanged` runs the setter on every move, but a 200 ms `DispatcherQueueTimer` (restarted on each change) collapses the entire interaction into a single DDC/CI write once the user stops sliding. Mouse, touch, tap-on-track, and held arrow keys all use the same code path.

It also adds a small `SliderExtensions` helper (Toolkit-style attached properties) so the brightness / contrast / volume sliders can be adjusted by mouse-wheel scroll. The wheel event is marked handled so the parent `ScrollViewer` does not also scroll, and the existing 200 ms debounce coalesces wheel input into a single DDC/CI write.

## PR Checklist

- [x] Closes: #47724
- [x] **Communication:** I've discussed this with core contributors already.
- [x] **Tests:** Manual smoke; no automated coverage exists for the slider flyout.
- [x] **Localization:** No new end-user-facing strings.
- [x] **Dev docs:** N/A
- [x] **New binaries:** N/A
- [x] **Documentation updated:** N/A

## Detailed Description of the Pull Request / Additional comments

### Debounced commit

- `MonitorViewModel.Brightness/Contrast/Volume` setters now: assign field → `OnPropertyChanged()` → `ScheduleCommit(...)` which (re)starts a per-metric `DispatcherQueueTimer`. On `Tick` the closure calls `SetBrightnessAsync(_brightness)` (etc.), reading the latest field value so intermediate drag values are coalesced into one hardware write.
- `SetBrightnessAsync` / `SetContrastAsync` / `SetVolumeAsync` (used by hotkeys, profile load, hardware refresh) keep their immediate-apply behavior — they bypass the public setters, so a TwoWay source-update from one of those paths does **not** reschedule a commit.
- `MonitorViewModel.Dispose()` stops the three timers. Pending writes are intentionally dropped: `Dispose` only runs when the monitor is gone (unplug / refresh) or the app is shutting down, in which case a hardware write would race a half-torn-down `MonitorManager`.
- `AppConstants.UI.SliderCommitDebounceMs = 200` is the single source of truth for the delay.
- Removed the six `Handle{Brightness|Contrast|Volume}{PointerCaptureLost|KeyUp}` methods and the now-unused `IsArrowKey` helper.
- `using DispatcherQueueTimer = Microsoft.UI.Dispatching.DispatcherQueueTimer;` alias avoids ambiguity with `Windows.System.DispatcherQueueTimer`.

### Wheel-scrollable sliders

- New `PowerDisplay.Helpers.SliderExtensions` — a Toolkit-style `public static class <Control>Extensions` with two attached properties:
  - `SliderExtensions.IsMouseWheelEnabled` (bool) — opt in to wheel input.
  - `SliderExtensions.MouseWheelChange` (double, default `NaN` → falls back to the slider's own `Slider.SmallChange`) — per-notch delta.
- Handler computes `notches = MouseWheelDelta / 120`, clamps to `[Minimum, Maximum]`, sets `Value`, and marks `e.Handled = true` so the enclosing `MainScrollViewer` doesn't also scroll.
- Wired on the brightness, contrast, and volume sliders with `MouseWheelChange="5"` (20 notches for a full sweep).
- Body has zero PowerDisplay-specific dependencies (only `Microsoft.UI.Xaml.*`) so the helper is straightforward to lift into the WinUI Community Toolkit later.

## Validation Steps Performed

- `tools/build/build.cmd` against `src/modules/powerdisplay/PowerDisplay/PowerDisplay.csproj` — exit code 0.
- Manual smoke on a touchscreen device:
  - Touch drag thumb 50 → 80, lift finger → monitor commits once at 80.
  - Tap on the track at 25 % → monitor commits once at 25 %.
- Manual smoke with mouse:
  - Drag 50 → 80, release → exactly one DDC/CI write at 80.
- Manual smoke with keyboard:
  - Hold Right arrow on the brightness slider → repeated nudges collapse into a single write 200 ms after key release.
- Manual smoke with mouse wheel:
  - Hover brightness slider, scroll wheel → value moves by 5 per notch, monitor commits once after scrolling stops.
  - Wheel over a slider does **not** scroll the flyout's `MainScrollViewer`; wheel outside the sliders still scrolls.
  - Wheel past `Minimum` / `Maximum` clamps at the boundary.
- Hotkey-driven brightness change still applies immediately (regression check on the `SetBrightnessAsync` path).
- `DisplayChangeWatcher`-driven hardware refresh does not schedule a spurious commit.
