### PR TITLE
Quick Accent: Add ¡ and ¿ to ! and ? quick accent menu (#20618)

### DIFF
--- a/src/modules/poweraccent/PowerAccent.Common/CharacterMappings.cs
+++ b/src/modules/poweraccent/PowerAccent.Common/CharacterMappings.cs
@@ -90,6 +90,7 @@ public static class CharacterMappings
 
         new(Language.CA, "Catalan", LanguageGroup.Language, new Dictionary<LetterKey, string[]>
         {
+            [LetterKey.VK_1] = ["¡"],
             [LetterKey.VK_A] = ["à", "á"],
             [LetterKey.VK_C] = ["ç"],
             [LetterKey.VK_E] = ["è", "é", "€"],
@@ -99,6 +100,7 @@ public static class CharacterMappings
             [LetterKey.VK_U] = ["ù", "ú", "ü"],
             [LetterKey.VK_L] = ["·"],
             [LetterKey.VK_COMMA] = ["¿", "?", "¡", "!", "«", "»", "“", "”", "‘", "’"],
+            [LetterKey.VK_SLASH_] = ["¿"],
         }),
 
         new(Language.CRH, "Crimean", LanguageGroup.Language, new Dictionary<LetterKey, string[]>
@@ -605,6 +607,7 @@ public static class CharacterMappings
 
         new(Language.SP, "Spanish", LanguageGroup.Language, new Dictionary<LetterKey, string[]>
         {
+            [LetterKey.VK_1] = ["¡"],
             [LetterKey.VK_A] = ["á"],
             [LetterKey.VK_E] = ["é", "€"],
             [LetterKey.VK_H] = ["ḥ"],
@@ -614,6 +617,7 @@ public static class CharacterMappings
             [LetterKey.VK_O] = ["ó"],
             [LetterKey.VK_U] = ["ú", "ü"],
             [LetterKey.VK_COMMA] = ["¿", "?", "¡", "!", "«", "»", "“", "”", "‘", "’"],
+            [LetterKey.VK_SLASH_] = ["¿"],
         }),
 
         new(Language.SR, "Serbian", LanguageGroup.Language, new Dictionary<LetterKey, string[]>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This PR addresses issue #20618 by adding the inverted exclamation mark (**¡**) to the **!** key (`VK_1`) and the inverted question mark (**¿**) to the **?** key (`VK_SLASH_`) for both Spanish (`SP`) and Catalan (`CA`) character mappings in Quick Accent.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #20618
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [x] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [x] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

Adds the inverted punctuation marks `¡` (inverted exclamation mark) and `¿` (inverted question mark) to the character mappings of Spanish (`SP`) and Catalan (`CA`) languages in `CharacterMappings.cs`.
- `LetterKey.VK_1` (`!`) now maps to `¡`
- `LetterKey.VK_SLASH_` (`?`) now maps to `¿`

This enables quick accent popups when pressing these respective keys, aligning with the expected behavior for these languages.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

1. Verified character mapping changes build successfully.
2. Verified that the PowerToys CI pipeline checks completed successfully.
