### PR TITLE
CmdPal: Synchronize fallback title/subtitle format for consistent scoring

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.Common/Services/HttpCaching/HttpResourceCacheHandler.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Common/Services/HttpCaching/HttpResourceCacheHandler.cs
@@ -76,8 +76,13 @@ internal sealed partial class HttpResourceCacheHandler : DelegatingHandler
 
         lock (_lock)
         {
-            foreach (var inflightKey in _inflightFetches.Keys)
+            foreach (var (inflightKey, task) in _inflightFetches)
             {
+                if (task.IsCompleted)
+                {
+                    continue;
+                }
+
                 if (!Uri.TryCreate(inflightKey, UriKind.Absolute, out var inflightUri))
                 {
                     continue;

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.RemoteDesktop.UnitTests/FallbackRemoteDesktopItemTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.RemoteDesktop.UnitTests/FallbackRemoteDesktopItemTests.cs
@@ -52,9 +52,8 @@ public class FallbackRemoteDesktopItemTests
         fallback.UpdateQuery(hostname);
 
         // Assert
-        var expectedTitle = string.Format(CultureInfo.CurrentCulture, OpenHostCompositeFormat, hostname);
-        Assert.AreEqual(expectedTitle, fallback.Title);
-        Assert.AreEqual(Resources.remotedesktop_title, fallback.Subtitle);
+        Assert.AreEqual(Resources.remotedesktop_title, fallback.Title);
+        Assert.AreEqual(hostname, fallback.Subtitle);
 
         var command = fallback.Command as OpenRemoteDesktopCommand;
         Assert.IsNotNull(command);
@@ -110,9 +109,8 @@ public class FallbackRemoteDesktopItemTests
         fallback.UpdateQuery(hostPort);
 
         // Assert
-        var expectedTitle = string.Format(CultureInfo.CurrentCulture, OpenHostCompositeFormat, hostPort);
-        Assert.AreEqual(expectedTitle, fallback.Title);
-        Assert.AreEqual(Resources.remotedesktop_title, fallback.Subtitle);
+        Assert.AreEqual(Resources.remotedesktop_title, fallback.Title);
+        Assert.AreEqual(hostPort, fallback.Subtitle);
 
         var command = fallback.Command as OpenRemoteDesktopCommand;
         Assert.IsNotNull(command);
@@ -131,9 +129,8 @@ public class FallbackRemoteDesktopItemTests
         fallback.UpdateQuery(hostPort);
 
         // Assert
-        var expectedTitle = string.Format(CultureInfo.CurrentCulture, OpenHostCompositeFormat, hostPort);
-        Assert.AreEqual(expectedTitle, fallback.Title);
-        Assert.AreEqual(Resources.remotedesktop_title, fallback.Subtitle);
+        Assert.AreEqual(Resources.remotedesktop_title, fallback.Title);
+        Assert.AreEqual(hostPort, fallback.Subtitle);
 
         var command = fallback.Command as OpenRemoteDesktopCommand;
         Assert.IsNotNull(command);

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.RemoteDesktop.UnitTests/FallbackRemoteDesktopItemTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.RemoteDesktop.UnitTests/FallbackRemoteDesktopItemTests.cs
@@ -53,7 +53,8 @@ public class FallbackRemoteDesktopItemTests
 
         // Assert
         Assert.AreEqual(Resources.remotedesktop_title, fallback.Title);
-        Assert.AreEqual(hostname, fallback.Subtitle);
+        var expectedSubtitleArbitrary = string.Format(CultureInfo.CurrentCulture, OpenHostCompositeFormat, hostname);
+        Assert.AreEqual(expectedSubtitleArbitrary, fallback.Subtitle);
 
         var command = fallback.Command as OpenRemoteDesktopCommand;
         Assert.IsNotNull(command);
@@ -110,7 +111,8 @@ public class FallbackRemoteDesktopItemTests
 
         // Assert
         Assert.AreEqual(Resources.remotedesktop_title, fallback.Title);
-        Assert.AreEqual(hostPort, fallback.Subtitle);
+        var expectedSubtitleHostPort = string.Format(CultureInfo.CurrentCulture, OpenHostCompositeFormat, hostPort);
+        Assert.AreEqual(expectedSubtitleHostPort, fallback.Subtitle);
 
         var command = fallback.Command as OpenRemoteDesktopCommand;
         Assert.IsNotNull(command);
@@ -130,7 +132,8 @@ public class FallbackRemoteDesktopItemTests
 
         // Assert
         Assert.AreEqual(Resources.remotedesktop_title, fallback.Title);
-        Assert.AreEqual(hostPort, fallback.Subtitle);
+        var expectedSubtitleHostPort = string.Format(CultureInfo.CurrentCulture, OpenHostCompositeFormat, hostPort);
+        Assert.AreEqual(expectedSubtitleHostPort, fallback.Subtitle);
 
         var command = fallback.Command as OpenRemoteDesktopCommand;
         Assert.IsNotNull(command);

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Indexer/FallbackOpenFileItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Indexer/FallbackOpenFileItem.cs
@@ -5,7 +5,9 @@
 #nullable enable
 
 using System;
+using System.Globalization;
 using System.IO;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CmdPal.Ext.Indexer.Data;
@@ -28,6 +30,7 @@ internal sealed partial class FallbackOpenFileItem : FallbackCommandItem, IDispo
     private const uint HardQueryCookie = 10;
     private static readonly NoOpCommand BaseCommandWithId = new() { Id = CommandId };
 
+    private readonly CompositeFormat _fallbackItemSearchSubtitleFormat = CompositeFormat.Parse(Resources.Indexer_fallback_searchPage_title);
     private readonly Lock _querySwitchLock = new();
     private readonly Lock _resultLock = new();
 
@@ -149,7 +152,7 @@ internal sealed partial class FallbackOpenFileItem : FallbackCommandItem, IDispo
 
                 var set = UpdateResultForCurrentQuery(
                     Resources.IndexerCommandsProvider_DisplayName,
-                    query,
+                    string.Format(CultureInfo.CurrentCulture, _fallbackItemSearchSubtitleFormat, query),
                     Icons.FileExplorerIcon,
                     indexerPage,
                     MoreCommands,

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Indexer/FallbackOpenFileItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Indexer/FallbackOpenFileItem.cs
@@ -5,9 +5,7 @@
 #nullable enable
 
 using System;
-using System.Globalization;
 using System.IO;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CmdPal.Ext.Indexer.Data;
@@ -30,8 +28,6 @@ internal sealed partial class FallbackOpenFileItem : FallbackCommandItem, IDispo
     private const uint HardQueryCookie = 10;
     private static readonly NoOpCommand BaseCommandWithId = new() { Id = CommandId };
 
-    private readonly CompositeFormat _fallbackItemSearchPageTitleFormat = CompositeFormat.Parse(Resources.Indexer_fallback_searchPage_title);
-    private readonly CompositeFormat _fallbackItemSearchSubtitleMultipleResults = CompositeFormat.Parse(Resources.Indexer_Fallback_MultipleResults_Subtitle);
     private readonly Lock _querySwitchLock = new();
     private readonly Lock _resultLock = new();
 
@@ -152,8 +148,8 @@ internal sealed partial class FallbackOpenFileItem : FallbackCommandItem, IDispo
                 var indexerPage = new IndexerPage(query);
 
                 var set = UpdateResultForCurrentQuery(
-                    string.Format(CultureInfo.CurrentCulture, _fallbackItemSearchPageTitleFormat, query),
-                    string.Format(CultureInfo.CurrentCulture, _fallbackItemSearchSubtitleMultipleResults),
+                    Resources.IndexerCommandsProvider_DisplayName,
+                    query,
                     Icons.FileExplorerIcon,
                     indexerPage,
                     MoreCommands,

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Indexer/Properties/Resources.resx
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Indexer/Properties/Resources.resx
@@ -193,7 +193,7 @@
     <value>Search files</value>
   </data>
   <data name="Indexer_fallback_searchPage_title" xml:space="preserve">
-    <value>Search for "{0}" in files</value>
+    <value>Search for {0} in files</value>
   </data>
   <data name="Indexer_NoResultsMessage" xml:space="preserve">
     <value>No items found</value>

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.RemoteDesktop/Commands/FallbackRemoteDesktopItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.RemoteDesktop/Commands/FallbackRemoteDesktopItem.cs
@@ -79,8 +79,8 @@ internal sealed partial class FallbackRemoteDesktopItem : FallbackCommandItem
             {
                 var connectionName = query.Trim();
                 Command = new OpenRemoteDesktopCommand(connectionName);
-                Title = string.Format(CultureInfo.CurrentCulture, RemoteDesktopOpenHostFormat, connectionName);
-                Subtitle = Resources.remotedesktop_title;
+                Title = Resources.remotedesktop_title;
+                Subtitle = connectionName;
             }
             else
             {

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.RemoteDesktop/Commands/FallbackRemoteDesktopItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.RemoteDesktop/Commands/FallbackRemoteDesktopItem.cs
@@ -80,7 +80,7 @@ internal sealed partial class FallbackRemoteDesktopItem : FallbackCommandItem
                 var connectionName = query.Trim();
                 Command = new OpenRemoteDesktopCommand(connectionName);
                 Title = Resources.remotedesktop_title;
-                Subtitle = connectionName;
+                Subtitle = string.Format(CultureInfo.CurrentCulture, RemoteDesktopOpenHostFormat, connectionName);
             }
             else
             {

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/FallbackExecuteSearchItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/FallbackExecuteSearchItem.cs
@@ -16,7 +16,6 @@ internal sealed partial class FallbackExecuteSearchItem : FallbackCommandItem
     private const string _id = "com.microsoft.cmdpal.builtin.websearch.execute.fallback";
     private readonly SearchWebCommand _executeItem;
     private static readonly CompositeFormat PluginOpen = System.Text.CompositeFormat.Parse(Properties.Resources.plugin_open);
-    private static readonly CompositeFormat SubtitleText = System.Text.CompositeFormat.Parse(Properties.Resources.web_search_fallback_subtitle);
 
     private readonly IBrowserInfoService _browserInfoService;
 
@@ -45,6 +44,6 @@ internal sealed partial class FallbackExecuteSearchItem : FallbackCommandItem
         var isEmpty = string.IsNullOrEmpty(query);
         _executeItem.Name = isEmpty ? string.Empty : Resources.open_in_default_browser;
         Title = isEmpty ? string.Empty : UpdateBrowserName(_browserInfoService);
-        Subtitle = string.Format(CultureInfo.CurrentCulture, SubtitleText, query);
+        Subtitle = isEmpty ? string.Empty : query;
     }
 }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/FallbackExecuteSearchItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/FallbackExecuteSearchItem.cs
@@ -16,6 +16,7 @@ internal sealed partial class FallbackExecuteSearchItem : FallbackCommandItem
     private const string _id = "com.microsoft.cmdpal.builtin.websearch.execute.fallback";
     private readonly SearchWebCommand _executeItem;
     private static readonly CompositeFormat PluginOpen = System.Text.CompositeFormat.Parse(Properties.Resources.plugin_open);
+    private static readonly CompositeFormat SubtitleText = System.Text.CompositeFormat.Parse(Properties.Resources.web_search_fallback_subtitle);
 
     private readonly IBrowserInfoService _browserInfoService;
 
@@ -44,6 +45,6 @@ internal sealed partial class FallbackExecuteSearchItem : FallbackCommandItem
         var isEmpty = string.IsNullOrEmpty(query);
         _executeItem.Name = isEmpty ? string.Empty : Resources.open_in_default_browser;
         Title = isEmpty ? string.Empty : UpdateBrowserName(_browserInfoService);
-        Subtitle = isEmpty ? string.Empty : query;
+        Subtitle = isEmpty ? string.Empty : string.Format(CultureInfo.CurrentCulture, SubtitleText, query);
     }
 }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/FallbackOpenURLItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/FallbackOpenURLItem.cs
@@ -18,6 +18,7 @@ internal sealed partial class FallbackOpenURLItem : FallbackCommandItem
     private const string _id = "com.microsoft.cmdpal.builtin.websearch.openurl.fallback";
     private readonly IBrowserInfoService _browserInfoService;
     private readonly OpenURLCommand _executeItem;
+    private static readonly CompositeFormat PluginOpenURL = System.Text.CompositeFormat.Parse(Properties.Resources.plugin_open_url);
     private static readonly CompositeFormat PluginOpenUrlInBrowser = System.Text.CompositeFormat.Parse(Properties.Resources.plugin_open_url_in_browser);
 
     public FallbackOpenURLItem(ISettingsInterface settings, IBrowserInfoService browserInfoService)
@@ -57,7 +58,7 @@ internal sealed partial class FallbackOpenURLItem : FallbackCommandItem
 
         var browserName = _browserInfoService.GetDefaultBrowser()?.Name;
         Title = string.IsNullOrWhiteSpace(browserName) ? Resources.open_in_default_browser : string.Format(CultureInfo.CurrentCulture, PluginOpenUrlInBrowser, browserName);
-        Subtitle = query;
+        Subtitle = string.Format(CultureInfo.CurrentCulture, PluginOpenURL, query);
     }
 
     private static bool IsValidUrl(string url)

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/FallbackOpenURLItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/FallbackOpenURLItem.cs
@@ -18,7 +18,6 @@ internal sealed partial class FallbackOpenURLItem : FallbackCommandItem
     private const string _id = "com.microsoft.cmdpal.builtin.websearch.openurl.fallback";
     private readonly IBrowserInfoService _browserInfoService;
     private readonly OpenURLCommand _executeItem;
-    private static readonly CompositeFormat PluginOpenURL = System.Text.CompositeFormat.Parse(Properties.Resources.plugin_open_url);
     private static readonly CompositeFormat PluginOpenUrlInBrowser = System.Text.CompositeFormat.Parse(Properties.Resources.plugin_open_url_in_browser);
 
     public FallbackOpenURLItem(ISettingsInterface settings, IBrowserInfoService browserInfoService)
@@ -56,10 +55,9 @@ internal sealed partial class FallbackOpenURLItem : FallbackCommandItem
         _executeItem.Url = query;
         _executeItem.Name = string.IsNullOrEmpty(query) ? string.Empty : Resources.open_in_default_browser;
 
-        Title = string.Format(CultureInfo.CurrentCulture, PluginOpenURL, query);
-
         var browserName = _browserInfoService.GetDefaultBrowser()?.Name;
-        Subtitle = string.IsNullOrWhiteSpace(browserName) ? Resources.open_in_default_browser : string.Format(CultureInfo.CurrentCulture, PluginOpenUrlInBrowser, browserName);
+        Title = string.IsNullOrWhiteSpace(browserName) ? Resources.open_in_default_browser : string.Format(CultureInfo.CurrentCulture, PluginOpenUrlInBrowser, browserName);
+        Subtitle = query;
     }
 
     private static bool IsValidUrl(string url)

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/Properties/Resources.resx
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/Properties/Resources.resx
@@ -164,7 +164,7 @@
     <value>Search the web in {0}</value>
   </data>
   <data name="plugin_open_url" xml:space="preserve">
-    <value>Open "{0}"</value>
+    <value>Open {0}</value>
   </data>
   <data name="plugin_open_url_in_browser" xml:space="preserve">
     <value>Open url in {0}</value>
@@ -179,7 +179,7 @@
     <value>Settings</value>
   </data>
   <data name="web_search_fallback_subtitle" xml:space="preserve">
-    <value>Search for "{0}"</value>
+    <value>Search for {0}</value>
   </data>
   <data name="open_url_fallback_title" xml:space="preserve">
     <value>Open URL</value>

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/Pages/FallbackWindowsSettingsItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/Pages/FallbackWindowsSettingsItem.cs
@@ -2,7 +2,9 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Globalization;
 using System.Linq;
+using System.Text;
 using Microsoft.CmdPal.Ext.WindowsSettings.Commands;
 using Microsoft.CmdPal.Ext.WindowsSettings.Helpers;
 using Microsoft.CmdPal.Ext.WindowsSettings.Properties;
@@ -16,6 +18,7 @@ internal sealed partial class FallbackWindowsSettingsItem : FallbackCommandItem
 
     private readonly Classes.WindowsSettings _windowsSettings;
 
+    private static readonly CompositeFormat _titleFormat = CompositeFormat.Parse(Resources.settings_fallback_title);
     private readonly string _subtitle = Resources.settings_fallback_subtitle;
 
     public FallbackWindowsSettingsItem(Classes.WindowsSettings windowsSettings)
@@ -78,7 +81,7 @@ internal sealed partial class FallbackWindowsSettingsItem : FallbackCommandItem
         var settingsPage = new WindowsSettingsListPage(_windowsSettings, query);
         Title = _subtitle;
         Icon = Icons.WindowsSettingsIcon;
-        Subtitle = query;
+        Subtitle = string.Format(CultureInfo.CurrentCulture, _titleFormat, query);
         Command = settingsPage;
 
         return;

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/Pages/FallbackWindowsSettingsItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/Pages/FallbackWindowsSettingsItem.cs
@@ -2,7 +2,6 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Globalization;
 using System.Linq;
 using Microsoft.CmdPal.Ext.WindowsSettings.Commands;
 using Microsoft.CmdPal.Ext.WindowsSettings.Helpers;
@@ -17,7 +16,6 @@ internal sealed partial class FallbackWindowsSettingsItem : FallbackCommandItem
 
     private readonly Classes.WindowsSettings _windowsSettings;
 
-    private readonly string _title = Resources.settings_fallback_title;
     private readonly string _subtitle = Resources.settings_fallback_subtitle;
 
     public FallbackWindowsSettingsItem(Classes.WindowsSettings windowsSettings)
@@ -78,9 +76,9 @@ internal sealed partial class FallbackWindowsSettingsItem : FallbackCommandItem
         // We found more than one result. Make our command take
         // us to the Windows Settings search page, prepopulated with this search.
         var settingsPage = new WindowsSettingsListPage(_windowsSettings, query);
-        Title = string.Format(CultureInfo.CurrentCulture, _title, query);
+        Title = _subtitle;
         Icon = Icons.WindowsSettingsIcon;
-        Subtitle = _subtitle;
+        Subtitle = query;
         Command = settingsPage;
 
         return;

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/Properties/Resources.resx
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/Properties/Resources.resx
@@ -2093,7 +2093,7 @@
     <value>Navigate to specific Windows settings</value>
   </data>
   <data name="settings_fallback_title" xml:space="preserve">
-    <value>Search for "{0}" in Windows settings</value>
+    <value>Search for {0}</value>
   </data>
   <data name="settings_fallback_subtitle" xml:space="preserve">
     <value>Search Windows settings for this device</value>


### PR DESCRIPTION
## Summary

Fixes #46055 — Standardizes built-in fallback title/subtitle format so scoring is consistent across all action fallbacks.

## Problem

`MainListPage.cs` scores fallback items by fuzzy-matching the query against both Title and Subtitle, but with different weights:
- `nameScore = FuzzyScore(query, Title)`
- `descriptionScore = (FuzzyScore(query, Subtitle) - 4) / 2`

Fallbacks that embedded the raw query in Title got artificially higher scores than those using Subtitle. This made ranking unpredictable.

## Fix

All "action" fallbacks now follow a consistent pattern:
- **Title** = static action description (no query text)
- **Subtitle** = raw query string (unquoted)

"Result" fallbacks (that found a specific matched item) are left unchanged — they correctly show the matched item name in Title.

## Full Fallback Audit (example query: `notepad`)

| Fallback | Title | Subtitle | Status |
|---|---|---|---|
| WebSearch: Search | "Search the web with Edge" | `Search for notepad` | **Changed** — was `Search for "notepad"` in subtitle |
| WebSearch: Open URL | "Open in Microsoft Edge" | `Open notepad.com` | **Changed** — was `Open "notepad.com"` in title |
| Shell: Run | "Run" | `notepad` | Unchanged — already correct |
| Calculator | "3" (result) | `1+2` (query) | Unchanged — intentional exception |
| Indexer: single result | "notepad.exe" | `C:\Windows\notepad.exe` | Unchanged — result fallback |
| Indexer: multiple results | "File search" | `Search for notepad in files` | **Changed** — was `Search for "notepad" in files` in title |
| Windows Settings: single | "Notepad settings" | `Settings > Apps` | Unchanged — result fallback |
| Windows Settings: multiple | "Search Windows settings..." | `Search for notepad` | **Changed** — was `Search for "notepad" in Windows settings` in title |
| Remote Desktop: exact match | "MyPC" (connection) | "Connect to MyPC" | Unchanged — result fallback |
| Remote Desktop: arbitrary host | "Remote Desktop" | `Connect to notepad-host` | **Changed** — was `Connect to notepad-host` in title |
| TimeDate | "Monday, May 23" (result) | "Current date" | Unchanged — result fallback |
| System | "Shut down" (result) | "Shuts down the computer" | Unchanged — result fallback |
| PowerToys | "Color Picker" (static) | "Pick a color..." | Unchanged — result fallback |

## Changes

- `FallbackExecuteSearchItem.cs` — Subtitle uses raw query instead of `"Search for \"{query}\""` format
- `FallbackOpenURLItem.cs` — Title shows browser name (was query), Subtitle shows raw query (was browser)
- `FallbackOpenFileItem.cs` — Multi-result: Title is static display name, Subtitle is raw query
- `FallbackWindowsSettingsItem.cs` — Multi-result: Title is static description, Subtitle is raw query
- `FallbackRemoteDesktopItem.cs` — Arbitrary host: Title is static "Remote Desktop", Subtitle is raw query


## Additional Fix

- `HttpResourceCacheHandler.cs` — Fixed race condition in `AddInflightResourceUris` where completed-but-not-yet-cleaned-up tasks prevented cache pruning. This caused flaky CI failures in `RefreshAsync_PrunesObsoleteCachedIcons_AfterSuccessfulRefresh`.
