### PR TITLE
[CmdPal][System] Add Chinese (ZH) translation guidance for Sleep vs Hibernate (#48534)

### DIFF
--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.System/Properties/Resources.resx
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.System/Properties/Resources.resx
@@ -129,6 +129,7 @@
   </data>
   <data name="Microsoft_plugin_command_name_hibernate" xml:space="preserve">
     <value>Hibernate</value>
+    <comment>ZH: translate as '休眠' (hibernation, not sleep)</comment>
   </data>
   <data name="Microsoft_plugin_command_name_lock" xml:space="preserve">
     <value>Lock</value>
@@ -200,11 +201,11 @@
   </data>
   <data name="Microsoft_plugin_sys_hibernate" xml:space="preserve">
     <value>Hibernate computer</value>
-    <comment>This should align to the action in Windows of a hibernating your computer.</comment>
+    <comment>This should align to the action in Windows of a hibernating your computer. ZH: translate as '让计算机休眠' (use 休眠 not 睡眠)</comment>
   </data>
   <data name="Microsoft_plugin_sys_hibernate_confirmation" xml:space="preserve">
     <value>You are about to put this computer into hibernation, are you sure?</value>
-    <comment>This should align to the action in Windows of a hibernating your computer.</comment>
+    <comment>This should align to the action in Windows of a hibernating your computer. ZH: translate as '即将让计算机进入休眠状态' (use 休眠 not 睡眠)</comment>
   </data>
   <data name="Microsoft_plugin_sys_Ip4Address" xml:space="preserve">
     <value>IPv4 address</value>
@@ -336,11 +337,11 @@
   </data>
   <data name="Microsoft_plugin_sys_sleep" xml:space="preserve">
     <value>Put computer to sleep</value>
-    <comment>This should align to the action in Windows of a making your computer go to sleep.</comment>
+    <comment>This should align to the action in Windows of a making your computer go to sleep. ZH: translate as '让计算机睡眠' (use 睡眠 not 休眠)</comment>
   </data>
   <data name="Microsoft_plugin_sys_sleep_confirmation" xml:space="preserve">
     <value>You are about to put this computer to sleep, are you sure?</value>
-    <comment>This should align to the action in Windows of a making your computer go to sleep.</comment>
+    <comment>This should align to the action in Windows of a making your computer go to sleep. ZH: translate as '即将让计算机进入睡眠状态' (use 睡眠 not 休眠)</comment>
   </data>
   <data name="Microsoft_plugin_sys_Speed" xml:space="preserve">
     <value>Speed</value>
@@ -381,6 +382,7 @@
   </data>
   <data name="Microsoft_plugin_command_name_sleep" xml:space="preserve">
     <value>Sleep</value>
+    <comment>ZH: translate as '睡眠' (sleep, not hibernation). Do NOT use '休眠'.</comment>
   </data>
   <data name="Microsoft_plugin_ext_fallback_display_title" xml:space="preserve">
     <value>Execute system commands</value>


### PR DESCRIPTION
## Summary

Fixes incorrect Chinese translation where both Sleep and Hibernate commands showed '休眠' (hibernation) instead of using distinct terms: '睡眠' for Sleep and '休眠' for Hibernate.

## Changes

Added \<comment>\ elements with \ZH:\ guidance to 6 resource entries in \Microsoft.CmdPal.Ext.System\\Properties\\Resources.resx\:

| Resource Key | Current Comment | Added ZH Guidance |
|---|---|---|
| \Microsoft_plugin_command_name_hibernate\ | *(none)* | translate as '休眠' |
| \Microsoft_plugin_sys_hibernate\ | Existing English comment | use 休眠 not 睡眠 |
| \Microsoft_plugin_sys_hibernate_confirmation\ | Existing English comment | use 休眠 not 睡眠 |
| \Microsoft_plugin_command_name_sleep\ | *(none)* | translate as '睡眠', do NOT use '休眠' |
| \Microsoft_plugin_sys_sleep\ | Existing English comment | use 睡眠 not 休眠 |
| \Microsoft_plugin_sys_sleep_confirmation\ | Existing English comment | use 睡眠 not 休眠 |

## Why comments only?

Chinese translations are managed by the internal CDPX localization pipeline. Adding \<comment>\ elements to the English \.resx\ file is the standard way to guide translators for the next localization pass. See similar fix in PR #48649 for Japanese translation guidance.