### PR TITLE
Add FancyZones layout unit test seed

### DIFF
--- a/src/modules/fancyzones/FancyZonesTests/UnitTests/LayoutSeed.Tests.cpp
+++ b/src/modules/fancyzones/FancyZonesTests/UnitTests/LayoutSeed.Tests.cpp
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "pch.h"
+
+#include <FancyZonesLib/FancyZonesDataTypes.h>
+#include <FancyZonesLib/Layout.h>
+#include <FancyZonesLib/util.h>
+
+#include "Util.h"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+using namespace FancyZonesDataTypes;
+using namespace FancyZonesUtils;
+
+namespace FancyZonesUnitTests
+{
+    TEST_CLASS(LayoutSeedTests)
+    {
+    public:
+        TEST_METHOD(LayoutColumns2Zones)
+        {
+            LayoutData data{
+                .uuid = FancyZonesUtils::GuidFromString(L"{00000000-0000-0000-0000-000000000002}").value(),
+                .type = ZoneSetLayoutType::Columns,
+                .showSpacing = false,
+                .spacing = 0,
+                .zoneCount = 2,
+                .sensitivityRadius = 20,
+            };
+
+            auto layout = std::make_unique<Layout>(data);
+            Assert::IsTrue(layout->Init(RECT{ 0, 0, 1920, 1080 }, Mocks::Monitor()));
+            Assert::AreEqual(static_cast<size_t>(2), layout->Zones().size());
+
+            for (const auto& [id, zone] : layout->Zones())
+            {
+                UNREFERENCED_PARAMETER(id);
+
+                const auto& zoneRect = zone.GetZoneRect();
+                Assert::IsTrue(zoneRect.left >= 0);
+                Assert::IsTrue(zoneRect.top >= 0);
+                Assert::IsTrue(zoneRect.left < zoneRect.right);
+                Assert::IsTrue(zoneRect.top < zoneRect.bottom);
+                Assert::IsTrue(zoneRect.right <= 1920);
+                Assert::IsTrue(zoneRect.bottom <= 1080);
+            }
+        }
+    };
+}

--- a/src/modules/fancyzones/FancyZonesTests/UnitTests/UnitTests.vcxproj
+++ b/src/modules/fancyzones/FancyZonesTests/UnitTests/UnitTests.vcxproj
@@ -46,6 +46,7 @@
     <ClCompile Include="DefaultLayoutsTests.Spec.cpp" />
     <ClCompile Include="FancyZonesSettings.Spec.cpp" />
     <ClCompile Include="JsonHelpers.Tests.cpp" />
+    <ClCompile Include="LayoutSeed.Tests.cpp" />
     <ClCompile Include="Layout.Spec.cpp" />
     <ClCompile Include="LayoutHotkeysTests.Spec.cpp" />
     <ClCompile Include="LayoutTemplatesTests.Spec.cpp" />

--- a/src/modules/fancyzones/FancyZonesTests/UnitTests/UnitTests.vcxproj.filters
+++ b/src/modules/fancyzones/FancyZonesTests/UnitTests/UnitTests.vcxproj.filters
@@ -27,6 +27,9 @@
     <ClCompile Include="JsonHelpers.Tests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="LayoutSeed.Tests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="Util.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>


### PR DESCRIPTION
## Summary
- Adds one deterministic FancyZones native unit test to the existing `FancyZones.UnitTests` project.
- Covers a two-column layout producing two valid zones inside a 1920x1080 work area.
- Keeps the original large FancyZones test branch as draft backlog in #46930.

## Validation
- `tools\build\build.ps1 -Platform x64 -Configuration Debug -Path src\modules\fancyzones\FancyZonesTests\UnitTests`
- `vstest.console.exe ...\FancyZones.UnitTests.dll /Platform:x64 /Tests:LayoutColumns2Zones`
- Confirmed VSTest ran 1/1 selected test successfully.