### PR TITLE
[AlwaysOnTop] Guard m_frameDrawer in WindowBorder::UpdateBorderPosition

### DIFF
--- a/src/modules/alwaysontop/AlwaysOnTop/WindowBorder.cpp
+++ b/src/modules/alwaysontop/AlwaysOnTop/WindowBorder.cpp
@@ -160,7 +160,7 @@ bool WindowBorder::Init(HINSTANCE hinstance)
 
 void WindowBorder::UpdateBorderPosition() const
 {
-    if (!m_trackingWindow)
+    if (!m_trackingWindow || !m_frameDrawer || !m_window)
     {
         return;
     }


### PR DESCRIPTION
## Summary

`WindowBorder::UpdateBorderPosition()` dereferences `m_frameDrawer` without a null check when `GetFrameRect` fails on the tracked window:

```cpp
auto rectOpt = GetFrameRect(m_trackingWindow);
if (!rectOpt.has_value())
{
    m_frameDrawer->Hide();   // <-- AV if m_frameDrawer == nullptr
    return;
}
```

The sibling routine `WindowBorder::UpdateBorderProperties()` already guards both `m_trackingWindow` and `m_frameDrawer` before doing any work:

```cpp
if (!m_trackingWindow || !m_frameDrawer)
{
    return;
}
```

`UpdateBorderPosition` was the only call site that didn't match that pattern. This PR brings it in line, and also adds a guard for `m_window` for symmetry (the subsequent `SetWindowPos(m_window, ...)` would otherwise fail silently with `ERROR_INVALID_WINDOW_HANDLE` but it's cleaner to early-return).

## Why `m_frameDrawer` can be null when `UpdateBorderPosition` runs

`WindowBorder` registers itself as a `SettingsObserver` in its base-class constructor — *before* `Init()` finishes. `Init()` is what actually allocates `m_frameDrawer` (via `FrameDrawer::Create`). So between those two steps there is a window where the object is alive and observable but `m_frameDrawer == nullptr`.

The destructor has a similar shape:

```cpp
WindowBorder::~WindowBorder()
{
    if (m_frameDrawer)
    {
        m_frameDrawer->Hide();
        m_frameDrawer = nullptr;
    }

    if (m_window)
    {
        SetWindowLongPtrW(m_window, GWLP_USERDATA, 0);
        DestroyWindow(m_window);
    }
}
```

`m_frameDrawer` is nulled before `GWLP_USERDATA` is cleared and before `DestroyWindow` is called. Any `WM_TIMER` that fires through `s_WndProc` in that window dispatches to `WndProc → UpdateBorderPosition()` on an instance whose `m_frameDrawer` has already been released — same null deref, same access violation.

`UpdateBorderPosition` is also invoked from `EVENT_OBJECT_LOCATIONCHANGE` / `EVENT_SYSTEM_MOVESIZEEND` in `AlwaysOnTop.cpp` and from `WM_TIMER` in `WndProc`; both run on the message-loop thread and either path can land here while the object is in a transient half-constructed or half-destructed state.

## Change

Add `!m_frameDrawer` (and `!m_window`) to the early-return guard at the top of `UpdateBorderPosition`. Three-line patch.

## How this was found

While reviewing the `WindowBorder` lifecycle for an unrelated AlwaysOnTop tweak, the asymmetry between `UpdateBorderPosition` and `UpdateBorderProperties` jumped out — the former dereferences `m_frameDrawer` without the null check the latter performs.

## Tests

`src/modules/alwaysontop` has no test project today — `WindowBorder` is tightly bound to Win32 (`HWND`, `DwmGetWindowAttribute`, `SetWindowPos`) and `FrameDrawer` (Direct2D / D3D), with no abstraction layer to mock. Adding meaningful native unit tests here would require a substantial refactor that's well out of scope for this fix.

Manual validation:
- Build clean: `MSBuild src\modules\alwaysontop\AlwaysOnTop\AlwaysOnTop.vcxproj /p:Configuration=Release /p:Platform=x64` produces `PowerToys.AlwaysOnTop.exe` with no warnings.
- Behavioural: with the guard added, the early-return path for "tracked window has no valid extended frame bounds" simply skips the `Hide()` call instead of crashing — same end-state for the user (border position is left as-is until the next timer tick recovers it).

If we want a runtime regression net here, the right level is a UI / lifecycle test that creates and pins/unpins windows under churn; that's a separate piece of work and not gated on this fix.

## Risk

Three guarded conditions on a path that was already guarding one of them. The behavioural delta only fires when the dereference *would* have crashed — anywhere else the function is unchanged.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
