### PR TITLE
CmdPal: Fix dock hiding on Win+D (Show Desktop)

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockWindow.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockWindow.xaml.cs
@@ -753,6 +753,14 @@ public sealed partial class DockWindow : WindowEx,
     {
         DispatcherQueue.TryEnqueue(() =>
         {
+            if (message.BringToFront)
+            {
+                // Win+D (Show Desktop) on Windows 11 can cloak windows at the DWM
+                // level without triggering WM_SHOWWINDOW. SetWindowPos alone won't
+                // restore a cloaked window — we must explicitly show it first.
+                PInvoke.ShowWindow(_hwnd, SHOW_WINDOW_CMD.SW_SHOWNOACTIVATE);
+            }
+
             UpdateTopmostState(message.BringToFront);
         });
     }


### PR DESCRIPTION
## Summary

Fixes #47584

The CmdPal dock disappears when the user presses Win+D (Show Desktop), requiring a restart or re-trigger to bring it back.

## Root Cause

Windows 11's Show Desktop mechanism cloaks windows at the DWM level rather than sending traditional `WM_SHOWWINDOW` or `SC_MINIMIZE` messages. The dock's existing `ShowDesktop` hook correctly detects the event (via `EVENT_SYSTEM_FOREGROUND` on WorkerW/Progman) and calls `UpdateTopmostState(true)`, which uses `SetWindowPos(HWND_TOPMOST)`. However, `SetWindowPos` alone cannot restore a DWM-cloaked window's visibility.

## Fix

Call `ShowWindow(SW_SHOWNOACTIVATE)` in the `BringToTopMessage` handler when `BringToFront` is true. This uncloaks the window at the DWM level, then the existing `UpdateTopmostState` call positions it correctly above the desktop.