### PR TITLE
Revert "Move storyboards used to show/hide breadcrumbs to XAML"

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/SettingsWindow.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/SettingsWindow.xaml
@@ -23,33 +23,6 @@
         <MicaBackdrop />
     </winuiex:WindowEx.SystemBackdrop>
     <Grid x:Name="RootElement">
-        <Grid.Resources>
-            <Storyboard x:Key="BreadcrumbFadeInStoryboard">
-                <DoubleAnimation
-                    Storyboard.TargetName="BreadcrumbContainer"
-                    Storyboard.TargetProperty="Opacity"
-                    To="1"
-                    Duration="0:0:0.25">
-                    <DoubleAnimation.EasingFunction>
-                        <CubicEase EasingMode="EaseOut" />
-                    </DoubleAnimation.EasingFunction>
-                </DoubleAnimation>
-            </Storyboard>
-            <Storyboard x:Key="BreadcrumbFadeOutStoryboard">
-                <DoubleAnimation
-                    Storyboard.TargetName="BreadcrumbContainer"
-                    Storyboard.TargetProperty="Opacity"
-                    To="0"
-                    Duration="0:0:0.2">
-                    <DoubleAnimation.EasingFunction>
-                        <CubicEase EasingMode="EaseIn" />
-                    </DoubleAnimation.EasingFunction>
-                </DoubleAnimation>
-                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BreadcrumbContainer" Storyboard.TargetProperty="Visibility">
-                    <DiscreteObjectKeyFrame KeyTime="0:0:0.2" Value="Collapsed" />
-                </ObjectAnimationUsingKeyFrames>
-            </Storyboard>
-        </Grid.Resources>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/SettingsWindow.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/SettingsWindow.xaml.cs
@@ -33,9 +33,8 @@ public sealed partial class SettingsWindow : WindowEx,
     private readonly LocalKeyboardListener _localKeyboardListener;
 
     private readonly NavigationViewItem? _internalNavItem;
-    private readonly Storyboard _breadcrumbFadeInStoryboard;
-    private readonly Storyboard _breadcrumbFadeOutStoryboard;
 
+    private Storyboard? _breadcrumbStoryboard;
     private IReadOnlyList<ExtensionGalleryScreenshotViewModel> _currentScreenshotSet = [];
     private ExtensionGalleryScreenshotViewModel? _currentScreenshot;
 
@@ -54,8 +53,6 @@ public sealed partial class SettingsWindow : WindowEx,
     public SettingsWindow()
     {
         this.InitializeComponent();
-        _breadcrumbFadeInStoryboard = (Storyboard)RootElement.Resources["BreadcrumbFadeInStoryboard"];
-        _breadcrumbFadeOutStoryboard = (Storyboard)RootElement.Resources["BreadcrumbFadeOutStoryboard"];
         this.ExtendsContentIntoTitleBar = true;
         this.SetIcon();
         var title = RS_.GetString("SettingsWindowTitle");
@@ -323,30 +320,54 @@ public sealed partial class SettingsWindow : WindowEx,
 
     private void HideBreadcrumb()
     {
-        if (BreadcrumbContainer.Visibility == Visibility.Collapsed)
-        {
-            return;
-        }
+        _breadcrumbStoryboard?.Stop();
 
-        _breadcrumbFadeInStoryboard.Stop();
-        _breadcrumbFadeOutStoryboard.Stop();
-        _breadcrumbFadeOutStoryboard.Begin();
+        var fadeOut = new DoubleAnimation
+        {
+            To = 0,
+            Duration = new Duration(TimeSpan.FromMilliseconds(200)),
+            EasingFunction = new CubicEase { EasingMode = EasingMode.EaseIn },
+        };
+        Storyboard.SetTarget(fadeOut, BreadcrumbContainer);
+        Storyboard.SetTargetProperty(fadeOut, "Opacity");
+
+        _breadcrumbStoryboard = new Storyboard();
+        _breadcrumbStoryboard.Children.Add(fadeOut);
+        _breadcrumbStoryboard.Completed += (_, _) =>
+        {
+            BreadcrumbContainer.Visibility = Visibility.Collapsed;
+            BreadcrumbContainer.Opacity = 1;
+            _breadcrumbStoryboard = null;
+        };
+        _breadcrumbStoryboard.Begin();
     }
 
     private void ShowBreadcrumb()
     {
-        _breadcrumbFadeInStoryboard.Stop();
-        _breadcrumbFadeOutStoryboard.Stop();
+        _breadcrumbStoryboard?.Stop();
+        _breadcrumbStoryboard = null;
 
         if (BreadcrumbContainer.Visibility == Visibility.Collapsed)
         {
             BreadcrumbContainer.Opacity = 0;
             BreadcrumbContainer.Visibility = Visibility.Visible;
-            _breadcrumbFadeInStoryboard.Begin();
+
+            var fadeIn = new DoubleAnimation
+            {
+                To = 1,
+                Duration = new Duration(TimeSpan.FromMilliseconds(250)),
+                EasingFunction = new CubicEase { EasingMode = EasingMode.EaseOut },
+            };
+            Storyboard.SetTarget(fadeIn, BreadcrumbContainer);
+            Storyboard.SetTargetProperty(fadeIn, "Opacity");
+
+            _breadcrumbStoryboard = new Storyboard();
+            _breadcrumbStoryboard.Children.Add(fadeIn);
+            _breadcrumbStoryboard.Completed += (_, _) => _breadcrumbStoryboard = null;
+            _breadcrumbStoryboard.Begin();
         }
         else
         {
-            BreadcrumbContainer.Visibility = Visibility.Visible;
             BreadcrumbContainer.Opacity = 1;
         }
     }
@@ -361,7 +382,7 @@ public sealed partial class SettingsWindow : WindowEx,
     private void NavFrame_OnNavigated(object sender, NavigationEventArgs e)
     {
         BreadCrumbs.Clear();
-        var shouldShowBreadcrumb = true;
+        ShowBreadcrumb();
 
         if (e.SourcePageType == typeof(GeneralPage))
         {
@@ -384,14 +405,14 @@ public sealed partial class SettingsWindow : WindowEx,
         else if (e.SourcePageType == typeof(ExtensionGalleryPage))
         {
             NavView.SelectedItem = GalleryPageNavItem;
-            shouldShowBreadcrumb = false;
+            HideBreadcrumb();
             var pageType = RS_.GetString("Settings_PageTitles_GalleryPage");
             BreadCrumbs.Add(new(pageType, pageType));
         }
         else if (e.SourcePageType == typeof(ExtensionGalleryItemPage) && e.Parameter is ExtensionGalleryItemViewModel galleryExtension)
         {
             NavView.SelectedItem = GalleryPageNavItem;
-            shouldShowBreadcrumb = false;
+            HideBreadcrumb();
             var galleryPageType = RS_.GetString("Settings_PageTitles_GalleryPage");
             BreadCrumbs.Add(new(galleryPageType, "Gallery"));
             BreadCrumbs.Add(new(galleryExtension.Title, galleryExtension));
@@ -419,15 +440,6 @@ public sealed partial class SettingsWindow : WindowEx,
         {
             BreadCrumbs.Add(new($"[{e.SourcePageType?.Name}]", string.Empty));
             Logger.LogError($"Unknown breadcrumb for page type '{e.SourcePageType}'");
-        }
-
-        if (shouldShowBreadcrumb)
-        {
-            ShowBreadcrumb();
-        }
-        else
-        {
-            HideBreadcrumb();
         }
     }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

This PR reverts #47900: it causes an exception in the Release+AOT build configuration when retrieving a storyboard from XAML resources and casting it to a local field.

- [x] Closes: #47970 
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

