### PR TITLE
CmdPal: Fix dock subtitle visibility in compact mode after async update

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockItemControl.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockItemControl.xaml.cs
@@ -120,6 +120,7 @@ public sealed partial class DockItemControl : Control
         {
             control.UpdateTextVisibility();
             control.UpdateAlignment();
+            control.UpdateCompactState();
         }
     }
 


### PR DESCRIPTION
## Summary

When an extension updates its `Subtitle` property asynchronously after initial render, the `TextVisibilityStates` visual state group transitions from `TitleOnly` → `TextVisible`. This transition sets `SubtitleText.Visibility = Visible`, overriding the `CompactStates` setter that had hidden it.

## Fix

Added `control.UpdateCompactState()` to `OnTextPropertyChanged` in `DockItemControl.xaml.cs`. This re-applies the compact state after any text property change. When `IsCompact` is `false`, `UpdateCompactState` is a no-op — no behavior change for the non-compact path.

Fixes #47980