### PR TITLE
Add AlwaysOnTop product unit test seed

### DIFF
--- a/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.vcxproj
+++ b/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.vcxproj
@@ -135,6 +135,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="AlwaysOnTop.h" />
+    <ClInclude Include="ColorUtils.h" />
     <ClInclude Include="FrameDrawer.h" />
     <ClInclude Include="Generated Files/resource.h" />
     <ClInclude Include="ModuleConstants.h" />

--- a/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.vcxproj.filters
+++ b/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.vcxproj.filters
@@ -79,6 +79,9 @@
     <ClInclude Include="AlwaysOnTop.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="ColorUtils.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="FrameDrawer.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/src/modules/alwaysontop/AlwaysOnTop/ColorUtils.h
+++ b/src/modules/alwaysontop/AlwaysOnTop/ColorUtils.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <Windows.h>
+
+#include <cwctype>
+#include <string_view>
+
+namespace AlwaysOnTopColorUtils
+{
+    inline int HexDigitValue(wchar_t value) noexcept
+    {
+        if (value >= L'0' && value <= L'9')
+        {
+            return value - L'0';
+        }
+
+        if (value >= L'a' && value <= L'f')
+        {
+            return value - L'a' + 10;
+        }
+
+        if (value >= L'A' && value <= L'F')
+        {
+            return value - L'A' + 10;
+        }
+
+        return -1;
+    }
+
+    inline COLORREF HexToRGB(std::wstring_view hex, const COLORREF fallbackColor = RGB(255, 255, 255)) noexcept
+    {
+        while (!hex.empty() && std::iswspace(hex.front()) != 0)
+        {
+            hex.remove_prefix(1);
+        }
+
+        while (!hex.empty() && std::iswspace(hex.back()) != 0)
+        {
+            hex.remove_suffix(1);
+        }
+
+        if (!hex.empty() && hex.front() == L'#')
+        {
+            hex.remove_prefix(1);
+        }
+
+        if (hex.length() != 6)
+        {
+            return fallbackColor;
+        }
+
+        int values[6]{};
+        for (size_t index = 0; index < hex.length(); ++index)
+        {
+            values[index] = HexDigitValue(hex[index]);
+            if (values[index] < 0)
+            {
+                return fallbackColor;
+            }
+        }
+
+        return RGB((values[0] << 4) | values[1], (values[2] << 4) | values[3], (values[4] << 4) | values[5]);
+    }
+}

--- a/src/modules/alwaysontop/AlwaysOnTop/Settings.cpp
+++ b/src/modules/alwaysontop/AlwaysOnTop/Settings.cpp
@@ -1,6 +1,7 @@
 #include "pch.h"
 #include "Settings.h"
 
+#include <ColorUtils.h>
 #include <ModuleConstants.h>
 #include <SettingsObserver.h>
 #include <WinHookEventIDs.h>
@@ -25,25 +26,6 @@ namespace NonLocalizable
     const static wchar_t* ExcludedAppsID = L"excluded-apps";
     const static wchar_t* FrameAccentColor = L"frame-accent-color";
     const static wchar_t* RoundCornersEnabledID = L"round-corners-enabled";
-}
-
-// TODO: move to common utils
-inline COLORREF HexToRGB(std::wstring_view hex, const COLORREF fallbackColor = RGB(255, 255, 255))
-{
-    hex = left_trim<wchar_t>(trim<wchar_t>(hex), L"#");
-
-    try
-    {
-        const long long tmp = std::stoll(hex.data(), nullptr, 16);
-        const BYTE nR = static_cast<BYTE>((tmp & 0xFF0000) >> 16);
-        const BYTE nG = static_cast<BYTE>((tmp & 0xFF00) >> 8);
-        const BYTE nB = static_cast<BYTE>((tmp & 0xFF));
-        return RGB(nR, nG, nB);
-    }
-    catch (const std::exception&)
-    {
-        return fallbackColor;
-    }
 }
 
 AlwaysOnTopSettings::AlwaysOnTopSettings() :
@@ -150,7 +132,7 @@ void AlwaysOnTopSettings::LoadSettings()
 
         if (const auto jsonVal = values.get_string_value(NonLocalizable::FrameColorID))
         {
-            auto val = HexToRGB(*jsonVal);
+            auto val = AlwaysOnTopColorUtils::HexToRGB(*jsonVal);
             if (updatedSettings->frameColor != val)
             {
                 updatedSettings->frameColor = val;

--- a/src/modules/alwaysontop/AlwaysOnTopUnitTests/AlwaysOnTopUnitTests.vcxproj
+++ b/src/modules/alwaysontop/AlwaysOnTopUnitTests/AlwaysOnTopUnitTests.vcxproj
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <ProjectGuid>{D1C2C9B6-EB0A-44AF-A55C-0C0C9AB273C6}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>AlwaysOnTopUnitTests</RootNamespace>
+    <ProjectSubType>NativeUnitTestProject</ProjectSubType>
+    <ProjectName>AlwaysOnTop.UnitTests</ProjectName>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <OutDir>$(RepoRoot)$(Platform)\$(Configuration)\tests\AlwaysOnTopUnitTests\</OutDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(RepoRoot)src\modules\alwaysontop;$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <UseFullPaths>true</UseFullPaths>
+    </ClCompile>
+    <Link>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="pch.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="pch.cpp">
+      <PrecompiledHeader Condition="'$(UsePrecompiledHeaders)' != 'false'">Create</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="ColorUtilsTests.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+</Project>

--- a/src/modules/alwaysontop/AlwaysOnTopUnitTests/ColorUtilsTests.cpp
+++ b/src/modules/alwaysontop/AlwaysOnTopUnitTests/ColorUtilsTests.cpp
@@ -1,0 +1,22 @@
+#include "pch.h"
+
+#include <AlwaysOnTop\ColorUtils.h>
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace AlwaysOnTopUnitTests
+{
+    TEST_CLASS(ColorUtilsTests)
+    {
+    public:
+        TEST_METHOD(HexToRGBParsesValidColorAndUsesFallbackForInvalidValue)
+        {
+            const COLORREF parsedColor = AlwaysOnTopColorUtils::HexToRGB(L"#1A2B3C");
+            Assert::AreEqual(static_cast<DWORD>(RGB(0x1A, 0x2B, 0x3C)), static_cast<DWORD>(parsedColor));
+
+            const COLORREF fallbackColor = RGB(1, 2, 3);
+            const COLORREF invalidColor = AlwaysOnTopColorUtils::HexToRGB(L"not-a-color", fallbackColor);
+            Assert::AreEqual(static_cast<DWORD>(fallbackColor), static_cast<DWORD>(invalidColor));
+        }
+    };
+}

--- a/src/modules/alwaysontop/AlwaysOnTopUnitTests/pch.cpp
+++ b/src/modules/alwaysontop/AlwaysOnTopUnitTests/pch.cpp
@@ -1,0 +1,1 @@
+#include "pch.h"

--- a/src/modules/alwaysontop/AlwaysOnTopUnitTests/pch.h
+++ b/src/modules/alwaysontop/AlwaysOnTopUnitTests/pch.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <Windows.h>
+
+#pragma warning(disable : 26466)
+#include "CppUnitTest.h"


### PR DESCRIPTION
Adds a dedicated AlwaysOnTop product unit-test seed that exercises module-owned runtime color parsing instead of Settings UI serialization.\n\nValidation:\n- Built AlwaysOnTop.UnitTests x64 Debug\n- Ran VSTest filtered to HexToRGBParsesValidColorAndUsesFallbackForInvalidValue: 1 passed