### PR TITLE
CmdPal: fix initializing the Run history in AOT builds

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AppStateModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AppStateModel.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
-using System.Text.Json.Serialization;
 
 namespace Microsoft.CmdPal.UI.ViewModels;
 
@@ -20,6 +19,9 @@ public record AppStateModel
         init => _recentCommands = value;
     }
 
+    // HERE BE DRAGONS: Using an ImmutableList<T> for a setting may explode in
+    // AOT builds. Make sure to test IN AOT setting this setting to null, [],
+    // and and array with values.
     private ImmutableList<string>? _runHistory = ImmutableList<string>.Empty;
 
     public ImmutableList<string> RunHistory

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/RunHistoryService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/RunHistoryService.cs
@@ -24,9 +24,21 @@ internal sealed class RunHistoryService : IRunHistoryService
         if (_appStateService.State.RunHistory.IsEmpty)
         {
             var history = Microsoft.Terminal.UI.RunHistory.CreateRunHistory();
+
+            // Copy the WinRT-projected IVector<string> into a plain List<string>
+            // before building the ImmutableList. ImmutableList.CreateRange tries to
+            // cast the source to IReadOnlyCollection<string>, which requires a WinRT
+            // helper type that isn't available in AOT builds and throws
+            // NotSupportedException.
+            var historyList = new List<string>(history.Count);
+            for (var i = 0; i < history.Count; i++)
+            {
+                historyList.Add(history[i]);
+            }
+
             _appStateService.UpdateState(state => state with
             {
-                RunHistory = history.ToImmutableList(),
+                RunHistory = historyList.ToImmutableList(),
             });
         }
 


### PR DESCRIPTION
Regressed in one of the last two releases.

The problem was that `history.ToImmutableList()` ran on the projected `IVector<string>`. `ImmutableList.CreateRange` checks for `IReadOnlyCollection<string>`, and resolving that interface on a WinRT object requires a helper type that AOT can't generate.

So we have to just _not do that_.

Closes #48445
