### PR TITLE
build(common): align C++ standard and spdlog include settings

### DIFF
--- a/src/common/CalculatorEngineCommon/CalculatorEngineCommon.vcxproj
+++ b/src/common/CalculatorEngineCommon/CalculatorEngineCommon.vcxproj
@@ -161,7 +161,7 @@
     <ClCompile>
       <!-- We use MultiThreadedDebug, rather than MultiThreadedDebugDLL, to avoid DLL dependencies on VCRUNTIME140d.dll and MSVCP140d.dll. -->
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">stdcpp17</LanguageStandard>
+      <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <!-- Link statically against the runtime and STL, but link dynamically against the CRT by ignoring the static CRT

--- a/src/common/UnitTests-CommonUtils/UnitTests-CommonUtils.vcxproj
+++ b/src/common/UnitTests-CommonUtils/UnitTests-CommonUtils.vcxproj
@@ -30,6 +30,7 @@
       <AdditionalIncludeDirectories>..\;..\utils;..\Telemetry;..\..\;..\..\..\deps\;..\..\..\deps\spdlog\include;..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.260126.7\include;$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp23</LanguageStandard>
       <PreprocessorDefinitions>SPDLOG_WCHAR_TO_UTF8_SUPPORT;SPDLOG_HEADER_ONLY;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ForcedIncludeFiles>..\..\..\deps\spdlog-msvc-fix\include\spdlog-msvc-fix.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>


### PR DESCRIPTION
## Summary of the Pull Request

This PR updates common project build settings to improve reliability and compatibility.

Impacted paths:
- [src/common/CalculatorEngineCommon/CalculatorEngineCommon.vcxproj](src/common/CalculatorEngineCommon/CalculatorEngineCommon.vcxproj): Debug|x64 language standard updated from stdcpp17 to stdcpp20.
- [src/common/UnitTests-CommonUtils/UnitTests-CommonUtils.vcxproj](src/common/UnitTests-CommonUtils/UnitTests-CommonUtils.vcxproj): added forced include for spdlog MSVC compatibility header via deps/spdlog-msvc-fix/include/spdlog-msvc-fix.h.

## PR Checklist

- [x] Closes: #48020 
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Dev docs:** Added/updated

N/A:
- Localization (no end-user-facing string changes)
- New binaries (no new binaries or test projects introduced)
- Documentation updated (no product/docs content changes)

## Detailed Description of the Pull Request / Additional comments

The change set focuses on build/toolchain configuration only:

1. CalculatorEngineCommon now targets C++20 for Debug x64, aligning with modern language requirements in this component.
2. UnitTests-CommonUtils now force-includes the spdlog MSVC fix header to prevent compiler/environment-specific issues during test project builds.

Risk is low and scoped to build configuration, but downstream effects may include stricter compiler behavior in Debug x64 for CalculatorEngineCommon.

## Validation Steps Performed

Automated tests run:
- None in this drafting step.

Build/test status:
- Not executed as part of this PR-summary generation workflow.

Reason:
- This output was generated from branch diff and status inspection only. Please replace this section with actual build/test results before opening or updating the PR.