### PR TITLE
[CmdPal][PerfMon] Use `% Processor Time` for system CPU dock

### DIFF
--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/DevHome/Helpers/CPUStats.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/DevHome/Helpers/CPUStats.cs
@@ -46,7 +46,11 @@ internal sealed partial class CPUStats : PerformanceCounterSourceBase, IDisposab
             new ProcessStats()
         ];
 
-        _procPerf = CreatePerformanceCounter("Processor Information", "% Processor Utility", "_Total");
+        // Use "% Processor Time" instead of "% Processor Utility": the latter is unbounded above 100%
+        // when cores boost above their nominal base frequency (it is scaled by % Processor Performance),
+        // which produced values like 144% in the dock under heavy load. % Processor Time is the same
+        // counter Task Manager renders and is naturally bounded to 0-100%. See issue #46381.
+        _procPerf = CreatePerformanceCounter("Processor Information", "% Processor Time", "_Total");
         _procPerformance = CreatePerformanceCounter("Processor Information", "% Processor Performance", "_Total");
         _procFrequency = CreatePerformanceCounter("Processor Information", "Processor Frequency", "_Total");
     }


### PR DESCRIPTION
## Summary of the Pull Request

The system-wide CPU counter in the Command Palette Performance monitor used `% Processor Utility`, which is scaled by `% Processor Performance` and is intentionally unbounded above 100% when cores boost above their nominal base frequency. Under load this produced values like 144% in the dock, as reported in #46381.

Switch to `% Processor Time` — the same counter Task Manager renders — which is naturally bounded to 0-100%.

The per-process branch is unaffected; it already divides by `Environment.ProcessorCount` and continues to use `% Processor Time`, so individual process readings remain correct.

Closes: #46381

## PR Checklist

- [x] **Closes:** #46381
- [x] **Communication:** I've discussed this with the team/maintainers via the linked issue.
- [x] **Tests:** Manually tested locally. Built `Microsoft.CmdPal.Ext.PerformanceMonitor` and the full `CommandPalette.slnf` (Debug|x64). Verified the built DLL contains `% Processor Time` and no longer contains `% Processor Utility`.
- [x] **Manual tests:** Ran the rebuilt dev build under sustained CPU load; the system CPU figure now stays bounded to 100%.
- [x] **Localization:** Not applicable — counter name is an OS API string, not user-visible text.

## Detailed Description of the Pull Request / Additional comments

`% Processor Utility` is documented by Microsoft as deliberately unbounded; it represents an "effective" utilization that accounts for turbo/boost frequencies. It is well-suited for billing/capacity contexts but not for a "% of CPU used" UI element where users expect a 0-100% reading consistent with Task Manager and Resource Monitor.

`_procPerformance` (the `% Processor Performance` counter) is retained because it is still used by `CpuSpeed` to compute the live frequency display, so removing it would regress the speed readout.

### Before
System CPU dock showed values >100% under load (reported 144% in the issue).

### After
System CPU dock is bounded to 0-100%, matching Task Manager.