### PR TITLE
Add Find My Mouse product unit test seed

### DIFF
--- a/PowerToys.slnx
+++ b/PowerToys.slnx
@@ -519,6 +519,7 @@
     <Project Path="src/modules/MouseUtils/MousePointerCrosshairs/MousePointerCrosshairs.vcxproj" Id="eae14c0e-7a6b-45da-9080-a7d8c077ba6e" />
   </Folder>
   <Folder Name="/modules/MouseUtils/Tests/">
+    <Project Path="src/modules/MouseUtils/FindMyMouse.UnitTests/FindMyMouse.UnitTests.vcxproj" Id="6a671c60-5bf8-4909-8dfe-ad6e38e9a8c3" />
     <Project Path="src/modules/MouseUtils/MouseJump.Common.UnitTests/MouseJump.Common.UnitTests.csproj">
       <Platform Solution="*|ARM64" Project="ARM64" />
       <Platform Solution="*|x64" Project="x64" />

--- a/src/modules/MouseUtils/FindMyMouse.UnitTests/FindMyMouse.UnitTests.vcxproj
+++ b/src/modules/MouseUtils/FindMyMouse.UnitTests/FindMyMouse.UnitTests.vcxproj
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <ProjectGuid>{6A671C60-5BF8-4909-8DFE-AD6E38E9A8C3}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>FindMyMouseUnitTests</RootNamespace>
+    <ProjectSubType>NativeUnitTestProject</ProjectSubType>
+    <ProjectName>FindMyMouse.UnitTests</ProjectName>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <OutDir>$(RepoRoot)$(Platform)\$(Configuration)\tests\FindMyMouse.UnitTests\</OutDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\FindMyMouse;$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <PreprocessorDefinitions>WIN32;UNIT_TEST;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <UseFullPaths>true</UseFullPaths>
+      <DisableSpecificWarnings>26466;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+    </ClCompile>
+    <Link>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="pch.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="FindMyMouseLogicTests.cpp" />
+    <ClCompile Include="pch.cpp">
+      <PrecompiledHeader Condition="'$(UsePrecompiledHeaders)' != 'false'">Create</PrecompiledHeader>
+    </ClCompile>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+</Project>

--- a/src/modules/MouseUtils/FindMyMouse.UnitTests/FindMyMouse.UnitTests.vcxproj.filters
+++ b/src/modules/MouseUtils/FindMyMouse.UnitTests/FindMyMouse.UnitTests.vcxproj.filters
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4B04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="FindMyMouseLogicTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="pch.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="pch.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/src/modules/MouseUtils/FindMyMouse.UnitTests/FindMyMouseLogicTests.cpp
+++ b/src/modules/MouseUtils/FindMyMouse.UnitTests/FindMyMouseLogicTests.cpp
@@ -1,0 +1,35 @@
+#include "pch.h"
+
+#include <FindMyMouseLogic.h>
+
+#include <vector>
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace FindMyMouseUnitTests
+{
+    TEST_CLASS(FindMyMouseLogicTests)
+    {
+    public:
+        TEST_METHOD(ShouldActivateFromShake_ActivatesForBackAndForthMovementButNotStraightMovement)
+        {
+            using FindMyMouseLogic::PointerRecentMovement;
+
+            constexpr int minimumShakeDistance = 1000;
+            constexpr int shakeFactorPercent = 400;
+            const std::vector<PointerRecentMovement> backAndForthMovement{
+                { { 500, 0 }, 0 },
+                { { -500, 0 }, 1 },
+                { { 500, 0 }, 2 },
+                { { -500, 0 }, 3 },
+                { { 500, 0 }, 4 },
+            };
+            const std::vector<PointerRecentMovement> straightLineMovement{
+                { { 2500, 0 }, 0 },
+            };
+
+            Assert::IsTrue(FindMyMouseLogic::ShouldActivateFromShake(backAndForthMovement, minimumShakeDistance, shakeFactorPercent));
+            Assert::IsFalse(FindMyMouseLogic::ShouldActivateFromShake(straightLineMovement, minimumShakeDistance, shakeFactorPercent));
+        }
+    };
+}

--- a/src/modules/MouseUtils/FindMyMouse.UnitTests/pch.cpp
+++ b/src/modules/MouseUtils/FindMyMouse.UnitTests/pch.cpp
@@ -1,0 +1,1 @@
+#include "pch.h"

--- a/src/modules/MouseUtils/FindMyMouse.UnitTests/pch.h
+++ b/src/modules/MouseUtils/FindMyMouse.UnitTests/pch.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
+#pragma warning(push)
+#pragma warning(disable : 26466)
+#include "CppUnitTest.h"
+#pragma warning(pop)

--- a/src/modules/MouseUtils/FindMyMouse/FindMyMouse.cpp
+++ b/src/modules/MouseUtils/FindMyMouse/FindMyMouse.cpp
@@ -2,6 +2,7 @@
 //
 #include "pch.h"
 #include "FindMyMouse.h"
+#include "FindMyMouseLogic.h"
 #include "WinHookEventIDs.h"
 #include "trace.h"
 #include "common/utils/game_mode.h"
@@ -88,12 +89,7 @@ protected:
 
 private:
     // Save the mouse movement that occurred in any direction.
-    struct PointerRecentMovement
-    {
-        POINT diff;
-        ULONGLONG tick;
-    };
-    std::vector<PointerRecentMovement> m_movementHistory;
+    std::vector<FindMyMouseLogic::PointerRecentMovement> m_movementHistory;
     // Raw Input may give relative or absolute values. Need to take each case into account.
     bool m_seenAnAbsoluteMousePosition = false;
     POINT m_lastAbsolutePosition = { 0, 0 };
@@ -419,34 +415,9 @@ void SuperSonar<D>::DetectShake()
     ULONGLONG shakeStartTick = GetTickCount64() - m_shakeIntervalMs;
 
     // Prune the story of movements for those movements that started too long ago.
-    std::erase_if(m_movementHistory, [shakeStartTick](const PointerRecentMovement& movement) { return movement.tick < shakeStartTick; });
+    std::erase_if(m_movementHistory, [shakeStartTick](const FindMyMouseLogic::PointerRecentMovement& movement) { return movement.tick < shakeStartTick; });
 
-    double distanceTravelled = 0;
-    LONGLONG currentX = 0, minX = 0, maxX = 0;
-    LONGLONG currentY = 0, minY = 0, maxY = 0;
-
-    for (const PointerRecentMovement& movement : m_movementHistory)
-    {
-        currentX += movement.diff.x;
-        currentY += movement.diff.y;
-        distanceTravelled += sqrt(static_cast<double>(movement.diff.x) * movement.diff.x + static_cast<double>(movement.diff.y) * movement.diff.y); // Pythagorean theorem
-        minX = min(currentX, minX);
-        maxX = max(currentX, maxX);
-        minY = min(currentY, minY);
-        maxY = max(currentY, maxY);
-    }
-
-    if (distanceTravelled < m_shakeMinimumDistance)
-    {
-        return;
-    }
-
-    // Size of the rectangle that the pointer moved in.
-    double rectangleWidth = static_cast<double>(maxX) - minX;
-    double rectangleHeight = static_cast<double>(maxY) - minY;
-
-    double diagonal = sqrt(rectangleWidth * rectangleWidth + rectangleHeight * rectangleHeight);
-    if (diagonal > 0 && distanceTravelled / diagonal > (m_shakeFactor / 100.f))
+    if (FindMyMouseLogic::ShouldActivateFromShake(m_movementHistory, m_shakeMinimumDistance, m_shakeFactor))
     {
         m_movementHistory.clear();
         StartSonar(m_activationMethod);
@@ -485,7 +456,7 @@ void SuperSonar<D>::OnSonarMouseInput(RAWINPUT const& input)
         }
         if (m_movementHistory.size() > 0)
         {
-            PointerRecentMovement& lastMovement = m_movementHistory.back();
+            auto& lastMovement = m_movementHistory.back();
             // If the pointer is still moving in the same direction, just add to that movement instead of adding a new movement.
             // This helps in keeping the list of movements smaller even in cases where a high number of messages is sent.
             if (GetSign(lastMovement.diff.x) == GetSign(relativeX) && GetSign(lastMovement.diff.y) == GetSign(relativeY))

--- a/src/modules/MouseUtils/FindMyMouse/FindMyMouse.vcxproj
+++ b/src/modules/MouseUtils/FindMyMouse/FindMyMouse.vcxproj
@@ -107,6 +107,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="FindMyMouse.h" />
+    <ClInclude Include="FindMyMouseLogic.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="trace.h" />

--- a/src/modules/MouseUtils/FindMyMouse/FindMyMouse.vcxproj.filters
+++ b/src/modules/MouseUtils/FindMyMouse/FindMyMouse.vcxproj.filters
@@ -44,6 +44,9 @@
     <ClInclude Include="FindMyMouse.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="FindMyMouseLogic.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="resource.h">
       <Filter>Resource Files</Filter>
     </ClInclude>

--- a/src/modules/MouseUtils/FindMyMouse/FindMyMouseLogic.h
+++ b/src/modules/MouseUtils/FindMyMouse/FindMyMouseLogic.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <Windows.h>
+
+#include <cmath>
+#include <vector>
+
+namespace FindMyMouseLogic
+{
+    struct PointerRecentMovement
+    {
+        POINT diff;
+        ULONGLONG tick;
+    };
+
+    inline bool ShouldActivateFromShake(const std::vector<PointerRecentMovement>& movementHistory, int shakeMinimumDistance, int shakeFactor) noexcept
+    {
+        double distanceTravelled = 0;
+        LONGLONG currentX = 0;
+        LONGLONG minX = 0;
+        LONGLONG maxX = 0;
+        LONGLONG currentY = 0;
+        LONGLONG minY = 0;
+        LONGLONG maxY = 0;
+
+        for (const PointerRecentMovement& movement : movementHistory)
+        {
+            currentX += movement.diff.x;
+            currentY += movement.diff.y;
+            distanceTravelled += std::sqrt(static_cast<double>(movement.diff.x) * movement.diff.x + static_cast<double>(movement.diff.y) * movement.diff.y);
+
+            if (currentX < minX)
+            {
+                minX = currentX;
+            }
+            if (currentX > maxX)
+            {
+                maxX = currentX;
+            }
+            if (currentY < minY)
+            {
+                minY = currentY;
+            }
+            if (currentY > maxY)
+            {
+                maxY = currentY;
+            }
+        }
+
+        if (distanceTravelled < static_cast<double>(shakeMinimumDistance))
+        {
+            return false;
+        }
+
+        const double rectangleWidth = static_cast<double>(maxX) - minX;
+        const double rectangleHeight = static_cast<double>(maxY) - minY;
+        const double diagonal = std::sqrt(rectangleWidth * rectangleWidth + rectangleHeight * rectangleHeight);
+        return diagonal > 0 && distanceTravelled / diagonal > (static_cast<double>(shakeFactor) / 100.0);
+    }
+}


### PR DESCRIPTION
Adds a Find My Mouse product unit-test seed for shake activation logic. This covers runtime behavior instead of Settings UI serialization.\n\nValidation:\n- Built FindMyMouse.vcxproj x64 Debug\n- Built FindMyMouse.UnitTests.vcxproj x64 Debug\n- Ran VSTest filtered to ShouldActivateFromShake_ActivatesForBackAndForthMovementButNotStraightMovement: 1 passed