### PR TITLE
[KBM] Add per-app single key remapping support (#48041)

### DIFF
--- a/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardEventHandlers.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardEventHandlers.cpp
@@ -95,6 +95,124 @@ namespace KeyboardEventHandlers
         if (!GeneratedByKBM(data))
         {
             UpdateNumpadWithShift(data, state);
+
+            // Check app-specific single key remaps first (per-app mapping has priority over global)
+            std::wstring process_name;
+            process_name.resize(MAX_PATH);
+            ii.GetForegroundProcess(process_name);
+            process_name.erase(std::find(process_name.begin(), process_name.end(), L'\0'), process_name.end());
+
+            if (!process_name.empty())
+            {
+                std::transform(process_name.begin(), process_name.end(), process_name.begin(), towlower);
+
+                auto appRemapping = state.GetAppSpecificSingleKeyRemap(data->lParam->vkCode, process_name);
+                if (!appRemapping)
+                {
+                    size_t extensionIndex = process_name.find_last_of(L".");
+                    if (extensionIndex != std::wstring::npos)
+                    {
+                        appRemapping = state.GetAppSpecificSingleKeyRemap(data->lParam->vkCode, process_name.substr(0, extensionIndex));
+                    }
+                }
+
+                if (appRemapping)
+                {
+                    auto it = appRemapping.value();
+                    // Handle remap using the same logic as the global path below
+                    // For simplicity, we reuse the result as if it came from the global table
+                    const bool remapToKey = it->second.index() == 0;
+
+                    if (remapToKey)
+                    {
+                        if (std::get<DWORD>(it->second) == CommonSharedConstants::VK_DISABLED)
+                        {
+                            return 1;
+                        }
+                    }
+
+                    int key_count;
+                    if (remapToKey)
+                    {
+                        key_count = 1;
+                    }
+                    else
+                    {
+                        key_count = std::get<Shortcut>(it->second).Size();
+                    }
+
+                    std::vector<INPUT> keyEventList;
+                    DWORD target;
+                    if (remapToKey)
+                    {
+                        target = Helpers::FilterArtificialKeys(std::get<DWORD>(it->second));
+                    }
+                    else
+                    {
+                        target = Helpers::FilterArtificialKeys(std::get<Shortcut>(it->second).GetActionKey());
+                    }
+
+                    if (data->wParam == WM_KEYDOWN || data->wParam == WM_SYSKEYDOWN)
+                    {
+                        ResetIfModifierKeyForLowerLevelKeyHandlers(ii, it->first, target);
+                    }
+
+                    if (remapToKey)
+                    {
+                        if (data->wParam == WM_KEYUP || data->wParam == WM_SYSKEYUP)
+                        {
+                            Helpers::SetKeyEvent(keyEventList, INPUT_KEYBOARD, static_cast<WORD>(target), KEYEVENTF_KEYUP, KeyboardManagerConstants::KEYBOARDMANAGER_SINGLEKEY_FLAG);
+                        }
+                        else
+                        {
+                            Helpers::SetKeyEvent(keyEventList, INPUT_KEYBOARD, static_cast<WORD>(target), 0, KeyboardManagerConstants::KEYBOARDMANAGER_SINGLEKEY_FLAG);
+                        }
+                    }
+                    else
+                    {
+                        Shortcut targetShortcut = std::get<Shortcut>(it->second);
+                        if (data->wParam == WM_KEYUP || data->wParam == WM_SYSKEYUP)
+                        {
+                            Helpers::SetKeyEvent(keyEventList, INPUT_KEYBOARD, static_cast<WORD>(targetShortcut.GetActionKey()), KEYEVENTF_KEYUP, KeyboardManagerConstants::KEYBOARDMANAGER_SINGLEKEY_FLAG);
+                            Helpers::SetModifierKeyEvents(targetShortcut, Modifiers(), keyEventList, false, KeyboardManagerConstants::KEYBOARDMANAGER_SINGLEKEY_FLAG);
+                        }
+                        else
+                        {
+                            Helpers::SetModifierKeyEvents(targetShortcut, Modifiers(), keyEventList, true, KeyboardManagerConstants::KEYBOARDMANAGER_SINGLEKEY_FLAG);
+                            Helpers::SetKeyEvent(keyEventList, INPUT_KEYBOARD, static_cast<WORD>(targetShortcut.GetActionKey()), 0, KeyboardManagerConstants::KEYBOARDMANAGER_SINGLEKEY_FLAG);
+                        }
+                    }
+
+                    ii.SendVirtualInput(keyEventList);
+
+                    if (data->wParam == WM_KEYDOWN || data->wParam == WM_SYSKEYDOWN)
+                    {
+                        if (remapToKey)
+                        {
+                            ResetIfModifierKeyForLowerLevelKeyHandlers(ii, target, it->first);
+                        }
+                        else
+                        {
+                            std::vector<DWORD> shortcutKeys = std::get<Shortcut>(it->second).GetKeyCodes();
+                            for (auto& itSk : shortcutKeys)
+                            {
+                                ResetIfModifierKeyForLowerLevelKeyHandlers(ii, itSk, it->first);
+                            }
+                        }
+
+                        static int dayWeLastSentKeyToKeyTelemetryOn = -1;
+                        auto currentDay = std::chrono::duration_cast<std::chrono::days>(std::chrono::system_clock::now().time_since_epoch()).count();
+                        if (dayWeLastSentKeyToKeyTelemetryOn != currentDay)
+                        {
+                            Trace::DailyKeyToKeyRemapInvoked();
+                            dayWeLastSentKeyToKeyTelemetryOn = currentDay;
+                        }
+                    }
+
+                    return 1;
+                }
+            }
+
             const auto remapping = state.GetSingleKeyRemap(data->lParam->vkCode);
             if (remapping)
             {

--- a/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/State.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/State.cpp
@@ -14,6 +14,22 @@ std::optional<SingleKeyRemapTable::iterator> State::GetSingleKeyRemap(const DWOR
     return std::nullopt;
 }
 
+// Function to get the iterator of an app-specific single key remap given the source key and app name. Returns nullopt if it isn't remapped
+std::optional<SingleKeyRemapTable::iterator> State::GetAppSpecificSingleKeyRemap(const DWORD& originalKey, const std::wstring& appName)
+{
+    auto appIt = appSpecificSingleKeyReMap.find(appName);
+    if (appIt != appSpecificSingleKeyReMap.end())
+    {
+        auto it = appIt->second.find(originalKey);
+        if (it != appIt->second.end())
+        {
+            return it;
+        }
+    }
+
+    return std::nullopt;
+}
+
 std::optional<std::wstring> State::GetSingleKeyToTextRemapEvent(const DWORD originalKey) const
 {
     if (auto it = singleKeyToTextReMap.find(originalKey); it != end(singleKeyToTextReMap))

--- a/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/State.h
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/State.h
@@ -11,6 +11,9 @@ public:
     // Function to get the iterator of a single key remap given the source key. Returns nullopt if it isn't remapped
     std::optional<SingleKeyRemapTable::iterator> GetSingleKeyRemap(const DWORD& originalKey);
 
+    // Function to get the iterator of an app-specific single key remap given the source key and app name. Returns nullopt if it isn't remapped
+    std::optional<SingleKeyRemapTable::iterator> GetAppSpecificSingleKeyRemap(const DWORD& originalKey, const std::wstring& appName);
+
     // Function to get a unicode string remap given the source key. Returns nullopt if it isn't remapped
     std::optional<std::wstring> GetSingleKeyToTextRemapEvent(const DWORD originalKey) const;
 

--- a/src/modules/keyboardmanager/common/KeyboardManagerConstants.h
+++ b/src/modules/keyboardmanager/common/KeyboardManagerConstants.h
@@ -37,6 +37,9 @@ namespace KeyboardManagerConstants
     // Name of the property use to store app specific shortcut remaps array.
     inline const std::wstring AppSpecificRemapShortcutsSettingName = L"appSpecific";
 
+    // Name of the property use to store app specific single key remaps array.
+    inline const std::wstring AppSpecificRemapKeysSettingName = L"appSpecific";
+
     // Name of the property use to store original keys.
     inline const std::wstring OriginalKeysSettingName = L"originalKeys";
 

--- a/src/modules/keyboardmanager/common/MappingConfiguration.cpp
+++ b/src/modules/keyboardmanager/common/MappingConfiguration.cpp
@@ -37,6 +37,12 @@ void MappingConfiguration::ClearAppSpecificShortcuts()
     appSpecificShortcutReMapSortedKeys.clear();
 }
 
+// Function to clear the App specific single key remapping table
+void MappingConfiguration::ClearAppSpecificSingleKeyRemaps()
+{
+    appSpecificSingleKeyReMap.clear();
+}
+
 // Function to add a new OS level shortcut remapping
 bool MappingConfiguration::AddOSLevelShortcut(const Shortcut& originalSC, const KeyShortcutTextUnion& newSC)
 {
@@ -117,6 +123,26 @@ bool MappingConfiguration::AddAppSpecificShortcut(const std::wstring& app, const
     appSpecificShortcutReMap[process_name][originalSC] = RemapShortcut(newSC);
     appSpecificShortcutReMapSortedKeys[process_name].push_back(originalSC);
     Helpers::SortShortcutVectorBasedOnSize(appSpecificShortcutReMapSortedKeys[process_name]);
+    return true;
+}
+
+// Function to add a new app specific single key remapping
+bool MappingConfiguration::AddAppSpecificSingleKeyRemap(const std::wstring& app, const DWORD& originalKey, const KeyShortcutTextUnion& newRemapKey)
+{
+    std::wstring process_name;
+    process_name.resize(app.length());
+    std::transform(app.begin(), app.end(), process_name.begin(), towlower);
+
+    auto appIt = appSpecificSingleKeyReMap.find(process_name);
+    if (appIt != appSpecificSingleKeyReMap.end())
+    {
+        if (appIt->second.find(originalKey) != appIt->second.end())
+        {
+            return false;
+        }
+    }
+
+    appSpecificSingleKeyReMap[process_name][originalKey] = newRemapKey;
     return true;
 }
 
@@ -304,6 +330,52 @@ bool MappingConfiguration::LoadAppSpecificShortcutRemaps(const json::JsonObject&
     return result;
 }
 
+bool MappingConfiguration::LoadAppSpecificSingleKeyRemaps(const json::JsonObject& jsonData)
+{
+    bool result = true;
+
+    try
+    {
+        auto remapKeysData = jsonData.GetNamedObject(KeyboardManagerConstants::RemapKeysSettingName);
+        if (!remapKeysData)
+        {
+            return result;
+        }
+
+        auto appSpecificRemapKeys = remapKeysData.GetNamedArray(KeyboardManagerConstants::AppSpecificRemapKeysSettingName);
+        for (const auto& it : appSpecificRemapKeys)
+        {
+            try
+            {
+                auto originalKey = it.GetObjectW().GetNamedString(KeyboardManagerConstants::OriginalKeysSettingName);
+                auto newRemapKey = it.GetObjectW().GetNamedString(KeyboardManagerConstants::NewRemapKeysSettingName);
+                auto targetApp = it.GetObjectW().GetNamedString(KeyboardManagerConstants::TargetAppSettingName);
+
+                if (std::wstring(newRemapKey).find(L";") != std::string::npos)
+                {
+                    AddAppSpecificSingleKeyRemap(targetApp.c_str(), std::stoul(originalKey.c_str()), Shortcut(newRemapKey.c_str()));
+                }
+                else
+                {
+                    AddAppSpecificSingleKeyRemap(targetApp.c_str(), std::stoul(originalKey.c_str()), std::stoul(newRemapKey.c_str()));
+                }
+            }
+            catch (...)
+            {
+                Logger::error(L"Improper Key Data JSON for app-specific single key remap. Try the next remap.");
+                result = false;
+            }
+        }
+    }
+    catch (...)
+    {
+        Logger::error(L"Improper JSON format for app-specific single key remaps. Skip to next remap type");
+        result = false;
+    }
+
+    return result;
+}
+
 bool MappingConfiguration::LoadShortcutRemaps(const json::JsonObject& jsonData, const std::wstring& objectName)
 {
     bool result = true;
@@ -430,6 +502,8 @@ bool MappingConfiguration::LoadSettings()
         }
 
         bool result = LoadSingleKeyRemaps(*configFile);
+        ClearAppSpecificSingleKeyRemaps();
+        result = LoadAppSpecificSingleKeyRemaps(*configFile) && result;
         ClearOSLevelShortcuts();
         ClearAppSpecificShortcuts();
         result = LoadShortcutRemaps(*configFile, KeyboardManagerConstants::RemapShortcutsSettingName) && result;
@@ -459,6 +533,8 @@ bool MappingConfiguration::SaveSettingsToFile()
 
     json::JsonArray inProcessRemapKeysArray;
     json::JsonArray inProcessRemapKeysToTextArray;
+
+    json::JsonArray appSpecificRemapKeysArray;
 
     json::JsonArray appSpecificRemapShortcutsArray;
     json::JsonArray appSpecificRemapShortcutsToTextArray;
@@ -630,7 +706,29 @@ bool MappingConfiguration::SaveSettingsToFile()
     remapShortcutsToText.SetNamedValue(KeyboardManagerConstants::GlobalRemapShortcutsSettingName, globalRemapShortcutsToTextArray);
     remapShortcutsToText.SetNamedValue(KeyboardManagerConstants::AppSpecificRemapShortcutsSettingName, appSpecificRemapShortcutsToTextArray);
 
+    for (const auto& itApp : appSpecificSingleKeyReMap)
+    {
+        for (const auto& itKeys : itApp.second)
+        {
+            json::JsonObject keys;
+            keys.SetNamedValue(KeyboardManagerConstants::OriginalKeysSettingName, json::value(winrt::to_hstring(static_cast<unsigned int>(itKeys.first))));
+
+            if (itKeys.second.index() == 0)
+            {
+                keys.SetNamedValue(KeyboardManagerConstants::NewRemapKeysSettingName, json::value(winrt::to_hstring((unsigned int)std::get<DWORD>(itKeys.second))));
+            }
+            else
+            {
+                keys.SetNamedValue(KeyboardManagerConstants::NewRemapKeysSettingName, json::value(std::get<Shortcut>(itKeys.second).ToHstringVK()));
+            }
+
+            keys.SetNamedValue(KeyboardManagerConstants::TargetAppSettingName, json::value(itApp.first));
+            appSpecificRemapKeysArray.Append(keys);
+        }
+    }
+
     remapKeys.SetNamedValue(KeyboardManagerConstants::InProcessRemapKeysSettingName, inProcessRemapKeysArray);
+    remapKeys.SetNamedValue(KeyboardManagerConstants::AppSpecificRemapKeysSettingName, appSpecificRemapKeysArray);
     remapKeysToText.SetNamedValue(KeyboardManagerConstants::InProcessRemapKeysSettingName, inProcessRemapKeysToTextArray);
     configJson.SetNamedValue(KeyboardManagerConstants::RemapKeysSettingName, remapKeys);
     configJson.SetNamedValue(KeyboardManagerConstants::RemapKeysToTextSettingName, remapKeysToText);

--- a/src/modules/keyboardmanager/common/MappingConfiguration.h
+++ b/src/modules/keyboardmanager/common/MappingConfiguration.h
@@ -10,6 +10,7 @@ using SingleKeyRemapTable = std::unordered_map<DWORD, KeyShortcutTextUnion>;
 using SingleKeyToTextRemapTable = SingleKeyRemapTable;
 using ShortcutRemapTable = std::map<Shortcut, RemapShortcut>;
 using AppSpecificShortcutRemapTable = std::map<std::wstring, ShortcutRemapTable>;
+using AppSpecificSingleKeyRemapTable = std::map<std::wstring, SingleKeyRemapTable>;
 
 class MappingConfiguration
 {
@@ -34,6 +35,9 @@ public:
     // Function to clear the App specific shortcut remapping table
     void ClearAppSpecificShortcuts();
 
+    // Function to clear the App specific single key remapping table
+    void ClearAppSpecificSingleKeyRemaps();
+
     // Function to add a new single key to key remapping
     bool AddSingleKeyRemap(const DWORD& originalKey, const KeyShortcutTextUnion& newRemapKey);
 
@@ -45,6 +49,9 @@ public:
 
     // Function to add a new App specific level shortcut remapping
     bool AddAppSpecificShortcut(const std::wstring& app, const Shortcut& originalSC, const KeyShortcutTextUnion& newSC);
+
+    // Function to add a new app specific single key remapping
+    bool AddAppSpecificSingleKeyRemap(const std::wstring& app, const DWORD& originalKey, const KeyShortcutTextUnion& newRemapKey);
 
     // The map members and their mutexes are left as public since the maps are used extensively in dllmain.cpp.
     // Maps which store the remappings for each of the features. The bool fields should be initialized to false. They are used to check the current state of the shortcut (i.e is that particular shortcut currently pressed down or not).
@@ -66,6 +73,9 @@ public:
     AppSpecificShortcutRemapTable appSpecificShortcutReMap;
     std::map<std::wstring, std::vector<Shortcut>> appSpecificShortcutReMapSortedKeys;
 
+    // Stores the app-specific single key remappings. Maps application name to the single key remap table
+    AppSpecificSingleKeyRemapTable appSpecificSingleKeyReMap;
+
     // Stores the current configuration name.
     std::wstring currentConfig = KeyboardManagerConstants::DefaultConfiguration;
 
@@ -74,4 +84,5 @@ private:
     bool LoadSingleKeyToTextRemaps(const json::JsonObject& jsonData);
     bool LoadShortcutRemaps(const json::JsonObject& jsonData, const std::wstring& objectName);
     bool LoadAppSpecificShortcutRemaps(const json::JsonObject& remapShortcutsData);
+    bool LoadAppSpecificSingleKeyRemaps(const json::JsonObject& jsonData);
 };


### PR DESCRIPTION
Fixes #48041

## Summary

Adds **per-app single key remapping** to Keyboard Manager. Previously, single key remapping was global-only ? per-app remapping was only available for shortcuts (modifier + action key). This prevented users from remapping standalone keys like Play/Pause, Volume Mute, or function keys to different targets depending on the foreground application.

## Changes (6 files)

### Engine layer
- **`MappingConfiguration.h/cpp`**: Added `AppSpecificSingleKeyRemapTable` (`std::map<std::wstring, SingleKeyRemapTable>`) with load/save in JSON format under `remapKeys.appSpecific`
- **`State.h/cpp`**: Added `GetAppSpecificSingleKeyRemap()` with extension-less fallback matching (matches both `teams.exe` and `teams`)
- **`KeyboardEventHandlers.cpp`**: Modified `HandleSingleKeyRemapEvent` to check per-app single key remaps first (by foreground process) before falling back to the global table

### Settings serialization
- **`KeyboardManagerConstants.h`**: Added `AppSpecificRemapKeysSettingName` constant
- JSON format: `{ "remapKeys": { "inProcess": [...], "appSpecific": [{ "originalKeys": "179", "newRemapKeys": "Ctrl+Shift+M", "targetApp": "teams.exe" }] } }`

## Example usage

To remap the Play/Pause media key (VK=0xB3=179) to Ctrl+Shift+M only in Teams:
```json
"remapKeys": {
  "appSpecific": [
    {
      "originalKeys": "179",
      "newRemapKeys": "Ctrl;Shift;M",
      "targetApp": "teams.exe"
    }
  ]
}
```

When Teams is focused, Play/Pause sends Ctrl+Shift+M. In any other app, Play/Pause works normally.

## Follow-up work (not in this PR)
- C# Settings UI update to expose app-specific single key remapping in the editor
- Wrapper library export for `AddAppSpecificSingleKeyRemap`
