### PR TITLE
Ignore superpowers-generated docs directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -375,3 +375,6 @@ installer/*/*.wxs.bk
 vcpkg_installed/
 
 deps/vcpkg/
+
+# Superpowers-generated docs (specs, design, plans) — local-only, not committed
+docs/superpowers/


### PR DESCRIPTION
## Summary

Add `docs/superpowers/` to `.gitignore` so all locally generated superpowers artifacts (specs, design docs, and plans) are not committed.

These files are produced by local AI tooling and are workspace-local only; they should not land in the repository.

## Change

```gitignore
# Superpowers-generated docs (specs, design, plans) — local-only, not committed
docs/superpowers/
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)