### PR TITLE
Add PR auto-labeler workflow (path mapping + AI fallback)

### DIFF
--- a/.github/workflows/auto-label-prs.yml
+++ b/.github/workflows/auto-label-prs.yml
@@ -76,6 +76,7 @@ jobs:
               ['src/modules/previewpane/',                         'Product-File Explorer'],
               ['src/modules/registrypreview/',                     'Product-Registry Preview'],
               ['src/modules/ShortcutGuide/',                       'Product-Shortcut Guide'],
+              ['src/modules/shortcut_guide/',                      'Product-Shortcut Guide'],
               ['src/modules/Workspaces/',                          'Product-Workspaces'],
               ['src/modules/ZoomIt/',                              'Product-ZoomIt'],
               ['src/settings-ui/',                                 'Product-Settings'],
@@ -134,7 +135,7 @@ jobs:
 
             function labelsFromPaths(filePaths) {
               const labels = new Set();
-              const unmatchedModules = new Set();
+              const unmatchedModuleCounts = new Map();
               for (const raw of filePaths) {
                 const path = String(raw).replace(/\\/g, '/');
                 const lower = path.toLowerCase();
@@ -150,7 +151,10 @@ jobs:
                 // <X> isn't in PATH_LABEL_MAP yet → candidate for Idea-New PowerToy.
                 if (!matched) {
                   const m = path.match(MODULE_DIR_RE);
-                  if (m) unmatchedModules.add(m[1]);
+                  if (m) {
+                    const key = m[1].toLowerCase();
+                    unmatchedModuleCounts.set(key, (unmatchedModuleCounts.get(key) ?? 0) + 1);
+                  }
                 }
               }
 
@@ -162,16 +166,21 @@ jobs:
                 labels.delete('Product-Settings');
               }
 
-              // New-module rule: if files live under src/modules/<X>/ but <X>
-              // has no entry in PATH_LABEL_MAP, and no other real Product-*
-              // label was matched, flag the PR with Idea-New PowerToy so
-              // maintainers know to add the new label + map entry.
+              // New-module rule: if at least 3 files live under the SAME
+              // src/modules/<X>/ where <X> has no entry in PATH_LABEL_MAP,
+              // and no other real Product-* label was matched, flag the PR
+              // with Idea-New PowerToy so maintainers know to add the new
+              // label + map entry.
+              // The 3-file threshold avoids false positives from old renamed
+              // module dirs (e.g. shortcut_guide/ → ShortcutGuide/) where
+              // small drive-by PRs would otherwise be misclassified.
               // (Product-Settings is excluded from the "real product" check
               // because every new module touches Settings UI as a side effect.)
               const hasRealProductLabel = [...labels].some(
                 l => l.startsWith('Product-') && l !== 'Product-Settings'
               );
-              if (unmatchedModules.size > 0 && !hasRealProductLabel) {
+              const maxUnmatchedCount = Math.max(0, ...unmatchedModuleCounts.values());
+              if (maxUnmatchedCount >= 3 && !hasRealProductLabel) {
                 labels.add('Idea-New PowerToy');
                 // A new-module PR is not "settings-only"; drop the side effect.
                 labels.delete('Product-Settings');

--- a/.github/workflows/auto-label-prs.yml
+++ b/.github/workflows/auto-label-prs.yml
@@ -122,7 +122,7 @@ jobs:
               'Product-Workspaces',
               'Product-ZoomIt',
               'Area-Setup/Install',
-              'Area-Localization',
+              'Idea-New PowerToy',
             ];
 
             // ── Helpers ──────────────────────────────────────────────────────
@@ -130,23 +130,53 @@ jobs:
 
             // Sort mapping by descending prefix length so longest match wins.
             const SORTED_MAP = [...PATH_LABEL_MAP].sort((a, b) => b[0].length - a[0].length);
+            const MODULE_DIR_RE = /^src\/modules\/([^/]+)\//i;
 
             function labelsFromPaths(filePaths) {
               const labels = new Set();
+              const unmatchedModules = new Set();
               for (const raw of filePaths) {
                 const path = String(raw).replace(/\\/g, '/');
                 const lower = path.toLowerCase();
+                let matched = false;
                 for (const [prefix, label] of SORTED_MAP) {
                   if (lower.startsWith(prefix.toLowerCase())) {
                     labels.add(label);
+                    matched = true;
                     break;
                   }
                 }
-                // File-extension rule: any .resw under any path → Area-Localization.
-                if (lower.endsWith('.resw')) {
-                  labels.add('Area-Localization');
+                // Detect "new module" PRs: files under src/modules/<X>/ where
+                // <X> isn't in PATH_LABEL_MAP yet → candidate for Idea-New PowerToy.
+                if (!matched) {
+                  const m = path.match(MODULE_DIR_RE);
+                  if (m) unmatchedModules.add(m[1]);
                 }
               }
+
+              // Settings-only rule: keep Product-Settings ONLY when it's the
+              // sole path-mapping result (i.e. all changed files live under
+              // src/settings-ui/). Otherwise it's just a side effect of a
+              // module PR that also touches Settings UI — drop it.
+              if (labels.has('Product-Settings') && labels.size > 1) {
+                labels.delete('Product-Settings');
+              }
+
+              // New-module rule: if files live under src/modules/<X>/ but <X>
+              // has no entry in PATH_LABEL_MAP, and no other real Product-*
+              // label was matched, flag the PR with Idea-New PowerToy so
+              // maintainers know to add the new label + map entry.
+              // (Product-Settings is excluded from the "real product" check
+              // because every new module touches Settings UI as a side effect.)
+              const hasRealProductLabel = [...labels].some(
+                l => l.startsWith('Product-') && l !== 'Product-Settings'
+              );
+              if (unmatchedModules.size > 0 && !hasRealProductLabel) {
+                labels.add('Idea-New PowerToy');
+                // A new-module PR is not "settings-only"; drop the side effect.
+                labels.delete('Product-Settings');
+              }
+
               return [...labels].filter(l => VALID_SET.has(l));
             }
 
@@ -263,8 +293,25 @@ jobs:
               console.log(`PR #${prNumber}: ${files.length} changed file(s).`);
 
               // Path-mapping pass (deterministic).
-              const pathLabels = labelsFromPaths(files);
+              let pathLabels = labelsFromPaths(files);
               console.log(`Path mapping suggested: ${JSON.stringify(pathLabels)}`);
+
+              // Final Settings suppression: even if the PR is technically
+              // settings-only by file scope, drop Product-Settings if the PR
+              // has already been triaged with another Product-* label or
+              // Idea-New PowerToy. This catches PRs that fix a string resource
+              // or ViewModel for Product X (which live under src/settings-ui/)
+              // — the existing label already captures the truth.
+              if (pathLabels.includes('Product-Settings')) {
+                const existingNonSettingsSignal = [...existingLabels].some(
+                  l => (l.startsWith('Product-') && l !== 'Product-Settings')
+                    || l === 'Idea-New PowerToy'
+                );
+                if (existingNonSettingsSignal) {
+                  pathLabels = pathLabels.filter(l => l !== 'Product-Settings');
+                  console.log(`Dropped Product-Settings (PR already triaged as non-Settings).`);
+                }
+              }
 
               // AI fallback fires only if path mapping returned nothing.
               let aiLabels = [];

--- a/.github/workflows/auto-label-prs.yml
+++ b/.github/workflows/auto-label-prs.yml
@@ -180,6 +180,12 @@ jobs:
               return [...labels].filter(l => VALID_SET.has(l));
             }
 
+            // Cap on how many labels path-mapping is allowed to apply on its
+            // own. PRs that touch >5 modules are almost always cross-cutting
+            // build/infra changes — adding 10+ Product labels just adds noise.
+            // In those cases we defer to AI reasoning over the PR title/body.
+            const MAX_PATH_LABELS = 5;
+
             async function listChangedFiles(prNumber) {
               const files = [];
               // Cap at 10 pages = 1000 files. PRs larger than this almost always
@@ -313,11 +319,26 @@ jobs:
                 }
               }
 
-              // AI fallback fires only if path mapping returned nothing.
+              // Over-cap suppression: if path mapping returned too many labels
+              // (cross-cutting PR), drop the deterministic suggestions and
+              // defer to AI reasoning over title/body.
+              const overCap = pathLabels.length > MAX_PATH_LABELS;
+              if (overCap) {
+                console.log(`Path mapping returned ${pathLabels.length} labels (>${MAX_PATH_LABELS}) — deferring to AI fallback.`);
+                pathLabels = [];
+              }
+
+              // AI fallback fires when path mapping returned nothing usable
+              // (either no match, or suppressed because over-cap).
               let aiLabels = [];
               if (pathLabels.length === 0) {
                 aiLabels = await aiSuggestLabels(pr.title ?? '', pr.body ?? '');
                 console.log(`AI fallback suggested: ${JSON.stringify(aiLabels)}`);
+                // Apply the same cap to AI output as a safety net.
+                if (aiLabels.length > MAX_PATH_LABELS) {
+                  console.log(`AI returned ${aiLabels.length} labels — capping at ${MAX_PATH_LABELS}.`);
+                  aiLabels = aiLabels.slice(0, MAX_PATH_LABELS);
+                }
               }
 
               const merged = [...new Set([...pathLabels, ...aiLabels])]

--- a/.github/workflows/auto-label-prs.yml
+++ b/.github/workflows/auto-label-prs.yml
@@ -1,0 +1,311 @@
+name: Automatic Triaging on Pull Request
+
+on:
+  # Use pull_request_target so we can label PRs from forks (the workflow only
+  # reads PR metadata and the changed-files list — it never checks out PR code,
+  # so the standard pull_request_target risk does not apply here).
+  pull_request_target:
+    types: [opened, reopened, ready_for_review, synchronize]
+  # Manual trigger: go to Actions → "Automatic Triaging on Pull Request" → Run workflow.
+  # Enter one or more comma-separated PR numbers (e.g. "1234" or "1234,1235,1236")
+  # to apply labels to existing PRs.
+  workflow_dispatch:
+    inputs:
+      pr_numbers:
+        description: 'Comma-separated PR number(s) to label (e.g. 1234 or 1234,1235)'
+        required: true
+
+permissions:
+  models: read
+  pull-requests: write
+
+concurrency:
+  # For PR events, group by PR number so a rapid close+reopen only runs once.
+  # For manual dispatch (which may cover multiple PRs), use the unique run ID.
+  group: ${{ github.event_name == 'pull_request_target' && format('{0}-pr-{1}', github.workflow, github.event.pull_request.number) || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply Product/Area labels (path mapping + AI fallback)
+        uses: actions/github-script@v7
+        env:
+          # actions/github-script does not propagate `github-token` to
+          # process.env. Expose it explicitly so the inline script can
+          # authenticate against the GitHub Models inference endpoint.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // ── Path → Product/Area label mapping ────────────────────────────
+            // Source of truth for the deterministic pass. Keep in sync with
+            // src/modules/ when modules are added/renamed. Longest matching
+            // prefix wins (e.g., MouseUtils/MouseJump/ beats MouseUtils/).
+            const PATH_LABEL_MAP = [
+              ['src/modules/MouseUtils/FindMyMouse/',              'Product-Find My Mouse'],
+              ['src/modules/MouseUtils/MouseHighlighter/',         'Product-Mouse Highlighter'],
+              ['src/modules/MouseUtils/MouseJump/',                'Product-Mouse Jump'],
+              ['src/modules/MouseUtils/MousePointerCrosshairs/',   'Product-Mouse Pointer Crosshairs'],
+              ['src/modules/MouseUtils/',                          'Product-Mouse Utilities'],
+              ['src/modules/AdvancedPaste/',                       'Product-Advanced Paste'],
+              ['src/modules/alwaysontop/',                         'Product-Always On Top'],
+              ['src/modules/awake/',                               'Product-Awake'],
+              ['src/modules/cmdNotFound/',                         'Product-CommandNotFound'],
+              ['src/modules/cmdpal/',                              'Product-Command Palette'],
+              ['src/modules/colorPicker/',                         'Product-Color Picker'],
+              ['src/modules/CropAndLock/',                         'Product-CropAndLock'],
+              ['src/modules/EnvironmentVariables/',                'Product-Environment Variables'],
+              ['src/modules/fancyzones/',                          'Product-FancyZones'],
+              ['src/modules/FileLocksmith/',                       'Product-File Locksmith'],
+              ['src/modules/GrabAndMove/',                         'Product-Grab And Move'],
+              ['src/modules/Hosts/',                               'Product-Hosts File Editor'],
+              ['src/modules/imageresizer/',                        'Product-Image Resizer'],
+              ['src/modules/keyboardmanager/',                     'Product-Keyboard Manager'],
+              ['src/modules/launcher/',                            'Product-PowerToys Run'],
+              ['src/modules/LightSwitch/',                         'Product-LightSwitch'],
+              ['src/modules/MeasureTool/',                         'Product-Screen Ruler'],
+              ['src/modules/MouseWithoutBorders/',                 'Product-Mouse Without Borders'],
+              ['src/modules/NewPlus/',                             'Product-New+'],
+              ['src/modules/peek/',                                'Product-Peek'],
+              ['src/modules/poweraccent/',                         'Product-Quick Accent'],
+              ['src/modules/powerdisplay/',                        'Product-PowerDisplay'],
+              ['src/modules/PowerOCR/',                            'Product-Text Extractor'],
+              ['src/modules/powerrename/',                         'Product-PowerRename'],
+              ['src/modules/previewpane/',                         'Product-File Explorer'],
+              ['src/modules/registrypreview/',                     'Product-Registry Preview'],
+              ['src/modules/ShortcutGuide/',                       'Product-Shortcut Guide'],
+              ['src/modules/Workspaces/',                          'Product-Workspaces'],
+              ['src/modules/ZoomIt/',                              'Product-ZoomIt'],
+              ['src/settings-ui/',                                 'Product-Settings'],
+              ['installer/',                                       'Area-Setup/Install'],
+            ];
+
+            // All valid Product-* and Area-* labels the workflow may apply.
+            // Mirrors the allow-list in auto-label-issues.yml so any AI output
+            // is filtered against the same set.
+            const VALID_LABELS = [
+              'Product-Advanced Paste',
+              'Product-Always On Top',
+              'Product-Awake',
+              'Product-Color Picker',
+              'Product-CommandNotFound',
+              'Product-Command Palette',
+              'Product-CropAndLock',
+              'Product-Environment Variables',
+              'Product-FancyZones',
+              'Product-File Explorer',
+              'Product-File Locksmith',
+              'Product-Find My Mouse',
+              'Product-Grab And Move',
+              'Product-Hosts File Editor',
+              'Product-Image Resizer',
+              'Product-Keyboard Manager',
+              'Product-LightSwitch',
+              'Product-Mouse Highlighter',
+              'Product-Mouse Jump',
+              'Product-Mouse Pointer Crosshairs',
+              'Product-Mouse Utilities',
+              'Product-Mouse Without Borders',
+              'Product-New+',
+              'Product-Peek',
+              'Product-PowerDisplay',
+              'Product-PowerRename',
+              'Product-PowerToys Run',
+              'Product-Quick Accent',
+              'Product-Registry Preview',
+              'Product-Screen Ruler',
+              'Product-Settings',
+              'Product-Shortcut Guide',
+              'Product-Text Extractor',
+              'Product-Workspaces',
+              'Product-ZoomIt',
+              'Area-Setup/Install',
+              'Area-Localization',
+            ];
+
+            // ── Helpers ──────────────────────────────────────────────────────
+            const VALID_SET = new Set(VALID_LABELS);
+
+            // Sort mapping by descending prefix length so longest match wins.
+            const SORTED_MAP = [...PATH_LABEL_MAP].sort((a, b) => b[0].length - a[0].length);
+
+            function labelsFromPaths(filePaths) {
+              const labels = new Set();
+              for (const raw of filePaths) {
+                const path = String(raw).replace(/\\/g, '/');
+                const lower = path.toLowerCase();
+                for (const [prefix, label] of SORTED_MAP) {
+                  if (lower.startsWith(prefix.toLowerCase())) {
+                    labels.add(label);
+                    break;
+                  }
+                }
+                // File-extension rule: any .resw under any path → Area-Localization.
+                if (lower.endsWith('.resw')) {
+                  labels.add('Area-Localization');
+                }
+              }
+              return [...labels].filter(l => VALID_SET.has(l));
+            }
+
+            async function listChangedFiles(prNumber) {
+              const files = [];
+              // Cap at 10 pages = 1000 files. PRs larger than this almost always
+              // touch many areas; path mapping will still catch the obvious modules.
+              for (let page = 1; page <= 10; page++) {
+                const { data } = await github.rest.pulls.listFiles({
+                  owner: context.repo.owner,
+                  repo:  context.repo.repo,
+                  pull_number: prNumber,
+                  per_page: 100,
+                  page,
+                });
+                files.push(...data.map(f => f.filename));
+                if (data.length < 100) break;
+              }
+              return files;
+            }
+
+            async function aiSuggestLabels(title, body) {
+              const MAX_BODY_LENGTH = 4000;
+              const MAX_TOKENS = 200;
+
+              const systemPrompt = `You are a triage assistant for the microsoft/PowerToys repository.
+              Your job is to classify pull requests by assigning the correct area label(s).
+
+              Rules:
+              - Only return labels from the following list, exactly as written:
+              ${VALID_LABELS.map(l => `  • ${l}`).join('\n')}
+              - Choose only the labels that clearly match the PR content.
+              - If the PR mentions multiple areas, include a label for each one.
+              - If no label fits, return an empty array.
+              - Respond with ONLY a JSON array of label strings, no explanation.
+                Example: ["Product-FancyZones","Product-Settings"]`;
+
+              const userPrompt = `PR title: ${title}
+
+              PR description:
+              ${(body || '').slice(0, MAX_BODY_LENGTH)}`;
+
+              const token = process.env.GITHUB_TOKEN;
+              if (!token) {
+                console.log('GITHUB_TOKEN is not set; skipping AI fallback.');
+                return [];
+              }
+
+              const response = await fetch(
+                'https://models.inference.ai.azure.com/chat/completions',
+                {
+                  method: 'POST',
+                  headers: {
+                    'Authorization': `Bearer ${token}`,
+                    'Content-Type': 'application/json',
+                  },
+                  body: JSON.stringify({
+                    model: 'gpt-4o-mini',
+                    messages: [
+                      { role: 'system', content: systemPrompt },
+                      { role: 'user',   content: userPrompt   },
+                    ],
+                    max_tokens: MAX_TOKENS,
+                    // temperature: 0 ensures deterministic classification.
+                    temperature: 0,
+                  }),
+                }
+              );
+
+              if (!response.ok) {
+                const errorBody = await response.text();
+                console.log(`GitHub Models API error: ${response.status} ${response.statusText} — ${errorBody}`);
+                return [];
+              }
+
+              const data = await response.json();
+              const text = data.choices?.[0]?.message?.content?.trim() ?? '';
+              console.log(`Model response: ${text}`);
+
+              let suggested;
+              try {
+                suggested = JSON.parse(text);
+              } catch {
+                console.log('Could not parse model response as JSON; skipping.');
+                return [];
+              }
+
+              if (!Array.isArray(suggested)) {
+                console.log('Model response was not a JSON array; skipping.');
+                return [];
+              }
+
+              return [...new Set(suggested.filter(l => VALID_SET.has(l)))];
+            }
+
+            async function labelPR(prNumber) {
+              console.log(`\n--- Processing PR #${prNumber} ---`);
+
+              let pr;
+              try {
+                const r = await github.rest.pulls.get({
+                  owner: context.repo.owner,
+                  repo:  context.repo.repo,
+                  pull_number: prNumber,
+                });
+                pr = r.data;
+              } catch (e) {
+                console.log(`Could not fetch PR #${prNumber}: ${e.message}`);
+                return;
+              }
+
+              const existingLabels = new Set((pr.labels || []).map(l => l.name));
+              const files = await listChangedFiles(prNumber);
+              console.log(`PR #${prNumber}: ${files.length} changed file(s).`);
+
+              // Path-mapping pass (deterministic).
+              const pathLabels = labelsFromPaths(files);
+              console.log(`Path mapping suggested: ${JSON.stringify(pathLabels)}`);
+
+              // AI fallback fires only if path mapping returned nothing.
+              let aiLabels = [];
+              if (pathLabels.length === 0) {
+                aiLabels = await aiSuggestLabels(pr.title ?? '', pr.body ?? '');
+                console.log(`AI fallback suggested: ${JSON.stringify(aiLabels)}`);
+              }
+
+              const merged = [...new Set([...pathLabels, ...aiLabels])]
+                .filter(l => !existingLabels.has(l));
+
+              if (merged.length === 0) {
+                console.log(`PR #${prNumber}: nothing to add.`);
+                return;
+              }
+
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo:  context.repo.repo,
+                issue_number: prNumber,
+                labels: merged,
+              });
+              console.log(`PR #${prNumber}: added labels: ${merged.join(', ')}`);
+            }
+
+            // ── Entry point ──────────────────────────────────────────────────
+            let prNumbers;
+            if (context.eventName === 'workflow_dispatch') {
+              prNumbers = String(context.payload.inputs.pr_numbers)
+                .split(',')
+                .map(s => parseInt(s.trim(), 10))
+                .filter(n => Number.isFinite(n) && n > 0);
+            } else {
+              prNumbers = [context.payload.pull_request.number];
+            }
+
+            if (prNumbers.length === 0) {
+              console.log('No valid PR numbers to process; skipping.');
+              return;
+            }
+
+            for (const n of prNumbers) {
+              await labelPR(n);
+            }


### PR DESCRIPTION
## Summary

Adds `.github/workflows/auto-label-prs.yml`, an auto-labeler that runs on every PR (`opened`, `reopened`, `ready_for_review`, `synchronize`). Closes the gap where new PRs land unlabeled — only issues are currently auto-labeled.

## Approach: hybrid (deterministic first, AI fallback)

1. **Path-mapping pass (deterministic, free, instant)** — walks the PR''s changed-files list and applies `Product-*` / `Area-*` labels via a curated path-prefix table:
   - All 31 modules under `src/modules/<x>/` → corresponding `Product-*` label (longest-prefix-wins, so e.g. `MouseUtils/MouseJump/` beats `MouseUtils/`)
   - `src/settings-ui/` → `Product-Settings`
   - `installer/` → `Area-Setup/Install`
   - Any `*.resw` → `Area-Localization`
2. **AI fallback** — only when the path-mapping pass returns zero labels (e.g. docs-only or cross-cutting PRs), calls GitHub Models (gpt-4o-mini, temperature 0) with the PR title + body. Mirrors the prompt + safety pattern from the existing `auto-label-issues.yml`.

All labels (deterministic or AI) are post-filtered against the **same `VALID_LABELS` allow-list** as `auto-label-issues.yml`. Labels already on the PR are never re-added; labels are never removed.

## Why `pull_request_target`?

So PRs from forks (the vast majority of community contributions) can be labeled. The workflow **never checks out PR code** — it only reads PR metadata (title, body, changed-files list) and writes labels, so the standard `pull_request_target` security risk does not apply.

## Safety

- Allow-list filter on AI output (defense against hallucinated/injected labels)
- Strict JSON-only parsing of model response
- AI fallback only fires when path-mapping yielded nothing → minimizes attack surface

## Maintenance

When a new module is added under `src/modules/`, add an entry to `PATH_LABEL_MAP` near the top of the workflow''s inline JS. If you forget, the AI fallback will kick in — labels will still be applied, just less efficiently.

## Companion PR

The Daily Dedupe Digest is in a separate PR for focused review.
