### PR TITLE
Add Settings UI serialization test for Peek properties

### DIFF
--- a/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/PeekSettingsTests.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/PeekSettingsTests.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json;
+
+using Microsoft.PowerToys.Settings.UI.Library;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ViewModelTests
+{
+    [TestClass]
+    public class PeekSettingsTests
+    {
+        [TestMethod]
+        public void JsonRoundTrip_PreservesAllFields()
+        {
+            var settings = new PeekSettings
+            {
+                Name = PeekSettings.ModuleName,
+                Version = PeekSettings.CurrentModuleVersion,
+                Properties = new PeekProperties
+                {
+                    ActivationShortcut = new HotkeySettings(true, false, true, true, 0x50) { Key = "P" },
+                    AlwaysRunNotElevated = new BoolProperty(false),
+                    CloseAfterLosingFocus = new BoolProperty(true),
+                    ConfirmFileDelete = new BoolProperty(false),
+                    EnableSpaceToActivate = new BoolProperty(false),
+                    ShowFilePreviewTooltip = new BoolProperty(false),
+                },
+            };
+
+            var json = settings.ToJsonString();
+
+            var roundTripped = JsonSerializer.Deserialize(json, SettingsSerializationContext.Default.PeekSettings);
+
+            Assert.IsNotNull(roundTripped);
+            Assert.AreEqual(settings.Name, roundTripped.Name);
+            Assert.AreEqual(settings.Version, roundTripped.Version);
+            Assert.AreEqual(settings.Properties.ActivationShortcut.Win, roundTripped.Properties.ActivationShortcut.Win);
+            Assert.AreEqual(settings.Properties.ActivationShortcut.Ctrl, roundTripped.Properties.ActivationShortcut.Ctrl);
+            Assert.AreEqual(settings.Properties.ActivationShortcut.Alt, roundTripped.Properties.ActivationShortcut.Alt);
+            Assert.AreEqual(settings.Properties.ActivationShortcut.Shift, roundTripped.Properties.ActivationShortcut.Shift);
+            Assert.AreEqual(settings.Properties.ActivationShortcut.Code, roundTripped.Properties.ActivationShortcut.Code);
+            Assert.AreEqual(settings.Properties.ActivationShortcut.Key, roundTripped.Properties.ActivationShortcut.Key);
+            Assert.AreEqual(settings.Properties.AlwaysRunNotElevated.Value, roundTripped.Properties.AlwaysRunNotElevated.Value);
+            Assert.AreEqual(settings.Properties.CloseAfterLosingFocus.Value, roundTripped.Properties.CloseAfterLosingFocus.Value);
+            Assert.AreEqual(settings.Properties.ConfirmFileDelete.Value, roundTripped.Properties.ConfirmFileDelete.Value);
+            Assert.AreEqual(settings.Properties.EnableSpaceToActivate.Value, roundTripped.Properties.EnableSpaceToActivate.Value);
+            Assert.AreEqual(settings.Properties.ShowFilePreviewTooltip.Value, roundTripped.Properties.ShowFilePreviewTooltip.Value);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds one **Settings UI** test for `PeekSettings` / `PeekProperties` JSON serialization.
- Verifies the Settings model preserves current Peek settings fields through a JSON round trip.
- Keeps this separate from any Peek product/unit test coverage.

## What this tests
This is settings-layer coverage only. It serializes and deserializes a `PeekSettings` payload and verifies settings fields such as activation shortcut, always-run-not-elevated, close-after-focus-loss, delete confirmation, space-to-activate, and preview tooltip settings survive the round trip.

## What this does not test
This does **not** test Peek product behavior: file previewer selection, preview rendering, Explorer integration, file-type support, activation handling, or the Peek UI/file preview pipeline. Peek has UI automation tests, but this PR is only the settings-model side and should not be counted as Peek product/unit coverage.

## Validation
- Build: `subst P: C:\Users\crutkas\source\repos\PtTestingRestructure-worktrees\peek-settings` then `P:\tools\build\build.ps1 -Platform x64 -Configuration Debug -Path P:\src\settings-ui\Settings.UI.UnitTests`
- VSTest: `"C:\Program Files\Microsoft Visual Studio\18\Enterprise\Common7\IDE\Extensions\TestPlatform\vstest.console.exe" "C:\Users\crutkas\source\repos\PtTestingRestructure-worktrees\peek-settings\Debug\x64\tests\SettingsTests\net10.0-windows10.0.26100.0\Settings.UI.UnitTests.dll" /TestCaseFilter:"FullyQualifiedName~JsonRoundTrip_PreservesAllFields"`
- Result: 1 test passed.