### PR TITLE
[PowerDisplay] Fix false-positive crash detection on cooperative shutdown

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -1970,6 +1970,7 @@ UNORM
 unparsable
 unremapped
 Unsend
+Unsubscribes
 untriaged
 unvirtualized
 unwide

--- a/src/modules/powerdisplay/PowerDisplay.Lib.UnitTests/CrashDetectionScopeTests.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Lib.UnitTests/CrashDetectionScopeTests.cs
@@ -1,0 +1,195 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PowerDisplay.Common.Services;
+
+namespace PowerDisplay.UnitTests;
+
+[TestClass]
+public class CrashDetectionScopeTests
+{
+    private string _tempDir = string.Empty;
+    private string _lockPath = string.Empty;
+
+    [TestInitialize]
+    public void SetUp()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"pd-scope-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _lockPath = Path.Combine(_tempDir, "discovery.lock");
+    }
+
+    [TestCleanup]
+    public void TearDown()
+    {
+        try
+        {
+            if (Directory.Exists(_tempDir))
+            {
+                Directory.Delete(_tempDir, recursive: true);
+            }
+        }
+        catch
+        {
+            // best-effort cleanup
+        }
+    }
+
+    private sealed class FakeProcessExitHook : IProcessExitHook
+    {
+        public List<EventHandler> Handlers { get; } = new();
+
+        public void Subscribe(EventHandler handler) => Handlers.Add(handler);
+
+        public void Unsubscribe(EventHandler handler) => Handlers.Remove(handler);
+
+        public void RaiseExit()
+        {
+            // Copy to tolerate handlers that mutate the list (e.g. self-unsubscribe).
+            foreach (var h in Handlers.ToList())
+            {
+                h(this, EventArgs.Empty);
+            }
+        }
+    }
+
+    [TestMethod]
+    public void Begin_WritesLockFileAtomically()
+    {
+        var hook = new FakeProcessExitHook();
+
+        using var scope = CrashDetectionScope.Begin(_lockPath, hook);
+
+        Assert.IsTrue(File.Exists(_lockPath), "lock file should exist after Begin");
+        Assert.IsFalse(File.Exists(_lockPath + ".tmp"), "temp file should not linger");
+    }
+
+    [TestMethod]
+    public void Begin_SubscribesToProcessExit()
+    {
+        var hook = new FakeProcessExitHook();
+
+        using var scope = CrashDetectionScope.Begin(_lockPath, hook);
+
+        Assert.AreEqual(1, hook.Handlers.Count, "Begin should subscribe exactly one ProcessExit handler");
+    }
+
+    [TestMethod]
+    public void Dispose_UnsubscribesFromProcessExit()
+    {
+        var hook = new FakeProcessExitHook();
+        var scope = CrashDetectionScope.Begin(_lockPath, hook);
+
+        scope.Dispose();
+
+        Assert.AreEqual(0, hook.Handlers.Count, "Dispose should unsubscribe the ProcessExit handler");
+    }
+
+    [TestMethod]
+    public void Dispose_DeletesLockFile()
+    {
+        var hook = new FakeProcessExitHook();
+        var scope = CrashDetectionScope.Begin(_lockPath, hook);
+        Assert.IsTrue(File.Exists(_lockPath));
+
+        scope.Dispose();
+
+        Assert.IsFalse(File.Exists(_lockPath), "Dispose should delete the lock file");
+    }
+
+    [TestMethod]
+    public void ProcessExitFired_BeforeDispose_DeletesLock()
+    {
+        var hook = new FakeProcessExitHook();
+        var scope = CrashDetectionScope.Begin(_lockPath, hook);
+        Assert.IsTrue(File.Exists(_lockPath));
+
+        // Simulate Environment.Exit firing ProcessExit while the scope is still alive
+        // (i.e. discovery is mid-flight, Dispose hasn't run).
+        hook.RaiseExit();
+
+        Assert.IsFalse(File.Exists(_lockPath), "ProcessExit handler should best-effort delete the lock");
+    }
+
+    [TestMethod]
+    public void ProcessExitFired_AfterDispose_DoesNothing()
+    {
+        var hook = new FakeProcessExitHook();
+        var scope = CrashDetectionScope.Begin(_lockPath, hook);
+
+        scope.Dispose();
+        Assert.IsFalse(File.Exists(_lockPath));
+
+        // Even if a stale handler somehow fires after Dispose, it must not throw.
+        // (In practice Dispose unsubscribed it; this guards against ordering races.)
+        hook.RaiseExit();
+
+        Assert.IsFalse(File.Exists(_lockPath), "lock should remain deleted");
+    }
+
+    [TestMethod]
+    public void Dispose_AfterProcessExit_DoesNotThrow()
+    {
+        var hook = new FakeProcessExitHook();
+        var scope = CrashDetectionScope.Begin(_lockPath, hook);
+
+        hook.RaiseExit();
+        Assert.IsFalse(File.Exists(_lockPath));
+
+        // Late Dispose (e.g. from a finally block on a still-running thread) must be safe.
+        scope.Dispose();
+
+        Assert.IsFalse(File.Exists(_lockPath));
+    }
+
+    [TestMethod]
+    public void ProcessExitFired_LockFileMissing_DoesNotThrow()
+    {
+        var hook = new FakeProcessExitHook();
+        var scope = CrashDetectionScope.Begin(_lockPath, hook);
+
+        // Simulate the lock being removed by something else first.
+        File.Delete(_lockPath);
+
+        // No exception expected — ProcessExit handlers must not throw or they'd
+        // disrupt the CLR shutdown sequence.
+        hook.RaiseExit();
+    }
+
+    [TestMethod]
+    public void Dispose_IsIdempotent()
+    {
+        var hook = new FakeProcessExitHook();
+        var scope = CrashDetectionScope.Begin(_lockPath, hook);
+
+        scope.Dispose();
+        scope.Dispose();
+
+        Assert.AreEqual(0, hook.Handlers.Count);
+    }
+
+    [TestMethod]
+    public void MultipleScopes_DoNotShareState()
+    {
+        var hook1 = new FakeProcessExitHook();
+        var path1 = Path.Combine(_tempDir, "lock1");
+        var path2 = Path.Combine(_tempDir, "lock2");
+
+        var scope1 = CrashDetectionScope.Begin(path1, hook1);
+        scope1.Dispose();
+
+        var hook2 = new FakeProcessExitHook();
+        using var scope2 = CrashDetectionScope.Begin(path2, hook2);
+
+        Assert.AreEqual(0, hook1.Handlers.Count, "first scope's handler should be unsubscribed");
+        Assert.AreEqual(1, hook2.Handlers.Count, "second scope should subscribe on its own hook");
+        Assert.IsFalse(File.Exists(path1));
+        Assert.IsTrue(File.Exists(path2));
+    }
+}

--- a/src/modules/powerdisplay/PowerDisplay.Lib/Services/CrashDetectionScope.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Lib/Services/CrashDetectionScope.cs
@@ -20,10 +20,22 @@ namespace PowerDisplay.Common.Services
     /// PowerDisplay.exe startup CrashRecovery detects the orphan and disables the module.
     ///
     /// On normal completion or .NET exception, Dispose() removes the lock.
+    ///
+    /// As a safety net for cooperative shutdowns (Runner's TerminateApp NamedPipe, Terminate
+    /// named event, tray-quit, Runner-exit detection, PowerToys upgrade), Begin() also
+    /// subscribes to <see cref="AppDomain.ProcessExit"/>. Those paths currently call
+    /// <see cref="Environment.Exit"/>, which terminates the process without unwinding
+    /// background-thread finally blocks — so without this hook the lock would orphan and
+    /// the next startup would false-positive. ProcessExit fires for Environment.Exit but
+    /// NOT for FailFast / BSOD / external TerminateProcess, which is exactly the partition
+    /// we want: cooperative exit → best-effort delete the lock; involuntary kill → leave the
+    /// lock for Phase 0 to detect.
     /// </summary>
     public sealed partial class CrashDetectionScope : IDisposable
     {
         private readonly string _lockPath;
+        private readonly IProcessExitHook _processExitHook;
+        private readonly EventHandler _processExitHandler;
         private int _disposedFlag;
 
         /// <summary>
@@ -35,9 +47,13 @@ namespace PowerDisplay.Common.Services
         /// </summary>
         /// <param name="lockPath">Override the default lock path. Defaults to
         /// <see cref="PathConstants.DiscoveryLockPath"/>. Test code passes a temp path.</param>
-        public static CrashDetectionScope Begin(string? lockPath = null)
+        /// <param name="processExitHook">Override the default <see cref="AppDomain.ProcessExit"/>
+        /// subscription. Test code passes a fake so it can simulate process exit without
+        /// terminating the test runner.</param>
+        public static CrashDetectionScope Begin(string? lockPath = null, IProcessExitHook? processExitHook = null)
         {
             var path = lockPath ?? PathConstants.DiscoveryLockPath;
+            var hook = processExitHook ?? AppDomainProcessExitHook.Instance;
 
             var dir = Path.GetDirectoryName(path);
             if (!string.IsNullOrEmpty(dir))
@@ -91,12 +107,39 @@ namespace PowerDisplay.Common.Services
             }
 
             Logger.LogInfo($"CrashDetectionScope: lock written at {path}");
-            return new CrashDetectionScope(path);
+            var scope = new CrashDetectionScope(path, hook);
+            hook.Subscribe(scope._processExitHandler);
+            return scope;
         }
 
-        private CrashDetectionScope(string lockPath)
+        private CrashDetectionScope(string lockPath, IProcessExitHook processExitHook)
         {
             _lockPath = lockPath;
+            _processExitHook = processExitHook;
+            _processExitHandler = OnProcessExit;
+        }
+
+        // Fired when the process is exiting cooperatively (Environment.Exit). Best-effort delete
+        // the lock so the next startup does not false-positive. Must not throw: ProcessExit
+        // handlers run inside the CLR shutdown sequence and any exception here disrupts it.
+        // Interlocked guards against a race with Dispose() — only one of the two wins and does
+        // the delete; the other returns early.
+        private void OnProcessExit(object? sender, EventArgs e)
+        {
+            if (Interlocked.Exchange(ref _disposedFlag, 1) != 0)
+            {
+                return;
+            }
+
+            try
+            {
+                File.Delete(_lockPath);
+            }
+            catch
+            {
+                // Worst case: false-positive on next start — same as today's behavior, so this
+                // hook is strictly an improvement.
+            }
         }
 
         public void Dispose()
@@ -105,6 +148,8 @@ namespace PowerDisplay.Common.Services
             {
                 return;
             }
+
+            _processExitHook.Unsubscribe(_processExitHandler);
 
             try
             {

--- a/src/modules/powerdisplay/PowerDisplay.Lib/Services/IProcessExitHook.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Lib/Services/IProcessExitHook.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace PowerDisplay.Common.Services
+{
+    /// <summary>
+    /// Abstraction over <see cref="AppDomain.ProcessExit"/> so <see cref="CrashDetectionScope"/>
+    /// can be unit-tested without invoking real process termination.
+    /// </summary>
+    public interface IProcessExitHook
+    {
+        void Subscribe(EventHandler handler);
+
+        void Unsubscribe(EventHandler handler);
+    }
+
+    /// <summary>
+    /// Default production implementation that bridges to <see cref="AppDomain.ProcessExit"/>.
+    /// </summary>
+    internal sealed class AppDomainProcessExitHook : IProcessExitHook
+    {
+        public static readonly AppDomainProcessExitHook Instance = new AppDomainProcessExitHook();
+
+        private AppDomainProcessExitHook()
+        {
+        }
+
+        public void Subscribe(EventHandler handler) => AppDomain.CurrentDomain.ProcessExit += handler;
+
+        public void Unsubscribe(EventHandler handler) => AppDomain.CurrentDomain.ProcessExit -= handler;
+    }
+}


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Cooperative shutdowns of `PowerDisplay.exe` — Runner's `TerminateApp` NamedPipe message, the `Terminate` named event, tray-quit, Runner-exit detection, and PowerToys upgrades — all call `Environment.Exit(0)` immediately. If DDC/CI discovery is mid-flight, that path skips the `try/finally` that owns `CrashDetectionScope`, leaving `discovery.lock` on disk. Phase 0 at the next `PowerDisplay.exe` startup then treats this orphan as evidence of a real crash and auto-disables the module, surfacing the "PowerDisplay has crashed" InfoBar in Settings UI.

This PR adds an `AppDomain.ProcessExit` safety-net inside `CrashDetectionScope`. ProcessExit fires for `Environment.Exit` but **not** for `FailFast` / BSOD / external `TerminateProcess` — exactly the partition we need: cooperative exit → best-effort delete the lock; involuntary kill → leave the lock for Phase 0 to detect (original design intent preserved).

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #48169
- [x] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** All end-user-facing strings can be localized <!-- no user-facing strings changed -->
- [x] **Dev docs:** Added/updated <!-- inline XML doc on CrashDetectionScope explains the ProcessExit partition -->
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

### Root cause

`CrashDetectionScope.Begin()` writes `discovery.lock` before DDC/CI capability fetch and `Dispose()` deletes it when the `using` block exits. The lock is intentionally designed to survive any code path that cannot run user-mode cleanup (BSOD, kernel OOM, `TerminateProcess`), so that the next `PowerDisplay.exe` start can see it and run Phase 0 (write `crash_detected.flag`, set `enabled.PowerDisplay=false` in global `settings.json`, signal `AutoDisablePowerDisplayEvent`).

The bug is that several **cooperative** shutdown paths route to `Environment.Exit(0)` immediately:

| Path | Code |
|---|---|
| Runner's `TerminateApp` NamedPipe | `App.xaml.cs::OnNamedPipeMessage` → `Shutdown()` → `Environment.Exit(0)` |
| `Terminate` named event | `App.xaml.cs::OnLaunched` → `RegisterEvent(..., () => Environment.Exit(0), "Terminate")` |
| Tray-quit | `TrayIconService` callback → `Environment.Exit(0)` |
| Runner-exit detection | `RunnerHelper.WaitForPowerToysRunner` callback → `Environment.Exit(0)` |

`Environment.Exit` calls `ExitProcess` under the hood, which terminates all threads abruptly. Background `Task.WhenAll` doing DDC capability fetch is killed mid-flight; the `finally` block that calls `scope.Dispose()` never runs; `discovery.lock` orphans; Phase 0 next time false-positives.

Concrete repro from logs:
- `15:08:42.510` lock written
- `15:08:42.79` probe monitor #1
- `15:08:46.92` probe monitor #2 (started, not finished — typical probe takes ~5s)
- `15:08:49.03` `TerminateApp` received → `Environment.Exit(0)` → no `Dispose` log line
- `15:10:10.03` next startup: Phase 0 sees orphan lock with `pid:17712, startedAt:2026-05-28T07:08:42Z` → writes `crash_detected.flag` → auto-disables

### Fix

`CrashDetectionScope.Begin()` now also subscribes to `AppDomain.CurrentDomain.ProcessExit`. The handler does a best-effort `File.Delete(_lockPath)` (swallowing exceptions, as required for ProcessExit handlers). `Dispose()` unsubscribes before deleting. An `Interlocked.Exchange` guards the race between Dispose and ProcessExit so only one of the two performs the delete.

ProcessExit's semantics match the cooperative/involuntary partition exactly:

| Shutdown path | ProcessExit fires? | Behavior after this PR |
|---|---|---|
| `Environment.Exit(code)` (all 4 paths above) | yes | lock deleted by handler |
| `Environment.FailFast` | no | lock survives → Phase 0 catches it (correct: explicit FailFast = real failure) |
| BSOD / external `TerminateProcess` / kernel OOM | no | lock survives → Phase 0 catches it (correct: original design) |
| Discovery completes normally / throws | n/a | `try/finally` calls `Dispose()` as before; handler unsubscribed first |

### Testability

A new `IProcessExitHook` interface abstracts the subscription so unit tests can simulate ProcessExit without terminating the test runner. Production code uses the default `AppDomainProcessExitHook` singleton; tests inject a fake whose `RaiseExit()` invokes subscribed handlers synchronously.

### Files touched

- `src/modules/powerdisplay/PowerDisplay.Lib/Services/IProcessExitHook.cs` *(new)* — interface + production singleton
- `src/modules/powerdisplay/PowerDisplay.Lib/Services/CrashDetectionScope.cs` — subscribe in `Begin`, unsubscribe in `Dispose`, add `OnProcessExit` handler, expanded class doc
- `src/modules/powerdisplay/PowerDisplay.Lib.UnitTests/CrashDetectionScopeTests.cs` *(new)* — 10 unit tests

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

### Automated

10 new unit tests in `CrashDetectionScopeTests`, all passing:

```
Passed Begin_WritesLockFileAtomically
Passed Begin_SubscribesToProcessExit
Passed Dispose_UnsubscribesFromProcessExit
Passed Dispose_DeletesLockFile
Passed ProcessExitFired_BeforeDispose_DeletesLock      (core scenario)
Passed ProcessExitFired_AfterDispose_DoesNothing
Passed Dispose_AfterProcessExit_DoesNotThrow
Passed ProcessExitFired_LockFileMissing_DoesNotThrow
Passed Dispose_IsIdempotent
Passed MultipleScopes_DoNotShareState
```

Full `PowerDisplay.Lib.UnitTests` suite: **129 / 132 passing**. The 3 failures (`DetectOrphanAndDisable_RunsFullSequenceWhenOrphanPresent`, `DetectOrphanAndDisable_HandlesUnknownVersionAsOrphan`, `DetectOrphanAndDisable_LeavesLockIntactOnSignalFailure`) are **pre-existing on `main`** — they fail with `REGDB_E_CLASSNOTREG` from `Constants.AutoDisablePowerDisplayEvent()` (WinRT activation factory not COM-registered in the test environment). Verified by stashing this PR's changes and re-running the same 3 tests on baseline `main` — same failures, same cause, unrelated to this change.

### Manual

1. Reproduced the original false-positive on `main`:
   - Enable PowerDisplay → open Settings UI → quickly toggle PowerDisplay off
   - Observe `discovery.lock` left in `%LOCALAPPDATA%\Microsoft\PowerToys\PowerDisplay\`
   - Re-enable PowerDisplay → Phase 0 writes `crash_detected.flag` → InfoBar appears
2. Repeated the same steps with this branch:
   - Toggling PowerDisplay off cleanly deletes `discovery.lock` (ProcessExit handler ran)
   - Re-enabling PowerDisplay shows no InfoBar, no `crash_detected.flag` created
3. BSOD path is unchanged (verified by inspecting the conditional logic — `AppDomain.ProcessExit` does not fire for involuntary terminations; the lock survives just as before).
