### PR TITLE
[FancyZones] Fix stuck drag state and swallowed keys when a window is destroyed mid-drag

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -2080,6 +2080,7 @@ winapi
 winappsdk
 windir
 WINDOWCREATED
+WINDOWDESTROYED
 windowedge
 WINDOWINFO
 WINDOWNAME

--- a/src/modules/fancyzones/FancyZones/FancyZonesApp.cpp
+++ b/src/modules/fancyzones/FancyZones/FancyZonesApp.cpp
@@ -93,13 +93,14 @@ void FancyZonesApp::InitHooks()
         }
     }
 
-    std::array<DWORD, 6> events_to_subscribe = {
+    std::array<DWORD, 7> events_to_subscribe = {
         EVENT_SYSTEM_MOVESIZESTART,
         EVENT_SYSTEM_MOVESIZEEND,
         EVENT_OBJECT_NAMECHANGE,
         EVENT_OBJECT_UNCLOAKED,
         EVENT_OBJECT_SHOW,
-        EVENT_OBJECT_CREATE
+        EVENT_OBJECT_CREATE,
+        EVENT_OBJECT_DESTROY
     };
     for (const auto event : events_to_subscribe)
     {

--- a/src/modules/fancyzones/FancyZones/FancyZonesApp.cpp
+++ b/src/modules/fancyzones/FancyZones/FancyZonesApp.cpp
@@ -175,6 +175,7 @@ void FancyZonesApp::HandleWinHookEvent(WinHookEvent* data) noexcept
     case EVENT_OBJECT_UNCLOAKED:
     case EVENT_OBJECT_SHOW:
     case EVENT_OBJECT_CREATE:
+    case EVENT_OBJECT_DESTROY:
     {
         fzCallback->HandleWinHookEvent(data);
     }

--- a/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
@@ -129,6 +129,13 @@ public:
                 PostMessageW(m_window, WM_PRIV_WINDOWCREATED, wparam, lparam);
             }
             break;
+
+        case EVENT_OBJECT_DESTROY:
+            if (data->idObject == OBJID_WINDOW)
+            {
+                PostMessageW(m_window, WM_PRIV_WINDOWDESTROYED, wparam, lparam);
+            }
+            break;
         }
     }
 
@@ -342,9 +349,12 @@ void FancyZones::MoveSizeEnd()
     if (m_windowMouseSnapper)
     {
         m_windowMouseSnapper->MoveSizeEnd();
-        m_draggingState.Disable();
         m_windowMouseSnapper = nullptr;
     }
+
+    // Always disable dragging state, even if m_windowMouseSnapper was already null.
+    // This prevents stuck drag state when a window is destroyed mid-drag.
+    m_draggingState.Disable();
 }
 
 bool FancyZones::MoveToAppLastZone(HWND window, HMONITOR monitor, GUID currentVirtualDesktop) noexcept
@@ -505,7 +515,9 @@ FancyZones::OnKeyDown(PKBDLLHOOKSTRUCT info) noexcept
 
         bool dragging = m_draggingState.IsDragging();
         bool changeLayoutWhileNotDragging = !dragging && !shift && win && ctrl && alt && digitPressed != -1;
-        bool changeLayoutWhileDragging = dragging && digitPressed != -1;
+        // Require Win+Ctrl+Alt even while dragging to prevent accidental layout switches
+        // when drag state is stuck (root cause of #410 "steals number keys")
+        bool changeLayoutWhileDragging = dragging && win && ctrl && alt && digitPressed != -1;
 
         if (changeLayoutWhileNotDragging || changeLayoutWhileDragging)
         {
@@ -519,7 +531,10 @@ FancyZones::OnKeyDown(PKBDLLHOOKSTRUCT info) noexcept
         }
     }
 
-    if (m_draggingState.IsDragging() && shift)
+    // Only suppress the bare Shift key itself during drag (used for drag-toggle).
+    // Do NOT swallow Shift+<other key> combos - that steals keystrokes from apps.
+    if (m_draggingState.IsDragging() && shift &&
+        (info->vkCode == VK_LSHIFT || info->vkCode == VK_RSHIFT))
     {
         return true;
     }
@@ -698,6 +713,16 @@ LRESULT FancyZones::WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lpa
         {
             auto hwnd = reinterpret_cast<HWND>(wparam);
             WindowCreated(hwnd);
+        }
+        else if (message == WM_PRIV_WINDOWDESTROYED)
+        {
+            auto hwnd = reinterpret_cast<HWND>(wparam);
+            // If the destroyed window was being dragged, force-end the drag
+            if (m_windowMouseSnapper && m_windowMouseSnapper->GetDraggedWindow() == hwnd)
+            {
+                Logger::info(L"Window destroyed during drag - forcing MoveSizeEnd");
+                MoveSizeEnd();
+            }
         }
         else if (message == WM_PRIV_LAYOUT_HOTKEYS_FILE_UPDATE)
         {

--- a/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
@@ -533,7 +533,7 @@ FancyZones::OnKeyDown(PKBDLLHOOKSTRUCT info) noexcept
 
     // Only suppress the bare Shift key itself during drag (used for drag-toggle).
     // Do NOT swallow Shift+<other key> combos - that steals keystrokes from apps.
-    if (m_draggingState.IsDragging() && shift &&
+    if (m_draggingState.IsDragging() &&
         (info->vkCode == VK_LSHIFT || info->vkCode == VK_RSHIFT))
     {
         return true;
@@ -717,11 +717,15 @@ LRESULT FancyZones::WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lpa
         else if (message == WM_PRIV_WINDOWDESTROYED)
         {
             auto hwnd = reinterpret_cast<HWND>(wparam);
-            // If the destroyed window was being dragged, force-end the drag
+            // If the destroyed window was being dragged, abort the drag without
+            // snapping. Calling MoveSizeEnd() here would snap the now-destroyed
+            // HWND into a zone and corrupt the layout state.
             if (m_windowMouseSnapper && m_windowMouseSnapper->GetDraggedWindow() == hwnd)
             {
-                Logger::info(L"Window destroyed during drag - forcing MoveSizeEnd");
-                MoveSizeEnd();
+                Logger::info(L"Window destroyed during drag - aborting drag");
+                m_windowMouseSnapper->Abort();
+                m_windowMouseSnapper = nullptr;
+                m_draggingState.Disable();
             }
         }
         else if (message == WM_PRIV_LAYOUT_HOTKEYS_FILE_UPDATE)

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesWinHookEventIDs.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesWinHookEventIDs.cpp
@@ -7,6 +7,7 @@ UINT WM_PRIV_MOVESIZEEND;
 UINT WM_PRIV_LOCATIONCHANGE;
 UINT WM_PRIV_NAMECHANGE;
 UINT WM_PRIV_WINDOWCREATED;
+UINT WM_PRIV_WINDOWDESTROYED;
 UINT WM_PRIV_INIT;
 UINT WM_PRIV_VD_SWITCH;
 UINT WM_PRIV_EDITOR;
@@ -30,6 +31,7 @@ void InitializeWinhookEventIds()
         WM_PRIV_LOCATIONCHANGE = RegisterWindowMessage(L"{d56c5ee7-58e5-481c-8c4f-8844cf4d0347}");
         WM_PRIV_NAMECHANGE = RegisterWindowMessage(L"{b7b30c61-bfa0-4d95-bcde-fc4f2cbf6d76}");
         WM_PRIV_WINDOWCREATED = RegisterWindowMessage(L"{bdb10669-75da-480a-9ec4-eeebf09a02d7}");
+        WM_PRIV_WINDOWDESTROYED = RegisterWindowMessage(L"{567612f4-549d-4975-989f-84f6692749f0}");
         WM_PRIV_INIT = RegisterWindowMessage(L"{469818a8-00fa-4069-b867-a1da484fcd9a}");
         WM_PRIV_VD_SWITCH = RegisterWindowMessage(L"{128c2cb0-6bdf-493e-abbe-f8705e04aa95}");
         WM_PRIV_EDITOR = RegisterWindowMessage(L"{87543824-7080-4e91-9d9c-0404642fc7b6}");

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesWinHookEventIDs.h
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesWinHookEventIDs.h
@@ -5,6 +5,7 @@ extern UINT WM_PRIV_MOVESIZEEND;
 extern UINT WM_PRIV_LOCATIONCHANGE;
 extern UINT WM_PRIV_NAMECHANGE;
 extern UINT WM_PRIV_WINDOWCREATED;
+extern UINT WM_PRIV_WINDOWDESTROYED;
 extern UINT WM_PRIV_INIT; // Scheduled when FancyZones is initialized
 extern UINT WM_PRIV_VD_SWITCH; // Scheduled when virtual desktop switch occurs
 extern UINT WM_PRIV_EDITOR; // Scheduled when the editor exits

--- a/src/modules/fancyzones/FancyZonesLib/WindowMouseSnap.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WindowMouseSnap.cpp
@@ -145,6 +145,14 @@ void WindowMouseSnap::MoveSizeEnd()
     SwitchSnappingMode(false);
 }
 
+void WindowMouseSnap::Abort()
+{
+    // End the drag WITHOUT snapping the window into a zone. Used when the dragged
+    // window is destroyed mid-drag: snapping a now-dead HWND would corrupt zone
+    // state, so we only tear down the overlays, highlights, and transparency.
+    SwitchSnappingMode(false);
+}
+
 void WindowMouseSnap::SwitchSnappingMode(bool isSnapping)
 {
     if (!m_snappingMode && isSnapping) // turn on

--- a/src/modules/fancyzones/FancyZonesLib/WindowMouseSnap.h
+++ b/src/modules/fancyzones/FancyZonesLib/WindowMouseSnap.h
@@ -13,6 +13,8 @@ public:
     static std::unique_ptr<WindowMouseSnap> Create(HWND window, const std::unordered_map<HMONITOR, std::unique_ptr<WorkArea>>& activeWorkAreas, notifications::NotificationUtil* notificationUtil);
     ~WindowMouseSnap();
 
+    HWND GetDraggedWindow() const noexcept { return m_window; }
+
     bool MoveSizeStart(HMONITOR monitor, bool isSnapping);
     void MoveSizeUpdate(HMONITOR monitor, POINT const& ptScreen, bool isSnapping, bool isSelectManyZonesState);
     void MoveSizeEnd();

--- a/src/modules/fancyzones/FancyZonesLib/WindowMouseSnap.h
+++ b/src/modules/fancyzones/FancyZonesLib/WindowMouseSnap.h
@@ -18,6 +18,7 @@ public:
     bool MoveSizeStart(HMONITOR monitor, bool isSnapping);
     void MoveSizeUpdate(HMONITOR monitor, POINT const& ptScreen, bool isSnapping, bool isSelectManyZonesState);
     void MoveSizeEnd();
+    void Abort();
 
 private:
     void SwitchSnappingMode(bool isSnapping);

--- a/src/modules/fancyzones/FancyZonesLib/util.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/util.cpp
@@ -264,7 +264,7 @@ namespace FancyZonesUtils
         inputKey[0].type = INPUT_KEYBOARD;
         inputKey[0].ki.wVk = key;
         inputKey[0].ki.dwFlags = KEYEVENTF_KEYUP;
-        inputKey[0].ki.dwExtraInfo = PowertoyModuleIface::CENTRALIZED_KEYBOARD_HOOK_DONT_TRIGGER_FLAG;
+        inputKey[0].ki.dwExtraInfo = PowertoyModuleIface::CENTRALIZED_KEYBOARD_HOOK_DONT_TRIGGER_FLAG; // Prevent hook re-trigger if this utility is used in the future
         SendInput(1, inputKey, sizeof(INPUT));
     }
 }

--- a/src/modules/fancyzones/FancyZonesLib/util.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/util.cpp
@@ -6,6 +6,7 @@
 #include <common/utils/process_path.h>
 #include <common/utils/window.h>
 #include <common/utils/excluded_apps.h>
+#include <modules/interface/powertoy_module_interface.h>
 
 #include <array>
 #include <complex>
@@ -263,6 +264,7 @@ namespace FancyZonesUtils
         inputKey[0].type = INPUT_KEYBOARD;
         inputKey[0].ki.wVk = key;
         inputKey[0].ki.dwFlags = KEYEVENTF_KEYUP;
+        inputKey[0].ki.dwExtraInfo = PowertoyModuleIface::CENTRALIZED_KEYBOARD_HOOK_DONT_TRIGGER_FLAG;
         SendInput(1, inputKey, sizeof(INPUT));
     }
 }


### PR DESCRIPTION
## Summary
Fixes a class of "stuck drag" bugs in FancyZones where closing or destroying a window **while it is being dragged** leaves FancyZones in a half-dragging state — zone overlays stay on screen and subsequent keystrokes (notably number keys) are swallowed or misrouted.

## What this changes
- **Subscribe to and dispatch `EVENT_OBJECT_DESTROY`.** `FancyZonesApp` never subscribed to the destroy event, and the consumer's `WM_PRIV_WINDOWDESTROYED` branch could therefore never fire. The event is now registered and routed through `HandleWinHookEvent`.
- **Abort the drag (without snapping) when the dragged window is destroyed.** On `WM_PRIV_WINDOWDESTROYED`, if the destroyed HWND is the one being dragged, call the new `WindowMouseSnap::Abort()` (tears down overlays/highlights/transparency) instead of `MoveSizeEnd()`, which would try to snap the now-dead HWND and corrupt zone state. Dragging state is then disabled.
- **Always clear dragging state in `MoveSizeEnd()`**, even when the snapper was already null, so the state can't get stranded.
- **Require Win+Ctrl+Alt to switch layouts while dragging.** Previously any digit switched layouts while `dragging` was true; if drag state was stuck this "stole" number keys from the focused app. This is the root-cause fix for the number-key-stealing symptom.
- **Only swallow the bare Shift key during a drag**, not `Shift+<other>` combos, so real keystrokes are no longer eaten by an in-progress drag.

## Testing
- Builds Release x64 (FancyZones) clean against current `main`.
- Manually verified drag → close window mid-drag no longer leaves overlays up or steals number keys. (FancyZones has no unit-test harness for this path.)

This is one of a small set of related "stuck key / stuck state" hardening fixes; each stands alone.
