### PR TITLE
Add Settings UI defaulting test for Workspaces properties

### DIFF
--- a/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/WorkspacesSettingsTests.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/WorkspacesSettingsTests.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json;
+
+using Microsoft.PowerToys.Settings.UI.Library;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ViewModelTests
+{
+    [TestClass]
+    public class WorkspacesSettingsTests
+    {
+        [TestMethod]
+        public void Deserialization_FromPartialJson_PreservesProvidedValues()
+        {
+            const string json = "{\"sortby\":2}";
+
+            var deserialized = JsonSerializer.Deserialize<WorkspacesProperties>(json);
+
+            Assert.IsNotNull(deserialized);
+            Assert.AreEqual(WorkspacesProperties.SortByProperty.Name, deserialized.SortBy);
+            Assert.IsTrue(deserialized.Hotkey.Value.Win);
+            Assert.IsTrue(deserialized.Hotkey.Value.Ctrl);
+            Assert.IsFalse(deserialized.Hotkey.Value.Alt);
+            Assert.IsFalse(deserialized.Hotkey.Value.Shift);
+            Assert.AreEqual(0xC0, deserialized.Hotkey.Value.Code);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds one **Settings UI** test for `WorkspacesProperties` partial JSON deserialization/defaulting.
- Verifies the Settings model maps the supplied sort value and keeps the expected default Workspaces hotkey values.
- Keeps this separate from any Workspaces product/runtime test coverage.

## What this tests
This is settings-layer coverage only. It deserializes a partial Workspaces settings JSON payload:

```json
{"sortby":2}
```

Then it verifies `Settings.UI.Library` maps that supplied value to the expected sort mode and preserves the default Workspaces activation hotkey values.

## What this does not test
This does **not** test Workspaces product/runtime behavior: workspace capture, snapshot creation, window matching, window arrangement, app launching, monitor/layout restore, or editor/runtime UI flows. Those need separate Workspaces module/product tests if we want real Workspaces coverage.

## Validation
- `tools\build\build.ps1 -Platform x64 -Configuration Debug -Path src\settings-ui\Settings.UI.UnitTests`
- `vstest.console.exe Debug\x64\tests\SettingsTests\net10.0-windows10.0.26100.0\Settings.UI.UnitTests.dll /TestCaseFilter:FullyQualifiedName~WorkspacesSettingsTests.Deserialization_FromPartialJson_PreservesProvidedValues`