### PR TITLE
[CmdPal][PerfMon] Add battery widget (charge, status, time remaining)

### DIFF
--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/DevHome/Helpers/BatteryStats.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/DevHome/Helpers/BatteryStats.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Windows.Win32;
+using Windows.Win32.System.Power;
+
+namespace CoreWidgetProvider.Helpers;
+
+internal sealed partial class BatteryStats
+{
+    // GetSystemPowerStatus returns 255 (0xFF) for percent / time when unknown.
+    private const byte BatteryPercentUnknown = 255;
+    private const uint BatteryLifeTimeUnknown = 0xFFFFFFFF;
+
+    // BatteryFlag bits.
+    private const byte BatteryFlagCharging = 0x08;
+    private const byte BatteryFlagNoBattery = 0x80;
+    private const byte BatteryFlagUnknown = 0xFF;
+
+    public bool HasBattery { get; set; }
+
+    public bool IsCharging { get; set; }
+
+    public bool IsOnAcPower { get; set; }
+
+    /// <summary>
+    /// Charge level in [0, 1], or -1 when unknown.
+    /// </summary>
+    public float ChargePercent { get; set; } = -1f;
+
+    /// <summary>
+    /// Estimated seconds of battery life remaining, or -1 when unknown / charging / on AC.
+    /// </summary>
+    public int SecondsRemaining { get; set; } = -1;
+
+    public void GetData()
+    {
+        if (!PInvoke.GetSystemPowerStatus(out SYSTEM_POWER_STATUS status))
+        {
+            HasBattery = false;
+            IsCharging = false;
+            IsOnAcPower = false;
+            ChargePercent = -1f;
+            SecondsRemaining = -1;
+            return;
+        }
+
+        HasBattery = status.BatteryFlag != BatteryFlagUnknown && (status.BatteryFlag & BatteryFlagNoBattery) == 0;
+        IsCharging = HasBattery && (status.BatteryFlag & BatteryFlagCharging) != 0;
+        IsOnAcPower = status.ACLineStatus == 1;
+
+        ChargePercent = status.BatteryLifePercent != BatteryPercentUnknown
+            ? status.BatteryLifePercent / 100f
+            : -1f;
+
+        SecondsRemaining = status.BatteryLifeTime != BatteryLifeTimeUnknown
+            ? (int)status.BatteryLifeTime
+            : -1;
+    }
+}

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/DevHome/Helpers/DataManager.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/DevHome/Helpers/DataManager.cs
@@ -61,6 +61,14 @@ internal sealed partial class DataManager : IDisposable
         }
     }
 
+    private void GetBatteryData()
+    {
+        lock (_systemData.BatteryStats)
+        {
+            _systemData.BatteryStats.GetData();
+        }
+    }
+
     private void UpdateTimer_Elapsed(object? sender, System.Timers.ElapsedEventArgs e)
     {
         var firstUpdateBlockSuffix = GetFirstUpdateBlockSuffix();
@@ -98,6 +106,12 @@ internal sealed partial class DataManager : IDisposable
                         GetNetworkData();
                         break;
                     }
+
+                case DataType.Battery:
+                    {
+                        GetBatteryData();
+                        break;
+                    }
             }
 
             if (isTracked)
@@ -132,6 +146,7 @@ internal sealed partial class DataManager : IDisposable
             DataType.GPU => "GPU.FirstUpdate",
             DataType.Memory => "Memory.FirstUpdate",
             DataType.Network => "Network.FirstUpdate",
+            DataType.Battery => "Battery.FirstUpdate",
             _ => null,
         };
     }
@@ -165,6 +180,14 @@ internal sealed partial class DataManager : IDisposable
         lock (_systemData.CpuStats)
         {
             return _systemData.CpuStats;
+        }
+    }
+
+    internal BatteryStats GetBatteryStats()
+    {
+        lock (_systemData.BatteryStats)
+        {
+            return _systemData.BatteryStats;
         }
     }
 

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/DevHome/Helpers/DataType.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/DevHome/Helpers/DataType.cs
@@ -32,4 +32,9 @@ public enum DataType
     /// Network related data.
     /// </summary>
     Network,
+
+    /// <summary>
+    /// Battery related data.
+    /// </summary>
+    Battery,
 }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/DevHome/Helpers/SystemData.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/DevHome/Helpers/SystemData.cs
@@ -15,6 +15,7 @@ internal sealed partial class SystemData
     private readonly Lazy<NetworkStats> _networkStats = new(() => CreateGuarded("Network.Initialize", static () => new NetworkStats()));
     private readonly Lazy<GPUStats> _gpuStats = new(() => CreateGuarded("GPU.Initialize", static () => new GPUStats()));
     private readonly Lazy<CPUStats> _cpuStats = new(() => CreateGuarded("CPU.Initialize", static () => new CPUStats()));
+    private readonly Lazy<BatteryStats> _batteryStats = new(() => CreateGuarded("Battery.Initialize", static () => new BatteryStats()));
 
     public MemoryStats MemoryStats => _memoryStats.Value;
 
@@ -23,6 +24,8 @@ internal sealed partial class SystemData
     public GPUStats GPUStats => _gpuStats.Value;
 
     public CPUStats CpuStats => _cpuStats.Value;
+
+    public BatteryStats BatteryStats => _batteryStats.Value;
 
     private SystemData()
     {

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/DevHome/Templates/SystemBatteryTemplate.json
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/DevHome/Templates/SystemBatteryTemplate.json
@@ -1,0 +1,90 @@
+{
+  "type": "AdaptiveCard",
+  "body": [
+    {
+      "type": "Container",
+      "$when": "${errorMessage != null}",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "${errorMessage}",
+          "wrap": true,
+          "size": "small"
+        }
+      ],
+      "style": "warning"
+    },
+    {
+      "type": "Container",
+      "$when": "${errorMessage == null}",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "columns": [
+            {
+              "type": "Column",
+              "items": [
+                {
+                  "text": "%Battery_Widget_Template/Charge%",
+                  "type": "TextBlock",
+                  "size": "small",
+                  "isSubtle": true
+                },
+                {
+                  "text": "${batteryCharge}",
+                  "type": "TextBlock",
+                  "size": "${if($host.widgetSize == \"small\", \"medium\", \"extraLarge\")}",
+                  "weight": "bolder"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "items": [
+                {
+                  "text": "%Battery_Widget_Template/Status%",
+                  "type": "TextBlock",
+                  "size": "small",
+                  "isSubtle": true,
+                  "horizontalAlignment": "right"
+                },
+                {
+                  "text": "${batteryStatus}",
+                  "type": "TextBlock",
+                  "size": "${if($host.widgetSize == \"small\", \"medium\", \"large\")}",
+                  "weight": "bolder",
+                  "horizontalAlignment": "right"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "ColumnSet",
+          "$when": "${$host.widgetSize != \"small\"}",
+          "columns": [
+            {
+              "type": "Column",
+              "items": [
+                {
+                  "text": "%Battery_Widget_Template/TimeRemaining%",
+                  "type": "TextBlock",
+                  "size": "small",
+                  "isSubtle": true
+                },
+                {
+                  "text": "${batteryTimeRemaining}",
+                  "type": "TextBlock",
+                  "size": "medium",
+                  "wrap": true
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "version": "1.5"
+}

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/Icons.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/Icons.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 
 namespace Microsoft.CmdPal.Ext.PerformanceMonitor;
@@ -23,6 +24,40 @@ internal static class Icons
     internal static IconInfo StackedAreaIcon => new("\uE9D2"); // StackedArea icon
 
     internal static IconInfo GpuIcon => new("\uE950"); // Component icon
+
+    internal static IconInfo BatteryIcon => BatteryIcons[10]; // MobBattery10 (page identity)
+
+    // Pre-built cache so the 1 Hz dock-band update reuses IconInfo instances
+    // instead of allocating one per tick. 11 discharging (MobBattery0..10), 11
+    // charging (MobBatteryCharging0..10), 1 unknown (MobBatteryUnknown).
+    private static readonly IconInfo[] BatteryIcons = BuildBatteryGlyphs(0xEBA0);
+    private static readonly IconInfo[] BatteryChargingIcons = BuildBatteryGlyphs(0xEBAB);
+    private static readonly IconInfo BatteryUnknownIcon = new("\uEC02");
+
+    private static IconInfo[] BuildBatteryGlyphs(int baseCodepoint)
+    {
+        var icons = new IconInfo[11];
+        for (var i = 0; i <= 10; i++)
+        {
+            icons[i] = new IconInfo(char.ConvertFromUtf32(baseCodepoint + i));
+        }
+
+        return icons;
+    }
+
+    // Returns a MobBattery glyph that reflects the actual charge level so the dock-band icon
+    // is never misread as "100%". Range maps 0-100% to MobBattery0..MobBattery10 (\uEBA0..\uEBAA);
+    // charging swaps to MobBatteryCharging0..10 (\uEBAB..\uEBB5); unknown/no battery uses MobBatteryUnknown.
+    internal static IconInfo BatteryGlyph(double percent01, bool isCharging, bool hasBattery)
+    {
+        if (!hasBattery || percent01 < 0)
+        {
+            return BatteryUnknownIcon;
+        }
+
+        var level = (int)Math.Round(Math.Clamp(percent01, 0, 1) * 10);
+        return isCharging ? BatteryChargingIcons[level] : BatteryIcons[level];
+    }
 
     internal static IconInfo NavigateBackwardIcon => new("\uE72B"); // Previous icon
 

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/Microsoft.CmdPal.Ext.PerformanceMonitor.csproj
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/Microsoft.CmdPal.Ext.PerformanceMonitor.csproj
@@ -53,6 +53,9 @@
     <None Update="DevHome\Templates\SystemNetworkUsageTemplate.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="DevHome\Templates\SystemBatteryTemplate.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Content Update="Assets\**\*.*">

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/NativeMethods.txt
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/NativeMethods.txt
@@ -1,1 +1,2 @@
 GlobalMemoryStatusEx
+GetSystemPowerStatus

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceWidgetsPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceWidgetsPage.cs
@@ -49,6 +49,9 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
     private readonly SystemGPUUsageWidgetPage _gpuPage = new();
     private readonly ListItem _gpuItem;
 
+    private readonly SystemBatteryUsageWidgetPage _batteryPage = new();
+    private readonly ListItem _batteryItem;
+
     // For bands, we want two bands, one for up and one for down
     private ListItem? _networkUpItem;
     private ListItem? _networkDownItem;
@@ -107,6 +110,18 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
             _gpuItem.Title = _gpuPage.GetItemTitle(isBandPage);
         };
 
+        _batteryItem = new ListItem(_batteryPage)
+        {
+            Title = _batteryPage.GetItemTitle(isBandPage),
+            Icon = _batteryPage.CurrentIcon,
+        };
+
+        _batteryPage.Updated += (s, e) =>
+        {
+            _batteryItem.Title = _batteryPage.GetItemTitle(isBandPage);
+            _batteryItem.Icon = _batteryPage.CurrentIcon;
+        };
+
         if (_isBandPage)
         {
             // add subtitles to them all
@@ -114,6 +129,7 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
             _memoryItem.Subtitle = Resources.GetResource("Memory_Usage_Subtitle");
             _networkItem.Subtitle = Resources.GetResource("Network_Usage_Subtitle");
             _gpuItem.Subtitle = Resources.GetResource("GPU_Usage_Subtitle");
+            _batteryItem.Subtitle = Resources.GetResource("Battery_Usage_Subtitle");
         }
     }
 
@@ -123,6 +139,7 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
         _memoryPage.PushActivate();
         _networkPage.PushActivate();
         _gpuPage.PushActivate();
+        _batteryPage.PushActivate();
     }
 
     protected override void Unloaded()
@@ -131,6 +148,7 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
         _memoryPage.PopActivate();
         _networkPage.PopActivate();
         _gpuPage.PopActivate();
+        _batteryPage.PopActivate();
     }
 
     public override IListItem[] GetItems()
@@ -138,7 +156,7 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
         if (!_isBandPage)
         {
             // TODO add details
-            return new[] { _cpuItem, _memoryItem, _networkItem, _gpuItem };
+            return new[] { _cpuItem, _memoryItem, _networkItem, _gpuItem, _batteryItem };
         }
         else
         {
@@ -156,7 +174,7 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
                 MoreCommands = _networkPage.Commands,
             };
 
-            return new[] { _cpuItem, _memoryItem, _networkDownItem, _networkUpItem, _gpuItem };
+            return new[] { _cpuItem, _memoryItem, _networkDownItem, _networkUpItem, _gpuItem, _batteryItem };
         }
     }
 
@@ -166,6 +184,7 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
         _memoryPage.Dispose();
         _networkPage.Dispose();
         _gpuPage.Dispose();
+        _batteryPage.Dispose();
     }
 }
 
@@ -979,6 +998,153 @@ internal sealed partial class SystemGPUUsageWidgetPage : WidgetPage, IDisposable
             _page.HandleNextGPU();
             return CommandResult.KeepOpen();
         }
+    }
+}
+
+internal sealed partial class SystemBatteryUsageWidgetPage : WidgetPage, IDisposable
+{
+    public override string Id => "com.microsoft.cmdpal.battery_widget";
+
+    public override string Title => Resources.GetResource("Battery_Usage_Title");
+
+    public override IconInfo Icon => Icons.BatteryIcon;
+
+    public IconInfo CurrentIcon { get; private set; } = Icons.BatteryIcon;
+
+    private readonly DataManager _dataManager;
+
+    public SystemBatteryUsageWidgetPage()
+    {
+        _dataManager = new(DataType.Battery, () => UpdateWidget());
+    }
+
+    protected override void LoadContentData()
+    {
+        try
+        {
+            ContentData.Clear();
+
+            var stats = _dataManager.GetBatteryStats();
+
+            CurrentIcon = Icons.BatteryGlyph(stats.ChargePercent, stats.IsCharging, stats.HasBattery);
+
+            if (!stats.HasBattery)
+            {
+                ContentData["batteryCharge"] = "—";
+                ContentData["batteryStatus"] = Resources.GetResource("Battery_Usage_Unknown");
+                ContentData["batteryTimeRemaining"] = string.Empty;
+                return;
+            }
+
+            ContentData["batteryCharge"] = stats.ChargePercent >= 0
+                ? FloatToPercentString(stats.ChargePercent)
+                : "—";
+
+            ContentData["batteryStatus"] = GetStatusText(stats);
+            ContentData["batteryTimeRemaining"] = GetTimeRemainingText(stats);
+        }
+        catch (Exception e)
+        {
+            ContentData.Clear();
+            ContentData["errorMessage"] = e.Message;
+            CurrentIcon = Icons.BatteryGlyph(-1, false, false);
+            return;
+        }
+    }
+
+    protected override string GetTemplatePath(WidgetPageState page)
+    {
+        return page switch
+        {
+            WidgetPageState.Content => @"DevHome\Templates\SystemBatteryTemplate.json",
+            WidgetPageState.Loading => @"DevHome\Templates\SystemBatteryTemplate.json",
+            _ => throw new NotImplementedException(),
+        };
+    }
+
+    public string GetItemTitle(bool isBandPage)
+    {
+        if (!ContentData.TryGetValue("batteryCharge", out var charge))
+        {
+            return isBandPage ? Resources.GetResource("Battery_Usage_Unknown") : Resources.GetResource("Battery_Usage_Unknown_Label");
+        }
+
+        if (charge == "—")
+        {
+            return isBandPage ? Resources.GetResource("Battery_Usage_Unknown") : Resources.GetResource("Battery_Usage_Unknown_Label");
+        }
+
+        if (isBandPage)
+        {
+            return charge;
+        }
+
+        var isCharging = ContentData.TryGetValue("batteryStatus", out var status)
+            && status == Resources.GetResource("Battery_Status_Charging");
+
+        var labelKey = isCharging ? "Battery_Usage_Charging_Label" : "Battery_Usage_Label";
+        return string.Format(CultureInfo.CurrentCulture, Resources.GetResource(labelKey), charge);
+    }
+
+    private static string GetStatusText(BatteryStats stats)
+    {
+        if (stats.IsCharging)
+        {
+            return Resources.GetResource("Battery_Status_Charging");
+        }
+
+        return stats.IsOnAcPower
+            ? Resources.GetResource("Battery_Status_OnAc")
+            : Resources.GetResource("Battery_Status_OnBattery");
+    }
+
+    private static string GetTimeRemainingText(BatteryStats stats)
+    {
+        if (stats.IsCharging || stats.IsOnAcPower || stats.SecondsRemaining < 0)
+        {
+            return Resources.GetResource("Battery_Time_Remaining_Unknown");
+        }
+
+        var totalMinutes = stats.SecondsRemaining / 60;
+        var hours = totalMinutes / 60;
+        var minutes = totalMinutes % 60;
+
+        if (hours > 0)
+        {
+            return string.Format(
+                CultureInfo.CurrentCulture,
+                Resources.GetResource("Battery_Time_Remaining_Format"),
+                hours,
+                minutes);
+        }
+
+        return string.Format(
+            CultureInfo.CurrentCulture,
+            Resources.GetResource("Battery_Time_Remaining_Minutes_Format"),
+            minutes);
+    }
+
+    internal override void PushActivate()
+    {
+        base.PushActivate();
+        if (IsActive)
+        {
+            _dataManager.Start();
+        }
+    }
+
+    internal override void PopActivate()
+    {
+        base.PopActivate();
+        if (!IsActive)
+        {
+            _dataManager.Stop();
+        }
+    }
+
+    public void Dispose()
+    {
+        _dataManager.Dispose();
     }
 }
 

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceWidgetsPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceWidgetsPage.cs
@@ -1100,7 +1100,17 @@ internal sealed partial class SystemBatteryUsageWidgetPage : WidgetPage, IDispos
 
     private static string GetTimeRemainingText(BatteryStats stats)
     {
-        if (stats.IsCharging || stats.IsOnAcPower || stats.SecondsRemaining < 0)
+        if (stats.IsCharging)
+        {
+            return Resources.GetResource("Battery_Time_Remaining_Charging");
+        }
+
+        if (stats.IsOnAcPower)
+        {
+            return Resources.GetResource("Battery_Time_Remaining_OnAc");
+        }
+
+        if (stats.SecondsRemaining < 0)
         {
             return Resources.GetResource("Battery_Time_Remaining_Unknown");
         }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceWidgetsPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceWidgetsPage.cs
@@ -110,7 +110,9 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
             _gpuItem.Title = _gpuPage.GetItemTitle(isBandPage);
         };
 
-        if (new BatteryStats().HasBattery)
+        var batteryStats = new BatteryStats();
+        batteryStats.GetData();
+        if (batteryStats.HasBattery)
         {
             _batteryPage = new SystemBatteryUsageWidgetPage();
             _batteryItem = new ListItem(_batteryPage)

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceWidgetsPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceWidgetsPage.cs
@@ -49,8 +49,8 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
     private readonly SystemGPUUsageWidgetPage _gpuPage = new();
     private readonly ListItem _gpuItem;
 
-    private readonly SystemBatteryUsageWidgetPage _batteryPage = new();
-    private readonly ListItem _batteryItem;
+    private readonly SystemBatteryUsageWidgetPage? _batteryPage;
+    private readonly ListItem? _batteryItem;
 
     // For bands, we want two bands, one for up and one for down
     private ListItem? _networkUpItem;
@@ -110,17 +110,21 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
             _gpuItem.Title = _gpuPage.GetItemTitle(isBandPage);
         };
 
-        _batteryItem = new ListItem(_batteryPage)
+        if (new BatteryStats().HasBattery)
         {
-            Title = _batteryPage.GetItemTitle(isBandPage),
-            Icon = _batteryPage.CurrentIcon,
-        };
+            _batteryPage = new SystemBatteryUsageWidgetPage();
+            _batteryItem = new ListItem(_batteryPage)
+            {
+                Title = _batteryPage.GetItemTitle(isBandPage),
+                Icon = _batteryPage.CurrentIcon,
+            };
 
-        _batteryPage.Updated += (s, e) =>
-        {
-            _batteryItem.Title = _batteryPage.GetItemTitle(isBandPage);
-            _batteryItem.Icon = _batteryPage.CurrentIcon;
-        };
+            _batteryPage.Updated += (s, e) =>
+            {
+                _batteryItem.Title = _batteryPage.GetItemTitle(isBandPage);
+                _batteryItem.Icon = _batteryPage.CurrentIcon;
+            };
+        }
 
         if (_isBandPage)
         {
@@ -129,7 +133,10 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
             _memoryItem.Subtitle = Resources.GetResource("Memory_Usage_Subtitle");
             _networkItem.Subtitle = Resources.GetResource("Network_Usage_Subtitle");
             _gpuItem.Subtitle = Resources.GetResource("GPU_Usage_Subtitle");
-            _batteryItem.Subtitle = Resources.GetResource("Battery_Usage_Subtitle");
+            if (_batteryItem is not null)
+            {
+                _batteryItem.Subtitle = Resources.GetResource("Battery_Usage_Subtitle");
+            }
         }
     }
 
@@ -139,7 +146,7 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
         _memoryPage.PushActivate();
         _networkPage.PushActivate();
         _gpuPage.PushActivate();
-        _batteryPage.PushActivate();
+        _batteryPage?.PushActivate();
     }
 
     protected override void Unloaded()
@@ -148,7 +155,7 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
         _memoryPage.PopActivate();
         _networkPage.PopActivate();
         _gpuPage.PopActivate();
-        _batteryPage.PopActivate();
+        _batteryPage?.PopActivate();
     }
 
     public override IListItem[] GetItems()
@@ -156,7 +163,9 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
         if (!_isBandPage)
         {
             // TODO add details
-            return new[] { _cpuItem, _memoryItem, _networkItem, _gpuItem, _batteryItem };
+            return _batteryItem is not null
+                ? new[] { _cpuItem, _memoryItem, _networkItem, _gpuItem, _batteryItem }
+                : new[] { _cpuItem, _memoryItem, _networkItem, _gpuItem };
         }
         else
         {
@@ -174,7 +183,9 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
                 MoreCommands = _networkPage.Commands,
             };
 
-            return new[] { _cpuItem, _memoryItem, _networkDownItem, _networkUpItem, _gpuItem, _batteryItem };
+            return _batteryItem is not null
+                ? new[] { _cpuItem, _memoryItem, _networkDownItem, _networkUpItem, _gpuItem, _batteryItem }
+                : new[] { _cpuItem, _memoryItem, _networkDownItem, _networkUpItem, _gpuItem };
         }
     }
 
@@ -184,7 +195,7 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
         _memoryPage.Dispose();
         _networkPage.Dispose();
         _gpuPage.Dispose();
-        _batteryPage.Dispose();
+        _batteryPage?.Dispose();
     }
 }
 

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/Strings/en-US/Resources.resw
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/Strings/en-US/Resources.resw
@@ -298,6 +298,12 @@
   <data name="Battery_Time_Remaining_Unknown" xml:space="preserve">
     <value>Calculating time remaining…</value>
   </data>
+  <data name="Battery_Time_Remaining_Charging" xml:space="preserve">
+    <value>Charging</value>
+  </data>
+  <data name="Battery_Time_Remaining_OnAc" xml:space="preserve">
+    <value>Not discharging</value>
+  </data>
   <data name="Battery_Status_Charging" xml:space="preserve">
     <value>Charging</value>
   </data>

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/Strings/en-US/Resources.resw
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/Strings/en-US/Resources.resw
@@ -186,6 +186,9 @@
   <data name="GPU_Usage_Subtitle" xml:space="preserve">
     <value>GPU</value>
   </data>
+  <data name="Battery_Usage_Subtitle" xml:space="preserve">
+    <value>Battery</value>
+  </data>
   <data name="Performance_Monitor_Title" xml:space="preserve">
     <value>Performance monitor</value>
   </data>
@@ -266,6 +269,52 @@
   </data>
   <data name="GPU_Usage_Unknown_Label" xml:space="preserve">
     <value>GPU Usage: ???</value>
+  </data>
+  <data name="Battery_Usage_Title" xml:space="preserve">
+    <value>Battery</value>
+  </data>
+  <data name="Battery_Usage_Label" xml:space="preserve">
+    <value>Battery: {0}</value>
+    <comment>{0} is the battery charge percentage</comment>
+  </data>
+  <data name="Battery_Usage_Charging_Label" xml:space="preserve">
+    <value>Battery: {0} (charging)</value>
+    <comment>{0} is the battery charge percentage</comment>
+  </data>
+  <data name="Battery_Usage_Unknown" xml:space="preserve">
+    <value>No battery</value>
+  </data>
+  <data name="Battery_Usage_Unknown_Label" xml:space="preserve">
+    <value>Battery: No battery detected</value>
+  </data>
+  <data name="Battery_Time_Remaining_Format" xml:space="preserve">
+    <value>{0}h {1}m remaining</value>
+    <comment>{0} is hours, {1} is minutes</comment>
+  </data>
+  <data name="Battery_Time_Remaining_Minutes_Format" xml:space="preserve">
+    <value>{0}m remaining</value>
+    <comment>{0} is minutes</comment>
+  </data>
+  <data name="Battery_Time_Remaining_Unknown" xml:space="preserve">
+    <value>Calculating time remaining…</value>
+  </data>
+  <data name="Battery_Status_Charging" xml:space="preserve">
+    <value>Charging</value>
+  </data>
+  <data name="Battery_Status_OnAc" xml:space="preserve">
+    <value>Plugged in</value>
+  </data>
+  <data name="Battery_Status_OnBattery" xml:space="preserve">
+    <value>On battery</value>
+  </data>
+  <data name="Battery_Widget_Template.Charge" xml:space="preserve">
+    <value>Charge</value>
+  </data>
+  <data name="Battery_Widget_Template.Status" xml:space="preserve">
+    <value>Status</value>
+  </data>
+  <data name="Battery_Widget_Template.TimeRemaining" xml:space="preserve">
+    <value>Time remaining</value>
   </data>
   <data name="Open_Task_Manager_Title" xml:space="preserve">
     <value>Open Task Manager</value>


### PR DESCRIPTION
## Summary

Adds a Battery widget to the CmdPal Performance Monitor dock, exposing live charge percentage, charging/AC status, and estimated time remaining. The dock-band icon updates each tick to reflect the current charge level and charging state, matching the existing CPU/RAM/GPU/Network widget pattern.

Closes #47218

## Detail

- New `SystemBatteryUsageWidgetPage` in `PerformanceWidgetsPage.cs`, mirroring the existing widget pattern.
- Data source: `GetSystemPowerStatus` via CsWin32 (AOT-safe), wrapped in `BatteryStats` and surfaced through `SystemData` / `DataManager` on the shared 1 s timer.
- Live dock-band icon: `Icons.cs` caches 23 `IconInfo` instances (`BatteryIcons[0..10]`, `BatteryChargingIcons[0..10]`, `BatteryUnknownIcon`); alloc-free `BatteryGlyph()` selects the glyph per tick. Codepoints `0xEBA0`–`0xEBB5` / `0xEC02` (Segoe Fluent Icons MobBattery family).
- Adaptive card template `SystemBatteryTemplate.json` registered as `<None Update … PreserveNewest>`, consistent with the other PerfMon templates.
- New `Battery_*` strings under `Strings\en-US\Resources.resw`.
- Handles `GetSystemPowerStatus` sentinels: `BatteryLifePercent == 255`, `BatteryLifeTime == 0xFFFFFFFF`, `BatteryFlag == 0xFF`, `0x80` (no battery), `0x08` (charging).

## Screenshots

<img width="1660" height="401" alt="image" src="https://github.com/user-attachments/assets/6e26f10a-267b-4f6b-b43a-b2c63c092a6d" />

When the battery is at 100%, the widget will always show the "full" icon (`MobBatteryCharging10`).
<img width="537" height="37" alt="image" src="https://github.com/user-attachments/assets/d925a328-b9b6-4760-a488-f936910a1715" />
Otherwise and when on AC, it will show the "charging" variant of the icon: 
<img width="85" height="61" alt="image" src="https://github.com/user-attachments/assets/065e3a53-c210-4d65-8ca2-02dccf63edf6" />
The icon also always reflects the current charging state: It resolves to the correct glyph in both charging and discharging states, rounded to the nearest 10% (so 0%, 10%, … 100%).

## How tested

- `MSBuild CommandPalette.slnf /p:Configuration=Release /p:Platform=x64 /m /restore` — green, 0 errors, 0 warnings.
- Launched dev `Microsoft.CmdPal.UI.exe`, opened PerfMon dock, confirmed Battery widget renders charge %, status, time remaining, and that the dock-band glyph matches the current charge level (verified on AC, on battery, and while charging).