### PR TITLE
[CmdPal][PerfMon] Add CPU temperature widget via ACPI thermal zone

### DIFF
--- a/.github/actions/spell-check/allow/code.txt
+++ b/.github/actions/spell-check/allow/code.txt
@@ -435,3 +435,7 @@ WIDGETBOARD
 
 # URIs
 actioncenter
+
+# Performance / hardware terms
+acpi
+PDH

--- a/.github/actions/spell-check/allow/code.txt
+++ b/.github/actions/spell-check/allow/code.txt
@@ -438,4 +438,5 @@ actioncenter
 
 # Performance / hardware terms
 acpi
+ACPI
 PDH

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/DevHome/Helpers/DataManager.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/DevHome/Helpers/DataManager.cs
@@ -77,6 +77,14 @@ internal sealed partial class DataManager : IDisposable
         }
     }
 
+    private void GetTemperatureData()
+    {
+        lock (_systemData.TemperatureStats)
+        {
+            _systemData.TemperatureStats.GetData();
+        }
+    }
+
     private void UpdateTimer_Elapsed(object? sender, System.Timers.ElapsedEventArgs e)
     {
         var firstUpdateBlockSuffix = GetFirstUpdateBlockSuffix();
@@ -127,6 +135,12 @@ internal sealed partial class DataManager : IDisposable
                         GetBatteryData();
                         break;
                     }
+
+                case DataType.Temperature:
+                    {
+                        GetTemperatureData();
+                        break;
+                    }
             }
 
             if (isTracked)
@@ -163,6 +177,7 @@ internal sealed partial class DataManager : IDisposable
             DataType.Network => "Network.FirstUpdate",
             DataType.Disk => "Disk.FirstUpdate",
             DataType.Battery => "Battery.FirstUpdate",
+            DataType.Temperature => "Temperature.FirstUpdate",
             _ => null,
         };
     }
@@ -212,6 +227,14 @@ internal sealed partial class DataManager : IDisposable
         lock (_systemData.BatteryStats)
         {
             return _systemData.BatteryStats;
+        }
+    }
+
+    internal TemperatureStats GetTemperatureStats()
+    {
+        lock (_systemData.TemperatureStats)
+        {
+            return _systemData.TemperatureStats;
         }
     }
 

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/DevHome/Helpers/DataType.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/DevHome/Helpers/DataType.cs
@@ -42,4 +42,6 @@ public enum DataType
     /// Disk related data.
     /// </summary>
     Disk,
+
+    Temperature,
 }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/DevHome/Helpers/SystemData.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/DevHome/Helpers/SystemData.cs
@@ -17,6 +17,7 @@ internal sealed partial class SystemData
     private readonly Lazy<GPUStats> _gpuStats = new(() => CreateGuarded("GPU.Initialize", static () => new GPUStats()));
     private readonly Lazy<CPUStats> _cpuStats = new(() => CreateGuarded("CPU.Initialize", static () => new CPUStats()));
     private readonly Lazy<BatteryStats> _batteryStats = new(() => CreateGuarded("Battery.Initialize", static () => new BatteryStats()));
+    private readonly Lazy<TemperatureStats> _temperatureStats = new(() => CreateGuarded("Temperature.Initialize", static () => new TemperatureStats()));
 
     public MemoryStats MemoryStats => _memoryStats.Value;
 
@@ -29,6 +30,8 @@ internal sealed partial class SystemData
     public CPUStats CpuStats => _cpuStats.Value;
 
     public BatteryStats BatteryStats => _batteryStats.Value;
+
+    public TemperatureStats TemperatureStats => _temperatureStats.Value;
 
     private SystemData()
     {

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/DevHome/Helpers/TemperatureStats.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/DevHome/Helpers/TemperatureStats.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+
+namespace CoreWidgetProvider.Helpers;
+
+// Reads CPU temperature from the "Thermal Zone Information" PDH category (ACPI thermal zones).
+// Raw counter values are in tenths of Kelvin; we convert to Celsius on read.
+// Not available on all systems (e.g. VMs without ACPI thermal zones) - check IsAvailable first.
+internal sealed partial class TemperatureStats : PerformanceCounterSourceBase
+{
+    private const string CategoryName = "Thermal Zone Information";
+    private const string CounterName = "High Precision Temperature";
+
+    // Tenths of Kelvin -> Celsius: (raw - 2731.5) / 10
+    private const double TenthsKelvinOffset = 2731.5;
+
+    private readonly PerformanceCounter? _thermalCounter;
+    private bool _readFailureLogged;
+
+    public bool IsAvailable => _thermalCounter is not null;
+
+    /// <summary>Gets the last sampled CPU thermal zone temperature in °C, or -1 if unavailable.</summary>
+    public double CpuTemperatureCelsius { get; private set; } = -1;
+
+    public TemperatureStats()
+    {
+        var category = CreatePerformanceCounterCategory(CategoryName, logFailure: false);
+        if (category is null)
+        {
+            return;
+        }
+
+        var instances = category.GetInstanceNames();
+        if (instances.Length == 0)
+        {
+            return;
+        }
+
+        // Prefer standard ACPI thermal zone instances (_TZ.*), fall back to the first available.
+        var preferred = Array.Find(instances, n => n.StartsWith("_TZ.", StringComparison.OrdinalIgnoreCase))
+            ?? instances[0];
+
+        _thermalCounter = CreatePerformanceCounter(CategoryName, CounterName, preferred, logFailure: false);
+    }
+
+    public void GetData()
+    {
+        if (_thermalCounter is null)
+        {
+            CpuTemperatureCelsius = -1;
+            return;
+        }
+
+        try
+        {
+            var raw = _thermalCounter.NextValue();
+            CpuTemperatureCelsius = (raw - TenthsKelvinOffset) / 10.0;
+        }
+        catch (Exception ex)
+        {
+            LogFailureOnce(ref _readFailureLogged, $"Failed to read {CategoryName}\\{CounterName}.", ex);
+            CpuTemperatureCelsius = -1;
+        }
+    }
+}

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/DevHome/Helpers/TemperatureStats.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/DevHome/Helpers/TemperatureStats.cs
@@ -10,7 +10,7 @@ namespace CoreWidgetProvider.Helpers;
 // Reads CPU temperature from the "Thermal Zone Information" PDH category (ACPI thermal zones).
 // Raw counter values are in tenths of Kelvin; we convert to Celsius on read.
 // Not available on all systems (e.g. VMs without ACPI thermal zones) - check IsAvailable first.
-internal sealed partial class TemperatureStats : PerformanceCounterSourceBase
+internal sealed partial class TemperatureStats : PerformanceCounterSourceBase, IDisposable
 {
     private const string CategoryName = "Thermal Zone Information";
     private const string CounterName = "High Precision Temperature";
@@ -28,23 +28,30 @@ internal sealed partial class TemperatureStats : PerformanceCounterSourceBase
 
     public TemperatureStats()
     {
-        var category = CreatePerformanceCounterCategory(CategoryName, logFailure: false);
-        if (category is null)
+        try
         {
-            return;
-        }
+            var category = CreatePerformanceCounterCategory(CategoryName, logFailure: false);
+            if (category is null)
+            {
+                return;
+            }
 
-        var instances = category.GetInstanceNames();
-        if (instances.Length == 0)
+            var instances = category.GetInstanceNames();
+            if (instances.Length == 0)
+            {
+                return;
+            }
+
+            // Prefer standard ACPI thermal zone instances (_TZ.*), fall back to the first available.
+            var preferred = Array.Find(instances, n => n.StartsWith("_TZ.", StringComparison.OrdinalIgnoreCase))
+                ?? instances[0];
+
+            _thermalCounter = CreatePerformanceCounter(CategoryName, CounterName, preferred, logFailure: false);
+        }
+        catch (Exception ex)
         {
-            return;
+            LogFailureOnce(ref _readFailureLogged, $"Failed to initialize {CategoryName} performance counter.", ex);
         }
-
-        // Prefer standard ACPI thermal zone instances (_TZ.*), fall back to the first available.
-        var preferred = Array.Find(instances, n => n.StartsWith("_TZ.", StringComparison.OrdinalIgnoreCase))
-            ?? instances[0];
-
-        _thermalCounter = CreatePerformanceCounter(CategoryName, CounterName, preferred, logFailure: false);
     }
 
     public void GetData()
@@ -65,5 +72,10 @@ internal sealed partial class TemperatureStats : PerformanceCounterSourceBase
             LogFailureOnce(ref _readFailureLogged, $"Failed to read {CategoryName}\\{CounterName}.", ex);
             CpuTemperatureCelsius = -1;
         }
+    }
+
+    public void Dispose()
+    {
+        _thermalCounter?.Dispose();
     }
 }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/DevHome/Helpers/TemperatureStats.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/DevHome/Helpers/TemperatureStats.cs
@@ -7,9 +7,10 @@ using System.Diagnostics;
 
 namespace CoreWidgetProvider.Helpers;
 
-// Reads CPU temperature from the "Thermal Zone Information" PDH category (ACPI thermal zones).
+// Reads temperature from the "Thermal Zone Information" PDH category (ACPI thermal zones).
 // Raw counter values are in tenths of Kelvin; we convert to Celsius on read.
 // Not available on all systems (e.g. VMs without ACPI thermal zones) - check IsAvailable first.
+// Note: ACPI thermal zones often reflect an ambient/skin/motherboard sensor, not a CPU die.
 internal sealed partial class TemperatureStats : PerformanceCounterSourceBase, IDisposable
 {
     private const string CategoryName = "Thermal Zone Information";
@@ -18,13 +19,17 @@ internal sealed partial class TemperatureStats : PerformanceCounterSourceBase, I
     // Tenths of Kelvin -> Celsius: (raw - 2731.5) / 10
     private const double TenthsKelvinOffset = 2731.5;
 
+    // Plausibility range: reject readings outside this window as sensor noise or bad samples.
+    private const double MinPlausibleCelsius = -20.0;
+    private const double MaxPlausibleCelsius = 150.0;
+
     private readonly PerformanceCounter? _thermalCounter;
     private bool _readFailureLogged;
 
     public bool IsAvailable => _thermalCounter is not null;
 
-    /// <summary>Gets the last sampled CPU thermal zone temperature in °C, or -1 if unavailable.</summary>
-    public double CpuTemperatureCelsius { get; private set; } = -1;
+    /// <summary>Gets the last sampled thermal zone temperature in °C, or -1 if unavailable or out of range.</summary>
+    public double TemperatureCelsius { get; private set; } = -1;
 
     public TemperatureStats()
     {
@@ -58,19 +63,23 @@ internal sealed partial class TemperatureStats : PerformanceCounterSourceBase, I
     {
         if (_thermalCounter is null)
         {
-            CpuTemperatureCelsius = -1;
+            TemperatureCelsius = -1;
             return;
         }
 
         try
         {
             var raw = _thermalCounter.NextValue();
-            CpuTemperatureCelsius = (raw - TenthsKelvinOffset) / 10.0;
+            var celsius = (raw - TenthsKelvinOffset) / 10.0;
+
+            TemperatureCelsius = celsius >= MinPlausibleCelsius && celsius <= MaxPlausibleCelsius
+                ? celsius
+                : -1;
         }
         catch (Exception ex)
         {
             LogFailureOnce(ref _readFailureLogged, $"Failed to read {CategoryName}\\{CounterName}.", ex);
-            CpuTemperatureCelsius = -1;
+            TemperatureCelsius = -1;
         }
     }
 

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/DevHome/Templates/SystemTemperatureTemplate.json
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/DevHome/Templates/SystemTemperatureTemplate.json
@@ -1,0 +1,68 @@
+{
+  "type": "AdaptiveCard",
+  "body": [
+    {
+      "type": "Container",
+      "$when": "${errorMessage != null}",
+      "items": [
+        {
+          "type": "TextBlock",
+          "text": "${errorMessage}",
+          "wrap": true,
+          "size": "small"
+        }
+      ],
+      "style": "warning"
+    },
+    {
+      "type": "Container",
+      "$when": "${errorMessage == null}",
+      "items": [
+        {
+          "type": "ColumnSet",
+          "columns": [
+            {
+              "type": "Column",
+              "items": [
+                {
+                  "text": "%Temperature_Widget_Template/CpuTemperature%",
+                  "type": "TextBlock",
+                  "size": "small",
+                  "isSubtle": true
+                },
+                {
+                  "text": "${cpuTemperature}",
+                  "type": "TextBlock",
+                  "size": "${if($host.widgetSize == \"small\", \"medium\", \"extraLarge\")}",
+                  "weight": "bolder"
+                }
+              ]
+            },
+            {
+              "type": "Column",
+              "items": [
+                {
+                  "text": "%Temperature_Widget_Template/Source%",
+                  "type": "TextBlock",
+                  "size": "small",
+                  "isSubtle": true,
+                  "horizontalAlignment": "right"
+                },
+                {
+                  "text": "${temperatureSource}",
+                  "type": "TextBlock",
+                  "size": "${if($host.widgetSize == \"small\", \"small\", \"medium\")}",
+                  "weight": "bolder",
+                  "horizontalAlignment": "right",
+                  "wrap": true
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+  "version": "1.5"
+}

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/DevHome/Templates/SystemTemperatureTemplate.json
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/DevHome/Templates/SystemTemperatureTemplate.json
@@ -25,13 +25,13 @@
               "type": "Column",
               "items": [
                 {
-                  "text": "%Temperature_Widget_Template/CpuTemperature%",
+                  "text": "%Temperature_Widget_Template/ThermalZone%",
                   "type": "TextBlock",
                   "size": "small",
                   "isSubtle": true
                 },
                 {
-                  "text": "${cpuTemperature}",
+                  "text": "${thermalZoneTemperature}",
                   "type": "TextBlock",
                   "size": "${if($host.widgetSize == \"small\", \"medium\", \"extraLarge\")}",
                   "weight": "bolder"

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/Icons.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/Icons.cs
@@ -33,6 +33,8 @@ internal static class Icons
 
     internal static IconInfo GpuIcon => new("\uE950"); // Component icon
 
+    internal static IconInfo TemperatureIcon => new("\uE9CA"); // Temperature/thermometer icon
+
     internal static IconInfo BatteryIcon => BatteryIcons[10]; // MobBattery10 (page identity)
 
     // Pre-built cache so the 1 Hz dock-band update reuses IconInfo instances

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/Microsoft.CmdPal.Ext.PerformanceMonitor.csproj
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/Microsoft.CmdPal.Ext.PerformanceMonitor.csproj
@@ -59,6 +59,9 @@
     <None Update="DevHome\Templates\SystemBatteryTemplate.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="DevHome\Templates\SystemTemperatureTemplate.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Content Update="Assets\**\*.*">

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceWidgetsPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceWidgetsPage.cs
@@ -34,6 +34,7 @@ internal enum PerformanceMetricKind
     Disk,
     Gpu,
     Battery,
+    Temperature,
 }
 
 /// <summary>
@@ -63,6 +64,7 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
         PerformanceMetricKind.Disk => Icons.HardDriveIcon,
         PerformanceMetricKind.Gpu => Icons.GpuIcon,
         PerformanceMetricKind.Battery => _batteryPage?.CurrentIcon ?? Icons.BatteryIcon,
+        PerformanceMetricKind.Temperature => Icons.TemperatureIcon,
         _ => Icons.PerformanceMonitorIcon,
     };
 
@@ -87,6 +89,9 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
 
     private readonly SystemBatteryUsageWidgetPage? _batteryPage;
     private readonly ListItem? _batteryItem;
+
+    private readonly SystemTemperatureWidgetPage? _temperaturePage;
+    private readonly ListItem? _temperatureItem;
 
     // For bands, we want two bands, one for up and one for down
     private ListItem? _networkUpItem;
@@ -238,6 +243,21 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
             }
         }
 
+        if (IncludesMetric(PerformanceMetricKind.Temperature))
+        {
+            _temperaturePage = new SystemTemperatureWidgetPage();
+            _temperatureItem = new ListItem(_temperaturePage)
+            {
+                Title = _temperaturePage.GetItemTitle(isBandPage),
+                Icon = Icons.TemperatureIcon,
+            };
+
+            _temperaturePage.Updated += (s, e) =>
+            {
+                _temperatureItem.Title = _temperaturePage.GetItemTitle(isBandPage);
+            };
+        }
+
         if (_isBandPage)
         {
             // add subtitles to them all
@@ -271,6 +291,11 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
             {
                 _batteryItem.Subtitle = Resources.GetResource("Battery_Usage_Subtitle");
             }
+
+            if (_temperatureItem is not null)
+            {
+                _temperatureItem.Subtitle = Resources.GetResource("Temperature_Usage_Subtitle");
+            }
         }
     }
 
@@ -282,6 +307,7 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
         _diskPage?.PushActivate();
         _gpuPage?.PushActivate();
         _batteryPage?.PushActivate();
+        _temperaturePage?.PushActivate();
     }
 
     protected override void Unloaded()
@@ -292,6 +318,7 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
         _diskPage?.PopActivate();
         _gpuPage?.PopActivate();
         _batteryPage?.PopActivate();
+        _temperaturePage?.PopActivate();
     }
 
     public override IListItem[] GetItems()
@@ -312,6 +339,7 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
                 PerformanceMetricKind.Disk => new IListItem[] { _diskItem! },
                 PerformanceMetricKind.Gpu => new IListItem[] { _gpuItem! },
                 PerformanceMetricKind.Battery => new IListItem[] { _batteryItem! },
+                PerformanceMetricKind.Temperature => new IListItem[] { _temperatureItem! },
                 _ => Array.Empty<IListItem>(),
             };
         }
@@ -319,9 +347,18 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
         if (!_isBandPage)
         {
             // TODO add details
-            return _batteryItem is not null
-                ? new[] { _cpuItem!, _memoryItem!, _networkItem!, _diskItem!, _gpuItem!, _batteryItem! }
-                : new[] { _cpuItem!, _memoryItem!, _networkItem!, _diskItem!, _gpuItem! };
+            var items = new System.Collections.Generic.List<IListItem> { _cpuItem!, _memoryItem!, _networkItem!, _diskItem!, _gpuItem! };
+            if (_batteryItem is not null)
+            {
+                items.Add(_batteryItem);
+            }
+
+            if (_temperatureItem is not null)
+            {
+                items.Add(_temperatureItem);
+            }
+
+            return items.ToArray();
         }
         else
         {
@@ -352,9 +389,21 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
             _networkDownItem.Title = _networkDownSpeed;
 
             CreateDiskBandItems();
-            return _batteryItem is not null
-                ? new[] { _cpuItem!, _memoryItem!, _networkUpItem!, _networkDownItem!, _diskReadItem!, _diskWriteItem!, _diskItem!, _gpuItem!, _batteryItem! }
-                : new[] { _cpuItem!, _memoryItem!, _networkUpItem!, _networkDownItem!, _diskReadItem!, _diskWriteItem!, _diskItem!, _gpuItem! };
+            var bandItems = new System.Collections.Generic.List<IListItem>
+            {
+                _cpuItem!, _memoryItem!, _networkUpItem!, _networkDownItem!, _diskReadItem!, _diskWriteItem!, _diskItem!, _gpuItem!,
+            };
+            if (_batteryItem is not null)
+            {
+                bandItems.Add(_batteryItem);
+            }
+
+            if (_temperatureItem is not null)
+            {
+                bandItems.Add(_temperatureItem);
+            }
+
+            return bandItems.ToArray();
         }
     }
 
@@ -387,6 +436,7 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
         _diskPage?.Dispose();
         _gpuPage?.Dispose();
         _batteryPage?.Dispose();
+        _temperaturePage?.Dispose();
     }
 
     internal static string GetBandId(PerformanceMetricKind? metric)
@@ -409,6 +459,7 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
             PerformanceMetricKind.Disk => "disk",
             PerformanceMetricKind.Gpu => "gpu",
             PerformanceMetricKind.Battery => "battery",
+            PerformanceMetricKind.Temperature => "temperature",
             _ => "unknown",
         };
     }
@@ -1449,6 +1500,98 @@ internal sealed partial class SystemBatteryUsageWidgetPage : WidgetPage, IDispos
             CultureInfo.CurrentCulture,
             Resources.GetResource("Battery_Time_Remaining_Minutes_Format"),
             minutes);
+    }
+
+    internal override void PushActivate()
+    {
+        base.PushActivate();
+        if (IsActive)
+        {
+            _dataManager.Start();
+        }
+    }
+
+    internal override void PopActivate()
+    {
+        base.PopActivate();
+        if (!IsActive)
+        {
+            _dataManager.Stop();
+        }
+    }
+
+    public void Dispose()
+    {
+        _dataManager.Dispose();
+    }
+}
+
+internal sealed partial class SystemTemperatureWidgetPage : WidgetPage, IDisposable
+{
+    public override string Id => "com.microsoft.cmdpal.temperature_widget";
+
+    public override string Title => Resources.GetResource("Temperature_Usage_Title");
+
+    public override IconInfo Icon => Icons.TemperatureIcon;
+
+    private readonly DataManager _dataManager;
+
+    public SystemTemperatureWidgetPage()
+    {
+        _dataManager = new(DataType.Temperature, () => UpdateWidget());
+    }
+
+    protected override void LoadContentData()
+    {
+        try
+        {
+            ContentData.Clear();
+
+            var stats = _dataManager.GetTemperatureStats();
+
+            if (!stats.IsAvailable || stats.CpuTemperatureCelsius < 0)
+            {
+                ContentData["cpuTemperature"] = Resources.GetResource("Temperature_Usage_Unknown");
+                ContentData["temperatureSource"] = Resources.GetResource("Temperature_Usage_Unavailable");
+                return;
+            }
+
+            ContentData["cpuTemperature"] = $"{stats.CpuTemperatureCelsius:F1} °C";
+            ContentData["temperatureSource"] = Resources.GetResource("Temperature_Source_Acpi");
+        }
+        catch (Exception e)
+        {
+            ContentData.Clear();
+            ContentData["errorMessage"] = e.Message;
+        }
+    }
+
+    protected override string GetTemplatePath(WidgetPageState page)
+    {
+        return page switch
+        {
+            WidgetPageState.Content => @"DevHome\Templates\SystemTemperatureTemplate.json",
+            WidgetPageState.Loading => @"DevHome\Templates\SystemTemperatureTemplate.json",
+            _ => throw new NotImplementedException(),
+        };
+    }
+
+    public string GetItemTitle(bool isBandPage)
+    {
+        if (!ContentData.TryGetValue("cpuTemperature", out var temp)
+            || temp == Resources.GetResource("Temperature_Usage_Unknown"))
+        {
+            return isBandPage
+                ? Resources.GetResource("Temperature_Usage_Unknown")
+                : Resources.GetResource("Temperature_Usage_Unknown_Label");
+        }
+
+        return isBandPage
+            ? temp
+            : string.Format(
+                System.Globalization.CultureInfo.CurrentCulture,
+                Resources.GetResource("Temperature_Usage_Label"),
+                temp);
     }
 
     internal override void PushActivate()

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceWidgetsPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceWidgetsPage.cs
@@ -1549,15 +1549,22 @@ internal sealed partial class SystemTemperatureWidgetPage : WidgetPage, IDisposa
 
             var stats = _dataManager.GetTemperatureStats();
 
-            if (!stats.IsAvailable || stats.CpuTemperatureCelsius < 0)
+            if (!stats.IsAvailable)
             {
                 ContentData["cpuTemperature"] = Resources.GetResource("Temperature_Usage_Unknown");
                 ContentData["temperatureSource"] = Resources.GetResource("Temperature_Usage_Unavailable");
                 return;
             }
 
-            ContentData["cpuTemperature"] = $"{stats.CpuTemperatureCelsius:F1} °C";
             ContentData["temperatureSource"] = Resources.GetResource("Temperature_Source_Acpi");
+
+            if (stats.CpuTemperatureCelsius < 0)
+            {
+                ContentData["cpuTemperature"] = Resources.GetResource("Temperature_Usage_Unknown");
+                return;
+            }
+
+            ContentData["cpuTemperature"] = $"{stats.CpuTemperatureCelsius:F1} \u00b0C";
         }
         catch (Exception e)
         {

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceWidgetsPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceWidgetsPage.cs
@@ -1551,7 +1551,7 @@ internal sealed partial class SystemTemperatureWidgetPage : WidgetPage, IDisposa
 
             if (!stats.IsAvailable)
             {
-                ContentData["cpuTemperature"] = Resources.GetResource("Temperature_Usage_Unknown");
+                ContentData["thermalZoneTemperature"] = Resources.GetResource("Temperature_Usage_Unknown");
                 ContentData["temperatureSource"] = Resources.GetResource("Temperature_Usage_Unavailable");
                 return;
             }
@@ -1560,11 +1560,11 @@ internal sealed partial class SystemTemperatureWidgetPage : WidgetPage, IDisposa
 
             if (stats.CpuTemperatureCelsius < 0)
             {
-                ContentData["cpuTemperature"] = Resources.GetResource("Temperature_Usage_Unknown");
+                ContentData["thermalZoneTemperature"] = Resources.GetResource("Temperature_Usage_Unknown");
                 return;
             }
 
-            ContentData["cpuTemperature"] = $"{stats.CpuTemperatureCelsius:F1} \u00b0C";
+            ContentData["thermalZoneTemperature"] = $"{stats.CpuTemperatureCelsius:F1} \u00b0C";
         }
         catch (Exception e)
         {
@@ -1585,7 +1585,7 @@ internal sealed partial class SystemTemperatureWidgetPage : WidgetPage, IDisposa
 
     public string GetItemTitle(bool isBandPage)
     {
-        if (!ContentData.TryGetValue("cpuTemperature", out var temp)
+        if (!ContentData.TryGetValue("thermalZoneTemperature", out var temp)
             || temp == Resources.GetResource("Temperature_Usage_Unknown"))
         {
             return isBandPage

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceWidgetsPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceWidgetsPage.cs
@@ -1536,6 +1536,10 @@ internal sealed partial class SystemTemperatureWidgetPage : WidgetPage, IDisposa
 
     private readonly DataManager _dataManager;
 
+    // Tracked explicitly so GetItemTitle doesn't have to string-compare display values.
+    private bool _hasReading;
+    private string _lastTemperatureString = string.Empty;
+
     public SystemTemperatureWidgetPage()
     {
         _dataManager = new(DataType.Temperature, () => UpdateWidget());
@@ -1551,6 +1555,7 @@ internal sealed partial class SystemTemperatureWidgetPage : WidgetPage, IDisposa
 
             if (!stats.IsAvailable)
             {
+                _hasReading = false;
                 ContentData["thermalZoneTemperature"] = Resources.GetResource("Temperature_Usage_Unknown");
                 ContentData["temperatureSource"] = Resources.GetResource("Temperature_Usage_Unavailable");
                 return;
@@ -1558,16 +1563,20 @@ internal sealed partial class SystemTemperatureWidgetPage : WidgetPage, IDisposa
 
             ContentData["temperatureSource"] = Resources.GetResource("Temperature_Source_Acpi");
 
-            if (stats.CpuTemperatureCelsius < 0)
+            if (stats.TemperatureCelsius < 0)
             {
+                _hasReading = false;
                 ContentData["thermalZoneTemperature"] = Resources.GetResource("Temperature_Usage_Unknown");
                 return;
             }
 
-            ContentData["thermalZoneTemperature"] = $"{stats.CpuTemperatureCelsius:F1} \u00b0C";
+            _hasReading = true;
+            _lastTemperatureString = $"{stats.TemperatureCelsius:F1} \u00b0C";
+            ContentData["thermalZoneTemperature"] = _lastTemperatureString;
         }
         catch (Exception e)
         {
+            _hasReading = false;
             ContentData.Clear();
             ContentData["errorMessage"] = e.Message;
         }
@@ -1585,8 +1594,7 @@ internal sealed partial class SystemTemperatureWidgetPage : WidgetPage, IDisposa
 
     public string GetItemTitle(bool isBandPage)
     {
-        if (!ContentData.TryGetValue("thermalZoneTemperature", out var temp)
-            || temp == Resources.GetResource("Temperature_Usage_Unknown"))
+        if (!_hasReading)
         {
             return isBandPage
                 ? Resources.GetResource("Temperature_Usage_Unknown")
@@ -1594,11 +1602,11 @@ internal sealed partial class SystemTemperatureWidgetPage : WidgetPage, IDisposa
         }
 
         return isBandPage
-            ? temp
+            ? _lastTemperatureString
             : string.Format(
                 System.Globalization.CultureInfo.CurrentCulture,
                 Resources.GetResource("Temperature_Usage_Label"),
-                temp);
+                _lastTemperatureString);
     }
 
     internal override void PushActivate()

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/Strings/en-US/Resources.resw
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/Strings/en-US/Resources.resw
@@ -463,4 +463,32 @@
   <data name="Disk_Speed_Unit_BinaryBytesPerSec" xml:space="preserve">
     <value>Binary bytes per second (KiB/s, MiB/s, GiB/s)</value>
   </data>
+  <data name="Temperature_Usage_Subtitle" xml:space="preserve">
+    <value>Temp</value>
+  </data>
+  <data name="Temperature_Usage_Title" xml:space="preserve">
+    <value>CPU Temperature</value>
+  </data>
+  <data name="Temperature_Usage_Label" xml:space="preserve">
+    <value>CPU Temp: {0}</value>
+    <comment>{0} is the temperature string, e.g. "72 °C"</comment>
+  </data>
+  <data name="Temperature_Usage_Unknown" xml:space="preserve">
+    <value>—</value>
+  </data>
+  <data name="Temperature_Usage_Unknown_Label" xml:space="preserve">
+    <value>CPU Temp: N/A</value>
+  </data>
+  <data name="Temperature_Usage_Unavailable" xml:space="preserve">
+    <value>Not available</value>
+  </data>
+  <data name="Temperature_Source_Acpi" xml:space="preserve">
+    <value>ACPI</value>
+  </data>
+  <data name="Temperature_Widget_Template.CpuTemperature" xml:space="preserve">
+    <value>CPU temperature</value>
+  </data>
+  <data name="Temperature_Widget_Template.Source" xml:space="preserve">
+    <value>Source</value>
+  </data>
 </root>

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/Strings/en-US/Resources.resw
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/Strings/en-US/Resources.resw
@@ -467,17 +467,17 @@
     <value>Temp</value>
   </data>
   <data name="Temperature_Usage_Title" xml:space="preserve">
-    <value>CPU Temperature</value>
+    <value>System temperature</value>
   </data>
   <data name="Temperature_Usage_Label" xml:space="preserve">
-    <value>CPU Temp: {0}</value>
+    <value>Thermal zone: {0}</value>
     <comment>{0} is the temperature string, e.g. "72 °C"</comment>
   </data>
   <data name="Temperature_Usage_Unknown" xml:space="preserve">
     <value>—</value>
   </data>
   <data name="Temperature_Usage_Unknown_Label" xml:space="preserve">
-    <value>CPU Temp: N/A</value>
+    <value>Thermal zone: N/A</value>
   </data>
   <data name="Temperature_Usage_Unavailable" xml:space="preserve">
     <value>Not available</value>
@@ -485,8 +485,8 @@
   <data name="Temperature_Source_Acpi" xml:space="preserve">
     <value>ACPI</value>
   </data>
-  <data name="Temperature_Widget_Template.CpuTemperature" xml:space="preserve">
-    <value>CPU temperature</value>
+  <data name="Temperature_Widget_Template.ThermalZone" xml:space="preserve">
+    <value>Thermal zone</value>
   </data>
   <data name="Temperature_Widget_Template.Source" xml:space="preserve">
     <value>Source</value>

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/Strings/en-US/Resources.resw
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/Strings/en-US/Resources.resw
@@ -474,7 +474,7 @@
     <comment>{0} is the temperature string, e.g. "72 °C"</comment>
   </data>
   <data name="Temperature_Usage_Unknown" xml:space="preserve">
-    <value>—</value>
+    <value>N/A</value>
   </data>
   <data name="Temperature_Usage_Unknown_Label" xml:space="preserve">
     <value>Thermal zone: N/A</value>


### PR DESCRIPTION
## Summary

Adds a CPU temperature widget to the CmdPal Performance Monitor dock, exposing the system thermal zone temperature sourced from the Windows `Thermal Zone Information` PDH performance counter category (ACPI thermal zones).

Closes #46434

## Detail

- New `TemperatureStats` class in `DevHome\Helpers\TemperatureStats.cs`, following the existing `BatteryStats` pattern. Reads the `High Precision Temperature` counter (tenths of Kelvin, converted to °C). Uses `PerformanceCounterSourceBase` helpers - no WMI, no third-party libraries, AOT-safe.
- New `DataType.Temperature` enum value, wired through `SystemData`, `DataManager` (`GetTemperatureData` / `GetTemperatureStats`), and `PerformanceMetricKind.Temperature`.
- New `SystemTemperatureWidgetPage` in `PerformanceWidgetsPage.cs`, following the existing widget pattern. Gracefully degrades on systems without ACPI thermal zones (VMs, some desktops) - shows "N/A" rather than erroring.
- Adaptive card template `SystemTemperatureTemplate.json` registered as `<None Update … PreserveNewest>`, consistent with other PerfMon templates.
- New `Temperature_*` strings under `Strings\en-US\Resources.resw`.
- New `Icons.TemperatureIcon` (`\uE9CA`).

### On per-component temperatures

Windows does not expose per-component CPU core or GPU temperatures through any native, AOT-compatible, driver-free API. The options that would give richer data all require either WMI (excluded from this project for AOT compatibility), vendor SDKs (NvAPI / ADLX), or a kernel driver like WinRing0/LibreHardwareMonitor. This implementation intentionally sticks to what Windows provides natively.

## Screenshots

<img width="352" height="39" alt="image" src="https://github.com/user-attachments/assets/f7bea6d1-a69d-4fb2-bcd2-62f1595fe736" />

## How tested

- Built `Microsoft.CmdPal.Ext.PerformanceMonitor` (Debug x64) - 0 errors.
- Launched dev `Microsoft.CmdPal.UI.exe`, pinned the Temperature widget from the Performance Monitor dock band, confirmed temperature renders correctly and updates on the 1 s timer.
- Verified graceful degradation path compiles and flows correctly.
