### PR TITLE
[Installer] Fix uninstall failure when cached MSI is missing

### DIFF
--- a/installer/PowerToysSetupCustomActionsVNext/CustomAction.cpp
+++ b/installer/PowerToysSetupCustomActionsVNext/CustomAction.cpp
@@ -43,6 +43,7 @@ const DWORD USERNAME_LEN = UNLEN + 1;                // User Name + '\0'
 
 static const wchar_t *POWERTOYS_EXE_COMPONENT = L"{A2C66D91-3485-4D00-B04D-91844E6B345B}";
 static const wchar_t *POWERTOYS_UPGRADE_CODE = L"{42B84BF7-5FBF-473B-9C8B-049DC16F7708}";
+static const wchar_t *POWERTOYS_UPGRADE_CODE_USER = L"{D8B559DB-4C98-487A-A33F-50A8EEE42726}";
 
 constexpr inline const wchar_t *DataDiagnosticsRegKey = L"Software\\Classes\\PowerToys";
 constexpr inline const wchar_t *DataDiagnosticsRegValueName = L"AllowDataDiagnostics";
@@ -1337,6 +1338,89 @@ UINT __stdcall DetectPrevInstallPathCA(MSIHANDLE hInstall)
     catch (...)
     {
     }
+    er = SUCCEEDED(hr) ? ERROR_SUCCESS : ERROR_INSTALL_FAILURE;
+    return WcaFinalize(er);
+}
+
+UINT __stdcall ForceRemoveOldVersionCA(MSIHANDLE hInstall)
+{
+    HRESULT hr = S_OK;
+    UINT er = ERROR_SUCCESS;
+    hr = WcaInitialize(hInstall, "ForceRemoveOldVersionCA");
+
+    try
+    {
+        LPWSTR currentScope = nullptr;
+        hr = WcaGetProperty(L"InstallScope", &currentScope);
+        if (FAILED(hr))
+        {
+            return WcaFinalize(ERROR_SUCCESS);
+        }
+
+        // Get the current product code to skip it during uninstall enumeration
+        wchar_t currentProductCode[39] = {};
+        DWORD currentProductCodeSize = ARRAYSIZE(currentProductCode);
+        if (MsiGetPropertyW(hInstall, L"ProductCode", currentProductCode, &currentProductCodeSize) != ERROR_SUCCESS)
+        {
+            currentProductCode[0] = L'\0';
+        }
+
+        const wchar_t* upgradeCode = (std::wstring(currentScope) == L"perUser")
+            ? POWERTOYS_UPGRADE_CODE_USER
+            : POWERTOYS_UPGRADE_CODE;
+
+        wchar_t productCode[39] = {};
+        DWORD index = 0;
+        while (MsiEnumRelatedProductsW(upgradeCode, 0, index++, productCode) == ERROR_SUCCESS)
+        {
+            if (MsiQueryProductStateW(productCode) != INSTALLSTATE_DEFAULT)
+            {
+                continue;
+            }
+
+            // Skip the current product during uninstall to avoid re-entrancy
+            if (currentProductCode[0] != L'\0' && wcscmp(productCode, currentProductCode) == 0)
+            {
+                continue;
+            }
+
+            DWORD pathSize = 0;
+            if (MsiGetProductInfoW(productCode, INSTALLPROPERTY_LOCALPACKAGE, nullptr, &pathSize) != ERROR_SUCCESS)
+            {
+                continue;
+            }
+
+            std::wstring localPackage(++pathSize, L'\0');
+            if (MsiGetProductInfoW(productCode, INSTALLPROPERTY_LOCALPACKAGE, localPackage.data(), &pathSize) != ERROR_SUCCESS)
+            {
+                continue;
+            }
+
+            if (!std::filesystem::exists(localPackage.c_str()))
+            {
+                Logger::info(L"PowerToys MSI source missing for product {}. Force-removing...", productCode);
+
+                UINT result = MsiConfigureProductExW(productCode, INSTALLLEVEL_DEFAULT, INSTALLSTATE_ABSENT, L"MSIFASTINSTALL=7 REMOVE=ALL");
+                if (result == ERROR_SUCCESS)
+                {
+                    Logger::info(L"Successfully force-removed old PowerToys product {}", productCode);
+                }
+                else
+                {
+                    Logger::warn(L"Failed to force-remove old PowerToys product {}. Error: {}", productCode, result);
+                }
+            }
+        }
+    }
+    catch (const std::exception& e)
+    {
+        Logger::error("ForceRemoveOldVersionCA exception: {}", e.what());
+    }
+    catch (...)
+    {
+        Logger::error("ForceRemoveOldVersionCA unknown exception");
+    }
+
     er = SUCCEEDED(hr) ? ERROR_SUCCESS : ERROR_INSTALL_FAILURE;
     return WcaFinalize(er);
 }

--- a/installer/PowerToysSetupCustomActionsVNext/CustomAction.def
+++ b/installer/PowerToysSetupCustomActionsVNext/CustomAction.def
@@ -38,3 +38,4 @@ EXPORTS
 	UninstallPackageIdentityMSIXCA
 	CreateWinAppSDKHardlinksCA
 	DeleteWinAppSDKHardlinksCA
+	ForceRemoveOldVersionCA

--- a/installer/PowerToysSetupVNext/Product.wxs
+++ b/installer/PowerToysSetupVNext/Product.wxs
@@ -123,6 +123,8 @@
 
       <Custom Action="SetUnApplyModulesRegistryChangeSetsParam" Before="UnApplyModulesRegistryChangeSets" />
       <Custom Action="CheckGPO" After="InstallInitialize" Condition="NOT Installed" />
+      <Custom Action="ForceRemoveOldVersion" Before="RemoveExistingProducts" Condition="WIX_UPGRADE_DETECTED" />
+      <Custom Action="ForceRemoveOldVersion" Before="RemoveFiles" Condition="Installed AND (REMOVE=&quot;ALL&quot;) AND (NOT WIX_UPGRADE_DETECTED)" />
       <Custom Action="SetBundleInstallLocationData" Before="SetBundleInstallLocation" Condition="NOT Installed OR WIX_UPGRADE_DETECTED" />
       <Custom Action="SetBundleInstallLocation" After="InstallFiles" Condition="NOT Installed OR WIX_UPGRADE_DETECTED" />
       <Custom Action="ApplyModulesRegistryChangeSets" After="InstallFiles" Condition="NOT Installed" />
@@ -247,6 +249,8 @@
     <CustomAction Id="TelemetryLogRepairFail" Return="ignore" Impersonate="yes" DllEntry="TelemetryLogRepairFailCA" BinaryRef="PTCustomActions" />
 
     <CustomAction Id="DetectPrevInstallPath" Return="check" Impersonate="yes" DllEntry="DetectPrevInstallPathCA" BinaryRef="PTCustomActions" />
+
+    <CustomAction Id="ForceRemoveOldVersion" Return="ignore" Impersonate="yes" Execute="deferred" DllEntry="ForceRemoveOldVersionCA" BinaryRef="PTCustomActions" />
 
     <CustomAction Id="CleanVideoConferenceRegistry" Return="ignore" Impersonate="yes" Execute="deferred" DllEntry="CleanVideoConferenceRegistryCA" BinaryRef="PTCustomActions" />
 

--- a/installer/PowerToysSetupVNext/force_remove_orphaned_msi.cmd
+++ b/installer/PowerToysSetupVNext/force_remove_orphaned_msi.cmd
@@ -1,0 +1,36 @@
+@echo off
+setlocal ENABLEDELAYEDEXPANSION
+
+REM This script is invoked during uninstall by the Burn bundle before the MSI package.
+REM It force-removes orphaned PowerToys MSI products whose cached MSI files are missing.
+REM This handles the "msi file for v0.86 not found" error during uninstall.
+REM The actual force-removal uses the native MsiConfigureProductExW API with MSIFASTINSTALL=7,
+REM which is done by the ForceRemoveOldVersionCA custom action in the MSI (Product.wxs).
+REM This script serves as an additional cleanup pass at the bundle level for products
+REM that may not be found by the MSI-level custom action (e.g., from a different scope).
+
+REM Find and remove orphaned per-machine products
+powershell -NoProfile -ExecutionPolicy Bypass -Command ^
+  $uc = '{42B84BF7-5FBF-473B-9C8B-049DC16F7708}'; ^
+  try { $i = New-Object -ComObject WindowsInstaller.Installer; ^
+    $products = @($i.RelatedProducts($uc)); ^
+    foreach ($p in $products) { ^
+      try { if ($i.ProductState($p) -eq 5) { ^
+        $lp = $i.ProductInfo($p, 'LocalPackage'); ^
+        if (-not (Test-Path -LiteralPath $lp -ErrorAction SilentlyContinue)) { ^
+          Write-Host ('Detected orphaned machine MSI, removing: ' + $p); ^
+          $i.ConfigureProduct($p, 0, 2); } } } catch { } } } catch { }
+
+REM Find and remove orphaned per-user products
+powershell -NoProfile -ExecutionPolicy Bypass -Command ^
+  $uc = '{D8B559DB-4C98-487A-A33F-50A8EEE42726}'; ^
+  try { $i = New-Object -ComObject WindowsInstaller.Installer; ^
+    $products = @($i.RelatedProducts($uc)); ^
+    foreach ($p in $products) { ^
+      try { if ($i.ProductState($p) -eq 5) { ^
+        $lp = $i.ProductInfo($p, 'LocalPackage'); ^
+        if (-not (Test-Path -LiteralPath $lp -ErrorAction SilentlyContinue)) { ^
+          Write-Host ('Detected orphaned user MSI, removing: ' + $p); ^
+          $i.ConfigureProduct($p, 0, 2); } } } catch { } } } catch { }
+
+exit /b 0


### PR DESCRIPTION
��This PR fixes the 'msi file for v0.86 not found' error during uninstall (issue #48668). When Windows Installer cache is cleaned, the cached MSI file for a previous PowerToys version may be missing, causing uninstall to fail.

**Root cause:** The ForceRemoveOldVersion custom action only ran during upgrades (WIX_UPGRADE_DETECTED), not during pure uninstall.

**Changes:**

1. **Product.wxs**   Schedule ForceRemoveOldVersion to run during pure uninstall as well:
   - During upgrades: before RemoveExistingProducts (unchanged)
   - During uninstall: before RemoveFiles (Installed AND (REMOVE="ALL") AND (NOT WIX_UPGRADE_DETECTED))

2. **CustomAction.cpp**   ForceRemoveOldVersionCA improvements:
   - Get the current product code via MsiGetPropertyW to skip it during enumeration (avoids re-entrancy)
   - For orphaned products with missing cached MSI, force-remove using MsiConfigureProductExW with MSIFASTINSTALL=7 REMOVE=ALL

3. **CustomAction.def**   Export ForceRemoveOldVersionCA

4. **force_remove_orphaned_msi.cmd**   New standalone cleanup script for detecting and force-removing orphaned PowerToys MSI products with missing cached files
