### PR TITLE
Add Settings UI defaulting test for MeasureTool properties

### DIFF
--- a/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/MeasureToolSettingsTests.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/MeasureToolSettingsTests.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json;
+
+using Microsoft.PowerToys.Settings.UI.Library;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ViewModelTests
+{
+    [TestClass]
+    public class MeasureToolSettingsTests
+    {
+        [TestMethod]
+        public void Deserialization_FromPartialJson_PreservesProvidedValues()
+        {
+            const string json = "{\"ContinuousCapture\":{\"value\":true},\"PixelTolerance\":{\"value\":50}}";
+
+            var deserialized = JsonSerializer.Deserialize<MeasureToolProperties>(json);
+
+            Assert.IsNotNull(deserialized);
+            Assert.IsTrue(deserialized.ContinuousCapture);
+            Assert.AreEqual(50, deserialized.PixelTolerance.Value);
+            Assert.IsTrue(deserialized.DrawFeetOnCross);
+            Assert.AreEqual(0, deserialized.UnitsOfMeasure.Value);
+            Assert.AreEqual("#FF4500", deserialized.MeasureCrossColor.Value);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds one **Settings UI** test for `MeasureToolProperties` partial JSON deserialization/defaulting.
- Verifies the Settings model preserves supplied MeasureTool settings fields and fills expected defaults for omitted fields.
- Keeps this separate from the native MeasureTool product/core seed PR (#48330).

## What this tests
This is settings-layer coverage only. It deserializes a partial MeasureTool settings JSON payload:

```json
{"ContinuousCapture":{"value":true},"PixelTolerance":{"value":50}}
```

Then it verifies `Settings.UI.Library` maps those supplied values correctly and keeps expected defaults for omitted settings such as draw-feet-on-cross, units of measure, and cross color.

## What this does not test
This does **not** test MeasureTool product/core behavior: screen capture, BGRA texture access, edge detection, pixel tolerance comparisons during measurement, overlay rendering, unit conversion/formatting in the runtime path, or crosshair/feet drawing. Native MeasureTool product coverage belongs in #48330 and follow-up MeasureTool core tests.

## Validation
- `tools\build\build.ps1 -Platform x64 -Configuration Debug -Path src\settings-ui\Settings.UI.UnitTests`
- `vstest.console.exe Debug\x64\tests\SettingsTests\net10.0-windows10.0.26100.0\Settings.UI.UnitTests.dll /TestCaseFilter:FullyQualifiedName~MeasureToolSettingsTests.Deserialization_FromPartialJson_PreservesProvidedValues`