### PR TITLE
Remove our dependency on expected-lite

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "deps/expected-lite"]
-	path = deps/expected-lite
-	url = https://github.com/martinmoene/expected-lite.git

--- a/deps/expected.props
+++ b/deps/expected.props
@@ -1,7 +1,0 @@
-<Project>
-	<ItemDefinitionGroup>
-		<ClCompile>
-			<AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)expected-lite\include\nonstd\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-		</ClCompile>
-	</ItemDefinitionGroup>
-</Project>

--- a/src/ActionRunner/actionRunner.vcxproj
+++ b/src/ActionRunner/actionRunner.vcxproj
@@ -14,7 +14,6 @@
   <PropertyGroup Label="Configuration">
     
   </PropertyGroup>
-  <Import Project="$(RepoRoot)deps\expected.props" />
   <PropertyGroup>
     <ConfigurationType>Application</ConfigurationType>
   </PropertyGroup>

--- a/src/Update/PowerToys.Update.vcxproj
+++ b/src/Update/PowerToys.Update.vcxproj
@@ -14,7 +14,6 @@
   <PropertyGroup Label="Configuration">
     
   </PropertyGroup>
-  <Import Project="$(RepoRoot)deps\expected.props" />
   <PropertyGroup>
     <ConfigurationType>Application</ConfigurationType>
   </PropertyGroup>

--- a/src/common/updating/pch.h
+++ b/src/common/updating/pch.h
@@ -24,7 +24,7 @@
 #include <regex>
 #include <charconv>
 
-#include <expected.hpp>
+#include <nonstd/expected.hpp>
 
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Foundation.Collections.h>

--- a/src/common/updating/pch.h
+++ b/src/common/updating/pch.h
@@ -24,8 +24,6 @@
 #include <regex>
 #include <charconv>
 
-#include <nonstd/expected.hpp>
-
 #include <winrt/Windows.Foundation.h>
 #include <winrt/Windows.Foundation.Collections.h>
 #include <winrt/Windows.ApplicationModel.h>

--- a/src/common/updating/updating.cpp
+++ b/src/common/updating/updating.cpp
@@ -87,11 +87,7 @@ namespace updating
         // If the current version starts with 0.0.*, it means we're on a local build from a farm and shouldn't check for updates.
         if constexpr (VERSION_MAJOR == 0 && VERSION_MINOR == 0)
         {
-#if USE_STD_EXPECTED
             co_return std::unexpected(LOCAL_BUILD_ERROR);
-#else
-            co_return nonstd::make_unexpected(LOCAL_BUILD_ERROR);
-#endif
         }
 
         try
@@ -143,11 +139,7 @@ namespace updating
         catch (...)
         {
         }
-#if USE_STD_EXPECTED
         co_return std::unexpected(NETWORK_ERROR);
-#else
-        co_return nonstd::make_unexpected(NETWORK_ERROR);
-#endif
     }
 #pragma warning(pop)
 

--- a/src/common/updating/updating.h
+++ b/src/common/updating/updating.h
@@ -5,14 +5,7 @@
 #include <filesystem>
 #include <variant>
 #include <winrt/Windows.Foundation.h>
-//#if __MSVC_VERSION__ >= 1933 // MSVC begin to support std::unexpected in 19.33
-#if __has_include(<expected> ) // use the same way with excepted-lite to detect std::unexcepted, as using it as backup
 #include <expected>
-#define USE_STD_EXPECTED 1
-#else
-#include <expected.hpp>
-#define USE_STD_EXPECTED 0
-#endif
 
 #include <common/version/helper.h>
 #include <wil/coroutine.h>
@@ -31,12 +24,7 @@ namespace updating
         std::wstring installer_filename;
     };
     using github_version_info = std::variant<new_version_download_info, version_up_to_date>;
-
-#if USE_STD_EXPECTED
     using github_version_result = std::expected<github_version_info, std::wstring>;
-#else
-    using github_version_result = nonstd::expected<github_version_info, std::wstring>;
-#endif
 
     wil::task<github_version_result> get_github_version_info_async(bool prerelease = false);
     wil::task<std::optional<std::filesystem::path>> download_new_version_async(new_version_download_info new_version);

--- a/src/common/updating/updating.vcxproj
+++ b/src/common/updating/updating.vcxproj
@@ -9,7 +9,6 @@
     <ProjectName>ApplicationUpdate</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <Import Project="..\..\..\deps\expected.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     

--- a/src/runner/runner.vcxproj
+++ b/src/runner/runner.vcxproj
@@ -28,7 +28,6 @@
     <PackageReference Include="Microsoft.Windows.ImplementationLibrary" GeneratePathProperty="true" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <Import Project="$(RepoRoot)deps\expected.props" />
   <ImportGroup Label="Shared" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,7 +5,14 @@
   "homepage": "https://github.com/microsoft/PowerToys",
   "license": "MIT",
   "dependencies": [
-    "spdlog"
+    "spdlog",
+    "expected-lite"
+  ],
+  "overrides": [
+    {
+      "name": "expected-lite",
+      "version": "0.6.3"
+    }
   ],
   "builtin-baseline": "56bb2411609227288b70117ead2c47585ba07713"
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,14 +5,7 @@
   "homepage": "https://github.com/microsoft/PowerToys",
   "license": "MIT",
   "dependencies": [
-    "spdlog",
-    "expected-lite"
-  ],
-  "overrides": [
-    {
-      "name": "expected-lite",
-      "version": "0.6.3"
-    }
+    "spdlog"
   ],
   "builtin-baseline": "56bb2411609227288b70117ead2c47585ba07713"
 }


### PR DESCRIPTION
This removes our last git submodule dependency!

We were using `expected-lite` in one place, which was being compiled out _anyway_ in favor of using `std::expected`.