### PR TITLE
CmdPal: Fix hotkey navigation when palette is showing transient dock page

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ShellViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ShellViewModel.cs
@@ -500,6 +500,18 @@ public partial class ShellViewModel : ObservableObject,
         WeakReferenceMessenger.Default.Send<GoHomeMessage>(new(withAnimation, focusSearch));
     }
 
+    /// <summary>
+    /// Resets navigation to the root page, clearing any transient state.
+    /// Use when entering from a hotkey while the palette may already be
+    /// showing a transient dock page.
+    /// </summary>
+    public void ResetToHome()
+    {
+        _currentlyTransient = false;
+        _rootPageService.GoHome();
+        WeakReferenceMessenger.Default.Send<PerformCommandMessage>(new(new ExtensionObject<ICommand>(_rootPage)));
+    }
+
     public void GoBack(bool withAnimation = true, bool focusSearch = true)
     {
         WeakReferenceMessenger.Default.Send<GoBackMessage>(new(withAnimation, focusSearch));

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
@@ -448,8 +448,9 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
                     if (isPage)
                     {
                         // If we're here, then the bound command was a page
-                        // of some kind. Let's pop the stack, show the window, and navigate to it.
-                        GoHome(false);
+                        // of some kind. Reset to root (clearing any transient dock state),
+                        // show the window, and navigate to it.
+                        ViewModel.ResetToHome();
 
                         WeakReferenceMessenger.Default.Send<ShowWindowMessage>(new(message.Hwnd));
                     }


### PR DESCRIPTION
## Summary

When a keyboard shortcut opens CmdPal to an extension while the palette is already showing a dock-launched transient page, `GoHome(false)` cannot restore the root page — the frame's back stack is empty because the transient dock page was never pushed on top of root. The user ends up with only the hotkey-target page in the frame with no way to navigate back to the main list.

## Root Cause

In `ShellPage.SummonOnUiThread()`, the hotkey-to-page branch called `GoHome(false)` before sending `ShowWindowMessage`. But when the active page is a transient dock page, `_currentlyTransient` is still `true` and the frame back stack is empty, so `GoHome` can't re-establish the root page as the frame base.

## Fix

Added `ResetToHome()` to `ShellViewModel`, mirroring the pattern already used in `WindowHiddenMessage` handling:
1. Clears `_currentlyTransient`
2. Calls `_rootPageService.GoHome()` to reset extension state
3. Sends `PerformCommandMessage` for `_rootPage` — navigating MainListPage into the frame as the base

In `ShellPage.SummonOnUiThread()`, the `GoHome(false)` call in the `isPage` branch is replaced with `ViewModel.ResetToHome()`. The root page is then cleanly in the frame before the hotkey target's `PerformCommandMessage` navigates on top of it.

Fixes #47994