### PR TITLE
[Shortcut Guide] Settings footer icon clip fix and vector nav icons

### DIFF
--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuideXAML/App.xaml
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuideXAML/App.xaml
@@ -29,6 +29,20 @@
                 TrueValue="Collapsed" />
             <tkconverters:StringVisibilityConverter x:Name="StringVisibilityConverter" />
             <converters:ShortcutDescriptionToKeysConverter x:Name="ShortcutDescriptionToKeysConverter" />
+
+            <!--
+                Path data for the 4-square Windows logo icon used by the "Windows" nav entry in MainWindow.
+                Sized for a 20x20 viewbox to match the icon slot in CustomNavigationViewStyle.
+                Same geometry as src/settings-ui/Settings.UI/SettingsXAML/Controls/Dashboard/ShortcutConflictWindow.xaml.
+                Defined here because the nav item is created in code-behind.
+            -->
+            <x:String x:Key="WindowsLogoPathData">M9 20H0V11H9V20ZM20 20H11V11H20V20ZM9 9H0V0H9V9ZM20 9H11V0H20V9Z</x:String>
+
+            <!--
+                Path data for the PowerToys app icon (rounded square with menu bar and three dots) used in the apps nav list.
+                Scaled from the 64x64 source SVG to fit a 20x20 viewbox; F0 = even-odd fill so the frame strokes render correctly.
+            -->
+            <x:String x:Key="PowerToysLogoPathData">F0 M17.5 0C18.8807 0 20 1.1193 20 2.5V17.5C20 18.8807 18.8807 20 17.5 20H2.5C1.1193 20 0 18.8807 0 17.5V2.5C0 1.1193 1.1193 0 2.5 0H17.5ZM2.5 1.25C1.8096 1.25 1.25 1.8096 1.25 2.5V17.5C1.25 18.1903 1.8096 18.75 2.5 18.75H17.5C18.1903 18.75 18.75 18.1903 18.75 17.5V2.5C18.75 1.8096 18.1903 1.25 17.5 1.25H2.5ZM3.75 15a1.25 1.25 0 1 0 2.5 0a1.25 1.25 0 1 0 -2.5 0ZM8.75 15a1.25 1.25 0 1 0 2.5 0a1.25 1.25 0 1 0 -2.5 0ZM13.75 15a1.25 1.25 0 1 0 2.5 0a1.25 1.25 0 1 0 -2.5 0ZM15 3.75C15.6903 3.75 16.25 4.3097 16.25 5V10C16.25 10.6903 15.6903 11.25 15 11.25H5C4.3097 11.25 3.75 10.6903 3.75 10V5C3.75 4.3097 4.3097 3.75 5 3.75H15ZM5 5V10H15V5H5Z</x:String>
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuideXAML/MainWindow.xaml
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuideXAML/MainWindow.xaml
@@ -38,13 +38,6 @@
                 Style="{StaticResource RailNavigationViewStyle}">
                 <NavigationView.MenuItems />
                 <NavigationView.FooterMenuItems>
-                    <!--  If footer only has one item, a visual bug can occur. This fake settings button will have set height to zero as soon as the content is loaded  -->
-                    <NavigationViewItem
-                        x:Name="FakeSettingsButton"
-                        Icon="Setting"
-                        SelectsOnInvoked="False"
-                        Tag="Settings"
-                        Tapped="Settings_Tapped" />
                     <NavigationViewItem
                         x:Uid="SettingsButton"
                         Icon="Setting"

--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuideXAML/MainWindow.xaml.cs
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuideXAML/MainWindow.xaml.cs
@@ -15,6 +15,8 @@ using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Markup;
+using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Imaging;
 using ShortcutGuide.Helpers;
 using ShortcutGuide.Models;
@@ -136,12 +138,6 @@ namespace ShortcutGuide
             // The code below sets the position of the window to the center of the monitor, but only if it hasn't been set before.
             if (!this._setPosition)
             {
-                Content.GettingFocus += (_, _) =>
-                {
-                    this.FakeSettingsButton.Height = 10;
-                    this.FakeSettingsButton.Height = 0;
-                };
-
                 this.SetWindowPosition();
                 this._setPosition = true;
 
@@ -186,7 +182,13 @@ namespace ShortcutGuide
                 {
                     if (item == defaultShellName)
                     {
-                        this.WindowSelector.MenuItems.Add(new NavigationViewItem { Name = item, Content = "Windows", Icon = new FontIcon() { Glyph = "\xE770" } });
+                        var pathData = (string)Application.Current.Resources["WindowsLogoPathData"];
+                        this.WindowSelector.MenuItems.Add(new NavigationViewItem { Name = item, Content = "Windows", Icon = CreatePathIcon(pathData) });
+                    }
+                    else if (item == "Microsoft.PowerToys")
+                    {
+                        var pathData = (string)Application.Current.Resources["PowerToysLogoPathData"];
+                        this.WindowSelector.MenuItems.Add(new NavigationViewItem { Name = item, Content = ManifestInterpreter.GetShortcutsOfApplication(item).Name, Icon = CreatePathIcon(pathData) });
                     }
                     else
                     {
@@ -218,6 +220,17 @@ namespace ShortcutGuide
             }
 
             return new FontIcon { Glyph = "\uEB91" };
+        }
+
+        private static PathIcon CreatePathIcon(string pathData)
+        {
+            var geometry = (Geometry)XamlBindingHelper.ConvertValue(typeof(Geometry), pathData);
+            return new PathIcon
+            {
+                Data = geometry,
+                Width = 20,
+                Height = 20,
+            };
         }
 
         private bool _hasMovedToRightMonitor;

--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuideXAML/Styles/CustomNavigationViewStyle.xaml
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuideXAML/Styles/CustomNavigationViewStyle.xaml
@@ -800,9 +800,10 @@
                                 MinHeight="{ThemeResource RailNavigationViewItemOnLeftMinHeight}"
                                 RowSpacing="6">
                                 <!--  Store: Added Grid.RowDefinitions & Removed Grid.ColumnDefinitions  -->
+                                <!--  Row 0 fixed height tuned so the 20px icon vertically aligns with the selection pill center (~y=28).  -->
                                 <Grid.RowDefinitions>
-                                    <RowDefinition />
-                                    <RowDefinition />
+                                    <RowDefinition Height="12" />
+                                    <RowDefinition Height="Auto" />
                                     <RowDefinition Height="Auto" />
                                     <RowDefinition />
                                 </Grid.RowDefinitions>


### PR DESCRIPTION
## Summary of the Pull Request

Visual polish for the Shortcut Guide UI, follow-up to #48383 and #48384.

- Fixes the Settings footer icon being clipped in the rail at startup. Root cause: the icon `RowDefinition` in `CustomNavigationViewStyle.xaml` was `*`, so the rail's `MinHeight` constraint compressed the 20px icon down. Changing it to `Auto` lets the row size to its content. This also removes the need for the `FakeSettingsButton` workaround.
- Replaces the laptop `FontIcon` used for the `Windows` nav entry with a 4-square Windows logo rendered as a `PathIcon`.
- Replaces the bitmap PowerToys app icon with a theme-aware vector `PathIcon` (rounded square frame + menu bar + three dots) so it matches the rest of the icons.
- Path data for both icons lives as `x:String` resources in `App.xaml`.
- Tunes the rail item `Row 0` height so the icon vertically aligns with the selection pill center.

<img width="681" height="1405" alt="image" src="https://github.com/user-attachments/assets/10787087-e32f-4018-b004-3f824648b962" />

## PR Checklist

- [x] **Closes:** part of the Shortcut Guide 0.100 polish set
- [x] **Communication:** internal only
- [x] **Tests:** manual verification
- [x] **Localization:** no new strings
- [x] **Dev docs:** N/A

## Validation Steps Performed

- Built locally and verified the Settings footer icon is no longer clipped on first show.
- Verified the Windows nav entry now uses the Windows logo PathIcon and renders correctly in light and dark.
- Verified the PowerToys entry now renders as a vector and follows the theme foreground.
- Verified the selection pill aligns vertically with the icon center.
