### PR TITLE
[QuickAccess] Suppress unhandled XAML exceptions in flyout host

### DIFF
--- a/src/settings-ui/QuickAccess.UI/QuickAccessXAML/App.xaml.cs
+++ b/src/settings-ui/QuickAccess.UI/QuickAccessXAML/App.xaml.cs
@@ -47,7 +47,7 @@ public partial class App : Application
         _window = null;
     }
 
-    private void App_UnhandledException(object sender, UnhandledExceptionEventArgs e)
+    private void App_UnhandledException(object sender, Microsoft.UI.Xaml.UnhandledExceptionEventArgs e)
     {
         // QuickAccess is a transient launcher flyout owned by the runner. An unhandled XAML
         // exception here would otherwise be stowed and FailFast the process; mark the event

--- a/src/settings-ui/QuickAccess.UI/QuickAccessXAML/App.xaml.cs
+++ b/src/settings-ui/QuickAccess.UI/QuickAccessXAML/App.xaml.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using ManagedCommon;
 using Microsoft.UI.Xaml;
 
 namespace Microsoft.PowerToys.QuickAccess;
@@ -14,14 +15,26 @@ public partial class App : Application
     public App()
     {
         InitializeComponent();
+        UnhandledException += App_UnhandledException;
     }
 
     protected override void OnLaunched(LaunchActivatedEventArgs args)
     {
-        var launchContext = QuickAccessLaunchContext.Parse(Environment.GetCommandLineArgs());
-        _window = new MainWindow(launchContext);
-        _window.Closed += OnWindowClosed;
-        _window.Activate();
+        try
+        {
+            var launchContext = QuickAccessLaunchContext.Parse(Environment.GetCommandLineArgs());
+            _window = new MainWindow(launchContext);
+            _window.Closed += OnWindowClosed;
+            _window.Activate();
+        }
+        catch (Exception ex)
+        {
+            // Failing here means the flyout host could not be constructed. Log and exit cleanly
+            // rather than letting the throw bubble out into a stowed XAML failure that crashes
+            // the runner-owned launcher.
+            Logger.LogError("QuickAccess: failed to launch flyout host.", ex);
+            Exit();
+        }
     }
 
     private static void OnWindowClosed(object sender, WindowEventArgs args)
@@ -32,5 +45,14 @@ public partial class App : Application
         }
 
         _window = null;
+    }
+
+    private void App_UnhandledException(object sender, UnhandledExceptionEventArgs e)
+    {
+        // QuickAccess is a transient launcher flyout owned by the runner. An unhandled XAML
+        // exception here would otherwise be stowed and FailFast the process; mark the event
+        // handled so the next summon can recover. The error is still recorded for diagnostics.
+        Logger.LogError("QuickAccess: unhandled XAML exception.", e.Exception);
+        e.Handled = true;
     }
 }

--- a/src/settings-ui/QuickAccess.UI/QuickAccessXAML/Flyout/ShellPage.xaml.cs
+++ b/src/settings-ui/QuickAccess.UI/QuickAccessXAML/Flyout/ShellPage.xaml.cs
@@ -2,11 +2,13 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using ManagedCommon;
 using Microsoft.PowerToys.QuickAccess.Services;
 using Microsoft.PowerToys.QuickAccess.ViewModels;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media.Animation;
+using Microsoft.UI.Xaml.Navigation;
 
 namespace Microsoft.PowerToys.QuickAccess.Flyout;
 
@@ -22,6 +24,7 @@ public sealed partial class ShellPage : Page
     public ShellPage()
     {
         InitializeComponent();
+        ContentFrame.NavigationFailed += ContentFrame_NavigationFailed;
     }
 
     public void Initialize(IQuickAccessCoordinator coordinator, LauncherViewModel launcherViewModel, AllAppsViewModel allAppsViewModel)
@@ -64,5 +67,14 @@ public sealed partial class ShellPage : Page
         {
             appsListPage.ViewModel?.RefreshSettings();
         }
+    }
+
+    private static void ContentFrame_NavigationFailed(object sender, NavigationFailedEventArgs e)
+    {
+        // A page constructor or XAML load failure here would otherwise bubble out of the
+        // Frame and crash the launcher. Log the failure and mark it handled so the flyout
+        // can remain available; the next summon will retry navigation.
+        Logger.LogError($"QuickAccess: navigation to '{e.SourcePageType?.FullName}' failed.", e.Exception);
+        e.Handled = true;
     }
 }


### PR DESCRIPTION
## Summary

Adds the two missing top-level exception handlers in the QuickAccess (Preview) flyout host so that an unhandled XAML exception during launch or page navigation no longer FailFasts `PowerToys.QuickAccess.exe`.

Spotted while reading through `App.OnLaunched` and `ShellPage` for an unrelated review of the flyout startup path — none of the existing handlers exist yet, so any throw during `MainWindow` construction, `ShellHost.Initialize`, or `ContentFrame.Navigate(typeof(LaunchPage) | typeof(AppsListPage), …)` bubbles all the way out to the Windows App SDK runtime and is stowed as a XAML failure. Compare with `src\settings-ui\Settings.UI\SettingsXAML\App.xaml.cs`, which already wires `UnhandledException += App_UnhandledException`.

## Changes

**`src\settings-ui\QuickAccess.UI\QuickAccessXAML\App.xaml.cs`**

- Hook `Application.UnhandledException` in the constructor. The handler logs the exception via `ManagedCommon.Logger.LogError` (same logger Settings uses) and sets `e.Handled = true`. QuickAccess is a transient launcher flyout owned by the runner, so swallowing a stray XAML error and keeping the host alive for the next summon is the correct trade-off — the failure is still recorded for diagnostics.
- Wrap the body of `OnLaunched` in a try/catch. If `MainWindow` (which sets up window chrome, listener threads, the IPC coordinator, and the XAML shell) fails to construct, log the exception and call `Exit()` cleanly rather than letting the throw escape into the Windows App SDK launch path.

**`src\settings-ui\QuickAccess.UI\QuickAccessXAML\Flyout\ShellPage.xaml.cs`**

- Subscribe to `ContentFrame.NavigationFailed` after `InitializeComponent`. A page constructor or XAML-load failure in `LaunchPage` / `AppsListPage` would otherwise bubble out of the `Frame` and crash the launcher. The handler logs the failure (`SourcePageType.FullName` + the exception) and marks it handled so the next summon retries navigation.

No production behaviour changes when things work — only the failure paths are different. No public API surface changes.

## Why both handlers, not just one

- `Application.UnhandledException` does not fire for `Frame.NavigationFailed`. The Frame raises its own event first and, if no handler runs or `e.Handled` is left `false`, then it rethrows on the dispatcher.
- Conversely, `Frame.NavigationFailed` only fires for navigation failures — not for an exception thrown directly in `OnLaunched` before any navigation happens.

The two events are complementary, so both need a handler to fully cover the launch + navigation paths.

## Testing

- The local NuGet feed on my dev box currently can't restore `Microsoft.NETCore.App.Runtime.win-x64 = 10.0.9` (the feed only has `11.0.0-preview.1.26104.118`), which fails the project restore for every WinUI project including this one. That's the same environment issue I called out on #48414 — pipeline restore uses a different feed and is fine.
- All three patterns added here are copy-paste analogues of code that already exists in `Settings.UI` (`App.xaml.cs:96, 106-109`, `ShellViewModel.cs:86, 136`), so namespace and signature drift risk is minimal. The only behavioural difference is `e.Handled = true`, which is the actual goal of this PR.

## Risk

- Low. Two new event handlers and one try/catch. No behaviour change on the success path.
- Worst-case regression is that a real, repeatable XAML failure becomes silent in the runner's eyes (no process crash) instead of loud — but it's logged via `Logger.LogError` so the user can still find the trace in `%LOCALAPPDATA%\Microsoft\PowerToys\Logs\`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

---

ADO: https://microsoft.visualstudio.com/DefaultCollection/OS/_workitems/edit/61258633/
