### PR TITLE
Add Settings UI serialization test for AlwaysOnTop properties

### DIFF
--- a/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/AlwaysOnTopSettingsTests.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/AlwaysOnTopSettingsTests.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json;
+
+using Microsoft.PowerToys.Settings.UI.Library;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ViewModelTests
+{
+    [TestClass]
+    public class AlwaysOnTopSettingsTests
+    {
+        [TestMethod]
+        public void JsonRoundTrip_PreservesAllFields()
+        {
+            var original = new AlwaysOnTopProperties
+            {
+                FrameThickness = new IntProperty(25),
+                FrameColor = new StringProperty("#FF0000"),
+                FrameOpacity = new IntProperty(80),
+                SoundEnabled = new BoolProperty(false),
+                ExcludedApps = new StringProperty("notepad.exe"),
+            };
+
+            var json = JsonSerializer.Serialize(original);
+            var deserialized = JsonSerializer.Deserialize<AlwaysOnTopProperties>(json);
+
+            Assert.IsNotNull(deserialized);
+            Assert.AreEqual(original.FrameEnabled.Value, deserialized.FrameEnabled.Value);
+            Assert.AreEqual(original.ShowInSystemMenu.Value, deserialized.ShowInSystemMenu.Value);
+            Assert.AreEqual(original.FrameThickness.Value, deserialized.FrameThickness.Value);
+            Assert.AreEqual(original.FrameColor.Value, deserialized.FrameColor.Value);
+            Assert.AreEqual(original.FrameAccentColor.Value, deserialized.FrameAccentColor.Value);
+            Assert.AreEqual(original.FrameOpacity.Value, deserialized.FrameOpacity.Value);
+            Assert.AreEqual(original.SoundEnabled.Value, deserialized.SoundEnabled.Value);
+            Assert.AreEqual(original.DoNotActivateOnGameMode.Value, deserialized.DoNotActivateOnGameMode.Value);
+            Assert.AreEqual(original.RoundCornersEnabled.Value, deserialized.RoundCornersEnabled.Value);
+            Assert.AreEqual(original.ExcludedApps.Value, deserialized.ExcludedApps.Value);
+            Assert.AreEqual(original.Hotkey.Value.Win, deserialized.Hotkey.Value.Win);
+            Assert.AreEqual(original.Hotkey.Value.Code, deserialized.Hotkey.Value.Code);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds one **Settings UI** test for `AlwaysOnTopProperties` serialization.
- Verifies the Settings model preserves the current AlwaysOnTop settings fields through a JSON round trip.
- Keeps the 46929 settings backlog split into a small, reviewable PR.

## What this tests
This is settings-layer coverage only. It exercises `src/settings-ui/Settings.UI.Library` model serialization/deserialization for the AlwaysOnTop settings payload.

## What this does not test
This does **not** test Always On Top runtime/product behavior: window pinning, border rendering, excluded-app matching, game-mode suppression, hotkey handling in the runner/module, or Z-order behavior. Those need a separate AlwaysOnTop module/product test PR if we want real AlwaysOnTop coverage.

## Validation
- `tools\build\build.ps1 -Platform x64 -Configuration Debug -Path src\settings-ui\Settings.UI.UnitTests`
- `vstest.console.exe Debug\x64\tests\SettingsTests\net10.0-windows10.0.26100.0\Settings.UI.UnitTests.dll /TestCaseFilter:FullyQualifiedName~AlwaysOnTopSettingsTests.JsonRoundTrip_PreservesAllFields`