### PR TITLE
Add Mouse Highlighter product unit test seed

### DIFF
--- a/PowerToys.slnx
+++ b/PowerToys.slnx
@@ -519,6 +519,7 @@
     <Project Path="src/modules/MouseUtils/MousePointerCrosshairs/MousePointerCrosshairs.vcxproj" Id="eae14c0e-7a6b-45da-9080-a7d8c077ba6e" />
   </Folder>
   <Folder Name="/modules/MouseUtils/Tests/">
+    <Project Path="src/modules/MouseUtils/MouseHighlighter.UnitTests/MouseHighlighter.UnitTests.vcxproj" Id="30150234-8c99-4f18-ae0a-05f6df2b38bf" />
     <Project Path="src/modules/MouseUtils/MouseJump.Common.UnitTests/MouseJump.Common.UnitTests.csproj">
       <Platform Solution="*|ARM64" Project="ARM64" />
       <Platform Solution="*|x64" Project="x64" />

--- a/src/modules/MouseUtils/MouseHighlighter.UnitTests/MouseHighlighter.UnitTests.vcxproj
+++ b/src/modules/MouseUtils/MouseHighlighter.UnitTests/MouseHighlighter.UnitTests.vcxproj
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props')" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{30150234-8C99-4F18-AE0A-05F6DF2B38BF}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>MouseHighlighterUnitTests</RootNamespace>
+    <ProjectSubType>NativeUnitTestProject</ProjectSubType>
+    <ProjectName>MouseHighlighter.UnitTests</ProjectName>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <OutDir>$(RepoRoot)$(Platform)\$(Configuration)\tests\MouseHighlighter.UnitTests\</OutDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\MouseHighlighter;$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;UNIT_TEST;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <UseFullPaths>true</UseFullPaths>
+      <DisableSpecificWarnings>26466;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>RuntimeObject.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="pch.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="pch.cpp">
+      <PrecompiledHeader Condition="'$(UsePrecompiledHeaders)' != 'false'">Create</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="MouseHighlighterSettingsTests.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
+  </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
+    <Error Condition="!Exists('$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+  </Target>
+</Project>

--- a/src/modules/MouseUtils/MouseHighlighter.UnitTests/MouseHighlighter.UnitTests.vcxproj.filters
+++ b/src/modules/MouseUtils/MouseHighlighter.UnitTests/MouseHighlighter.UnitTests.vcxproj.filters
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{7F8B7C9D-67E3-4F1D-A433-E4284DBD84D9}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{839B9C94-728A-4E04-BD97-0592B8827E94}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="pch.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="pch.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="MouseHighlighterSettingsTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+</Project>

--- a/src/modules/MouseUtils/MouseHighlighter.UnitTests/MouseHighlighterSettingsTests.cpp
+++ b/src/modules/MouseUtils/MouseHighlighter.UnitTests/MouseHighlighterSettingsTests.cpp
@@ -1,0 +1,37 @@
+#include "pch.h"
+
+#include <MouseHighlighter.h>
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace MouseHighlighterUnitTests
+{
+    TEST_CLASS(MouseHighlighterSettingsTests)
+    {
+    public:
+        TEST_METHOD(NormalizeMouseHighlighterSettings_SpotlightWithZeroFade_UsesRuntimeValues)
+        {
+            MouseHighlighterSettings settings;
+            settings.leftButtonColor = winrt::Windows::UI::ColorHelper::FromArgb(128, 1, 2, 3);
+            settings.rightButtonColor = winrt::Windows::UI::ColorHelper::FromArgb(129, 4, 5, 6);
+            settings.alwaysColor = winrt::Windows::UI::ColorHelper::FromArgb(200, 7, 8, 9);
+            settings.radius = 42;
+            settings.fadeDelayMs = 0;
+            settings.fadeDurationMs = 0;
+            settings.spotlightMode = true;
+
+            const auto runtimeSettings = NormalizeMouseHighlighterSettings(settings);
+
+            Assert::AreEqual(42.0f, runtimeSettings.radius);
+            Assert::AreEqual(MOUSE_HIGHLIGHTER_MIN_FADE_MS, runtimeSettings.fadeDelayMs);
+            Assert::AreEqual(MOUSE_HIGHLIGHTER_MIN_FADE_MS, runtimeSettings.fadeDurationMs);
+            Assert::IsFalse(runtimeSettings.leftPointerEnabled);
+            Assert::IsFalse(runtimeSettings.rightPointerEnabled);
+            Assert::IsTrue(runtimeSettings.alwaysPointerEnabled);
+            Assert::IsTrue(runtimeSettings.spotlightMode);
+            Assert::AreEqual(200, static_cast<int>(runtimeSettings.alwaysColor.A));
+            Assert::AreEqual(7, static_cast<int>(runtimeSettings.alwaysColor.R));
+            Assert::AreEqual(4, static_cast<int>(runtimeSettings.rightButtonColor.R));
+        }
+    };
+}

--- a/src/modules/MouseUtils/MouseHighlighter.UnitTests/packages.config
+++ b/src/modules/MouseUtils/MouseHighlighter.UnitTests/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.250303.1" targetFramework="native" />
+</packages>

--- a/src/modules/MouseUtils/MouseHighlighter.UnitTests/pch.cpp
+++ b/src/modules/MouseUtils/MouseHighlighter.UnitTests/pch.cpp
@@ -1,0 +1,1 @@
+#include "pch.h"

--- a/src/modules/MouseUtils/MouseHighlighter.UnitTests/pch.h
+++ b/src/modules/MouseUtils/MouseHighlighter.UnitTests/pch.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <winrt/Windows.UI.h>
+
+#pragma warning(push)
+#pragma warning(disable : 26466)
+#include "CppUnitTest.h"
+#pragma warning(pop)

--- a/src/modules/MouseUtils/MouseHighlighter/MouseHighlighter.cpp
+++ b/src/modules/MouseUtils/MouseHighlighter/MouseHighlighter.cpp
@@ -275,15 +275,7 @@ void Highlighter::StartDrawingPointFading(MouseButton button)
     auto animation = m_compositor.CreateColorKeyFrameAnimation();
     animation.InsertKeyFrame(1, winrt::Windows::UI::ColorHelper::FromArgb(0, brushColor.R, brushColor.G, brushColor.B));
     using timeSpan = std::chrono::duration<int, std::ratio<1, 1000>>;
-    // HACK: If user sets these durations to 0, the fade won't work. Setting them to 1ms instead to avoid this.
-    if (m_fadeDuration_ms == 0)
-    {
-        m_fadeDuration_ms = 1;
-    }
-    if (m_fadeDelay_ms == 0)
-    {
-        m_fadeDelay_ms = 1;
-    }
+
     std::chrono::milliseconds duration(m_fadeDuration_ms);
     std::chrono::milliseconds delay(m_fadeDelay_ms);
     animation.Duration(timeSpan(duration));
@@ -468,22 +460,17 @@ void Highlighter::SwitchActivationMode()
 
 void Highlighter::ApplySettings(MouseHighlighterSettings settings)
 {
-    m_radius = static_cast<float>(settings.radius);
-    m_fadeDelay_ms = settings.fadeDelayMs;
-    m_fadeDuration_ms = settings.fadeDurationMs;
-    m_leftClickColor = settings.leftButtonColor;
-    m_rightClickColor = settings.rightButtonColor;
-    m_alwaysColor = settings.alwaysColor;
-    m_leftPointerEnabled = settings.leftButtonColor.A != 0;
-    m_rightPointerEnabled = settings.rightButtonColor.A != 0;
-    m_alwaysPointerEnabled = settings.alwaysColor.A != 0;
-    m_spotlightMode = settings.spotlightMode && settings.alwaysColor.A != 0;
-
-    if (m_spotlightMode)
-    {
-        m_leftPointerEnabled = false;
-        m_rightPointerEnabled = false;
-    }
+    const auto runtimeSettings = NormalizeMouseHighlighterSettings(settings);
+    m_radius = runtimeSettings.radius;
+    m_fadeDelay_ms = runtimeSettings.fadeDelayMs;
+    m_fadeDuration_ms = runtimeSettings.fadeDurationMs;
+    m_leftClickColor = runtimeSettings.leftButtonColor;
+    m_rightClickColor = runtimeSettings.rightButtonColor;
+    m_alwaysColor = runtimeSettings.alwaysColor;
+    m_leftPointerEnabled = runtimeSettings.leftPointerEnabled;
+    m_rightPointerEnabled = runtimeSettings.rightPointerEnabled;
+    m_alwaysPointerEnabled = runtimeSettings.alwaysPointerEnabled;
+    m_spotlightMode = runtimeSettings.spotlightMode;
 
     // Keep spotlight overlay color updated
     if (m_spotlightSource)

--- a/src/modules/MouseUtils/MouseHighlighter/MouseHighlighter.h
+++ b/src/modules/MouseUtils/MouseHighlighter/MouseHighlighter.h
@@ -1,10 +1,14 @@
 #pragma once
-#include "pch.h"
+
+#include <algorithm>
+#include <windows.h>
+#include <winrt/Windows.UI.h>
 
 const winrt::Windows::UI::Color MOUSE_HIGHLIGHTER_DEFAULT_LEFT_BUTTON_COLOR = winrt::Windows::UI::ColorHelper::FromArgb(166, 255, 255, 0);
 const winrt::Windows::UI::Color MOUSE_HIGHLIGHTER_DEFAULT_RIGHT_BUTTON_COLOR = winrt::Windows::UI::ColorHelper::FromArgb(166, 0, 0, 255);
 const winrt::Windows::UI::Color MOUSE_HIGHLIGHTER_DEFAULT_ALWAYS_COLOR = winrt::Windows::UI::ColorHelper::FromArgb(0, 255, 0, 0);
 constexpr int MOUSE_HIGHLIGHTER_DEFAULT_RADIUS = 20;
+constexpr int MOUSE_HIGHLIGHTER_MIN_FADE_MS = 1;
 constexpr int MOUSE_HIGHLIGHTER_DEFAULT_DELAY_MS = 500;
 constexpr int MOUSE_HIGHLIGHTER_DEFAULT_DURATION_MS = 250;
 constexpr bool MOUSE_HIGHLIGHTER_DEFAULT_AUTO_ACTIVATE = false;
@@ -20,6 +24,48 @@ struct MouseHighlighterSettings
     bool autoActivate = MOUSE_HIGHLIGHTER_DEFAULT_AUTO_ACTIVATE;
     bool spotlightMode = false;
 };
+
+struct MouseHighlighterRuntimeSettings
+{
+    winrt::Windows::UI::Color leftButtonColor = MOUSE_HIGHLIGHTER_DEFAULT_LEFT_BUTTON_COLOR;
+    winrt::Windows::UI::Color rightButtonColor = MOUSE_HIGHLIGHTER_DEFAULT_RIGHT_BUTTON_COLOR;
+    winrt::Windows::UI::Color alwaysColor = MOUSE_HIGHLIGHTER_DEFAULT_ALWAYS_COLOR;
+    float radius = static_cast<float>(MOUSE_HIGHLIGHTER_DEFAULT_RADIUS);
+    int fadeDelayMs = MOUSE_HIGHLIGHTER_DEFAULT_DELAY_MS;
+    int fadeDurationMs = MOUSE_HIGHLIGHTER_DEFAULT_DURATION_MS;
+    bool leftPointerEnabled = true;
+    bool rightPointerEnabled = true;
+    bool alwaysPointerEnabled = false;
+    bool spotlightMode = false;
+};
+
+inline int NormalizeMouseHighlighterFadeMilliseconds(int milliseconds) noexcept
+{
+    return (std::max)(milliseconds, MOUSE_HIGHLIGHTER_MIN_FADE_MS);
+}
+
+inline MouseHighlighterRuntimeSettings NormalizeMouseHighlighterSettings(const MouseHighlighterSettings& settings) noexcept
+{
+    MouseHighlighterRuntimeSettings runtimeSettings;
+    runtimeSettings.leftButtonColor = settings.leftButtonColor;
+    runtimeSettings.rightButtonColor = settings.rightButtonColor;
+    runtimeSettings.alwaysColor = settings.alwaysColor;
+    runtimeSettings.radius = static_cast<float>(settings.radius);
+    runtimeSettings.fadeDelayMs = NormalizeMouseHighlighterFadeMilliseconds(settings.fadeDelayMs);
+    runtimeSettings.fadeDurationMs = NormalizeMouseHighlighterFadeMilliseconds(settings.fadeDurationMs);
+    runtimeSettings.leftPointerEnabled = settings.leftButtonColor.A != 0;
+    runtimeSettings.rightPointerEnabled = settings.rightButtonColor.A != 0;
+    runtimeSettings.alwaysPointerEnabled = settings.alwaysColor.A != 0;
+    runtimeSettings.spotlightMode = settings.spotlightMode && runtimeSettings.alwaysPointerEnabled;
+
+    if (runtimeSettings.spotlightMode)
+    {
+        runtimeSettings.leftPointerEnabled = false;
+        runtimeSettings.rightPointerEnabled = false;
+    }
+
+    return runtimeSettings;
+}
 
 int MouseHighlighterMain(HINSTANCE hinst, MouseHighlighterSettings settings);
 void MouseHighlighterDisable();


### PR DESCRIPTION
Adds a Mouse Highlighter product unit-test seed around runtime settings normalization, so the PR covers module behavior instead of Settings UI serialization.\n\nValidation:\n- Restored and built MouseHighlighter and MouseHighlighter.UnitTests x64 Debug\n- Ran VSTest filtered to NormalizeMouseHighlighterSettings_SpotlightWithZeroFade_UsesRuntimeValues: 1 passed