### PR TITLE
[GPO] Add policy to disable Awake's indefinitely mode

### DIFF
--- a/PowerToys.slnx
+++ b/PowerToys.slnx
@@ -9,11 +9,11 @@
       <Platform Solution="*|ARM64" Project="ARM64" />
       <Platform Solution="*|x64" Project="x64" />
     </Project>
-    <Project Path="src/common/Common.UI/Common.UI.csproj">
+    <Project Path="src/common/Common.UI.Controls/Common.UI.Controls.csproj">
       <Platform Solution="*|ARM64" Project="ARM64" />
       <Platform Solution="*|x64" Project="x64" />
     </Project>
-    <Project Path="src/common/Common.UI.Controls/Common.UI.Controls.csproj">
+    <Project Path="src/common/Common.UI/Common.UI.csproj">
       <Platform Solution="*|ARM64" Project="ARM64" />
       <Platform Solution="*|x64" Project="x64" />
     </Project>
@@ -136,6 +136,13 @@
       <Platform Solution="*|ARM64" Project="ARM64" />
       <Platform Solution="*|x64" Project="x64" />
     </Project>
+  </Folder>
+  <Folder Name="/gpo/" />
+  <Folder Name="/gpo/assets/">
+    <File Path="gpo/assets/PowerToys.admx" />
+  </Folder>
+  <Folder Name="/gpo/assets/en-US/">
+    <File Path="gpo/assets/en-US/PowerToys.adml" />
   </Folder>
   <Folder Name="/modules/" />
   <Folder Name="/modules/AdvancedPaste/">
@@ -713,11 +720,11 @@
     </Project>
   </Folder>
   <Folder Name="/modules/PowerDisplay/">
-    <Project Path="src/modules/powerdisplay/PowerDisplay.Models/PowerDisplay.Models.csproj">
+    <Project Path="src/modules/powerdisplay/PowerDisplay.Lib/PowerDisplay.Lib.csproj">
       <Platform Solution="*|ARM64" Project="ARM64" />
       <Platform Solution="*|x64" Project="x64" />
     </Project>
-    <Project Path="src/modules/powerdisplay/PowerDisplay.Lib/PowerDisplay.Lib.csproj">
+    <Project Path="src/modules/powerdisplay/PowerDisplay.Models/PowerDisplay.Models.csproj">
       <Platform Solution="*|ARM64" Project="ARM64" />
       <Platform Solution="*|x64" Project="x64" />
     </Project>
@@ -1102,14 +1109,14 @@
     <BuildDependency Project="src/modules/fancyzones/editor/FancyZonesEditor/FancyZonesEditor.csproj" />
     <BuildDependency Project="src/modules/fancyzones/FancyZonesLib/FancyZonesLib.vcxproj" />
     <BuildDependency Project="src/modules/fancyzones/FancyZonesModuleInterface/FancyZonesModuleInterface.vcxproj" />
+    <BuildDependency Project="src/modules/GrabAndMove/GrabAndMove/GrabAndMove.vcxproj" />
+    <BuildDependency Project="src/modules/GrabAndMove/GrabAndMoveModuleInterface/GrabAndMoveModuleInterface.vcxproj" />
     <BuildDependency Project="src/modules/imageresizer/dll/ImageResizerExt.vcxproj" />
     <BuildDependency Project="src/modules/imageresizer/ui/ImageResizerUI.csproj" />
     <BuildDependency Project="src/modules/keyboardmanager/dll/KeyboardManager.vcxproj" />
     <BuildDependency Project="src/modules/launcher/Microsoft.Launcher/Microsoft.Launcher.vcxproj" />
     <BuildDependency Project="src/modules/LightSwitch/LightSwitchModuleInterface/LightSwitchModuleInterface.vcxproj" />
     <BuildDependency Project="src/modules/LightSwitch/LightSwitchService/LightSwitchService.vcxproj" />
-    <BuildDependency Project="src/modules/GrabAndMove/GrabAndMoveModuleInterface/GrabAndMoveModuleInterface.vcxproj" />
-    <BuildDependency Project="src/modules/GrabAndMove/GrabAndMove/GrabAndMove.vcxproj" />
     <BuildDependency Project="src/modules/powerrename/dll/PowerRenameExt.vcxproj" />
     <BuildDependency Project="src/modules/powerrename/lib/PowerRenameLib.vcxproj" />
     <BuildDependency Project="src/modules/previewpane/Common/PreviewHandlerCommon.csproj" />

--- a/gpo/assets/PowerToys.admx
+++ b/gpo/assets/PowerToys.admx
@@ -1,0 +1,851 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) Microsoft Corporation.
+     Licensed under the MIT License. -->
+<policyDefinitions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.21" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
+  <policyNamespaces>
+    <target prefix="powertoys" namespace="Microsoft.Policies.PowerToys" />
+  </policyNamespaces>
+  <resources minRequiredRevision="1.21"/><!-- Last changed with PowerToys v0.98.0 -->
+  <supportedOn>
+    <definitions>
+      <definition name="SUPPORTED_POWERTOYS_0_64_0" displayName="$(string.SUPPORTED_POWERTOYS_0_64_0)"/>
+      <definition name="SUPPORTED_POWERTOYS_0_68_0" displayName="$(string.SUPPORTED_POWERTOYS_0_68_0)"/>
+      <definition name="SUPPORTED_POWERTOYS_0_69_0" displayName="$(string.SUPPORTED_POWERTOYS_0_69_0)"/>
+      <definition name="SUPPORTED_POWERTOYS_0_70_0" displayName="$(string.SUPPORTED_POWERTOYS_0_70_0)"/>
+      <definition name="SUPPORTED_POWERTOYS_0_73_0" displayName="$(string.SUPPORTED_POWERTOYS_0_73_0)"/>
+      <definition name="SUPPORTED_POWERTOYS_0_75_0" displayName="$(string.SUPPORTED_POWERTOYS_0_75_0)"/>
+      <definition name="SUPPORTED_POWERTOYS_0_76_0" displayName="$(string.SUPPORTED_POWERTOYS_0_76_0)"/>
+      <definition name="SUPPORTED_POWERTOYS_0_77_0" displayName="$(string.SUPPORTED_POWERTOYS_0_77_0)"/>
+      <definition name="SUPPORTED_POWERTOYS_0_78_0" displayName="$(string.SUPPORTED_POWERTOYS_0_78_0)"/>
+      <definition name="SUPPORTED_POWERTOYS_0_81_0" displayName="$(string.SUPPORTED_POWERTOYS_0_81_0)"/>
+      <definition name="SUPPORTED_POWERTOYS_0_81_1" displayName="$(string.SUPPORTED_POWERTOYS_0_81_1)"/>
+      <definition name="SUPPORTED_POWERTOYS_0_83_0" displayName="$(string.SUPPORTED_POWERTOYS_0_83_0)"/>
+      <definition name="SUPPORTED_POWERTOYS_0_84_0" displayName="$(string.SUPPORTED_POWERTOYS_0_84_0)"/>
+      <definition name="SUPPORTED_POWERTOYS_0_85_0" displayName="$(string.SUPPORTED_POWERTOYS_0_85_0)"/>
+      <definition name="SUPPORTED_POWERTOYS_0_86_0" displayName="$(string.SUPPORTED_POWERTOYS_0_86_0)"/>
+      <definition name="SUPPORTED_POWERTOYS_0_88_0" displayName="$(string.SUPPORTED_POWERTOYS_0_88_0)"/>
+      <definition name="SUPPORTED_POWERTOYS_0_89_0" displayName="$(string.SUPPORTED_POWERTOYS_0_89_0)"/>
+      <definition name="SUPPORTED_POWERTOYS_0_90_0" displayName="$(string.SUPPORTED_POWERTOYS_0_90_0)"/>
+      <definition name="SUPPORTED_POWERTOYS_0_96_0" displayName="$(string.SUPPORTED_POWERTOYS_0_96_0)"/>
+      <definition name="SUPPORTED_POWERTOYS_0_97_0" displayName="$(string.SUPPORTED_POWERTOYS_0_97_0)"/>
+      <definition name="SUPPORTED_POWERTOYS_0_98_0" displayName="$(string.SUPPORTED_POWERTOYS_0_98_0)"/>
+      <definition name="SUPPORTED_POWERTOYS_0_99_0" displayName="$(string.SUPPORTED_POWERTOYS_0_99_0)"/>
+	  <definition name="SUPPORTED_POWERTOYS_0_99_2" displayName="$(string.SUPPORTED_POWERTOYS_0_99_2)"/>
+	  <definition name="SUPPORTED_POWERTOYS_0_64_0_TO_0_87_1" displayName="$(string.SUPPORTED_POWERTOYS_0_64_0_TO_0_87_1)"/>
+    </definitions>
+  </supportedOn>
+  <categories>
+    <category name="PowerToys" displayName="$(string.PowerToys)" />
+    <category name="InstallerUpdates" displayName="$(string.InstallerUpdates)">
+      <parentCategory ref="PowerToys" />
+    </category>
+    <category name="PowerToysRun" displayName="$(string.PowerToysRun)">
+      <parentCategory ref="PowerToys" />
+    </category>
+    <category name="AdvancedPaste" displayName="$(string.AdvancedPaste)">
+      <parentCategory ref="PowerToys" />
+    </category>
+    <category name="MouseWithoutBorders" displayName="$(string.MouseWithoutBorders)">
+      <parentCategory ref="PowerToys" />
+    </category>
+    <category name="GeneralSettings" displayName="$(string.GeneralSettings)">
+      <parentCategory ref="PowerToys" />
+    </category>
+    <category name="NewPlus" displayName="$(string.NewPlus)">
+      <parentCategory ref="PowerToys" />
+    </category>
+    <category name="DeprecatedPolicies" displayName="$(string.DeprecatedPolicies)">
+      <parentCategory ref="PowerToys" />
+    </category>
+  </categories>
+  <policies>
+
+ <!--The name (id) of the policy is different to sort it as first policy in edit dialog. The order is sorted alphabetically based on the "name" property.-->
+    <policy name="ConfigureAllUtilityGlobalEnabledState" class="Both" displayName="$(string.ConfigureAllUtilityGlobalEnabledState)" explainText="$(string.ConfigureAllUtilityGlobalEnabledStateDescription)" key="Software\Policies\PowerToys" valueName="ConfigureGlobalUtilityEnabledState">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_75_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+
+    <policy name="ConfigureEnabledUtilityAdvancedPaste" class="Both" displayName="$(string.ConfigureEnabledUtilityAdvancedPaste)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityAdvancedPaste">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_81_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityAlwaysOnTop" class="Both" displayName="$(string.ConfigureEnabledUtilityAlwaysOnTop)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityAlwaysOnTop">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityAwake" class="Both" displayName="$(string.ConfigureEnabledUtilityAwake)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityAwake">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+	  <policy name="ConfigureEnabledAwakeIndefinitely" class="Both" displayName="$(string.ConfigureEnabledAwakeIndefinitely)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledAwakeIndefinitely">
+		  <parentCategory ref="PowerToys" />
+		  <supportedOn ref="SUPPORTED_POWERTOYS_0_99_2" />
+		  <enabledValue>
+			  <decimal value="1" />
+		  </enabledValue>
+		  <disabledValue>
+			  <decimal value="0" />
+		  </disabledValue>
+	  </policy>
+    <policy name="ConfigureEnabledUtilityCmdNotFound" class="Both" displayName="$(string.ConfigureEnabledUtilityCmdNotFound)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityCmdNotFound">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_77_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityCmdPal" class="Both" displayName="$(string.ConfigureEnabledUtilityCmdPal)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityCmdPal">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_90_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityColorPicker" class="Both" displayName="$(string.ConfigureEnabledUtilityColorPicker)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityColorPicker">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityCropAndLock" class="Both" displayName="$(string.ConfigureEnabledUtilityCropAndLock)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityCropAndLock">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_73_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityLightSwitch" class="Both" displayName="$(string.ConfigureEnabledUtilityLightSwitch)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityLightSwitch">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_95_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityPowerDisplay" class="Both" displayName="$(string.ConfigureEnabledUtilityPowerDisplay)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityPowerDisplay">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_99_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityEnvironmentVariables" class="Both" displayName="$(string.ConfigureEnabledUtilityEnvironmentVariables)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityEnvironmentVariables">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_75_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityFancyZones" class="Both" displayName="$(string.ConfigureEnabledUtilityFancyZones)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFancyZones">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityFileLocksmith" class="Both" displayName="$(string.ConfigureEnabledUtilityFileLocksmith)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileLocksmith">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityFileExplorerSVGPreview" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerSVGPreview)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerSVGPreview">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityFileExplorerMarkdownPreview" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerMarkdownPreview)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerMarkdownPreview">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityFileExplorerMonacoPreview" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerMonacoPreview)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerMonacoPreview">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityFileExplorerPDFPreview" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerPDFPreview)" explainText="$(string.ConfigureEnabledUtilityDescriptionPDFPreviewHandler)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerPDFPreview">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityFileExplorerGcodePreview" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerGcodePreview)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerGcodePreview">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityFileExplorerBgcodePreview" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerBgcodePreview)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerBgcodePreview">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_93_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityFileExplorerSVGThumbnails" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerSVGThumbnails)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerSVGThumbnails">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityFileExplorerPDFThumbnails" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerPDFThumbnails)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerPDFThumbnails">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityFileExplorerGcodeThumbnails" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerGcodeThumbnails)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerGcodeThumbnails">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityFileExplorerBgcodeThumbnails" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerBgcodeThumbnails)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerBgcodeThumbnails">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_93_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityFileExplorerQOIPreview" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerQOIPreview)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerQOIPreview">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_76_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityFileExplorerQOIThumbnails" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerQOIThumbnails)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerQOIThumbnails">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_76_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityFileExplorerSTLThumbnails" class="Both" displayName="$(string.ConfigureEnabledUtilityFileExplorerSTLThumbnails)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFileExplorerSTLThumbnails">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityHostsFileEditor" class="Both" displayName="$(string.ConfigureEnabledUtilityHostsFileEditor)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityHostsFileEditor">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityImageResizer" class="Both" displayName="$(string.ConfigureEnabledUtilityImageResizer)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityImageResizer">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityKeyboardManager" class="Both" displayName="$(string.ConfigureEnabledUtilityKeyboardManager)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityKeyboardManager">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityCursorWrap" class="Both" displayName="$(string.ConfigureEnabledUtilityCursorWrap)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityCursorWrap">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_97_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityFindMyMouse" class="Both" displayName="$(string.ConfigureEnabledUtilityFindMyMouse)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityFindMyMouse">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityMouseHighlighter" class="Both" displayName="$(string.ConfigureEnabledUtilityMouseHighlighter)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityMouseHighlighter">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityMousePointerCrosshairs" class="Both" displayName="$(string.ConfigureEnabledUtilityMousePointerCrosshairs)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityMousePointerCrosshairs">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityMouseJump" class="Both" displayName="$(string.ConfigureEnabledUtilityMouseJump)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityMouseJump">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_68_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityMouseWithoutBorders" class="Both" displayName="$(string.ConfigureEnabledUtilityMouseWithoutBorders)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityMouseWithoutBorders">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_70_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityNewPlus" class="Both" displayName="$(string.ConfigureEnabledUtilityNewPlus)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityNewPlus">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_85_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityPeek" class="Both" displayName="$(string.ConfigureEnabledUtilityPeek)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityPeek">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_70_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityPowerRename" class="Both" displayName="$(string.ConfigureEnabledUtilityPowerRename)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityPowerRename">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityPowerLauncher" class="Both" displayName="$(string.ConfigureEnabledUtilityPowerLauncher)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityPowerLauncher">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityWorkspaces" class="Both" displayName="$(string.ConfigureEnabledUtilityWorkspaces)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityWorkspaces">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_84_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityQuickAccent" class="Both" displayName="$(string.ConfigureEnabledUtilityQuickAccent)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityQuickAccent">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityRegistryPreview" class="Both" displayName="$(string.ConfigureEnabledUtilityRegistryPreview)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityRegistryPreview">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_69_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityScreenRuler" class="Both" displayName="$(string.ConfigureEnabledUtilityScreenRuler)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityScreenRuler">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityShortcutGuide" class="Both" displayName="$(string.ConfigureEnabledUtilityShortcutGuide)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityShortcutGuide">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityTextExtractor" class="Both" displayName="$(string.ConfigureEnabledUtilityTextExtractor)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityTextExtractor">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityVideoConferenceMute" class="Both" displayName="$(string.ConfigureEnabledUtilityVideoConferenceMute)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityVideoConferenceMute">
+      <parentCategory ref="DeprecatedPolicies" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_64_0_TO_0_87_1" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureEnabledUtilityZoomIt" class="Both" displayName="$(string.ConfigureEnabledUtilityZoomIt)" explainText="$(string.ConfigureEnabledUtilityDescription)" key="Software\Policies\PowerToys" valueName="ConfigureEnabledUtilityZoomIt">
+      <parentCategory ref="PowerToys" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_88_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="DisablePerUserInstallation" class="Machine" displayName="$(string.DisablePerUserInstallation)" explainText="$(string.DisablePerUserInstallationDescription)" key="Software\Policies\PowerToys" valueName="PerUserInstallationDisabled">
+      <parentCategory ref="InstallerUpdates" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_69_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="DisableAutomaticUpdateDownload" class="Both" displayName="$(string.DisableAutomaticUpdateDownload)" explainText="$(string.DisableAutomaticUpdateDownloadDescription)" key="Software\Policies\PowerToys" valueName="AutomaticUpdateDownloadDisabled">
+      <parentCategory ref="InstallerUpdates" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_68_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="SuspendNewUpdateToast" class="Both" displayName="$(string.SuspendNewUpdateToast)" explainText="$(string.SuspendNewUpdateToastDescription)" key="Software\Policies\PowerToys" valueName="SuspendNewUpdateAvailableToast">
+      <parentCategory ref="InstallerUpdates" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_68_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="DisableNewUpdateToast" class="Both" displayName="$(string.DisableNewUpdateToast)" explainText="$(string.DisableNewUpdateToastDescription)" key="Software\Policies\PowerToys" valueName="DisableNewUpdateAvailableToast">
+      <parentCategory ref="InstallerUpdates" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_78_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="DoNotShowWhatsNewAfterUpdates" class="Both" displayName="$(string.DoNotShowWhatsNewAfterUpdates)" explainText="$(string.DoNotShowWhatsNewAfterUpdatesDescription)" key="Software\Policies\PowerToys" valueName="DoNotShowWhatsNewAfterUpdates">
+      <parentCategory ref="InstallerUpdates" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_78_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="AllowExperimentation" class="Both" displayName="$(string.AllowExperimentation)" explainText="$(string.AllowExperimentationDescription)" key="Software\Policies\PowerToys" valueName="AllowExperimentation">
+      <parentCategory ref="GeneralSettings" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_68_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="AllowDiagnosticData" class="Both" displayName="$(string.AllowDiagnosticData)" explainText="$(string.AllowDiagnosticDataDescription)" key="Software\Policies\PowerToys" valueName="AllowDataDiagnostics">
+      <parentCategory ref="GeneralSettings" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_86_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="ConfigureRunAtStartup" class="Both" displayName="$(string.ConfigureRunAtStartup)" explainText="$(string.ConfigureRunAtStartupDescription)" key="Software\Policies\PowerToys" valueName="ConfigureRunAtStartup">
+      <parentCategory ref="GeneralSettings" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_89_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="PowerToysRunAllPluginsEnabledState" class="Both" displayName="$(string.PowerToysRunAllPluginsEnabledState)" explainText="$(string.PowerToysRunAllPluginsEnabledStateDescription)" key="Software\Policies\PowerToys" valueName="PowerLauncherAllPluginsEnabledState">
+      <parentCategory ref="PowerToysRun" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_75_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="PowerToysRunIndividualPluginEnabledState" class="Both" displayName="$(string.PowerToysRunIndividualPluginEnabledState)" explainText="$(string.PowerToysRunIndividualPluginEnabledStateDescription)" presentation="$(presentation.PowerToysRunIndividualPluginEnabledState)" key="Software\Policies\PowerToys\PowerLauncherIndividualPluginEnabledList">
+      <parentCategory ref="PowerToysRun" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_75_0"/>
+      <elements>
+        <list id="PowerToysRunIndividualPluginEnabledList" explicitValue="true" />
+      </elements>
+    </policy>
+    <policy name="AllowPowerToysAdvancedPasteOnlineAIModels" class="Both" displayName="$(string.AllowPowerToysAdvancedPasteOnlineAIModels)" explainText="$(string.AllowPowerToysAdvancedPasteOnlineAIModelsDescription)" key="Software\Policies\PowerToys" valueName="AllowPowerToysAdvancedPasteOnlineAIModels">
+      <parentCategory ref="AdvancedPaste" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_81_1" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="AllowAdvancedPasteOpenAI" class="Both" displayName="$(string.AllowAdvancedPasteOpenAI)" explainText="$(string.AllowAdvancedPasteOpenAIDescription)" key="Software\Policies\PowerToys" valueName="AllowAdvancedPasteOpenAI">
+      <parentCategory ref="AdvancedPaste" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_96_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="AllowAdvancedPasteAzureOpenAI" class="Both" displayName="$(string.AllowAdvancedPasteAzureOpenAI)" explainText="$(string.AllowAdvancedPasteAzureOpenAIDescription)" key="Software\Policies\PowerToys" valueName="AllowAdvancedPasteAzureOpenAI">
+      <parentCategory ref="AdvancedPaste" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_96_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="AllowAdvancedPasteAzureAIInference" class="Both" displayName="$(string.AllowAdvancedPasteAzureAIInference)" explainText="$(string.AllowAdvancedPasteAzureAIInferenceDescription)" key="Software\Policies\PowerToys" valueName="AllowAdvancedPasteAzureAIInference">
+      <parentCategory ref="AdvancedPaste" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_96_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="AllowAdvancedPasteMistral" class="Both" displayName="$(string.AllowAdvancedPasteMistral)" explainText="$(string.AllowAdvancedPasteMistralDescription)" key="Software\Policies\PowerToys" valueName="AllowAdvancedPasteMistral">
+      <parentCategory ref="AdvancedPaste" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_96_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="AllowAdvancedPasteGoogle" class="Both" displayName="$(string.AllowAdvancedPasteGoogle)" explainText="$(string.AllowAdvancedPasteGoogleDescription)" key="Software\Policies\PowerToys" valueName="AllowAdvancedPasteGoogle">
+      <parentCategory ref="AdvancedPaste" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_96_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="AllowAdvancedPasteAnthropic" class="Both" displayName="$(string.AllowAdvancedPasteAnthropic)" explainText="$(string.AllowAdvancedPasteAnthropicDescription)" key="Software\Policies\PowerToys" valueName="AllowAdvancedPasteAnthropic">
+      <parentCategory ref="AdvancedPaste" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_96_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="AllowAdvancedPasteOllama" class="Both" displayName="$(string.AllowAdvancedPasteOllama)" explainText="$(string.AllowAdvancedPasteOllamaDescription)" key="Software\Policies\PowerToys" valueName="AllowAdvancedPasteOllama">
+      <parentCategory ref="AdvancedPaste" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_96_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="AllowAdvancedPasteFoundryLocal" class="Both" displayName="$(string.AllowAdvancedPasteFoundryLocal)" explainText="$(string.AllowAdvancedPasteFoundryLocalDescription)" key="Software\Policies\PowerToys" valueName="AllowAdvancedPasteFoundryLocal">
+      <parentCategory ref="AdvancedPaste" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_96_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="MwbClipboardSharingEnabled" class="Both" displayName="$(string.MwbClipboardSharingEnabled)" explainText="$(string.MwbClipboardSharingEnabledDescription)" key="Software\Policies\PowerToys" valueName="MwbClipboardSharingEnabled">
+      <parentCategory ref="MouseWithoutBorders" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_83_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="MwbFileTransferEnabled" class="Both" displayName="$(string.MwbFileTransferEnabled)" explainText="$(string.MwbFileTransferEnabledDescription)" key="Software\Policies\PowerToys" valueName="MwbFileTransferEnabled">
+      <parentCategory ref="MouseWithoutBorders" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_83_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="MwbUseOriginalUserInterface" class="Both" displayName="$(string.MwbUseOriginalUserInterface)" explainText="$(string.MwbUseOriginalUserInterfaceDescription)" key="Software\Policies\PowerToys" valueName="MwbUseOriginalUserInterface">
+      <parentCategory ref="MouseWithoutBorders" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_83_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="MwbDisallowBlockingScreensaver" class="Both" displayName="$(string.MwbDisallowBlockingScreensaver)" explainText="$(string.MwbDisallowBlockingScreensaverDescription)" key="Software\Policies\PowerToys" valueName="MwbDisallowBlockingScreensaver">
+      <parentCategory ref="MouseWithoutBorders" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_83_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="MwbAllowServiceMode" class="Machine" displayName="$(string.MwbAllowServiceMode)" explainText="$(string.MwbAllowServiceModeDescription)" key="Software\Policies\PowerToys" valueName="MwbAllowServiceMode">
+      <parentCategory ref="MouseWithoutBorders" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_89_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="MwbSameSubnetOnly" class="Both" displayName="$(string.MwbSameSubnetOnly)" explainText="$(string.MwbSameSubnetOnlyDescription)" key="Software\Policies\PowerToys" valueName="MwbSameSubnetOnly">
+      <parentCategory ref="MouseWithoutBorders" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_83_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="MwbValidateRemoteIp" class="Both" displayName="$(string.MwbValidateRemoteIp)" explainText="$(string.MwbValidateRemoteIpDescription)" key="Software\Policies\PowerToys" valueName="MwbValidateRemoteIp">
+      <parentCategory ref="MouseWithoutBorders" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_83_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="MwbDisableUserDefinedIpMappingRules" class="Both" displayName="$(string.MwbDisableUserDefinedIpMappingRules)" explainText="$(string.MwbDisableUserDefinedIpMappingRulesDescription)" key="Software\Policies\PowerToys" valueName="MwbDisableUserDefinedIpMappingRules">
+      <parentCategory ref="MouseWithoutBorders" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_83_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="MwbPolicyDefinedIpMappingRules" class="Both" displayName="$(string.MwbPolicyDefinedIpMappingRules)" explainText="$(string.MwbPolicyDefinedIpMappingRulesDescription)" presentation="$(presentation.MwbPolicyDefinedIpMappingRules)" key="Software\Policies\PowerToys">
+      <parentCategory ref="MouseWithoutBorders" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_83_0" />
+      <elements>
+        <!--Max length means here max length per line. We support 65 characters per line. (A string containing the hostname, a space and an IPv6 Address is max. 55 characters long.)-->
+        <multiText id="MwbPolicyDefinedIpMappingsList" valueName="MwbPolicyDefinedIpMappingRules" maxLength="65" required="true"/>
+      </elements>
+    </policy>
+    <policy name="NewPlusHideTemplateFilenameExtension" class="Both" displayName="$(string.NewPlusHideTemplateFilenameExtension)" explainText="$(string.NewPlusHideTemplateFilenameExtensionDescription)" key="Software\Policies\PowerToys" valueName="NewPlusHideTemplateFilenameExtension">
+      <parentCategory ref="NewPlus" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_85_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="NewPlusReplaceVariablesInTemplateFilenames" class="Both" displayName="$(string.NewPlusReplaceVariablesInTemplateFilenames)" explainText="$(string.NewPlusReplaceVariablesInTemplateFilenamesDescription)" key="Software\Policies\PowerToys" valueName="NewPlusReplaceVariablesInTemplateFilenames">
+      <parentCategory ref="NewPlus" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_90_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+    <policy name="NewPlusHideBuiltInNewContextMenu" class="Both" displayName="$(string.NewPlusHideBuiltInNewContextMenu)" explainText="$(string.NewPlusHideBuiltInNewContextMenuDescription)" key="Software\Policies\PowerToys" valueName="NewPlusHideBuiltInNewContextMenu">
+      <parentCategory ref="NewPlus" />
+      <supportedOn ref="SUPPORTED_POWERTOYS_0_98_0" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+  </policies>
+</policyDefinitions>

--- a/gpo/assets/en-US/PowerToys.adml
+++ b/gpo/assets/en-US/PowerToys.adml
@@ -1,0 +1,384 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) Microsoft Corporation.
+     Licensed under the MIT License. -->
+<policyDefinitionResources xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" revision="1.20" schemaVersion="1.0" xmlns="http://schemas.microsoft.com/GroupPolicy/2006/07/PolicyDefinitions">
+  <displayName>PowerToys</displayName>
+  <description>PowerToys</description>
+  <resources>
+    <stringTable>
+      <string id="PowerToys">Microsoft PowerToys</string>
+      <string id="InstallerUpdates">Installer and Updates</string>
+      <string id="PowerToysRun">PowerToys Run</string>
+      <string id="AdvancedPaste">Advanced Paste</string>
+      <string id="MouseWithoutBorders">Mouse Without Borders</string>
+      <string id="GeneralSettings">General settings</string>
+      <string id="NewPlus">New+</string>
+      <string id="DeprecatedPolicies">Deprecated policies</string>
+
+      <string id="SUPPORTED_POWERTOYS_0_64_0">PowerToys version 0.64.0 or later</string>
+      <string id="SUPPORTED_POWERTOYS_0_68_0">PowerToys version 0.68.0 or later</string>
+      <string id="SUPPORTED_POWERTOYS_0_69_0">PowerToys version 0.69.0 or later</string>
+      <string id="SUPPORTED_POWERTOYS_0_70_0">PowerToys version 0.70.0 or later</string>
+      <string id="SUPPORTED_POWERTOYS_0_73_0">PowerToys version 0.73.0 or later</string>
+      <string id="SUPPORTED_POWERTOYS_0_75_0">PowerToys version 0.75.0 or later</string>
+      <string id="SUPPORTED_POWERTOYS_0_76_0">PowerToys version 0.76.0 or later</string>
+      <string id="SUPPORTED_POWERTOYS_0_77_0">PowerToys version 0.77.0 or later</string>
+      <string id="SUPPORTED_POWERTOYS_0_78_0">PowerToys version 0.78.0 or later</string>
+      <string id="SUPPORTED_POWERTOYS_0_81_0">PowerToys version 0.81.0 or later</string>
+      <string id="SUPPORTED_POWERTOYS_0_81_1">PowerToys version 0.81.1 or later</string>
+      <string id="SUPPORTED_POWERTOYS_0_83_0">PowerToys version 0.83.0 or later</string>
+      <string id="SUPPORTED_POWERTOYS_0_84_0">PowerToys version 0.84.0 or later</string>
+      <string id="SUPPORTED_POWERTOYS_0_85_0">PowerToys version 0.85.0 or later</string>
+      <string id="SUPPORTED_POWERTOYS_0_86_0">PowerToys version 0.86.0 or later</string>
+      <string id="SUPPORTED_POWERTOYS_0_88_0">PowerToys version 0.88.0 or later</string>
+      <string id="SUPPORTED_POWERTOYS_0_89_0">PowerToys version 0.89.0 or later</string>
+      <string id="SUPPORTED_POWERTOYS_0_90_0">PowerToys version 0.90.0 or later</string>
+      <string id="SUPPORTED_POWERTOYS_0_96_0">PowerToys version 0.96.0 or later</string>
+      <string id="SUPPORTED_POWERTOYS_0_97_0">PowerToys version 0.97.0 or later</string>
+      <string id="SUPPORTED_POWERTOYS_0_98_0">PowerToys version 0.98.0 or later</string>
+      <string id="SUPPORTED_POWERTOYS_0_99_0">PowerToys version 0.99.0 or later</string>
+	  <string id="SUPPORTED_POWERTOYS_0_100_0">PowerToys version 0.100.0 or later</string>
+	  <string id="SUPPORTED_POWERTOYS_0_64_0_TO_0_87_1">From PowerToys version 0.64.0 until PowerToys version 0.87.1</string>
+
+      <string id="ConfigureAllUtilityGlobalEnabledStateDescription">This policy configures the enabled state for all PowerToys utilities.
+
+If you enable this setting, all utilities will be always enabled and the user won't be able to disable it.
+
+If you disable this setting, all utilities will be always disabled and the user won't be able to enable it.
+
+If you don't configure this setting, users are able to enable or disable the utilities.
+
+The individual enabled state policies for the utilities will override this policy.
+</string>
+
+      <string id="ConfigureEnabledUtilityDescription">This policy configures the enabled state for a PowerToys utility.
+
+If you enable this setting, the utility will be always enabled and the user won't be able to disable it.
+
+If you disable this setting, the utility will be always disabled and the user won't be able to enable it.
+
+If you don't configure this setting, users are able to enable or disable the utility.
+
+This policy has a higher priority than the policy "Configure global utility enabled state" and overrides it.
+</string>
+      <string id="ConfigureEnabledUtilityDescriptionPDFPreviewHandler">(Note: There have been reports of incompatibility between the PDF Preview Handler and Outlook)
+
+This policy configures the enabled state for a PowerToys utility.
+
+If you enable this setting, the utility will be always enabled and the user won't be able to disable it.
+
+If you disable this setting, the utility will be always disabled and the user won't be able to enable it.
+
+If you don't configure this setting, users are able to enable or disable the utility.
+
+This policy has a higher priority than the policy "Configure global utility enabled state" and overrides it.
+</string>
+      <string id="DisablePerUserInstallationDescription">This policy configures whether per-user PowerToys installation is allowed or not.
+
+If enabled, per-user installation is not allowed.
+
+If disabled or not configured, per-user installation is allowed.
+</string>
+      <string id="DisableAutomaticUpdateDownloadDescription">This policy configures whether or not the automatic download and installation of available updates is disabled. (On metered connections updates are never downloaded.)
+
+If enabled, automatic download and installation is disabled.
+
+If disabled or not configured, the user can control this in the settings.
+</string>
+      <string id="SuspendNewUpdateToastDescription">This policy configures whether the action center notification for new updates is suspended for 2 minor releases. (Example: if the installed version is v0.60.0, then the next notification is shown for the v0.63.* release.)
+
+If enabled, the notification is suspended.
+
+If disabled or not configured, the notification is shown.
+
+Note: The notification about new major versions is always displayed.
+
+This policy has no effect if the update notification is disabled by the policy "Disable Action Center notification for new updates" or the user setting.
+</string>
+      <string id="DisableNewUpdateToastDescription">This policy configures whether or not the action center notification for new updates is shown.
+
+If enabled, the notification is disabled.
+
+If disabled or not configured, the user can control if the notification is shown or not.
+</string>
+      <string id="DoNotShowWhatsNewAfterUpdatesDescription">This policy allows you to configure if the window with the release notes is shown after updates.
+
+If enabled, the window with the release notes is not shown automatically.
+
+If disabled or not configured, the user can control this in the settings of PowerToys.
+</string>
+      <string id="AllowExperimentationDescription">This policy configures whether PowerToys experimentation is allowed. With experimentation allowed the user sees the new features being experimented if it gets selected as part of the test group. (Experimentation will only happen on Windows Insider builds.)
+
+If this setting is enabled or not configured, the user can control experimentation in the PowerToys settings menu.
+
+If this setting is disabled, experimentation is not allowed.
+</string>
+      <string id="AllowDiagnosticDataDescription">This policy configures whether sending of PowerToys diagnostic data is allowed. With diagnostic data sending allowed the user helps inform bug fixes, performance and improvements.
+
+If this setting is enabled or not configured, the user can control diagnostic data sending in the PowerToys settings menu.
+
+If this setting is disabled, diagnostic data sending is not allowed.
+</string>
+      <string id="ConfigureRunAtStartupDescription">This policy configures the "run at startup" setting of PowerToys.
+
+If you enable this setting, the "run at startup" setting will be always enabled and the user won't be able to disable it.
+
+If you disable this setting, the "run at startup" setting will be always disabled and the user won't be able to enable it.
+
+If you don't configure this setting, users are able to enable or disable "run at startup" at will.
+
+Note: This only controls the PowerToys method that creates a scheduled task to start PowerToys at login. It doesn't control other custom auto-start methods that the user might try to use outside of PowerToys or manually creating/deleting a scheduled task.
+</string>
+      <string id="PowerToysRunAllPluginsEnabledStateDescription">This policy configures the enabled state for all PowerToys Run plugins. All plugins will have the same state.
+
+If you enable this setting, the plugins will be always enabled and the user won't be able to disable it.
+
+If you disable this setting, the plugins will be always disabled and the user won't be able to enable it.
+
+If you don't configure this setting, users are able to enable or disable the plugins.
+
+You can override this policy for individual plugins using the policy "Configure enabled state for individual plugins".
+
+Note: Changes require a restart of PowerToys Run.
+</string>
+      <string id="PowerToysRunIndividualPluginEnabledStateDescription">With this policy you can configure an individual enabled state for each PowerToys Run plugin that you add to the list.
+
+If you enable this setting, you can define the list of plugins and their enabled states:
+  - The value name (first column) is the plugin ID. You will find it in the plugin.json file which is located in the plugin folder.
+  - The value (second column) is a numeric value: 0 for disabled, 1 for enabled and 2 for user takes control.
+  - Example to disable the Program plugin: 791FC278BA414111B8D1886DFE447410 | 0
+
+If you disable or don't configure this policy, either the user or the policy "Configure enabled state for all plugins" takes control over the enabled state of the plugins.
+
+You can set the enabled state for all plugins not configured by this policy using the policy "Configure enabled state for all plugins".
+
+Note: Changes require a restart of PowerToys Run.
+</string>
+      <string id="AllowPowerToysAdvancedPasteOnlineAIModelsDescription">This policy allows you to disable Advanced Paste online AI models.
+
+If you enable or don't configure this policy, the user takes control over the enabled state of the Enable paste with AI Advanced Paste setting.
+
+If you disable this policy, the user won't be able to enable Enable paste with AI Advanced Paste setting and use Advanced Paste AI prompt nor set up the Open AI key in PowerToys Settings.
+</string>
+      <string id="MwbClipboardSharingEnabledDescription">This policy configures if the user can share the clipboard between machines.
+
+If you enable or don't configure this policy, the user takes control over the clipboard sharing setting.
+
+If you disable this policy, the user won't be able to enable the clipboard sharing setting.
+</string>
+      <string id="MwbFileTransferEnabledDescription">This policy configures if the user can transfer files between machines.
+
+If you enable or don't configure this policy, the user takes control over the file sharing setting.
+
+If you disable this policy, the user won't be able to enable the file sharing Settings.
+
+Note: The file sharing feature depends on the clipboard sharing feature. Disabling clipboard sharing automatically disables file sharing too.
+</string>
+      <string id="MwbUseOriginalUserInterfaceDescription">This policy configures if the user can use the old Mouse Without Borders user interface.
+
+If you enable or don't configure this policy, the user takes control over the setting and can enable or disable the old user interface.
+
+If you disable this policy, the user won't be able to enable the old user interface.
+</string>
+      <string id="MwbDisallowBlockingScreensaverDescription">This policy configures if the user is allowed to disable the screensaver on the remote machines.
+
+If you enable this policy, the user won't be able to enable the "block screensaver" screensaver setting and the screensaver is not blocked.
+
+If you disable or don't configure this policy, the user takes control over the setting and can block the screensaver.
+</string>
+      <string id="MwbAllowServiceModeDescription">This policy configures if the user is allowed to use Mouse Without Borders in Service Mode.
+
+If this setting is enabled or not configured, the user can enable and use Mouse Without Borders in Service Mode.
+
+If this setting is disabled, the user won't be able to enable or use Mouse Without Borders in Service Mode.
+
+Note: As most other PowerToys policies, a restart of PowerToys is required for a change in this policy to take full effect.
+</string>
+      <string id="MwbSameSubnetOnlyDescription">This policy configures if connections are only allowed in the same subnet.
+
+If you enable this policy, the setting is enabled and only connections in the same subnet are allowed.
+
+If you disable this policy, the setting is disabled and all connections are allowed.
+
+If you don't configure this policy, the user takes control over the setting and can enable or disable it.
+</string>
+      <string id="MwbValidateRemoteIpDescription">This policy configures if reverse DNS lookup is used to validate the remote machine IP Address.
+
+If you enable this policy, the setting is enabled and the IP Address is validated.
+
+If you disable this policy, the setting is disabled and the IP Address is not validated.
+
+If you don't configure this policy, the user takes control over the setting and can enable or disable it.
+</string>
+      <string id="MwbDisableUserDefinedIpMappingRulesDescription">This policy configures if the user can define IP Address mapping rules.
+
+If you enable this policy, the setting is disabled and the user can't define rules or use existing ones.
+
+If you disable or don't configure this policy, the user takes control over the setting.
+
+Note: Enabling this policy does not prevent policy defined mapping rules from working.
+</string>
+      <string id="MwbPolicyDefinedIpMappingRulesDescription">This policy allows you to define IP Address mapping rules.
+
+If you enable this policy, you can define IP Address mapping rules that the user can't change or disable.
+Please enter one mapping per line in the format: "hostname IP"
+
+If you disable or don't configure this policy, no predefined rules are applied.
+</string>
+      <string id="NewPlusHideTemplateFilenameExtensionDescription">This policy configures if the template filenames are shown with extension or not.
+
+If you enable this policy, the setting is enabled and the extension is hidden.
+
+If you disable this policy, the setting is disabled and the extension is shown.
+
+If you don't configure this policy, the user takes control over the setting and can enable or disable it.
+</string>
+      <string id="NewPlusReplaceVariablesInTemplateFilenamesDescription">This policy configures if supported variables will get replaced in template filenames.
+
+If you enable this policy, the setting is enabled and supported variables in filenames will get replaced.
+
+If you disable this policy, the setting is disabled and variables in filenames will not get replaced.
+
+If you don't configure this policy, the user will be able to control the setting and can enable or disable it.
+</string>
+        
+      <string id="ConfigureAllUtilityGlobalEnabledState">Configure global utility enabled state</string>
+      <string id="ConfigureEnabledUtilityAdvancedPaste">Advanced Paste: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityAlwaysOnTop">Always On Top: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityAwake">Awake: Configure enabled state</string>
+      <string id="ConfigureEnabledAwakeIndefinitely">Awake: Configure indefinite's enabled state</string>
+      <string id="ConfigureEnabledUtilityColorPicker">Color Picker: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityCmdNotFound">Command Not Found: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityCmdPal">CmdPal: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityCropAndLock">Crop And Lock: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityLightSwitch">Light Switch: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityPowerDisplay">PowerDisplay: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityEnvironmentVariables">Environment Variables: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityFancyZones">FancyZones: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityFileLocksmith">File Locksmith: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityFileExplorerSVGPreview">SVG file preview: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityFileExplorerMarkdownPreview">Markdown file preview: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityFileExplorerMonacoPreview">Source code file preview: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityFileExplorerPDFPreview">PDF file preview: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityFileExplorerGcodePreview">Gcode file preview: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityFileExplorerBgcodePreview">BGcode file preview: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityFileExplorerSVGThumbnails">SVG file thumbnail: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityFileExplorerPDFThumbnails">PDF file thumbnail: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityFileExplorerGcodeThumbnails">Gcode file thumbnail: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityFileExplorerBgcodeThumbnails">BGcode file thumbnail: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityFileExplorerSTLThumbnails">STL file thumbnail: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityHostsFileEditor">Hosts file editor: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityImageResizer">Image Resizer: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityKeyboardManager">Keyboard Manager: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityFindMyMouse">Find My Mouse: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityMouseHighlighter">Mouse Highlighter: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityCursorWrap">CursorWrap: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityMouseJump">Mouse Jump: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityMousePointerCrosshairs">Mouse Pointer Crosshairs: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityMouseWithoutBorders">Mouse Without Borders: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityNewPlus">New+: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityPeek">Peek: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityPowerRename">Power Rename: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityPowerLauncher">PowerToys Run: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityWorkspaces">PowerToys Workspaces: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityQuickAccent">Quick Accent: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityRegistryPreview">Registry Preview: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityScreenRuler">Screen Ruler: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityShortcutGuide">Shortcut Guide: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityTextExtractor">Text Extractor: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityVideoConferenceMute">Video Conference Mute: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityZoomIt">Zoom It: Configure enabled state</string>
+      <string id="DisablePerUserInstallation">Disable per-user installation</string>
+      <string id="DisableAutomaticUpdateDownload">Disable automatic downloads</string>
+      <string id="DoNotShowWhatsNewAfterUpdates">Do not show the release notes after updates</string>
+      <string id="SuspendNewUpdateToast">Suspend Action Center notification for new updates</string>
+      <string id="DisableNewUpdateToast">Disable Action Center notification for new updates</string>
+      <string id="AllowExperimentation">Allow Experimentation</string>
+      <string id="PowerToysRunAllPluginsEnabledState">Configure enabled state for all plugins</string>
+      <string id="PowerToysRunIndividualPluginEnabledState">Configure enabled state for individual plugins</string>
+      <string id="ConfigureEnabledUtilityFileExplorerQOIPreview">QOI file preview: Configure enabled state</string>
+      <string id="ConfigureEnabledUtilityFileExplorerQOIThumbnails">QOI file thumbnail: Configure enabled state</string>
+      <string id="AllowPowerToysAdvancedPasteOnlineAIModels">Allow using online AI models</string>
+      <string id="AllowAdvancedPasteOpenAI">Advanced Paste: Allow OpenAI endpoint</string>
+      <string id="AllowAdvancedPasteOpenAIDescription">This policy controls whether users can use the OpenAI endpoint in Advanced Paste.
+
+If you enable or don't configure this policy, users can configure and use OpenAI as their AI provider.
+
+If you disable this policy, users will not be able to select or use OpenAI endpoint in Advanced Paste settings.</string>
+      <string id="AllowAdvancedPasteAzureOpenAI">Advanced Paste: Allow Azure OpenAI endpoint</string>
+      <string id="AllowAdvancedPasteAzureOpenAIDescription">This policy controls whether users can use the Azure OpenAI endpoint in Advanced Paste.
+
+If you enable or don't configure this policy, users can configure and use Azure OpenAI as their AI provider.
+
+If you disable this policy, users will not be able to select or use Azure OpenAI endpoint in Advanced Paste settings.</string>
+      <string id="AllowAdvancedPasteAzureAIInference">Advanced Paste: Allow Azure AI Inference endpoint</string>
+      <string id="AllowAdvancedPasteAzureAIInferenceDescription">This policy controls whether users can use the Azure AI Inference endpoint in Advanced Paste.
+
+If you enable or don't configure this policy, users can configure and use Azure AI Inference as their AI provider.
+
+If you disable this policy, users will not be able to select or use Azure AI Inference endpoint in Advanced Paste settings.</string>
+      <string id="AllowAdvancedPasteMistral">Advanced Paste: Allow Mistral endpoint</string>
+      <string id="AllowAdvancedPasteMistralDescription">This policy controls whether users can use the Mistral AI endpoint in Advanced Paste.
+
+If you enable or don't configure this policy, users can configure and use Mistral as their AI provider.
+
+If you disable this policy, users will not be able to select or use Mistral endpoint in Advanced Paste settings.</string>
+      <string id="AllowAdvancedPasteGoogle">Advanced Paste: Allow Google endpoint</string>
+      <string id="AllowAdvancedPasteGoogleDescription">This policy controls whether users can use the Google (Gemini) endpoint in Advanced Paste.
+
+If you enable or don't configure this policy, users can configure and use Google as their AI provider.
+
+If you disable this policy, users will not be able to select or use Google endpoint in Advanced Paste settings.</string>
+      <string id="AllowAdvancedPasteAnthropic">Advanced Paste: Allow Anthropic endpoint</string>
+      <string id="AllowAdvancedPasteAnthropicDescription">This policy controls whether users can use the Anthropic (Claude) endpoint in Advanced Paste.
+
+If you enable or don't configure this policy, users can configure and use Anthropic as their AI provider.
+
+If you disable this policy, users will not be able to select or use Anthropic endpoint in Advanced Paste settings.</string>
+      <string id="AllowAdvancedPasteOllama">Advanced Paste: Allow Ollama endpoint</string>
+      <string id="AllowAdvancedPasteOllamaDescription">This policy controls whether users can use the Ollama local model endpoint in Advanced Paste.
+
+If you enable or don't configure this policy, users can configure and use Ollama as their AI provider.
+
+If you disable this policy, users will not be able to select or use Ollama endpoint in Advanced Paste settings.</string>
+      <string id="AllowAdvancedPasteFoundryLocal">Advanced Paste: Allow Foundry Local endpoint</string>
+      <string id="AllowAdvancedPasteFoundryLocalDescription">This policy controls whether users can use the Foundry Local model endpoint in Advanced Paste.
+
+If you enable or don't configure this policy, users can configure and use Foundry Local as their AI provider.
+
+If you disable this policy, users will not be able to select or use Foundry Local endpoint in Advanced Paste settings.</string>
+      <string id="MwbClipboardSharingEnabled">Clipboard sharing enabled</string>
+      <string id="MwbFileTransferEnabled">File transfer enabled</string>
+      <string id="MwbUseOriginalUserInterface">Original user interface is available</string>
+      <string id="MwbDisallowBlockingScreensaver">Disallow blocking screensaver on other machines</string>
+      <string id="MwbAllowServiceMode">Allow Service Mode</string>
+      <string id="MwbSameSubnetOnly">Connect only in same subnet</string>
+      <string id="MwbValidateRemoteIp">Validate remote machine IP Address</string>
+      <string id="MwbDisableUserDefinedIpMappingRules">Disable user defined IP Address mapping rules</string>
+      <string id="MwbPolicyDefinedIpMappingRules">Predefined IP Address mapping rules</string>
+      <string id="NewPlusHideTemplateFilenameExtension">Hide template filename extension</string>
+      <string id="AllowDiagnosticData">Allow sending diagnostic data</string>
+      <string id="ConfigureRunAtStartup">Configure the run at startup setting</string>
+      <string id="NewPlusReplaceVariablesInTemplateFilenames">Replace variables in template filenames</string>
+      <string id="NewPlusHideBuiltInNewContextMenu">Hide the built-in "New" context menu</string>
+      <string id="NewPlusHideBuiltInNewContextMenuDescription">This policy configures if Windows' built-in New context menu should be hidden on the context menu.
+
+If you enable this policy, then the built-in New context menu will be hidden, and user can only create new files and folders using New+ and the explorer toolbar New button.
+
+If you disable this policy, then the build-in New context menu will be displayed as normal in Windows.
+
+If you don't configure this policy, the user will be able to control the setting and can enable or disable it.
+</string>        
+    </stringTable>
+
+    <presentationTable>
+      <presentation id="PowerToysRunIndividualPluginEnabledState">
+        <listBox refId="PowerToysRunIndividualPluginEnabledList">List of managed plugins:</listBox>
+      </presentation>
+      <presentation id="MwbPolicyDefinedIpMappingRules">
+        <multiTextBox refId="MwbPolicyDefinedIpMappingsList">List of IP Address mappings:</multiTextBox>
+      </presentation>
+    </presentationTable>
+
+  </resources>
+</policyDefinitionResources>

--- a/gpo/assets/en-US/PowerToys.adml
+++ b/gpo/assets/en-US/PowerToys.adml
@@ -37,7 +37,7 @@
       <string id="SUPPORTED_POWERTOYS_0_97_0">PowerToys version 0.97.0 or later</string>
       <string id="SUPPORTED_POWERTOYS_0_98_0">PowerToys version 0.98.0 or later</string>
       <string id="SUPPORTED_POWERTOYS_0_99_0">PowerToys version 0.99.0 or later</string>
-	  <string id="SUPPORTED_POWERTOYS_0_100_0">PowerToys version 0.100.0 or later</string>
+	  <string id="SUPPORTED_POWERTOYS_0_99_2">PowerToys version 0.99.2 or later</string>
 	  <string id="SUPPORTED_POWERTOYS_0_64_0_TO_0_87_1">From PowerToys version 0.64.0 until PowerToys version 0.87.1</string>
 
       <string id="ConfigureAllUtilityGlobalEnabledStateDescription">This policy configures the enabled state for all PowerToys utilities.

--- a/src/common/GPOWrapper/GPOWrapper.cpp
+++ b/src/common/GPOWrapper/GPOWrapper.cpp
@@ -12,6 +12,10 @@ namespace winrt::PowerToys::GPOWrapper::implementation
     {
         return static_cast<GpoRuleConfigured>(powertoys_gpo::getConfiguredAwakeEnabledValue());
     }
+    GpoRuleConfigured GPOWrapper::GetConfiguredAwakeIndefinitelyEnabledValue()
+    {
+        return static_cast<GpoRuleConfigured>(powertoys_gpo::getConfiguredAwakeIndefinitelyEnabledValue());
+    }
     GpoRuleConfigured GPOWrapper::GetConfiguredCmdNotFoundEnabledValue()
     {
         return static_cast<GpoRuleConfigured>(powertoys_gpo::getConfiguredCmdNotFoundEnabledValue());

--- a/src/common/GPOWrapper/GPOWrapper.h
+++ b/src/common/GPOWrapper/GPOWrapper.h
@@ -8,6 +8,7 @@ namespace winrt::PowerToys::GPOWrapper::implementation
     {
         GPOWrapper() = default;
         static GpoRuleConfigured GetConfiguredAlwaysOnTopEnabledValue();
+        static GpoRuleConfigured GetConfiguredAwakeIndefinitelyEnabledValue();
         static GpoRuleConfigured GetConfiguredAwakeEnabledValue();
         static GpoRuleConfigured GetConfiguredCmdNotFoundEnabledValue();
         static GpoRuleConfigured GetConfiguredCmdPalEnabledValue();

--- a/src/common/GPOWrapper/GPOWrapper.idl
+++ b/src/common/GPOWrapper/GPOWrapper.idl
@@ -13,6 +13,7 @@ namespace PowerToys
         [default_interface] static runtimeclass GPOWrapper {
             static GpoRuleConfigured GetConfiguredAlwaysOnTopEnabledValue();
             static GpoRuleConfigured GetConfiguredAwakeEnabledValue();
+            static GpoRuleConfigured GetConfiguredAwakeIndefinitelyEnabledValue();
             static GpoRuleConfigured GetConfiguredCmdNotFoundEnabledValue();
             static GpoRuleConfigured GetConfiguredCmdPalEnabledValue();
             static GpoRuleConfigured GetConfiguredColorPickerEnabledValue();

--- a/src/common/GPOWrapperProjection/GPOWrapper.cs
+++ b/src/common/GPOWrapperProjection/GPOWrapper.cs
@@ -17,6 +17,11 @@ namespace PowerToys.GPOWrapperProjection
     // This is a workaround to give access to GPOWrapper for WPF applications.
     public static class GPOWrapper
     {
+        public static GpoRuleConfigured GetConfiguredAwakeIndefinitelyEnabledValue()
+        {
+            return (GpoRuleConfigured)PowerToys.GPOWrapper.GPOWrapper.GetConfiguredAwakeIndefinitelyEnabledValue();
+        }
+
         public static GpoRuleConfigured GetConfiguredPowerLauncherEnabledValue()
         {
             return (GpoRuleConfigured)PowerToys.GPOWrapper.GPOWrapper.GetConfiguredPowerLauncherEnabledValue();

--- a/src/common/utils/gpo.h
+++ b/src/common/utils/gpo.h
@@ -293,6 +293,11 @@ namespace powertoys_gpo
         return getUtilityEnabledValue(POLICY_CONFIGURE_ENABLED_AWAKE);
     }
 
+        inline gpo_rule_configured_t getConfiguredAwakeIndefinitelyEnabledValue()
+    {
+        return getUtilityEnabledValue(POLICY_CONFIGURE_ENABLED_AWAKE_INDEFINITELY);
+    }
+
     inline gpo_rule_configured_t getConfiguredCmdNotFoundEnabledValue()
     {
         return getUtilityEnabledValue(POLICY_CONFIGURE_ENABLED_CMD_NOT_FOUND);

--- a/src/common/utils/gpo.h
+++ b/src/common/utils/gpo.h
@@ -84,7 +84,7 @@ namespace powertoys_gpo
     const std::wstring POLICY_ALLOW_EXPERIMENTATION = L"AllowExperimentation";
     const std::wstring POLICY_ALLOW_DATA_DIAGNOSTICS = L"AllowDataDiagnostics";
     const std::wstring POLICY_CONFIGURE_RUN_AT_STARTUP = L"ConfigureRunAtStartup";
-    const std::wstring POLICY_CONFIGURE_ENABLED_AWAKE_INDEFINITELY = L"ConfigureEnabledUtilityAwakeIndefinitely";
+    const std::wstring POLICY_CONFIGURE_ENABLED_AWAKE_INDEFINITELY = L"ConfigureEnabledAwakeIndefinitely";
     const std::wstring POLICY_CONFIGURE_ENABLED_POWER_LAUNCHER_ALL_PLUGINS = L"PowerLauncherAllPluginsEnabledState";
     const std::wstring POLICY_ALLOW_ADVANCED_PASTE_ONLINE_AI_MODELS = L"AllowPowerToysAdvancedPasteOnlineAIModels";
     const std::wstring POLICY_ALLOW_ADVANCED_PASTE_OPENAI = L"AllowAdvancedPasteOpenAI";

--- a/src/common/utils/gpo.h
+++ b/src/common/utils/gpo.h
@@ -28,6 +28,7 @@ namespace powertoys_gpo
     const std::wstring POLICY_CONFIGURE_ENABLED_GLOBAL_ALL_UTILITIES = L"ConfigureGlobalUtilityEnabledState";
     const std::wstring POLICY_CONFIGURE_ENABLED_ALWAYS_ON_TOP = L"ConfigureEnabledUtilityAlwaysOnTop";
     const std::wstring POLICY_CONFIGURE_ENABLED_AWAKE = L"ConfigureEnabledUtilityAwake";
+    const std::wstring POLICY_CONFIGURE_ENABLED_AWAKE_INDEFINITELY = L"ConfigureEnabledUtilityAwakeIndefinitely";
     const std::wstring POLICY_CONFIGURE_ENABLED_CMD_NOT_FOUND = L"ConfigureEnabledUtilityCmdNotFound";
     const std::wstring POLICY_CONFIGURE_ENABLED_COLOR_PICKER = L"ConfigureEnabledUtilityColorPicker";
     const std::wstring POLICY_CONFIGURE_ENABLED_CROP_AND_LOCK = L"ConfigureEnabledUtilityCropAndLock";

--- a/src/common/utils/gpo.h
+++ b/src/common/utils/gpo.h
@@ -294,7 +294,7 @@ namespace powertoys_gpo
         return getUtilityEnabledValue(POLICY_CONFIGURE_ENABLED_AWAKE);
     }
 
-        inline gpo_rule_configured_t getConfiguredAwakeIndefinitelyEnabledValue()
+    inline gpo_rule_configured_t getConfiguredAwakeIndefinitelyEnabledValue()
     {
         return getUtilityEnabledValue(POLICY_CONFIGURE_ENABLED_AWAKE_INDEFINITELY);
     }

--- a/src/common/utils/gpo.h
+++ b/src/common/utils/gpo.h
@@ -28,7 +28,6 @@ namespace powertoys_gpo
     const std::wstring POLICY_CONFIGURE_ENABLED_GLOBAL_ALL_UTILITIES = L"ConfigureGlobalUtilityEnabledState";
     const std::wstring POLICY_CONFIGURE_ENABLED_ALWAYS_ON_TOP = L"ConfigureEnabledUtilityAlwaysOnTop";
     const std::wstring POLICY_CONFIGURE_ENABLED_AWAKE = L"ConfigureEnabledUtilityAwake";
-    const std::wstring POLICY_CONFIGURE_ENABLED_AWAKE_INDEFINITELY = L"ConfigureEnabledUtilityAwakeIndefinitely";
     const std::wstring POLICY_CONFIGURE_ENABLED_CMD_NOT_FOUND = L"ConfigureEnabledUtilityCmdNotFound";
     const std::wstring POLICY_CONFIGURE_ENABLED_COLOR_PICKER = L"ConfigureEnabledUtilityColorPicker";
     const std::wstring POLICY_CONFIGURE_ENABLED_CROP_AND_LOCK = L"ConfigureEnabledUtilityCropAndLock";
@@ -85,6 +84,7 @@ namespace powertoys_gpo
     const std::wstring POLICY_ALLOW_EXPERIMENTATION = L"AllowExperimentation";
     const std::wstring POLICY_ALLOW_DATA_DIAGNOSTICS = L"AllowDataDiagnostics";
     const std::wstring POLICY_CONFIGURE_RUN_AT_STARTUP = L"ConfigureRunAtStartup";
+    const std::wstring POLICY_CONFIGURE_ENABLED_AWAKE_INDEFINITELY = L"ConfigureEnabledUtilityAwakeIndefinitely";
     const std::wstring POLICY_CONFIGURE_ENABLED_POWER_LAUNCHER_ALL_PLUGINS = L"PowerLauncherAllPluginsEnabledState";
     const std::wstring POLICY_ALLOW_ADVANCED_PASTE_ONLINE_AI_MODELS = L"AllowPowerToysAdvancedPasteOnlineAIModels";
     const std::wstring POLICY_ALLOW_ADVANCED_PASTE_OPENAI = L"AllowAdvancedPasteOpenAI";

--- a/src/common/utils/gpo.h
+++ b/src/common/utils/gpo.h
@@ -294,11 +294,6 @@ namespace powertoys_gpo
         return getUtilityEnabledValue(POLICY_CONFIGURE_ENABLED_AWAKE);
     }
 
-    inline gpo_rule_configured_t getConfiguredAwakeIndefinitelyEnabledValue()
-    {
-        return getUtilityEnabledValue(POLICY_CONFIGURE_ENABLED_AWAKE_INDEFINITELY);
-    }
-
     inline gpo_rule_configured_t getConfiguredCmdNotFoundEnabledValue()
     {
         return getUtilityEnabledValue(POLICY_CONFIGURE_ENABLED_CMD_NOT_FOUND);
@@ -561,6 +556,11 @@ namespace powertoys_gpo
     inline gpo_rule_configured_t getConfiguredRunAtStartupValue()
     {
         return getConfiguredValue(POLICY_CONFIGURE_RUN_AT_STARTUP);
+    }
+
+        inline gpo_rule_configured_t getConfiguredAwakeIndefinitelyEnabledValue()
+    {
+        return getConfiguredValue(POLICY_CONFIGURE_ENABLED_AWAKE_INDEFINITELY);
     }
 
     inline gpo_rule_configured_t getRunPluginEnabledValue(std::string pluginID)

--- a/src/modules/awake/Awake/Core/TrayHelper.cs
+++ b/src/modules/awake/Awake/Core/TrayHelper.cs
@@ -16,6 +16,7 @@ using Awake.Core.Models;
 using Awake.Core.Native;
 using Awake.Core.Threading;
 using Awake.Properties;
+using global::PowerToys.GPOWrapper;
 using ManagedCommon;
 using Microsoft.PowerToys.Settings.UI.Library;
 
@@ -341,8 +342,15 @@ namespace Awake.Core
 
                         case (uint)TrayCommands.TC_MODE_INDEFINITE:
                             {
+                                GpoRuleConfigured indefiniteEnabled = GPOWrapper.GetConfiguredAwakeIndefinitelyEnabledValue();
+
                                 AwakeSettings settings = Manager.ModuleSettings!.GetSettings<AwakeSettings>(Constants.AppName) ?? new AwakeSettings();
-                                Manager.SetIndefiniteKeepAwake(keepDisplayOn: settings.Properties.KeepDisplayOn);
+
+                                if (indefiniteEnabled == GpoRuleConfigured.Enabled)
+                                {
+                                    Manager.SetIndefiniteKeepAwake(keepDisplayOn: settings.Properties.KeepDisplayOn);
+                                }
+
                                 break;
                             }
 
@@ -426,6 +434,14 @@ namespace Awake.Core
 
         internal static void SetTray(AwakeSettings settings, bool startedFromPowerToys)
         {
+            GpoRuleConfigured indefiniteEnabled = GPOWrapper.GetConfiguredAwakeIndefinitelyEnabledValue();
+
+            if (settings.Properties.Mode == AwakeMode.INDEFINITE && indefiniteEnabled == GpoRuleConfigured.Disabled)
+            {
+                settings.Properties.Mode = AwakeMode.PASSIVE;
+                settings.Properties.KeepDisplayOn = false;
+            }
+
             SetTray(
                 settings.Properties.KeepDisplayOn,
                 settings.Properties.Mode,
@@ -515,7 +531,15 @@ namespace Awake.Core
             InsertSeparator(0);
 
             InsertMenuItem(0, TrayCommands.TC_MODE_PASSIVE, Resources.AWAKE_OFF, mode == AwakeMode.PASSIVE);
-            InsertMenuItem(0, TrayCommands.TC_MODE_INDEFINITE, Resources.AWAKE_KEEP_INDEFINITELY, mode == AwakeMode.INDEFINITE);
+
+            GpoRuleConfigured indefiniteEnabled = GPOWrapper.GetConfiguredAwakeIndefinitelyEnabledValue();
+            bool indefiniteMenuItemDisabled = false;
+            if (indefiniteEnabled == GpoRuleConfigured.Disabled)
+            {
+                indefiniteMenuItemDisabled = true;
+            }
+
+            InsertMenuItem(0, TrayCommands.TC_MODE_INDEFINITE, Resources.AWAKE_KEEP_INDEFINITELY, mode == AwakeMode.INDEFINITE, indefiniteMenuItemDisabled);
             InsertMenuItem(0, TrayCommands.TC_MODE_EXPIRABLE, Resources.AWAKE_KEEP_UNTIL_EXPIRATION, mode == AwakeMode.EXPIRABLE, true);
         }
     }

--- a/src/modules/awake/AwakeModuleInterface/dllmain.cpp
+++ b/src/modules/awake/AwakeModuleInterface/dllmain.cpp
@@ -86,7 +86,14 @@ public:
     // Return the configured status for the gpo policy for the module
     virtual powertoys_gpo::gpo_rule_configured_t gpo_policy_enabled_configuration() override
     {
+        powertoys_gpo::getConfiguredAwakeIndefinitelyEnabledValue();
         return powertoys_gpo::getConfiguredAwakeEnabledValue();
+    }
+
+    // Return the configured status for the gpo policy for the enabling awake indifinitely mode
+    virtual powertoys_gpo::gpo_rule_configured_t gpo_awake_indefinitely_policy_enabled_configuration()
+    {
+        return powertoys_gpo::getConfiguredAwakeIndefinitelyEnabledValue();
     }
 
     virtual void destroy() override

--- a/src/modules/awake/AwakeModuleInterface/dllmain.cpp
+++ b/src/modules/awake/AwakeModuleInterface/dllmain.cpp
@@ -86,7 +86,6 @@ public:
     // Return the configured status for the gpo policy for the module
     virtual powertoys_gpo::gpo_rule_configured_t gpo_policy_enabled_configuration() override
     {
-        powertoys_gpo::getConfiguredAwakeIndefinitelyEnabledValue();
         return powertoys_gpo::getConfiguredAwakeEnabledValue();
     }
 

--- a/src/modules/awake/AwakeModuleInterface/dllmain.cpp
+++ b/src/modules/awake/AwakeModuleInterface/dllmain.cpp
@@ -90,12 +90,6 @@ public:
         return powertoys_gpo::getConfiguredAwakeEnabledValue();
     }
 
-    // Return the configured status for the gpo policy for the enabling awake indifinitely mode
-    virtual powertoys_gpo::gpo_rule_configured_t gpo_awake_indefinitely_policy_enabled_configuration()
-    {
-        return powertoys_gpo::getConfiguredAwakeIndefinitelyEnabledValue();
-    }
-
     virtual void destroy() override
     {
         delete this;

--- a/src/settings-ui/Settings.UI.Library/AwakeProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/AwakeProperties.cs
@@ -20,7 +20,6 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             IntervalMinutes = 1;
             ExpirationDateTime = DateTimeOffset.Now;
             CustomTrayTimes = [];
-            AwakeIndefinitelyEnabled = true;
         }
 
         [JsonPropertyName("keepDisplayOn")]
@@ -41,8 +40,5 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         [JsonPropertyName("customTrayTimes")]
         [CmdConfigureIgnore]
         public Dictionary<string, uint> CustomTrayTimes { get; set; }
-
-        [JsonPropertyName("awakeIndefinitelyEnabled")]
-        public bool AwakeIndefinitelyEnabled { get; set; }
     }
 }

--- a/src/settings-ui/Settings.UI.Library/AwakeProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/AwakeProperties.cs
@@ -20,6 +20,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             IntervalMinutes = 1;
             ExpirationDateTime = DateTimeOffset.Now;
             CustomTrayTimes = [];
+            IndefiniteEnabledValue = false;
         }
 
         [JsonPropertyName("keepDisplayOn")]
@@ -40,5 +41,8 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         [JsonPropertyName("customTrayTimes")]
         [CmdConfigureIgnore]
         public Dictionary<string, uint> CustomTrayTimes { get; set; }
+
+        [JsonPropertyName("indefiniteEnabledValue")]
+        public bool IndefiniteEnabledValue { get; set; }
     }
 }

--- a/src/settings-ui/Settings.UI.Library/AwakeProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/AwakeProperties.cs
@@ -20,6 +20,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             IntervalMinutes = 1;
             ExpirationDateTime = DateTimeOffset.Now;
             CustomTrayTimes = [];
+            AwakeIndefinitelyEnabled = true;
         }
 
         [JsonPropertyName("keepDisplayOn")]
@@ -40,5 +41,8 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         [JsonPropertyName("customTrayTimes")]
         [CmdConfigureIgnore]
         public Dictionary<string, uint> CustomTrayTimes { get; set; }
+
+        [JsonPropertyName("awakeIndefinitelyEnabled")]
+        public bool AwakeIndefinitelyEnabled { get; set; }
     }
 }

--- a/src/settings-ui/Settings.UI.Library/AwakeSettings.cs
+++ b/src/settings-ui/Settings.UI.Library/AwakeSettings.cs
@@ -38,6 +38,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
                     KeepDisplayOn = Properties.KeepDisplayOn,
                     IntervalMinutes = Properties.IntervalMinutes,
                     IntervalHours = Properties.IntervalHours,
+                    IndefiniteEnabledValue = Properties.IndefiniteEnabledValue,
 
                     // Fix old buggy default value that might be saved in Settings. Some components don't deal well with negative time zones and minimum time offsets.
                     ExpirationDateTime = Properties.ExpirationDateTime.Year < 2 ? DateTimeOffset.Now : Properties.ExpirationDateTime,

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/AwakePage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/AwakePage.xaml
@@ -36,23 +36,23 @@
 
                 <controls:SettingsGroup x:Uid="Awake_BehaviorSettingsGroup" IsEnabled="{x:Bind ViewModel.IsEnabled, Mode=OneWay}">
                     <tkcontrols:SettingsCard
-                        Name="AwakeModeSettingsCard"
-                        x:Uid="Awake_ModeSettingsCard"
-                        HeaderIcon="{ui:FontIcon Glyph=&#xE945;}">
+        Name="AwakeModeSettingsCard"
+        x:Uid="Awake_ModeSettingsCard"
+        HeaderIcon="{ui:FontIcon Glyph=&#xE945;}">
                         <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}" SelectedIndex="{x:Bind Path=ViewModel.Mode, Mode=TwoWay, Converter={StaticResource AwakeModeToIntConverter}}">
                             <ComboBoxItem x:Uid="Awake_NoKeepAwakeSelector" />
-                            <ComboBoxItem x:Uid="Awake_IndefiniteKeepAwakeSelector" />
+                            <ComboBoxItem x:Uid="Awake_IndefiniteKeepAwakeSelector" IsEnabled="{x:Bind ViewModel.IsIndefiniteEnabled, Mode=OneWay }" />
                             <ComboBoxItem x:Uid="Awake_TemporaryKeepAwakeSelector" />
                             <ComboBoxItem x:Uid="Awake_ExpirableKeepAwakeSelector" />
                         </ComboBox>
                     </tkcontrols:SettingsCard>
 
                     <tkcontrols:SettingsExpander
-                        Name="AwakeExpirationSettingsExpander"
-                        x:Uid="Awake_ExpirationSettingsExpander"
-                        HeaderIcon="{ui:FontIcon Glyph=&#xEC92;}"
-                        IsExpanded="True"
-                        Visibility="{x:Bind ViewModel.IsExpirationConfigurationEnabled, Mode=OneWay}">
+        Name="AwakeExpirationSettingsExpander"
+        x:Uid="Awake_ExpirationSettingsExpander"
+        HeaderIcon="{ui:FontIcon Glyph=&#xEC92;}"
+        IsExpanded="True"
+        Visibility="{x:Bind ViewModel.IsExpirationConfigurationEnabled, Mode=OneWay}">
                         <tkcontrols:SettingsExpander.Items>
                             <tkcontrols:SettingsCard Name="AwakeExpirationSettingsExpanderDate" x:Uid="Awake_ExpirationSettingsExpander_Date">
                                 <DatePicker Date="{x:Bind ViewModel.ExpirationDateTime, Mode=TwoWay}" />
@@ -64,42 +64,44 @@
                     </tkcontrols:SettingsExpander>
 
                     <tkcontrols:SettingsCard
-                        Name="AwakeIntervalSettingsCard"
-                        x:Uid="Awake_IntervalSettingsCard"
-                        HeaderIcon="{ui:FontIcon Glyph=&#xE916;}"
-                        Visibility="{x:Bind ViewModel.IsTimeConfigurationEnabled, Mode=OneWay}">
+        Name="AwakeIntervalSettingsCard"
+        x:Uid="Awake_IntervalSettingsCard"
+        HeaderIcon="{ui:FontIcon Glyph=&#xE916;}"
+        Visibility="{x:Bind ViewModel.IsTimeConfigurationEnabled, Mode=OneWay}">
 
                         <StackPanel MinWidth="{StaticResource SettingActionControlMinWidth}" Orientation="Horizontal">
                             <NumberBox
-                                x:Uid="Awake_IntervalHoursInput"
-                                Width="96"
-                                HorizontalAlignment="Left"
-                                LargeChange="5"
-                                Minimum="0"
-                                SmallChange="1"
-                                SpinButtonPlacementMode="Compact"
-                                Value="{x:Bind ViewModel.IntervalHours, Mode=TwoWay}" />
+                x:Uid="Awake_IntervalHoursInput"
+                Width="96"
+                HorizontalAlignment="Left"
+                LargeChange="5"
+                Minimum="0"
+                SmallChange="1"
+                SpinButtonPlacementMode="Compact"
+                Value="{x:Bind ViewModel.IntervalHours, Mode=TwoWay}" />
                             <NumberBox
-                                x:Uid="Awake_IntervalMinutesInput"
-                                Width="96"
-                                Margin="8,0,0,0"
-                                HorizontalAlignment="Left"
-                                LargeChange="5"
-                                Maximum="60"
-                                Minimum="0"
-                                SmallChange="1"
-                                SpinButtonPlacementMode="Compact"
-                                Value="{x:Bind ViewModel.IntervalMinutes, Mode=TwoWay}" />
+                x:Uid="Awake_IntervalMinutesInput"
+                Width="96"
+                Margin="8,0,0,0"
+                HorizontalAlignment="Left"
+                LargeChange="5"
+                Maximum="60"
+                Minimum="0"
+                SmallChange="1"
+                SpinButtonPlacementMode="Compact"
+                Value="{x:Bind ViewModel.IntervalMinutes, Mode=TwoWay}" />
                         </StackPanel>
                     </tkcontrols:SettingsCard>
 
                     <tkcontrols:SettingsCard
-                        x:Uid="Awake_DisplaySettingsCard"
-                        HeaderIcon="{ui:FontIcon Glyph=&#xE7F4;}"
-                        IsEnabled="{x:Bind ViewModel.IsScreenConfigurationPossibleEnabled, Mode=OneWay}">
+        x:Uid="Awake_DisplaySettingsCard"
+        HeaderIcon="{ui:FontIcon Glyph=&#xE7F4;}"
+        IsEnabled="{x:Bind ViewModel.IsScreenConfigurationPossibleEnabled, Mode=OneWay}">
                         <ToggleSwitch IsOn="{x:Bind ViewModel.KeepDisplayOn, Mode=TwoWay}" />
                     </tkcontrols:SettingsCard>
                 </controls:SettingsGroup>
+                <controls:GPOInfoControl ShowWarning="{x:Bind ViewModel.IsIndefiniteEnabledGpoConfigured, Mode=OneWay}" />
+
             </StackPanel>
         </controls:SettingsPageControl.ModuleContent>
 

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/AwakePage.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/AwakePage.xaml.cs
@@ -135,9 +135,11 @@ namespace Microsoft.PowerToys.Settings.UI.Views
                 if (generalSettings != null)
                 {
                     ViewModel.IsEnabled = generalSettings.Enabled.Awake;
+                    ViewModel.IsIndefiniteEnabled = awakeSettings.Properties.IndefiniteEnabledValue;
                     ViewModel.ModuleSettings = (AwakeSettings)awakeSettings.Clone();
 
                     UpdateEnabledState(generalSettings.Enabled.Awake);
+                    UpdateIndefiniteEnabledState(awakeSettings.Properties.IndefiniteEnabledValue);
                 }
                 else
                 {
@@ -170,6 +172,22 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             }
         }
 
+        private void UpdateIndefiniteEnabledState(bool recommendedState)
+        {
+            var indefiniteEnabledGpoRuleConfiguration = GPOWrapper.GetConfiguredAwakeIndefinitelyEnabledValue();
+
+            if (indefiniteEnabledGpoRuleConfiguration == GpoRuleConfigured.Disabled || indefiniteEnabledGpoRuleConfiguration == GpoRuleConfigured.Enabled)
+            {
+                // Get the enabled state from GPO.
+                ViewModel.IsIndefiniteEnabledGpoConfigured = true;
+                ViewModel.IndefiniteEnabledGPOConfiguration = indefiniteEnabledGpoRuleConfiguration == GpoRuleConfigured.Enabled;
+            }
+            else
+            {
+                ViewModel.IsIndefiniteEnabled = recommendedState;
+            }
+        }
+
         private void Settings_Changed(object sender, FileSystemEventArgs e)
         {
             bool taskAdded = _dispatcherQueue.TryEnqueue(DispatcherQueuePriority.Normal, () =>
@@ -182,6 +200,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
         public void RefreshEnabledState()
         {
             UpdateEnabledState(_generalSettingsRepository.SettingsConfig.Enabled.Awake);
+            UpdateIndefiniteEnabledState(_moduleSettingsRepository.SettingsConfig.Properties.IndefiniteEnabledValue);
             ViewModel.RefreshEnabledState();
         }
     }

--- a/src/settings-ui/Settings.UI/ViewModels/AwakeViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/AwakeViewModel.cs
@@ -90,6 +90,65 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             }
         }
 
+        public bool IsIndefiniteEnabled
+        {
+            get
+            {
+                if (_enabledIndefiniteStateIsGPOConfigured)
+                {
+                    return _enabledIndefiniteGPOConfiguration;
+                }
+                else
+                {
+                    return _isIndefiniteEnabled;
+                }
+            }
+
+            set
+            {
+                if (_isIndefiniteEnabled != value)
+                {
+                    if (_enabledIndefiniteGPOConfiguration)
+                    {
+                        // If it's GPO configured, shouldn't be able to change this state.
+                        return;
+                    }
+
+                    _isIndefiniteEnabled = value;
+
+                    RefreshEnabledState();
+
+                    NotifyPropertyChanged();
+                }
+            }
+        }
+
+        public bool IsIndefiniteEnabledGpoConfigured
+        {
+            get => _enabledIndefiniteStateIsGPOConfigured;
+            set
+            {
+                if (_enabledIndefiniteStateIsGPOConfigured != value)
+                {
+                    _enabledIndefiniteStateIsGPOConfigured = value;
+                    NotifyPropertyChanged();
+                }
+            }
+        }
+
+        public bool IndefiniteEnabledGPOConfiguration
+        {
+            get => _enabledIndefiniteGPOConfiguration;
+            set
+            {
+                if (_enabledIndefiniteGPOConfiguration != value)
+                {
+                    _enabledIndefiniteGPOConfiguration = value;
+                    NotifyPropertyChanged();
+                }
+            }
+        }
+
         public bool IsExpirationConfigurationEnabled => ModuleSettings.Properties.Mode == AwakeMode.EXPIRABLE && IsEnabled;
 
         public bool IsTimeConfigurationEnabled => ModuleSettings.Properties.Mode == AwakeMode.TIMED && IsEnabled;
@@ -198,6 +257,19 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             }
         }
 
+        public bool IndefiniteEnabledValue
+        {
+            get => ModuleSettings.Properties.IndefiniteEnabledValue;
+            set
+            {
+                if (ModuleSettings.Properties.IndefiniteEnabledValue != value)
+                {
+                    ModuleSettings.Properties.IndefiniteEnabledValue = value;
+                    NotifyPropertyChanged();
+                }
+            }
+        }
+
         public void NotifyPropertyChanged([CallerMemberName] string propertyName = null)
         {
             Logger.LogInfo($"Changed the property {propertyName}");
@@ -219,11 +291,15 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             OnPropertyChanged(nameof(IntervalHours));
             OnPropertyChanged(nameof(IntervalMinutes));
             OnPropertyChanged(nameof(ExpirationDateTime));
+            OnPropertyChanged(nameof(IsIndefiniteEnabled));
         }
 
+        private bool _enabledIndefiniteStateIsGPOConfigured;
+        private bool _enabledIndefiniteGPOConfiguration;
         private bool _enabledStateIsGPOConfigured;
         private bool _enabledGPOConfiguration;
         private AwakeSettings _moduleSettings;
         private bool _isEnabled;
+        private bool _isIndefiniteEnabled;
     }
 }

--- a/tools/BugReportTool/BugReportTool/ReportGPOValues.cpp
+++ b/tools/BugReportTool/BugReportTool/ReportGPOValues.cpp
@@ -45,6 +45,7 @@ void ReportGPOValues(const std::filesystem::path &tmpDir)
     report << "getConfiguredAdvancedPasteEnabledValue: " << gpo_rule_configured_to_string(powertoys_gpo::getConfiguredAdvancedPasteEnabledValue()) << std::endl;
     report << "getConfiguredAlwaysOnTopEnabledValue: " << gpo_rule_configured_to_string(powertoys_gpo::getConfiguredAlwaysOnTopEnabledValue()) << std::endl;
     report << "getConfiguredAwakeEnabledValue: " << gpo_rule_configured_to_string(powertoys_gpo::getConfiguredAwakeEnabledValue()) << std::endl;
+    report << "getConfiguredAwakeIndefinitelyEnabledValue: " << gpo_rule_configured_to_string(powertoys_gpo::getConfiguredAwakeIndefinitelyEnabledValue()) << std::endl;
     report << "getConfiguredCmdPalEnabledValue: " << gpo_rule_configured_to_string(powertoys_gpo::getConfiguredCmdPalEnabledValue()) << std::endl;
     report << "getConfiguredColorPickerEnabledValue: " << gpo_rule_configured_to_string(powertoys_gpo::getConfiguredColorPickerEnabledValue()) << std::endl;
     report << "getConfiguredCropAndLockEnabledValue: " << gpo_rule_configured_to_string(powertoys_gpo::getConfiguredCropAndLockEnabledValue()) << std::endl;


### PR DESCRIPTION
## Summary of the Pull Request
This introduces a group policy to disable Awake's "Indefinitely" mode.

This PR follows the implementation of how Enabled state is managed by group policy.
The Indefinite state is saved in settings.json of module settings.
On file read, it reads the group policies value again to prevent users from enabling via settings.json.

## PR Checklist
- [x] Closes: #40546 
- [x] **Communication:** [I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected.](https://github.com/microsoft/PowerToys/issues/28769#issuecomment-4094647318)
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments
Updated PowerToys.adml.
- Revision number increased.
- Added supported version definition .
- Defined a policy with registry location.

Updated ADMX file:
- Increased revision number.
- Add strings for version, title, description.

Updated code:
- Added to GPO.h.
- Added to GPO wrapper for C# access.
- Updated module interface.
- Modified settings UI to show lock when policy applied.

Could not:
- Add checks in executable to prevent direct launching.
- Update dashboard helper to respect policy.

Updated Bug report tool:
- Added to bug report tool to capture policy state.

## Validation Steps Performed
1. Set ConfigureEnabledAwakeIndefinitely to 0 at Computer\HKEY_LOCAL_MACHINE\SOFTWARE\Policies\PowerToys.
2. Set ConfigureEnabledUtilityAwake to 1 as well.
3. Started PowerToys Settings and Awake.
4. Confirmed Awake Settings page showed Indefinite mode greyed out and a warning for GP enforced.
5. Confirmed Indefinite mode greyed out in Awake system tray.
6. Set ConfigureEnabledAwakeIndefinitely to 1 in registry.
7. On refresh or restart of PowerToys, greyed out options are now selectable.
8. Checked settings.json for IndefiniteEnabledValue and found to match registry value ConfigureEnabledAwakeIndefinitely.
9. Ran bug report tool and confirmed the ConfigureEnabledAwakeIndefinitely is working.

## Screenshots
<img width="881" height="301" alt="image" src="https://github.com/user-attachments/assets/b10b71c2-ea2d-4bc4-a1ae-b12e51e45a6d" />

<img width="1330" height="801" alt="image" src="https://github.com/user-attachments/assets/95bb01ca-137a-4cdd-b3fb-47b6c8832f0a" />

<img width="483" height="245" alt="image" src="https://github.com/user-attachments/assets/dec99d77-0c81-41d8-a702-7c0a5cb93b82" />
