### PR TITLE
Add PowerAccent excluded apps unit test seed

### DIFF
--- a/PowerToys.slnx
+++ b/PowerToys.slnx
@@ -818,6 +818,9 @@
     <Project Path="src/modules/poweraccent/PowerAccentKeyboardService/PowerAccentKeyboardService.vcxproj" Id="c97d9a5d-206c-454e-997e-009e227d7f02" />
     <Project Path="src/modules/poweraccent/PowerAccentModuleInterface/PowerAccentModuleInterface.vcxproj" Id="34a354c5-23c7-4343-916c-c52daf4fc39d" />
   </Folder>
+  <Folder Name="/modules/PowerAccent/Tests/">
+    <Project Path="src/modules/poweraccent/UnitTests/UnitTests-PowerAccent.vcxproj" Id="c2b3d4e5-2222-3333-4444-555566667777" />
+  </Folder>
   <Folder Name="/modules/PowerOCR/">
     <Project Path="src/modules/PowerOCR/PowerOCR/PowerOCR.csproj">
       <Platform Solution="*|ARM64" Project="ARM64" />
@@ -1139,5 +1142,4 @@
   <Project Path="src/Update/PowerToys.Update.vcxproj" Id="44ce9ae1-4390-42c5-bacc-0fd6b40aa203" />
   <Project Path="tools/project_template/ModuleTemplate/ModuleTemplateCompileTest.vcxproj" Id="64a80062-4d8b-4229-8a38-dfa1d7497749" />
 </Solution>
-
 

--- a/src/modules/poweraccent/PowerAccentKeyboardService/ExcludedApps.h
+++ b/src/modules/poweraccent/PowerAccentKeyboardService/ExcludedApps.h
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+#include <Windows.h>
+
+#include <algorithm>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <common/utils/string_utils.h>
+
+namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
+{
+    inline std::vector<std::wstring> ParseExcludedApps(std::wstring_view excludedAppsView)
+    {
+        std::vector<std::wstring> excludedApps;
+        auto excludedUppercase = std::wstring(excludedAppsView);
+        CharUpperBuffW(excludedUppercase.data(), static_cast<DWORD>(excludedUppercase.length()));
+        std::wstring_view view(excludedUppercase);
+        view = left_trim<wchar_t>(trim<wchar_t>(view));
+
+        while (!view.empty())
+        {
+            const auto pos = (std::min)(view.find_first_of(L"\r\n"), view.length());
+            const auto app = trim<wchar_t>(view.substr(0, pos));
+            if (!app.empty())
+            {
+                excludedApps.emplace_back(app);
+            }
+
+            view.remove_prefix(pos);
+            view = left_trim<wchar_t>(trim<wchar_t>(view));
+        }
+
+        return excludedApps;
+    }
+}

--- a/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.cpp
+++ b/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.cpp
@@ -1,4 +1,5 @@
 #include "pch.h"
+#include "ExcludedApps.h"
 #include "KeyboardListener.h"
 #include "KeyboardListener.g.cpp"
 
@@ -98,19 +99,7 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
 
     void KeyboardListener::UpdateExcludedApps(std::wstring_view excludedAppsView)
     {
-        std::vector<std::wstring> excludedApps;
-        auto excludedUppercase = std::wstring(excludedAppsView);
-        CharUpperBuffW(excludedUppercase.data(), static_cast<DWORD>(excludedUppercase.length()));
-        std::wstring_view view(excludedUppercase);
-        view = left_trim<wchar_t>(trim<wchar_t>(view));
-
-        while (!view.empty())
-        {
-            auto pos = (std::min)(view.find_first_of(L"\r\n"), view.length());
-            excludedApps.emplace_back(view.substr(0, pos));
-            view.remove_prefix(pos);
-            view = left_trim<wchar_t>(trim<wchar_t>(view));
-        }
+        auto excludedApps = ParseExcludedApps(excludedAppsView);
         {
             std::lock_guard<std::mutex> lock(m_mutex_excluded_apps);
             m_settings.excludedApps = std::move(excludedApps);

--- a/src/modules/poweraccent/PowerAccentKeyboardService/PowerAccentKeyboardService.vcxproj
+++ b/src/modules/poweraccent/PowerAccentKeyboardService/PowerAccentKeyboardService.vcxproj
@@ -79,6 +79,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="ExcludedApps.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="KeyboardListener.h">
       <DependentUpon>KeyboardListener.idl</DependentUpon>

--- a/src/modules/poweraccent/PowerAccentKeyboardService/PowerAccentKeyboardService.vcxproj.filters
+++ b/src/modules/poweraccent/PowerAccentKeyboardService/PowerAccentKeyboardService.vcxproj.filters
@@ -14,6 +14,7 @@
     <ClCompile Include="$(GeneratedFilesDir)module.g.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="ExcludedApps.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="resource.h" />
   </ItemGroup>

--- a/src/modules/poweraccent/UnitTests/PowerAccentTests.cpp
+++ b/src/modules/poweraccent/UnitTests/PowerAccentTests.cpp
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "pch.h"
+#include "CppUnitTest.h"
+
+#include <common/utils/string_utils.h>
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace PowerAccentUnitTests
+{
+    TEST_CLASS(StringUtilsTrimTests)
+    {
+    public:
+        TEST_METHOD(Trim_RemovesLeadingAndTrailingWhitespace)
+        {
+            const auto result = trim<wchar_t>(std::wstring_view(L"  hello  "));
+            Assert::IsTrue(result == L"hello");
+        }
+    };
+}

--- a/src/modules/poweraccent/UnitTests/PowerAccentTests.cpp
+++ b/src/modules/poweraccent/UnitTests/PowerAccentTests.cpp
@@ -5,19 +5,25 @@
 #include "pch.h"
 #include "CppUnitTest.h"
 
-#include <common/utils/string_utils.h>
+#include "../PowerAccentKeyboardService/ExcludedApps.h"
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
 namespace PowerAccentUnitTests
 {
-    TEST_CLASS(StringUtilsTrimTests)
+    TEST_CLASS(ExcludedAppsTests)
     {
     public:
-        TEST_METHOD(Trim_RemovesLeadingAndTrailingWhitespace)
+        TEST_METHOD(ParseExcludedApps_NormalizesMultilineSettingsForActivationSuppression)
         {
-            const auto result = trim<wchar_t>(std::wstring_view(L"  hello  "));
-            Assert::IsTrue(result == L"hello");
+            using namespace winrt::PowerToys::PowerAccentKeyboardService::implementation;
+
+            const auto result = ParseExcludedApps(L" notepad.exe\r\n\nChrome.exe \n  C:\\Tools\\MixedCase.exe ");
+
+            Assert::IsTrue(result.size() == 3);
+            Assert::AreEqual(L"NOTEPAD.EXE", result[0].c_str());
+            Assert::AreEqual(L"CHROME.EXE", result[1].c_str());
+            Assert::AreEqual(L"C:\\TOOLS\\MIXEDCASE.EXE", result[2].c_str());
         }
     };
 }

--- a/src/modules/poweraccent/UnitTests/UnitTests-PowerAccent.vcxproj
+++ b/src/modules/poweraccent/UnitTests/UnitTests-PowerAccent.vcxproj
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{C2B3D4E5-2222-3333-4444-555566667777}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>UnitTestsPowerAccent</RootNamespace>
+    <ProjectSubType>NativeUnitTestProject</ProjectSubType>
+    <ProjectName>PowerAccent.UnitTests</ProjectName>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <OutDir>$(RepoRoot)$(Platform)\$(Configuration)\tests\PowerAccent\</OutDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\;..\PowerAccentKeyboardService;$(RepoRoot)src\;$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;UNIT_TEST;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <UseFullPaths>true</UseFullPaths>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <DisableSpecificWarnings>26466;26495;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="pch.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="pch.cpp">
+      <PrecompiledHeader Condition="'$(UsePrecompiledHeaders)' != 'false'">Create</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="PowerAccentTests.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/modules/poweraccent/UnitTests/UnitTests-PowerAccent.vcxproj
+++ b/src/modules/poweraccent/UnitTests/UnitTests-PowerAccent.vcxproj
@@ -41,6 +41,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
+    <ClInclude Include="..\PowerAccentKeyboardService\ExcludedApps.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">

--- a/src/modules/poweraccent/UnitTests/UnitTests-PowerAccent.vcxproj.filters
+++ b/src/modules/poweraccent/UnitTests/UnitTests-PowerAccent.vcxproj.filters
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="pch.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="PowerAccentTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="pch.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/src/modules/poweraccent/UnitTests/UnitTests-PowerAccent.vcxproj.filters
+++ b/src/modules/poweraccent/UnitTests/UnitTests-PowerAccent.vcxproj.filters
@@ -22,5 +22,8 @@
     <ClInclude Include="pch.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\PowerAccentKeyboardService\ExcludedApps.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/src/modules/poweraccent/UnitTests/pch.cpp
+++ b/src/modules/poweraccent/UnitTests/pch.cpp
@@ -1,0 +1,1 @@
+#include "pch.h"

--- a/src/modules/poweraccent/UnitTests/pch.h
+++ b/src/modules/poweraccent/UnitTests/pch.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <string>
+#include <vector>
+#include <algorithm>
+#include <chrono>
+#include <functional>
+#include "CppUnitTest.h"


### PR DESCRIPTION
## Summary
- add a dedicated PowerAccent native unit test project
- extract PowerAccent excluded-app parsing into a small helper used by `KeyboardListener::UpdateExcludedApps`
- seed the project with one real PowerAccent behavior test: multiline excluded-app settings are trimmed, uppercased, and normalized for activation suppression
- fix the parser so trailing spaces before a newline do not become part of an excluded app entry

## Validation
- `tools\build\build.ps1 -Platform x64 -Configuration Debug -Path src\modules\poweraccent\PowerAccentKeyboardService`
- `tools\build\build.ps1 -Platform x64 -Configuration Debug -Path src\modules\poweraccent\UnitTests`
- `vstest.console.exe x64\Debug\tests\PowerAccent\PowerAccent.UnitTests.dll /TestCaseFilter:FullyQualifiedName~ParseExcludedApps_NormalizesMultilineSettingsForActivationSuppression`