### PR TITLE
CmdPal: Fix 1px gap between dock window and screen edge

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockWindow.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockWindow.xaml.cs
@@ -200,6 +200,11 @@ public sealed partial class DockWindow : WindowEx,
         {
             BOOL value = false;
             PInvoke.DwmSetWindowAttribute(_hwnd, DWMWINDOWATTRIBUTE.DWMWA_WINDOW_CORNER_PREFERENCE, &value, (uint)sizeof(BOOL));
+
+            // Remove the 1px accent border that Windows 11 DWM draws on all windows.
+            // DWMWA_BORDER_COLOR (34) set to DWMWA_COLOR_NONE (0xFFFFFFFE) hides it.
+            uint borderColorNone = 0xFFFFFFFE;
+            PInvoke.DwmSetWindowAttribute(_hwnd, (DWMWINDOWATTRIBUTE)34, &borderColorNone, (uint)sizeof(uint));
         }
     }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockWindow.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockWindow.xaml.cs
@@ -202,9 +202,9 @@ public sealed partial class DockWindow : WindowEx,
             PInvoke.DwmSetWindowAttribute(_hwnd, DWMWINDOWATTRIBUTE.DWMWA_WINDOW_CORNER_PREFERENCE, &value, (uint)sizeof(BOOL));
 
             // Remove the 1px accent border that Windows 11 DWM draws on all windows.
-            // DWMWA_BORDER_COLOR (34) set to DWMWA_COLOR_NONE (0xFFFFFFFE) hides it.
+            // DWMWA_COLOR_NONE (0xFFFFFFFE) instructs DWM to render no border color.
             uint borderColorNone = 0xFFFFFFFE;
-            PInvoke.DwmSetWindowAttribute(_hwnd, (DWMWINDOWATTRIBUTE)34, &borderColorNone, (uint)sizeof(uint));
+            PInvoke.DwmSetWindowAttribute(_hwnd, DWMWINDOWATTRIBUTE.DWMWA_BORDER_COLOR, &borderColorNone, (uint)sizeof(uint));
         }
     }
 


### PR DESCRIPTION
A 1-pixel gap was visible between the CmdPal dock window and the screen edge. Windows 11's DWM draws an accent border on all windows — including borderless ones — that's responsible for this gap.

`UpdateWindowFrame()` in `DockWindow.xaml.cs` already removes the window shadow/border via `ToggleWindowStyle` and disables rounded corners via `DWMWA_WINDOW_CORNER_PREFERENCE`, but it didn't suppress the DWM accent border introduced in Windows 11.

Added a `DwmSetWindowAttribute` call inside the existing `unsafe` block in `UpdateWindowFrame()` to set `DWMWA_BORDER_COLOR` (attribute 34) to `DWMWA_COLOR_NONE` (`0xFFFFFFFE`). This instructs DWM to render no border color, eliminating the 1px gap.

Fixes #47652
Fixes #48586