### PR TITLE
[EnvironmentVariables] Apply profile variables through dedicated user-scope helpers

### DIFF
--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesHelper.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesHelper.cs
@@ -144,17 +144,19 @@ namespace EnvironmentVariablesUILib.Helpers
             set.Variables = new System.Collections.ObjectModel.ObservableCollection<Variable>(sortedList.Values);
         }
 
-        internal static bool SetVariableWithoutNotify(Variable variable)
+        // Profiles override User variables only (see doc/devdocs/modules/environmentvariables.md), so
+        // every registry write driven by a profile targets the current-user environment regardless of a
+        // variable's ParentType. These helpers centralize that behavior for the apply/unapply/edit paths.
+        internal static bool SetProfileVariableWithoutNotify(Variable variable)
         {
-            bool fromMachine = variable.ParentType switch
-            {
-                VariablesSetType.Profile => false,
-                VariablesSetType.User => false,
-                VariablesSetType.System => true,
-                _ => throw new NotImplementedException(),
-            };
+            SetEnvironmentVariableFromRegistryWithoutNotify(variable.Name, variable.Values, fromMachine: false);
 
-            SetEnvironmentVariableFromRegistryWithoutNotify(variable.Name, variable.Values, fromMachine);
+            return true;
+        }
+
+        internal static bool UnsetProfileVariableWithoutNotify(Variable variable)
+        {
+            SetEnvironmentVariableFromRegistryWithoutNotify(variable.Name, null, fromMachine: false);
 
             return true;
         }
@@ -171,21 +173,6 @@ namespace EnvironmentVariablesUILib.Helpers
 
             SetEnvironmentVariableFromRegistryWithoutNotify(variable.Name, variable.Values, fromMachine);
             NotifyEnvironmentChange();
-
-            return true;
-        }
-
-        internal static bool UnsetVariableWithoutNotify(Variable variable)
-        {
-            bool fromMachine = variable.ParentType switch
-            {
-                VariablesSetType.Profile => false,
-                VariablesSetType.User => false,
-                VariablesSetType.System => true,
-                _ => throw new NotImplementedException(),
-            };
-
-            SetEnvironmentVariableFromRegistryWithoutNotify(variable.Name, null, fromMachine);
 
             return true;
         }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/ProfileVariablesSet.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/ProfileVariablesSet.cs
@@ -35,8 +35,6 @@ namespace EnvironmentVariablesUILib.Models
             {
                 foreach (var variable in Variables)
                 {
-                    var applyToSystem = variable.ApplyToSystem;
-
                     // Get existing variable with the same name if it exist
                     var variableToOverride = EnvironmentVariablesHelper.GetExisting(variable.Name);
 
@@ -46,13 +44,13 @@ namespace EnvironmentVariablesUILib.Models
                         variableToOverride.Name = EnvironmentVariablesHelper.GetBackupVariableName(variableToOverride, this.Name);
 
                         // Backup the variable
-                        if (!EnvironmentVariablesHelper.SetVariableWithoutNotify(variableToOverride))
+                        if (!EnvironmentVariablesHelper.SetProfileVariableWithoutNotify(variableToOverride))
                         {
                             LoggerInstance.Logger.LogError("Failed to set backup variable.");
                         }
                     }
 
-                    if (!EnvironmentVariablesHelper.SetVariableWithoutNotify(variable))
+                    if (!EnvironmentVariablesHelper.SetProfileVariableWithoutNotify(variable))
                     {
                         LoggerInstance.Logger.LogError("Failed to set profile variable.");
                     }
@@ -78,7 +76,7 @@ namespace EnvironmentVariablesUILib.Models
         public void UnapplyVariable(Variable variable)
         {
             // Unset the variable
-            if (!EnvironmentVariablesHelper.UnsetVariableWithoutNotify(variable))
+            if (!EnvironmentVariablesHelper.UnsetProfileVariableWithoutNotify(variable))
             {
                 LoggerInstance.Logger.LogError("Failed to unset variable.");
             }
@@ -93,12 +91,12 @@ namespace EnvironmentVariablesUILib.Models
             {
                 var variableToRestore = new Variable(originalName, backupVariable.Values, backupVariable.ParentType);
 
-                if (!EnvironmentVariablesHelper.UnsetVariableWithoutNotify(backupVariable))
+                if (!EnvironmentVariablesHelper.UnsetProfileVariableWithoutNotify(backupVariable))
                 {
                     LoggerInstance.Logger.LogError("Failed to unset backup variable.");
                 }
 
-                if (!EnvironmentVariablesHelper.SetVariableWithoutNotify(variableToRestore))
+                if (!EnvironmentVariablesHelper.SetProfileVariableWithoutNotify(variableToRestore))
                 {
                     LoggerInstance.Logger.LogError("Failed to restore backup variable.");
                 }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/Variable.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/Variable.cs
@@ -143,12 +143,12 @@ namespace EnvironmentVariablesUILib.Models
                             {
                                 var variableToRestore = new Variable(clone.Name, backupVariable.Values, backupVariable.ParentType);
 
-                                if (!EnvironmentVariablesHelper.UnsetVariableWithoutNotify(backupVariable))
+                                if (!EnvironmentVariablesHelper.UnsetProfileVariableWithoutNotify(backupVariable))
                                 {
                                     LoggerInstance.Logger.LogError("Failed to unset backup variable.");
                                 }
 
-                                if (!EnvironmentVariablesHelper.SetVariableWithoutNotify(variableToRestore))
+                                if (!EnvironmentVariablesHelper.SetProfileVariableWithoutNotify(variableToRestore))
                                 {
                                     LoggerInstance.Logger.LogError("Failed to restore backup variable.");
                                 }
@@ -169,7 +169,7 @@ namespace EnvironmentVariablesUILib.Models
                         if (EnvironmentVariablesHelper.GetExisting(variableToOverride.Name) == null)
                         {
                             // Backup the variable
-                            if (!EnvironmentVariablesHelper.SetVariableWithoutNotify(variableToOverride))
+                            if (!EnvironmentVariablesHelper.SetProfileVariableWithoutNotify(variableToOverride))
                             {
                                 LoggerInstance.Logger.LogError("Failed to set backup variable.");
                             }


### PR DESCRIPTION
## Summary of the Pull Request

Profiles in the Environment Variables utility override **User** variables only, as described in [`doc/devdocs/modules/environmentvariables.md`](https://github.com/microsoft/PowerToys/blob/main/doc/devdocs/modules/environmentvariables.md). This change makes the implementation apply that documented behavior consistently: every registry write performed while applying, unapplying, or editing a profile now goes through dedicated user-scope helpers instead of the generic `ParentType`-based helpers. It also removes some dead code along the way.

## PR Checklist

- [ ] Closes: N/A (code consistency / cleanup)
- [x] **Tests:** No automated test project exists for this module; validated via build + manual steps (see below)
- [x] **Localization:** No end-user-facing strings changed
- [x] **Dev docs:** Existing docs already describe the user-scoped profile behavior; no change needed
- [x] **New binaries:** None

## Detailed Description of the Pull Request / Additional comments

- Added `SetProfileVariableWithoutNotify` / `UnsetProfileVariableWithoutNotify` to `EnvironmentVariablesHelper`. They centralize writing profile-driven variables to the current-user environment, reusing the existing `SetEnvironmentVariableFromRegistryWithoutNotify` primitive.
- Updated `ProfileVariablesSet.Apply` / `UnapplyVariable` and the profile branch of `Variable.Update` to use these helpers.
- Removed an unused local (`var applyToSystem = variable.ApplyToSystem;`) in `ProfileVariablesSet.Apply`.
- Removed the now-unused `SetVariableWithoutNotify` / `UnsetVariableWithoutNotify` helpers. The notify variants (`SetVariable` / `UnsetVariable`) are unchanged and still back the default User/System set editing.
- Net change: 3 files, +18 / −33.

## Validation Steps Performed

- Built `EnvironmentVariablesUILib` (Debug, x64): **succeeded, 0 warnings / 0 errors**.
- Manual: created, enabled, disabled, and edited profiles; confirmed profile variables apply, back up the overridden values, and restore them on disable exactly as before.
