### PR TITLE
[General] Update issue tracker's duplicate resolution message

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -163,7 +163,7 @@ configuration:
             association: Collaborator
       then:
       - addReply:
-          reply: Hi! We've identified this issue as a duplicate of another one that already exists on this Issue Tracker. This specific instance is being closed in favor of tracking the concern over on the referenced thread. Thanks for your report!
+          reply: We've identified this issue as a duplicate of an existing one and are closing this thread so discussion stays in one place.<br/><br/>Please see the comment above for the link to the original tracking issue, and feel free to subscribe there for updates.
       - closeIssue
       - removeLabel:
           label: Needs-Triage


### PR DESCRIPTION
Reopens the change from #46743 (which appears to be broken) on a fresh branch.

Original author: @daverayment

## Summary

GitHub newcomers can be confused by the current duplicate resolution message, as it doesn't clearly point to the original referenced issue - see https://github.com/microsoft/PowerToys/issues/46347#issuecomment-4103681050. They may not realise that the #12345 in the duplicate comment is the relevant link.

This small wording update to the duplicate resolution message tightens up wording slightly and includes reference to the prior `/dup #nnn` comment so newcomers don't miss it.

### Before
> Hi! We've identified this issue as a duplicate of another one that already exists on this Issue Tracker. This specific instance is being closed in favor of tracking the concern over on the referenced thread. Thanks for your report!

### After
> We've identified this issue as a duplicate of an existing one and are closing this thread so discussion stays in one place.<br/><br/>Please see the comment above for the link to the original tracking issue, and feel free to subscribe there for updates.

## Validation Steps Performed
N/A - bot reply text change only.
