### PR TITLE
CmdPal: Enable entrance animation for End dock bands

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockControl.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockControl.xaml
@@ -294,8 +294,7 @@
                     ItemsPanel="{StaticResource HorizontalItemsPanel}"
                     ItemsSource="{x:Bind ViewModel.EndItems, Mode=OneWay}"
                     SelectionMode="None"
-                    Style="{StaticResource DockBandListViewStyle}">
-                </ListView>
+                    Style="{StaticResource DockBandListViewStyle}" />
             </local:DockContentControl.EndSource>
             <local:DockContentControl.EndActionButton>
                 <Button

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockControl.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockControl.xaml
@@ -295,9 +295,6 @@
                     ItemsSource="{x:Bind ViewModel.EndItems, Mode=OneWay}"
                     SelectionMode="None"
                     Style="{StaticResource DockBandListViewStyle}">
-                    <ListView.ItemContainerTransitions>
-                        <TransitionCollection />
-                    </ListView.ItemContainerTransitions>
                 </ListView>
             </local:DockContentControl.EndSource>
             <local:DockContentControl.EndActionButton>


### PR DESCRIPTION
## Summary

Fixes #46767

Items pinned to the End section of the dock did not animate on startup, while Start and Center items did. The EndListView had an explicit empty `ItemContainerTransitions` collection that suppressed all container transitions. Removing it allows the default WinUI entrance animations to play, matching Start and Center behavior.

## Changes

- `DockControl.xaml`: Remove empty `TransitionCollection` override from EndListView