### PR TITLE
Add LightSwitch schedule unit test seed

### DIFF
--- a/PowerToys.slnx
+++ b/PowerToys.slnx
@@ -713,6 +713,7 @@
       <Platform Solution="*|x64" Project="x64" />
       <Deploy />
     </Project>
+    <Project Path="src/modules/LightSwitch/UnitTests/UnitTests-LightSwitch.vcxproj" Id="b1a2c3d4-1111-2222-3333-444455556666" />
   </Folder>
   <Folder Name="/modules/PowerDisplay/">
     <Project Path="src/modules/powerdisplay/PowerDisplay.Models/PowerDisplay.Models.csproj">
@@ -1139,5 +1140,4 @@
   <Project Path="src/Update/PowerToys.Update.vcxproj" Id="44ce9ae1-4390-42c5-bacc-0fd6b40aa203" />
   <Project Path="tools/project_template/ModuleTemplate/ModuleTemplateCompileTest.vcxproj" Id="64a80062-4d8b-4229-8a38-dfa1d7497749" />
 </Solution>
-
 

--- a/src/modules/LightSwitch/UnitTests/LightSwitchTests.cpp
+++ b/src/modules/LightSwitch/UnitTests/LightSwitchTests.cpp
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "pch.h"
+#include "CppUnitTest.h"
+
+#include "../LightSwitchService/LightSwitchUtils.h"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace LightSwitchUnitTests
+{
+    TEST_CLASS(ShouldBeLightTests)
+    {
+    public:
+        TEST_METHOD(NormalRange_BeforeLightTime_ReturnsDark)
+        {
+            Assert::IsFalse(ShouldBeLight(360, 480, 1200));
+        }
+    };
+}

--- a/src/modules/LightSwitch/UnitTests/UnitTests-LightSwitch.vcxproj
+++ b/src/modules/LightSwitch/UnitTests/UnitTests-LightSwitch.vcxproj
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{B1A2C3D4-1111-2222-3333-444455556666}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>UnitTestsLightSwitch</RootNamespace>
+    <ProjectSubType>NativeUnitTestProject</ProjectSubType>
+    <ProjectName>LightSwitch.UnitTests</ProjectName>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <OutDir>$(RepoRoot)$(Platform)\$(Configuration)\tests\LightSwitch\</OutDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\;..\LightSwitchLib;..\LightSwitchService;$(RepoRoot)src\;$(RepoRoot)src\common;$(RepoRoot)src\common\SettingsAPI;$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;UNIT_TEST;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <UseFullPaths>true</UseFullPaths>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <DisableSpecificWarnings>26466;26495;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>Advapi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="pch.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="pch.cpp">
+      <PrecompiledHeader Condition="'$(UsePrecompiledHeaders)' != 'false'">Create</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="LightSwitchTests.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/modules/LightSwitch/UnitTests/UnitTests-LightSwitch.vcxproj.filters
+++ b/src/modules/LightSwitch/UnitTests/UnitTests-LightSwitch.vcxproj.filters
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="pch.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="LightSwitchTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="pch.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/src/modules/LightSwitch/UnitTests/pch.cpp
+++ b/src/modules/LightSwitch/UnitTests/pch.cpp
@@ -1,0 +1,1 @@
+#include "pch.h"

--- a/src/modules/LightSwitch/UnitTests/pch.h
+++ b/src/modules/LightSwitch/UnitTests/pch.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <string>
+#include <vector>
+#include <algorithm>
+#include "CppUnitTest.h"


### PR DESCRIPTION
## Summary
- add a dedicated LightSwitch native unit test project
- seed it with one deterministic schedule-boundary test for `ShouldBeLight`
- keep the first PR focused on test infrastructure plus one executed test

## Validation
- `tools\build\build.ps1 -Platform x64 -Configuration Debug -Path src\modules\LightSwitch\UnitTests`
- `vstest.console.exe x64\Debug\tests\LightSwitch\LightSwitch.UnitTests.dll /TestCaseFilter:FullyQualifiedName~NormalRange_BeforeLightTime_ReturnsDark`