### PR TITLE
Shortcut Guide: capture foreground app at startup to fix active-app nav

### DIFF
--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/Helpers/ForegroundAppInfo.cs
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/Helpers/ForegroundAppInfo.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace ShortcutGuide.Helpers
+{
+    /// <summary>
+    /// Snapshot of the user's foreground application at Shortcut Guide startup.
+    /// Captured before any Shortcut Guide window is created so that the foreground
+    /// process is the user's app and not Shortcut Guide itself.
+    /// </summary>
+    /// <param name="ModuleName">Main module file name (for example, "msedge.exe"); null when unavailable.</param>
+    /// <param name="ExecutablePath">Full path to the main module executable; null when unavailable.</param>
+    public readonly record struct ForegroundAppInfo(string? ModuleName, string? ExecutablePath);
+}

--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/Helpers/ManifestInterpreter.cs
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/Helpers/ManifestInterpreter.cs
@@ -102,52 +102,69 @@ namespace ShortcutGuide.Helpers
         /// <summary>
         /// Retrieves all application IDs that should be displayed, based on the foreground window and background processes.
         /// </summary>
+        /// <param name="capturedForeground">
+        /// Optional snapshot of the foreground app captured at process startup, before any
+        /// Shortcut Guide window was created. When provided, this is used in preference to
+        /// the live foreground window to avoid a race where Shortcut Guide's own window has
+        /// become foreground by the time this method runs. When <c>null</c>, the method
+        /// falls back to querying the live foreground window.
+        /// </param>
         /// <returns>
         /// A dictionary mapping each application ID to the full path of the executable
         /// that caused the match (used for icon extraction), or <c>null</c> when no
         /// specific executable is associated (for example, wildcard filters like the
         /// default shell).
         /// </returns>
-        public static Dictionary<string, string?> GetAllCurrentApplicationIds()
+        public static Dictionary<string, string?> GetAllCurrentApplicationIds(ForegroundAppInfo? capturedForeground = null)
         {
-            nint handle = NativeMethods.GetForegroundWindow();
-
             Dictionary<string, string?> applicationIds = new(StringComparer.Ordinal);
 
-            if (NativeMethods.GetWindowThreadProcessId(handle, out uint processId) > 0)
+            string? name;
+            string? executablePath;
+
+            if (capturedForeground is { } captured)
             {
-                string? name = null;
-                string? executablePath = null;
+                name = captured.ModuleName;
+                executablePath = captured.ExecutablePath;
+            }
+            else
+            {
+                name = null;
+                executablePath = null;
 
-                try
-                {
-                    ProcessModule? mainModule = Process.GetProcessById((int)processId).MainModule;
-                    name = mainModule?.ModuleName;
-                    executablePath = mainModule?.FileName;
-                }
-                catch (Win32Exception)
-                {
-                    // Access denied for elevated processes; we cannot read the module.
-                }
-                catch (InvalidOperationException)
-                {
-                    // Process exited between enumeration and access.
-                }
-
-                if (name is not null)
+                nint handle = NativeMethods.GetForegroundWindow();
+                if (NativeMethods.GetWindowThreadProcessId(handle, out uint processId) > 0)
                 {
                     try
                     {
-                        IndexFile.IndexItem match = ManifestInterpreter.GetCachedIndexYamlFile().Index.First((s) => !s.BackgroundProcess && IsMatch(name, s.WindowFilter));
-                        string? pathForApp = match.WindowFilter == "*" ? null : executablePath;
-                        foreach (var item in match.Apps)
-                        {
-                            applicationIds[item] = pathForApp;
-                        }
+                        ProcessModule? mainModule = Process.GetProcessById((int)processId).MainModule;
+                        name = mainModule?.ModuleName;
+                        executablePath = mainModule?.FileName;
+                    }
+                    catch (Win32Exception)
+                    {
+                        // Access denied for elevated processes; we cannot read the module.
                     }
                     catch (InvalidOperationException)
                     {
+                        // Process exited between enumeration and access.
                     }
+                }
+            }
+
+            if (name is not null)
+            {
+                try
+                {
+                    IndexFile.IndexItem match = ManifestInterpreter.GetCachedIndexYamlFile().Index.First((s) => !s.BackgroundProcess && IsMatch(name, s.WindowFilter));
+                    string? pathForApp = match.WindowFilter == "*" ? null : executablePath;
+                    foreach (var item in match.Apps)
+                    {
+                        applicationIds[item] = pathForApp;
+                    }
+                }
+                catch (InvalidOperationException)
+                {
                 }
             }
 

--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/Program.cs
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/Program.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Threading;
@@ -20,6 +21,16 @@ namespace ShortcutGuide
     public sealed class Program
     {
         public static Thread CopyAndIndexGenerationThread { get; private set; } = null!;
+
+        /// <summary>
+        /// Snapshot of the user's foreground application captured at process startup,
+        /// before any Shortcut Guide window has been created. Consumed by
+        /// <see cref="ManifestInterpreter.GetAllCurrentApplicationIds(ForegroundAppInfo?)"/>
+        /// to avoid a race where Shortcut Guide's own window becomes foreground before
+        /// the active-app lookup runs (which can be delayed by first-run manifest copy
+        /// and index generation).
+        /// </summary>
+        public static ForegroundAppInfo? InitialForegroundApp { get; private set; }
 
         [STAThread]
         public static void Main(string[] args)
@@ -46,6 +57,12 @@ namespace ShortcutGuide
             {
                 return;
             }
+
+            // Capture the user's foreground app now, before any Shortcut Guide window
+            // is created and before the manifest copy / index generation thread starts.
+            // The active-app lookup runs after that thread finishes, by which time the
+            // foreground window would otherwise be Shortcut Guide itself.
+            InitialForegroundApp = CaptureForegroundApp();
 
             // Copy every shipped manifest from the install directory to the per-user manifest folder.
             // Enumerating the source folder avoids drift between the deployed assets and a hard-coded list.
@@ -131,6 +148,45 @@ namespace ShortcutGuide
 
             // The WinRT/WinUI dispatcher thread doesn't terminate cleanly; force exit.
             Environment.Exit(0);
+        }
+
+        private static ForegroundAppInfo? CaptureForegroundApp()
+        {
+            try
+            {
+                nint hwnd = NativeMethods.GetForegroundWindow();
+                if (hwnd == IntPtr.Zero)
+                {
+                    return null;
+                }
+
+                if (NativeMethods.GetWindowThreadProcessId(hwnd, out uint processId) == 0)
+                {
+                    return null;
+                }
+
+                using Process process = Process.GetProcessById((int)processId);
+                ProcessModule? mainModule = process.MainModule;
+                return new ForegroundAppInfo(mainModule?.ModuleName, mainModule?.FileName);
+            }
+            catch (Win32Exception ex)
+            {
+                // Access denied for elevated processes; we cannot read the module.
+                Logger.LogInfo($"Could not capture foreground app at startup (access denied): {ex.Message}");
+                return null;
+            }
+            catch (InvalidOperationException ex)
+            {
+                // Process exited between enumeration and access.
+                Logger.LogInfo($"Could not capture foreground app at startup (process exited): {ex.Message}");
+                return null;
+            }
+            catch (ArgumentException ex)
+            {
+                // GetProcessById can throw ArgumentException for stale PIDs.
+                Logger.LogInfo($"Could not capture foreground app at startup (invalid pid): {ex.Message}");
+                return null;
+            }
         }
 
         private static void SendSettingsTelemetry()

--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuideXAML/MainWindow.xaml.cs
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuideXAML/MainWindow.xaml.cs
@@ -51,7 +51,7 @@ namespace ShortcutGuide
             _getAppIdsTask = Task.Run(() =>
             {
                 Program.CopyAndIndexGenerationThread.Join();
-                _currentApplicationIds = ManifestInterpreter.GetAllCurrentApplicationIds();
+                _currentApplicationIds = ManifestInterpreter.GetAllCurrentApplicationIds(Program.InitialForegroundApp);
                 return _currentApplicationIds;
             });
 


### PR DESCRIPTION
## Summary

Fixes a race that prevents Shortcut Guide from ever showing the active app's shortcuts.

## The bug

`ManifestInterpreter.GetAllCurrentApplicationIds` reads `GetForegroundWindow()` to pick the matching manifest (Edge, VSCode, Word, etc.), but in `MainWindow.xaml.cs` it's called from inside a `Task.Run` that first joins `Program.CopyAndIndexGenerationThread` -- which on first run copies 30+ shipped yml manifests and shells out to `PowerToys.ShortcutGuide.IndexYmlGenerator.exe`. By the time `GetForegroundWindow()` runs, Shortcut Guide's own `MainWindow` is already shown and is the foreground window, so no manifest matches and only the always-on background entries (Windows shell, PowerToys) appear.

Even on warm runs there's enough latency between MainWindow construction and the call for SG to win foreground.

## The fix

Capture the foreground app's module name and executable path in `Program.Main()`, right after the existing `IsCurrentWindowExcludedFromShortcutGuide` check (which already relies on the user's app still being foreground) and before any window or dispatcher is created. Pass that snapshot into `GetAllCurrentApplicationIds`, which prefers it over the live `GetForegroundWindow()` call.

If capture fails (elevated foreground we can't read, race on shutdown), the method falls back to today's behavior -- so this is strictly an improvement.

## Changes

- `Helpers/ForegroundAppInfo.cs` (new) -- tiny `record struct` for the captured `(ModuleName, ExecutablePath)`.
- `Program.cs` -- capture once in `Main` into `Program.InitialForegroundApp`; helper handles `Win32Exception` / `InvalidOperationException` / `ArgumentException`.
- `Helpers/ManifestInterpreter.cs` -- `GetAllCurrentApplicationIds` now takes an optional `ForegroundAppInfo?` and uses it when provided. Background-process scan unchanged.
- `ShortcutGuideXAML/MainWindow.xaml.cs` -- pass `Program.InitialForegroundApp` into the call.

## Testing

- Built `ShortcutGuide.Ui.csproj` clean (exit 0).
- Manual repro should be straightforward: focus Edge / VSCode / Word, launch SG with `Win+Shift+/`, confirm the active app appears as the first nav item with its app icon.
