### PR TITLE
CmdPal: Fix opening a IPage from a context menu on a dock item

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContextMenuViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContextMenuViewModel.cs
@@ -234,6 +234,14 @@ public partial class ContextMenuViewModel : ObservableObject,
     /// </summary>
     public event EventHandler<CommandItemViewModel>? CommandInvoked;
 
+    /// <summary>
+    /// Raised immediately before the <see cref="PerformCommandMessage"/> is sent.
+    /// Subscribers can decorate the message (for example, to attach an
+    /// <see cref="PerformCommandMessage.OnBeforeShowConfirmation"/> callback).
+    /// Not raised when the user navigates into a submenu.
+    /// </summary>
+    public event EventHandler<PerformCommandMessage>? CommandInvoking;
+
     public ContextKeybindingResult InvokeCommand(CommandItemViewModel? command)
     {
         if (command is null)
@@ -251,7 +259,9 @@ public partial class ContextMenuViewModel : ObservableObject,
         }
         else
         {
-            WeakReferenceMessenger.Default.Send<PerformCommandMessage>(new(command.Command.Model, command.Model));
+            var message = new PerformCommandMessage(command.Command.Model, command.Model);
+            CommandInvoking?.Invoke(this, message);
+            WeakReferenceMessenger.Default.Send(message);
             UpdateContextItems();
             CommandInvoked?.Invoke(this, command);
             return ContextKeybindingResult.Hide;

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContextMenuViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContextMenuViewModel.cs
@@ -228,6 +228,12 @@ public partial class ContextMenuViewModel : ObservableObject,
         }
     }
 
+    /// <summary>
+    /// Raised after a command is actually invoked (i.e. sent as a <see cref="PerformCommandMessage"/>)
+    /// from this context menu. Not raised when the user navigates into a submenu.
+    /// </summary>
+    public event EventHandler<CommandItemViewModel>? CommandInvoked;
+
     public ContextKeybindingResult InvokeCommand(CommandItemViewModel? command)
     {
         if (command is null)
@@ -247,6 +253,7 @@ public partial class ContextMenuViewModel : ObservableObject,
         {
             WeakReferenceMessenger.Default.Send<PerformCommandMessage>(new(command.Command.Model, command.Model));
             UpdateContextItems();
+            CommandInvoked?.Invoke(this, command);
             return ContextKeybindingResult.Hide;
         }
     }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Messages/PerformCommandMessage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Messages/PerformCommandMessage.cs
@@ -20,6 +20,15 @@ public record PerformCommandMessage
 
     public bool TransientPage { get; set; }
 
+    /// <summary>
+    /// Optional callback raised by <see cref="ShellViewModel"/> just before a
+    /// <see cref="ShowConfirmationMessage"/> is dispatched for this command's
+    /// result. Lets the sender prepare UI (for example, the dock uses this to
+    /// open the cmdpal window anchored at the invoking dock item so that the
+    /// confirmation dialog appears in the right place).
+    /// </summary>
+    public Action? OnBeforeShowConfirmation { get; set; }
+
     public PerformCommandMessage(ExtensionObject<ICommand> command)
     {
         Command = command;

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ShellViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ShellViewModel.cs
@@ -386,7 +386,7 @@ public partial class ShellViewModel : ObservableObject,
             var result = invokable.Invoke(message.Context);
 
             // But if it did succeed, we need to handle the result.
-            UnsafeHandleCommandResult(result);
+            UnsafeHandleCommandResult(result, message.OnBeforeShowConfirmation);
 
             success = true;
             _handleInvokeTask = null;
@@ -412,7 +412,7 @@ public partial class ShellViewModel : ObservableObject,
         }
     }
 
-    private void UnsafeHandleCommandResult(ICommandResult? result)
+    private void UnsafeHandleCommandResult(ICommandResult? result, Action? onBeforeShowConfirmation = null)
     {
         if (result is null)
         {
@@ -464,6 +464,17 @@ public partial class ShellViewModel : ObservableObject,
                 {
                     if (result.Args is IConfirmationArgs a)
                     {
+                        // Give the original sender (e.g. the dock) a chance to
+                        // prepare UI before the confirmation dialog surfaces.
+                        try
+                        {
+                            onBeforeShowConfirmation?.Invoke();
+                        }
+                        catch (Exception ex)
+                        {
+                            CoreLogger.LogError(ex.ToString());
+                        }
+
                         WeakReferenceMessenger.Default.Send<ShowConfirmationMessage>(new(a));
                     }
 
@@ -475,7 +486,7 @@ public partial class ShellViewModel : ObservableObject,
                     if (result.Args is IToastArgs a)
                     {
                         WeakReferenceMessenger.Default.Send<ShowToastMessage>(new(a.Message));
-                        UnsafeHandleCommandResult(a.Result);
+                        UnsafeHandleCommandResult(a.Result, onBeforeShowConfirmation);
                     }
 
                     break;

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockControl.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockControl.xaml.cs
@@ -98,6 +98,9 @@ public sealed partial class DockControl : UserControl, IRecipient<CloseContextMe
         WeakReferenceMessenger.Default.Register<ExitDockEditModeMessage>(this);
         WeakReferenceMessenger.Default.Register<CrossMonitorBandDropMessage>(this);
 
+        ContextControl.ViewModel.CommandInvoked -= ContextMenu_CommandInvoked;
+        ContextControl.ViewModel.CommandInvoked += ContextMenu_CommandInvoked;
+
         ViewModel.CenterItems.CollectionChanged -= CenterItems_CollectionChanged;
         ViewModel.CenterItems.CollectionChanged += CenterItems_CollectionChanged;
 
@@ -107,6 +110,8 @@ public sealed partial class DockControl : UserControl, IRecipient<CloseContextMe
     private void DockControl_Unloaded(object sender, RoutedEventArgs e)
     {
         WeakReferenceMessenger.Default.UnregisterAll(this);
+
+        ContextControl.ViewModel.CommandInvoked -= ContextMenu_CommandInvoked;
 
         ViewModel.CenterItems.CollectionChanged -= CenterItems_CollectionChanged;
 
@@ -291,10 +296,7 @@ public sealed partial class DockControl : UserControl, IRecipient<CloseContextMe
         if (sender is DockItemControl dockItem && dockItem.DataContext is DockBandViewModel band && dockItem.Tag is DockItemViewModel item)
         {
             // Use the center of the border as the point to open at
-            var borderPos = dockItem.TransformToVisual(null).TransformPoint(new Point(0, 0));
-            var borderCenter = new Point(
-                borderPos.X + (dockItem.ActualWidth / 2),
-                borderPos.Y + (dockItem.ActualHeight / 2));
+            var borderCenter = GetDockItemCenter(dockItem);
 
             InvokeItem(item, borderCenter);
             e.Handled = true;
@@ -310,6 +312,11 @@ public sealed partial class DockControl : UserControl, IRecipient<CloseContextMe
 
     // Stores the band that was right-clicked for edit mode context menu
     private DockBandViewModel? _editModeContextBand;
+
+    // Position (in window coords) of the dock item whose context menu is currently
+    // open, used to anchor the cmdpal palette when a Page command is invoked from
+    // the context menu. Null when the open context menu is not anchored to a band.
+    private Point? _bandContextMenuPalettePos;
 
     private void BandItem_RightTapped(object sender, Microsoft.UI.Xaml.Input.RightTappedRoutedEventArgs e)
     {
@@ -348,6 +355,10 @@ public sealed partial class DockControl : UserControl, IRecipient<CloseContextMe
             // Normal mode - show the command context menu
             if (item.CanOpenContextMenu)
             {
+                // Remember where to anchor the palette if the user picks a Page
+                // command from the context menu.
+                _bandContextMenuPalettePos = GetDockItemCenter(dockItem);
+
                 ContextControl.ViewModel.SelectedItem = item;
                 ContextControl.ShowFilterBox = true;
                 ContextControl.PrepareForOpen(GetDockContextMenuFilterLocation());
@@ -399,8 +410,7 @@ public sealed partial class DockControl : UserControl, IRecipient<CloseContextMe
             m.TransientPage = true;
             WeakReferenceMessenger.Default.Send(m);
 
-            var isPage = command.Model.Unsafe is not IInvokableCommand invokable;
-            if (isPage)
+            if (IsPageCommand(command.Model.Unsafe))
             {
                 WeakReferenceMessenger.Default.Send<RequestShowPaletteAtMessage>(new(pos, OwnerHwnd));
             }
@@ -408,6 +418,41 @@ public sealed partial class DockControl : UserControl, IRecipient<CloseContextMe
         catch (COMException e)
         {
             Logger.LogError("Error invoking dock command", e);
+        }
+    }
+
+    private static bool IsPageCommand(ICommand? command)
+    {
+        // A Page command is one that's not directly invokable - selecting it
+        // navigates into a page rather than performing an action in place.
+        return command is not null and not IInvokableCommand;
+    }
+
+    private static Point GetDockItemCenter(FrameworkElement dockItem)
+    {
+        var borderPos = dockItem.TransformToVisual(null).TransformPoint(new Point(0, 0));
+        return new Point(
+            borderPos.X + (dockItem.ActualWidth / 2),
+            borderPos.Y + (dockItem.ActualHeight / 2));
+    }
+
+    private void ContextMenu_CommandInvoked(object? sender, CommandItemViewModel command)
+    {
+        // The context menu just invoked a command. If it came from a dock band
+        // (i.e. _bandContextMenuPalettePos is set) and the command is a Page,
+        // open the cmdpal palette anchored at the dock item — mirroring what
+        // a direct click on the band does.
+        var pos = _bandContextMenuPalettePos;
+        _bandContextMenuPalettePos = null;
+
+        if (pos is null)
+        {
+            return;
+        }
+
+        if (IsPageCommand(command.Command.Model.Unsafe))
+        {
+            WeakReferenceMessenger.Default.Send<RequestShowPaletteAtMessage>(new(pos.Value, OwnerHwnd));
         }
     }
 
@@ -433,6 +478,10 @@ public sealed partial class DockControl : UserControl, IRecipient<CloseContextMe
         {
             return;
         }
+
+        // This context menu is for the dock itself (not a band), so the palette
+        // should not be opened on invocation.
+        _bandContextMenuPalettePos = null;
 
         var pos = e.GetPosition(null);
         var item = this.ViewModel.GetContextMenuForDock();

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockControl.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockControl.xaml.cs
@@ -100,6 +100,8 @@ public sealed partial class DockControl : UserControl, IRecipient<CloseContextMe
 
         ContextControl.ViewModel.CommandInvoked -= ContextMenu_CommandInvoked;
         ContextControl.ViewModel.CommandInvoked += ContextMenu_CommandInvoked;
+        ContextControl.ViewModel.CommandInvoking -= ContextMenu_CommandInvoking;
+        ContextControl.ViewModel.CommandInvoking += ContextMenu_CommandInvoking;
 
         ViewModel.CenterItems.CollectionChanged -= CenterItems_CollectionChanged;
         ViewModel.CenterItems.CollectionChanged += CenterItems_CollectionChanged;
@@ -112,6 +114,7 @@ public sealed partial class DockControl : UserControl, IRecipient<CloseContextMe
         WeakReferenceMessenger.Default.UnregisterAll(this);
 
         ContextControl.ViewModel.CommandInvoked -= ContextMenu_CommandInvoked;
+        ContextControl.ViewModel.CommandInvoking -= ContextMenu_CommandInvoking;
 
         ViewModel.CenterItems.CollectionChanged -= CenterItems_CollectionChanged;
 
@@ -403,16 +406,25 @@ public sealed partial class DockControl : UserControl, IRecipient<CloseContextMe
     private void InvokeItem(DockItemViewModel item, Point pos)
     {
         var command = item.Command;
+        var hwnd = OwnerHwnd;
         try
         {
-            PerformCommandMessage m = new(command.Model);
-            m.WithAnimation = false;
-            m.TransientPage = true;
+            PerformCommandMessage m = new(command.Model)
+            {
+                WithAnimation = false,
+                TransientPage = true,
+
+                // If the command is invokable and its result asks for a
+                // confirmation dialog, surface the cmdpal window anchored at
+                // this dock item before the dialog appears.
+                OnBeforeShowConfirmation = () =>
+                    WeakReferenceMessenger.Default.Send<RequestShowPaletteAtMessage>(new(pos, hwnd)),
+            };
             WeakReferenceMessenger.Default.Send(m);
 
             if (IsPageCommand(command.Model.Unsafe))
             {
-                WeakReferenceMessenger.Default.Send<RequestShowPaletteAtMessage>(new(pos, OwnerHwnd));
+                WeakReferenceMessenger.Default.Send<RequestShowPaletteAtMessage>(new(pos, hwnd));
             }
         }
         catch (COMException e)
@@ -454,6 +466,24 @@ public sealed partial class DockControl : UserControl, IRecipient<CloseContextMe
         {
             WeakReferenceMessenger.Default.Send<RequestShowPaletteAtMessage>(new(pos.Value, OwnerHwnd));
         }
+    }
+
+    private void ContextMenu_CommandInvoking(object? sender, PerformCommandMessage message)
+    {
+        // The context menu is about to dispatch a command. If it was opened
+        // from a dock band, attach a callback so that an invokable command
+        // whose result is a Confirm surfaces the cmdpal window anchored at the
+        // dock item before the confirmation dialog appears.
+        var pos = _bandContextMenuPalettePos;
+        if (pos is null)
+        {
+            return;
+        }
+
+        var hwnd = OwnerHwnd;
+        var capturedPos = pos.Value;
+        message.OnBeforeShowConfirmation = () =>
+            WeakReferenceMessenger.Default.Send<RequestShowPaletteAtMessage>(new(capturedPos, hwnd));
     }
 
     private void ContextMenuFlyout_Opened(object sender, object e)


### PR DESCRIPTION
Currently, if the user clicks on a dock item which is a Page command, then we'll attempt to show the cmdpal where the user clicked on a dock item. This works great. However, if the user right-clicks a dock item to invoke the context menu, then from that menu clicks on a Page command, then nothing happens - we don't show the cmdpal window. 

Similarly - IInvokableCommand's that return a CommandResult.Confirm - we never show the cmdpal window so that the confirmation ContentDialog is shown to the user. 

Yes in the long run, these will make more sense to have a better UI for the "dock flyout" (see #45861). But until then, this fixes these scenarios.

Closes #45963

very relevant for #47989