### PR TITLE
Add Peek file previewer unit test seed

### DIFF
--- a/PowerToys.slnx
+++ b/PowerToys.slnx
@@ -787,6 +787,10 @@
       <Platform Solution="*|ARM64" Project="ARM64" />
       <Platform Solution="*|x64" Project="x64" />
     </Project>
+    <Project Path="src/modules/peek/Peek.FilePreviewer.UnitTests/Peek.FilePreviewer.UnitTests.csproj">
+      <Platform Solution="*|ARM64" Project="ARM64" />
+      <Platform Solution="*|x64" Project="x64" />
+    </Project>
     <Project Path="src/modules/peek/Peek.UI/Peek.UI.csproj">
       <Platform Solution="*|ARM64" Project="ARM64" />
       <Platform Solution="*|x64" Project="x64" />
@@ -1139,5 +1143,4 @@
   <Project Path="src/Update/PowerToys.Update.vcxproj" Id="44ce9ae1-4390-42c5-bacc-0fd6b40aa203" />
   <Project Path="tools/project_template/ModuleTemplate/ModuleTemplateCompileTest.vcxproj" Id="64a80062-4d8b-4229-8a38-dfa1d7497749" />
 </Solution>
-
 

--- a/src/modules/peek/Peek.FilePreviewer.UnitTests/Peek.FilePreviewer.UnitTests.csproj
+++ b/src/modules/peek/Peek.FilePreviewer.UnitTests/Peek.FilePreviewer.UnitTests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$(RepoRoot)src\Common.Dotnet.CsWinRT.props" />
+
+  <PropertyGroup>
+    <ProjectGuid>{7E2F9161-0F5F-49E0-B64D-0F5D27AB1A26}</ProjectGuid>
+    <RootNamespace>Peek.FilePreviewer.UnitTests</RootNamespace>
+    <Nullable>enable</Nullable>
+    <UseWinUI>true</UseWinUI>
+    <OutputType>Library</OutputType>
+    <OutputPath>$(RepoRoot)$(Platform)\$(Configuration)\tests\Peek.FilePreviewer.UnitTests\</OutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Peek.FilePreviewer\Peek.FilePreviewer.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/modules/peek/Peek.FilePreviewer.UnitTests/PreviewerSupportTests.cs
+++ b/src/modules/peek/Peek.FilePreviewer.UnitTests/PreviewerSupportTests.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Peek.Common.Models;
+using Peek.FilePreviewer.Previewers;
+using Peek.FilePreviewer.Previewers.Archives;
+
+using Windows.Storage;
+
+namespace Peek.FilePreviewer.UnitTests;
+
+[TestClass]
+public class PreviewerSupportTests
+{
+    [TestMethod]
+    public void IsItemSupported_RoutesFileTypesToExpectedPreviewers()
+    {
+        Assert.IsTrue(WebBrowserPreviewer.IsItemSupported(new TestFileSystemItem(".md")));
+        Assert.IsTrue(WebBrowserPreviewer.IsItemSupported(new TestFileSystemItem(".svg")));
+        Assert.IsTrue(WebBrowserPreviewer.IsItemSupported(new TestFileSystemItem(".pdf")));
+
+        Assert.IsTrue(ArchivePreviewer.IsItemSupported(new TestFileSystemItem(".zip")));
+        Assert.IsTrue(ArchivePreviewer.IsItemSupported(new TestFileSystemItem(".tgz")));
+
+        Assert.IsFalse(ArchivePreviewer.IsItemSupported(new TestFileSystemItem(".txt")));
+    }
+
+    private sealed class TestFileSystemItem : IFileSystemItem
+    {
+        public TestFileSystemItem(string extension)
+        {
+            Extension = extension;
+        }
+
+        public string Extension { get; }
+
+        public string Name => $"test{Extension}";
+
+        public string ParsingName => Name;
+
+        public string Path => Name;
+
+        public Task<IStorageItem?> GetStorageItemAsync() => Task.FromResult<IStorageItem?>(null);
+    }
+}


### PR DESCRIPTION
Adds a lightweight Peek.FilePreviewer unit-test project and one product test for previewer support routing. This covers Peek file previewer behavior rather than Settings UI defaults/serialization.\n\nValidation:\n- Restored and built Peek.FilePreviewer.UnitTests x64 Debug\n- Ran VSTest filtered to IsItemSupported_RoutesFileTypesToExpectedPreviewers: 1 passed