### PR TITLE
Fix project template settings heading

### DIFF
--- a/tools/project_template/README.md
+++ b/tools/project_template/README.md
@@ -153,7 +153,7 @@ Here's an example settings implementation:
   }
 ```
 
-### Settings Informations
+### Settings Information
 The PowerToys settings object supports adding additional information to a PowerToys Settings description:
 
 #### name


### PR DESCRIPTION
## Summary
- Fix a grammar typo in the PowerToy project template README heading.
- Change "Settings Informations" to "Settings Information".

## Validation
- Ran `git diff --check`.
