### PR TITLE
[CmdPal] Animated notification

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -24,7 +24,7 @@ advancedpaste
 advapi
 advfirewall
 AFeature
-affordances
+affordance
 afterfx
 AFX
 agentskills
@@ -466,13 +466,12 @@ DWMNCRENDERINGCHANGED
 Dwmp
 DWMSENDICONICLIVEPREVIEWBITMAP
 DWMSENDICONICTHUMBNAIL
-DWMWA
-DWMWCP
+dwmwa
+dwmwcp
 DWMWINDOWATTRIBUTE
 DWMWINDOWMAXIMIZEDCHANGE
 DWORDLONG
 dworigin
-DWRITE
 dxgi
 Dxva
 eab
@@ -998,7 +997,6 @@ luid
 lusrmgr
 LVDS
 LWA
-LWIN
 LZero
 MAGTRANSFORM
 makeappx
@@ -1208,7 +1206,6 @@ nonclient
 NONCLIENTMETRICSW
 NONELEVATED
 nonspace
-nonstd
 NOOWNERZORDER
 NOPARENTNOTIFY
 NOPREFIX
@@ -2000,7 +1997,6 @@ valuegenerator
 VARTYPE
 vbcscompiler
 vcamp
-VCENTER
 vcgtq
 VCINSTALLDIR
 vcp
@@ -2038,7 +2034,6 @@ vorrq
 VOS
 vpaddlq
 vqsubq
-VREDRAW
 vreinterpretq
 VSC
 VSCBD

--- a/src/common/Common.UI.Controls/Backdrops/AlwaysActiveDesktopAcrylicBackdrop.cs
+++ b/src/common/Common.UI.Controls/Backdrops/AlwaysActiveDesktopAcrylicBackdrop.cs
@@ -1,0 +1,103 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Microsoft.UI.Composition;
+using Microsoft.UI.Composition.SystemBackdrops;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Media;
+
+namespace Microsoft.PowerToys.Common.UI.Controls.Backdrops;
+
+/// <summary>
+/// A <see cref="SystemBackdrop"/> that renders desktop acrylic and stays in
+/// the active visual state even when the hosting window is not activated.
+/// </summary>
+/// <remarks>
+/// The built-in <see cref="DesktopAcrylicBackdrop"/> tracks the host window's
+/// <c>IsInputActive</c> state and falls back to a solid color whenever the
+/// window is not the foreground window. That makes it unusable for transient,
+/// non-activating surfaces such as toasts or popups created with
+/// <c>SW_SHOWNA</c> / <c>WS_EX_TRANSPARENT</c>, where the window is never
+/// activated by design.
+///
+/// This backdrop drives a <see cref="DesktopAcrylicController"/> with a
+/// <see cref="SystemBackdropConfiguration"/> whose <c>IsInputActive</c> is
+/// permanently <see langword="true"/>, so the native acrylic effect is always
+/// rendered.
+/// </remarks>
+public sealed partial class AlwaysActiveDesktopAcrylicBackdrop : SystemBackdrop
+{
+    private readonly Dictionary<ICompositionSupportsSystemBackdrop, BackdropTarget> _targets = new();
+
+    protected override void OnTargetConnected(ICompositionSupportsSystemBackdrop connectedTarget, XamlRoot xamlRoot)
+    {
+        base.OnTargetConnected(connectedTarget, xamlRoot);
+
+        var configuration = new SystemBackdropConfiguration
+        {
+            IsInputActive = true,
+            Theme = ResolveTheme(xamlRoot),
+        };
+
+        var controller = new DesktopAcrylicController();
+        controller.SetSystemBackdropConfiguration(configuration);
+        controller.AddSystemBackdropTarget(connectedTarget);
+
+        var target = new BackdropTarget(controller, configuration, xamlRoot);
+        _targets[connectedTarget] = target;
+
+        if (xamlRoot.Content is FrameworkElement rootElement)
+        {
+            rootElement.ActualThemeChanged += target.OnActualThemeChanged;
+        }
+    }
+
+    protected override void OnTargetDisconnected(ICompositionSupportsSystemBackdrop disconnectedTarget)
+    {
+        base.OnTargetDisconnected(disconnectedTarget);
+
+        if (_targets.Remove(disconnectedTarget, out var target))
+        {
+            if (target.XamlRoot.Content is FrameworkElement rootElement)
+            {
+                rootElement.ActualThemeChanged -= target.OnActualThemeChanged;
+            }
+
+            target.Controller.RemoveSystemBackdropTarget(disconnectedTarget);
+            target.Controller.Dispose();
+        }
+    }
+
+    private static SystemBackdropTheme ResolveTheme(XamlRoot xamlRoot) =>
+        xamlRoot.Content is FrameworkElement rootElement
+            ? rootElement.ActualTheme switch
+            {
+                ElementTheme.Dark => SystemBackdropTheme.Dark,
+                ElementTheme.Light => SystemBackdropTheme.Light,
+                _ => SystemBackdropTheme.Default,
+            }
+            : SystemBackdropTheme.Default;
+
+    private sealed class BackdropTarget
+    {
+        public BackdropTarget(DesktopAcrylicController controller, SystemBackdropConfiguration configuration, XamlRoot xamlRoot)
+        {
+            Controller = controller;
+            Configuration = configuration;
+            XamlRoot = xamlRoot;
+        }
+
+        public DesktopAcrylicController Controller { get; }
+
+        public SystemBackdropConfiguration Configuration { get; }
+
+        public XamlRoot XamlRoot { get; }
+
+        public void OnActualThemeChanged(FrameworkElement sender, object args)
+        {
+            Configuration.Theme = ResolveTheme(XamlRoot);
+        }
+    }
+}

--- a/src/common/Common.UI.Controls/Common.UI.Controls.csproj
+++ b/src/common/Common.UI.Controls/Common.UI.Controls.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.WindowsAppSDK" />
     <PackageReference Include="WinUIEx" />
+    <PackageReference Include="CommunityToolkit.WinUI.Animations" />
     <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" />
     <PackageReference Include="CommunityToolkit.WinUI.Extensions" />
     <PackageReference Include="CommunityToolkit.WinUI.Converters" />

--- a/src/common/Common.UI.Controls/Controls/TransparentCard/TransparentCard.cs
+++ b/src/common/Common.UI.Controls/Controls/TransparentCard/TransparentCard.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.UI.Xaml.Controls;
+
+namespace Microsoft.PowerToys.Common.UI.Controls;
+
+/// <summary>
+/// A floating "card" surface for transient PowerToys overlays (toasts,
+/// banners, indicators). Provides the PowerToys-standard chrome — 1 px
+/// border in <c>SurfaceStrokeColorDefaultBrush</c>, 8 px corner radius,
+/// a <c>ThemeShadow</c>, and an always-active desktop acrylic backdrop —
+/// via a default <see cref="Microsoft.UI.Xaml.Controls.ControlTemplate"/>.
+/// </summary>
+/// <remarks>
+/// Lives inside a <see cref="Window.TransparentWindow"/>. Apps that want a
+/// different look supply their own <c>Style TargetType="TransparentCard"</c>
+/// in resources — the standard WinUI restyle path.
+/// </remarks>
+public sealed partial class TransparentCard : ContentControl
+{
+    public TransparentCard()
+    {
+        DefaultStyleKey = typeof(TransparentCard);
+    }
+}

--- a/src/common/Common.UI.Controls/Controls/TransparentCard/TransparentCard.xaml
+++ b/src/common/Common.UI.Controls/Controls/TransparentCard/TransparentCard.xaml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:backdrops="using:Microsoft.PowerToys.Common.UI.Controls.Backdrops"
+    xmlns:local="using:Microsoft.PowerToys.Common.UI.Controls">
+
+    <Style BasedOn="{StaticResource DefaultTransparentCardStyle}" TargetType="local:TransparentCard" />
+
+    <Style x:Key="DefaultTransparentCardStyle" TargetType="local:TransparentCard">
+        <Setter Property="BorderBrush" Value="{ThemeResource SurfaceStrokeColorDefaultBrush}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="CornerRadius" Value="8" />
+        <Setter Property="IsTabStop" Value="False" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="VerticalContentAlignment" Value="Stretch" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="local:TransparentCard">
+                    <Grid
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        CornerRadius="{TemplateBinding CornerRadius}"
+                        Translation="0,0,24">
+                        <Grid.Shadow>
+                            <ThemeShadow />
+                        </Grid.Shadow>
+                        <SystemBackdropElement CornerRadius="{TemplateBinding CornerRadius}">
+                            <SystemBackdropElement.SystemBackdrop>
+                                <backdrops:AlwaysActiveDesktopAcrylicBackdrop />
+                            </SystemBackdropElement.SystemBackdrop>
+                        </SystemBackdropElement>
+                        <ContentPresenter
+                            Padding="{TemplateBinding Padding}"
+                            HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                            VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                            Content="{TemplateBinding Content}"
+                            ContentTemplate="{TemplateBinding ContentTemplate}" />
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+</ResourceDictionary>

--- a/src/common/Common.UI.Controls/Themes/Generic.xaml
+++ b/src/common/Common.UI.Controls/Themes/Generic.xaml
@@ -4,5 +4,6 @@
         <ResourceDictionary Source="ms-appx:///PowerToys.Common.UI.Controls/Controls/KeyVisual/KeyCharPresenter.xaml" />
         <ResourceDictionary Source="ms-appx:///PowerToys.Common.UI.Controls/Controls/IsEnabledTextBlock/IsEnabledTextBlock.xaml" />
         <ResourceDictionary Source="ms-appx:///PowerToys.Common.UI.Controls/Controls/ShortcutWithTextLabelControl/ShortcutWithTextLabelControl.xaml" />
+        <ResourceDictionary Source="ms-appx:///PowerToys.Common.UI.Controls/Controls/TransparentCard/TransparentCard.xaml" />
     </ResourceDictionary.MergedDictionaries>
 </ResourceDictionary>

--- a/src/common/Common.UI.Controls/Window/TransparentWindow.cs
+++ b/src/common/Common.UI.Controls/Window/TransparentWindow.cs
@@ -1,0 +1,290 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using CommunityToolkit.WinUI;
+using CommunityToolkit.WinUI.Animations;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Windowing;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Markup;
+using WinUIEx;
+
+namespace Microsoft.PowerToys.Common.UI.Controls.Window;
+
+/// <summary>
+/// Reusable transparent host window for transient overlays
+/// (toasts, banners, indicators) that should not steal foreground.
+/// </summary>
+/// <remarks>
+/// <para>The constructor applies all of the boilerplate that PowerToys overlays
+/// currently hand-roll:</para>
+/// <list type="bullet">
+///   <item>Strip the native frame and caption (<c>WS_THICKFRAME</c> etc.).</item>
+///   <item>Disable the Win11 1-pixel DWM border and corner rounding.</item>
+///   <item>Mark the window as a tool window so it stays out of the taskbar and Alt-Tab.</item>
+///   <item>Extend content into the title bar and collapse the title bar.</item>
+/// </list>
+/// <para>The visible chrome (acrylic + border + corner radius + shadow) lives
+/// in a <see cref="TransparentCard"/> that the constructor assigns to
+/// <see cref="Microsoft.UI.Xaml.Window.Content"/>. Consumers supply their own
+/// UI via <see cref="InnerContent"/> — which is the XAML default-content slot
+/// thanks to <see cref="ContentPropertyAttribute"/> — so a derived window can
+/// be written as <c>&lt;common:TransparentWindow&gt;&lt;TextBlock/&gt;&lt;/common:TransparentWindow&gt;</c>.</para>
+/// <para>Transparency is achieved with a <see cref="TransparentTintBackdrop"/>
+/// system backdrop so the area outside the <see cref="TransparentCard"/> is
+/// fully see-through. That buffer area is NOT click-through, so consumers
+/// should keep it as small as possible (just enough to give the card's
+/// shadow + slide animation room to breathe — roughly 24 px on each side).</para>
+/// <para><see cref="Show"/> and <see cref="Hide"/> coordinate <c>SW_SHOWNA</c>
+/// (no-activate), the <see cref="Microsoft.UI.Xaml.UIElement.Visibility"/>
+/// toggle on the card, and a debounced
+/// <see cref="Microsoft.UI.Windowing.AppWindow.Hide"/> sized from the longest
+/// animation in <see cref="HideAnimations"/>. Animations target the card so
+/// the entire surface (border, acrylic, shadow, inner content) slides as one.</para>
+/// </remarks>
+[ContentProperty(Name = nameof(InnerContent))]
+public partial class TransparentWindow : WinUIEx.WindowEx
+{
+    private const uint DwmwaColorNone = 0xFFFFFFFE;
+    private const int DwmwaWindowCornerPreference = 33;
+    private const int DwmwaBorderColor = 34;
+    private const int DwmwcpDoNotRound = 1;
+
+    private const int GwlExStyle = -20;
+    private const int WsExToolWindow = 0x00000080;
+
+    private const int SwShowNa = 8;
+
+    private readonly DispatcherQueueTimer _hideCloseTimer = DispatcherQueue.GetForCurrentThread().CreateTimer();
+    private readonly nint _hwnd;
+    private readonly TransparentCard _card;
+
+    private ImplicitAnimationSet _showAnimations;
+    private ImplicitAnimationSet _hideAnimations;
+
+    public TransparentWindow()
+    {
+        AppWindow.Hide();
+        ExtendsContentIntoTitleBar = true;
+        AppWindow.TitleBar.PreferredHeightOption = TitleBarHeightOption.Collapsed;
+
+        _hwnd = WinRT.Interop.WindowNative.GetWindowHandle(this);
+
+        HwndExtensions.ToggleWindowStyle(_hwnd, false, WindowStyle.TiledWindow);
+
+        unsafe
+        {
+            uint borderColor = DwmwaColorNone;
+            _ = DwmSetWindowAttribute(_hwnd, DwmwaBorderColor, &borderColor, sizeof(uint));
+
+            int cornerPref = DwmwcpDoNotRound;
+            _ = DwmSetWindowAttribute(_hwnd, DwmwaWindowCornerPreference, &cornerPref, sizeof(int));
+        }
+
+        ApplyExStyleBit(WsExToolWindow, true);
+
+        _showAnimations = BuildDefaultShowAnimations();
+        _hideAnimations = BuildDefaultHideAnimations();
+
+        _card = new TransparentCard();
+        Content = _card;
+
+        SystemBackdrop = new TransparentTintBackdrop();
+    }
+
+    /// <summary>
+    /// Gets the <see cref="TransparentCard"/> that provides the window's
+    /// visible chrome (acrylic + border + shadow). Consumers can configure
+    /// its layout (e.g. <c>HorizontalAlignment</c>, <c>VerticalAlignment</c>,
+    /// <c>MaxWidth</c>, <c>Margin</c>) to position the card inside the
+    /// window, or apply a custom <c>Style</c> to change its look.
+    /// </summary>
+    public TransparentCard Card => _card;
+
+    /// <summary>
+    /// Gets or sets the visual hosted inside the window's
+    /// <see cref="TransparentCard"/>. This is the XAML default-content slot:
+    /// child elements declared between the opening and closing
+    /// <c>TransparentWindow</c> tags in a derived .xaml are routed here.
+    /// </summary>
+    public object? InnerContent
+    {
+        get => _card.Content;
+        set => _card.Content = value;
+    }
+
+    /// <summary>
+    /// Gets or sets the animations played against
+    /// <see cref="Microsoft.UI.Xaml.Window.Content"/> when <see cref="Show"/>
+    /// flips it to <see cref="Visibility.Visible"/>. Defaults to a 200 ms
+    /// fade-in plus a 250 ms slide-up of 24 px.
+    /// </summary>
+    public ImplicitAnimationSet ShowAnimations
+    {
+        get => _showAnimations;
+        set => _showAnimations = value ?? new ImplicitAnimationSet();
+    }
+
+    /// <summary>
+    /// Gets or sets the animations played against
+    /// <see cref="Microsoft.UI.Xaml.Window.Content"/> when <see cref="Hide"/>
+    /// flips it to <see cref="Visibility.Collapsed"/>. Defaults to a 180 ms
+    /// fade-out plus a 180 ms slide-down of 12 px.
+    /// </summary>
+    public ImplicitAnimationSet HideAnimations
+    {
+        get => _hideAnimations;
+        set => _hideAnimations = value ?? new ImplicitAnimationSet();
+    }
+
+    /// <summary>
+    /// Shows the window without activation (<c>SW_SHOWNA</c>) and flips
+    /// <see cref="Microsoft.UI.Xaml.Window.Content"/> to
+    /// <see cref="Visibility.Visible"/> so <see cref="ShowAnimations"/> plays.
+    /// Repeated calls reset the content to its hidden pose first so the show
+    /// animation re-triggers cleanly. Any pending hide is cancelled.
+    /// </summary>
+    public void Show()
+    {
+        DispatcherQueue.TryEnqueue(
+            DispatcherQueuePriority.Low,
+            () =>
+            {
+                _hideCloseTimer.Stop();
+
+                if (Content is UIElement content)
+                {
+                    // Re-apply each call so swapping animation collections at
+                    // runtime takes effect on the next show/hide cycle.
+                    Implicit.SetShowAnimations(content, _showAnimations);
+                    Implicit.SetHideAnimations(content, _hideAnimations);
+
+                    // Reset to the hidden pose so the show animation always
+                    // animates from the configured starting frame.
+                    content.Visibility = Visibility.Collapsed;
+                }
+
+                _ = ShowWindow(_hwnd, SwShowNa);
+
+                if (Content is UIElement c2)
+                {
+                    c2.Visibility = Visibility.Visible;
+                }
+            });
+    }
+
+    /// <summary>
+    /// Flips <see cref="Microsoft.UI.Xaml.Window.Content"/> to
+    /// <see cref="Visibility.Collapsed"/> so <see cref="HideAnimations"/>
+    /// plays, then hides the underlying
+    /// <see cref="Microsoft.UI.Windowing.AppWindow"/> once the longest
+    /// animation in <see cref="HideAnimations"/> (delay + duration) has
+    /// completed.
+    /// </summary>
+    public void Hide()
+    {
+        DispatcherQueue.TryEnqueue(
+            DispatcherQueuePriority.Low,
+            () =>
+            {
+                if (Content is UIElement content)
+                {
+                    content.Visibility = Visibility.Collapsed;
+                }
+
+                _hideCloseTimer.Debounce(
+                    AppWindow.Hide,
+                    interval: GetAnimationSetTotalDuration(_hideAnimations),
+                    immediate: false);
+            });
+    }
+
+    private static TimeSpan GetAnimationSetTotalDuration(ImplicitAnimationSet set)
+    {
+        TimeSpan longest = TimeSpan.Zero;
+        foreach (var animation in set)
+        {
+            if (animation is Animation anim)
+            {
+                var total = (anim.Delay ?? TimeSpan.Zero) + (anim.Duration ?? TimeSpan.Zero);
+                if (total > longest)
+                {
+                    longest = total;
+                }
+            }
+        }
+
+        return longest;
+    }
+
+    private void ApplyExStyleBit(int bit, bool set)
+    {
+        if (_hwnd == 0)
+        {
+            return;
+        }
+
+        nint exStyle = GetWindowLongPtr(_hwnd, GwlExStyle);
+        nint updated = set ? exStyle | bit : exStyle & ~(nint)bit;
+        if (updated != exStyle)
+        {
+            _ = SetWindowLongPtr(_hwnd, GwlExStyle, updated);
+        }
+    }
+
+    private static ImplicitAnimationSet BuildDefaultShowAnimations() => new()
+    {
+        new OpacityAnimation
+        {
+            From = 0,
+            To = 1.0,
+            Duration = TimeSpan.FromMilliseconds(200),
+            EasingMode = Microsoft.UI.Xaml.Media.Animation.EasingMode.EaseOut,
+            EasingType = EasingType.Cubic,
+        },
+        new TranslationAnimation
+        {
+            From = "0,24,32",
+            To = "0,0,32",
+            Duration = TimeSpan.FromMilliseconds(250),
+            EasingMode = Microsoft.UI.Xaml.Media.Animation.EasingMode.EaseOut,
+            EasingType = EasingType.Cubic,
+        },
+    };
+
+    private static ImplicitAnimationSet BuildDefaultHideAnimations() => new()
+    {
+        new OpacityAnimation
+        {
+            From = 1.0,
+            To = 0,
+            Duration = TimeSpan.FromMilliseconds(180),
+            EasingMode = Microsoft.UI.Xaml.Media.Animation.EasingMode.EaseIn,
+            EasingType = EasingType.Cubic,
+        },
+        new TranslationAnimation
+        {
+            From = "0,0,32",
+            To = "0,12,32",
+            Duration = TimeSpan.FromMilliseconds(180),
+            EasingMode = Microsoft.UI.Xaml.Media.Animation.EasingMode.EaseIn,
+            EasingType = EasingType.Cubic,
+        },
+    };
+
+    [LibraryImport("user32.dll", EntryPoint = "GetWindowLongPtrW")]
+    private static partial nint GetWindowLongPtr(nint hWnd, int nIndex);
+
+    [LibraryImport("user32.dll", EntryPoint = "SetWindowLongPtrW")]
+    private static partial nint SetWindowLongPtr(nint hWnd, int nIndex, nint dwNewLong);
+
+    [LibraryImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool ShowWindow(nint hWnd, int nCmdShow);
+
+    [LibraryImport("dwmapi.dll")]
+    private static unsafe partial int DwmSetWindowAttribute(nint hwnd, int dwAttribute, void* pvAttribute, int cbAttribute);
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ToastWindow.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ToastWindow.xaml
@@ -1,24 +1,16 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<winuiex:WindowEx
+<?xml version="1.0" encoding="utf-8" ?>
+<common:TransparentWindow
     x:Class="Microsoft.CmdPal.UI.ToastWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:common="using:Microsoft.PowerToys.Common.UI.Controls.Window"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:Microsoft.CmdPal.UI"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:ui="using:CommunityToolkit.WinUI"
-    xmlns:winuiex="using:WinUIEx"
-    Title="Command Palette Toast"
     mc:Ignorable="d">
-    <winuiex:WindowEx.SystemBackdrop>
-        <DesktopAcrylicBackdrop />
-    </winuiex:WindowEx.SystemBackdrop>
-    <Grid x:Name="ToastGrid">
-        <!--  This padding is used to calculate the dimensions of the ToastWindow  -->
-        <TextBlock
-            x:Name="ToastText"
-            Padding="12,12,24,20"
-            Text="{x:Bind ViewModel.ToastMessage, Mode=OneWay}"
-            TextAlignment="Center" />
-    </Grid>
-</winuiex:WindowEx>
+    <TextBlock
+        Margin="16,10,20,12"
+        Text="{x:Bind ViewModel.ToastMessage, Mode=OneWay}"
+        TextAlignment="Center"
+        TextWrapping="Wrap" />
+</common:TransparentWindow>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ToastWindow.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ToastWindow.xaml.cs
@@ -2,107 +2,86 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using CommunityToolkit.Mvvm.Messaging;
 using CommunityToolkit.WinUI;
-using ManagedCommon;
 using Microsoft.CmdPal.UI.Helpers;
 using Microsoft.CmdPal.UI.ViewModels;
 using Microsoft.CmdPal.UI.ViewModels.Messages;
+using Microsoft.PowerToys.Common.UI.Controls.Window;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Windowing;
-using Windows.Win32;
-using Windows.Win32.Foundation;
-using Windows.Win32.Graphics.Gdi;
-using Windows.Win32.UI.HiDpi;
-using Windows.Win32.UI.WindowsAndMessaging;
 using WinUIEx;
 using RS_ = Microsoft.CmdPal.UI.Helpers.ResourceLoaderInstance;
 
 namespace Microsoft.CmdPal.UI;
 
-public sealed partial class ToastWindow : WindowEx,
+/// <summary>
+/// CmdPal's transient toast banner. Inherits all of its chrome, click-through,
+/// acrylic, and fade/slide animations from
+/// <see cref="TransparentWindow"/>; adds only the bits that are bespoke to
+/// CmdPal toasts: a bound message <c>TextBlock</c>, a 2.5 s auto-dismiss timer,
+/// bottom-center positioning, and <see cref="QuitMessage"/> handling.
+/// </summary>
+public sealed partial class ToastWindow : TransparentWindow,
     IRecipient<QuitMessage>
 {
-    private readonly HWND _hwnd;
-    private readonly DispatcherQueueTimer _debounceTimer = DispatcherQueue.GetForCurrentThread().CreateTimer();
-    private readonly HiddenOwnerWindowBehavior _hiddenOwnerWindowBehavior = new();
+    private static readonly TimeSpan VisibleDuration = TimeSpan.FromMilliseconds(2500);
+
+    private readonly DispatcherQueueTimer _autoHideTimer = DispatcherQueue.GetForCurrentThread().CreateTimer();
 
     public ToastViewModel ViewModel { get; } = new();
 
     public ToastWindow()
     {
         this.InitializeComponent();
-        AppWindow.Hide();
-        ExtendsContentIntoTitleBar = true;
-        AppWindow.SetPresenter(AppWindowPresenterKind.CompactOverlay);
         this.SetIcon();
         AppWindow.Title = RS_.GetString("ToastWindowTitle");
-        AppWindow.TitleBar.PreferredHeightOption = TitleBarHeightOption.Collapsed;
-        _hiddenOwnerWindowBehavior.ShowInTaskbar(this, false);
+        this.SetWindowSize(600, 180);
 
-        _hwnd = new HWND(WinRT.Interop.WindowNative.GetWindowHandle(this).ToInt32());
-        PInvoke.EnableWindow(_hwnd, false);
+        // Pin the chrome card to bottom-center with the toast's classic 560-wide
+        // pill shape. The window itself stays 600x180 so the slide animations
+        // have headroom and we don't have to chase SizeToContent.
+        Card.HorizontalAlignment = Microsoft.UI.Xaml.HorizontalAlignment.Center;
+        Card.VerticalAlignment = Microsoft.UI.Xaml.VerticalAlignment.Bottom;
+        Card.MaxWidth = 560;
+        Card.Margin = new Microsoft.UI.Xaml.Thickness(24, 24, 24, 16);
 
         WeakReferenceMessenger.Default.Register<QuitMessage>(this);
-    }
-
-    private static double GetScaleFactor(HWND hwnd)
-    {
-        try
-        {
-            var monitor = PInvoke.MonitorFromWindow(hwnd, MONITOR_FROM_FLAGS.MONITOR_DEFAULTTONEAREST);
-            _ = PInvoke.GetDpiForMonitor(monitor, MONITOR_DPI_TYPE.MDT_EFFECTIVE_DPI, out var dpiX, out _);
-            return dpiX / 96.0;
-        }
-        catch (Exception ex)
-        {
-            Logger.LogError($"Failed to get scale factor, error: {ex.Message}");
-            return 1.0;
-        }
-    }
-
-    private void PositionCentered()
-    {
-        this.SetWindowSize(ToastText.ActualWidth, ToastText.ActualHeight);
-
-        var displayArea = DisplayArea.GetFromWindowId(AppWindow.Id, DisplayAreaFallback.Nearest);
-        if (displayArea is not null)
-        {
-            var centeredPosition = AppWindow.Position;
-            centeredPosition.X = (displayArea.WorkArea.Width - AppWindow.Size.Width) / 2;
-
-            var monitorHeight = displayArea.WorkArea.Height;
-            var windowHeight = AppWindow.Size.Height;
-            centeredPosition.Y = monitorHeight - (windowHeight + 8); // Align with other shell toasts, like the volume indicator.
-            AppWindow.Move(centeredPosition);
-        }
     }
 
     public void ShowToast(string message)
     {
         ViewModel.ToastMessage = message;
+
         DispatcherQueue.TryEnqueue(
             DispatcherQueuePriority.Low,
             () =>
-        {
-            PositionCentered();
-
-            // SW_SHOWNA prevents us from getting activated (and stealing FG)
-            PInvoke.ShowWindow(_hwnd, SHOW_WINDOW_CMD.SW_SHOWNA);
-
-            _debounceTimer.Debounce(
-                () =>
-                {
-                    AppWindow.Hide();
-                },
-                interval: TimeSpan.FromMilliseconds(2500),
-                immediate: false);
-        });
+            {
+                _autoHideTimer.Stop();
+                PositionBottomCenter();
+                Show();
+                _autoHideTimer.Debounce(Hide, interval: VisibleDuration, immediate: false);
+            });
     }
 
     public void Receive(QuitMessage message)
     {
-        // This might come in on a background thread
+        // This might come in on a background thread.
         DispatcherQueue.TryEnqueue(() => Close());
+    }
+
+    private void PositionBottomCenter()
+    {
+        var displayArea = DisplayArea.GetFromWindowId(AppWindow.Id, DisplayAreaFallback.Nearest);
+        if (displayArea is null)
+        {
+            return;
+        }
+
+        var position = AppWindow.Position;
+        position.X = displayArea.WorkArea.X + ((displayArea.WorkArea.Width - AppWindow.Size.Width) / 2);
+        position.Y = displayArea.WorkArea.Y + displayArea.WorkArea.Height - AppWindow.Size.Height;
+        AppWindow.Move(position);
     }
 }

--- a/src/modules/cmdpal/ext/SamplePagesExtension/Pages/SampleToastsPage.cs
+++ b/src/modules/cmdpal/ext/SamplePagesExtension/Pages/SampleToastsPage.cs
@@ -1,0 +1,126 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+
+namespace SamplePagesExtension;
+
+internal sealed partial class SampleToastsPage : DynamicListPage
+{
+    public SampleToastsPage()
+    {
+        Icon = new IconInfo("\uE789"); // QuickNote glyph
+        Name = "Toast Notifications";
+        Title = "Toast Notification Samples";
+        PlaceholderText = "Type a custom message and press Enter…";
+    }
+
+    public override void UpdateSearchText(string oldSearch, string newSearch) => RaiseItemsChanged();
+
+    public override IListItem[] GetItems()
+    {
+        var query = SearchText?.Trim() ?? string.Empty;
+
+        // When the user has typed something, the first item becomes a
+        // "send this custom message" affordance — the easiest way to play
+        // with the toast window from the palette.
+        var customItem = !string.IsNullOrEmpty(query)
+            ? new ListItem(new AnonymousCommand(() => { })
+            {
+                Name = "Send custom toast",
+                Result = CommandResult.ShowToast(new ToastArgs
+                {
+                    Message = query,
+
+                    // KeepOpen lets you fire more toasts without re-opening
+                    // the palette, which is handy for rapid-fire testing.
+                    Result = CommandResult.KeepOpen(),
+                }),
+            })
+            {
+                Title = $"Show toast: \"{query}\"",
+                Subtitle = "Uses CommandResult.ShowToast(...) and keeps the palette open",
+                Icon = new IconInfo("\uE724"), // Send
+            }
+            : new ListItem(new NoOpCommand())
+            {
+                Title = "Type a message above to send a custom toast",
+                Subtitle = "Start typing — the first item becomes a 'Show toast' action",
+                Icon = new IconInfo("\uE8BD"), // Edit
+            };
+
+        return
+        [
+            customItem,
+
+            // Simplest possible call: dismiss the palette and show a short toast.
+            new ListItem(new ShowToastCommand("Hello from the Command Palette!"))
+            {
+                Title = "Short toast (dismisses the palette)",
+                Subtitle = "CommandResult.ShowToast(\"...\") with the default Dismiss result",
+                Icon = new IconInfo("\uE91C"),
+            },
+
+            // Same call, but keep the palette visible after firing.
+            new ListItem(new AnonymousCommand(() => { })
+            {
+                Name = "Show toast (keep palette open)",
+                Result = CommandResult.ShowToast(new ToastArgs
+                {
+                    Message = "The palette stays open — press Enter again to re-fire.",
+                    Result = CommandResult.KeepOpen(),
+                }),
+            })
+            {
+                Title = "Short toast (keeps the palette open)",
+                Subtitle = "ToastArgs.Result = CommandResult.KeepOpen()",
+                Icon = new IconInfo("\uE8A7"),
+            },
+
+            // Long message exercises wrapping inside the banner.
+            new ListItem(new AnonymousCommand(() => { })
+            {
+                Name = "Show long toast",
+                Result = CommandResult.ShowToast(new ToastArgs
+                {
+                    Message = "This is a much longer toast message designed to verify that the banner inside the transparent toast window wraps gracefully across multiple lines without clipping its drop shadow or its slide-in animation.",
+                    Result = CommandResult.KeepOpen(),
+                }),
+            })
+            {
+                Title = "Long, wrapping toast",
+                Subtitle = "Verifies multi-line wrapping inside the banner",
+                Icon = new IconInfo("\uE7C3"),
+            },
+
+            // Re-invoking the same item should cancel the pending hide and
+            // restart the show animation with the same message.
+            new ListItem(new AnonymousCommand(() => { })
+            {
+                Name = "Re-fire toast",
+                Result = CommandResult.ShowToast(new ToastArgs
+                {
+                    Message = "Re-fired! Press Enter again to restart the toast.",
+                    Result = CommandResult.KeepOpen(),
+                }),
+            })
+            {
+                Title = "Rapid re-fire (press Enter repeatedly)",
+                Subtitle = "Each press resets the hide timer and restarts the show animation",
+                Icon = new IconInfo("\uE895"),
+            },
+
+            // The other path: ToastStatusMessage routes through the extension
+            // host and renders as an in-page status banner instead of the
+            // transparent toast window. Included for contrast.
+            new ListItem(new ToastCommand("This is an in-page status message", MessageState.Success))
+            {
+                Title = "In-page status message (different path)",
+                Subtitle = "Uses ToastStatusMessage — renders inline, NOT in the toast window",
+                Icon = new IconInfo("\uE7BA"),
+            },
+        ];
+    }
+}

--- a/src/modules/cmdpal/ext/SamplePagesExtension/SamplesListPage.cs
+++ b/src/modules/cmdpal/ext/SamplePagesExtension/SamplesListPage.cs
@@ -19,6 +19,11 @@ public partial class SamplesListPage : ListPage
             Title = "List Page Sample Command",
             Subtitle = "Display a list of items",
         },
+        new ListItem(new SampleToastsPage())
+        {
+            Title = "Toast Notification Samples",
+            Subtitle = "Demonstrates CommandResult.ShowToast and lets you send custom toasts",
+        },
         new ListItem(new SampleListPageWithDetails())
         {
             Title = "List Page With Details",


### PR DESCRIPTION
## Summary of the Pull Request

Gives the CmdPal toast notification a glow-up: it now slides in/out with a nice fade, has acrylic + a soft shadow, and stops fighting with `SizeToContent`.

Along the way, the toast guts got refactored into a couple of reusable bits that live in `PowerToys.Common.UI.Controls` so other PowerToys utilities can grab them for their own transient overlays:

- **`TransparentWindow`** — a `WindowEx`-derived host that strips the native frame, hides from taskbar/Alt-Tab, uses `TransparentTintBackdrop` for transparency, and runs show/hide implicit animations on its content. Supply your own animations via `ShowAnimations` / `HideAnimations`, or take the defaults (fade + slide).
- **`TransparentCard`** — a templated `ContentControl` with acrylic (`AlwaysActiveDesktopAcrylicBackdrop`), rounded corners, border, and shadow. Drop whatever XAML you want inside.
- **`AlwaysActiveDesktopAcrylicBackdrop`** — small `SystemBackdrop` wrapper so the acrylic doesn''t go grey when the window isn''t focused (transient overlays are never focused).

CmdPal''s `ToastWindow` is now basically a 16-line wrapper: derives from `TransparentWindow`, drops a bound `TextBlock` inside, and handles its own 2.5s auto-hide timer + bottom-center positioning.


https://github.com/user-attachments/assets/3a62080c-22f0-480c-ac4d-028bcc32f07d



## PR Checklist

- [x] Closes: #40886
- [x] **Communication:** I''ve discussed this with core contributors already.
- [ ] **Tests:** Added/updated and all pass
- [x] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places

## Detailed Description of the Pull Request / Additional comments

A couple of design notes worth calling out:

- The window is sized slightly bigger than the visible card (~24px breathing room on each side) so the shadow and slide animation have room to render without clipping. That buffer area is transparent but NOT click-through — kept it small on purpose. We explored `SetWindowRgn` and `EnableWindow` tricks to make it click-through too, but neither plays nicely with WinUI 3''s DesktopWindowXamlSource. Small transparent frame is the pragmatic compromise.
- Animations use the Toolkit''s implicit `ShowAnimations` / `HideAnimations` so there''s zero animation code in `ToastWindow.xaml.cs`.
- `TransparentCard.xaml` is registered in `Themes/Generic.xaml` — required for templated controls in a library project; `<GenerateLibraryLayout>` alone doesn''t auto-merge per-control xaml.

## Validation Steps Performed

- Built clean (arm64 Debug).
- Triggered a CmdPal toast manually: fades + slides in, hangs for 2.5s, fades + slides out.
- Acrylic stays active when the window isn''t focused (toasts are never focused).
- Shadow renders fully without clipping.