### PR TITLE
[Settings] Extract HandleNavigationFailure and test all null permutations

### DIFF
--- a/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/ShellViewModelTests.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/ShellViewModelTests.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+using Microsoft.PowerToys.Settings.UI.ViewModels;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ViewModelTests
+{
+    [TestClass]
+    public class ShellViewModelTests
+    {
+        [TestMethod]
+        public void GetPageDisplayName_ReturnsFullName_ForKnownType()
+        {
+            string actual = ShellViewModel.GetPageDisplayName(typeof(ShellViewModelTests));
+
+            Assert.AreEqual(typeof(ShellViewModelTests).FullName, actual);
+        }
+
+        [TestMethod]
+        public void GetPageDisplayName_ReturnsPlaceholder_ForNullType()
+        {
+            // NavigationFailedEventArgs.SourcePageType can be null when navigation fails
+            // before the runtime can resolve the requested page type. The handler must
+            // tolerate this without throwing NullReferenceException.
+            string actual = ShellViewModel.GetPageDisplayName(null);
+
+            Assert.AreEqual("<unknown>", actual);
+        }
+
+        [TestMethod]
+        public void HandleNavigationFailure_DoesNotThrow_ForNullInputs()
+        {
+            // Frame_NavigationFailed must never throw - re-throwing back into the
+            // WinUI dispatcher tears the process down via RoFailFastWithErrorContextInternal2.
+            // Both SourcePageType and Exception can legitimately be null on a failed
+            // Frame.Navigate, so the failure-handling path must tolerate that.
+            ShellViewModel.HandleNavigationFailure(null, null);
+        }
+
+        [TestMethod]
+        public void HandleNavigationFailure_DoesNotThrow_ForNullException()
+        {
+            ShellViewModel.HandleNavigationFailure(typeof(ShellViewModelTests), null);
+        }
+
+        [TestMethod]
+        public void HandleNavigationFailure_DoesNotThrow_ForNullPageType()
+        {
+            ShellViewModel.HandleNavigationFailure(null, new InvalidOperationException("simulated navigation failure"));
+        }
+
+        [TestMethod]
+        public void HandleNavigationFailure_DoesNotThrow_ForBothInputsPresent()
+        {
+            ShellViewModel.HandleNavigationFailure(typeof(ShellViewModelTests), new InvalidOperationException("simulated navigation failure"));
+        }
+    }
+}

--- a/src/settings-ui/Settings.UI/ViewModels/ShellViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/ShellViewModel.cs
@@ -136,8 +136,33 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
 
         private void Frame_NavigationFailed(object sender, NavigationFailedEventArgs e)
         {
+            // Mark the failure as handled so WinUI does not fail-fast the process.
+            // Re-throwing from a NavigationFailed handler propagates back through the
+            // WinRT marshalling layer as a stowed exception and terminates Settings.
             e.Handled = true;
-            Logger.LogError($"Failed to load page '{e.SourcePageType?.FullName}'", e.Exception);
+
+            HandleNavigationFailure(e.SourcePageType, e.Exception);
+        }
+
+        // Pure, side-effect-free entry point for the failure-handling logic so the
+        // contract ("must not throw, regardless of null inputs") can be exercised by
+        // unit tests without standing up a real WinUI Frame.
+        public static void HandleNavigationFailure(Type sourcePageType, Exception exception)
+        {
+            var pageName = GetPageDisplayName(sourcePageType);
+            if (exception != null)
+            {
+                Logger.LogError($"Failed to navigate to page '{pageName}'.", exception);
+            }
+            else
+            {
+                Logger.LogError($"Failed to navigate to page '{pageName}'.");
+            }
+        }
+
+        public static string GetPageDisplayName(Type sourcePageType)
+        {
+            return sourcePageType?.FullName ?? "<unknown>";
         }
 
         private void Frame_Navigated(object sender, NavigationEventArgs e)


### PR DESCRIPTION
## Summary

Follow-up to #48409. That PR rewrote `ShellViewModel.Frame_NavigationFailed` to set `e.Handled = true` and log instead of re-throwing, but the unit tests it added only covered the `GetPageDisplayName` formatting helper. The actual contract that matters - "this handler must never throw, regardless of which fields on `NavigationFailedEventArgs` happen to be null" - was not directly testable because `NavigationFailedEventArgs` is a sealed WinRT type that cannot be constructed from MSTest.

## Change

Tiny refactor: split the failure-handling logic out of `Frame_NavigationFailed` into a pure static `HandleNavigationFailure(Type sourcePageType, Exception exception)`. The WinUI-shaped handler now just sets `Handled = true` and delegates.

This makes the "must not throw" invariant testable in isolation - no WinUI Frame, no Microsoft.UI.Xaml.Navigation types needed.

## Tests

Added four new cases under `ShellViewModelTests`, exercising all four `(SourcePageType, Exception)` null permutations:

| `sourcePageType` | `exception` |
| - | - |
| null | null |
| typeof(...) | null |
| null | new Exception(...) |
| typeof(...) | new Exception(...) |

Each test simply calls the helper and relies on MSTest's default "if it throws, the test fails" behavior. Any future change that re-introduces an unguarded dereference of `e.SourcePageType` or `e.Exception` will turn the corresponding test red.

## Validation

All six tests pass:

```
Passed GetPageDisplayName_ReturnsFullName_ForKnownType
Passed GetPageDisplayName_ReturnsPlaceholder_ForNullType
Passed HandleNavigationFailure_DoesNotThrow_ForNullInputs
Passed HandleNavigationFailure_DoesNotThrow_ForNullException
Passed HandleNavigationFailure_DoesNotThrow_ForNullPageType
Passed HandleNavigationFailure_DoesNotThrow_ForBothInputsPresent
Total tests: 6, Passed: 6
```

`PowerToys.Settings.csproj` and `Settings.UI.UnitTests.csproj` both build clean (Release|x64).

## Note

This PR is stacked on top of #48409 (same branch lineage). If #48409 is merged first this PR will rebase cleanly to a small diff on `ShellViewModel.cs` + the additional test cases.