### PR TITLE
Add Awake module services unit test seed

### DIFF
--- a/PowerToys.slnx
+++ b/PowerToys.slnx
@@ -163,6 +163,10 @@
       <Platform Solution="*|ARM64" Project="ARM64" />
       <Platform Solution="*|x64" Project="x64" />
     </Project>
+    <Project Path="src/modules/awake/Awake.ModuleServices.UnitTests/Awake.ModuleServices.UnitTests.csproj">
+      <Platform Solution="*|ARM64" Project="ARM64" />
+      <Platform Solution="*|x64" Project="x64" />
+    </Project>
     <Project Path="src/modules/awake/Awake/Awake.csproj">
       <Platform Solution="*|ARM64" Project="ARM64" />
       <Platform Solution="*|x64" Project="x64" />

--- a/src/modules/awake/Awake.ModuleServices.UnitTests/Awake.ModuleServices.UnitTests.csproj
+++ b/src/modules/awake/Awake.ModuleServices.UnitTests/Awake.ModuleServices.UnitTests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!-- Look at Directory.Build.props in root for common stuff as well -->
+  <Import Project="$(RepoRoot)src\Common.Dotnet.CsWinRT.props" />
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <RootNamespace>Awake.ModuleServices.UnitTests</RootNamespace>
+    <OutputType>Exe</OutputType>
+    <OutputPath>$(RepoRoot)$(Platform)\$(Configuration)\tests\Awake.ModuleServices.UnitTests\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Awake.ModuleServices\Awake.ModuleServices.csproj" />
+    <ProjectReference Include="..\..\..\settings-ui\Settings.UI.Library\Settings.UI.Library.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/modules/awake/Awake.ModuleServices.UnitTests/AwakeStateMappingTests.cs
+++ b/src/modules/awake/Awake.ModuleServices.UnitTests/AwakeStateMappingTests.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.PowerToys.Settings.UI.Library;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Awake.ModuleServices.UnitTests;
+
+[TestClass]
+public sealed class AwakeStateMappingTests
+{
+    [TestMethod]
+    public void CreateState_TimedSettings_ReturnsTimedStateWithDuration()
+    {
+        var settings = new AwakeSettings
+        {
+            Properties =
+            {
+                Mode = AwakeMode.TIMED,
+                KeepDisplayOn = true,
+                IntervalHours = 1,
+                IntervalMinutes = 30,
+                ExpirationDateTime = new DateTimeOffset(2030, 1, 2, 3, 4, 5, TimeSpan.Zero),
+            },
+        };
+
+        var state = AwakeService.CreateState(isRunning: true, settings);
+
+        Assert.IsTrue(state.IsRunning);
+        Assert.AreEqual(AwakeStateMode.Timed, state.Mode);
+        Assert.IsTrue(state.KeepDisplayOn);
+        Assert.AreEqual(TimeSpan.FromMinutes(90), state.Duration);
+        Assert.IsNull(state.Expiration);
+    }
+}

--- a/src/modules/awake/Awake.ModuleServices/Awake.ModuleServices.csproj
+++ b/src/modules/awake/Awake.ModuleServices/Awake.ModuleServices.csproj
@@ -11,6 +11,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Awake.ModuleServices.UnitTests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\..\common\ManagedCommon\ManagedCommon.csproj" />
     <ProjectReference Include="..\..\..\common\interop\PowerToys.Interop.vcxproj" />
     <ProjectReference Include="..\..\..\common\Common.UI\Common.UI.csproj" />

--- a/src/modules/awake/Awake.ModuleServices/AwakeService.cs
+++ b/src/modules/awake/Awake.ModuleServices/AwakeService.cs
@@ -33,6 +33,11 @@ public sealed class AwakeService : ModuleServiceBase, IAwakeService
         var isRunning = IsAwakeProcessRunning();
         var settings = ReadSettings();
 
+        return CreateState(isRunning, settings);
+    }
+
+    internal static AwakeState CreateState(bool isRunning, AwakeSettings? settings)
+    {
         if (settings is null)
         {
             return new AwakeState(isRunning, AwakeStateMode.Passive, false, null, null);


### PR DESCRIPTION
Adds an Awake module-services unit-test seed for runtime state creation from timed settings. This is product/module coverage, not Settings UI model serialization.\n\nValidation:\n- Restored and built Awake.ModuleServices.UnitTests x64 Debug\n- Ran the filtered test CreateState_TimedSettings_ReturnsTimedStateWithDuration: 1 passed