### PR TITLE
[CmdPal][Dock] Fix performance meter showing '???' after restart

### DIFF
--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceWidgetsPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceWidgetsPage.cs
@@ -107,6 +107,7 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
             _cpuPage.Updated += (s, e) =>
             {
                 _cpuItem.Title = _cpuPage.GetItemTitle(isBandPage);
+                RaiseItemsChanged();
             };
         }
 
@@ -122,6 +123,7 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
             _memoryPage.Updated += (s, e) =>
             {
                 _memoryItem.Title = _memoryPage.GetItemTitle(isBandPage);
+                RaiseItemsChanged();
             };
         }
 
@@ -141,6 +143,7 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
                 _networkDownSpeed = _networkPage.GetDownSpeed();
                 _networkDownItem?.Title = $"{_networkDownSpeed}";
                 _networkUpItem?.Title = $"{_networkUpSpeed}";
+                RaiseItemsChanged();
             };
         }
 
@@ -156,6 +159,7 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
             _gpuPage.Updated += (s, e) =>
             {
                 _gpuItem.Title = _gpuPage.GetItemTitle(isBandPage);
+                RaiseItemsChanged();
             };
         }
 
@@ -176,6 +180,7 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
                 {
                     _batteryItem.Title = _batteryPage.GetItemTitle(isBandPage);
                     _batteryItem.Icon = _batteryPage.CurrentIcon;
+                    RaiseItemsChanged();
                 };
             }
         }


### PR DESCRIPTION
This PR fixes Issue #48680 where the CmdPal dock performance meter shows '???' after restart.

**Root cause**: The PerformanceWidgetsPage initially returns items with a placeholder title ('???') because ContentData hasn't loaded yet. The DataManager timer starts when the dock subscribes to ItemsChanged, and the Updated event fires 1 second later with real data. However, the Updated event handlers were updating ListItem.Title directly without calling RaiseItemsChanged() on the page, so the dock was never notified that the items had changed and continued to display the stale '???' title.

**Fix**: Added a RaiseItemsChanged() call to each of the 5 Updated event handlers (CPU, Memory, Network, GPU, Battery) after the item titles are updated. This causes the dock to re-call GetItems() and refresh the displayed titles.

Fixes #48680