### PR TITLE
[Settings] Stop fail-fast in ShellViewModel.Frame_NavigationFailed

### DIFF
--- a/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/ShellViewModelTests.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/ShellViewModelTests.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.PowerToys.Settings.UI.ViewModels;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ViewModelTests
+{
+    [TestClass]
+    public class ShellViewModelTests
+    {
+        [TestMethod]
+        public void GetPageDisplayName_ReturnsFullName_ForKnownType()
+        {
+            string actual = ShellViewModel.GetPageDisplayName(typeof(ShellViewModelTests));
+
+            Assert.AreEqual(typeof(ShellViewModelTests).FullName, actual);
+        }
+
+        [TestMethod]
+        public void GetPageDisplayName_ReturnsPlaceholder_ForNullType()
+        {
+            // NavigationFailedEventArgs.SourcePageType can be null when navigation fails
+            // before the runtime can resolve the requested page type. The handler must
+            // tolerate this without throwing NullReferenceException.
+            string actual = ShellViewModel.GetPageDisplayName(null);
+
+            Assert.AreEqual("<unknown>", actual);
+        }
+    }
+}

--- a/src/settings-ui/Settings.UI/ViewModels/ShellViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/ShellViewModel.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
 
+using ManagedCommon;
 using Microsoft.PowerToys.Settings.UI.Helpers;
 using Microsoft.PowerToys.Settings.UI.Library;
 using Microsoft.PowerToys.Settings.UI.Library.Helpers;
@@ -135,7 +136,25 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
 
         private void Frame_NavigationFailed(object sender, NavigationFailedEventArgs e)
         {
-            throw e.Exception;
+            // Mark the failure as handled so WinUI does not fail-fast the process.
+            // Re-throwing from a NavigationFailed handler propagates back through the
+            // WinRT marshalling layer as a stowed exception and terminates Settings.
+            e.Handled = true;
+
+            var pageName = GetPageDisplayName(e.SourcePageType);
+            if (e.Exception != null)
+            {
+                Logger.LogError($"Failed to navigate to page '{pageName}'.", e.Exception);
+            }
+            else
+            {
+                Logger.LogError($"Failed to navigate to page '{pageName}'.");
+            }
+        }
+
+        public static string GetPageDisplayName(Type sourcePageType)
+        {
+            return sourcePageType?.FullName ?? "<unknown>";
         }
 
         private void Frame_Navigated(object sender, NavigationEventArgs e)


### PR DESCRIPTION
## Summary

`ShellViewModel.Frame_NavigationFailed` unconditionally re-threw `e.Exception`. When the WinUI `Frame` raises `NavigationFailed`, throwing back from the handler propagates through the WinRT marshalling layer as a stowed exception and the runtime tears the process down via `RoFailFastWithErrorContextInternal2` - Settings crashes instead of surfacing a recoverable error.

`e.Exception` can also be null in some failure paths (e.g., the requested page type cannot be resolved), in which case the previous code immediately raised a `NullReferenceException` on the throw statement itself.

This was spotted while reading through `ShellViewModel` for an unrelated review.

## Fix

- Set `e.Handled = true` so WinUI does not fail-fast.
- Use `Logger.LogError(...)` (the existing house pattern via `ManagedCommon`) to record the navigation failure with the source page name and exception, so it still shows up in PowerToys logs for diagnosis.
- Tolerate a null `SourcePageType` by extracting `GetPageDisplayName` and falling back to `"<unknown>"`.
- Tolerate a null `Exception` by calling the `LogError(string)` overload in that case.

## Tests

Added `ShellViewModelTests` under `Settings.UI.UnitTests` covering both branches of `GetPageDisplayName`:
- known `Type` -> returns `FullName`
- `null` -> returns `<unknown>` (no NRE)

Both pass locally (`dotnet test ... --filter ShellViewModelTests`).

## Validation

- `MSBuild PowerToys.Settings.csproj /p:Configuration=Release /p:Platform=x64` builds.
- `MSBuild Settings.UI.UnitTests.csproj` builds.
- Unit tests pass.

## Notes

- The other `Frame_NavigationFailed` in `NavigationService.cs` is just `NavigationFailed?.Invoke(sender, e);` so it does not need changes - the fix is on the actual subscriber.
- No string-resource changes (the log message is engineering diagnostics, not user-facing UI).