### PR TITLE
Fix duplicate extension entries and uninstall detection in CmdPal

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Models/ExtensionService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Models/ExtensionService.cs
@@ -217,8 +217,15 @@ public partial class ExtensionService : IExtensionService, IDisposable
 
     private static void UpdateExtensionsListsFromWrappers(List<ExtensionWrapper> wrappers)
     {
+        var existingIds = new HashSet<string>(_installedExtensions.Select(e => e.ExtensionUniqueId), StringComparer.Ordinal);
+
         foreach (var extensionWrapper in wrappers)
         {
+            if (!existingIds.Add(extensionWrapper.ExtensionUniqueId))
+            {
+                continue;
+            }
+
             // var localSettingsService = Application.Current.GetService<ILocalSettingsService>();
             var extensionUniqueId = extensionWrapper.ExtensionUniqueId;
             var isExtensionDisabled = false; // await localSettingsService.ReadSettingAsync<bool>(extensionUniqueId + "-ExtensionDisabled");
@@ -282,8 +289,14 @@ public partial class ExtensionService : IExtensionService, IDisposable
         _installedExtensions.Clear();
         _enabledExtensions.Clear();
 
+        var seenIds = new HashSet<string>(StringComparer.Ordinal);
         foreach (var extensionWrapper in refreshedWrappers)
         {
+            if (!seenIds.Add(extensionWrapper.ExtensionUniqueId))
+            {
+                continue;
+            }
+
             _installedExtensions.Add(extensionWrapper);
 
             var wasPreviouslyInstalled = previouslyInstalledExtensionIds.Contains(extensionWrapper.ExtensionUniqueId);

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandManager.cs
@@ -400,13 +400,18 @@ public sealed partial class TopLevelCommandManager : ObservableObject,
 
     private async Task<RegisterAndLoadSummary> RegisterAndLoadCommandsAsync(ICollection<CommandProviderWrapper> wrappers, CancellationToken ct)
     {
+        List<CommandProviderWrapper> wrappersToAdd;
         lock (_commandProvidersLock)
         {
-            _extensionCommandProviders.AddRange(wrappers);
+            var existingIds = new HashSet<string>(_extensionCommandProviders
+                .Where(p => p.IsExtension)
+                .Select(p => p.Extension!.ExtensionUniqueId), StringComparer.Ordinal);
+            wrappersToAdd = [.. wrappers.Where(w => !w.IsExtension || !existingIds.Contains(w.Extension!.ExtensionUniqueId))];
+            _extensionCommandProviders.AddRange(wrappersToAdd);
         }
 
-        // Load the commands from the providers in parallel
-        var loadResults = await Task.WhenAll(wrappers.Select(w => TryLoadCommandsAsync(w, ct))).ConfigureAwait(false);
+        // Load the commands from the new providers in parallel
+        var loadResults = await Task.WhenAll(wrappersToAdd.Select(w => TryLoadCommandsAsync(w, ct))).ConfigureAwait(false);
 
         var totalCommands = 0;
         var totalDockBands = 0;
@@ -608,6 +613,17 @@ public sealed partial class TopLevelCommandManager : ObservableObject,
         _ = Task.Run(
             async () =>
             {
+                var removedIds = new HashSet<string>(extensions.Select(e => e.ExtensionUniqueId), StringComparer.Ordinal);
+
+                // Remove the CommandProviderWrapper from our tracked extension providers
+                // so it no longer appears in the settings page.
+                List<CommandProviderWrapper> removedProviders = [];
+                lock (_commandProvidersLock)
+                {
+                    removedProviders = [.. _extensionCommandProviders.Where(p => p.Extension is not null && removedIds.Contains(p.Extension.ExtensionUniqueId))];
+                    _extensionCommandProviders.RemoveAll(p => removedProviders.Contains(p));
+                }
+
                 // Then find all the top-level commands that belonged to that extension
                 List<TopLevelViewModel> commandsToRemove = [];
                 List<TopLevelViewModel> bandsToRemove = [];


### PR DESCRIPTION
## Summary

Fixes #48643 - two bugs in CmdPal extension management:

### Bug 1: Duplicate extension entries in settings
In \ExtensionService.UpdateExtensionsListsFromWrappers\ and \RebuildInstalledExtensionsCacheAsync\, the same extension could be added multiple times because there was no deduplication by \ExtensionUniqueId\. If an extension declares multiple COM class IDs or the \PackageInstalling\ event fires redundantly, the extension appears multiple times in settings.

**Fix:** Added \HashSet\-based deduplication by \ExtensionUniqueId\ before adding wrappers to the installed/enabled lists.

### Bug 2: Extensions remain visible in settings after uninstall
In \TopLevelCommandManager.ExtensionService_OnExtensionRemoved\, only the top-level commands and dock bands were removed — the \CommandProviderWrapper\ stayed in \_extensionCommandProviders\, keeping the extension visible in settings with 0 commands.

**Fix:** Also remove the matching \CommandProviderWrapper\ from \_extensionCommandProviders\ when an extension is uninstalled. Additionally added a deduplication guard in \RegisterAndLoadCommandsAsync\ to prevent registering the same extension provider twice.

## Changes

| File | Change |
|------|--------|
| \Microsoft.CmdPal.UI.ViewModels/Models/ExtensionService.cs\ | Deduplicate wrappers by \ExtensionUniqueId\ in \UpdateExtensionsListsFromWrappers\ and \RebuildInstalledExtensionsCacheAsync\ |
| \Microsoft.CmdPal.UI.ViewModels/TopLevelCommandManager.cs\ | Remove \CommandProviderWrapper\ from \_extensionCommandProviders\ on uninstall; deduplicate in \RegisterAndLoadCommandsAsync\ |

Closes #48643