### PR TITLE
Upgrade Windows App SDK to 2.2.0 stable

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -78,10 +78,10 @@
     <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
     <PackageVersion Include="Microsoft.Windows.ImplementationLibrary" Version="1.0.250325.1"/>
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.6901" />
-    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="2.0.1" />
-    <PackageVersion Include="Microsoft.WindowsAppSDK.Foundation" Version="2.0.20" />
-    <PackageVersion Include="Microsoft.WindowsAppSDK.AI" Version="2.0.185" />
-    <PackageVersion Include="Microsoft.WindowsAppSDK.Runtime" Version="2.0.1" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="2.2.0" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK.Foundation" Version="2.1.0" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK.AI" Version="2.2.3" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK.Runtime" Version="2.2.0" />
     <PackageVersion Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.0.9" />
     <PackageVersion Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.39" />
     <PackageVersion Include="ModernWpfUI" Version="0.9.4" />

--- a/src/modules/cmdpal/ExtensionTemplate/TemplateCmdPalExtension/Directory.Packages.props
+++ b/src/modules/cmdpal/ExtensionTemplate/TemplateCmdPalExtension/Directory.Packages.props
@@ -10,7 +10,7 @@
     <PackageVersion Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.4188" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools.MSIX" Version="1.7.20250829.1" />
-    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="2.0.1" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="2.2.0" />
     <PackageVersion Include="Shmuelie.WinRTServer" Version="2.1.1" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <PackageVersion Include="System.Text.Json" Version="9.0.8" />


### PR DESCRIPTION
## Summary

Upgrades the centrally-managed Windows App SDK package versions to the **2.2.0 stable** umbrella released on NuGet.

| Package | Before | After |
|---|---|---|
| `Microsoft.WindowsAppSDK` | 2.0.1 | **2.2.0** |
| `Microsoft.WindowsAppSDK.Foundation` | 2.0.20 | **2.1.0** |
| `Microsoft.WindowsAppSDK.AI` | 2.0.185 | **2.2.3** |
| `Microsoft.WindowsAppSDK.Runtime` | 2.0.1 | **2.2.0** |

Foundation/AI/Runtime versions match the dependency graph declared by `Microsoft.WindowsAppSDK` `2.2.0`'s own nuspec (`Foundation=2.1.0`, `AI=2.2.3`, `Runtime=[2.2.0]`), so transitive resolution is exact and no version-conflict warnings are introduced.

Also bumps the CmdPal `ExtensionTemplate` sample's local `Directory.Packages.props` so the template stays in sync with the main repo.

## Files changed

- `Directory.Packages.props`
- `src/modules/cmdpal/ExtensionTemplate/TemplateCmdPalExtension/Directory.Packages.props`

## Validation

Ran `tools/build/build-essentials.cmd` on a clean `origin/main` worktree:

- `msbuild PowerToys.slnx /t:restore /p:RestorePackagesConfig=true` — **Build succeeded, 0 warnings, 0 errors** (00:02:50)
- `src/runner/runner.vcxproj` (x64 Debug) — **Build succeeded, 0 warnings, 0 errors** (00:04:15)
- `src/settings-ui/Settings.UI/PowerToys.Settings.csproj` (x64 Debug) — **Build succeeded, 0 warnings, 0 errors** (00:03:14)

Full module test suite has **not** been run yet — this PR only certifies the build-essentials baseline. CI will exercise the wider build/test matrix.

## Notes

- This is an atomic packaging-only change. No source code touched, no behavior changes.
- If WinAppSDK 2.2.0 surfaces any runtime regression downstream, it can be reverted as a single commit.
