### PR TITLE
Fix dock icons disappearing on discard after size change (#47253)

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Dock/DockViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Dock/DockViewModel.cs
@@ -638,13 +638,17 @@ public sealed partial class DockViewModel : IDisposable
     /// Restores the band order and label settings from the snapshot taken when entering edit mode.
     /// Call this when discarding edit mode changes.
     /// </summary>
-    public void RestoreBandOrder()
+    /// <returns>The restored DockSettings, or null if no snapshot exists.</returns>
+    public DockSettings? RestoreBandOrder()
     {
         if (_snapshotDockSettings == null || _snapshotBandViewModels == null)
         {
             Logger.LogWarning("No snapshot to restore from");
-            return;
+            return null;
         }
+
+        // Capture the snapshot before clearing
+        var restoredSettings = _snapshotDockSettings;
 
         // Restore ShowLabels for all snapshotted bands
         foreach (var band in _snapshotBandViewModels.Values)
@@ -658,10 +662,17 @@ public sealed partial class DockViewModel : IDisposable
         // Rebuild UI collections from restored settings using the snapshotted ViewModels
         RebuildUICollectionsFromSnapshot();
 
+        // Persist restored settings back to the service while _isEditing is still true,
+        // so that if SettingsChanged fires and calls UpdateSettings(), the _isEditing
+        // guard prevents redundant SetupBands() (we just rebuilt from snapshot).
+        SaveSettings();
+
         _snapshotDockSettings = null;
         _snapshotBandViewModels = null;
         _isEditing = false;
         Logger.LogDebug("Restored band order from snapshot");
+
+        return restoredSettings;
     }
 
     private void RebuildUICollectionsFromSnapshot()

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockControl.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockControl.xaml.cs
@@ -261,7 +261,12 @@ public sealed partial class DockControl : UserControl, IRecipient<CloseContextMe
         IsEditMode = false;
 
         // Restore the original band order from snapshot
-        ViewModel.RestoreBandOrder();
+        var restoredSettings = ViewModel.RestoreBandOrder();
+        if (restoredSettings != null)
+        {
+            // Sync DockControl state (DockSize, Side, etc.) to the restored settings
+            UpdateSettings(restoredSettings);
+        }
     }
 
     private void DoneEditingButton_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
When dock size is changed in CmdPal settings while the dock is in edit mode, `DockControl.DockSize` DP is updated but `ViewModel.UpdateSettings()` is blocked by `_isEditing`. On discard, `RestoreBandOrder()` restored the ViewModel settings but never synced `DockControl.DockSize` back, leaving the view in an inconsistent state.

This PR:

- Updates `RestoreBandOrder()` to now return the restored `DockSettings` and persists them to the service (while `_isEditing` is true to prevent redundant SetupBands).
- Also, `DiscardEditMode()` calls `UpdateSettings()` on DockControl with restored settings to sync DockSize/Side.

Fixes #47253