### PR TITLE
Document NU1503 NuGet restore warnings on dotnet restore

### DIFF
--- a/tools/build/BUILD-GUIDELINES.md
+++ b/tools/build/BUILD-GUIDELINES.md
@@ -46,3 +46,20 @@ Tip: Add `D:\PowerToys\tools\build` to your PATH to use the wrappers anywhere.
 ## Notes
 - Override platform explicitly with `-Platform x64|arm64` if needed.
 - CMD wrappers: `build.cmd`, `build-essentials.cmd` forward all arguments to the PowerShell scripts.
+
+## NuGet restore caveats
+
+PowerToys is a mixed C#/C++ solution with ~120 `.vcxproj` projects. Always restore via `msbuild /t:restore` (which is what `tools\build\build-essentials.cmd` does internally) rather than `dotnet restore`.
+
+Running `dotnet restore PowerToys.slnx` directly will produce ~112 `NU1503` warnings:
+
+```
+warning NU1503: Skipping restore for project '...vcxproj'. The project file may be invalid or missing targets required for restore.
+```
+
+These warnings are **informational and benign**. They occur because `dotnet restore` does not understand the native C++ project system used by `.vcxproj` files that do not consume `PackageReference` items. The `Microsoft.Cpp` MSBuild SDK invoked by `msbuild /t:restore` handles these projects correctly and emits no warnings.
+
+If you want a warning-free restore for the full solution, use either:
+
+- `tools\build\build-essentials.cmd` (recommended), or
+- `msbuild PowerToys.slnx /t:restore /p:RestorePackagesConfig=true` from a Developer PowerShell.


### PR DESCRIPTION
## Summary

Investigates the ~112 warnings emitted during `dotnet restore` on the PowerToys solution and documents the canonical no-warning restore path. No code/build behavior changes - documentation only.

## Investigation

Running `dotnet restore PowerToys.slnx` produces 112 `NU1503` warnings of the form:

`warning NU1503: Skipping restore for project '...vcxproj'. The project file may be invalid or missing targets required for restore.`

Verified that:

- All 112 warnings are `NU1503` and all reference `.vcxproj` files.
- They originate from native C++ projects that do **not** consume `PackageReference` items - the `dotnet restore` engine does not know how to restore them.
- Running `msbuild /t:restore PowerToys.slnx` (which is what `tools/build/build-essentials.cmd` does internally) emits **0** NU1503 warnings. The `Microsoft.Cpp` SDK handles vcxproj restore correctly.
- Suppression via per-project `<NoWarn>NU1503</NoWarn>` in `Directory.Build.props` does **not** work because NU1503 is emitted at the solution-level NuGet restore engine before per-project targets are evaluated. Tested - no reduction in warning count.
- Adding an empty `<Target Name=""Restore"" />` in `Directory.Build.targets` also does not help for the same reason.

## Conclusion

The warnings only appear to developers who run `dotnet restore` directly. PowerToys CI and the canonical build scripts already use `msbuild` and produce a clean restore. The pragmatic and correct fix is documentation that guides contributors to the supported restore path.

## Change

Adds a "NuGet restore caveats" section to `tools/build/BUILD-GUIDELINES.md` explaining:

- The NU1503 warnings are informational and benign.
- Why they appear with `dotnet restore` but not with `msbuild /t:restore`.
- The two warning-free restore commands (`build-essentials.cmd` or direct `msbuild /t:restore`).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
