### PR TITLE
[PowerDisplay] Allow waking a monitor from standby via power-state On

### DIFF
--- a/src/modules/powerdisplay/PowerDisplay/ViewModels/MonitorViewModel.cs
+++ b/src/modules/powerdisplay/PowerDisplay/ViewModels/MonitorViewModel.cs
@@ -681,8 +681,8 @@ public partial class MonitorViewModel : ObservableObject, IDisposable
     }
 
     /// <summary>
-    /// Set power state for this monitor.
-    /// Note: Setting any state other than "On" will turn off the display.
+    /// Set the monitor's power state via VCP 0xD6: On (0x01) wakes the display,
+    /// Standby/Suspend/Off put it to sleep.
     /// </summary>
     public async Task SetPowerStateAsync(int powerState)
     {
@@ -709,18 +709,6 @@ public partial class MonitorViewModel : ObservableObject, IDisposable
         catch (Exception ex)
         {
             Logger.LogError($"[{Id}] Exception setting power state: {ex.Message}");
-        }
-    }
-
-    /// <summary>
-    /// Command to set power state
-    /// </summary>
-    [RelayCommand]
-    private async Task SetPowerState(int? state)
-    {
-        if (state.HasValue)
-        {
-            await SetPowerStateAsync(state.Value);
         }
     }
 
@@ -880,11 +868,9 @@ public partial class MonitorViewModel : ObservableObject, IDisposable
             return;
         }
 
-        if (item.Value == PowerStateItem.PowerStateOn)
-        {
-            return;
-        }
-
+        // Send the selected state straight to the hardware. Selecting On (0x01) wakes a
+        // sleeping monitor: DDC/CI stays reachable in Standby/Suspend/Off(DPM), so the
+        // write turns the panel back on (Off(Hard)/0x05 may still need a physical wake).
         await SetPowerStateAsync(item.Value);
     }
 

--- a/src/modules/powerdisplay/PowerDisplay/ViewModels/PowerStateItem.cs
+++ b/src/modules/powerdisplay/PowerDisplay/ViewModels/PowerStateItem.cs
@@ -13,11 +13,6 @@ namespace PowerDisplay.ViewModels;
 public class PowerStateItem
 {
     /// <summary>
-    /// VCP power mode value representing On state
-    /// </summary>
-    public const int PowerStateOn = 0x01;
-
-    /// <summary>
     /// VCP value for this power state
     /// </summary>
     public int Value { get; set; }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Power Display could put a monitor to sleep but never wake it back up. Selecting **On** in the per-monitor power-state list was a hard-coded no-op, so the DDC/CI wake command (VCP `0xD6` = `0x01`) was never sent. This removes that guard so selecting **On** wakes the display, and cleans up the dead code/comment left behind by the original one-directional design.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #48428
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [x] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [x] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

`MonitorViewModel.HandlePowerStateSelectionChanged` early-returned when the selected power state was **On** (`0x01`), so `SetPowerStateAsync` was never called for On and the wake write never reached the monitor. As a result Power Display's power control was one-directional: it could send Standby/Suspend/Off but could never turn a monitor back on.

The guard dates back to the very first power-state commit and was paired with a single-monitor assumption — *"the monitor must be on to see the UI"*, so On was treated as the always-current state and skipped. A later change made the selection reflect the monitor's real power state (so a monitor in the list can legitimately be asleep), and multi-monitor support means the flyout can be shown on monitor A while the user wants to wake monitor B. Those changes invalidated the assumption, but the action-side guard survived a subsequent refactor.

The lower layers already do the right thing: `MonitorManager.SetPowerStateAsync` → `DdcCiController.SetPowerStateAsync` → `SetVcpFeatureAsync(monitor, 0xD6, value)` passes the value through unchanged, so the fix is purely removing the UI-layer guard. DDC/CI stays reachable while the panel is in Standby/Suspend/Off(DPM), so writing `0x01` turns it back on (this is the same mechanism Twinkle Tray uses). `Off (Hard)` / `0x05` may still require a physical wake on some monitors, since that state can cut the DDC command channel.

Cleanup included in this PR:
- Removed the now-unused `PowerStateItem.PowerStateOn` constant (its only consumer was the deleted guard).
- Removed the dead `SetPowerState` `[RelayCommand]` (the generated `SetPowerStateCommand` had zero references — the XAML wires `SelectionChanged`, not a command).
- Updated the `SetPowerStateAsync` doc comment from the one-directional framing to a neutral bidirectional description.

Net change: 2 files, +5 / −24.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

- **Build:** `MSBuild PowerDisplay.csproj -p:Platform=x64 -p:Configuration=Debug` (CoreCompile) — **0 errors / 0 warnings**.
- **Static check:** repo-wide grep confirms no remaining references to `PowerStateOn` or `SetPowerStateCommand`; the power-state ListView binds only `ItemsSource` + `SelectionChanged` (no `SelectedItem` binding), so opening the flyout cannot spuriously re-fire a selection.
- **Manual (requires a DDC/CI monitor):** enable *Power state control* for a monitor → open its flyout and select **Standby** or **Off (DPM)** (screen blanks) → reopen the flyout and select **On** → the display wakes.

No automated test was added: with the guard removed the handler is an unconditional pass-through (identical in shape to `HandleInputSourceSelectionChanged`), and it is an `async void` WinUI event handler over real DDC/CI hardware, which is outside the `PowerDisplay.Lib` unit-test seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
