### PR TITLE
Add FileLocksmith CLI unit test seed

### DIFF
--- a/src/modules/FileLocksmith/FileLocksmithCLI/tests/FileLocksmithCLITests.cpp
+++ b/src/modules/FileLocksmith/FileLocksmithCLI/tests/FileLocksmithCLITests.cpp
@@ -132,5 +132,17 @@ namespace FileLocksmithCLIUnitTests
             Assert::AreEqual(1, result.exit_code);
             Assert::AreEqual(std::wstring(L"query-wait"), result.command_name);
         }
+
+        TEST_METHOD(TestNoPathsAfterFlags)
+        {
+            MockProcessFinder finder;
+            MockProcessTerminator terminator;
+            MockStringProvider strings;
+
+            wchar_t* argv[] = { (wchar_t*)L"exe", (wchar_t*)L"--json" };
+            auto result = run_command(2, argv, finder, terminator, strings);
+
+            Assert::AreEqual(1, result.exit_code);
+        }
     };
 }


### PR DESCRIPTION
## Summary
- Adds one FileLocksmith CLI unit test to the existing native test project.
- Covers the flags-without-paths guard for `--json`.
- Avoids the product header changes from the larger draft backlog PR.

## Validation
- `tools\build\build.ps1 -Platform x64 -Configuration Debug -Path src\modules\FileLocksmith\FileLocksmithCLI\tests`
- `vstest.console.exe x64\Debug\tests\FileLocksmithCLI\FileLocksmithCLI.UnitTests.dll /Platform:x64 /Tests:TestNoPathsAfterFlags`
- Confirmed VSTest ran 1/1 selected test successfully.

Split out from the draft FileLocksmith test work in #46936.