### PR TITLE
CmdPal: Fix LayoutCycleException in gallery screenshot strip

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/ExtensionGalleryItemPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/ExtensionGalleryItemPage.xaml
@@ -332,7 +332,7 @@
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto" />
                                 <RowDefinition Height="Auto" />
-                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="232" />
                             </Grid.RowDefinitions>
 
                             <TextBlock
@@ -365,6 +365,7 @@
                                                 <SolidColorBrush x:Key="ItemContainerBackgroundPressed" Color="Transparent" />
                                             </ItemContainer.Resources>
                                             <Border
+                                                Width="356"
                                                 Height="200"
                                                 Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
                                                 BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"


### PR DESCRIPTION
Extension Gallery detail pages crash with `LayoutCycleException` / `AG_E_LAYOUT_CYCLE` when scrolling the screenshot strip horizontally on extensions that have many screenshots.

The screenshot `ItemsView` uses a horizontal `StackLayout` and is placed in a Grid row with `Height="Auto"`, inside a vertical `ScrollViewer`. The `ItemsView` itself contains an internal `ScrollView` for horizontal scrolling.

When screenshots load asynchronously (`BitmapImage` decode completes), this triggers a layout feedback loop:

1. Image decodes → `ItemContainer` re-measures
2. Auto-height Grid row re-measures, offering `ItemsView` new available height
3. `ItemsView`'s internal `ScrollView` recalculates extents
4. Parent Grid row invalidates → outer `ScrollViewer` re-layouts → re-measures children → back to step 1

To solve that, I made two XAML-only changes to `ExtensionGalleryItemPage.xaml`:

1. Changed the screenshot strip row from `Height="Auto"` to `Height="232"` (200px image + 16px top/bottom padding).
    - This means the parent no longer queries `ItemsView` for desired height, breaking the cycle.
2. Added `Width="356"` to the screenshot `Border` template (16:9 ratio: 200 × 16/9 ≈ 356) to provide a stable size before async image decode, preventing re-measure triggers.

Fixes #47901