### PR TITLE
[CmdPal] Preserve search text when navigating back with Escape (#48648)

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/SearchBar.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/SearchBar.xaml.cs
@@ -39,6 +39,7 @@ public sealed partial class SearchBar : UserControl,
     /// </summary>
     private readonly DispatcherQueueTimer _debounceTimer = DispatcherQueue.GetForCurrentThread().CreateTimer();
     private bool _isBackspaceHeld;
+    private bool _preserveQueryOnGoHome;
 
     // Inline text suggestions
     // In 0.4-0.5 we would replace the text of the search box with the TextToSuggest
@@ -168,6 +169,7 @@ public sealed partial class SearchBar : UserControl,
             switch (Settings.EscapeKeyBehaviorSetting)
             {
                 case EscapeKeyBehavior.AlwaysGoBack:
+                    _preserveQueryOnGoHome = !string.IsNullOrEmpty(FilterBox.Text);
                     WeakReferenceMessenger.Default.Send<NavigateBackMessage>(new());
                     break;
 
@@ -491,6 +493,12 @@ public sealed partial class SearchBar : UserControl,
 
     public void Receive(GoHomeMessage message)
     {
+        if (_preserveQueryOnGoHome)
+        {
+            _preserveQueryOnGoHome = false;
+            return;
+        }
+
         if (!Settings.KeepPreviousQuery)
         {
             ClearSearch();


### PR DESCRIPTION
## Summary

When using the Command Palette with **EscapeKeyBehavior = AlwaysGoBack**, pressing Escape navigates back to the previous page but the typed search text was silently cleared. This fix preserves the search text across the back navigation.

## Root cause

Two code paths cleared the search text:
1. **SearchBar.FilterBox_KeyDown** — the Escape handler for *AlwaysGoBack* sends NavigateBackMessage without touching the text (correct)
2. **SearchBar.Receive(GoHomeMessage)** — when the back navigation reaches the root page, GoHome() sends GoHomeMessage, which unconditionally calls ClearSearch() (the bug)

## Fix

Added a _preserveQueryOnGoHome flag in SearchBar.xaml.cs:
- Set to 	rue *before* sending NavigateBackMessage when the search box has text
- Checked in Receive(GoHomeMessage): if true, skip ClearSearch() and reset the flag

This is a minimal 3-hunk change: one field, one line in the Escape handler, and a guard in the GoHome receiver.

Closes #48648