### PR TITLE
Add permissions for PR labeling

### DIFF
--- a/.github/workflows/auto-labeler.yml
+++ b/.github/workflows/auto-labeler.yml
@@ -4,7 +4,7 @@ on:
   issues:
     types: [opened, reopened]
   pull_request_target:
-    types: [opened, reopened, edited, synchronize]
+    types: [opened, reopened, synchronize]
   # Manual trigger: go to Actions → "Automatic Triaging on Issue Creation" → Run workflow.
   # Enter one or more comma-separated issue numbers (e.g. "1234" or "1234,1235,1236")
   # to apply AI-generated area labels to existing untriaged issues.
@@ -17,6 +17,7 @@ on:
 permissions:
   models: read
   issues: write
+  pull-requests: write
 
 concurrency:
   # Each workflow run gets its own concurrency group.


### PR DESCRIPTION
This pull request makes minor adjustments to the `.github/workflows/auto-labeler.yml` GitHub Actions workflow, focusing on permissions and event triggers.

Workflow configuration updates:

* Added `pull-requests: write` permission to the workflow to ensure it has the necessary access for managing pull requests.
* Removed the `edited` event from the list of triggers for `pull_request_target`, so the workflow will no longer run when a pull request is edited.