### PR TITLE
[Shortcut Guide] Restore long-press Windows key activation

### DIFF
--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuideXAML/App.xaml.cs
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuideXAML/App.xaml.cs
@@ -45,6 +45,16 @@ namespace ShortcutGuide
                     MainWindow.SessionDurationMs,
                     MainWindow.CloseType));
                 TaskBarWindow.Close();
+
+                // WinUI3's dispatcher loop does not auto-exit when the last
+                // window closes (unlike WPF/WinForms). Without this explicit
+                // shutdown, Application.Start in Program.cs never returns and
+                // SG.exe keeps running after the window is gone, which makes
+                // the module's IsProcessActive() report the zombie as alive on
+                // the next hotkey press; the toggle path in OnHotkeyEx then
+                // terminates the zombie instead of showing a new window, so
+                // every other press appears to do nothing.
+                Microsoft.UI.Xaml.Application.Current.Exit();
             };
         }
 

--- a/src/modules/ShortcutGuide/ShortcutGuideModuleInterface/dllmain.cpp
+++ b/src/modules/ShortcutGuide/ShortcutGuideModuleInterface/dllmain.cpp
@@ -134,6 +134,15 @@ public:
     virtual std::optional<HotkeyEx> GetHotkeyEx() override
     {
         Logger::trace("GetHotkeyEx()");
+
+        // When the user opted into the legacy long-press Windows-key activation,
+        // suppress the customized shortcut so the two activation methods stay
+        // mutually exclusive (matches v0.99 behavior).
+        if (m_shouldReactToPressedWinKey)
+        {
+            return std::nullopt;
+        }
+
         return m_hotkey;
     }
 
@@ -169,6 +178,19 @@ public:
         }
     }
 
+    // Enables the legacy long-press-Windows-key activation in the runner's
+    // CentralizedKeyboardHook. The runner re-asks this method whenever settings
+    // change (via UpdateHotkeyEx), so toggling the setting takes effect immediately.
+    virtual bool keep_track_of_pressed_win_key() override
+    {
+        return m_shouldReactToPressedWinKey;
+    }
+
+    virtual UINT milliseconds_win_key_must_be_pressed() override
+    {
+        return m_millisecondsWinKeyPressTime;
+    }
+
 private:
     std::wstring app_name;
     //contains the non localized key of the powertoy
@@ -179,11 +201,10 @@ private:
     // Hotkey to invoke the module
     HotkeyEx m_hotkey;
 
-    // If the module should be activated through the legacy pressing windows key behavior.
-    const UINT DEFAULT_MILLISECONDS_WIN_KEY_PRESS_TIME_FOR_GLOBAL_WINDOWS_SHORTCUTS = 900;
-    const UINT DEFAULT_MILLISECONDS_WIN_KEY_PRESS_TIME_FOR_TASKBAR_ICON_SHORTCUTS = 900;
-    UINT m_millisecondsWinKeyPressTimeForGlobalWindowsShortcuts = DEFAULT_MILLISECONDS_WIN_KEY_PRESS_TIME_FOR_GLOBAL_WINDOWS_SHORTCUTS;
-    UINT m_millisecondsWinKeyPressTimeForTaskbarIconShortcuts = DEFAULT_MILLISECONDS_WIN_KEY_PRESS_TIME_FOR_TASKBAR_ICON_SHORTCUTS;
+    // Legacy long-press-Windows-key activation (mutually exclusive with m_hotkey).
+    static constexpr UINT DEFAULT_MILLISECONDS_WIN_KEY_PRESS_TIME = 900;
+    bool m_shouldReactToPressedWinKey = false;
+    UINT m_millisecondsWinKeyPressTime = DEFAULT_MILLISECONDS_WIN_KEY_PRESS_TIME;
 
     HANDLE triggerEvent;
     HANDLE exitEvent;
@@ -263,6 +284,11 @@ private:
     void ParseSettings(PowerToysSettings::PowerToyValues& settings)
     {
         auto settingsObject = settings.get_raw_json();
+
+        // Reset to defaults so a removed key in settings.json restores default behavior.
+        m_shouldReactToPressedWinKey = false;
+        m_millisecondsWinKeyPressTime = DEFAULT_MILLISECONDS_WIN_KEY_PRESS_TIME;
+
         if (settingsObject.GetView().Size())
         {
             try
@@ -296,6 +322,32 @@ private:
             catch (...)
             {
                 Logger::warn("Failed to initialize Shortcut Guide start shortcut");
+            }
+
+            // Parse legacy long-press-Windows-key activation. Both keys are optional;
+            // missing or malformed entries leave the defaults above untouched.
+            try
+            {
+                auto propertiesObject = settingsObject.GetNamedObject(L"properties");
+                if (propertiesObject.HasKey(L"use_legacy_press_win_key_behavior"))
+                {
+                    auto legacyObject = propertiesObject.GetNamedObject(L"use_legacy_press_win_key_behavior");
+                    m_shouldReactToPressedWinKey = legacyObject.GetNamedBoolean(L"value", false);
+                }
+
+                if (propertiesObject.HasKey(L"press_time"))
+                {
+                    auto pressTimeObject = propertiesObject.GetNamedObject(L"press_time");
+                    int value = static_cast<int>(pressTimeObject.GetNamedNumber(L"value", DEFAULT_MILLISECONDS_WIN_KEY_PRESS_TIME));
+                    if (value > 0)
+                    {
+                        m_millisecondsWinKeyPressTime = static_cast<UINT>(value);
+                    }
+                }
+            }
+            catch (...)
+            {
+                Logger::warn("Failed to parse Shortcut Guide legacy activation settings");
             }
         }
         else

--- a/src/modules/ShortcutGuide/ShortcutGuideModuleInterface/dllmain.cpp
+++ b/src/modules/ShortcutGuide/ShortcutGuideModuleInterface/dllmain.cpp
@@ -156,6 +156,13 @@ public:
 
         if (IsProcessActive())
         {
+            // Toggle: re-pressing the hotkey while SG is open dismisses it.
+            // In a Debug build the SG window doesn't auto-close on Deactivated
+            // (#if !DEBUG guard in MainWindow.xaml.cs), so a held-over instance
+            // can cause every other long-press to land here instead of launching
+            // a new window. In Release the deactivate-handler closes SG, so this
+            // path only fires when the user explicitly re-invokes the hotkey.
+            Logger::trace("OnHotkeyEx: existing SG instance is alive, terminating it");
             TerminateProcess(m_hProcess, 0);
             return;
         }

--- a/src/runner/centralized_kb_hook.cpp
+++ b/src/runner/centralized_kb_hook.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "centralized_kb_hook.h"
+#include <set>
 #include <common/debug_control.h>
 #include <common/utils/winapi_error.h>
 #include <common/logger/logger.h>
@@ -40,6 +41,14 @@ namespace CentralizedKeyboardHook
     std::multiset<PressedKeyDescriptor> pressedKeyDescriptors;
     std::mutex pressedKeyMutex;
 
+    // Virtual key codes whose long-press timer fired and that requested
+    // Start Menu suppression. The dummy keystroke is injected when the
+    // matching key is finally released so the chord break is fresh when
+    // Windows processes the Win-up; injecting it at timer-fire time is
+    // ~press_time ms early and is sometimes "forgotten" by the shell.
+    std::set<DWORD> pendingChordBreaks;
+    std::mutex pendingChordBreakMutex;
+
     // keep track of last pressed key, to detect repeated keys and if there are more keys pressed.
     const DWORD VK_DISABLED = CommonSharedConstants::VK_DISABLED;
     DWORD vkCodePressed = VK_DISABLED;
@@ -74,13 +83,10 @@ namespace CentralizedKeyboardHook
             {
                 if (it.action())
                 {
-                    // The action requested Start Menu suppression. Sending a dummy
-                    // keyup matches what KeyboardHookProc does for regular hotkeys.
-                    INPUT dummyEvent[1] = {};
-                    dummyEvent[0].type = INPUT_KEYBOARD;
-                    dummyEvent[0].ki.wVk = 0xFF;
-                    dummyEvent[0].ki.dwFlags = KEYEVENTF_KEYUP;
-                    SendInput(1, dummyEvent, sizeof(INPUT));
+                    // Defer the actual SendInput until the matching key is
+                    // released. See pendingChordBreaks comment above.
+                    std::unique_lock lock{ pendingChordBreakMutex };
+                    pendingChordBreaks.insert(it.virtualKey);
                 }
                 // The descriptor is one-shot per hold: clearing it avoids
                 // double-firing when the same module re-registers the action
@@ -140,13 +146,41 @@ namespace CentralizedKeyboardHook
             }
             if (wParam == WM_KEYUP || wParam == WM_SYSKEYUP)
             {
-                std::unique_lock lock{ pressedKeyMutex };
-                PressedKeyDescriptor dummy{ .virtualKey = keyPressInfo.vkCode };
-                auto [it, last] = pressedKeyDescriptors.equal_range(dummy);
-                for (; it != last; ++it)
                 {
-                    KillTimer(runnerWindow, it->idTimer);
+                    std::unique_lock lock{ pressedKeyMutex };
+                    PressedKeyDescriptor dummy{ .virtualKey = keyPressInfo.vkCode };
+                    auto [it, last] = pressedKeyDescriptors.equal_range(dummy);
+                    for (; it != last; ++it)
+                    {
+                        KillTimer(runnerWindow, it->idTimer);
+                    }
                 }
+
+                // If a long-press action fired earlier for this key and the
+                // module asked for Start Menu suppression, inject the dummy
+                // event NOW -- while this Win-up is still in-flight in the
+                // hook and before the shell sees it. This matches the v0.99
+                // ShortcutGuide trick of breaking the Win-only chord at the
+                // moment of release.
+                bool sendChordBreak = false;
+                {
+                    std::unique_lock lock{ pendingChordBreakMutex };
+                    auto it = pendingChordBreaks.find(keyPressInfo.vkCode);
+                    if (it != pendingChordBreaks.end())
+                    {
+                        pendingChordBreaks.erase(it);
+                        sendChordBreak = true;
+                    }
+                }
+                if (sendChordBreak)
+                {
+                    INPUT dummyEvent[1] = {};
+                    dummyEvent[0].type = INPUT_KEYBOARD;
+                    dummyEvent[0].ki.wVk = 0xFF;
+                    dummyEvent[0].ki.dwFlags = KEYEVENTF_KEYUP;
+                    SendInput(1, dummyEvent, sizeof(INPUT));
+                }
+
                 vkCodePressed = 0x100;
             }
         }

--- a/src/runner/centralized_kb_hook.cpp
+++ b/src/runner/centralized_kb_hook.cpp
@@ -72,7 +72,20 @@ namespace CentralizedKeyboardHook
         {
             if (it.idTimer == idTimer)
             {
-                it.action();
+                if (it.action())
+                {
+                    // The action requested Start Menu suppression. Sending a dummy
+                    // keyup matches what KeyboardHookProc does for regular hotkeys.
+                    INPUT dummyEvent[1] = {};
+                    dummyEvent[0].type = INPUT_KEYBOARD;
+                    dummyEvent[0].ki.wVk = 0xFF;
+                    dummyEvent[0].ki.dwFlags = KEYEVENTF_KEYUP;
+                    SendInput(1, dummyEvent, sizeof(INPUT));
+                }
+                // The descriptor is one-shot per hold: clearing it avoids
+                // double-firing when the same module re-registers the action
+                // before the next press.
+                break;
             }
         }
 
@@ -223,19 +236,26 @@ namespace CentralizedKeyboardHook
                 }
             }
         }
+        ClearModulePressedKeyActions(moduleName);
+    }
+
+    void ClearModulePressedKeyActions(const std::wstring& moduleName) noexcept
+    {
+        std::unique_lock lock{ pressedKeyMutex };
+        auto it = pressedKeyDescriptors.begin();
+        while (it != pressedKeyDescriptors.end())
         {
-            std::unique_lock lock{ pressedKeyMutex };
-            auto it = pressedKeyDescriptors.begin();
-            while (it != pressedKeyDescriptors.end())
+            if (it->moduleName == moduleName)
             {
-                if (it->moduleName == moduleName)
+                if (runnerWindow)
                 {
-                    it = pressedKeyDescriptors.erase(it);
+                    KillTimer(runnerWindow, it->idTimer);
                 }
-                else
-                {
-                    ++it;
-                }
+                it = pressedKeyDescriptors.erase(it);
+            }
+            else
+            {
+                ++it;
             }
         }
     }

--- a/src/runner/centralized_kb_hook.h
+++ b/src/runner/centralized_kb_hook.h
@@ -11,5 +11,6 @@ namespace CentralizedKeyboardHook
     void SetHotkeyAction(const std::wstring& moduleName, const Hotkey& hotkey, std::function<bool()>&& action) noexcept;
     void AddPressedKeyAction(const std::wstring& moduleName, const DWORD vk, const UINT milliseconds, std::function<bool()>&& action) noexcept;
     void ClearModuleHotkeys(const std::wstring& moduleName) noexcept;
+    void ClearModulePressedKeyActions(const std::wstring& moduleName) noexcept;
     void RegisterWindow(HWND hwnd) noexcept;
 };

--- a/src/runner/powertoy_module.cpp
+++ b/src/runner/powertoy_module.cpp
@@ -102,12 +102,22 @@ void PowertoyModule::UpdateHotkeyEx()
     // Just for enabling the shortcut guide legacy behavior of pressing the Windows Key.
     // This is not the sort of behavior we'd like to have generalized on other modules.
     // But this was a way to bring back the long windows key behavior that the community wanted back while maintaining the separate process.
-    if (pt_module->keep_track_of_pressed_win_key())
+    //
+    // Always clear any previous registrations first: UpdateHotkeyEx can be called
+    // without a preceding update_hotkeys (e.g. enable/disable toggles, general
+    // settings updates), and AddPressedKeyAction would otherwise accumulate
+    // duplicate descriptors so a single Win-hold fires the action N times.
+    CentralizedKeyboardHook::ClearModulePressedKeyActions(pt_module->get_key());
+
+    if (pt_module->keep_track_of_pressed_win_key() && pt_module->is_enabled())
     {
         auto modulePtr = pt_module.get();
         auto action = [modulePtr] {
             modulePtr->OnHotkeyEx();
-            return false;
+            // Return true so PressedKeyTimerProc sends a dummy keystroke; this
+            // prevents the subsequent Win-key release from activating the Start
+            // Menu over the freshly-shown module window.
+            return true;
         };
         CentralizedKeyboardHook::AddPressedKeyAction(pt_module->get_key(), VK_LWIN, pt_module->milliseconds_win_key_must_be_pressed(), action);
         CentralizedKeyboardHook::AddPressedKeyAction(pt_module->get_key(), VK_RWIN, pt_module->milliseconds_win_key_must_be_pressed(), action);

--- a/src/settings-ui/Settings.UI.Library/ShortcutGuideProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/ShortcutGuideProperties.cs
@@ -20,7 +20,13 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             OpenShortcutGuide = DefaultOpenShortcutGuide;
             FirstRun = new BoolProperty(true);
             WindowPosition = new IntProperty((int)ShortcutGuideWindowPosition.Left);
+            UseLegacyPressWinKeyBehavior = new BoolProperty(false);
+            PressTime = new IntProperty(DefaultPressTimeMs);
         }
+
+        // Default press duration (ms) for the long-press Windows-key activation.
+        // Matches the v0.99 default so users upgrading from the pre-V2 release pick up the same feel.
+        public const int DefaultPressTimeMs = 900;
 
         [JsonPropertyName("open_shortcutguide")]
         public HotkeySettings OpenShortcutGuide { get; set; }
@@ -39,5 +45,15 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         [JsonPropertyName("window_position")]
         [JsonConverter(typeof(ShortcutGuideWindowPositionConverter))]
         public IntProperty WindowPosition { get; set; }
+
+        // When true, Shortcut Guide opens on long-press of the Windows key (legacy v0.99 behavior)
+        // and the customized shortcut is not registered. Mutually exclusive by design.
+        [JsonPropertyName("use_legacy_press_win_key_behavior")]
+        public BoolProperty UseLegacyPressWinKeyBehavior { get; set; }
+
+        // Milliseconds the Windows key must be held before Shortcut Guide is shown.
+        // Only honored when UseLegacyPressWinKeyBehavior is true.
+        [JsonPropertyName("press_time")]
+        public IntProperty PressTime { get; set; }
     }
 }

--- a/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/ShortcutGuide.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/ShortcutGuide.cs
@@ -104,5 +104,47 @@ namespace ViewModelTests
             Func<string, bool> isDark = s => JsonSerializer.Deserialize<ShortcutGuideSettings>(s).Properties.Theme.Value == "dark";
             settingsUtilsMock.Verify(x => x.SaveSettings(It.Is<string>(y => isDark(y)), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
         }
+
+        [TestMethod]
+        public void LegacyPressWinKeyDefaultsMatchPreV2Behavior()
+        {
+            // Customized shortcut is the default; long-press is opt-in.
+            var settingsUtilsMock = new Mock<SettingsUtils>(new FileSystem(), null);
+            ShortcutGuideViewModel viewModel = new ShortcutGuideViewModel(settingsUtilsMock.Object, SettingsRepository<GeneralSettings>.GetInstance(mockGeneralSettingsUtils.Object), SettingsRepository<ShortcutGuideSettings>.GetInstance(mockShortcutGuideSettingsUtils.Object), msg => { return 0; }, ShortCutGuideTestFolderName);
+
+            Assert.IsFalse(viewModel.UseLegacyPressWinKeyBehavior);
+            Assert.AreEqual(ShortcutGuideProperties.DefaultPressTimeMs, viewModel.PressTime);
+        }
+
+        [TestMethod]
+        public void TogglingUseLegacyPressWinKeyBehaviorPersistsSetting()
+        {
+            // Arrange
+            var settingsUtilsMock = new Mock<SettingsUtils>(new FileSystem(), null);
+            ShortcutGuideViewModel viewModel = new ShortcutGuideViewModel(settingsUtilsMock.Object, SettingsRepository<GeneralSettings>.GetInstance(mockGeneralSettingsUtils.Object), SettingsRepository<ShortcutGuideSettings>.GetInstance(mockShortcutGuideSettingsUtils.Object), msg => { return 0; }, ShortCutGuideTestFolderName);
+
+            // Act
+            viewModel.UseLegacyPressWinKeyBehavior = true;
+
+            // Assert: SaveSettings is called once with a payload that has the legacy flag flipped on.
+            Func<string, bool> isLegacy = s => JsonSerializer.Deserialize<ShortcutGuideSettings>(s).Properties.UseLegacyPressWinKeyBehavior.Value;
+            settingsUtilsMock.Verify(x => x.SaveSettings(It.Is<string>(y => isLegacy(y)), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+        }
+
+        [TestMethod]
+        public void SettingPressTimeRoundTripsThroughSerialization()
+        {
+            // Arrange
+            var settingsUtilsMock = new Mock<SettingsUtils>(new FileSystem(), null);
+            ShortcutGuideViewModel viewModel = new ShortcutGuideViewModel(settingsUtilsMock.Object, SettingsRepository<GeneralSettings>.GetInstance(mockGeneralSettingsUtils.Object), SettingsRepository<ShortcutGuideSettings>.GetInstance(mockShortcutGuideSettingsUtils.Object), msg => { return 0; }, ShortCutGuideTestFolderName);
+
+            // Act
+            viewModel.PressTime = 1500;
+
+            // Assert
+            Assert.AreEqual(1500, viewModel.PressTime);
+            Func<string, bool> hasPressTime = s => JsonSerializer.Deserialize<ShortcutGuideSettings>(s).Properties.PressTime.Value == 1500;
+            settingsUtilsMock.Verify(x => x.SaveSettings(It.Is<string>(y => hasPressTime(y)), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+        }
     }
 }

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/ShortcutGuidePage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/ShortcutGuidePage.xaml
@@ -23,9 +23,39 @@
                     </tkcontrols:SettingsCard>
                 </controls:GPOInfoControl>
                 <controls:SettingsGroup x:Uid="Shortcut" IsEnabled="{x:Bind ViewModel.IsEnabled, Mode=OneWay}">
-                    <tkcontrols:SettingsCard x:Uid="Activation_Shortcut" HeaderIcon="{ui:FontIcon Glyph=&#xEDA7;}">
+                    <tkcontrols:SettingsCard
+                        Name="ShortcutGuideActivationMethod"
+                        x:Uid="ShortcutGuide_ActivationMethod"
+                        HeaderIcon="{ui:FontIcon Glyph=&#xEDA7;}">
+                        <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}" SelectedIndex="{x:Bind ViewModel.UseLegacyPressWinKeyBehavior, Mode=TwoWay, Converter={StaticResource BoolToComboBoxIndexConverter}}">
+                            <ComboBoxItem x:Uid="Radio_ShortcutGuide_ActivationMethod_CustomizedShortcut" />
+                            <ComboBoxItem x:Uid="Radio_ShortcutGuide_ActivationMethod_LongPressWindowsKey" />
+                        </ComboBox>
+                    </tkcontrols:SettingsCard>
+                    <tkcontrols:SettingsCard
+                        x:Uid="Activation_Shortcut"
+                        HeaderIcon="{ui:FontIcon Glyph=&#xEDA7;}"
+                        Visibility="{x:Bind ViewModel.UseLegacyPressWinKeyBehavior, Mode=OneWay, Converter={StaticResource ReverseBoolToVisibilityConverter}}">
                         <controls:ShortcutControl MinWidth="{StaticResource SettingActionControlMinWidth}" HotkeySettings="{x:Bind Path=ViewModel.OpenShortcutGuide, Mode=TwoWay}" />
                     </tkcontrols:SettingsCard>
+                    <tkcontrols:SettingsCard
+                        Name="ShortcutGuidePressTime"
+                        x:Uid="ShortcutGuide_PressTime"
+                        HeaderIcon="{ui:FontIcon Glyph=&#xE916;}"
+                        Visibility="{x:Bind ViewModel.UseLegacyPressWinKeyBehavior, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
+                        <NumberBox
+                            MinWidth="{StaticResource SettingActionControlMinWidth}"
+                            Minimum="100"
+                            SmallChange="50"
+                            SpinButtonPlacementMode="Compact"
+                            Value="{x:Bind ViewModel.PressTime, Mode=TwoWay}" />
+                    </tkcontrols:SettingsCard>
+                    <InfoBar
+                        x:Uid="ShortcutGuide_PressWinKeyWarning"
+                        IsClosable="False"
+                        IsOpen="{x:Bind ViewModel.UseLegacyPressWinKeyBehavior, Mode=OneWay}"
+                        IsTabStop="True"
+                        Severity="Warning" />
                 </controls:SettingsGroup>
 
                 <controls:SettingsGroup x:Uid="Appearance_Behavior" IsEnabled="{x:Bind ViewModel.IsEnabled, Mode=OneWay}">

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -1168,6 +1168,12 @@ opera.exe</value>
   <data name="ShortcutGuide_WindowPosition.Header" xml:space="preserve">
     <value>Window position</value>
   </data>
+  <data name="ShortcutGuide_PressTime.Header" xml:space="preserve">
+    <value>Press duration</value>
+  </data>
+  <data name="ShortcutGuide_PressTime.Description" xml:space="preserve">
+    <value>How long the Windows key must be held to open Shortcut Guide, in milliseconds</value>
+  </data>
   <data name="ShortcutGuide_WindowPosition_Left.Content" xml:space="preserve">
     <value>Left</value>
   </data>

--- a/src/settings-ui/Settings.UI/ViewModels/ShortcutGuideViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/ShortcutGuideViewModel.cs
@@ -152,6 +152,42 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             }
         }
 
+        // Activation method: false = customized shortcut (default), true = long-press of Windows key.
+        // Surfaced as the index of a two-item ComboBox in the settings page via BoolToComboBoxIndexConverter.
+        public bool UseLegacyPressWinKeyBehavior
+        {
+            get
+            {
+                return Settings.Properties.UseLegacyPressWinKeyBehavior.Value;
+            }
+
+            set
+            {
+                if (Settings.Properties.UseLegacyPressWinKeyBehavior.Value != value)
+                {
+                    Settings.Properties.UseLegacyPressWinKeyBehavior.Value = value;
+                    NotifyPropertyChanged();
+                }
+            }
+        }
+
+        public int PressTime
+        {
+            get
+            {
+                return Settings.Properties.PressTime.Value;
+            }
+
+            set
+            {
+                if (Settings.Properties.PressTime.Value != value)
+                {
+                    Settings.Properties.PressTime.Value = value;
+                    NotifyPropertyChanged();
+                }
+            }
+        }
+
         public int ThemeIndex
         {
             get


### PR DESCRIPTION
## Summary of the Pull Request

Restores the pre-V2 long-press Windows key activation for Shortcut Guide. Users can now choose between the customized keyboard shortcut (default Win + Shift + /) **or** holding the Windows key for a configurable duration (default 900 ms). The two modes are mutually exclusive, matching the v0.99 behavior.

Closes #48491

## PR Checklist

- [x] **Closes:** #48491
- [x] **Communication:** I've discussed this with core contributors already.
- [x] **Tests:** Added unit tests for the new view-model properties (defaults, persistence, serialization round-trip).
- [x] **Manual tests:** Verified switching activation modes triggers immediate runner re-registration; long-press fires the overlay; conflict warning surfaces appropriately.
- [x] **Localization:** New strings (ShortcutGuide_PressTime.Header, .Description) added; the activation-method and warning strings already existed in Resources.resw from v0.99 and are reused as-is.

## Detailed Description of the Pull Request / Additional comments

### New settings (settings.json)

| Key | Type | Default |
|-----|------|---------|
| `use_legacy_press_win_key_behavior` | bool | `false` |
| `press_time` | int (ms) | `900` |

When `use_legacy_press_win_key_behavior` is true:

- The C++ module returns `std::nullopt` from `GetHotkeyEx()` so the runner does **not** register the customized shortcut.
- The module returns `true` from `keep_track_of_pressed_win_key()` and the configured ms from `milliseconds_win_key_must_be_pressed()`, which causes `powertoy_module.cpp::UpdateHotkeyEx` to register a press-action on `VK_LWIN`/`VK_RWIN` via `CentralizedKeyboardHook::AddPressedKeyAction`.
- Toggling the setting in the Settings UI fires IPC -> `set_config` -> `UpdateHotkeyEx` immediately, so no restart is needed.

### Simplifications vs v0.99

v0.99 had two press-time settings (`press_time` and `press_time_for_taskbar_icon_shortcuts`). V2 shows the taskbar indicator inline whenever the selected section has a `<TASKBAR1-9>` marker, so the dual-stage timing is no longer meaningful. This PR ships **one** `press_time` setting.

### Backwards compat

- Existing V2 users with no extra keys -> defaults apply, no behavior change.
- Users upgraded from v0.99 silently pick up their existing `use_legacy_press_win_key_behavior` / `press_time` values.

### Files changed

| File | Change |
|------|--------|
| `ShortcutGuideProperties.cs` | Added `UseLegacyPressWinKeyBehavior` and `PressTime` (default 900 ms) |
| `ShortcutGuideModuleInterface/dllmain.cpp` | Parses new keys; overrides `keep_track_of_pressed_win_key` / `milliseconds_win_key_must_be_pressed`; gates `GetHotkeyEx` |
| `ShortcutGuideViewModel.cs` | New observable properties wired through `NotifyPropertyChanged` (which both raises change and saves+sends IPC) |
| `ShortcutGuidePage.xaml` | New `Activation method` ComboBox; the existing shortcut card and the new press-duration NumberBox toggle visibility; warning InfoBar |
| `Resources.resw` | New `ShortcutGuide_PressTime.Header` / `.Description` |
| `Settings.UI.UnitTests/ViewModelTests/ShortcutGuide.cs` | 3 new tests |

## Validation Steps Performed

- `Settings.UI.Library`, `ShortcutGuideModuleInterface`, `PowerToys.Settings`, `Settings.UI.UnitTests` all build clean (exit 0, empty errors logs) on arm64 / Debug.
- `Settings.UI.UnitTests` -> all 10 ShortcutGuide tests pass, including the 3 new ones.
- Manually toggled the new ComboBox; verified the shortcut card hides, the press-duration NumberBox appears, and changing the duration takes effect without restart.
- Verified long-press triggers the overlay; verified switching back to `Custom shortcut` re-registers the shortcut.

