### PR TITLE
CmdPal: Fix settings page clipping on smaller windows

### DIFF
--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/CmdPalPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/CmdPalPage.xaml
@@ -17,12 +17,8 @@
             <Grid>
                 <Grid
                     MaxWidth="{StaticResource PageMaxWidth}"
-                    Padding="16,0,16,0"
+                    Padding="0"
                     VerticalAlignment="Top"
-                    Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-                    BorderThickness="1"
-                    CornerRadius="16"
                     RowSpacing="8">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
@@ -32,7 +28,7 @@
                         <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
                     <tkcontrols:OpacityMaskView
-                        Margin="-16,0,-16,0"
+                        Margin="0"
                         HorizontalAlignment="Stretch"
                         HorizontalContentAlignment="Stretch">
                         <tkcontrols:OpacityMaskView.OpacityMask>


### PR DESCRIPTION
## Summary

Fixes #46806

The Command Palette settings page used a unique card-style wrapper (`Background`, `BorderBrush`, `BorderThickness`, `CornerRadius=16`, `Padding=16,0,16,0`) that no other settings page uses. This consumed extra horizontal space and caused content to be cut off on smaller window sizes.

## Changes

- `CmdPalPage.xaml`: Remove card-style wrapper properties (`Background`, `BorderBrush`, `BorderThickness`, `CornerRadius`) from the inner content Grid
- `CmdPalPage.xaml`: Remove extra 16px horizontal padding
- `CmdPalPage.xaml`: Remove compensating `-16px` margin on OpacityMaskView

The hero section and all settings cards remain unchanged — only the outer wrapper styling is removed to match other settings pages.