### PR TITLE
[Modules] Handle WM_ENDSESSION in run_message_loop daemons (GrabAndMove, AlwaysOnTop, FancyZones)

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -238,6 +238,7 @@ closesocket
 clp
 CLSCTX
 CLSIDs
+CLOSEAPP
 clsids
 Clusion
 cmder

--- a/src/modules/GrabAndMove/GrabAndMove/main.cpp
+++ b/src/modules/GrabAndMove/GrabAndMove/main.cpp
@@ -27,6 +27,7 @@ static ULONG_PTR g_gdiplusToken = 0; // GDI+ token for overlay border rendering
 static HHOOK g_hhkKeyboard = nullptr;
 static HHOOK g_hhkMouse = nullptr;
 static HWND g_hMsgWnd = nullptr;
+static bool g_systemSessionEnding = false;
 
 // 0 = Alt (default), 1 = Win
 enum class GrabAndMoveModifier
@@ -1740,8 +1741,30 @@ static LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
         return 0;
 
     case WM_DESTROY:
-        RemoveTrayIcon();
+        if (!g_systemSessionEnding)
+        {
+            RemoveTrayIcon();
+        }
         PostQuitMessage(0);
+        return 0;
+    }
+
+    return DefWindowProcW(hwnd, msg, wParam, lParam);
+}
+
+static LRESULT CALLBACK OverlayWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+    switch (msg)
+    {
+    case WM_QUERYENDSESSION:
+        return TRUE;
+
+    case WM_ENDSESSION:
+        if (wParam)
+        {
+            g_systemSessionEnding = !(lParam & ENDSESSION_CLOSEAPP);
+            PostQuitMessage(0);
+        }
         return 0;
     }
 
@@ -1821,7 +1844,7 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, LPWSTR lpCmdLine, int)
     // Register the overlay window class (layered per-pixel-alpha surface, ARROW cursor)
     WNDCLASSEXW overlayWindowClass = {};
     overlayWindowClass.cbSize = sizeof(overlayWindowClass);
-    overlayWindowClass.lpfnWndProc = DefWindowProcW;
+    overlayWindowClass.lpfnWndProc = OverlayWndProc;
     overlayWindowClass.hInstance = hInstance;
     overlayWindowClass.hCursor = LoadCursorW(nullptr, IDC_ARROW);
     overlayWindowClass.hbrBackground = nullptr; // per-pixel alpha via UpdateLayeredWindow
@@ -1836,6 +1859,16 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, LPWSTR lpCmdLine, int)
     g_hMsgWnd = CreateWindowExW(0, CLASS_NAME, APP_TITLE, 0, 0, 0, 0, 0, HWND_MESSAGE, nullptr, hInstance, nullptr);
     if (!g_hMsgWnd)
     {
+        TraceLoggingUnregister(g_hProvider);
+        return 1;
+    }
+
+    // The message-only window does not receive session-end broadcasts. Keep a
+    // hidden top-level overlay window so the process can exit its message loop.
+    EnsureOverlayWindow();
+    if (!g_hOverlay)
+    {
+        DestroyWindow(g_hMsgWnd);
         TraceLoggingUnregister(g_hProvider);
         return 1;
     }
@@ -1912,7 +1945,10 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, LPWSTR lpCmdLine, int)
         DestroyWindow(g_hOverlay);
         g_hOverlay = nullptr;
     }
-    RemoveTrayIcon();
+    if (!g_systemSessionEnding)
+    {
+        RemoveTrayIcon();
+    }
     if (g_gdiplusToken)
     {
         Gdiplus::GdiplusShutdown(g_gdiplusToken);

--- a/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.cpp
+++ b/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.cpp
@@ -211,7 +211,21 @@ void AlwaysOnTop::SettingsUpdate(SettingId id)
 
 LRESULT AlwaysOnTop::WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lparam) noexcept
 {
-    if (message == WM_HOTKEY)
+    if (message == WM_QUERYENDSESSION)
+    {
+        return TRUE;
+    }
+    else if (message == WM_ENDSESSION)
+    {
+        if (wparam)
+        {
+            // This window has no WM_DESTROY -> PostQuitMessage path, so it
+            // cannot use handle_stateless_session_end_message.
+            PostQuitMessage(0);
+        }
+        return 0;
+    }
+    else if (message == WM_HOTKEY)
     {
         int hotkeyId = static_cast<int>(wparam);
         if (HWND fw{ GetForegroundWindow() })

--- a/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
@@ -596,6 +596,18 @@ LRESULT FancyZones::WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lpa
 {
     switch (message)
     {
+    case WM_QUERYENDSESSION:
+        return TRUE;
+
+    case WM_ENDSESSION:
+        if (wparam)
+        {
+            // This window has no WM_DESTROY -> PostQuitMessage path, so it
+            // cannot use handle_stateless_session_end_message.
+            PostQuitMessage(0);
+        }
+        return 0;
+
     case WM_HOTKEY:
     {
         if (wparam == static_cast<WPARAM>(HotkeyId::Editor))


### PR DESCRIPTION
## Summary

Companion PR to #48378 (runner). Fixes the same `APPLICATION_HANG_QUIESCE_*_PowerToys.exe!run_message_loop` WER bucket in the other PowerToys daemons whose top-level windows ignored `WM_ENDSESSION`.

## Root cause (same as #48378)

`run_message_loop` (`src/common/utils/window.h`) calls `GetMessageW` which only returns `0` on `WM_QUIT`. If a daemon's WndProc lets `WM_ENDSESSION` fall through to `DefWindowProc`, no `WM_QUIT` is ever posted on logoff/shutdown, the loop blocks, CSRSS hits the quiesce timeout (~5s), `TerminateProcess` fires, and Watson logs `APPLICATION_HANG_QUIESCE`.

## `run_message_loop` callsite audit

8 production callsites. Persistent daemons that own a top-level window and were affected:

| Module | Status before | Fix here |
|---|---|---|
| `runner` | hang | Fixed in #48378 |
| `GrabAndMove` | hang (tray icon, NIM_DELETE in WM_DESTROY) | ✅ `main.cpp` |
| `AlwaysOnTop` | hang | ✅ `AlwaysOnTop.cpp` |
| `FancyZones` | hang | ✅ `FancyZones.cpp` |
| `KeyboardManagerEngine` | n/a | No top-level window → OS skips WM_ENDSESSION and TerminateProcess directly; no hang bucket possible |
| `ZoomIt` | already handled | SysInternals heritage |
| `PowerLauncher` | already handled | Managed `SessionEnding` event |
| `MeasureTool`, `Notifications` | transient/spawned on demand | Not a shutdown-time daemon |

## Fix pattern

For `AlwaysOnTop` and `FancyZones` (no tray icon to clean up) — minimal:

```cpp
case WM_ENDSESSION:
    if (wparam) PostQuitMessage(0);  // wparam==FALSE => shutdown vetoed
    return 0;
```

For `GrabAndMove` (has `Shell_NotifyIcon` cleanup in `WM_DESTROY` that must not run on shutdown) — use a `g_session_ending` flag and skip the tray-icon delete in `WM_DESTROY`, mirroring runner's `tray_icon.cpp` pattern from #48378.

No shared header: each module's `WM_DESTROY` cleanup is module-specific; the abstraction would be too thin and would hide the variance in what to *skip*.

## Why no logging on the shutdown path

Same reasoning as #48378 review feedback — `spdlog::flush_on(info)` synchronously flushes to disk; emitting log lines from `WM_ENDSESSION`/`WM_DESTROY` burns the ~5s quiesce budget for no diagnostic value (Watson already records the bucket on failure).

## Verification

- Built clean (Debug|x64): GrabAndMove.vcxproj, AlwaysOnTop.vcxproj, FancyZonesLib.vcxproj — all exit 0.
- Runner counterpart fix (#48378) verified end-to-end with real reboot + WM_ENDSESSION injection; quiesce 1–8 ms. Same OS-level mechanism applies here.

## Related

- #48378 — runner fix (this PR's companion)
- #48363 — original community fix (over-engineered; this approach is the minimal correct one)
