### PR TITLE
Fix runner APPLICATION_HANG_QUIESCE without bypassing WM_CLOSE or blocking on shutdown

### DIFF
--- a/src/runner/tray_icon.cpp
+++ b/src/runner/tray_icon.cpp
@@ -35,6 +35,10 @@ namespace
     NOTIFYICONDATAW tray_icon_data;
     bool tray_icon_created = false;
 
+    // True once OS-initiated shutdown is in progress, so WM_DESTROY can
+    // skip cross-process cleanup that the OS is reaping in parallel.
+    bool g_session_ending = false;
+
     bool about_box_shown = false;
 
     HMENU h_menu = nullptr;
@@ -174,17 +178,33 @@ LRESULT __stdcall tray_icon_window_proc(HWND window, UINT message, WPARAM wparam
         }
         break;
     case WM_DESTROY:
-        if (tray_icon_created)
+        // Skip cross-process cleanup on OS shutdown: shell is dying and
+        // close_settings_window() blocks 1.5s on Settings.exe which the
+        // OS is reaping anyway — that wait would burn the quiesce budget.
+        if (!g_session_ending)
         {
-            Shell_NotifyIcon(NIM_DELETE, &tray_icon_data);
-            tray_icon_created = false;
+            if (tray_icon_created)
+            {
+                Shell_NotifyIcon(NIM_DELETE, &tray_icon_data);
+                tray_icon_created = false;
+            }
+            close_settings_window();
         }
-        close_settings_window();
         PostQuitMessage(0);
         break;
     case WM_CLOSE:
         DestroyWindow(window);
         break;
+    case WM_ENDSESSION:
+        // wparam==FALSE means shutdown was vetoed; must not tear down.
+        // Route through WM_CLOSE so close path stays single-sourced.
+        // WM_QUERYENDSESSION intentionally unhandled: DefWindowProc returns TRUE.
+        if (wparam)
+        {
+            g_session_ending = true;
+            SendMessageW(window, WM_CLOSE, 0, 0);
+        }
+        return 0;
     case WM_COMMAND:
         handle_tray_command(window, wparam, lparam);
         break;

--- a/src/runner/tray_icon.cpp
+++ b/src/runner/tray_icon.cpp
@@ -181,9 +181,9 @@ LRESULT __stdcall tray_icon_window_proc(HWND window, UINT message, WPARAM wparam
         // Skip cross-process cleanup on OS shutdown: shell is dying and
         // close_settings_window() blocks 1.5s on Settings.exe which the
         // OS is reaping anyway — that wait would burn the quiesce budget.
-        Logger::info(L"WM_DESTROY received, session_ending={}", g_session_ending);
         if (!g_session_ending)
         {
+            Logger::info(L"WM_DESTROY received (user-initiated)");
             if (tray_icon_created)
             {
                 Shell_NotifyIcon(NIM_DELETE, &tray_icon_data);
@@ -200,7 +200,7 @@ LRESULT __stdcall tray_icon_window_proc(HWND window, UINT message, WPARAM wparam
         // wparam==FALSE means shutdown was vetoed; must not tear down.
         // Route through WM_CLOSE so close path stays single-sourced.
         // WM_QUERYENDSESSION intentionally unhandled: DefWindowProc returns TRUE.
-        Logger::info(L"WM_ENDSESSION received, wparam={}", wparam);
+        // No logging on the shutdown path: spdlog flush_on(info) would burn quiesce budget.
         if (wparam)
         {
             g_session_ending = true;

--- a/src/runner/tray_icon.cpp
+++ b/src/runner/tray_icon.cpp
@@ -194,8 +194,12 @@ LRESULT __stdcall tray_icon_window_proc(HWND window, UINT message, WPARAM wparam
         PostQuitMessage(0);
         break;
     case WM_CLOSE:
+        // Return 0 (don't fall through to DefWindowProc, which would attempt a
+        // second DestroyWindow on the already-destroyed HWND and set
+        // ERROR_INVALID_WINDOW_HANDLE). This path is now hit on every OS
+        // shutdown because WM_ENDSESSION routes through WM_CLOSE.
         DestroyWindow(window);
-        break;
+        return 0;
     case WM_ENDSESSION:
         // wparam==FALSE means shutdown was vetoed; must not tear down.
         // Route through WM_CLOSE so close path stays single-sourced.

--- a/src/runner/tray_icon.cpp
+++ b/src/runner/tray_icon.cpp
@@ -181,6 +181,7 @@ LRESULT __stdcall tray_icon_window_proc(HWND window, UINT message, WPARAM wparam
         // Skip cross-process cleanup on OS shutdown: shell is dying and
         // close_settings_window() blocks 1.5s on Settings.exe which the
         // OS is reaping anyway — that wait would burn the quiesce budget.
+        Logger::info(L"WM_DESTROY received, session_ending={}", g_session_ending);
         if (!g_session_ending)
         {
             if (tray_icon_created)
@@ -199,6 +200,7 @@ LRESULT __stdcall tray_icon_window_proc(HWND window, UINT message, WPARAM wparam
         // wparam==FALSE means shutdown was vetoed; must not tear down.
         // Route through WM_CLOSE so close path stays single-sourced.
         // WM_QUERYENDSESSION intentionally unhandled: DefWindowProc returns TRUE.
+        Logger::info(L"WM_ENDSESSION received, wparam={}", wparam);
         if (wparam)
         {
             g_session_ending = true;


### PR DESCRIPTION
## Summary

Fixes `APPLICATION_HANG_QUIESCE_cfffffff_PowerToys.exe!run_message_loop` by handling `WM_ENDSESSION` in the runner's tray-icon window procedure, and avoiding any blocking work on the OS-shutdown path.

Alternative approach to #48363 — both target the same Watson bucket. Reviewers can choose whichever fits the project's direction.

## Root cause

`tray_icon_window_proc` does not handle `WM_ENDSESSION`. `DefWindowProc` returns `0` for it without posting `WM_QUIT`, so `run_message_loop` keeps calling `GetMessageW` until the OS quiesce timeout (~5 s) fires and the process is force-terminated.

## Fix

Three coordinated changes in `src/runner/tray_icon.cpp`:

### 1. Handle `WM_ENDSESSION` inline; do not handle `WM_QUERYENDSESSION`

Per the [WM_QUERYENDSESSION docs](https://learn.microsoft.com/windows/win32/shutdown/wm-queryendsession), `DefWindowProc` already returns `TRUE` for that message, which is the behavior we want (the runner has no unsaved state worth vetoing for). Only `WM_ENDSESSION` needs handling.

### 2. Route `WM_ENDSESSION` through `WM_CLOSE`

```cpp
case WM_ENDSESSION:
    if (wparam)
    {
        g_session_ending = true;
        SendMessageW(window, WM_CLOSE, 0, 0);
    }
    return 0;
```

The `wparam` guard is required per [the docs](https://learn.microsoft.com/windows/win32/shutdown/wm-endsession): `wparam == FALSE` means another app vetoed shutdown and the session is staying up.

Chaining through `WM_CLOSE` (rather than calling `DestroyWindow` directly) keeps `WM_CLOSE` as the single chokepoint for window teardown. Any future logic added to `WM_CLOSE` (telemetry, flushes, logging) will apply to the OS-shutdown path automatically without a second edit site.

### 3. Skip cross-process cleanup in `WM_DESTROY` when shutting down

`close_settings_window()` (`src/runner/settings_window.cpp:712`) does `WaitForSingleObject(proc, 1500)` on `PowerToys.Settings.exe`. The [shutdown guidance](https://learn.microsoft.com/windows/win32/shutdown/shutting-down) is clear that handlers must not block. On OS-initiated shutdown the OS is delivering `WM_ENDSESSION` to `PowerToys.Settings.exe` directly and will reap it independently, so the wait isn't needed and would consume a sizable share of the ~5 s quiesce budget.

`WM_DESTROY` now branches on `g_session_ending`:

```cpp
case WM_DESTROY:
    if (!g_session_ending)
    {
        if (tray_icon_created)
        {
            Shell_NotifyIcon(NIM_DELETE, &tray_icon_data);
            tray_icon_created = false;
        }
        close_settings_window();
    }
    PostQuitMessage(0);
    break;
```

- **User-initiated close** (right-click tray → Exit): unchanged — full graceful cleanup.
- **OS-initiated shutdown**: `PostQuitMessage(0)` only, loop unwinds in milliseconds.

## Tests / validation

- **Build:** `tools\build\build-essentials.cmd` passes locally (0 warnings, 0 errors, ~3m16s).
- **Manual validation:**
  1. Build PowerToys `Debug|x64` and start the runner.
  2. Initiate sign-off (`logoff` from elevated prompt) or restart.
  3. Confirm Event Viewer (`Windows Logs → Application`) shows no `Application Hang` event for `PowerToys.exe`.
  4. Right-click tray → Exit. Confirm Settings.exe shuts down gracefully and no ghost tray icon remains (verifies the user-close path is unchanged).
- **Unit tests:** Not added. The fix lives inside `tray_icon_window_proc` which transitively depends on most of the runner (logger, theme listener, settings IPC, hotkey detector, etc.), and there is no existing `UnitTests-Runner` project to extend. Per AGENTS.md ("If tests skipped, state why") — this is stated. Happy to add a UI-test-level smoke check (post `WM_ENDSESSION` to the tray window, assert the runner exits) as a follow-up if reviewers prefer.

## Possible follow-ups (out of scope)

- Apply the same pattern to other modules that own their own message loops (FancyZones, AlwaysOnTop, KBM Engine, WorkspacesWindowArranger, MeasureTool overlay, CropAndLock, GrabAndMove, ZoomIt SelectRectangle, notifications COM activator). Each module has different cleanup semantics, so the decisions are per-module.
- Honor `ENDSESSION_CRITICAL` in `lparam` for forced shutdowns where the quiesce budget is even shorter.
- Use `ShutdownBlockReasonCreate` for any path that legitimately needs more than ~5 s.

## Quality checklist

- [x] No new binaries
- [x] Localization: no end-user strings changed
- [x] Build verification: `build-essentials.cmd` clean (0 warnings, 0 errors)
- [x] Tests skipped explanation included

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
