### PR TITLE
[CI] Sign YamlDotNet.dll (ShortcutGuide V2 dependency)

### DIFF
--- a/.pipelines/ESRPSigning_core.json
+++ b/.pipelines/ESRPSigning_core.json
@@ -391,6 +391,7 @@
                 "WinUI3Apps\\Google.Apis.Auth.dll",
                 "WinUI3Apps\\Google.Apis.Core.dll",
                 "WinUI3Apps\\Google.GenAI.dll",
+                "WinUI3Apps\\YamlDotNet.dll",
 
                 "boost_regex-vc143-mt-gd-x32-1_87.dll",
                 "boost_regex-vc143-mt-gd-x64-1_87.dll",


### PR DESCRIPTION
## Summary

Fixes the **stable** signed release pipeline failure (Dart build [`147590319`](https://microsoft.visualstudio.com/Dart/_build/results?buildId=147590319)) at the *"Verify all binaries are signed and versioned"* task on both `Build Release_x64` and `Build Release_arm64`:

```
Not Signed: + …\extractedMachineMsi\File\WinUI3ApplicationsFiles_File_YamlDotNet.dll
```

## Root cause

PR #40834 (*Shortcut Guide V2*) added a `YamlDotNet` `PackageReference` to:

- `src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuide.Ui.csproj`
- `src/modules/ShortcutGuide/ShortcutGuide.IndexYmlGenerator/ShortcutGuide.IndexYmlGenerator.csproj`

Both projects publish into `WinUI3Apps\`, so `YamlDotNet.dll` is harvested into the MSI by `installer/PowerToysSetupVNext/generateAllFileComponents.ps1`. The PR updated `ESRPSigning_core.json` for its own new binaries but missed this 3rd-party transitive dependency, so ESRP never signs it and `.pipelines/versionAndSignCheck.ps1` correctly fails the build.

## Fix

One additive line to `.pipelines/ESRPSigning_core.json`, placing `WinUI3Apps\YamlDotNet.dll` next to the other 3rd-party `WinUI3Apps\` entries (`Google.Apis.*`, `Google.GenAI.dll`, `ReverseMarkdown.dll`, `SharpCompress.dll`, …).

## Validation

- `git diff` shows exactly one additive line.
- File still parses as valid JSON (`ConvertFrom-Json` round-trip OK).
- Both ShortcutGuide csprojs target `$(Platform)\$(Configuration)\WinUI3Apps`, so a single `WinUI3Apps\YamlDotNet.dll` entry covers all uses.

## Follow-up

After merge to `main`, cherry-pick / merge into `stable` so build `147590319` can be re-queued and the 0.100 release pipeline can proceed.