### PR TITLE
fix: show Mouse Pointer Crosshairs in the Quick Access flyout

### DIFF
--- a/src/settings-ui/Settings.UI.Controls/QuickAccess/QuickAccessLauncher.cs
+++ b/src/settings-ui/Settings.UI.Controls/QuickAccess/QuickAccessLauncher.cs
@@ -134,6 +134,13 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
                     }
 
                     return true;
+                case ModuleType.MousePointerCrosshairs:
+                    using (var eventHandle = new EventWaitHandle(false, EventResetMode.AutoReset, Constants.MouseCrosshairsTriggerEvent()))
+                    {
+                        eventHandle.Set();
+                    }
+
+                    return true;
                 case ModuleType.MouseWithoutBorders:
                     using (var eventHandle = new EventWaitHandle(false, EventResetMode.AutoReset, Constants.MWBReconnectEvent()))
                     {

--- a/src/settings-ui/Settings.UI.Controls/QuickAccess/QuickAccessViewModel.cs
+++ b/src/settings-ui/Settings.UI.Controls/QuickAccess/QuickAccessViewModel.cs
@@ -77,6 +77,7 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
             AddFlyoutMenuItem(ModuleType.KeyboardManager);
             AddFlyoutMenuItem(ModuleType.LightSwitch);
             AddFlyoutMenuItem(ModuleType.MouseWithoutBorders);
+            AddFlyoutMenuItem(ModuleType.MousePointerCrosshairs);
             AddFlyoutMenuItem(ModuleType.PowerDisplay);
             AddFlyoutMenuItem(ModuleType.PowerLauncher);
             AddFlyoutMenuItem(ModuleType.PowerOCR);
@@ -170,6 +171,7 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
                 ModuleType.MeasureTool => SettingsRepository<MeasureToolSettings>.GetInstance(SettingsUtils.Default).SettingsConfig.Properties.ActivationShortcut.ToString(),
                 ModuleType.ShortcutGuide => SettingsRepository<ShortcutGuideSettings>.GetInstance(SettingsUtils.Default).SettingsConfig.Properties.OpenShortcutGuide.ToString(),
                 ModuleType.MouseWithoutBorders => SettingsRepository<MouseWithoutBordersSettings>.GetInstance(SettingsUtils.Default).SettingsConfig.Properties.ReconnectShortcut.ToString(),
+                ModuleType.MousePointerCrosshairs => SettingsRepository<MousePointerCrosshairsSettings>.GetInstance(SettingsUtils.Default).SettingsConfig.Properties.ActivationShortcut.ToString(),
                 _ => string.Empty,
             };
         }

--- a/src/settings-ui/Settings.UI.Controls/QuickAccess/QuickAccessViewModel.cs
+++ b/src/settings-ui/Settings.UI.Controls/QuickAccess/QuickAccessViewModel.cs
@@ -76,8 +76,8 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
             AddFlyoutMenuItem(ModuleType.Hosts);
             AddFlyoutMenuItem(ModuleType.KeyboardManager);
             AddFlyoutMenuItem(ModuleType.LightSwitch);
-            AddFlyoutMenuItem(ModuleType.MouseWithoutBorders);
             AddFlyoutMenuItem(ModuleType.MousePointerCrosshairs);
+            AddFlyoutMenuItem(ModuleType.MouseWithoutBorders);
             AddFlyoutMenuItem(ModuleType.PowerDisplay);
             AddFlyoutMenuItem(ModuleType.PowerLauncher);
             AddFlyoutMenuItem(ModuleType.PowerOCR);


### PR DESCRIPTION
## Summary of the Pull Request

On 0.100, enabling "Mouse Pointer Crosshairs" does not add a corresponding button to the PowerToys Quick Access flyout (tray icon > More > Quick access panel). A user expects every launchable utility to appear there so they need not memorize its activation shortcut. A repo contributor (skycommand) confirmed this is a bug, noting that Quick Access should only exempt a tool when there is a strong rationale (e.g. Find My Mouse, whose whole point is keyboard-only invocation) and that Mouse Pointer Crosshairs has no such rationale.

## PR Checklist

- [x] Closes: #48484
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [x] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places

## Detailed Description of the Pull Request / Additional comments

The Quick Access flyout menu is built from an explicit hardcoded allow-list in `QuickAccessViewModel.InitializeItems()`, which calls `AddFlyoutMenuItem(ModuleType...)` for each included module. `ModuleType.MousePointerCrosshairs` is simply absent from that list, which is why it never appears. Add `AddFlyoutMenuItem(ModuleType.MousePointerCrosshairs)` to `InitializeItems()` and add a `ModuleType.MousePointerCrosshairs => SettingsRepository<MousePointerCrosshairsSettings>.GetInstance(SettingsUtils.Default).SettingsConfig.Properties.ActivationShortcut.ToString()` case to `GetModuleToolTip()` so the tooltip shows the activation shortcut like the other entries. Visibility (`GetItemVisibility`) and launch (`_launcher.Launch(moduleType)`) are already generic over `ModuleType`, so no further wiring is required. There are no existing unit tests for this ViewModel; verification is the maintainer-requested screen recording showing the crosshairs button appearing and launching from Quick Access.

## Validation Steps Performed

- Happy path: enable Mouse Pointer Crosshairs, open the Quick Access flyout, confirm a Mouse Pointer Crosshairs button appears and clicking it toggles the crosshairs.
- Tooltip: hover the new button and confirm it shows the configured activation shortcut (default Win+Alt+P).
- Disabled/GPO: with the module GPO-disabled, confirm `AddFlyoutMenuItem` early-returns and the button does not appear; with the module simply turned off, confirm `GetItemVisibility` hides it.

Fixes #48484

AI was used for assistance.
