### PR TITLE
Fix DiskAnalyzer plugin link and author

### DIFF
--- a/doc/thirdPartyRunPlugins.md
+++ b/doc/thirdPartyRunPlugins.md
@@ -79,4 +79,4 @@ Below are community created plugins that target a website or software.  They are
 | [Linear](https://github.com/vednig/powertoys-linear) | [vednig](https://github.com/vednig) | Create Linear Issues directly from Powertoys Run |
 | [PerplexitySearchShortcut](https://github.com/0x6f677548/PowerToys-Run-PerplexitySearchShortcut) | [0x6f677548](https://github.com/0x6f677548) | Search Perplexity |
 | [SpeedTest](https://github.com/ruslanlap/PowerToysRun-SpeedTest) | [ruslanlap](https://github.com/ruslanlap) | One-command internet speed tests with real-time results, modern UI, and shareable links. |
-| [DiskAnalyzer](https://github.com/thetsaw/PowerToys.Plugin) | [thetsaw](https://github.com/thetsaw) | Scan folders, find the largest files, and view drive space usage with visual progress bars. |
+| [DiskAnalyzer](https://github.com/valley-soft/powertoys-diskanalyzer) | [ValleySoft](https://github.com/valley-soft) | Scan folders, find the largest files, and view drive space usage. |


### PR DESCRIPTION
Updated the DiskAnalyzer plugin link and author information to point to the ValleySoft organization repository instead of my personal account.

## Summary of the Pull Request

Documentation-only change. Updates the DiskAnalyzer entry in `thirdPartyRunPlugins.md`:
- Plugin URL: `thetsaw/PowerToys.Plugin` → `valley-soft/powertoys-diskanalyzer`
- Author: `thetsaw` → `ValleySoft`

## PR Checklist

- [ ] Closes: N/A
- [x] **Communication:** This is a minor doc-only update to correct a repo link — no prior discussion needed
- [x] **Tests:** N/A — documentation change only
- [x] **Localization:** N/A — no user-facing strings changed
- [x] **Dev docs:** Updated `doc/thirdPartyRunPlugins.md`
- [ ] **New binaries:** N/A

## Detailed Description of the Pull Request / Additional comments

The DiskAnalyzer PowerToys Run plugin was originally submitted under my personal GitHub account (`thetsaw`). The project has since been moved to the official **ValleySoft** organization at:
https://github.com/valley-soft/powertoys-diskanalyzer

## Validation Steps Performed

Verified all URLs are live and resolve correctly:
- https://github.com/valley-soft/powertoys-diskanalyzer ✅
- https://github.com/valley-soft ✅


