### PR TITLE
CmdPal: Prevent same-page settings navigation

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/SettingsWindow.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/SettingsWindow.xaml.cs
@@ -160,20 +160,24 @@ public sealed partial class SettingsWindow : WindowEx,
                 break;
         }
 
-        if (pageType is not null)
+        if (pageType is null)
         {
-            NavFrame.Navigate(pageType);
+            return;
+        }
 
-            // Now, make sure to actually select the correct menu item too
-            foreach (var obj in NavView.MenuItems)
+        if (NavFrame.Content?.GetType() == pageType)
+        {
+            return;
+        }
+
+        NavFrame.Navigate(pageType);
+
+        // Now, make sure to actually select the correct menu item too
+        foreach (var obj in NavView.MenuItems)
+        {
+            if (obj is NavigationViewItem item && item.Tag is string s && s == page)
             {
-                if (obj is NavigationViewItem item)
-                {
-                    if (item.Tag is string s && s == page)
-                    {
-                        NavView.SelectedItem = item;
-                    }
-                }
+                NavView.SelectedItem = item;
             }
         }
     }


### PR DESCRIPTION
Fixes #48698 by preventing the Command Palette settings frame from navigating to the same page again, which avoids adding a self-navigation entry to the back stack.