### PR TITLE
[Settings UI] Remove duplicate QuickAccent_SelectedLanguage_Greek_Polytonic resource

### DIFF
--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -6172,7 +6172,4 @@ Text uses the current drawing color.</value>
     <value>Example: outlook</value>
     <comment>{Locked="outlook"}</comment>
   </data>
-  <data name="QuickAccent_SelectedLanguage_Greek_Polytonic" xml:space="preserve">
-    <value>Greek Polytonic</value>
-  </data>
 </root>


### PR DESCRIPTION
## Summary

Fixes the **"Build PowerToys main project"** failure on every PR/CI build off current `main` (e.g. Dart build [`147597426`](https://microsoft.visualstudio.com/Dart/_build/results?buildId=147597426)):

```
WINAPPSDKGENERATEPROJECTPRIFILE: Error PRI175: Processing Resources failed with error: Duplicate Entry.
WINAPPSDKGENERATEPROJECTPRIFILE: Error PRI277: Conflicting values for resource
                                  'Resources/QuickAccent_SelectedLanguage_Greek_Polytonic'
```

## Root cause

`src/settings-ui/Settings.UI/Strings/en-us/Resources.resw` contained two `<data name="QuickAccent_SelectedLanguage_Greek_Polytonic">` entries:

- Line 3597 — original, added by #47021 (*"[PowerAccent] adding greek polytonic"*), placed in the alphabetized QuickAccent block.
- Line 6175 — duplicate, appended at the file tail by #47211 (*"[Quick Accent] Move language data to PowerAccent.Common library, refactor"*).

The two entries are byte-identical (same value `Greek Polytonic`, same `xml:space="preserve"`). The WinAppSDK PRI generator (`MakePri`) rejects duplicates, so every build off current `main` fails before reaching the compile step.

## Fix

Remove the tail duplicate (3-line block right before `</root>`). Keeps the original entry in its alphabetized location.

## Validation

- `git diff` shows exactly 3 deleted lines.
- `[xml](Get-Content … -Raw)` round-trip succeeds — file is still well-formed XML.
- `Select-String` count of `QuickAccent_SelectedLanguage_Greek_Polytonic` in the file is now **1** (was 2).
- Only `en-us` has this key (other localized `.resw` files are populated later via Touchdown), so no other file needs touching.

## Note

Discovered while investigating a CI failure unrelated to my other PR #48050 (signing of `WinUI3Apps\YamlDotNet.dll`). Both fixes are needed for the 0.100 release pipeline; this PR unblocks PR builds off `main`, and #48050 unblocks the signed release pipeline once both are merged to `main` and the next `main → stable` sync happens.