### PR TITLE
Disable Shortcut Guide by default on clean installs

### DIFF
--- a/src/settings-ui/Settings.UI.Library/EnabledModules.cs
+++ b/src/settings-ui/Settings.UI.Library/EnabledModules.cs
@@ -71,7 +71,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             }
         }
 
-        private bool shortcutGuide = true;
+        private bool shortcutGuide; // defaulting to off
 
         [JsonPropertyName("Shortcut Guide")]
         public bool ShortcutGuide

--- a/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/General.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/General.cs
@@ -349,7 +349,7 @@ namespace ViewModelTests
             Assert.IsTrue(modules.FancyZones);
             Assert.IsTrue(modules.ImageResizer);
             Assert.IsTrue(modules.PowerPreview);
-            Assert.IsTrue(modules.ShortcutGuide);
+            Assert.IsFalse(modules.ShortcutGuide);
             Assert.IsTrue(modules.PowerRename);
             Assert.IsFalse(modules.PowerLauncher);
             Assert.IsTrue(modules.ColorPicker);


### PR DESCRIPTION
## Summary

Flips the default for the `Shortcut Guide` entry in `enabledModules` from `true` to `false`. New PowerToys installs (no prior `settings.json`) will start with Shortcut Guide disabled, matching how other newer modules (PowerToys Run, MouseJump, AdvancedPaste, MouseWithoutBorders, CropAndLock, QuickAccent, TextExtractor, MousePointerCrosshairs, KeyboardManager) already ship off-by-default in `EnabledModules.cs`.

## Why

Shortcut Guide has been on-by-default since the early days, but it is an opt-in style utility (overlay launched on hotkey). It should not be active for users who never asked for it on a fresh install.

## Changes

- `src/settings-ui/Settings.UI.Library/EnabledModules.cs` -- flip `shortcutGuide` backing field from `= true` to bare declaration with the file's `// defaulting to off` comment convention.
- `src/settings-ui/Settings.UI.UnitTests/ViewModelTests/General.cs` -- update the corresponding `AllModulesAreEnabledByDefault` assertion.

## Compatibility

Existing installs are unaffected: their `settings.json` already persists the user's prior value (`true`), so anyone who has it on today keeps it on. Only freshly created `EnabledModules` instances pick up the new default.
