### PR TITLE
[CI] Sign PowerAccent.Common.dll (new managed library from #47211)

### DIFF
--- a/.pipelines/ESRPSigning_core.json
+++ b/.pipelines/ESRPSigning_core.json
@@ -212,6 +212,7 @@
             "WinUI3Apps\\PowerToys.NewPlus.ShellExtension.win10.dll",
 
             "PowerAccent.Core.dll",
+            "PowerAccent.Common.dll",
             "PowerToys.PowerAccent.dll",
             "PowerToys.PowerAccent.exe",
             "PowerToys.PowerAccentModuleInterface.dll",


### PR DESCRIPTION
## Summary

Fixes the **stable** signed release pipeline failure (Dart build [`147621162`](https://microsoft.visualstudio.com/Dart/_build/results?buildId=147621162)) at the *"Verify all binaries are signed and versioned"* task:

```
Not Signed: + …\extractedMachineMsi\File\BaseApplicationsFiles_File_PowerAccent.Common.dll
```

## Root cause

PR #47211 (*"[Quick Accent] Move language data to PowerAccent.Common library, refactor"*) introduced the new managed library:

- `src/modules/poweraccent/PowerAccent.Common/PowerAccent.Common.csproj`

`PowerAccent.Common.dll` is referenced by both `PowerAccent.Core` (ships in the installer root) and `PowerToys.Settings` (ships in WinUI3Apps; deduplicated against root by `generateAllFileComponents.ps1`). The DLL is harvested into the MSI's `BaseApplicationsFiles` component group, but the PR did not update `.pipelines/ESRPSigning_core.json`, so ESRP never signs it and `versionAndSignCheck.ps1` correctly fails the build.

This is the same kind of omission that PR #48050 fixed for `YamlDotNet.dll` introduced by #40834 — a new managed library shipping in the MSI without a matching signing config entry.

## Fix

One additive line in `.pipelines/ESRPSigning_core.json`, placing `"PowerAccent.Common.dll"` inside the existing alphabetized PowerAccent block (next to `PowerAccent.Core.dll`).

```diff
             "PowerAccent.Core.dll",
+            "PowerAccent.Common.dll",
             "PowerToys.PowerAccent.dll",
```

## Validation

- `git diff` shows exactly one additive line.
- File still parses as valid JSON (`ConvertFrom-Json` round-trip OK).
- Audited the full file list of PR #47211: `PowerAccent.Common.dll` is the only new shippable assembly it added (the other new project, `PowerAccent.Common.UnitTests`, is a test project and is not included in the installer).
- Dedup logic in `installer/PowerToysSetupVNext/generateAllFileComponents.ps1` keeps only the root copy when WinUI3Apps and root copies are byte-identical, so a single root-level entry is sufficient.

## Follow-up

After merge to `main`, cherry-pick / merge into `stable` to unblock the 0.100 release pipeline. This is the third (and hopefully final) PR in the 0.100 release-pipeline unblock sequence, after #48050 (sign `YamlDotNet.dll`) and #48054 (remove duplicate `QuickAccent_SelectedLanguage_Greek_Polytonic` resource).