### PR TITLE
Add CmdPal debugging information

### DIFF
--- a/doc/devdocs/development/debugging.md
+++ b/doc/devdocs/development/debugging.md
@@ -97,6 +97,10 @@ The Shell Process Debugging Tool is a Visual Studio extension that helps debug m
 - Check Event Viewer for application crashes related to `PowerToys.Settings.exe`
 - Crash dumps can be obtained from Event Viewer
 
+### Debugging Command Palette
+Command Palette can be easily debugged using the solution filter in `src/modules/cmdpal/Command Palette.slnf`. This will open Command Palette as its own Visual Studio solution that can be run and debugged directly in Visual Studio without the need for the Shell Process Debugging Tool.
+
+
 ## Troubleshooting Build Errors
 
 ### Missing Image Files or Corrupted Build State


### PR DESCRIPTION
## Summary of the Pull Request
Adding information about using the Command Palette Visual Studio solution filter based on https://github.com/microsoft/PowerToys/issues/47997#issuecomment-4524045763.

## PR Checklist

- [ ] Closes: #47997 

## Detailed Description of the Pull Request / Additional comments
I found this really useful and couldn't see a reference to it anywhere else in the devdocs. Not sure if this is the best way to describe the process, but I think adding this information somewhere in the debugging doc would really help newcomers to CmdPal development!