### PR TITLE
Fix Performance Monitor settings file path collision

### DIFF
--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/SettingsManager.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/SettingsManager.cs
@@ -34,7 +34,7 @@ internal sealed class SettingsManager : JsonSettingsManager
     {
         var directory = Utilities.BaseSettingsPath("Microsoft.CmdPal");
         Directory.CreateDirectory(directory);
-        return Path.Combine(directory, "settings.json");
+        return Path.Combine(directory, $"{Namespace}.settings.json");
     }
 
     public SettingsManager()


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Fixes #48224

The Performance Monitor extension was still storing its settings in the shared settings.json file. Since Command Palette built-in extensions now use extension-specific sibling settings files, the extension's settings could be overwritten when Command Palette personalization settings were saved.

This change updates SettingsJsonPath() to store Performance Monitor settings in an extension-specific settings file (performanceMonitor.settings.json), ensuring the network speed unit setting persists correctly.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #48224 
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [x] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

The Performance Monitor extension had not been migrated to the newer extension-specific settings file architecture. As a result, its settings were stored in the shared settings.json file and could be lost when the Command Palette host rewrote its configuration.

Following @zadjii-msft's guidance in the issue, this PR updates SettingsManager.cs to store Performance Monitor settings in an extension-specific settings file:

performanceMonitor.settings.json

instead of the shared:

settings.json

This aligns the extension with the current Command Palette settings architecture and prevents the network speed unit setting from being overwritten.


<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

* Changed Network Speed Unit to "Binary bytes per second" in Performance Monitor settings.
* Verified the setting was successfully saved to the newly created `performanceMonitor.settings.json` file.
* Modified core Command Palette personalization settings.
* Verified the Performance Monitor setting was preserved and not overwritten.
* Restarted PowerToys and verified the setting persisted correctly.

**Note to reviewers:** I left the "Tests" box unchecked because this is a single-line file path configuration change. I did not add an automated test, but I have thoroughly verified the fix manually as described in the Validation steps above.

