### PR TITLE
fix(GrabAndMove): pin CppWinRT NuGet to unblock CI

### DIFF
--- a/src/modules/GrabAndMove/GrabAndMove/GrabAndMove.vcxproj
+++ b/src/modules/GrabAndMove/GrabAndMove/GrabAndMove.vcxproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -194,4 +195,14 @@
     <Manifest Include="GrabAndMove.manifest" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
+  </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
+    <Error Condition="!Exists('$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+  </Target>
 </Project>

--- a/src/modules/GrabAndMove/GrabAndMove/GrabAndMove.vcxproj
+++ b/src/modules/GrabAndMove/GrabAndMove/GrabAndMove.vcxproj
@@ -194,6 +194,9 @@
   <ItemGroup>
     <Manifest Include="GrabAndMove.manifest" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets')" />

--- a/src/modules/GrabAndMove/GrabAndMove/packages.config
+++ b/src/modules/GrabAndMove/GrabAndMove/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.250303.1" targetFramework="native" />
+</packages>

--- a/src/modules/GrabAndMove/GrabAndMoveModuleInterface/GrabAndMoveModuleInterface.vcxproj
+++ b/src/modules/GrabAndMove/GrabAndMoveModuleInterface/GrabAndMoveModuleInterface.vcxproj
@@ -186,6 +186,9 @@
     <ResourceCompile Include="GrabAndMoveModuleInterface.rc" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="$(RepoRoot)src\common\logger\logger.vcxproj">
       <Project>{d9b8fc84-322a-4f9f-bbb9-20915c47ddfd}</Project>
     </ProjectReference>

--- a/src/modules/GrabAndMove/GrabAndMoveModuleInterface/packages.config
+++ b/src/modules/GrabAndMove/GrabAndMoveModuleInterface/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.250303.1" targetFramework="native" />
+</packages>


### PR DESCRIPTION
## Summary

- main has been failing on every PR since #47024 (GrabAndMove) was merged, with `LNK2038: mismatch detected for 'C++/WinRT version': value '2.0.250303.1' doesn't match value '2.0.250303.5' in main.obj` from `PowerToys.GrabAndMove.exe`.
- Root cause: `GrabAndMove.vcxproj` never imports the `Microsoft.Windows.CppWinRT` NuGet props/targets, so `main.cpp`'s transitive `<winrt/Windows.Foundation.h>` (via `common/SettingsAPI/settings_objects.h` → `common/utils/json.h`) resolves `<winrt/base.h>` from whichever Windows SDK the build agent has installed. CI agents now ship an SDK whose bundled cppwinrt is `2.0.250303.5`, while `SettingsAPI.lib` is pinned via `packages.config` to `2.0.250303.1`, so the link step rejects the mismatch.
- Mirror the imports already used by other Application/DLL modules (`AlwaysOnTop`, `FancyZones`, `CropAndLock`) — declare `Microsoft.Windows.CppWinRT 2.0.250303.1` in a project-local `packages.config` and import its `.props`/`.targets` plus the `EnsureNuGetPackageBuildImports` guard. Apply the same to the sibling `GrabAndMoveModuleInterface` for module-folder consistency.

## Test plan

- [x] Local x64 Debug build of `src/modules/GrabAndMove/GrabAndMove/` succeeds (0 warnings, 0 errors).
- [x] Local x64 Debug build of `src/modules/GrabAndMove/GrabAndMoveModuleInterface/` succeeds (0 warnings, 0 errors).
- [x] Build log shows the NuGet props/targets are imported and `\$(CppWinRT_IncludePath)` points at the project's `Generated Files\` (so the system-SDK `winrt/base.h` no longer wins).
- [ ] PowerToys CI passes on x64 + arm64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)