### PR TITLE
CmdPal: Add Usage of X and x in place of * for Calculator

### DIFF
--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Calc.UnitTests/XConverterTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Calc.UnitTests/XConverterTests.cs
@@ -20,28 +20,25 @@ public class XConverterTests
     [DataRow("2X3")]
     [DataRow("pi x 5")]
     [DataRow("e X 2")]
-
+    [DataRow("3x(5)")]
+    [DataRow("(10)x5")]
+    [DataRow("3x0xFF")]
+    [DataRow("0xFFx5")]
+    [DataRow("5 x 10")]
+    [DataRow("pi x e")]
     public void InputValid_XMultiplication_IsValid(string input)
     {
-        var result = CalculateHelper.InputValid(input);
+        var normalized = CalculateHelper.NormalizeMultiplicationSymbols(input);
+        var result = CalculateHelper.InputValid(normalized);
         Assert.IsTrue(result, $"'{input}' should be valid");
-    }
-
-    [DataTestMethod]
-    [DataRow("3x5", "3 * 5")]
-    [DataRow("3X5", "3 * 5")]
-    [DataRow("10x2", "10 * 2")]
-    [DataRow("2X3", "2 * 3")]
-    public void FixHumanMultiplicationExpressions_XMultiplication_ConvertedToAsterisk(string input, string expectedContains)
-    {
-        var result = CalculateHelper.FixHumanMultiplicationExpressions(input);
-        Assert.IsTrue(result.Contains('*'), $"'{input}' should be converted to contain '*'");
     }
 
     [DataTestMethod]
     [DataRow("0xFF")]
     [DataRow("0x10")]
     [DataRow("0XAB")]
+    [DataRow("0X123")]
+    [DataRow("0x123+0XFF")]
     public void InputValid_HexLiterals_AreValid(string input)
     {
         var result = CalculateHelper.InputValid(input);
@@ -50,41 +47,102 @@ public class XConverterTests
 
     [DataTestMethod]
     [DataRow("exp(5)")]
-    [DataRow("EXP(5)")]
     [DataRow("max(3,5)")]
-    public void FixHumanMultiplicationExpressions_FunctionNamesPreserved(string input)
+    [DataRow("max (3, 5)")]
+    public void InputValid_FunctionNames_AreValid(string input)
     {
-        var result = CalculateHelper.FixHumanMultiplicationExpressions(input);
-
-        Assert.IsFalse(result.Contains("e*p"), "exp() should not have x replaced");
-        Assert.IsFalse(result.Contains("m*x"), "max() should not have x replaced");
+        var result = CalculateHelper.InputValid(input);
+        Assert.IsTrue(result, $"Function '{input}' should be valid");
     }
 
     [DataTestMethod]
-    [DataRow("3x5")]
-    [DataRow("3X5")]
-    public void NormalizeCharsForDisplayQuery_XNotReplaced_StaysAsX(string input)
+    [DataRow("3x5", "3*5")]
+    [DataRow("3X5", "3*5")]
+    [DataRow("10 x 2", "10*2")]
+    [DataRow("2 X 3", "2*3")]
+    [DataRow("pi x 5", "pi*5")]
+    [DataRow("e X 2", "e*2")]
+    public void NormalizeMultiplicationSymbols_BasicXMultiplication_CorrectlyConverted(string input, string expected)
     {
-        var result = CalculateHelper.NormalizeCharsForDisplayQuery(input);
-        Assert.IsTrue(result.Contains('x') || result.Contains('X'), $"'{input}' should preserve x in display");
+        var result = CalculateHelper.NormalizeMultiplicationSymbols(input);
+        Assert.AreEqual(expected, result, $"'{input}' should convert to '{expected}'");
+    }
+
+    [DataTestMethod]
+    [DataRow("0XFF", "0xFF")]
+    [DataRow("0X123", "0x123")]
+    [DataRow("0XAB+5", "0xAB+5")]
+    public void NormalizeMultiplicationSymbols_UppercaseHexPrefix_NormalizedToLowercase(string input, string expected)
+    {
+        var result = CalculateHelper.NormalizeMultiplicationSymbols(input);
+        Assert.AreEqual(expected, result, $"'{input}' uppercase hex prefix should normalize to '{expected}'");
     }
 
     [TestMethod]
-    public void InputValid_XFollowedByHexLiteralNoSpace_IsValid()
+    public void NormalizeMultiplicationSymbols_HexFollowedByXMultiplication_PreservesHexAndConverts()
     {
-        var result = CalculateHelper.InputValid("5x0xFF");
-        Assert.IsTrue(result, "5x0xFF should be valid (x multiplication before hex literal)");
+        var input = "0xFFx5";
+        var result = CalculateHelper.NormalizeMultiplicationSymbols(input);
+        Assert.AreEqual("0xFF*5", result, "Hex literal should be preserved, x converted to *");
+    }
+
+    [DataTestMethod]
+    [DataRow("exp(5)", "exp(5)")]
+    [DataRow("max(3,5)", "max(3,5)")]
+    [DataRow("max (3, 5)", "max (3, 5)")]
+    public void NormalizeMultiplicationSymbols_FunctionNames_Preserved(string input, string expected)
+    {
+        var result = CalculateHelper.NormalizeMultiplicationSymbols(input);
+        Assert.AreEqual(expected, result, $"Function '{input}' should remain unchanged as '{expected}'");
     }
 
     [TestMethod]
-    public void FixHumanMultiplicationExpressions_XWithMultipleBases_ConvertsCorrectly()
+    public void NormalizeMultiplicationSymbols_MultipleBasesWithXMultiplication_CorrectlyHandled()
     {
         var input = "0xFFx5x0b1010";
-        var result = CalculateHelper.FixHumanMultiplicationExpressions(input);
+        var result = CalculateHelper.NormalizeMultiplicationSymbols(input);
+        Assert.AreEqual("0xFF*5*0b1010", result, "Both x multiplications should convert, bases preserved");
+    }
 
-        Assert.IsTrue(result.Contains("0x"), "Hex literal 0x should be preserved");
-        Assert.IsTrue(result.Contains("0b"), "Binary literal 0b should be preserved");
-        var asteriskCount = result.Split('*').Length - 1;
-        Assert.IsTrue(asteriskCount >= 2, "Both x multiplications should be converted to *");
+    [TestMethod]
+    public void NormalizeMultiplicationSymbols_BracketedExpressions_CorrectlyHandled()
+    {
+        var input = "3x(5x2)";
+        var result = CalculateHelper.NormalizeMultiplicationSymbols(input);
+        Assert.AreEqual("3*(5*2)", result, "Both x multiplications in nested expressions should convert");
+    }
+
+    [TestMethod]
+    public void NormalizeMultiplicationSymbols_ComplexExpressionWithFunctionAndBases_CorrectlyHandled()
+    {
+        var input = "3x(5 x max(0xFF, 256))";
+        var result = CalculateHelper.NormalizeMultiplicationSymbols(input);
+
+        // Only the clearly between-operands x's will convert
+        Assert.AreEqual("3*(5*max(0xFF, 256))", result);
+    }
+
+    [TestMethod]
+    public void NormalizeMultiplicationSymbols_TrailingX_NotConverted()
+    {
+        var input = "5x";
+        var result = CalculateHelper.NormalizeMultiplicationSymbols(input);
+        Assert.AreEqual("5x", result, "Trailing x should not be converted (will be caught by validator)");
+    }
+
+    [TestMethod]
+    public void NormalizeMultiplicationSymbols_LeadingX_NotConverted()
+    {
+        var input = "x5";
+        var result = CalculateHelper.NormalizeMultiplicationSymbols(input);
+        Assert.AreEqual("x5", result, "Leading x should not be converted (will be caught by validator)");
+    }
+
+    [TestMethod]
+    public void NormalizeMultiplicationSymbols_BareXSequence_NotConverted()
+    {
+        var input = "xXxXx";
+        var result = CalculateHelper.NormalizeMultiplicationSymbols(input);
+        Assert.AreEqual("xXxXx", result, "Bare x sequence should not be converted (will be caught by validator)");
     }
 }

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Calc.UnitTests/XConverterTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Calc.UnitTests/XConverterTests.cs
@@ -1,0 +1,90 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Globalization;
+using System.Numerics;
+using Microsoft.CmdPal.Ext.Calc.Helper;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CmdPal.Ext.Calc.UnitTests;
+
+[TestClass]
+public class XConverterTests
+{
+    [DataTestMethod]
+    [DataRow("3x5")]
+    [DataRow("3X5")]
+    [DataRow("10x2")]
+    [DataRow("2X3")]
+    [DataRow("pi x 5")]
+    [DataRow("e X 2")]
+
+    public void InputValid_XMultiplication_IsValid(string input)
+    {
+        var result = CalculateHelper.InputValid(input);
+        Assert.IsTrue(result, $"'{input}' should be valid");
+    }
+
+    [DataTestMethod]
+    [DataRow("3x5", "3 * 5")]
+    [DataRow("3X5", "3 * 5")]
+    [DataRow("10x2", "10 * 2")]
+    [DataRow("2X3", "2 * 3")]
+    public void FixHumanMultiplicationExpressions_XMultiplication_ConvertedToAsterisk(string input, string expectedContains)
+    {
+        var result = CalculateHelper.FixHumanMultiplicationExpressions(input);
+        Assert.IsTrue(result.Contains('*'), $"'{input}' should be converted to contain '*'");
+    }
+
+    [DataTestMethod]
+    [DataRow("0xFF")]
+    [DataRow("0x10")]
+    [DataRow("0XAB")]
+    public void InputValid_HexLiterals_AreValid(string input)
+    {
+        var result = CalculateHelper.InputValid(input);
+        Assert.IsTrue(result, $"Hex literal '{input}' should be valid");
+    }
+
+    [DataTestMethod]
+    [DataRow("exp(5)")]
+    [DataRow("EXP(5)")]
+    [DataRow("max(3,5)")]
+    public void FixHumanMultiplicationExpressions_FunctionNamesPreserved(string input)
+    {
+        var result = CalculateHelper.FixHumanMultiplicationExpressions(input);
+
+        Assert.IsFalse(result.Contains("e*p"), "exp() should not have x replaced");
+        Assert.IsFalse(result.Contains("m*x"), "max() should not have x replaced");
+    }
+
+    [DataTestMethod]
+    [DataRow("3x5")]
+    [DataRow("3X5")]
+    public void NormalizeCharsForDisplayQuery_XNotReplaced_StaysAsX(string input)
+    {
+        var result = CalculateHelper.NormalizeCharsForDisplayQuery(input);
+        Assert.IsTrue(result.Contains('x') || result.Contains('X'), $"'{input}' should preserve x in display");
+    }
+
+    [TestMethod]
+    public void InputValid_XFollowedByHexLiteralNoSpace_IsValid()
+    {
+        var result = CalculateHelper.InputValid("5x0xFF");
+        Assert.IsTrue(result, "5x0xFF should be valid (x multiplication before hex literal)");
+    }
+
+    [TestMethod]
+    public void FixHumanMultiplicationExpressions_XWithMultipleBases_ConvertsCorrectly()
+    {
+        var input = "0xFFx5x0b1010";
+        var result = CalculateHelper.FixHumanMultiplicationExpressions(input);
+
+        Assert.IsTrue(result.Contains("0x"), "Hex literal 0x should be preserved");
+        Assert.IsTrue(result.Contains("0b"), "Binary literal 0b should be preserved");
+        var asteriskCount = result.Split('*').Length - 1;
+        Assert.IsTrue(asteriskCount >= 2, "Both x multiplications should be converted to *");
+    }
+}

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Helper/CalculateEngine.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Helper/CalculateEngine.cs
@@ -38,6 +38,9 @@ public static partial class CalculateEngine
     {
         error = default;
 
+        // Normalize x/X before validation
+        input = CalculateHelper.NormalizeMultiplicationSymbols(input);
+
         if (!CalculateHelper.InputValid(input))
         {
             return default;

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Helper/CalculateHelper.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Helper/CalculateHelper.cs
@@ -120,12 +120,19 @@ public static partial class CalculateHelper
         return input;
     }
 
+    private static string NormalizeMultiplicationSymbols(string input)
+    {
+        return input.Replace("x", "*").Replace("X", "*");
+    }
+
     public static bool InputValid(string input)
     {
         if (string.IsNullOrWhiteSpace(input))
         {
             return false;
         }
+
+        input = NormalizeMultiplicationSymbols(input);
 
         if (!RegValidExpressChar.IsMatch(input))
         {
@@ -161,6 +168,7 @@ public static partial class CalculateHelper
 
     public static string FixHumanMultiplicationExpressions(string input)
     {
+        input = input.Replace("x", "*").Replace("X", "*");
         var output = CheckScientificNotation(input);
         output = CheckNumberOrConstantThenParenthesisExpr(output);
         output = CheckNumberOrConstantThenFunc(output);

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Helper/CalculateHelper.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Helper/CalculateHelper.cs
@@ -21,7 +21,7 @@ public static partial class CalculateHelper
         @"pi|" +
         @"==|~=|&&|\|\||" +
         @"((\d+(?:\.\d*)?|\.\d+)[eE](-?\d+))|" + /* expression from CheckScientificNotation between parenthesis */
-        @"e|[0-9]|0[xX][0-9a-fA-F]+|0[bB][01]+|0[oO][0-7]+|[\+\-\*\/\^\., ""]|[\(\)\|\!\[\]]" +
+        @"e|[0-9]|0[xX][0-9a-fA-F]+|0[bB][01]+|0[oO][0-7]+|[\+\-\*\/\^\.,xX ""]|[\(\)\|\!\[\]]" +
         @")+$",
         RegexOptions.Compiled);
 
@@ -122,7 +122,12 @@ public static partial class CalculateHelper
 
     private static string NormalizeMultiplicationSymbols(string input)
     {
-        return input.Replace("x", "*").Replace("X", "*");
+        input = System.Text.RegularExpressions.Regex.Replace(
+            input,
+            @"(?<!\b0)[xX](?![a-zA-Z(])",
+            "*");
+
+        return input;
     }
 
     public static bool InputValid(string input)
@@ -131,8 +136,6 @@ public static partial class CalculateHelper
         {
             return false;
         }
-
-        input = NormalizeMultiplicationSymbols(input);
 
         if (!RegValidExpressChar.IsMatch(input))
         {
@@ -168,7 +171,7 @@ public static partial class CalculateHelper
 
     public static string FixHumanMultiplicationExpressions(string input)
     {
-        input = input.Replace("x", "*").Replace("X", "*");
+        input = NormalizeMultiplicationSymbols(input);
         var output = CheckScientificNotation(input);
         output = CheckNumberOrConstantThenParenthesisExpr(output);
         output = CheckNumberOrConstantThenFunc(output);

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Helper/CalculateHelper.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Helper/CalculateHelper.cs
@@ -21,7 +21,7 @@ public static partial class CalculateHelper
         @"pi|" +
         @"==|~=|&&|\|\||" +
         @"((\d+(?:\.\d*)?|\.\d+)[eE](-?\d+))|" + /* expression from CheckScientificNotation between parenthesis */
-        @"e|[0-9]|0[xX][0-9a-fA-F]+|0[bB][01]+|0[oO][0-7]+|[\+\-\*\/\^\.,xX ""]|[\(\)\|\!\[\]]" +
+        @"e|[0-9]|0[xX][0-9a-fA-F]+|0[bB][01]+|0[oO][0-7]+|[\+\-\*\/\^\., ""]|[\(\)\|\!\[\]]" +
         @")+$",
         RegexOptions.Compiled);
 
@@ -68,6 +68,11 @@ public static partial class CalculateHelper
         // unary operators; can appear at the end of a query
         ')', ']', '!',
     ];
+
+    private static readonly string[] FunctionNamesWithX = new[]
+    {
+        "exp", "max",
+    };
 
     private static readonly Regex ReplaceScientificNotationRegex = CreateReplaceScientificNotationRegex();
 
@@ -120,12 +125,26 @@ public static partial class CalculateHelper
         return input;
     }
 
-    private static string NormalizeMultiplicationSymbols(string input)
+    public static string NormalizeMultiplicationSymbols(string input)
     {
-        input = System.Text.RegularExpressions.Regex.Replace(
-            input,
-            @"(?<!\b0)[xX](?![a-zA-Z(])",
-            "*");
+        if (string.IsNullOrEmpty(input))
+        {
+            return input;
+        }
+
+        var functionsWithX = string.Join("|", FunctionNamesWithX);
+
+        input = Regex.Replace(input, @"\b0[X](?=[0-9a-fA-F])", "0x");
+        input = Regex.Replace(input, @"\b0x([0-9a-fA-F]+)", "0__HEX__$1");
+        input = Regex.Replace(input, $@"\b({functionsWithX})\b", "$1__FUNC__", RegexOptions.IgnoreCase);
+        input = Regex.Replace(input, $@"\b({functionsWithX})(?=\s*\()", "$1__FUNC__", RegexOptions.IgnoreCase);
+
+        var leftSide = @"(?<=\d|\)|pi|e|π|[a-fA-F])";
+        var rightSide = $@"(?=\d|\(|pi|e|π|(?:{functionsWithX})__FUNC__)";
+        input = Regex.Replace(input, leftSide + @"\s*[xX]\s*" + rightSide, "*");
+
+        input = input.Replace("__FUNC__", string.Empty);
+        input = Regex.Replace(input, @"0__HEX__([0-9a-fA-F]+)", "0x$1");
 
         return input;
     }
@@ -171,7 +190,6 @@ public static partial class CalculateHelper
 
     public static string FixHumanMultiplicationExpressions(string input)
     {
-        input = NormalizeMultiplicationSymbols(input);
         var output = CheckScientificNotation(input);
         output = CheckNumberOrConstantThenParenthesisExpr(output);
         output = CheckNumberOrConstantThenFunc(output);

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Helper/QueryHelper.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Helper/QueryHelper.cs
@@ -32,6 +32,8 @@ public static partial class QueryHelper
         // Enables better looking characters for multiplication and division (e.g., '×' and '÷')
         displayQuery = CalculateHelper.NormalizeCharsForDisplayQuery(query);
 
+        displayQuery = CalculateHelper.NormalizeMultiplicationSymbols(displayQuery);
+
         // Happens if the user has only typed the action key so far
         if (string.IsNullOrEmpty(displayQuery))
         {
@@ -58,6 +60,8 @@ public static partial class QueryHelper
 
         // normalize again to engine chars after translation
         input = CalculateHelper.NormalizeCharsToEngine(input);
+
+        input = CalculateHelper.NormalizeMultiplicationSymbols(input);
 
         // Auto fix incomplete queries (if enabled)
         if (settings.AutoFixQuery && TryGetIncompleteQuery(input, out var newInput))


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Implements #38007 
The calculator now supports using x and X instead of * for multiplication, accounting for hex and usage of x in spelling (e.g. in exp).

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Changes made to `CalculateHelper.cs` inside `src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc` to add regex parsing and input validation to allow for x and X to be treated as valid replacements for *.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
#### Manual Validation
Manually validated by running the CmdPal calculator for as many input types as possible, such as 0xFF*0b01x0o11 etc, where multiple types of multiplication chars are used, while also being among non multiplication x's (0xFF).
#### Unit Tests
Created a unit test file under `src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Calc.UnitTests` called XConverterTests.cs`, which tests a wide range of cases for using x and X in place of *.
