### PR TITLE
Add MeasureTool native unit test seed

### DIFF
--- a/PowerToys.slnx
+++ b/PowerToys.slnx
@@ -752,6 +752,7 @@
       <Platform Solution="*|ARM64" Project="ARM64" />
       <Platform Solution="*|x64" Project="x64" />
     </Project>
+    <Project Path="src/modules/MeasureTool/UnitTests/UnitTests-MeasureTool.vcxproj" Id="a8f12d3e-5b6c-4e7f-9a0b-c1d2e3f4a5b6" />
   </Folder>
   <Folder Name="/modules/MouseWithoutBorders/">
     <Project Path="src/modules/MouseWithoutBorders/App/Helper/MouseWithoutBordersHelper.csproj">
@@ -1139,5 +1140,4 @@
   <Project Path="src/Update/PowerToys.Update.vcxproj" Id="44ce9ae1-4390-42c5-bacc-0fd6b40aa203" />
   <Project Path="tools/project_template/ModuleTemplate/ModuleTemplateCompileTest.vcxproj" Id="64a80062-4d8b-4229-8a38-dfa1d7497749" />
 </Solution>
-
 

--- a/src/modules/MeasureTool/UnitTests/MeasureToolTests.cpp
+++ b/src/modules/MeasureTool/UnitTests/MeasureToolTests.cpp
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "pch.h"
+
+#pragma warning(push)
+#pragma warning(disable : 26466)
+#include "CppUnitTest.h"
+#pragma warning(pop)
+
+#include "BGRATextureView.h"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace MeasureToolUnitTests
+{
+    static BGRATextureView MakeTexture(const uint32_t* data, size_t width, size_t height, size_t pitch = 0)
+    {
+        BGRATextureView view;
+        view.pixels = data;
+        view.width = width;
+        view.height = height;
+        view.pitch = pitch ? pitch : width;
+        return view;
+    }
+
+    TEST_CLASS(BGRATextureViewTests)
+    {
+    public:
+        TEST_METHOD(GetPixel_BasicAccess)
+        {
+            const uint32_t data[] = {
+                0x01, 0x02, 0x03,
+                0x04, 0x05, 0x06,
+                0x07, 0x08, 0x09,
+            };
+            const auto view = MakeTexture(data, 3, 3);
+
+            Assert::AreEqual(0x01u, view.GetPixel(0, 0));
+            Assert::AreEqual(0x05u, view.GetPixel(1, 1));
+            Assert::AreEqual(0x09u, view.GetPixel(2, 2));
+            Assert::AreEqual(0x06u, view.GetPixel(2, 1));
+        }
+    };
+}

--- a/src/modules/MeasureTool/UnitTests/UnitTests-MeasureTool.vcxproj
+++ b/src/modules/MeasureTool/UnitTests/UnitTests-MeasureTool.vcxproj
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props')" />
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <ProjectGuid>{A8F12D3E-5B6C-4E7F-9A0B-C1D2E3F4A5B6}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>UnitTestsMeasureTool</RootNamespace>
+    <ProjectSubType>NativeUnitTestProject</ProjectSubType>
+    <ProjectName>MeasureTool.UnitTests</ProjectName>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseOfMfc>false</UseOfMfc>
+
+    <OutDir>$(RepoRoot)$(Platform)\$(Configuration)\tests\MeasureTool\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\tests\MeasureTool\</IntDir>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <TargetName>MeasureTool.UnitTests</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\MeasureToolCore\;$(RepoRoot)packages\Microsoft.Windows.ImplementationLibrary.1.0.250325.1\include;$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="pch.cpp">
+      <PrecompiledHeader Condition="'$(UsePrecompiledHeaders)' != 'false'">Create</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="MeasureToolTests.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="pch.h" />
+    <ClInclude Include="..\MeasureToolCore\BGRATextureView.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
+  </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
+    <Error Condition="!Exists('$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+  </Target>
+</Project>

--- a/src/modules/MeasureTool/UnitTests/UnitTests-MeasureTool.vcxproj.filters
+++ b/src/modules/MeasureTool/UnitTests/UnitTests-MeasureTool.vcxproj.filters
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="pch.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="MeasureToolTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\MeasureToolCore\EdgeDetection.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="MeasurementForTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="pch.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\MeasureToolCore\BGRATextureView.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\MeasureToolCore\EdgeDetection.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="MeasurementForTests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\MeasureToolCore\constants.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+</Project>

--- a/src/modules/MeasureTool/UnitTests/packages.config
+++ b/src/modules/MeasureTool/UnitTests/packages.config
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.250303.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.250325.1" targetFramework="native" />
+</packages>

--- a/src/modules/MeasureTool/UnitTests/pch.cpp
+++ b/src/modules/MeasureTool/UnitTests/pch.cpp
@@ -1,0 +1,5 @@
+// pch.cpp: source file corresponding to the pre-compiled header
+
+#include "pch.h"
+
+// When you are using pre-compiled headers, this source file is necessary for compilation to succeed.

--- a/src/modules/MeasureTool/UnitTests/pch.h
+++ b/src/modules/MeasureTool/UnitTests/pch.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#ifndef PCH_H
+#define PCH_H
+
+#define NOMINMAX
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <Unknwn.h>
+#include <d3d11.h>
+#include <dcommon.h>
+
+#include <cinttypes>
+#include <cassert>
+#include <limits>
+#include <chrono>
+#include <algorithm>
+#include <cmath>
+#include <string>
+#include <vector>
+#include <sstream>
+#include <iomanip>
+#include <iostream>
+#include <functional>
+#include <thread>
+#include <string_view>
+
+// C++/WinRT base types (winrt::com_ptr used in BGRATextureView.h MappedTextureView)
+#include <winrt/base.h>
+
+#endif // PCH_H


### PR DESCRIPTION
## Summary
- Adds a minimal native MeasureTool unit-test project from current `main`.
- Includes exactly one deterministic seed test: `GetPixel_BasicAccess` for `BGRATextureView`.
- Avoids the production-code/testability changes from the larger draft backlog PR.

## Validation
- `tools\build\build.ps1 -Platform x64 -Configuration Debug -Path src\modules\MeasureTool\UnitTests`
- `vstest.console.exe x64\Debug\tests\MeasureTool\MeasureTool.UnitTests.dll /Platform:x64 /Tests:GetPixel_BasicAccess`
- Confirmed the DLL name matches CI discovery (`*UnitTest*.dll`) and VSTest ran 1/1 selected test successfully.

Split out from the draft MeasureTool test work in #46933.