### PR TITLE
[Settings] Add UI smoke test that visits every shell NavigationView item

### DIFF
--- a/src/settings-ui/UITest-Settings/NavigationSmokeTests.cs
+++ b/src/settings-ui/UITest-Settings/NavigationSmokeTests.cs
@@ -1,0 +1,117 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.PowerToys.UITest;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Settings.UITests
+{
+    /// <summary>
+    /// End-to-end smoke tests that exercise every Settings shell NavigationView item
+    /// and assert the Settings process stays alive throughout.
+    ///
+    /// <para>
+    /// These tests are the runtime counterpart to the unit tests on
+    /// <c>ShellViewModel.HandleNavigationFailure</c>. The unit tests prove the helper
+    /// does not throw for null inputs; these UI tests prove that any module page that
+    /// would fail to construct (and therefore raise <c>Frame.NavigationFailed</c>) does
+    /// not crash the Settings process - i.e. <c>Frame_NavigationFailed</c> does not
+    /// re-throw and trigger a WinUI fail-fast.
+    /// </para>
+    /// </summary>
+    [TestClass]
+    public class NavigationSmokeTests : UITestBase
+    {
+        private const string SettingsWindowTitle = "Settings";
+
+        // AutomationId of each NavigationViewItem in the shell. Using AutomationId
+        // (rather than Content) makes the test localization-independent.
+        // Parent group items use SelectsOnInvoked="False" and only expand a submenu
+        // when clicked - they must be expanded before their children become visible.
+        private static readonly (string? ParentId, string ItemId)[] NavigationItems = new (string?, string)[]
+        {
+            // Top-level (always visible)
+            (null, "DashboardNavItem"),
+            (null, "GeneralNavItem"),
+
+            // System tools
+            ("SystemToolsNavItem", "AdvancedPasteNavItem"),
+            ("SystemToolsNavItem", "AwakeNavItem"),
+            ("SystemToolsNavItem", "CmdPalNavItem"),
+            ("SystemToolsNavItem", "ColorPickerNavItem"),
+            ("SystemToolsNavItem", "LightSwitchNavItem"),
+            ("SystemToolsNavItem", "PowerLauncherNavItem"),
+            ("SystemToolsNavItem", "MeasureToolNavItem"),
+            ("SystemToolsNavItem", "ShortcutGuideNavItem"),
+            ("SystemToolsNavItem", "TextExtractorNavItem"),
+            ("SystemToolsNavItem", "ZoomItNavItem"),
+
+            // Windowing & layouts
+            ("WindowingAndLayoutsNavItem", "AlwaysOnTopNavItem"),
+            ("WindowingAndLayoutsNavItem", "CropAndLockNavItem"),
+            ("WindowingAndLayoutsNavItem", "FancyZonesNavItem"),
+            ("WindowingAndLayoutsNavItem", "GrabAndMoveNavItem"),
+            ("WindowingAndLayoutsNavItem", "WorkspacesNavItem"),
+
+            // Input / Output
+            ("InputOutputNavItem", "KeyboardManagerNavItem"),
+            ("InputOutputNavItem", "MouseUtilitiesNavItem"),
+            ("InputOutputNavItem", "MouseWithoutBordersNavItem"),
+            ("InputOutputNavItem", "PowerDisplayNavItem"),
+            ("InputOutputNavItem", "QuickAccentNavItem"),
+
+            // File management
+            ("FileManagementNavItem", "PowerPreviewNavItem"),
+            ("FileManagementNavItem", "FileLocksmithNavItem"),
+            ("FileManagementNavItem", "ImageResizerNavItem"),
+            ("FileManagementNavItem", "NewPlusNavItem"),
+            ("FileManagementNavItem", "PeekNavItem"),
+            ("FileManagementNavItem", "PowerRenameNavItem"),
+
+            // Advanced
+            ("AdvancedNavItem", "CmdNotFoundNavItem"),
+            ("AdvancedNavItem", "EnvironmentVariablesNavItem"),
+            ("AdvancedNavItem", "HostsNavItem"),
+            ("AdvancedNavItem", "RegistryPreviewNavItem"),
+        };
+
+        public NavigationSmokeTests()
+            : base(PowerToysModule.PowerToysSettings, size: WindowSize.Large)
+        {
+        }
+
+        [TestMethod("PowerToys.Settings.Navigation.AllItemsNavigateWithoutCrashing")]
+        [TestCategory("Settings Navigation Smoke")]
+        public void AllNavigationViewItems_NavigateWithoutCrashing()
+        {
+            var expandedGroups = new HashSet<string>();
+
+            foreach (var (parentId, itemId) in NavigationItems)
+            {
+                if (parentId != null && expandedGroups.Add(parentId))
+                {
+                    var parent = this.Find<NavigationViewItem>(By.AccessibilityId(parentId));
+                    Assert.IsNotNull(parent, $"Could not find parent NavigationViewItem '{parentId}'.");
+                    parent.Click();
+                    Task.Delay(300).Wait();
+                }
+
+                var item = this.Find<NavigationViewItem>(By.AccessibilityId(itemId));
+                Assert.IsNotNull(item, $"Could not find NavigationViewItem '{itemId}'.");
+                item.Click();
+                Task.Delay(500).Wait();
+
+                // If a page constructor or navigation handler had thrown back into the
+                // WinUI dispatcher (the regression behind ShellViewModel.Frame_NavigationFailed),
+                // the Settings process would have been FailFasted by the runtime and this
+                // check would fail.
+                Assert.IsTrue(
+                    this.IsWindowOpen(SettingsWindowTitle),
+                    $"Settings window terminated after navigating to '{itemId}'. This indicates a regression in Frame_NavigationFailed re-throwing or in a page constructor.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a WinAppDriver smoke test that drives the real `PowerToys.Settings.exe` through every NavigationView item in the shell and asserts the Settings process stays alive after each navigation. This is the runtime counterpart to the unit tests being added for `ShellViewModel.HandleNavigationFailure` - the unit tests prove the helper does not throw for null inputs, this UI test proves no page in the shell triggers a navigation-failure path that crashes the process.

## Background

The Settings shell wires `Frame.NavigationFailed` to a handler that, in the past, simply re-threw `e.Exception`. Throwing from a `NavigationFailed` handler propagates back through the WinRT marshalling layer as a stowed exception and the runtime tears the process down via `RoFailFastWithErrorContextInternal2`. A regression of this kind in `ShellViewModel.Frame_NavigationFailed` is invisible to the existing `Settings.UI.UnitTests` because `NavigationFailedEventArgs` is a sealed WinRT type that cannot be constructed from MSTest - the failure can only be observed by actually attempting navigation against a running WinUI Frame.

This UI test fills that gap: any future change that re-introduces a throw from `Frame_NavigationFailed`, or breaks a module page's constructor, will turn this test red instead of shipping to users.

## Change

New file: `src/settings-ui/UITest-Settings/NavigationSmokeTests.cs`.

- Single class `NavigationSmokeTests` deriving from `Microsoft.PowerToys.UITest.UITestBase`, scoped to `PowerToysModule.PowerToysSettings`.
- Hardcoded list of `(ParentGroupId, ItemId)` tuples covering all NavigationView items in the shell (Dashboard, General, plus every module under System tools, Windowing & layouts, Input / Output, File management, Advanced). Items reference UIA `AutomationId` rather than `Content`, so the test is localization-independent.
- Single test method `AllNavigationViewItems_NavigateWithoutCrashing` iterates the list, expands each parent group on first encounter, clicks each item, and asserts `IsWindowOpen("Settings")` returns true after every navigation.

## Validation

`MSBuild src\settings-ui\UITest-Settings\UITest-Settings.csproj /p:Configuration=Release /p:Platform=x64` builds clean.

The UITest project has `<RunVSTest>false</RunVSTest>` so it does not execute as part of normal MSBuild PR validation - it runs in the dedicated UI-test pipeline alongside the existing `SettingsTests` and `OOBEUITests`. The test follows the same patterns those existing classes use (`UITestBase` constructor scope, `Find<NavigationViewItem>(...)` for element lookup, `Task.Delay` for navigation settle).

## Notes

- I deliberately did not add a search-box submission case in this PR - that requires interacting with the `AutoSuggestBox` (`x:Name="SearchBox"`, `x:Uid="Shell_SearchBox"`) and asserting on free-text query navigation, which deserves its own test class once we settle on the right pattern for typed text in WinAppDriver. The navigation-item smoke is the highest-value first cut.
- The list of nav items is hardcoded rather than discovered dynamically because dynamic enumeration would mask additions (a new module added without a smoke entry would silently go untested). Adding a new module's nav item to this list is the intended way to opt that page into the smoke.