### PR TITLE
CmdPal: Fix bookmark dock bands disappearing on restart

### DIFF
--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Bookmark/BookmarksCommandProvider.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Bookmark/BookmarksCommandProvider.cs
@@ -168,4 +168,40 @@ public sealed partial class BookmarksCommandProvider : CommandProvider
 
         return bands.Count > 0 ? bands.ToArray() : null;
     }
+
+    public override ICommandItem? GetCommandItem(string id)
+    {
+        const string prefix = "Bookmarks.Launch.";
+        if (string.IsNullOrEmpty(id) || !id.StartsWith(prefix, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        var guidString = id.Substring(prefix.Length);
+        if (!Guid.TryParse(guidString, out var bookmarkId))
+        {
+            return null;
+        }
+
+        BookmarkData? bookmark;
+        lock (_bookmarksLock)
+        {
+            bookmark = _bookmarksManager.Bookmarks.FirstOrDefault(b => b.Id == bookmarkId);
+        }
+
+        if (bookmark is null)
+        {
+            return null;
+        }
+
+        var listItem = new BookmarkListItem(
+            bookmark,
+            _bookmarksManager,
+            _commandResolver,
+            _iconLocator,
+            _placeholderParser,
+            asBand: true);
+
+        return new WrappedDockItem(items: [listItem], id: id, displayTitle: listItem.BookmarkTitle);
+    }
 }


### PR DESCRIPTION
Bookmarks pinned to the dock disappear after a restart. That's because `BookmarksCommandProvider` does not override `GetCommandItem(string id)`. When `InitializeCommands` in `CommandProviderWrapper` processes pinned dock band settings, the fallback path calls `provider.GetCommandItem(commandId)`, which hit the base-class no-op returning `null`. Any bookmark band that `GetDockBands()` failed to return (due to a race, transient file error, or exception) was irreversibly lost from the dock.

Added a `GetCommandItem` override to `BookmarksCommandProvider`. Given a `"Bookmarks.Launch.{guid}"` ID, it:

1. Parses the GUID suffix
2. Looks up the `BookmarkData` in `_bookmarksManager` (under lock)
3. Constructs a `BookmarkListItem` (with `asBand: true`) and wraps it in a `WrappedDockItem`

Fixes #46270