### PR TITLE
[Settings] Fix FancyZones page scroll bounce at Excluded apps

### DIFF
--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/FancyZonesPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/FancyZonesPage.xaml
@@ -294,10 +294,9 @@
                                     x:Uid="FancyZones_ExcludeApps_TextBoxControl"
                                     MinWidth="240"
                                     MinHeight="160"
+                                    MaxHeight="320"
                                     AcceptsReturn="True"
-                                    ScrollViewer.IsVerticalRailEnabled="True"
-                                    ScrollViewer.VerticalScrollBarVisibility="Visible"
-                                    ScrollViewer.VerticalScrollMode="Enabled"
+                                    ScrollViewer.VerticalScrollBarVisibility="Auto"
                                     Text="{x:Bind ViewModel.ExcludedApps, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                     TextWrapping="Wrap" />
                             </tkcontrols:SettingsCard>


### PR DESCRIPTION
## Summary

Fixes #25353 — the FancyZones Settings page bounces / jumps when the user scrolls down to the bottom (the **Excluded apps** expander). Several closed dupes report the same behavior: #31500, #34259, #30164, #45173, #32099, #32361.

## Root cause

The Excluded-apps `TextBox` (lines 283-305 of `FancyZonesPage.xaml`) forced its own inner `ScrollViewer` to be permanently enabled with a visible scrollbar, nested inside the page-level `ScrollViewer` provided by `SettingsPageControl`:

```xml
ScrollViewer.IsVerticalRailEnabled="True"
ScrollViewer.VerticalScrollBarVisibility="Visible"
ScrollViewer.VerticalScrollMode="Enabled"
```

The expander is `IsExpanded="True"` and sits at the very bottom of the page, so when you wheel-scroll down the page the pointer ends up over the TextBox. The TextBox''s inner scroller intercepts the wheel events; when it has nothing left to scroll the event bubbles back to the outer page scroller, which tries to over-scroll past content end. The result is the bounce/jump visible in the videos on the issue.

The unbounded `MinHeight="160"` (with no `MaxHeight`) made it worse, because the box can grow as users type, triggering layout re-measures during scrolling.

## Fix

Minimal change to the same TextBox:

- Drop `ScrollViewer.IsVerticalRailEnabled` and `ScrollViewer.VerticalScrollMode` — `AcceptsReturn="True"` already wires up the inner scroller correctly.
- Change `ScrollViewer.VerticalScrollBarVisibility` from `Visible` to `Auto`, so the inner scroller only competes with the outer one when there is actual overflow to scroll.
- Add `MaxHeight="320"` so the box cannot keep growing as the user types.

## Validation

- Builds clean (`tools\build\build.cmd` from `src\settings-ui\Settings.UI`, arm64 Debug, exit 0, 0 errors).
- The same nested-scroller pattern exists on 9 other Settings pages (AlwaysOnTop, GrabAndMove, MouseUtils, MouseWithoutBorders, PowerAccent, PowerLauncher, ShortcutGuide). Keeping this PR atomic to the page called out in #25353; happy to follow up with a sibling PR for those if reviewers want them in the same pass.