### PR TITLE
Validate cached installer filename from UpdateState.json in the updater

### DIFF
--- a/src/Update/PowerToys.Update.cpp
+++ b/src/Update/PowerToys.Update.cpp
@@ -95,6 +95,9 @@ std::optional<fs::path> CopySelfToTempDir()
     return dst_path;
 }
 
+// The installer filename read from UpdateState.json is validated by
+// updating::IsSafeDownloadedInstallerFilename (common/updating/updateLifecycle.h)
+// so it can be unit-tested. See ObtainInstaller below for how it's used.
 std::optional<fs::path> ObtainInstaller(bool& isUpToDate)
 {
     using namespace updating;
@@ -107,7 +110,25 @@ std::optional<fs::path> ObtainInstaller(bool& isUpToDate)
     // so we don't need a GitHub API call (which may fail if offline).
     if (state.state == UpdateState::readyToInstall)
     {
-        fs::path installer{ get_pending_updates_path() / state.downloadedInstallerFilename };
+        if (!IsSafeDownloadedInstallerFilename(state.downloadedInstallerFilename))
+        {
+            Logger::error(L"Ignoring unexpected downloadedInstallerFilename from update state: {}", state.downloadedInstallerFilename);
+            return std::nullopt;
+        }
+
+        const fs::path updatesDir = get_pending_updates_path();
+        fs::path installer{ updatesDir / state.downloadedInstallerFilename };
+
+        // Make sure the resolved path actually stays within the Updates directory.
+        std::error_code ec;
+        const fs::path normalizedInstaller = fs::weakly_canonical(installer, ec);
+        const fs::path normalizedUpdatesDir = fs::weakly_canonical(updatesDir, ec);
+        if (ec || normalizedInstaller.parent_path() != normalizedUpdatesDir)
+        {
+            Logger::error(L"Resolved installer path is outside the updates directory: {}", installer.native());
+            return std::nullopt;
+        }
+
         if (fs::is_regular_file(installer))
         {
             return std::move(installer);

--- a/src/common/updating/UnitTests/UpdatingTests.cpp
+++ b/src/common/updating/UnitTests/UpdatingTests.cpp
@@ -676,4 +676,61 @@ namespace UpdatingUnitTests
             LocalFree(argv);
         }
     };
+
+    // Tests for IsSafeDownloadedInstallerFilename: the updater reads
+    // downloadedInstallerFilename from the persisted UpdateState.json and must only
+    // accept a plain filename so it never looks outside the Updates folder when the
+    // cached state is stale, corrupted, or otherwise unexpected.
+    TEST_CLASS(IsSafeDownloadedInstallerFilenameTests)
+    {
+    public:
+        // Normal installer asset names are bare filenames and must be accepted,
+        // so the regular update flow does not regress.
+        TEST_METHOD(NormalInstallerFilenamesAreAccepted)
+        {
+            Assert::IsTrue(updating::IsSafeDownloadedInstallerFilename(L"PowerToysSetup-0.95.0-x64.exe"));
+            Assert::IsTrue(updating::IsSafeDownloadedInstallerFilename(L"PowerToysUserSetup-0.95.0-arm64.exe"));
+            Assert::IsTrue(updating::IsSafeDownloadedInstallerFilename(L"PowerToysSetup-1.0.0-x64.msi"));
+        }
+
+        // Empty values must be rejected (no installer to run).
+        TEST_METHOD(EmptyFilenameIsRejected)
+        {
+            Assert::IsFalse(updating::IsSafeDownloadedInstallerFilename(L""));
+        }
+
+        // Relative parent-directory components must be rejected.
+        TEST_METHOD(ParentDirectoryComponentsAreRejected)
+        {
+            Assert::IsFalse(updating::IsSafeDownloadedInstallerFilename(L"..\\..\\setup.msi"));
+            Assert::IsFalse(updating::IsSafeDownloadedInstallerFilename(L"../../setup.exe"));
+            Assert::IsFalse(updating::IsSafeDownloadedInstallerFilename(L".."));
+            Assert::IsFalse(updating::IsSafeDownloadedInstallerFilename(L"."));
+        }
+
+        // Any directory component (even without "..") must be rejected — the value
+        // must be a single bare filename.
+        TEST_METHOD(NestedPathComponentsAreRejected)
+        {
+            Assert::IsFalse(updating::IsSafeDownloadedInstallerFilename(L"sub\\setup.exe"));
+            Assert::IsFalse(updating::IsSafeDownloadedInstallerFilename(L"sub/setup.exe"));
+        }
+
+        // Absolute paths, drive-relative paths and UNC paths must be rejected,
+        // because fs::path's operator/ would let them replace the Updates directory.
+        TEST_METHOD(AbsoluteAndUncPathsAreRejected)
+        {
+            Assert::IsFalse(updating::IsSafeDownloadedInstallerFilename(L"C:\\setup.msi"));
+            Assert::IsFalse(updating::IsSafeDownloadedInstallerFilename(L"C:setup.msi"));
+            Assert::IsFalse(updating::IsSafeDownloadedInstallerFilename(L"\\setup.msi"));
+            Assert::IsFalse(updating::IsSafeDownloadedInstallerFilename(L"\\\\server\\share\\setup.exe"));
+        }
+
+        // A bare filename that merely contains a ".." substring is rejected as a
+        // conservative measure (real asset names never contain "..").
+        TEST_METHOD(EmbeddedDotDotSubstringIsRejected)
+        {
+            Assert::IsFalse(updating::IsSafeDownloadedInstallerFilename(L"setup..name.exe"));
+        }
+    };
 }

--- a/src/common/updating/updateLifecycle.h
+++ b/src/common/updating/updateLifecycle.h
@@ -44,4 +44,43 @@ namespace updating
         // args[0]=exe, args[1]=action, args[2]=installer, args[3]=installDir
         return argCount >= 4;
     }
+
+    // Returns true when the value read from UpdateState.json is a plain installer
+    // filename that can be combined with the pending-updates directory. UpdateState.json
+    // is persisted state that may be stale, corrupted, or otherwise unexpected, so the
+    // cached filename could contain path separators or an absolute/drive-relative path.
+    // Only a single bare filename (the form produced by the download step) is accepted;
+    // anything else is rejected so the updater never looks outside the Updates folder.
+    inline bool IsSafeDownloadedInstallerFilename(const std::wstring& filename)
+    {
+        if (filename.empty())
+        {
+            return false;
+        }
+
+        // Reject any path separators or parent-directory tokens outright. Installer
+        // asset filenames never contain these.
+        if (filename.find(L'/') != std::wstring::npos ||
+            filename.find(L'\\') != std::wstring::npos ||
+            filename.find(L"..") != std::wstring::npos)
+        {
+            return false;
+        }
+
+        const fs::path candidate{ filename };
+
+        // Must be a single path component: no drive/root and no directory portion.
+        if (candidate.has_root_name() || candidate.has_root_directory() || candidate.has_parent_path())
+        {
+            return false;
+        }
+
+        const auto name = candidate.filename().wstring();
+        if (name != filename || name == L"." || name == L"..")
+        {
+            return false;
+        }
+
+        return true;
+    }
 }


### PR DESCRIPTION
## Summary of the Pull Request

`PowerToys.Update` reads `downloadedInstallerFilename` from the persisted `UpdateState.json` and combines it with the `Updates` folder to locate the installer to run. If that cached state is stale, corrupted, or otherwise unexpected, the stored value could contain path separators or an absolute path, which would make the updater look for the installer outside the `Updates` folder.

This PR validates that the cached value is a plain filename and that the resolved path stays inside the `Updates` folder before using it; otherwise the update is treated as unavailable. The normal update flow (a bare asset filename produced by the download step) is unaffected.

## PR Checklist

- [ ] **Communication:** I've discussed this with core contributors already.
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** No end-user-facing strings added
- [x] **Dev docs:** N/A
- [x] **New binaries:** None

## Detailed Description of the Pull Request / Additional comments

- The filename check is factored into an inline helper `updating::IsSafeDownloadedInstallerFilename` in `src/common/updating/updateLifecycle.h` (next to the other inline update helpers) so it can be unit-tested without a project reference.
- `ObtainInstaller` in `src/Update/PowerToys.Update.cpp` now calls that helper and additionally confirms, via `weakly_canonical`, that the resolved installer path's parent is the `Updates` directory.
- No behavior change for normal installer filenames, so the regular update flow does not regress.

## Validation Steps Performed

- Added `IsSafeDownloadedInstallerFilenameTests` to `Updating.UnitTests` covering normal filenames, empty values, parent-directory components, nested path components, and absolute/drive-relative/UNC paths.
- Built `Updating.UnitTests` (Debug x64): 0 warnings, 0 errors.
- Ran the full `Updating.UnitTests` suite: 36/36 passed (30 existing + 6 new).
