### PR TITLE
Fix CmdPal extension installed state detection for Store-only package…

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.Common/WinGet/Services/IWinGetPackageManagerService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Common/WinGet/Services/IWinGetPackageManagerService.cs
@@ -43,6 +43,16 @@ public interface IWinGetPackageManagerService
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Resolves packages by Microsoft Store id.
+    /// </summary>
+    /// <param name="storeIds">The store ids to resolve.</param>
+    /// <param name="cancellationToken">A token that cancels the lookup.</param>
+    /// <returns>A query result containing the resolved packages keyed by store id.</returns>
+    Task<WinGetQueryResult<IReadOnlyDictionary<string, CatalogPackage>>> GetStorePackagesByIdAsync(
+        IEnumerable<string> storeIds,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Installs or updates the provided package and refreshes package catalogs when possible.
     /// </summary>
     /// <param name="package">The package to install or update.</param>

--- a/src/modules/cmdpal/Microsoft.CmdPal.Common/WinGet/Services/WinGetPackageManagerService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Common/WinGet/Services/WinGetPackageManagerService.cs
@@ -203,7 +203,7 @@ public sealed class WinGetPackageManagerService : IWinGetPackageManagerService
         }
 
         var initialization = _initialization.Value;
-        if (!initialization.State.IsAvailable || initialization.Factory is null || initialization.StoreCatalog is null)
+        if (!initialization.State.IsAvailable || initialization.Factory is null)
         {
             return new WinGetQueryResult<IReadOnlyDictionary<string, CatalogPackage>>(null, true, initialization.State.Message);
         }
@@ -636,19 +636,19 @@ public sealed class WinGetPackageManagerService : IWinGetPackageManagerService
                 _operationTracker.UpdateOperation(operationId, WinGetPackageOperationState.Queued, isIndeterminate: true);
                 break;
             case PackageInstallProgressState.Downloading:
-            {
-                var progressPercent = progress.BytesRequired > 0
-                    ? (uint?)Math.Min(100, (progress.BytesDownloaded * 100UL) / progress.BytesRequired)
-                    : null;
-                _operationTracker.UpdateOperation(
-                    operationId,
-                    WinGetPackageOperationState.Downloading,
-                    isIndeterminate: progress.BytesRequired == 0,
-                    progressPercent: progressPercent,
-                    bytesDownloaded: progress.BytesDownloaded,
-                    bytesRequired: progress.BytesRequired);
-                break;
-            }
+                {
+                    var progressPercent = progress.BytesRequired > 0
+                        ? (uint?)Math.Min(100, (progress.BytesDownloaded * 100UL) / progress.BytesRequired)
+                        : null;
+                    _operationTracker.UpdateOperation(
+                        operationId,
+                        WinGetPackageOperationState.Downloading,
+                        isIndeterminate: progress.BytesRequired == 0,
+                        progressPercent: progressPercent,
+                        bytesDownloaded: progress.BytesDownloaded,
+                        bytesRequired: progress.BytesRequired);
+                    break;
+                }
 
             case PackageInstallProgressState.Installing:
                 _operationTracker.UpdateOperation(operationId, WinGetPackageOperationState.Installing, isIndeterminate: true);

--- a/src/modules/cmdpal/Microsoft.CmdPal.Common/WinGet/Services/WinGetPackageManagerService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Common/WinGet/Services/WinGetPackageManagerService.cs
@@ -25,9 +25,11 @@ public sealed class WinGetPackageManagerService : IWinGetPackageManagerService
     private readonly Lazy<InitializationState> _initialization;
     private readonly object _allCatalogTaskLock = new();
     private readonly object _wingetCatalogTaskLock = new();
+    private readonly object _allCatalogAllSearchTaskLock = new();
 
     private Task<WinGetQueryResult<PackageCatalog>>? _allCatalogTask;
     private Task<WinGetQueryResult<PackageCatalog>>? _wingetCatalogTask;
+    private Task<WinGetQueryResult<PackageCatalog>>? _allCatalogAllSearchTask;
 
     public WinGetPackageManagerService()
         : this(CreateFactory, new WinGetOperationTrackerService())
@@ -212,7 +214,7 @@ public sealed class WinGetPackageManagerService : IWinGetPackageManagerService
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var catalogResult = await GetCompositeCatalogResultAsync(includeStoreCatalog: true, cancellationToken).ConfigureAwait(false);
+            var catalogResult = await GetCompositeCatalogResultAsync(includeStoreCatalog: true, CompositeSearchBehavior.AllCatalogs, cancellationToken).ConfigureAwait(false);
             if (!catalogResult.IsSuccess || catalogResult.Value is null)
             {
                 return new WinGetQueryResult<IReadOnlyDictionary<string, CatalogPackage>>(null, catalogResult.IsUnavailable, catalogResult.ErrorMessage);
@@ -221,6 +223,9 @@ public sealed class WinGetPackageManagerService : IWinGetPackageManagerService
             var catalog = catalogResult.Value;
             Dictionary<string, CatalogPackage> results = new(OrdinalIgnoreCase);
 
+            // A batched FindPackages query did not reliably resolve all requested
+            // Store IDs, so each Store ID is queried independently.
+            // Lookups are executed concurrently (throttled to 4) to keep latency low.
             using var throttle = new SemaphoreSlim(4);
 
             var tasks = normalizedIds.Select(async id =>
@@ -269,7 +274,12 @@ public sealed class WinGetPackageManagerService : IWinGetPackageManagerService
 
             return new WinGetQueryResult<IReadOnlyDictionary<string, CatalogPackage>>(results, false, null);
         }
-        catch (Exception ex) when (ex is COMException or InvalidOperationException or TaskCanceledException)
+        catch (OperationCanceledException ex)
+        {
+            CoreLogger.LogWarning($"Microsoft Store package lookup canceled: {ex.Message}");
+            return new WinGetQueryResult<IReadOnlyDictionary<string, CatalogPackage>>(null, false, ex.Message);
+        }
+        catch (Exception ex) when (ex is COMException or InvalidOperationException)
         {
             CoreLogger.LogWarning($"Microsoft Store package lookup failed: {ex.Message}");
             return new WinGetQueryResult<IReadOnlyDictionary<string, CatalogPackage>>(null, false, ex.Message);
@@ -475,14 +485,35 @@ public sealed class WinGetPackageManagerService : IWinGetPackageManagerService
         }
     }
 
-    private async Task<WinGetQueryResult<PackageCatalog>> GetCompositeCatalogResultAsync(bool includeStoreCatalog, CancellationToken cancellationToken)
+    private async Task<WinGetQueryResult<PackageCatalog>> GetCompositeCatalogResultAsync(
+        bool includeStoreCatalog,
+        CancellationToken cancellationToken)
+    {
+        return await GetCompositeCatalogResultAsync(
+            includeStoreCatalog,
+            CompositeSearchBehavior.RemotePackagesFromAllCatalogs,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<WinGetQueryResult<PackageCatalog>> GetCompositeCatalogResultAsync(
+        bool includeStoreCatalog,
+        CompositeSearchBehavior searchBehavior,
+        CancellationToken cancellationToken)
     {
         Task<WinGetQueryResult<PackageCatalog>> task;
-        if (includeStoreCatalog)
+        if (includeStoreCatalog && searchBehavior == CompositeSearchBehavior.AllCatalogs)
+        {
+            lock (_allCatalogAllSearchTaskLock)
+            {
+                _allCatalogAllSearchTask ??= CreateCompositeCatalogAsync(includeStoreCatalog, searchBehavior, cancellationToken);
+                task = _allCatalogAllSearchTask;
+            }
+        }
+        else if (includeStoreCatalog)
         {
             lock (_allCatalogTaskLock)
             {
-                _allCatalogTask ??= CreateCompositeCatalogAsync(includeStoreCatalog, cancellationToken);
+                _allCatalogTask ??= CreateCompositeCatalogAsync(includeStoreCatalog, searchBehavior, cancellationToken);
                 task = _allCatalogTask;
             }
         }
@@ -490,7 +521,7 @@ public sealed class WinGetPackageManagerService : IWinGetPackageManagerService
         {
             lock (_wingetCatalogTaskLock)
             {
-                _wingetCatalogTask ??= CreateCompositeCatalogAsync(includeStoreCatalog, cancellationToken);
+                _wingetCatalogTask ??= CreateCompositeCatalogAsync(includeStoreCatalog, searchBehavior, cancellationToken);
                 task = _wingetCatalogTask;
             }
         }
@@ -498,13 +529,16 @@ public sealed class WinGetPackageManagerService : IWinGetPackageManagerService
         var result = await task.ConfigureAwait(false);
         if (!result.IsSuccess || result.Value is null)
         {
-            ClearCachedCompositeCatalogTask(includeStoreCatalog, task);
+            ClearCachedCompositeCatalogTask(includeStoreCatalog, searchBehavior, task);
         }
 
         return result;
     }
 
-    private async Task<WinGetQueryResult<PackageCatalog>> CreateCompositeCatalogAsync(bool includeStoreCatalog, CancellationToken cancellationToken)
+    private async Task<WinGetQueryResult<PackageCatalog>> CreateCompositeCatalogAsync(
+        bool includeStoreCatalog,
+        CompositeSearchBehavior searchBehavior,
+        CancellationToken cancellationToken)
     {
         var initialization = _initialization.Value;
         if (!initialization.State.IsAvailable || initialization.Factory is null || initialization.PackageManager is null || initialization.WingetCatalog is null)
@@ -517,7 +551,7 @@ public sealed class WinGetPackageManagerService : IWinGetPackageManagerService
             cancellationToken.ThrowIfCancellationRequested();
 
             var options = initialization.Factory.CreateCreateCompositePackageCatalogOptions();
-            options.CompositeSearchBehavior = CompositeSearchBehavior.AllCatalogs;
+            options.CompositeSearchBehavior = searchBehavior;
             options.Catalogs.Add(initialization.WingetCatalog);
 
             if (includeStoreCatalog && initialization.StoreCatalog is not null)
@@ -556,11 +590,29 @@ public sealed class WinGetPackageManagerService : IWinGetPackageManagerService
         {
             _wingetCatalogTask = null;
         }
+
+        lock (_allCatalogAllSearchTaskLock)
+        {
+            _allCatalogAllSearchTask = null;
+        }
     }
 
-    private void ClearCachedCompositeCatalogTask(bool includeStoreCatalog, Task<WinGetQueryResult<PackageCatalog>> task)
+    private void ClearCachedCompositeCatalogTask(
+        bool includeStoreCatalog,
+        CompositeSearchBehavior searchBehavior,
+        Task<WinGetQueryResult<PackageCatalog>> task)
     {
-        if (includeStoreCatalog)
+        if (includeStoreCatalog && searchBehavior == CompositeSearchBehavior.AllCatalogs)
+        {
+            lock (_allCatalogAllSearchTaskLock)
+            {
+                if (ReferenceEquals(_allCatalogAllSearchTask, task))
+                {
+                    _allCatalogAllSearchTask = null;
+                }
+            }
+        }
+        else if (includeStoreCatalog)
         {
             lock (_allCatalogTaskLock)
             {

--- a/src/modules/cmdpal/Microsoft.CmdPal.Common/WinGet/Services/WinGetPackageManagerService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Common/WinGet/Services/WinGetPackageManagerService.cs
@@ -245,7 +245,8 @@ public sealed class WinGetPackageManagerService : IWinGetPackageManagerService
                     var findResult = await Task.Run(() => catalog.FindPackages(options), cancellationToken).ConfigureAwait(false);
                     if (findResult.Status != FindPackagesResultStatus.Ok)
                     {
-                        throw new InvalidOperationException($"Microsoft Store package lookup failed for '{id}': {findResult.Status}");
+                        CoreLogger.LogWarning($"Microsoft Store package lookup failed for '{id}': {findResult.Status}");
+                        return (id, (CatalogPackage?)null);
                     }
 
                     if (findResult.Matches.Count > 0 )
@@ -548,7 +549,10 @@ public sealed class WinGetPackageManagerService : IWinGetPackageManagerService
 
         try
         {
-            cancellationToken.ThrowIfCancellationRequested();
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return new WinGetQueryResult<PackageCatalog>(null, false, "Operation canceled.");
+            }
 
             var options = initialization.Factory.CreateCreateCompositePackageCatalogOptions();
             options.CompositeSearchBehavior = searchBehavior;

--- a/src/modules/cmdpal/Microsoft.CmdPal.Common/WinGet/Services/WinGetPackageManagerService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Common/WinGet/Services/WinGetPackageManagerService.cs
@@ -191,6 +191,86 @@ public sealed class WinGetPackageManagerService : IWinGetPackageManagerService
         }
     }
 
+    public async Task<WinGetQueryResult<IReadOnlyDictionary<string, CatalogPackage>>> GetStorePackagesByIdAsync(
+        IEnumerable<string> storeIds,
+        CancellationToken cancellationToken = default)
+    {
+        var normalizedIds = NormalizePackageIds(storeIds);
+        if (normalizedIds.Count == 0)
+        {
+            return new WinGetQueryResult<IReadOnlyDictionary<string, CatalogPackage>>(
+                new Dictionary<string, CatalogPackage>(OrdinalIgnoreCase), false, null);
+        }
+
+        var initialization = _initialization.Value;
+        if (!initialization.State.IsAvailable || initialization.Factory is null || initialization.StoreCatalog is null)
+        {
+            return new WinGetQueryResult<IReadOnlyDictionary<string, CatalogPackage>>(null, true, initialization.State.Message);
+        }
+
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var catalogResult = await GetCompositeCatalogResultAsync(includeStoreCatalog: true, cancellationToken).ConfigureAwait(false);
+            if (!catalogResult.IsSuccess || catalogResult.Value is null)
+            {
+                return new WinGetQueryResult<IReadOnlyDictionary<string, CatalogPackage>>(null, catalogResult.IsUnavailable, catalogResult.ErrorMessage);
+            }
+
+            var catalog = catalogResult.Value;
+            Dictionary<string, CatalogPackage> results = new(OrdinalIgnoreCase);
+
+            using var throttle = new SemaphoreSlim(4);
+
+            var tasks = normalizedIds.Select(async id =>
+            {
+                await throttle.WaitAsync(cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    var options = initialization.Factory.CreateFindPackagesOptions();
+                    options.ResultLimit = 1;
+
+                    var selector = initialization.Factory.CreatePackageMatchFilter();
+                    selector.Field = PackageMatchField.Id;
+                    selector.Option = PackageFieldMatchOption.Equals;
+                    selector.Value = id;
+                    options.Selectors.Add(selector);
+
+                    var findResult = await Task.Run(() => catalog.FindPackages(options), cancellationToken).ConfigureAwait(false);
+                    if (findResult.Status == FindPackagesResultStatus.Ok && findResult.Matches.Count > 0)
+                    {
+                        var package = findResult.Matches[0].CatalogPackage;
+                        return (id, package);
+                    }
+
+                    return (id, (CatalogPackage?)null);
+                }
+                finally
+                {
+                    throttle.Release();
+                }
+            });
+
+            var completed = await Task.WhenAll(tasks).ConfigureAwait(false);
+
+            foreach (var (id, package) in completed)
+            {
+                if (package is not null)
+                {
+                    results[id] = package;
+                }
+            }
+
+            return new WinGetQueryResult<IReadOnlyDictionary<string, CatalogPackage>>(results, false, null);
+        }
+        catch (Exception ex) when (ex is COMException or InvalidOperationException or TaskCanceledException)
+        {
+            CoreLogger.LogWarning($"Microsoft Store package lookup failed: {ex.Message}");
+            return new WinGetQueryResult<IReadOnlyDictionary<string, CatalogPackage>>(null, false, ex.Message);
+        }
+    }
+
     public async Task<WinGetPackageOperationResult> InstallPackageAsync(
         CatalogPackage package,
         bool skipDependencies = false,
@@ -432,7 +512,7 @@ public sealed class WinGetPackageManagerService : IWinGetPackageManagerService
             cancellationToken.ThrowIfCancellationRequested();
 
             var options = initialization.Factory.CreateCreateCompositePackageCatalogOptions();
-            options.CompositeSearchBehavior = CompositeSearchBehavior.RemotePackagesFromAllCatalogs;
+            options.CompositeSearchBehavior = CompositeSearchBehavior.AllCatalogs;
             options.Catalogs.Add(initialization.WingetCatalog);
 
             if (includeStoreCatalog && initialization.StoreCatalog is not null)

--- a/src/modules/cmdpal/Microsoft.CmdPal.Common/WinGet/Services/WinGetPackageManagerService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Common/WinGet/Services/WinGetPackageManagerService.cs
@@ -234,11 +234,16 @@ public sealed class WinGetPackageManagerService : IWinGetPackageManagerService
                     var selector = initialization.Factory.CreatePackageMatchFilter();
                     selector.Field = PackageMatchField.Id;
                     selector.Option = PackageFieldMatchOption.Equals;
-                    selector.Value = id;
+                    selector.Value = id.ToUpperInvariant();
                     options.Selectors.Add(selector);
 
                     var findResult = await Task.Run(() => catalog.FindPackages(options), cancellationToken).ConfigureAwait(false);
-                    if (findResult.Status == FindPackagesResultStatus.Ok && findResult.Matches.Count > 0)
+                    if (findResult.Status != FindPackagesResultStatus.Ok)
+                    {
+                        throw new InvalidOperationException($"Microsoft Store package lookup failed for '{id}': {findResult.Status}");
+                    }
+
+                    if (findResult.Matches.Count > 0 )
                     {
                         var package = findResult.Matches[0].CatalogPackage;
                         return (id, package);

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Gallery/ExtensionGalleryViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Gallery/ExtensionGalleryViewModel.cs
@@ -395,28 +395,28 @@ public sealed partial class ExtensionGalleryViewModel : ObservableObject, IDispo
 
         if (_winGetPackageStatusService is not null)
         {
-        if (refreshWinGetCatalogs && _winGetPackageManagerService is not null && _winGetPackageManagerService.State.IsAvailable)
-        {
-            try
+            if (refreshWinGetCatalogs && _winGetPackageManagerService is not null && _winGetPackageManagerService.State.IsAvailable)
             {
-                using var refreshCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                refreshCts.CancelAfter(WinGetRefreshTimeout);
-                await RunInBackgroundAsync(
-                    () => _winGetPackageManagerService.RefreshCatalogsAsync(refreshCts.Token),
-                    refreshCts.Token);
-                refreshCts.Token.ThrowIfCancellationRequested();
+                try
+                {
+                    using var refreshCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                    refreshCts.CancelAfter(WinGetRefreshTimeout);
+                    await RunInBackgroundAsync(
+                        () => _winGetPackageManagerService.RefreshCatalogsAsync(refreshCts.Token),
+                        refreshCts.Token);
+                    refreshCts.Token.ThrowIfCancellationRequested();
+                }
+                catch (OperationCanceledException)
+                {
+                    // Proceed to next pass
+                }
+                catch (Exception ex)
+                {
+                    LogRefreshWinGetCatalogsError(_logger, ex);
+                }
             }
-            catch (OperationCanceledException)
-            {
-                // Proceed to next pass
-            }
-            catch (Exception ex)
-            {
-                LogRefreshWinGetCatalogsError(_logger, ex);
-            }
-        }
 
-        try
+            try
             {
                 lock (_entriesLock)
                 {
@@ -474,10 +474,15 @@ public sealed partial class ExtensionGalleryViewModel : ObservableObject, IDispo
         {
             try
             {
+                lock (_entriesLock)
+                {
+                    snapshot = [.. _allEntries];
+                }
+
                 var storeIdsToLookup = snapshot
                     .Where(e => !e.IsInstalledStateKnown && !string.IsNullOrWhiteSpace(e.StoreId))
                     .Select(e => e.StoreId!)
-                    .Distinct()
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
                     .ToList();
 
                 if (storeIdsToLookup.Count > 0)
@@ -501,17 +506,17 @@ public sealed partial class ExtensionGalleryViewModel : ObservableObject, IDispo
 
                             if (results.Value.TryGetValue(entry.StoreId, out var catalogPackage))
                             {
-                                var isInstalled = catalogPackage.InstalledVersion != null;
+                                entry.IsInstalled = catalogPackage.InstalledVersion != null;
+                                entry.IsInstalledStateKnown = true;
+                            }
+                        }
 
-                                if (isInstalled)
-                                {
-                                    entry.IsInstalled = true;
-                                }
-                                else
-                                {
-                                    entry.IsInstalled = false;
-                                }
-
+                        // Mark any Store-ID entries not found in the catalog as known-not-installed.
+                        foreach (var entry in snapshot)
+                        {
+                            if (!entry.IsInstalledStateKnown && !string.IsNullOrWhiteSpace(entry.StoreId))
+                            {
+                                entry.IsInstalled = false;
                                 entry.IsInstalledStateKnown = true;
                             }
                         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Gallery/ExtensionGalleryViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Gallery/ExtensionGalleryViewModel.cs
@@ -344,12 +344,6 @@ public sealed partial class ExtensionGalleryViewModel : ObservableObject, IDispo
         bool refreshInstalledExtensions = false,
         bool refreshWinGetCatalogs = false)
     {
-        List<ExtensionGalleryItemViewModel> snapshot = [];
-        lock (_entriesLock)
-        {
-            snapshot = [.. _allEntries];
-        }
-
         try
         {
             var installedExtensions = refreshInstalledExtensions
@@ -367,6 +361,7 @@ public sealed partial class ExtensionGalleryViewModel : ObservableObject, IDispo
                     .Where(pfn => !string.IsNullOrEmpty(pfn)),
                 StringComparer.OrdinalIgnoreCase);
 
+            List<ExtensionGalleryItemViewModel> snapshot = [];
             lock (_entriesLock)
             {
                 snapshot = [.. _allEntries];
@@ -418,6 +413,7 @@ public sealed partial class ExtensionGalleryViewModel : ObservableObject, IDispo
 
             try
             {
+                List<ExtensionGalleryItemViewModel> snapshot = [];
                 lock (_entriesLock)
                 {
                     snapshot = [.. _allEntries];
@@ -474,6 +470,7 @@ public sealed partial class ExtensionGalleryViewModel : ObservableObject, IDispo
         {
             try
             {
+                List<ExtensionGalleryItemViewModel> snapshot = [];
                 lock (_entriesLock)
                 {
                     snapshot = [.. _allEntries];

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Gallery/ExtensionGalleryViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Gallery/ExtensionGalleryViewModel.cs
@@ -344,6 +344,12 @@ public sealed partial class ExtensionGalleryViewModel : ObservableObject, IDispo
         bool refreshInstalledExtensions = false,
         bool refreshWinGetCatalogs = false)
     {
+        List<ExtensionGalleryItemViewModel> snapshot;
+        lock (_entriesLock)
+        {
+            snapshot = [.. _allEntries];
+        }
+
         try
         {
             var installedExtensions = refreshInstalledExtensions
@@ -360,12 +366,6 @@ public sealed partial class ExtensionGalleryViewModel : ObservableObject, IDispo
                     .Select(e => e.PackageFamilyName)
                     .Where(pfn => !string.IsNullOrEmpty(pfn)),
                 StringComparer.OrdinalIgnoreCase);
-
-            List<ExtensionGalleryItemViewModel> snapshot = [];
-            lock (_entriesLock)
-            {
-                snapshot = [.. _allEntries];
-            }
 
             foreach (var entry in snapshot)
             {
@@ -413,12 +413,6 @@ public sealed partial class ExtensionGalleryViewModel : ObservableObject, IDispo
 
             try
             {
-                List<ExtensionGalleryItemViewModel> snapshot = [];
-                lock (_entriesLock)
-                {
-                    snapshot = [.. _allEntries];
-                }
-
                 var wingetIds = snapshot
                     .Select(entry => entry.WinGetId)
                     .Where(static id => !string.IsNullOrWhiteSpace(id))
@@ -470,12 +464,6 @@ public sealed partial class ExtensionGalleryViewModel : ObservableObject, IDispo
         {
             try
             {
-                List<ExtensionGalleryItemViewModel> snapshot = [];
-                lock (_entriesLock)
-                {
-                    snapshot = [.. _allEntries];
-                }
-
                 var storeIdsToLookup = snapshot
                     .Where(e => !e.IsInstalledStateKnown && !string.IsNullOrWhiteSpace(e.StoreId))
                     .Select(e => e.StoreId!)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Gallery/ExtensionGalleryViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Gallery/ExtensionGalleryViewModel.cs
@@ -344,7 +344,12 @@ public sealed partial class ExtensionGalleryViewModel : ObservableObject, IDispo
         bool refreshInstalledExtensions = false,
         bool refreshWinGetCatalogs = false)
     {
-        List<ExtensionGalleryItemViewModel> snapshot;
+        List<ExtensionGalleryItemViewModel> snapshot = [];
+        lock (_entriesLock)
+        {
+            snapshot = [.. _allEntries];
+        }
+
         try
         {
             var installedExtensions = refreshInstalledExtensions
@@ -388,11 +393,8 @@ public sealed partial class ExtensionGalleryViewModel : ObservableObject, IDispo
             LogCheckInstalledExtensionsError(_logger, ex);
         }
 
-        if (_winGetPackageStatusService is null)
+        if (_winGetPackageStatusService is not null)
         {
-            return;
-        }
-
         if (refreshWinGetCatalogs && _winGetPackageManagerService is not null && _winGetPackageManagerService.State.IsAvailable)
         {
             try
@@ -406,69 +408,126 @@ public sealed partial class ExtensionGalleryViewModel : ObservableObject, IDispo
             }
             catch (OperationCanceledException)
             {
-                return;
+                // Proceed to next pass
             }
             catch (Exception ex)
             {
                 LogRefreshWinGetCatalogsError(_logger, ex);
-                return;
             }
         }
 
         try
-        {
-            lock (_entriesLock)
             {
-                snapshot = [.. _allEntries];
-            }
-
-            var wingetIds = snapshot
-                .Select(entry => entry.WinGetId)
-                .Where(static id => !string.IsNullOrWhiteSpace(id))
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .Cast<string>()
-                .ToArray();
-            if (wingetIds.Length == 0)
-            {
-                return;
-            }
-
-            using var wingetCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            wingetCts.CancelAfter(WinGetRefreshTimeout);
-            var wingetInfos = await RunInBackgroundAsync(
-                () => _winGetPackageStatusService.TryGetPackageInfosAsync(wingetIds, wingetCts.Token),
-                wingetCts.Token);
-            wingetCts.Token.ThrowIfCancellationRequested();
-            if (wingetInfos is null)
-            {
-                return;
-            }
-
-            foreach (var entry in snapshot)
-            {
-                if (string.IsNullOrWhiteSpace(entry.WinGetId))
+                lock (_entriesLock)
                 {
-                    continue;
+                    snapshot = [.. _allEntries];
                 }
 
-                if (!wingetInfos.TryGetValue(entry.WinGetId, out var packageInfo))
+                var wingetIds = snapshot
+                    .Select(entry => entry.WinGetId)
+                    .Where(static id => !string.IsNullOrWhiteSpace(id))
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .Cast<string>()
+                    .ToArray();
+                if (wingetIds.Length > 0)
                 {
-                    continue;
+                    using var wingetCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                    wingetCts.CancelAfter(WinGetRefreshTimeout);
+                    var wingetInfos = await RunInBackgroundAsync(
+                        () => _winGetPackageStatusService.TryGetPackageInfosAsync(wingetIds, wingetCts.Token),
+                        wingetCts.Token);
+                    wingetCts.Token.ThrowIfCancellationRequested();
+                    if (wingetInfos is not null)
+                    {
+                        foreach (var entry in snapshot)
+                        {
+                            if (string.IsNullOrWhiteSpace(entry.WinGetId))
+                            {
+                                continue;
+                            }
+
+                            if (!wingetInfos.TryGetValue(entry.WinGetId, out var packageInfo))
+                            {
+                                continue;
+                            }
+
+                            entry.ApplyWinGetPackageInfo(packageInfo);
+                        }
+                    }
+
+                    QueueApplyFilter();
                 }
-
-                entry.ApplyWinGetPackageInfo(packageInfo);
             }
+            catch (OperationCanceledException)
+            {
+                // Cancelled or timed out — non-critical.
+            }
+            catch (Exception ex)
+            {
+                // Non-critical; keep the gallery visible with its existing state.
+                LogCheckWinGetPackageStatusError(_logger, ex);
+            }
+        }
 
-            QueueApplyFilter();
-        }
-        catch (OperationCanceledException)
+        // Pass 3 (WinGet Store Catalog Search)
+        if (_winGetPackageManagerService is not null && _winGetPackageManagerService.State.IsAvailable)
         {
-            // Cancelled or timed out — non-critical.
-        }
-        catch (Exception ex)
-        {
-            // Non-critical; keep the gallery visible with its existing state.
-            LogCheckWinGetPackageStatusError(_logger, ex);
+            try
+            {
+                var storeIdsToLookup = snapshot
+                    .Where(e => !e.IsInstalledStateKnown && !string.IsNullOrWhiteSpace(e.StoreId))
+                    .Select(e => e.StoreId!)
+                    .Distinct()
+                    .ToList();
+
+                if (storeIdsToLookup.Count > 0)
+                {
+                    using var storeCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                    storeCts.CancelAfter(WinGetRefreshTimeout);
+
+                    var results = await RunInBackgroundAsync(
+                        () => _winGetPackageManagerService.GetStorePackagesByIdAsync(storeIdsToLookup, storeCts.Token),
+                        storeCts.Token);
+                    storeCts.Token.ThrowIfCancellationRequested();
+
+                    if (results?.Value != null)
+                    {
+                        foreach (var entry in snapshot)
+                        {
+                            if (entry.IsInstalledStateKnown || string.IsNullOrWhiteSpace(entry.StoreId))
+                            {
+                                continue;
+                            }
+
+                            if (results.Value.TryGetValue(entry.StoreId, out var catalogPackage))
+                            {
+                                var isInstalled = catalogPackage.InstalledVersion != null;
+
+                                if (isInstalled)
+                                {
+                                    entry.IsInstalled = true;
+                                }
+                                else
+                                {
+                                    entry.IsInstalled = false;
+                                }
+
+                                entry.IsInstalledStateKnown = true;
+                            }
+                        }
+                    }
+
+                    QueueApplyFilter();
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // Cancelled
+            }
+            catch (Exception ex)
+            {
+                LogCheckWinGetPackageStatusError(_logger, ex);
+            }
         }
     }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Gallery/ExtensionGalleryViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Gallery/ExtensionGalleryViewModel.cs
@@ -496,8 +496,6 @@ public sealed partial class ExtensionGalleryViewModel : ObservableObject, IDispo
                                 entry.IsInstalledStateKnown = true;
                             }
                         }
-
-
                     }
 
                     QueueApplyFilter();

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Gallery/ExtensionGalleryViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Gallery/ExtensionGalleryViewModel.cs
@@ -24,6 +24,7 @@ public sealed partial class ExtensionGalleryViewModel : ObservableObject, IDispo
     private const string GenericErrorIconGlyph = "\u26A0";
     private const string RateLimitedErrorIconGlyph = "\U0001F984";
     private static readonly TimeSpan WinGetRefreshTimeout = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan StoreLookupTimeout = TimeSpan.FromSeconds(30);
     private static readonly StringComparer SortStringComparer = StringComparer.CurrentCultureIgnoreCase;
     private static readonly CompositeFormat LabelGalleryExtensionsAvailable
         = CompositeFormat.Parse(Resources.gallery_n_extensions_available!);
@@ -473,7 +474,7 @@ public sealed partial class ExtensionGalleryViewModel : ObservableObject, IDispo
                 if (storeIdsToLookup.Count > 0)
                 {
                     using var storeCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                    storeCts.CancelAfter(WinGetRefreshTimeout);
+                    storeCts.CancelAfter(StoreLookupTimeout);
 
                     var results = await RunInBackgroundAsync(
                         () => _winGetPackageManagerService.GetStorePackagesByIdAsync(storeIdsToLookup, storeCts.Token),
@@ -496,15 +497,7 @@ public sealed partial class ExtensionGalleryViewModel : ObservableObject, IDispo
                             }
                         }
 
-                        // Mark any Store-ID entries not found in the catalog as known-not-installed.
-                        foreach (var entry in snapshot)
-                        {
-                            if (!entry.IsInstalledStateKnown && !string.IsNullOrWhiteSpace(entry.StoreId))
-                            {
-                                entry.IsInstalled = false;
-                                entry.IsInstalledStateKnown = true;
-                            }
-                        }
+
                     }
 
                     QueueApplyFilter();


### PR DESCRIPTION
## Summary of the Pull Request
Store-only Command Palette extensions (e.g., Process Killer, ADB Extension, Browser Tabs) lacked both a WinGet package ID and a Package Family Name (PFN), meaning they were never detected as installed in the Extension Gallery—even when actively running on the system. This PR adds a third fallback detection pass that queries the WinGet composite catalog using Store IDs, successfully marking these extensions as installed when a local installation is found

https://github.com/user-attachments/assets/ff554b1a-ccb0-456e-853e-525d3098593a

*Recording 1: Reproducing the original bug (Store-only extensions showing as not installed).*


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #48433 
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [x] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [x] **Tests:** Manually validated (see Validation Steps below). No automated tests added
- [X] **Localization:** No new user-facing strings introduced.
- [X] **Dev docs:** No doc changes needed (internal implementation detail)
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments


https://github.com/user-attachments/assets/95da9902-d05e-401b-bd62-c8d9fc57756f

*Recording 2: Running cmdpal with the bug fixed (Extensions correctly marked as installed).*

### 1. Store Package Lookup Service

- **`IWinGetPackageManagerService.cs` & `WinGetPackageManagerService.cs`:**
  - Added `GetStorePackagesByIdAsync(IEnumerable<string> storeIds, ...)` to resolve Microsoft Store packages using the WinGet composite catalog.
  - Store ID lookups are executed concurrently (throttled with `SemaphoreSlim(4)`) to avoid overloading the WinGet engine while keeping lookup latency low.
  - Pass 3 only runs for extensions that remain unresolved after the existing detection passes, minimizing additional catalog queries.
  - Added an overload of `GetCompositeCatalogResultAsync` / `CreateCompositeCatalogAsync` that accepts a `CompositeSearchBehavior`. `GetStorePackagesByIdAsync` uses `CompositeSearchBehavior.AllCatalogs`, allowing WinGet to populate `InstalledVersion` and reliably determine whether Store-only extensions are installed. Existing callers (`SearchPackagesAsync`, `GetPackagesByIdAsync`) continue using `RemotePackagesFromAllCatalogs`. Composite catalogs are cached separately for each search behavior to avoid incorrect cache reuse.

* ### 2. Gallery ViewModel Integration
* **`ExtensionGalleryViewModel.cs`**:
  * Refactored `CheckInstalledAsync()` to avoid early returns if there are no WinGet package IDs to check, ensuring the new Pass 3 for Store-only packages is allowed to run.
  * Added **Pass 3 (WinGet Store Catalog Search)**: Collects all unmatched gallery entries that have a `StoreId` but whose installation state is not yet verified.
  * Queries these Store IDs using the new `GetStorePackagesByIdAsync` helper and marks the items as installed or not based on whether the returned `CatalogPackage.InstalledVersion` is non-null.

**Detection order now becomes:**

1. PFN lookup (Pass 1)
2. WinGet package ID lookup (Pass 2)
3. Store ID lookup via WinGet Store catalog (Pass 3)


**Note on caching lag:**
Due to existing `PackageManager` caching, extensions installed while CmdPal is running may not be detected until CmdPal is restarted or WinGet refreshes its index.

### Long-term data-side fix

The proper permanent fix for Store-only packages is to add `"detection": { "packageFamilyName": "<PFN>" }` entries to the remote `extensions.json` in the [microsoft/CmdPal-Extensions](https://github.com/microsoft/CmdPal-Extensions) repository. When that field is present, Pass 1 resolves the installed state instantly without any WinGet involvement. Pass 3 acts as a fallback for extensions that do not yet have a PFN defined in the feed


https://github.com/user-attachments/assets/b1c0a9f2-9539-42b7-912a-f1bab146199e

*Recording 3: Demonstration that adding a PFN to the extension feed allows Pass 1 detection without the fallback path.*

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

1. Built a local debug version of PowerToys with this change applied.
2. Opened the CmdPal Extension Gallery and confirmed that Store-only extensions which were previously always shown as "not installed" (e.g. **Symbols and Emojis for Command Palette**, `9NZ06M9CNV77`) now correctly show as **Installed** when the package is present on the system.
3. Confirmed that extensions with a WinGet package ID (Pass 2) continue to show the correct installed state, unaffected by this change.

