### PR TITLE
Add Runner hotkey conflict unit test seed

### DIFF
--- a/PowerToys.slnx
+++ b/PowerToys.slnx
@@ -1137,7 +1137,7 @@
     <BuildDependency Project="src/PackageIdentity/PackageIdentity.vcxproj" />
   </Project>
   <Project Path="src/Update/PowerToys.Update.vcxproj" Id="44ce9ae1-4390-42c5-bacc-0fd6b40aa203" />
+  <Project Path="src/runner/UnitTests/UnitTests-Runner.vcxproj" Id="97bdacf8-261d-4e23-a708-a27e0b60e444" />
   <Project Path="tools/project_template/ModuleTemplate/ModuleTemplateCompileTest.vcxproj" Id="64a80062-4d8b-4229-8a38-dfa1d7497749" />
 </Solution>
-
 

--- a/src/runner/UnitTests/HotkeyConflictTests.cpp
+++ b/src/runner/UnitTests/HotkeyConflictTests.cpp
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "pch.h"
+#include "CppUnitTest.h"
+
+#include "../hotkey_conflict_detector.h"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace RunnerUnitTests
+{
+    TEST_CLASS(HotkeyConflictTests)
+    {
+    public:
+        TEST_METHOD(HasConflict_TwoModulesSameHotkey_InAppConflict)
+        {
+            using namespace HotkeyConflictDetector;
+
+            auto& manager = HotkeyConflictManager::GetInstance();
+            const Hotkey hotkey{ .win = false, .ctrl = false, .shift = false, .alt = false, .key = 'T' };
+
+            Assert::IsTrue(manager.AddHotkey(hotkey, L"ModuleA", 1, true));
+            Assert::AreEqual(static_cast<int>(InAppConflict), static_cast<int>(manager.HasConflict(hotkey, L"ModuleB", 1)));
+
+            manager.RemoveHotkeyByModule(L"ModuleA");
+            manager.RemoveHotkeyByModule(L"ModuleB");
+        }
+    };
+}

--- a/src/runner/UnitTests/UnitTests-Runner.vcxproj
+++ b/src/runner/UnitTests/UnitTests-Runner.vcxproj
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{97BDACF8-261D-4E23-A708-A27E0B60E444}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>UnitTestsRunner</RootNamespace>
+    <ProjectSubType>NativeUnitTestProject</ProjectSubType>
+    <ProjectName>Runner.UnitTests</ProjectName>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <OutDir>$(RepoRoot)$(Platform)\$(Configuration)\tests\Runner\</OutDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\;..\..\;..\..\common\inc;..\..\common\os-detection;..\..\common\Telemetry;..\..\modules;$(RepoRoot)packages\Microsoft.Windows.ImplementationLibrary.1.0.260126.7\include;$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;UNIT_TEST;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <UseFullPaths>true</UseFullPaths>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <DisableSpecificWarnings>26466;26495;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>RuntimeObject.lib;User32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="pch.cpp">
+      <PrecompiledHeader Condition="'$(UsePrecompiledHeaders)' != 'false'">Create</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="HotkeyConflictTests.cpp" />
+    <ClCompile Include="..\hotkey_conflict_detector.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="pch.h" />
+    <ClInclude Include="..\hotkey_conflict_detector.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+</Project>

--- a/src/runner/UnitTests/UnitTests-Runner.vcxproj.filters
+++ b/src/runner/UnitTests/UnitTests-Runner.vcxproj.filters
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="pch.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="HotkeyConflictTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\hotkey_conflict_detector.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="pch.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\hotkey_conflict_detector.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/src/runner/UnitTests/pch.cpp
+++ b/src/runner/UnitTests/pch.cpp
@@ -1,0 +1,5 @@
+// pch.cpp: source file corresponding to the pre-compiled header
+
+#include "pch.h"
+
+// When you are using pre-compiled headers, this source file is necessary for compilation to succeed.

--- a/src/runner/UnitTests/pch.h
+++ b/src/runner/UnitTests/pch.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#ifndef PCH_H
+#define PCH_H
+
+// Mirror the runner's pch.h includes so that when hotkey_conflict_detector.h
+// includes the runner's pch.h, all headers are already present (#pragma once).
+#include <winrt/base.h>
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Foundation.Collections.h>
+#include <Windows.h>
+#include <dxgi1_3.h>
+#include <d3d11_2.h>
+#include <d2d1_3.h>
+#include <d2d1_3helper.h>
+#include <d2d1helper.h>
+#include <dwrite.h>
+#include <dcomp.h>
+#include <dwmapi.h>
+#include <Shobjidl.h>
+#include <Shlwapi.h>
+#include <string>
+#include <algorithm>
+#include <chrono>
+#include <mutex>
+#include <thread>
+#include <functional>
+#include <condition_variable>
+#include <stdexcept>
+#include <tuple>
+#include <unordered_set>
+#include <unordered_map>
+#include <set>
+
+#include <winrt/Windows.ApplicationModel.h>
+#include <winrt/Windows.Networking.Connectivity.h>
+#include <winrt/Windows.Storage.h>
+#include <winrt/Windows.Data.Json.h>
+
+#include <wil/resource.h>
+#include <wil/coroutine.h>
+
+#include <optional>
+#include <fstream>
+#include <compare>
+#include <cwchar>
+#include <vector>
+#include <Shlobj.h>
+
+#endif // PCH_H


### PR DESCRIPTION
## Summary
- add a dedicated Runner native unit test project
- seed it with one deterministic in-app hotkey conflict test
- keep Runner native test discovery working by linking `RuntimeObject.lib` and `User32.lib` only; `WindowsApp.lib` caused VSTest to discover zero C++ tests

## Validation
- `tools\build\build.ps1 -Platform x64 -Configuration Debug -Path src\runner\UnitTests`
- `vstest.console.exe x64\Debug\tests\Runner\Runner.UnitTests.dll /ListTests`
- `vstest.console.exe x64\Debug\tests\Runner\Runner.UnitTests.dll /TestCaseFilter:FullyQualifiedName~HasConflict_TwoModulesSameHotkey_InAppConflict`