### PR TITLE
Fix WebView2 launch issues under AppContainer ACLs

### DIFF
--- a/src/modules/previewpane/MarkdownPreviewHandler/Program.cs
+++ b/src/modules/previewpane/MarkdownPreviewHandler/Program.cs
@@ -23,6 +23,14 @@ namespace Microsoft.PowerToys.PreviewHandler.Markdown
         [STAThread]
         public static void Main(string[] args)
         {
+            try
+            {
+                System.IO.Directory.SetCurrentDirectory(AppContext.BaseDirectory);
+            }
+            catch
+            {
+            }
+
             ApplicationConfiguration.Initialize();
             if (args != null)
             {

--- a/src/modules/previewpane/MarkdownPreviewHandler/Program.cs
+++ b/src/modules/previewpane/MarkdownPreviewHandler/Program.cs
@@ -25,9 +25,13 @@ namespace Microsoft.PowerToys.PreviewHandler.Markdown
         {
             try
             {
+                // The out-of-process preview host inherits File Explorer's working directory, which can be
+                // an AppContainer-ACL-restricted folder that breaks WebView2's sandboxed child processes.
+                // Reset it to this handler's own install directory. Best-effort by design: if the directory
+                // cannot be changed we still continue, so only the expected filesystem/ACL exceptions are swallowed.
                 System.IO.Directory.SetCurrentDirectory(AppContext.BaseDirectory);
             }
-            catch
+            catch (Exception ex) when (ex is System.IO.IOException or System.UnauthorizedAccessException or System.Security.SecurityException or System.ArgumentException)
             {
             }
 

--- a/src/modules/previewpane/MonacoPreviewHandler/Program.cs
+++ b/src/modules/previewpane/MonacoPreviewHandler/Program.cs
@@ -23,6 +23,14 @@ namespace Microsoft.PowerToys.PreviewHandler.Monaco
         [STAThread]
         public static void Main(string[] args)
         {
+            try
+            {
+                System.IO.Directory.SetCurrentDirectory(AppContext.BaseDirectory);
+            }
+            catch
+            {
+            }
+
             Logger.InitializeLogger("\\FileExplorer_localLow\\Monaco\\logs", true);
 
             ApplicationConfiguration.Initialize();

--- a/src/modules/previewpane/MonacoPreviewHandler/Program.cs
+++ b/src/modules/previewpane/MonacoPreviewHandler/Program.cs
@@ -25,9 +25,13 @@ namespace Microsoft.PowerToys.PreviewHandler.Monaco
         {
             try
             {
+                // The out-of-process preview host inherits File Explorer's working directory, which can be
+                // an AppContainer-ACL-restricted folder that breaks WebView2's sandboxed child processes.
+                // Reset it to this handler's own install directory. Best-effort by design: if the directory
+                // cannot be changed we still continue, so only the expected filesystem/ACL exceptions are swallowed.
                 System.IO.Directory.SetCurrentDirectory(AppContext.BaseDirectory);
             }
-            catch
+            catch (Exception ex) when (ex is System.IO.IOException or System.UnauthorizedAccessException or System.Security.SecurityException or System.ArgumentException)
             {
             }
 

--- a/src/modules/previewpane/SvgPreviewHandler/Program.cs
+++ b/src/modules/previewpane/SvgPreviewHandler/Program.cs
@@ -23,6 +23,14 @@ namespace Microsoft.PowerToys.PreviewHandler.Svg
         [STAThread]
         public static void Main(string[] args)
         {
+            try
+            {
+                System.IO.Directory.SetCurrentDirectory(AppContext.BaseDirectory);
+            }
+            catch
+            {
+            }
+
             ApplicationConfiguration.Initialize();
             if (args != null)
             {

--- a/src/modules/previewpane/SvgPreviewHandler/Program.cs
+++ b/src/modules/previewpane/SvgPreviewHandler/Program.cs
@@ -25,9 +25,13 @@ namespace Microsoft.PowerToys.PreviewHandler.Svg
         {
             try
             {
+                // The out-of-process preview host inherits File Explorer's working directory, which can be
+                // an AppContainer-ACL-restricted folder that breaks WebView2's sandboxed child processes.
+                // Reset it to this handler's own install directory. Best-effort by design: if the directory
+                // cannot be changed we still continue, so only the expected filesystem/ACL exceptions are swallowed.
                 System.IO.Directory.SetCurrentDirectory(AppContext.BaseDirectory);
             }
-            catch
+            catch (Exception ex) when (ex is System.IO.IOException or System.UnauthorizedAccessException or System.Security.SecurityException or System.ArgumentException)
             {
             }
 

--- a/src/modules/previewpane/SvgThumbnailProvider/Program.cs
+++ b/src/modules/previewpane/SvgThumbnailProvider/Program.cs
@@ -18,6 +18,14 @@ namespace Microsoft.PowerToys.ThumbnailHandler.Svg
         [STAThread]
         public static void Main(string[] args)
         {
+            try
+            {
+                System.IO.Directory.SetCurrentDirectory(AppContext.BaseDirectory);
+            }
+            catch
+            {
+            }
+
             ApplicationConfiguration.Initialize();
             Logger.InitializeLogger("\\FileExplorer_localLow\\SvgThumbnails\\logs", true);
             if (args != null)

--- a/src/modules/previewpane/SvgThumbnailProvider/Program.cs
+++ b/src/modules/previewpane/SvgThumbnailProvider/Program.cs
@@ -20,9 +20,13 @@ namespace Microsoft.PowerToys.ThumbnailHandler.Svg
         {
             try
             {
+                // The out-of-process preview host inherits File Explorer's working directory, which can be
+                // an AppContainer-ACL-restricted folder that breaks WebView2's sandboxed child processes.
+                // Reset it to this handler's own install directory. Best-effort by design: if the directory
+                // cannot be changed we still continue, so only the expected filesystem/ACL exceptions are swallowed.
                 System.IO.Directory.SetCurrentDirectory(AppContext.BaseDirectory);
             }
-            catch
+            catch (Exception ex) when (ex is System.IO.IOException or System.UnauthorizedAccessException or System.Security.SecurityException or System.ArgumentException)
             {
             }
 


### PR DESCRIPTION
setting the working directory of out-of-process preview and thumbnail handlers using WebView2 to the application base directory at startup prevents the WebView2 child processes from inheriting restricted directory paths (e.g. folders with AppContainer ACL entries) as their working directory, which otherwise causes WebView2 initialization/renderer process failures.

Closes: #48601