### PR TITLE
[PowerAccent] Fix injection hygiene and reset state on hide

### DIFF
--- a/src/modules/poweraccent/PowerAccent.Core/PowerAccent.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/PowerAccent.cs
@@ -266,6 +266,7 @@ public partial class PowerAccent : IDisposable
                 }
         }
 
+        _keyboardListener.ForceReset();
         OnChangeDisplay?.Invoke(false, null);
         _selectedIndex = -1;
         _visible = false;

--- a/src/modules/poweraccent/PowerAccent.Core/Tools/WindowsFunctions.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/Tools/WindowsFunctions.cs
@@ -17,7 +17,7 @@ internal static class WindowsFunctions
 {
     // Mirrors PowertoyModuleIface::CENTRALIZED_KEYBOARD_HOOK_DONT_TRIGGER_FLAG (0x110) so the
     // centralized keyboard hook ignores the keys PowerAccent injects and they don't re-trigger shortcuts.
-    private const nuint POWERTOYS_INJECTED_TAG = 0x110;
+    private const nuint PowerToysInjectedTag = 0x110;
 
     public static void Insert(string s, bool back = false)
     {
@@ -36,7 +36,7 @@ internal static class WindowsFunctions
                             ki = new KEYBDINPUT
                             {
                                 wVk = VIRTUAL_KEY.VK_BACK,
-                                dwExtraInfo = POWERTOYS_INJECTED_TAG,
+                                dwExtraInfo = PowerToysInjectedTag,
                             },
                         },
                     },
@@ -49,7 +49,7 @@ internal static class WindowsFunctions
                             {
                                 wVk = VIRTUAL_KEY.VK_BACK,
                                 dwFlags = KEYBD_EVENT_FLAGS.KEYEVENTF_KEYUP,
-                                dwExtraInfo = POWERTOYS_INJECTED_TAG,
+                                dwExtraInfo = PowerToysInjectedTag,
                             },
                         },
                     },
@@ -60,6 +60,7 @@ internal static class WindowsFunctions
                 {
                     Logger.LogError($"SendInput backspace failed: sent {backSent}/{inputsBack.Length}");
                 }
+
                 Thread.Sleep(1); // Some apps, like Terminal, need a little wait to process the sent backspace or they'll ignore it.
             }
 
@@ -77,7 +78,7 @@ internal static class WindowsFunctions
                             {
                                 wScan = s[i],
                                 dwFlags = KEYBD_EVENT_FLAGS.KEYEVENTF_UNICODE,
-                                dwExtraInfo = POWERTOYS_INJECTED_TAG,
+                                dwExtraInfo = PowerToysInjectedTag,
                             },
                         },
                     };
@@ -90,7 +91,7 @@ internal static class WindowsFunctions
                             {
                                 wScan = s[i],
                                 dwFlags = KEYBD_EVENT_FLAGS.KEYEVENTF_UNICODE | KEYBD_EVENT_FLAGS.KEYEVENTF_KEYUP,
-                                dwExtraInfo = POWERTOYS_INJECTED_TAG,
+                                dwExtraInfo = PowerToysInjectedTag,
                             },
                         },
                     };
@@ -188,7 +189,8 @@ internal static class WindowsFunctions
                         ki = new KEYBDINPUT
                         {
                             wVk = arrowKey,
-                            dwExtraInfo = POWERTOYS_INJECTED_TAG,
+                            dwFlags = KEYBD_EVENT_FLAGS.KEYEVENTF_EXTENDEDKEY,
+                            dwExtraInfo = PowerToysInjectedTag,
                         },
                     },
                 },
@@ -200,8 +202,8 @@ internal static class WindowsFunctions
                         ki = new KEYBDINPUT
                         {
                             wVk = arrowKey,
-                            dwFlags = KEYBD_EVENT_FLAGS.KEYEVENTF_KEYUP,
-                            dwExtraInfo = POWERTOYS_INJECTED_TAG,
+                            dwFlags = KEYBD_EVENT_FLAGS.KEYEVENTF_EXTENDEDKEY | KEYBD_EVENT_FLAGS.KEYEVENTF_KEYUP,
+                            dwExtraInfo = PowerToysInjectedTag,
                         },
                     },
                 },

--- a/src/modules/poweraccent/PowerAccent.Core/Tools/WindowsFunctions.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/Tools/WindowsFunctions.cs
@@ -4,6 +4,7 @@
 
 using System.Runtime.InteropServices;
 
+using ManagedCommon;
 using Windows.Win32;
 using Windows.Win32.Graphics.Gdi;
 using Windows.Win32.UI.HiDpi;
@@ -14,6 +15,10 @@ namespace PowerAccent.Core.Tools;
 
 internal static class WindowsFunctions
 {
+    // Mirrors PowertoyModuleIface::CENTRALIZED_KEYBOARD_HOOK_DONT_TRIGGER_FLAG (0x110) so the
+    // centralized keyboard hook ignores the keys PowerAccent injects and they don't re-trigger shortcuts.
+    private const nuint POWERTOYS_INJECTED_TAG = 0x110;
+
     public static void Insert(string s, bool back = false)
     {
         unsafe
@@ -31,6 +36,7 @@ internal static class WindowsFunctions
                             ki = new KEYBDINPUT
                             {
                                 wVk = VIRTUAL_KEY.VK_BACK,
+                                dwExtraInfo = POWERTOYS_INJECTED_TAG,
                             },
                         },
                     },
@@ -43,12 +49,17 @@ internal static class WindowsFunctions
                             {
                                 wVk = VIRTUAL_KEY.VK_BACK,
                                 dwFlags = KEYBD_EVENT_FLAGS.KEYEVENTF_KEYUP,
+                                dwExtraInfo = POWERTOYS_INJECTED_TAG,
                             },
                         },
                     },
                 };
 
-                _ = PInvoke.SendInput(inputsBack, Marshal.SizeOf<INPUT>());
+                uint backSent = PInvoke.SendInput(inputsBack, Marshal.SizeOf<INPUT>());
+                if (backSent != (uint)inputsBack.Length)
+                {
+                    Logger.LogError($"SendInput backspace failed: sent {backSent}/{inputsBack.Length}");
+                }
                 Thread.Sleep(1); // Some apps, like Terminal, need a little wait to process the sent backspace or they'll ignore it.
             }
 
@@ -66,6 +77,7 @@ internal static class WindowsFunctions
                             {
                                 wScan = s[i],
                                 dwFlags = KEYBD_EVENT_FLAGS.KEYEVENTF_UNICODE,
+                                dwExtraInfo = POWERTOYS_INJECTED_TAG,
                             },
                         },
                     };
@@ -78,12 +90,17 @@ internal static class WindowsFunctions
                             {
                                 wScan = s[i],
                                 dwFlags = KEYBD_EVENT_FLAGS.KEYEVENTF_UNICODE | KEYBD_EVENT_FLAGS.KEYEVENTF_KEYUP,
+                                dwExtraInfo = POWERTOYS_INJECTED_TAG,
                             },
                         },
                     };
                 }
 
-                _ = PInvoke.SendInput(inputsInsert, Marshal.SizeOf<INPUT>());
+                uint charSent = PInvoke.SendInput(inputsInsert, Marshal.SizeOf<INPUT>());
+                if (charSent != (uint)inputsInsert.Length)
+                {
+                    Logger.LogError($"SendInput character failed: sent {charSent}/{inputsInsert.Length}");
+                }
             }
         }
     }
@@ -155,5 +172,46 @@ internal static class WindowsFunctions
     {
         var shift = PInvoke.GetAsyncKeyState((int)VIRTUAL_KEY.VK_SHIFT);
         return shift < 0;
+    }
+
+    public static void SendArrowKey(VIRTUAL_KEY arrowKey)
+    {
+        unsafe
+        {
+            var inputs = new INPUT[]
+            {
+                new INPUT
+                {
+                    type = INPUT_TYPE.INPUT_KEYBOARD,
+                    Anonymous = new INPUT._Anonymous_e__Union
+                    {
+                        ki = new KEYBDINPUT
+                        {
+                            wVk = arrowKey,
+                            dwExtraInfo = POWERTOYS_INJECTED_TAG,
+                        },
+                    },
+                },
+                new INPUT
+                {
+                    type = INPUT_TYPE.INPUT_KEYBOARD,
+                    Anonymous = new INPUT._Anonymous_e__Union
+                    {
+                        ki = new KEYBDINPUT
+                        {
+                            wVk = arrowKey,
+                            dwFlags = KEYBD_EVENT_FLAGS.KEYEVENTF_KEYUP,
+                            dwExtraInfo = POWERTOYS_INJECTED_TAG,
+                        },
+                    },
+                },
+            };
+
+            uint arrowSent = PInvoke.SendInput(inputs, Marshal.SizeOf<INPUT>());
+            if (arrowSent != (uint)inputs.Length)
+            {
+                Logger.LogError($"SendInput arrow key failed: sent {arrowSent}/{inputs.Length}");
+            }
+        }
     }
 }

--- a/src/modules/poweraccent/PowerAccent.Core/Tools/WindowsFunctions.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/Tools/WindowsFunctions.cs
@@ -120,6 +120,7 @@ internal static class WindowsFunctions
                     {
                         wVk = key,
                         dwFlags = KEYBD_EVENT_FLAGS.KEYEVENTF_EXTENDEDKEY,
+                        dwExtraInfo = PowerToysInjectedTag,
                     },
                 },
             },
@@ -132,12 +133,17 @@ internal static class WindowsFunctions
                     {
                         wVk = key,
                         dwFlags = KEYBD_EVENT_FLAGS.KEYEVENTF_EXTENDEDKEY | KEYBD_EVENT_FLAGS.KEYEVENTF_KEYUP,
+                        dwExtraInfo = PowerToysInjectedTag,
                     },
                 },
             },
         };
 
-        _ = PInvoke.SendInput(inputs, Marshal.SizeOf<INPUT>());
+        uint arrowSent = PInvoke.SendInput(inputs, Marshal.SizeOf<INPUT>());
+        if (arrowSent != (uint)inputs.Length)
+        {
+            Logger.LogError($"SendInput arrow key failed: sent {arrowSent}/{inputs.Length}");
+        }
     }
 
     public static (Point Location, Size Size, double Dpi) GetActiveDisplay()
@@ -173,47 +179,5 @@ internal static class WindowsFunctions
     {
         var shift = PInvoke.GetAsyncKeyState((int)VIRTUAL_KEY.VK_SHIFT);
         return shift < 0;
-    }
-
-    public static void SendArrowKey(VIRTUAL_KEY arrowKey)
-    {
-        unsafe
-        {
-            var inputs = new INPUT[]
-            {
-                new INPUT
-                {
-                    type = INPUT_TYPE.INPUT_KEYBOARD,
-                    Anonymous = new INPUT._Anonymous_e__Union
-                    {
-                        ki = new KEYBDINPUT
-                        {
-                            wVk = arrowKey,
-                            dwFlags = KEYBD_EVENT_FLAGS.KEYEVENTF_EXTENDEDKEY,
-                            dwExtraInfo = PowerToysInjectedTag,
-                        },
-                    },
-                },
-                new INPUT
-                {
-                    type = INPUT_TYPE.INPUT_KEYBOARD,
-                    Anonymous = new INPUT._Anonymous_e__Union
-                    {
-                        ki = new KEYBDINPUT
-                        {
-                            wVk = arrowKey,
-                            dwFlags = KEYBD_EVENT_FLAGS.KEYEVENTF_EXTENDEDKEY | KEYBD_EVENT_FLAGS.KEYEVENTF_KEYUP,
-                            dwExtraInfo = PowerToysInjectedTag,
-                        },
-                    },
-                },
-            };
-
-            uint arrowSent = PInvoke.SendInput(inputs, Marshal.SizeOf<INPUT>());
-            if (arrowSent != (uint)inputs.Length)
-            {
-                Logger.LogError($"SendInput arrow key failed: sent {arrowSent}/{inputs.Length}");
-            }
-        }
     }
 }

--- a/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.cpp
+++ b/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.cpp
@@ -51,6 +51,23 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
         }
     }
 
+    void KeyboardListener::ForceReset()
+    {
+        Logger::debug(L"ForceReset: clearing all state");
+        letterPressed = LetterKey::None;
+        m_toolbarVisible = false;
+        m_triggeredWithSpace = false;
+        m_triggeredWithLeftArrow = false;
+        m_triggeredWithRightArrow = false;
+        m_leftShiftPressed = false;
+        m_rightShiftPressed = false;
+
+        if (m_hideToolbarCb)
+        {
+            m_hideToolbarCb(InputType::None);
+        }
+    }
+
     void KeyboardListener::SetShowToolbarEvent(ShowToolbar showToolbarEvent)
     {
         m_showToolbarCb = [trigger = std::move(showToolbarEvent)](LetterKey key) {

--- a/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.cpp
+++ b/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.cpp
@@ -53,7 +53,6 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
 
     void KeyboardListener::ForceReset()
     {
-        Logger::debug(L"ForceReset: clearing all state");
         letterPressed = LetterKey::None;
         m_toolbarVisible = false;
         m_triggeredWithSpace = false;
@@ -61,11 +60,6 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
         m_triggeredWithRightArrow = false;
         m_leftShiftPressed = false;
         m_rightShiftPressed = false;
-
-        if (m_hideToolbarCb)
-        {
-            m_hideToolbarCb(InputType::None);
-        }
     }
 
     void KeyboardListener::SetShowToolbarEvent(ShowToolbar showToolbarEvent)

--- a/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.h
+++ b/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.h
@@ -44,6 +44,8 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
         void UpdateHoldDuration(int32_t holdDuration);
         void UpdateExcludedApps(std::wstring_view excludedApps);
 
+        void ForceReset();
+
         static LRESULT CALLBACK LowLevelKeyboardProc(int nCode, WPARAM wParam, LPARAM lParam);
 
     private:

--- a/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.idl
+++ b/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.idl
@@ -85,6 +85,7 @@ namespace PowerToys
             void UpdateInputTime(Int32 inputTime);
             void UpdateHoldDuration(Int32 holdDuration);
             void UpdateExcludedApps(String excludedApps);
+            void ForceReset();
         }
     }
 }


### PR DESCRIPTION
## Summary
Keeps Quick Accent-injected keys from retriggering centralized shortcuts and clears native keyboard-listener state whenever the toolbar closes.

## What this changes
- Tags backspace, Unicode, and arrow `SendInput` events with `dwExtraInfo = 0x110`, mirroring `CENTRALIZED_KEYBOARD_HOOK_DONT_TRIGGER_FLAG`.
- Uses the existing `SendArrowKey(bool)` implementation as the single arrow-injection path, preserving `KEYEVENTF_EXTENDEDKEY` on key-down and key-up.
- Checks the number of events sent by every `SendInput` call and logs incomplete sends.
- Adds `ForceReset()` to the keyboard service WinRT API and invokes it from the core hide path immediately before `OnChangeDisplay(false)`.
- Keeps listener state non-atomic because the low-level hook is installed on the WinUI thread and its callbacks execute on that same thread, as documented by `MainWindow.RunOnUiThread`.

## Testing
- Built `PowerAccent.Core.csproj` in Release x64, including `PowerAccentKeyboardService`.