### PR TITLE
Add Settings UI defaulting test for PowerAccent properties

### DIFF
--- a/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/PowerAccentSettingsTests.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/PowerAccentSettingsTests.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json;
+
+using Microsoft.PowerToys.Settings.UI.Library;
+using Microsoft.PowerToys.Settings.UI.Library.Enumerations;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ViewModelTests
+{
+    [TestClass]
+    public class PowerAccentSettingsTests
+    {
+        [TestMethod]
+        public void Deserialization_FromPartialJson_FillsDefaults()
+        {
+            const string json = "{\"activation_key\":1,\"show_description\":true}";
+
+            var deserialized = JsonSerializer.Deserialize<PowerAccentProperties>(json);
+
+            Assert.IsNotNull(deserialized);
+            Assert.AreEqual(PowerAccentActivationKey.Space, deserialized.ActivationKey);
+            Assert.IsTrue(deserialized.ShowUnicodeDescription);
+            Assert.IsTrue(deserialized.DoNotActivateOnGameMode);
+            Assert.AreEqual("Top center", deserialized.ToolbarPosition.Value);
+            Assert.AreEqual(PowerAccentSettings.DefaultInputTimeMs, deserialized.InputTime.Value);
+            Assert.AreEqual("ALL", deserialized.SelectedLang.Value);
+            Assert.AreEqual(string.Empty, deserialized.ExcludedApps.Value);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds one **Settings UI** test for `PowerAccentProperties` partial JSON deserialization/defaulting.
- Verifies the Settings model preserves supplied fields and fills expected defaults for omitted PowerAccent settings fields.
- Keeps this separate from the native PowerAccent runtime seed PR (#48324).

## What this tests
This is settings-layer coverage only. It deserializes a partial PowerAccent settings JSON payload:

```json
{"activation_key":1,"show_description":true}
```

Then it verifies `Settings.UI.Library` maps those supplied values correctly and fills defaults for missing settings such as game-mode suppression, toolbar position, input time, selected language, and excluded apps.

## What this does not test
This does **not** test PowerAccent runtime/native behavior: keyboard hook handling, activation timing, character selection, language filtering, toolbar rendering, foreground-app exclusion matching, or game-mode suppression in the running module. Runtime/native PowerAccent coverage belongs in #48324 and follow-up PowerAccent product tests.

## Validation
- `tools\build\build.ps1 -Platform x64 -Configuration Debug -Path src\settings-ui\Settings.UI.UnitTests`
- `vstest.console.exe Debug\x64\tests\SettingsTests\net10.0-windows10.0.26100.0\Settings.UI.UnitTests.dll /TestCaseFilter:FullyQualifiedName~PowerAccentSettingsTests.Deserialization_FromPartialJson_FillsDefaults`