### PR TITLE
Add Workspaces PWA parsing unit test

### DIFF
--- a/src/modules/Workspaces/WorkspacesLib.UnitTests/PwaHelperTests.cpp
+++ b/src/modules/Workspaces/WorkspacesLib.UnitTests/PwaHelperTests.cpp
@@ -76,6 +76,15 @@ namespace WorkspacesLibUnitTests
             Assert::IsTrue(result == nonExistentWindowAumid);
         }
 
+        TEST_METHOD(PwaHelper_GetAppIdFromCommandLineArgs_StripsEdgePrefixAndTrailingArguments)
+        {
+            const std::wstring commandLineArgs = L"--app-id=abcdefghijklmnop --profile-directory=Default";
+
+            const auto result = Utils::PwaHelper::GetAppIdFromCommandLineArgs(commandLineArgs);
+
+            Assert::AreEqual(std::wstring(L"abcdefghijklmnop"), result);
+        }
+
         TEST_METHOD (PwaHelper_GetEdgeAppId_ValidConstruction_DoesNotCrash)
         {
             // Arrange

--- a/src/modules/Workspaces/WorkspacesLib/PwaHelper.cpp
+++ b/src/modules/Workspaces/WorkspacesLib/PwaHelper.cpp
@@ -238,7 +238,7 @@ namespace Utils
         return nameFromAumid;
     }
 
-    std::wstring PwaHelper::GetAppIdFromCommandLineArgs(const std::wstring& commandLineArgs) const
+    std::wstring PwaHelper::GetAppIdFromCommandLineArgs(const std::wstring& commandLineArgs)
     {
         auto result = commandLineArgs;
 

--- a/src/modules/Workspaces/WorkspacesLib/PwaHelper.h
+++ b/src/modules/Workspaces/WorkspacesLib/PwaHelper.h
@@ -12,6 +12,8 @@ namespace Utils
         PwaHelper();
         ~PwaHelper() = default;
 
+        static std::wstring GetAppIdFromCommandLineArgs(const std::wstring& commandLineArgs);
+
         std::optional<std::wstring> GetEdgeAppId(const std::wstring& windowAumid) const;
         std::optional<std::wstring> GetChromeAppId(const std::wstring& windowAumid) const;
         std::wstring SearchPwaName(const std::wstring& pwaAppId, const std::wstring& windowAumid) const;
@@ -20,8 +22,6 @@ namespace Utils
         void InitAppIds(const std::wstring& browserDataFolder, const std::wstring& browserDirPrefix, const std::function<void(const std::wstring&)>& addingAppIdCallback);
         void InitEdgeAppIds();
         void InitChromeAppIds();
-
-        std::wstring GetAppIdFromCommandLineArgs(const std::wstring& commandLineArgs) const;
 
         std::map<std::wstring, std::wstring> m_edgeAppIds;
         std::vector<std::wstring> m_chromeAppIds;


### PR DESCRIPTION
Adds a WorkspacesLib product logic test for Edge PWA app-id parsing using the existing WorkspacesLib.UnitTests infrastructure. This avoids adding another Settings UI-only Workspaces test.\n\nValidation:\n- Built WorkspacesLibUnitTests x64 Debug\n- Ran VSTest filtered to PwaHelper_GetAppIdFromCommandLineArgs_StripsEdgePrefixAndTrailingArguments: 1 passed