### PR TITLE
[Runner] Harden centralized keyboard hook against stuck/ghost keys

### DIFF
--- a/src/runner/centralized_kb_hook.cpp
+++ b/src/runner/centralized_kb_hook.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "centralized_kb_hook.h"
+#include <atomic>
 #include <common/debug_control.h>
 #include <common/utils/winapi_error.h>
 #include <common/logger/logger.h>
@@ -42,7 +43,7 @@ namespace CentralizedKeyboardHook
 
     // keep track of last pressed key, to detect repeated keys and if there are more keys pressed.
     const DWORD VK_DISABLED = CommonSharedConstants::VK_DISABLED;
-    DWORD vkCodePressed = VK_DISABLED;
+    std::atomic<DWORD> vkCodePressed{ VK_DISABLED };
 
     // Save the runner window handle for registering timers.
     HWND runnerWindow;
@@ -72,7 +73,12 @@ namespace CentralizedKeyboardHook
         {
             if (it.idTimer == idTimer)
             {
-                it.action();
+                // Revalidate that the key is still physically held before firing.
+                // This prevents ghost activations after the key was already released.
+                if (GetAsyncKeyState(static_cast<int>(it.virtualKey)) & 0x8000)
+                {
+                    it.action();
+                }
             }
         }
 
@@ -177,6 +183,7 @@ namespace CentralizedKeyboardHook
                 dummyEvent[0].type = INPUT_KEYBOARD;
                 dummyEvent[0].ki.wVk = 0xFF;
                 dummyEvent[0].ki.dwFlags = KEYEVENTF_KEYUP;
+                dummyEvent[0].ki.dwExtraInfo = PowertoyModuleIface::CENTRALIZED_KEYBOARD_HOOK_DONT_TRIGGER_FLAG;
                 SendInput(1, dummyEvent, sizeof(INPUT));
 
                 // Swallow the key press
@@ -263,6 +270,18 @@ namespace CentralizedKeyboardHook
 
     void Stop() noexcept
     {
+        // Kill all pending pressed-key timers before unhooking to prevent
+        // ghost callbacks firing after the hook is removed.
+        {
+            std::unique_lock lock{ pressedKeyMutex };
+            for (const auto& it : pressedKeyDescriptors)
+            {
+                KillTimer(runnerWindow, it.idTimer);
+            }
+        }
+
+        vkCodePressed = VK_DISABLED;
+
         if (hHook && UnhookWindowsHookEx(hHook))
         {
             hHook = NULL;


### PR DESCRIPTION
## Summary
Hardens the runner's centralized keyboard hook against stuck and "ghost" key activations — cases where a hotkey action fires after the key was already released, or a pending timer fires after the hook was torn down.

## What this changes
- **`vkCodePressed` is now `std::atomic<DWORD>`.** It is read/written from the low-level hook callback and from the timer/teardown paths; the plain `DWORD` was a data race.
- **Revalidate the key is still physically held before firing a held-key timer.** The pressed-key timer callback now checks `GetAsyncKeyState(virtualKey) & 0x8000` before invoking the action, preventing ghost activations after the user has let go.
- **Tag the injected dummy `0xFF` key-up** with `CENTRALIZED_KEYBOARD_HOOK_DONT_TRIGGER_FLAG` so the hook does not reprocess its own synthetic event.
- **`Stop()` kills all pending pressed-key timers and resets `vkCodePressed` before unhooking**, so a timer can't fire a callback into a half-removed hook.

## Testing
- Builds Release x64 (runner / `PowerToys.exe`) clean against current `main`.

This is one of a small set of related "stuck key" hardening fixes; each stands alone.
