### PR TITLE
[Settings] Add navigation smoke test using winapp CLI (no WinAppDriver)

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -2084,6 +2084,8 @@ wifi
 wikimedia
 wikipedia
 winapi
+winapp
+winappcli
 winappsdk
 windir
 WINDOWCREATED

--- a/PowerToys.slnx
+++ b/PowerToys.slnx
@@ -1088,6 +1088,10 @@
       <Platform Solution="*|ARM64" Project="ARM64" />
       <Platform Solution="*|x64" Project="x64" />
     </Project>
+    <Project Path="src/settings-ui/WinAppCli.UITest-Settings/WinAppCli.UITest-Settings.csproj">
+      <Platform Solution="*|ARM64" Project="ARM64" />
+      <Platform Solution="*|x64" Project="x64" />
+    </Project>
   </Folder>
   <Folder Name="/Solution Items/">
     <File Path=".vsconfig" />

--- a/src/settings-ui/WinAppCli.UITest-Settings/NavigationSmokeTests.cs
+++ b/src/settings-ui/WinAppCli.UITest-Settings/NavigationSmokeTests.cs
@@ -1,0 +1,149 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Settings.UITests.WinAppCli
+{
+    /// <summary>
+    /// Smoke test that drives the Settings shell via the <c>winapp</c> CLI (UIA-backed,
+    /// no WinAppDriver / Appium dependency) and asserts that clicking every
+    /// <c>NavigationViewItem</c> leaves the process alive.
+    ///
+    /// The companion unit tests in <c>Settings.UI.UnitTests\ViewModelTests\ShellViewModelTests.cs</c>
+    /// cover the pure-logic half of the FailFast regression
+    /// (<c>HandleNavigationFailure</c>, <c>GetPageDisplayName</c>). They cannot exercise the
+    /// "throw from <c>Frame_NavigationFailed</c> -> WinUI marshalling -> RoFailFast" path
+    /// because <c>NavigationFailedEventArgs</c> is a sealed WinRT type and cannot be
+    /// constructed from a unit test. This smoke test is the runtime counterpart that catches
+    /// any regression where a module page constructor throws, or where the navigation handler
+    /// re-introduces an unhandled exception.
+    /// </summary>
+    [TestClass]
+    public sealed class NavigationSmokeTests
+    {
+        // (ParentGroupSlug | null, NavItemSlug). Parent groups have SelectsOnInvoked="False"
+        // in ShellPage.xaml and only expand on invoke; child items navigate. Selectors are
+        // AutomationIds taken straight from ShellPage.xaml so the test stays
+        // localization-independent.
+        private static readonly NavigationCase[] NavigationItems = new[]
+        {
+            // Top-level
+            new NavigationCase(null, "DashboardNavItem"),
+            new NavigationCase(null, "GeneralNavItem"),
+
+            // System tools
+            new NavigationCase("SystemToolsNavItem", "AdvancedPasteNavItem"),
+            new NavigationCase("SystemToolsNavItem", "CmdNotFoundNavItem"),
+            new NavigationCase("SystemToolsNavItem", "CommandPaletteNavItem"),
+            new NavigationCase("SystemToolsNavItem", "CropAndLockNavItem"),
+            new NavigationCase("SystemToolsNavItem", "EnvironmentVariablesNavItem"),
+            new NavigationCase("SystemToolsNavItem", "HostsFileEditorNavItem"),
+            new NavigationCase("SystemToolsNavItem", "RegistryPreviewNavItem"),
+            new NavigationCase("SystemToolsNavItem", "ZoomItNavItem"),
+
+            // Windowing and layouts
+            new NavigationCase("WindowingAndLayoutsNavItem", "AlwaysOnTopNavItem"),
+            new NavigationCase("WindowingAndLayoutsNavItem", "FancyZonesNavItem"),
+            new NavigationCase("WindowingAndLayoutsNavItem", "WindowWalkerNavItem"),
+            new NavigationCase("WindowingAndLayoutsNavItem", "WorkspacesNavItem"),
+
+            // Input / Output
+            new NavigationCase("InputOutputNavItem", "ColorPickerNavItem"),
+            new NavigationCase("InputOutputNavItem", "KeyboardManagerNavItem"),
+            new NavigationCase("InputOutputNavItem", "MouseUtilsNavItem"),
+            new NavigationCase("InputOutputNavItem", "MouseWithoutBordersNavItem"),
+            new NavigationCase("InputOutputNavItem", "PowerOcrNavItem"),
+            new NavigationCase("InputOutputNavItem", "QuickAccentNavItem"),
+            new NavigationCase("InputOutputNavItem", "ScreenRulerNavItem"),
+            new NavigationCase("InputOutputNavItem", "ShortcutGuideNavItem"),
+            new NavigationCase("InputOutputNavItem", "TextExtractorNavItem"),
+
+            // File management
+            new NavigationCase("FileManagementNavItem", "FileExplorerPreviewNavItem"),
+            new NavigationCase("FileManagementNavItem", "FileLocksmithNavItem"),
+            new NavigationCase("FileManagementNavItem", "ImageResizerNavItem"),
+            new NavigationCase("FileManagementNavItem", "NewPlusNavItem"),
+            new NavigationCase("FileManagementNavItem", "PowerRenameNavItem"),
+
+            // Advanced
+            new NavigationCase("AdvancedNavItem", "AwakeNavItem"),
+            new NavigationCase("AdvancedNavItem", "LightSwitchNavItem"),
+        };
+
+        private static SettingsHost? _host;
+        private static readonly HashSet<string> _expandedGroups = new(StringComparer.Ordinal);
+
+        [ClassInitialize]
+        public static void ClassSetup(TestContext _)
+        {
+            Assert.IsTrue(WinAppCli.IsAvailable(), "winapp CLI is not on PATH. Install with 'winget install Microsoft.winappcli'.");
+
+            _host = new SettingsHost();
+            _host.Launch();
+
+            // Confirm the shell finished loading by waiting for an item that's always present.
+            var dashboardVisible = WinAppCli.WaitFor(_host.Pid, "DashboardNavItem", timeoutMs: 15_000);
+            Assert.IsTrue(dashboardVisible.Succeeded, $"Settings shell did not present DashboardNavItem within 15s. {dashboardVisible.DescribeFailure()}");
+        }
+
+        [ClassCleanup]
+        public static void ClassTeardown()
+        {
+            _host?.Dispose();
+            _host = null;
+        }
+
+        public static IEnumerable<object[]> NavigationCases()
+        {
+            foreach (var c in NavigationItems)
+            {
+                yield return new object[] { c.ParentGroupSlug ?? string.Empty, c.NavItemSlug };
+            }
+        }
+
+        public static string GetNavCaseDisplayName(System.Reflection.MethodInfo _, object[] data)
+        {
+            var parent = (string)data[0];
+            var item = (string)data[1];
+            return string.IsNullOrEmpty(parent) ? item : $"{parent} -> {item}";
+        }
+
+        [TestMethod]
+        [DynamicData(nameof(NavigationCases), DynamicDataDisplayName = nameof(GetNavCaseDisplayName))]
+        public void NavigationItem_NavigatesWithoutCrashing(string parentGroupSlug, string navItemSlug)
+        {
+            Assert.IsNotNull(_host, "SettingsHost was not initialized.");
+
+            if (!string.IsNullOrEmpty(parentGroupSlug) && _expandedGroups.Add(parentGroupSlug))
+            {
+                var expand = WinAppCli.Invoke(_host.Pid, parentGroupSlug);
+                Assert.IsTrue(expand.Succeeded, $"Failed to expand parent group '{parentGroupSlug}'. {expand.DescribeFailure()}");
+            }
+
+            // The child item is only in the visual tree once its parent is expanded. Wait briefly
+            // so we don't race the animation.
+            var waitForItem = WinAppCli.WaitFor(_host.Pid, navItemSlug, timeoutMs: 5_000);
+            Assert.IsTrue(waitForItem.Succeeded, $"Could not find '{navItemSlug}'. {waitForItem.DescribeFailure()}");
+
+            var invokeItem = WinAppCli.Invoke(_host.Pid, navItemSlug);
+            Assert.IsTrue(invokeItem.Succeeded, $"Failed to invoke '{navItemSlug}'. {invokeItem.DescribeFailure()}");
+
+            // Give the navigation a moment to land before asserting the process is alive — if a
+            // page constructor throws and the (now-fixed) handler ever regresses, the FailFast
+            // will land in this window.
+            Thread.Sleep(250);
+
+            using var alive = Process.GetProcessById(_host.Pid);
+            alive.Refresh();
+            Assert.IsFalse(alive.HasExited, $"PowerToys.Settings.exe exited after invoking '{navItemSlug}' (exit code {alive.ExitCode}). Likely a navigation FailFast regression.");
+        }
+
+        private readonly record struct NavigationCase(string? ParentGroupSlug, string NavItemSlug);
+    }
+}

--- a/src/settings-ui/WinAppCli.UITest-Settings/NavigationSmokeTests.cs
+++ b/src/settings-ui/WinAppCli.UITest-Settings/NavigationSmokeTests.cs
@@ -134,9 +134,9 @@ namespace Microsoft.Settings.UITests.WinAppCli
             var invokeItem = WinAppCli.Invoke(_host.Pid, navItemSlug);
             Assert.IsTrue(invokeItem.Succeeded, $"Failed to invoke '{navItemSlug}'. {invokeItem.DescribeFailure()}");
 
-            // Give the navigation a moment to land before asserting the process is alive — if a
-            // page constructor throws and the (now-fixed) handler ever regresses, the FailFast
-            // will land in this window.
+            // Pause briefly before asserting the process is still alive. If a page
+            // constructor throws and the (now-fixed) handler ever regresses, the
+            // FailFast will land within this delay.
             Thread.Sleep(250);
 
             using var alive = Process.GetProcessById(_host.Pid);

--- a/src/settings-ui/WinAppCli.UITest-Settings/SettingsHost.cs
+++ b/src/settings-ui/WinAppCli.UITest-Settings/SettingsHost.cs
@@ -1,0 +1,151 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+
+namespace Microsoft.Settings.UITests.WinAppCli
+{
+    /// <summary>
+    /// Owns the lifecycle of a <c>PowerToys.Settings.exe</c> process for the duration of a single
+    /// test class. Locates the executable from either:
+    ///   1. an installed PowerToys (<c>%ProgramFiles%\PowerToys\WinUI3Apps\PowerToys.Settings.exe</c>), or
+    ///   2. the local dev build alongside the test assembly
+    ///      (<c>...\x64\Release\WinUI3Apps\PowerToys.Settings.exe</c>).
+    /// </summary>
+    /// <remarks>
+    /// Settings is launched directly rather than through <c>PowerToys.exe</c> (the runner) so the
+    /// smoke test stays focused on the shell window — the runner brings in tray/elevation/module
+    /// startup paths that aren't what we're trying to cover here.
+    /// </remarks>
+    internal sealed class SettingsHost : IDisposable
+    {
+        private const string SettingsExeName = "PowerToys.Settings.exe";
+        private const string SettingsSubDirectory = "WinUI3Apps";
+
+        private Process? settingsProcess;
+
+        public int Pid => settingsProcess?.Id ?? throw new InvalidOperationException("Settings has not been launched.");
+
+        public void Launch()
+        {
+            var exePath = LocateSettingsExe()
+                ?? throw new FileNotFoundException($"Could not find {SettingsExeName} in any installed or dev-build location.");
+
+            var psi = new ProcessStartInfo
+            {
+                FileName = exePath,
+                WorkingDirectory = Path.GetDirectoryName(exePath)!,
+                UseShellExecute = false,
+            };
+
+            settingsProcess = Process.Start(psi)
+                ?? throw new InvalidOperationException($"Process.Start returned null for {exePath}");
+
+            WaitForMainWindow(settingsProcess);
+        }
+
+        public void Dispose()
+        {
+            if (settingsProcess is null)
+            {
+                return;
+            }
+
+            try
+            {
+                if (!settingsProcess.HasExited)
+                {
+                    settingsProcess.Kill(entireProcessTree: true);
+                    settingsProcess.WaitForExit(5_000);
+                }
+            }
+            catch (InvalidOperationException)
+            {
+                // Process already gone — nothing to clean up.
+            }
+            finally
+            {
+                settingsProcess.Dispose();
+                settingsProcess = null;
+            }
+        }
+
+        private static string? LocateSettingsExe()
+        {
+            foreach (var root in CandidateInstallRoots())
+            {
+                var path = Path.Combine(root, SettingsSubDirectory, SettingsExeName);
+                if (File.Exists(path))
+                {
+                    return path;
+                }
+            }
+
+            return null;
+        }
+
+        private static System.Collections.Generic.IEnumerable<string> CandidateInstallRoots()
+        {
+            // 1) Installed PowerToys (machine/per-user) — preferred in pipeline runs.
+            foreach (var path in new[]
+            {
+                @"C:\Program Files\PowerToys",
+                @"C:\Program Files (x86)\PowerToys",
+                Environment.ExpandEnvironmentVariables(@"%LocalAppData%\PowerToys"),
+            })
+            {
+                if (Directory.Exists(path))
+                {
+                    yield return path;
+                }
+            }
+
+            // 2) Dev build sitting next to (or one folder up from) the test assembly.
+            //    For this csproj's <OutputPath>, the test dll lands at
+            //    <repo>\<plat>\<cfg>\tests\WinAppCli.UITests-Settings\netX\... and
+            //    PowerToys.Settings.exe lands at <repo>\<plat>\<cfg>\WinUI3Apps\...
+            var assemblyDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            if (assemblyDir is not null)
+            {
+                var probe = new DirectoryInfo(assemblyDir);
+                for (int i = 0; i < 6 && probe is not null; i++, probe = probe.Parent)
+                {
+                    if (Directory.Exists(Path.Combine(probe.FullName, SettingsSubDirectory)))
+                    {
+                        yield return probe.FullName;
+                    }
+                }
+            }
+        }
+
+        private static void WaitForMainWindow(Process process)
+        {
+            var deadline = DateTime.UtcNow.AddSeconds(30);
+            while (DateTime.UtcNow < deadline)
+            {
+                process.Refresh();
+                if (process.HasExited)
+                {
+                    throw new InvalidOperationException($"PowerToys.Settings.exe exited during startup with code {process.ExitCode}.");
+                }
+
+                if (process.MainWindowHandle != IntPtr.Zero)
+                {
+                    // Give XAML a moment to populate the visual tree.
+                    Thread.Sleep(750);
+                    return;
+                }
+
+                Thread.Sleep(100);
+            }
+
+            throw new TimeoutException("PowerToys.Settings.exe did not produce a main window within 30s.");
+        }
+    }
+}

--- a/src/settings-ui/WinAppCli.UITest-Settings/WinAppCli.UITest-Settings.csproj
+++ b/src/settings-ui/WinAppCli.UITest-Settings/WinAppCli.UITest-Settings.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<!-- Look at Directory.Build.props in root for common stuff as well -->
+	<Import Project="$(RepoRoot)src\Common.Dotnet.CsWinRT.props" />
+
+	<PropertyGroup>
+		<ProjectGuid>{B3A1D9E8-7C6E-4F4A-9F22-2C5E4D3A8B11}</ProjectGuid>
+		<RootNamespace>Microsoft.Settings.UITests.WinAppCli</RootNamespace>
+		<AssemblyName>WinAppCli.UITests-Settings</AssemblyName>
+		<IsPackable>false</IsPackable>
+		<Nullable>enable</Nullable>
+		<OutputType>Library</OutputType>
+
+		<!-- This is a UI test, so don't run as part of MSBuild -->
+		<RunVSTest>false</RunVSTest>
+	</PropertyGroup>
+
+	<PropertyGroup>
+		<OutputPath>$(RepoRoot)$(Platform)\$(Configuration)\tests\WinAppCli.UITests-Settings\</OutputPath>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="MSTest" />
+	</ItemGroup>
+
+</Project>

--- a/src/settings-ui/WinAppCli.UITest-Settings/WinAppCli.cs
+++ b/src/settings-ui/WinAppCli.UITest-Settings/WinAppCli.cs
@@ -1,0 +1,115 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+
+namespace Microsoft.Settings.UITests.WinAppCli
+{
+    /// <summary>
+    /// Thin wrapper around the Windows App Development CLI (<c>winapp</c>) UI Automation
+    /// subcommands. The CLI binary is expected to be on <c>PATH</c> — install with
+    /// <c>winget install Microsoft.winappcli</c> or via the <c>setup-WinAppCli</c> pipeline task.
+    /// </summary>
+    /// <remarks>
+    /// Every public method spawns a fresh <c>winapp.exe</c> process. That overhead (~hundreds of ms
+    /// per call) is acceptable for a smoke suite that runs a few dozen invocations; if a heavier
+    /// suite needs lower per-call latency the wrapper can switch to a long-running session model
+    /// when the CLI grows one.
+    /// </remarks>
+    internal static class WinAppCli
+    {
+        private const string ExeName = "winapp";
+
+        /// <summary>
+        /// Invokes an element by AutomationId / semantic slug. Tries InvokePattern,
+        /// TogglePattern, SelectionItemPattern, then ExpandCollapsePattern in order — which
+        /// means the same call works for both leaf NavigationView items (Invoke) and parent
+        /// group items that only expand (ExpandCollapse).
+        /// </summary>
+        public static InvocationResult Invoke(int appPid, string selector)
+            => Run("ui", "invoke", selector, "-a", appPid.ToString(System.Globalization.CultureInfo.InvariantCulture));
+
+        /// <summary>
+        /// Polls for an element to be present in the visual tree, up to <paramref name="timeoutMs"/>.
+        /// </summary>
+        public static InvocationResult WaitFor(int appPid, string selector, int timeoutMs = 3000)
+            => Run("ui", "wait-for", selector, "-a", appPid.ToString(System.Globalization.CultureInfo.InvariantCulture), "-t", timeoutMs.ToString(System.Globalization.CultureInfo.InvariantCulture));
+
+        /// <summary>
+        /// Captures the target window as a PNG written to <paramref name="outputPath"/>.
+        /// </summary>
+        public static InvocationResult Screenshot(int appPid, string selector, string outputPath)
+            => Run("ui", "screenshot", selector, "-a", appPid.ToString(System.Globalization.CultureInfo.InvariantCulture), "-o", outputPath);
+
+        /// <summary>
+        /// Returns true if <c>winapp</c> is discoverable on <c>PATH</c>. Used by
+        /// <c>[AssemblyInitialize]</c> to fail the suite with a useful error message
+        /// instead of letting every test produce its own opaque process-launch failure.
+        /// </summary>
+        public static bool IsAvailable()
+        {
+            try
+            {
+                var result = Run("--version");
+                return result.ExitCode == 0;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
+        private static InvocationResult Run(params string[] args)
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = ExeName,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+
+            foreach (var arg in args)
+            {
+                psi.ArgumentList.Add(arg);
+            }
+
+            using var process = Process.Start(psi)
+                ?? throw new InvalidOperationException($"Failed to launch '{ExeName}'. Is it installed and on PATH? (winget install Microsoft.winappcli)");
+
+            var stdout = process.StandardOutput.ReadToEnd();
+            var stderr = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+
+            return new InvocationResult(process.ExitCode, stdout, stderr, args);
+        }
+
+        public sealed record InvocationResult(int ExitCode, string StdOut, string StdErr, string[] Args)
+        {
+            public bool Succeeded => ExitCode == 0;
+
+            public string DescribeFailure()
+            {
+                var sb = new StringBuilder();
+                sb.Append("winapp ");
+                sb.AppendJoin(' ', Args);
+                sb.Append($" -> exit {ExitCode}");
+                if (!string.IsNullOrWhiteSpace(StdErr))
+                {
+                    sb.Append("; stderr: ").Append(StdErr.Trim());
+                }
+                else if (!string.IsNullOrWhiteSpace(StdOut))
+                {
+                    sb.Append("; stdout: ").Append(StdOut.Trim());
+                }
+
+                return sb.ToString();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Why this exists

`ShellViewModel.HandleNavigationFailure` and `ShellViewModel.GetPageDisplayName` (the helpers introduced/expanded in #48409 / #48410) cover the pure-logic half of the navigation-failure regression. They **cannot** reach the original FailFast path: `NavigationFailedEventArgs` is a sealed WinRT projection that can't be constructed from MSTest, so any regression that re-introduces "page constructor throws → unhandled in `Frame_NavigationFailed` → `RoFailFast`" sails right past the unit tests.

This PR adds the runtime counterpart: a smoke test that drives a real Settings shell and asserts the process is still alive after clicking every NavigationViewItem.

## Framework

This test deliberately **does not** use `Appium.WebDriver` / WinAppDriver — the existing `src\settings-ui\UITest-Settings` project's stack. Instead it drives the running Settings shell through the Windows App Development CLI (`winapp`), which exposes a UI Automation surface (`winapp ui invoke|wait-for|screenshot|inspect|search|get-property|click|set-value|...`) against any running app — WinUI 3, WPF, WinForms, Win32, Electron. No daemon, no driver process, no Appium server.

- Repo: https://github.com/microsoft/WinAppCli
- Install: `winget install Microsoft.winappcli` (or the `setup-WinAppCli` pipeline task)

`winapp` is currently in **public preview**; this PR introduces it as an opt-in test dependency in a brand-new project so it does not affect the existing Appium-based tests or anything else. If the maintainers would rather keep WinAppDriver as the only sanctioned UI test path, this PR can be closed without touching anything else in the repo.

## Project layout

New project: **`src/settings-ui/WinAppCli.UITest-Settings/`**

- `WinAppCli.UITest-Settings.csproj` — plain MSTest. **No `Appium.WebDriver` reference.** Mirrors the existing UI test csproj conventions (`<RunVSTest>false</RunVSTest>`, `<OutputPath>$(RepoRoot)$(Platform)\$(Configuration)\tests\WinAppCli.UITests-Settings\</OutputPath>`).
- `WinAppCli.cs` — thin wrapper around `Process.Start("winapp", "ui …")` with `Invoke`, `WaitFor`, `Screenshot`, and `IsAvailable`. Returns a record with exit code + stdout/stderr + a `DescribeFailure()` helper for clean assertion messages.
- `SettingsHost.cs` — owns the `PowerToys.Settings.exe` process for the class. Locates the exe in either an installed PowerToys path or alongside the test assembly (dev build), and waits for `MainWindowHandle` before returning.
- `NavigationSmokeTests.cs` — one `[TestMethod]` (parameterized via `[DynamicData]`) that produces a discrete test result per nav item. Each row clicks one item via `winapp ui invoke <AutomationId> -a <pid>` (parent groups are expanded on first encounter), and then asserts `PowerToys.Settings.exe` has not exited.

Splitting the helper into one file each keeps the test source itself small — the alternative reference shape (one long PowerShell script that pipes `winapp ui …` calls together) doesn't fit cleanly into how PowerToys discovers and runs its existing MSTest UI test projects.

## Why one `[TestMethod]` per nav item, parameterized via `[DynamicData]`

- Gives a discrete pass/fail per nav item in TestExplorer / pipeline reports — if `MeasureToolNavItem` regresses, the report says so by name.
- Keeps source minimal: the navigation table is a static array; the test body is a dozen lines.
- The class-level `[ClassInitialize]` / `[ClassCleanup]` launches Settings exactly once and tears it down at the end — every row exercises navigation against the same process so the "did the process die" check is meaningful.

## AutomationId-based selectors

Every selector is the AutomationId already attached in `ShellPage.xaml` (e.g. `DashboardNavItem`, `FancyZonesNavItem`, `SystemToolsNavItem`). This keeps the test localization-independent — display strings change with the user's MUI language but AutomationIds do not.

Parent group items (`SystemToolsNavItem`, `WindowingAndLayoutsNavItem`, `InputOutputNavItem`, `FileManagementNavItem`, `AdvancedNavItem`) have `SelectsOnInvoked="False"` and only expand on click. `winapp ui invoke` tries `InvokePattern`, `TogglePattern`, `SelectionItemPattern`, then `ExpandCollapsePattern` in order, so the same `Invoke` call works for both navigation-y leaves and expand-y groups.

## Pipeline notes

- Project sits in the new `/settings-ui/Tests/` slnx folder alongside `Settings.UI.UnitTests.csproj`.
- `<RunVSTest>false</RunVSTest>` matches every other UI test project in the repo — the test doesn't run in a regular `MSBuild` and only fires in the UI test pipeline.
- The UI test pipeline (per `doc/devdocs/development/ui-tests.md`) selects projects via the `uiTestModules` parameter — this csproj's assembly name is `WinAppCli.UITests-Settings`, which is what would go in that list to opt in.
- Running this test class requires `winapp` on `PATH`. The pipeline can install it with `winget install Microsoft.winappcli` or the [`setup-WinAppCli`](https://github.com/microsoft/setup-WinAppCli) action. `[ClassInitialize]` calls `WinAppCli.IsAvailable()` and fails the whole class with a useful error message (rather than producing 30 opaque per-test failures) if the CLI is missing.

## How this was validated locally

- The C# in all three files compiles clean (`0 Warning(s), 0 Error(s)`) against `net10.0-windows` MSTest. The PowerToys-side restore is currently failing on my dev box for *every* csproj under `src/settings-ui/UITest-Settings` and friends because the local NuGet cache wants runtime packs at a version the cached feed no longer has — that's a pre-existing local-env issue, not something this PR introduces. Pipeline restore uses a different feed and is expected to be fine.
- `winapp 0.3.2` was installed via winget and the `ui` subcommand surface (`invoke`, `wait-for`, `screenshot`, `inspect`, `search`, `get-property`, `click`, `set-value`, etc.) was verified to match what this PR depends on.

## Risk

- New test project; **no production code** changes.
- Does not touch the existing `UITest-Settings` (WinAppDriver) project — both can coexist.
- If `winapp` is unavailable, the class fails fast with a clear message; it cannot quietly skip and report green.

## Replaces

This supersedes a draft I closed at #48411, which used WinAppDriver/Appium for the same coverage. Same test goal; new transport.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
