### PR TITLE
[FancyZones] Support custom-framed popup windows and fallback drag detection (#48641)

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -862,6 +862,7 @@ jobject
 JOBOBJECT
 jpe
 JPN
+JUCE
 jpnime
 jrsoftware
 Jsons

--- a/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
@@ -691,7 +691,33 @@ LRESULT FancyZones::WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lpa
         {
             if (auto monitor = MonitorFromPoint(ptScreen, MONITOR_DEFAULTTONULL))
             {
-                MoveSizeUpdate(monitor, ptScreen);
+                if (!m_windowMouseSnapper)
+                {
+                    // Fallback: detect custom window dragging for apps that don't
+                    // fire EVENT_SYSTEM_MOVESIZESTART (e.g., JUCE, Electron, custom
+                    // canvas frameworks that handle their own window movement).
+                    if (GetAsyncKeyState(VK_LBUTTON) & 0x8000)
+                    {
+                        auto hwnd = reinterpret_cast<HWND>(wparam);
+                        if (hwnd && FancyZonesWindowUtils::IsRoot(hwnd) && FancyZonesWindowProcessing::IsProcessableManually(hwnd))
+                        {
+                            MoveSizeStart(hwnd, monitor);
+                            MoveSizeUpdate(monitor, ptScreen);
+                        }
+                    }
+                }
+                else
+                {
+                    MoveSizeUpdate(monitor, ptScreen);
+
+                    // End the drag if the user released the mouse button.
+                    // This handles the case where EVENT_SYSTEM_MOVESIZEEND
+                    // never fires for custom-drag windows.
+                    if (!(GetAsyncKeyState(VK_LBUTTON) & 0x8000))
+                    {
+                        MoveSizeEnd();
+                    }
+                }
             }
         }
         else if (message == WM_PRIV_WINDOWCREATED)

--- a/src/modules/fancyzones/FancyZonesLib/FancyZonesWindowProcessing.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZonesWindowProcessing.cpp
@@ -34,16 +34,22 @@ FancyZonesWindowProcessing::ProcessabilityType FancyZonesWindowProcessing::Defin
     }
 
     bool isPopup = FancyZonesWindowUtils::HasStyle(style, WS_POPUP);
-    bool hasThickFrame = FancyZonesWindowUtils::HasStyle(style, WS_THICKFRAME);
-    bool hasCaption = FancyZonesWindowUtils::HasStyle(style, WS_CAPTION);
-    bool hasMinimizeMaximizeButtons = FancyZonesWindowUtils::HasStyle(style, WS_MINIMIZEBOX) || FancyZonesWindowUtils::HasStyle(style, WS_MAXIMIZEBOX);
-    if (isPopup && !(hasThickFrame && (hasCaption || hasMinimizeMaximizeButtons)))
+    if (isPopup)
     {
+        bool hasThickFrame = FancyZonesWindowUtils::HasStyle(style, WS_THICKFRAME);
+        bool hasCaption = FancyZonesWindowUtils::HasStyle(style, WS_CAPTION);
+        bool hasMinimizeMaximizeButtons = FancyZonesWindowUtils::HasStyle(style, WS_MINIMIZEBOX) || FancyZonesWindowUtils::HasStyle(style, WS_MAXIMIZEBOX);
+
         // popup windows we want to snap: e.g. Calculator, Telegram   
         // popup windows we don't want to snap: start menu, notification popup, tray window, etc.
         // WS_CAPTION, WS_MINIMIZEBOX, WS_MAXIMIZEBOX are used for filtering out menus,
         // e.g., in Edge "Running as admin" menu when creating a new PowerToys issue.
-        return ProcessabilityType::NonProcessablePopupWindow;
+        // WS_EX_APPWINDOW marks top-level application windows (visible on the taskbar).
+        bool isAppWindow = FancyZonesWindowUtils::HasStyle(exStyle, WS_EX_APPWINDOW);
+        if (!(isAppWindow || (hasThickFrame && (hasCaption || hasMinimizeMaximizeButtons))))
+        {
+            return ProcessabilityType::NonProcessablePopupWindow;
+        }
     }
 
     // allow child windows


### PR DESCRIPTION
## Summary

Two fixes to support snapping custom-framed application windows (JUCE, Electron, etc.) that don't use standard Win32 window styles or the standard Windows drag loop.

### Fix 1: Popup window type check refinement (FancyZonesWindowProcessing.cpp)

The DefineWindowType function was rejecting all popup windows without combined WS_THICKFRAME + (WS_CAPTION | min/max buttons). Custom-framed apps create popup windows with WS_EX_APPWINDOW (taskbar-visible) but may lack WS_THICKFRAME or WS_CAPTION. The fix adds WS_EX_APPWINDOW as an alternative qualifier — taskbar-visible app windows are allowed even without standard frame styles.

Transient popups (menus, dropdowns, tooltips) without WS_EX_APPWINDOW remain correctly blocked.

### Fix 2: Fallback drag detection (FancyZones.cpp)

Some custom-drag frameworks (JUCE, some Electron configs) don't fire EVENT_SYSTEM_MOVESIZESTART when the user drags the window by a custom title bar. This fix adds fallback detection in the existing WM_PRIV_LOCATIONCHANGE handler:

- When m_windowMouseSnapper is null but the left mouse button is held and a tracked window moves → triggers MoveSizeStart + MoveSizeUpdate
- When a drag is active (m_windowMouseSnapper exists) and the left mouse button is released → triggers MoveSizeEnd (handles missing EVENT_SYSTEM_MOVESIZEEND)

## Testing notes

- All 15 existing WindowProcessingUnitTests pass with the updated popup check
- The drag fallback activates only when the app doesn't fire standard drag events (existing behavior unchanged for normal apps)
- GetAsyncKeyState(VK_LBUTTON) gates prevent spurious start/end calls

Fixes #48641