### PR TITLE
CmdPal: Fix GPU index out of range crash in PerfMon widget

### DIFF
--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/DevHome/Helpers/GPUStats.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/DevHome/Helpers/GPUStats.cs
@@ -212,6 +212,11 @@ internal sealed partial class GPUStats : PerformanceCounterSourceBase, IDisposab
 
     internal string CreateGPUImageUrl(int gpuChartIndex)
     {
+        if (_stats.Count <= gpuChartIndex)
+        {
+            return string.Empty;
+        }
+
         return ChartHelper.CreateImageUrl(_stats[gpuChartIndex].GpuChartValues, ChartHelper.ChartType.GPU);
     }
 


### PR DESCRIPTION
## Summary

Fixes #47821

The GPU Performance Monitor widget crashes with `IndexOutOfRangeException` on systems where GPU performance counters fail to enumerate (common on Intel Arc and hybrid GPU configurations). The dock band shows `???` and opening the flyout causes an error.

## Root Cause

`GPUStats.CreateGPUImageUrl()` accessed `_stats[index]` without bounds checking. When `GetGPUPerfCounters()` finds no matching counter instances, `_stats` remains empty but callers still pass index 0.

`GetGPUName()`, `GetGPUUsage()`, and `GetGPUTemperature()` already have proper guards (`if (_stats.Count <= index) return ...`) — this fix adds the same pattern to the one remaining unguarded method.

## Changes

- `GPUStats.cs`: Add bounds check to `CreateGPUImageUrl()` — return empty string if index out of range