### PR TITLE
Dock: Add a teachingtip to docks while pinning

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockWindow.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockWindow.xaml
@@ -45,5 +45,12 @@
             TintColor="{x:Bind WindowViewModel.BackgroundImageTint, Mode=OneWay}"
             TintIntensity="{x:Bind WindowViewModel.BackgroundImageTintIntensity, Mode=OneWay}"
             Visibility="{x:Bind WindowViewModel.ShowBackgroundImage, Mode=OneWay}" />
+
+        <!--  Teaching tip shown while the Pin To Dock dialog is open, to identify this monitor  -->
+        <TeachingTip
+            x:Name="MonitorLabelTeachingTip"
+            IsLightDismissEnabled="False"
+            ShouldConstrainToRootBounds="False"
+            Target="{x:Bind Root}" />
     </Grid>
 </winuiex:WindowEx>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockWindow.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockWindow.xaml.cs
@@ -18,6 +18,7 @@ using Microsoft.UI.Composition.SystemBackdrops;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
 using Windows.Foundation;
 using Windows.Win32;
 using Windows.Win32.Foundation;
@@ -37,6 +38,7 @@ namespace Microsoft.CmdPal.UI.Dock;
 public sealed partial class DockWindow : WindowEx,
     IRecipient<BringToTopMessage>,
     IRecipient<RequestShowPaletteAtMessage>,
+    IRecipient<ShowDockMonitorLabelsMessage>,
     IRecipient<QuitMessage>,
     IDisposable
 {
@@ -140,6 +142,7 @@ public sealed partial class DockWindow : WindowEx,
 
         WeakReferenceMessenger.Default.Register<BringToTopMessage>(this);
         WeakReferenceMessenger.Default.Register<RequestShowPaletteAtMessage>(this);
+        WeakReferenceMessenger.Default.Register<ShowDockMonitorLabelsMessage>(this);
         WeakReferenceMessenger.Default.Register<QuitMessage>(this);
 
         // Subclass the window to intercept messages
@@ -777,6 +780,55 @@ public sealed partial class DockWindow : WindowEx,
         DispatcherQueue.TryEnqueue(DispatcherQueuePriority.Low, () => RequestShowPaletteOnUiThread(message.PosDips));
     }
 
+    void IRecipient<ShowDockMonitorLabelsMessage>.Receive(ShowDockMonitorLabelsMessage message)
+    {
+        DispatcherQueue.TryEnqueue(() =>
+        {
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            if (message.Show)
+            {
+                ShowMonitorLabel();
+            }
+            else
+            {
+                HideMonitorLabel();
+            }
+        });
+    }
+
+    private void ShowMonitorLabel()
+    {
+        var name = _targetMonitor?.DisplayName
+            ?? _monitorService.GetPrimaryMonitor()?.DisplayName
+            ?? string.Empty;
+
+        MonitorLabelTeachingTip.Title = name;
+        MonitorLabelTeachingTip.Target = Root;
+
+        // Open the tip on the side opposite the dock alignment so it stays
+        // within the bounds of the monitor the dock is on (e.g. a top dock
+        // shows its tip below the bar).
+        MonitorLabelTeachingTip.PreferredPlacement = EffectiveSide switch
+        {
+            DockSide.Top => TeachingTipPlacementMode.Bottom,
+            DockSide.Bottom => TeachingTipPlacementMode.Top,
+            DockSide.Left => TeachingTipPlacementMode.Right,
+            DockSide.Right => TeachingTipPlacementMode.Left,
+            _ => TeachingTipPlacementMode.Bottom,
+        };
+
+        MonitorLabelTeachingTip.IsOpen = true;
+    }
+
+    private void HideMonitorLabel()
+    {
+        MonitorLabelTeachingTip.IsOpen = false;
+    }
+
     private void RequestShowPaletteOnUiThread(Point posDips)
     {
         // pos is relative to our root. We need to convert to absolute
@@ -1000,6 +1052,8 @@ internal static class ShowDesktop
 internal sealed record BringToTopMessage(bool BringToFront);
 
 internal sealed record RequestShowPaletteAtMessage(Point PosDips, IntPtr OwnerHwnd);
+
+internal sealed record ShowDockMonitorLabelsMessage(bool Show);
 
 internal sealed record ShowPaletteAtMessage(Point PosPixels, AnchorPoint Anchor);
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
@@ -229,25 +229,37 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
 
     private async Task HandlePinToDockDialogOnUiThread(ShowPinToDockDialogMessage message)
     {
-        var (result, content) = await PinToDockDialogContent.ShowAsync(
-            this.XamlRoot,
-            message.Title,
-            message.Subtitle,
-            message.Icon,
-            message.DockSide,
-            message.AvailableMonitors);
+        // Ask each dock window to display a teaching tip identifying its monitor,
+        // so the user can correlate the dialog's monitor list with the physical docks.
+        WeakReferenceMessenger.Default.Send(new ShowDockMonitorLabelsMessage(true));
 
-        if (result == ContentDialogResult.Primary)
+        try
         {
-            var pinMessage = new PinToDockMessage(
-                message.ProviderId,
-                message.CommandId,
-                Pin: true,
-                Side: content.SelectedSide,
-                ShowTitles: content.ShowTitles,
-                ShowSubtitles: content.ShowSubtitles,
-                MonitorDeviceId: content.SelectedMonitorDeviceId);
-            WeakReferenceMessenger.Default.Send(pinMessage);
+            var (result, content) = await PinToDockDialogContent.ShowAsync(
+                this.XamlRoot,
+                message.Title,
+                message.Subtitle,
+                message.Icon,
+                message.DockSide,
+                message.AvailableMonitors);
+
+            if (result == ContentDialogResult.Primary)
+            {
+                var pinMessage = new PinToDockMessage(
+                    message.ProviderId,
+                    message.CommandId,
+                    Pin: true,
+                    Side: content.SelectedSide,
+                    ShowTitles: content.ShowTitles,
+                    ShowSubtitles: content.ShowSubtitles,
+                    MonitorDeviceId: content.SelectedMonitorDeviceId);
+                WeakReferenceMessenger.Default.Send(pinMessage);
+            }
+        }
+        finally
+        {
+            // Hide the teaching tips once the dialog is saved or dismissed.
+            WeakReferenceMessenger.Default.Send(new ShowDockMonitorLabelsMessage(false));
         }
     }
 


### PR DESCRIPTION
When you're pinning something to the dock with the dialog, I have _no_ idea what display is 1,2,3,4. That's meaningless to me.

This attempts to resolve that by adding a teachingtip to each dock while pinning. When we open that pin to dock dialog, we'll display the teachingtips, and dismiss them when the dialog is closed.

That way folks have at least some indication of where each display is when pinning.
