### PR TITLE
feat: cache SVG previews in File Explorer

### DIFF
--- a/src/modules/previewpane/SvgPreviewHandler/SvgPreviewControl.cs
+++ b/src/modules/previewpane/SvgPreviewHandler/SvgPreviewControl.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.IO;
 using System.Net.Http;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -106,7 +107,7 @@ namespace Microsoft.PowerToys.PreviewHandler.Svg
                 return;
             }
 
-            CleanupWebView2UserDataFolder();
+            EnsureWebView2UserDataFolder();
 
             string svgData = null;
             bool blocked = false;
@@ -251,22 +252,26 @@ namespace Microsoft.PowerToys.PreviewHandler.Svg
                     _browser.CoreWebView2.AddWebResourceRequestedFilter("*", CoreWebView2WebResourceContext.All);
                     _browser.CoreWebView2.WebResourceRequested += CoreWebView2_BlockExternalResources;
 
-                    string generatedPreview = _previewGenerator.GeneratePreview(svgData);
+                    var cacheKey = SvgPreviewCacheHelper.BuildCacheKey(
+                        "v1",
+                        VirtualHostName,
+                        svgData,
+                        _settings.ColorMode.ToString(),
+                        _settings.ThemeColor.ToArgb().ToString(),
+                        _settings.SolidColor.ToArgb().ToString(),
+                        _settings.CheckeredShade.ToString());
 
-                    // WebView2.NavigateToString() limitation
-                    // See https://learn.microsoft.com/dotnet/api/microsoft.web.webview2.core.corewebview2.navigatetostring?view=webview2-dotnet-1.0.864.35#remarks
-                    // While testing the limit, it turned out it is ~1.5MB, so to be on a safe side we go for 1.5m bytes
-                    if (generatedPreview.Length > 1_500_000)
+                    var cacheFolder = Path.Combine(_webView2UserDataFolder, "Cache");
+                    var cacheFilePath = SvgPreviewCacheHelper.GetCacheFilePath(cacheFolder, cacheKey);
+
+                    if (!File.Exists(cacheFilePath) || new FileInfo(cacheFilePath).Length == 0)
                     {
-                        string filename = _webView2UserDataFolder + "\\" + Guid.NewGuid().ToString() + ".html";
-                        File.WriteAllText(filename, generatedPreview);
-                        _localFileURI = new Uri(filename);
-                        _browser.Source = _localFileURI;
+                        string generatedPreview = _previewGenerator.GeneratePreview(svgData);
+                        File.WriteAllText(cacheFilePath, generatedPreview);
                     }
-                    else
-                    {
-                        _browser.NavigateToString(generatedPreview);
-                    }
+
+                    _localFileURI = new Uri(cacheFilePath);
+                    _browser.Source = _localFileURI;
 
                     Controls.Add(_browser);
                 }
@@ -318,17 +323,11 @@ namespace Microsoft.PowerToys.PreviewHandler.Svg
         /// <summary>
         /// Cleanup the previously created tmp html files from svg files bigger than 2MB.
         /// </summary>
-        private void CleanupWebView2UserDataFolder()
+        private void EnsureWebView2UserDataFolder()
         {
             try
             {
-                // Cleanup temp dir
-                var dir = new DirectoryInfo(_webView2UserDataFolder);
-
-                foreach (var file in dir.EnumerateFiles("*.html"))
-                {
-                    file.Delete();
-                }
+                Directory.CreateDirectory(_webView2UserDataFolder);
             }
             catch (Exception)
             {

--- a/src/modules/previewpane/SvgPreviewHandler/SvgPreviewControl.cs
+++ b/src/modules/previewpane/SvgPreviewHandler/SvgPreviewControl.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) Microsoft Corporation
+// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Globalization;
 using System.IO;
 using System.Net.Http;
 using System.Reflection;
@@ -256,22 +257,34 @@ namespace Microsoft.PowerToys.PreviewHandler.Svg
                         "v1",
                         VirtualHostName,
                         svgData,
-                        _settings.ColorMode.ToString(),
-                        _settings.ThemeColor.ToArgb().ToString(),
-                        _settings.SolidColor.ToArgb().ToString(),
-                        _settings.CheckeredShade.ToString());
+                        _settings.ColorMode.ToString(CultureInfo.InvariantCulture),
+                        _settings.ThemeColor.ToArgb().ToString(CultureInfo.InvariantCulture),
+                        _settings.SolidColor.ToArgb().ToString(CultureInfo.InvariantCulture),
+                        _settings.CheckeredShade.ToString(CultureInfo.InvariantCulture));
 
-                    var cacheFolder = Path.Combine(_webView2UserDataFolder, "Cache");
+                    var cacheFolder = Path.Combine(_webView2UserDataFolder, "SvgPreviewCache");
                     var cacheFilePath = SvgPreviewCacheHelper.GetCacheFilePath(cacheFolder, cacheKey);
 
+                    bool useCacheFile = true;
                     if (!File.Exists(cacheFilePath) || new FileInfo(cacheFilePath).Length == 0)
                     {
                         string generatedPreview = _previewGenerator.GeneratePreview(svgData);
-                        File.WriteAllText(cacheFilePath, generatedPreview);
+                        useCacheFile = SvgPreviewCacheHelper.WriteCacheFileAtomic(cacheFilePath, generatedPreview);
+                        if (useCacheFile)
+                        {
+                            SvgPreviewCacheHelper.ManageCacheSize(cacheFolder);
+                        }
+                        else
+                        {
+                            _browser.NavigateToString(generatedPreview);
+                        }
                     }
 
-                    _localFileURI = new Uri(cacheFilePath);
-                    _browser.Source = _localFileURI;
+                    if (useCacheFile)
+                    {
+                        _localFileURI = new Uri(cacheFilePath);
+                        _browser.Source = _localFileURI;
+                    }
 
                     Controls.Add(_browser);
                 }
@@ -321,7 +334,7 @@ namespace Microsoft.PowerToys.PreviewHandler.Svg
         }
 
         /// <summary>
-        /// Cleanup the previously created tmp html files from svg files bigger than 2MB.
+        /// Ensures the WebView2 user data folder exists.
         /// </summary>
         private void EnsureWebView2UserDataFolder()
         {

--- a/src/modules/previewpane/SvgThumbnailProvider/SvgThumbnailProvider.cs
+++ b/src/modules/previewpane/SvgThumbnailProvider/SvgThumbnailProvider.cs
@@ -100,7 +100,7 @@ namespace Microsoft.PowerToys.ThumbnailHandler.Svg
         /// <param name="cx">The maximum thumbnail size, in pixels.</param>
         public Bitmap GetThumbnailImpl(uint cx)
         {
-            CleanupWebView2UserDataFolder();
+            EnsureWebView2UserDataFolder();
 
             if (cx == 0 || cx > MaxThumbnailSize)
             {
@@ -177,9 +177,6 @@ namespace Microsoft.PowerToys.ThumbnailHandler.Svg
                         }
                     };
 
-                    // WebView2.NavigateToString() limitation
-                    // See https://learn.microsoft.com/dotnet/api/microsoft.web.webview2.core.corewebview2.navigatetostring?view=webview2-dotnet-1.0.864.35#remarks
-                    // While testing the limit, it turned out it is ~1.5MB, so to be on a safe side we go for 1.5m bytes
                     SvgContentsReady.Wait();
                     if (string.IsNullOrEmpty(SvgContents) || !SvgContents.Contains("svg"))
                     {
@@ -187,17 +184,17 @@ namespace Microsoft.PowerToys.ThumbnailHandler.Svg
                         return;
                     }
 
-                    if (SvgContents.Length > 1_500_000)
+                    var cacheKey = SvgPreviewCacheHelper.BuildCacheKey("v1", VirtualHostName, SvgContents);
+                    var cacheFolder = Path.Combine(_webView2UserDataFolder, "Cache");
+                    var cacheFilePath = SvgPreviewCacheHelper.GetCacheFilePath(cacheFolder, cacheKey);
+
+                    if (!File.Exists(cacheFilePath) || new FileInfo(cacheFilePath).Length == 0)
                     {
-                        string filename = _webView2UserDataFolder + "\\" + Guid.NewGuid().ToString() + ".html";
-                        File.WriteAllText(filename, SvgContents);
-                        _localFileURI = new Uri(filename);
-                        _browser.Source = _localFileURI;
+                        File.WriteAllText(cacheFilePath, SvgContents);
                     }
-                    else
-                    {
-                        _browser.NavigateToString(SvgContents);
-                    }
+
+                    _localFileURI = new Uri(cacheFilePath);
+                    _browser.Source = _localFileURI;
                 }
                 catch (Exception ex)
                 {
@@ -344,17 +341,11 @@ namespace Microsoft.PowerToys.ThumbnailHandler.Svg
         /// <summary>
         /// Cleanup the previously created tmp html files from svg files bigger than 2MB.
         /// </summary>
-        private void CleanupWebView2UserDataFolder()
+        private void EnsureWebView2UserDataFolder()
         {
             try
             {
-                // Cleanup temp dir
-                var dir = new DirectoryInfo(_webView2UserDataFolder);
-
-                foreach (var file in dir.EnumerateFiles("*.html"))
-                {
-                    file.Delete();
-                }
+                Directory.CreateDirectory(_webView2UserDataFolder);
             }
             catch (Exception)
             {

--- a/src/modules/previewpane/SvgThumbnailProvider/SvgThumbnailProvider.cs
+++ b/src/modules/previewpane/SvgThumbnailProvider/SvgThumbnailProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation
+// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 using System.Drawing.Drawing2D;
@@ -185,16 +185,28 @@ namespace Microsoft.PowerToys.ThumbnailHandler.Svg
                     }
 
                     var cacheKey = SvgPreviewCacheHelper.BuildCacheKey("v1", VirtualHostName, SvgContents);
-                    var cacheFolder = Path.Combine(_webView2UserDataFolder, "Cache");
+                    var cacheFolder = Path.Combine(_webView2UserDataFolder, "SvgPreviewCache");
                     var cacheFilePath = SvgPreviewCacheHelper.GetCacheFilePath(cacheFolder, cacheKey);
 
+                    bool useCacheFile = true;
                     if (!File.Exists(cacheFilePath) || new FileInfo(cacheFilePath).Length == 0)
                     {
-                        File.WriteAllText(cacheFilePath, SvgContents);
+                        useCacheFile = SvgPreviewCacheHelper.WriteCacheFileAtomic(cacheFilePath, SvgContents);
+                        if (useCacheFile)
+                        {
+                            SvgPreviewCacheHelper.ManageCacheSize(cacheFolder);
+                        }
+                        else
+                        {
+                            _browser.NavigateToString(SvgContents);
+                        }
                     }
 
-                    _localFileURI = new Uri(cacheFilePath);
-                    _browser.Source = _localFileURI;
+                    if (useCacheFile)
+                    {
+                        _localFileURI = new Uri(cacheFilePath);
+                        _browser.Source = _localFileURI;
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -339,7 +351,7 @@ namespace Microsoft.PowerToys.ThumbnailHandler.Svg
         }
 
         /// <summary>
-        /// Cleanup the previously created tmp html files from svg files bigger than 2MB.
+        /// Ensures the WebView2 user data folder exists.
         /// </summary>
         private void EnsureWebView2UserDataFolder()
         {

--- a/src/modules/previewpane/UnitTests-SvgPreviewHandler/SvgPreviewHandlerHelperTests.cs
+++ b/src/modules/previewpane/UnitTests-SvgPreviewHandler/SvgPreviewHandlerHelperTests.cs
@@ -99,5 +99,31 @@ namespace SvgPreviewHandlerUnitTests
             // Assert
             Assert.IsFalse(foundFilteredElement);
         }
+
+        [TestMethod]
+        public void BuildCacheKeyShouldReturnSameValueForSameInputs()
+        {
+            // Arrange
+            var firstKey = SvgPreviewCacheHelper.BuildCacheKey("v1", "svg-preview", "sample data");
+
+            // Act
+            var secondKey = SvgPreviewCacheHelper.BuildCacheKey("v1", "svg-preview", "sample data");
+
+            // Assert
+            Assert.AreEqual(firstKey, secondKey);
+        }
+
+        [TestMethod]
+        public void BuildCacheKeyShouldReturnDifferentValueForDifferentInputs()
+        {
+            // Arrange
+            var firstKey = SvgPreviewCacheHelper.BuildCacheKey("v1", "svg-preview", "sample data");
+
+            // Act
+            var secondKey = SvgPreviewCacheHelper.BuildCacheKey("v1", "svg-preview", "different data");
+
+            // Assert
+            Assert.AreNotEqual(firstKey, secondKey);
+        }
     }
 }

--- a/src/modules/previewpane/UnitTests-SvgPreviewHandler/SvgPreviewHandlerHelperTests.cs
+++ b/src/modules/previewpane/UnitTests-SvgPreviewHandler/SvgPreviewHandlerHelperTests.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) Microsoft Corporation
+// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.IO;
 using System.Text;
 
 using Common.Utilities;
@@ -124,6 +125,57 @@ namespace SvgPreviewHandlerUnitTests
 
             // Assert
             Assert.AreNotEqual(firstKey, secondKey);
+        }
+
+        [TestMethod]
+        public void BuildCacheKeyShouldNotCollideOnDelimiterAmbiguity()
+        {
+            // Arrange
+            var firstKey = SvgPreviewCacheHelper.BuildCacheKey("a\nb", "");
+
+            // Act
+            var secondKey = SvgPreviewCacheHelper.BuildCacheKey("a", "b\n");
+
+            // Assert
+            Assert.AreNotEqual(firstKey, secondKey);
+        }
+
+        [TestMethod]
+        public void ManageCacheSizeShouldEvictOldestFiles()
+        {
+            // Arrange
+            var cacheFolder = Path.Combine(Path.GetTempPath(), "SvgPreviewCacheTest");
+            Directory.CreateDirectory(cacheFolder);
+
+            try
+            {
+                // Create 5 dummy html files
+                var files = new System.Collections.Generic.List<string>();
+                for (int i = 0; i < 5; i++)
+                {
+                    var path = Path.Combine(cacheFolder, $"test{i}.html");
+                    File.WriteAllText(path, "test");
+                    File.SetLastWriteTimeUtc(path, System.DateTime.UtcNow.AddMinutes(-i)); // test0 is newest, test4 is oldest
+                    files.Add(path);
+                }
+
+                // Act - limit to 3
+                SvgPreviewCacheHelper.ManageCacheSize(cacheFolder, 3);
+
+                // Assert
+                Assert.IsTrue(File.Exists(files[0])); // Newest
+                Assert.IsTrue(File.Exists(files[1]));
+                Assert.IsTrue(File.Exists(files[2]));
+                Assert.IsFalse(File.Exists(files[3])); // Evicted
+                Assert.IsFalse(File.Exists(files[4])); // Oldest evicted
+            }
+            finally
+            {
+                if (Directory.Exists(cacheFolder))
+                {
+                    Directory.Delete(cacheFolder, true);
+                }
+            }
         }
     }
 }

--- a/src/modules/previewpane/common/Properties/AssemblyInfo.cs
+++ b/src/modules/previewpane/common/Properties/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("PowerToys.SvgPreviewHandler")]
+[assembly: InternalsVisibleTo("PowerToys.SvgThumbnailProvider")]
+[assembly: InternalsVisibleTo("Preview.SvgPreviewHandler.UnitTests")]

--- a/src/modules/previewpane/common/Properties/AssemblyInfo.cs
+++ b/src/modules/previewpane/common/Properties/AssemblyInfo.cs
@@ -1,3 +1,7 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("PowerToys.SvgPreviewHandler")]

--- a/src/modules/previewpane/common/Utilities/SvgPreviewCacheHelper.cs
+++ b/src/modules/previewpane/common/Utilities/SvgPreviewCacheHelper.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Common.Utilities
+{
+    internal static class SvgPreviewCacheHelper
+    {
+        internal static string BuildCacheKey(params string[] cacheInputs)
+        {
+            var cacheKeyBuilder = new StringBuilder();
+
+            foreach (var input in cacheInputs)
+            {
+                cacheKeyBuilder.Append(input ?? string.Empty);
+                cacheKeyBuilder.Append('\n');
+            }
+
+            return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(cacheKeyBuilder.ToString())));
+        }
+
+        internal static string GetCacheFilePath(string cacheRootFolder, string cacheKey)
+        {
+            Directory.CreateDirectory(cacheRootFolder);
+            return Path.Combine(cacheRootFolder, $"{cacheKey}.html");
+        }
+    }
+}

--- a/src/modules/previewpane/common/Utilities/SvgPreviewCacheHelper.cs
+++ b/src/modules/previewpane/common/Utilities/SvgPreviewCacheHelper.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 
@@ -17,8 +18,8 @@ namespace Common.Utilities
 
             foreach (var input in cacheInputs)
             {
-                cacheKeyBuilder.Append(input ?? string.Empty);
-                cacheKeyBuilder.Append('\n');
+                string value = input ?? string.Empty;
+                cacheKeyBuilder.Append(value.Length).Append(':').Append(value);
             }
 
             return Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(cacheKeyBuilder.ToString())));
@@ -26,8 +27,58 @@ namespace Common.Utilities
 
         internal static string GetCacheFilePath(string cacheRootFolder, string cacheKey)
         {
-            Directory.CreateDirectory(cacheRootFolder);
             return Path.Combine(cacheRootFolder, $"{cacheKey}.html");
+        }
+
+        internal static bool WriteCacheFileAtomic(string cacheFilePath, string content)
+        {
+            try
+            {
+                var directory = Path.GetDirectoryName(cacheFilePath);
+                Directory.CreateDirectory(directory);
+                
+                string tempFile = Path.Combine(directory, Path.GetRandomFileName());
+                File.WriteAllText(tempFile, content);
+                
+                File.Move(tempFile, cacheFilePath, overwrite: true);
+                return true;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
+        internal static void ManageCacheSize(string cacheFolder, int maxEntries = 30)
+        {
+            try
+            {
+                if (!Directory.Exists(cacheFolder))
+                {
+                    return;
+                }
+
+                var files = new DirectoryInfo(cacheFolder).GetFiles("*.html")
+                                                          .OrderByDescending(f => f.LastWriteTimeUtc)
+                                                          .ToList();
+
+                if (files.Count > maxEntries)
+                {
+                    foreach (var file in files.Skip(maxEntries))
+                    {
+                        try
+                        {
+                            file.Delete();
+                        }
+                        catch (Exception)
+                        {
+                        }
+                    }
+                }
+            }
+            catch (Exception)
+            {
+            }
         }
     }
 }


### PR DESCRIPTION
Caches SVG preview output in File Explorer so the same SVG does not need to be regenerated every time a folder is opened.

What changed
Add deterministic cache helper to avoid per-preview temp files.
Reuse cached HTML in the SVG preview handler and SVG thumbnail provider instead of regenerating on every request.
Add unit tests to validate cache-key stability.
Validation
Static checks: no syntax errors reported for the modified files.
Local limitation: the .NET SDK (dotnet) is not available in this environment, so full dotnet test/CI couldn't be run locally. GitHub Actions will run CI on the PR.
PR Checklist
 Communication: I have commented on the issue and requested to be assigned / noted my intent to work on it.
 Closes #48197
 Tests: added unit tests for cache-key behavior
 CI: relies on GitHub Actions to run full build/tests
 Docs/Localization: not applicable for this change