### PR TITLE
Add Settings UI defaulting test for Awake properties

### DIFF
--- a/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/AwakeSettingsTests.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/AwakeSettingsTests.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json;
+
+using Microsoft.PowerToys.Settings.UI.Library;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ViewModelTests
+{
+    [TestClass]
+    public class AwakeSettingsTests
+    {
+        [TestMethod]
+        public void Deserialization_FromPartialJson_PreservesProvidedValues()
+        {
+            string json = "{\"keepDisplayOn\":true,\"mode\":1}";
+
+            AwakeProperties properties = JsonSerializer.Deserialize<AwakeProperties>(json);
+
+            Assert.IsNotNull(properties);
+            Assert.IsTrue(properties.KeepDisplayOn);
+            Assert.AreEqual(AwakeMode.INDEFINITE, properties.Mode);
+            Assert.AreEqual(1u, properties.IntervalMinutes);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds one **Settings UI** test for `AwakeProperties` partial JSON deserialization/defaulting.
- Verifies the Settings model preserves supplied Awake settings fields and keeps expected defaults for omitted fields.
- Keeps this separate from any Awake product/runtime test coverage.

## What this tests
This is settings-layer coverage only. It deserializes a partial Awake settings JSON payload:

```json
{"keepDisplayOn":true,"mode":1}
```

Then it verifies `Settings.UI.Library` maps those supplied values correctly and keeps the default interval value.

## What this does not test
This does **not** test Awake product/runtime behavior: power-request management, actually keeping the machine or display awake, timed expiration, tray state, runtime mode transitions, or interaction with Windows power APIs. Those need separate Awake module/product tests if we want real Awake logic coverage.

## Validation
- `tools\build\build.ps1 -Platform x64 -Configuration Debug -Path C:\Users\crutkas\source\repos\PtTestingRestructure-worktrees\awake-settings\src\settings-ui\Settings.UI.UnitTests`
- `C:\Program Files\Microsoft Visual Studio\18\Enterprise\Common7\IDE\Extensions\TestPlatform\vstest.console.exe C:\Users\crutkas\source\repos\PtTestingRestructure-worktrees\awake-settings\Debug\x64\tests\SettingsTests\net10.0-windows10.0.26100.0\Settings.UI.UnitTests.dll /TestCaseFilter:"FullyQualifiedName~ViewModelTests.AwakeSettingsTests.Deserialization_FromPartialJson_PreservesProvidedValues"`