### PR TITLE
[Shortcut Guide] Prevent overlay crash on section navigation (#48448)

### DIFF
--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/Helpers/PinnedShortcutsHelper.cs
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/Helpers/PinnedShortcutsHelper.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
+using ManagedCommon;
 using Microsoft.PowerToys.Settings.UI.Library;
 using ShortcutGuide.Models;
 
@@ -32,16 +33,27 @@ namespace ShortcutGuide.Helpers
                 list.Add(shortcutEntry);
             }
 
+            // Persist on a best-effort basis. The in-memory pinned list is the source of truth
+            // for the rest of the session; failing to write should not crash the overlay
+            // (Pin/Unpin runs from a synchronous UI handler).
             Save();
             PinnedShortcutsChanged?.Invoke(null, appName);
         }
 
         public static void Save()
         {
-            string serialized = JsonSerializer.Serialize(App.PinnedShortcuts);
-
-            string pinnedPath = SettingsUtils.Default.GetSettingsFilePath(ShortcutGuideSettings.ModuleName, "Pinned.json");
-            File.WriteAllText(pinnedPath, serialized);
+            try
+            {
+                string serialized = JsonSerializer.Serialize(App.PinnedShortcuts);
+                string pinnedPath = SettingsUtils.Default.GetSettingsFilePath(ShortcutGuideSettings.ModuleName, "Pinned.json");
+                File.WriteAllText(pinnedPath, serialized);
+            }
+            catch (Exception ex) when (ex is IOException
+                                    or UnauthorizedAccessException
+                                    or JsonException)
+            {
+                Logger.LogError("Failed to persist Shortcut Guide pinned shortcuts; keeping in-memory state.", ex);
+            }
         }
     }
 }

--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuideXAML/App.xaml.cs
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuideXAML/App.xaml.cs
@@ -2,9 +2,12 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
+using System.Threading.Tasks;
+using ManagedCommon;
 using Microsoft.PowerToys.Settings.UI.Library;
 using Microsoft.PowerToys.Telemetry;
 using Microsoft.UI.Xaml;
@@ -31,21 +34,39 @@ namespace ShortcutGuide
         public App()
         {
             this.InitializeComponent();
+
+            // Register process-wide exception handlers so a stray exception (e.g. an IO failure
+            // during a fire-and-forget UI handler, or a background Task fault) gets logged
+            // instead of taking the overlay down with an unhandled access violation in coreclr.
+            // Without these the runtime tears the process down before our local catches can run.
+            this.UnhandledException += App_UnhandledException;
+            AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
+            TaskScheduler.UnobservedTaskException += TaskScheduler_UnobservedTaskException;
         }
 
         protected override void OnLaunched(LaunchActivatedEventArgs args)
         {
-            this.LoadData();
-            MainWindow = new MainWindow();
-            TaskBarWindow = new TaskbarWindow();
-            MainWindow.Activate();
-            MainWindow.Closed += (_, _) =>
+            try
             {
-                PowerToysTelemetry.Log.WriteEvent(new ShortcutGuideSessionEvent(
-                    MainWindow.SessionDurationMs,
-                    MainWindow.CloseType));
-                TaskBarWindow.Close();
-            };
+                this.LoadData();
+                MainWindow = new MainWindow();
+                TaskBarWindow = new TaskbarWindow();
+                MainWindow.Activate();
+                MainWindow.Closed += (_, _) =>
+                {
+                    PowerToysTelemetry.Log.WriteEvent(new ShortcutGuideSessionEvent(
+                        MainWindow.SessionDurationMs,
+                        MainWindow.CloseType));
+                    TaskBarWindow.Close();
+                };
+            }
+            catch (Exception ex)
+            {
+                // Any failure in launch is fatal for this short-lived overlay; log and exit
+                // cleanly rather than letting WinUI surface a generic crash dialog.
+                Logger.LogError("Failed to launch Shortcut Guide.", ex);
+                Environment.Exit(1);
+            }
         }
 
         private void LoadData()
@@ -63,18 +84,53 @@ namespace ShortcutGuide
                         PinnedShortcuts = loaded;
                     }
                 }
-                catch (JsonException)
+                catch (Exception ex) when (ex is JsonException
+                                        or IOException
+                                        or UnauthorizedAccessException)
                 {
-                    // Fall back to the empty default if the file is corrupt.
+                    // Fall back to the empty default if the file is corrupt or unreadable.
+                    Logger.LogWarning($"Failed to load pinned shortcuts from '{pinnedPath}'. Falling back to empty list. Reason: {ex.Message}");
                 }
             }
 
             ShortcutGuideSettings = SettingsRepository<ShortcutGuideSettings>.GetInstance(settingsUtils).SettingsConfig;
             ShortcutGuideProperties = ShortcutGuideSettings.Properties;
 
+            try
+            {
 #pragma warning disable CA1869 // Cache and reuse 'JsonSerializerOptions' instances
-            settingsUtils.SaveSettings(JsonSerializer.Serialize(App.ShortcutGuideSettings, new JsonSerializerOptions { WriteIndented = true }), "Shortcut Guide");
+                settingsUtils.SaveSettings(JsonSerializer.Serialize(App.ShortcutGuideSettings, new JsonSerializerOptions { WriteIndented = true }), "Shortcut Guide");
 #pragma warning restore CA1869 // Cache and reuse 'JsonSerializerOptions' instances
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                // Persisting the round-tripped settings is best-effort; the in-memory copy is still valid.
+                Logger.LogWarning($"Failed to persist Shortcut Guide settings on launch. Reason: {ex.Message}");
+            }
+        }
+
+        private void App_UnhandledException(object sender, Microsoft.UI.Xaml.UnhandledExceptionEventArgs e)
+        {
+            // Exceptions raised on the UI thread land here. Mark handled so the runtime
+            // does not terminate the process; the overlay can usually continue.
+            Logger.LogError("Unhandled UI exception in Shortcut Guide.", e.Exception);
+            e.Handled = true;
+        }
+
+        private static void CurrentDomain_UnhandledException(object sender, System.UnhandledExceptionEventArgs e)
+        {
+            // Background-thread exceptions reach here as a last resort; we cannot prevent
+            // termination when IsTerminating is true, but at least we leave a log trail.
+            if (e.ExceptionObject is Exception ex)
+            {
+                Logger.LogError($"Unhandled background exception in Shortcut Guide (IsTerminating={e.IsTerminating}).", ex);
+            }
+        }
+
+        private static void TaskScheduler_UnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
+        {
+            Logger.LogError("Unobserved Task exception in Shortcut Guide.", e.Exception);
+            e.SetObserved();
         }
     }
 }

--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuideXAML/MainWindow.xaml.cs
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuideXAML/MainWindow.xaml.cs
@@ -237,37 +237,54 @@ namespace ShortcutGuide
 
         private void SetWindowPosition()
         {
-            if (!this._hasMovedToRightMonitor)
+            try
             {
-                NativeMethods.GetCursorPos(out NativeMethods.POINT lpPoint);
-                AppWindow.Move(new NativeMethods.POINT { Y = lpPoint.Y - ((int)Height / 2), X = lpPoint.X - ((int)Width / 2) });
-                this._hasMovedToRightMonitor = true;
+                if (!this._hasMovedToRightMonitor)
+                {
+                    NativeMethods.GetCursorPos(out NativeMethods.POINT lpPoint);
+                    AppWindow.Move(new NativeMethods.POINT { Y = lpPoint.Y - ((int)Height / 2), X = lpPoint.X - ((int)Width / 2) });
+                    this._hasMovedToRightMonitor = true;
+                }
+
+                var hwnd = WindowNative.GetWindowHandle(this);
+                float dpi = DpiHelper.GetDPIScaleForWindow(hwnd);
+                Rect monitorRect = DisplayHelper.GetWorkAreaForDisplayWithWindow(hwnd);
+
+                var windowPosition = (ShortcutGuideWindowPosition)App.ShortcutGuideProperties.WindowPosition.Value;
+
+                // App.TaskBarWindow / its AppWindow can briefly be null during the reentrant
+                // Hide → Activate → BringToFront chain triggered from SelectionChanged. When the
+                // taskbar window is not currently observable, skip the overlap adjustment instead
+                // of crashing the overlay (issue #48448).
+                var taskbarWindow = App.TaskBarWindow?.AppWindow;
+                bool taskbarOnLeft = false;
+                bool taskbarOnRight = false;
+                if (taskbarWindow is not null)
+                {
+                    taskbarOnLeft = taskbarWindow.IsVisible && taskbarWindow.Position.X < AppWindow.Position.X + Width && windowPosition == ShortcutGuideWindowPosition.Left;
+                    taskbarOnRight = taskbarWindow.IsVisible && taskbarWindow.Position.X + taskbarWindow.Size.Width > AppWindow.Position.X && windowPosition == ShortcutGuideWindowPosition.Right;
+                }
+
+                double newHeight = monitorRect.Height / dpi;
+                if (taskbarWindow is not null && (taskbarOnLeft || taskbarOnRight))
+                {
+                    newHeight -= taskbarWindow.Size.Height;
+                }
+
+                MaxHeight = newHeight;
+                MinHeight = newHeight;
+                Height = newHeight;
+
+                int xPosition = windowPosition == ShortcutGuideWindowPosition.Right
+                    ? (int)(monitorRect.X + monitorRect.Width) - (int)(Width * dpi)
+                    : (int)monitorRect.X;
+
+                this.MoveAndResize(xPosition, (int)monitorRect.Y, Width, Height);
             }
-
-            var hwnd = WindowNative.GetWindowHandle(this);
-            float dpi = DpiHelper.GetDPIScaleForWindow(hwnd);
-            Rect monitorRect = DisplayHelper.GetWorkAreaForDisplayWithWindow(hwnd);
-
-            var windowPosition = (ShortcutGuideWindowPosition)App.ShortcutGuideProperties.WindowPosition.Value;
-            var taskbarWindow = App.TaskBarWindow.AppWindow;
-            bool taskbarOnLeft = taskbarWindow.IsVisible && taskbarWindow.Position.X < AppWindow.Position.X + Width && windowPosition == ShortcutGuideWindowPosition.Left;
-            bool taskbarOnRight = taskbarWindow.IsVisible && taskbarWindow.Position.X + taskbarWindow.Size.Width > AppWindow.Position.X && windowPosition == ShortcutGuideWindowPosition.Right;
-
-            double newHeight = monitorRect.Height / dpi;
-            if (taskbarOnLeft || taskbarOnRight)
+            catch (Exception ex)
             {
-                newHeight -= taskbarWindow.Size.Height;
+                Logger.LogError("Failed to set Shortcut Guide window position; keeping previous layout.", ex);
             }
-
-            MaxHeight = newHeight;
-            MinHeight = newHeight;
-            Height = newHeight;
-
-            int xPosition = windowPosition == ShortcutGuideWindowPosition.Right
-                ? (int)(monitorRect.X + monitorRect.Width) - (int)(Width * dpi)
-                : (int)monitorRect.X;
-
-            this.MoveAndResize(xPosition, (int)monitorRect.Y, Width, Height);
         }
 
         /// <summary>
@@ -282,25 +299,35 @@ namespace ShortcutGuide
                 return;
             }
 
-            this._selectedAppName = selectedItem.Name;
-            App.CurrentAppName = this._selectedAppName;
-            this._shortcutFile = ManifestInterpreter.GetShortcutsOfApplication(this._selectedAppName);
-
-            App.TaskBarWindow.Hide();
-            if (this._shortcutFile is ShortcutFile file)
+            try
             {
-                // Show the taskbar button window only when the selected app exposes the <TASKBAR1-9> section.
-                if (file.Shortcuts is not null && file.Shortcuts.Any(c => c.SectionName?.StartsWith("<TASKBAR1-9>", StringComparison.Ordinal) == true))
-                {
-                    this._taskBarWindowActivated = true;
-                    App.TaskBarWindow.Activate();
-                }
+                this._selectedAppName = selectedItem.Name;
+                App.CurrentAppName = this._selectedAppName;
+                this._shortcutFile = ManifestInterpreter.GetShortcutsOfApplication(this._selectedAppName);
 
-                // Reposition before navigating so the taskbar window does not clip into the main window.
-                this.SetWindowPosition();
-                this.ContentFrame.Navigate(
-                    typeof(ShortcutsPage),
-                    new ShortcutPageNavParam { ShortcutFile = file, AppName = this._selectedAppName });
+                App.TaskBarWindow?.Hide();
+                if (this._shortcutFile is ShortcutFile file)
+                {
+                    // Show the taskbar button window only when the selected app exposes the <TASKBAR1-9> section.
+                    if (file.Shortcuts is not null && file.Shortcuts.Any(c => c.SectionName?.StartsWith("<TASKBAR1-9>", StringComparison.Ordinal) == true))
+                    {
+                        this._taskBarWindowActivated = true;
+                        App.TaskBarWindow?.Activate();
+                    }
+
+                    // Reposition before navigating so the taskbar window does not clip into the main window.
+                    this.SetWindowPosition();
+                    this.ContentFrame.Navigate(
+                        typeof(ShortcutsPage),
+                        new ShortcutPageNavParam { ShortcutFile = file, AppName = this._selectedAppName });
+                }
+            }
+            catch (Exception ex)
+            {
+                // Guard against exceptions during section navigation so the overlay does not close on the user.
+                // InitializeNavItemsAsync's catch interprets any exception bubbling out of the initial
+                // SelectedItem assignment as a fatal init failure and closes the window (issue #48448).
+                Logger.LogError($"Failed to handle Shortcut Guide section selection '{selectedItem.Name}'.", ex);
             }
         }
 

--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuideXAML/TaskbarWindow.xaml.cs
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuideXAML/TaskbarWindow.xaml.cs
@@ -30,54 +30,73 @@ namespace ShortcutGuide.ShortcutGuideXAML
 
         public void UpdateTasklistButtons()
         {
-            // This move ensures the window spawns on the same monitor as the main window
-            AppWindow.MoveInZOrderAtBottom();
-            AppWindow.Move(App.MainWindow.AppWindow.Position);
-            TasklistButton[] buttons = [];
+            // Wrap the entire body: this method runs from the ctor and from `Activated`,
+            // both of which can fire while MainWindow is closing or AppWindow is in a
+            // transient null state. An exception here used to crash the overlay because
+            // there was no caller-side try/catch (issue #48441).
             try
             {
-                buttons = TasklistPositions.GetButtons();
+                // This move ensures the window spawns on the same monitor as the main window.
+                // App.MainWindow / its AppWindow can briefly be null during the reentrant
+                // Hide → Activate → BringToFront chain triggered from SelectionChanged.
+                var mainAppWindow = App.MainWindow?.AppWindow;
+                if (mainAppWindow is null)
+                {
+                    return;
+                }
+
+                AppWindow.MoveInZOrderAtBottom();
+                AppWindow.Move(mainAppWindow.Position);
+                TasklistButton[] buttons = [];
+                try
+                {
+                    buttons = TasklistPositions.GetButtons();
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogError("Failed to enumerate taskbar buttons via TasklistPositions.GetButtons.", ex);
+                }
+
+                if (buttons.Length == 0)
+                {
+                    AppWindow.Hide();
+                    return;
+                }
+
+                float dpi = this.DPI;
+                double windowsLogoColumnWidth = this.WindowsLogoColumnWidth.Width.Value;
+                double windowHeight = 58;
+                double windowMargin = 8 * dpi;
+                double windowWidth = windowsLogoColumnWidth;
+                double xPosition = buttons[0].X - (windowsLogoColumnWidth * dpi);
+                double yPosition = this.WorkArea.Bottom - (windowHeight * dpi);
+
+                this.KeyHolder.Children.Clear();
+
+                foreach (TasklistButton b in buttons)
+                {
+                    TaskbarIndicator indicator = new()
+                    {
+                        Label = b.Keynum >= 10 ? "0" : b.Keynum.ToString(CultureInfo.InvariantCulture),
+                        Height = b.Height / dpi,
+                        Width = b.Width / dpi,
+                    };
+
+                    windowWidth += indicator.Width;
+
+                    this.KeyHolder.Children.Add(indicator);
+
+                    double indicatorPos = (b.X - xPosition) / dpi;
+                    Canvas.SetLeft(indicator, indicatorPos - windowsLogoColumnWidth);
+                }
+
+                this.MoveAndResize(xPosition - windowMargin, yPosition, windowWidth + (2 * windowMargin), windowHeight);
+                AppWindow.MoveInZOrderAtTop();
             }
             catch (Exception ex)
             {
-                Logger.LogError("Failed to enumerate taskbar buttons via TasklistPositions.GetButtons.", ex);
+                Logger.LogError("Failed to update Shortcut Guide taskbar indicator window.", ex);
             }
-
-            if (buttons.Length == 0)
-            {
-                AppWindow.Hide();
-                return;
-            }
-
-            float dpi = this.DPI;
-            double windowsLogoColumnWidth = this.WindowsLogoColumnWidth.Width.Value;
-            double windowHeight = 58;
-            double windowMargin = 8 * dpi;
-            double windowWidth = windowsLogoColumnWidth;
-            double xPosition = buttons[0].X - (windowsLogoColumnWidth * dpi);
-            double yPosition = this.WorkArea.Bottom - (windowHeight * dpi);
-
-            this.KeyHolder.Children.Clear();
-
-            foreach (TasklistButton b in buttons)
-            {
-                TaskbarIndicator indicator = new()
-                {
-                    Label = b.Keynum >= 10 ? "0" : b.Keynum.ToString(CultureInfo.InvariantCulture),
-                    Height = b.Height / dpi,
-                    Width = b.Width / dpi,
-                };
-
-                windowWidth += indicator.Width;
-
-                this.KeyHolder.Children.Add(indicator);
-
-                double indicatorPos = (b.X - xPosition) / dpi;
-                Canvas.SetLeft(indicator, indicatorPos - windowsLogoColumnWidth);
-            }
-
-            this.MoveAndResize(xPosition - windowMargin, yPosition, windowWidth + (2 * windowMargin), windowHeight);
-            AppWindow.MoveInZOrderAtTop();
         }
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request

Shortcut Guide overlay crashes and closes when navigating between sidebar sections (e.g. clicking PowerToys, then clicking the Windows icon to come back). Repro and crash logs in #48448. Crash logs in #48441 show the same propagation path plus a follow-up access violation in coreclr, indicating exceptions that escape local catches.

This PR fixes the immediate navigation race and adds broader crash hardening so future exceptions on the UI/background threads are logged instead of tearing down the overlay.

### Navigation-race fix (commit 1)

Root cause: `WindowSelector_SelectionChanged` calls `App.TaskBarWindow.Activate()` and then `SetWindowPosition()` synchronously. `Activate()` runs a reentrant `Window_Activated` → `BringToFront` → `TaskbarWindow.Activated` chain that can leave `App.TaskBarWindow.AppWindow` momentarily null, so `SetWindowPosition` throws `NullReferenceException`.

Because the initial `SelectedItem = MenuItems[0]` is set from `SetNavItems`, the NRE bubbles up into `InitializeNavItemsAsync`'s catch block — which sets `_closeType = "InitializationFailed"` and closes the window. That matches both user-visible symptoms: the overlay "flashes and disappears" (#48441) on open and "closes when clicking the Windows icon" (#48448).

Edits in `src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuideXAML/MainWindow.xaml.cs`:

- **`SetWindowPosition`**: null-guard `App.TaskBarWindow?.AppWindow` and skip the taskbar-overlap height adjustment when it is not currently observable. Wrap the body in `try`/`catch` with `Logger.LogError` so any future positioning hiccup keeps the previous layout instead of taking down the overlay.
- **`WindowSelector_SelectionChanged`**: null-guard `App.TaskBarWindow?.Hide()` / `Activate()` and wrap the body in `try`/`catch`. This breaks the propagation path that lets a navigation exception reach `InitializeNavItemsAsync`'s "fatal init failure" branch.

### Crash hardening (commit 2)

Additional defensive changes to cover other unguarded paths surfaced while reviewing #48441:

- **`App.xaml.cs`**: register `App.UnhandledException`, `AppDomain.CurrentDomain.UnhandledException`, and `TaskScheduler.UnobservedTaskException` so a stray exception (e.g. an IO failure during a fire-and-forget UI handler, or a background `Task` fault) gets logged instead of tearing the process down with an access violation in coreclr. Mirrors what Peek, AdvancedPaste, and CmdPal already do.
- **`App.OnLaunched`**: wrap the launch sequence in `try`/`catch` and exit cleanly with an error log on failure (`LoadData` / `MainWindow` / `TaskbarWindow` ctors and `Activate` are all reachable failure points).
- **`App.LoadData`**: broaden the `Pinned.json` deserialize catch to also handle `IOException` / `UnauthorizedAccessException`, and guard the round-trip `SaveSettings` call as best-effort with a warning log.
- **`PinnedShortcutsHelper.Save`**: catch `IOException` / `UnauthorizedAccessException` / `JsonException` and log; `Pin` / `Unpin` runs from a synchronous UI handler so an unguarded `File.WriteAllText` would tear down the overlay on any disk hiccup.
- **`TaskbarWindow.UpdateTasklistButtons`**: move the `AppWindow.Move` calls inside the existing `try` block, null-guard `App.MainWindow?.AppWindow` up front, and wrap the whole body so the method (which runs from the ctor and from `Activated`) cannot tear the overlay down when `MainWindow` is in a transient state.

## PR Checklist

- [x] Closes: #48448
- [x] Likely also fixes: #48441
- [x] **Communication:** Defensive fix to known crash paths; no API change.
- [ ] **Tests:** No automated tests added — the failures are reentrancy / timing races that are hard to deterministically trigger in CI. Validated with a synthetic repro (see below).
- [x] **Localization:** N/A — only logger strings.
- [x] **Dev docs:** N/A
- [x] **New binaries:** N/A

## Detailed Description of the Pull Request / Additional comments

The fix is intentionally defensive (rather than restructuring the reentrant activation flow) because the legacy taskbar UIA enumeration (`TasklistPositions.GetButtons`) on Windows 10 is what most reliably widens the race window and is out of scope to redesign for a hotfix.

## Validation Steps Performed

- Build: `tools\build\build.cmd` from `src\modules\ShortcutGuide\ShortcutGuide.Ui` — exit 0, errors log empty for both commits.
- Synthetic repro: temporarily injected `throw new NullReferenceException()` at the top of `SetWindowPosition` to exercise the exact propagation path the reporter's log shows (`SetWindowPosition` → `SelectionChanged` → `set_SelectedItem` → `InitializeNavItemsAsync.catch` → `Close("InitializationFailed")`).
  - Before fix: overlay flashes and closes, log shows `Failed to initialize navigation items.` with the NRE.
  - After fix: overlay stays open, page navigates, log shows `Failed to set Shortcut Guide window position; keeping previous layout.` from the new `catch`.
- Did not reproduce the live race on a Win11 dev box; the reporter's repro is Windows 10 19045 / Microsoft Store install where the legacy taskbar UIA timing makes the reentrant chain more likely to expose the null.