### PR TITLE
Add ShowClipboardHistory setting to hide clipboard history button in …

### DIFF
--- a/src/modules/AdvancedPaste/AdvancedPaste.UnitTests/Mocks/IntegrationTestUserSettings.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste.UnitTests/Mocks/IntegrationTestUserSettings.cs
@@ -51,6 +51,8 @@ internal sealed class IntegrationTestUserSettings : IUserSettings
 
     public bool EnableClipboardPreview => true;
 
+    public bool ShowClipboardHistory => true;
+
     public IReadOnlyList<AdvancedPasteCustomAction> CustomActions => _customActions;
 
     public IReadOnlyList<PasteFormats> AdditionalActions => _additionalActions;

--- a/src/modules/AdvancedPaste/AdvancedPaste/Helpers/IUserSettings.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/Helpers/IUserSettings.cs
@@ -21,6 +21,8 @@ namespace AdvancedPaste.Settings
 
         public bool EnableClipboardPreview { get; }
 
+        public bool ShowClipboardHistory { get; }
+
         public IReadOnlyList<AdvancedPasteCustomAction> CustomActions { get; }
 
         public IReadOnlyList<PasteFormats> AdditionalActions { get; }

--- a/src/modules/AdvancedPaste/AdvancedPaste/Helpers/UserSettings.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/Helpers/UserSettings.cs
@@ -42,6 +42,8 @@ namespace AdvancedPaste.Settings
 
         public bool EnableClipboardPreview { get; private set; }
 
+        public bool ShowClipboardHistory { get; private set; }
+
         public IReadOnlyList<PasteFormats> AdditionalActions => _additionalActions;
 
         public IReadOnlyList<AdvancedPasteCustomAction> CustomActions => _customActions;
@@ -56,6 +58,7 @@ namespace AdvancedPaste.Settings
             ShowCustomPreview = true;
             CloseAfterLosingFocus = false;
             EnableClipboardPreview = true;
+            ShowClipboardHistory = true;
             PasteAIConfiguration = new PasteAIConfiguration();
             _additionalActions = [];
             _customActions = [];
@@ -111,6 +114,7 @@ namespace AdvancedPaste.Settings
                                 ShowCustomPreview = properties.ShowCustomPreview;
                                 CloseAfterLosingFocus = properties.CloseAfterLosingFocus;
                                 EnableClipboardPreview = properties.EnableClipboardPreview;
+                                ShowClipboardHistory = properties.ShowClipboardHistory;
                                 PasteAIConfiguration = properties.PasteAIConfiguration ?? new PasteAIConfiguration();
 
                                 var sourceAdditionalActions = properties.AdditionalActions;

--- a/src/modules/AdvancedPaste/AdvancedPaste/ViewModels/OptionsViewModel.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/ViewModels/OptionsViewModel.cs
@@ -232,7 +232,7 @@ namespace AdvancedPaste.ViewModels
 
         public bool ShowClipboardPreview => _userSettings.EnableClipboardPreview;
 
-        public bool ShowClipboardHistoryButton => ClipboardHistoryEnabled;
+        public bool ShowClipboardHistoryButton => _userSettings.ShowClipboardHistory && ClipboardHistoryEnabled;
 
         public bool HasIndeterminateTransformProgress => double.IsNaN(TransformProgress);
 

--- a/src/modules/AdvancedPaste/AdvancedPaste/ViewModels/OptionsViewModel.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/ViewModels/OptionsViewModel.cs
@@ -320,6 +320,7 @@ namespace AdvancedPaste.ViewModels
             OnPropertyChanged(nameof(AIProviders));
             OnPropertyChanged(nameof(AllowedAIProviders));
             OnPropertyChanged(nameof(ShowClipboardPreview));
+            OnPropertyChanged(nameof(ShowClipboardHistoryButton));
 
             NotifyActiveProviderChanged();
 

--- a/src/settings-ui/Settings.UI.Library/AdvancedPasteProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/AdvancedPasteProperties.cs
@@ -28,6 +28,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             ShowCustomPreview = true;
             CloseAfterLosingFocus = false;
             EnableClipboardPreview = true;
+            ShowClipboardHistory = true;
             AutoCopySelectionForCustomActionHotkey = false;
             PasteAIConfiguration = new();
         }
@@ -79,6 +80,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 
         [JsonConverter(typeof(BoolPropertyJsonConverter))]
         public bool EnableClipboardPreview { get; set; }
+
+        [JsonConverter(typeof(BoolPropertyJsonConverter))]
+        public bool ShowClipboardHistory { get; set; }
 
         [JsonConverter(typeof(BoolPropertyJsonConverter))]
         public bool AutoCopySelectionForCustomActionHotkey { get; set; }

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/AdvancedPastePage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/AdvancedPastePage.xaml
@@ -169,6 +169,9 @@
                                 <tkcontrols:SettingsCard Name="AdvancedPasteEnableClipboardPreview" ContentAlignment="Left">
                                     <ptcontrols:CheckBoxWithDescriptionControl x:Uid="AdvancedPaste_EnableClipboardPreview" IsChecked="{x:Bind ViewModel.EnableClipboardPreview, Mode=TwoWay}" />
                                 </tkcontrols:SettingsCard>
+                                <tkcontrols:SettingsCard Name="AdvancedPasteShowClipboardHistory" ContentAlignment="Left">
+                                    <ptcontrols:CheckBoxWithDescriptionControl x:Uid="AdvancedPaste_ShowClipboardHistory" IsChecked="{x:Bind ViewModel.ShowClipboardHistory, Mode=TwoWay}" />
+                                </tkcontrols:SettingsCard>
                                 <tkcontrols:SettingsCard Name="AdvancedPasteAutoCopySelectionCustomAction" ContentAlignment="Left">
                                     <ptcontrols:CheckBoxWithDescriptionControl x:Uid="AdvancedPaste_AutoCopySelectionForCustomActionHotkey" IsChecked="{x:Bind ViewModel.AutoCopySelectionForCustomActionHotkey, Mode=TwoWay}" />
                                 </tkcontrols:SettingsCard>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -4386,6 +4386,10 @@ Activate by holding the key for the character you want to add an accent to, then
     <value>Show clipboard preview</value>
     <comment>Enables display of clipboard contents preview in the Advanced Paste window</comment>
   </data>
+  <data name="AdvancedPaste_ShowClipboardHistory.Header" xml:space="preserve">
+    <value>Show clipboard history</value>
+    <comment>Enables display of clipboard history button in the Advanced Paste window</comment>
+  </data>
   <data name="AdvancedPaste_AutoCopySelectionForCustomActionHotkey.Header" xml:space="preserve">
     <value>Auto-copy selection for custom action hotkeys</value>
     <comment>Advanced Paste is a product name</comment>
@@ -5906,6 +5910,9 @@ The break timer font matches the text font.</value>
   </data>
   <data name="AdvancedPaste_EnableClipboardPreview.Description" xml:space="preserve">
     <value>Display a preview of the current clipboard content</value>
+  </data>
+  <data name="AdvancedPaste_ShowClipboardHistory.Description" xml:space="preserve">
+    <value>Display a button to access clipboard history in the Advanced Paste window</value>
   </data>
   <data name="AdvancedPaste_FL_LearnMoreFoundryLocal.Content" xml:space="preserve">
     <value>Learn more</value>

--- a/src/settings-ui/Settings.UI/ViewModels/AdvancedPasteViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/AdvancedPasteViewModel.cs
@@ -569,6 +569,19 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             }
         }
 
+        public bool ShowClipboardHistory
+        {
+            get => _advancedPasteSettings.Properties.ShowClipboardHistory;
+            set
+            {
+                if (value != _advancedPasteSettings.Properties.ShowClipboardHistory)
+                {
+                    _advancedPasteSettings.Properties.ShowClipboardHistory = value;
+                    NotifySettingsChanged();
+                }
+            }
+        }
+
         public bool AutoCopySelectionForCustomActionHotkey
         {
             get => _advancedPasteSettings.Properties.AutoCopySelectionForCustomActionHotkey;
@@ -1244,6 +1257,12 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             {
                 target.EnableClipboardPreview = source.EnableClipboardPreview;
                 OnPropertyChanged(nameof(EnableClipboardPreview));
+            }
+
+            if (target.ShowClipboardHistory != source.ShowClipboardHistory)
+            {
+                target.ShowClipboardHistory = source.ShowClipboardHistory;
+                OnPropertyChanged(nameof(ShowClipboardHistory));
             }
 
             if (target.AutoCopySelectionForCustomActionHotkey != source.AutoCopySelectionForCustomActionHotkey)


### PR DESCRIPTION
**Summary**

Adds a new `ShowClipboardHistory` setting to Advanced Paste that allows users to hide the clipboard history button from the main UI, independent of the Windows clipboard history system setting.

Closes [#35703](https://github.com/microsoft/PowerToys/issues/35703)

**Changes**

- Added `ShowClipboardHistory` property to `AdvancedPasteProperties` with default value `true` for backward compatibility
- Exposed the setting in `AdvancedPasteViewModel` (settings UI) with getter, setter, and file-watcher synchronization
- Added `ShowClipboardHistory` to `IUserSettings` interface and `UserSettings` implementation
- Modified `ShowClipboardHistoryButton` in `OptionsViewModel` to require both the new PowerToys setting AND Windows clipboard history to be enabled
- Added checkbox in `AdvancedPastePage.xaml` settings page
- Added localized strings (en-us) for the new setting
- Updated `IntegrationTestUserSettings` mock

**Validation**

- Full solution build passes for all projects touched (AdvancedPaste, Settings.UI, Settings.UI.Library)
- Existing pattern followed: replicated the `EnableClipboardPreview` setting pattern across all layers


