### PR TITLE
[CmdPal][Localization] Add JA translation guidance comments for Download and Battery strings

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Properties/Resources.resx
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Properties/Resources.resx
@@ -453,10 +453,11 @@
   </data>
   <data name="gallery_item_winget_action_downloading_with_progress" xml:space="preserve">
     <value>Downloading with WinGet... {0}%</value>
-    <comment>{0}=download percent</comment>
+    <comment>{0}=download percent. JA: translate "Downloading" as "受信" not "受け取り".</comment>
   </data>
   <data name="gallery_item_winget_action_downloading" xml:space="preserve">
     <value>Downloading with WinGet...</value>
+    <comment>JA: translate "Downloading" as "受信" not "受け取り".</comment>
   </data>
   <data name="gallery_item_winget_action_uninstalling" xml:space="preserve">
     <value>Uninstalling with WinGet...</value>
@@ -561,10 +562,11 @@
   </data>
   <data name="winget_operation_status_downloading" xml:space="preserve">
     <value>Downloading</value>
+    <comment>JA: translate as "受信" not "受け取り" for consistency.</comment>
   </data>
   <data name="winget_operation_status_downloading_percent" xml:space="preserve">
     <value>Downloading {0}%</value>
-    <comment>{0}=download percent</comment>
+    <comment>{0}=download percent. JA: translate "Downloading" as "受信" not "受け取り".</comment>
   </data>
   <data name="winget_operation_status_failed" xml:space="preserve">
     <value>Failed</value>

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WinGet/Properties/Resources.resx
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WinGet/Properties/Resources.resx
@@ -172,7 +172,7 @@
 </data>
 <data name="winget_downloading" xml:space="preserve">
   <value>Downloading</value>
-  <comment></comment>
+  <comment>JA: translate as "受信" not "受け取り" for consistency with "Upload" → "送信". "受け取り" implies physical package receipt; "受信" is the correct IT term for data download.</comment>
 </data>
 <data name="winget_queued_package_download" xml:space="preserve">
   <value>Queued {0} for download...</value>
@@ -180,7 +180,7 @@
 </data>
 <data name="winget_download_progress" xml:space="preserve">
   <value>Downloading. {0} of {1}</value>
-  <comment>{0} will be replaced with a number of bytes downloaded, and {1} will be replaced with the total number to download</comment>
+  <comment>{0} will be replaced with a number of bytes downloaded, and {1} will be replaced with the total number to download. JA: translate "Downloading" as "受信" not "受け取り".</comment>
 </data>
 <data name="winget_install_package_finishing" xml:space="preserve">
   <value>Finishing install for {0}...</value>

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/Properties/Resources.resx
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/Properties/Resources.resx
@@ -373,18 +373,18 @@
   </data>
   <data name="BatterySaver" xml:space="preserve">
     <value>Battery Saver</value>
-    <comment>Area System, only available on devices that have a battery, such as a tablet</comment>
+    <comment>Area System, only available on devices that have a battery, such as a tablet. JA: translate "Battery" as "バッテリー" not "電池" when referring to built-in laptop/tablet batteries.</comment>
   </data>
   <data name="BatterySaverSettings" xml:space="preserve">
     <value>Battery Saver settings</value>
-    <comment>Area System, only available on devices that have a battery, such as a tablet</comment>
+    <comment>Area System, only available on devices that have a battery, such as a tablet. JA: translate "Battery" as "バッテリー" not "電池".</comment>
   </data>
   <data name="BatterySaverUsageDetails" xml:space="preserve">
     <value>Battery saver usage details</value>
   </data>
   <data name="BatteryUse" xml:space="preserve">
     <value>Battery use</value>
-    <comment>Area System, only available on devices that have a battery, such as a tablet</comment>
+    <comment>Area System, only available on devices that have a battery, such as a tablet. JA: translate "Battery" as "バッテリー" not "電池".</comment>
   </data>
   <data name="BiometricDevices" xml:space="preserve">
     <value>Biometric Devices</value>


### PR DESCRIPTION
## Summary

Adds translation guidance comments to English .resx resource strings that have incorrect Japanese translations in the CDPX localization pipeline.

## Problem

- **Download/Downloading** — translated as 受け取り (implies physical package receipt) instead of the correct IT term 受信
- **Battery** (laptop/tablet context) — translated as 電池 (dry cell) instead of バッテリー (built-in battery)

## Fix

Added comment elements to 9 resource entries across 3 files with the prefix JA: to guide the localization team:

| File | Strings | Comment |
|------|---------|---------|
| Microsoft.CmdPal.Ext.WinGet\Properties\Resources.resx | winget_downloading, winget_download_progress | JA: translate as 受信 not 受け取り |
| Microsoft.CmdPal.UI.ViewModels\Properties\Resources.resx | winget_operation_status_downloading, winget_operation_status_downloading_percent, gallery_item_winget_action_downloading_with_progress, gallery_item_winget_action_downloading | JA: translate as 受信 not 受け取り |
| Microsoft.CmdPal.Ext.WindowsSettings\Properties\Resources.resx | BatterySaver, BatterySaverSettings, BatteryUse | JA: translate as バッテリー not 電池 |

## Background

As documented in doc/devdocs/development/localization.md, localized .resx files are generated at build time by the CDPX pipeline from .lcl files managed by the internal localization team. The comment elements in English .resx files are surfaced to translators and are the correct mechanism for providing translation guidance. The actual .lcl file fixes must be applied by the internal team.

Closes #48598