### PR TITLE
Ripple effect for Mouse Highlighter

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -2182,6 +2182,7 @@ xclip
 xcopy
 xdf
 xfd
+xhair
 xmp
 Xoshiro
 xsi

--- a/src/modules/MouseUtils/MouseHighlighter/MouseHighlighter.cpp
+++ b/src/modules/MouseUtils/MouseHighlighter/MouseHighlighter.cpp
@@ -50,16 +50,15 @@ private:
     void ClearDrawingPoint();
     void ClearDrawing();
     void BringToFront();
-    // Ripple pulse variants. Press = expanding ring+glow+dot, Release = contracting
-    // dimmer echo on button-up, Drag = small fading dot emitted along a held drag.
-    enum class RippleKind
-    {
-        Press,
-        Release,
-        Drag
-    };
-    // Spawn a ClickLight-style ripple pulse at the given client-area point.
-    void SpawnRipplePulse(POINT clientPt, MouseButton button, RippleKind kind);
+    // Ripple mode: spawn the press/hold ring + glow at the click point and
+    // continue the animation into a fade-out on release. The held ring may
+    // optionally follow the cursor while held (gated by m_rippleShowDragTrail).
+    void SpawnRippleHoldDot(MouseButton button);
+    void FadeRippleHoldDot(MouseButton button);
+    // Spotlight mode: pressed-state animation that shrinks the mask while
+    // a mouse button is held and restores it on release.
+    void SpotlightAnimatePress();
+    void SpotlightAnimateRelease();
     HHOOK m_mouseHook = NULL;
     static LRESULT CALLBACK MouseHookProc(int nCode, WPARAM wParam, LPARAM lParam) noexcept;
     // Helpers for spotlight overlay
@@ -83,6 +82,16 @@ private:
     winrt::CompositionSpriteShape m_leftPointer{ nullptr };
     winrt::CompositionSpriteShape m_rightPointer{ nullptr };
     winrt::CompositionSpriteShape m_alwaysPointer{ nullptr };
+    // Ellipse geometries kept alongside the pointer shapes so press-down /
+    // release animations can target the radius directly.
+    winrt::CompositionEllipseGeometry m_leftGeometry{ nullptr };
+    winrt::CompositionEllipseGeometry m_rightGeometry{ nullptr };
+    // Ripple-mode held glow (the soft halo behind the ring) — paired with
+    // m_left/rightPointer (which holds the ring shape) while a button is held.
+    winrt::CompositionSpriteShape m_leftRippleGlow{ nullptr };
+    winrt::CompositionSpriteShape m_rightRippleGlow{ nullptr };
+    winrt::CompositionEllipseGeometry m_leftGlowGeometry{ nullptr };
+    winrt::CompositionEllipseGeometry m_rightGlowGeometry{ nullptr };
     // Spotlight overlay (mask with soft feathered edge)
     winrt::SpriteVisual m_overlay{ nullptr };
     winrt::CompositionMaskBrush m_spotlightMask{ nullptr };
@@ -96,18 +105,13 @@ private:
     bool m_rightPointerEnabled = true;
     bool m_alwaysPointerEnabled = true;
     bool m_spotlightMode = false;
-    bool m_rippleMode = false;
+    bool m_spotlightPressed = false;
+    bool m_rippleMode = true;
     bool m_rippleShowDragTrail = MOUSE_HIGHLIGHTER_DEFAULT_RIPPLE_SHOW_DRAG_TRAIL;
     bool m_rippleShowReleasePulse = MOUSE_HIGHLIGHTER_DEFAULT_RIPPLE_SHOW_RELEASE_PULSE;
     float m_rippleSize = static_cast<float>(MOUSE_HIGHLIGHTER_DEFAULT_RIPPLE_SIZE);
     float m_rippleIntensity = static_cast<float>(MOUSE_HIGHLIGHTER_DEFAULT_RIPPLE_INTENSITY);
     int m_rippleDurationMs = MOUSE_HIGHLIGHTER_DEFAULT_RIPPLE_DURATION_MS;
-
-    // Tracking for ripple-mode drag emission (independent of the legacy
-    // m_leftButtonPressed / m_rightButtonPressed which drive the circle mode).
-    bool m_rippleLeftPressed = false;
-    bool m_rippleRightPressed = false;
-    POINT m_lastRippleDragPt = { 0, 0 };
 
     bool m_leftButtonPressed = false;
     bool m_rightButtonPressed = false;
@@ -218,11 +222,34 @@ void Highlighter::AddDrawingPoint(MouseButton button)
     {
         circleShape.FillBrush(m_compositor.CreateColorBrush(m_leftClickColor));
         m_leftPointer = circleShape;
+        m_leftGeometry = circleGeometry;
+
+        // Niels-style press-down shrink: holding the button squeezes the
+        // circle to 70% over 180ms after a 150ms delay so quick clicks skip
+        // it. StartDrawingPointFading stops this animation on release.
+        const float pressedRadius = m_radius * 0.70f;
+        auto ease = m_compositor.CreateCubicBezierEasingFunction({ 0.2f, 0.0f }, { 0.4f, 1.0f });
+        auto anim = m_compositor.CreateVector2KeyFrameAnimation();
+        anim.InsertKeyFrame(0.0f, { m_radius, m_radius });
+        anim.InsertKeyFrame(1.0f, { pressedRadius, pressedRadius }, ease);
+        anim.Duration(std::chrono::milliseconds(180));
+        anim.DelayTime(std::chrono::milliseconds(150));
+        circleGeometry.StartAnimation(L"Radius", anim);
     }
     else if (button == MouseButton::Right)
     {
         circleShape.FillBrush(m_compositor.CreateColorBrush(m_rightClickColor));
         m_rightPointer = circleShape;
+        m_rightGeometry = circleGeometry;
+
+        const float pressedRadius = m_radius * 0.70f;
+        auto ease = m_compositor.CreateCubicBezierEasingFunction({ 0.2f, 0.0f }, { 0.4f, 1.0f });
+        auto anim = m_compositor.CreateVector2KeyFrameAnimation();
+        anim.InsertKeyFrame(0.0f, { m_radius, m_radius });
+        anim.InsertKeyFrame(1.0f, { pressedRadius, pressedRadius }, ease);
+        anim.Duration(std::chrono::milliseconds(180));
+        anim.DelayTime(std::chrono::milliseconds(150));
+        circleGeometry.StartAnimation(L"Radius", anim);
     }
     else
     {
@@ -262,17 +289,36 @@ void Highlighter::UpdateDrawingPointPosition(MouseButton button)
     if (button == MouseButton::Left)
     {
         m_leftPointer.Offset({ static_cast<float>(pt.x), static_cast<float>(pt.y) });
+        if (m_leftRippleGlow)
+        {
+            m_leftRippleGlow.Offset({ static_cast<float>(pt.x), static_cast<float>(pt.y) });
+        }
     }
     else if (button == MouseButton::Right)
     {
         m_rightPointer.Offset({ static_cast<float>(pt.x), static_cast<float>(pt.y) });
+        if (m_rightRippleGlow)
+        {
+            m_rightRippleGlow.Offset({ static_cast<float>(pt.x), static_cast<float>(pt.y) });
+        }
     }
     else
     {
         // always / spotlight idle
         if (m_spotlightMode)
         {
-            UpdateSpotlightMask(static_cast<float>(pt.x), static_cast<float>(pt.y), m_radius, true);
+            if (m_spotlightPressed)
+            {
+                // Only update position while pressed — radius is being animated
+                if (m_spotlightMaskGradient)
+                {
+                    m_spotlightMaskGradient.EllipseCenter({ static_cast<float>(pt.x), static_cast<float>(pt.y) });
+                }
+            }
+            else
+            {
+                UpdateSpotlightMask(static_cast<float>(pt.x), static_cast<float>(pt.y), m_radius, true);
+            }
         }
         else if (m_alwaysPointer)
         {
@@ -283,14 +329,24 @@ void Highlighter::UpdateDrawingPointPosition(MouseButton button)
 void Highlighter::StartDrawingPointFading(MouseButton button)
 {
     winrt::Windows::UI::Composition::CompositionSpriteShape circleShape{ nullptr };
+    winrt::Windows::UI::Composition::CompositionEllipseGeometry geom{ nullptr };
     if (button == MouseButton::Left)
     {
         circleShape = m_leftPointer;
+        geom = m_leftGeometry;
     }
     else
     {
         // right
         circleShape = m_rightPointer;
+        geom = m_rightGeometry;
+    }
+
+    // Stop any in-flight press-down shrink so the geometry doesn't keep
+    // animating while the fill is being faded out.
+    if (geom && m_compositor)
+    {
+        geom.StopAnimation(L"Radius");
     }
 
     auto brushColor = circleShape.FillBrush().as<winrt::Windows::UI::Composition::CompositionColorBrush>().Color();
@@ -353,15 +409,17 @@ LRESULT CALLBACK Highlighter::MouseHookProc(int nCode, WPARAM wParam, LPARAM lPa
         switch (wParam)
         {
         case WM_LBUTTONDOWN:
+            if (instance->m_spotlightMode)
+            {
+                instance->SpotlightAnimatePress();
+                break;
+            }
             if (instance->m_rippleMode)
             {
                 if (instance->m_leftPointerEnabled)
                 {
-                    POINT pt = hookData->pt;
-                    ScreenToClient(instance->m_hwnd, &pt);
-                    instance->SpawnRipplePulse(pt, MouseButton::Left, Highlighter::RippleKind::Press);
-                    instance->m_rippleLeftPressed = true;
-                    instance->m_lastRippleDragPt = hookData->pt;
+                    instance->SpawnRippleHoldDot(MouseButton::Left);
+                    instance->m_leftButtonPressed = true;
                     if (instance->m_timer_id == 0)
                     {
                         instance->m_timer_id = SetTimer(instance->m_hwnd, BRING_TO_FRONT_TIMER_ID, 10, nullptr);
@@ -394,15 +452,17 @@ LRESULT CALLBACK Highlighter::MouseHookProc(int nCode, WPARAM wParam, LPARAM lPa
             }
             break;
         case WM_RBUTTONDOWN:
+            if (instance->m_spotlightMode)
+            {
+                instance->SpotlightAnimatePress();
+                break;
+            }
             if (instance->m_rippleMode)
             {
                 if (instance->m_rightPointerEnabled)
                 {
-                    POINT pt = hookData->pt;
-                    ScreenToClient(instance->m_hwnd, &pt);
-                    instance->SpawnRipplePulse(pt, MouseButton::Right, Highlighter::RippleKind::Press);
-                    instance->m_rippleRightPressed = true;
-                    instance->m_lastRippleDragPt = hookData->pt;
+                    instance->SpawnRippleHoldDot(MouseButton::Right);
+                    instance->m_rightButtonPressed = true;
                     if (instance->m_timer_id == 0)
                     {
                         instance->m_timer_id = SetTimer(instance->m_hwnd, BRING_TO_FRONT_TIMER_ID, 10, nullptr);
@@ -434,19 +494,18 @@ LRESULT CALLBACK Highlighter::MouseHookProc(int nCode, WPARAM wParam, LPARAM lPa
         case WM_MOUSEMOVE:
             if (instance->m_rippleMode)
             {
-                if (instance->m_rippleShowDragTrail && (instance->m_rippleLeftPressed || instance->m_rippleRightPressed))
+                // Held ripple ring follows the cursor while a button is down,
+                // gated by the "follow cursor while held" setting. When the
+                // setting is off, the ring stays anchored at the click point.
+                if (instance->m_rippleShowDragTrail)
                 {
-                    // Throttle: only emit a drag dot when the cursor has moved a
-                    // few pixels — matches ClickLight's ~2.5 px append threshold.
-                    LONG dx = hookData->pt.x - instance->m_lastRippleDragPt.x;
-                    LONG dy = hookData->pt.y - instance->m_lastRippleDragPt.y;
-                    if ((dx * dx + dy * dy) >= 9)
+                    if (instance->m_leftButtonPressed && instance->m_leftPointer)
                     {
-                        MouseButton heldButton = instance->m_rippleLeftPressed ? MouseButton::Left : MouseButton::Right;
-                        POINT pt = hookData->pt;
-                        ScreenToClient(instance->m_hwnd, &pt);
-                        instance->SpawnRipplePulse(pt, heldButton, Highlighter::RippleKind::Drag);
-                        instance->m_lastRippleDragPt = hookData->pt;
+                        instance->UpdateDrawingPointPosition(MouseButton::Left);
+                    }
+                    if (instance->m_rightButtonPressed && instance->m_rightPointer)
+                    {
+                        instance->UpdateDrawingPointPosition(MouseButton::Right);
                     }
                 }
                 break;
@@ -465,25 +524,22 @@ LRESULT CALLBACK Highlighter::MouseHookProc(int nCode, WPARAM wParam, LPARAM lPa
             }
             break;
         case WM_LBUTTONUP:
-            if (instance->m_rippleMode)
+            if (instance->m_spotlightPressed)
             {
-                if (instance->m_rippleLeftPressed)
-                {
-                    if (instance->m_rippleShowReleasePulse && instance->m_leftPointerEnabled)
-                    {
-                        POINT pt = hookData->pt;
-                        ScreenToClient(instance->m_hwnd, &pt);
-                        instance->SpawnRipplePulse(pt, MouseButton::Left, Highlighter::RippleKind::Release);
-                    }
-                    instance->m_rippleLeftPressed = false;
-                }
-                break;
+                instance->SpotlightAnimateRelease();
             }
             if (instance->m_leftButtonPressed)
             {
-                instance->StartDrawingPointFading(MouseButton::Left);
+                if (instance->m_rippleMode)
+                {
+                    instance->FadeRippleHoldDot(MouseButton::Left);
+                }
+                else
+                {
+                    instance->StartDrawingPointFading(MouseButton::Left);
+                }
                 instance->m_leftButtonPressed = false;
-                if (instance->m_alwaysPointerEnabled && !instance->m_rightButtonPressed)
+                if (!instance->m_rippleMode && instance->m_alwaysPointerEnabled && !instance->m_rightButtonPressed)
                 {
                     // Add AlwaysPointer only when it's enabled and RightPointer is not active
                     instance->AddDrawingPoint(MouseButton::None);
@@ -491,25 +547,22 @@ LRESULT CALLBACK Highlighter::MouseHookProc(int nCode, WPARAM wParam, LPARAM lPa
             }
             break;
         case WM_RBUTTONUP:
-            if (instance->m_rippleMode)
+            if (instance->m_spotlightPressed)
             {
-                if (instance->m_rippleRightPressed)
-                {
-                    if (instance->m_rippleShowReleasePulse && instance->m_rightPointerEnabled)
-                    {
-                        POINT pt = hookData->pt;
-                        ScreenToClient(instance->m_hwnd, &pt);
-                        instance->SpawnRipplePulse(pt, MouseButton::Right, Highlighter::RippleKind::Release);
-                    }
-                    instance->m_rippleRightPressed = false;
-                }
-                break;
+                instance->SpotlightAnimateRelease();
             }
             if (instance->m_rightButtonPressed)
             {
-                instance->StartDrawingPointFading(MouseButton::Right);
+                if (instance->m_rippleMode)
+                {
+                    instance->FadeRippleHoldDot(MouseButton::Right);
+                }
+                else
+                {
+                    instance->StartDrawingPointFading(MouseButton::Right);
+                }
                 instance->m_rightButtonPressed = false;
-                if (instance->m_alwaysPointerEnabled && !instance->m_leftButtonPressed)
+                if (!instance->m_rippleMode && instance->m_alwaysPointerEnabled && !instance->m_leftButtonPressed)
                 {
                     // Add AlwaysPointer only when it's enabled and LeftPointer is not active
                     instance->AddDrawingPoint(MouseButton::None);
@@ -551,11 +604,16 @@ void Highlighter::StopDrawing()
     m_visible = false;
     m_leftButtonPressed = false;
     m_rightButtonPressed = false;
-    m_rippleLeftPressed = false;
-    m_rippleRightPressed = false;
+    m_spotlightPressed = false;
     m_leftPointer = nullptr;
     m_rightPointer = nullptr;
     m_alwaysPointer = nullptr;
+    m_leftGeometry = nullptr;
+    m_rightGeometry = nullptr;
+    m_leftRippleGlow = nullptr;
+    m_rightRippleGlow = nullptr;
+    m_leftGlowGeometry = nullptr;
+    m_rightGlowGeometry = nullptr;
     if (m_overlay)
     {
         m_overlay.IsVisible(false);
@@ -589,6 +647,10 @@ void Highlighter::ApplySettings(MouseHighlighterSettings settings)
     m_rippleDurationMs = (settings.rippleDurationMs > 0) ? settings.rippleDurationMs : MOUSE_HIGHLIGHTER_DEFAULT_RIPPLE_DURATION_MS;
     m_rippleShowDragTrail = settings.rippleShowDragTrail;
     m_rippleShowReleasePulse = settings.rippleShowReleasePulse;
+
+    // Reset transient pressed-state flag so a settings change while a button
+    // happens to be down doesn't leave the spotlight stuck at a shrunken size.
+    m_spotlightPressed = false;
 
     if (m_spotlightMode)
     {
@@ -754,36 +816,179 @@ void Highlighter::UpdateSpotlightMask(float cx, float cy, float radius, bool sho
     }
 }
 
-// Spawn a ClickLight-inspired expanding ring + glow pulse at the cursor.
-// Each click emits a transient, self-cleaning pulse — pulses can overlap.
-void Highlighter::SpawnRipplePulse(POINT clientPt, MouseButton button, RippleKind kind)
+// Spotlight press-down: shrink the mask radius briefly while a button is held.
+void Highlighter::SpotlightAnimatePress()
+{
+    if (!m_spotlightMode || !m_spotlightMaskGradient)
+    {
+        return;
+    }
+
+    m_spotlightPressed = true;
+    const float pressedRadius = m_radius * 0.85f;
+
+    auto ease = m_compositor.CreateCubicBezierEasingFunction({ 0.2f, 0.0f }, { 0.4f, 1.0f });
+    auto anim = m_compositor.CreateVector2KeyFrameAnimation();
+    anim.InsertKeyFrame(0.0f, { m_radius, m_radius });
+    anim.InsertKeyFrame(1.0f, { pressedRadius, pressedRadius }, ease);
+    anim.Duration(std::chrono::milliseconds(120));
+    m_spotlightMaskGradient.StartAnimation(L"EllipseRadius", anim);
+}
+
+// Spotlight release: animate the mask back to the configured radius.
+void Highlighter::SpotlightAnimateRelease()
+{
+    m_spotlightPressed = false;
+
+    if (!m_spotlightMode || !m_spotlightMaskGradient)
+    {
+        return;
+    }
+
+    auto ease = m_compositor.CreateCubicBezierEasingFunction({ 0.215f, 0.61f }, { 0.355f, 1.0f });
+    auto current = m_spotlightMaskGradient.EllipseRadius();
+    auto anim = m_compositor.CreateVector2KeyFrameAnimation();
+    anim.InsertKeyFrame(0.0f, current);
+    anim.InsertKeyFrame(1.0f, { m_radius, m_radius }, ease);
+    anim.Duration(std::chrono::milliseconds(200));
+    m_spotlightMaskGradient.StartAnimation(L"EllipseRadius", anim);
+}
+
+// Spawn the press/hold ring + glow at the click point. The shapes persist
+// until FadeRippleHoldDot is called (button-up). While held they can be
+// re-positioned to follow the cursor (UpdateDrawingPointPosition).
+void Highlighter::SpawnRippleHoldDot(MouseButton button)
 {
     if (!m_compositor || !m_shape)
     {
         return;
     }
 
-    winrt::Windows::UI::Color color;
-    if (button == MouseButton::Left)
-    {
-        color = m_leftClickColor;
-    }
-    else if (button == MouseButton::Right)
-    {
-        color = m_rightClickColor;
-    }
-    else
-    {
-        color = m_alwaysColor;
-    }
-
+    winrt::Windows::UI::Color color = (button == MouseButton::Left) ? m_leftClickColor : m_rightClickColor;
     if (color.A == 0)
     {
         return;
     }
 
-    // Resolve sizing/intensity/duration from the ripple-specific settings so
-    // they're independent of the legacy "always-on dot" controls.
+    POINT pt{};
+    if (!GetCursorPos(&pt))
+    {
+        return;
+    }
+    ScreenToClient(m_hwnd, &pt);
+    const float fx = static_cast<float>(pt.x);
+    const float fy = static_cast<float>(pt.y);
+
+    // Resolve sizing/intensity from the ripple-specific settings so they're
+    // independent of the legacy "always-on dot" controls.
+    const float baseSize = (m_rippleSize > 1.0f) ? m_rippleSize : 1.0f;
+    float intensity = m_rippleIntensity;
+    if (intensity < 0.15f) intensity = 0.15f;
+    if (intensity > 1.35f) intensity = 1.35f;
+
+    const float ringStart = baseSize * 0.20f;
+    const float ringHeld = baseSize * 0.55f;
+    const float glowStart = baseSize * 0.30f;
+    const float glowHeld = baseSize * 0.65f;
+    const float lineWidth = (std::max)(2.25f, baseSize * (0.035f + intensity * 0.045f));
+
+    auto ease = m_compositor.CreateCubicBezierEasingFunction({ 0.215f, 0.61f }, { 0.355f, 1.0f });
+    auto dur = std::chrono::milliseconds(250);
+
+    auto clampByte = [](float v) -> uint8_t {
+        if (v < 0.0f) v = 0.0f;
+        if (v > 255.0f) v = 255.0f;
+        return static_cast<uint8_t>(v);
+    };
+
+    // Glow color is the click color, lower alpha (×0.30), scaled by intensity.
+    const float glowAlpha = static_cast<float>(color.A) * 0.30f * intensity;
+    auto glowColor = winrt::Windows::UI::ColorHelper::FromArgb(clampByte(glowAlpha), color.R, color.G, color.B);
+
+    // Ring color uses full base alpha (alphaMul like the press recipe).
+    const float alphaMul = 0.18f + intensity * 0.78f;
+    auto ringColor = winrt::Windows::UI::ColorHelper::FromArgb(clampByte(static_cast<float>(color.A) * alphaMul), color.R, color.G, color.B);
+
+    // Clean up any stray "still held" shapes for this button — guards against
+    // stray button-down without matching button-up (e.g. focus loss).
+    winrt::CompositionSpriteShape& heldRing = (button == MouseButton::Left) ? m_leftPointer : m_rightPointer;
+    winrt::CompositionSpriteShape& heldGlow = (button == MouseButton::Left) ? m_leftRippleGlow : m_rightRippleGlow;
+    winrt::CompositionEllipseGeometry& heldGeom = (button == MouseButton::Left) ? m_leftGeometry : m_rightGeometry;
+    winrt::CompositionEllipseGeometry& heldGlowGeom = (button == MouseButton::Left) ? m_leftGlowGeometry : m_rightGlowGeometry;
+
+    if (m_shape && m_shape.Shapes())
+    {
+        auto shapes = m_shape.Shapes();
+        uint32_t idx = 0;
+        if (heldRing && shapes.IndexOf(heldRing, idx))
+        {
+            shapes.RemoveAt(idx);
+        }
+        if (heldGlow && shapes.IndexOf(heldGlow, idx))
+        {
+            shapes.RemoveAt(idx);
+        }
+    }
+
+    // Glow (filled) — added first so the ring renders on top.
+    auto glowGeom = m_compositor.CreateEllipseGeometry();
+    glowGeom.Radius({ glowStart, glowStart });
+    auto glowBrush = m_compositor.CreateColorBrush(glowColor);
+    auto glowShape = m_compositor.CreateSpriteShape(glowGeom);
+    glowShape.Offset({ fx, fy });
+    glowShape.FillBrush(glowBrush);
+    m_shape.Shapes().Append(glowShape);
+
+    auto glowAnim = m_compositor.CreateVector2KeyFrameAnimation();
+    glowAnim.InsertKeyFrame(0.0f, { glowStart, glowStart });
+    glowAnim.InsertKeyFrame(1.0f, { glowHeld, glowHeld }, ease);
+    glowAnim.Duration(dur);
+    glowGeom.StartAnimation(L"Radius", glowAnim);
+
+    // Ring (stroked).
+    auto ringGeom = m_compositor.CreateEllipseGeometry();
+    ringGeom.Radius({ ringStart, ringStart });
+    auto ringBrush = m_compositor.CreateColorBrush(ringColor);
+    auto ringShape = m_compositor.CreateSpriteShape(ringGeom);
+    ringShape.Offset({ fx, fy });
+    ringShape.StrokeBrush(ringBrush);
+    ringShape.StrokeThickness(lineWidth);
+    ringShape.IsStrokeNonScaling(true);
+    m_shape.Shapes().Append(ringShape);
+
+    auto ringAnim = m_compositor.CreateVector2KeyFrameAnimation();
+    ringAnim.InsertKeyFrame(0.0f, { ringStart, ringStart });
+    ringAnim.InsertKeyFrame(1.0f, { ringHeld, ringHeld }, ease);
+    ringAnim.Duration(dur);
+    ringGeom.StartAnimation(L"Radius", ringAnim);
+
+    heldRing = ringShape;
+    heldGlow = glowShape;
+    heldGeom = ringGeom;
+    heldGlowGeom = glowGeom;
+}
+
+// Continue the held-ring/glow animation outward and fade both to transparent.
+// For right-click, optionally spawn the expanding crosshair lines.
+void Highlighter::FadeRippleHoldDot(MouseButton button)
+{
+    if (!m_compositor || !m_shape)
+    {
+        return;
+    }
+
+    winrt::CompositionSpriteShape& heldRing = (button == MouseButton::Left) ? m_leftPointer : m_rightPointer;
+    winrt::CompositionSpriteShape& heldGlow = (button == MouseButton::Left) ? m_leftRippleGlow : m_rightRippleGlow;
+    winrt::CompositionEllipseGeometry& heldGeom = (button == MouseButton::Left) ? m_leftGeometry : m_rightGeometry;
+    winrt::CompositionEllipseGeometry& heldGlowGeom = (button == MouseButton::Left) ? m_leftGlowGeometry : m_rightGlowGeometry;
+
+    if (!heldRing && !heldGlow)
+    {
+        return;
+    }
+
+    winrt::Windows::UI::Color color = (button == MouseButton::Left) ? m_leftClickColor : m_rightClickColor;
+
     const float baseSize = (m_rippleSize > 1.0f) ? m_rippleSize : 1.0f;
     float intensity = m_rippleIntensity;
     if (intensity < 0.15f) intensity = 0.15f;
@@ -792,124 +997,134 @@ void Highlighter::SpawnRipplePulse(POINT clientPt, MouseButton button, RippleKin
     int durationMs = m_rippleDurationMs;
     if (durationMs < 60) durationMs = 60;
     if (durationMs > 2000) durationMs = 2000;
-    if (kind == RippleKind::Release)
-    {
-        durationMs = static_cast<int>(durationMs * 0.78f);
-    }
-    else if (kind == RippleKind::Drag)
-    {
-        durationMs = (std::min)(380, static_cast<int>(durationMs * 0.82f));
-    }
-    if (durationMs < 40) durationMs = 40;
     auto dur = std::chrono::milliseconds(durationMs);
 
-    // Cubic ease-out (matches ClickLight's 1 - (1 - p)^3 feel).
+    const float ringHeld = baseSize * 0.55f;
+    const float ringEnd = baseSize * 1.05f;
+    const float glowHeld = baseSize * 0.65f;
+    const float glowEnd = baseSize * 1.40f;
+
     auto ease = m_compositor.CreateCubicBezierEasingFunction({ 0.215f, 0.61f }, { 0.355f, 1.0f });
-
-    // ClickLight visual recipe: alpha = (0.18 + intensity * 0.78) * baseColor.A,
-    // line width = max(2.25, baseSize * (0.035 + intensity * 0.045)).
-    const float alphaMul = 0.18f + intensity * 0.78f;
-
-    auto makeColor = [&](float mul) {
-        float a = static_cast<float>(color.A) * mul;
-        if (a < 0.0f) a = 0.0f;
-        if (a > 255.0f) a = 255.0f;
-        return winrt::Windows::UI::ColorHelper::FromArgb(static_cast<uint8_t>(a), color.R, color.G, color.B);
-    };
     auto transparent = winrt::Windows::UI::ColorHelper::FromArgb(0, color.R, color.G, color.B);
 
-    const float fx = static_cast<float>(clientPt.x);
-    const float fy = static_cast<float>(clientPt.y);
-
-    // Track shapes spawned by this pulse so the completion callback can remove them.
+    // Track everything spawned by this fade (and the held shapes themselves)
+    // so the completion callback can remove them in one pass.
     auto spawned = std::make_shared<std::vector<winrt::CompositionSpriteShape>>();
 
-    auto addEllipseShape = [&](float startRadius,
-                               float endRadius,
-                               winrt::Windows::UI::Color startColor,
-                               bool stroked,
-                               float strokeWidth) {
-        auto geom = m_compositor.CreateEllipseGeometry();
-        geom.Radius({ startRadius, startRadius });
-        auto brush = m_compositor.CreateColorBrush(startColor);
-        auto shape = m_compositor.CreateSpriteShape(geom);
-        shape.Offset({ fx, fy });
-        if (stroked)
-        {
-            shape.StrokeBrush(brush);
-            shape.StrokeThickness(strokeWidth);
-            shape.IsStrokeNonScaling(true);
-        }
-        else
-        {
-            shape.FillBrush(brush);
-        }
-        m_shape.Shapes().Append(shape);
-        spawned->push_back(shape);
+    auto batch = m_compositor.CreateScopedBatch(winrt::CompositionBatchTypes::Animation);
 
-        auto sizeAnim = m_compositor.CreateVector2KeyFrameAnimation();
-        sizeAnim.InsertKeyFrame(0.0f, { startRadius, startRadius });
-        sizeAnim.InsertKeyFrame(1.0f, { endRadius, endRadius }, ease);
-        sizeAnim.Duration(dur);
-        geom.StartAnimation(L"Radius", sizeAnim);
+    if (heldGlow && heldGlowGeom)
+    {
+        // Capture current radius so we animate continuously from where the
+        // press animation left off (or from glowHeld if the press is finished).
+        auto curR = heldGlowGeom.Radius();
+        auto glowAnim = m_compositor.CreateVector2KeyFrameAnimation();
+        glowAnim.InsertKeyFrame(0.0f, curR);
+        glowAnim.InsertKeyFrame(1.0f, { glowEnd, glowEnd }, ease);
+        glowAnim.Duration(dur);
+        heldGlowGeom.StopAnimation(L"Radius");
+        heldGlowGeom.StartAnimation(L"Radius", glowAnim);
 
+        auto brush = heldGlow.FillBrush().as<winrt::Windows::UI::Composition::CompositionColorBrush>();
+        auto startColor = brush.Color();
         auto colorAnim = m_compositor.CreateColorKeyFrameAnimation();
         colorAnim.InsertKeyFrame(0.0f, startColor);
         colorAnim.InsertKeyFrame(1.0f, transparent, ease);
         colorAnim.Duration(dur);
         brush.StartAnimation(L"Color", colorAnim);
-    };
 
-    auto batch = m_compositor.CreateScopedBatch(winrt::CompositionBatchTypes::Animation);
-
-    if (kind == RippleKind::Press)
-    {
-        const float ringStart = baseSize * 0.18f;
-        const float ringEnd = baseSize * 0.80f;
-        const float glowStart = baseSize * 0.28f;
-        const float glowEnd = baseSize * 1.06f;
-        const float lineWidth = (std::max)(2.25f, baseSize * (0.035f + intensity * 0.045f));
-
-        // Optional outer glow (only at higher intensities, like ClickLight).
-        if (intensity >= 0.7f)
-        {
-            const float glowMul = (intensity >= 1.2f) ? 0.18f : 0.08f;
-            addEllipseShape(glowStart, glowEnd, makeColor(glowMul * intensity), /*stroked*/ false, 0.0f);
-        }
-        // Expanding stroked ring.
-        addEllipseShape(ringStart, ringEnd, makeColor(alphaMul), /*stroked*/ true, lineWidth);
-        // Small filled center dot for extra punch.
-        const float dotRadius = baseSize * 0.085f;
-        addEllipseShape(dotRadius, dotRadius, makeColor(alphaMul * 0.75f), /*stroked*/ false, 0.0f);
+        spawned->push_back(heldGlow);
     }
-    else if (kind == RippleKind::Release)
-    {
-        // Contracting echo: the ring starts large and shrinks inward at lower alpha.
-        const float relSize = baseSize * 0.82f;
-        const float ringStart = relSize * 0.76f;
-        const float ringEnd = relSize * 0.34f;
-        const float glowStart = relSize * 0.76f * 1.25f;
-        const float glowEnd = relSize * 0.34f * 1.25f;
-        const float lineWidth = (std::max)(2.25f, relSize * (0.035f + intensity * 0.045f)) * 0.55f;
-        const float releaseAlpha = alphaMul * 0.55f;
 
-        if (intensity >= 0.7f)
-        {
-            const float glowMul = (intensity >= 1.2f) ? 0.18f : 0.08f;
-            addEllipseShape(glowStart, glowEnd, makeColor(glowMul * intensity * 0.45f), /*stroked*/ false, 0.0f);
-        }
-        addEllipseShape(ringStart, ringEnd, makeColor(releaseAlpha), /*stroked*/ true, lineWidth);
-    }
-    else // RippleKind::Drag
+    if (heldRing && heldGeom)
     {
-        // Small fading dot along the drag path.
-        const float dragBase = baseSize * 0.6f;
-        const float dotRadius = dragBase * (0.08f + 0.065f * intensity);
-        if (dotRadius >= 0.5f)
-        {
-            addEllipseShape(dotRadius, dotRadius, makeColor(alphaMul * 0.78f), /*stroked*/ false, 0.0f);
-        }
+        auto curR = heldGeom.Radius();
+        auto ringAnim = m_compositor.CreateVector2KeyFrameAnimation();
+        ringAnim.InsertKeyFrame(0.0f, curR);
+        ringAnim.InsertKeyFrame(1.0f, { ringEnd, ringEnd }, ease);
+        ringAnim.Duration(dur);
+        heldGeom.StopAnimation(L"Radius");
+        heldGeom.StartAnimation(L"Radius", ringAnim);
+
+        auto brush = heldRing.StrokeBrush().as<winrt::Windows::UI::Composition::CompositionColorBrush>();
+        auto startColor = brush.Color();
+        auto colorAnim = m_compositor.CreateColorKeyFrameAnimation();
+        colorAnim.InsertKeyFrame(0.0f, startColor);
+        colorAnim.InsertKeyFrame(1.0f, transparent, ease);
+        colorAnim.Duration(dur);
+        brush.StartAnimation(L"Color", colorAnim);
+
+        spawned->push_back(heldRing);
     }
+
+    // Right-click only: spawn expanding crosshair lines centered on the ring.
+    // Gated by the "show crosshairs on right-click release" toggle.
+    if (button == MouseButton::Right && m_rippleShowReleasePulse && heldRing)
+    {
+        const float xhairAlphaMul = 0.18f + intensity * 0.78f;
+        auto clampByte = [](float v) -> uint8_t {
+            if (v < 0.0f) v = 0.0f;
+            if (v > 255.0f) v = 255.0f;
+            return static_cast<uint8_t>(v);
+        };
+        auto xhairColor = winrt::Windows::UI::ColorHelper::FromArgb(clampByte(static_cast<float>(color.A) * xhairAlphaMul), color.R, color.G, color.B);
+        const float xhairThickness = (std::max)(1.25f, baseSize * (0.025f + intensity * 0.03f));
+
+        auto center = heldRing.Offset();
+        const float startSpan = ringHeld * 0.85f;
+        const float endSpan = ringEnd * 0.85f;
+
+        auto makeLine = [&](float ax1, float ay1, float ax2, float ay2,
+                            float bx1, float by1, float bx2, float by2) {
+            auto lineGeom = m_compositor.CreateLineGeometry();
+            lineGeom.Start({ ax1, ay1 });
+            lineGeom.End({ ax2, ay2 });
+
+            auto lineBrush = m_compositor.CreateColorBrush(xhairColor);
+            auto lineShape = m_compositor.CreateSpriteShape(lineGeom);
+            lineShape.StrokeBrush(lineBrush);
+            lineShape.StrokeThickness(xhairThickness);
+            lineShape.IsStrokeNonScaling(true);
+            m_shape.Shapes().Append(lineShape);
+            spawned->push_back(lineShape);
+
+            auto startAnim = m_compositor.CreateVector2KeyFrameAnimation();
+            startAnim.InsertKeyFrame(0.0f, { ax1, ay1 });
+            startAnim.InsertKeyFrame(1.0f, { bx1, by1 }, ease);
+            startAnim.Duration(dur);
+            lineGeom.StartAnimation(L"Start", startAnim);
+
+            auto endAnim = m_compositor.CreateVector2KeyFrameAnimation();
+            endAnim.InsertKeyFrame(0.0f, { ax2, ay2 });
+            endAnim.InsertKeyFrame(1.0f, { bx2, by2 }, ease);
+            endAnim.Duration(dur);
+            lineGeom.StartAnimation(L"End", endAnim);
+
+            auto colorAnim = m_compositor.CreateColorKeyFrameAnimation();
+            colorAnim.InsertKeyFrame(0.0f, xhairColor);
+            colorAnim.InsertKeyFrame(1.0f, transparent, ease);
+            colorAnim.Duration(dur);
+            lineBrush.StartAnimation(L"Color", colorAnim);
+        };
+
+        // Horizontal line (left half, right half).
+        makeLine(center.x - startSpan, center.y, center.x - startSpan * 0.30f, center.y,
+                 center.x - endSpan,   center.y, center.x - endSpan   * 0.30f, center.y);
+        makeLine(center.x + startSpan * 0.30f, center.y, center.x + startSpan, center.y,
+                 center.x + endSpan   * 0.30f, center.y, center.x + endSpan,   center.y);
+        // Vertical line (top half, bottom half).
+        makeLine(center.x, center.y - startSpan, center.x, center.y - startSpan * 0.30f,
+                 center.x, center.y - endSpan,   center.x, center.y - endSpan   * 0.30f);
+        makeLine(center.x, center.y + startSpan * 0.30f, center.x, center.y + startSpan,
+                 center.x, center.y + endSpan   * 0.30f, center.x, center.y + endSpan);
+    }
+
+    // Detach our member handles BEFORE the batch completes so subsequent
+    // press events on this button create fresh shapes rather than racing.
+    heldRing = nullptr;
+    heldGlow = nullptr;
+    heldGeom = nullptr;
+    heldGlowGeom = nullptr;
 
     batch.End();
 
@@ -920,7 +1135,6 @@ void Highlighter::SpawnRipplePulse(POINT clientPt, MouseButton button, RippleKin
 
     auto dispatcher = m_dispatcherQueueController.DispatcherQueue();
     batch.Completed([dispatcher, spawned](auto&&, auto&&) {
-        // Marshal shape removal back to the dispatcher thread.
         dispatcher.TryEnqueue([spawned]() {
             try
             {

--- a/src/modules/MouseUtils/MouseHighlighter/MouseHighlighter.cpp
+++ b/src/modules/MouseUtils/MouseHighlighter/MouseHighlighter.cpp
@@ -6,6 +6,8 @@
 #include "trace.h"
 #include <cmath>
 #include <algorithm>
+#include <memory>
+#include <vector>
 
 #ifdef COMPOSITION
 namespace winrt
@@ -48,8 +50,16 @@ private:
     void ClearDrawingPoint();
     void ClearDrawing();
     void BringToFront();
-    // Spawn a ClickLight-style expanding ripple pulse for the given click.
-    void SpawnRipplePulse(MouseButton button);
+    // Ripple pulse variants. Press = expanding ring+glow+dot, Release = contracting
+    // dimmer echo on button-up, Drag = small fading dot emitted along a held drag.
+    enum class RippleKind
+    {
+        Press,
+        Release,
+        Drag
+    };
+    // Spawn a ClickLight-style ripple pulse at the given client-area point.
+    void SpawnRipplePulse(POINT clientPt, MouseButton button, RippleKind kind);
     HHOOK m_mouseHook = NULL;
     static LRESULT CALLBACK MouseHookProc(int nCode, WPARAM wParam, LPARAM lParam) noexcept;
     // Helpers for spotlight overlay
@@ -87,6 +97,17 @@ private:
     bool m_alwaysPointerEnabled = true;
     bool m_spotlightMode = false;
     bool m_rippleMode = false;
+    bool m_rippleShowDragTrail = MOUSE_HIGHLIGHTER_DEFAULT_RIPPLE_SHOW_DRAG_TRAIL;
+    bool m_rippleShowReleasePulse = MOUSE_HIGHLIGHTER_DEFAULT_RIPPLE_SHOW_RELEASE_PULSE;
+    float m_rippleSize = static_cast<float>(MOUSE_HIGHLIGHTER_DEFAULT_RIPPLE_SIZE);
+    float m_rippleIntensity = static_cast<float>(MOUSE_HIGHLIGHTER_DEFAULT_RIPPLE_INTENSITY);
+    int m_rippleDurationMs = MOUSE_HIGHLIGHTER_DEFAULT_RIPPLE_DURATION_MS;
+
+    // Tracking for ripple-mode drag emission (independent of the legacy
+    // m_leftButtonPressed / m_rightButtonPressed which drive the circle mode).
+    bool m_rippleLeftPressed = false;
+    bool m_rippleRightPressed = false;
+    POINT m_lastRippleDragPt = { 0, 0 };
 
     bool m_leftButtonPressed = false;
     bool m_rightButtonPressed = false;
@@ -336,7 +357,11 @@ LRESULT CALLBACK Highlighter::MouseHookProc(int nCode, WPARAM wParam, LPARAM lPa
             {
                 if (instance->m_leftPointerEnabled)
                 {
-                    instance->SpawnRipplePulse(MouseButton::Left);
+                    POINT pt = hookData->pt;
+                    ScreenToClient(instance->m_hwnd, &pt);
+                    instance->SpawnRipplePulse(pt, MouseButton::Left, Highlighter::RippleKind::Press);
+                    instance->m_rippleLeftPressed = true;
+                    instance->m_lastRippleDragPt = hookData->pt;
                     if (instance->m_timer_id == 0)
                     {
                         instance->m_timer_id = SetTimer(instance->m_hwnd, BRING_TO_FRONT_TIMER_ID, 10, nullptr);
@@ -373,7 +398,11 @@ LRESULT CALLBACK Highlighter::MouseHookProc(int nCode, WPARAM wParam, LPARAM lPa
             {
                 if (instance->m_rightPointerEnabled)
                 {
-                    instance->SpawnRipplePulse(MouseButton::Right);
+                    POINT pt = hookData->pt;
+                    ScreenToClient(instance->m_hwnd, &pt);
+                    instance->SpawnRipplePulse(pt, MouseButton::Right, Highlighter::RippleKind::Press);
+                    instance->m_rippleRightPressed = true;
+                    instance->m_lastRippleDragPt = hookData->pt;
                     if (instance->m_timer_id == 0)
                     {
                         instance->m_timer_id = SetTimer(instance->m_hwnd, BRING_TO_FRONT_TIMER_ID, 10, nullptr);
@@ -403,6 +432,25 @@ LRESULT CALLBACK Highlighter::MouseHookProc(int nCode, WPARAM wParam, LPARAM lPa
             }
             break;
         case WM_MOUSEMOVE:
+            if (instance->m_rippleMode)
+            {
+                if (instance->m_rippleShowDragTrail && (instance->m_rippleLeftPressed || instance->m_rippleRightPressed))
+                {
+                    // Throttle: only emit a drag dot when the cursor has moved a
+                    // few pixels — matches ClickLight's ~2.5 px append threshold.
+                    LONG dx = hookData->pt.x - instance->m_lastRippleDragPt.x;
+                    LONG dy = hookData->pt.y - instance->m_lastRippleDragPt.y;
+                    if ((dx * dx + dy * dy) >= 9)
+                    {
+                        MouseButton heldButton = instance->m_rippleLeftPressed ? MouseButton::Left : MouseButton::Right;
+                        POINT pt = hookData->pt;
+                        ScreenToClient(instance->m_hwnd, &pt);
+                        instance->SpawnRipplePulse(pt, heldButton, Highlighter::RippleKind::Drag);
+                        instance->m_lastRippleDragPt = hookData->pt;
+                    }
+                }
+                break;
+            }
             if (instance->m_leftButtonPressed)
             {
                 instance->UpdateDrawingPointPosition(MouseButton::Left);
@@ -417,6 +465,20 @@ LRESULT CALLBACK Highlighter::MouseHookProc(int nCode, WPARAM wParam, LPARAM lPa
             }
             break;
         case WM_LBUTTONUP:
+            if (instance->m_rippleMode)
+            {
+                if (instance->m_rippleLeftPressed)
+                {
+                    if (instance->m_rippleShowReleasePulse && instance->m_leftPointerEnabled)
+                    {
+                        POINT pt = hookData->pt;
+                        ScreenToClient(instance->m_hwnd, &pt);
+                        instance->SpawnRipplePulse(pt, MouseButton::Left, Highlighter::RippleKind::Release);
+                    }
+                    instance->m_rippleLeftPressed = false;
+                }
+                break;
+            }
             if (instance->m_leftButtonPressed)
             {
                 instance->StartDrawingPointFading(MouseButton::Left);
@@ -429,6 +491,20 @@ LRESULT CALLBACK Highlighter::MouseHookProc(int nCode, WPARAM wParam, LPARAM lPa
             }
             break;
         case WM_RBUTTONUP:
+            if (instance->m_rippleMode)
+            {
+                if (instance->m_rippleRightPressed)
+                {
+                    if (instance->m_rippleShowReleasePulse && instance->m_rightPointerEnabled)
+                    {
+                        POINT pt = hookData->pt;
+                        ScreenToClient(instance->m_hwnd, &pt);
+                        instance->SpawnRipplePulse(pt, MouseButton::Right, Highlighter::RippleKind::Release);
+                    }
+                    instance->m_rippleRightPressed = false;
+                }
+                break;
+            }
             if (instance->m_rightButtonPressed)
             {
                 instance->StartDrawingPointFading(MouseButton::Right);
@@ -475,6 +551,8 @@ void Highlighter::StopDrawing()
     m_visible = false;
     m_leftButtonPressed = false;
     m_rightButtonPressed = false;
+    m_rippleLeftPressed = false;
+    m_rippleRightPressed = false;
     m_leftPointer = nullptr;
     m_rightPointer = nullptr;
     m_alwaysPointer = nullptr;
@@ -506,6 +584,11 @@ void Highlighter::ApplySettings(MouseHighlighterSettings settings)
     m_alwaysPointerEnabled = settings.alwaysColor.A != 0;
     m_spotlightMode = settings.spotlightMode && settings.alwaysColor.A != 0;
     m_rippleMode = settings.rippleMode && !m_spotlightMode;
+    m_rippleSize = (settings.rippleSize > 0) ? static_cast<float>(settings.rippleSize) : static_cast<float>(MOUSE_HIGHLIGHTER_DEFAULT_RIPPLE_SIZE);
+    m_rippleIntensity = (settings.rippleIntensity > 0.0) ? static_cast<float>(settings.rippleIntensity) : static_cast<float>(MOUSE_HIGHLIGHTER_DEFAULT_RIPPLE_INTENSITY);
+    m_rippleDurationMs = (settings.rippleDurationMs > 0) ? settings.rippleDurationMs : MOUSE_HIGHLIGHTER_DEFAULT_RIPPLE_DURATION_MS;
+    m_rippleShowDragTrail = settings.rippleShowDragTrail;
+    m_rippleShowReleasePulse = settings.rippleShowReleasePulse;
 
     if (m_spotlightMode)
     {
@@ -673,16 +756,12 @@ void Highlighter::UpdateSpotlightMask(float cx, float cy, float radius, bool sho
 
 // Spawn a ClickLight-inspired expanding ring + glow pulse at the cursor.
 // Each click emits a transient, self-cleaning pulse — pulses can overlap.
-void Highlighter::SpawnRipplePulse(MouseButton button)
+void Highlighter::SpawnRipplePulse(POINT clientPt, MouseButton button, RippleKind kind)
 {
     if (!m_compositor || !m_shape)
     {
         return;
     }
-
-    POINT pt;
-    GetCursorPos(&pt);
-    ScreenToClient(m_hwnd, &pt);
 
     winrt::Windows::UI::Color color;
     if (button == MouseButton::Left)
@@ -703,92 +782,146 @@ void Highlighter::SpawnRipplePulse(MouseButton button)
         return;
     }
 
-    const float baseRadius = (m_radius < 1.0f) ? 1.0f : m_radius;
+    // Resolve sizing/intensity/duration from the ripple-specific settings so
+    // they're independent of the legacy "always-on dot" controls.
+    const float baseSize = (m_rippleSize > 1.0f) ? m_rippleSize : 1.0f;
+    float intensity = m_rippleIntensity;
+    if (intensity < 0.15f) intensity = 0.15f;
+    if (intensity > 1.35f) intensity = 1.35f;
 
-    // ClickLight-style proportions: ring expands from ~0.20× to ~1.05× of the base radius,
-    // glow halo follows from ~0.30× to ~1.40× at a lower intensity.
-    const float ringStart = baseRadius * 0.20f;
-    const float ringEnd = baseRadius * 1.05f;
-    const float glowStart = baseRadius * 0.30f;
-    const float glowEnd = baseRadius * 1.40f;
-
-    int duration = m_fadeDuration_ms;
-    if (duration < 60)
+    int durationMs = m_rippleDurationMs;
+    if (durationMs < 60) durationMs = 60;
+    if (durationMs > 2000) durationMs = 2000;
+    if (kind == RippleKind::Release)
     {
-        duration = 60;
+        durationMs = static_cast<int>(durationMs * 0.78f);
     }
-    if (duration > 2000)
+    else if (kind == RippleKind::Drag)
     {
-        duration = 2000;
+        durationMs = (std::min)(380, static_cast<int>(durationMs * 0.82f));
     }
-    auto dur = std::chrono::milliseconds(duration);
+    if (durationMs < 40) durationMs = 40;
+    auto dur = std::chrono::milliseconds(durationMs);
 
     // Cubic ease-out (matches ClickLight's 1 - (1 - p)^3 feel).
     auto ease = m_compositor.CreateCubicBezierEasingFunction({ 0.215f, 0.61f }, { 0.355f, 1.0f });
 
-    // Final, fully-transparent target color (preserves RGB to avoid mid-animation tint shifts).
-    auto transparentColor = winrt::Windows::UI::ColorHelper::FromArgb(0, color.R, color.G, color.B);
+    // ClickLight visual recipe: alpha = (0.18 + intensity * 0.78) * baseColor.A,
+    // line width = max(2.25, baseSize * (0.035 + intensity * 0.045)).
+    const float alphaMul = 0.18f + intensity * 0.78f;
 
-    // Glow (filled, low-alpha halo).
-    auto glowColor = winrt::Windows::UI::ColorHelper::FromArgb(
-        static_cast<uint8_t>(static_cast<float>(color.A) * 0.35f),
-        color.R,
-        color.G,
-        color.B);
-    auto glowGeom = m_compositor.CreateEllipseGeometry();
-    glowGeom.Radius({ glowStart, glowStart });
-    auto glowBrush = m_compositor.CreateColorBrush(glowColor);
-    auto glowShape = m_compositor.CreateSpriteShape(glowGeom);
-    glowShape.Offset({ static_cast<float>(pt.x), static_cast<float>(pt.y) });
-    glowShape.FillBrush(glowBrush);
+    auto makeColor = [&](float mul) {
+        float a = static_cast<float>(color.A) * mul;
+        if (a < 0.0f) a = 0.0f;
+        if (a > 255.0f) a = 255.0f;
+        return winrt::Windows::UI::ColorHelper::FromArgb(static_cast<uint8_t>(a), color.R, color.G, color.B);
+    };
+    auto transparent = winrt::Windows::UI::ColorHelper::FromArgb(0, color.R, color.G, color.B);
 
-    // Ring (stroked, full color).
-    auto ringGeom = m_compositor.CreateEllipseGeometry();
-    ringGeom.Radius({ ringStart, ringStart });
-    auto ringBrush = m_compositor.CreateColorBrush(color);
-    auto ringShape = m_compositor.CreateSpriteShape(ringGeom);
-    ringShape.Offset({ static_cast<float>(pt.x), static_cast<float>(pt.y) });
-    ringShape.StrokeBrush(ringBrush);
-    ringShape.StrokeThickness((std::max)(2.0f, baseRadius * 0.18f));
-    ringShape.IsStrokeNonScaling(true);
+    const float fx = static_cast<float>(clientPt.x);
+    const float fy = static_cast<float>(clientPt.y);
 
-    m_shape.Shapes().Append(glowShape);
-    m_shape.Shapes().Append(ringShape);
+    // Track shapes spawned by this pulse so the completion callback can remove them.
+    auto spawned = std::make_shared<std::vector<winrt::CompositionSpriteShape>>();
 
-    // Radius animations (scale-equivalent, keeps stroke crisp).
-    auto glowSizeAnim = m_compositor.CreateVector2KeyFrameAnimation();
-    glowSizeAnim.InsertKeyFrame(0.0f, { glowStart, glowStart });
-    glowSizeAnim.InsertKeyFrame(1.0f, { glowEnd, glowEnd }, ease);
-    glowSizeAnim.Duration(dur);
+    auto addEllipseShape = [&](float startRadius,
+                               float endRadius,
+                               winrt::Windows::UI::Color startColor,
+                               bool stroked,
+                               float strokeWidth) {
+        auto geom = m_compositor.CreateEllipseGeometry();
+        geom.Radius({ startRadius, startRadius });
+        auto brush = m_compositor.CreateColorBrush(startColor);
+        auto shape = m_compositor.CreateSpriteShape(geom);
+        shape.Offset({ fx, fy });
+        if (stroked)
+        {
+            shape.StrokeBrush(brush);
+            shape.StrokeThickness(strokeWidth);
+            shape.IsStrokeNonScaling(true);
+        }
+        else
+        {
+            shape.FillBrush(brush);
+        }
+        m_shape.Shapes().Append(shape);
+        spawned->push_back(shape);
 
-    auto ringSizeAnim = m_compositor.CreateVector2KeyFrameAnimation();
-    ringSizeAnim.InsertKeyFrame(0.0f, { ringStart, ringStart });
-    ringSizeAnim.InsertKeyFrame(1.0f, { ringEnd, ringEnd }, ease);
-    ringSizeAnim.Duration(dur);
+        auto sizeAnim = m_compositor.CreateVector2KeyFrameAnimation();
+        sizeAnim.InsertKeyFrame(0.0f, { startRadius, startRadius });
+        sizeAnim.InsertKeyFrame(1.0f, { endRadius, endRadius }, ease);
+        sizeAnim.Duration(dur);
+        geom.StartAnimation(L"Radius", sizeAnim);
 
-    // Color (alpha) fade-out animations.
-    auto glowColorAnim = m_compositor.CreateColorKeyFrameAnimation();
-    glowColorAnim.InsertKeyFrame(0.0f, glowColor);
-    glowColorAnim.InsertKeyFrame(1.0f, transparentColor, ease);
-    glowColorAnim.Duration(dur);
+        auto colorAnim = m_compositor.CreateColorKeyFrameAnimation();
+        colorAnim.InsertKeyFrame(0.0f, startColor);
+        colorAnim.InsertKeyFrame(1.0f, transparent, ease);
+        colorAnim.Duration(dur);
+        brush.StartAnimation(L"Color", colorAnim);
+    };
 
-    auto ringColorAnim = m_compositor.CreateColorKeyFrameAnimation();
-    ringColorAnim.InsertKeyFrame(0.0f, color);
-    ringColorAnim.InsertKeyFrame(1.0f, transparentColor, ease);
-    ringColorAnim.Duration(dur);
-
-    // Batch the four animations so we can clean up the shapes when the pulse ends.
     auto batch = m_compositor.CreateScopedBatch(winrt::CompositionBatchTypes::Animation);
-    glowGeom.StartAnimation(L"Radius", glowSizeAnim);
-    ringGeom.StartAnimation(L"Radius", ringSizeAnim);
-    glowBrush.StartAnimation(L"Color", glowColorAnim);
-    ringBrush.StartAnimation(L"Color", ringColorAnim);
+
+    if (kind == RippleKind::Press)
+    {
+        const float ringStart = baseSize * 0.18f;
+        const float ringEnd = baseSize * 0.80f;
+        const float glowStart = baseSize * 0.28f;
+        const float glowEnd = baseSize * 1.06f;
+        const float lineWidth = (std::max)(2.25f, baseSize * (0.035f + intensity * 0.045f));
+
+        // Optional outer glow (only at higher intensities, like ClickLight).
+        if (intensity >= 0.7f)
+        {
+            const float glowMul = (intensity >= 1.2f) ? 0.18f : 0.08f;
+            addEllipseShape(glowStart, glowEnd, makeColor(glowMul * intensity), /*stroked*/ false, 0.0f);
+        }
+        // Expanding stroked ring.
+        addEllipseShape(ringStart, ringEnd, makeColor(alphaMul), /*stroked*/ true, lineWidth);
+        // Small filled center dot for extra punch.
+        const float dotRadius = baseSize * 0.085f;
+        addEllipseShape(dotRadius, dotRadius, makeColor(alphaMul * 0.75f), /*stroked*/ false, 0.0f);
+    }
+    else if (kind == RippleKind::Release)
+    {
+        // Contracting echo: the ring starts large and shrinks inward at lower alpha.
+        const float relSize = baseSize * 0.82f;
+        const float ringStart = relSize * 0.76f;
+        const float ringEnd = relSize * 0.34f;
+        const float glowStart = relSize * 0.76f * 1.25f;
+        const float glowEnd = relSize * 0.34f * 1.25f;
+        const float lineWidth = (std::max)(2.25f, relSize * (0.035f + intensity * 0.045f)) * 0.55f;
+        const float releaseAlpha = alphaMul * 0.55f;
+
+        if (intensity >= 0.7f)
+        {
+            const float glowMul = (intensity >= 1.2f) ? 0.18f : 0.08f;
+            addEllipseShape(glowStart, glowEnd, makeColor(glowMul * intensity * 0.45f), /*stroked*/ false, 0.0f);
+        }
+        addEllipseShape(ringStart, ringEnd, makeColor(releaseAlpha), /*stroked*/ true, lineWidth);
+    }
+    else // RippleKind::Drag
+    {
+        // Small fading dot along the drag path.
+        const float dragBase = baseSize * 0.6f;
+        const float dotRadius = dragBase * (0.08f + 0.065f * intensity);
+        if (dotRadius >= 0.5f)
+        {
+            addEllipseShape(dotRadius, dotRadius, makeColor(alphaMul * 0.78f), /*stroked*/ false, 0.0f);
+        }
+    }
+
     batch.End();
 
+    if (spawned->empty())
+    {
+        return;
+    }
+
     auto dispatcher = m_dispatcherQueueController.DispatcherQueue();
-    batch.Completed([dispatcher, glowShape, ringShape](auto&&, auto&&) {
-        // Marshal shape removal back to the compositor thread.
-        dispatcher.TryEnqueue([glowShape, ringShape]() {
+    batch.Completed([dispatcher, spawned](auto&&, auto&&) {
+        // Marshal shape removal back to the dispatcher thread.
+        dispatcher.TryEnqueue([spawned]() {
             try
             {
                 if (Highlighter::instance == nullptr || Highlighter::instance->m_shape == nullptr)
@@ -796,14 +929,13 @@ void Highlighter::SpawnRipplePulse(MouseButton button)
                     return;
                 }
                 auto shapes = Highlighter::instance->m_shape.Shapes();
-                uint32_t index = 0;
-                if (shapes.IndexOf(ringShape, index))
+                for (auto const& s : *spawned)
                 {
-                    shapes.RemoveAt(index);
-                }
-                if (shapes.IndexOf(glowShape, index))
-                {
-                    shapes.RemoveAt(index);
+                    uint32_t index = 0;
+                    if (shapes.IndexOf(s, index))
+                    {
+                        shapes.RemoveAt(index);
+                    }
                 }
             }
             catch (...)

--- a/src/modules/MouseUtils/MouseHighlighter/MouseHighlighter.cpp
+++ b/src/modules/MouseUtils/MouseHighlighter/MouseHighlighter.cpp
@@ -55,6 +55,9 @@ private:
     // optionally follow the cursor while held (gated by m_rippleShowDragTrail).
     void SpawnRippleHoldDot(MouseButton button);
     void FadeRippleHoldDot(MouseButton button);
+    // Ripple mode: emit a single self-contained ripple (grow + fade) for a quick
+    // click, independent of any held indicator.
+    void EmitSingleRipple(MouseButton button);
     // Spotlight mode: pressed-state animation that shrinks the mask while
     // a mouse button is held and restores it on release.
     void SpotlightAnimatePress();
@@ -115,6 +118,12 @@ private:
 
     bool m_leftButtonPressed = false;
     bool m_rightButtonPressed = false;
+    // Pending hold-detection timers. A ripple "held indicator" is only spawned
+    // once the button has been held past a short threshold; a quick click that
+    // releases before then emits a single self-contained ripple instead. This
+    // prevents a single click from rendering two ripples (press + release).
+    UINT_PTR m_leftHoldTimer = 0;
+    UINT_PTR m_rightHoldTimer = 0;
     UINT_PTR m_timer_id = 0;
 
     bool m_visible = false;
@@ -130,6 +139,11 @@ private:
     winrt::Windows::UI::Color m_alwaysColor = MOUSE_HIGHLIGHTER_DEFAULT_ALWAYS_COLOR;
 };
 static const uint32_t BRING_TO_FRONT_TIMER_ID = 123;
+static const uint32_t HOLD_RIPPLE_TIMER_LEFT = 124;
+static const uint32_t HOLD_RIPPLE_TIMER_RIGHT = 125;
+// How long a ripple button must be held before the persistent "held indicator"
+// is shown. Releasing before this is treated as a quick click (single ripple).
+static const uint32_t HOLD_RIPPLE_THRESHOLD_MS = 180;
 Highlighter* Highlighter::instance = nullptr;
 
 bool Highlighter::CreateHighlighter()
@@ -418,8 +432,14 @@ LRESULT CALLBACK Highlighter::MouseHookProc(int nCode, WPARAM wParam, LPARAM lPa
             {
                 if (instance->m_leftPointerEnabled)
                 {
-                    instance->SpawnRippleHoldDot(MouseButton::Left);
+                    // Defer the held indicator: only spawn it if the button is
+                    // still down after the hold threshold. A quick click handled
+                    // on button-up emits a single ripple instead.
                     instance->m_leftButtonPressed = true;
+                    if (instance->m_leftHoldTimer == 0)
+                    {
+                        instance->m_leftHoldTimer = SetTimer(instance->m_hwnd, HOLD_RIPPLE_TIMER_LEFT, HOLD_RIPPLE_THRESHOLD_MS, nullptr);
+                    }
                     if (instance->m_timer_id == 0)
                     {
                         instance->m_timer_id = SetTimer(instance->m_hwnd, BRING_TO_FRONT_TIMER_ID, 10, nullptr);
@@ -461,8 +481,12 @@ LRESULT CALLBACK Highlighter::MouseHookProc(int nCode, WPARAM wParam, LPARAM lPa
             {
                 if (instance->m_rightPointerEnabled)
                 {
-                    instance->SpawnRippleHoldDot(MouseButton::Right);
+                    // Defer the held indicator (see WM_LBUTTONDOWN).
                     instance->m_rightButtonPressed = true;
+                    if (instance->m_rightHoldTimer == 0)
+                    {
+                        instance->m_rightHoldTimer = SetTimer(instance->m_hwnd, HOLD_RIPPLE_TIMER_RIGHT, HOLD_RIPPLE_THRESHOLD_MS, nullptr);
+                    }
                     if (instance->m_timer_id == 0)
                     {
                         instance->m_timer_id = SetTimer(instance->m_hwnd, BRING_TO_FRONT_TIMER_ID, 10, nullptr);
@@ -532,7 +556,18 @@ LRESULT CALLBACK Highlighter::MouseHookProc(int nCode, WPARAM wParam, LPARAM lPa
             {
                 if (instance->m_rippleMode)
                 {
-                    instance->FadeRippleHoldDot(MouseButton::Left);
+                    if (instance->m_leftHoldTimer != 0)
+                    {
+                        // Released before the hold threshold => quick click.
+                        KillTimer(instance->m_hwnd, instance->m_leftHoldTimer);
+                        instance->m_leftHoldTimer = 0;
+                        instance->EmitSingleRipple(MouseButton::Left);
+                    }
+                    else
+                    {
+                        // Held indicator was already shown; expand + fade it.
+                        instance->FadeRippleHoldDot(MouseButton::Left);
+                    }
                 }
                 else
                 {
@@ -555,7 +590,17 @@ LRESULT CALLBACK Highlighter::MouseHookProc(int nCode, WPARAM wParam, LPARAM lPa
             {
                 if (instance->m_rippleMode)
                 {
-                    instance->FadeRippleHoldDot(MouseButton::Right);
+                    if (instance->m_rightHoldTimer != 0)
+                    {
+                        // Released before the hold threshold => quick click.
+                        KillTimer(instance->m_hwnd, instance->m_rightHoldTimer);
+                        instance->m_rightHoldTimer = 0;
+                        instance->EmitSingleRipple(MouseButton::Right);
+                    }
+                    else
+                    {
+                        instance->FadeRippleHoldDot(MouseButton::Right);
+                    }
                 }
                 else
                 {
@@ -721,6 +766,7 @@ LRESULT CALLBACK Highlighter::WndProc(HWND hWnd, UINT message, WPARAM wParam, LP
             // If we would use a timer with a 50 ms period, there would be a flickering on the UI, as in most of the cases
             // the pinned window hides our window in a few milliseconds.
         case BRING_TO_FRONT_TIMER_ID:
+        {
             static int fireCount = 0;
             if (fireCount++ >= 4)
             {
@@ -729,6 +775,24 @@ LRESULT CALLBACK Highlighter::WndProc(HWND hWnd, UINT message, WPARAM wParam, LP
                 fireCount = 0;
             }
             instance->BringToFront();
+            break;
+        }
+        case HOLD_RIPPLE_TIMER_LEFT:
+            // Button held past the threshold: show the persistent held indicator.
+            KillTimer(instance->m_hwnd, instance->m_leftHoldTimer);
+            instance->m_leftHoldTimer = 0;
+            if (instance->m_leftButtonPressed)
+            {
+                instance->SpawnRippleHoldDot(MouseButton::Left);
+            }
+            break;
+        case HOLD_RIPPLE_TIMER_RIGHT:
+            KillTimer(instance->m_hwnd, instance->m_rightHoldTimer);
+            instance->m_rightHoldTimer = 0;
+            if (instance->m_rightButtonPressed)
+            {
+                instance->SpawnRippleHoldDot(MouseButton::Right);
+            }
             break;
         }
         break;
@@ -886,14 +950,19 @@ void Highlighter::SpawnRippleHoldDot(MouseButton button)
     if (intensity < 0.15f) intensity = 0.15f;
     if (intensity > 1.35f) intensity = 1.35f;
 
-    const float ringStart = baseSize * 0.20f;
     const float ringHeld = baseSize * 0.55f;
-    const float glowStart = baseSize * 0.30f;
     const float glowHeld = baseSize * 0.65f;
     const float lineWidth = (std::max)(2.25f, baseSize * (0.035f + intensity * 0.045f));
 
     auto ease = m_compositor.CreateCubicBezierEasingFunction({ 0.215f, 0.61f }, { 0.355f, 1.0f });
-    auto dur = std::chrono::milliseconds(250);
+    // Held indicator: appears once the button has been held past the hold
+    // threshold and sits at the held radius until release. It must NOT expand
+    // outward on appearance — it only FADES IN at the held size. The single
+    // outward "ripple" expansion happens exclusively on release
+    // (FadeRippleHoldDot). If this grew outward, a slow single click (release
+    // shortly after the threshold) would show grow-to-held + release as two
+    // expansions — the double-ripple bug.
+    auto dur = std::chrono::milliseconds(120);
 
     auto clampByte = [](float v) -> uint8_t {
         if (v < 0.0f) v = 0.0f;
@@ -904,10 +973,12 @@ void Highlighter::SpawnRippleHoldDot(MouseButton button)
     // Glow color is the click color, lower alpha (×0.30), scaled by intensity.
     const float glowAlpha = static_cast<float>(color.A) * 0.30f * intensity;
     auto glowColor = winrt::Windows::UI::ColorHelper::FromArgb(clampByte(glowAlpha), color.R, color.G, color.B);
+    auto glowTransparent = winrt::Windows::UI::ColorHelper::FromArgb(0, color.R, color.G, color.B);
 
     // Ring color uses full base alpha (alphaMul like the press recipe).
     const float alphaMul = 0.18f + intensity * 0.78f;
     auto ringColor = winrt::Windows::UI::ColorHelper::FromArgb(clampByte(static_cast<float>(color.A) * alphaMul), color.R, color.G, color.B);
+    auto ringTransparent = winrt::Windows::UI::ColorHelper::FromArgb(0, color.R, color.G, color.B);
 
     // Clean up any stray "still held" shapes for this button — guards against
     // stray button-down without matching button-up (e.g. focus loss).
@@ -930,25 +1001,26 @@ void Highlighter::SpawnRippleHoldDot(MouseButton button)
         }
     }
 
-    // Glow (filled) — added first so the ring renders on top.
+    // Glow (filled) — added first so the ring renders on top. Sits at the held
+    // radius and fades its alpha in (no outward size growth).
     auto glowGeom = m_compositor.CreateEllipseGeometry();
-    glowGeom.Radius({ glowStart, glowStart });
-    auto glowBrush = m_compositor.CreateColorBrush(glowColor);
+    glowGeom.Radius({ glowHeld, glowHeld });
+    auto glowBrush = m_compositor.CreateColorBrush(glowTransparent);
     auto glowShape = m_compositor.CreateSpriteShape(glowGeom);
     glowShape.Offset({ fx, fy });
     glowShape.FillBrush(glowBrush);
     m_shape.Shapes().Append(glowShape);
 
-    auto glowAnim = m_compositor.CreateVector2KeyFrameAnimation();
-    glowAnim.InsertKeyFrame(0.0f, { glowStart, glowStart });
-    glowAnim.InsertKeyFrame(1.0f, { glowHeld, glowHeld }, ease);
-    glowAnim.Duration(dur);
-    glowGeom.StartAnimation(L"Radius", glowAnim);
+    auto glowFadeIn = m_compositor.CreateColorKeyFrameAnimation();
+    glowFadeIn.InsertKeyFrame(0.0f, glowTransparent);
+    glowFadeIn.InsertKeyFrame(1.0f, glowColor, ease);
+    glowFadeIn.Duration(dur);
+    glowBrush.StartAnimation(L"Color", glowFadeIn);
 
-    // Ring (stroked).
+    // Ring (stroked) — same: fixed at held radius, alpha fade-in only.
     auto ringGeom = m_compositor.CreateEllipseGeometry();
-    ringGeom.Radius({ ringStart, ringStart });
-    auto ringBrush = m_compositor.CreateColorBrush(ringColor);
+    ringGeom.Radius({ ringHeld, ringHeld });
+    auto ringBrush = m_compositor.CreateColorBrush(ringTransparent);
     auto ringShape = m_compositor.CreateSpriteShape(ringGeom);
     ringShape.Offset({ fx, fy });
     ringShape.StrokeBrush(ringBrush);
@@ -956,11 +1028,11 @@ void Highlighter::SpawnRippleHoldDot(MouseButton button)
     ringShape.IsStrokeNonScaling(true);
     m_shape.Shapes().Append(ringShape);
 
-    auto ringAnim = m_compositor.CreateVector2KeyFrameAnimation();
-    ringAnim.InsertKeyFrame(0.0f, { ringStart, ringStart });
-    ringAnim.InsertKeyFrame(1.0f, { ringHeld, ringHeld }, ease);
-    ringAnim.Duration(dur);
-    ringGeom.StartAnimation(L"Radius", ringAnim);
+    auto ringFadeIn = m_compositor.CreateColorKeyFrameAnimation();
+    ringFadeIn.InsertKeyFrame(0.0f, ringTransparent);
+    ringFadeIn.InsertKeyFrame(1.0f, ringColor, ease);
+    ringFadeIn.Duration(dur);
+    ringBrush.StartAnimation(L"Color", ringFadeIn);
 
     heldRing = ringShape;
     heldGlow = glowShape;
@@ -1004,6 +1076,12 @@ void Highlighter::FadeRippleHoldDot(MouseButton button)
     const float glowHeld = baseSize * 0.65f;
     const float glowEnd = baseSize * 1.40f;
 
+    auto clampByte = [](float v) -> uint8_t {
+        if (v < 0.0f) v = 0.0f;
+        if (v > 255.0f) v = 255.0f;
+        return static_cast<uint8_t>(v);
+    };
+
     auto ease = m_compositor.CreateCubicBezierEasingFunction({ 0.215f, 0.61f }, { 0.355f, 1.0f });
     auto transparent = winrt::Windows::UI::ColorHelper::FromArgb(0, color.R, color.G, color.B);
 
@@ -1015,14 +1093,13 @@ void Highlighter::FadeRippleHoldDot(MouseButton button)
 
     if (heldGlow && heldGlowGeom)
     {
-        // Capture current radius so we animate continuously from where the
-        // press animation left off (or from glowHeld if the press is finished).
-        auto curR = heldGlowGeom.Radius();
+        // The held indicator has settled at the held radius; expand it outward
+        // from there and fade it to transparent.
+        heldGlowGeom.StopAnimation(L"Radius");
         auto glowAnim = m_compositor.CreateVector2KeyFrameAnimation();
-        glowAnim.InsertKeyFrame(0.0f, curR);
+        glowAnim.InsertKeyFrame(0.0f, { glowHeld, glowHeld });
         glowAnim.InsertKeyFrame(1.0f, { glowEnd, glowEnd }, ease);
         glowAnim.Duration(dur);
-        heldGlowGeom.StopAnimation(L"Radius");
         heldGlowGeom.StartAnimation(L"Radius", glowAnim);
 
         auto brush = heldGlow.FillBrush().as<winrt::Windows::UI::Composition::CompositionColorBrush>();
@@ -1038,12 +1115,11 @@ void Highlighter::FadeRippleHoldDot(MouseButton button)
 
     if (heldRing && heldGeom)
     {
-        auto curR = heldGeom.Radius();
+        heldGeom.StopAnimation(L"Radius");
         auto ringAnim = m_compositor.CreateVector2KeyFrameAnimation();
-        ringAnim.InsertKeyFrame(0.0f, curR);
+        ringAnim.InsertKeyFrame(0.0f, { ringHeld, ringHeld });
         ringAnim.InsertKeyFrame(1.0f, { ringEnd, ringEnd }, ease);
         ringAnim.Duration(dur);
-        heldGeom.StopAnimation(L"Radius");
         heldGeom.StartAnimation(L"Radius", ringAnim);
 
         auto brush = heldRing.StrokeBrush().as<winrt::Windows::UI::Composition::CompositionColorBrush>();
@@ -1062,11 +1138,6 @@ void Highlighter::FadeRippleHoldDot(MouseButton button)
     if (button == MouseButton::Right && m_rippleShowReleasePulse && heldRing)
     {
         const float xhairAlphaMul = 0.18f + intensity * 0.78f;
-        auto clampByte = [](float v) -> uint8_t {
-            if (v < 0.0f) v = 0.0f;
-            if (v > 255.0f) v = 255.0f;
-            return static_cast<uint8_t>(v);
-        };
         auto xhairColor = winrt::Windows::UI::ColorHelper::FromArgb(clampByte(static_cast<float>(color.A) * xhairAlphaMul), color.R, color.G, color.B);
         const float xhairThickness = (std::max)(1.25f, baseSize * (0.025f + intensity * 0.03f));
 
@@ -1132,6 +1203,197 @@ void Highlighter::FadeRippleHoldDot(MouseButton button)
     {
         return;
     }
+
+    auto dispatcher = m_dispatcherQueueController.DispatcherQueue();
+    batch.Completed([dispatcher, spawned](auto&&, auto&&) {
+        dispatcher.TryEnqueue([spawned]() {
+            try
+            {
+                if (Highlighter::instance == nullptr || Highlighter::instance->m_shape == nullptr)
+                {
+                    return;
+                }
+                auto shapes = Highlighter::instance->m_shape.Shapes();
+                for (auto const& s : *spawned)
+                {
+                    uint32_t index = 0;
+                    if (shapes.IndexOf(s, index))
+                    {
+                        shapes.RemoveAt(index);
+                    }
+                }
+            }
+            catch (...)
+            {
+                // Highlighter may have torn down between batch completion and dispatch — ignore.
+            }
+        });
+    });
+}
+
+// Self-contained single ripple for a quick click (press + release before the
+// hold threshold). Spawns a fresh ring + glow that grow from the click point
+// outward and fade to transparent in one continuous animation — no held
+// indicator, so a single click produces exactly one ripple. For right-click,
+// optionally spawns the expanding crosshair lines too.
+void Highlighter::EmitSingleRipple(MouseButton button)
+{
+    if (!m_compositor || !m_shape)
+    {
+        return;
+    }
+
+    winrt::Windows::UI::Color color = (button == MouseButton::Left) ? m_leftClickColor : m_rightClickColor;
+    if (color.A == 0)
+    {
+        return;
+    }
+
+    POINT pt{};
+    if (!GetCursorPos(&pt))
+    {
+        return;
+    }
+    ScreenToClient(m_hwnd, &pt);
+    const float fx = static_cast<float>(pt.x);
+    const float fy = static_cast<float>(pt.y);
+
+    const float baseSize = (m_rippleSize > 1.0f) ? m_rippleSize : 1.0f;
+    float intensity = m_rippleIntensity;
+    if (intensity < 0.15f) intensity = 0.15f;
+    if (intensity > 1.35f) intensity = 1.35f;
+
+    int durationMs = m_rippleDurationMs;
+    if (durationMs < 60) durationMs = 60;
+    if (durationMs > 2000) durationMs = 2000;
+    auto dur = std::chrono::milliseconds(durationMs);
+
+    const float ringStart = baseSize * 0.20f;
+    const float ringEnd = baseSize * 1.05f;
+    const float glowStart = baseSize * 0.30f;
+    const float glowEnd = baseSize * 1.40f;
+    const float lineWidth = (std::max)(2.25f, baseSize * (0.035f + intensity * 0.045f));
+
+    auto clampByte = [](float v) -> uint8_t {
+        if (v < 0.0f) v = 0.0f;
+        if (v > 255.0f) v = 255.0f;
+        return static_cast<uint8_t>(v);
+    };
+
+    const float glowAlpha = static_cast<float>(color.A) * 0.30f * intensity;
+    auto glowColor = winrt::Windows::UI::ColorHelper::FromArgb(clampByte(glowAlpha), color.R, color.G, color.B);
+    const float alphaMul = 0.18f + intensity * 0.78f;
+    auto ringColor = winrt::Windows::UI::ColorHelper::FromArgb(clampByte(static_cast<float>(color.A) * alphaMul), color.R, color.G, color.B);
+
+    auto ease = m_compositor.CreateCubicBezierEasingFunction({ 0.215f, 0.61f }, { 0.355f, 1.0f });
+    auto transparent = winrt::Windows::UI::ColorHelper::FromArgb(0, color.R, color.G, color.B);
+
+    auto spawned = std::make_shared<std::vector<winrt::CompositionSpriteShape>>();
+
+    auto batch = m_compositor.CreateScopedBatch(winrt::CompositionBatchTypes::Animation);
+
+    // Glow (filled) — added first so the ring renders on top.
+    auto glowGeom = m_compositor.CreateEllipseGeometry();
+    glowGeom.Radius({ glowStart, glowStart });
+    auto glowBrush = m_compositor.CreateColorBrush(glowColor);
+    auto glowShape = m_compositor.CreateSpriteShape(glowGeom);
+    glowShape.Offset({ fx, fy });
+    glowShape.FillBrush(glowBrush);
+    m_shape.Shapes().Append(glowShape);
+    spawned->push_back(glowShape);
+
+    auto glowAnim = m_compositor.CreateVector2KeyFrameAnimation();
+    glowAnim.InsertKeyFrame(0.0f, { glowStart, glowStart });
+    glowAnim.InsertKeyFrame(1.0f, { glowEnd, glowEnd }, ease);
+    glowAnim.Duration(dur);
+    glowGeom.StartAnimation(L"Radius", glowAnim);
+
+    auto glowColorAnim = m_compositor.CreateColorKeyFrameAnimation();
+    glowColorAnim.InsertKeyFrame(0.0f, glowColor);
+    glowColorAnim.InsertKeyFrame(1.0f, transparent, ease);
+    glowColorAnim.Duration(dur);
+    glowBrush.StartAnimation(L"Color", glowColorAnim);
+
+    // Ring (stroked).
+    auto ringGeom = m_compositor.CreateEllipseGeometry();
+    ringGeom.Radius({ ringStart, ringStart });
+    auto ringBrush = m_compositor.CreateColorBrush(ringColor);
+    auto ringShape = m_compositor.CreateSpriteShape(ringGeom);
+    ringShape.Offset({ fx, fy });
+    ringShape.StrokeBrush(ringBrush);
+    ringShape.StrokeThickness(lineWidth);
+    ringShape.IsStrokeNonScaling(true);
+    m_shape.Shapes().Append(ringShape);
+    spawned->push_back(ringShape);
+
+    auto ringAnim = m_compositor.CreateVector2KeyFrameAnimation();
+    ringAnim.InsertKeyFrame(0.0f, { ringStart, ringStart });
+    ringAnim.InsertKeyFrame(1.0f, { ringEnd, ringEnd }, ease);
+    ringAnim.Duration(dur);
+    ringGeom.StartAnimation(L"Radius", ringAnim);
+
+    auto ringColorAnim = m_compositor.CreateColorKeyFrameAnimation();
+    ringColorAnim.InsertKeyFrame(0.0f, ringColor);
+    ringColorAnim.InsertKeyFrame(1.0f, transparent, ease);
+    ringColorAnim.Duration(dur);
+    ringBrush.StartAnimation(L"Color", ringColorAnim);
+
+    // Right-click only: spawn expanding crosshair lines centered on the click
+    // point. Gated by the "show crosshairs on right-click release" toggle.
+    if (button == MouseButton::Right && m_rippleShowReleasePulse)
+    {
+        auto xhairColor = ringColor;
+        const float xhairThickness = (std::max)(1.25f, baseSize * (0.025f + intensity * 0.03f));
+
+        const float startSpan = (baseSize * 0.55f) * 0.85f;
+        const float endSpan = ringEnd * 0.85f;
+
+        auto makeLine = [&](float ax1, float ay1, float ax2, float ay2,
+                            float bx1, float by1, float bx2, float by2) {
+            auto lineGeom = m_compositor.CreateLineGeometry();
+            lineGeom.Start({ ax1, ay1 });
+            lineGeom.End({ ax2, ay2 });
+
+            auto lineBrush = m_compositor.CreateColorBrush(xhairColor);
+            auto lineShape = m_compositor.CreateSpriteShape(lineGeom);
+            lineShape.StrokeBrush(lineBrush);
+            lineShape.StrokeThickness(xhairThickness);
+            lineShape.IsStrokeNonScaling(true);
+            m_shape.Shapes().Append(lineShape);
+            spawned->push_back(lineShape);
+
+            auto startAnim = m_compositor.CreateVector2KeyFrameAnimation();
+            startAnim.InsertKeyFrame(0.0f, { ax1, ay1 });
+            startAnim.InsertKeyFrame(1.0f, { bx1, by1 }, ease);
+            startAnim.Duration(dur);
+            lineGeom.StartAnimation(L"Start", startAnim);
+
+            auto endAnim = m_compositor.CreateVector2KeyFrameAnimation();
+            endAnim.InsertKeyFrame(0.0f, { ax2, ay2 });
+            endAnim.InsertKeyFrame(1.0f, { bx2, by2 }, ease);
+            endAnim.Duration(dur);
+            lineGeom.StartAnimation(L"End", endAnim);
+
+            auto colorAnim = m_compositor.CreateColorKeyFrameAnimation();
+            colorAnim.InsertKeyFrame(0.0f, xhairColor);
+            colorAnim.InsertKeyFrame(1.0f, transparent, ease);
+            colorAnim.Duration(dur);
+            lineBrush.StartAnimation(L"Color", colorAnim);
+        };
+
+        // Horizontal line (left half, right half).
+        makeLine(fx - startSpan, fy, fx - startSpan * 0.30f, fy,
+                 fx - endSpan,   fy, fx - endSpan   * 0.30f, fy);
+        makeLine(fx + startSpan * 0.30f, fy, fx + startSpan, fy,
+                 fx + endSpan   * 0.30f, fy, fx + endSpan,   fy);
+        // Vertical line (top half, bottom half).
+        makeLine(fx, fy - startSpan, fx, fy - startSpan * 0.30f,
+                 fx, fy - endSpan,   fx, fy - endSpan   * 0.30f);
+        makeLine(fx, fy + startSpan * 0.30f, fx, fy + startSpan,
+                 fx, fy + endSpan   * 0.30f, fx, fy + endSpan);
+    }
+
+    batch.End();
 
     auto dispatcher = m_dispatcherQueueController.DispatcherQueue();
     batch.Completed([dispatcher, spawned](auto&&, auto&&) {

--- a/src/modules/MouseUtils/MouseHighlighter/MouseHighlighter.cpp
+++ b/src/modules/MouseUtils/MouseHighlighter/MouseHighlighter.cpp
@@ -48,6 +48,8 @@ private:
     void ClearDrawingPoint();
     void ClearDrawing();
     void BringToFront();
+    // Spawn a ClickLight-style expanding ripple pulse for the given click.
+    void SpawnRipplePulse(MouseButton button);
     HHOOK m_mouseHook = NULL;
     static LRESULT CALLBACK MouseHookProc(int nCode, WPARAM wParam, LPARAM lParam) noexcept;
     // Helpers for spotlight overlay
@@ -84,6 +86,7 @@ private:
     bool m_rightPointerEnabled = true;
     bool m_alwaysPointerEnabled = true;
     bool m_spotlightMode = false;
+    bool m_rippleMode = false;
 
     bool m_leftButtonPressed = false;
     bool m_rightButtonPressed = false;
@@ -329,6 +332,18 @@ LRESULT CALLBACK Highlighter::MouseHookProc(int nCode, WPARAM wParam, LPARAM lPa
         switch (wParam)
         {
         case WM_LBUTTONDOWN:
+            if (instance->m_rippleMode)
+            {
+                if (instance->m_leftPointerEnabled)
+                {
+                    instance->SpawnRipplePulse(MouseButton::Left);
+                    if (instance->m_timer_id == 0)
+                    {
+                        instance->m_timer_id = SetTimer(instance->m_hwnd, BRING_TO_FRONT_TIMER_ID, 10, nullptr);
+                    }
+                }
+                break;
+            }
             if (instance->m_leftPointerEnabled)
             {
                 if (instance->m_alwaysPointerEnabled && !instance->m_rightButtonPressed)
@@ -354,6 +369,18 @@ LRESULT CALLBACK Highlighter::MouseHookProc(int nCode, WPARAM wParam, LPARAM lPa
             }
             break;
         case WM_RBUTTONDOWN:
+            if (instance->m_rippleMode)
+            {
+                if (instance->m_rightPointerEnabled)
+                {
+                    instance->SpawnRipplePulse(MouseButton::Right);
+                    if (instance->m_timer_id == 0)
+                    {
+                        instance->m_timer_id = SetTimer(instance->m_hwnd, BRING_TO_FRONT_TIMER_ID, 10, nullptr);
+                    }
+                }
+                break;
+            }
             if (instance->m_rightPointerEnabled)
             {
                 if (instance->m_alwaysPointerEnabled && !instance->m_leftButtonPressed)
@@ -478,6 +505,7 @@ void Highlighter::ApplySettings(MouseHighlighterSettings settings)
     m_rightPointerEnabled = settings.rightButtonColor.A != 0;
     m_alwaysPointerEnabled = settings.alwaysColor.A != 0;
     m_spotlightMode = settings.spotlightMode && settings.alwaysColor.A != 0;
+    m_rippleMode = settings.rippleMode && !m_spotlightMode;
 
     if (m_spotlightMode)
     {
@@ -641,6 +669,149 @@ void Highlighter::UpdateSpotlightMask(float cx, float cy, float radius, bool sho
     {
         m_overlay.IsVisible(show);
     }
+}
+
+// Spawn a ClickLight-inspired expanding ring + glow pulse at the cursor.
+// Each click emits a transient, self-cleaning pulse — pulses can overlap.
+void Highlighter::SpawnRipplePulse(MouseButton button)
+{
+    if (!m_compositor || !m_shape)
+    {
+        return;
+    }
+
+    POINT pt;
+    GetCursorPos(&pt);
+    ScreenToClient(m_hwnd, &pt);
+
+    winrt::Windows::UI::Color color;
+    if (button == MouseButton::Left)
+    {
+        color = m_leftClickColor;
+    }
+    else if (button == MouseButton::Right)
+    {
+        color = m_rightClickColor;
+    }
+    else
+    {
+        color = m_alwaysColor;
+    }
+
+    if (color.A == 0)
+    {
+        return;
+    }
+
+    const float baseRadius = (m_radius < 1.0f) ? 1.0f : m_radius;
+
+    // ClickLight-style proportions: ring expands from ~0.20× to ~1.05× of the base radius,
+    // glow halo follows from ~0.30× to ~1.40× at a lower intensity.
+    const float ringStart = baseRadius * 0.20f;
+    const float ringEnd = baseRadius * 1.05f;
+    const float glowStart = baseRadius * 0.30f;
+    const float glowEnd = baseRadius * 1.40f;
+
+    int duration = m_fadeDuration_ms;
+    if (duration < 60)
+    {
+        duration = 60;
+    }
+    if (duration > 2000)
+    {
+        duration = 2000;
+    }
+    auto dur = std::chrono::milliseconds(duration);
+
+    // Cubic ease-out (matches ClickLight's 1 - (1 - p)^3 feel).
+    auto ease = m_compositor.CreateCubicBezierEasingFunction({ 0.215f, 0.61f }, { 0.355f, 1.0f });
+
+    // Final, fully-transparent target color (preserves RGB to avoid mid-animation tint shifts).
+    auto transparentColor = winrt::Windows::UI::ColorHelper::FromArgb(0, color.R, color.G, color.B);
+
+    // Glow (filled, low-alpha halo).
+    auto glowColor = winrt::Windows::UI::ColorHelper::FromArgb(
+        static_cast<uint8_t>(static_cast<float>(color.A) * 0.35f),
+        color.R,
+        color.G,
+        color.B);
+    auto glowGeom = m_compositor.CreateEllipseGeometry();
+    glowGeom.Radius({ glowStart, glowStart });
+    auto glowBrush = m_compositor.CreateColorBrush(glowColor);
+    auto glowShape = m_compositor.CreateSpriteShape(glowGeom);
+    glowShape.Offset({ static_cast<float>(pt.x), static_cast<float>(pt.y) });
+    glowShape.FillBrush(glowBrush);
+
+    // Ring (stroked, full color).
+    auto ringGeom = m_compositor.CreateEllipseGeometry();
+    ringGeom.Radius({ ringStart, ringStart });
+    auto ringBrush = m_compositor.CreateColorBrush(color);
+    auto ringShape = m_compositor.CreateSpriteShape(ringGeom);
+    ringShape.Offset({ static_cast<float>(pt.x), static_cast<float>(pt.y) });
+    ringShape.StrokeBrush(ringBrush);
+    ringShape.StrokeThickness((std::max)(2.0f, baseRadius * 0.18f));
+    ringShape.IsStrokeNonScaling(true);
+
+    m_shape.Shapes().Append(glowShape);
+    m_shape.Shapes().Append(ringShape);
+
+    // Radius animations (scale-equivalent, keeps stroke crisp).
+    auto glowSizeAnim = m_compositor.CreateVector2KeyFrameAnimation();
+    glowSizeAnim.InsertKeyFrame(0.0f, { glowStart, glowStart });
+    glowSizeAnim.InsertKeyFrame(1.0f, { glowEnd, glowEnd }, ease);
+    glowSizeAnim.Duration(dur);
+
+    auto ringSizeAnim = m_compositor.CreateVector2KeyFrameAnimation();
+    ringSizeAnim.InsertKeyFrame(0.0f, { ringStart, ringStart });
+    ringSizeAnim.InsertKeyFrame(1.0f, { ringEnd, ringEnd }, ease);
+    ringSizeAnim.Duration(dur);
+
+    // Color (alpha) fade-out animations.
+    auto glowColorAnim = m_compositor.CreateColorKeyFrameAnimation();
+    glowColorAnim.InsertKeyFrame(0.0f, glowColor);
+    glowColorAnim.InsertKeyFrame(1.0f, transparentColor, ease);
+    glowColorAnim.Duration(dur);
+
+    auto ringColorAnim = m_compositor.CreateColorKeyFrameAnimation();
+    ringColorAnim.InsertKeyFrame(0.0f, color);
+    ringColorAnim.InsertKeyFrame(1.0f, transparentColor, ease);
+    ringColorAnim.Duration(dur);
+
+    // Batch the four animations so we can clean up the shapes when the pulse ends.
+    auto batch = m_compositor.CreateScopedBatch(winrt::CompositionBatchTypes::Animation);
+    glowGeom.StartAnimation(L"Radius", glowSizeAnim);
+    ringGeom.StartAnimation(L"Radius", ringSizeAnim);
+    glowBrush.StartAnimation(L"Color", glowColorAnim);
+    ringBrush.StartAnimation(L"Color", ringColorAnim);
+    batch.End();
+
+    auto dispatcher = m_dispatcherQueueController.DispatcherQueue();
+    batch.Completed([dispatcher, glowShape, ringShape](auto&&, auto&&) {
+        // Marshal shape removal back to the compositor thread.
+        dispatcher.TryEnqueue([glowShape, ringShape]() {
+            try
+            {
+                if (Highlighter::instance == nullptr || Highlighter::instance->m_shape == nullptr)
+                {
+                    return;
+                }
+                auto shapes = Highlighter::instance->m_shape.Shapes();
+                uint32_t index = 0;
+                if (shapes.IndexOf(ringShape, index))
+                {
+                    shapes.RemoveAt(index);
+                }
+                if (shapes.IndexOf(glowShape, index))
+                {
+                    shapes.RemoveAt(index);
+                }
+            }
+            catch (...)
+            {
+                // Highlighter may have torn down between batch completion and dispatch — ignore.
+            }
+        });
+    });
 }
 
 #pragma region MouseHighlighter_API

--- a/src/modules/MouseUtils/MouseHighlighter/MouseHighlighter.h
+++ b/src/modules/MouseUtils/MouseHighlighter/MouseHighlighter.h
@@ -8,6 +8,12 @@ constexpr int MOUSE_HIGHLIGHTER_DEFAULT_RADIUS = 20;
 constexpr int MOUSE_HIGHLIGHTER_DEFAULT_DELAY_MS = 500;
 constexpr int MOUSE_HIGHLIGHTER_DEFAULT_DURATION_MS = 250;
 constexpr bool MOUSE_HIGHLIGHTER_DEFAULT_AUTO_ACTIVATE = false;
+// Ripple-specific defaults (independent of the always-on circle settings above).
+constexpr int MOUSE_HIGHLIGHTER_DEFAULT_RIPPLE_SIZE = 60;
+constexpr double MOUSE_HIGHLIGHTER_DEFAULT_RIPPLE_INTENSITY = 0.7;
+constexpr int MOUSE_HIGHLIGHTER_DEFAULT_RIPPLE_DURATION_MS = 480;
+constexpr bool MOUSE_HIGHLIGHTER_DEFAULT_RIPPLE_SHOW_DRAG_TRAIL = true;
+constexpr bool MOUSE_HIGHLIGHTER_DEFAULT_RIPPLE_SHOW_RELEASE_PULSE = true;
 
 struct MouseHighlighterSettings
 {
@@ -20,6 +26,11 @@ struct MouseHighlighterSettings
     bool autoActivate = MOUSE_HIGHLIGHTER_DEFAULT_AUTO_ACTIVATE;
     bool spotlightMode = false;
     bool rippleMode = false;
+    int rippleSize = MOUSE_HIGHLIGHTER_DEFAULT_RIPPLE_SIZE;
+    double rippleIntensity = MOUSE_HIGHLIGHTER_DEFAULT_RIPPLE_INTENSITY;
+    int rippleDurationMs = MOUSE_HIGHLIGHTER_DEFAULT_RIPPLE_DURATION_MS;
+    bool rippleShowDragTrail = MOUSE_HIGHLIGHTER_DEFAULT_RIPPLE_SHOW_DRAG_TRAIL;
+    bool rippleShowReleasePulse = MOUSE_HIGHLIGHTER_DEFAULT_RIPPLE_SHOW_RELEASE_PULSE;
 };
 
 int MouseHighlighterMain(HINSTANCE hinst, MouseHighlighterSettings settings);

--- a/src/modules/MouseUtils/MouseHighlighter/MouseHighlighter.h
+++ b/src/modules/MouseUtils/MouseHighlighter/MouseHighlighter.h
@@ -4,9 +4,9 @@
 const winrt::Windows::UI::Color MOUSE_HIGHLIGHTER_DEFAULT_LEFT_BUTTON_COLOR = winrt::Windows::UI::ColorHelper::FromArgb(166, 255, 255, 0);
 const winrt::Windows::UI::Color MOUSE_HIGHLIGHTER_DEFAULT_RIGHT_BUTTON_COLOR = winrt::Windows::UI::ColorHelper::FromArgb(166, 0, 0, 255);
 const winrt::Windows::UI::Color MOUSE_HIGHLIGHTER_DEFAULT_ALWAYS_COLOR = winrt::Windows::UI::ColorHelper::FromArgb(0, 255, 0, 0);
-constexpr int MOUSE_HIGHLIGHTER_DEFAULT_RADIUS = 20;
-constexpr int MOUSE_HIGHLIGHTER_DEFAULT_DELAY_MS = 500;
-constexpr int MOUSE_HIGHLIGHTER_DEFAULT_DURATION_MS = 250;
+constexpr int MOUSE_HIGHLIGHTER_DEFAULT_RADIUS = 30;
+constexpr int MOUSE_HIGHLIGHTER_DEFAULT_DELAY_MS = 400;
+constexpr int MOUSE_HIGHLIGHTER_DEFAULT_DURATION_MS = 400;
 constexpr bool MOUSE_HIGHLIGHTER_DEFAULT_AUTO_ACTIVATE = false;
 // Ripple-specific defaults (independent of the always-on circle settings above).
 constexpr int MOUSE_HIGHLIGHTER_DEFAULT_RIPPLE_SIZE = 60;
@@ -25,7 +25,7 @@ struct MouseHighlighterSettings
     int fadeDurationMs = MOUSE_HIGHLIGHTER_DEFAULT_DURATION_MS;
     bool autoActivate = MOUSE_HIGHLIGHTER_DEFAULT_AUTO_ACTIVATE;
     bool spotlightMode = false;
-    bool rippleMode = false;
+    bool rippleMode = true;
     int rippleSize = MOUSE_HIGHLIGHTER_DEFAULT_RIPPLE_SIZE;
     double rippleIntensity = MOUSE_HIGHLIGHTER_DEFAULT_RIPPLE_INTENSITY;
     int rippleDurationMs = MOUSE_HIGHLIGHTER_DEFAULT_RIPPLE_DURATION_MS;

--- a/src/modules/MouseUtils/MouseHighlighter/MouseHighlighter.h
+++ b/src/modules/MouseUtils/MouseHighlighter/MouseHighlighter.h
@@ -19,6 +19,7 @@ struct MouseHighlighterSettings
     int fadeDurationMs = MOUSE_HIGHLIGHTER_DEFAULT_DURATION_MS;
     bool autoActivate = MOUSE_HIGHLIGHTER_DEFAULT_AUTO_ACTIVATE;
     bool spotlightMode = false;
+    bool rippleMode = false;
 };
 
 int MouseHighlighterMain(HINSTANCE hinst, MouseHighlighterSettings settings);

--- a/src/modules/MouseUtils/MouseHighlighter/dllmain.cpp
+++ b/src/modules/MouseUtils/MouseHighlighter/dllmain.cpp
@@ -21,6 +21,7 @@ namespace
     const wchar_t JSON_KEY_HIGHLIGHT_FADE_DURATION_MS[] = L"highlight_fade_duration_ms";
     const wchar_t JSON_KEY_AUTO_ACTIVATE[] = L"auto_activate";
     const wchar_t JSON_KEY_SPOTLIGHT_MODE[] = L"spotlight_mode";
+    const wchar_t JSON_KEY_RIPPLE_MODE[] = L"ripple_mode";
 }
 
 extern "C" IMAGE_DOS_HEADER __ImageBase;
@@ -391,6 +392,16 @@ public:
             catch (...)
             {
                 Logger::warn("Failed to initialize spotlight mode settings. Will use default value");
+            }
+            try
+            {
+                // Parse ripple mode
+                auto jsonPropertiesObject = settingsObject.GetNamedObject(JSON_KEY_PROPERTIES).GetNamedObject(JSON_KEY_RIPPLE_MODE);
+                highlightSettings.rippleMode = jsonPropertiesObject.GetNamedBoolean(JSON_KEY_VALUE);
+            }
+            catch (...)
+            {
+                Logger::warn("Failed to initialize ripple mode settings. Will use default value");
             }
         }
         else

--- a/src/modules/MouseUtils/MouseHighlighter/dllmain.cpp
+++ b/src/modules/MouseUtils/MouseHighlighter/dllmain.cpp
@@ -22,6 +22,11 @@ namespace
     const wchar_t JSON_KEY_AUTO_ACTIVATE[] = L"auto_activate";
     const wchar_t JSON_KEY_SPOTLIGHT_MODE[] = L"spotlight_mode";
     const wchar_t JSON_KEY_RIPPLE_MODE[] = L"ripple_mode";
+    const wchar_t JSON_KEY_RIPPLE_SIZE[] = L"ripple_size";
+    const wchar_t JSON_KEY_RIPPLE_INTENSITY[] = L"ripple_intensity";
+    const wchar_t JSON_KEY_RIPPLE_DURATION_MS[] = L"ripple_duration_ms";
+    const wchar_t JSON_KEY_RIPPLE_SHOW_DRAG_TRAIL[] = L"ripple_show_drag_trail";
+    const wchar_t JSON_KEY_RIPPLE_SHOW_RELEASE_PULSE[] = L"ripple_show_release_pulse";
 }
 
 extern "C" IMAGE_DOS_HEADER __ImageBase;
@@ -402,6 +407,80 @@ public:
             catch (...)
             {
                 Logger::warn("Failed to initialize ripple mode settings. Will use default value");
+            }
+            try
+            {
+                // Parse ripple size
+                auto jsonPropertiesObject = settingsObject.GetNamedObject(JSON_KEY_PROPERTIES).GetNamedObject(JSON_KEY_RIPPLE_SIZE);
+                int value = static_cast<int>(jsonPropertiesObject.GetNamedNumber(JSON_KEY_VALUE));
+                if (value > 0)
+                {
+                    highlightSettings.rippleSize = value;
+                }
+                else
+                {
+                    throw std::runtime_error("Invalid ripple size value");
+                }
+            }
+            catch (...)
+            {
+                Logger::warn("Failed to initialize ripple size from settings. Will use default value");
+            }
+            try
+            {
+                // Parse ripple intensity
+                auto jsonPropertiesObject = settingsObject.GetNamedObject(JSON_KEY_PROPERTIES).GetNamedObject(JSON_KEY_RIPPLE_INTENSITY);
+                double value = jsonPropertiesObject.GetNamedNumber(JSON_KEY_VALUE);
+                if (value > 0.0)
+                {
+                    highlightSettings.rippleIntensity = value;
+                }
+                else
+                {
+                    throw std::runtime_error("Invalid ripple intensity value");
+                }
+            }
+            catch (...)
+            {
+                Logger::warn("Failed to initialize ripple intensity from settings. Will use default value");
+            }
+            try
+            {
+                // Parse ripple duration
+                auto jsonPropertiesObject = settingsObject.GetNamedObject(JSON_KEY_PROPERTIES).GetNamedObject(JSON_KEY_RIPPLE_DURATION_MS);
+                int value = static_cast<int>(jsonPropertiesObject.GetNamedNumber(JSON_KEY_VALUE));
+                if (value > 0)
+                {
+                    highlightSettings.rippleDurationMs = value;
+                }
+                else
+                {
+                    throw std::runtime_error("Invalid ripple duration value");
+                }
+            }
+            catch (...)
+            {
+                Logger::warn("Failed to initialize ripple duration from settings. Will use default value");
+            }
+            try
+            {
+                // Parse ripple show drag trail
+                auto jsonPropertiesObject = settingsObject.GetNamedObject(JSON_KEY_PROPERTIES).GetNamedObject(JSON_KEY_RIPPLE_SHOW_DRAG_TRAIL);
+                highlightSettings.rippleShowDragTrail = jsonPropertiesObject.GetNamedBoolean(JSON_KEY_VALUE);
+            }
+            catch (...)
+            {
+                Logger::warn("Failed to initialize ripple show drag trail from settings. Will use default value");
+            }
+            try
+            {
+                // Parse ripple show release pulse
+                auto jsonPropertiesObject = settingsObject.GetNamedObject(JSON_KEY_PROPERTIES).GetNamedObject(JSON_KEY_RIPPLE_SHOW_RELEASE_PULSE);
+                highlightSettings.rippleShowReleasePulse = jsonPropertiesObject.GetNamedBoolean(JSON_KEY_VALUE);
+            }
+            catch (...)
+            {
+                Logger::warn("Failed to initialize ripple show release pulse from settings. Will use default value");
             }
         }
         else

--- a/src/settings-ui/Settings.UI.Library/MouseHighlighterProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/MouseHighlighterProperties.cs
@@ -44,6 +44,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         [JsonPropertyName("spotlight_mode")]
         public BoolProperty SpotlightMode { get; set; }
 
+        [JsonPropertyName("ripple_mode")]
+        public BoolProperty RippleMode { get; set; }
+
         public MouseHighlighterProperties()
         {
             ActivationShortcut = DefaultActivationShortcut;
@@ -56,6 +59,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             HighlightFadeDurationMs = new IntProperty(250);
             AutoActivate = new BoolProperty(false);
             SpotlightMode = new BoolProperty(false);
+            RippleMode = new BoolProperty(false);
         }
     }
 }

--- a/src/settings-ui/Settings.UI.Library/MouseHighlighterProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/MouseHighlighterProperties.cs
@@ -47,6 +47,21 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         [JsonPropertyName("ripple_mode")]
         public BoolProperty RippleMode { get; set; }
 
+        [JsonPropertyName("ripple_size")]
+        public IntProperty RippleSize { get; set; }
+
+        [JsonPropertyName("ripple_intensity")]
+        public DoubleProperty RippleIntensity { get; set; }
+
+        [JsonPropertyName("ripple_duration_ms")]
+        public IntProperty RippleDurationMs { get; set; }
+
+        [JsonPropertyName("ripple_show_drag_trail")]
+        public BoolProperty RippleShowDragTrail { get; set; }
+
+        [JsonPropertyName("ripple_show_release_pulse")]
+        public BoolProperty RippleShowReleasePulse { get; set; }
+
         public MouseHighlighterProperties()
         {
             ActivationShortcut = DefaultActivationShortcut;
@@ -60,6 +75,11 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             AutoActivate = new BoolProperty(false);
             SpotlightMode = new BoolProperty(false);
             RippleMode = new BoolProperty(false);
+            RippleSize = new IntProperty(60);
+            RippleIntensity = new DoubleProperty(0.7);
+            RippleDurationMs = new IntProperty(480);
+            RippleShowDragTrail = new BoolProperty(true);
+            RippleShowReleasePulse = new BoolProperty(true);
         }
     }
 }

--- a/src/settings-ui/Settings.UI.Library/MouseHighlighterProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/MouseHighlighterProperties.cs
@@ -69,12 +69,12 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             RightButtonClickColor = new StringProperty("#a60000FF");
             AlwaysColor = new StringProperty("#00FF0000");
             HighlightOpacity = new IntProperty(166); // for migration from <=1.1 to 1.2
-            HighlightRadius = new IntProperty(20);
-            HighlightFadeDelayMs = new IntProperty(500);
-            HighlightFadeDurationMs = new IntProperty(250);
+            HighlightRadius = new IntProperty(30);
+            HighlightFadeDelayMs = new IntProperty(400);
+            HighlightFadeDurationMs = new IntProperty(400);
             AutoActivate = new BoolProperty(false);
             SpotlightMode = new BoolProperty(false);
-            RippleMode = new BoolProperty(false);
+            RippleMode = new BoolProperty(true);
             RippleSize = new IntProperty(60);
             RippleIntensity = new DoubleProperty(0.7);
             RippleDurationMs = new IntProperty(480);

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/MouseUtilsPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/MouseUtilsPage.xaml
@@ -283,9 +283,10 @@
                                 <ComboBox
                                     x:Uid="MouseUtils_MouseHighlighter_SpotlightModeType"
                                     MinWidth="{StaticResource SettingActionControlMinWidth}"
-                                    SelectedIndex="{x:Bind ViewModel.IsSpotlightModeEnabled, Converter={StaticResource ReverseBoolToComboBoxIndexConverter}, Mode=TwoWay}">
+                                    SelectedIndex="{x:Bind ViewModel.HighlightModeIndex, Mode=TwoWay}">
                                     <ComboBoxItem x:Uid="HighlightMode_Spotlight_Mode" />
                                     <ComboBoxItem x:Uid="HighlightMode_Circle_Highlight_Mode" />
+                                    <ComboBoxItem x:Uid="HighlightMode_Ripple_Mode" />
                                 </ComboBox>
                             </tkcontrols:SettingsCard>
                             <tkcontrols:SettingsCard x:Uid="MouseUtils_MouseHighlighter_HighlightRadius">

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/MouseUtilsPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/MouseUtilsPage.xaml
@@ -8,6 +8,7 @@
     xmlns:local="using:Microsoft.PowerToys.Settings.UI.Helpers"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:panels="using:Microsoft.PowerToys.Settings.UI.Panels"
+    xmlns:ptcontrols="using:Microsoft.PowerToys.Common.UI.Controls"
     xmlns:tkcontrols="using:CommunityToolkit.WinUI.Controls"
     xmlns:tkconverters="using:CommunityToolkit.WinUI.Converters"
     xmlns:ui="using:CommunityToolkit.WinUI"
@@ -265,31 +266,29 @@
                     </tkcontrols:SettingsExpander>
                     <tkcontrols:SettingsExpander
                         Name="MouseHighlighterAppearanceBehavior"
-                        x:Uid="Appearance_Behavior"
+                        x:Uid="MouseUtils_MouseHighlighter_Appearance"
                         AutomationProperties.AutomationId="MouseUtils_MouseHighlighterAppearanceBehaviorId"
-                        HeaderIcon="{ui:FontIcon Glyph=&#xEB3C;}"
+                        HeaderIcon="{ui:FontIcon Glyph=&#xE790;}"
                         IsEnabled="{x:Bind ViewModel.IsMouseHighlighterEnabled, Mode=OneWay}">
+                        <ComboBox
+                            x:Uid="MouseUtils_MouseHighlighter_SpotlightModeType"
+                            MinWidth="{StaticResource SettingActionControlMinWidth}"
+                            SelectedIndex="{x:Bind ViewModel.HighlightModeIndex, Mode=TwoWay}">
+                            <ComboBoxItem x:Uid="HighlightMode_Spotlight_Mode" />
+                            <ComboBoxItem x:Uid="HighlightMode_Circle_Highlight_Mode" />
+                            <ComboBoxItem x:Uid="HighlightMode_Ripple_Mode" />
+                        </ComboBox>
                         <tkcontrols:SettingsExpander.Items>
-                            <tkcontrols:SettingsCard x:Uid="MouseUtils_MouseHighlighter_PrimaryButtonClickColor" IsEnabled="{x:Bind ViewModel.IsSpotlightModeEnabled, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}">
+                            <tkcontrols:SettingsCard x:Uid="MouseUtils_MouseHighlighter_PrimaryButtonClickColor" Visibility="{x:Bind ViewModel.HighlightModeIndex, Mode=OneWay, Converter={StaticResource IndexBitFieldToVisibilityConverter}, ConverterParameter=0x6}">
                                 <controls:ColorPickerButton IsAlphaEnabled="True" SelectedColor="{x:Bind Path=ViewModel.MouseHighlighterLeftButtonClickColor, Mode=TwoWay}" />
                             </tkcontrols:SettingsCard>
-                            <tkcontrols:SettingsCard x:Uid="MouseUtils_MouseHighlighter_SecondaryButtonClickColor" IsEnabled="{x:Bind ViewModel.IsSpotlightModeEnabled, Mode=OneWay, Converter={StaticResource BoolNegationConverter}}">
+                            <tkcontrols:SettingsCard x:Uid="MouseUtils_MouseHighlighter_SecondaryButtonClickColor" Visibility="{x:Bind ViewModel.HighlightModeIndex, Mode=OneWay, Converter={StaticResource IndexBitFieldToVisibilityConverter}, ConverterParameter=0x6}">
                                 <controls:ColorPickerButton IsAlphaEnabled="True" SelectedColor="{x:Bind Path=ViewModel.MouseHighlighterRightButtonClickColor, Mode=TwoWay}" />
                             </tkcontrols:SettingsCard>
-                            <tkcontrols:SettingsCard Name="MouseUtilsMouseHighlighterAlwaysColor" x:Uid="MouseUtils_MouseHighlighter_AlwaysColor">
+                            <tkcontrols:SettingsCard Name="MouseUtilsMouseHighlighterAlwaysColor" x:Uid="MouseUtils_MouseHighlighter_AlwaysColor" Visibility="{x:Bind ViewModel.HighlightModeIndex, Mode=OneWay, Converter={StaticResource IndexBitFieldToVisibilityConverter}, ConverterParameter=0x3}">
                                 <controls:ColorPickerButton IsAlphaEnabled="True" SelectedColor="{x:Bind Path=ViewModel.MouseHighlighterAlwaysColor, Mode=TwoWay}" />
                             </tkcontrols:SettingsCard>
-                            <tkcontrols:SettingsCard x:Uid="HighlightMode">
-                                <ComboBox
-                                    x:Uid="MouseUtils_MouseHighlighter_SpotlightModeType"
-                                    MinWidth="{StaticResource SettingActionControlMinWidth}"
-                                    SelectedIndex="{x:Bind ViewModel.HighlightModeIndex, Mode=TwoWay}">
-                                    <ComboBoxItem x:Uid="HighlightMode_Spotlight_Mode" />
-                                    <ComboBoxItem x:Uid="HighlightMode_Circle_Highlight_Mode" />
-                                    <ComboBoxItem x:Uid="HighlightMode_Ripple_Mode" />
-                                </ComboBox>
-                            </tkcontrols:SettingsCard>
-                            <tkcontrols:SettingsCard x:Uid="MouseUtils_MouseHighlighter_HighlightRadius">
+                            <tkcontrols:SettingsCard x:Uid="MouseUtils_MouseHighlighter_HighlightRadius" Visibility="{x:Bind ViewModel.HighlightModeIndex, Mode=OneWay, Converter={StaticResource IndexBitFieldToVisibilityConverter}, ConverterParameter=0x3}">
                                 <NumberBox
                                     MinWidth="{StaticResource SettingActionControlMinWidth}"
                                     LargeChange="10"
@@ -298,7 +297,7 @@
                                     SpinButtonPlacementMode="Compact"
                                     Value="{x:Bind ViewModel.MouseHighlighterRadius, Mode=TwoWay}" />
                             </tkcontrols:SettingsCard>
-                            <tkcontrols:SettingsCard Name="MouseUtilsMouseHighlighterFadeDelayMs" x:Uid="MouseUtils_MouseHighlighter_FadeDelayMs">
+                            <tkcontrols:SettingsCard Name="MouseUtilsMouseHighlighterFadeDelayMs" x:Uid="MouseUtils_MouseHighlighter_FadeDelayMs" Visibility="{x:Bind ViewModel.HighlightModeIndex, Mode=OneWay, Converter={StaticResource IndexBitFieldToVisibilityConverter}, ConverterParameter=0x3}">
                                 <NumberBox
                                     MinWidth="{StaticResource SettingActionControlMinWidth}"
                                     LargeChange="100"
@@ -307,7 +306,7 @@
                                     SpinButtonPlacementMode="Compact"
                                     Value="{x:Bind ViewModel.MouseHighlighterFadeDelayMs, Mode=TwoWay}" />
                             </tkcontrols:SettingsCard>
-                            <tkcontrols:SettingsCard Name="MouseUtilsMouseHighlighterFadeDurationMs" x:Uid="MouseUtils_MouseHighlighter_FadeDurationMs">
+                            <tkcontrols:SettingsCard Name="MouseUtilsMouseHighlighterFadeDurationMs" x:Uid="MouseUtils_MouseHighlighter_FadeDurationMs" Visibility="{x:Bind ViewModel.HighlightModeIndex, Mode=OneWay, Converter={StaticResource IndexBitFieldToVisibilityConverter}, ConverterParameter=0x3}">
                                 <NumberBox
                                     MinWidth="{StaticResource SettingActionControlMinWidth}"
                                     LargeChange="100"
@@ -316,7 +315,7 @@
                                     SpinButtonPlacementMode="Compact"
                                     Value="{x:Bind ViewModel.MouseHighlighterFadeDurationMs, Mode=TwoWay}" />
                             </tkcontrols:SettingsCard>
-                            <tkcontrols:SettingsCard x:Uid="MouseUtils_MouseHighlighter_RippleSize">
+                            <tkcontrols:SettingsCard x:Uid="MouseUtils_MouseHighlighter_RippleSize" Visibility="{x:Bind ViewModel.HighlightModeIndex, Mode=OneWay, Converter={StaticResource IndexBitFieldToVisibilityConverter}, ConverterParameter=0x4}">
                                 <NumberBox
                                     MinWidth="{StaticResource SettingActionControlMinWidth}"
                                     LargeChange="10"
@@ -326,7 +325,7 @@
                                     SpinButtonPlacementMode="Compact"
                                     Value="{x:Bind ViewModel.RippleSize, Mode=TwoWay}" />
                             </tkcontrols:SettingsCard>
-                            <tkcontrols:SettingsCard x:Uid="MouseUtils_MouseHighlighter_RippleIntensity">
+                            <tkcontrols:SettingsCard x:Uid="MouseUtils_MouseHighlighter_RippleIntensity" Visibility="{x:Bind ViewModel.HighlightModeIndex, Mode=OneWay, Converter={StaticResource IndexBitFieldToVisibilityConverter}, ConverterParameter=0x4}">
                                 <Slider
                                     MinWidth="{StaticResource SettingActionControlMinWidth}"
                                     LargeChange="0.1"
@@ -336,7 +335,7 @@
                                     StepFrequency="0.05"
                                     Value="{x:Bind ViewModel.RippleIntensity, Mode=TwoWay}" />
                             </tkcontrols:SettingsCard>
-                            <tkcontrols:SettingsCard x:Uid="MouseUtils_MouseHighlighter_RippleDurationMs">
+                            <tkcontrols:SettingsCard x:Uid="MouseUtils_MouseHighlighter_RippleDurationMs" Visibility="{x:Bind ViewModel.HighlightModeIndex, Mode=OneWay, Converter={StaticResource IndexBitFieldToVisibilityConverter}, ConverterParameter=0x4}">
                                 <NumberBox
                                     MinWidth="{StaticResource SettingActionControlMinWidth}"
                                     LargeChange="100"
@@ -346,11 +345,11 @@
                                     SpinButtonPlacementMode="Compact"
                                     Value="{x:Bind ViewModel.RippleDurationMs, Mode=TwoWay}" />
                             </tkcontrols:SettingsCard>
-                            <tkcontrols:SettingsCard x:Uid="MouseUtils_MouseHighlighter_RippleShowDragTrail">
-                                <ToggleSwitch IsOn="{x:Bind ViewModel.RippleShowDragTrail, Mode=TwoWay}" />
+                            <tkcontrols:SettingsCard ContentAlignment="Left" Visibility="{x:Bind ViewModel.HighlightModeIndex, Mode=OneWay, Converter={StaticResource IndexBitFieldToVisibilityConverter}, ConverterParameter=0x4}">
+                                <ptcontrols:CheckBoxWithDescriptionControl x:Uid="MouseUtils_MouseHighlighter_RippleShowDragTrail" IsChecked="{x:Bind ViewModel.RippleShowDragTrail, Mode=TwoWay}" />
                             </tkcontrols:SettingsCard>
-                            <tkcontrols:SettingsCard x:Uid="MouseUtils_MouseHighlighter_RippleShowReleasePulse">
-                                <ToggleSwitch IsOn="{x:Bind ViewModel.RippleShowReleasePulse, Mode=TwoWay}" />
+                            <tkcontrols:SettingsCard ContentAlignment="Left" Visibility="{x:Bind ViewModel.HighlightModeIndex, Mode=OneWay, Converter={StaticResource IndexBitFieldToVisibilityConverter}, ConverterParameter=0x4}">
+                                <ptcontrols:CheckBoxWithDescriptionControl x:Uid="MouseUtils_MouseHighlighter_RippleShowReleasePulse" IsChecked="{x:Bind ViewModel.RippleShowReleasePulse, Mode=TwoWay}" />
                             </tkcontrols:SettingsCard>
                         </tkcontrols:SettingsExpander.Items>
                     </tkcontrols:SettingsExpander>

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/MouseUtilsPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/MouseUtilsPage.xaml
@@ -316,6 +316,42 @@
                                     SpinButtonPlacementMode="Compact"
                                     Value="{x:Bind ViewModel.MouseHighlighterFadeDurationMs, Mode=TwoWay}" />
                             </tkcontrols:SettingsCard>
+                            <tkcontrols:SettingsCard x:Uid="MouseUtils_MouseHighlighter_RippleSize">
+                                <NumberBox
+                                    MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                    LargeChange="10"
+                                    Maximum="300"
+                                    Minimum="10"
+                                    SmallChange="1"
+                                    SpinButtonPlacementMode="Compact"
+                                    Value="{x:Bind ViewModel.RippleSize, Mode=TwoWay}" />
+                            </tkcontrols:SettingsCard>
+                            <tkcontrols:SettingsCard x:Uid="MouseUtils_MouseHighlighter_RippleIntensity">
+                                <Slider
+                                    MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                    LargeChange="0.1"
+                                    Maximum="1.35"
+                                    Minimum="0.15"
+                                    SmallChange="0.05"
+                                    StepFrequency="0.05"
+                                    Value="{x:Bind ViewModel.RippleIntensity, Mode=TwoWay}" />
+                            </tkcontrols:SettingsCard>
+                            <tkcontrols:SettingsCard x:Uid="MouseUtils_MouseHighlighter_RippleDurationMs">
+                                <NumberBox
+                                    MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                    LargeChange="100"
+                                    Maximum="2000"
+                                    Minimum="60"
+                                    SmallChange="10"
+                                    SpinButtonPlacementMode="Compact"
+                                    Value="{x:Bind ViewModel.RippleDurationMs, Mode=TwoWay}" />
+                            </tkcontrols:SettingsCard>
+                            <tkcontrols:SettingsCard x:Uid="MouseUtils_MouseHighlighter_RippleShowDragTrail">
+                                <ToggleSwitch IsOn="{x:Bind ViewModel.RippleShowDragTrail, Mode=TwoWay}" />
+                            </tkcontrols:SettingsCard>
+                            <tkcontrols:SettingsCard x:Uid="MouseUtils_MouseHighlighter_RippleShowReleasePulse">
+                                <ToggleSwitch IsOn="{x:Bind ViewModel.RippleShowReleasePulse, Mode=TwoWay}" />
+                            </tkcontrols:SettingsCard>
                         </tkcontrols:SettingsExpander.Items>
                     </tkcontrols:SettingsExpander>
                 </controls:SettingsGroup>

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/MouseUtilsPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/MouseUtilsPage.xaml
@@ -285,7 +285,10 @@
                             <tkcontrols:SettingsCard x:Uid="MouseUtils_MouseHighlighter_SecondaryButtonClickColor" Visibility="{x:Bind ViewModel.HighlightModeIndex, Mode=OneWay, Converter={StaticResource IndexBitFieldToVisibilityConverter}, ConverterParameter=0x6}">
                                 <controls:ColorPickerButton IsAlphaEnabled="True" SelectedColor="{x:Bind Path=ViewModel.MouseHighlighterRightButtonClickColor, Mode=TwoWay}" />
                             </tkcontrols:SettingsCard>
-                            <tkcontrols:SettingsCard Name="MouseUtilsMouseHighlighterAlwaysColor" x:Uid="MouseUtils_MouseHighlighter_AlwaysColor" Visibility="{x:Bind ViewModel.HighlightModeIndex, Mode=OneWay, Converter={StaticResource IndexBitFieldToVisibilityConverter}, ConverterParameter=0x3}">
+                            <tkcontrols:SettingsCard
+                                Name="MouseUtilsMouseHighlighterAlwaysColor"
+                                x:Uid="MouseUtils_MouseHighlighter_AlwaysColor"
+                                Visibility="{x:Bind ViewModel.HighlightModeIndex, Mode=OneWay, Converter={StaticResource IndexBitFieldToVisibilityConverter}, ConverterParameter=0x3}">
                                 <controls:ColorPickerButton IsAlphaEnabled="True" SelectedColor="{x:Bind Path=ViewModel.MouseHighlighterAlwaysColor, Mode=TwoWay}" />
                             </tkcontrols:SettingsCard>
                             <tkcontrols:SettingsCard x:Uid="MouseUtils_MouseHighlighter_HighlightRadius" Visibility="{x:Bind ViewModel.HighlightModeIndex, Mode=OneWay, Converter={StaticResource IndexBitFieldToVisibilityConverter}, ConverterParameter=0x3}">
@@ -297,7 +300,10 @@
                                     SpinButtonPlacementMode="Compact"
                                     Value="{x:Bind ViewModel.MouseHighlighterRadius, Mode=TwoWay}" />
                             </tkcontrols:SettingsCard>
-                            <tkcontrols:SettingsCard Name="MouseUtilsMouseHighlighterFadeDelayMs" x:Uid="MouseUtils_MouseHighlighter_FadeDelayMs" Visibility="{x:Bind ViewModel.HighlightModeIndex, Mode=OneWay, Converter={StaticResource IndexBitFieldToVisibilityConverter}, ConverterParameter=0x3}">
+                            <tkcontrols:SettingsCard
+                                Name="MouseUtilsMouseHighlighterFadeDelayMs"
+                                x:Uid="MouseUtils_MouseHighlighter_FadeDelayMs"
+                                Visibility="{x:Bind ViewModel.HighlightModeIndex, Mode=OneWay, Converter={StaticResource IndexBitFieldToVisibilityConverter}, ConverterParameter=0x3}">
                                 <NumberBox
                                     MinWidth="{StaticResource SettingActionControlMinWidth}"
                                     LargeChange="100"
@@ -306,7 +312,10 @@
                                     SpinButtonPlacementMode="Compact"
                                     Value="{x:Bind ViewModel.MouseHighlighterFadeDelayMs, Mode=TwoWay}" />
                             </tkcontrols:SettingsCard>
-                            <tkcontrols:SettingsCard Name="MouseUtilsMouseHighlighterFadeDurationMs" x:Uid="MouseUtils_MouseHighlighter_FadeDurationMs" Visibility="{x:Bind ViewModel.HighlightModeIndex, Mode=OneWay, Converter={StaticResource IndexBitFieldToVisibilityConverter}, ConverterParameter=0x3}">
+                            <tkcontrols:SettingsCard
+                                Name="MouseUtilsMouseHighlighterFadeDurationMs"
+                                x:Uid="MouseUtils_MouseHighlighter_FadeDurationMs"
+                                Visibility="{x:Bind ViewModel.HighlightModeIndex, Mode=OneWay, Converter={StaticResource IndexBitFieldToVisibilityConverter}, ConverterParameter=0x3}">
                                 <NumberBox
                                     MinWidth="{StaticResource SettingActionControlMinWidth}"
                                     LargeChange="100"

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -2823,6 +2823,46 @@ Right-click to remove the key combination, thereby deactivating the shortcut.</v
     <value>Duration of the disappear animation (ms)</value>
     <comment>ms = milliseconds</comment>
   </data>
+  <data name="MouseUtils_MouseHighlighter_RippleSize.Header" xml:space="preserve">
+    <value>Ripple size (px)</value>
+    <comment>Ripple mode only. px = pixels. Base radius of the click pulse.</comment>
+  </data>
+  <data name="MouseUtils_MouseHighlighter_RippleSize.Description" xml:space="preserve">
+    <value>Base radius of the ripple pulse in pixels (ripple mode only)</value>
+    <comment>Description for the Ripple size setting.</comment>
+  </data>
+  <data name="MouseUtils_MouseHighlighter_RippleIntensity.Header" xml:space="preserve">
+    <value>Ripple intensity</value>
+    <comment>Ripple mode only. Brightness/punch of the pulse.</comment>
+  </data>
+  <data name="MouseUtils_MouseHighlighter_RippleIntensity.Description" xml:space="preserve">
+    <value>Brightness and stroke weight of the ripple pulse. Higher values add a soft glow halo.</value>
+    <comment>Description for the Ripple intensity slider.</comment>
+  </data>
+  <data name="MouseUtils_MouseHighlighter_RippleDurationMs.Header" xml:space="preserve">
+    <value>Ripple duration (ms)</value>
+    <comment>Ripple mode only. ms = milliseconds.</comment>
+  </data>
+  <data name="MouseUtils_MouseHighlighter_RippleDurationMs.Description" xml:space="preserve">
+    <value>How long each ripple pulse takes to fade out (ms)</value>
+    <comment>Description for the Ripple duration setting. ms = milliseconds.</comment>
+  </data>
+  <data name="MouseUtils_MouseHighlighter_RippleShowDragTrail.Header" xml:space="preserve">
+    <value>Show drag trail</value>
+    <comment>Ripple mode only. Toggle for emitting small dots while a mouse button is held down and the cursor moves.</comment>
+  </data>
+  <data name="MouseUtils_MouseHighlighter_RippleShowDragTrail.Description" xml:space="preserve">
+    <value>Emit small fading dots along the cursor path while a mouse button is held down</value>
+    <comment>Description for the Show drag trail toggle in ripple mode.</comment>
+  </data>
+  <data name="MouseUtils_MouseHighlighter_RippleShowReleasePulse.Header" xml:space="preserve">
+    <value>Show release pulse</value>
+    <comment>Ripple mode only. Toggle for the contracting pulse drawn when a mouse button is released.</comment>
+  </data>
+  <data name="MouseUtils_MouseHighlighter_RippleShowReleasePulse.Description" xml:space="preserve">
+    <value>Show a smaller contracting pulse when a mouse button is released</value>
+    <comment>Description for the Show release pulse toggle in ripple mode.</comment>
+  </data>
   <data name="MouseUtils_MousePointerCrosshairs.Header" xml:space="preserve">
     <value>Mouse Pointer Crosshairs</value>
     <comment>Refers to the utility name</comment>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -5155,7 +5155,7 @@ The break timer font matches the text font.</value>
     <value>No shortcuts to show.</value>
   </data>
   <data name="HighlightMode.Description" xml:space="preserve">
-    <value>Highlight the cursor or dim the screen to spotlight it</value>
+    <value>Highlight the cursor, dim the screen to spotlight it, or pulse a ripple on each click</value>
   </data>
   <data name="HighlightMode.Header" xml:space="preserve">
     <value>Highlight mode</value>
@@ -5165,6 +5165,10 @@ The break timer font matches the text font.</value>
   </data>
   <data name="HighlightMode_Spotlight_Mode.Content" xml:space="preserve">
     <value>Spotlight</value>
+  </data>
+  <data name="HighlightMode_Ripple_Mode.Content" xml:space="preserve">
+    <value>Ripple</value>
+    <comment>Name of the highlight mode that draws an expanding ring pulse on each click.</comment>
   </data>
   <data name="GeneralPage_EnableDataDiagnosticsText.Text" xml:space="preserve">
     <value>Helps us make PowerToys faster, more stable, and better over time</value>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -1149,6 +1149,12 @@ opera.exe</value>
   <data name="Appearance_Behavior.Header" xml:space="preserve">
     <value>Appearance &amp; behavior</value>
   </data>
+  <data name="MouseUtils_MouseHighlighter_Appearance.Header" xml:space="preserve">
+    <value>Highlight mode</value>
+  </data>
+  <data name="MouseUtils_MouseHighlighter_Appearance.Description" xml:space="preserve">
+    <value>Choose the highlight style and customize its appearance</value>
+  </data>
   <data name="StartupAndPermissions.Header" xml:space="preserve">
     <value>Startup &amp; permissions</value>
   </data>
@@ -2811,57 +2817,29 @@ Right-click to remove the key combination, thereby deactivating the shortcut.</v
     <value>Fade delay (ms)</value>
     <comment>ms = milliseconds</comment>
   </data>
-  <data name="MouseUtils_MouseHighlighter_FadeDelayMs.Description" xml:space="preserve">
-    <value>Time before the highlight begins to fade (ms)</value>
-    <comment>ms = milliseconds</comment>
-  </data>
   <data name="MouseUtils_MouseHighlighter_FadeDurationMs.Header" xml:space="preserve">
     <value>Fade duration (ms)</value>
     <comment>ms = milliseconds</comment>
   </data>
-  <data name="MouseUtils_MouseHighlighter_FadeDurationMs.Description" xml:space="preserve">
-    <value>Duration of the disappear animation (ms)</value>
-    <comment>ms = milliseconds</comment>
-  </data>
   <data name="MouseUtils_MouseHighlighter_RippleSize.Header" xml:space="preserve">
-    <value>Ripple size (px)</value>
+    <value>Size (px)</value>
     <comment>Ripple mode only. px = pixels. Base radius of the click pulse.</comment>
   </data>
-  <data name="MouseUtils_MouseHighlighter_RippleSize.Description" xml:space="preserve">
-    <value>Base radius of the ripple pulse in pixels (ripple mode only)</value>
-    <comment>Description for the Ripple size setting.</comment>
-  </data>
   <data name="MouseUtils_MouseHighlighter_RippleIntensity.Header" xml:space="preserve">
-    <value>Ripple intensity</value>
+    <value>Intensity</value>
     <comment>Ripple mode only. Brightness/punch of the pulse.</comment>
   </data>
-  <data name="MouseUtils_MouseHighlighter_RippleIntensity.Description" xml:space="preserve">
-    <value>Brightness and stroke weight of the ripple pulse. Higher values add a soft glow halo.</value>
-    <comment>Description for the Ripple intensity slider.</comment>
-  </data>
   <data name="MouseUtils_MouseHighlighter_RippleDurationMs.Header" xml:space="preserve">
-    <value>Ripple duration (ms)</value>
+    <value>Duration (ms)</value>
     <comment>Ripple mode only. ms = milliseconds.</comment>
-  </data>
-  <data name="MouseUtils_MouseHighlighter_RippleDurationMs.Description" xml:space="preserve">
-    <value>How long each ripple pulse takes to fade out (ms)</value>
-    <comment>Description for the Ripple duration setting. ms = milliseconds.</comment>
   </data>
   <data name="MouseUtils_MouseHighlighter_RippleShowDragTrail.Header" xml:space="preserve">
     <value>Follow cursor while held</value>
     <comment>Ripple mode only. Toggle for whether the held ring tracks the cursor when dragged.</comment>
   </data>
-  <data name="MouseUtils_MouseHighlighter_RippleShowDragTrail.Description" xml:space="preserve">
-    <value>The held ripple ring moves with the cursor when you drag; turn off to anchor the ring at the click point</value>
-    <comment>Description for the Follow cursor while held toggle in ripple mode.</comment>
-  </data>
   <data name="MouseUtils_MouseHighlighter_RippleShowReleasePulse.Header" xml:space="preserve">
     <value>Show crosshairs on right-click release</value>
     <comment>Ripple mode only. Toggle for the expanding crosshair lines drawn when a right-click is released.</comment>
-  </data>
-  <data name="MouseUtils_MouseHighlighter_RippleShowReleasePulse.Description" xml:space="preserve">
-    <value>Draw expanding crosshair lines when a right-click is released</value>
-    <comment>Description for the Show crosshairs on right-click release toggle in ripple mode.</comment>
   </data>
   <data name="MouseUtils_MousePointerCrosshairs.Header" xml:space="preserve">
     <value>Mouse Pointer Crosshairs</value>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -2848,20 +2848,20 @@ Right-click to remove the key combination, thereby deactivating the shortcut.</v
     <comment>Description for the Ripple duration setting. ms = milliseconds.</comment>
   </data>
   <data name="MouseUtils_MouseHighlighter_RippleShowDragTrail.Header" xml:space="preserve">
-    <value>Show drag trail</value>
-    <comment>Ripple mode only. Toggle for emitting small dots while a mouse button is held down and the cursor moves.</comment>
+    <value>Follow cursor while held</value>
+    <comment>Ripple mode only. Toggle for whether the held ring tracks the cursor when dragged.</comment>
   </data>
   <data name="MouseUtils_MouseHighlighter_RippleShowDragTrail.Description" xml:space="preserve">
-    <value>Emit small fading dots along the cursor path while a mouse button is held down</value>
-    <comment>Description for the Show drag trail toggle in ripple mode.</comment>
+    <value>The held ripple ring moves with the cursor when you drag; turn off to anchor the ring at the click point</value>
+    <comment>Description for the Follow cursor while held toggle in ripple mode.</comment>
   </data>
   <data name="MouseUtils_MouseHighlighter_RippleShowReleasePulse.Header" xml:space="preserve">
-    <value>Show release pulse</value>
-    <comment>Ripple mode only. Toggle for the contracting pulse drawn when a mouse button is released.</comment>
+    <value>Show crosshairs on right-click release</value>
+    <comment>Ripple mode only. Toggle for the expanding crosshair lines drawn when a right-click is released.</comment>
   </data>
   <data name="MouseUtils_MouseHighlighter_RippleShowReleasePulse.Description" xml:space="preserve">
-    <value>Show a smaller contracting pulse when a mouse button is released</value>
-    <comment>Description for the Show release pulse toggle in ripple mode.</comment>
+    <value>Draw expanding crosshair lines when a right-click is released</value>
+    <comment>Description for the Show crosshairs on right-click release toggle in ripple mode.</comment>
   </data>
   <data name="MouseUtils_MousePointerCrosshairs.Header" xml:space="preserve">
     <value>Mouse Pointer Crosshairs</value>

--- a/src/settings-ui/Settings.UI/ViewModels/MouseUtilsViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/MouseUtilsViewModel.cs
@@ -78,6 +78,11 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             _highlighterAlwaysColor = !string.IsNullOrEmpty(alwaysColor) ? alwaysColor : "#00FF0000";
             _isSpotlightModeEnabled = MouseHighlighterSettingsConfig.Properties.SpotlightMode.Value;
             _isRippleModeEnabled = MouseHighlighterSettingsConfig.Properties.RippleMode.Value;
+            _rippleSize = MouseHighlighterSettingsConfig.Properties.RippleSize.Value;
+            _rippleIntensity = MouseHighlighterSettingsConfig.Properties.RippleIntensity.Value;
+            _rippleDurationMs = MouseHighlighterSettingsConfig.Properties.RippleDurationMs.Value;
+            _rippleShowDragTrail = MouseHighlighterSettingsConfig.Properties.RippleShowDragTrail.Value;
+            _rippleShowReleasePulse = MouseHighlighterSettingsConfig.Properties.RippleShowReleasePulse.Value;
 
             _highlighterRadius = MouseHighlighterSettingsConfig.Properties.HighlightRadius.Value;
             _highlightFadeDelayMs = MouseHighlighterSettingsConfig.Properties.HighlightFadeDelayMs.Value;
@@ -739,6 +744,76 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             }
         }
 
+        public int RippleSize
+        {
+            get => _rippleSize;
+            set
+            {
+                if (value != _rippleSize)
+                {
+                    _rippleSize = value;
+                    MouseHighlighterSettingsConfig.Properties.RippleSize.Value = value;
+                    NotifyMouseHighlighterPropertyChanged();
+                }
+            }
+        }
+
+        public double RippleIntensity
+        {
+            get => _rippleIntensity;
+            set
+            {
+                if (value != _rippleIntensity)
+                {
+                    _rippleIntensity = value;
+                    MouseHighlighterSettingsConfig.Properties.RippleIntensity.Value = value;
+                    NotifyMouseHighlighterPropertyChanged();
+                }
+            }
+        }
+
+        public int RippleDurationMs
+        {
+            get => _rippleDurationMs;
+            set
+            {
+                if (value != _rippleDurationMs)
+                {
+                    _rippleDurationMs = value;
+                    MouseHighlighterSettingsConfig.Properties.RippleDurationMs.Value = value;
+                    NotifyMouseHighlighterPropertyChanged();
+                }
+            }
+        }
+
+        public bool RippleShowDragTrail
+        {
+            get => _rippleShowDragTrail;
+            set
+            {
+                if (value != _rippleShowDragTrail)
+                {
+                    _rippleShowDragTrail = value;
+                    MouseHighlighterSettingsConfig.Properties.RippleShowDragTrail.Value = value;
+                    NotifyMouseHighlighterPropertyChanged();
+                }
+            }
+        }
+
+        public bool RippleShowReleasePulse
+        {
+            get => _rippleShowReleasePulse;
+            set
+            {
+                if (value != _rippleShowReleasePulse)
+                {
+                    _rippleShowReleasePulse = value;
+                    MouseHighlighterSettingsConfig.Properties.RippleShowReleasePulse.Value = value;
+                    NotifyMouseHighlighterPropertyChanged();
+                }
+            }
+        }
+
         public void NotifyMouseHighlighterPropertyChanged([CallerMemberName] string propertyName = null)
         {
             OnPropertyChanged(propertyName);
@@ -1274,6 +1349,11 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         private string _highlighterAlwaysColor;
         private bool _isSpotlightModeEnabled;
         private bool _isRippleModeEnabled;
+        private int _rippleSize;
+        private double _rippleIntensity;
+        private int _rippleDurationMs;
+        private bool _rippleShowDragTrail;
+        private bool _rippleShowReleasePulse;
         private int _highlighterRadius;
         private int _highlightFadeDelayMs;
         private int _highlightFadeDurationMs;

--- a/src/settings-ui/Settings.UI/ViewModels/MouseUtilsViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/MouseUtilsViewModel.cs
@@ -77,6 +77,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             string alwaysColor = MouseHighlighterSettingsConfig.Properties.AlwaysColor.Value;
             _highlighterAlwaysColor = !string.IsNullOrEmpty(alwaysColor) ? alwaysColor : "#00FF0000";
             _isSpotlightModeEnabled = MouseHighlighterSettingsConfig.Properties.SpotlightMode.Value;
+            _isRippleModeEnabled = MouseHighlighterSettingsConfig.Properties.RippleMode.Value;
 
             _highlighterRadius = MouseHighlighterSettingsConfig.Properties.HighlightRadius.Value;
             _highlightFadeDelayMs = MouseHighlighterSettingsConfig.Properties.HighlightFadeDelayMs.Value;
@@ -603,6 +604,64 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 {
                     _isSpotlightModeEnabled = value;
                     MouseHighlighterSettingsConfig.Properties.SpotlightMode.Value = value;
+                    NotifyMouseHighlighterPropertyChanged();
+                }
+            }
+        }
+
+        public bool IsRippleModeEnabled
+        {
+            get => _isRippleModeEnabled;
+            set
+            {
+                if (_isRippleModeEnabled != value)
+                {
+                    _isRippleModeEnabled = value;
+                    MouseHighlighterSettingsConfig.Properties.RippleMode.Value = value;
+                    NotifyMouseHighlighterPropertyChanged();
+                }
+            }
+        }
+
+        // ComboBox index for the highlight mode selector.
+        // 0 = Spotlight, 1 = Circle, 2 = Ripple
+        public int HighlightModeIndex
+        {
+            get
+            {
+                if (_isSpotlightModeEnabled)
+                {
+                    return 0;
+                }
+
+                return _isRippleModeEnabled ? 2 : 1;
+            }
+
+            set
+            {
+                bool spotlight = value == 0;
+                bool ripple = value == 2;
+                bool changed = false;
+
+                if (_isSpotlightModeEnabled != spotlight)
+                {
+                    _isSpotlightModeEnabled = spotlight;
+                    MouseHighlighterSettingsConfig.Properties.SpotlightMode.Value = spotlight;
+                    OnPropertyChanged(nameof(IsSpotlightModeEnabled));
+                    changed = true;
+                }
+
+                if (_isRippleModeEnabled != ripple)
+                {
+                    _isRippleModeEnabled = ripple;
+                    MouseHighlighterSettingsConfig.Properties.RippleMode.Value = ripple;
+                    OnPropertyChanged(nameof(IsRippleModeEnabled));
+                    changed = true;
+                }
+
+                if (changed)
+                {
+                    OnPropertyChanged(nameof(HighlightModeIndex));
                     NotifyMouseHighlighterPropertyChanged();
                 }
             }
@@ -1214,6 +1273,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         private string _highlighterRightButtonClickColor;
         private string _highlighterAlwaysColor;
         private bool _isSpotlightModeEnabled;
+        private bool _isRippleModeEnabled;
         private int _highlighterRadius;
         private int _highlightFadeDelayMs;
         private int _highlightFadeDurationMs;


### PR DESCRIPTION
## Summary of the Pull Request

Adds a follow-up metadata fix to the existing Mouse Highlighter ripple v2.1 work by allowing the term `xhair` in repo spell-check configuration.

## PR Checklist

- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments

- Added `xhair` to `.github/actions/spell-check/expect.txt`.
- This addresses spelling feedback on MouseHighlighter ripple/crosshair code without changing runtime behavior.
- No functional changes to Mouse Highlighter logic were made in this follow-up commit.

## Validation Steps Performed

- Verified the only content change is the new `xhair` entry in spell-check expected words.
- Ran secret scanning on changed file (`.github/actions/spell-check/expect.txt`) with no findings.
- Ran parallel validation:
  - Code Review: no issues.
  - CodeQL: skipped as trivial metadata-only change.