### PR TITLE
Fix auto-label-issues workflow

### DIFF
--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -29,6 +29,11 @@ jobs:
     steps:
       - name: Apply area labels with AI
         uses: actions/github-script@v7
+        env:
+          # actions/github-script does not propagate `github-token` to
+          # process.env. Expose it explicitly so the inline script can
+          # authenticate against the GitHub Models inference endpoint.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
## Summary

Fixes the `Auto-label Issues by Area` workflow, which currently logs `GITHUB_TOKEN is not set; skipping.` on every run and never applies labels.

Failing run on issue #47818: https://github.com/microsoft/PowerToys/actions/runs/25722067064/job/75525452318

## Root cause

`actions/github-script@v7` consumes its `github-token` input only to authenticate the injected `github` Octokit object. It does **not** export that value to `process.env.GITHUB_TOKEN`. The inline script reads `process.env.GITHUB_TOKEN` to authorize a direct `fetch()` against `https://models.inference.ai.azure.com/chat/completions`, so the token check at the top of `labelIssue()` always fails and the function returns early before calling the model.

## Fix

Add a step-level `env:` block exposing `GITHUB_TOKEN` to the Node process running the inline script. The existing `with.github-token` input is preserved so the injected `github` Octokit continues to authenticate.

`yaml
- name: Apply area labels with AI
  uses: actions/github-script@v7
  env:
    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
  with:
    github-token: ${{ secrets.GITHUB_TOKEN }}
`

5 lines added, 0 removed.

## Security

- `secrets.GITHUB_TOKEN` is the workflow's built-in ephemeral token (auto-issued per run, auto-revoked at job end). Not a PAT.
- Scope is already constrained by `permissions: models: read, issues: write` at the top of the workflow. No widening.
- Exposure is unchanged: the token is already loaded into the same Node process by `actions/github-script` via `github-token:`. The `env:` mapping just lets the script body read what the action already has in the same process.
- The token is sent only to GitHub's own GitHub Models inference endpoint, which is the documented use of `models: read`.
- Triggers are safe: `issues: opened/reopened` (issue body is JSON-encoded into the request body, never interpolated into a shell) and `workflow_dispatch` (write-access required).
- Token is never logged.

## Validation

After merge, re-run the workflow on issue #47818 via Actions -> "Auto-label Issues by Area" -> Run workflow, and confirm logs show `Model response: ...` instead of `GITHUB_TOKEN is not set; skipping.`
