### PR TITLE
[Runner] Make tray icon context menu theme aware

### DIFF
--- a/src/common/Themes/Themes.vcxproj
+++ b/src/common/Themes/Themes.vcxproj
@@ -30,12 +30,14 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="dark_mode.h" />
     <ClInclude Include="icon_helpers.h" />
     <ClInclude Include="theme_listener.h" />
     <ClInclude Include="theme_helpers.h" />
     <ClInclude Include="windows_colors.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="dark_mode.cpp" />
     <ClCompile Include="icon_helpers.cpp" />
     <ClCompile Include="theme_listener.cpp" />
     <ClCompile Include="theme_helpers.cpp" />

--- a/src/common/Themes/dark_mode.cpp
+++ b/src/common/Themes/dark_mode.cpp
@@ -1,0 +1,119 @@
+// Native Win32 dark-mode helpers built on top of the undocumented
+// uxtheme.dll ordinals shipped with Windows 10 1903+ / Windows 11.
+//
+// Reference: https://github.com/microsoft/PowerToys/issues/31813
+// Precedent: src/modules/ZoomIt/ZoomIt/Utility.cpp
+#include "dark_mode.h"
+#include "theme_helpers.h"
+
+#include <mutex>
+
+namespace
+{
+    enum class PreferredAppMode
+    {
+        Default,
+        AllowDark,
+        ForceDark,
+        ForceLight,
+        Max
+    };
+
+    using fnSetPreferredAppMode = PreferredAppMode(WINAPI*)(PreferredAppMode appMode);
+    using fnShouldAppsUseDarkMode = bool(WINAPI*)();
+    using fnFlushMenuThemes = void(WINAPI*)();
+
+    fnSetPreferredAppMode pSetPreferredAppMode = nullptr;
+    fnShouldAppsUseDarkMode pShouldAppsUseDarkMode = nullptr;
+    fnFlushMenuThemes pFlushMenuThemes = nullptr;
+
+    std::once_flag init_flag;
+    HBRUSH dark_menu_brush = nullptr;
+
+    // Mirrors the surface color used by ZoomIt's dark menus for visual
+    // consistency across PowerToys-owned native menus.
+    constexpr COLORREF DarkMenuSurfaceColor = RGB(45, 45, 45);
+
+    void LoadOrdinals()
+    {
+        HMODULE hUxTheme = GetModuleHandleW(L"uxtheme.dll");
+        if (!hUxTheme)
+        {
+            hUxTheme = LoadLibraryExW(L"uxtheme.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
+        }
+        if (!hUxTheme)
+        {
+            return;
+        }
+
+        pSetPreferredAppMode = reinterpret_cast<fnSetPreferredAppMode>(
+            GetProcAddress(hUxTheme, MAKEINTRESOURCEA(135)));
+        pShouldAppsUseDarkMode = reinterpret_cast<fnShouldAppsUseDarkMode>(
+            GetProcAddress(hUxTheme, MAKEINTRESOURCEA(132)));
+        pFlushMenuThemes = reinterpret_cast<fnFlushMenuThemes>(
+            GetProcAddress(hUxTheme, MAKEINTRESOURCEA(136)));
+    }
+
+    void ApplyPreferredAppMode()
+    {
+        if (!pSetPreferredAppMode)
+        {
+            return;
+        }
+
+        const bool dark = DarkMode::IsDarkModeEnabled();
+        pSetPreferredAppMode(dark ? PreferredAppMode::ForceDark : PreferredAppMode::ForceLight);
+
+        if (pFlushMenuThemes)
+        {
+            pFlushMenuThemes();
+        }
+    }
+}
+
+void DarkMode::Initialize()
+{
+    std::call_once(init_flag, LoadOrdinals);
+    ApplyPreferredAppMode();
+}
+
+void DarkMode::Refresh()
+{
+    Initialize();
+}
+
+bool DarkMode::IsDarkModeEnabled()
+{
+    if (pShouldAppsUseDarkMode)
+    {
+        return pShouldAppsUseDarkMode();
+    }
+
+    return ThemeHelpers::GetSystemTheme() == Theme::Dark;
+}
+
+void DarkMode::ApplyToMenu(HMENU menu)
+{
+    if (!menu)
+    {
+        return;
+    }
+
+    MENUINFO mi = { sizeof(mi) };
+    mi.fMask = MIM_BACKGROUND | MIM_APPLYTOSUBMENUS;
+
+    if (IsDarkModeEnabled())
+    {
+        if (!dark_menu_brush)
+        {
+            dark_menu_brush = CreateSolidBrush(DarkMenuSurfaceColor);
+        }
+        mi.hbrBack = dark_menu_brush;
+    }
+    else
+    {
+        mi.hbrBack = nullptr;
+    }
+
+    SetMenuInfo(menu, &mi);
+}

--- a/src/common/Themes/dark_mode.cpp
+++ b/src/common/Themes/dark_mode.cpp
@@ -99,6 +99,12 @@ void DarkMode::ApplyToMenu(HMENU menu)
         return;
     }
 
+    Initialize();
+    if (!pSetPreferredAppMode)
+    {
+        return;
+    }
+
     MENUINFO mi = { sizeof(mi) };
     mi.fMask = MIM_BACKGROUND | MIM_APPLYTOSUBMENUS;
 

--- a/src/common/Themes/dark_mode.h
+++ b/src/common/Themes/dark_mode.h
@@ -1,0 +1,25 @@
+#pragma once
+#include <windows.h>
+
+// Lightweight helpers for opting native Win32 popup menus into the
+// system dark / light theme. Built on top of undocumented uxtheme.dll
+// ordinals (SetPreferredAppMode / FlushMenuThemes / AllowDarkModeForWindow)
+// that ship with Windows 10 1903+ and Windows 11.
+struct DarkMode
+{
+    // Loads the uxtheme.dll ordinals (idempotent) and applies the current
+    // system theme as the preferred app mode. Safe to call multiple times.
+    static void Initialize();
+
+    // Re-evaluates the current system theme and re-applies the preferred
+    // app mode. Call this from a theme-change handler.
+    static void Refresh();
+
+    // Returns true if the system is currently in dark mode.
+    static bool IsDarkModeEnabled();
+
+    // Applies a dark or light background brush to the given menu and all of
+    // its submenus, based on the current system theme. No-op when the
+    // uxtheme.dll ordinals are unavailable.
+    static void ApplyToMenu(HMENU menu);
+};

--- a/src/common/Themes/dark_mode.h
+++ b/src/common/Themes/dark_mode.h
@@ -3,7 +3,7 @@
 
 // Lightweight helpers for opting native Win32 popup menus into the
 // system dark / light theme. Built on top of undocumented uxtheme.dll
-// ordinals (SetPreferredAppMode / FlushMenuThemes / AllowDarkModeForWindow)
+// ordinals (SetPreferredAppMode / ShouldAppsUseDarkMode / FlushMenuThemes)
 // that ship with Windows 10 1903+ and Windows 11.
 struct DarkMode
 {

--- a/src/runner/tray_icon.cpp
+++ b/src/runner/tray_icon.cpp
@@ -16,6 +16,7 @@
 #include <common/utils/elevation.h>
 #include <common/Themes/theme_listener.h>
 #include <common/Themes/theme_helpers.h>
+#include <common/Themes/dark_mode.h>
 #include "bug_report.h"
 #include <common/updating/updateState.h>
 
@@ -285,6 +286,8 @@ LRESULT __stdcall tray_icon_window_proc(HWND window, UINT message, WPARAM wparam
                     InsertMenuW(h_sub_menu, 1, MF_BYPOSITION | MF_SEPARATOR, 0, nullptr);
                 }
 
+                DarkMode::ApplyToMenu(h_menu);
+
                 POINT mouse_pointer;
                 GetCursorPos(&mouse_pointer);
                 SetForegroundWindow(window); // Needed for the context menu to disappear.
@@ -374,6 +377,8 @@ static void handle_theme_change()
         tray_icon_data.hIcon = get_icon(ThemeHelpers::GetSystemTheme());
         Shell_NotifyIcon(NIM_MODIFY, &tray_icon_data);
     }
+
+    DarkMode::Refresh();
 }
 
 void update_bug_report_menu_status(bool isRunning)
@@ -443,6 +448,7 @@ void start_tray_icon(bool isProcessElevated, bool theme_adaptive)
 
         tray_icon_created = Shell_NotifyIcon(NIM_ADD, &tray_icon_data) == TRUE;
         theme_listener.AddSystemThemeChangedHandler(&handle_theme_change);
+        DarkMode::Initialize();
 
         // Register callback to update bug report menu item status
         BugReportManager::instance().register_callback([](bool isRunning) {


### PR DESCRIPTION
## Summary

Makes the PowerToys runner's system tray icon right-click context menu honor the OS dark / light theme. Previously the popup menu was always rendered in the default light Win32 style regardless of the system theme.

Closes #31813

## Detail

- Adds a small native helper `DarkMode` under `src/common/Themes/dark_mode.{h,cpp}` that loads the undocumented `uxtheme.dll` ordinals shipped on Windows 10 1903+ / Windows 11:
  - 132 `ShouldAppsUseDarkMode`
  - 135 `SetPreferredAppMode` (applied as `ForceDark` / `ForceLight`)
  - 136 `FlushMenuThemes`
  - `ApplyToMenu(HMENU)` sets `MIM_BACKGROUND` with `MIM_APPLYTOSUBMENUS` so the popup and any future submenus pick up the right background brush.
- Wires it into `src/runner/tray_icon.cpp`:
  - `DarkMode::Initialize()` once at the end of `start_tray_icon`.
  - `DarkMode::ApplyToMenu(h_menu)` inside the `WM_RBUTTONUP` / `WM_CONTEXTMENU` branch, immediately before `TrackPopupMenu`, so the theme is re-evaluated every time the menu opens.
  - `DarkMode::Refresh()` from the existing `handle_theme_change` so a live OS theme switch is picked up without restarting PowerToys.
- Precedent: this is the same approach already used by ZoomIt — see `src/modules/ZoomIt/ZoomIt/Utility.cpp` (`InitializeDarkModeSupport`, `ApplyDarkModeToMenu`). The helper is intentionally minimal and only exposes what the tray menu needs.

## Screenshots

Before: white menu background on a dark Windows theme (per issue #31813).

After: menu background matches the OS theme; tested live in both dark and light mode with a runtime theme switch (no restart required).
 
<img width="274" height="170" alt="image" src="https://github.com/user-attachments/assets/777d887a-19ef-4ab9-9be7-8dbb2aa8051b" />
<img width="294" height="187" alt="image" src="https://github.com/user-attachments/assets/e7fa5634-4e91-48ce-b7d5-b47216ff5aa9" />

## How tested

- `MSBuild src\common\Themes\Themes.vcxproj /p:Configuration=Release /p:Platform=x64 /m /restore` — green, 0 warnings, 0 errors.
- `MSBuild src\runner\runner.vcxproj /p:Configuration=Release /p:Platform=x64 /m /restore` — green, 0 warnings, 0 errors.
- Ran the freshly-built `src\runner\x64\Release\PowerToys.exe`:
  - System in dark mode → right-clicked tray icon → context menu rendered with dark background.
  - Switched Windows to light mode → re-opened menu → rendered with light background, no restart needed.