### PR TITLE
Fix check-spelling: exclude ZoomIt rnnoise third-party tree and dedupe excludes

### DIFF
--- a/.github/actions/spell-check/excludes.txt
+++ b/.github/actions/spell-check/excludes.txt
@@ -112,8 +112,6 @@
 ^src/modules/cmdpal/Microsoft\.CmdPal\.UI/Settings/InternalPage\.SampleData\.cs$
 ^src/modules/cmdpal/Tests/Microsoft\.CmdPal\.Common\.UnitTests/.*\.TestData\.cs$
 ^src/modules/cmdpal/Tests/Microsoft\.CmdPal\.Common\.UnitTests/Text/.*\.cs$
-^src/modules/cmdpal/Tests/Microsoft\.CommandPalette\.Extensions\.Toolkit\.UnitTests/FuzzyMatcherComparisonTests.cs$
-^src/modules/cmdpal/Tests/Microsoft\.CommandPalette\.Extensions\.Toolkit\.UnitTests/FuzzyMatcherDiacriticsTests.cs$
 ^src/modules/colorPicker/ColorPickerUI/Shaders/GridShader\.cso$
 ^src/modules/launcher/Plugins/Microsoft\.PowerToys\.Run\.Plugin\.TimeDate/Properties/
 ^src/modules/MouseUtils/MouseJumpUI/MainForm\.resx$
@@ -137,6 +135,8 @@
 ^src/modules/previewpane/SvgPreviewHandler/SvgHTMLPreviewGenerator\.cs$
 ^src/modules/previewpane/UnitTests-MarkdownPreviewHandler/HelperFiles/MarkdownWithHTMLImageTag\.txt$
 ^src/modules/registrypreview/RegistryPreviewUILib/Controls/HexBox/.*$
+^src/modules/ZoomIt/ZoomIt/rnnoise/
+^src/modules/ZoomIt/ZoomIt/selfie_segmentation\.onnx$
 ^src/modules/ZoomIt/ZoomIt/ZoomIt\.idc$
 ^src/Monaco/
 ^tools/project_template/ModuleTemplate/resource\.h$


### PR DESCRIPTION
## Summary

The `Check Spelling` workflow has been failing on PRs against `main` (e.g. #48546) due to issues introduced by the recent ZoomIt webcam-blur / noise-cancellation change (#48266) plus two pre-existing duplicate entries in `.github/actions/spell-check/excludes.txt`.

## What the bot reported

| Severity | Type | Location |
|---|---|---|
| ❌ | `forbidden-pattern` (Should be `a`) | `src/modules/ZoomIt/ZoomIt/rnnoise/kiss_fft.h:79` — third-party kiss_fft header contains `an fft` |
| ⚠️ | `large-file` (~30 MB) | `src/modules/ZoomIt/ZoomIt/rnnoise/rnnoise_data_little.c` |
| ⚠️ | `binary-file` | `src/modules/ZoomIt/ZoomIt/selfie_segmentation.onnx` |
| ⚠️ | `duplicate-pattern` ×2 | `excludes.txt` lines 115/116 duplicate lines 108/109 (`FuzzyMatcher{Comparison,Diacritics}Tests.cs`) |

## Fix

`.github/actions/spell-check/excludes.txt`:

- **Drop 2 duplicate** `FuzzyMatcher*Tests.cs` lines.
- **Add 2 new exclusions** for the new third-party ZoomIt assets:
  - `^src/modules/ZoomIt/ZoomIt/rnnoise/` — entire third-party rnnoise/kiss_fft tree (covers both the `an fft` forbidden-pattern in `kiss_fft.h` and the 30 MB `rnnoise_data_little.c` large-file).
  - `^src/modules/ZoomIt/ZoomIt/selfie_segmentation\.onnx$` — the ML model binary.

Net change: `-2` duplicates, `+2` new exclusions → file count unchanged at 148 lines.

## Notes

- Third-party content under `rnnoise/` should not be spell-checked; this matches how other vendored/third-party trees in the repo are handled (e.g. `src/common/CalculatorEngineCommon/exprtk.hpp`, `src/common/sysinternals/Eula/`).
- No source code changes; pure config.
- Unblocks #48546 and any other PR currently failing `Check Spelling` on `main`.
