### PR TITLE
[CmdPal] Add stable AutomationIds across XAML for UI testing

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ProviderSettingsViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ProviderSettingsViewModel.cs
@@ -49,6 +49,14 @@ public partial class ProviderSettingsViewModel : ObservableObject
 
     public string DisplayName => _provider.DisplayName;
 
+    /// <summary>
+    /// Stable, non-localized identifier from the underlying provider (e.g.
+    /// "com.microsoft.cmdpal.builtin.calculator"). Exposed for UI tests
+    /// to target the per-provider <see cref="ProviderSettingsViewModel"/>
+    /// row via <c>AutomationProperties.AutomationId</c>.
+    /// </summary>
+    public string Id => _provider.Id;
+
     public string ExtensionName => _provider.Extension?.ExtensionDisplayName ?? Resources.builtin_extension_name;
 
     public string ExtensionSubtext

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListItemsView.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListItemsView.xaml
@@ -350,7 +350,10 @@
             Small="{StaticResource IconGridViewItemStyle}" />
 
         <DataTemplate x:Key="ListItemSingleRowViewModelTemplate" x:DataType="viewModels:ListItemViewModel">
-            <Grid AutomationProperties.Name="{x:Bind Title, Mode=OneWay}" ColumnSpacing="12">
+            <Grid
+                AutomationProperties.AutomationId="{x:Bind Command.Id, Mode=OneWay}"
+                AutomationProperties.Name="{x:Bind Title, Mode=OneWay}"
+                ColumnSpacing="12">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="28" />
                     <ColumnDefinition Width="*" />
@@ -462,6 +465,7 @@
             <StackPanel
                 HorizontalAlignment="Center"
                 VerticalAlignment="Center"
+                AutomationProperties.AutomationId="{x:Bind Command.Id, Mode=OneWay}"
                 AutomationProperties.Name="{x:Bind Title, Mode=OneWay}"
                 BorderThickness="0"
                 CornerRadius="{StaticResource SmallGridViewItemCornerRadius}"
@@ -486,6 +490,7 @@
                 Width="{StaticResource MediumGridContainerSize}"
                 Height="{StaticResource MediumGridContainerSize}"
                 Padding="8"
+                AutomationProperties.AutomationId="{x:Bind Command.Id, Mode=OneWay}"
                 AutomationProperties.Name="{x:Bind Title, Mode=OneWay}"
                 CornerRadius="{StaticResource MediumGridViewItemCornerRadius}"
                 ToolTipService.ToolTip="{x:Bind Title, Mode=OneWay}">
@@ -528,6 +533,7 @@
                 Padding="0"
                 HorizontalAlignment="Center"
                 VerticalAlignment="Center"
+                AutomationProperties.AutomationId="{x:Bind Command.Id, Mode=OneWay}"
                 AutomationProperties.Name="{x:Bind Title, Mode=OneWay}"
                 BorderThickness="0"
                 CornerRadius="{StaticResource GalleryGridViewItemRadius}"

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml
@@ -84,6 +84,7 @@
                         Name="Command"
                         HorizontalAlignment="Stretch"
                         HorizontalContentAlignment="Left"
+                        AutomationProperties.AutomationId="{x:Bind Id, Mode=OneWay}"
                         Click="Command_Click"
                         Style="{StaticResource SubtleButtonStyle}"
                         UseSystemFocusVisuals="{StaticResource UseSystemFocusVisuals}">

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/AppearancePage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/AppearancePage.xaml
@@ -70,7 +70,10 @@
                     </StackPanel>
 
                     <controls:SettingsCard x:Uid="Settings_GeneralPage_AppTheme_SettingsCard" HeaderIcon="{ui:FontIcon Glyph=&#xE793;}">
-                        <ComboBox AutomationProperties.AutomationId="CmdPal_AppearancePage_Theme" MinWidth="{StaticResource SettingActionControlMinWidth}" SelectedIndex="{x:Bind ViewModel.Appearance.ThemeIndex, Mode=TwoWay}">
+                        <ComboBox
+                            MinWidth="{StaticResource SettingActionControlMinWidth}"
+                            AutomationProperties.AutomationId="CmdPal_AppearancePage_Theme"
+                            SelectedIndex="{x:Bind ViewModel.Appearance.ThemeIndex, Mode=TwoWay}">
 
                             <ComboBoxItem x:Uid="Settings_GeneralPage_AppTheme_Mode_System_Automation" Tag="Default">
                                 <StackPanel Orientation="Horizontal" Spacing="8">
@@ -100,7 +103,10 @@
                         x:Uid="Settings_GeneralPage_BackdropStyle_SettingsCard"
                         HeaderIcon="{ui:FontIcon Glyph=&#xF5EF;}"
                         IsExpanded="{x:Bind ViewModel.Appearance.IsBackdropOpacityVisible, Mode=OneWay}">
-                        <ComboBox AutomationProperties.AutomationId="CmdPal_AppearancePage_BackdropStyle" MinWidth="{StaticResource SettingActionControlMinWidth}" SelectedIndex="{x:Bind ViewModel.Appearance.BackdropStyleIndex, Mode=TwoWay}">
+                        <ComboBox
+                            MinWidth="{StaticResource SettingActionControlMinWidth}"
+                            AutomationProperties.AutomationId="CmdPal_AppearancePage_BackdropStyle"
+                            SelectedIndex="{x:Bind ViewModel.Appearance.BackdropStyleIndex, Mode=TwoWay}">
                             <ComboBoxItem x:Uid="Settings_GeneralPage_BackdropStyle_Acrylic" />
                             <ComboBoxItem x:Uid="Settings_GeneralPage_BackdropStyle_Transparent" />
                             <ComboBoxItem x:Uid="Settings_GeneralPage_BackdropStyle_Mica" />
@@ -128,9 +134,9 @@
                             <controls:SettingsCard x:Uid="Settings_GeneralPage_BackdropOpacity_SettingsCard" Visibility="{x:Bind ViewModel.Appearance.IsBackdropOpacityVisible, Mode=OneWay}">
                                 <Slider
                                     MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                    AutomationProperties.AutomationId="CmdPal_AppearancePage_BackdropOpacity"
                                     Maximum="100"
                                     Minimum="0"
-                                    AutomationProperties.AutomationId="CmdPal_AppearancePage_BackdropOpacity"
                                     StepFrequency="1"
                                     Value="{x:Bind ViewModel.Appearance.BackdropOpacity, Mode=TwoWay}" />
                             </controls:SettingsCard>
@@ -206,23 +212,26 @@
                                 x:Uid="Settings_GeneralPage_BackgroundImage_SettingsCard"
                                 Description="{x:Bind ViewModel.Appearance.BackgroundImagePath, Mode=OneWay}"
                                 Visibility="{x:Bind ViewModel.Appearance.IsBackgroundControlsVisible, Mode=OneWay}">
-                                <Button x:Uid="Settings_GeneralPage_BackgroundImage_ChooseImageButton" AutomationProperties.AutomationId="CmdPal_AppearancePage_ChooseBackgroundImage" Click="PickBackgroundImage_Click" />
+                                <Button
+                                    x:Uid="Settings_GeneralPage_BackgroundImage_ChooseImageButton"
+                                    AutomationProperties.AutomationId="CmdPal_AppearancePage_ChooseBackgroundImage"
+                                    Click="PickBackgroundImage_Click" />
                             </controls:SettingsCard>
                             <controls:SettingsCard x:Uid="Settings_GeneralPage_BackgroundImageBrightness_SettingsCard" Visibility="{x:Bind ViewModel.Appearance.IsBackgroundControlsVisible, Mode=OneWay}">
                                 <Slider
                                     MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                    AutomationProperties.AutomationId="CmdPal_AppearancePage_BgImageBrightness"
                                     Maximum="100"
                                     Minimum="-100"
-                                    AutomationProperties.AutomationId="CmdPal_AppearancePage_BgImageBrightness"
                                     StepFrequency="1"
                                     Value="{x:Bind ViewModel.Appearance.BackgroundImageBrightness, Mode=TwoWay}" />
                             </controls:SettingsCard>
                             <controls:SettingsCard x:Uid="Settings_GeneralPage_BackgroundImageBlur_SettingsCard" Visibility="{x:Bind ViewModel.Appearance.IsBackgroundControlsVisible, Mode=OneWay}">
                                 <Slider
                                     MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                    AutomationProperties.AutomationId="CmdPal_AppearancePage_BgImageBlur"
                                     Maximum="50"
                                     Minimum="0"
-                                    AutomationProperties.AutomationId="CmdPal_AppearancePage_BgImageBlur"
                                     StepFrequency="1"
                                     Value="{x:Bind ViewModel.Appearance.BackgroundImageBlurAmount, Mode=TwoWay}" />
                             </controls:SettingsCard>
@@ -236,27 +245,27 @@
                             <!--  Background tint color and intensity  -->
                             <controls:SettingsCard x:Uid="Settings_GeneralPage_BackgroundTint_SettingsCard" Visibility="{x:Bind ViewModel.Appearance.IsCustomTintVisible, Mode=OneWay}">
                                 <ptControls:ColorPickerButton
+                                    AutomationProperties.AutomationId="CmdPal_AppearancePage_BgTintColor"
                                     HasSelectedColor="True"
                                     IsAlphaEnabled="False"
-                                    AutomationProperties.AutomationId="CmdPal_AppearancePage_BgTintColor"
                                     PaletteColors="{x:Bind ViewModel.Appearance.Swatches}"
                                     SelectedColor="{x:Bind ViewModel.Appearance.ThemeColor, Mode=TwoWay}" />
                             </controls:SettingsCard>
                             <controls:SettingsCard x:Uid="Settings_GeneralPage_BackgroundTintIntensity_SettingsCard" Visibility="{x:Bind ViewModel.Appearance.IsColorIntensityVisible, Mode=OneWay}">
                                 <Slider
                                     MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                    AutomationProperties.AutomationId="CmdPal_AppearancePage_BgTintIntensity"
                                     Maximum="100"
                                     Minimum="1"
-                                    AutomationProperties.AutomationId="CmdPal_AppearancePage_BgTintIntensity"
                                     StepFrequency="1"
                                     Value="{x:Bind ViewModel.Appearance.ColorIntensity, Mode=TwoWay}" />
                             </controls:SettingsCard>
                             <controls:SettingsCard x:Uid="Settings_GeneralPage_ImageTintIntensity_SettingsCard" Visibility="{x:Bind ViewModel.Appearance.IsImageTintIntensityVisible, Mode=OneWay}">
                                 <Slider
                                     MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                    AutomationProperties.AutomationId="CmdPal_AppearancePage_BgImageTintIntensity"
                                     Maximum="100"
                                     Minimum="0"
-                                    AutomationProperties.AutomationId="CmdPal_AppearancePage_BgImageTintIntensity"
                                     StepFrequency="1"
                                     Value="{x:Bind ViewModel.Appearance.BackgroundImageTintIntensity, Mode=TwoWay}" />
                             </controls:SettingsCard>
@@ -264,7 +273,10 @@
                             <!--  Reset appearance properties  -->
                             <controls:SettingsCard x:Uid="Settings_GeneralPage_BackgroundImage_ResetProperties_SettingsCard" Visibility="{x:Bind ViewModel.Appearance.IsResetButtonVisible, Mode=OneWay}">
                                 <StackPanel Orientation="Horizontal" Spacing="8">
-                                    <Button x:Uid="Settings_GeneralPage_Background_ResetImagePropertiesButton" AutomationProperties.AutomationId="CmdPal_AppearancePage_ResetBgImage" Command="{x:Bind ViewModel.Appearance.ResetBackgroundImagePropertiesCommand}" />
+                                    <Button
+                                        x:Uid="Settings_GeneralPage_Background_ResetImagePropertiesButton"
+                                        AutomationProperties.AutomationId="CmdPal_AppearancePage_ResetBgImage"
+                                        Command="{x:Bind ViewModel.Appearance.ResetBackgroundImagePropertiesCommand}" />
                                 </StackPanel>
                             </controls:SettingsCard>
 
@@ -284,7 +296,10 @@
                     </controls:SettingsCard>
 
                     <controls:SettingsCard x:Uid="Settings_GeneralPage_EscapeKeyBehavior_SettingsCard" HeaderIcon="{ui:FontIcon Glyph=&#xE845;}">
-                        <ComboBox AutomationProperties.AutomationId="CmdPal_AppearancePage_EscapeKeyBehavior" MinWidth="{StaticResource SettingActionControlMinWidth}" SelectedIndex="{x:Bind ViewModel.EscapeKeyBehaviorIndex, Mode=TwoWay}">
+                        <ComboBox
+                            MinWidth="{StaticResource SettingActionControlMinWidth}"
+                            AutomationProperties.AutomationId="CmdPal_AppearancePage_EscapeKeyBehavior"
+                            SelectedIndex="{x:Bind ViewModel.EscapeKeyBehaviorIndex, Mode=TwoWay}">
                             <ComboBoxItem x:Uid="Settings_GeneralPage_EscapeKeyBehavior_Option_DismissEmptySearchOrGoBack" />
                             <ComboBoxItem x:Uid="Settings_GeneralPage_EscapeKeyBehavior_Option_AlwaysGoBack" />
                             <ComboBoxItem x:Uid="Settings_GeneralPage_EscapeKeyBehavior_Option_AlwaysDismiss" />

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/AppearancePage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/AppearancePage.xaml
@@ -46,6 +46,7 @@
                                 x:Uid="Settings_AppearancePage_OpenCommandPaletteButton"
                                 MinWidth="200"
                                 HorizontalContentAlignment="Left"
+                                AutomationProperties.AutomationId="CmdPal_AppearancePage_OpenCommandPalette"
                                 Click="OpenCommandPalette_Click"
                                 Style="{StaticResource SubtleButtonStyle}">
                                 <StackPanel Orientation="Horizontal" Spacing="8">
@@ -57,6 +58,7 @@
                                 x:Uid="Settings_AppearancePage_ResetAppearanceButton"
                                 MinWidth="200"
                                 HorizontalContentAlignment="Left"
+                                AutomationProperties.AutomationId="CmdPal_AppearancePage_ResetAppearance"
                                 Command="{x:Bind ViewModel.Appearance.ResetAppearanceSettingsCommand}"
                                 Style="{StaticResource SubtleButtonStyle}">
                                 <StackPanel Orientation="Horizontal" Spacing="8">
@@ -68,7 +70,7 @@
                     </StackPanel>
 
                     <controls:SettingsCard x:Uid="Settings_GeneralPage_AppTheme_SettingsCard" HeaderIcon="{ui:FontIcon Glyph=&#xE793;}">
-                        <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}" SelectedIndex="{x:Bind ViewModel.Appearance.ThemeIndex, Mode=TwoWay}">
+                        <ComboBox AutomationProperties.AutomationId="CmdPal_AppearancePage_Theme" MinWidth="{StaticResource SettingActionControlMinWidth}" SelectedIndex="{x:Bind ViewModel.Appearance.ThemeIndex, Mode=TwoWay}">
 
                             <ComboBoxItem x:Uid="Settings_GeneralPage_AppTheme_Mode_System_Automation" Tag="Default">
                                 <StackPanel Orientation="Horizontal" Spacing="8">
@@ -98,7 +100,7 @@
                         x:Uid="Settings_GeneralPage_BackdropStyle_SettingsCard"
                         HeaderIcon="{ui:FontIcon Glyph=&#xF5EF;}"
                         IsExpanded="{x:Bind ViewModel.Appearance.IsBackdropOpacityVisible, Mode=OneWay}">
-                        <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}" SelectedIndex="{x:Bind ViewModel.Appearance.BackdropStyleIndex, Mode=TwoWay}">
+                        <ComboBox AutomationProperties.AutomationId="CmdPal_AppearancePage_BackdropStyle" MinWidth="{StaticResource SettingActionControlMinWidth}" SelectedIndex="{x:Bind ViewModel.Appearance.BackdropStyleIndex, Mode=TwoWay}">
                             <ComboBoxItem x:Uid="Settings_GeneralPage_BackdropStyle_Acrylic" />
                             <ComboBoxItem x:Uid="Settings_GeneralPage_BackdropStyle_Transparent" />
                             <ComboBoxItem x:Uid="Settings_GeneralPage_BackdropStyle_Mica" />
@@ -128,6 +130,7 @@
                                     MinWidth="{StaticResource SettingActionControlMinWidth}"
                                     Maximum="100"
                                     Minimum="0"
+                                    AutomationProperties.AutomationId="CmdPal_AppearancePage_BackdropOpacity"
                                     StepFrequency="1"
                                     Value="{x:Bind ViewModel.Appearance.BackdropOpacity, Mode=TwoWay}" />
                             </controls:SettingsCard>
@@ -143,6 +146,7 @@
                             <ComboBox
                                 x:Uid="Settings_GeneralPage_ColorizationMode"
                                 MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                AutomationProperties.AutomationId="CmdPal_AppearancePage_ColorizationMode"
                                 SelectedIndex="{x:Bind ViewModel.Appearance.ColorizationModeIndex, Mode=TwoWay}"
                                 Visibility="{x:Bind ViewModel.Appearance.IsBackgroundSettingsEnabled, Mode=OneWay}">
                                 <ComboBoxItem x:Uid="Settings_GeneralPage_ColorizationMode_None" />
@@ -202,13 +206,14 @@
                                 x:Uid="Settings_GeneralPage_BackgroundImage_SettingsCard"
                                 Description="{x:Bind ViewModel.Appearance.BackgroundImagePath, Mode=OneWay}"
                                 Visibility="{x:Bind ViewModel.Appearance.IsBackgroundControlsVisible, Mode=OneWay}">
-                                <Button x:Uid="Settings_GeneralPage_BackgroundImage_ChooseImageButton" Click="PickBackgroundImage_Click" />
+                                <Button x:Uid="Settings_GeneralPage_BackgroundImage_ChooseImageButton" AutomationProperties.AutomationId="CmdPal_AppearancePage_ChooseBackgroundImage" Click="PickBackgroundImage_Click" />
                             </controls:SettingsCard>
                             <controls:SettingsCard x:Uid="Settings_GeneralPage_BackgroundImageBrightness_SettingsCard" Visibility="{x:Bind ViewModel.Appearance.IsBackgroundControlsVisible, Mode=OneWay}">
                                 <Slider
                                     MinWidth="{StaticResource SettingActionControlMinWidth}"
                                     Maximum="100"
                                     Minimum="-100"
+                                    AutomationProperties.AutomationId="CmdPal_AppearancePage_BgImageBrightness"
                                     StepFrequency="1"
                                     Value="{x:Bind ViewModel.Appearance.BackgroundImageBrightness, Mode=TwoWay}" />
                             </controls:SettingsCard>
@@ -217,11 +222,12 @@
                                     MinWidth="{StaticResource SettingActionControlMinWidth}"
                                     Maximum="50"
                                     Minimum="0"
+                                    AutomationProperties.AutomationId="CmdPal_AppearancePage_BgImageBlur"
                                     StepFrequency="1"
                                     Value="{x:Bind ViewModel.Appearance.BackgroundImageBlurAmount, Mode=TwoWay}" />
                             </controls:SettingsCard>
                             <controls:SettingsCard x:Uid="Settings_GeneralPage_BackgroundImageFit_SettingsCard" Visibility="{x:Bind ViewModel.Appearance.IsBackgroundControlsVisible, Mode=OneWay}">
-                                <ComboBox SelectedIndex="{x:Bind ViewModel.Appearance.BackgroundImageFitIndex, Mode=TwoWay}">
+                                <ComboBox AutomationProperties.AutomationId="CmdPal_AppearancePage_BgImageFit" SelectedIndex="{x:Bind ViewModel.Appearance.BackgroundImageFitIndex, Mode=TwoWay}">
                                     <ComboBoxItem x:Uid="BackgroundImageFit_ComboBoxItem_Fill" />
                                     <ComboBoxItem x:Uid="BackgroundImageFit_ComboBoxItem_Stretch" />
                                 </ComboBox>
@@ -232,6 +238,7 @@
                                 <ptControls:ColorPickerButton
                                     HasSelectedColor="True"
                                     IsAlphaEnabled="False"
+                                    AutomationProperties.AutomationId="CmdPal_AppearancePage_BgTintColor"
                                     PaletteColors="{x:Bind ViewModel.Appearance.Swatches}"
                                     SelectedColor="{x:Bind ViewModel.Appearance.ThemeColor, Mode=TwoWay}" />
                             </controls:SettingsCard>
@@ -240,6 +247,7 @@
                                     MinWidth="{StaticResource SettingActionControlMinWidth}"
                                     Maximum="100"
                                     Minimum="1"
+                                    AutomationProperties.AutomationId="CmdPal_AppearancePage_BgTintIntensity"
                                     StepFrequency="1"
                                     Value="{x:Bind ViewModel.Appearance.ColorIntensity, Mode=TwoWay}" />
                             </controls:SettingsCard>
@@ -248,6 +256,7 @@
                                     MinWidth="{StaticResource SettingActionControlMinWidth}"
                                     Maximum="100"
                                     Minimum="0"
+                                    AutomationProperties.AutomationId="CmdPal_AppearancePage_BgImageTintIntensity"
                                     StepFrequency="1"
                                     Value="{x:Bind ViewModel.Appearance.BackgroundImageTintIntensity, Mode=TwoWay}" />
                             </controls:SettingsCard>
@@ -255,7 +264,7 @@
                             <!--  Reset appearance properties  -->
                             <controls:SettingsCard x:Uid="Settings_GeneralPage_BackgroundImage_ResetProperties_SettingsCard" Visibility="{x:Bind ViewModel.Appearance.IsResetButtonVisible, Mode=OneWay}">
                                 <StackPanel Orientation="Horizontal" Spacing="8">
-                                    <Button x:Uid="Settings_GeneralPage_Background_ResetImagePropertiesButton" Command="{x:Bind ViewModel.Appearance.ResetBackgroundImagePropertiesCommand}" />
+                                    <Button x:Uid="Settings_GeneralPage_Background_ResetImagePropertiesButton" AutomationProperties.AutomationId="CmdPal_AppearancePage_ResetBgImage" Command="{x:Bind ViewModel.Appearance.ResetBackgroundImagePropertiesCommand}" />
                                 </StackPanel>
                             </controls:SettingsCard>
 
@@ -267,15 +276,15 @@
                     <TextBlock x:Uid="BehaviorSettingsHeader" Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" />
 
                     <controls:SettingsCard x:Uid="Settings_GeneralPage_ShowAppDetails_SettingsCard" HeaderIcon="{ui:FontIcon Glyph=&#xE8A0;}">
-                        <ToggleSwitch IsOn="{x:Bind ViewModel.ShowAppDetails, Mode=TwoWay}" />
+                        <ToggleSwitch AutomationProperties.AutomationId="CmdPal_AppearancePage_ShowAppDetails" IsOn="{x:Bind ViewModel.ShowAppDetails, Mode=TwoWay}" />
                     </controls:SettingsCard>
 
                     <controls:SettingsCard x:Uid="Settings_GeneralPage_BackspaceGoesBack_SettingsCard" HeaderIcon="{ui:FontIcon Glyph=&#xE750;}">
-                        <ToggleSwitch IsOn="{x:Bind ViewModel.BackspaceGoesBack, Mode=TwoWay}" />
+                        <ToggleSwitch AutomationProperties.AutomationId="CmdPal_AppearancePage_BackspaceGoesBack" IsOn="{x:Bind ViewModel.BackspaceGoesBack, Mode=TwoWay}" />
                     </controls:SettingsCard>
 
                     <controls:SettingsCard x:Uid="Settings_GeneralPage_EscapeKeyBehavior_SettingsCard" HeaderIcon="{ui:FontIcon Glyph=&#xE845;}">
-                        <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}" SelectedIndex="{x:Bind ViewModel.EscapeKeyBehaviorIndex, Mode=TwoWay}">
+                        <ComboBox AutomationProperties.AutomationId="CmdPal_AppearancePage_EscapeKeyBehavior" MinWidth="{StaticResource SettingActionControlMinWidth}" SelectedIndex="{x:Bind ViewModel.EscapeKeyBehaviorIndex, Mode=TwoWay}">
                             <ComboBoxItem x:Uid="Settings_GeneralPage_EscapeKeyBehavior_Option_DismissEmptySearchOrGoBack" />
                             <ComboBoxItem x:Uid="Settings_GeneralPage_EscapeKeyBehavior_Option_AlwaysGoBack" />
                             <ComboBoxItem x:Uid="Settings_GeneralPage_EscapeKeyBehavior_Option_AlwaysDismiss" />
@@ -284,11 +293,11 @@
                     </controls:SettingsCard>
 
                     <controls:SettingsCard x:Uid="Settings_GeneralPage_SingleClickActivation_SettingsCard" HeaderIcon="{ui:FontIcon Glyph=&#xE962;}">
-                        <ToggleSwitch IsOn="{x:Bind ViewModel.SingleClickActivates, Mode=TwoWay}" />
+                        <ToggleSwitch AutomationProperties.AutomationId="CmdPal_AppearancePage_SingleClickActivates" IsOn="{x:Bind ViewModel.SingleClickActivates, Mode=TwoWay}" />
                     </controls:SettingsCard>
 
                     <controls:SettingsCard x:Uid="Settings_GeneralPage_DisableAnimations_SettingsCard" HeaderIcon="{ui:FontIcon Glyph=&#xE945;}">
-                        <ToggleSwitch IsOn="{x:Bind ViewModel.DisableAnimations, Mode=TwoWay}" />
+                        <ToggleSwitch AutomationProperties.AutomationId="CmdPal_AppearancePage_DisableAnimations" IsOn="{x:Bind ViewModel.DisableAnimations, Mode=TwoWay}" />
                     </controls:SettingsCard>
                 </StackPanel>
             </Grid>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/DockSettingsPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/DockSettingsPage.xaml
@@ -259,17 +259,22 @@
                         <ItemsRepeater.ItemTemplate>
                             <DataTemplate x:DataType="dockVm:DockMonitorConfigViewModel">
                                 <controls:SettingsExpander
-                                    AutomationProperties.AutomationId="{x:Bind DisplayName, Mode=OneWay}"
+                                    AutomationProperties.AutomationId="{x:Bind DeviceId, Mode=OneWay}"
                                     Description="{x:Bind Resolution, Mode=OneWay}"
                                     Header="{x:Bind DisplayName, Mode=OneWay}"
                                     HeaderIcon="{ui:FontIcon Glyph=&#xE7F4;}"
                                     IsExpanded="False">
-                                    <ToggleSwitch AutomationProperties.AutomationId="CmdPal_DockSettingsPage_Monitor_Enable" IsOn="{x:Bind IsEnabled, Mode=TwoWay}" />
+                                    <!--
+                                        AutomationId on the inner ToggleSwitch / ComboBox is intentionally
+                                        omitted because the parent SettingsExpander already exposes a
+                                        per-monitor unique AutomationId (DeviceId), so tests can locate
+                                        each control relative to its monitor without ambiguity.
+                                    -->
+                                    <ToggleSwitch IsOn="{x:Bind IsEnabled, Mode=TwoWay}" />
                                     <controls:SettingsExpander.Items>
                                         <controls:SettingsCard x:Uid="DockMonitor_Position_SettingsCard">
                                             <ComboBox
                                                 MinWidth="{StaticResource SettingActionControlMinWidth}"
-                                                AutomationProperties.AutomationId="CmdPal_DockSettingsPage_Monitor_Position"
                                                 IsEnabled="{x:Bind IsEnabled, Mode=OneWay}"
                                                 SelectedIndex="{x:Bind SideOverrideIndex, Mode=TwoWay}">
                                                 <ComboBoxItem x:Uid="DockMonitor_Position_UseDefault" />

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/DockSettingsPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/DockSettingsPage.xaml
@@ -41,11 +41,12 @@
                         x:Uid="CmdPalDock_LearnMore"
                         Margin="0,0,0,36"
                         Padding="0"
+                        AutomationProperties.AutomationId="CmdPal_DockSettingsPage_LearnMore"
                         FontWeight="SemiBold"
                         NavigateUri="https://aka.ms/cmdpal-dock" />
                     <!--  Enable Dock  -->
                     <controls:SettingsCard x:Uid="Settings_GeneralPage_EnableDock_SettingsCard" HeaderIcon="{ui:FontIcon Glyph=&#xF596;}">
-                        <ToggleSwitch IsOn="{x:Bind ViewModel.EnableDock, Mode=TwoWay}" />
+                        <ToggleSwitch AutomationProperties.AutomationId="CmdPal_DockSettingsPage_EnableDock" IsOn="{x:Bind ViewModel.EnableDock, Mode=TwoWay}" />
                     </controls:SettingsCard>
 
                     <!--  Appearance Section  -->
@@ -82,7 +83,7 @@
                     </controls:SettingsCard>
 
                     <controls:SettingsCard x:Uid="DockAppearance_AppTheme_SettingsCard" HeaderIcon="{ui:FontIcon Glyph=&#xE793;}">
-                        <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}" SelectedIndex="{x:Bind ViewModel.DockAppearance.ThemeIndex, Mode=TwoWay}">
+                        <ComboBox AutomationProperties.AutomationId="CmdPal_DockSettingsPage_Theme" MinWidth="{StaticResource SettingActionControlMinWidth}" SelectedIndex="{x:Bind ViewModel.DockAppearance.ThemeIndex, Mode=TwoWay}">
                             <ComboBoxItem x:Uid="Settings_GeneralPage_AppTheme_Mode_System_Automation" Tag="Default">
                                 <StackPanel Orientation="Horizontal" Spacing="8">
                                     <FontIcon FontSize="16" Glyph="&#xE770;" />
@@ -123,7 +124,7 @@
                         x:Uid="DockAppearance_Background_SettingsExpander"
                         HeaderIcon="{ui:FontIcon Glyph=&#xE790;}"
                         IsExpanded="{x:Bind ViewModel.DockAppearance.IsColorizationDetailsExpanded, Mode=TwoWay}">
-                        <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}" SelectedIndex="{x:Bind ViewModel.DockAppearance.ColorizationModeIndex, Mode=TwoWay}">
+                        <ComboBox AutomationProperties.AutomationId="CmdPal_DockSettingsPage_ColorizationMode" MinWidth="{StaticResource SettingActionControlMinWidth}" SelectedIndex="{x:Bind ViewModel.DockAppearance.ColorizationModeIndex, Mode=TwoWay}">
                             <ComboBoxItem x:Uid="Settings_GeneralPage_ColorizationMode_None" />
                             <ComboBoxItem x:Uid="Settings_GeneralPage_ColorizationMode_WindowsAccent" />
                             <ComboBoxItem x:Uid="Settings_GeneralPage_ColorizationMode_CustomColor" />
@@ -176,13 +177,14 @@
                                 x:Uid="DockAppearance_BackgroundImage_SettingsCard"
                                 Description="{x:Bind ViewModel.DockAppearance.BackgroundImagePath, Mode=OneWay}"
                                 Visibility="{x:Bind ViewModel.DockAppearance.IsBackgroundControlsVisible, Mode=OneWay}">
-                                <Button x:Uid="Settings_GeneralPage_BackgroundImage_ChooseImageButton" Click="PickBackgroundImage_Click" />
+                                <Button x:Uid="Settings_GeneralPage_BackgroundImage_ChooseImageButton" AutomationProperties.AutomationId="CmdPal_DockSettingsPage_ChooseBackgroundImage" Click="PickBackgroundImage_Click" />
                             </controls:SettingsCard>
                             <controls:SettingsCard x:Uid="DockAppearance_BackgroundImageBrightness_SettingsCard" Visibility="{x:Bind ViewModel.DockAppearance.IsBackgroundControlsVisible, Mode=OneWay}">
                                 <Slider
                                     MinWidth="{StaticResource SettingActionControlMinWidth}"
                                     Maximum="100"
                                     Minimum="-100"
+                                    AutomationProperties.AutomationId="CmdPal_DockSettingsPage_BgImageBrightness"
                                     StepFrequency="1"
                                     Value="{x:Bind ViewModel.DockAppearance.BackgroundImageBrightness, Mode=TwoWay}" />
                             </controls:SettingsCard>
@@ -191,11 +193,12 @@
                                     MinWidth="{StaticResource SettingActionControlMinWidth}"
                                     Maximum="50"
                                     Minimum="0"
+                                    AutomationProperties.AutomationId="CmdPal_DockSettingsPage_BgImageBlur"
                                     StepFrequency="1"
                                     Value="{x:Bind ViewModel.DockAppearance.BackgroundImageBlurAmount, Mode=TwoWay}" />
                             </controls:SettingsCard>
                             <controls:SettingsCard x:Uid="DockAppearance_BackgroundImageFit_SettingsCard" Visibility="{x:Bind ViewModel.DockAppearance.IsBackgroundControlsVisible, Mode=OneWay}">
-                                <ComboBox SelectedIndex="{x:Bind ViewModel.DockAppearance.BackgroundImageFitIndex, Mode=TwoWay}">
+                                <ComboBox AutomationProperties.AutomationId="CmdPal_DockSettingsPage_BgImageFit" SelectedIndex="{x:Bind ViewModel.DockAppearance.BackgroundImageFitIndex, Mode=TwoWay}">
                                     <ComboBoxItem x:Uid="BackgroundImageFit_ComboBoxItem_Fill" />
                                     <ComboBoxItem x:Uid="BackgroundImageFit_ComboBoxItem_Stretch" />
                                 </ComboBox>
@@ -214,13 +217,14 @@
                                     MinWidth="{StaticResource SettingActionControlMinWidth}"
                                     Maximum="100"
                                     Minimum="1"
+                                    AutomationProperties.AutomationId="CmdPal_DockSettingsPage_BgTintIntensity"
                                     StepFrequency="1"
                                     Value="{x:Bind ViewModel.DockAppearance.ColorIntensity, Mode=TwoWay}" />
                             </controls:SettingsCard>
 
                             <!--  Reset background image properties  -->
                             <controls:SettingsCard x:Uid="DockAppearance_BackgroundImage_ResetProperties_SettingsCard" Visibility="{x:Bind ViewModel.DockAppearance.IsBackgroundControlsVisible, Mode=OneWay}">
-                                <Button x:Uid="Settings_GeneralPage_Background_ResetImagePropertiesButton" Command="{x:Bind ViewModel.DockAppearance.ResetBackgroundImagePropertiesCommand}" />
+                                <Button x:Uid="Settings_GeneralPage_Background_ResetImagePropertiesButton" AutomationProperties.AutomationId="CmdPal_DockSettingsPage_ResetBgImage" Command="{x:Bind ViewModel.DockAppearance.ResetBackgroundImagePropertiesCommand}" />
                             </controls:SettingsCard>
 
                         </controls:SettingsExpander.Items>
@@ -230,7 +234,7 @@
                     <TextBlock x:Uid="BehaviorSettingsHeader" Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" />
 
                     <controls:SettingsCard x:Uid="DockBehavior_AlwaysOnTop_SettingsCard" HeaderIcon="{ui:FontIcon Glyph=&#xE840;}">
-                        <ToggleSwitch IsOn="{x:Bind ViewModel.Dock_AlwaysOnTop, Mode=TwoWay}" />
+                        <ToggleSwitch AutomationProperties.AutomationId="CmdPal_DockSettingsPage_AlwaysOnTop" IsOn="{x:Bind ViewModel.Dock_AlwaysOnTop, Mode=TwoWay}" />
                     </controls:SettingsCard>
 
                     <!--  Monitors Section  -->
@@ -245,13 +249,15 @@
                                 <controls:SettingsExpander
                                     Description="{x:Bind Resolution, Mode=OneWay}"
                                     Header="{x:Bind DisplayName, Mode=OneWay}"
+                                    AutomationProperties.AutomationId="{x:Bind DisplayName, Mode=OneWay}"
                                     HeaderIcon="{ui:FontIcon Glyph=&#xE7F4;}"
                                     IsExpanded="False">
-                                    <ToggleSwitch IsOn="{x:Bind IsEnabled, Mode=TwoWay}" />
+                                    <ToggleSwitch AutomationProperties.AutomationId="CmdPal_DockSettingsPage_Monitor_Enable" IsOn="{x:Bind IsEnabled, Mode=TwoWay}" />
                                     <controls:SettingsExpander.Items>
                                         <controls:SettingsCard x:Uid="DockMonitor_Position_SettingsCard">
                                             <ComboBox
                                                 MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                                AutomationProperties.AutomationId="CmdPal_DockSettingsPage_Monitor_Position"
                                                 IsEnabled="{x:Bind IsEnabled, Mode=OneWay}"
                                                 SelectedIndex="{x:Bind SideOverrideIndex, Mode=TwoWay}">
                                                 <ComboBoxItem x:Uid="DockMonitor_Position_UseDefault" />

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/DockSettingsPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/DockSettingsPage.xaml
@@ -83,7 +83,10 @@
                     </controls:SettingsCard>
 
                     <controls:SettingsCard x:Uid="DockAppearance_AppTheme_SettingsCard" HeaderIcon="{ui:FontIcon Glyph=&#xE793;}">
-                        <ComboBox AutomationProperties.AutomationId="CmdPal_DockSettingsPage_Theme" MinWidth="{StaticResource SettingActionControlMinWidth}" SelectedIndex="{x:Bind ViewModel.DockAppearance.ThemeIndex, Mode=TwoWay}">
+                        <ComboBox
+                            MinWidth="{StaticResource SettingActionControlMinWidth}"
+                            AutomationProperties.AutomationId="CmdPal_DockSettingsPage_Theme"
+                            SelectedIndex="{x:Bind ViewModel.DockAppearance.ThemeIndex, Mode=TwoWay}">
                             <ComboBoxItem x:Uid="Settings_GeneralPage_AppTheme_Mode_System_Automation" Tag="Default">
                                 <StackPanel Orientation="Horizontal" Spacing="8">
                                     <FontIcon FontSize="16" Glyph="&#xE770;" />
@@ -124,7 +127,10 @@
                         x:Uid="DockAppearance_Background_SettingsExpander"
                         HeaderIcon="{ui:FontIcon Glyph=&#xE790;}"
                         IsExpanded="{x:Bind ViewModel.DockAppearance.IsColorizationDetailsExpanded, Mode=TwoWay}">
-                        <ComboBox AutomationProperties.AutomationId="CmdPal_DockSettingsPage_ColorizationMode" MinWidth="{StaticResource SettingActionControlMinWidth}" SelectedIndex="{x:Bind ViewModel.DockAppearance.ColorizationModeIndex, Mode=TwoWay}">
+                        <ComboBox
+                            MinWidth="{StaticResource SettingActionControlMinWidth}"
+                            AutomationProperties.AutomationId="CmdPal_DockSettingsPage_ColorizationMode"
+                            SelectedIndex="{x:Bind ViewModel.DockAppearance.ColorizationModeIndex, Mode=TwoWay}">
                             <ComboBoxItem x:Uid="Settings_GeneralPage_ColorizationMode_None" />
                             <ComboBoxItem x:Uid="Settings_GeneralPage_ColorizationMode_WindowsAccent" />
                             <ComboBoxItem x:Uid="Settings_GeneralPage_ColorizationMode_CustomColor" />
@@ -177,23 +183,26 @@
                                 x:Uid="DockAppearance_BackgroundImage_SettingsCard"
                                 Description="{x:Bind ViewModel.DockAppearance.BackgroundImagePath, Mode=OneWay}"
                                 Visibility="{x:Bind ViewModel.DockAppearance.IsBackgroundControlsVisible, Mode=OneWay}">
-                                <Button x:Uid="Settings_GeneralPage_BackgroundImage_ChooseImageButton" AutomationProperties.AutomationId="CmdPal_DockSettingsPage_ChooseBackgroundImage" Click="PickBackgroundImage_Click" />
+                                <Button
+                                    x:Uid="Settings_GeneralPage_BackgroundImage_ChooseImageButton"
+                                    AutomationProperties.AutomationId="CmdPal_DockSettingsPage_ChooseBackgroundImage"
+                                    Click="PickBackgroundImage_Click" />
                             </controls:SettingsCard>
                             <controls:SettingsCard x:Uid="DockAppearance_BackgroundImageBrightness_SettingsCard" Visibility="{x:Bind ViewModel.DockAppearance.IsBackgroundControlsVisible, Mode=OneWay}">
                                 <Slider
                                     MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                    AutomationProperties.AutomationId="CmdPal_DockSettingsPage_BgImageBrightness"
                                     Maximum="100"
                                     Minimum="-100"
-                                    AutomationProperties.AutomationId="CmdPal_DockSettingsPage_BgImageBrightness"
                                     StepFrequency="1"
                                     Value="{x:Bind ViewModel.DockAppearance.BackgroundImageBrightness, Mode=TwoWay}" />
                             </controls:SettingsCard>
                             <controls:SettingsCard x:Uid="DockAppearance_BackgroundImageBlur_SettingsCard" Visibility="{x:Bind ViewModel.DockAppearance.IsBackgroundControlsVisible, Mode=OneWay}">
                                 <Slider
                                     MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                    AutomationProperties.AutomationId="CmdPal_DockSettingsPage_BgImageBlur"
                                     Maximum="50"
                                     Minimum="0"
-                                    AutomationProperties.AutomationId="CmdPal_DockSettingsPage_BgImageBlur"
                                     StepFrequency="1"
                                     Value="{x:Bind ViewModel.DockAppearance.BackgroundImageBlurAmount, Mode=TwoWay}" />
                             </controls:SettingsCard>
@@ -215,16 +224,19 @@
                             <controls:SettingsCard x:Uid="DockAppearance_BackgroundTintIntensity_SettingsCard" Visibility="{x:Bind ViewModel.DockAppearance.IsCustomTintIntensityVisible, Mode=OneWay}">
                                 <Slider
                                     MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                    AutomationProperties.AutomationId="CmdPal_DockSettingsPage_BgTintIntensity"
                                     Maximum="100"
                                     Minimum="1"
-                                    AutomationProperties.AutomationId="CmdPal_DockSettingsPage_BgTintIntensity"
                                     StepFrequency="1"
                                     Value="{x:Bind ViewModel.DockAppearance.ColorIntensity, Mode=TwoWay}" />
                             </controls:SettingsCard>
 
                             <!--  Reset background image properties  -->
                             <controls:SettingsCard x:Uid="DockAppearance_BackgroundImage_ResetProperties_SettingsCard" Visibility="{x:Bind ViewModel.DockAppearance.IsBackgroundControlsVisible, Mode=OneWay}">
-                                <Button x:Uid="Settings_GeneralPage_Background_ResetImagePropertiesButton" AutomationProperties.AutomationId="CmdPal_DockSettingsPage_ResetBgImage" Command="{x:Bind ViewModel.DockAppearance.ResetBackgroundImagePropertiesCommand}" />
+                                <Button
+                                    x:Uid="Settings_GeneralPage_Background_ResetImagePropertiesButton"
+                                    AutomationProperties.AutomationId="CmdPal_DockSettingsPage_ResetBgImage"
+                                    Command="{x:Bind ViewModel.DockAppearance.ResetBackgroundImagePropertiesCommand}" />
                             </controls:SettingsCard>
 
                         </controls:SettingsExpander.Items>
@@ -247,9 +259,9 @@
                         <ItemsRepeater.ItemTemplate>
                             <DataTemplate x:DataType="dockVm:DockMonitorConfigViewModel">
                                 <controls:SettingsExpander
+                                    AutomationProperties.AutomationId="{x:Bind DisplayName, Mode=OneWay}"
                                     Description="{x:Bind Resolution, Mode=OneWay}"
                                     Header="{x:Bind DisplayName, Mode=OneWay}"
-                                    AutomationProperties.AutomationId="{x:Bind DisplayName, Mode=OneWay}"
                                     HeaderIcon="{ui:FontIcon Glyph=&#xE7F4;}"
                                     IsExpanded="False">
                                     <ToggleSwitch AutomationProperties.AutomationId="CmdPal_DockSettingsPage_Monitor_Enable" IsOn="{x:Bind IsEnabled, Mode=TwoWay}" />

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/ExtensionGalleryItemPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/ExtensionGalleryItemPage.xaml
@@ -38,6 +38,7 @@
                     <Button
                         Margin="0,12,0,0"
                         HorizontalAlignment="Stretch"
+                        AutomationProperties.AutomationId="CmdPal_GalleryItemPage_InstallViaWinGet"
                         Command="{x:Bind ViewModel.InstallViaWinGetCommand, Mode=OneWay}"
                         Content="{x:Bind ViewModel.InstallViaWinGetText, Mode=OneWay}"
                         IsEnabled="{x:Bind ViewModel.CanInstallViaWinGet, Mode=OneWay}"
@@ -48,6 +49,7 @@
                         Width="32"
                         Height="32"
                         Padding="0"
+                        AutomationProperties.AutomationId="CmdPal_GalleryItemPage_CancelWinGetAction"
                         Command="{x:Bind ViewModel.CancelWinGetActionCommand, Mode=OneWay}"
                         Style="{StaticResource SubtleButtonStyle}"
                         Visibility="{x:Bind help:BindTransformers.BoolToVisibility(ViewModel.ShowCancelWinGetActionButton), Mode=OneWay, FallbackValue=Collapsed}">
@@ -83,6 +85,7 @@
                         Height="28"
                         Padding="0"
                         VerticalAlignment="Center"
+                        AutomationProperties.AutomationId="CmdPal_GalleryItemPage_CopyInstallCommand"
                         Command="{x:Bind ViewModel.CopyWinGetInstallCommand, Mode=OneWay}"
                         IsEnabled="{x:Bind ViewModel.CanCopyWinGetInstallCommand, Mode=OneWay}"
                         Style="{StaticResource SubtleButtonStyle}">
@@ -216,6 +219,7 @@
                             <HyperlinkButton
                                 x:Uid="Settings_GalleryItemPage_AuthorLink"
                                 Padding="0"
+                                AutomationProperties.AutomationId="CmdPal_GalleryItemPage_AuthorLink"
                                 Command="{x:Bind ViewModel.OpenAuthorPageCommand, Mode=OneWay}"
                                 Visibility="{x:Bind help:BindTransformers.BoolToVisibility(ViewModel.HasAuthorUrl), Mode=OneWay, FallbackValue=Collapsed}">
                                 <StackPanel Orientation="Horizontal" Spacing="4">
@@ -227,6 +231,7 @@
                             <HyperlinkButton
                                 Grid.Row="3"
                                 Padding="0"
+                                AutomationProperties.AutomationId="CmdPal_GalleryItemPage_ViewRepository"
                                 NavigateUri="{x:Bind ViewModel.Homepage, Mode=OneWay}"
                                 ToolTipService.ToolTip="{x:Bind ViewModel.Homepage, Mode=OneWay}"
                                 Visibility="{x:Bind help:BindTransformers.BoolToVisibility(ViewModel.HasHomepage), Mode=OneWay, FallbackValue=Collapsed}">
@@ -310,6 +315,7 @@
                         x:Uid="Settings_GalleryItemPage_Uninstall_Link"
                         Padding="0"
                         VerticalAlignment="Center"
+                        AutomationProperties.AutomationId="CmdPal_GalleryItemPage_OpenInstalledApps"
                         Command="{x:Bind ViewModel.OpenInstalledAppsCommand}"
                         FontSize="12"
                         Visibility="{x:Bind help:BindTransformers.BoolToVisibility(ViewModel.ShowInstalledBadge), Mode=OneWay, FallbackValue=Collapsed}" />

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/ExtensionPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/ExtensionPage.xaml
@@ -71,7 +71,7 @@
                                 <Run Text="{x:Bind ViewModel.DisplayName}" />
                             </TextBlock>
                         </controls:SettingsCard.Header>
-                        <ToggleSwitch IsOn="{x:Bind ViewModel.IsEnabled, Mode=TwoWay}" />
+                        <ToggleSwitch AutomationProperties.AutomationId="CmdPal_ExtensionPage_Enable" IsOn="{x:Bind ViewModel.IsEnabled, Mode=TwoWay}" />
                     </controls:SettingsCard>
                     <controls:SwitchPresenter
                         HorizontalAlignment="Stretch"
@@ -109,11 +109,12 @@
                                                         <TextBox
                                                             x:Uid="Settings_ExtensionPage_Alias_PlaceholderText"
                                                             MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                                            AutomationProperties.AutomationId="CmdPal_ExtensionPage_AliasText"
                                                             AutomationProperties.LabeledBy="{x:Bind AliasSettingsCard}"
                                                             Text="{x:Bind AliasText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                                                     </controls:SettingsCard>
                                                     <controls:SettingsCard x:Uid="Settings_ExtensionPage_AliasActivation_SettingsCard" IsEnabled="{x:Bind AliasText, Converter={StaticResource StringEmptyToBoolConverter}, Mode=OneWay}">
-                                                        <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}" SelectedIndex="{x:Bind IsDirectAlias, Converter={StaticResource BoolToOptionConverter}, Mode=TwoWay}">
+                                                        <ComboBox AutomationProperties.AutomationId="CmdPal_ExtensionPage_AliasActivationType" MinWidth="{StaticResource SettingActionControlMinWidth}" SelectedIndex="{x:Bind IsDirectAlias, Converter={StaticResource BoolToOptionConverter}, Mode=TwoWay}">
                                                             <ComboBoxItem x:Uid="Settings_ExtensionPage_Alias_DirectComboBox" />
                                                             <ComboBoxItem x:Uid="Settings_ExtensionPage_Alias_IndirectComboBox" />
                                                         </ComboBox>
@@ -136,6 +137,7 @@
                                         Margin="0,0,0,4"
                                         Padding="0"
                                         VerticalAlignment="Bottom"
+                                        AutomationProperties.AutomationId="CmdPal_ExtensionPage_ManageFallbackRank"
                                         Click="RankButton_Click">
                                         <HyperlinkButton.Content>
                                             <StackPanel Orientation="Horizontal" Spacing="8">
@@ -172,7 +174,7 @@
                                                     </cpcontrols:ContentIcon>
                                                 </controls:SettingsExpander.HeaderIcon>
 
-                                                <ToggleSwitch IsOn="{x:Bind IsEnabled, Mode=TwoWay}" />
+                                                <ToggleSwitch AutomationProperties.AutomationId="CmdPal_ExtensionPage_FallbackCommand_Enable" IsOn="{x:Bind IsEnabled, Mode=TwoWay}" />
 
                                                 <controls:SettingsExpander.Items>
                                                     <controls:SettingsCard ContentAlignment="Left">

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/ExtensionPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/ExtensionPage.xaml
@@ -162,6 +162,7 @@
                                         <DataTemplate x:DataType="viewModels:FallbackSettingsViewModel">
                                             <controls:SettingsExpander
                                                 Grid.Column="1"
+                                                AutomationProperties.AutomationId="{x:Bind Id, Mode=OneWay}"
                                                 Header="{x:Bind DisplayName, Mode=OneWay}"
                                                 IsExpanded="False">
                                                 <controls:SettingsExpander.HeaderIcon>
@@ -177,7 +178,14 @@
                                                     </cpcontrols:ContentIcon>
                                                 </controls:SettingsExpander.HeaderIcon>
 
-                                                <ToggleSwitch AutomationProperties.AutomationId="CmdPal_ExtensionPage_FallbackCommand_Enable" IsOn="{x:Bind IsEnabled, Mode=TwoWay}" />
+                                                <!--
+                                                    AutomationId on the inner ToggleSwitch is intentionally
+                                                    omitted because the parent SettingsExpander already
+                                                    exposes a per-fallback unique AutomationId (Id), so
+                                                    tests can locate the toggle relative to that without
+                                                    ambiguity across rows.
+                                                -->
+                                                <ToggleSwitch IsOn="{x:Bind IsEnabled, Mode=TwoWay}" />
 
                                                 <controls:SettingsExpander.Items>
                                                     <controls:SettingsCard ContentAlignment="Left">

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/ExtensionPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/ExtensionPage.xaml
@@ -114,7 +114,10 @@
                                                             Text="{x:Bind AliasText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                                                     </controls:SettingsCard>
                                                     <controls:SettingsCard x:Uid="Settings_ExtensionPage_AliasActivation_SettingsCard" IsEnabled="{x:Bind AliasText, Converter={StaticResource StringEmptyToBoolConverter}, Mode=OneWay}">
-                                                        <ComboBox AutomationProperties.AutomationId="CmdPal_ExtensionPage_AliasActivationType" MinWidth="{StaticResource SettingActionControlMinWidth}" SelectedIndex="{x:Bind IsDirectAlias, Converter={StaticResource BoolToOptionConverter}, Mode=TwoWay}">
+                                                        <ComboBox
+                                                            MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                                            AutomationProperties.AutomationId="CmdPal_ExtensionPage_AliasActivationType"
+                                                            SelectedIndex="{x:Bind IsDirectAlias, Converter={StaticResource BoolToOptionConverter}, Mode=TwoWay}">
                                                             <ComboBoxItem x:Uid="Settings_ExtensionPage_Alias_DirectComboBox" />
                                                             <ComboBoxItem x:Uid="Settings_ExtensionPage_Alias_IndirectComboBox" />
                                                         </ComboBox>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/ExtensionsPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/ExtensionsPage.xaml
@@ -248,7 +248,13 @@
                                             </cpcontrols:ContentIcon.Content>
                                         </cpcontrols:ContentIcon>
                                     </controls:SettingsCard.HeaderIcon>
-                                    <ToggleSwitch AutomationProperties.AutomationId="CmdPal_ExtensionsPage_Provider_Enable" IsOn="{x:Bind IsEnabled, Mode=TwoWay}" />
+                                    <!--
+                                        AutomationId on the inner ToggleSwitch is intentionally omitted
+                                        because the parent SettingsCard already exposes a unique
+                                        provider-derived AutomationId (Provider.Id), so tests can locate
+                                        the toggle relative to that without ambiguity across rows.
+                                    -->
+                                    <ToggleSwitch IsOn="{x:Bind IsEnabled, Mode=TwoWay}" />
                                 </controls:SettingsCard>
                             </DataTemplate>
                         </ItemsRepeater.ItemTemplate>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/ExtensionsPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/ExtensionsPage.xaml
@@ -100,7 +100,10 @@
                             Grid.Column="1"
                             Orientation="Horizontal"
                             Spacing="8">
-                            <Button x:Uid="Settings_ExtensionsPage_FindExtensions_MicrosoftStore" AutomationProperties.AutomationId="CmdPal_ExtensionsPage_OpenMicrosoftStore" Command="{x:Bind viewModel.Extensions.OpenStoreWithExtensionCommand}">
+                            <Button
+                                x:Uid="Settings_ExtensionsPage_FindExtensions_MicrosoftStore"
+                                AutomationProperties.AutomationId="CmdPal_ExtensionsPage_OpenMicrosoftStore"
+                                Command="{x:Bind viewModel.Extensions.OpenStoreWithExtensionCommand}">
                                 <StackPanel Orientation="Horizontal" Spacing="8">
                                     <Viewbox Width="16">
                                         <Image AutomationProperties.AccessibilityView="Raw" Source="{ThemeResource StoreLogo}" />
@@ -213,8 +216,8 @@
                         <ItemsRepeater.ItemTemplate>
                             <DataTemplate x:DataType="viewModels:ProviderSettingsViewModel">
                                 <controls:SettingsCard
-                                    Click="SettingsCard_Click"
                                     AutomationProperties.AutomationId="{x:Bind Id, Mode=OneWay}"
+                                    Click="SettingsCard_Click"
                                     DataContext="{x:Bind}"
                                     Description="{x:Bind ExtensionSubtext, Mode=OneWay}"
                                     Header="{x:Bind DisplayName, Mode=OneWay}"

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/ExtensionsPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/ExtensionsPage.xaml
@@ -92,6 +92,7 @@
                             <HyperlinkButton
                                 x:Uid="Settings_ExtensionsPage_Banner_Hyperlink"
                                 Padding="0"
+                                AutomationProperties.AutomationId="CmdPal_ExtensionsPage_LearnMore"
                                 NavigateUri="https://aka.ms/building-cmdpal-extensions" />
                         </StackPanel>
                         <StackPanel
@@ -99,7 +100,7 @@
                             Grid.Column="1"
                             Orientation="Horizontal"
                             Spacing="8">
-                            <Button x:Uid="Settings_ExtensionsPage_FindExtensions_MicrosoftStore" Command="{x:Bind viewModel.Extensions.OpenStoreWithExtensionCommand}">
+                            <Button x:Uid="Settings_ExtensionsPage_FindExtensions_MicrosoftStore" AutomationProperties.AutomationId="CmdPal_ExtensionsPage_OpenMicrosoftStore" Command="{x:Bind viewModel.Extensions.OpenStoreWithExtensionCommand}">
                                 <StackPanel Orientation="Horizontal" Spacing="8">
                                     <Viewbox Width="16">
                                         <Image AutomationProperties.AccessibilityView="Raw" Source="{ThemeResource StoreLogo}" />
@@ -213,6 +214,7 @@
                             <DataTemplate x:DataType="viewModels:ProviderSettingsViewModel">
                                 <controls:SettingsCard
                                     Click="SettingsCard_Click"
+                                    AutomationProperties.AutomationId="{x:Bind Id, Mode=OneWay}"
                                     DataContext="{x:Bind}"
                                     Description="{x:Bind ExtensionSubtext, Mode=OneWay}"
                                     Header="{x:Bind DisplayName, Mode=OneWay}"
@@ -243,7 +245,7 @@
                                             </cpcontrols:ContentIcon.Content>
                                         </cpcontrols:ContentIcon>
                                     </controls:SettingsCard.HeaderIcon>
-                                    <ToggleSwitch IsOn="{x:Bind IsEnabled, Mode=TwoWay}" />
+                                    <ToggleSwitch AutomationProperties.AutomationId="CmdPal_ExtensionsPage_Provider_Enable" IsOn="{x:Bind IsEnabled, Mode=TwoWay}" />
                                 </controls:SettingsCard>
                             </DataTemplate>
                         </ItemsRepeater.ItemTemplate>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/GeneralPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/GeneralPage.xaml
@@ -39,27 +39,29 @@
                     <HyperlinkButton
                         x:Uid="CmdPal_LearnMore"
                         Padding="0"
+                        AutomationProperties.AutomationId="CmdPal_GeneralPage_LearnMore"
                         FontWeight="SemiBold"
                         NavigateUri="https://aka.ms/cmdpal" />
 
                     <TextBlock x:Uid="ActivationSettingsHeader" Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" />
                     <controls:SettingsExpander
                         x:Uid="Settings_GeneralPage_ActivationKey_SettingsExpander"
+                        AutomationProperties.AutomationId="CmdPal_GeneralPage_ActivationKey"
                         HeaderIcon="{ui:FontIcon Glyph=&#xEDA7;}"
                         IsExpanded="True">
-                        <ptControls:ShortcutControl HotkeySettings="{x:Bind viewModel.Hotkey, Mode=TwoWay}" />
+                        <ptControls:ShortcutControl AutomationProperties.AutomationId="CmdPal_GeneralPage_HotkeyShortcut" HotkeySettings="{x:Bind viewModel.Hotkey, Mode=TwoWay}" />
                         <controls:SettingsExpander.Items>
                             <controls:SettingsCard ContentAlignment="Left">
-                                <ptcontrols:CheckBoxWithDescriptionControl x:Uid="Settings_GeneralPage_LowLevelHook_SettingsCard" IsChecked="{x:Bind viewModel.UseLowLevelGlobalHotkey, Mode=TwoWay}" />
+                                <ptcontrols:CheckBoxWithDescriptionControl x:Uid="Settings_GeneralPage_LowLevelHook_SettingsCard" AutomationProperties.AutomationId="CmdPal_GeneralPage_LowLevelHook" IsChecked="{x:Bind viewModel.UseLowLevelGlobalHotkey, Mode=TwoWay}" />
                             </controls:SettingsCard>
                             <controls:SettingsCard ContentAlignment="Left">
-                                <ptcontrols:CheckBoxWithDescriptionControl x:Uid="Settings_GeneralPage_IgnoreShortcutWhenFullscreen_SettingsCard" IsChecked="{x:Bind viewModel.IgnoreShortcutWhenFullscreen, Mode=TwoWay}" />
+                                <ptcontrols:CheckBoxWithDescriptionControl x:Uid="Settings_GeneralPage_IgnoreShortcutWhenFullscreen_SettingsCard" AutomationProperties.AutomationId="CmdPal_GeneralPage_IgnoreShortcutWhenFullscreen" IsChecked="{x:Bind viewModel.IgnoreShortcutWhenFullscreen, Mode=TwoWay}" />
                             </controls:SettingsCard>
                             <controls:SettingsCard ContentAlignment="Left">
-                                <ptcontrols:CheckBoxWithDescriptionControl x:Uid="Settings_GeneralPage_IgnoreShortcutWhenBusy_SettingsCard" IsChecked="{x:Bind viewModel.IgnoreShortcutWhenBusy, Mode=TwoWay}" />
+                                <ptcontrols:CheckBoxWithDescriptionControl x:Uid="Settings_GeneralPage_IgnoreShortcutWhenBusy_SettingsCard" AutomationProperties.AutomationId="CmdPal_GeneralPage_IgnoreShortcutWhenBusy" IsChecked="{x:Bind viewModel.IgnoreShortcutWhenBusy, Mode=TwoWay}" />
                             </controls:SettingsCard>
                             <controls:SettingsCard ContentAlignment="Left">
-                                <ptcontrols:CheckBoxWithDescriptionControl x:Uid="Settings_GeneralPage_AllowBreakthroughShortcut_SettingsCard" IsChecked="{x:Bind viewModel.AllowBreakthroughShortcut, Mode=TwoWay}" />
+                                <ptcontrols:CheckBoxWithDescriptionControl x:Uid="Settings_GeneralPage_AllowBreakthroughShortcut_SettingsCard" AutomationProperties.AutomationId="CmdPal_GeneralPage_AllowBreakthroughShortcut" IsChecked="{x:Bind viewModel.AllowBreakthroughShortcut, Mode=TwoWay}" />
                             </controls:SettingsCard>
                         </controls:SettingsExpander.Items>
                         <controls:SettingsExpander.ItemsFooter>
@@ -71,7 +73,7 @@
                         </controls:SettingsExpander.ItemsFooter>
                     </controls:SettingsExpander>
                     <controls:SettingsCard x:Uid="Settings_GeneralPage_AutoGoHome_SettingsCard" HeaderIcon="{ui:FontIcon Glyph=&#xE80F;}">
-                        <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}" SelectedIndex="{x:Bind viewModel.AutoGoBackIntervalIndex, Mode=TwoWay}">
+                        <ComboBox AutomationProperties.AutomationId="CmdPal_GeneralPage_AutoGoHome" MinWidth="{StaticResource SettingActionControlMinWidth}" SelectedIndex="{x:Bind viewModel.AutoGoBackIntervalIndex, Mode=TwoWay}">
                             <ComboBoxItem x:Uid="Settings_GeneralPage_AutoGoHome_Item_Never" />
                             <ComboBoxItem x:Uid="Settings_GeneralPage_AutoGoHome_Item_Immediately" />
                             <ComboBoxItem x:Uid="Settings_GeneralPage_AutoGoHome_Item_After10Seconds" />
@@ -84,13 +86,13 @@
                         </ComboBox>
                     </controls:SettingsCard>
                     <controls:SettingsCard x:Uid="Settings_GeneralPage_HighlightSearch_SettingsCard" HeaderIcon="{ui:FontIcon Glyph=&#xE933;}">
-                        <ToggleSwitch IsOn="{x:Bind viewModel.HighlightSearchOnActivate, Mode=TwoWay}" />
+                        <ToggleSwitch AutomationProperties.AutomationId="CmdPal_GeneralPage_HighlightSearch" IsOn="{x:Bind viewModel.HighlightSearchOnActivate, Mode=TwoWay}" />
                     </controls:SettingsCard>
                     <controls:SettingsCard x:Uid="Settings_GeneralPage_KeepPreviousQuery_SettingsCard" HeaderIcon="{ui:FontIcon Glyph=&#xE81C;}">
-                        <ToggleSwitch IsOn="{x:Bind viewModel.KeepPreviousQuery, Mode=TwoWay}" />
+                        <ToggleSwitch AutomationProperties.AutomationId="CmdPal_GeneralPage_KeepPreviousQuery" IsOn="{x:Bind viewModel.KeepPreviousQuery, Mode=TwoWay}" />
                     </controls:SettingsCard>
                     <controls:SettingsCard x:Uid="Run_PositionHeader" HeaderIcon="{ui:FontIcon Glyph=&#xe78b;}">
-                        <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}" SelectedIndex="{x:Bind viewModel.MonitorPositionIndex, Mode=TwoWay}">
+                        <ComboBox AutomationProperties.AutomationId="CmdPal_GeneralPage_MonitorPosition" MinWidth="{StaticResource SettingActionControlMinWidth}" SelectedIndex="{x:Bind viewModel.MonitorPositionIndex, Mode=TwoWay}">
                             <ComboBoxItem x:Uid="Run_Radio_Position_Cursor" />
                             <ComboBoxItem x:Uid="Run_Radio_Position_Primary_Monitor" />
                             <ComboBoxItem x:Uid="Run_Radio_Position_Focus" />
@@ -104,7 +106,7 @@
                     <TextBlock x:Uid="BehaviorSettingsHeader" Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" />
 
                     <controls:SettingsCard x:Uid="Settings_GeneralPage_ShowSystemTrayIcon_SettingsCard" HeaderIcon="{ui:FontIcon Glyph=&#xE75B;}">
-                        <ToggleSwitch IsOn="{x:Bind viewModel.ShowSystemTrayIcon, Mode=TwoWay}" />
+                        <ToggleSwitch AutomationProperties.AutomationId="CmdPal_GeneralPage_ShowSystemTrayIcon" IsOn="{x:Bind viewModel.ShowSystemTrayIcon, Mode=TwoWay}" />
                     </controls:SettingsCard>
 
                     <!--  'For Developers' section  -->
@@ -112,14 +114,14 @@
                     <TextBlock x:Uid="ForDevelopersSettingsHeader" Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" />
 
                     <controls:SettingsCard x:Uid="Settings_GeneralPage_AllowExternalReload_SettingsCard" HeaderIcon="{ui:FontIcon Glyph=&#xE777;}">
-                        <ToggleSwitch IsOn="{x:Bind viewModel.AllowExternalReload, Mode=TwoWay}" />
+                        <ToggleSwitch AutomationProperties.AutomationId="CmdPal_GeneralPage_AllowExternalReload" IsOn="{x:Bind viewModel.AllowExternalReload, Mode=TwoWay}" />
                     </controls:SettingsCard>
 
                     <!--  'About' section  -->
 
                     <TextBlock x:Uid="AboutSettingsHeader" Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" />
 
-                    <controls:SettingsExpander x:Uid="Settings_GeneralPage_About_SettingsExpander" HeaderIcon="{ui:BitmapIcon Source=ms-appx:///Assets/StoreLogo.png}">
+                    <controls:SettingsExpander x:Uid="Settings_GeneralPage_About_SettingsExpander" AutomationProperties.AutomationId="CmdPal_GeneralPage_About" HeaderIcon="{ui:BitmapIcon Source=ms-appx:///Assets/StoreLogo.png}">
                         <TextBlock
                             Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                             IsTextSelectionEnabled="True"
@@ -127,8 +129,8 @@
                         <controls:SettingsExpander.Items>
                             <controls:SettingsCard HorizontalContentAlignment="Left" ContentAlignment="Left">
                                 <StackPanel Margin="-12,0,0,0" Orientation="Vertical">
-                                    <HyperlinkButton x:Uid="Settings_GeneralPage_About_GithubLink_Hyperlink" NavigateUri="https://go.microsoft.com/fwlink/?linkid=2310837" />
-                                    <HyperlinkButton x:Uid="Settings_GeneralPage_About_SDKDocs_Hyperlink" NavigateUri="https://aka.ms/cmdpalextensions-devdocs" />
+                                    <HyperlinkButton x:Uid="Settings_GeneralPage_About_GithubLink_Hyperlink" AutomationProperties.AutomationId="CmdPal_GeneralPage_GithubLink" NavigateUri="https://go.microsoft.com/fwlink/?linkid=2310837" />
+                                    <HyperlinkButton x:Uid="Settings_GeneralPage_About_SDKDocs_Hyperlink" AutomationProperties.AutomationId="CmdPal_GeneralPage_SDKDocs" NavigateUri="https://aka.ms/cmdpalextensions-devdocs" />
                                 </StackPanel>
                             </controls:SettingsCard>
                         </controls:SettingsExpander.Items>
@@ -136,6 +138,7 @@
                     <HyperlinkButton
                         x:Uid="Settings_GeneralPage_SendFeedback_Hyperlink"
                         Margin="0,8,0,0"
+                        AutomationProperties.AutomationId="CmdPal_GeneralPage_SendFeedback"
                         NavigateUri="https://go.microsoft.com/fwlink/?linkid=2310638" />
                 </StackPanel>
             </Grid>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/GeneralPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/GeneralPage.xaml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8" ?>
 <Page
     x:Class="Microsoft.CmdPal.UI.Settings.GeneralPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
@@ -52,16 +52,28 @@
                         <ptControls:ShortcutControl AutomationProperties.AutomationId="CmdPal_GeneralPage_HotkeyShortcut" HotkeySettings="{x:Bind viewModel.Hotkey, Mode=TwoWay}" />
                         <controls:SettingsExpander.Items>
                             <controls:SettingsCard ContentAlignment="Left">
-                                <ptcontrols:CheckBoxWithDescriptionControl x:Uid="Settings_GeneralPage_LowLevelHook_SettingsCard" AutomationProperties.AutomationId="CmdPal_GeneralPage_LowLevelHook" IsChecked="{x:Bind viewModel.UseLowLevelGlobalHotkey, Mode=TwoWay}" />
+                                <ptcontrols:CheckBoxWithDescriptionControl
+                                    x:Uid="Settings_GeneralPage_LowLevelHook_SettingsCard"
+                                    AutomationProperties.AutomationId="CmdPal_GeneralPage_LowLevelHook"
+                                    IsChecked="{x:Bind viewModel.UseLowLevelGlobalHotkey, Mode=TwoWay}" />
                             </controls:SettingsCard>
                             <controls:SettingsCard ContentAlignment="Left">
-                                <ptcontrols:CheckBoxWithDescriptionControl x:Uid="Settings_GeneralPage_IgnoreShortcutWhenFullscreen_SettingsCard" AutomationProperties.AutomationId="CmdPal_GeneralPage_IgnoreShortcutWhenFullscreen" IsChecked="{x:Bind viewModel.IgnoreShortcutWhenFullscreen, Mode=TwoWay}" />
+                                <ptcontrols:CheckBoxWithDescriptionControl
+                                    x:Uid="Settings_GeneralPage_IgnoreShortcutWhenFullscreen_SettingsCard"
+                                    AutomationProperties.AutomationId="CmdPal_GeneralPage_IgnoreShortcutWhenFullscreen"
+                                    IsChecked="{x:Bind viewModel.IgnoreShortcutWhenFullscreen, Mode=TwoWay}" />
                             </controls:SettingsCard>
                             <controls:SettingsCard ContentAlignment="Left">
-                                <ptcontrols:CheckBoxWithDescriptionControl x:Uid="Settings_GeneralPage_IgnoreShortcutWhenBusy_SettingsCard" AutomationProperties.AutomationId="CmdPal_GeneralPage_IgnoreShortcutWhenBusy" IsChecked="{x:Bind viewModel.IgnoreShortcutWhenBusy, Mode=TwoWay}" />
+                                <ptcontrols:CheckBoxWithDescriptionControl
+                                    x:Uid="Settings_GeneralPage_IgnoreShortcutWhenBusy_SettingsCard"
+                                    AutomationProperties.AutomationId="CmdPal_GeneralPage_IgnoreShortcutWhenBusy"
+                                    IsChecked="{x:Bind viewModel.IgnoreShortcutWhenBusy, Mode=TwoWay}" />
                             </controls:SettingsCard>
                             <controls:SettingsCard ContentAlignment="Left">
-                                <ptcontrols:CheckBoxWithDescriptionControl x:Uid="Settings_GeneralPage_AllowBreakthroughShortcut_SettingsCard" AutomationProperties.AutomationId="CmdPal_GeneralPage_AllowBreakthroughShortcut" IsChecked="{x:Bind viewModel.AllowBreakthroughShortcut, Mode=TwoWay}" />
+                                <ptcontrols:CheckBoxWithDescriptionControl
+                                    x:Uid="Settings_GeneralPage_AllowBreakthroughShortcut_SettingsCard"
+                                    AutomationProperties.AutomationId="CmdPal_GeneralPage_AllowBreakthroughShortcut"
+                                    IsChecked="{x:Bind viewModel.AllowBreakthroughShortcut, Mode=TwoWay}" />
                             </controls:SettingsCard>
                         </controls:SettingsExpander.Items>
                         <controls:SettingsExpander.ItemsFooter>
@@ -73,7 +85,10 @@
                         </controls:SettingsExpander.ItemsFooter>
                     </controls:SettingsExpander>
                     <controls:SettingsCard x:Uid="Settings_GeneralPage_AutoGoHome_SettingsCard" HeaderIcon="{ui:FontIcon Glyph=&#xE80F;}">
-                        <ComboBox AutomationProperties.AutomationId="CmdPal_GeneralPage_AutoGoHome" MinWidth="{StaticResource SettingActionControlMinWidth}" SelectedIndex="{x:Bind viewModel.AutoGoBackIntervalIndex, Mode=TwoWay}">
+                        <ComboBox
+                            MinWidth="{StaticResource SettingActionControlMinWidth}"
+                            AutomationProperties.AutomationId="CmdPal_GeneralPage_AutoGoHome"
+                            SelectedIndex="{x:Bind viewModel.AutoGoBackIntervalIndex, Mode=TwoWay}">
                             <ComboBoxItem x:Uid="Settings_GeneralPage_AutoGoHome_Item_Never" />
                             <ComboBoxItem x:Uid="Settings_GeneralPage_AutoGoHome_Item_Immediately" />
                             <ComboBoxItem x:Uid="Settings_GeneralPage_AutoGoHome_Item_After10Seconds" />
@@ -92,7 +107,10 @@
                         <ToggleSwitch AutomationProperties.AutomationId="CmdPal_GeneralPage_KeepPreviousQuery" IsOn="{x:Bind viewModel.KeepPreviousQuery, Mode=TwoWay}" />
                     </controls:SettingsCard>
                     <controls:SettingsCard x:Uid="Run_PositionHeader" HeaderIcon="{ui:FontIcon Glyph=&#xe78b;}">
-                        <ComboBox AutomationProperties.AutomationId="CmdPal_GeneralPage_MonitorPosition" MinWidth="{StaticResource SettingActionControlMinWidth}" SelectedIndex="{x:Bind viewModel.MonitorPositionIndex, Mode=TwoWay}">
+                        <ComboBox
+                            MinWidth="{StaticResource SettingActionControlMinWidth}"
+                            AutomationProperties.AutomationId="CmdPal_GeneralPage_MonitorPosition"
+                            SelectedIndex="{x:Bind viewModel.MonitorPositionIndex, Mode=TwoWay}">
                             <ComboBoxItem x:Uid="Run_Radio_Position_Cursor" />
                             <ComboBoxItem x:Uid="Run_Radio_Position_Primary_Monitor" />
                             <ComboBoxItem x:Uid="Run_Radio_Position_Focus" />
@@ -121,7 +139,10 @@
 
                     <TextBlock x:Uid="AboutSettingsHeader" Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" />
 
-                    <controls:SettingsExpander x:Uid="Settings_GeneralPage_About_SettingsExpander" AutomationProperties.AutomationId="CmdPal_GeneralPage_About" HeaderIcon="{ui:BitmapIcon Source=ms-appx:///Assets/StoreLogo.png}">
+                    <controls:SettingsExpander
+                        x:Uid="Settings_GeneralPage_About_SettingsExpander"
+                        AutomationProperties.AutomationId="CmdPal_GeneralPage_About"
+                        HeaderIcon="{ui:BitmapIcon Source=ms-appx:///Assets/StoreLogo.png}">
                         <TextBlock
                             Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                             IsTextSelectionEnabled="True"
@@ -129,8 +150,14 @@
                         <controls:SettingsExpander.Items>
                             <controls:SettingsCard HorizontalContentAlignment="Left" ContentAlignment="Left">
                                 <StackPanel Margin="-12,0,0,0" Orientation="Vertical">
-                                    <HyperlinkButton x:Uid="Settings_GeneralPage_About_GithubLink_Hyperlink" AutomationProperties.AutomationId="CmdPal_GeneralPage_GithubLink" NavigateUri="https://go.microsoft.com/fwlink/?linkid=2310837" />
-                                    <HyperlinkButton x:Uid="Settings_GeneralPage_About_SDKDocs_Hyperlink" AutomationProperties.AutomationId="CmdPal_GeneralPage_SDKDocs" NavigateUri="https://aka.ms/cmdpalextensions-devdocs" />
+                                    <HyperlinkButton
+                                        x:Uid="Settings_GeneralPage_About_GithubLink_Hyperlink"
+                                        AutomationProperties.AutomationId="CmdPal_GeneralPage_GithubLink"
+                                        NavigateUri="https://go.microsoft.com/fwlink/?linkid=2310837" />
+                                    <HyperlinkButton
+                                        x:Uid="Settings_GeneralPage_About_SDKDocs_Hyperlink"
+                                        AutomationProperties.AutomationId="CmdPal_GeneralPage_SDKDocs"
+                                        NavigateUri="https://aka.ms/cmdpalextensions-devdocs" />
                                 </StackPanel>
                             </controls:SettingsCard>
                         </controls:SettingsExpander.Items>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/InternalPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/InternalPage.xaml
@@ -32,13 +32,22 @@
                         IsExpanded="True">
                         <controls:SettingsExpander.Items>
                             <controls:SettingsCard Header="Throw an unhandled exception from the UI thread">
-                                <Button AutomationProperties.AutomationId="CmdPal_InternalPage_ThrowMainThreadException" Click="ThrowPlainMainThreadException_Click" Content="Throw" />
+                                <Button
+                                    AutomationProperties.AutomationId="CmdPal_InternalPage_ThrowMainThreadException"
+                                    Click="ThrowPlainMainThreadException_Click"
+                                    Content="Throw" />
                             </controls:SettingsCard>
                             <controls:SettingsCard Header="Throw an unhandled exception from the UI thread (with PII)">
-                                <Button AutomationProperties.AutomationId="CmdPal_InternalPage_ThrowMainThreadExceptionPii" Click="ThrowPlainMainThreadExceptionPii_Click" Content="Throw" />
+                                <Button
+                                    AutomationProperties.AutomationId="CmdPal_InternalPage_ThrowMainThreadExceptionPii"
+                                    Click="ThrowPlainMainThreadExceptionPii_Click"
+                                    Content="Throw" />
                             </controls:SettingsCard>
                             <controls:SettingsCard Description="Throw with delay, when the task is collected by the GC" Header="Throw unobserved exception from a task">
-                                <Button AutomationProperties.AutomationId="CmdPal_InternalPage_ThrowUnobservedTaskException" Click="ThrowExceptionInUnobservedTask_Click" Content="Throw" />
+                                <Button
+                                    AutomationProperties.AutomationId="CmdPal_InternalPage_ThrowUnobservedTaskException"
+                                    Click="ThrowExceptionInUnobservedTask_Click"
+                                    Content="Throw" />
                             </controls:SettingsCard>
                         </controls:SettingsExpander.Items>
                     </controls:SettingsExpander>
@@ -49,20 +58,29 @@
                         x:Name="LogsSettingsCard"
                         Header="Logs folder"
                         HeaderIcon="{ui:FontIcon Glyph=&#xE8B7;}">
-                        <Button AutomationProperties.AutomationId="CmdPal_InternalPage_OpenLogsFolder" Click="OpenLogsCardClicked" Content="Open folder" />
+                        <Button
+                            AutomationProperties.AutomationId="CmdPal_InternalPage_OpenLogsFolder"
+                            Click="OpenLogsCardClicked"
+                            Content="Open folder" />
                     </controls:SettingsCard>
                     <controls:SettingsCard
                         x:Name="CurrentLogFileSettingsCard"
                         Header="Current log file"
                         HeaderIcon="{ui:FontIcon Glyph=&#xF7BB;}">
-                        <Button AutomationProperties.AutomationId="CmdPal_InternalPage_OpenCurrentLog" Click="OpenCurrentLogCardClicked" Content="Open log" />
+                        <Button
+                            AutomationProperties.AutomationId="CmdPal_InternalPage_OpenCurrentLog"
+                            Click="OpenCurrentLogCardClicked"
+                            Content="Open log" />
                     </controls:SettingsCard>
                     <controls:SettingsCard
                         x:Name="ToggleDevRibbonVisibilitySettingsCard"
                         Description="This is only temporary and state is not saved"
                         Header="Toggle dev ribbon visibility"
                         HeaderIcon="{ui:FontIcon Glyph=&#xE8EC;}">
-                        <Button AutomationProperties.AutomationId="CmdPal_InternalPage_ToggleDevRibbon" Click="ToggleDevRibbonClicked" Content="Toggle dev ribbon" />
+                        <Button
+                            AutomationProperties.AutomationId="CmdPal_InternalPage_ToggleDevRibbon"
+                            Click="ToggleDevRibbonClicked"
+                            Content="Toggle dev ribbon" />
                     </controls:SettingsCard>
 
                     <!--  Gallery Section  -->
@@ -85,7 +103,10 @@
                         x:Name="ConfigurationFolderSettingsCard"
                         Header="Configuration folder"
                         HeaderIcon="{ui:FontIcon Glyph=&#xF73D;}">
-                        <Button AutomationProperties.AutomationId="CmdPal_InternalPage_OpenConfigFolder" Click="OpenConfigFolderCardClick" Content="Open folder" />
+                        <Button
+                            AutomationProperties.AutomationId="CmdPal_InternalPage_OpenConfigFolder"
+                            Click="OpenConfigFolderCardClick"
+                            Content="Open folder" />
                     </controls:SettingsCard>
 
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/InternalPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/InternalPage.xaml
@@ -32,13 +32,13 @@
                         IsExpanded="True">
                         <controls:SettingsExpander.Items>
                             <controls:SettingsCard Header="Throw an unhandled exception from the UI thread">
-                                <Button Click="ThrowPlainMainThreadException_Click" Content="Throw" />
+                                <Button AutomationProperties.AutomationId="CmdPal_InternalPage_ThrowMainThreadException" Click="ThrowPlainMainThreadException_Click" Content="Throw" />
                             </controls:SettingsCard>
                             <controls:SettingsCard Header="Throw an unhandled exception from the UI thread (with PII)">
-                                <Button Click="ThrowPlainMainThreadExceptionPii_Click" Content="Throw" />
+                                <Button AutomationProperties.AutomationId="CmdPal_InternalPage_ThrowMainThreadExceptionPii" Click="ThrowPlainMainThreadExceptionPii_Click" Content="Throw" />
                             </controls:SettingsCard>
                             <controls:SettingsCard Description="Throw with delay, when the task is collected by the GC" Header="Throw unobserved exception from a task">
-                                <Button Click="ThrowExceptionInUnobservedTask_Click" Content="Throw" />
+                                <Button AutomationProperties.AutomationId="CmdPal_InternalPage_ThrowUnobservedTaskException" Click="ThrowExceptionInUnobservedTask_Click" Content="Throw" />
                             </controls:SettingsCard>
                         </controls:SettingsExpander.Items>
                     </controls:SettingsExpander>
@@ -49,20 +49,20 @@
                         x:Name="LogsSettingsCard"
                         Header="Logs folder"
                         HeaderIcon="{ui:FontIcon Glyph=&#xE8B7;}">
-                        <Button Click="OpenLogsCardClicked" Content="Open folder" />
+                        <Button AutomationProperties.AutomationId="CmdPal_InternalPage_OpenLogsFolder" Click="OpenLogsCardClicked" Content="Open folder" />
                     </controls:SettingsCard>
                     <controls:SettingsCard
                         x:Name="CurrentLogFileSettingsCard"
                         Header="Current log file"
                         HeaderIcon="{ui:FontIcon Glyph=&#xF7BB;}">
-                        <Button Click="OpenCurrentLogCardClicked" Content="Open log" />
+                        <Button AutomationProperties.AutomationId="CmdPal_InternalPage_OpenCurrentLog" Click="OpenCurrentLogCardClicked" Content="Open log" />
                     </controls:SettingsCard>
                     <controls:SettingsCard
                         x:Name="ToggleDevRibbonVisibilitySettingsCard"
                         Description="This is only temporary and state is not saved"
                         Header="Toggle dev ribbon visibility"
                         HeaderIcon="{ui:FontIcon Glyph=&#xE8EC;}">
-                        <Button Click="ToggleDevRibbonClicked" Content="Toggle dev ribbon" />
+                        <Button AutomationProperties.AutomationId="CmdPal_InternalPage_ToggleDevRibbon" Click="ToggleDevRibbonClicked" Content="Toggle dev ribbon" />
                     </controls:SettingsCard>
 
                     <!--  Gallery Section  -->
@@ -85,7 +85,7 @@
                         x:Name="ConfigurationFolderSettingsCard"
                         Header="Configuration folder"
                         HeaderIcon="{ui:FontIcon Glyph=&#xF73D;}">
-                        <Button Click="OpenConfigFolderCardClick" Content="Open folder" />
+                        <Button AutomationProperties.AutomationId="CmdPal_InternalPage_OpenConfigFolder" Click="OpenConfigFolderCardClick" Content="Open folder" />
                     </controls:SettingsCard>
 
 


### PR DESCRIPTION
## Summary

Adds **77 explicit `AutomationProperties.AutomationId`** declarations (4 → 81, ~20x) to Command Palette XAML so UI-testing tools (WinAppDriver, FlaUI, winappCli, Appium) can address controls deterministically instead of falling back to runtime slugs that change every session. Also covers the `DataTemplate`-generated long tail (search results, file results, every extension item, every monitor in Dock settings) by binding `AutomationId` to existing stable model identifiers via `{x:Bind}`.

Headline: a one-line addition to the four CmdPal `ListItem` `DataTemplate`s now exposes each instance's underlying `Command.Id` (e.g. `com.microsoft.cmdpal.builtin.calculator`) as its `AutomationId`. This is the same pattern as web's `<li data-testid={item.id}>`.

## Why

CmdPal today ships with only **4** explicit `AutomationProperties.AutomationId` declarations across **44** XAML files (~303 interactive controls). UI tests are forced to fall back to:

- runtime-generated slugs like `itm-12-9dda` that change every CmdPal restart, or
- regex-parsing the text output of `winappCli ui inspect`, or
- walking the UIA tree client-side and matching by `Name` (localized, ambiguous when several controls share a label).

## What changed

### Source changes
- **`Microsoft.CmdPal.UI/ExtViews/ListItemsView.xaml`** — bind `AutomationProperties.AutomationId="{x:Bind Command.Id, Mode=OneWay}"` on the root of all 4 `ListItem` `DataTemplate`s (single-row, small-grid, medium-grid, gallery). Covers **every** runtime list item across all built-in and third-party providers.
- **`Microsoft.CmdPal.UI/Settings/GeneralPage.xaml`** — 14 IDs on activation hotkey controls, auto-go-home combo, behaviour toggles, about-section hyperlinks.
- **`Microsoft.CmdPal.UI/Settings/AppearancePage.xaml`** — 19 IDs on theme/backdrop/colorization, background image controls, 5 sliders, behaviour toggles.
- **`Microsoft.CmdPal.UI/Settings/DockSettingsPage.xaml`** — 14 IDs on enable toggle, theme/colorization/backdrop, background image controls, plus per-monitor data-bound ID using `DisplayName`.
- **`Microsoft.CmdPal.UI/Settings/ExtensionsPage.xaml`** — 4 IDs on banner/store hyperlinks plus the per-provider `SettingsCard` (data-bound to the provider's `Id`, e.g. `com.microsoft.cmdpal.builtin.calculator`).
- **`Microsoft.CmdPal.UI/Settings/ExtensionPage.xaml`** — 5 IDs on provider enable toggle, alias text/activation, fallback rank link.
- **`Microsoft.CmdPal.UI/Settings/ExtensionGalleryItemPage.xaml`** — 5 IDs on install/cancel/copy-command buttons and author/repo/uninstall links.
- **`Microsoft.CmdPal.UI/Settings/InternalPage.xaml`** — 7 IDs on the dev-only "Throw exception" and folder/log-opening buttons.
- **`Microsoft.CmdPal.UI/Pages/ShellPage.xaml`** — 1 data-bound ID on the `CommandTemplate` button (binds to `CommandViewModel.Id`).
- **`Microsoft.CmdPal.UI.ViewModels/ProviderSettingsViewModel.cs`** — single-line addition exposing the underlying `CommandProviderWrapper.Id` so the ExtensionsPage template can bind to it.

### Naming convention applied

`CmdPal_<Page>_<Semantic>` PascalCase, with the existing well-known IDs left untouched to avoid breaking the `modules/cmdpal/*` checklist tests already referencing them. `Id` / `TestId` suffixes deliberately omitted (the attribute is already `AutomationId`); control-type suffixes (`Toggle` / `Button` / `ComboBox`) omitted because the type lives on the UIA `type` field already.

### Files NOT touched (deferred)

About 5–7 secondary files (`SettingsWindow.xaml`, `ExtensionGalleryPage.xaml`, `DockControl.xaml`, `DevRibbon.xaml`, deep style/viewer XAML) — their interactive controls already carry `x:Name`, which WinUI auto-promotes to `AutomationId` at runtime, so practical testability is mostly already there. Can be tightened up in a follow-up PR.

## Risk

- ✅ Zero runtime cost (`AutomationProperties.AutomationId` is metadata only)
- ✅ Does not affect localization (`AutomationId` is non-localized by design)
- ✅ Does not affect user-facing accessibility (screen readers consume `Name` / `AutomationProperties.Name`, untouched)
- ✅ Does not rename any existing ID; `modules/cmdpal/*` tests referencing `MainSearchBox` / `PrimaryCommandButton` / `ItemsList` / etc. remain valid
- ✅ All 51 CmdPal XAML files parse as valid XML (PowerShell `[xml]` round-trip)
- ✅ All `x:Bind` paths verified against the relevant ViewModel types (`CommandViewModel.Id`, `DockMonitorConfigViewModel.DisplayName`, `ProviderSettingsViewModel.Id`)

## Validation requested before merge

XAML compilation was attempted locally but blocked by a missing native NuGet package (`Microsoft.Windows.ImplementationLibrary`) — needs `tools\build\build-essentials.cmd` to fully restore first. **Reviewer please run a clean local build of `Microsoft.CmdPal.UI` (or rely on CI) to confirm the XAML compiler is happy.**

Once built, a quick smoke check:

```powershell
# After CmdPal restart with the new bits installed:
winapp ui search 'CmdPal_'           -w <hwnd> --json  # should list all the new IDs
winapp ui invoke 'CmdPal_AppearancePage_OpenCommandPalette' -w <hwnd>
winapp ui invoke 'com.microsoft.cmdpal.builtin.calculator' -w <hwnd>   # ListItem template binding
```

## Why this matters beyond our tools

This is the same pattern Microsoft's accessibility and WinUI teams already recommend for any XAML app intended to be automated. It's the WinUI equivalent of adding `data-testid` in a web app — universally accepted as low-risk, high-leverage. WinAppDriver, FlaUI, Appium and any future automation framework all benefit from the same change.
