### PR TITLE
[Peek] Fix crash dialog and improve error handling for CoreMessaging exceptions

### DIFF
--- a/src/modules/peek/Peek.UI/NativeEventWaiter.cs
+++ b/src/modules/peek/Peek.UI/NativeEventWaiter.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Threading;
 
+using ManagedCommon;
 using Microsoft.UI.Dispatching;
 
 namespace Peek.UI.Native
@@ -19,9 +20,17 @@ namespace Peek.UI.Native
                 var eventHandle = new EventWaitHandle(false, EventResetMode.AutoReset, eventName);
                 while (true)
                 {
-                    if (eventHandle.WaitOne())
+                    try
                     {
-                        dispatcherQueue.TryEnqueue(() => callback());
+                        if (eventHandle.WaitOne())
+                        {
+                            dispatcherQueue.TryEnqueue(() => callback());
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.LogError($"NativeEventWaiter error for {eventName}: {ex.Message}");
+                        break;
                     }
                 }
             });

--- a/src/modules/peek/Peek.UI/PeekXAML/App.xaml.cs
+++ b/src/modules/peek/Peek.UI/PeekXAML/App.xaml.cs
@@ -5,6 +5,7 @@
 using System;
 using System.IO;
 using System.Threading;
+using System.Threading.Tasks;
 using ManagedCommon;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -58,6 +59,9 @@ namespace Peek.UI
 
             InitializeComponent();
             Logger.InitializeLogger("\\Peek\\Logs");
+
+            AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
+            TaskScheduler.UnobservedTaskException += TaskScheduler_UnobservedTaskException;
 
             Host = Microsoft.Extensions.Hosting.Host
                 .CreateDefaultBuilder()
@@ -144,7 +148,20 @@ namespace Peek.UI
 
         private void App_UnhandledException(object sender, Microsoft.UI.Xaml.UnhandledExceptionEventArgs e)
         {
+            Logger.LogError("Unhandled UI exception: " + e.Exception.ToString());
             PowerToysTelemetry.Log.WriteEvent(new ErrorEvent() { HResult = (Common.Models.HResult)e.Exception.HResult, Failure = ErrorEvent.FailureType.AppCrash });
+            e.Handled = true;
+        }
+
+        private static void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
+        {
+            Logger.LogError("AppDomain unhandled exception: " + (e.ExceptionObject?.ToString() ?? "null"));
+        }
+
+        private static void TaskScheduler_UnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e)
+        {
+            Logger.LogError("Unobserved task exception: " + (e.Exception?.ToString() ?? "null"));
+            e.SetObserved();
         }
 
         /// <summary>


### PR DESCRIPTION
This PR addresses the crash reported in #48665 where Peek shows a hard crash dialog with \