### PR TITLE
[CmdPal][PerfMon] Use distinct up/down arrow icons for network Send/Receive

### DIFF
--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/Icons.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/Icons.cs
@@ -21,6 +21,10 @@ internal static class Icons
 
     internal static IconInfo NetworkIcon => new("\uEC05"); // Network icon
 
+    internal static IconInfo NetworkUpIcon => new("\uE74A"); // Up arrow icon
+
+    internal static IconInfo NetworkDownIcon => new("\uE74B"); // Down arrow icon
+
     internal static IconInfo StackedAreaIcon => new("\uE9D2"); // StackedArea icon
 
     internal static IconInfo GpuIcon => new("\uE950"); // Component icon

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceWidgetsPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceWidgetsPage.cs
@@ -257,6 +257,7 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
             {
                 Title = $"{_networkUpSpeed}",
                 Subtitle = Resources.GetResource("Network_Send_Subtitle"),
+                Icon = Icons.NetworkUpIcon,
                 MoreCommands = _networkPage!.Commands,
             };
 
@@ -264,6 +265,7 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
             {
                 Title = $"{_networkDownSpeed}",
                 Subtitle = Resources.GetResource("Network_Receive_Subtitle"),
+                Icon = Icons.NetworkDownIcon,
                 MoreCommands = _networkPage!.Commands,
             };
 

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/Strings/en-US/Resources.resw
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/Strings/en-US/Resources.resw
@@ -326,10 +326,10 @@
     <value>Open Task Manager</value>
   </data>
   <data name="Network_Send_Subtitle" xml:space="preserve">
-    <value>Send ↑</value>
+    <value>Send</value>
   </data>
   <data name="Network_Receive_Subtitle" xml:space="preserve">
-    <value>Receive ↓</value>
+    <value>Receive</value>
   </data>
   <data name="Network_Speed_Unit_Setting_Title" xml:space="preserve">
     <value>Network speed unit</value>


### PR DESCRIPTION
## Summary of the Pull Request

On the Command Palette Performance Monitor extension's Network widget page, the **Send** and **Receive** list items both used the generic `NetworkIcon` (`\uEC05`), making them visually indistinguishable at a glance.

This PR gives each direction its own glyph:
- Send → up arrow `\uE74A`
- Receive → down arrow `\uE74B`

The redundant `↑`/`↓` characters are removed from the Send/Receive subtitles since the icons now carry that meaning.

Before vs after:

<img width="918" height="122" alt="image" src="https://github.com/user-attachments/assets/4af3a2fc-d5a7-4fb5-98c6-f1889c7e80f2" />


## PR Checklist

- [x] **Closes:** N/A (no existing issue found)
- [x] **Communication:** I've discussed this with collaborators
- [x] **Tests:** Manually verified
- [x] **Localization:** Updated en-US resw (other locales still contain the arrow characters and can be translated/updated by the loc pipeline)

## Detailed Description of the Pull Request / Additional comments

Files changed:
- `Icons.cs` – added `NetworkUpIcon` and `NetworkDownIcon`
- `PerformanceWidgetsPage.cs` – set `Icon` on `_networkUpItem` and `_networkDownItem`
- `Strings/en-US/Resources.resw` – `Send ↑` → `Send`, `Receive ↓` → `Receive`

## Validation Steps Performed

Local visual verification in Command Palette.