### PR TITLE
CmdPal: Pass extension log messages into logging system

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AppExtensionHost.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AppExtensionHost.cs
@@ -60,7 +60,19 @@ public abstract partial class AppExtensionHost : IExtensionHost
             return Task.CompletedTask.AsAsyncAction();
         }
 
-        CoreLogger.LogDebug(message.Message);
+        switch (message.State)
+        {
+            case MessageState.Error:
+                CoreLogger.LogError(message.Message);
+                break;
+            case MessageState.Warning:
+                CoreLogger.LogWarning(message.Message);
+                break;
+            case MessageState.Info:
+            default:
+                CoreLogger.LogInfo(message.Message);
+                break;
+        }
 
         _ = Task.Run(() =>
         {


### PR DESCRIPTION
This pull request updates the logging behavior in the `LogMessage` method to ensure that log messages are categorized and logged according to their severity (Error, Warning, or Info), instead of always using debug-level logging.

Logging improvements:

* Updated the `LogMessage` method in `AppExtensionHost.cs` to log messages using `CoreLogger.LogError`, `CoreLogger.LogWarning`, or `CoreLogger.LogInfo` based on the `MessageState` of the incoming message, improving log clarity and severity categorization.

Previously, any logging sent to LogMessage (which is exposed in the toolkit) would only be written when debugging. Any error/warning/info messages sent as part of the normal operation would be bypassed because it only used `CoreLogger.LogDebug`

Now extension developers can log errors/warnings and use PowerToys log export /  bug report feature to help their users provide them with actionable data to make their extensions better.