### PR TITLE
Add Settings UI serialization test for CursorWrap properties

### DIFF
--- a/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/CursorWrapSettingsTests.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/CursorWrapSettingsTests.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json;
+
+using Microsoft.PowerToys.Settings.UI.Library;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ViewModelTests
+{
+    [TestClass]
+    public class CursorWrapSettingsTests
+    {
+        [TestMethod]
+        public void JsonRoundTrip_PreservesAllFields()
+        {
+            var settings = new CursorWrapSettings
+            {
+                Name = CursorWrapSettings.ModuleName,
+                Version = "1.2",
+                Properties = new CursorWrapProperties
+                {
+                    ActivationShortcut = new HotkeySettings(true, true, false, true, 0x57)
+                    {
+                        Key = "W",
+                    },
+                    AutoActivate = new BoolProperty(true),
+                    DisableWrapDuringDrag = new BoolProperty(false),
+                    WrapMode = new IntProperty(2),
+                    ActivationMode = new IntProperty(1),
+                    DisableCursorWrapOnSingleMonitor = new BoolProperty(true),
+                },
+            };
+
+            var json = settings.ToJsonString();
+
+            var roundTripped = JsonSerializer.Deserialize(json, SettingsSerializationContext.Default.CursorWrapSettings);
+
+            Assert.IsNotNull(roundTripped);
+            Assert.AreEqual(CursorWrapSettings.ModuleName, roundTripped.Name);
+            Assert.AreEqual("1.2", roundTripped.Version);
+            Assert.IsNotNull(roundTripped.Properties);
+            Assert.IsNotNull(roundTripped.Properties.ActivationShortcut);
+            Assert.IsTrue(roundTripped.Properties.ActivationShortcut.Win);
+            Assert.IsTrue(roundTripped.Properties.ActivationShortcut.Ctrl);
+            Assert.IsFalse(roundTripped.Properties.ActivationShortcut.Alt);
+            Assert.IsTrue(roundTripped.Properties.ActivationShortcut.Shift);
+            Assert.AreEqual(0x57, roundTripped.Properties.ActivationShortcut.Code);
+            Assert.AreEqual("W", roundTripped.Properties.ActivationShortcut.Key);
+            Assert.IsTrue(roundTripped.Properties.AutoActivate.Value);
+            Assert.IsFalse(roundTripped.Properties.DisableWrapDuringDrag.Value);
+            Assert.AreEqual(2, roundTripped.Properties.WrapMode.Value);
+            Assert.AreEqual(1, roundTripped.Properties.ActivationMode.Value);
+            Assert.IsTrue(roundTripped.Properties.DisableCursorWrapOnSingleMonitor.Value);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds one **Settings UI** test for `CursorWrapSettings` / `CursorWrapProperties` JSON serialization.
- Verifies the Settings model preserves current CursorWrap settings fields through a JSON round trip.
- Keeps this separate from the native CursorWrap product seed PR (#48326).

## What this tests
This is settings-layer coverage only. It serializes and deserializes a `CursorWrapSettings` payload and verifies settings fields such as activation shortcut, auto-activation, drag suppression, wrap mode, activation mode, and single-monitor suppression survive the round trip.

## What this does not test
This does **not** test CursorWrap product/native behavior: monitor topology, edge classification, wrap-mode decisions, drag suppression while moving the pointer, single-monitor suppression in runtime code, activation-mode handling in the module, or actual cursor movement. The native CursorWrap product seed is #48326; this PR is only the settings-model side.

## Validation
- `tools\build\build.ps1 -Platform x64 -Configuration Debug -Path C:\Users\crutkas\source\repos\PtTestingRestructure-worktrees\cursorwrap-settings\src\settings-ui\Settings.UI.UnitTests`
- `vstest.console.exe C:\Users\crutkas\source\repos\PtTestingRestructure-worktrees\cursorwrap-settings\Debug\x64\tests\SettingsTests\net10.0-windows10.0.26100.0\Settings.UI.UnitTests.dll /TestCaseFilter:"FullyQualifiedName~JsonRoundTrip_PreservesAllFields" /Logger:console`