### PR TITLE
Add Grab And Move middle-click maximize

### DIFF
--- a/DATA_AND_PRIVACY.md
+++ b/DATA_AND_PRIVACY.md
@@ -247,7 +247,7 @@ Thank you for using PowerToys!
 | Event Name | Description |
 | --- | --- |
 | Microsoft.PowerToys.GrabAndMove_EnableGrabAndMove | Triggered when Grab And Move is enabled or disabled. |
-| Microsoft.PowerToys.GrabAndMove_ShortcutUse | Logs an attempt to move, resize, or maximize/restore a window via Grab And Move mouse shortcuts, including whether it succeeded, the action type (move, resize, or maximize), and the reason (e.g., started, toggled, blocked by game mode, or not maximizable). |
+| Microsoft.PowerToys.GrabAndMove_ShortcutUse | Logs an attempt to move, resize, or maximize/restore a window via Grab And Move mouse shortcuts, including whether it succeeded, the action type (move, resize, or maximize), and the reason (e.g., started, toggled, blocked by game mode, or missing a maximize box). |
 
 ### Hosts File Editor
 

--- a/DATA_AND_PRIVACY.md
+++ b/DATA_AND_PRIVACY.md
@@ -247,7 +247,7 @@ Thank you for using PowerToys!
 | Event Name | Description |
 | --- | --- |
 | Microsoft.PowerToys.GrabAndMove_EnableGrabAndMove | Triggered when Grab And Move is enabled or disabled. |
-| Microsoft.PowerToys.GrabAndMove_ShortcutUse | Logs an attempt to move or resize a window via the Alt+Drag shortcut, including whether it succeeded, the action type (move or resize), and the reason (e.g., started, blocked by game mode). |
+| Microsoft.PowerToys.GrabAndMove_ShortcutUse | Logs an attempt to move, resize, or maximize/restore a window via Grab And Move mouse shortcuts, including whether it succeeded, the action type (move, resize, or maximize), and the reason (e.g., started, toggled, blocked by game mode, or not maximizable). |
 
 ### Hosts File Editor
 

--- a/src/modules/GrabAndMove/GrabAndMove/main.cpp
+++ b/src/modules/GrabAndMove/GrabAndMove/main.cpp
@@ -58,7 +58,9 @@ static DWORD g_absorbedFlags = 0;      // flags for replay (extended key, etc.)
 static bool g_showGeometry = false;            // true if we want to draw the X, Y, W and H on the overlay on move and resize
 static bool g_doNotActivateOnGameMode = true; // true if GrabAndMove is suppressed when Windows Game Mode is active
 
-static bool g_useAltResize = true;      // This can be toggled from the settings. If false, Alt + right click does nothing.
+static bool g_useAltResize = true;             // This can be toggled from the settings. If false, Alt + right click does nothing.
+static bool g_useMiddleClickMaximize = true;   // If true, modifier + middle click toggles maximize/restore.
+static bool g_middleClickConsumed = false;     // Swallow the matching middle-button release after a handled press.
 
 // Count of non-modifier keys currently held. Used to suppress GrabAndMove when the
 // modifier key is pressed while another key is already down (e.g. Q held, then modifier pressed).
@@ -225,11 +227,23 @@ enum class GrabAndMoveShortcutAction
 {
     Move,
     Resize,
+    Maximize,
 };
 
 static void TraceShortcutUse(bool successful, GrabAndMoveShortcutAction action, const wchar_t* reason) noexcept
 {
-    const wchar_t* actionName = action == GrabAndMoveShortcutAction::Move ? L"move" : L"resize";
+    const wchar_t* actionName = L"move";
+    switch (action)
+    {
+    case GrabAndMoveShortcutAction::Resize:
+        actionName = L"resize";
+        break;
+    case GrabAndMoveShortcutAction::Maximize:
+        actionName = L"maximize";
+        break;
+    default:
+        break;
+    }
 
     TraceLoggingWrite(
         g_hProvider,
@@ -239,6 +253,22 @@ static void TraceShortcutUse(bool successful, GrabAndMoveShortcutAction action, 
         TraceLoggingBoolean(successful, "Successful"),
         TraceLoggingWideString(actionName, "Action"),
         TraceLoggingWideString(reason, "Reason"));
+}
+
+static bool IsWindowMaximizable(HWND hwnd)
+{
+    return (GetWindowLongPtrW(hwnd, GWL_STYLE) & WS_MAXIMIZEBOX) != 0;
+}
+
+static bool ToggleWindowMaximized(HWND hwnd)
+{
+    if (!hwnd || !IsWindowMaximizable(hwnd))
+    {
+        return false;
+    }
+
+    ShowWindow(hwnd, IsZoomed(hwnd) ? SW_RESTORE : SW_MAXIMIZE);
+    return true;
 }
 
 // ---------------------------------------------------------------------------
@@ -268,6 +298,11 @@ static void LoadSettingsFromFile()
         if (auto v = values.get_bool_value(L"useAltResize"))
         {
             g_useAltResize = *v;
+        }
+
+        if (auto v = values.get_bool_value(L"useMiddleClickMaximize"))
+        {
+            g_useMiddleClickMaximize = *v;
         }
 
         if (auto v = values.get_int_value(L"modifierKey"))
@@ -1011,14 +1046,50 @@ static LRESULT CALLBACK MouseProc(int nCode, WPARAM wParam, LPARAM lParam)
             goto forward;
 
         // Recovery path: if a non-modifier click occurs while stale drag/resize state exists, clear it.
-        if ((wParam == WM_LBUTTONDOWN || wParam == WM_RBUTTONDOWN) && !IsActivationModifierPressed())
+        if ((wParam == WM_LBUTTONDOWN || wParam == WM_RBUTTONDOWN || wParam == WM_MBUTTONDOWN) && !IsActivationModifierPressed())
         {
             EndInteraction(true, true);
+        }
+
+        if (wParam == WM_MBUTTONUP && g_middleClickConsumed)
+        {
+            g_middleClickConsumed = false;
+            return 1;
         }
 
         if (!g_dragging && !g_resizing && g_hOverlay && IsWindowVisible(g_hOverlay))
         {
             HideOverlay();
+        }
+
+        // ----- Alt + Middle Button Down: toggle maximize/restore -----
+        if (wParam == WM_MBUTTONDOWN && g_useMiddleClickMaximize && IsActivationModifierPressed())
+        {
+            if (IsSuppressedByGameMode())
+            {
+                TraceShortcutUse(false, GrabAndMoveShortcutAction::Maximize, L"game_mode");
+                goto forward;
+            }
+
+            POINT pt = ms->pt;
+            HWND hwnd = ResolveTargetWindow(pt);
+            if (hwnd)
+            {
+                if (IsExcluded(hwnd))
+                {
+                    goto forward;
+                }
+
+                if (ToggleWindowMaximized(hwnd))
+                {
+                    g_dragConsumedAlt = true;
+                    g_middleClickConsumed = true;
+                    TraceShortcutUse(true, GrabAndMoveShortcutAction::Maximize, L"toggled");
+                    return 1;
+                }
+
+                TraceShortcutUse(false, GrabAndMoveShortcutAction::Maximize, L"not_maximizable");
+            }
         }
 
         // ----- Alt + Left Button Down: start drag -----

--- a/src/modules/GrabAndMove/GrabAndMove/main.cpp
+++ b/src/modules/GrabAndMove/GrabAndMove/main.cpp
@@ -255,14 +255,14 @@ static void TraceShortcutUse(bool successful, GrabAndMoveShortcutAction action, 
         TraceLoggingWideString(reason, "Reason"));
 }
 
-static bool IsWindowMaximizable(HWND hwnd)
+static bool CanWindowMaximize(HWND hwnd)
 {
     return (GetWindowLongPtrW(hwnd, GWL_STYLE) & WS_MAXIMIZEBOX) != 0;
 }
 
 static bool ToggleWindowMaximized(HWND hwnd)
 {
-    if (!hwnd || !IsWindowMaximizable(hwnd))
+    if (!hwnd || !CanWindowMaximize(hwnd))
     {
         return false;
     }
@@ -1088,7 +1088,7 @@ static LRESULT CALLBACK MouseProc(int nCode, WPARAM wParam, LPARAM lParam)
                     return 1;
                 }
 
-                TraceShortcutUse(false, GrabAndMoveShortcutAction::Maximize, L"not_maximizable");
+                TraceShortcutUse(false, GrabAndMoveShortcutAction::Maximize, L"missing_maximize_box");
             }
         }
 

--- a/src/settings-ui/Settings.UI.Library/GrabAndMoveProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/GrabAndMoveProperties.cs
@@ -14,6 +14,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             DoNotActivateOnGameMode = new BoolProperty(true);
             ShowGeometry = new BoolProperty(false);
             UseAltResize = new BoolProperty(true);
+            UseMiddleClickMaximize = new BoolProperty(true);
             ExcludedApps = new StringProperty();
             ModifierKey = new IntProperty(0); // 0 = Alt, 1 = Win
         }
@@ -29,6 +30,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 
         [JsonPropertyName("useAltResize")]
         public BoolProperty UseAltResize { get; set; }
+
+        [JsonPropertyName("useMiddleClickMaximize")]
+        public BoolProperty UseMiddleClickMaximize { get; set; }
 
         [JsonPropertyName("doNotActivateOnGameMode")]
         public BoolProperty DoNotActivateOnGameMode { get; set; }

--- a/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/GrabAndMove.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/GrabAndMove.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json;
+using Microsoft.PowerToys.Settings.UI.Library;
+using Microsoft.PowerToys.Settings.UI.UnitTests.Mocks;
+using Microsoft.PowerToys.Settings.UI.ViewModels;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ViewModelTests
+{
+    [TestClass]
+    public class GrabAndMove
+    {
+        [TestMethod]
+        public void MiddleClickMaximizeIsEnabledByDefault()
+        {
+            var settings = new GrabAndMoveSettings();
+
+            Assert.IsTrue(settings.Properties.UseMiddleClickMaximize.Value);
+        }
+
+        [TestMethod]
+        public void UpdatingMiddleClickMaximizeNotifiesRunner()
+        {
+            var moduleSettings = new GrabAndMoveSettings();
+            string serializedSettings = string.Empty;
+
+            using var viewModel = new GrabAndMoveViewModel(
+                SettingsRepository<GeneralSettings>.GetInstance(ISettingsUtilsMocks.GetStubSettingsUtils<GeneralSettings>().Object),
+                moduleSettings,
+                msg =>
+                {
+                    serializedSettings = msg;
+                    return 0;
+                });
+
+            viewModel.UseMiddleClickMaximize = false;
+
+            var outgoingSettings = JsonSerializer.Deserialize<SndModuleSettings<SndGrabAndMoveSettings>>(serializedSettings);
+            Assert.IsFalse(outgoingSettings!.PowertoysSetting.Settings.Properties.UseMiddleClickMaximize.Value);
+        }
+    }
+}

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/GrabAndMovePage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/GrabAndMovePage.xaml
@@ -59,6 +59,9 @@
                     <tkcontrols:SettingsCard x:Uid="GrabAndMove_ShowGeometry" HeaderIcon="{ui:FontIcon Glyph=&#xE809;}">
                         <ToggleSwitch IsOn="{x:Bind ViewModel.ShowGeometry, Mode=TwoWay}" />
                     </tkcontrols:SettingsCard>
+                    <tkcontrols:SettingsCard x:Uid="GrabAndMove_UseMiddleClickMaximize" HeaderIcon="{ui:FontIcon Glyph=&#xE740;}">
+                        <ToggleSwitch IsOn="{x:Bind ViewModel.UseMiddleClickMaximize, Mode=TwoWay}" />
+                    </tkcontrols:SettingsCard>
                 </controls:SettingsGroup>
 
                 <controls:SettingsGroup x:Uid="ExcludedApps" IsEnabled="{x:Bind ViewModel.IsEnabled, Mode=OneWay}">

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -6162,6 +6162,13 @@ Text uses the current drawing color.</value>
   <data name="GrabAndMove_UseAltResize.Description" xml:space="preserve">
     <value>Hold the modifier key and drag with the right mouse button from the nearest edge or corner to resize the window</value>
   </data>
+  <data name="GrabAndMove_UseMiddleClickMaximize.Header" xml:space="preserve">
+    <value>Maximize or restore windows with the modifier key + middle-click</value>
+    <comment>Middle-click refers to clicking the mouse wheel button.</comment>
+  </data>
+  <data name="GrabAndMove_UseMiddleClickMaximize.Description" xml:space="preserve">
+    <value>Hold the modifier key and middle-click inside a window to toggle between maximized and restored</value>
+  </data>
   <data name="GrabAndMove_ExcludeApps.Header" xml:space="preserve">
     <value>Excluded apps</value>
   </data>

--- a/src/settings-ui/Settings.UI/ViewModels/GrabAndMoveViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/GrabAndMoveViewModel.cs
@@ -147,6 +147,21 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             }
         }
 
+        public bool UseMiddleClickMaximize
+        {
+            get => _moduleSettings.Properties.UseMiddleClickMaximize.Value;
+
+            set
+            {
+                if (_moduleSettings.Properties.UseMiddleClickMaximize.Value != value)
+                {
+                    _moduleSettings.Properties.UseMiddleClickMaximize.Value = value;
+                    NotifyModuleSettingsChanged();
+                    OnPropertyChanged(nameof(UseMiddleClickMaximize));
+                }
+            }
+        }
+
         public bool DoNotActivateOnGameMode
         {
             get => _moduleSettings.Properties.DoNotActivateOnGameMode.Value;


### PR DESCRIPTION
## Summary of the Pull Request

Adds an optional Grab And Move shortcut for modifier + middle-click on the window under the cursor:

- maximizes normal windows
- restores maximized windows
- respects the existing Grab And Move exclusions and Game Mode behavior
- ignores windows that do not expose a maximize box

This also updates DATA_AND_PRIVACY.md because the existing `Microsoft.PowerToys.GrabAndMove_ShortcutUse` event can now report `Action=maximize`.

Related to #47754. This intentionally does not close #47754 because that issue also discusses double-click and minimize behavior.

## PR Checklist

- [ ] Closes: #47754
- [x] **Communication:** Commented on #47754 and #28769; PR is draft pending maintainer agreement
- [x] **Tests:** Added/updated targeted ViewModel tests and they pass locally
- [x] **Localization:** New end-user strings are in Resources.resw
- [x] **Dev docs:** Not applicable
- [x] **New binaries:** Not applicable
- [x] **Documentation updated:** DATA_AND_PRIVACY.md updated in this PR; docs repo update not applicable

## Detailed Description of the Pull Request / Additional comments

This keeps middle-click maximize/restore separate from edge snap behavior so the PR stays atomic. The shortcut uses the same configured modifier as Grab And Move and emits the existing shortcut telemetry event with the new maximize action.

## Validation Steps Performed

- `git diff --check main...HEAD`
- `tools\build\build.ps1 -Platform x64 -Configuration Debug -Path src\modules\GrabAndMove\GrabAndMove`
- `tools\build\build.ps1 -Platform x64 -Configuration Debug -Path src\settings-ui\Settings.UI.UnitTests` with `DOTNET_MSBUILD_SDK_RESOLVER_*` pointed at SDK `10.0.301`
- `vstest.console.exe ... /TestCaseFilter:"FullyQualifiedName~ViewModelTests.GrabAndMove"`: 2 tests passed
- Attempted full `PowerToys.slnx` Debug x64 build; restore was blocked by a 401 from the `shine-oss` Azure DevOps feed while downloading .NET 8 packages