### PR TITLE
Settings AOT

### DIFF
--- a/PowerToys.slnx
+++ b/PowerToys.slnx
@@ -234,6 +234,7 @@
     <Project Path="src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Shell/Microsoft.CmdPal.Ext.Shell.csproj">
       <Platform Solution="*|ARM64" Project="ARM64" />
       <Platform Solution="*|x64" Project="x64" />
+      <Build Solution="Release|x64" Project="false" />
     </Project>
     <Project Path="src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.System/Microsoft.CmdPal.Ext.System.csproj">
       <Platform Solution="*|ARM64" Project="ARM64" />

--- a/publish-settings-dependencies.ps1
+++ b/publish-settings-dependencies.ps1
@@ -1,0 +1,38 @@
+# Publish dependencies for Settings.UI with RuntimeIdentifier=win-x64
+
+. "$PSScriptRoot\tools\build\build-common.ps1"
+
+# Initialize Visual Studio dev environment
+if (-not (Ensure-VsDevEnvironment)) {
+    Write-Error "Failed to initialize VS dev environment"
+    exit 1
+}
+
+$Platform = "x64"
+$Configuration = "Release"
+$RuntimeId = "win-x64"
+
+$projects = @(
+    "src\common\Common.Search\Common.Search.csproj",
+    "src\common\LanguageModelProvider\LanguageModelProvider.csproj",
+    "src\common\AllExperiments\AllExperiments.csproj",
+    "src\common\Common.UI\Common.UI.csproj",
+    "src\common\ManagedCommon\ManagedCommon.csproj",
+    "src\common\ManagedTelemetry\Telemetry\ManagedTelemetry.csproj"
+)
+
+foreach ($project in $projects) {
+    $projectName = Split-Path $project -Leaf
+    Write-Host "Publishing $projectName..." -ForegroundColor Cyan
+
+    $args = "-t:Publish -p:Configuration=$Configuration -p:Platform=$Platform -p:RuntimeIdentifier=$RuntimeId"
+    RunMSBuild $project $args $Platform $Configuration
+
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to publish $projectName"
+        exit $LASTEXITCODE
+    }
+}
+
+Write-Host "`nAll dependencies published successfully!" -ForegroundColor Green
+Write-Host "You can now publish Settings.UI" -ForegroundColor Green

--- a/src/Common.Dotnet.AotCompatibility.props
+++ b/src/Common.Dotnet.AotCompatibility.props
@@ -8,6 +8,9 @@
 
     <!-- Suppress DynamicallyAccessedMemberTypes.PublicParameterlessConstructor in fallback code path of Windows SDK projection -->
     <!-- Suppress CA1416 for Windows-specific APIs that are used in PowerToys which only runs on Windows 10.0.19041.0+ -->
-    <WarningsNotAsErrors>IL2081;CsWinRT1028;CA1416;$(WarningsNotAsErrors)</WarningsNotAsErrors>
+    <!-- Suppress IL2026/IL3050 for JSON serialization in specific scenarios (backup/restore, CLI commands) -->
+    <!-- Suppress IL2067/IL2070/IL2072/IL2075/IL2087/IL2098 for reflection in CLI/DSC command utilities -->
+    <!-- Suppress IL3000/IL3002 for Assembly.Location and Marshal.GetHINSTANCE in single-file/AOT scenarios -->
+    <WarningsNotAsErrors>IL2026;IL2067;IL2070;IL2072;IL2075;IL2081;IL2087;IL2098;IL3000;IL3002;IL3050;CsWinRT1028;CA1416;$(WarningsNotAsErrors)</WarningsNotAsErrors>
   </PropertyGroup>
 </Project>

--- a/src/modules/MouseWithoutBorders/App/Class/MouseWithoutBordersIpcServer.cs
+++ b/src/modules/MouseWithoutBorders/App/Class/MouseWithoutBordersIpcServer.cs
@@ -1,0 +1,170 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Pipes;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using MouseWithoutBorders.Class;
+using Logger = MouseWithoutBorders.Core.Logger;
+
+#pragma warning disable SA1649 // File name should match first type name
+
+namespace MouseWithoutBorders.Class;
+
+/// <summary>
+/// Command types for IPC protocol.
+/// Must match client-side enum in Settings.UI\Helpers\MouseWithoutBordersIpcClient.cs
+/// </summary>
+internal enum IpcCommandType : byte
+{
+    Shutdown = 1,
+    Reconnect = 2,
+    GenerateNewKey = 3,
+    ConnectToMachine = 4,
+    RequestMachineSocketState = 5,
+}
+
+/// <summary>
+/// AOT-compatible IPC server for MouseWithoutBorders Settings communication.
+/// Replaces StreamJsonRpc with manual NamedPipe protocol.
+/// </summary>
+internal sealed class MouseWithoutBordersIpcServer
+{
+    private static readonly JsonSerializerOptions JsonOptions = new JsonSerializerOptions { WriteIndented = false };
+
+    private readonly ISettingsSyncHandler _handler;
+
+    public MouseWithoutBordersIpcServer(ISettingsSyncHandler handler)
+    {
+        _handler = handler ?? throw new ArgumentNullException(nameof(handler));
+    }
+
+    /// <summary>
+    /// Handles a single client connection
+    /// </summary>
+    public async Task HandleClientAsync(Stream stream, CancellationToken cancellationToken)
+    {
+        using var reader = new BinaryReader(stream, Encoding.UTF8, leaveOpen: true);
+        using var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true);
+
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested && stream.CanRead)
+            {
+                // Read command type (1 byte)
+                var commandByte = reader.ReadByte();
+                var command = (IpcCommandType)commandByte;
+
+                switch (command)
+                {
+                    case IpcCommandType.Shutdown:
+                        _handler.Shutdown();
+                        break;
+
+                    case IpcCommandType.Reconnect:
+                        _handler.Reconnect();
+                        break;
+
+                    case IpcCommandType.GenerateNewKey:
+                        _handler.GenerateNewKey();
+                        break;
+
+                    case IpcCommandType.ConnectToMachine:
+                        {
+                            var machineName = ReadString(reader);
+                            var securityKey = ReadString(reader);
+                            _handler.ConnectToMachine(machineName, securityKey);
+                        }
+
+                        break;
+
+                    case IpcCommandType.RequestMachineSocketState:
+                        {
+                            var states = await _handler.RequestMachineSocketStateAsync();
+                            var json = JsonSerializer.Serialize(states, JsonOptions);
+                            WriteString(writer, json);
+                            await stream.FlushAsync(cancellationToken);
+                        }
+
+                        break;
+
+                    default:
+                        Logger.Log($"Unknown IPC command: {commandByte}");
+                        return; // Invalid command, close connection
+                }
+            }
+        }
+        catch (EndOfStreamException)
+        {
+            // Client disconnected, normal termination
+        }
+        catch (IOException)
+        {
+            // Pipe broken, normal termination
+        }
+        catch (Exception ex)
+        {
+            Logger.Log($"IPC error: {ex}");
+        }
+    }
+
+    /// <summary>
+    /// Reads a length-prefixed UTF-8 string
+    /// </summary>
+    private static string ReadString(BinaryReader reader)
+    {
+        var length = reader.ReadInt32();
+        if (length <= 0 || length > 1024 * 1024)
+        {
+            return string.Empty;
+        }
+
+        var bytes = reader.ReadBytes(length);
+        return Encoding.UTF8.GetString(bytes);
+    }
+
+    /// <summary>
+    /// Writes a length-prefixed UTF-8 string
+    /// </summary>
+    private static void WriteString(BinaryWriter writer, string value)
+    {
+        var bytes = Encoding.UTF8.GetBytes(value);
+        writer.Write(bytes.Length);
+        writer.Write(bytes);
+    }
+}
+
+/// <summary>
+/// Interface for handling IPC commands.
+/// Implemented by SettingsSyncHelper in Program.cs
+/// </summary>
+internal interface ISettingsSyncHandler
+{
+    void Shutdown();
+
+    void Reconnect();
+
+    void GenerateNewKey();
+
+    void ConnectToMachine(string machineName, string securityKey);
+
+    Task<MachineSocketState[]> RequestMachineSocketStateAsync();
+}
+
+/// <summary>
+/// Machine socket state for serialization.
+/// Uses SocketStatus from SocketStuff.cs in MouseWithoutBorders.Class namespace.
+/// </summary>
+public struct MachineSocketState
+{
+    public string Name { get; set; }
+
+    public MouseWithoutBorders.Class.SocketStatus Status { get; set; }
+}

--- a/src/modules/MouseWithoutBorders/App/Class/SocketStuff.cs
+++ b/src/modules/MouseWithoutBorders/App/Class/SocketStuff.cs
@@ -51,7 +51,11 @@ using Thread = MouseWithoutBorders.Core.Thread;
 
 namespace MouseWithoutBorders.Class
 {
-    internal enum SocketStatus : int
+    /// <summary>
+    /// Socket status enumeration - made public for IPC serialization.
+    /// Must match Settings.UI.Library\MouseWithoutBordersIpcModels.cs
+    /// </summary>
+    public enum SocketStatus : int
     {
         NA = 0,
         Resolving = 1,

--- a/src/modules/MouseWithoutBorders/App/Core/Common.cs
+++ b/src/modules/MouseWithoutBorders/App/Core/Common.cs
@@ -24,6 +24,7 @@ using MouseWithoutBorders.Class;
 using MouseWithoutBorders.Exceptions;
 
 using Clipboard = MouseWithoutBorders.Core.Clipboard;
+using SocketStatus = MouseWithoutBorders.Class.SocketStatus;
 using Thread = MouseWithoutBorders.Core.Thread;
 
 // Log is enough

--- a/src/settings-ui/QuickAccess.UI/PowerToys.QuickAccess.csproj
+++ b/src/settings-ui/QuickAccess.UI/PowerToys.QuickAccess.csproj
@@ -1,6 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\Common.Dotnet.CsWinRT.props" />
   <Import Project="..\..\Common.SelfContained.props" />
+  <Import Project="..\..\Common.Dotnet.AotCompatibility.props" />
+
+  <PropertyGroup Condition="'$(EnableSettingsAOT)' == 'true'">
+    <PublishAot>true</PublishAot>
+  </PropertyGroup>
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>

--- a/src/settings-ui/Settings.UI.Library/GenericProperty`1.cs
+++ b/src/settings-ui/Settings.UI.Library/GenericProperty`1.cs
@@ -2,12 +2,13 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 
 namespace Microsoft.PowerToys.Settings.UI.Library
 {
-    public class GenericProperty<T> : ICmdLineRepresentable
+    public class GenericProperty<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T> : ICmdLineRepresentable
     {
         [JsonPropertyName("value")]
         public T Value { get; set; }

--- a/src/settings-ui/Settings.UI.Library/Interfaces/ICmdLineRepresentable.cs
+++ b/src/settings-ui/Settings.UI.Library/Interfaces/ICmdLineRepresentable.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
 
@@ -17,7 +18,7 @@ public interface ICmdLineRepresentable
 
     public abstract bool TryToCmdRepresentable(out string result);
 
-    public static sealed bool TryToCmdRepresentableFor(Type type, object value, out string result)
+    public static sealed bool TryToCmdRepresentableFor([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type type, object value, out string result)
     {
         result = null;
         if (!typeof(ICmdLineRepresentable).IsAssignableFrom(type))
@@ -36,7 +37,7 @@ public interface ICmdLineRepresentable
         return false;
     }
 
-    public static sealed bool TryParseFromCmdFor(Type type, string cmd, out object result)
+    public static sealed bool TryParseFromCmdFor([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type type, string cmd, out object result)
     {
         result = null;
         if (!typeof(ICmdLineRepresentable).IsAssignableFrom(type))
@@ -55,7 +56,7 @@ public interface ICmdLineRepresentable
         return false;
     }
 
-    public static sealed object ParseFor(Type type, string cmdRepr)
+    public static sealed object ParseFor([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type type, string cmdRepr)
     {
         if (type.IsEnum)
         {
@@ -98,7 +99,7 @@ public interface ICmdLineRepresentable
         throw new NotImplementedException($"Parsing type {type} is not supported yet");
     }
 
-    public static string ToCmdRepr(Type type, object value)
+    public static string ToCmdRepr([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type type, object value)
     {
         if (type.IsEnum || type.IsPrimitive)
         {

--- a/src/settings-ui/Settings.UI.Library/MouseWithoutBordersIpcModels.cs
+++ b/src/settings-ui/Settings.UI.Library/MouseWithoutBordersIpcModels.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json.Serialization;
+
+#pragma warning disable SA1649 // File name should match first type name
+
+namespace Microsoft.PowerToys.Settings.UI.Library;
+
+/// <summary>
+/// Socket status enumeration for MouseWithoutBorders machine connections.
+/// Must match the enum in MouseWithoutBorders\App\Class\Program.cs
+/// </summary>
+public enum SocketStatus : int
+{
+    NA = 0,
+    Resolving = 1,
+    Connecting = 2,
+    Handshaking = 3,
+    Error = 4,
+    ForceClosed = 5,
+    InvalidKey = 6,
+    Timeout = 7,
+    SendError = 8,
+    Connected = 9,
+}
+
+/// <summary>
+/// Represents the connection state of a machine in the MouseWithoutBorders network.
+/// Used for IPC communication between Settings UI and MouseWithoutBorders service.
+/// </summary>
+public struct MachineSocketState
+{
+    [JsonPropertyName("Name")]
+    public string Name { get; set; }
+
+    [JsonPropertyName("Status")]
+    public SocketStatus Status { get; set; }
+}

--- a/src/settings-ui/Settings.UI.Library/Settings.UI.Library.csproj
+++ b/src/settings-ui/Settings.UI.Library/Settings.UI.Library.csproj
@@ -2,6 +2,7 @@
   <!-- Look at Directory.Build.props in root for common stuff as well -->
   <Import Project="..\..\Common.Dotnet.CsWinRT.props" />
   <Import Project="..\..\Common.SelfContained.props" />
+  <Import Project="..\..\Common.Dotnet.AotCompatibility.props" />
     <PropertyGroup>
         <Description>PowerToys Settings UI Library</Description>
         <AssemblyName>PowerToys.Settings.UI.Lib</AssemblyName>

--- a/src/settings-ui/Settings.UI.Library/SettingsFactory.cs
+++ b/src/settings-ui/Settings.UI.Library/SettingsFactory.cs
@@ -1,11 +1,9 @@
-﻿// Copyright (c) Microsoft Corporation
+// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
 using Microsoft.PowerToys.Settings.UI.Library;
 using Microsoft.PowerToys.Settings.UI.Library.Helpers;
 using Microsoft.PowerToys.Settings.UI.Library.Interfaces;
@@ -13,88 +11,111 @@ using Microsoft.PowerToys.Settings.UI.Library.Interfaces;
 namespace Microsoft.PowerToys.Settings.UI.Services
 {
     /// <summary>
-    /// Factory service for getting PowerToys module Settings that implement IHotkeyConfig
+    /// AOT-compatible factory service for PowerToys module Settings.
+    /// Uses static type registration instead of reflection-based discovery.
     /// </summary>
+    /// <remarks>
+    /// When adding a new PowerToys module, add it to both InitializeFactories() and InitializeTypes() methods.
+    /// </remarks>
     public class SettingsFactory
     {
         private readonly SettingsUtils _settingsUtils;
+        private readonly Dictionary<string, Func<IHotkeyConfig>> _settingsFactories;
         private readonly Dictionary<string, Type> _settingsTypes;
 
         public SettingsFactory(SettingsUtils settingsUtils)
         {
             _settingsUtils = settingsUtils ?? throw new ArgumentNullException(nameof(settingsUtils));
-            _settingsTypes = DiscoverSettingsTypes();
+            _settingsFactories = InitializeFactories();
+            _settingsTypes = InitializeTypes();
         }
 
         /// <summary>
-        /// Dynamically discovers all Settings types that implement IHotkeyConfig
+        /// Static registry of all module settings factories.
+        /// IMPORTANT: When adding a new module, add it here.
         /// </summary>
-        private Dictionary<string, Type> DiscoverSettingsTypes()
+        private Dictionary<string, Func<IHotkeyConfig>> InitializeFactories()
         {
-            var settingsTypes = new Dictionary<string, Type>();
-
-            // Get the Settings.UI.Library assembly
-            var assembly = Assembly.GetAssembly(typeof(IHotkeyConfig));
-            if (assembly == null)
+            return new Dictionary<string, Func<IHotkeyConfig>>
             {
-                return settingsTypes;
+                ["GeneralSettings"] = () => SettingsRepository<GeneralSettings>.GetInstance(_settingsUtils).SettingsConfig,
+                ["AdvancedPaste"] = () => SettingsRepository<AdvancedPasteSettings>.GetInstance(_settingsUtils).SettingsConfig,
+                ["AlwaysOnTop"] = () => SettingsRepository<AlwaysOnTopSettings>.GetInstance(_settingsUtils).SettingsConfig,
+                ["ColorPicker"] = () => SettingsRepository<ColorPickerSettings>.GetInstance(_settingsUtils).SettingsConfig,
+                ["CropAndLock"] = () => SettingsRepository<CropAndLockSettings>.GetInstance(_settingsUtils).SettingsConfig,
+                ["CursorWrap"] = () => SettingsRepository<CursorWrapSettings>.GetInstance(_settingsUtils).SettingsConfig,
+                ["FindMyMouse"] = () => SettingsRepository<FindMyMouseSettings>.GetInstance(_settingsUtils).SettingsConfig,
+                ["LightSwitch"] = () => SettingsRepository<LightSwitchSettings>.GetInstance(_settingsUtils).SettingsConfig,
+                ["MeasureTool"] = () => SettingsRepository<MeasureToolSettings>.GetInstance(_settingsUtils).SettingsConfig,
+                ["MouseHighlighter"] = () => SettingsRepository<MouseHighlighterSettings>.GetInstance(_settingsUtils).SettingsConfig,
+                ["MouseJump"] = () => SettingsRepository<MouseJumpSettings>.GetInstance(_settingsUtils).SettingsConfig,
+                ["MousePointerCrosshairs"] = () => SettingsRepository<MousePointerCrosshairsSettings>.GetInstance(_settingsUtils).SettingsConfig,
+                ["MouseWithoutBorders"] = () => SettingsRepository<MouseWithoutBordersSettings>.GetInstance(_settingsUtils).SettingsConfig,
+                ["Peek"] = () => SettingsRepository<PeekSettings>.GetInstance(_settingsUtils).SettingsConfig,
+                ["PowerLauncher"] = () => SettingsRepository<PowerLauncherSettings>.GetInstance(_settingsUtils).SettingsConfig,
+                ["PowerOCR"] = () => SettingsRepository<PowerOcrSettings>.GetInstance(_settingsUtils).SettingsConfig,
+                ["ShortcutGuide"] = () => SettingsRepository<ShortcutGuideSettings>.GetInstance(_settingsUtils).SettingsConfig,
+                ["Workspaces"] = () => SettingsRepository<WorkspacesSettings>.GetInstance(_settingsUtils).SettingsConfig,
+            };
+        }
+
+        /// <summary>
+        /// Static registry of module name to settings type mapping.
+        /// IMPORTANT: When adding a new module, add it here.
+        /// </summary>
+        private Dictionary<string, Type> InitializeTypes()
+        {
+            return new Dictionary<string, Type>
+            {
+                ["GeneralSettings"] = typeof(GeneralSettings),
+                ["AdvancedPaste"] = typeof(AdvancedPasteSettings),
+                ["AlwaysOnTop"] = typeof(AlwaysOnTopSettings),
+                ["ColorPicker"] = typeof(ColorPickerSettings),
+                ["CropAndLock"] = typeof(CropAndLockSettings),
+                ["CursorWrap"] = typeof(CursorWrapSettings),
+                ["FindMyMouse"] = typeof(FindMyMouseSettings),
+                ["LightSwitch"] = typeof(LightSwitchSettings),
+                ["MeasureTool"] = typeof(MeasureToolSettings),
+                ["MouseHighlighter"] = typeof(MouseHighlighterSettings),
+                ["MouseJump"] = typeof(MouseJumpSettings),
+                ["MousePointerCrosshairs"] = typeof(MousePointerCrosshairsSettings),
+                ["MouseWithoutBorders"] = typeof(MouseWithoutBordersSettings),
+                ["Peek"] = typeof(PeekSettings),
+                ["PowerLauncher"] = typeof(PowerLauncherSettings),
+                ["PowerOCR"] = typeof(PowerOcrSettings),
+                ["ShortcutGuide"] = typeof(ShortcutGuideSettings),
+                ["Workspaces"] = typeof(WorkspacesSettings),
+            };
+        }
+
+        /// <summary>
+        /// Gets a settings instance for the specified module using SettingsRepository.
+        /// AOT-compatible: uses static factory lookup instead of reflection.
+        /// </summary>
+        /// <param name="moduleKey">The module key/name</param>
+        /// <returns>The settings instance implementing IHotkeyConfig, or null if not found</returns>
+        public IHotkeyConfig GetSettings(string moduleKey)
+        {
+            if (!_settingsFactories.TryGetValue(moduleKey, out var factory))
+            {
+                return null;
             }
 
             try
             {
-                // Find all types that implement IHotkeyConfig and ISettingsConfig
-                var hotkeyConfigTypes = assembly.GetTypes()
-                    .Where(type =>
-                        type.IsClass &&
-                        !type.IsAbstract &&
-                        typeof(IHotkeyConfig).IsAssignableFrom(type) &&
-                        typeof(ISettingsConfig).IsAssignableFrom(type))
-                    .ToList();
-
-                foreach (var type in hotkeyConfigTypes)
-                {
-                    // Try to get the ModuleName using SettingsRepository
-                    try
-                    {
-                        var repositoryType = typeof(SettingsRepository<>).MakeGenericType(type);
-                        var getInstanceMethod = repositoryType.GetMethod("GetInstance", BindingFlags.Public | BindingFlags.Static);
-                        var repository = getInstanceMethod?.Invoke(null, new object[] { _settingsUtils });
-
-                        if (repository != null)
-                        {
-                            var settingsConfigProperty = repository.GetType().GetProperty("SettingsConfig");
-                            var settingsInstance = settingsConfigProperty?.GetValue(repository) as ISettingsConfig;
-
-                            if (settingsInstance != null)
-                            {
-                                var moduleName = settingsInstance.GetModuleName();
-                                if (string.IsNullOrEmpty(moduleName) && type == typeof(GeneralSettings))
-                                {
-                                    moduleName = "GeneralSettings";
-                                }
-
-                                if (!string.IsNullOrEmpty(moduleName))
-                                {
-                                    settingsTypes[moduleName] = type;
-                                    System.Diagnostics.Debug.WriteLine($"Discovered settings type: {type.Name} for module: {moduleName}");
-                                }
-                            }
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        System.Diagnostics.Debug.WriteLine($"Error getting module name for {type.Name}: {ex.Message}");
-                    }
-                }
+                return factory();
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Debug.WriteLine($"Error scanning assembly {assembly.FullName}: {ex.Message}");
+                System.Diagnostics.Debug.WriteLine($"Error getting Settings for {moduleKey}: {ex.Message}");
+                return null;
             }
-
-            return settingsTypes;
         }
 
+        /// <summary>
+        /// Gets fresh settings from disk for the specified module.
+        /// AOT-compatible: uses static type dispatch instead of MakeGenericMethod.
+        /// </summary>
         public IHotkeyConfig GetFreshSettings(string moduleKey)
         {
             if (!_settingsTypes.TryGetValue(moduleKey, out var settingsType))
@@ -104,20 +125,8 @@ namespace Microsoft.PowerToys.Settings.UI.Services
 
             try
             {
-                // Create a generic method call to _settingsUtils.GetSettingsOrDefault<T>(moduleKey)
-                var getSettingsMethod = typeof(SettingsUtils).GetMethod("GetSettingsOrDefault", new[] { typeof(string), typeof(string) });
-                var genericMethod = getSettingsMethod?.MakeGenericMethod(settingsType);
-
-                // Call GetSettingsOrDefault<T>(moduleKey) to get fresh settings from file
-                string actualModuleKey = moduleKey;
-                if (moduleKey == "GeneralSettings")
-                {
-                    actualModuleKey = string.Empty;
-                }
-
-                var freshSettings = genericMethod?.Invoke(_settingsUtils, new object[] { actualModuleKey, "settings.json" });
-
-                return freshSettings as IHotkeyConfig;
+                string actualModuleKey = moduleKey == "GeneralSettings" ? string.Empty : moduleKey;
+                return GetFreshSettingsForType(settingsType, actualModuleKey);
             }
             catch (Exception ex)
             {
@@ -127,35 +136,33 @@ namespace Microsoft.PowerToys.Settings.UI.Services
         }
 
         /// <summary>
-        /// Gets a settings instance for the specified module using SettingsRepository
+        /// Static dispatch for GetSettingsOrDefault using pattern matching.
+        /// Replaces reflection-based MakeGenericMethod/Invoke pattern.
         /// </summary>
-        /// <param name="moduleKey">The module key/name</param>
-        /// <returns>The settings instance implementing IHotkeyConfig, or null if not found</returns>
-        public IHotkeyConfig GetSettings(string moduleKey)
+        private IHotkeyConfig GetFreshSettingsForType(Type settingsType, string moduleKey)
         {
-            if (!_settingsTypes.TryGetValue(moduleKey, out var settingsType))
+            return settingsType.Name switch
             {
-                return null;
-            }
-
-            try
-            {
-                var repositoryType = typeof(SettingsRepository<>).MakeGenericType(settingsType);
-                var getInstanceMethod = repositoryType.GetMethod("GetInstance", BindingFlags.Public | BindingFlags.Static);
-                var repository = getInstanceMethod?.Invoke(null, new object[] { _settingsUtils });
-
-                if (repository != null)
-                {
-                    var settingsConfigProperty = repository.GetType().GetProperty("SettingsConfig");
-                    return settingsConfigProperty?.GetValue(repository) as IHotkeyConfig;
-                }
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Debug.WriteLine($"Error getting Settings for {moduleKey}: {ex.Message}");
-            }
-
-            return null;
+                nameof(GeneralSettings) => _settingsUtils.GetSettingsOrDefault<GeneralSettings>(moduleKey, "settings.json"),
+                nameof(AdvancedPasteSettings) => _settingsUtils.GetSettingsOrDefault<AdvancedPasteSettings>(moduleKey, "settings.json"),
+                nameof(AlwaysOnTopSettings) => _settingsUtils.GetSettingsOrDefault<AlwaysOnTopSettings>(moduleKey, "settings.json"),
+                nameof(ColorPickerSettings) => _settingsUtils.GetSettingsOrDefault<ColorPickerSettings>(moduleKey, "settings.json"),
+                nameof(CropAndLockSettings) => _settingsUtils.GetSettingsOrDefault<CropAndLockSettings>(moduleKey, "settings.json"),
+                nameof(CursorWrapSettings) => _settingsUtils.GetSettingsOrDefault<CursorWrapSettings>(moduleKey, "settings.json"),
+                nameof(FindMyMouseSettings) => _settingsUtils.GetSettingsOrDefault<FindMyMouseSettings>(moduleKey, "settings.json"),
+                nameof(LightSwitchSettings) => _settingsUtils.GetSettingsOrDefault<LightSwitchSettings>(moduleKey, "settings.json"),
+                nameof(MeasureToolSettings) => _settingsUtils.GetSettingsOrDefault<MeasureToolSettings>(moduleKey, "settings.json"),
+                nameof(MouseHighlighterSettings) => _settingsUtils.GetSettingsOrDefault<MouseHighlighterSettings>(moduleKey, "settings.json"),
+                nameof(MouseJumpSettings) => _settingsUtils.GetSettingsOrDefault<MouseJumpSettings>(moduleKey, "settings.json"),
+                nameof(MousePointerCrosshairsSettings) => _settingsUtils.GetSettingsOrDefault<MousePointerCrosshairsSettings>(moduleKey, "settings.json"),
+                nameof(MouseWithoutBordersSettings) => _settingsUtils.GetSettingsOrDefault<MouseWithoutBordersSettings>(moduleKey, "settings.json"),
+                nameof(PeekSettings) => _settingsUtils.GetSettingsOrDefault<PeekSettings>(moduleKey, "settings.json"),
+                nameof(PowerLauncherSettings) => _settingsUtils.GetSettingsOrDefault<PowerLauncherSettings>(moduleKey, "settings.json"),
+                nameof(PowerOcrSettings) => _settingsUtils.GetSettingsOrDefault<PowerOcrSettings>(moduleKey, "settings.json"),
+                nameof(ShortcutGuideSettings) => _settingsUtils.GetSettingsOrDefault<ShortcutGuideSettings>(moduleKey, "settings.json"),
+                nameof(WorkspacesSettings) => _settingsUtils.GetSettingsOrDefault<WorkspacesSettings>(moduleKey, "settings.json"),
+                _ => null,
+            };
         }
 
         /// <summary>
@@ -164,7 +171,7 @@ namespace Microsoft.PowerToys.Settings.UI.Services
         /// <returns>List of module names</returns>
         public List<string> GetAvailableModuleNames()
         {
-            return _settingsTypes.Keys.ToList();
+            return new List<string>(_settingsTypes.Keys);
         }
 
         /// <summary>

--- a/src/settings-ui/Settings.UI.Library/SettingsSerializationContext.cs
+++ b/src/settings-ui/Settings.UI.Library/SettingsSerializationContext.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using SettingsUILibrary = Settings.UI.Library;
 using SettingsUILibraryHelpers = Settings.UI.Library.Helpers;
@@ -166,6 +167,15 @@ namespace Microsoft.PowerToys.Settings.UI.Library
     [JsonSerializable(typeof(SndModuleSettings<SndPowerPreviewSettings>))]
     [JsonSerializable(typeof(SndModuleSettings<SndPowerRenameSettings>))]
     [JsonSerializable(typeof(SndModuleSettings<SndShortcutGuideSettings>))]
+
+    // CLI/DSC command support types
+    [JsonSerializable(typeof(PowerLauncherPluginSettings))]
+    [JsonSerializable(typeof(PowerLauncherPluginSettings[]))]
+
+    // MouseWithoutBorders IPC types
+    [JsonSerializable(typeof(MachineSocketState))]
+    [JsonSerializable(typeof(MachineSocketState[]))]
+    [JsonSerializable(typeof(SocketStatus))]
 
     public partial class SettingsSerializationContext : JsonSerializerContext
     {

--- a/src/settings-ui/Settings.UI.Library/Utilities/CommandLineUtils.cs
+++ b/src/settings-ui/Settings.UI.Library/Utilities/CommandLineUtils.cs
@@ -1,69 +1,181 @@
-﻿// Copyright (c) Microsoft Corporation
+// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Linq;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
-
 using Microsoft.PowerToys.Settings.UI.Library.Interfaces;
 
 namespace Microsoft.PowerToys.Settings.UI.Library;
 
+/// <summary>
+/// AOT-compatible command line utilities.
+/// Uses static type mapping instead of AppDomain reflection.
+/// </summary>
 public class CommandLineUtils
 {
-    private static Type GetSettingsConfigType(string moduleName, Assembly settingsLibraryAssembly)
+    private static readonly Dictionary<string, Type> _settingsTypes = new()
     {
-        var settingsClassName = moduleName == "GeneralSettings" ? moduleName : moduleName + "Settings";
-        return settingsLibraryAssembly.GetType(typeof(CommandLineUtils).Namespace + "." + settingsClassName);
+        ["GeneralSettings"] = typeof(GeneralSettings),
+        ["AdvancedPaste"] = typeof(AdvancedPasteSettings),
+        ["AlwaysOnTop"] = typeof(AlwaysOnTopSettings),
+        ["Awake"] = typeof(AwakeSettings),
+        ["CmdNotFound"] = typeof(CmdNotFoundSettings),
+        ["ColorPicker"] = typeof(ColorPickerSettings),
+        ["CropAndLock"] = typeof(CropAndLockSettings),
+        ["CursorWrap"] = typeof(CursorWrapSettings),
+        ["EnvironmentVariables"] = typeof(EnvironmentVariablesSettings),
+        ["FancyZones"] = typeof(FancyZonesSettings),
+        ["FileLocksmith"] = typeof(FileLocksmithSettings),
+        ["FindMyMouse"] = typeof(FindMyMouseSettings),
+        ["Hosts"] = typeof(HostsSettings),
+        ["ImageResizer"] = typeof(ImageResizerSettings),
+        ["KeyboardManager"] = typeof(KeyboardManagerSettings),
+        ["LightSwitch"] = typeof(LightSwitchSettings),
+        ["MeasureTool"] = typeof(MeasureToolSettings),
+        ["MouseHighlighter"] = typeof(MouseHighlighterSettings),
+        ["MouseJump"] = typeof(MouseJumpSettings),
+        ["MousePointerCrosshairs"] = typeof(MousePointerCrosshairsSettings),
+        ["MouseWithoutBorders"] = typeof(MouseWithoutBordersSettings),
+        ["NewPlus"] = typeof(NewPlusSettings),
+        ["Peek"] = typeof(PeekSettings),
+        ["PowerAccent"] = typeof(PowerAccentSettings),
+        ["PowerLauncher"] = typeof(PowerLauncherSettings),
+        ["PowerOCR"] = typeof(PowerOcrSettings),
+        ["PowerRename"] = typeof(PowerRenameSettings),
+        ["PowerPreview"] = typeof(PowerPreviewSettings),
+        ["RegistryPreview"] = typeof(RegistryPreviewSettings),
+        ["ShortcutGuide"] = typeof(ShortcutGuideSettings),
+        ["Workspaces"] = typeof(WorkspacesSettings),
+        ["ZoomIt"] = typeof(ZoomItSettings),
+    };
+
+    public static ISettingsConfig GetSettingsConfigFor(string moduleName, SettingsUtils settingsUtils, Assembly settingsLibraryAssembly = null)
+    {
+        if (!_settingsTypes.TryGetValue(moduleName, out var settingsType))
+        {
+            return null;
+        }
+
+        return GetSettingsConfigFor(settingsType, settingsUtils);
     }
 
-    public static ISettingsConfig GetSettingsConfigFor(string moduleName, SettingsUtils settingsUtils, Assembly settingsLibraryAssembly)
-    {
-        return GetSettingsConfigFor(GetSettingsConfigType(moduleName, settingsLibraryAssembly), settingsUtils);
-    }
-
-    /// Executes SettingsRepository<moduleSettingsType>.GetInstance(settingsUtils).SettingsConfig
+    /// <summary>
+    /// Gets settings config for a given type using static dispatch.
+    /// AOT-compatible: replaces MakeGenericType/GetMethod/Invoke pattern.
+    /// </summary>
     public static ISettingsConfig GetSettingsConfigFor(Type moduleSettingsType, SettingsUtils settingsUtils)
     {
-        var genericSettingsRepositoryType = typeof(SettingsRepository<>);
-        var moduleSettingsRepositoryType = genericSettingsRepositoryType.MakeGenericType(moduleSettingsType);
-
-        // Note: GeneralSettings is only used here only to satisfy nameof constrains, i.e. the choice of this particular type doesn't have any special significance.
-        var getInstanceInfo = moduleSettingsRepositoryType.GetMethod(nameof(SettingsRepository<GeneralSettings>.GetInstance));
-        var settingsRepository = getInstanceInfo.Invoke(null, new object[] { settingsUtils });
-        var settingsConfigProperty = getInstanceInfo.ReturnType.GetProperty(nameof(SettingsRepository<GeneralSettings>.SettingsConfig));
-        return settingsConfigProperty.GetValue(settingsRepository) as ISettingsConfig;
+        return moduleSettingsType.Name switch
+        {
+            nameof(GeneralSettings) => SettingsRepository<GeneralSettings>.GetInstance(settingsUtils).SettingsConfig,
+            nameof(AdvancedPasteSettings) => SettingsRepository<AdvancedPasteSettings>.GetInstance(settingsUtils).SettingsConfig,
+            nameof(AlwaysOnTopSettings) => SettingsRepository<AlwaysOnTopSettings>.GetInstance(settingsUtils).SettingsConfig,
+            nameof(AwakeSettings) => SettingsRepository<AwakeSettings>.GetInstance(settingsUtils).SettingsConfig,
+            nameof(CmdNotFoundSettings) => SettingsRepository<CmdNotFoundSettings>.GetInstance(settingsUtils).SettingsConfig,
+            nameof(ColorPickerSettings) => SettingsRepository<ColorPickerSettings>.GetInstance(settingsUtils).SettingsConfig,
+            nameof(CropAndLockSettings) => SettingsRepository<CropAndLockSettings>.GetInstance(settingsUtils).SettingsConfig,
+            nameof(CursorWrapSettings) => SettingsRepository<CursorWrapSettings>.GetInstance(settingsUtils).SettingsConfig,
+            nameof(EnvironmentVariablesSettings) => SettingsRepository<EnvironmentVariablesSettings>.GetInstance(settingsUtils).SettingsConfig,
+            nameof(FancyZonesSettings) => SettingsRepository<FancyZonesSettings>.GetInstance(settingsUtils).SettingsConfig,
+            nameof(FileLocksmithSettings) => SettingsRepository<FileLocksmithSettings>.GetInstance(settingsUtils).SettingsConfig,
+            nameof(FindMyMouseSettings) => SettingsRepository<FindMyMouseSettings>.GetInstance(settingsUtils).SettingsConfig,
+            nameof(HostsSettings) => SettingsRepository<HostsSettings>.GetInstance(settingsUtils).SettingsConfig,
+            nameof(ImageResizerSettings) => SettingsRepository<ImageResizerSettings>.GetInstance(settingsUtils).SettingsConfig,
+            nameof(KeyboardManagerSettings) => SettingsRepository<KeyboardManagerSettings>.GetInstance(settingsUtils).SettingsConfig,
+            nameof(LightSwitchSettings) => SettingsRepository<LightSwitchSettings>.GetInstance(settingsUtils).SettingsConfig,
+            nameof(MeasureToolSettings) => SettingsRepository<MeasureToolSettings>.GetInstance(settingsUtils).SettingsConfig,
+            nameof(MouseHighlighterSettings) => SettingsRepository<MouseHighlighterSettings>.GetInstance(settingsUtils).SettingsConfig,
+            nameof(MouseJumpSettings) => SettingsRepository<MouseJumpSettings>.GetInstance(settingsUtils).SettingsConfig,
+            nameof(MousePointerCrosshairsSettings) => SettingsRepository<MousePointerCrosshairsSettings>.GetInstance(settingsUtils).SettingsConfig,
+            nameof(MouseWithoutBordersSettings) => SettingsRepository<MouseWithoutBordersSettings>.GetInstance(settingsUtils).SettingsConfig,
+            nameof(NewPlusSettings) => SettingsRepository<NewPlusSettings>.GetInstance(settingsUtils).SettingsConfig,
+            nameof(PeekSettings) => SettingsRepository<PeekSettings>.GetInstance(settingsUtils).SettingsConfig,
+            nameof(PowerAccentSettings) => SettingsRepository<PowerAccentSettings>.GetInstance(settingsUtils).SettingsConfig,
+            nameof(PowerLauncherSettings) => SettingsRepository<PowerLauncherSettings>.GetInstance(settingsUtils).SettingsConfig,
+            nameof(PowerOcrSettings) => SettingsRepository<PowerOcrSettings>.GetInstance(settingsUtils).SettingsConfig,
+            nameof(PowerRenameSettings) => SettingsRepository<PowerRenameSettings>.GetInstance(settingsUtils).SettingsConfig,
+            nameof(PowerPreviewSettings) => SettingsRepository<PowerPreviewSettings>.GetInstance(settingsUtils).SettingsConfig,
+            nameof(RegistryPreviewSettings) => SettingsRepository<RegistryPreviewSettings>.GetInstance(settingsUtils).SettingsConfig,
+            nameof(ShortcutGuideSettings) => SettingsRepository<ShortcutGuideSettings>.GetInstance(settingsUtils).SettingsConfig,
+            nameof(WorkspacesSettings) => SettingsRepository<WorkspacesSettings>.GetInstance(settingsUtils).SettingsConfig,
+            nameof(ZoomItSettings) => SettingsRepository<ZoomItSettings>.GetInstance(settingsUtils).SettingsConfig,
+            _ => null,
+        };
     }
 
-    public static Assembly GetSettingsAssembly()
-    {
-        return AppDomain.CurrentDomain.GetAssemblies()
-                        .FirstOrDefault(a => a.GetName().Name == "PowerToys.Settings.UI.Lib");
-    }
-
-    public static object GetPropertyValue(string propertyName, ISettingsConfig settingsConfig)
-    {
-        var (settingInfo, properties) = LocateSetting(propertyName, settingsConfig);
-        return settingInfo.GetValue(properties);
-    }
-
+    /// <summary>
+    /// Gets the Properties object from a settings config.
+    /// For GeneralSettings, returns the settings itself. For others, returns the Properties property.
+    /// </summary>
     public static object GetProperties(ISettingsConfig settingsConfig)
     {
+        // Use reflection fallback for all settings types to preserve compatibility
+        // This is needed because not all settings have static patterns
         var settingsType = settingsConfig.GetType();
         if (settingsType == typeof(GeneralSettings))
         {
             return settingsConfig;
         }
 
-        var settingsConfigInfo = settingsType.GetProperty("Properties");
-        return settingsConfigInfo.GetValue(settingsConfig);
+        var propertiesProperty = settingsType.GetProperty("Properties");
+        return propertiesProperty?.GetValue(settingsConfig);
     }
 
+    /// <summary>
+    /// Gets enabled state for a specific module.
+    /// AOT-compatible: static dispatch instead of reflection.
+    /// </summary>
+    public static bool GetEnabledModuleValue(string moduleName, EnabledModules enabled)
+    {
+        return moduleName switch
+        {
+            "AdvancedPaste" => enabled.AdvancedPaste,
+            "AlwaysOnTop" => enabled.AlwaysOnTop,
+            "Awake" => enabled.Awake,
+            "CmdNotFound" => enabled.CmdNotFound,
+            "ColorPicker" => enabled.ColorPicker,
+            "CropAndLock" => enabled.CropAndLock,
+            "CursorWrap" => enabled.CursorWrap,
+            "EnvironmentVariables" => enabled.EnvironmentVariables,
+            "FancyZones" => enabled.FancyZones,
+            "FileLocksmith" => enabled.FileLocksmith,
+            "FindMyMouse" => enabled.FindMyMouse,
+            "Hosts" => enabled.Hosts,
+            "ImageResizer" => enabled.ImageResizer,
+            "KeyboardManager" => enabled.KeyboardManager,
+            "LightSwitch" => enabled.LightSwitch,
+            "MeasureTool" => enabled.MeasureTool,
+            "MouseHighlighter" => enabled.MouseHighlighter,
+            "MouseJump" => enabled.MouseJump,
+            "MousePointerCrosshairs" => enabled.MousePointerCrosshairs,
+            "MouseWithoutBorders" => enabled.MouseWithoutBorders,
+            "NewPlus" => enabled.NewPlus,
+            "Peek" => enabled.Peek,
+            "PowerAccent" => enabled.PowerAccent,
+            "PowerLauncher" => enabled.PowerLauncher,
+            "PowerOcr" => enabled.PowerOcr,
+            "PowerRename" => enabled.PowerRename,
+            "RegistryPreview" => enabled.RegistryPreview,
+            "ShortcutGuide" => enabled.ShortcutGuide,
+            "Workspaces" => enabled.Workspaces,
+            "ZoomIt" => enabled.ZoomIt,
+            _ => false,
+        };
+    }
+
+    /// <summary>
+    /// Locates a setting property and returns both the PropertyInfo and the properties object.
+    /// Uses reflection on properties which is preserved via DynamicallyAccessedMembers on property types.
+    /// </summary>
     public static (PropertyInfo SettingInfo, object Properties) LocateSetting(string propertyName, ISettingsConfig settingsConfig)
     {
         var properties = GetProperties(settingsConfig);
         var propertiesType = properties.GetType();
+
+        // Special handling for GeneralSettings.Enabled.*
         if (propertiesType == typeof(GeneralSettings) && propertyName.StartsWith("Enabled.", StringComparison.InvariantCulture))
         {
             var moduleNameToToggle = propertyName.Replace("Enabled.", string.Empty);
@@ -75,6 +187,18 @@ public class CommandLineUtils
         return (propertiesType.GetProperty(propertyName), properties);
     }
 
+    /// <summary>
+    /// Gets the value of a property from a settings config.
+    /// </summary>
+    public static object GetPropertyValue(string propertyName, ISettingsConfig settingsConfig)
+    {
+        var (settingInfo, properties) = LocateSetting(propertyName, settingsConfig);
+        return settingInfo?.GetValue(properties);
+    }
+
+    /// <summary>
+    /// Gets the PropertyInfo for a setting property.
+    /// </summary>
     public static PropertyInfo GetSettingPropertyInfo(string propertyName, ISettingsConfig settingsConfig)
     {
         return LocateSetting(propertyName, settingsConfig).SettingInfo;

--- a/src/settings-ui/Settings.UI.Library/Utilities/GetSettingCommandLineCommand.cs
+++ b/src/settings-ui/Settings.UI.Library/Utilities/GetSettingCommandLineCommand.cs
@@ -47,9 +47,7 @@ public sealed class GetSettingCommandLineCommand
     {
         var modulesSettings = new Dictionary<string, Dictionary<string, object>>();
 
-        var settingsAssembly = CommandLineUtils.GetSettingsAssembly();
         var settingsUtils = SettingsUtils.Default;
-
         var enabledModules = SettingsRepository<GeneralSettings>.GetInstance(settingsUtils).SettingsConfig.Enabled;
 
         foreach (var (moduleName, settings) in settingNamesForModules)
@@ -57,10 +55,10 @@ public sealed class GetSettingCommandLineCommand
             var moduleSettings = new Dictionary<string, object>();
             if (moduleName != nameof(GeneralSettings))
             {
-                moduleSettings.Add("Enabled", typeof(EnabledModules).GetProperty(moduleName).GetValue(enabledModules));
+                moduleSettings.Add("Enabled", CommandLineUtils.GetEnabledModuleValue(moduleName, enabledModules));
             }
 
-            var settingsConfig = CommandLineUtils.GetSettingsConfigFor(moduleName, settingsUtils, settingsAssembly);
+            var settingsConfig = CommandLineUtils.GetSettingsConfigFor(moduleName, settingsUtils);
             foreach (var settingName in settings)
             {
                 var value = CommandLineUtils.GetPropertyValue(settingName, settingsConfig);

--- a/src/settings-ui/Settings.UI.Library/Utilities/Helper.cs
+++ b/src/settings-ui/Settings.UI.Library/Utilities/Helper.cs
@@ -115,7 +115,8 @@ namespace Microsoft.PowerToys.Settings.UI.Library.Utilities
         public static string GetPowerToysInstallationFolder()
         {
             // PowerToys.exe is in the parent folder relative to Settings.
-            var settingsPath = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
+            // Use AppContext.BaseDirectory for AOT/single-file compatibility
+            var settingsPath = AppContext.BaseDirectory;
             return Directory.GetParent(settingsPath).FullName;
         }
 

--- a/src/settings-ui/Settings.UI.Library/Utilities/SetAdditionalSettingsCommandLineCommand.cs
+++ b/src/settings-ui/Settings.UI.Library/Utilities/SetAdditionalSettingsCommandLineCommand.cs
@@ -246,10 +246,8 @@ public sealed class SetAdditionalSettingsCommandLineCommand
 
     public static void Execute(string moduleName, JsonDocument settings, SettingsUtils settingsUtils)
     {
-        Assembly settingsLibraryAssembly = CommandLineUtils.GetSettingsAssembly();
-
-        var settingsConfig = CommandLineUtils.GetSettingsConfigFor(moduleName, settingsUtils, settingsLibraryAssembly);
-        var settingsConfigType = settingsConfig.GetType();
+        var settingsConfig = CommandLineUtils.GetSettingsConfigFor(moduleName, settingsUtils);
+        var settingsConfigType = settingsConfig?.GetType();
 
         if (!SupportedAdditionalPropertiesInfoForModules.TryGetValue(moduleName, out var additionalPropertiesInfo))
         {

--- a/src/settings-ui/Settings.UI.Library/Utilities/SetSettingCommandLineCommand.cs
+++ b/src/settings-ui/Settings.UI.Library/Utilities/SetSettingCommandLineCommand.cs
@@ -27,11 +27,9 @@ public sealed class SetSettingCommandLineCommand
 
     public static void Execute(string settingName, string settingValue, SettingsUtils settingsUtils)
     {
-        Assembly settingsLibraryAssembly = CommandLineUtils.GetSettingsAssembly();
-
         var (moduleName, propertyName) = ParseSettingName(settingName);
 
-        var settingsConfig = CommandLineUtils.GetSettingsConfigFor(moduleName, settingsUtils, settingsLibraryAssembly);
+        var settingsConfig = CommandLineUtils.GetSettingsConfigFor(moduleName, settingsUtils);
 
         var propertyInfo = CommandLineUtils.GetSettingPropertyInfo(propertyName, settingsConfig);
         if (propertyInfo == null)

--- a/src/settings-ui/Settings.UI/Helpers/MouseWithoutBordersIpcClient.cs
+++ b/src/settings-ui/Settings.UI/Helpers/MouseWithoutBordersIpcClient.cs
@@ -1,0 +1,199 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.IO.Pipes;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.PowerToys.Settings.UI.Library;
+
+namespace Microsoft.PowerToys.Settings.UI.Helpers;
+
+/// <summary>
+/// AOT-compatible IPC client for MouseWithoutBorders service communication.
+/// Replaces StreamJsonRpc with manual NamedPipe protocol using length-prefixed messages.
+/// </summary>
+public sealed class MouseWithoutBordersIpcClient : IDisposable
+{
+    private readonly Stream _stream;
+    private readonly BinaryWriter _writer;
+    private readonly BinaryReader _reader;
+    private readonly object _lock = new();
+    private bool _disposed;
+
+    /// <summary>
+    /// Command types for IPC protocol.
+    /// Must match server-side enum in MouseWithoutBorders Program.cs
+    /// </summary>
+    private enum CommandType : byte
+    {
+        Shutdown = 1,
+        Reconnect = 2,
+        GenerateNewKey = 3,
+        ConnectToMachine = 4,
+        RequestMachineSocketState = 5,
+    }
+
+    public MouseWithoutBordersIpcClient(Stream stream)
+    {
+        _stream = stream ?? throw new ArgumentNullException(nameof(stream));
+        _writer = new BinaryWriter(_stream, Encoding.UTF8, leaveOpen: true);
+        _reader = new BinaryReader(_stream, Encoding.UTF8, leaveOpen: true);
+    }
+
+    /// <summary>
+    /// Sends shutdown command to MouseWithoutBorders service
+    /// </summary>
+    public async Task ShutdownAsync()
+    {
+        await SendCommandAsync(CommandType.Shutdown);
+        await FlushAsync();
+    }
+
+    /// <summary>
+    /// Sends reconnect command to MouseWithoutBorders service
+    /// </summary>
+    public async Task ReconnectAsync()
+    {
+        await SendCommandAsync(CommandType.Reconnect);
+        await FlushAsync();
+    }
+
+    /// <summary>
+    /// Requests generation of a new security key
+    /// </summary>
+    public async Task GenerateNewKeyAsync()
+    {
+        await SendCommandAsync(CommandType.GenerateNewKey);
+        await FlushAsync();
+    }
+
+    /// <summary>
+    /// Requests connection to a specific machine
+    /// </summary>
+    public async Task ConnectToMachineAsync(string machineName, string securityKey)
+    {
+        lock (_lock)
+        {
+            _writer.Write((byte)CommandType.ConnectToMachine);
+
+            // Write machine name (length-prefixed string)
+            WriteString(machineName ?? string.Empty);
+
+            // Write security key (length-prefixed string)
+            WriteString(securityKey ?? string.Empty);
+        }
+
+        await FlushAsync();
+    }
+
+    /// <summary>
+    /// Requests current state of all connected machines
+    /// </summary>
+    public async Task<MachineSocketState[]> RequestMachineSocketStateAsync()
+    {
+        // Send command
+        await SendCommandAsync(CommandType.RequestMachineSocketState);
+        await FlushAsync();
+
+        // Read response
+        var jsonResponse = await ReadStringAsync();
+
+        if (string.IsNullOrEmpty(jsonResponse))
+        {
+            return Array.Empty<MachineSocketState>();
+        }
+
+        try
+        {
+            // Use source-generated JSON serialization
+            return JsonSerializer.Deserialize(jsonResponse, SettingsSerializationContext.Default.MachineSocketStateArray)
+                   ?? Array.Empty<MachineSocketState>();
+        }
+        catch (JsonException ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"Failed to deserialize MachineSocketState: {ex.Message}");
+            return Array.Empty<MachineSocketState>();
+        }
+    }
+
+    /// <summary>
+    /// Flushes the underlying stream asynchronously
+    /// </summary>
+    public async Task FlushAsync()
+    {
+        await _stream.FlushAsync();
+    }
+
+    /// <summary>
+    /// Sends a simple command without parameters
+    /// </summary>
+    private Task SendCommandAsync(CommandType command)
+    {
+        lock (_lock)
+        {
+            _writer.Write((byte)command);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Writes a length-prefixed UTF-8 string
+    /// </summary>
+    private void WriteString(string value)
+    {
+        var bytes = Encoding.UTF8.GetBytes(value);
+        _writer.Write(bytes.Length); // 4-byte length prefix
+        _writer.Write(bytes);
+    }
+
+    /// <summary>
+    /// Reads a length-prefixed UTF-8 string asynchronously
+    /// </summary>
+    private async Task<string> ReadStringAsync()
+    {
+        var lengthBytes = new byte[4];
+        var bytesRead = await _stream.ReadAsync(lengthBytes.AsMemory(0, 4));
+
+        if (bytesRead != 4)
+        {
+            return string.Empty;
+        }
+
+        var length = BitConverter.ToInt32(lengthBytes, 0);
+
+        // Max 1MB to prevent memory exhaustion
+        if (length <= 0 || length > 1024 * 1024)
+        {
+            return string.Empty;
+        }
+
+        var stringBytes = new byte[length];
+        bytesRead = await _stream.ReadAsync(stringBytes.AsMemory(0, length));
+
+        if (bytesRead != length)
+        {
+            return string.Empty;
+        }
+
+        return Encoding.UTF8.GetString(stringBytes);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _writer?.Dispose();
+        _reader?.Dispose();
+
+        // Note: Do not dispose _stream as it's owned by the caller (NamedPipeClientStream)
+    }
+}

--- a/src/settings-ui/Settings.UI/Helpers/TypePreservation.cs
+++ b/src/settings-ui/Settings.UI/Helpers/TypePreservation.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Microsoft.PowerToys.Settings.UI.Helpers;
+
+/// <summary>
+/// Preserves types required by XAML for Native AOT compilation.
+/// Called from App constructor when BUILD_INFO_PUBLISH_AOT is defined.
+/// </summary>
+internal static class TypePreservation
+{
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(Microsoft.UI.Xaml.Controls.FontIconSource))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(Microsoft.UI.Xaml.Controls.PathIcon))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(Microsoft.UI.Xaml.Controls.SymbolIcon))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(Microsoft.UI.Xaml.Controls.SymbolIconSource))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(Microsoft.UI.Xaml.Controls.ImageIcon))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(Microsoft.UI.Xaml.Controls.BitmapIcon))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(Microsoft.UI.Xaml.DataTemplate))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(Microsoft.UI.Xaml.Controls.DataTemplateSelector))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(Microsoft.UI.Xaml.Controls.NavigationView))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(Microsoft.UI.Xaml.Controls.NavigationViewItem))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(Microsoft.UI.Xaml.Controls.Frame))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(Microsoft.UI.Xaml.Controls.Page))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(Microsoft.UI.Xaml.Controls.ContentControl))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(Microsoft.UI.Xaml.Controls.ListView))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(Microsoft.UI.Xaml.Controls.ListViewItem))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(Microsoft.UI.Xaml.Controls.Grid))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(Microsoft.UI.Xaml.Controls.StackPanel))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(Microsoft.UI.Xaml.Controls.Border))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(Microsoft.UI.Xaml.Controls.TextBlock))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(Microsoft.UI.Xaml.Controls.TextBox))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(Microsoft.UI.Xaml.Controls.Button))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(Microsoft.UI.Xaml.Controls.ComboBox))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(Microsoft.UI.Xaml.Controls.CheckBox))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(Microsoft.UI.Xaml.Controls.ToggleSwitch))]
+    public static void PreserveTypes()
+    {
+        // This method exists only to hold DynamicDependency attributes.
+        // Called from App constructor to ensure types aren't trimmed during AOT compilation.
+    }
+}

--- a/src/settings-ui/Settings.UI/ILLink.Descriptors.xml
+++ b/src/settings-ui/Settings.UI/ILLink.Descriptors.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<linker>
+  <!-- Preserve all of StreamJsonRpc -->
+  <assembly fullname="StreamJsonRpc" preserve="all" />
+
+  <!-- Preserve all of Newtonsoft.Json -->
+  <assembly fullname="Newtonsoft.Json" preserve="all" />
+
+  <!-- Preserve all of Nerdbank.Streams -->
+  <assembly fullname="Nerdbank.Streams" preserve="all" />
+
+  <!-- Preserve Microsoft.VisualStudio assemblies -->
+  <assembly fullname="Microsoft.VisualStudio.Threading" preserve="all" />
+  <assembly fullname="Microsoft.VisualStudio.Validation" preserve="all" />
+
+  <!-- Preserve PowerToys assemblies -->
+  <assembly fullname="PowerToys.Settings.UI.Lib" preserve="all" />
+  <assembly fullname="PowerToys.ManagedCommon" preserve="all" />
+  <assembly fullname="PowerToys.Common.UI" preserve="all" />
+  <assembly fullname="PowerToys.ManagedTelemetry" preserve="all" />
+  <assembly fullname="Common.Search" preserve="all" />
+  <assembly fullname="LanguageModelProvider" preserve="all" />
+  <assembly fullname="PowerToys.AllExperiments" preserve="all" />
+</linker>

--- a/src/settings-ui/Settings.UI/PowerToys.Settings.csproj
+++ b/src/settings-ui/Settings.UI/PowerToys.Settings.csproj
@@ -2,6 +2,7 @@
 	<!-- Look at Directory.Build.props in root for common stuff as well -->
 	<Import Project="..\..\Common.Dotnet.CsWinRT.props" />
 	<Import Project="..\..\Common.SelfContained.props" />
+	<Import Project="..\..\Common.Dotnet.AotCompatibility.props" />
 
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
@@ -31,6 +32,18 @@
 		<IlcOptimizationPreference>Speed</IlcOptimizationPreference>
 		<DebugType>none</DebugType>
 		<DebugSymbols>false</DebugSymbols>
+	</PropertyGroup>
+
+	<!-- For debugging purposes, uncomment this block to enable AOT builds -->
+	<PropertyGroup>
+		<EnableSettingsAOT>true</EnableSettingsAOT>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(EnableSettingsAOT)' == 'true'">
+		<SelfContained>true</SelfContained>
+		<PublishSingleFile>false</PublishSingleFile>
+		<DisableRuntimeMarshalling>false</DisableRuntimeMarshalling>
+		<PublishAot>true</PublishAot>
 	</PropertyGroup>
 	<ItemGroup>
 		<None Remove="Assets\Settings\Icons\Models\Azure.svg" />
@@ -98,12 +111,12 @@
 		<PackageReference Include="System.Private.Uri" />
 		<PackageReference Include="System.Text.RegularExpressions" />
 		<PackageReference Include="WinUIEx" />
-		<!-- Including MessagePack to force version, since it's used by StreamJsonRpc but contains vulnerabilities. After StreamJsonRpc updates the version of MessagePack, we can upgrade StreamJsonRpc instead. -->
-		<PackageReference Include="MessagePack" />
+		<!-- StreamJsonRpc and MessagePack are excluded in AOT builds due to reflection dependencies -->
+		<PackageReference Include="MessagePack" Condition="'$(EnableSettingsAOT)' != 'true'" />
+		<PackageReference Include="StreamJsonRpc" Condition="'$(EnableSettingsAOT)' != 'true'" />
 		<PackageReference Include="Microsoft.WindowsAppSDK" />
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" />
 		<PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" />
-		<PackageReference Include="StreamJsonRpc" />
 		<!-- HACK: Microsoft.Extensions.Hosting is referenced, even if it is not used, to force dll versions to be the same as in other projects. Really only needed since the Experimentation APIs that are added in CI reference some net standard 2.0 assemblies. -->
 		<PackageReference Include="Microsoft.Extensions.Hosting" />
 		<!-- HACK: To make sure the version pulled in by Microsoft.Extensions.Hosting is current. -->
@@ -147,10 +160,9 @@
 
 	<!-- No RID/Platform plumbing needed here. XamlIndexBuilder handles generation after its own Build. -->
 
-	<PropertyGroup>
-		<!-- TODO: fix issues and reenable -->
+	<PropertyGroup Condition="'$(EnableSettingsAOT)' != 'true'">
 		<!-- These are caused by streamjsonrpc dependency on Microsoft.VisualStudio.Threading.Analyzers -->
-		<!-- We might want to add that to the project and fix the issues as well -->
+		<!-- Only relevant when StreamJsonRpc is included (non-AOT builds) -->
 		<NoWarn>VSTHRD002;VSTHRD110;VSTHRD100;VSTHRD200;VSTHRD101</NoWarn>
 	</PropertyGroup>
 
@@ -231,4 +243,9 @@
 		<Message Importance="high" Text="[Settings] Building XamlIndexBuilder prior to compile. Views='$(MSBuildProjectDirectory)\SettingsXAML\Views' Out='$(GeneratedJsonFile)'" />
 		<MSBuild Projects="..\Settings.UI.XamlIndexBuilder\Settings.UI.XamlIndexBuilder.csproj" Targets="Build" Properties="Configuration=$(Configuration);Platform=Any CPU;TargetFramework=net9.0;XamlViewsDir=$(MSBuildProjectDirectory)\SettingsXAML\Views;GeneratedJsonFile=$(GeneratedJsonFile)" />
 	</Target>
+
+	<!-- Build information defines -->
+	<PropertyGroup Condition="'$(PublishAot)' == 'true'">
+		<DefineConstants>$(DefineConstants);BUILD_INFO_PUBLISH_AOT</DefineConstants>
+	</PropertyGroup>
 </Project>

--- a/src/settings-ui/Settings.UI/PowerToys.Settings.csproj
+++ b/src/settings-ui/Settings.UI/PowerToys.Settings.csproj
@@ -44,6 +44,7 @@
 		<PublishSingleFile>false</PublishSingleFile>
 		<DisableRuntimeMarshalling>false</DisableRuntimeMarshalling>
 		<PublishAot>true</PublishAot>
+		<DefineConstants>$(DefineConstants);BUILD_INFO_PUBLISH_AOT;STANDALONE</DefineConstants>
 	</PropertyGroup>
 	<ItemGroup>
 		<None Remove="Assets\Settings\Icons\Models\Azure.svg" />
@@ -114,6 +115,7 @@
 		<!-- StreamJsonRpc and MessagePack are excluded in AOT builds due to reflection dependencies -->
 		<PackageReference Include="MessagePack" Condition="'$(EnableSettingsAOT)' != 'true'" />
 		<PackageReference Include="StreamJsonRpc" Condition="'$(EnableSettingsAOT)' != 'true'" />
+		<!-- Microsoft.DotNet.ILCompiler is implicitly referenced when PublishAot=true, version defined in Directory.Packages.props -->
 		<PackageReference Include="Microsoft.WindowsAppSDK" />
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" />
 		<PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" />
@@ -135,6 +137,26 @@
 
 	<ItemGroup Condition="'$(DisableMsixProjectCapabilityAddedByProject)'!='true' and '$(EnablePreviewMsixTooling)'=='true'">
 		<ProjectCapability Include="Msix" />
+	</ItemGroup>
+
+	<!-- Protect assemblies from being trimmed when PublishTrimmed=true -->
+	<PropertyGroup>
+		<TrimMode>partial</TrimMode>
+		<ILLinkTreatWarningsAsErrors>false</ILLinkTreatWarningsAsErrors>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<TrimmerRootDescriptor Include="ILLink.Descriptors.xml" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<TrimmerRootAssembly Include="StreamJsonRpc" />
+		<TrimmerRootAssembly Include="Newtonsoft.Json" />
+		<TrimmerRootAssembly Include="Nerdbank.Streams" />
+		<TrimmerRootAssembly Include="Microsoft.VisualStudio.Threading" />
+		<TrimmerRootAssembly Include="Microsoft.VisualStudio.Validation" />
+		<TrimmerRootAssembly Include="PowerToys.Settings.UI.Lib" />
+		<TrimmerRootAssembly Include="PowerToys.ManagedCommon" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/settings-ui/Settings.UI/PowerToys.Settings.csproj
+++ b/src/settings-ui/Settings.UI/PowerToys.Settings.csproj
@@ -18,6 +18,19 @@
 		<OutputPath>..\..\..\$(Platform)\$(Configuration)\WinUI3Apps</OutputPath>
 		<!-- MRT from windows app sdk will search for a pri file with the same name of the module before defaulting to resources.pri -->
 		<ProjectPriFileName>PowerToys.Settings.pri</ProjectPriFileName>
+
+		<!-- .NET Performance Optimizations -->
+		<TieredCompilation>true</TieredCompilation>
+		<TieredCompilationQuickJit>true</TieredCompilationQuickJit>
+		<PublishReadyToRun>true</PublishReadyToRun>
+		<ReadyToRunUseCrossgen2>true</ReadyToRunUseCrossgen2>
+	</PropertyGroup>
+
+	<!-- Additional optimizations for Release builds -->
+	<PropertyGroup Condition="'$(Configuration)' == 'Release'">
+		<IlcOptimizationPreference>Speed</IlcOptimizationPreference>
+		<DebugType>none</DebugType>
+		<DebugSymbols>false</DebugSymbols>
 	</PropertyGroup>
 	<ItemGroup>
 		<None Remove="Assets\Settings\Icons\Models\Azure.svg" />

--- a/src/settings-ui/Settings.UI/Properties/PublishProfiles/InstallationPublishProfile.pubxml
+++ b/src/settings-ui/Settings.UI/Properties/PublishProfiles/InstallationPublishProfile.pubxml
@@ -1,18 +1,23 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
 https://go.microsoft.com/fwlink/?LinkID=208121.
 -->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>net9.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net9.0-windows10.0.26100.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
     <SupportedOSPlatformVersion>10.0.19041.0</SupportedOSPlatformVersion>
-    <PublishDir>$(PowerToysRoot)\$(Platform)\$(Configuration)\WinUI3Apps</PublishDir>
-    <RuntimeIdentifier>win-$(Platform)</RuntimeIdentifier>
+    <PublishDir>C:\Users\shuaiyuan\source\repos\PowerToys\x64\Release\WinUI3Apps\Publish</PublishDir>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
-    <PublishSingleFile>False</PublishSingleFile>
-    <PublishReadyToRun>False</PublishReadyToRun>
+    <UseAppHost>true</UseAppHost>
+    <PublishAot>true</PublishAot>
+    <PublishSingleFile>false</PublishSingleFile>
+    <PublishReadyToRun>false</PublishReadyToRun>
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+    <Configuration>Release</Configuration>
+    <Platform>x64</Platform>
+    <PublishTrimmed>true</PublishTrimmed>
   </PropertyGroup>
 </Project>

--- a/src/settings-ui/Settings.UI/SettingsXAML/App.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/App.xaml.cs
@@ -321,8 +321,8 @@ namespace Microsoft.PowerToys.Settings.UI
             }
             else
             {
-#if DEBUG
-                // For debugging purposes
+#if DEBUG || STANDALONE
+                // For debugging purposes or standalone mode
                 // Window is also needed to show MessageDialog
                 settingsWindow = new MainWindow();
                 settingsWindow.ExtendsContentIntoTitleBar = true;
@@ -330,10 +330,10 @@ namespace Microsoft.PowerToys.Settings.UI
                 settingsWindow.Activate();
                 settingsWindow.NavigateToSection(StartupPage);
 
-                // In DEBUG mode, we might not have IPC set up, so provide a dummy implementation
+                // In DEBUG/STANDALONE mode, we might not have IPC set up, so provide a dummy implementation
                 GlobalHotkeyConflictManager.Initialize(message =>
                 {
-                    // In debug mode, just log or do nothing
+                    // In standalone mode, just log or do nothing
                     System.Diagnostics.Debug.WriteLine($"IPC Message: {message}");
                     return 0;
                 });

--- a/src/settings-ui/Settings.UI/SettingsXAML/App.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/App.xaml.cs
@@ -79,6 +79,9 @@ namespace Microsoft.PowerToys.Settings.UI
         /// </summary>
         public App()
         {
+#if BUILD_INFO_PUBLISH_AOT
+            Helpers.TypePreservation.PreserveTypes();
+#endif
             Logger.InitializeLogger(@"\Settings\Logs");
 
             string appLanguage = LanguageHelper.LoadLanguage();

--- a/src/settings-ui/Settings.UI/ViewModels/LightSwitchViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/LightSwitchViewModel.cs
@@ -16,7 +16,6 @@ using Microsoft.PowerToys.Settings.UI.Library;
 using Microsoft.PowerToys.Settings.UI.Library.Helpers;
 using Microsoft.PowerToys.Settings.UI.Library.Interfaces;
 using Microsoft.PowerToys.Settings.UI.SerializationContext;
-using Newtonsoft.Json.Linq;
 using PowerToys.GPOWrapper;
 using Settings.UI.Library;
 using Settings.UI.Library.Helpers;

--- a/src/settings-ui/Settings.UI/ViewModels/MouseWithoutBordersViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/MouseWithoutBordersViewModel.cs
@@ -26,6 +26,7 @@ using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml.Media;
 #if !BUILD_INFO_PUBLISH_AOT
 using StreamJsonRpc;
+using Newtonsoft.Json;
 #endif
 using Windows.ApplicationModel.DataTransfer;
 


### PR DESCRIPTION
This pull request introduces significant improvements to AOT (Ahead-Of-Time) compatibility, especially for the MouseWithoutBorders module and the Settings UI. The main changes include replacing StreamJsonRpc-based IPC with a new AOT-friendly named pipe protocol, updating type annotations for trimming safety, and ensuring shared models for cross-process communication. There are also updates to build scripts and project files to support these changes.

**AOT Compatibility and IPC Overhaul:**

- Introduced a new AOT-compatible IPC server for MouseWithoutBorders, replacing StreamJsonRpc with a custom named pipe protocol. This includes the new `MouseWithoutBordersIpcServer` class, a corresponding handler interface, and a serializable `MachineSocketState` struct for communication. (`src/modules/MouseWithoutBorders/App/Class/MouseWithoutBordersIpcServer.cs`, `src/modules/MouseWithoutBorders/App/Class/Program.cs`) [[1]](diffhunk://#diff-4e74c4b487cc22a45e7ef7f1e5dce2bfc7969ab482d7ae239da0737e9f35b541R1-R170) [[2]](diffhunk://#diff-692f607b3d86d1012b691360bf5355a41a3e203efa730478059968a1a8ec03e0L279-R280) [[3]](diffhunk://#diff-692f607b3d86d1012b691360bf5355a41a3e203efa730478059968a1a8ec03e0R303-R324) [[4]](diffhunk://#diff-692f607b3d86d1012b691360bf5355a41a3e203efa730478059968a1a8ec03e0R405-R462)
- Updated the `SocketStatus` enum to be public for serialization, ensuring it matches between the service and the Settings UI. (`src/modules/MouseWithoutBorders/App/Class/SocketStuff.cs`)
- Added a shared model for `SocketStatus` and `MachineSocketState` in the Settings UI library for consistent IPC communication. (`src/settings-ui/Settings.UI.Library/MouseWithoutBordersIpcModels.cs`)

**AOT/Trimming Safety Improvements:**

- Annotated generic and reflection-heavy APIs with `[DynamicallyAccessedMembers]` to ensure correct behavior under trimming/AOT. This includes updates to `GenericProperty<T>` and methods in `ICmdLineRepresentable`. (`src/settings-ui/Settings.UI.Library/GenericProperty`1.cs`, `src/settings-ui/Settings.UI.Library/Interfaces/ICmdLineRepresentable.cs`) [[1]](diffhunk://#diff-3c6d2ffe0de080195605fd68508e3c1d31b78432de25654575cdf3f86ca2a3b1R5-R11) [[2]](diffhunk://#diff-0f82b8b7355cec0eff65475954413310dcbc8e1212d6da2aa966fe4b0cb5dd15L20-R21) [[3]](diffhunk://#diff-0f82b8b7355cec0eff65475954413310dcbc8e1212d6da2aa966fe4b0cb5dd15L39-R40) [[4]](diffhunk://#diff-0f82b8b7355cec0eff65475954413310dcbc8e1212d6da2aa966fe4b0cb5dd15L58-R59) [[5]](diffhunk://#diff-0f82b8b7355cec0eff65475954413310dcbc8e1212d6da2aa966fe4b0cb5dd15L101-R102)
- Expanded the list of warnings suppressed for AOT compatibility in the shared props file. (`src/Common.Dotnet.AotCompatibility.props`)

**Build and Project File Updates:**

- Added AOT compatibility imports and conditional AOT publish settings to Settings UI and QuickAccess UI project files. (`src/settings-ui/Settings.UI.Library/Settings.UI.Library.csproj`, `src/settings-ui/QuickAccess.UI/PowerToys.QuickAccess.csproj`) [[1]](diffhunk://#diff-e9e9424b3ee3d287b7e790cf4fb08c29e391deef7e847ce57fd7e226a124b02eR5) [[2]](diffhunk://#diff-9f4e0c85f54287a3864ad4734116a7deec2ee921d3cf3dee72de891badf1fcafR4-R8)
- Introduced a new PowerShell script to publish Settings UI dependencies with the correct runtime identifier for AOT scenarios. (`publish-settings-dependencies.ps1`)

**Infrastructure and Solution Tweaks:**

- Updated the solution file to exclude `Microsoft.CmdPal.Ext.Shell` from Release|x64 builds, possibly for AOT build streamlining. (`PowerToys.slnx`)

**Minor Internal Refactors:**

- Added missing using directives and minor namespace adjustments to support the above changes. (`src/modules/MouseWithoutBorders/App/Core/Common.cs`, `src/modules/MouseWithoutBorders/App/Class/Program.cs`, `src/settings-ui/Settings.UI.Library/Interfaces/ICmdLineRepresentable.cs`) [[1]](diffhunk://#diff-a0f264da4411acbb5598f349fb162db12a571f839b57307b4f7fac38eab10459R27) [[2]](diffhunk://#diff-692f607b3d86d1012b691360bf5355a41a3e203efa730478059968a1a8ec03e0R22) [[3]](diffhunk://#diff-0f82b8b7355cec0eff65475954413310dcbc8e1212d6da2aa966fe4b0cb5dd15R6)

