### PR TITLE
CmdPal: Fix dock subtitle showing in compact mode when extension updates Subtitle after initial render

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockItemControl.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockItemControl.xaml.cs
@@ -120,6 +120,7 @@ public sealed partial class DockItemControl : Control
         {
             control.UpdateTextVisibility();
             control.UpdateAlignment();
+            control.UpdateCompactState();
         }
     }
 


### PR DESCRIPTION
## Summary

- Subtitle is visible in compact dock mode when an extension updates its `Subtitle` property asynchronously after initial render
- Compact mode correctly hides the subtitle on first load, but once the subtitle changes from empty to a real value the compact visual state is silently overridden
- Fix: re-apply `UpdateCompactState()` at the end of `OnTextPropertyChanged` (1-line change)

## Root Cause

`DockItemControl` has two independent `VisualStateGroup`s that both write to `SubtitleText.Visibility`:

| Group | State | Setter |
|---|---|---|
| `TextVisibilityStates` | `TitleOnly` | `SubtitleText.Visibility = Collapsed` |
| `CompactStates` | `Compact` | `SubtitleText.Visibility = Collapsed` |

When `OnTextPropertyChanged` fires because an extension's `Subtitle` changed from `""` to a real value, `UpdateTextVisibilityState()` transitions `TextVisibilityStates` from `TitleOnly` → `TextVisible`. `TextVisible` has no setters, so when `TitleOnly` exits, WinUI 3 does not cleanly maintain the concurrent `CompactStates / Compact` setter for the same property — `SubtitleText.Visibility` reverts to `Visible`.

`UpdateAllVisibility()` (called on `Loaded` and on `IsCompact` change) correctly calls `UpdateCompactState()` last and works fine. The gap is that `OnTextPropertyChanged` only calls `UpdateTextVisibility()` and `UpdateAlignment()`, never re-applying the compact state.

## Fix

Call `UpdateCompactState()` at the end of `OnTextPropertyChanged`. This is a no-op when `IsCompact` is `false` and a 1-line change overall.

## Steps to Reproduce

1. Add a dock band extension that sets `Subtitle = ""` at construction and updates it to a non-empty value asynchronously (e.g. after a media session is detected ~150ms later)
2. Set the dock to compact mode
3. **Expected:** subtitle is hidden
4. **Actual:** subtitle is visible. Opening and closing the extension's settings page causes a re-render that makes it disappear.

## Test Plan

- [ ] Dock in compact mode with an extension that sets Subtitle asynchronously — subtitle should remain hidden after the update
- [ ] Dock in non-compact mode with same extension — subtitle should be visible (behavior unchanged)
- [ ] `UpdateAllVisibility()` path (Loaded, IsCompact toggle) still works correctly
