### PR TITLE
Fix VS Code Workspaces portable shared storage path detection

### DIFF
--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/WorkspacesHelper/VSCodeWorkspacesApi.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/WorkspacesHelper/VSCodeWorkspacesApi.cs
@@ -97,6 +97,7 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.WorkspacesHelper
 
                     // User/globalStorage/state.vscdb - history.recentlyOpenedPathsList - vscode v1.64 or later
                     var vscode_storage_db = Path.Combine(vscodeInstance.AppData, "User/globalStorage/state.vscdb");
+                    var vscode_shared_storage_db = GetSharedStorageDbPath(vscodeInstance);
 
                     if (File.Exists(vscode_storage))
                     {
@@ -109,10 +110,40 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.WorkspacesHelper
                         var storageDbResults = GetWorkspacesInVscdb(vscodeInstance, vscode_storage_db);
                         results.AddRange(storageDbResults);
                     }
+
+                    if (!string.IsNullOrEmpty(vscode_shared_storage_db) && File.Exists(vscode_shared_storage_db))
+                    {
+                        var sharedStorageDbResults = GetWorkspacesInVscdb(vscodeInstance, vscode_shared_storage_db);
+                        results.AddRange(sharedStorageDbResults);
+                    }
                 }
 
                 return results;
             }
+        }
+
+
+        private string GetSharedStorageDbPath(VSCodeInstance vscodeInstance)
+        {
+            var portableAppDataRoot = Path.GetDirectoryName(Path.GetDirectoryName(vscodeInstance.AppData));
+            if (!string.IsNullOrEmpty(portableAppDataRoot))
+            {
+                var portableSharedStorageDb = Path.Combine(portableAppDataRoot + "-shared", "sharedStorage", "state.vscdb");
+                if (portableSharedStorageDb.Contains("data-shared", StringComparison.OrdinalIgnoreCase))
+                {
+                    return portableSharedStorageDb;
+                }
+            }
+
+            return Path.GetFileName(vscodeInstance.AppData) switch
+            {
+                "Code" => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".vscode-shared", "sharedStorage", "state.vscdb"),
+                "Code - Insiders" => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".vscode-insiders-shared", "sharedStorage", "state.vscdb"),
+                "Code - Exploration" => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".vscode-exploration-shared", "sharedStorage", "state.vscdb"),
+                "VSCodium" => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".vscodium-shared", "sharedStorage", "state.vscdb"),
+                "VSCodium - Insiders" => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".vscodium-insiders-shared", "sharedStorage", "state.vscdb"),
+                _ => string.Empty,
+            };
         }
 
         private List<VSCodeWorkspace> GetWorkspacesInJson(VSCodeInstance vscodeInstance, string filePath)

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/WorkspacesHelper/VSCodeWorkspacesApi.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/WorkspacesHelper/VSCodeWorkspacesApi.cs
@@ -137,13 +137,15 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.WorkspacesHelper
                 }
             }
 
+            var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
             return Path.GetFileName(vscodeInstance.AppData) switch
             {
-                "Code" => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".vscode-shared", "sharedStorage", "state.vscdb"),
-                "Code - Insiders" => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".vscode-insiders-shared", "sharedStorage", "state.vscdb"),
-                "Code - Exploration" => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".vscode-exploration-shared", "sharedStorage", "state.vscdb"),
-                "VSCodium" => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".vscodium-shared", "sharedStorage", "state.vscdb"),
-                "VSCodium - Insiders" => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".vscodium-insiders-shared", "sharedStorage", "state.vscdb"),
+                "Code" => Path.Combine(userProfile, ".vscode-shared", "sharedStorage", "state.vscdb"),
+                "Code - Insiders" => Path.Combine(userProfile, ".vscode-insiders-shared", "sharedStorage", "state.vscdb"),
+                "Code - Exploration" => Path.Combine(userProfile, ".vscode-exploration-shared", "sharedStorage", "state.vscdb"),
+                "VSCodium" => Path.Combine(userProfile, ".vscodium-shared", "sharedStorage", "state.vscdb"),
+                "VSCodium - Insiders" => Path.Combine(userProfile, ".vscodium-insiders-shared", "sharedStorage", "state.vscdb"),
                 _ => string.Empty,
             };
         }

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/WorkspacesHelper/VSCodeWorkspacesApi.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/WorkspacesHelper/VSCodeWorkspacesApi.cs
@@ -125,13 +125,15 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.WorkspacesHelper
 
         private string GetSharedStorageDbPath(VSCodeInstance vscodeInstance)
         {
-            var portableAppDataRoot = Path.GetDirectoryName(Path.GetDirectoryName(vscodeInstance.AppData));
-            if (!string.IsNullOrEmpty(portableAppDataRoot))
+            var appDataDirectoryInfo = new DirectoryInfo(vscodeInstance.AppData);
+            var portableDataDirectoryInfo = appDataDirectoryInfo.Parent;
+            if (portableDataDirectoryInfo != null &&
+                portableDataDirectoryInfo.Name.Equals("data", StringComparison.OrdinalIgnoreCase))
             {
-                var portableSharedStorageDb = Path.Combine(portableAppDataRoot + "-shared", "sharedStorage", "state.vscdb");
-                if (portableSharedStorageDb.Contains("data-shared", StringComparison.OrdinalIgnoreCase))
+                var installRoot = portableDataDirectoryInfo.Parent?.FullName;
+                if (!string.IsNullOrEmpty(installRoot))
                 {
-                    return portableSharedStorageDb;
+                    return Path.Combine(installRoot, "data-shared", "sharedStorage", "state.vscdb");
                 }
             }
 


### PR DESCRIPTION
## Summary of the Pull Request

Fixes VS Code Workspaces discovery for portable installs by correcting the shared storage DB path calculation.

The previous portable path detection could construct incorrect paths from `AppData` and miss the real `state.vscdb` location. This PR updates the logic to:

- Detect portable layout only when `AppData` is under a `data` directory.
- Resolve shared DB path as `<install-root>/data-shared/sharedStorage/state.vscdb`.
- Keep existing fallback mappings for standard shared profile locations (`Code`, `Code - Insiders`, `Code - Exploration`, `VSCodium`, `VSCodium - Insiders`).

## PR Checklist

- [x] Closes: #47445
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [x] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [x] **New binaries:** Added on the required places
   - [x] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [x] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [x] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [x] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments

Addressed inline review feedback on portable/shared path handling by replacing the string-based detection with explicit directory-structure checks.

No functional changes were made outside VSCode Workspaces shared-storage path resolution.

## Validation Steps Performed

- Reviewed path derivation for portable layout:
  - `.../data/user-data` → `.../data-shared/sharedStorage/state.vscdb`
- Confirmed standard-install fallback mappings remain unchanged.
- Environment note: local `dotnet` build/test could not be executed in this container (`dotnet: command not found`).