### PR TITLE
CmdPal: Reorder dock network stats to match Task Manager order

### DIFF
--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceWidgetsPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceWidgetsPage.cs
@@ -268,8 +268,8 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
             };
 
             return _batteryItem is not null
-                ? new[] { _cpuItem!, _memoryItem!, _networkDownItem!, _networkUpItem!, _gpuItem!, _batteryItem! }
-                : new[] { _cpuItem!, _memoryItem!, _networkDownItem!, _networkUpItem!, _gpuItem! };
+                ? new[] { _cpuItem!, _memoryItem!, _networkUpItem!, _networkDownItem!, _gpuItem!, _batteryItem! }
+                : new[] { _cpuItem!, _memoryItem!, _networkUpItem!, _networkDownItem!, _gpuItem! };
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #47939

The Performance Monitor dock band displayed network stats as Receive → Send, but Task Manager shows Send → Receive. This swaps the order to match Task Manager.

## Changes

- `PerformanceWidgetsPage.cs`: Swap `_networkUpItem` (Send) before `_networkDownItem` (Receive) in the band items array.