### PR TITLE
Add Mouse Pointer Crosshairs product unit test seed

### DIFF
--- a/PowerToys.slnx
+++ b/PowerToys.slnx
@@ -523,6 +523,7 @@
       <Platform Solution="*|ARM64" Project="ARM64" />
       <Platform Solution="*|x64" Project="x64" />
     </Project>
+    <Project Path="src/modules/MouseUtils/MousePointerCrosshairs.UnitTests/MousePointerCrosshairs.UnitTests.vcxproj" Id="6ff4b4e9-0336-470c-a711-b9adba249a8d" />
     <Project Path="src/modules/MouseUtils/MouseUtils.UITests/MouseUtils.UITests.csproj">
       <Platform Solution="*|ARM64" Project="ARM64" />
       <Platform Solution="*|x64" Project="x64" />
@@ -1139,5 +1140,4 @@
   <Project Path="src/Update/PowerToys.Update.vcxproj" Id="44ce9ae1-4390-42c5-bacc-0fd6b40aa203" />
   <Project Path="tools/project_template/ModuleTemplate/ModuleTemplateCompileTest.vcxproj" Id="64a80062-4d8b-4229-8a38-dfa1d7497749" />
 </Solution>
-
 

--- a/src/modules/MouseUtils/MousePointerCrosshairs.UnitTests/CrosshairsGeometry.Tests.cpp
+++ b/src/modules/MouseUtils/MousePointerCrosshairs.UnitTests/CrosshairsGeometry.Tests.cpp
@@ -1,0 +1,44 @@
+#include "pch.h"
+
+#include <CrosshairsGeometry.h>
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace MousePointerCrosshairsUnitTests
+{
+    TEST_CLASS(CrosshairsGeometryTests)
+    {
+    private:
+        static void AssertBounds(const CrosshairsVisualBounds& actual, double offsetX, double offsetY, double width, double height)
+        {
+            Assert::AreEqual(offsetX, static_cast<double>(actual.offsetX), 0.001, L"offsetX");
+            Assert::AreEqual(offsetY, static_cast<double>(actual.offsetY), 0.001, L"offsetY");
+            Assert::AreEqual(width, static_cast<double>(actual.width), 0.001, L"width");
+            Assert::AreEqual(height, static_cast<double>(actual.height), 0.001, L"height");
+        }
+
+    public:
+        TEST_METHOD(CalculateCrosshairsLayout_HorizontalOnly_HidesVerticalCrosshairsAndCentersHorizontalLines)
+        {
+            CrosshairsLayoutInput input{};
+            input.cursorPosition = { 100, 75 };
+            input.monitorUpperLeft = { 0, 0 };
+            input.monitorBottomRight = { 200, 150 };
+            input.crosshairsRadius = 10;
+            input.crosshairsThickness = 5;
+            input.crosshairsBorderSize = 2;
+            input.crosshairsOrientation = CrosshairsOrientation::HorizontalOnly;
+
+            const auto layout = CalculateCrosshairsLayout(input);
+
+            AssertBounds(layout.left.line, 91.0, 75.5, 91.0, 5.0);
+            AssertBounds(layout.left.border, 93.0, 75.5, 93.0, 9.0);
+            AssertBounds(layout.right.line, 110.0, 75.5, 90.0, 5.0);
+            AssertBounds(layout.right.border, 108.0, 75.5, 92.0, 9.0);
+            AssertBounds(layout.top.line, 0.0, 0.0, 0.0, 0.0);
+            AssertBounds(layout.top.border, 0.0, 0.0, 0.0, 0.0);
+            AssertBounds(layout.bottom.line, 0.0, 0.0, 0.0, 0.0);
+            AssertBounds(layout.bottom.border, 0.0, 0.0, 0.0, 0.0);
+        }
+    };
+}

--- a/src/modules/MouseUtils/MousePointerCrosshairs.UnitTests/MousePointerCrosshairs.UnitTests.vcxproj
+++ b/src/modules/MouseUtils/MousePointerCrosshairs.UnitTests/MousePointerCrosshairs.UnitTests.vcxproj
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <ProjectGuid>{6ff4b4e9-0336-470c-a711-b9adba249a8d}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>MousePointerCrosshairsUnitTests</RootNamespace>
+    <ProjectSubType>NativeUnitTestProject</ProjectSubType>
+    <ProjectName>MousePointerCrosshairs.UnitTests</ProjectName>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseOfMfc>false</UseOfMfc>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <OutDir>$(RepoRoot)$(Platform)\$(Configuration)\tests\MousePointerCrosshairs.UnitTests\</OutDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;$(RepoRoot)src\modules\MouseUtils\MousePointerCrosshairs;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <UseFullPaths>true</UseFullPaths>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="pch.cpp">
+      <PrecompiledHeader Condition="'$(UsePrecompiledHeaders)' != 'false'">Create</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="CrosshairsGeometry.Tests.cpp" />
+    <ClCompile Include="..\MousePointerCrosshairs\CrosshairsGeometry.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="pch.h" />
+    <ClInclude Include="..\MousePointerCrosshairs\CrosshairsGeometry.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+</Project>

--- a/src/modules/MouseUtils/MousePointerCrosshairs.UnitTests/MousePointerCrosshairs.UnitTests.vcxproj.filters
+++ b/src/modules/MouseUtils/MousePointerCrosshairs.UnitTests/MousePointerCrosshairs.UnitTests.vcxproj.filters
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4fc737f1-c7a5-4376-a066-2a32d752a2ff}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89bd-4b04-88eb-625fbe52ebfb}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="pch.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="CrosshairsGeometry.Tests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\MousePointerCrosshairs\CrosshairsGeometry.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="pch.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\MousePointerCrosshairs\CrosshairsGeometry.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/src/modules/MouseUtils/MousePointerCrosshairs.UnitTests/pch.cpp
+++ b/src/modules/MouseUtils/MousePointerCrosshairs.UnitTests/pch.cpp
@@ -1,0 +1,1 @@
+#include "pch.h"

--- a/src/modules/MouseUtils/MousePointerCrosshairs.UnitTests/pch.h
+++ b/src/modules/MouseUtils/MousePointerCrosshairs.UnitTests/pch.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+
+#pragma warning(push)
+#pragma warning(disable : 26466)
+#include "CppUnitTest.h"
+#pragma warning(pop)

--- a/src/modules/MouseUtils/MousePointerCrosshairs/CrosshairsGeometry.cpp
+++ b/src/modules/MouseUtils/MousePointerCrosshairs/CrosshairsGeometry.cpp
@@ -1,0 +1,95 @@
+#include "CrosshairsGeometry.h"
+
+namespace
+{
+    constexpr CrosshairsVisualBounds MakeBounds(
+        float offsetX,
+        float offsetY,
+        float width,
+        float height) noexcept
+    {
+        return { offsetX, offsetY, width, height };
+    }
+}
+
+CrosshairsLayout CalculateCrosshairsLayout(const CrosshairsLayoutInput& input) noexcept
+{
+    CrosshairsLayout layout{};
+
+    const float cursorX = static_cast<float>(input.cursorPosition.x);
+    const float cursorY = static_cast<float>(input.cursorPosition.y);
+    const float monitorLeft = static_cast<float>(input.monitorUpperLeft.x);
+    const float monitorTop = static_cast<float>(input.monitorUpperLeft.y);
+    const float monitorRight = static_cast<float>(input.monitorBottomRight.x);
+    const float monitorBottom = static_cast<float>(input.monitorBottomRight.y);
+    const float radius = static_cast<float>(input.crosshairsRadius);
+    const float thickness = static_cast<float>(input.crosshairsThickness);
+    const float borderSize = static_cast<float>(input.crosshairsBorderSize);
+    const float halfPixelAdjustment = input.crosshairsThickness % 2 == 1 ? 0.5f : 0.0f;
+    const float borderSizePadding = borderSize * 2.0f;
+    const float fixedLength = static_cast<float>(input.crosshairsFixedLength);
+
+    if (input.crosshairsOrientation == CrosshairsOrientation::Both || input.crosshairsOrientation == CrosshairsOrientation::HorizontalOnly)
+    {
+        const float leftCrosshairsFullScreenLength = cursorX - monitorLeft - radius + halfPixelAdjustment * 2.0f;
+        const float leftCrosshairsLength = input.crosshairsIsFixedLengthEnabled ? fixedLength : leftCrosshairsFullScreenLength;
+        const float leftCrosshairsBorderLength = input.crosshairsIsFixedLengthEnabled ? fixedLength + borderSizePadding : leftCrosshairsFullScreenLength + borderSize;
+        layout.left.border = MakeBounds(
+            cursorX - radius + borderSize + halfPixelAdjustment * 2.0f,
+            cursorY + halfPixelAdjustment,
+            leftCrosshairsBorderLength,
+            thickness + borderSizePadding);
+        layout.left.line = MakeBounds(
+            cursorX - radius + halfPixelAdjustment * 2.0f,
+            cursorY + halfPixelAdjustment,
+            leftCrosshairsLength,
+            thickness);
+
+        const float rightCrosshairsFullScreenLength = monitorRight - cursorX - radius;
+        const float rightCrosshairsLength = input.crosshairsIsFixedLengthEnabled ? fixedLength : rightCrosshairsFullScreenLength;
+        const float rightCrosshairsBorderLength = input.crosshairsIsFixedLengthEnabled ? fixedLength + borderSizePadding : rightCrosshairsFullScreenLength + borderSize;
+        layout.right.border = MakeBounds(
+            cursorX + radius - borderSize,
+            cursorY + halfPixelAdjustment,
+            rightCrosshairsBorderLength,
+            thickness + borderSizePadding);
+        layout.right.line = MakeBounds(
+            cursorX + radius,
+            cursorY + halfPixelAdjustment,
+            rightCrosshairsLength,
+            thickness);
+    }
+
+    if (input.crosshairsOrientation == CrosshairsOrientation::Both || input.crosshairsOrientation == CrosshairsOrientation::VerticalOnly)
+    {
+        const float topCrosshairsFullScreenLength = cursorY - monitorTop - radius + halfPixelAdjustment * 2.0f;
+        const float topCrosshairsLength = input.crosshairsIsFixedLengthEnabled ? fixedLength : topCrosshairsFullScreenLength;
+        const float topCrosshairsBorderLength = input.crosshairsIsFixedLengthEnabled ? fixedLength + borderSizePadding : topCrosshairsFullScreenLength + borderSize;
+        layout.top.border = MakeBounds(
+            cursorX + halfPixelAdjustment,
+            cursorY - radius + borderSize + halfPixelAdjustment * 2.0f,
+            thickness + borderSizePadding,
+            topCrosshairsBorderLength);
+        layout.top.line = MakeBounds(
+            cursorX + halfPixelAdjustment,
+            cursorY - radius + halfPixelAdjustment * 2.0f,
+            thickness,
+            topCrosshairsLength);
+
+        const float bottomCrosshairsFullScreenLength = monitorBottom - cursorY - radius;
+        const float bottomCrosshairsLength = input.crosshairsIsFixedLengthEnabled ? fixedLength : bottomCrosshairsFullScreenLength;
+        const float bottomCrosshairsBorderLength = input.crosshairsIsFixedLengthEnabled ? fixedLength + borderSizePadding : bottomCrosshairsFullScreenLength + borderSize;
+        layout.bottom.border = MakeBounds(
+            cursorX + halfPixelAdjustment,
+            cursorY + radius - borderSize,
+            thickness + borderSizePadding,
+            bottomCrosshairsBorderLength);
+        layout.bottom.line = MakeBounds(
+            cursorX + halfPixelAdjustment,
+            cursorY + radius,
+            thickness,
+            bottomCrosshairsLength);
+    }
+
+    return layout;
+}

--- a/src/modules/MouseUtils/MousePointerCrosshairs/CrosshairsGeometry.h
+++ b/src/modules/MouseUtils/MousePointerCrosshairs/CrosshairsGeometry.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <Windows.h>
+
+enum struct CrosshairsOrientation : int
+{
+    Both = 0,
+    VerticalOnly = 1,
+    HorizontalOnly = 2,
+};
+
+struct CrosshairsVisualBounds
+{
+    float offsetX = 0.0f;
+    float offsetY = 0.0f;
+    float width = 0.0f;
+    float height = 0.0f;
+};
+
+struct CrosshairsLineBounds
+{
+    CrosshairsVisualBounds border;
+    CrosshairsVisualBounds line;
+};
+
+struct CrosshairsLayout
+{
+    CrosshairsLineBounds left;
+    CrosshairsLineBounds right;
+    CrosshairsLineBounds top;
+    CrosshairsLineBounds bottom;
+};
+
+struct CrosshairsLayoutInput
+{
+    POINT cursorPosition{};
+    POINT monitorUpperLeft{};
+    POINT monitorBottomRight{};
+    int crosshairsRadius = 0;
+    int crosshairsThickness = 0;
+    int crosshairsBorderSize = 0;
+    bool crosshairsIsFixedLengthEnabled = false;
+    int crosshairsFixedLength = 0;
+    CrosshairsOrientation crosshairsOrientation = CrosshairsOrientation::Both;
+};
+
+CrosshairsLayout CalculateCrosshairsLayout(const CrosshairsLayoutInput& input) noexcept;

--- a/src/modules/MouseUtils/MousePointerCrosshairs/InclusiveCrosshairs.cpp
+++ b/src/modules/MouseUtils/MousePointerCrosshairs/InclusiveCrosshairs.cpp
@@ -298,65 +298,38 @@ void InclusiveCrosshairs::UpdateCrosshairsPosition()
     ScreenToClient(m_hwnd, &ptMonitorUpperLeft);
     ScreenToClient(m_hwnd, &ptMonitorBottomRight);
 
-    // Crosshair position should receive a minor adjustment for odd values to prevent anti-aliasing due to half pixels, while still looking like it's centered around the mouse pointer.
-    float halfPixelAdjustment = m_crosshairs_thickness % 2 == 1 ? 0.5f : 0.0f;
-    float borderSizePadding = m_crosshairs_border_size * 2.f;
+    CrosshairsLayoutInput layoutInput{};
+    layoutInput.cursorPosition = ptCursor;
+    layoutInput.monitorUpperLeft = ptMonitorUpperLeft;
+    layoutInput.monitorBottomRight = ptMonitorBottomRight;
+    layoutInput.crosshairsRadius = m_crosshairs_radius;
+    layoutInput.crosshairsThickness = m_crosshairs_thickness;
+    layoutInput.crosshairsBorderSize = m_crosshairs_border_size;
+    layoutInput.crosshairsIsFixedLengthEnabled = m_crosshairs_is_fixed_length_enabled;
+    layoutInput.crosshairsFixedLength = m_crosshairs_fixed_length;
+    layoutInput.crosshairsOrientation = m_crosshairs_orientation;
 
-    // Left and Right crosshairs (horizontal line)
-    if (m_crosshairs_orientation == CrosshairsOrientation::Both || m_crosshairs_orientation == CrosshairsOrientation::HorizontalOnly)
-    {
-        float leftCrosshairsFullScreenLength = ptCursor.x - ptMonitorUpperLeft.x - m_crosshairs_radius + halfPixelAdjustment * 2.f;
-        float leftCrosshairsLength = m_crosshairs_is_fixed_length_enabled ? m_crosshairs_fixed_length : leftCrosshairsFullScreenLength;
-        float leftCrosshairsBorderLength = m_crosshairs_is_fixed_length_enabled ? m_crosshairs_fixed_length + borderSizePadding : leftCrosshairsFullScreenLength + m_crosshairs_border_size;
-        m_left_crosshairs_border.Offset({ ptCursor.x - m_crosshairs_radius + m_crosshairs_border_size + halfPixelAdjustment * 2.f, ptCursor.y + halfPixelAdjustment, .0f });
-        m_left_crosshairs_border.Size({ leftCrosshairsBorderLength, m_crosshairs_thickness + borderSizePadding });
-        m_left_crosshairs.Offset({ ptCursor.x - m_crosshairs_radius + halfPixelAdjustment * 2.f, ptCursor.y + halfPixelAdjustment, .0f });
-        m_left_crosshairs.Size({ leftCrosshairsLength, static_cast<float>(m_crosshairs_thickness) });
+    const auto layout = CalculateCrosshairsLayout(layoutInput);
 
-        float rightCrosshairsFullScreenLength = static_cast<float>(ptMonitorBottomRight.x) - ptCursor.x - m_crosshairs_radius;
-        float rightCrosshairsLength = m_crosshairs_is_fixed_length_enabled ? m_crosshairs_fixed_length : rightCrosshairsFullScreenLength;
-        float rightCrosshairsBorderLength = m_crosshairs_is_fixed_length_enabled ? m_crosshairs_fixed_length + borderSizePadding : rightCrosshairsFullScreenLength + m_crosshairs_border_size;
-        m_right_crosshairs_border.Offset({ static_cast<float>(ptCursor.x) + m_crosshairs_radius - m_crosshairs_border_size, ptCursor.y + halfPixelAdjustment, .0f });
-        m_right_crosshairs_border.Size({ rightCrosshairsBorderLength, m_crosshairs_thickness + borderSizePadding });
-        m_right_crosshairs.Offset({ static_cast<float>(ptCursor.x) + m_crosshairs_radius, ptCursor.y + halfPixelAdjustment, .0f });
-        m_right_crosshairs.Size({ rightCrosshairsLength, static_cast<float>(m_crosshairs_thickness) });
-    }
-    else
-    {
-        // Hide horizontal crosshairs by setting size to 0
-        m_left_crosshairs_border.Size({ 0.0f, 0.0f });
-        m_left_crosshairs.Size({ 0.0f, 0.0f });
-        m_right_crosshairs_border.Size({ 0.0f, 0.0f });
-        m_right_crosshairs.Size({ 0.0f, 0.0f });
-    }
+    m_left_crosshairs_border.Offset({ layout.left.border.offsetX, layout.left.border.offsetY, 0.0f });
+    m_left_crosshairs_border.Size({ layout.left.border.width, layout.left.border.height });
+    m_left_crosshairs.Offset({ layout.left.line.offsetX, layout.left.line.offsetY, 0.0f });
+    m_left_crosshairs.Size({ layout.left.line.width, layout.left.line.height });
 
-    // Top and Bottom crosshairs (vertical line)
-    if (m_crosshairs_orientation == CrosshairsOrientation::Both || m_crosshairs_orientation == CrosshairsOrientation::VerticalOnly)
-    {
-        float topCrosshairsFullScreenLength = ptCursor.y - ptMonitorUpperLeft.y - m_crosshairs_radius + halfPixelAdjustment * 2.f;
-        float topCrosshairsLength = m_crosshairs_is_fixed_length_enabled ? m_crosshairs_fixed_length : topCrosshairsFullScreenLength;
-        float topCrosshairsBorderLength = m_crosshairs_is_fixed_length_enabled ? m_crosshairs_fixed_length + borderSizePadding : topCrosshairsFullScreenLength + m_crosshairs_border_size;
-        m_top_crosshairs_border.Offset({ ptCursor.x + halfPixelAdjustment, ptCursor.y - m_crosshairs_radius + m_crosshairs_border_size + halfPixelAdjustment * 2.f, .0f });
-        m_top_crosshairs_border.Size({ m_crosshairs_thickness + borderSizePadding, topCrosshairsBorderLength });
-        m_top_crosshairs.Offset({ ptCursor.x + halfPixelAdjustment, ptCursor.y - m_crosshairs_radius + halfPixelAdjustment * 2.f, .0f });
-        m_top_crosshairs.Size({ static_cast<float>(m_crosshairs_thickness), topCrosshairsLength });
+    m_right_crosshairs_border.Offset({ layout.right.border.offsetX, layout.right.border.offsetY, 0.0f });
+    m_right_crosshairs_border.Size({ layout.right.border.width, layout.right.border.height });
+    m_right_crosshairs.Offset({ layout.right.line.offsetX, layout.right.line.offsetY, 0.0f });
+    m_right_crosshairs.Size({ layout.right.line.width, layout.right.line.height });
 
-        float bottomCrosshairsFullScreenLength = static_cast<float>(ptMonitorBottomRight.y) - ptCursor.y - m_crosshairs_radius;
-        float bottomCrosshairsLength = m_crosshairs_is_fixed_length_enabled ? m_crosshairs_fixed_length : bottomCrosshairsFullScreenLength;
-        float bottomCrosshairsBorderLength = m_crosshairs_is_fixed_length_enabled ? m_crosshairs_fixed_length + borderSizePadding : bottomCrosshairsFullScreenLength + m_crosshairs_border_size;
-        m_bottom_crosshairs_border.Offset({ ptCursor.x + halfPixelAdjustment, static_cast<float>(ptCursor.y) + m_crosshairs_radius - m_crosshairs_border_size, .0f });
-        m_bottom_crosshairs_border.Size({ m_crosshairs_thickness + borderSizePadding, bottomCrosshairsBorderLength });
-        m_bottom_crosshairs.Offset({ ptCursor.x + halfPixelAdjustment, static_cast<float>(ptCursor.y) + m_crosshairs_radius, .0f });
-        m_bottom_crosshairs.Size({ static_cast<float>(m_crosshairs_thickness), bottomCrosshairsLength });
-    }
-    else
-    {
-        // Hide vertical crosshairs by setting size to 0
-        m_top_crosshairs_border.Size({ 0.0f, 0.0f });
-        m_top_crosshairs.Size({ 0.0f, 0.0f });
-        m_bottom_crosshairs_border.Size({ 0.0f, 0.0f });
-        m_bottom_crosshairs.Size({ 0.0f, 0.0f });
-    }
+    m_top_crosshairs_border.Offset({ layout.top.border.offsetX, layout.top.border.offsetY, 0.0f });
+    m_top_crosshairs_border.Size({ layout.top.border.width, layout.top.border.height });
+    m_top_crosshairs.Offset({ layout.top.line.offsetX, layout.top.line.offsetY, 0.0f });
+    m_top_crosshairs.Size({ layout.top.line.width, layout.top.line.height });
+
+    m_bottom_crosshairs_border.Offset({ layout.bottom.border.offsetX, layout.bottom.border.offsetY, 0.0f });
+    m_bottom_crosshairs_border.Size({ layout.bottom.border.width, layout.bottom.border.height });
+    m_bottom_crosshairs.Offset({ layout.bottom.line.offsetX, layout.bottom.line.offsetY, 0.0f });
+    m_bottom_crosshairs.Size({ layout.bottom.line.width, layout.bottom.line.height });
 }
 
 LRESULT CALLBACK InclusiveCrosshairs::MouseHookProc(int nCode, WPARAM wParam, LPARAM lParam) noexcept

--- a/src/modules/MouseUtils/MousePointerCrosshairs/InclusiveCrosshairs.h
+++ b/src/modules/MouseUtils/MousePointerCrosshairs/InclusiveCrosshairs.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "pch.h"
+#include "CrosshairsGeometry.h"
 
 constexpr int INCLUSIVE_MOUSE_DEFAULT_CROSSHAIRS_OPACITY = 75;
 const winrt::Windows::UI::Color INCLUSIVE_MOUSE_DEFAULT_CROSSHAIRS_COLOR = winrt::Windows::UI::ColorHelper::FromArgb(255, 255, 0, 0);
@@ -12,13 +13,6 @@ constexpr bool INCLUSIVE_MOUSE_DEFAULT_CROSSHAIRS_IS_FIXED_LENGTH_ENABLED = fals
 constexpr int INCLUSIVE_MOUSE_DEFAULT_CROSSHAIRS_FIXED_LENGTH = 1;
 constexpr int INCLUSIVE_MOUSE_DEFAULT_CROSSHAIRS_ORIENTATION = 0; // 0=Both, 1=Vertical, 2=Horizontal
 constexpr bool INCLUSIVE_MOUSE_DEFAULT_AUTO_ACTIVATE = false;
-
-enum struct CrosshairsOrientation : int
-{
-    Both = 0,
-    VerticalOnly = 1,
-    HorizontalOnly = 2,
-};
 
 struct InclusiveCrosshairsSettings
 {

--- a/src/modules/MouseUtils/MousePointerCrosshairs/MousePointerCrosshairs.vcxproj
+++ b/src/modules/MouseUtils/MousePointerCrosshairs/MousePointerCrosshairs.vcxproj
@@ -84,12 +84,16 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="CrosshairsGeometry.h" />
     <ClInclude Include="InclusiveCrosshairs.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="trace.h" />
     <ClInclude Include="resource.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="CrosshairsGeometry.cpp">
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="dllmain.cpp" />
     <ClCompile Include="InclusiveCrosshairs.cpp" />
     <ClCompile Include="pch.cpp">

--- a/src/modules/MouseUtils/MousePointerCrosshairs/MousePointerCrosshairs.vcxproj.filters
+++ b/src/modules/MouseUtils/MousePointerCrosshairs/MousePointerCrosshairs.vcxproj.filters
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
+    <ClCompile Include="CrosshairsGeometry.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="dllmain.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -23,6 +26,9 @@
     </ClInclude>
     <ClInclude Include="resource.h">
       <Filter>Resource Files</Filter>
+    </ClInclude>
+    <ClInclude Include="CrosshairsGeometry.h">
+      <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="InclusiveCrosshairs.h">
       <Filter>Header Files</Filter>


### PR DESCRIPTION
Adds a Mouse Pointer Crosshairs product unit-test seed for crosshair layout geometry. This covers runtime rendering/layout behavior instead of Settings UI serialization.\n\nValidation:\n- Built MousePointerCrosshairs.UnitTests x64 Debug\n- Built MousePointerCrosshairs x64 Debug\n- Ran VSTest filtered to CalculateCrosshairsLayout_HorizontalOnly_HidesVerticalCrosshairsAndCentersHorizontalLines: 1 passed