### PR TITLE
CmdPal: Allow connecting to arbitrary hostnames in Remote Desktop list page

### DIFF
--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.RemoteDesktop.UnitTests/RemoteDesktopListPageTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.RemoteDesktop.UnitTests/RemoteDesktopListPageTests.cs
@@ -1,0 +1,189 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CmdPal.Ext.RemoteDesktop.Commands;
+using Microsoft.CmdPal.Ext.RemoteDesktop.Pages;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CmdPal.Ext.RemoteDesktop.UnitTests;
+
+[TestClass]
+public class RemoteDesktopListPageTests
+{
+    // Helper: create a RemoteDesktopListPage backed by mock connections.
+    private static RemoteDesktopListPage CreatePage(params string[] connectionNames)
+    {
+        var settingsManager = new MockSettingsManager(connectionNames);
+        var connectionsManager = new MockRdpConnectionsManager(settingsManager);
+        return new RemoteDesktopListPage(connectionsManager);
+    }
+
+    [TestMethod]
+    public void EmptyQuery_ReturnsOnlyExistingConnections()
+    {
+        // Arrange
+        var page = CreatePage("server1", "server2");
+
+        // Act
+        page.UpdateSearchText(string.Empty, string.Empty);
+        var items = page.GetItems();
+
+        // Assert — only the 2 pre-existing connections, no arbitrary host item
+        Assert.AreEqual(2, items.Length);
+    }
+
+    [TestMethod]
+    public void WhitespaceQuery_ReturnsOnlyExistingConnections()
+    {
+        // Arrange
+        var page = CreatePage("server1");
+
+        // Act
+        page.UpdateSearchText(string.Empty, "   ");
+        var items = page.GetItems();
+
+        // Assert
+        Assert.AreEqual(1, items.Length);
+    }
+
+    [TestMethod]
+    public void ValidHostname_NotMatchingConnection_PrependsArbitraryItem()
+    {
+        // Arrange
+        var page = CreatePage("server1");
+
+        // Act
+        page.UpdateSearchText(string.Empty, "newhost.corp");
+        var items = page.GetItems();
+
+        // Assert — arbitrary item prepended, then the existing connection
+        Assert.AreEqual(2, items.Length);
+        var firstItem = items[0] as ConnectionListItem;
+        Assert.IsNotNull(firstItem, "First item should be a ConnectionListItem for the arbitrary host");
+        Assert.AreEqual("newhost.corp", firstItem.ConnectionName);
+    }
+
+    [TestMethod]
+    public void QueryExactlyMatchingExistingConnection_NoArbitraryItem()
+    {
+        // Arrange
+        var page = CreatePage("myserver");
+
+        // Act
+        page.UpdateSearchText(string.Empty, "myserver");
+        var items = page.GetItems();
+
+        // Assert — no extra item; count stays at 1
+        Assert.AreEqual(1, items.Length);
+        var item = items[0] as ConnectionListItem;
+        Assert.IsNotNull(item);
+        Assert.AreEqual("myserver", item.ConnectionName);
+    }
+
+    [TestMethod]
+    public void InvalidHostname_ReturnsOnlyExistingConnections()
+    {
+        // Arrange
+        var page = CreatePage("server1");
+
+        // Act
+        page.UpdateSearchText(string.Empty, "!!!invalid");
+        var items = page.GetItems();
+
+        // Assert — no arbitrary item for an invalid hostname
+        Assert.AreEqual(1, items.Length);
+    }
+
+    [TestMethod]
+    public void ValidHostnameWithPort_ArbitraryItemIncludesPort()
+    {
+        // Arrange
+        var page = CreatePage("server1");
+
+        // Act
+        page.UpdateSearchText(string.Empty, "myhost:3389");
+        var items = page.GetItems();
+
+        // Assert — full host:port string preserved as the ConnectionName
+        Assert.AreEqual(2, items.Length);
+        var firstItem = items[0] as ConnectionListItem;
+        Assert.IsNotNull(firstItem);
+        Assert.AreEqual("myhost:3389", firstItem.ConnectionName);
+    }
+
+    [TestMethod]
+    public void SequentialCalls_ValidThenEmpty_ClearsArbitraryItem()
+    {
+        // Arrange
+        var page = CreatePage("server1");
+
+        // Act — first call adds arbitrary item
+        page.UpdateSearchText(string.Empty, "newhost.corp");
+        var itemsAfterValid = page.GetItems();
+
+        // Assert — arbitrary item present
+        Assert.AreEqual(2, itemsAfterValid.Length);
+        var firstItem = itemsAfterValid[0] as ConnectionListItem;
+        Assert.IsNotNull(firstItem);
+        Assert.AreEqual("newhost.corp", firstItem.ConnectionName);
+
+        // Act — second call clears it
+        page.UpdateSearchText("newhost.corp", string.Empty);
+        var itemsAfterEmpty = page.GetItems();
+
+        // Assert — back to only existing connections
+        Assert.AreEqual(1, itemsAfterEmpty.Length);
+    }
+
+    [TestMethod]
+    public void ValidHostname_NoExistingConnections_ReturnsSingleArbitraryItem()
+    {
+        // Arrange — no pre-existing connections
+        var page = CreatePage();
+
+        // Act
+        page.UpdateSearchText(string.Empty, "standalone.corp");
+        var items = page.GetItems();
+
+        // Assert
+        Assert.AreEqual(1, items.Length);
+        var firstItem = items[0] as ConnectionListItem;
+        Assert.IsNotNull(firstItem);
+        Assert.AreEqual("standalone.corp", firstItem.ConnectionName);
+    }
+
+    [TestMethod]
+    public void IPv4Address_ReturnsArbitraryItem()
+    {
+        // Arrange
+        var page = CreatePage();
+
+        // Act
+        page.UpdateSearchText(string.Empty, "192.168.1.100");
+        var items = page.GetItems();
+
+        // Assert
+        Assert.AreEqual(1, items.Length);
+        var firstItem = items[0] as ConnectionListItem;
+        Assert.IsNotNull(firstItem);
+        Assert.AreEqual("192.168.1.100", firstItem.ConnectionName);
+    }
+
+    [TestMethod]
+    public void IPv4AddressWithPort_ReturnsArbitraryItemWithPort()
+    {
+        // Arrange
+        var page = CreatePage();
+
+        // Act
+        page.UpdateSearchText(string.Empty, "192.168.1.100:3390");
+        var items = page.GetItems();
+
+        // Assert — full IP:port string preserved
+        Assert.AreEqual(1, items.Length);
+        var firstItem = items[0] as ConnectionListItem;
+        Assert.IsNotNull(firstItem);
+        Assert.AreEqual("192.168.1.100:3390", firstItem.ConnectionName);
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.RemoteDesktop.UnitTests/RemoteDesktopListPageTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.RemoteDesktop.UnitTests/RemoteDesktopListPageTests.cs
@@ -29,7 +29,7 @@ public class RemoteDesktopListPageTests
         page.UpdateSearchText(string.Empty, string.Empty);
         var items = page.GetItems();
 
-        // Assert — only the 2 pre-existing connections, no arbitrary host item
+        // Assert — only the 2 preexisting connections, no arbitrary host item
         Assert.AreEqual(2, items.Length);
     }
 
@@ -54,31 +54,31 @@ public class RemoteDesktopListPageTests
         var page = CreatePage("server1");
 
         // Act
-        page.UpdateSearchText(string.Empty, "newhost.corp");
+        page.UpdateSearchText(string.Empty, "test.corp");
         var items = page.GetItems();
 
         // Assert — arbitrary item prepended, then the existing connection
         Assert.AreEqual(2, items.Length);
         var firstItem = items[0] as ConnectionListItem;
         Assert.IsNotNull(firstItem, "First item should be a ConnectionListItem for the arbitrary host");
-        Assert.AreEqual("newhost.corp", firstItem.ConnectionName);
+        Assert.AreEqual("test.corp", firstItem.ConnectionName);
     }
 
     [TestMethod]
     public void QueryExactlyMatchingExistingConnection_NoArbitraryItem()
     {
         // Arrange
-        var page = CreatePage("myserver");
+        var page = CreatePage("rdp-server");
 
         // Act
-        page.UpdateSearchText(string.Empty, "myserver");
+        page.UpdateSearchText(string.Empty, "rdp-server");
         var items = page.GetItems();
 
         // Assert — no extra item; count stays at 1
         Assert.AreEqual(1, items.Length);
         var item = items[0] as ConnectionListItem;
         Assert.IsNotNull(item);
-        Assert.AreEqual("myserver", item.ConnectionName);
+        Assert.AreEqual("rdp-server", item.ConnectionName);
     }
 
     [TestMethod]
@@ -102,14 +102,14 @@ public class RemoteDesktopListPageTests
         var page = CreatePage("server1");
 
         // Act
-        page.UpdateSearchText(string.Empty, "remotepc:3389");
+        page.UpdateSearchText(string.Empty, "localhost:3389");
         var items = page.GetItems();
 
         // Assert — full host:port string preserved as the ConnectionName
         Assert.AreEqual(2, items.Length);
         var firstItem = items[0] as ConnectionListItem;
         Assert.IsNotNull(firstItem);
-        Assert.AreEqual("remotepc:3389", firstItem.ConnectionName);
+        Assert.AreEqual("localhost:3389", firstItem.ConnectionName);
     }
 
     [TestMethod]
@@ -119,17 +119,17 @@ public class RemoteDesktopListPageTests
         var page = CreatePage("server1");
 
         // Act — first call adds arbitrary item
-        page.UpdateSearchText(string.Empty, "newhost.corp");
+        page.UpdateSearchText(string.Empty, "test.corp");
         var itemsAfterValid = page.GetItems();
 
         // Assert — arbitrary item present
         Assert.AreEqual(2, itemsAfterValid.Length);
         var firstItem = itemsAfterValid[0] as ConnectionListItem;
         Assert.IsNotNull(firstItem);
-        Assert.AreEqual("newhost.corp", firstItem.ConnectionName);
+        Assert.AreEqual("test.corp", firstItem.ConnectionName);
 
         // Act — second call clears it
-        page.UpdateSearchText("newhost.corp", string.Empty);
+        page.UpdateSearchText("test.corp", string.Empty);
         var itemsAfterEmpty = page.GetItems();
 
         // Assert — back to only existing connections
@@ -139,18 +139,18 @@ public class RemoteDesktopListPageTests
     [TestMethod]
     public void ValidHostname_NoExistingConnections_ReturnsSingleArbitraryItem()
     {
-        // Arrange — no pre-existing connections
+        // Arrange — no preexisting connections
         var page = CreatePage();
 
         // Act
-        page.UpdateSearchText(string.Empty, "standalone.corp");
+        page.UpdateSearchText(string.Empty, "alpha.corp");
         var items = page.GetItems();
 
         // Assert
         Assert.AreEqual(1, items.Length);
         var firstItem = items[0] as ConnectionListItem;
         Assert.IsNotNull(firstItem);
-        Assert.AreEqual("standalone.corp", firstItem.ConnectionName);
+        Assert.AreEqual("alpha.corp", firstItem.ConnectionName);
     }
 
     [TestMethod]

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.RemoteDesktop.UnitTests/RemoteDesktopListPageTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.RemoteDesktop.UnitTests/RemoteDesktopListPageTests.cs
@@ -102,14 +102,14 @@ public class RemoteDesktopListPageTests
         var page = CreatePage("server1");
 
         // Act
-        page.UpdateSearchText(string.Empty, "myhost:3389");
+        page.UpdateSearchText(string.Empty, "remotepc:3389");
         var items = page.GetItems();
 
         // Assert — full host:port string preserved as the ConnectionName
         Assert.AreEqual(2, items.Length);
         var firstItem = items[0] as ConnectionListItem;
         Assert.IsNotNull(firstItem);
-        Assert.AreEqual("myhost:3389", firstItem.ConnectionName);
+        Assert.AreEqual("remotepc:3389", firstItem.ConnectionName);
     }
 
     [TestMethod]

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.RemoteDesktop/Pages/RemoteDesktopListPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.RemoteDesktop/Pages/RemoteDesktopListPage.cs
@@ -1,8 +1,10 @@
-﻿// Copyright (c) Microsoft Corporation
+// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Linq;
+using Microsoft.CmdPal.Ext.RemoteDesktop.Commands;
 using Microsoft.CmdPal.Ext.RemoteDesktop.Helper;
 using Microsoft.CmdPal.Ext.RemoteDesktop.Properties;
 using Microsoft.CommandPalette.Extensions;
@@ -10,9 +12,16 @@ using Microsoft.CommandPalette.Extensions.Toolkit;
 
 namespace Microsoft.CmdPal.Ext.RemoteDesktop.Pages;
 
-internal sealed partial class RemoteDesktopListPage : ListPage
+internal sealed partial class RemoteDesktopListPage : DynamicListPage
 {
+    private static readonly UriHostNameType[] ValidUriHostNameTypes = [
+        UriHostNameType.IPv6,
+        UriHostNameType.IPv4,
+        UriHostNameType.Dns,
+    ];
+
     private readonly IRdpConnectionsManager _rdpConnectionsManager;
+    private ConnectionListItem? _arbitraryHostItem;
 
     public RemoteDesktopListPage(IRdpConnectionsManager rdpConnectionsManager)
     {
@@ -23,5 +32,68 @@ internal sealed partial class RemoteDesktopListPage : ListPage
         _rdpConnectionsManager = rdpConnectionsManager;
     }
 
-    public override IListItem[] GetItems() => _rdpConnectionsManager.Connections.ToArray();
+    public override void UpdateSearchText(string oldSearch, string newSearch)
+    {
+        var query = newSearch?.Trim() ?? string.Empty;
+
+        if (string.IsNullOrWhiteSpace(query))
+        {
+            _arbitraryHostItem = null;
+            RaiseItemsChanged(0);
+            return;
+        }
+
+        var connections = _rdpConnectionsManager.Connections.Where(w => !string.IsNullOrWhiteSpace(w.ConnectionName));
+        var existingMatch = ConnectionHelpers.FindConnection(query, connections);
+
+        if (existingMatch is not null && string.Equals(existingMatch.ConnectionName, query, StringComparison.OrdinalIgnoreCase))
+        {
+            // Exact match — no need for an arbitrary host item
+            _arbitraryHostItem = null;
+        }
+        else if (IsValidHostname(query))
+        {
+            _arbitraryHostItem = new ConnectionListItem(query);
+        }
+        else
+        {
+            _arbitraryHostItem = null;
+        }
+
+        RaiseItemsChanged(0);
+    }
+
+    public override IListItem[] GetItems()
+    {
+        var connections = _rdpConnectionsManager.Connections.ToArray();
+
+        if (_arbitraryHostItem is null)
+        {
+            return connections;
+        }
+
+        // Prepend the arbitrary host item so it appears at the top
+        var result = new IListItem[connections.Length + 1];
+        result[0] = _arbitraryHostItem;
+        connections.CopyTo(result, 1);
+        return result;
+    }
+
+    private static bool IsValidHostname(string query)
+    {
+        // Strip port suffix (e.g. "myhost:3389") before validation,
+        // since Uri.CheckHostName does not accept host:port strings.
+        var hostForValidation = query;
+        var lastColon = hostForValidation.LastIndexOf(':');
+        if (lastColon > 0 && lastColon < hostForValidation.Length - 1)
+        {
+            var portPart = hostForValidation.Substring(lastColon + 1);
+            if (ushort.TryParse(portPart, out _))
+            {
+                hostForValidation = hostForValidation.Substring(0, lastColon);
+            }
+        }
+
+        return ValidUriHostNameTypes.Contains(Uri.CheckHostName(hostForValidation));
+    }
 }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.RemoteDesktop/Pages/RemoteDesktopListPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.RemoteDesktop/Pages/RemoteDesktopListPage.cs
@@ -81,7 +81,7 @@ internal sealed partial class RemoteDesktopListPage : DynamicListPage
 
     private static bool IsValidHostname(string query)
     {
-        // Strip port suffix (e.g. "myhost:3389") before validation,
+        // Strip port suffix (e.g. "host:3389") before validation,
         // since Uri.CheckHostName does not accept host:port strings.
         var hostForValidation = query;
         var lastColon = hostForValidation.LastIndexOf(':');


### PR DESCRIPTION
## Summary of the Pull Request

Fixes #48053 — Remote Desktop extension now allows connecting to arbitrary hostnames when navigated into the extension's list page.

Previously, `RemoteDesktopListPage` only displayed previously saved connections. This converts it from `ListPage` to `DynamicListPage`, adding search-driven behavior:

- Typing a valid hostname/IP that **doesn't** match an existing saved connection shows a **"Connect to {hostname}"** item at the top of the list
- Typing something that **exactly matches** a saved connection shows only the normal results (no duplicate arbitrary-host item)
- Typing an invalid string (not a valid hostname/IP) shows no arbitrary-host item

The hostname validation reuses the same logic as `FallbackRemoteDesktopItem`: strip the port suffix (e.g. `myhost:3389` → `myhost`), then check `Uri.CheckHostName` against `IPv4`, `IPv6`, `Dns`.

## PR Checklist
- [x] Closes: #48053
- [ ] **Communication:** I've discussed this with core contributors already.
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized