### PR TITLE
[ZoomIt] Theme-aware system-tray menu + a reusable helper for tray utilities

### DIFF
--- a/src/modules/ZoomIt/ZoomIt/Utility.cpp
+++ b/src/modules/ZoomIt/ZoomIt/Utility.cpp
@@ -526,9 +526,49 @@ HBRUSH HandleDarkModeCtlColor(HDC hdc, HWND hCtrl, UINT message)
 
 //----------------------------------------------------------------------------
 //
+// IsMenuDarkModeEnabled
+//
+// Public-API dark-mode check used by the owner-drawn tray context menu.
+// Respects the ZoomIt theme override, then the documented per-user
+// AppsUseLightTheme value. Unlike IsDarkModeEnabled(), it never loads or calls
+// the undocumented uxtheme.dll ordinals.
+//
+//----------------------------------------------------------------------------
+bool IsMenuDarkModeEnabled()
+{
+    if (g_ThemeOverride == 0)
+    {
+        return false; // Force light mode
+    }
+    else if (g_ThemeOverride == 1)
+    {
+        return true; // Force dark mode
+    }
+
+    HKEY hKey;
+    if (RegOpenKeyExW(HKEY_CURRENT_USER,
+        L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
+        0, KEY_READ, &hKey) == ERROR_SUCCESS)
+    {
+        DWORD value = 1;
+        DWORD size = sizeof(value);
+        RegQueryValueExW(hKey, L"AppsUseLightTheme", nullptr, nullptr,
+            reinterpret_cast<LPBYTE>(&value), &size);
+        RegCloseKey(hKey);
+        return value == 0; // 0 = dark mode, 1 = light mode
+    }
+
+    return false;
+}
+
+//----------------------------------------------------------------------------
+//
 // ApplyDarkModeToMenu
 //
-// Uses undocumented uxtheme functions to enable dark mode for menus
+// Sets a dark (or default) background brush on a popup menu using the public
+// SetMenuInfo API. The item foreground (text, check, highlight) is rendered
+// separately via owner-draw, so this no longer depends on the undocumented
+// uxtheme menu-theming ordinals.
 //
 //----------------------------------------------------------------------------
 void ApplyDarkModeToMenu(HMENU hMenu)
@@ -538,7 +578,7 @@ void ApplyDarkModeToMenu(HMENU hMenu)
         return;
     }
 
-    if (!IsDarkModeEnabled())
+    if (!IsMenuDarkModeEnabled())
     {
         // Light mode - clear any dark background
         MENUINFO mi = { sizeof(mi) };

--- a/src/modules/ZoomIt/ZoomIt/Utility.h
+++ b/src/modules/ZoomIt/ZoomIt/Utility.h
@@ -77,6 +77,12 @@ HBRUSH HandleDarkModeCtlColor(HDC hdc, HWND hCtrl, UINT message);
 // Apply dark mode theme to a popup menu
 void ApplyDarkModeToMenu(HMENU hMenu);
 
+// Public-API dark-mode check for owner-drawn popup menus. Respects the ZoomIt
+// theme override, then the documented per-user AppsUseLightTheme setting.
+// Unlike IsDarkModeEnabled(), it never loads or calls the undocumented
+// uxtheme.dll ordinals.
+bool IsMenuDarkModeEnabled();
+
 // Force redraw of a window and all its children for theme change
 void RefreshWindowTheme(HWND hWnd);
 

--- a/src/modules/ZoomIt/ZoomIt/Zoomit.cpp
+++ b/src/modules/ZoomIt/ZoomIt/Zoomit.cpp
@@ -7402,6 +7402,192 @@ void ShowMainWindow(HWND hWnd, const MONITORINFO& monInfo, int width, int height
 
 //----------------------------------------------------------------------------
 //
+// GetTrayMenuFont
+//
+// Returns the system menu font scaled for the given window's DPI. The caller
+// owns the returned HFONT. ZoomIt targets _WIN32_WINNT=0x602, so the Win10
+// per-monitor metrics API is used through the runtime-resolved pointer when
+// available, falling back to the system-DPI metrics otherwise.
+//
+//----------------------------------------------------------------------------
+static HFONT GetTrayMenuFont( HWND hWnd )
+{
+    LOGFONTW logFont{};
+    bool haveLogFont = false;
+
+    if( pSystemParametersInfoForDpi && pGetDpiForWindow )
+    {
+        NONCLIENTMETRICSW metrics{};
+        metrics.cbSize = sizeof( metrics );
+        if( pSystemParametersInfoForDpi( SPI_GETNONCLIENTMETRICS, sizeof( metrics ), &metrics, 0, pGetDpiForWindow( hWnd ) ) )
+        {
+            CopyMemory( &logFont, &metrics.lfMenuFont, sizeof( logFont ) );
+            haveLogFont = true;
+        }
+    }
+
+    if( !haveLogFont )
+    {
+        NONCLIENTMETRICSW metrics{};
+        metrics.cbSize = sizeof( metrics );
+        if( SystemParametersInfoW( SPI_GETNONCLIENTMETRICS, sizeof( metrics ), &metrics, 0 ) )
+        {
+            CopyMemory( &logFont, &metrics.lfMenuFont, sizeof( logFont ) );
+            haveLogFont = true;
+        }
+    }
+
+    if( !haveLogFont )
+    {
+        HFONT stockFont = static_cast<HFONT>( GetStockObject( DEFAULT_GUI_FONT ) );
+        GetObjectW( stockFont, sizeof( logFont ), &logFont );
+    }
+
+    return CreateFontIndirectW( &logFont );
+}
+
+//----------------------------------------------------------------------------
+//
+// MeasureTrayMenuItem
+//
+// Owner-draw measurement for the theme-aware tray context menu. Public Win32
+// APIs only. Returns true when the item was handled.
+//
+//----------------------------------------------------------------------------
+static bool MeasureTrayMenuItem( HWND hWnd, MEASUREITEMSTRUCT* measureItem )
+{
+    if( measureItem == nullptr || measureItem->CtlType != ODT_MENU )
+    {
+        return false;
+    }
+
+    const std::wstring* itemText = reinterpret_cast<const std::wstring*>( measureItem->itemData );
+    const UINT dpi = GetDpiForWindowHelper( hWnd );
+
+    HFONT menuFont = GetTrayMenuFont( hWnd );
+    HDC hdc = GetDC( hWnd );
+    HGDIOBJ oldFont = SelectObject( hdc, menuFont );
+
+    SIZE textSize{ 0, 0 };
+    if( itemText != nullptr && !itemText->empty() )
+    {
+        GetTextExtentPoint32W( hdc, itemText->c_str(), static_cast<int>( itemText->length() ), &textSize );
+    }
+
+    SelectObject( hdc, oldFont );
+    ReleaseDC( hWnd, hdc );
+    DeleteObject( menuFont );
+
+    const int gutter = ScaleForDpi( 22, dpi );
+    const int rightPadding = ScaleForDpi( 24, dpi );
+    const int verticalPadding = ScaleForDpi( 8, dpi );
+    const int minHeight = ScaleForDpi( 22, dpi );
+
+    measureItem->itemWidth = static_cast<UINT>( gutter + textSize.cx + rightPadding );
+
+    int itemHeight = textSize.cy + verticalPadding;
+    if( itemHeight < minHeight )
+    {
+        itemHeight = minHeight;
+    }
+    measureItem->itemHeight = static_cast<UINT>( itemHeight );
+    return true;
+}
+
+//----------------------------------------------------------------------------
+//
+// DrawTrayMenuItem
+//
+// Owner-draw rendering for the theme-aware tray context menu. Public Win32
+// APIs only (no uxtheme ordinals). Returns true when the item was handled.
+//
+//----------------------------------------------------------------------------
+static bool DrawTrayMenuItem( HWND hWnd, const DRAWITEMSTRUCT* drawItem )
+{
+    if( drawItem == nullptr || drawItem->CtlType != ODT_MENU )
+    {
+        return false;
+    }
+
+    const std::wstring* itemText = reinterpret_cast<const std::wstring*>( drawItem->itemData );
+    const bool dark = IsMenuDarkModeEnabled();
+    const bool selected = ( drawItem->itemState & ODS_SELECTED ) != 0;
+    const bool disabled = ( drawItem->itemState & ( ODS_DISABLED | ODS_GRAYED ) ) != 0;
+    const bool checked = ( drawItem->itemState & ODS_CHECKED ) != 0;
+    const UINT dpi = GetDpiForWindowHelper( hWnd );
+
+    COLORREF backColor;
+    COLORREF textColor;
+    if( dark )
+    {
+        backColor = selected ? DarkMode::HoverColor : DarkMode::SurfaceColor;
+        textColor = disabled ? DarkMode::DisabledTextColor : DarkMode::TextColor;
+    }
+    else
+    {
+        backColor = GetSysColor( selected ? COLOR_HIGHLIGHT : COLOR_MENU );
+        textColor = disabled ? GetSysColor( COLOR_GRAYTEXT )
+                             : GetSysColor( selected ? COLOR_HIGHLIGHTTEXT : COLOR_MENUTEXT );
+    }
+
+    HBRUSH backBrush = CreateSolidBrush( backColor );
+    FillRect( drawItem->hDC, &drawItem->rcItem, backBrush );
+    DeleteObject( backBrush );
+
+    const int prevBkMode = SetBkMode( drawItem->hDC, TRANSPARENT );
+    const COLORREF prevTextColor = SetTextColor( drawItem->hDC, textColor );
+    const int gutter = ScaleForDpi( 22, dpi );
+
+    // Checkmark drawn with a pen so it picks up the themed text color.
+    if( checked )
+    {
+        HPEN markPen = CreatePen( PS_SOLID, ScaleForDpi( 2, dpi ), textColor );
+        HGDIOBJ oldPen = SelectObject( drawItem->hDC, markPen );
+
+        const int centerX = drawItem->rcItem.left + gutter / 2;
+        const int centerY = ( drawItem->rcItem.top + drawItem->rcItem.bottom ) / 2;
+        const int arm = ScaleForDpi( 3, dpi );
+        POINT check[3] = {
+            { centerX - 2 * arm, centerY },
+            { centerX - arm, centerY + arm },
+            { centerX + 2 * arm, centerY - arm }
+        };
+        Polyline( drawItem->hDC, check, 3 );
+
+        SelectObject( drawItem->hDC, oldPen );
+        DeleteObject( markPen );
+    }
+
+    // Label text (DrawText handles '&' mnemonics; underline follows keyboard cues).
+    if( itemText != nullptr && !itemText->empty() )
+    {
+        HFONT menuFont = GetTrayMenuFont( hWnd );
+        HGDIOBJ oldFont = SelectObject( drawItem->hDC, menuFont );
+
+        RECT textRect = drawItem->rcItem;
+        textRect.left += gutter;
+        textRect.right -= ScaleForDpi( 8, dpi );
+
+        UINT drawFlags = DT_SINGLELINE | DT_VCENTER | DT_LEFT;
+        BOOL keyboardCues = TRUE;
+        if( SystemParametersInfoW( SPI_GETKEYBOARDCUES, 0, &keyboardCues, 0 ) && !keyboardCues )
+        {
+            drawFlags |= DT_HIDEPREFIX;
+        }
+
+        DrawTextW( drawItem->hDC, itemText->c_str(), -1, &textRect, drawFlags );
+
+        SelectObject( drawItem->hDC, oldFont );
+        DeleteObject( menuFont );
+    }
+
+    SetBkMode( drawItem->hDC, prevBkMode );
+    SetTextColor( drawItem->hDC, prevTextColor );
+    return true;
+}
+
+//----------------------------------------------------------------------------
+//
 // MainWndProc
 //
 //----------------------------------------------------------------------------
@@ -10149,21 +10335,34 @@ LRESULT APIENTRY MainWndProc(
             POINT pt;
             GetCursorPos( &pt );
             hPopupMenu = CreatePopupMenu();
+
+            // The menu items are owner-drawn so the popup is theme-aware using
+            // only public Win32 APIs (see MeasureTrayMenuItem / DrawTrayMenuItem).
+            // Each label is owned by this list for the lifetime of the menu and
+            // passed through as the item's owner-draw data.
+            std::list<std::wstring> menuItemText;
+            auto insertItem = [&]( UINT flags, UINT_PTR id, PCWSTR label ) {
+                menuItemText.emplace_back( label );
+                InsertMenuW( hPopupMenu, 0, MF_BYPOSITION | MF_OWNERDRAW | flags, id,
+                             reinterpret_cast<LPCWSTR>( &menuItemText.back() ) );
+            };
+
             if(!g_StartedByPowerToys) {
                 // Exiting will happen through disabling in PowerToys, not the context menu.
-                InsertMenu( hPopupMenu, 0, MF_BYPOSITION, IDCANCEL, L"E&xit" );
+                insertItem( 0, IDCANCEL, L"E&xit" );
                 InsertMenu( hPopupMenu, 0, MF_BYPOSITION|MF_SEPARATOR, 0, NULL );
             }
-            InsertMenu( hPopupMenu, 0, MF_BYPOSITION | ( g_RecordToggle ? MF_CHECKED : 0 ), IDC_RECORD, L"&Record" );
-            InsertMenu( hPopupMenu, 0, MF_BYPOSITION, IDC_ZOOM, L"&Zoom" );
-            InsertMenu( hPopupMenu, 0, MF_BYPOSITION, IDC_DRAW, L"&Draw" );
-            InsertMenu( hPopupMenu, 0, MF_BYPOSITION, IDC_BREAK, L"&Break Timer" );
+            insertItem( g_RecordToggle ? MF_CHECKED : 0, IDC_RECORD, L"&Record" );
+            insertItem( 0, IDC_ZOOM, L"&Zoom" );
+            insertItem( 0, IDC_DRAW, L"&Draw" );
+            insertItem( 0, IDC_BREAK, L"&Break Timer" );
             if(!g_StartedByPowerToys) {
                 // When started by PowerToys, options are configured through the PowerToys Settings.
                 InsertMenu( hPopupMenu, 0, MF_BYPOSITION|MF_SEPARATOR, 0, NULL );
-                InsertMenu( hPopupMenu, 0, MF_BYPOSITION, IDC_OPTIONS, L"&Options" );
+                insertItem( 0, IDC_OPTIONS, L"&Options" );
             }
-            // Apply dark mode theme to the menu
+            // Paint a dark background brush behind the items and separators
+            // (public SetMenuInfo); item foreground is owner-drawn above.
             ApplyDarkModeToMenu( hPopupMenu );
             TrackPopupMenu( hPopupMenu, 0, pt.x , pt.y, 0, hWnd, NULL );
             DestroyMenu( hPopupMenu );
@@ -11252,6 +11451,20 @@ LRESULT APIENTRY MainWndProc(
         WTSUnRegisterSessionNotification( hWnd );
         CleanupDarkModeResources();
         PostQuitMessage( 0 );
+        break;
+
+    case WM_MEASUREITEM:
+        if( MeasureTrayMenuItem( hWnd, reinterpret_cast<MEASUREITEMSTRUCT*>( lParam ) ) )
+        {
+            return TRUE;
+        }
+        break;
+
+    case WM_DRAWITEM:
+        if( DrawTrayMenuItem( hWnd, reinterpret_cast<const DRAWITEMSTRUCT*>( lParam ) ) )
+        {
+            return TRUE;
+        }
         break;
 
     default:


### PR DESCRIPTION
## Summary

Makes ZoomIt's **system-tray context menu** correctly follow the OS **light/dark theme** (including live theme switches), and factors the logic into a small **reusable helper** that any PowerToys system-tray utility can adopt.

## Why

Several PowerToys Win32 utilities have classic system-tray context menus, and the light/dark handling tends to be re-implemented per module (or missing). This PR fixes it for ZoomIt **and** introduces one shared, tested helper so other tray utilities can get the same behavior in a single call — and drop their own copies.

## Reusable helper — `src/common/Themes/dark_menu.h` (header-only)

- `SetAppMode(bool dark)` — render this process's popup menus dark or light.
- `IsSystemDarkMode()` — current app theme from the documented `AppsUseLightTheme` value, read fresh.
- Drop-in:
  ```cpp
  theme::dark_menu::SetAppMode(theme::dark_menu::IsSystemDarkMode());
  TrackPopupMenu(menu, ...);
  ```
- Header-only — no project/linker wiring; a module just `#include <common/Themes/dark_menu.h>`.

## ZoomIt (first adopter)

- Tray menu now follows **Light/Dark** and **updates live** on a theme switch with no restart (runtime switches weren't picked up before).
- The OS draws the **real themed menu** — native keyboard, accessibility, checkmarks, separators and DPI; only the colors change.
- Standalone (non-PowerToys) build is unchanged (guarded by `__ZOOMIT_POWERTOYS__`).

## Follow-up

Once this lands, a follow-up will adopt the helper in the other system-tray utilities (e.g. the runner tray menu) and remove their duplicate theme handling.

## Testing

- `MSBuild src\modules\ZoomIt\ZoomIt\ZoomIt.vcxproj /p:Configuration=Release /p:Platform=x64 /m` — **0 warnings, 0 errors**.
- Verified on Windows 11: tray menu in **Light**, in **Dark**, and a **live Light↔Dark switch** (menu follows without restart).
