### PR TITLE
ZoomIt - Fix race condition in audio init

### DIFF
--- a/src/modules/ZoomIt/ZoomIt/VideoRecordingSession.cpp
+++ b/src/modules/ZoomIt/ZoomIt/VideoRecordingSession.cpp
@@ -1149,13 +1149,10 @@ VideoRecordingSession::VideoRecordingSession(
     // Store frame interval for timeout-based frame production when webcam is active.
     m_frameIntervalTicks = ( frameRate > 0 ) ? ( 10'000'000LL / frameRate ) : 333'333LL;
 
-    if (m_audioGenerator)
-    {
-        // Always set up audio profile for loopback capture (stereo AAC)
-        auto audioProps = m_audioGenerator->GetEncodingProperties();
-        m_encodingProfile.Audio(winrt::AudioEncodingProperties::CreateAac(
-            audioProps.SampleRate(), audioProps.ChannelCount(), 192000));
-    }
+    // NOTE: Audio encoding profile (m_encodingProfile.Audio) is set in
+    // StartAsync() after the audio graph is fully initialized, not here.
+    // Calling GetEncodingProperties() before InitializeAsync completes
+    // would crash because m_audioOutputNode is still null.
 
     // Describe our input: uncompressed BGRA8 buffers
     auto properties = winrt::VideoEncodingProperties::CreateUncompressed(
@@ -1233,7 +1230,16 @@ winrt::IAsyncAction VideoRecordingSession::StartAsync()
                 co_await m_audioGenerator->InitializeAsync();
             }
             RecDiag( L"StartAsync: audio initialized\n" );
-            m_streamSource = winrt::MediaStreamSource(m_videoDescriptor, winrt::AudioStreamDescriptor(m_audioGenerator->GetEncodingProperties()));
+
+            // Set up the audio encoding profile now that the audio graph is
+            // fully initialized.  GetEncodingProperties() requires
+            // m_audioOutputNode to be valid, which is only guaranteed after
+            // InitializeAsync completes.
+            auto audioProps = m_audioGenerator->GetEncodingProperties();
+            m_encodingProfile.Audio(winrt::AudioEncodingProperties::CreateAac(
+                audioProps.SampleRate(), audioProps.ChannelCount(), 192000));
+
+            m_streamSource = winrt::MediaStreamSource(m_videoDescriptor, winrt::AudioStreamDescriptor(audioProps));
         }
         else {
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
ZoomIt - Fix a race condition where audio was being initialized async

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] Closes: #xxx
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [x] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

