### PR TITLE
[DOCS] Add auto-generated github page for dev docs

### DIFF
--- a/.github/workflows/regenerate-devdocs-website.yml
+++ b/.github/workflows/regenerate-devdocs-website.yml
@@ -1,0 +1,67 @@
+# Builds the Dev Docs website from doc/devdocs with docmd and publishes it to GitHub Pages.
+#
+# The generated site is uploaded as a Pages artifact and deployed directly. It is never
+# committed to the repo, so doc/devdocs-website/site stays untracked (see .gitignore).
+#
+# Requires GitHub Pages to be enabled with "Source: GitHub Actions" under the repository
+# Settings -> Pages.
+name: Publish Dev Docs Website
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'doc/devdocs/**'
+      - 'doc/devdocs-website/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one Pages deployment at a time and let an in-progress deploy finish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          # Full history so docmd's git plugin can resolve per-page "last updated" dates.
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: latest
+
+      - name: Build static site with docmd
+        working-directory: doc/devdocs-website
+        # docmd is pinned in package.json; dependencies are installed fresh each run.
+        run: |
+          npm install
+          npm run build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: doc/devdocs-website/site
+          # v4+ excludes dotfiles by default; keep docmd's generated .nojekyll.
+          include-hidden-files: true
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/doc/devdocs-website/.gitignore
+++ b/doc/devdocs-website/.gitignore
@@ -1,0 +1,2 @@
+# docmd build output — published to GitHub Pages by CI, not committed.
+site/

--- a/doc/devdocs-website/.npmrc
+++ b/doc/devdocs-website/.npmrc
@@ -1,0 +1,3 @@
+# No lockfile: docmd is pinned in package.json and installed fresh on every build
+# (locally and in CI), so a tracked package-lock.json is unnecessary here.
+package-lock=false

--- a/doc/devdocs-website/README.md
+++ b/doc/devdocs-website/README.md
@@ -1,0 +1,37 @@
+# Dev Docs Website
+
+This folder hosts the [docmd](https://docmd.io/) project that turns the PowerToys developer
+documentation in [`doc/devdocs`](../devdocs) into a static website.
+
+## Generated site
+
+The `site/` folder is the docmd build output. It is **not committed** to the repository &mdash; it is
+git-ignored and rebuilt on demand. You only need it locally when previewing your changes (see below).
+
+Publishing is handled by the
+[Publish Dev Docs Website](../../.github/workflows/regenerate-devdocs-website.yml) GitHub Action, which
+runs whenever files under `doc/devdocs` (or this folder) change on the `main` branch &mdash; it can also
+be triggered manually from the **Actions** tab. The action builds the site and deploys it straight to
+GitHub Pages as an artifact, so nothing is written back to the repository.
+
+> [!NOTE]
+> The action requires GitHub Pages to be enabled with **Source: GitHub Actions** under the repository
+> **Settings → Pages**.
+
+## Editing the docs
+
+To change the documentation, edit the Markdown files under [`doc/devdocs`](../devdocs). The remaining
+files in this folder are maintained by hand and are safe to edit:
+
+- `docmd.config.json` &mdash; docmd configuration (title, source, output, and so on)
+- `package.json` &mdash; pins the docmd version used to build the site
+
+## Building locally
+
+Requires [Node.js](https://nodejs.org/).
+
+```powershell
+npm install      # install dependencies (first time only)
+npm run dev      # start a local preview server at http://localhost:3000
+npm run build    # generate the static site into ./site
+```

--- a/doc/devdocs-website/docmd.config.json
+++ b/doc/devdocs-website/docmd.config.json
@@ -1,0 +1,6 @@
+{
+  "title": "PowerToys Dev Docs",
+  "src": "../devdocs",
+  "out": "site",
+  "base": "/"
+}

--- a/doc/devdocs-website/package.json
+++ b/doc/devdocs-website/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "powertoys-devdocs-website",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Static Dev Docs website generated from doc/devdocs with docmd.",
+  "scripts": {
+    "dev": "docmd dev",
+    "build": "docmd build"
+  },
+  "devDependencies": {
+    "@docmd/core": "0.8.6"
+  }
+}


### PR DESCRIPTION
This pull request introduces a new, automated workflow for building and publishing the developer documentation website using [docmd](https://docmd.io/). The static site is now generated from `doc/devdocs`, built in the `doc/devdocs-website` folder, and deployed to GitHub Pages via a GitHub Actions workflow. The build output is not committed to the repository but is instead published as an artifact. Supporting configuration files, documentation, and `.gitignore` entries are also added to streamline local development and CI/CD.

**Automated build and deployment:**

* Added `.github/workflows/regenerate-devdocs-website.yml` to build the static site with docmd and deploy it to GitHub Pages automatically on changes to `doc/devdocs` or `doc/devdocs-website`, or via manual trigger.

**Project setup and configuration:**

* Added `doc/devdocs-website/package.json` to define the Node.js project, pin the docmd version, and provide scripts for local development and builds.
* Added `doc/devdocs-website/docmd.config.json` to configure docmd (site title, source, output directory, base path).
* Added `doc/devdocs-website/.npmrc` to disable lockfile generation, ensuring fresh dependency installs each build.

**Documentation and housekeeping:**

* Added `doc/devdocs-website/README.md` with instructions for editing, building, and publishing the docs website.
* Added `doc/devdocs-website/.gitignore` to exclude the generated `site/` output from version control.