### PR TITLE
[Run] Add friendly date/time format to TimeDate plugin

### DIFF
--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests/TimeAndDateHelperTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests/TimeAndDateHelperTests.cs
@@ -166,6 +166,117 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests
             Assert.AreEqual(result, week);
         }
 
+        // Fixed reference "now" used by all friendly-format tests. Picking a midday weekday avoids
+        // accidentally crossing a midnight boundary when adjusting by hours, and avoids landing on a
+        // month/year boundary that would mask off-by-one mistakes elsewhere.
+        private static readonly DateTime FriendlyReferenceNow = new DateTime(2026, 06, 15, 12, 00, 00);
+
+        [DataTestMethod]
+        [DataRow(0, "Today")]
+        [DataRow(-1, "Yesterday")]
+        [DataRow(1, "Tomorrow")]
+        [DataRow(-2, "2 days ago")]
+        [DataRow(-7, "7 days ago")]
+        [DataRow(2, "in 2 days")]
+        [DataRow(7, "in 7 days")]
+        public void GetFriendlyDate_WithinSupportedWindow_ReturnsLocalizedLabel(int dayDelta, string expected)
+        {
+            // Arrange
+            DateTime target = FriendlyReferenceNow.AddDays(dayDelta);
+
+            // Act
+            string result = TimeAndDateHelper.GetFriendlyDate(target, FriendlyReferenceNow, CultureInfo.CurrentCulture);
+
+            // Assert
+            Assert.AreEqual(expected, result);
+        }
+
+        [DataTestMethod]
+        [DataRow(-8)]
+        [DataRow(-30)]
+        [DataRow(8)]
+        [DataRow(365)]
+        public void GetFriendlyDate_OutsideSupportedWindow_ReturnsNull(int dayDelta)
+        {
+            // Arrange
+            DateTime target = FriendlyReferenceNow.AddDays(dayDelta);
+
+            // Act
+            string result = TimeAndDateHelper.GetFriendlyDate(target, FriendlyReferenceNow, CultureInfo.CurrentCulture);
+
+            // Assert
+            Assert.IsNull(result);
+        }
+
+        [TestMethod]
+        public void GetFriendlyDate_TargetBeforeMidnight_ComparesByCalendarDay()
+        {
+            // Reference "now" at 00:30 today; target at 23:00 yesterday. 22.5h delta but one calendar day apart.
+            DateTime now = new DateTime(2026, 06, 15, 00, 30, 00);
+            DateTime target = new DateTime(2026, 06, 14, 23, 00, 00);
+
+            string result = TimeAndDateHelper.GetFriendlyDate(target, now, CultureInfo.CurrentCulture);
+
+            Assert.AreEqual("Yesterday", result);
+        }
+
+        [DataTestMethod]
+        [DataRow(0, "just now")]
+        [DataRow(-15, "just now")] // within 30s threshold
+        [DataRow(29, "just now")]
+        public void GetFriendlyDateTime_WithinJustNowThreshold_ReturnsJustNow(int secondsDelta, string expected)
+        {
+            DateTime target = FriendlyReferenceNow.AddSeconds(secondsDelta);
+
+            string result = TimeAndDateHelper.GetFriendlyDateTime(target, FriendlyReferenceNow, CultureInfo.CurrentCulture);
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [DataTestMethod]
+        [DataRow(-30, "1 minutes ago")] // boundary: 30s rounds up to 1 minute past
+        [DataRow(-300, "5 minutes ago")]
+        [DataRow(-3540, "59 minutes ago")]
+        [DataRow(300, "in 5 minutes")]
+        [DataRow(60, "in 1 minutes")]
+        public void GetFriendlyDateTime_WithinHour_ReturnsMinutesLabel(int secondsDelta, string expected)
+        {
+            DateTime target = FriendlyReferenceNow.AddSeconds(secondsDelta);
+
+            string result = TimeAndDateHelper.GetFriendlyDateTime(target, FriendlyReferenceNow, CultureInfo.CurrentCulture);
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [DataTestMethod]
+        [DataRow(-1, "1 hours ago")]
+        [DataRow(-3, "3 hours ago")]
+        [DataRow(-23, "23 hours ago")]
+        [DataRow(2, "in 2 hours")]
+        [DataRow(23, "in 23 hours")]
+        public void GetFriendlyDateTime_WithinDay_ReturnsHoursLabel(int hoursDelta, string expected)
+        {
+            DateTime target = FriendlyReferenceNow.AddHours(hoursDelta);
+
+            string result = TimeAndDateHelper.GetFriendlyDateTime(target, FriendlyReferenceNow, CultureInfo.CurrentCulture);
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [DataTestMethod]
+        [DataRow(-24)]
+        [DataRow(-48)]
+        [DataRow(24)]
+        [DataRow(720)]
+        public void GetFriendlyDateTime_AtOrBeyondDay_ReturnsNull(int hoursDelta)
+        {
+            DateTime target = FriendlyReferenceNow.AddHours(hoursDelta);
+
+            string result = TimeAndDateHelper.GetFriendlyDateTime(target, FriendlyReferenceNow, CultureInfo.CurrentCulture);
+
+            Assert.IsNull(result);
+        }
+
         [TestCleanup]
         public void CleanUp()
         {

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests/TimeAndDateHelperTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests/TimeAndDateHelperTests.cs
@@ -234,11 +234,14 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests
         }
 
         [DataTestMethod]
-        [DataRow(-30, "1 minutes ago")] // boundary: 30s rounds up to 1 minute past
+        [DataRow(-30, "1 minute ago")] // boundary: 30s rounds up to 1 minute past
+        [DataRow(-60, "1 minute ago")]
+        [DataRow(-120, "2 minutes ago")]
         [DataRow(-300, "5 minutes ago")]
         [DataRow(-3540, "59 minutes ago")]
+        [DataRow(60, "in 1 minute")]
+        [DataRow(120, "in 2 minutes")]
         [DataRow(300, "in 5 minutes")]
-        [DataRow(60, "in 1 minutes")]
         public void GetFriendlyDateTime_WithinHour_ReturnsMinutesLabel(int secondsDelta, string expected)
         {
             DateTime target = FriendlyReferenceNow.AddSeconds(secondsDelta);
@@ -249,9 +252,11 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests
         }
 
         [DataTestMethod]
-        [DataRow(-1, "1 hours ago")]
+        [DataRow(-1, "1 hour ago")]
+        [DataRow(-2, "2 hours ago")]
         [DataRow(-3, "3 hours ago")]
         [DataRow(-23, "23 hours ago")]
+        [DataRow(1, "in 1 hour")]
         [DataRow(2, "in 2 hours")]
         [DataRow(23, "in 23 hours")]
         public void GetFriendlyDateTime_WithinDay_ReturnsHoursLabel(int hoursDelta, string expected)
@@ -278,10 +283,10 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests
         }
 
         [DataTestMethod]
-        [DataRow(-3570, "1 hours ago")]      // 59m30s ago: rounds to 60 min, promotes to 1h
-        [DataRow(-3599, "1 hours ago")]      // 59m59s ago
-        [DataRow(3570, "in 1 hours")]
-        [DataRow(3599, "in 1 hours")]
+        [DataRow(-3570, "1 hour ago")]      // 59m30s ago: rounds to 60 min, promotes to 1h
+        [DataRow(-3599, "1 hour ago")]      // 59m59s ago
+        [DataRow(3570, "in 1 hour")]
+        [DataRow(3599, "in 1 hour")]
         public void GetFriendlyDateTime_MinuteBoundaryRollsToHours(int secondsDelta, string expected)
         {
             DateTime target = FriendlyReferenceNow.AddSeconds(secondsDelta);

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests/TimeAndDateHelperTests.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests/TimeAndDateHelperTests.cs
@@ -277,6 +277,34 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.UnitTests
             Assert.IsNull(result);
         }
 
+        [DataTestMethod]
+        [DataRow(-3570, "1 hours ago")]      // 59m30s ago: rounds to 60 min, promotes to 1h
+        [DataRow(-3599, "1 hours ago")]      // 59m59s ago
+        [DataRow(3570, "in 1 hours")]
+        [DataRow(3599, "in 1 hours")]
+        public void GetFriendlyDateTime_MinuteBoundaryRollsToHours(int secondsDelta, string expected)
+        {
+            DateTime target = FriendlyReferenceNow.AddSeconds(secondsDelta);
+
+            string result = TimeAndDateHelper.GetFriendlyDateTime(target, FriendlyReferenceNow, CultureInfo.CurrentCulture);
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [DataTestMethod]
+        [DataRow(-23.5)]   // rounds to 24 hours, defer to friendly date
+        [DataRow(-23.99)]
+        [DataRow(23.5)]
+        [DataRow(23.99)]
+        public void GetFriendlyDateTime_HourBoundaryReturnsNull(double hoursDelta)
+        {
+            DateTime target = FriendlyReferenceNow.AddHours(hoursDelta);
+
+            string result = TimeAndDateHelper.GetFriendlyDateTime(target, FriendlyReferenceNow, CultureInfo.CurrentCulture);
+
+            Assert.IsNull(result);
+        }
+
         [TestCleanup]
         public void CleanUp()
         {

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate/Components/AvailableResultsList.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate/Components/AvailableResultsList.cs
@@ -66,11 +66,13 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.Components
             if (isKeywordSearch || !TimeDateSettings.Instance.OnlyDateTimeNowGlobal)
             {
                 // Friendly (relative) date/time results.
-                // The "now" reference is always the system clock so that supplying a timestamp via the input
-                // parser (for example `friendly date::u1700000000`) describes that instant relative to today.
-                // Helpers return null when the delta is outside the supported window; those entries get
-                // filtered out by the final `Where(x => !string.IsNullOrEmpty(x.Value))` pass.
-                DateTime friendlyReferenceNow = DateTime.Now;
+                // For system-time queries `dateTimeNow` is already DateTime.Now and gets reused as the
+                // reference, which avoids a midnight race between two separate DateTime.Now calls.
+                // For parsed-timestamp queries we take a single fresh sample so the friendly label
+                // describes the input instant relative to the current moment.
+                // Helpers return null when the delta is outside the supported window; those entries
+                // get filtered out by the final `Where(x => !string.IsNullOrEmpty(x.Value))` pass.
+                DateTime friendlyReferenceNow = isSystemDateTime ? dateTimeNow : DateTime.Now;
                 results.AddRange(new[]
                 {
                     new AvailableResult()

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate/Components/AvailableResultsList.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate/Components/AvailableResultsList.cs
@@ -65,6 +65,30 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.Components
 
             if (isKeywordSearch || !TimeDateSettings.Instance.OnlyDateTimeNowGlobal)
             {
+                // Friendly (relative) date/time results.
+                // The "now" reference is always the system clock so that supplying a timestamp via the input
+                // parser (for example `friendly date::u1700000000`) describes that instant relative to today.
+                // Helpers return null when the delta is outside the supported window; those entries get
+                // filtered out by the final `Where(x => !string.IsNullOrEmpty(x.Value))` pass.
+                DateTime friendlyReferenceNow = DateTime.Now;
+                results.AddRange(new[]
+                {
+                    new AvailableResult()
+                    {
+                        Value = TimeAndDateHelper.GetFriendlyDate(dateTimeNow, friendlyReferenceNow, CultureInfo.CurrentCulture) ?? string.Empty,
+                        Label = Resources.Microsoft_plugin_timedate_FriendlyDate,
+                        AlternativeSearchTag = Resources.Microsoft_plugin_timedate_SearchTagFriendly,
+                        IconType = ResultIconType.Date,
+                    },
+                    new AvailableResult()
+                    {
+                        Value = TimeAndDateHelper.GetFriendlyDateTime(dateTimeNow, friendlyReferenceNow, CultureInfo.CurrentCulture) ?? string.Empty,
+                        Label = Resources.Microsoft_plugin_timedate_FriendlyDateTime,
+                        AlternativeSearchTag = Resources.Microsoft_plugin_timedate_SearchTagFriendly,
+                        IconType = ResultIconType.DateTime,
+                    },
+                });
+
                 // We use long instead of int for unix time stamp because int is too small after 03:14:07 UTC 2038-01-19
                 long unixTimestamp = ((DateTimeOffset)dateTimeNowUtc).ToUnixTimeSeconds();
                 long unixTimestampMilliseconds = ((DateTimeOffset)dateTimeNowUtc).ToUnixTimeMilliseconds();

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate/Components/TimeAndDateHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate/Components/TimeAndDateHelper.cs
@@ -439,20 +439,31 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.Components
 
             if (roundedMinutes < 60)
             {
+                if (roundedMinutes == 1)
+                {
+                    return isPast
+                        ? Resources.Microsoft_plugin_timedate_FriendlyMinuteAgo
+                        : Resources.Microsoft_plugin_timedate_FriendlyInMinute;
+                }
+
                 string key = isPast
                     ? Resources.Microsoft_plugin_timedate_FriendlyMinutesAgo
                     : Resources.Microsoft_plugin_timedate_FriendlyInMinutes;
                 return string.Format(culture, CompositeFormat.Parse(key), roundedMinutes);
             }
 
+            // Once we reach this branch roundedMinutes >= 60, which implies absolute delta is at least
+            // 59.5 minutes; that rounds to at least 1 hour, so no zero-clamp is needed here.
             int roundedHours = (int)Math.Round(Math.Abs(delta.TotalHours));
-            if (roundedHours < 1)
-            {
-                roundedHours = 1;
-            }
-
             if (roundedHours < 24)
             {
+                if (roundedHours == 1)
+                {
+                    return isPast
+                        ? Resources.Microsoft_plugin_timedate_FriendlyHourAgo
+                        : Resources.Microsoft_plugin_timedate_FriendlyInHour;
+                }
+
                 string key = isPast
                     ? Resources.Microsoft_plugin_timedate_FriendlyHoursAgo
                     : Resources.Microsoft_plugin_timedate_FriendlyInHours;

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate/Components/TimeAndDateHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate/Components/TimeAndDateHelper.cs
@@ -373,6 +373,90 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.Components
         }
 
         /// <summary>
+        /// Returns a human-readable relative date label (e.g. "Today", "Yesterday", "in 3 days").
+        /// </summary>
+        /// <param name="target">The date to describe.</param>
+        /// <param name="now">Reference "now" value used to compute the relative offset. Tests pass a fixed value; callers in production pass <see cref="DateTime.Now"/>.</param>
+        /// <param name="culture">Culture used for formatting the integer day count.</param>
+        /// <returns>Localized label, or <c>null</c> if the delta exceeds the supported range (more than 7 calendar days in either direction).</returns>
+        internal static string GetFriendlyDate(DateTime target, DateTime now, CultureInfo culture)
+        {
+            // Compare calendar days, not 24-hour deltas: 1am vs yesterday 11pm must read "Yesterday", not "Today".
+            int dayDelta = (target.Date - now.Date).Days;
+
+            switch (dayDelta)
+            {
+                case 0:
+                    return Resources.Microsoft_plugin_timedate_FriendlyToday;
+                case -1:
+                    return Resources.Microsoft_plugin_timedate_FriendlyYesterday;
+                case 1:
+                    return Resources.Microsoft_plugin_timedate_FriendlyTomorrow;
+            }
+
+            if (dayDelta >= -7 && dayDelta <= -2)
+            {
+                CompositeFormat fmt = CompositeFormat.Parse(Resources.Microsoft_plugin_timedate_FriendlyDaysAgo);
+                return string.Format(culture, fmt, -dayDelta);
+            }
+
+            if (dayDelta >= 2 && dayDelta <= 7)
+            {
+                CompositeFormat fmt = CompositeFormat.Parse(Resources.Microsoft_plugin_timedate_FriendlyInDays);
+                return string.Format(culture, fmt, dayDelta);
+            }
+
+            // Outside the supported window: omit the result rather than producing "in 14000 days".
+            return null;
+        }
+
+        /// <summary>
+        /// Returns a human-readable relative date/time label (e.g. "just now", "5 minutes ago", "in 2 hours").
+        /// </summary>
+        /// <param name="target">The instant to describe.</param>
+        /// <param name="now">Reference "now" value used to compute the relative offset.</param>
+        /// <param name="culture">Culture used for formatting the integer counts.</param>
+        /// <returns>Localized label, or <c>null</c> if the delta is 24 hours or larger (defer to <see cref="GetFriendlyDate"/> in that case).</returns>
+        internal static string GetFriendlyDateTime(DateTime target, DateTime now, CultureInfo culture)
+        {
+            TimeSpan delta = target - now;
+            double absSeconds = Math.Abs(delta.TotalSeconds);
+
+            if (absSeconds < 30)
+            {
+                return Resources.Microsoft_plugin_timedate_FriendlyJustNow;
+            }
+
+            double absMinutes = Math.Abs(delta.TotalMinutes);
+            if (absMinutes < 60)
+            {
+                int minutes = (int)Math.Round(absMinutes);
+                if (minutes == 0)
+                {
+                    // Rounding 30s..59s down would land us back at "just now"; clamp instead.
+                    minutes = 1;
+                }
+
+                string key = delta.TotalSeconds < 0
+                    ? Resources.Microsoft_plugin_timedate_FriendlyMinutesAgo
+                    : Resources.Microsoft_plugin_timedate_FriendlyInMinutes;
+                return string.Format(culture, CompositeFormat.Parse(key), minutes);
+            }
+
+            double absHours = Math.Abs(delta.TotalHours);
+            if (absHours < 24)
+            {
+                int hours = Math.Max(1, (int)Math.Round(absHours));
+                string key = delta.TotalSeconds < 0
+                    ? Resources.Microsoft_plugin_timedate_FriendlyHoursAgo
+                    : Resources.Microsoft_plugin_timedate_FriendlyInHours;
+                return string.Format(culture, CompositeFormat.Parse(key), hours);
+            }
+
+            return null;
+        }
+
+        /// <summary>
         /// Returns a CalendarWeekRule enum value based on the plugin setting.
         /// </summary>
         internal static CalendarWeekRule GetCalendarWeekRule(int pluginSetting)

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate/Components/TimeAndDateHelper.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate/Components/TimeAndDateHelper.cs
@@ -421,38 +421,45 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.Components
         {
             TimeSpan delta = target - now;
             double absSeconds = Math.Abs(delta.TotalSeconds);
+            bool isPast = delta.TotalSeconds < 0;
 
             if (absSeconds < 30)
             {
                 return Resources.Microsoft_plugin_timedate_FriendlyJustNow;
             }
 
-            double absMinutes = Math.Abs(delta.TotalMinutes);
-            if (absMinutes < 60)
+            // Rounded counts can land on a bucket boundary (e.g. 59m45s rounds to 60 min). When that
+            // happens we promote to the next bucket rather than emit "60 minutes ago" or "in 24 hours".
+            int roundedMinutes = (int)Math.Round(Math.Abs(delta.TotalMinutes));
+            if (roundedMinutes == 0)
             {
-                int minutes = (int)Math.Round(absMinutes);
-                if (minutes == 0)
-                {
-                    // Rounding 30s..59s down would land us back at "just now"; clamp instead.
-                    minutes = 1;
-                }
+                // 30s..59s rounds down to 0 minutes; clamp to 1 instead of falling back to "just now".
+                roundedMinutes = 1;
+            }
 
-                string key = delta.TotalSeconds < 0
+            if (roundedMinutes < 60)
+            {
+                string key = isPast
                     ? Resources.Microsoft_plugin_timedate_FriendlyMinutesAgo
                     : Resources.Microsoft_plugin_timedate_FriendlyInMinutes;
-                return string.Format(culture, CompositeFormat.Parse(key), minutes);
+                return string.Format(culture, CompositeFormat.Parse(key), roundedMinutes);
             }
 
-            double absHours = Math.Abs(delta.TotalHours);
-            if (absHours < 24)
+            int roundedHours = (int)Math.Round(Math.Abs(delta.TotalHours));
+            if (roundedHours < 1)
             {
-                int hours = Math.Max(1, (int)Math.Round(absHours));
-                string key = delta.TotalSeconds < 0
+                roundedHours = 1;
+            }
+
+            if (roundedHours < 24)
+            {
+                string key = isPast
                     ? Resources.Microsoft_plugin_timedate_FriendlyHoursAgo
                     : Resources.Microsoft_plugin_timedate_FriendlyInHours;
-                return string.Format(culture, CompositeFormat.Parse(key), hours);
+                return string.Format(culture, CompositeFormat.Parse(key), roundedHours);
             }
 
+            // 23h30m+ rounds to 24h, which belongs in the date bucket; defer to GetFriendlyDate.
             return null;
         }
 

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate/Properties/Resources.Designer.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate/Properties/Resources.Designer.cs
@@ -248,7 +248,115 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.Properties {
                 return ResourceManager.GetString("Microsoft_plugin_timedate_filename_compatible", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Friendly date.
+        /// </summary>
+        internal static string Microsoft_plugin_timedate_FriendlyDate {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_timedate_FriendlyDate", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Friendly date and time.
+        /// </summary>
+        internal static string Microsoft_plugin_timedate_FriendlyDateTime {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_timedate_FriendlyDateTime", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to {0} days ago.
+        /// </summary>
+        internal static string Microsoft_plugin_timedate_FriendlyDaysAgo {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_timedate_FriendlyDaysAgo", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to {0} hours ago.
+        /// </summary>
+        internal static string Microsoft_plugin_timedate_FriendlyHoursAgo {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_timedate_FriendlyHoursAgo", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to in {0} days.
+        /// </summary>
+        internal static string Microsoft_plugin_timedate_FriendlyInDays {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_timedate_FriendlyInDays", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to in {0} hours.
+        /// </summary>
+        internal static string Microsoft_plugin_timedate_FriendlyInHours {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_timedate_FriendlyInHours", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to in {0} minutes.
+        /// </summary>
+        internal static string Microsoft_plugin_timedate_FriendlyInMinutes {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_timedate_FriendlyInMinutes", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to just now.
+        /// </summary>
+        internal static string Microsoft_plugin_timedate_FriendlyJustNow {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_timedate_FriendlyJustNow", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to {0} minutes ago.
+        /// </summary>
+        internal static string Microsoft_plugin_timedate_FriendlyMinutesAgo {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_timedate_FriendlyMinutesAgo", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Today.
+        /// </summary>
+        internal static string Microsoft_plugin_timedate_FriendlyToday {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_timedate_FriendlyToday", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Tomorrow.
+        /// </summary>
+        internal static string Microsoft_plugin_timedate_FriendlyTomorrow {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_timedate_FriendlyTomorrow", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Yesterday.
+        /// </summary>
+        internal static string Microsoft_plugin_timedate_FriendlyYesterday {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_timedate_FriendlyYesterday", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Hour.
         /// </summary>
@@ -563,7 +671,16 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.Properties {
                 return ResourceManager.GetString("Microsoft_plugin_timedate_SearchTagFormatNow", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Friendly; Relative; Human.
+        /// </summary>
+        internal static string Microsoft_plugin_timedate_SearchTagFriendly {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_timedate_SearchTagFriendly", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Time.
         /// </summary>

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate/Properties/Resources.Designer.cs
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate/Properties/Resources.Designer.cs
@@ -277,6 +277,15 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.Properties {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to 1 hour ago.
+        /// </summary>
+        internal static string Microsoft_plugin_timedate_FriendlyHourAgo {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_timedate_FriendlyHourAgo", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to {0} hours ago.
         /// </summary>
         internal static string Microsoft_plugin_timedate_FriendlyHoursAgo {
@@ -295,11 +304,29 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.Properties {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to in 1 hour.
+        /// </summary>
+        internal static string Microsoft_plugin_timedate_FriendlyInHour {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_timedate_FriendlyInHour", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to in {0} hours.
         /// </summary>
         internal static string Microsoft_plugin_timedate_FriendlyInHours {
             get {
                 return ResourceManager.GetString("Microsoft_plugin_timedate_FriendlyInHours", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to in 1 minute.
+        /// </summary>
+        internal static string Microsoft_plugin_timedate_FriendlyInMinute {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_timedate_FriendlyInMinute", resourceCulture);
             }
         }
 
@@ -318,6 +345,15 @@ namespace Microsoft.PowerToys.Run.Plugin.TimeDate.Properties {
         internal static string Microsoft_plugin_timedate_FriendlyJustNow {
             get {
                 return ResourceManager.GetString("Microsoft_plugin_timedate_FriendlyJustNow", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to 1 minute ago.
+        /// </summary>
+        internal static string Microsoft_plugin_timedate_FriendlyMinuteAgo {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_timedate_FriendlyMinuteAgo", resourceCulture);
             }
         }
 

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate/Properties/Resources.resx
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate/Properties/Resources.resx
@@ -197,29 +197,45 @@
     <value>{0} days ago</value>
     <comment>Relative date in the past. {0} is replaced with an integer count of days (always greater than 1).</comment>
   </data>
+  <data name="Microsoft_plugin_timedate_FriendlyHourAgo" xml:space="preserve">
+    <value>1 hour ago</value>
+    <comment>Singular form of "{0} hours ago" for when the count is exactly 1.</comment>
+  </data>
   <data name="Microsoft_plugin_timedate_FriendlyHoursAgo" xml:space="preserve">
     <value>{0} hours ago</value>
-    <comment>Relative time in the past. {0} is replaced with an integer count of hours (1 or more).</comment>
+    <comment>Relative time in the past. {0} is replaced with an integer count of hours (2 or more).</comment>
   </data>
   <data name="Microsoft_plugin_timedate_FriendlyInDays" xml:space="preserve">
     <value>in {0} days</value>
     <comment>Relative date in the future. {0} is replaced with an integer count of days (always greater than 1).</comment>
   </data>
+  <data name="Microsoft_plugin_timedate_FriendlyInHour" xml:space="preserve">
+    <value>in 1 hour</value>
+    <comment>Singular form of "in {0} hours" for when the count is exactly 1.</comment>
+  </data>
   <data name="Microsoft_plugin_timedate_FriendlyInHours" xml:space="preserve">
     <value>in {0} hours</value>
-    <comment>Relative time in the future. {0} is replaced with an integer count of hours (1 or more).</comment>
+    <comment>Relative time in the future. {0} is replaced with an integer count of hours (2 or more).</comment>
+  </data>
+  <data name="Microsoft_plugin_timedate_FriendlyInMinute" xml:space="preserve">
+    <value>in 1 minute</value>
+    <comment>Singular form of "in {0} minutes" for when the count is exactly 1.</comment>
   </data>
   <data name="Microsoft_plugin_timedate_FriendlyInMinutes" xml:space="preserve">
     <value>in {0} minutes</value>
-    <comment>Relative time in the future. {0} is replaced with an integer count of minutes (1 or more).</comment>
+    <comment>Relative time in the future. {0} is replaced with an integer count of minutes (2 or more).</comment>
   </data>
   <data name="Microsoft_plugin_timedate_FriendlyJustNow" xml:space="preserve">
     <value>just now</value>
     <comment>Shown when the target time is within ~30 seconds of the current time, in either direction.</comment>
   </data>
+  <data name="Microsoft_plugin_timedate_FriendlyMinuteAgo" xml:space="preserve">
+    <value>1 minute ago</value>
+    <comment>Singular form of "{0} minutes ago" for when the count is exactly 1.</comment>
+  </data>
   <data name="Microsoft_plugin_timedate_FriendlyMinutesAgo" xml:space="preserve">
     <value>{0} minutes ago</value>
-    <comment>Relative time in the past. {0} is replaced with an integer count of minutes (1 or more).</comment>
+    <comment>Relative time in the past. {0} is replaced with an integer count of minutes (2 or more).</comment>
   </data>
   <data name="Microsoft_plugin_timedate_FriendlyToday" xml:space="preserve">
     <value>Today</value>

--- a/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate/Properties/Resources.resx
+++ b/src/modules/launcher/Plugins/Microsoft.PowerToys.Run.Plugin.TimeDate/Properties/Resources.resx
@@ -185,6 +185,54 @@
     <value>Date and time in filename-compatible format</value>
     <comment>The format allows for embedding in filenames</comment>
   </data>
+  <data name="Microsoft_plugin_timedate_FriendlyDate" xml:space="preserve">
+    <value>Friendly date</value>
+    <comment>Label for a human-readable relative date like "Today" or "Yesterday".</comment>
+  </data>
+  <data name="Microsoft_plugin_timedate_FriendlyDateTime" xml:space="preserve">
+    <value>Friendly date and time</value>
+    <comment>Label for a human-readable relative date/time like "5 minutes ago" or "in 2 hours".</comment>
+  </data>
+  <data name="Microsoft_plugin_timedate_FriendlyDaysAgo" xml:space="preserve">
+    <value>{0} days ago</value>
+    <comment>Relative date in the past. {0} is replaced with an integer count of days (always greater than 1).</comment>
+  </data>
+  <data name="Microsoft_plugin_timedate_FriendlyHoursAgo" xml:space="preserve">
+    <value>{0} hours ago</value>
+    <comment>Relative time in the past. {0} is replaced with an integer count of hours (1 or more).</comment>
+  </data>
+  <data name="Microsoft_plugin_timedate_FriendlyInDays" xml:space="preserve">
+    <value>in {0} days</value>
+    <comment>Relative date in the future. {0} is replaced with an integer count of days (always greater than 1).</comment>
+  </data>
+  <data name="Microsoft_plugin_timedate_FriendlyInHours" xml:space="preserve">
+    <value>in {0} hours</value>
+    <comment>Relative time in the future. {0} is replaced with an integer count of hours (1 or more).</comment>
+  </data>
+  <data name="Microsoft_plugin_timedate_FriendlyInMinutes" xml:space="preserve">
+    <value>in {0} minutes</value>
+    <comment>Relative time in the future. {0} is replaced with an integer count of minutes (1 or more).</comment>
+  </data>
+  <data name="Microsoft_plugin_timedate_FriendlyJustNow" xml:space="preserve">
+    <value>just now</value>
+    <comment>Shown when the target time is within ~30 seconds of the current time, in either direction.</comment>
+  </data>
+  <data name="Microsoft_plugin_timedate_FriendlyMinutesAgo" xml:space="preserve">
+    <value>{0} minutes ago</value>
+    <comment>Relative time in the past. {0} is replaced with an integer count of minutes (1 or more).</comment>
+  </data>
+  <data name="Microsoft_plugin_timedate_FriendlyToday" xml:space="preserve">
+    <value>Today</value>
+    <comment>Shown when the target date is the same calendar day as today.</comment>
+  </data>
+  <data name="Microsoft_plugin_timedate_FriendlyTomorrow" xml:space="preserve">
+    <value>Tomorrow</value>
+    <comment>Shown when the target date is exactly one calendar day after today.</comment>
+  </data>
+  <data name="Microsoft_plugin_timedate_FriendlyYesterday" xml:space="preserve">
+    <value>Yesterday</value>
+    <comment>Shown when the target date is exactly one calendar day before today.</comment>
+  </data>
   <data name="Microsoft_plugin_timedate_Millisecond" xml:space="preserve">
     <value>Millisecond</value>
   </data>
@@ -245,6 +293,10 @@
   <data name="Microsoft_plugin_timedate_SearchTagFormat" xml:space="preserve">
     <value>Date and time; Time and Date</value>
     <comment>Don't change order</comment>
+  </data>
+  <data name="Microsoft_plugin_timedate_SearchTagFriendly" xml:space="preserve">
+    <value>Friendly; Relative; Human</value>
+    <comment>Don't change order. Search tags for the friendly date/time results.</comment>
   </data>
   <data name="Microsoft_plugin_timedate_SearchTagCustom" xml:space="preserve">
     <value>Date and time; Time and Date; Custom format</value>


### PR DESCRIPTION
## Summary of the Pull Request

Adds two new predefined results to the **Time and Date** plugin so users can get a human-readable relative description of the current moment (or a parsed timestamp):

- **Friendly date** — `Today` / `Yesterday` / `Tomorrow` / `N days ago` / `in N days`
- **Friendly date and time** — `just now` / `N minutes ago` / `in N hours`

Both new entries sit just inside the existing `OnlyDateTimeNowGlobal` gate in `AvailableResultsList.GetList`, so they respect the same global-query suppression as the rest of the predefined formats. The helpers return `null` outside their supported window (beyond ±7 calendar days for the date, ±24 hours for the time), and the existing `Where(x => !string.IsNullOrEmpty(x.Value))` pass drops those entries.

## PR Checklist

- [x] Closes: #16809
- [x] **Communication:** Posted an intent comment on the issue before submitting outlining scope (output-only friendly results; natural-language input parsing deferred to a follow-up).
- [x] **Tests:** Added direct `[DataTestMethod]` coverage for the new helpers in `TimeAndDateHelperTests`, covering: today/yesterday/tomorrow, `±2..±7` day buckets, beyond-window (returns null), within-30s threshold, sub-hour minutes both directions, sub-day hours both directions, beyond-day (returns null), and a calendar-day boundary case (1am vs yesterday 23:00 reads "Yesterday" not "Today").
- [x] **Localization:** Added en-US strings to `Resources.resx`. Per CONTRIBUTING.md, non-English translations are owned by the internal Microsoft localization team and aren't part of this PR.
- [ ] **Dev docs:** Not updated — no architectural changes; the plugin's user-facing surface gains two more rows in the predefined-formats list, which matches existing documentation patterns.
- [ ] **New binaries:** N/A — no new assemblies.

## Detailed Description of the Pull Request / Additional comments

### Design notes

- **Why `null` instead of empty string from the helpers?** The call site uses `?? string.Empty` so the entries always get added to the list, and the file's existing `IsNullOrEmpty(x.Value)` filter (line 397) drops them on the way out. This keeps the new code consistent with how the file handles the existing `era == eraShort` case (line 306).
- **Why pass an explicit `now` reference into the helpers?** Makes them pure and unit-testable without time-mocking. The production call site passes `DateTime.Now`; tests pass a fixed `DateTime(2026, 06, 15, 12, 00, 00)`.
- **Calendar-day comparison for the date helper.** `(target.Date - now.Date).Days` instead of `(target - now).TotalDays` so "1am today" vs "11pm yesterday" reads as `Yesterday`, not `Today`.
- **Plural-form simplification.** Strings are always plural (`1 minutes ago`, `1 hours ago`). Singular/plural distinction would more than double the resource string count and adds localization surface area; treating it as a follow-up if reviewers want it polished.

### Scope deliberately deferred

The original issue's discussion at #16800 hints at parsing natural-language inputs like `yesterday` → today's date minus one. That requires either a parser library (Microsoft.Recognizers.Text, Chronic.NET) or a hand-rolled English-only parser, and has a thornier localization story. Filing as a follow-up if there's appetite for it.

## Validation Steps Performed

- **Code review pass on the full diff** — caught a `Resources.resx` alphabetical ordering bug (`Today` came after `Tomorrow`) and fixed before commit.
- **Partial `dotnet build` against the test project** — the C# dependency graph (`MouseJump.Common`, `PowerDisplay.Models`, `ManagedTelemetry`, etc.) restored and compiled cleanly with .NET 10 SDK 10.0.301. Local toolchain didn't have the VC++ Build Tools workload installed, so the transitive `PowerToys.Interop.vcxproj` reference (`ManagedCommon → interop`) couldn't link, blocking `dotnet test` from running. **The C# parts that this PR actually touches did parse and resolve.** Microsoft's CI has the full workload and will exercise the new tests.
- **Manual trace through the helpers** with the test rows: at `-30s` the clamp branch (`Math.Round(0.5) → 0 → clamped to 1`) yields `"1 minutes ago"`; at `+60s` natural rounding (`Math.Round(1.0) → 1`) yields `"in 1 minutes"`; calendar-day comparison confirmed against the `1am vs 23:00 yesterday` edge case.