### PR TITLE
Remove "NEW" tag from Power Display and Grab and Move

### DIFF
--- a/src/settings-ui/Settings.UI/OOBE/ViewModel/OobeShellViewModel.cs
+++ b/src/settings-ui/Settings.UI/OOBE/ViewModel/OobeShellViewModel.cs
@@ -36,7 +36,7 @@ namespace Microsoft.PowerToys.Settings.UI.OOBE.ViewModel
             (PowerToysModules.MouseUtils, false),
             (PowerToysModules.MouseWithoutBorders, false),
             (PowerToysModules.Peek, false),
-            (PowerToysModules.PowerDisplay, true),
+            (PowerToysModules.PowerDisplay, false),
             (PowerToysModules.PowerRename, false),
             (PowerToysModules.Run, false),
             (PowerToysModules.QuickAccent, false),

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/ShellPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/ShellPage.xaml
@@ -263,9 +263,6 @@
                     AutomationProperties.AutomationId="WindowingAndLayoutsNavItem"
                     Icon="{ui:BitmapIcon Source=/Assets/Settings/Icons/WindowingAndLayouts.png}"
                     SelectsOnInvoked="False">
-                    <NavigationViewItem.InfoBadge>
-                        <InfoBadge Style="{StaticResource NewInfoBadge}" />
-                    </NavigationViewItem.InfoBadge>
                     <NavigationViewItem.MenuItems>
                         <NavigationViewItem
                             x:Name="AlwaysOnTopNavigationItem"
@@ -290,11 +287,7 @@
                             x:Uid="Shell_GrabAndMove"
                             helpers:NavHelper.NavigateTo="views:GrabAndMovePage"
                             AutomationProperties.AutomationId="GrabAndMoveNavItem"
-                            Icon="{ui:BitmapIcon Source=/Assets/Settings/Icons/GrabAndMove.png}">
-                            <NavigationViewItem.InfoBadge>
-                                <InfoBadge Style="{StaticResource NewInfoBadge}" />
-                            </NavigationViewItem.InfoBadge>
-                        </NavigationViewItem>
+                            Icon="{ui:BitmapIcon Source=/Assets/Settings/Icons/GrabAndMove.png}" />
                         <NavigationViewItem
                             x:Name="WorkspacesNavigationItem"
                             x:Uid="Shell_Workspaces"
@@ -311,9 +304,6 @@
                     AutomationProperties.AutomationId="InputOutputNavItem"
                     Icon="{ui:BitmapIcon Source=/Assets/Settings/Icons/InputOutput.png}"
                     SelectsOnInvoked="False">
-                    <NavigationViewItem.InfoBadge>
-                        <InfoBadge Style="{StaticResource NewInfoBadge}" />
-                    </NavigationViewItem.InfoBadge>
                     <NavigationViewItem.MenuItems>
                         <NavigationViewItem
                             x:Name="KeyboardManagerNavigationItem"
@@ -338,11 +328,7 @@
                             x:Uid="Shell_PowerDisplay"
                             helpers:NavHelper.NavigateTo="views:PowerDisplayPage"
                             AutomationProperties.AutomationId="PowerDisplayNavItem"
-                            Icon="{ui:BitmapIcon Source=/Assets/Settings/Icons/PowerDisplay.png}">
-                            <NavigationViewItem.InfoBadge>
-                                <InfoBadge Style="{StaticResource NewInfoBadge}" />
-                            </NavigationViewItem.InfoBadge>
-                        </NavigationViewItem>
+                            Icon="{ui:BitmapIcon Source=/Assets/Settings/Icons/PowerDisplay.png}" />
                         <NavigationViewItem
                             x:Name="QuickAccentNavigationItem"
                             x:Uid="Shell_QuickAccent"


### PR DESCRIPTION
## Summary of the Pull Request
Both Power Display and Grab and Move have matured beyond their initial release phase. This removes the "NEW" `InfoBadge` from their navigation items in Settings, the two parent navigation groups (Windowing & Layouts, Input / Output) that surfaced the badge when collapsed, and clears the `IsNew` flag for Power Display in the OOBE shell.

<img width="1867" height="973" alt="image" src="https://github.com/user-attachments/assets/533f271c-c70f-414f-a76a-43fd9ffbbd44" />
<img width="497" height="575" alt="image" src="https://github.com/user-attachments/assets/fe1e97c3-c806-4f42-a836-76e042630d61" />
<img width="1619" height="1027" alt="image" src="https://github.com/user-attachments/assets/f5db715b-bc69-4505-803a-18a9b2716280" />


## PR Checklist

- [x] Closes: #48153
- [x] **Communication:** Tracked by the linked issue
- [x] **Tests:** Markup-only change; Settings.UI builds clean with WinUI markup compiler (no XAML errors)
- [x] **Localization:** No end-user-facing strings changed
- [ ] **Dev docs:** N/A
- [ ] **New binaries:** N/A
- [ ] **Documentation updated:** N/A

## Detailed Description of the Pull Request / Additional comments
Files touched:
- `src/settings-ui/Settings.UI/SettingsXAML/Views/ShellPage.xaml` — removed four `<InfoBadge Style="{StaticResource NewInfoBadge}" />` blocks on `GrabAndMoveNavigationItem`, `PowerDisplayNavigationItem`, and on the two parent group headers `WindowingAndLayoutsNavigationItem` and `InputOutputNavigationItem` (the parent badges existed only to surface a NEW child when the group was collapsed; with no NEW children left in those groups, the parent badges are now stale).
- `src/settings-ui/Settings.UI/OOBE/ViewModel/OobeShellViewModel.cs` — flipped `(PowerToysModules.PowerDisplay, true)` to `(PowerToysModules.PowerDisplay, false)`. Grab and Move was already `false`.

No other modules or strings affected.

## Validation Steps Performed
- Built `src\settings-ui\Settings.UI\PowerToys.Settings.csproj` (Release|x64) with MSBuild from VS 18 Enterprise; `PowerToys.Settings.dll` produced with 0 errors related to this change. WinUI markup compiler would have aborted before producing the DLL if the XAML had syntax issues.
- Diff inspected: only the five intended deletions/edits, no collateral changes.
- Visual run-time verification of the Settings navigation pane is recommended before merge.