### PR TITLE
[CI] Sign Google.Apis.* and Google.GenAI DLLs (AdvancedPaste Gemini deps)

### DIFF
--- a/.pipelines/ESRPSigning_core.json
+++ b/.pipelines/ESRPSigning_core.json
@@ -383,6 +383,10 @@
                 "ColorCode.Core.dll", 
                 "Microsoft.SemanticKernel.Connectors.Ollama.dll",
                 "OllamaSharp.dll",
+                "WinUI3Apps\\Google.Apis.dll",
+                "WinUI3Apps\\Google.Apis.Auth.dll",
+                "WinUI3Apps\\Google.Apis.Core.dll",
+                "WinUI3Apps\\Google.GenAI.dll",
 
                 "boost_regex-vc143-mt-gd-x32-1_87.dll",
                 "boost_regex-vc143-mt-gd-x64-1_87.dll",


### PR DESCRIPTION
## Summary

Adds the four Google.* DLLs shipped by AdvancedPaste (via `Microsoft.SemanticKernel.Connectors.Google` for Gemini support) to the ESRP sign list.

## Problem

The `Verify all binaries are signed and versioned` pipeline step (`.pipelines/versionAndSignCheck.ps1`) was failing with:

```
Not Signed:  + ...\extractedMachineMsi\File\WinUI3ApplicationsFiles_File_Google.Apis.Auth.dll
Not Signed:  + ...\extractedMachineMsi\File\WinUI3ApplicationsFiles_File_Google.Apis.Core.dll
Not Signed:  + ...\extractedMachineMsi\File\WinUI3ApplicationsFiles_File_Google.Apis.dll
Not Signed:  + ...\extractedMachineMsi\File\WinUI3ApplicationsFiles_File_Google.GenAI.dll
```

These DLLs are transitive NuGet dependencies of `Microsoft.SemanticKernel.Connectors.Google` (referenced by `src/modules/AdvancedPaste/AdvancedPaste/AdvancedPaste.csproj`) and deploy to `WinUI3Apps\`, but were never added to `.pipelines/ESRPSigning_core.json`.

## Fix

Added the four DLLs to the second `SignBatch` (`CP-231522`, the third-party / OSS-library identity) — same batch used for other connector DLLs like `OpenAI.dll`, `OllamaSharp.dll` and `Microsoft.SemanticKernel.Connectors.Ollama.dll`.

## Validation

- `ConvertFrom-Json` on the modified file confirms valid JSON.
- Sign-list entries match the actual deploy paths flagged by `versionAndSignCheck.ps1`.
- The next ESRP signing run will pick them up; the verify step should pass.