### PR TITLE
Fix runner APPLICATION_HANG_QUIESCE: handle WM_ENDSESSION and skip blocking shutdown cleanup

### DIFF
--- a/src/common/UnitTests-CommonUtils/Window.Tests.cpp
+++ b/src/common/UnitTests-CommonUtils/Window.Tests.cpp
@@ -231,6 +231,9 @@ namespace UnitTestsCommonUtils
 
             // After DestroyWindow the window must no longer exist and the
             // message loop must exit promptly because WM_QUIT was posted.
+            // The timeout was 1000 ms; assert well under that (2000 ms gives
+            // headroom for slow CI VMs while still failing if the loop is
+            // actually waiting out the full timeout).
             auto start = std::chrono::steady_clock::now();
             run_message_loop(false, 1000);
             auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -238,7 +241,7 @@ namespace UnitTestsCommonUtils
 
             Assert::IsFalse(IsWindow(hwnd) == TRUE,
                             L"Window must be destroyed after WM_ENDSESSION(TRUE)");
-            Assert::IsTrue(elapsed.count() < 500,
+            Assert::IsTrue(elapsed.count() < 2000,
                            L"Message loop must exit quickly after WM_ENDSESSION, not wait for the timeout");
 
             UnregisterClassW(L"EndSessionTest_Confirmed", GetModuleHandleW(nullptr));

--- a/src/common/UnitTests-CommonUtils/Window.Tests.cpp
+++ b/src/common/UnitTests-CommonUtils/Window.Tests.cpp
@@ -155,5 +155,103 @@ namespace UnitTestsCommonUtils
 
             Assert::IsTrue(true);
         }
+
+        // handle_session_end_message tests
+        //
+        // These guard the fix for APPLICATION_HANG_QUIESCE in
+        // PowerToys.exe!run_message_loop, where the runner and most modules
+        // failed to handle WM_QUERYENDSESSION / WM_ENDSESSION and were
+        // force-terminated on every OS shutdown, sign-out, or restart.
+        TEST_METHOD(HandleSessionEndMessage_QueryEndSession_AllowsShutdown)
+        {
+            LRESULT result = 0;
+            bool handled = handle_session_end_message(nullptr, WM_QUERYENDSESSION, 0, result);
+
+            Assert::IsTrue(handled, L"WM_QUERYENDSESSION should be handled");
+            Assert::AreEqual(static_cast<LRESULT>(TRUE), result,
+                             L"WM_QUERYENDSESSION must return TRUE so the OS can proceed with shutdown");
+        }
+
+        TEST_METHOD(HandleSessionEndMessage_EndSessionCancelled_DoesNotTearDown)
+        {
+            // wparam == FALSE means another app vetoed shutdown; we must not
+            // tear down. We pass a real HWND so that an accidental
+            // DestroyWindow call would be observable.
+            WNDCLASSW wc{};
+            wc.lpfnWndProc = DefWindowProcW;
+            wc.hInstance = GetModuleHandleW(nullptr);
+            wc.lpszClassName = L"EndSessionTest_Cancelled";
+            RegisterClassW(&wc);
+
+            HWND hwnd = CreateWindowExW(0, L"EndSessionTest_Cancelled", L"Test",
+                                        0, 0, 0, 0, 0, HWND_MESSAGE, nullptr,
+                                        GetModuleHandleW(nullptr), nullptr);
+            Assert::IsNotNull(hwnd, L"Test window must be created");
+
+            LRESULT result = 0xDEAD;
+            bool handled = handle_session_end_message(hwnd, WM_ENDSESSION, FALSE, result);
+
+            Assert::IsTrue(handled, L"WM_ENDSESSION should be handled");
+            Assert::AreEqual(static_cast<LRESULT>(0), result);
+            Assert::IsTrue(IsWindow(hwnd) == TRUE,
+                           L"Window must survive WM_ENDSESSION when shutdown is cancelled");
+
+            DestroyWindow(hwnd);
+            UnregisterClassW(L"EndSessionTest_Cancelled", GetModuleHandleW(nullptr));
+        }
+
+        TEST_METHOD(HandleSessionEndMessage_EndSessionConfirmed_TearsDownAndExitsLoop)
+        {
+            // wparam == TRUE means shutdown is actually proceeding. The
+            // helper must DestroyWindow, which routes through WM_DESTROY ->
+            // PostQuitMessage(0), so a subsequent run_message_loop returns.
+            WNDCLASSW wc{};
+            wc.lpfnWndProc = [](HWND hwnd, UINT msg, WPARAM w, LPARAM l) -> LRESULT {
+                if (msg == WM_DESTROY)
+                {
+                    PostQuitMessage(0);
+                    return 0;
+                }
+                return DefWindowProcW(hwnd, msg, w, l);
+            };
+            wc.hInstance = GetModuleHandleW(nullptr);
+            wc.lpszClassName = L"EndSessionTest_Confirmed";
+            RegisterClassW(&wc);
+
+            HWND hwnd = CreateWindowExW(0, L"EndSessionTest_Confirmed", L"Test",
+                                        0, 0, 0, 0, 0, HWND_MESSAGE, nullptr,
+                                        GetModuleHandleW(nullptr), nullptr);
+            Assert::IsNotNull(hwnd, L"Test window must be created");
+
+            LRESULT result = 0xDEAD;
+            bool handled = handle_session_end_message(hwnd, WM_ENDSESSION, TRUE, result);
+
+            Assert::IsTrue(handled, L"WM_ENDSESSION should be handled");
+            Assert::AreEqual(static_cast<LRESULT>(0), result);
+
+            // After DestroyWindow the window must no longer exist and the
+            // message loop must exit promptly because WM_QUIT was posted.
+            auto start = std::chrono::steady_clock::now();
+            run_message_loop(false, 1000);
+            auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - start);
+
+            Assert::IsFalse(IsWindow(hwnd) == TRUE,
+                            L"Window must be destroyed after WM_ENDSESSION(TRUE)");
+            Assert::IsTrue(elapsed.count() < 500,
+                           L"Message loop must exit quickly after WM_ENDSESSION, not wait for the timeout");
+
+            UnregisterClassW(L"EndSessionTest_Confirmed", GetModuleHandleW(nullptr));
+        }
+
+        TEST_METHOD(HandleSessionEndMessage_UnrelatedMessage_NotHandled)
+        {
+            LRESULT result = 0xDEAD;
+            bool handled = handle_session_end_message(nullptr, WM_USER, 0, result);
+
+            Assert::IsFalse(handled, L"Non-end-session messages must fall through");
+            Assert::AreEqual(static_cast<LRESULT>(0xDEAD), result,
+                             L"out_result must be left untouched when not handled");
+        }
     };
 }

--- a/src/common/UnitTests-CommonUtils/Window.Tests.cpp
+++ b/src/common/UnitTests-CommonUtils/Window.Tests.cpp
@@ -253,5 +253,72 @@ namespace UnitTestsCommonUtils
             Assert::AreEqual(static_cast<LRESULT>(0xDEAD), result,
                              L"out_result must be left untouched when not handled");
         }
+
+        // out_session_ending tests
+        //
+        // The optional out-param lets a caller's WM_DESTROY skip blocking
+        // cross-process cleanup (the 1.5s wait on PowerToys.Settings.exe in the
+        // runner) only on a real OS-initiated shutdown, which is what keeps the
+        // teardown inside the quiesce budget.
+        TEST_METHOD(HandleSessionEndMessage_EndSessionConfirmed_SignalsSessionEnding)
+        {
+            // wparam == TRUE must flag session-ending before tearing the window down.
+            WNDCLASSW wc{};
+            wc.lpfnWndProc = [](HWND hwnd, UINT msg, WPARAM w, LPARAM l) -> LRESULT {
+                if (msg == WM_DESTROY)
+                {
+                    PostQuitMessage(0);
+                    return 0;
+                }
+                return DefWindowProcW(hwnd, msg, w, l);
+            };
+            wc.hInstance = GetModuleHandleW(nullptr);
+            wc.lpszClassName = L"EndSessionTest_Signals";
+            RegisterClassW(&wc);
+
+            HWND hwnd = CreateWindowExW(0, L"EndSessionTest_Signals", L"Test",
+                                        0, 0, 0, 0, 0, HWND_MESSAGE, nullptr,
+                                        GetModuleHandleW(nullptr), nullptr);
+            Assert::IsNotNull(hwnd, L"Test window must be created");
+
+            LRESULT result = 0;
+            bool session_ending = false;
+            bool handled = handle_session_end_message(hwnd, WM_ENDSESSION, TRUE, result, &session_ending);
+
+            Assert::IsTrue(handled, L"WM_ENDSESSION should be handled");
+            Assert::IsTrue(session_ending,
+                           L"WM_ENDSESSION(TRUE) must flag session-ending so WM_DESTROY can skip blocking cleanup");
+
+            // Drain the WM_QUIT posted by the test WndProc so it cannot leak into
+            // a subsequent test running on the same thread.
+            run_message_loop(false, 1000);
+            UnregisterClassW(L"EndSessionTest_Signals", GetModuleHandleW(nullptr));
+        }
+
+        TEST_METHOD(HandleSessionEndMessage_EndSessionCancelled_DoesNotSignalSessionEnding)
+        {
+            // wparam == FALSE (another app vetoed) must not flag session-ending, so a
+            // caller keeps doing its normal cleanup if it later closes on its own.
+            LRESULT result = 0;
+            bool session_ending = false;
+            bool handled = handle_session_end_message(nullptr, WM_ENDSESSION, FALSE, result, &session_ending);
+
+            Assert::IsTrue(handled, L"WM_ENDSESSION should be handled");
+            Assert::IsFalse(session_ending,
+                            L"A cancelled shutdown must not flag session-ending");
+        }
+
+        TEST_METHOD(HandleSessionEndMessage_QueryEndSession_DoesNotSignalSessionEnding)
+        {
+            // The query phase only asks permission; it must not flag teardown.
+            LRESULT result = 0;
+            bool session_ending = false;
+            bool handled = handle_session_end_message(nullptr, WM_QUERYENDSESSION, 0, result, &session_ending);
+
+            Assert::IsTrue(handled, L"WM_QUERYENDSESSION should be handled");
+            Assert::AreEqual(static_cast<LRESULT>(TRUE), result);
+            Assert::IsFalse(session_ending,
+                            L"WM_QUERYENDSESSION must not flag session-ending");
+        }
     };
 }

--- a/src/common/UnitTests-CommonUtils/Window.Tests.cpp
+++ b/src/common/UnitTests-CommonUtils/Window.Tests.cpp
@@ -156,23 +156,23 @@ namespace UnitTestsCommonUtils
             Assert::IsTrue(true);
         }
 
-        // handle_session_end_message tests
+        // handle_stateless_session_end_message tests
         //
         // These guard the fix for APPLICATION_HANG_QUIESCE in
-        // PowerToys.exe!run_message_loop, where the runner and most modules
-        // failed to handle WM_QUERYENDSESSION / WM_ENDSESSION and were
-        // force-terminated on every OS shutdown, sign-out, or restart.
-        TEST_METHOD(HandleSessionEndMessage_QueryEndSession_AllowsShutdown)
+        // PowerToys.exe!run_message_loop, where the runner failed to handle
+        // WM_QUERYENDSESSION / WM_ENDSESSION and was force-terminated on OS
+        // shutdown, sign-out, or restart.
+        TEST_METHOD(HandleStatelessSessionEndMessage_QueryEndSession_AllowsShutdown)
         {
             LRESULT result = 0;
-            bool handled = handle_session_end_message(nullptr, WM_QUERYENDSESSION, 0, result);
+            bool handled = handle_stateless_session_end_message(nullptr, WM_QUERYENDSESSION, 0, 0, result);
 
             Assert::IsTrue(handled, L"WM_QUERYENDSESSION should be handled");
             Assert::AreEqual(static_cast<LRESULT>(TRUE), result,
                              L"WM_QUERYENDSESSION must return TRUE so the OS can proceed with shutdown");
         }
 
-        TEST_METHOD(HandleSessionEndMessage_EndSessionCancelled_DoesNotTearDown)
+        TEST_METHOD(HandleStatelessSessionEndMessage_EndSessionCancelled_DoesNotTearDown)
         {
             // wparam == FALSE means another app vetoed shutdown; we must not
             // tear down. We pass a real HWND so that an accidental
@@ -189,7 +189,7 @@ namespace UnitTestsCommonUtils
             Assert::IsNotNull(hwnd, L"Test window must be created");
 
             LRESULT result = 0xDEAD;
-            bool handled = handle_session_end_message(hwnd, WM_ENDSESSION, FALSE, result);
+            bool handled = handle_stateless_session_end_message(hwnd, WM_ENDSESSION, FALSE, 0, result);
 
             Assert::IsTrue(handled, L"WM_ENDSESSION should be handled");
             Assert::AreEqual(static_cast<LRESULT>(0), result);
@@ -200,7 +200,7 @@ namespace UnitTestsCommonUtils
             UnregisterClassW(L"EndSessionTest_Cancelled", GetModuleHandleW(nullptr));
         }
 
-        TEST_METHOD(HandleSessionEndMessage_EndSessionConfirmed_TearsDownAndExitsLoop)
+        TEST_METHOD(HandleStatelessSessionEndMessage_EndSessionConfirmed_TearsDownAndExitsLoop)
         {
             // wparam == TRUE means shutdown is actually proceeding. The
             // helper must DestroyWindow, which routes through WM_DESTROY ->
@@ -224,18 +224,17 @@ namespace UnitTestsCommonUtils
             Assert::IsNotNull(hwnd, L"Test window must be created");
 
             LRESULT result = 0xDEAD;
-            bool handled = handle_session_end_message(hwnd, WM_ENDSESSION, TRUE, result);
+            bool handled = handle_stateless_session_end_message(hwnd, WM_ENDSESSION, TRUE, 0, result);
 
             Assert::IsTrue(handled, L"WM_ENDSESSION should be handled");
             Assert::AreEqual(static_cast<LRESULT>(0), result);
 
             // After DestroyWindow the window must no longer exist and the
             // message loop must exit promptly because WM_QUIT was posted.
-            // The timeout was 1000 ms; assert well under that (2000 ms gives
-            // headroom for slow CI VMs while still failing if the loop is
-            // actually waiting out the full timeout).
+            // The timeout exceeds the assertion threshold so the test fails
+            // if the loop waits for the timer instead of consuming WM_QUIT.
             auto start = std::chrono::steady_clock::now();
-            run_message_loop(false, 1000);
+            run_message_loop(false, 3000);
             auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
                 std::chrono::steady_clock::now() - start);
 
@@ -247,25 +246,26 @@ namespace UnitTestsCommonUtils
             UnregisterClassW(L"EndSessionTest_Confirmed", GetModuleHandleW(nullptr));
         }
 
-        TEST_METHOD(HandleSessionEndMessage_UnrelatedMessage_NotHandled)
+        TEST_METHOD(HandleStatelessSessionEndMessage_UnrelatedMessage_NotHandled)
         {
             LRESULT result = 0xDEAD;
-            bool handled = handle_session_end_message(nullptr, WM_USER, 0, result);
+            bool handled = handle_stateless_session_end_message(nullptr, WM_USER, 0, 0, result);
 
             Assert::IsFalse(handled, L"Non-end-session messages must fall through");
             Assert::AreEqual(static_cast<LRESULT>(0xDEAD), result,
                              L"out_result must be left untouched when not handled");
         }
 
-        // out_session_ending tests
+        // out_system_session_ending tests
         //
         // The optional out-param lets a caller's WM_DESTROY skip blocking
         // cross-process cleanup (the 1.5s wait on PowerToys.Settings.exe in the
-        // runner) only on a real OS-initiated shutdown, which is what keeps the
-        // teardown inside the quiesce budget.
-        TEST_METHOD(HandleSessionEndMessage_EndSessionConfirmed_SignalsSessionEnding)
+        // runner) only when the full Windows session is ending, which keeps the
+        // teardown inside the quiesce budget without orphaning child processes
+        // during a Restart Manager ENDSESSION_CLOSEAPP request.
+        TEST_METHOD(HandleStatelessSessionEndMessage_EndSessionConfirmed_SignalsSystemSessionEnding)
         {
-            // wparam == TRUE must flag session-ending before tearing the window down.
+            // wparam == TRUE must flag the system session ending before teardown.
             WNDCLASSW wc{};
             wc.lpfnWndProc = [](HWND hwnd, UINT msg, WPARAM w, LPARAM l) -> LRESULT {
                 if (msg == WM_DESTROY)
@@ -285,12 +285,12 @@ namespace UnitTestsCommonUtils
             Assert::IsNotNull(hwnd, L"Test window must be created");
 
             LRESULT result = 0;
-            bool session_ending = false;
-            bool handled = handle_session_end_message(hwnd, WM_ENDSESSION, TRUE, result, &session_ending);
+            bool system_session_ending = false;
+            bool handled = handle_stateless_session_end_message(hwnd, WM_ENDSESSION, TRUE, 0, result, &system_session_ending);
 
             Assert::IsTrue(handled, L"WM_ENDSESSION should be handled");
-            Assert::IsTrue(session_ending,
-                           L"WM_ENDSESSION(TRUE) must flag session-ending so WM_DESTROY can skip blocking cleanup");
+            Assert::IsTrue(system_session_ending,
+                           L"WM_ENDSESSION(TRUE) must flag a full system session end so WM_DESTROY can skip blocking cleanup");
 
             // Drain the WM_QUIT posted by the test WndProc so it cannot leak into
             // a subsequent test running on the same thread.
@@ -298,30 +298,57 @@ namespace UnitTestsCommonUtils
             UnregisterClassW(L"EndSessionTest_Signals", GetModuleHandleW(nullptr));
         }
 
-        TEST_METHOD(HandleSessionEndMessage_EndSessionCancelled_DoesNotSignalSessionEnding)
+        TEST_METHOD(HandleStatelessSessionEndMessage_CloseApp_DoesNotSignalSystemSessionEnding)
+        {
+            WNDCLASSW wc{};
+            wc.lpfnWndProc = DefWindowProcW;
+            wc.hInstance = GetModuleHandleW(nullptr);
+            wc.lpszClassName = L"EndSessionTest_CloseApp";
+            RegisterClassW(&wc);
+
+            HWND hwnd = CreateWindowExW(0, L"EndSessionTest_CloseApp", L"Test",
+                                        0, 0, 0, 0, 0, HWND_MESSAGE, nullptr,
+                                        GetModuleHandleW(nullptr), nullptr);
+            Assert::IsNotNull(hwnd, L"Test window must be created");
+
+            LRESULT result = 0;
+            bool system_session_ending = false;
+            bool handled = handle_stateless_session_end_message(
+                hwnd, WM_ENDSESSION, TRUE, ENDSESSION_CLOSEAPP, result, &system_session_ending);
+
+            Assert::IsTrue(handled, L"WM_ENDSESSION should be handled");
+            Assert::IsFalse(system_session_ending,
+                            L"ENDSESSION_CLOSEAPP must retain normal child-process cleanup");
+            Assert::IsFalse(IsWindow(hwnd) == TRUE,
+                            L"The window must still close for ENDSESSION_CLOSEAPP");
+
+            UnregisterClassW(L"EndSessionTest_CloseApp", GetModuleHandleW(nullptr));
+        }
+
+        TEST_METHOD(HandleStatelessSessionEndMessage_EndSessionCancelled_DoesNotSignalSystemSessionEnding)
         {
             // wparam == FALSE (another app vetoed) must not flag session-ending, so a
             // caller keeps doing its normal cleanup if it later closes on its own.
             LRESULT result = 0;
-            bool session_ending = false;
-            bool handled = handle_session_end_message(nullptr, WM_ENDSESSION, FALSE, result, &session_ending);
+            bool system_session_ending = false;
+            bool handled = handle_stateless_session_end_message(nullptr, WM_ENDSESSION, FALSE, 0, result, &system_session_ending);
 
             Assert::IsTrue(handled, L"WM_ENDSESSION should be handled");
-            Assert::IsFalse(session_ending,
-                            L"A cancelled shutdown must not flag session-ending");
+            Assert::IsFalse(system_session_ending,
+                            L"A cancelled shutdown must not flag the system session ending");
         }
 
-        TEST_METHOD(HandleSessionEndMessage_QueryEndSession_DoesNotSignalSessionEnding)
+        TEST_METHOD(HandleStatelessSessionEndMessage_QueryEndSession_DoesNotSignalSystemSessionEnding)
         {
             // The query phase only asks permission; it must not flag teardown.
             LRESULT result = 0;
-            bool session_ending = false;
-            bool handled = handle_session_end_message(nullptr, WM_QUERYENDSESSION, 0, result, &session_ending);
+            bool system_session_ending = false;
+            bool handled = handle_stateless_session_end_message(nullptr, WM_QUERYENDSESSION, 0, 0, result, &system_session_ending);
 
             Assert::IsTrue(handled, L"WM_QUERYENDSESSION should be handled");
             Assert::AreEqual(static_cast<LRESULT>(TRUE), result);
-            Assert::IsFalse(session_ending,
-                            L"WM_QUERYENDSESSION must not flag session-ending");
+            Assert::IsFalse(system_session_ending,
+                            L"WM_QUERYENDSESSION must not flag the system session ending");
         }
     };
 }

--- a/src/common/utils/window.h
+++ b/src/common/utils/window.h
@@ -41,6 +41,42 @@ inline int run_message_loop(const bool until_idle = false,
     return static_cast<int>(msg.wParam);
 }
 
+// Handles WM_QUERYENDSESSION / WM_ENDSESSION for processes that have no
+// unsaved user state of their own (the PowerToys runner and most modules).
+//
+// WndProcs should call this at the top of their dispatch and return early
+// when it reports the message was handled. Without this, the OS quiesce
+// handshake on shutdown / sign-out / restart / suspend has nothing to wait
+// on except the full timeout, producing APPLICATION_HANG_QUIESCE failure
+// buckets even though the process is idle in GetMessage.
+//
+// On WM_QUERYENDSESSION we always allow the session to end (returns TRUE).
+// On WM_ENDSESSION with wparam == TRUE we DestroyWindow(window), which then
+// drives the existing WM_DESTROY -> PostQuitMessage(0) path and lets
+// run_message_loop unwind cleanly. wparam == FALSE means the session was
+// cancelled by another application's WM_QUERYENDSESSION response, in which
+// case we must not tear down.
+//
+// Returns true if the message was an end-session message and out_result has
+// been set; the caller should return out_result without further dispatch.
+inline bool handle_session_end_message(HWND window, UINT message, WPARAM wparam, LRESULT& out_result)
+{
+    switch (message)
+    {
+    case WM_QUERYENDSESSION:
+        out_result = TRUE;
+        return true;
+    case WM_ENDSESSION:
+        if (wparam)
+        {
+            DestroyWindow(window);
+        }
+        out_result = 0;
+        return true;
+    }
+    return false;
+}
+
 // Check if window is part of the shell or the taskbar.
 inline bool is_system_window(HWND hwnd, const char* class_name)
 {

--- a/src/common/utils/window.h
+++ b/src/common/utils/window.h
@@ -59,7 +59,14 @@ inline int run_message_loop(const bool until_idle = false,
 //
 // Returns true if the message was an end-session message and out_result has
 // been set; the caller should return out_result without further dispatch.
-inline bool handle_session_end_message(HWND window, UINT message, WPARAM wparam, LRESULT& out_result)
+//
+// When out_session_ending is non-null it is set to true exactly when an actual
+// teardown begins (WM_ENDSESSION with wparam == TRUE) and is left untouched
+// otherwise. Callers whose WM_DESTROY performs blocking cross-process cleanup
+// (for example waiting on a child process) can read this flag and skip that
+// work on OS shutdown, where the OS is already reaping those processes in
+// parallel and the quiesce budget is too short to wait on them.
+inline bool handle_session_end_message(HWND window, UINT message, WPARAM wparam, LRESULT& out_result, bool* out_session_ending = nullptr)
 {
     switch (message)
     {
@@ -69,6 +76,10 @@ inline bool handle_session_end_message(HWND window, UINT message, WPARAM wparam,
     case WM_ENDSESSION:
         if (wparam)
         {
+            if (out_session_ending)
+            {
+                *out_session_ending = true;
+            }
             DestroyWindow(window);
         }
         out_result = 0;

--- a/src/common/utils/window.h
+++ b/src/common/utils/window.h
@@ -41,14 +41,14 @@ inline int run_message_loop(const bool until_idle = false,
     return static_cast<int>(msg.wParam);
 }
 
-// Handles WM_QUERYENDSESSION / WM_ENDSESSION for processes that have no
-// unsaved user state of their own (the PowerToys runner and most modules).
+// Handles WM_QUERYENDSESSION / WM_ENDSESSION for a window whose process has no
+// unsaved user state of its own.
 //
 // WndProcs should call this at the top of their dispatch and return early
 // when it reports the message was handled. Without this, the OS quiesce
-// handshake on shutdown / sign-out / restart / suspend has nothing to wait
-// on except the full timeout, producing APPLICATION_HANG_QUIESCE failure
-// buckets even though the process is idle in GetMessage.
+// handshake on shutdown / sign-out / restart has nothing to wait on except
+// the full timeout, producing APPLICATION_HANG_QUIESCE failure buckets even
+// though the process is idle in GetMessage.
 //
 // On WM_QUERYENDSESSION we always allow the session to end (returns TRUE).
 // On WM_ENDSESSION with wparam == TRUE we DestroyWindow(window), which then
@@ -60,13 +60,16 @@ inline int run_message_loop(const bool until_idle = false,
 // Returns true if the message was an end-session message and out_result has
 // been set; the caller should return out_result without further dispatch.
 //
-// When out_session_ending is non-null it is set to true exactly when an actual
-// teardown begins (WM_ENDSESSION with wparam == TRUE) and is left untouched
-// otherwise. Callers whose WM_DESTROY performs blocking cross-process cleanup
-// (for example waiting on a child process) can read this flag and skip that
-// work on OS shutdown, where the OS is already reaping those processes in
-// parallel and the quiesce budget is too short to wait on them.
-inline bool handle_session_end_message(HWND window, UINT message, WPARAM wparam, LRESULT& out_result, bool* out_session_ending = nullptr)
+// When out_system_session_ending is non-null it is set to true exactly when
+// the full Windows session is ending. ENDSESSION_CLOSEAPP only closes this
+// application, so callers must retain their normal child-process cleanup.
+// The value is left untouched for all other messages and cancelled shutdowns.
+inline bool handle_stateless_session_end_message(HWND window,
+                                                 UINT message,
+                                                 WPARAM wparam,
+                                                 LPARAM lparam,
+                                                 LRESULT& out_result,
+                                                 bool* out_system_session_ending = nullptr)
 {
     switch (message)
     {
@@ -76,9 +79,9 @@ inline bool handle_session_end_message(HWND window, UINT message, WPARAM wparam,
     case WM_ENDSESSION:
         if (wparam)
         {
-            if (out_session_ending)
+            if (out_system_session_ending && !(lparam & ENDSESSION_CLOSEAPP))
             {
-                *out_session_ending = true;
+                *out_system_session_ending = true;
             }
             DestroyWindow(window);
         }

--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -352,7 +352,15 @@ int runner(bool isProcessElevated, bool openSettings, std::string settingsWindow
         result = -1;
     }
     Trace::UnregisterProvider();
-    QuickAccessHost::stop();
+    // On OS-initiated shutdown the OS reaps the Quick Access host process in
+    // parallel, so blocking up to the QuickAccessHost::stop() wait timeout here
+    // is pure dead time against the quiesce budget. Skip when the runner
+    // observed WM_ENDSESSION(TRUE); the user-initiated tray->Exit path still
+    // calls stop() and unwinds cleanly.
+    if (!is_session_ending())
+    {
+        QuickAccessHost::stop();
+    }
     return result;
 }
 

--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -352,12 +352,11 @@ int runner(bool isProcessElevated, bool openSettings, std::string settingsWindow
         result = -1;
     }
     Trace::UnregisterProvider();
-    // On OS-initiated shutdown the OS reaps the Quick Access host process in
-    // parallel, so blocking up to the QuickAccessHost::stop() wait timeout here
-    // is pure dead time against the quiesce budget. Skip when the runner
-    // observed WM_ENDSESSION(TRUE); the user-initiated tray->Exit path still
-    // calls stop() and unwinds cleanly.
-    if (!is_session_ending())
+    // When the full Windows session is ending, the OS reaps the Quick Access
+    // host process in parallel, so its stop timeout is pure dead time against
+    // the quiesce budget. User exits and Restart Manager ENDSESSION_CLOSEAPP
+    // requests retain the full graceful cleanup.
+    if (!is_system_session_ending())
     {
         QuickAccessHost::stop();
     }

--- a/src/runner/tray_icon.cpp
+++ b/src/runner/tray_icon.cpp
@@ -563,6 +563,11 @@ void stop_tray_icon()
         SendMessage(tray_icon_hwnd, WM_CLOSE, 0, 0);
     }
 }
+
+bool is_session_ending()
+{
+    return g_session_ending;
+}
 void update_quick_access_hotkey(bool enabled, PowerToysSettings::HotkeyObject hotkey)
 {
     static PowerToysSettings::HotkeyObject current_hotkey;

--- a/src/runner/tray_icon.cpp
+++ b/src/runner/tray_icon.cpp
@@ -36,6 +36,11 @@ namespace
     NOTIFYICONDATAW tray_icon_data;
     bool tray_icon_created = false;
 
+    // Set once the OS confirms session end (WM_ENDSESSION, wparam == TRUE) so the
+    // WM_DESTROY handler below can skip cross-process cleanup the OS is already
+    // reaping in parallel.
+    bool g_session_ending = false;
+
     bool about_box_shown = false;
 
     HMENU h_menu = nullptr;
@@ -157,7 +162,7 @@ void click_timer_elapsed()
 LRESULT __stdcall tray_icon_window_proc(HWND window, UINT message, WPARAM wparam, LPARAM lparam)
 {
     LRESULT session_end_result = 0;
-    if (handle_session_end_message(window, message, wparam, session_end_result))
+    if (handle_session_end_message(window, message, wparam, session_end_result, &g_session_ending))
     {
         return session_end_result;
     }
@@ -181,12 +186,23 @@ LRESULT __stdcall tray_icon_window_proc(HWND window, UINT message, WPARAM wparam
         }
         break;
     case WM_DESTROY:
-        if (tray_icon_created)
+        // On OS-initiated shutdown skip cross-process cleanup: the shell is tearing
+        // down and close_settings_window() blocks up to 1.5s waiting on
+        // PowerToys.Settings.exe, which the OS is reaping in parallel. That wait, plus
+        // Shell_NotifyIcon during explorer teardown, would burn the limited quiesce
+        // budget and trip APPLICATION_HANG_QUIESCE. PostQuitMessage alone unwinds the
+        // loop in milliseconds. User-initiated Exit (session_ending == false) keeps the
+        // full graceful cleanup.
+        Logger::info(L"Runner WM_DESTROY, session_ending={}", g_session_ending);
+        if (!g_session_ending)
         {
-            Shell_NotifyIcon(NIM_DELETE, &tray_icon_data);
-            tray_icon_created = false;
+            if (tray_icon_created)
+            {
+                Shell_NotifyIcon(NIM_DELETE, &tray_icon_data);
+                tray_icon_created = false;
+            }
+            close_settings_window();
         }
-        close_settings_window();
         PostQuitMessage(0);
         break;
     case WM_CLOSE:

--- a/src/runner/tray_icon.cpp
+++ b/src/runner/tray_icon.cpp
@@ -11,6 +11,7 @@
 #include <Windows.h>
 
 #include <common/utils/resources.h>
+#include <common/utils/window.h>
 #include <common/version/version.h>
 #include <common/logger/logger.h>
 #include <common/utils/elevation.h>
@@ -155,6 +156,12 @@ void click_timer_elapsed()
 
 LRESULT __stdcall tray_icon_window_proc(HWND window, UINT message, WPARAM wparam, LPARAM lparam)
 {
+    LRESULT session_end_result = 0;
+    if (handle_session_end_message(window, message, wparam, session_end_result))
+    {
+        return session_end_result;
+    }
+
     switch (message)
     {
     case WM_HOTKEY:

--- a/src/runner/tray_icon.cpp
+++ b/src/runner/tray_icon.cpp
@@ -36,10 +36,9 @@ namespace
     NOTIFYICONDATAW tray_icon_data;
     bool tray_icon_created = false;
 
-    // Set once the OS confirms session end (WM_ENDSESSION, wparam == TRUE) so the
-    // WM_DESTROY handler below can skip cross-process cleanup the OS is already
-    // reaping in parallel.
-    bool g_session_ending = false;
+    // Set when Windows confirms that the full session is ending so WM_DESTROY
+    // can skip cross-process cleanup the OS is already performing in parallel.
+    bool g_system_session_ending = false;
 
     bool about_box_shown = false;
 
@@ -162,7 +161,7 @@ void click_timer_elapsed()
 LRESULT __stdcall tray_icon_window_proc(HWND window, UINT message, WPARAM wparam, LPARAM lparam)
 {
     LRESULT session_end_result = 0;
-    if (handle_session_end_message(window, message, wparam, session_end_result, &g_session_ending))
+    if (handle_stateless_session_end_message(window, message, wparam, lparam, session_end_result, &g_system_session_ending))
     {
         return session_end_result;
     }
@@ -191,10 +190,10 @@ LRESULT __stdcall tray_icon_window_proc(HWND window, UINT message, WPARAM wparam
         // PowerToys.Settings.exe, which the OS is reaping in parallel. That wait, plus
         // Shell_NotifyIcon during explorer teardown, would burn the limited quiesce
         // budget and trip APPLICATION_HANG_QUIESCE. PostQuitMessage alone unwinds the
-        // loop in milliseconds. User-initiated Exit (session_ending == false) keeps the
-        // full graceful cleanup.
-        Logger::info(L"Runner WM_DESTROY, session_ending={}", g_session_ending);
-        if (!g_session_ending)
+        // loop in milliseconds. User-initiated Exit and Restart Manager
+        // ENDSESSION_CLOSEAPP requests keep the full graceful cleanup.
+        Logger::info(L"Runner WM_DESTROY, system_session_ending={}", g_system_session_ending);
+        if (!g_system_session_ending)
         {
             if (tray_icon_created)
             {
@@ -564,9 +563,9 @@ void stop_tray_icon()
     }
 }
 
-bool is_session_ending()
+bool is_system_session_ending()
 {
-    return g_session_ending;
+    return g_system_session_ending;
 }
 void update_quick_access_hotkey(bool enabled, PowerToysSettings::HotkeyObject hotkey)
 {

--- a/src/runner/tray_icon.h
+++ b/src/runner/tray_icon.h
@@ -13,6 +13,10 @@ void set_tray_icon_theme_adaptive(bool theme_adaptive);
 void set_tray_icon_update_available(bool available);
 // Stop the Tray Icon
 void stop_tray_icon();
+// True after the runner observed an OS-confirmed WM_ENDSESSION (wparam == TRUE).
+// Callers can use this to skip blocking cross-process cleanup the OS is already
+// reaping in parallel during shutdown / sign-off / restart.
+bool is_session_ending();
 // Open the Settings Window
 void open_settings_window(std::optional<std::wstring> settings_window);
 // Update Quick Access Hotkey

--- a/src/runner/tray_icon.h
+++ b/src/runner/tray_icon.h
@@ -13,10 +13,9 @@ void set_tray_icon_theme_adaptive(bool theme_adaptive);
 void set_tray_icon_update_available(bool available);
 // Stop the Tray Icon
 void stop_tray_icon();
-// True after the runner observed an OS-confirmed WM_ENDSESSION (wparam == TRUE).
-// Callers can use this to skip blocking cross-process cleanup the OS is already
-// reaping in parallel during shutdown / sign-off / restart.
-bool is_session_ending();
+// True after the runner observed that the full Windows session is ending.
+// ENDSESSION_CLOSEAPP is excluded because child processes still need cleanup.
+bool is_system_session_ending();
 // Open the Settings Window
 void open_settings_window(std::optional<std::wstring> settings_window);
 // Update Quick Access Hotkey


### PR DESCRIPTION
## Summary

The runner WndProc (`tray_icon_window_proc`) does not handle `WM_QUERYENDSESSION` / `WM_ENDSESSION`, **and** its `WM_DESTROY` teardown performs blocking cross-process cleanup. Both contribute to the Watson failure `APPLICATION_HANG_QUIESCE_cfffffff_PowerToys.exe!run_message_loop` on OS shutdown, sign-out, or restart:

1. Without a `WM_ENDSESSION` handler, `DefWindowProc` returns `0` without posting a quit message, so `run_message_loop` stays parked in `GetMessageW` until the OS quiesce timeout (~5 s) force-terminates the process.
2. Even once teardown starts, `WM_DESTROY` calls `close_settings_window()`, which blocks up to 1.5 s on `WaitForSingleObject` against `PowerToys.Settings.exe` (`src/runner/settings_window.cpp:712`), plus `Shell_NotifyIcon(NIM_DELETE)` during Explorer teardown. The Windows [shutdown guidance](https://learn.microsoft.com/windows/win32/shutdown/shutting-down) is explicit that handlers must not block.

This PR fixes both issues for the always-on runner. Rollout to module-owned windows is intentionally separate and tracked in #49539.

> Supersedes #48378 (same Watson bucket) by combining its no-blocking-cleanup fix with a reusable helper and unit tests. The cleanup-skip insight is credited to @yeelam-gordon.

Related (same failure class, different binary): #41260.

## Root cause

`src/runner/tray_icon.cpp` → `tray_icon_window_proc` had no case for `WM_QUERYENDSESSION` / `WM_ENDSESSION`, and `WM_DESTROY` unconditionally ran cross-process cleanup. On a full Windows session end, the OS delivers `WM_ENDSESSION` to child applications and reaps them independently, so the runner's waits consume the quiesce budget without helping shutdown complete.

## Fix

### 1. Explicitly stateless helper in `src/common/utils/window.h`

`handle_stateless_session_end_message`:

- `WM_QUERYENDSESSION` → returns `TRUE`. The name makes clear that this helper is only for processes with no unsaved user state.
- `WM_ENDSESSION(TRUE)` → calls `DestroyWindow(window)`, driving the existing `WM_DESTROY → PostQuitMessage(0)` path so `run_message_loop` unwinds.
- `WM_ENDSESSION(FALSE)` → leaves the window alone because another application cancelled shutdown.
- The optional `out_system_session_ending` flag is set only when the full Windows session is ending. `ENDSESSION_CLOSEAPP` still closes the runner but leaves the flag false so Restart Manager requests retain normal child-process cleanup.

Stateful modules must implement their own save/permission behavior rather than adopt this helper. `tray_icon_window_proc` calls it at the top of dispatch and returns immediately when the message is handled.

### 2. Skip blocking cleanup only for a full Windows session end

`WM_DESTROY` branches on `g_system_session_ending`:

- **User-initiated close or Restart Manager `ENDSESSION_CLOSEAPP`:** unchanged full cleanup (`Shell_NotifyIcon(NIM_DELETE)`, `close_settings_window()`, and `QuickAccessHost::stop()`).
- **Full OS shutdown, sign-out, or restart:** posts `WM_QUIT` without waiting on child processes the OS is already reaping in parallel.

### Scope and follow-up

This PR intentionally fixes the highest-volume contributor: the always-on runner. Native module processes with their own windows/message loops require module-specific review before adopting the pattern; that inventory and rollout is tracked in #49539.

### Why not centralize handling inside `run_message_loop`?

`WM_QUERYENDSESSION` / `WM_ENDSESSION` invoke the WndProc directly during `GetMessage`; they do not appear as a `MSG` returned to the loop. Handling must therefore live in, or be called from, each relevant WndProc.

## Tests

8 focused tests in `src/common/UnitTests-CommonUtils/Window.Tests.cpp`:

| Test | Guards |
|---|---|
| `HandleStatelessSessionEndMessage_QueryEndSession_AllowsShutdown` | `WM_QUERYENDSESSION` returns `TRUE`. |
| `HandleStatelessSessionEndMessage_EndSessionCancelled_DoesNotTearDown` | `WM_ENDSESSION(FALSE)` does not destroy the window. |
| `HandleStatelessSessionEndMessage_EndSessionConfirmed_TearsDownAndExitsLoop` | `WM_ENDSESSION(TRUE)` destroys the window and exits before the longer timer fallback. |
| `HandleStatelessSessionEndMessage_UnrelatedMessage_NotHandled` | Unrelated messages fall through untouched. |
| `HandleStatelessSessionEndMessage_EndSessionConfirmed_SignalsSystemSessionEnding` | A full session end enables the no-wait teardown path. |
| `HandleStatelessSessionEndMessage_CloseApp_DoesNotSignalSystemSessionEnding` | Restart Manager closes the window while retaining normal child cleanup. |
| `HandleStatelessSessionEndMessage_EndSessionCancelled_DoesNotSignalSystemSessionEnding` | Cancelled shutdown does not flag teardown. |
| `HandleStatelessSessionEndMessage_QueryEndSession_DoesNotSignalSystemSessionEnding` | The query phase does not flag teardown. |

**Build:** `runner.vcxproj` and `UnitTests-CommonUtils.vcxproj` build clean (`x64|Release`). The 8 focused tests pass.

## Manual validation

1. Build PowerToys and start the runner.
2. Initiate a sign-off (`logoff`) or restart.
3. Confirm Event Viewer (`Windows Logs → Application`) shows no `Application Hang` event for `PowerToys.exe`.
4. Right-click tray → Exit: confirm Settings.exe and the Quick Access host shut down gracefully and no ghost tray icon remains.

(#48378 additionally captured real logoff/restart runs showing `WM_ENDSESSION → WM_DESTROY` completing in 1–8 ms with no hang events—the same full-session path used here.)

## Quality checklist

- [x] Linked work item: AB#55588441
- [x] Module follow-up: #49539
- [x] Cross-references #41260; supersedes #48378
- [x] Unit tests (8 in `Window.Tests.cpp`)
- [x] No new binaries
- [x] Localization: no end-user strings changed
- [x] Shared helper documents its stateless contract

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
