### PR TITLE
Add Settings UI serialization test for MouseHighlighter properties

### DIFF
--- a/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/MouseHighlighterSettingsTests.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/MouseHighlighterSettingsTests.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json;
+
+using Microsoft.PowerToys.Settings.UI.Library;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ViewModelTests
+{
+    [TestClass]
+    public class MouseHighlighterSettingsTests
+    {
+        [TestMethod]
+        public void JsonRoundTrip_PreservesAllFields()
+        {
+            var original = new MouseHighlighterProperties
+            {
+                LeftButtonClickColor = new StringProperty("#00FF00"),
+                RightButtonClickColor = new StringProperty("#0000FF"),
+                AlwaysColor = new StringProperty("#FF0000"),
+                HighlightRadius = new IntProperty(35),
+                HighlightFadeDelayMs = new IntProperty(750),
+                HighlightFadeDurationMs = new IntProperty(400),
+                AutoActivate = new BoolProperty(true),
+                SpotlightMode = new BoolProperty(true),
+            };
+
+            var json = JsonSerializer.Serialize(original);
+            var deserialized = JsonSerializer.Deserialize<MouseHighlighterProperties>(json);
+
+            Assert.IsNotNull(deserialized);
+            Assert.AreEqual(original.LeftButtonClickColor.Value, deserialized.LeftButtonClickColor.Value);
+            Assert.AreEqual(original.RightButtonClickColor.Value, deserialized.RightButtonClickColor.Value);
+            Assert.AreEqual(original.AlwaysColor.Value, deserialized.AlwaysColor.Value);
+            Assert.AreEqual(original.HighlightOpacity.Value, deserialized.HighlightOpacity.Value);
+            Assert.AreEqual(original.HighlightRadius.Value, deserialized.HighlightRadius.Value);
+            Assert.AreEqual(original.HighlightFadeDelayMs.Value, deserialized.HighlightFadeDelayMs.Value);
+            Assert.AreEqual(original.HighlightFadeDurationMs.Value, deserialized.HighlightFadeDurationMs.Value);
+            Assert.AreEqual(original.AutoActivate.Value, deserialized.AutoActivate.Value);
+            Assert.AreEqual(original.SpotlightMode.Value, deserialized.SpotlightMode.Value);
+            Assert.AreEqual(original.ActivationShortcut.Code, deserialized.ActivationShortcut.Code);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds one **Settings UI** test for `MouseHighlighterProperties` JSON serialization.
- Verifies the Settings model preserves current Mouse Highlighter settings fields through a JSON round trip.
- Keeps this separate from any Mouse Highlighter product/runtime test coverage.

## What this tests
This is settings-layer coverage only. It serializes and deserializes a `MouseHighlighterProperties` object and verifies settings fields such as click colors, always color, radius, fade timings, auto-activation, spotlight mode, opacity, and activation shortcut survive the round trip.

## What this does not test
This does **not** test Mouse Highlighter product/runtime behavior: mouse input or hook handling, click detection, highlight rendering, fade timing in the running overlay, spotlight rendering, activation shortcut handling, or runtime auto-activation. Those need separate Mouse Highlighter module/product tests if we want real Mouse Highlighter coverage.

## Validation
- `tools\build\build.ps1 -Platform x64 -Configuration Debug -Path src\settings-ui\Settings.UI.UnitTests`
- `vstest.console.exe Debug\x64\tests\SettingsTests\net10.0-windows10.0.26100.0\Settings.UI.UnitTests.dll /TestCaseFilter:FullyQualifiedName~MouseHighlighterSettingsTests.JsonRoundTrip_PreservesAllFields`