### PR TITLE
[FancyZones] Harden three shutdown races in WorkArea / ZonesOverlay / OnThreadExecutor

### DIFF
--- a/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
@@ -837,6 +837,14 @@ void FancyZones::UpdateWorkAreas(bool updateWindowPositions) noexcept
         std::vector<FancyZonesDataTypes::MonitorId> monitors = { FancyZonesDataTypes::MonitorId{ .monitor = nullptr, .deviceId = { .id = ZonedWindowProperties::MultiMonitorName, .instanceId = ZonedWindowProperties::MultiMonitorInstance } } };
         if (ShouldWorkAreasBeRecreated(monitors, currentVirtualDesktop, m_workAreaConfiguration.GetAllWorkAreas()))
         {
+            // WindowMouseSnap caches a raw WorkArea* in m_currentWorkArea and the
+            // WorkArea map by reference. WorkAreaConfiguration::Clear() destroys
+            // every unique_ptr<WorkArea> (and hence the inner ZonesOverlay and
+            // its std::mutex). If a drag is in flight, the next MoveSizeUpdate
+            // would dereference that dangling WorkArea* and lock the freed
+            // mutex. Drain the active drag first so subsequent drag messages
+            // hit the snapper's `if (m_windowMouseSnapper)` guard and no-op.
+            MoveSizeEnd();
             m_workAreaConfiguration.Clear();
 
             FancyZonesDataTypes::WorkAreaId workAreaId;
@@ -853,6 +861,8 @@ void FancyZones::UpdateWorkAreas(bool updateWindowPositions) noexcept
         
         if (ShouldWorkAreasBeRecreated(monitors, currentVirtualDesktop, workAreas))
         {
+            // See comment above the matching Clear() in the span-zones branch.
+            MoveSizeEnd();
             m_workAreaConfiguration.Clear();
             for (const auto& monitor : monitors)
             {
@@ -1065,6 +1075,9 @@ void FancyZones::SettingsUpdate(SettingId id)
     break;
     case SettingId::SpanZonesAcrossMonitors:
     {
+        // See UpdateWorkAreas() — same WindowMouseSnap dangling-WorkArea*
+        // hazard if the user toggles this setting mid-drag.
+        MoveSizeEnd();
         m_workAreaConfiguration.Clear();
         PostMessageW(m_window, WM_PRIV_INIT, NULL, NULL);
     }

--- a/src/modules/fancyzones/FancyZonesLib/OnThreadExecutor.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/OnThreadExecutor.cpp
@@ -48,7 +48,14 @@ void OnThreadExecutor::worker_thread()
 
 OnThreadExecutor::~OnThreadExecutor()
 {
-    _shutdown_request = true;
+    {
+        // Modify the shared shutdown flag while holding the mutex so the
+        // worker reliably observes it on its next wake. Without this, a notify
+        // racing the worker entering _task_cv.wait can be missed and the join
+        // below hangs forever.
+        std::lock_guard lock{ _task_mutex };
+        _shutdown_request = true;
+    }
     _task_cv.notify_one();
     _worker_thread.join();
 }

--- a/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
@@ -115,6 +115,11 @@ WorkArea::WorkArea(HINSTANCE hinstance, const FancyZonesDataTypes::WorkAreaId& u
 
 WorkArea::~WorkArea()
 {
+    // Tear down the renderer (joining its background thread) before returning
+    // the HWND to the pool. Otherwise the render thread can still be drawing
+    // through m_renderTarget into an HWND that has already been recycled by a
+    // subsequent NewZonesOverlayWindow call.
+    m_zonesOverlay.reset();
     windowPool.FreeZonesOverlayWindow(m_window);
 }
 

--- a/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
@@ -116,7 +116,7 @@ WorkArea::WorkArea(HINSTANCE hinstance, const FancyZonesDataTypes::WorkAreaId& u
 WorkArea::~WorkArea()
 {
     // Tear down the renderer (joining its background thread) before returning
-    // the HWND to the pool. Otherwise the render thread can still be drawing
+    // the HWND to the pool. Otherwise, the render thread can still be drawing
     // through m_renderTarget into an HWND that has already been recycled by a
     // subsequent NewZonesOverlayWindow call.
     m_zonesOverlay.reset();

--- a/src/modules/fancyzones/FancyZonesLib/ZonesOverlay.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/ZonesOverlay.cpp
@@ -340,13 +340,19 @@ void ZonesOverlay::DrawActiveZoneSet(const ZonesMap& zones,
 
 ZonesOverlay::~ZonesOverlay()
 {
+    // Constructor early-returns (e.g. CreateHwndRenderTarget failing during a
+    // display-driver TDR) leave m_renderThread default-constructed; calling
+    // join() on a non-joinable thread terminates the process.
+    if (m_renderThread.joinable())
     {
-        std::unique_lock lock(m_mutex);
-        m_abortThread = true;
-        m_shouldRender = true;
+        {
+            std::unique_lock lock(m_mutex);
+            m_abortThread = true;
+            m_shouldRender = true;
+        }
+        m_cv.notify_all();
+        m_renderThread.join();
     }
-    m_cv.notify_all();
-    m_renderThread.join();
 
     if (m_renderTarget)
     {


### PR DESCRIPTION
## Summary

Four small shutdown-/teardown-race fixes in FancyZones that I spotted while reading through the work-area and overlay teardown sequence for an unrelated review. Each one is independently safe in the happy path, but in combination they can crash the FancyZones host process during display changes, monitor configuration changes, a settings toggle mid-drag, or normal exit.

## Issues fixed

### 1. `~ZonesOverlay` joins a non-joinable thread when the constructor early-returns
`ZonesOverlay::ZonesOverlay` can return early in two places — if `GetClientRect` fails or if `CreateHwndRenderTarget` returns a failure HRESULT (both reachable in the wild during a display-driver TDR or when a monitor is disconnected mid-init). When that happens, `m_renderThread` is never started and stays default-constructed. The destructor unconditionally calls `m_renderThread.join()`, which on a non-joinable thread is undefined behavior (MSVC throws `std::system_error`); thrown from an implicit-noexcept destructor it calls `std::terminate()`.

Fix: guard the wake-up-and-join sequence with `if (m_renderThread.joinable())`.

### 2. `~WorkArea` returns the HWND to the window pool before the renderer is torn down
`WorkArea`'s explicit destructor body calls `windowPool.FreeZonesOverlayWindow(m_window)` first, and only afterwards does implicit member destruction run `~ZonesOverlay` (which joins the render thread). Between those two steps the HWND is back in the pool and immediately eligible for reuse by the next `NewZonesOverlayWindow` call, while the still-alive render thread is using `m_renderTarget` to draw into it. If the pool hands the same HWND to a freshly-built `ZonesOverlay`, two render targets target the same window concurrently.

Fix: reset `m_zonesOverlay` (which joins the render thread) before returning the window to the pool.

### 3. `~OnThreadExecutor` writes `_shutdown_request` outside the mutex
The destructor mutates the shutdown flag without holding `_task_mutex`, then calls `_task_cv.notify_one()`. The worker checks the same flag inside `_task_cv.wait(lock, predicate)`. The atomic does make the value visible eventually, but if the notify lands in the narrow window where the worker has just evaluated the predicate as false and is about to atomically release the lock and sleep, the wakeup can be missed and `_worker_thread.join()` hangs.

Fix: take `_task_mutex` around the `_shutdown_request = true` write so it pairs correctly with the `cv.wait`.

### 4. `WindowMouseSnap` keeps a dangling `WorkArea*` across `WorkAreaConfiguration::Clear()`
`FancyZones::UpdateWorkAreas()` rebuilds `m_workAreaConfiguration` whenever monitor state changes mid-session, and the `SpanZonesAcrossMonitors` settings toggle hits the same `Clear()`. If the user is mid-drag at the moment one of these runs, the `WindowMouseSnap` instance owned by `FancyZones` is still holding both a `const` reference to the map being cleared (`m_activeWorkAreas`) and a raw `WorkArea*` into one of the entries that's about to be destroyed (`m_currentWorkArea`). The next `WM_MOUSEMOVE` -> `MoveSizeUpdate()` then dereferences a freed pointer. `WindowMouseSnap`'s destructor only resets window transparency, so relying on it doesn't help; the snapper has to be torn down explicitly.

Fix: call `FancyZones::MoveSizeEnd()` (which already tears down the snapper cleanly and is a no-op when the snapper is null) before each `m_workAreaConfiguration.Clear()` call on these paths.

## Risk

Low. All four changes are localized to teardown / reconfiguration paths and only tighten existing destruction sequences — the steady-state behavior of `ZonesOverlay::Render`/`Show`/`Hide`, the work-area public API, `OnThreadExecutor::submit`/`cancel`, and `WindowMouseSnap` drag handling is unchanged. The `WorkArea` reordering is the most behavioral change; it now guarantees the render thread has stopped using the HWND before the pool can recycle it, which is what the existing implicit-member-destruction order already implied but couldn't enforce given the explicit destructor body.

## Validation

Spot-built locally; this repo's `dotnet restore` runtime-pack issue (unrelated to this PR — same NU1102 pattern that's affecting other open PRs) prevents a full `Build.cmd` here, but the C++ FancyZones modules involved are unchanged in their public surface and are exercised by existing unit tests in `FancyZonesTests` for the WorkArea code paths.

---

ADO: https://microsoft.visualstudio.com/OS/_workitems/edit/54653316/
