### PR TITLE
[KBM] Enable new editor by default

### DIFF
--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PowerToys/Modules/KeyboardManagerModuleCommandProvider.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PowerToys/Modules/KeyboardManagerModuleCommandProvider.cs
@@ -58,7 +58,7 @@ internal sealed class KeyboardManagerModuleCommandProvider : ModuleCommandProvid
 
             if (!File.Exists(settingsPath))
             {
-                return false;
+                return true;
             }
 
             var json = File.ReadAllText(settingsPath);
@@ -72,9 +72,9 @@ internal sealed class KeyboardManagerModuleCommandProvider : ModuleCommandProvid
         }
         catch
         {
-            // If we can't read the setting, default to not showing the command
+            // If we can't read the setting, default to showing the command
         }
 
-        return false;
+        return true;
     }
 }

--- a/src/modules/keyboardmanager/dll/dllmain.cpp
+++ b/src/modules/keyboardmanager/dll/dllmain.cpp
@@ -60,7 +60,7 @@ private:
     Hotkey m_editorHotkey = { .key = 0 };
 
     // Whether to use the new WinUI3 editor
-    bool m_useNewEditor = false;
+    bool m_useNewEditor = true;
 
     ULONGLONG m_lastHotkeyTime = 0;
 
@@ -196,11 +196,11 @@ private:
             try
             {
                 auto propertiesObject = settingsObject.GetNamedObject(JSON_KEY_PROPERTIES);
-                m_useNewEditor = propertiesObject.GetNamedBoolean(JSON_KEY_USE_NEW_EDITOR, false);
+                m_useNewEditor = propertiesObject.GetNamedBoolean(JSON_KEY_USE_NEW_EDITOR, true);
             }
             catch (...)
             {
-                Logger::warn("Failed to parse useNewEditor setting, defaulting to false");
+                Logger::warn("Failed to parse useNewEditor setting, defaulting to true");
             }
         }
     }

--- a/src/settings-ui/Settings.UI.Library/KeyboardManagerProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/KeyboardManagerProperties.cs
@@ -33,7 +33,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         public HotkeySettings EditorShortcut { get; set; }
 
         [JsonPropertyName("useNewEditor")]
-        public bool UseNewEditor { get; set; }
+        public bool UseNewEditor { get; set; } = true;
 
         public string ToJsonString()
         {


### PR DESCRIPTION
## Summary

Make the new WinUI 3 Keyboard Manager editor the default by flipping `useNewEditor` from `false` to `true` everywhere a default is supplied.

## Behavior

- **New installs / new `settings.json`** → new editor enabled
- **Upgrades from a version before the `useNewEditor` key existed** → new editor enabled (the key is missing, so the default kicks in)
- **Users who have explicitly toggled the setting** → unchanged (we only change the default, not stored values)
- The "Go back to classic" button in the KBM settings page is untouched

## Changes

- `src/settings-ui/Settings.UI.Library/KeyboardManagerProperties.cs` — `UseNewEditor` property initializer now `true`
- `src/modules/keyboardmanager/dll/dllmain.cpp` — `m_useNewEditor` member init + `GetNamedBoolean` fallback now `true`; warn-log message updated to match
- `src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PowerToys/Modules/KeyboardManagerModuleCommandProvider.cs` — both fallback paths in `IsUseNewEditorEnabled` (file missing / unreadable) now return `true`, so the "Open New Editor" CmdPal command surfaces by default

## Validation

Built locally on ARM64 Debug (exit code 0):
- `src/modules/keyboardmanager/dll`
- `src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PowerToys`
- `src/settings-ui/Settings.UI.Library`