### PR TITLE
Scope autorun scheduled task permissions to its owner

### DIFF
--- a/src/runner/auto_start_helper.cpp
+++ b/src/runner/auto_start_helper.cpp
@@ -5,6 +5,7 @@
 
 #include <comdef.h>
 #include <taskschd.h>
+#include <sddl.h>
 #include <common/logger/logger.h>
 
 // Helper macros from wix.
@@ -32,6 +33,41 @@
 
 const DWORD USERNAME_DOMAIN_LEN = DNLEN + UNLEN + 2; // Domain Name + '\' + User Name + '\0'
 const DWORD USERNAME_LEN = UNLEN + 1; // User Name + '\0'
+
+// Builds the security descriptor (SDDL) used when registering the autorun task.
+// The task runs the PowerToys executable at logon, potentially elevated, so its
+// definition must not be writable by arbitrary local users. We grant full access
+// only to Local System, the Administrators group and the task's own user (so the
+// non-elevated runner can still enable/disable/delete its own task). We must never
+// grant write access to "Everyone", which would let any local user overwrite the
+// task's action and achieve local privilege escalation.
+static std::wstring get_auto_start_task_sddl()
+{
+    // Local System and Administrators always get full control.
+    std::wstring sddl = L"D:(A;;FA;;;SY)(A;;FA;;;BA)";
+
+    HANDLE hToken = NULL;
+    if (OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &hToken))
+    {
+        BYTE tokenInfo[sizeof(TOKEN_USER) + SECURITY_MAX_SID_SIZE];
+        DWORD tokenInfoLength = 0;
+        if (GetTokenInformation(hToken, TokenUser, tokenInfo, sizeof(tokenInfo), &tokenInfoLength))
+        {
+            auto pTokenUser = reinterpret_cast<TOKEN_USER*>(tokenInfo);
+            LPWSTR stringSid = NULL;
+            if (ConvertSidToStringSidW(pTokenUser->User.Sid, &stringSid))
+            {
+                sddl += L"(A;;FA;;;";
+                sddl += stringSid;
+                sddl += L")";
+                LocalFree(stringSid);
+            }
+        }
+        CloseHandle(hToken);
+    }
+
+    return sddl;
+}
 
 bool create_auto_start_task_for_this_user(bool runElevated)
 {
@@ -231,7 +267,8 @@ bool create_auto_start_task_for_this_user(bool runElevated)
     // ------------------------------------------------------
     //  Save the task in the PowerToys folder.
     {
-        _variant_t SDDL_FULL_ACCESS_FOR_EVERYONE = L"D:(A;;FA;;;WD)";
+        std::wstring sddl = get_auto_start_task_sddl();
+        _variant_t taskSecurityDescriptor = sddl.c_str();
         hr = pTaskFolder->RegisterTaskDefinition(
             _bstr_t(wstrTaskName.c_str()),
             pTask,
@@ -239,7 +276,7 @@ bool create_auto_start_task_for_this_user(bool runElevated)
             _variant_t(username_domain),
             _variant_t(),
             TASK_LOGON_INTERACTIVE_TOKEN,
-            SDDL_FULL_ACCESS_FOR_EVERYONE,
+            taskSecurityDescriptor,
             &pRegisteredTask);
         ExitOnFailure(hr, "Error saving the Task : {:x}", hr);
     }


### PR DESCRIPTION
## Summary

The per-user **"Autorun for &lt;user&gt;"** logon scheduled task (created in `src/runner/auto_start_helper.cpp`) was registered with a security descriptor that granted **full access to Everyone** (`D:(A;;FA;;;WD)`). This PR scopes the task's permissions to only the accounts that actually need them.

## Changes

- `src/runner/auto_start_helper.cpp`
  - Added a small `get_auto_start_task_sddl()` helper that builds the task's security descriptor granting full control to **Local System**, the **Administrators** group, and **the user the task belongs to** (SID read from the current process token).
  - Use it when calling `RegisterTaskDefinition` instead of the previous Everyone descriptor.
  - Added `#include <sddl.h>` for `ConvertSidToStringSidW`.

## Behavior / compatibility

- No change to the run-at-startup or run-elevated flows. The decision logic in `general_settings.cpp` is untouched — only the descriptor string passed to `RegisterTaskDefinition` changed.
- The task owner can still fully manage (enable / disable / delete) its own task in both elevated and non-elevated runner modes, because a user's token SID is identical across elevation.
- The Task Scheduler service (SYSTEM) retains full control, so the task still runs at logon as before.

## Validation

- Built `src/runner/runner.vcxproj` (x64 / Debug): **0 errors, 0 warnings**.
