### PR TITLE
fix(PowerDisplay): close window on Escape key (#48016)

### DIFF
--- a/src/modules/powerdisplay/PowerDisplay/PowerDisplayXAML/MainWindow.xaml
+++ b/src/modules/powerdisplay/PowerDisplay/PowerDisplayXAML/MainWindow.xaml
@@ -22,6 +22,7 @@
     <Grid
         x:Name="RootGrid"
         IsTabStop="True"
+        KeyDown="RootGrid_KeyDown"
         TabFocusNavigation="Local">
         <Grid.Resources>
             <GridLength x:Key="FlyoutStatusBarHeight">48</GridLength>

--- a/src/modules/powerdisplay/PowerDisplay/PowerDisplayXAML/MainWindow.xaml.cs
+++ b/src/modules/powerdisplay/PowerDisplay/PowerDisplayXAML/MainWindow.xaml.cs
@@ -18,6 +18,7 @@ using PowerDisplay.Helpers;
 using PowerDisplay.Models;
 using PowerDisplay.ViewModels;
 using Windows.Graphics;
+using Windows.System;
 using WinUIEx;
 using Monitor = PowerDisplay.Common.Models.Monitor;
 
@@ -302,6 +303,15 @@ namespace PowerDisplay
             // mainExecutableIsOnTheParentFolder = true because PowerDisplay is a WinUI 3 app
             // deployed in a subfolder (PowerDisplay\) while PowerToys.exe is in the parent folder
             SettingsDeepLink.OpenSettings(true);
+        }
+
+        private void RootGrid_KeyDown(object sender, KeyRoutedEventArgs e)
+        {
+            if (e.Key == VirtualKey.Escape)
+            {
+                HideWindow();
+                e.Handled = true;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
The PowerDisplay flyout had no keyboard close path: pressing Tab kept focus inside the window so it never deactivated, and there was no KeyDown / KeyboardAccelerator wired up. Handle Escape on RootGrid to hide the window, matching the behavior of other PowerToys flyouts.

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #48016
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

