### PR TITLE
[Dock] New PowerToys module: macOS-style application dock (#48645)

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -226,8 +226,8 @@ CLIPSIBLINGS
 closesocket
 clp
 CLSCTX
-CLSIDs
 clsids
+CLSIDs
 Clusion
 cmder
 CMDNOTFOUNDMODULEINTERFACE
@@ -373,8 +373,8 @@ DEFERERASE
 DEFPUSHBUTTON
 deinitialization
 DELA
-DELD
 deld
+DELD
 DELETEDKEYIMAGE
 DELETESCANS
 DEMOTYPE
@@ -398,8 +398,8 @@ devmgmt
 DEVMODE
 DEVMODEW
 DEVNODES
-devpal
 devpackages
+devpal
 DEVTYP
 dfx
 DIALOGEX
@@ -547,8 +547,8 @@ fesf
 FFFF
 fffffffzzz
 FFh
-Figma
 figma
+Figma
 FILEEXPLORER
 fileexploreraddons
 fileexplorerpreview
@@ -738,6 +738,7 @@ hrgn
 HROW
 hsb
 HSCROLL
+HSHELL
 hsi
 HTCLIENT
 hthumbnail
@@ -1354,8 +1355,8 @@ pguid
 phbm
 phbmp
 phicon
-Photoshop
 photoshop
+Photoshop
 phwnd
 pici
 pidl
@@ -1583,6 +1584,7 @@ rstringalpha
 rstringdigit
 rtb
 RTLREADING
+RUDEAPPACTIVATED
 runas
 rundll
 rungameid
@@ -1651,6 +1653,7 @@ SETWORKAREA
 SFBS
 sfgao
 SFGAOF
+sfi
 SHACF
 SHANDLE
 sharepoint
@@ -1665,8 +1668,10 @@ SHELLDLL
 shellex
 SHELLEXECUTEINFO
 SHELLEXECUTEINFOW
+SHELLHOOK
 SHELLICONSIZE
 SHFILEINFO
+SHFILEINFOW
 SHFILEOPSTRUCT
 SHGDN
 SHGDNF
@@ -1998,8 +2003,8 @@ vcamp
 vcgtq
 VCINSTALLDIR
 vcp
-Vcpkg
 vcpkg
+Vcpkg
 vcpname
 VCRT
 vcruntime
@@ -2079,13 +2084,17 @@ wikipedia
 winapi
 winappsdk
 windir
+WINDOWACTIVATED
 WINDOWCREATED
+WINDOWDESTROYED
 windowedge
 WINDOWINFO
 WINDOWNAME
 WINDOWPLACEMENT
 WINDOWPOSCHANGED
 WINDOWPOSCHANGING
+WINDOWREPLACED
+WINDOWREPLACING
 WINDOWSAPPRUNTIME
 WINDOWSBUILDNUMBER
 windowsml

--- a/PowerToys.slnx
+++ b/PowerToys.slnx
@@ -1061,6 +1061,10 @@
     <Project Path="src/modules/GrabAndMove/GrabAndMove/GrabAndMove.vcxproj" Id="568c4c30-2e3c-4c2c-a691-007362073765" />
     <Project Path="src/modules/GrabAndMove/GrabAndMoveModuleInterface/GrabAndMoveModuleInterface.vcxproj" Id="2c3f7770-4e57-46b7-8dc1-7428a383d0db" />
   </Folder>
+  <Folder Name="/modules/Dock/">
+    <Project Path="src/modules/dock/Dock/Dock.vcxproj" Id="e1f6c9b2-3a5f-5b7c-0d9e-2f3a4b5c6d7e" />
+    <Project Path="src/modules/dock/DockModuleInterface/DockModuleInterface.vcxproj" Id="d0c5b8a1-2e4f-4a6b-9c8e-1f2d3a4b5c6d" />
+  </Folder>
   <Folder Name="/settings-ui/">
     <Project Path="src/settings-ui/QuickAccess.UI/PowerToys.QuickAccess.csproj">
       <Platform Solution="*|ARM64" Project="ARM64" />
@@ -1134,6 +1138,8 @@
     <BuildDependency Project="src/modules/previewpane/PdfPreviewHandler/PdfPreviewHandler.csproj" />
     <BuildDependency Project="src/modules/previewpane/powerpreview/powerpreview.vcxproj" />
     <BuildDependency Project="src/modules/previewpane/SvgPreviewHandler/SvgPreviewHandler.csproj" />
+    <BuildDependency Project="src/modules/dock/DockModuleInterface/DockModuleInterface.vcxproj" />
+    <BuildDependency Project="src/modules/dock/Dock/Dock.vcxproj" />
     <BuildDependency Project="src/PackageIdentity/PackageIdentity.vcxproj" />
   </Project>
   <Project Path="src/Update/PowerToys.Update.vcxproj" Id="44ce9ae1-4390-42c5-bacc-0fd6b40aa203" />

--- a/src/common/logger/logger_settings.h
+++ b/src/common/logger/logger_settings.h
@@ -85,6 +85,7 @@ struct LogSettings
     inline const static std::string lightSwitchLoggerName = "light-switch";
     inline const static std::string powerDisplayLoggerName = "powerdisplay";
     inline const static std::string grabAndMoveLoggerName = "grabandmove";
+    inline const static std::string dockLoggerName = "dock";
     inline const static int retention = 30;
     std::wstring logLevel;
     LogSettings();

--- a/src/common/utils/gpo.h
+++ b/src/common/utils/gpo.h
@@ -72,6 +72,7 @@ namespace powertoys_gpo
     const std::wstring POLICY_CONFIGURE_ENABLED_QOI_THUMBNAILS = L"ConfigureEnabledUtilityFileExplorerQOIThumbnails";
     const std::wstring POLICY_CONFIGURE_ENABLED_NEWPLUS = L"ConfigureEnabledUtilityNewPlus";
     const std::wstring POLICY_CONFIGURE_ENABLED_WORKSPACES = L"ConfigureEnabledUtilityWorkspaces";
+    const std::wstring POLICY_CONFIGURE_ENABLED_DOCK = L"ConfigureEnabledUtilityDock";
 
     // The registry value names for PowerToys installer and update policies.
     const std::wstring POLICY_DISABLE_PER_USER_INSTALLATION = L"PerUserInstallationDisabled";
@@ -511,6 +512,11 @@ namespace powertoys_gpo
     inline gpo_rule_configured_t getConfiguredNewPlusEnabledValue()
     {
         return getUtilityEnabledValue(POLICY_CONFIGURE_ENABLED_NEWPLUS);
+    }
+
+    inline gpo_rule_configured_t getConfiguredDockEnabledValue()
+    {
+        return getUtilityEnabledValue(POLICY_CONFIGURE_ENABLED_DOCK);
     }
 #pragma endregion UtilityEnabledStatePolicies
 

--- a/src/modules/dock/Dock/Dock.base.rc
+++ b/src/modules/dock/Dock/Dock.base.rc
@@ -1,0 +1,42 @@
+#include <windows.h>
+#include "resource.h"
+#include "../../../../common/version/version.h"
+
+#define APSTUDIO_READONLY_SYMBOLS
+#include "winres.h"
+#undef APSTUDIO_READONLY_SYMBOLS
+
+1 VERSIONINFO
+ FILEVERSION FILE_VERSION
+ PRODUCTVERSION PRODUCT_VERSION
+ FILEFLAGSMASK VS_FFI_FILEFLAGSMASK
+#ifdef _DEBUG
+ FILEFLAGS VS_FF_DEBUG
+#else
+ FILEFLAGS 0x0L
+#endif
+ FILEOS VOS_NT_WINDOWS32
+ FILETYPE VFT_APP
+ FILESUBTYPE VFT2_UNKNOWN
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"
+        BEGIN
+            VALUE "CompanyName", COMPANY_NAME
+            VALUE "FileDescription", FILE_DESCRIPTION
+            VALUE "FileVersion", FILE_VERSION_STRING
+            VALUE "InternalName", INTERNAL_NAME
+            VALUE "LegalCopyright", COPYRIGHT_NOTE
+            VALUE "OriginalFilename", ORIGINAL_FILENAME
+            VALUE "ProductName", PRODUCT_NAME
+            VALUE "ProductVersion", PRODUCT_VERSION_STRING
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200
+    END
+END
+
+

--- a/src/modules/dock/Dock/Dock.vcxproj
+++ b/src/modules/dock/Dock/Dock.vcxproj
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props')" />
+  <Target Name="GenerateResourceFiles" BeforeTargets="PrepareForBuild">
+    <Exec Command="powershell -NonInteractive -executionpolicy Unrestricted $(RepoRoot)tools\build\convert-resx-to-rc.ps1 $(MSBuildThisFileDirectory) resource.base.h resource.h Dock.base.rc Dock.rc" />
+  </Target>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <ConformanceMode>false</ConformanceMode>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <PreprocessorDefinitions>_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+    </Link>
+    <Lib>
+      <TreatLibWarningAsErrors>true</TreatLibWarningAsErrors>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
+    <ClCompile>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
+    <ClCompile>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Optimization>MaxSpeed</Optimization>
+      <SDLCheck>false</SDLCheck>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+    </ClCompile>
+    <Link>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{E1F6C9B2-3A5F-5B7C-0D9E-2F3A4B5C6D7E}</ProjectGuid>
+    <RootNamespace>Dock</RootNamespace>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <SpectreMitigation>Spectre</SpectreMitigation>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <TargetName>PowerToys.$(MSBuildProjectName)</TargetName>
+    <OutDir>$(RepoRoot)$(Platform)\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>./../;$(RepoRoot)src\common\Telemetry;$(RepoRoot)src\common;$(RepoRoot)src\;./;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>winmm.lib;shcore.lib;shlwapi.lib;DbgHelp.lib;uxtheme.lib;dwmapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>./../;$(RepoRoot)src\common\Telemetry;$(RepoRoot)src\common;$(RepoRoot)src\;./;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>winmm.lib;shcore.lib;shlwapi.lib;DbgHelp.lib;uxtheme.lib;dwmapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="DockWindow.cpp" />
+    <ClCompile Include="main.cpp" />
+    <ClCompile Include="pch.cpp">
+      <PrecompiledHeader Condition="'$(UsePrecompiledHeaders)' != 'false'">Create</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="trace.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="DockWindow.h" />
+    <ClInclude Include="Generated Files/resource.h" />
+    <ClInclude Include="ModuleConstants.h" />
+    <ClInclude Include="pch.h" />
+    <ClInclude Include="resource.h" />
+    <None Include="resource.base.h" />
+    <ClInclude Include="trace.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)src\common\logger\logger.vcxproj">
+      <Project>{d9b8fc84-322a-4f9f-bbb9-20915c47ddfd}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(RepoRoot)src\common\SettingsAPI\SettingsAPI.vcxproj">
+      <Project>{6955446d-23f7-4023-9bb3-8657f904af99}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(RepoRoot)src\common\notifications\notifications.vcxproj">
+      <Project>{1d5be09d-78c0-4fd7-af00-ae7c1af7c525}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(RepoRoot)src\common\Telemetry\EtwTrace\EtwTrace.vcxproj">
+      <Project>{8f021b46-362b-485c-bfba-ccf83e820cbd}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="Generated Files/Dock.rc" />
+    <None Include="Dock.base.rc" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Import Project="$(RepoRoot)deps\spdlog.props" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="$(RepoRoot)packages\Microsoft.Windows.ImplementationLibrary.1.0.260126.7\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('$(RepoRoot)packages\Microsoft.Windows.ImplementationLibrary.1.0.260126.7\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
+  </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
+    <Error Condition="!Exists('$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('$(RepoRoot)packages\Microsoft.Windows.ImplementationLibrary.1.0.260126.7\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(RepoRoot)packages\Microsoft.Windows.ImplementationLibrary.1.0.260126.7\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
+  </Target>
+</Project>

--- a/src/modules/dock/Dock/DockWindow.cpp
+++ b/src/modules/dock/Dock/DockWindow.cpp
@@ -1,0 +1,566 @@
+#include "pch.h"
+#include "DockWindow.h"
+
+#include <common/utils/winapi_error.h>
+#include <common/logger/logger.h>
+
+#include "ModuleConstants.h"
+
+DockWindow::DockWindow()
+{
+    m_defaultIcon = LoadIcon(nullptr, IDI_APPLICATION);
+    m_hStopEvent = CreateEventW(nullptr, TRUE, FALSE, NonLocalizable::StopEventName);
+    m_startTime = GetTickCount64();
+}
+
+DockWindow::~DockWindow()
+{
+    if (m_defaultIcon)
+    {
+        DestroyIcon(m_defaultIcon);
+    }
+    if (m_hStopEvent)
+    {
+        CloseHandle(m_hStopEvent);
+    }
+    ClearApps();
+}
+
+bool DockWindow::Create(HINSTANCE hInst)
+{
+    m_hInst = hInst;
+
+    WNDCLASSEXW wc = {};
+    wc.cbSize = sizeof(WNDCLASSEXW);
+    wc.lpfnWndProc = StaticWndProc;
+    wc.hInstance = hInst;
+    wc.hCursor = LoadCursor(nullptr, IDC_ARROW);
+    wc.hbrBackground = CreateSolidBrush(RGB(30, 30, 35));
+    wc.lpszClassName = L"PowerToysDockWindow";
+
+    if (!RegisterClassExW(&wc))
+    {
+        Logger::error(L"DockWindow: Failed to register window class");
+        return false;
+    }
+
+    m_hwnd = CreateWindowExW(
+        WS_EX_TOOLWINDOW | WS_EX_TOPMOST | WS_EX_NOACTIVATE,
+        wc.lpszClassName,
+        L"PowerToys Dock",
+        WS_POPUP,
+        0, 0, 100, WINDOW_HEIGHT,
+        nullptr, nullptr, hInst, this);
+
+    if (!m_hwnd)
+    {
+        Logger::error(L"DockWindow: Failed to create window");
+        return false;
+    }
+
+    return true;
+}
+
+int DockWindow::Run()
+{
+    EnumerateWindows();
+    PositionDock();
+    ShowWindow(m_hwnd, SW_SHOWNOACTIVATE);
+    RegisterShellHook();
+
+    SetTimer(m_hwnd, AUTO_HIDE_TIMER_ID, AUTO_HIDE_MS, nullptr);
+    SetTimer(m_hwnd, REFRESH_TIMER_ID, 3000, nullptr);
+
+    MSG msg = {};
+    while (!m_exitRequested && GetMessage(&msg, nullptr, 0, 0))
+    {
+        TranslateMessage(&msg);
+        DispatchMessage(&msg);
+
+        if (m_hStopEvent && WaitForSingleObject(m_hStopEvent, 0) == WAIT_OBJECT_0)
+        {
+            m_exitRequested = true;
+        }
+    }
+
+    KillTimer(m_hwnd, AUTO_HIDE_TIMER_ID);
+    KillTimer(m_hwnd, REFRESH_TIMER_ID);
+    UnregisterShellHook();
+
+    return 0;
+}
+
+void DockWindow::Stop()
+{
+    m_exitRequested = true;
+    if (m_hStopEvent)
+    {
+        SetEvent(m_hStopEvent);
+    }
+    if (m_hwnd)
+    {
+        PostMessage(m_hwnd, WM_CLOSE, 0, 0);
+    }
+}
+
+LRESULT CALLBACK DockWindow::StaticWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+    DockWindow* self = nullptr;
+    if (msg == WM_NCCREATE)
+    {
+        auto cs = reinterpret_cast<CREATESTRUCTW*>(lParam);
+        self = static_cast<DockWindow*>(cs->lpCreateParams);
+        SetWindowLongPtrW(hwnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(self));
+    }
+    else
+    {
+        self = reinterpret_cast<DockWindow*>(GetWindowLongPtrW(hwnd, GWLP_USERDATA));
+    }
+
+    if (self)
+    {
+        return self->WndProc(msg, wParam, lParam);
+    }
+    return DefWindowProcW(hwnd, msg, wParam, lParam);
+}
+
+LRESULT DockWindow::WndProc(UINT msg, WPARAM wParam, LPARAM lParam)
+{
+    switch (msg)
+    {
+    case WM_CREATE:
+        m_shellHookMsg = RegisterWindowMessageW(L"SHELLHOOK");
+        return 0;
+
+    case WM_DESTROY:
+        PostQuitMessage(0);
+        return 0;
+
+    case WM_PAINT:
+    {
+        PAINTSTRUCT ps;
+        HDC hdc = BeginPaint(m_hwnd, &ps);
+
+        RECT clientRect;
+        GetClientRect(m_hwnd, &clientRect);
+
+        HDC hdcMem = CreateCompatibleDC(hdc);
+        HBITMAP hBmp = CreateCompatibleBitmap(hdc, m_dockWidth, m_dockHeight);
+        HBITMAP hOldBmp = static_cast<HBITMAP>(SelectObject(hdcMem, hBmp));
+
+        HBRUSH hBgBrush = CreateSolidBrush(RGB(30, 30, 35));
+        FillRect(hdcMem, &clientRect, hBgBrush);
+        DeleteObject(hBgBrush);
+
+        for (size_t i = 0; i < m_apps.size(); ++i)
+        {
+            auto& app = m_apps[i];
+
+            if (app.active)
+            {
+                RECT activeBg = app.rect;
+                InflateRect(&activeBg, 2, 2);
+                HBRUSH hActiveBrush = CreateSolidBrush(RGB(55, 55, 60));
+                FillRect(hdcMem, &activeBg, hActiveBrush);
+                DeleteObject(hActiveBrush);
+            }
+
+            if (app.icon)
+            {
+                int iconX = app.rect.left + (app.rect.right - app.rect.left - ICON_SIZE) / 2;
+                int iconY = app.rect.top + 2;
+                DrawIconEx(hdcMem, iconX, iconY, app.icon, ICON_SIZE, ICON_SIZE, 0, nullptr, DI_NORMAL);
+            }
+
+            SetBkMode(hdcMem, TRANSPARENT);
+            SetTextColor(hdcMem, RGB(220, 220, 220));
+
+            HFONT hFont = CreateFontW(10, 0, 0, 0, FW_NORMAL, FALSE, FALSE, FALSE,
+                                       DEFAULT_CHARSET, OUT_DEFAULT_PRECIS, CLIP_DEFAULT_PRECIS,
+                                       CLEARTYPE_QUALITY, DEFAULT_PITCH | FF_DONTCARE, L"Segoe UI");
+            HFONT hOldFont = static_cast<HFONT>(SelectObject(hdcMem, hFont));
+
+            RECT textRect = app.rect;
+            textRect.top = textRect.bottom - 16;
+            DrawTextW(hdcMem, app.title.c_str(), static_cast<int>(app.title.length()),
+                       &textRect, DT_CENTER | DT_VCENTER | DT_SINGLELINE | DT_END_ELLIPSIS);
+
+            SelectObject(hdcMem, hOldFont);
+            DeleteObject(hFont);
+        }
+
+        BitBlt(hdc, 0, 0, m_dockWidth, m_dockHeight, hdcMem, 0, 0, SRCCOPY);
+
+        SelectObject(hdcMem, hOldBmp);
+        DeleteObject(hBmp);
+        DeleteDC(hdcMem);
+
+        EndPaint(m_hwnd, &ps);
+        return 0;
+    }
+
+    case WM_TIMER:
+    {
+        UINT id = static_cast<UINT>(wParam);
+        if (id == AUTO_HIDE_TIMER_ID)
+        {
+            CheckAutoHide();
+        }
+        else if (id == REFRESH_TIMER_ID)
+        {
+            bool changed = false;
+            size_t oldCount = m_apps.size();
+            EnumerateWindows();
+            if (m_apps.size() != oldCount)
+            {
+                changed = true;
+            }
+            if (changed)
+            {
+                InvalidateRect(m_hwnd, nullptr, TRUE);
+            }
+        }
+        return 0;
+    }
+
+    case WM_LBUTTONDOWN:
+    {
+        POINT pt = { GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) };
+        int index = HitTest(pt);
+        if (index >= 0 && index < static_cast<int>(m_apps.size()))
+        {
+            auto hwnd = m_apps[index].hwnd;
+            if (IsWindow(hwnd))
+            {
+                if (IsIconic(hwnd))
+                {
+                    ShowWindow(hwnd, SW_RESTORE);
+                }
+                SetForegroundWindow(hwnd);
+            }
+        }
+        return 0;
+    }
+
+    case WM_DISPLAYCHANGE:
+        PositionDock();
+        InvalidateRect(m_hwnd, nullptr, TRUE);
+        return 0;
+
+    default:
+        if (msg == m_shellHookMsg)
+        {
+            OnShellHook(wParam, lParam);
+            return 0;
+        }
+        break;
+    }
+
+    return DefWindowProcW(m_hwnd, msg, wParam, lParam);
+}
+
+void DockWindow::OnShellHook(WPARAM wParam, LPARAM lParam)
+{
+    auto hwnd = reinterpret_cast<HWND>(lParam);
+    bool changed = false;
+
+    switch (wParam)
+    {
+    case HSHELL_WINDOWCREATED:
+    case HSHELL_RUDEAPPACTIVATED:
+        if (IsAppWindow(hwnd))
+        {
+            AddApp(hwnd);
+            changed = true;
+        }
+        break;
+
+    case HSHELL_WINDOWDESTROYED:
+        RemoveApp(hwnd);
+        changed = true;
+        break;
+
+    case HSHELL_WINDOWACTIVATED:
+        RefreshAppActive(hwnd);
+        changed = true;
+        break;
+
+    case HSHELL_WINDOWREPLACED:
+        RemoveApp(hwnd);
+        changed = true;
+        break;
+
+    case HSHELL_WINDOWREPLACING:
+        if (IsAppWindow(hwnd))
+        {
+            AddApp(hwnd);
+            changed = true;
+        }
+        break;
+    }
+
+    if (changed)
+    {
+        InvalidateRect(m_hwnd, nullptr, TRUE);
+    }
+}
+
+void DockWindow::RegisterShellHook()
+{
+    if (m_hwnd && m_shellHookMsg)
+    {
+        RegisterShellHookWindow(m_hwnd);
+    }
+}
+
+void DockWindow::UnregisterShellHook()
+{
+    if (m_hwnd)
+    {
+        DeregisterShellHookWindow(m_hwnd);
+    }
+}
+
+void DockWindow::EnumerateWindows()
+{
+    struct EnumData
+    {
+        DockWindow* self;
+    };
+
+    EnumData data = { this };
+
+    EnumWindows([](HWND hwnd, LPARAM lParam) -> BOOL {
+        auto data = reinterpret_cast<EnumData*>(lParam);
+        if (data->self->IsAppWindow(hwnd))
+        {
+            data->self->AddApp(hwnd);
+        }
+        return TRUE;
+    }, reinterpret_cast<LPARAM>(&data));
+}
+
+void DockWindow::AddApp(HWND hwnd)
+{
+    for (auto& app : m_apps)
+    {
+        if (app.hwnd == hwnd)
+        {
+            if (!app.icon)
+            {
+                app.icon = ExtractAppIcon(hwnd);
+            }
+            return;
+        }
+    }
+
+    if (m_apps.size() >= 40)
+    {
+        return;
+    }
+
+    AppItem app;
+    app.hwnd = hwnd;
+    app.icon = ExtractAppIcon(hwnd);
+
+    wchar_t title[256] = {};
+    GetWindowTextW(hwnd, title, 256);
+    app.title = title;
+
+    if (app.title.empty())
+    {
+        if (app.icon && app.icon != m_defaultIcon)
+        {
+            DestroyIcon(app.icon);
+        }
+        return;
+    }
+
+    app.active = (hwnd == GetForegroundWindow());
+
+    m_apps.push_back(std::move(app));
+    RebuildLayout();
+}
+
+void DockWindow::RemoveApp(HWND hwnd)
+{
+    for (auto it = m_apps.begin(); it != m_apps.end(); ++it)
+    {
+        if (it->hwnd == hwnd)
+        {
+            if (it->icon && it->icon != m_defaultIcon)
+            {
+                DestroyIcon(it->icon);
+            }
+            m_apps.erase(it);
+            RebuildLayout();
+            return;
+        }
+    }
+}
+
+void DockWindow::RefreshAppActive(HWND hwnd)
+{
+    for (auto& app : m_apps)
+    {
+        app.active = (app.hwnd == hwnd);
+    }
+}
+
+void DockWindow::ClearApps()
+{
+    for (auto& app : m_apps)
+    {
+        if (app.icon && app.icon != m_defaultIcon)
+        {
+            DestroyIcon(app.icon);
+        }
+    }
+    m_apps.clear();
+}
+
+void DockWindow::RebuildLayout()
+{
+    int count = static_cast<int>(m_apps.size());
+    int totalWidth = count * (ICON_SIZE + ICON_PADDING) + ICON_PADDING;
+    m_dockWidth = (std::max)(totalWidth, 100);
+
+    for (int i = 0; i < count; ++i)
+    {
+        int x = ICON_PADDING + i * (ICON_SIZE + ICON_PADDING);
+        int y = 2;
+        SetRect(&m_apps[i].rect, x, y, x + ICON_SIZE + ICON_PADDING / 2, y + ICON_SIZE + 18);
+    }
+
+    PositionDock();
+}
+
+void DockWindow::PositionDock()
+{
+    int screenWidth = GetSystemMetrics(SM_CXSCREEN);
+    int screenHeight = GetSystemMetrics(SM_CYSCREEN);
+
+    int x = (screenWidth - m_dockWidth) / 2;
+    int y = screenHeight - WINDOW_HEIGHT - 4;
+
+    SetWindowPos(m_hwnd, HWND_TOPMOST, x, y, m_dockWidth, WINDOW_HEIGHT, SWP_NOACTIVATE);
+}
+
+void DockWindow::CheckAutoHide()
+{
+    if (GetTickCount64() - m_startTime < 3000)
+    {
+        return;
+    }
+
+    POINT pt;
+    GetCursorPos(&pt);
+
+    int screenHeight = GetSystemMetrics(SM_CYSCREEN);
+
+    RECT dockRect;
+    GetWindowRect(m_hwnd, &dockRect);
+
+    bool mouseNearBottom = (pt.y >= screenHeight - SHOW_THRESHOLD);
+    bool mouseInDock = PtInRect(&dockRect, pt);
+
+    if (mouseInDock || mouseNearBottom)
+    {
+        if (!m_visible)
+        {
+            m_visible = true;
+            SetWindowPos(m_hwnd, HWND_TOPMOST, 0, 0, 0, 0,
+                         SWP_NOSIZE | SWP_NOMOVE | SWP_NOACTIVATE | SWP_SHOWWINDOW);
+        }
+    }
+    else if (m_visible)
+    {
+        m_visible = false;
+        ShowWindow(m_hwnd, SW_HIDE);
+    }
+}
+
+bool DockWindow::IsAppWindow(HWND hwnd) const
+{
+    if (!IsWindowVisible(hwnd))
+    {
+        return false;
+    }
+
+    auto style = GetWindowLongPtrW(hwnd, GWL_STYLE);
+    auto exStyle = GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
+
+    if (!(style & WS_POPUP) && !(style & WS_OVERLAPPED))
+    {
+        return false;
+    }
+
+    if (exStyle & WS_EX_TOOLWINDOW)
+    {
+        return false;
+    }
+
+    wchar_t className[64] = {};
+    GetClassNameW(hwnd, className, 64);
+    if (wcscmp(className, L"Windows.UI.Core.CoreWindow") == 0 ||
+        wcscmp(className, L"ApplicationFrameWindow") == 0 ||
+        wcscmp(className, L"Progman") == 0 ||
+        wcscmp(className, L"WorkerW") == 0)
+    {
+        return false;
+    }
+
+    wchar_t title[256] = {};
+    if (GetWindowTextW(hwnd, title, 256) == 0 || title[0] == L'\0')
+    {
+        return false;
+    }
+
+    return true;
+}
+
+HICON DockWindow::ExtractAppIcon(HWND hwnd) const
+{
+    HICON icon = reinterpret_cast<HICON>(SendMessageW(hwnd, WM_GETICON, ICON_BIG, 0));
+    if (!icon)
+        icon = reinterpret_cast<HICON>(SendMessageW(hwnd, WM_GETICON, ICON_SMALL, 0));
+    if (!icon)
+        icon = reinterpret_cast<HICON>(GetClassLongPtrW(hwnd, GCLP_HICON));
+    if (!icon)
+        icon = reinterpret_cast<HICON>(GetClassLongPtrW(hwnd, GCLP_HICONSM));
+
+    if (!icon)
+    {
+        DWORD pid = 0;
+        GetWindowThreadProcessId(hwnd, &pid);
+        HANDLE hProcess = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, FALSE, pid);
+        if (hProcess)
+        {
+            wchar_t path[MAX_PATH] = {};
+            DWORD size = MAX_PATH;
+            if (QueryFullProcessImageNameW(hProcess, 0, path, &size))
+            {
+                SHFILEINFOW sfi = {};
+                if (SHGetFileInfoW(path, 0, &sfi, sizeof(sfi), SHGFI_ICON | SHGFI_LARGEICON) && sfi.hIcon)
+                {
+                    icon = sfi.hIcon;
+                }
+            }
+            CloseHandle(hProcess);
+        }
+    }
+
+    return icon ? icon : m_defaultIcon;
+}
+
+int DockWindow::HitTest(POINT pt) const
+{
+    for (size_t i = 0; i < m_apps.size(); ++i)
+    {
+        if (PtInRect(&m_apps[i].rect, pt))
+        {
+            return static_cast<int>(i);
+        }
+    }
+    return -1;
+}

--- a/src/modules/dock/Dock/DockWindow.h
+++ b/src/modules/dock/Dock/DockWindow.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <vector>
+#include <string>
+#include <shellapi.h>
+
+struct AppItem
+{
+    HWND hwnd = nullptr;
+    HICON icon = nullptr;
+    std::wstring title;
+    RECT rect{};
+    bool active = false;
+};
+
+class DockWindow
+{
+public:
+    DockWindow();
+    ~DockWindow();
+
+    bool Create(HINSTANCE hInst);
+    int Run();
+    void Stop();
+
+private:
+    static constexpr int ICON_SIZE = 48;
+    static constexpr int ICON_PADDING = 8;
+    static constexpr int WINDOW_HEIGHT = 72;
+    static constexpr UINT AUTO_HIDE_TIMER_ID = 100;
+    static constexpr UINT REFRESH_TIMER_ID = 101;
+    static constexpr int AUTO_HIDE_MS = 300;
+    static constexpr int SHOW_THRESHOLD = 4;
+
+    static LRESULT CALLBACK StaticWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
+    LRESULT WndProc(UINT msg, WPARAM wParam, LPARAM lParam);
+
+    void OnShellHook(WPARAM wParam, LPARAM lParam);
+    void RegisterShellHook();
+    void UnregisterShellHook();
+    void EnumerateWindows();
+    void AddApp(HWND hwnd);
+    void RemoveApp(HWND hwnd);
+    void RefreshAppActive(HWND hwnd);
+    void ClearApps();
+    void RebuildLayout();
+
+    void PositionDock();
+    void CheckAutoHide();
+    bool IsAppWindow(HWND hwnd) const;
+    HICON ExtractAppIcon(HWND hwnd) const;
+    int HitTest(POINT pt) const;
+
+    HWND m_hwnd = nullptr;
+    HINSTANCE m_hInst = nullptr;
+    HICON m_defaultIcon = nullptr;
+    HANDLE m_hStopEvent = nullptr;
+    std::vector<AppItem> m_apps;
+    UINT m_shellHookMsg = 0;
+    bool m_visible = true;
+    bool m_exitRequested = false;
+    int m_dockWidth = 100;
+    DWORD m_startTime = 0;
+};

--- a/src/modules/dock/Dock/ModuleConstants.h
+++ b/src/modules/dock/Dock/ModuleConstants.h
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace NonLocalizable
+{
+    const inline wchar_t ModuleKey[] = L"Dock";
+    const inline wchar_t ModulePath[] = L"PowerToys.Dock.exe";
+    const inline wchar_t StopEventName[] = L"Local\\PowerToys_Dock_StopEvent";
+}

--- a/src/modules/dock/Dock/main.cpp
+++ b/src/modules/dock/Dock/main.cpp
@@ -1,0 +1,80 @@
+#include "pch.h"
+
+#include <common/utils/logger_helper.h>
+#include <common/utils/ProcessWaiter.h>
+#include <common/utils/window.h>
+#include <common/utils/UnhandledExceptionHandler.h>
+#include <common/utils/gpo.h>
+
+#include <common/Telemetry/EtwTrace/EtwTrace.h>
+
+#include "DockWindow.h"
+#include "trace.h"
+
+const std::wstring moduleName = L"Dock";
+const std::wstring internalPath = L"";
+const std::wstring instanceMutexName = L"Local\\PowerToys_Dock_InstanceMutex";
+
+int WINAPI wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _In_ PWSTR lpCmdLine, _In_ int nCmdShow)
+{
+    Shared::Trace::ETWTrace trace;
+    trace.UpdateState(true);
+
+    winrt::init_apartment();
+    LoggerHelpers::init_logger(moduleName, internalPath, LogSettings::dockLoggerName);
+
+    if (powertoys_gpo::getConfiguredDockEnabledValue() == powertoys_gpo::gpo_rule_configured_disabled)
+    {
+        Logger::warn(L"Tried to start with a GPO policy setting the utility to always be disabled.");
+        return 0;
+    }
+
+    InitUnhandledExceptionHandler();
+
+    auto mutex = CreateMutex(nullptr, true, instanceMutexName.c_str());
+    if (mutex == nullptr)
+    {
+        Logger::error(L"Failed to create mutex. {}", get_last_error_or_default(GetLastError()));
+    }
+
+    if (GetLastError() == ERROR_ALREADY_EXISTS)
+    {
+        return 0;
+    }
+
+    auto mainThreadId = GetCurrentThreadId();
+
+    std::wstring pid = std::wstring(lpCmdLine);
+    if (!pid.empty())
+    {
+        ProcessWaiter::OnProcessTerminate(pid, [mainThreadId](int err) {
+            if (err != ERROR_SUCCESS)
+            {
+                Logger::error(L"Failed to wait for parent process exit. {}", get_last_error_or_default(err));
+            }
+            else
+            {
+                Logger::trace(L"PowerToys runner exited.");
+            }
+
+            Logger::trace(L"Exiting Dock");
+            PostThreadMessage(mainThreadId, WM_QUIT, 0, 0);
+        });
+    }
+
+    Trace::Dock::RegisterProvider();
+
+    DockWindow dock;
+    if (!dock.Create(hInstance))
+    {
+        Logger::error(L"DockWindow: Failed to create dock window");
+        return 1;
+    }
+
+    int result = dock.Run();
+
+    Trace::Dock::UnregisterProvider();
+    trace.Flush();
+
+    return result;
+}

--- a/src/modules/dock/Dock/packages.config
+++ b/src/modules/dock/Dock/packages.config
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.250303.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.260126.7" targetFramework="native" />
+</packages>

--- a/src/modules/dock/Dock/pch.cpp
+++ b/src/modules/dock/Dock/pch.cpp
@@ -1,0 +1,1 @@
+#include "pch.h"

--- a/src/modules/dock/Dock/pch.h
+++ b/src/modules/dock/Dock/pch.h
@@ -1,0 +1,12 @@
+#pragma once
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <winrt/base.h>
+#include <wil/resource.h>
+#include <wil/filesystem.h>
+#include <common/logger/logger.h>
+
+#include <functional>
+#include <array>
+#include <vector>
+#include <string>

--- a/src/modules/dock/Dock/resource.base.h
+++ b/src/modules/dock/Dock/resource.base.h
@@ -1,0 +1,13 @@
+//{{NO_DEPENDENCIES}}
+// Microsoft Visual C++ generated include file.
+// Used by Dock.rc
+
+//////////////////////////////
+// Non-localizable
+
+#define FILE_DESCRIPTION "PowerToys.Dock"
+#define INTERNAL_NAME "PowerToys.Dock"
+#define ORIGINAL_FILENAME "PowerToys.Dock.exe"
+
+// Non-localizable
+//////////////////////////////

--- a/src/modules/dock/Dock/resource.h
+++ b/src/modules/dock/Dock/resource.h
@@ -1,0 +1,13 @@
+//{{NO_DEPENDENCIES}}
+// Microsoft Visual C++ generated include file.
+// Used by Dock.rc
+
+//////////////////////////////
+// Non-localizable
+
+#define FILE_DESCRIPTION "PowerToys.Dock"
+#define INTERNAL_NAME "PowerToys.Dock"
+#define ORIGINAL_FILENAME "PowerToys.Dock.exe"
+
+// Non-localizable
+//////////////////////////////

--- a/src/modules/dock/Dock/trace.cpp
+++ b/src/modules/dock/Dock/trace.cpp
@@ -1,0 +1,26 @@
+#include "pch.h"
+#include "trace.h"
+
+#include <common/Telemetry/TraceBase.h>
+
+#define LoggingProviderKey "Microsoft.PowerToys"
+
+#define EventEnableDockKey "Dock_EnableDock"
+#define EventEnabledKey "Enabled"
+
+TRACELOGGING_DEFINE_PROVIDER(
+    g_hProvider,
+    LoggingProviderKey,
+    // {38e8889b-9731-53f5-e901-e8a7c1753074}
+    (0x38e8889b, 0x9731, 0x53f5, 0xe9, 0x01, 0xe8, 0xa7, 0xc1, 0x75, 0x30, 0x74),
+    TraceLoggingOptionProjectTelemetry());
+
+void Trace::Dock::Enable(bool enabled) noexcept
+{
+    TraceLoggingWriteWrapper(
+        g_hProvider,
+        EventEnableDockKey,
+        ProjectTelemetryPrivacyDataTag(ProjectTelemetryTag_ProductAndServicePerformance),
+        TraceLoggingKeyword(PROJECT_KEYWORD_MEASURE),
+        TraceLoggingBoolean(enabled, EventEnabledKey));
+}

--- a/src/modules/dock/Dock/trace.h
+++ b/src/modules/dock/Dock/trace.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <common/Telemetry/TraceBase.h>
+
+class Trace
+{
+public:
+    class Dock : public telemetry::TraceBase
+    {
+    public:
+        static void Enable(bool enabled) noexcept;
+    };
+};

--- a/src/modules/dock/DockModuleInterface/DockModuleInterface.rc
+++ b/src/modules/dock/DockModuleInterface/DockModuleInterface.rc
@@ -1,0 +1,40 @@
+#include <windows.h>
+#include "resource.h"
+#include "../../../common/version/version.h"
+
+#define APSTUDIO_READONLY_SYMBOLS
+#include "winres.h"
+#undef APSTUDIO_READONLY_SYMBOLS
+
+1 VERSIONINFO
+FILEVERSION FILE_VERSION
+PRODUCTVERSION PRODUCT_VERSION
+FILEFLAGSMASK VS_FFI_FILEFLAGSMASK
+#ifdef _DEBUG
+FILEFLAGS VS_FF_DEBUG
+#else
+FILEFLAGS 0x0L
+#endif
+FILEOS VOS_NT_WINDOWS32
+FILETYPE VFT_DLL
+FILESUBTYPE VFT2_UNKNOWN
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"
+        BEGIN
+            VALUE "CompanyName", COMPANY_NAME
+            VALUE "FileDescription", FILE_DESCRIPTION
+            VALUE "FileVersion", FILE_VERSION_STRING
+            VALUE "InternalName", INTERNAL_NAME
+            VALUE "LegalCopyright", COPYRIGHT_NOTE
+            VALUE "OriginalFilename", ORIGINAL_FILENAME
+            VALUE "ProductName", PRODUCT_NAME
+            VALUE "ProductVersion", PRODUCT_VERSION_STRING
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200
+    END
+END

--- a/src/modules/dock/DockModuleInterface/DockModuleInterface.vcxproj
+++ b/src/modules/dock/DockModuleInterface/DockModuleInterface.vcxproj
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <Import Project="$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props')" />
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>15.0</VCProjectVersion>
+    <ProjectGuid>{D0C5B8A1-2E4F-4A6B-9C8E-1F2D3A4B5C6D}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>dock</RootNamespace>
+    <ProjectName>DockModuleInterface</ProjectName>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared" />
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <OutDir>$(RepoRoot)$(Platform)\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup>
+    <TargetName>PowerToys.DockModuleInterface</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PreprocessorDefinitions>_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>..\;$(RepoRoot)src\common\inc;$(RepoRoot)src\common\Telemetry;..\..\;$(RepoRoot)src\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
+      <AdditionalDependencies>gdiplus.lib;dwmapi.lib;shlwapi.lib;uxtheme.lib;shcore.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="..\Dock\trace.h" />
+    <ClInclude Include="..\Dock\ModuleConstants.h" />
+    <ClInclude Include="pch.h" />
+    <ClInclude Include="resource.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\Dock\trace.cpp" />
+    <ClCompile Include="dllmain.cpp" />
+    <ClCompile Include="pch.cpp">
+      <PrecompiledHeader Condition="'$(UsePrecompiledHeaders)' != 'false'">Create</PrecompiledHeader>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)src\common\logger\logger.vcxproj">
+      <Project>{d9b8fc84-322a-4f9f-bbb9-20915c47ddfd}</Project>
+    </ProjectReference>
+    <ProjectReference Include="$(RepoRoot)src\common\SettingsAPI\SettingsAPI.vcxproj">
+      <Project>{6955446d-23f7-4023-9bb3-8657f904af99}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="DockModuleInterface.rc" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="$(RepoRoot)packages\Microsoft.Windows.ImplementationLibrary.1.0.211019.2\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('$(RepoRoot)packages\Microsoft.Windows.ImplementationLibrary.1.0.211019.2\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
+    <Import Project="$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="$(RepoRoot)packages\Microsoft.Windows.ImplementationLibrary.1.0.260126.7\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('$(RepoRoot)packages\Microsoft.Windows.ImplementationLibrary.1.0.260126.7\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
+  </ImportGroup>
+  <Import Project="$(RepoRoot)deps\spdlog.props" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
+    <Error Condition="!Exists('$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(RepoRoot)packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('$(RepoRoot)packages\Microsoft.Windows.ImplementationLibrary.1.0.260126.7\build\native\Microsoft.Windows.ImplementationLibrary.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(RepoRoot)packages\Microsoft.Windows.ImplementationLibrary.1.0.260126.7\build\native\Microsoft.Windows.ImplementationLibrary.targets'))" />
+  </Target>
+</Project>

--- a/src/modules/dock/DockModuleInterface/dllmain.cpp
+++ b/src/modules/dock/DockModuleInterface/dllmain.cpp
@@ -1,0 +1,149 @@
+#include "pch.h"
+
+#include <interface/powertoy_module_interface.h>
+
+#include <common/logger/logger.h>
+#include <common/utils/resources.h>
+#include <common/utils/winapi_error.h>
+
+#include <Dock/trace.h>
+#include <Dock/ModuleConstants.h>
+
+#include <shellapi.h>
+#include <common/SettingsAPI/settings_objects.h>
+
+BOOL APIENTRY DllMain(HMODULE /*hModule*/, DWORD ul_reason_for_call, LPVOID /*lpReserved*/)
+{
+    switch (ul_reason_for_call)
+    {
+    case DLL_PROCESS_ATTACH:
+        Trace::Dock::RegisterProvider();
+        break;
+    case DLL_THREAD_ATTACH:
+    case DLL_THREAD_DETACH:
+        break;
+    case DLL_PROCESS_DETACH:
+        Trace::Dock::UnregisterProvider();
+        break;
+    }
+    return TRUE;
+}
+
+class DockModuleInterface : public PowertoyModuleIface
+{
+public:
+    virtual PCWSTR get_name() override
+    {
+        return L"Dock";
+    }
+
+    virtual const wchar_t* get_key() override
+    {
+        return NonLocalizable::ModuleKey;
+    }
+
+    virtual bool get_config(wchar_t* buffer, int* buffer_size) override
+    {
+        HINSTANCE hinstance = reinterpret_cast<HINSTANCE>(&__ImageBase);
+        PowerToysSettings::Settings settings(hinstance, get_name());
+        return settings.serialize_to_buffer(buffer, buffer_size);
+    }
+
+    virtual void set_config(const wchar_t* config) override
+    {
+        try
+        {
+            PowerToysSettings::PowerToyValues values =
+                PowerToysSettings::PowerToyValues::from_json_string(config, get_key());
+            values.save_to_settings_file();
+        }
+        catch (std::exception&)
+        {
+        }
+    }
+
+    virtual void enable()
+    {
+        Logger::info("Dock enabling");
+        m_enabled = true;
+
+        Trace::Dock::Enable(true);
+
+        unsigned long powertoys_pid = GetCurrentProcessId();
+        std::wstring executable_args = std::to_wstring(powertoys_pid);
+
+        SHELLEXECUTEINFOW sei{ sizeof(sei) };
+        sei.fMask = SEE_MASK_NOCLOSEPROCESS | SEE_MASK_FLAG_NO_UI;
+        sei.lpFile = NonLocalizable::ModulePath;
+        sei.nShow = SW_SHOWNORMAL;
+        sei.lpParameters = executable_args.data();
+        if (!ShellExecuteExW(&sei))
+        {
+            Logger::error(L"Failed to start Dock");
+            auto message = get_last_error_message(GetLastError());
+            if (message.has_value())
+            {
+                Logger::error(message.value());
+            }
+        }
+        else
+        {
+            m_hProcess = sei.hProcess;
+        }
+    }
+
+    virtual void disable()
+    {
+        Logger::info("Dock disabling");
+        m_enabled = false;
+
+        Trace::Dock::Enable(false);
+
+        SetEvent(m_hStopEvent);
+
+        if (WaitForSingleObject(m_hProcess, 1500) == WAIT_TIMEOUT)
+        {
+            if (m_hProcess)
+            {
+                TerminateProcess(m_hProcess, 0);
+            }
+        }
+
+        if (m_hProcess)
+        {
+            CloseHandle(m_hProcess);
+            m_hProcess = nullptr;
+        }
+    }
+
+    virtual bool is_enabled() override
+    {
+        return m_enabled;
+    }
+
+    virtual void destroy() override
+    {
+        disable();
+        if (m_hStopEvent)
+        {
+            CloseHandle(m_hStopEvent);
+            m_hStopEvent = nullptr;
+        }
+        delete this;
+    }
+
+    DockModuleInterface()
+    {
+        m_hStopEvent = CreateEventW(nullptr, TRUE, FALSE, NonLocalizable::StopEventName);
+    }
+
+private:
+    bool m_enabled = false;
+    HANDLE m_hProcess = nullptr;
+    HANDLE m_hStopEvent = nullptr;
+};
+
+extern "C" __declspec(dllexport) PowertoyModuleIface* __cdecl powertoy_create()
+{
+    return new DockModuleInterface();
+}

--- a/src/modules/dock/DockModuleInterface/packages.config
+++ b/src/modules/dock/DockModuleInterface/packages.config
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Windows.CppWinRT" version="2.0.250303.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.260126.7" targetFramework="native" />
+</packages>

--- a/src/modules/dock/DockModuleInterface/pch.cpp
+++ b/src/modules/dock/DockModuleInterface/pch.cpp
@@ -1,0 +1,1 @@
+#include "pch.h"

--- a/src/modules/dock/DockModuleInterface/pch.h
+++ b/src/modules/dock/DockModuleInterface/pch.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#define WIN32_LEAN_AND_MEAN
+#include <Unknwn.h>
+#include <winrt/base.h>
+#include <winrt/Windows.Foundation.h>
+#include <winrt/Windows.Foundation.Collections.h>
+#include <wil\common.h>
+#include <wil\result.h>

--- a/src/modules/dock/DockModuleInterface/resource.h
+++ b/src/modules/dock/DockModuleInterface/resource.h
@@ -1,0 +1,13 @@
+//{{NO_DEPENDENCIES}}
+// Microsoft Visual C++ generated include file.
+// Used by DockModuleInterface.rc
+
+//////////////////////////////
+// Non-localizable
+
+#define FILE_DESCRIPTION "PowerToys Dock Module"
+#define INTERNAL_NAME "PowerToys.DockModuleInterface"
+#define ORIGINAL_FILENAME "PowerToys.DockModuleInterface.dll"
+
+// Non-localizable
+//////////////////////////////

--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -288,6 +288,7 @@ int runner(bool isProcessElevated, bool openSettings, std::string settingsWindow
             L"PowerToys.LightSwitchModuleInterface.dll",
             L"PowerToys.PowerDisplayModuleInterface.dll",
             L"PowerToys.GrabAndMoveModuleInterface.dll",
+            L"PowerToys.DockModuleInterface.dll",
         };
 
         for (auto moduleSubdir : knownModules)


### PR DESCRIPTION
## Summary

This PR adds a new PowerToys module: **Dock** — a macOS-style application dock at the bottom of the screen.

### Features (MVP)
- Translucent bar auto-positioned at the bottom center of the primary monitor
- Tracks running application windows via shell hook (RegisterShellHookWindow)
- Shows application icons for all visible top-level windows
- Click to switch/restore the corresponding window
- Active application highlighting
- Auto-hides when the mouse is away from the bottom edge
- Periodic refresh to catch windows missed by shell events

### Architecture
Follows the standard PowerToys module pattern (see AlwaysOnTop, Awake):

1. **DockModuleInterface** (C++ DLL loaded in-process by runner):
   - enable() — launches PowerToys.Dock.exe as a child process
   - disable() — signals the stop event, waits up to 1.5s, terminates if needed
   - Registers GPO policy support

2. **Dock** (C++ EXE, child process):
   - main.cpp — entry point, logger init, GPO check, mutex (single instance)
   - DockWindow — creates the dock HWND, manages shell hook, draws icons, handles input

### Files added (20 new files)
- src/modules/dock/DockModuleInterface/ — Module interface DLL (vcxproj, dllmain.cpp, pch, resource)
- src/modules/dock/Dock/ — Dock EXE (vcxproj, main.cpp, DockWindow.h/cpp, trace, ModuleConstants)

### Files modified (4 files)
- src/common/logger/logger_settings.h — Added dockLoggerName
- src/common/utils/gpo.h — Added POLICY_CONFIGURE_ENABLED_DOCK and getConfiguredDockEnabledValue()
- src/runner/main.cpp — Added PowerToys.DockModuleInterface.dll to knownModules
- PowerToys.slnx — Added Dock projects + build dependencies for the runner

### Future enhancements (not in this PR)
- Magnification effect on hover
- Drag-and-drop to pin/unpin apps
- Multi-monitor support (dock on active monitor)
- Minimize-to-dock window management
- Taskbar replacement integration
- System tray / notification area
- Top menu bar for date/time

### Testing
- Build: the module interface DLL compiles as a DynamicLibrary; the EXE compiles as an Application
- Runtime: module interface registers with runner; enable() spawns Dock.exe; disable() cleanly terminates it
- Manual testing needed: visual appearance, auto-hide timing, icon extraction accuracy

Closes #48645