### PR TITLE
[Quick Accent] Add Belarusian Latin and Belarusian Cyrillic character sets

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -120,6 +120,7 @@ Badmode
 Badparam
 bbwe
 BCIE
+Belarusian
 BESTEFFORT
 bezelled
 bhid

--- a/src/modules/poweraccent/PowerAccent.Common/CharacterMappings.cs
+++ b/src/modules/poweraccent/PowerAccent.Common/CharacterMappings.cs
@@ -83,7 +83,7 @@ public static class CharacterMappings
             [LetterKey.VK_BACKSLASH] = ["`", "~"],
         }),
 
-        // Belarusian Latin (Łacinka)
+        // Belarusian Latin
         new(Language.BE, "Belarusian", LanguageGroup.Language, new Dictionary<LetterKey, string[]>
         {
             [LetterKey.VK_C] = ["ć", "č"],

--- a/src/modules/poweraccent/PowerAccent.Common/CharacterMappings.cs
+++ b/src/modules/poweraccent/PowerAccent.Common/CharacterMappings.cs
@@ -100,7 +100,7 @@ public static class CharacterMappings
             [LetterKey.VK_E] = ["ё"],
             [LetterKey.VK_G] = ["ґ"],
             [LetterKey.VK_I] = ["і"],
-            [LetterKey.VK_L] = ["ў"],
+            [LetterKey.VK_U] = ["ў"],
             [LetterKey.VK_COMMA] = ["’", "„", "“", "«", "»"],
         }),
 

--- a/src/modules/poweraccent/PowerAccent.Common/CharacterMappings.cs
+++ b/src/modules/poweraccent/PowerAccent.Common/CharacterMappings.cs
@@ -83,6 +83,27 @@ public static class CharacterMappings
             [LetterKey.VK_BACKSLASH] = ["`", "~"],
         }),
 
+        // Belarusian Latin (Łacinka)
+        new(Language.BE, "Belarusian", LanguageGroup.Language, new Dictionary<LetterKey, string[]>
+        {
+            [LetterKey.VK_C] = ["ć", "č"],
+            [LetterKey.VK_L] = ["ł"],
+            [LetterKey.VK_N] = ["ń"],
+            [LetterKey.VK_S] = ["ś", "š"],
+            [LetterKey.VK_U] = ["ŭ"],
+            [LetterKey.VK_Z] = ["ź", "ž"],
+            [LetterKey.VK_COMMA] = ["„", "“", "«", "»"],
+        }),
+
+        new(Language.BE_CYRL, "Belarusian_Cyrillic", LanguageGroup.Language, new Dictionary<LetterKey, string[]>
+        {
+            [LetterKey.VK_E] = ["ё"],
+            [LetterKey.VK_G] = ["ґ"],
+            [LetterKey.VK_I] = ["і"],
+            [LetterKey.VK_L] = ["ў"],
+            [LetterKey.VK_COMMA] = ["’", "„", "“", "«", "»"],
+        }),
+
         new(Language.BG, "Bulgarian", LanguageGroup.Language, new Dictionary<LetterKey, string[]>
         {
             [LetterKey.VK_I] = ["й"],
@@ -697,6 +718,8 @@ public static class CharacterMappings
     [
 
         // Spoken languages.
+        Language.BE,
+        Language.BE_CYRL,
         Language.BG,
         Language.CA,
         Language.CRH,

--- a/src/modules/poweraccent/PowerAccent.Common/Language.cs
+++ b/src/modules/poweraccent/PowerAccent.Common/Language.cs
@@ -7,6 +7,8 @@ namespace PowerAccent.Common;
 public enum Language
 {
     SPECIAL,
+    BE,
+    BE_CYRL,
     BG,
     CA,
     CRH,

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -3553,6 +3553,12 @@ Activate by holding the key for the character you want to add an accent to, then
   <data name="QuickAccent_SelectedLanguage_Special" xml:space="preserve">
     <value>Special Characters</value>
   </data>
+  <data name="QuickAccent_SelectedLanguage_Belarusian" xml:space="preserve">
+    <value>Belarusian</value>
+  </data>
+  <data name="QuickAccent_SelectedLanguage_Belarusian_Cyrillic" xml:space="preserve">
+    <value>Belarusian Cyrillic</value>
+  </data>
   <data name="QuickAccent_SelectedLanguage_Bulgarian" xml:space="preserve">
     <value>Bulgarian</value>
   </data>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -3554,7 +3554,7 @@ Activate by holding the key for the character you want to add an accent to, then
     <value>Special Characters</value>
   </data>
   <data name="QuickAccent_SelectedLanguage_Belarusian" xml:space="preserve">
-    <value>Belarusian</value>
+    <value>Belarusian Latin</value>
   </data>
   <data name="QuickAccent_SelectedLanguage_Belarusian_Cyrillic" xml:space="preserve">
     <value>Belarusian Cyrillic</value>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR adds support for Łacinka (Belarusian Latin) and Belarusian Cyrillic character sets to Quick Accent.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #36571
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [x] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
This is a standard character set addition, with new entries in the Language enum, the sets themselves added to CharacterMappings.All and new resource strings for the user-facing names in the Settings page.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
(Manual tests.)
- Confirmed that the new character set entries were present in the Quick Accent settings page list.
- Tested that each of the characters in both the sets could be selected and typed.