### PR TITLE
feat(cmdpal): phase 2 dock auto-hide settings integration

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Settings/DockSettings.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Settings/DockSettings.cs
@@ -24,6 +24,8 @@ public record DockSettings
 
     public bool AlwaysOnTop { get; set; } = true;
 
+    public bool AutoHide { get; set; } = false;
+
     // <Theme settings>
     public DockBackdrop Backdrop { get; init; } = DockBackdrop.Acrylic;
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsViewModel.cs
@@ -238,6 +238,15 @@ public partial class SettingsViewModel : INotifyPropertyChanged
         }
     }
 
+    public bool Dock_AutoHide
+    {
+        get => _settingsService.Settings.DockSettings.AutoHide;
+        set
+        {
+            _settingsService.UpdateSettings(s => s with { DockSettings = s.DockSettings with { AutoHide = value } });
+        }
+    }
+
     public bool EnableDock
     {
         get => _settingsService.Settings.EnableDock;

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/DockSettingsPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/DockSettingsPage.xaml
@@ -249,6 +249,10 @@
                         <ToggleSwitch AutomationProperties.AutomationId="CmdPal_DockSettingsPage_AlwaysOnTop" IsOn="{x:Bind ViewModel.Dock_AlwaysOnTop, Mode=TwoWay}" />
                     </controls:SettingsCard>
 
+                    <controls:SettingsCard x:Uid="DockBehavior_AutoHide_SettingsCard" HeaderIcon="{ui:FontIcon Glyph=&#xE8A7;}">
+                        <ToggleSwitch AutomationProperties.AutomationId="CmdPal_DockSettingsPage_AutoHide" IsOn="{x:Bind ViewModel.Dock_AutoHide, Mode=TwoWay}" />
+                    </controls:SettingsCard>
+
                     <!--  Monitors Section  -->
                     <TextBlock x:Uid="DockMonitors_Header" Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" />
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Strings/en-us/Resources.resw
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Strings/en-us/Resources.resw
@@ -476,6 +476,12 @@ Right-click to remove the key combination, thereby deactivating the shortcut.</v
   <data name="DockBehavior_AlwaysOnTop_SettingsCard.Description" xml:space="preserve">
     <value>Keep the dock above other windows, except while an app is fullscreen</value>
   </data>
+  <data name="DockBehavior_AutoHide_SettingsCard.Header" xml:space="preserve">
+    <value>Auto-hide dock</value>
+  </data>
+  <data name="DockBehavior_AutoHide_SettingsCard.Description" xml:space="preserve">
+    <value>Hide the dock until your pointer reaches the dock edge</value>
+  </data>
   <data name="BackButton.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Back</value>
   </data>

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/DockMultiMonitorTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/DockMultiMonitorTests.cs
@@ -345,6 +345,26 @@ public class DockMultiMonitorTests
         Assert.IsFalse(deserialized.MonitorConfigs[1].Enabled);
     }
 
+    [TestMethod]
+    public void DockSettings_AutoHide_DefaultsToFalse()
+    {
+        var settings = CreateMinimalDockSettings();
+
+        Assert.IsFalse(settings.AutoHide);
+    }
+
+    [TestMethod]
+    public void DockSettings_AutoHide_JsonRoundTrip()
+    {
+        var settings = CreateMinimalDockSettings() with { AutoHide = true };
+
+        var json = JsonSerializer.Serialize(settings, JsonSerializationContext.Default.DockSettings);
+        var deserialized = JsonSerializer.Deserialize(json, JsonSerializationContext.Default.DockSettings);
+
+        Assert.IsNotNull(deserialized);
+        Assert.IsTrue(deserialized.AutoHide);
+    }
+
     private static DockSettings CreateMinimalDockSettings()
     {
         // Deserialize from minimal JSON to avoid WinUI3 dependencies


### PR DESCRIPTION
## Summary
- add persisted  to  with default 
- add  in  using the existing dock settings update pattern
- add Auto-hide toggle to  Behavior section next to Always on top
- add localized strings for Auto-hide header/description in 
- add unit tests for  default and JSON round-trip

## Context
Implements Phase 2 of issue #46239 (settings model + settings page integration).

## Validation
- Environment limitation: .NET SDK not available in this runner (), so local build/test execution was not possible here.