### PR TITLE
Fix uitest pipeline install dotnet10 sdk

### DIFF
--- a/.pipelines/v2/templates/job-build-ui-tests.yml
+++ b/.pipelines/v2/templates/job-build-ui-tests.yml
@@ -64,7 +64,7 @@ jobs:
   - template: steps-ensure-dotnet-version.yml
     parameters:
       sdk: true
-      version: '9.0'
+      version: '10.0'
 
   - template: .\steps-restore-nuget.yml
 

--- a/.pipelines/v2/templates/pipeline-ui-tests-official-build.yml
+++ b/.pipelines/v2/templates/pipeline-ui-tests-official-build.yml
@@ -27,6 +27,7 @@ stages:
               name: SHINE-INT-L
             ${{ else }}:
               name: SHINE-OSS-L
+            demands: ImageOverride -equals SHINE-VS18-Latest
           buildPlatforms:
             - ${{ parameters.platform }}
           uiTestModules: ${{ parameters.uiTestModules }}


### PR DESCRIPTION
## Problem

The scheduled UI Test Automation pipeline ([Dart/161438](https://microsoft.visualstudio.com/Dart/_build?definitionId=161438)) has been failing daily since 2026-04-30 because PR #41280 (`.NET 10 Upgrade`) updated the main build template (`job-build-project.yml`) for .NET 10 / VS 2026 but the parallel changes were missed in the UI Test Automation templates.

Symptoms in recent runs (e.g. build [#20260512.1](https://microsoft.visualstudio.com/Dart/_build/results?buildId=146803928)):

```
error NETSDK1045: The current .NET SDK does not support targeting .NET 10.0.
   Either target .NET 9.0 or lower, or use a version of the .NET SDK that supports .NET 10.0.
```

…emitted ×179 across every csproj during the *Restore solution-level NuGet packages* step on both `Build UI Tests Only Release_x64` and `…_arm64` jobs.

## Changes

This PR mirrors the two pipeline changes that PR #41280 already applied to the main CI templates.

**1. Install the .NET 10 SDK on the build agent**
- File: `.pipelines/v2/templates/job-build-ui-tests.yml`
- Bump the pinned `steps-ensure-dotnet-version.yml` parameter from `version: '9.0'` → `'10.0'`.
- Matches `job-build-project.yml`, which already installs the .NET 10 SDK alongside 6.0/8.0.

**2. Pin the build agent image to VS 2026 (MSBuild 18)**
- File: `.pipelines/v2/templates/pipeline-ui-tests-official-build.yml`
- Add `demands: ImageOverride -equals SHINE-VS18-Latest` to the agent pool spec.
- The .NET 10 SDK (≥ 10.0.300) requires MSBuild 18, which only ships with VS 2026. Without this demand, the SHINE pool selects a default image with VS 2022 / MSBuild 17 and restore fails with `MSB4236: The SDK 'Microsoft.NET.Sdk' specified could not be found`.
- Mirrors the unconditional pattern in `pipeline-ci-build.yml` (lines 56–67), which applies the same demand across both `SHINE-INT-L` and `SHINE-OSS-L` pools.

## Validation

Queued pipeline 161438 against this branch:

| Build | Commit | Result |
| --- | --- | --- |
| [`146821554`](https://microsoft.visualstudio.com/Dart/_build/results?buildId=146821554) | `4dd13b9` (SDK fix only) | `NETSDK1045` gone ✅ — exposed VS 2022 / MSBuild 17 mismatch |
| [`146825355`](https://microsoft.visualstudio.com/Dart/_build/results?buildId=146825355) | `97cadbb` (SDK + agent demand) | Both errors gone ✅ — agent now `Visual Studio\18\Enterprise\` |

After this PR, the pipeline reaches NuGet restore and now hits a separate, **pre-existing** issue from the April 13–29 failure window: `401 Unauthorized` on the `shine-oss/PowerToysPublicDependencies` Artifacts feed for newly-released `Microsoft.NETCore.App.*/8.0.27` packages. That requires feed-admin action (granting the Dart pipeline build identity "save from upstream" on the feed, or pre-seeding those package versions) and is **out of scope for this PR**.
