### PR TITLE
[DOCS] docmd links to source files normalization

### DIFF
--- a/.github/workflows/regenerate-devdocs-website.yml
+++ b/.github/workflows/regenerate-devdocs-website.yml
@@ -1,0 +1,67 @@
+# Builds the Dev Docs website from doc/devdocs with docmd and publishes it to GitHub Pages.
+#
+# The generated site is uploaded as a Pages artifact and deployed directly. It is never
+# committed to the repo, so doc/devdocs-website/site stays untracked (see .gitignore).
+#
+# Requires GitHub Pages to be enabled with "Source: GitHub Actions" under the repository
+# Settings -> Pages.
+name: Publish Dev Docs Website
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'doc/devdocs/**'
+      - 'doc/devdocs-website/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one Pages deployment at a time and let an in-progress deploy finish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          # Full history so docmd's git plugin can resolve per-page "last updated" dates.
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: latest
+
+      - name: Build static site with docmd
+        working-directory: doc/devdocs-website
+        # docmd is pinned in package.json; dependencies are installed fresh each run.
+        run: |
+          npm install
+          npm run build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: doc/devdocs-website/site
+          # v4+ excludes dotfiles by default; keep docmd's generated .nojekyll.
+          include-hidden-files: true
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/doc/devdocs-website/.gitignore
+++ b/doc/devdocs-website/.gitignore
@@ -1,0 +1,2 @@
+# docmd build output — published to GitHub Pages by CI, not committed.
+site/

--- a/doc/devdocs-website/.npmrc
+++ b/doc/devdocs-website/.npmrc
@@ -1,0 +1,3 @@
+# No lockfile: docmd is pinned in package.json and installed fresh on every build
+# (locally and in CI), so a tracked package-lock.json is unnecessary here.
+package-lock=false

--- a/doc/devdocs-website/README.md
+++ b/doc/devdocs-website/README.md
@@ -1,0 +1,37 @@
+# Dev Docs Website
+
+This folder hosts the [docmd](https://docmd.io/) project that turns the PowerToys developer
+documentation in [`doc/devdocs`](../devdocs) into a static website.
+
+## Generated site
+
+The `site/` folder is the docmd build output. It is **not committed** to the repository &mdash; it is
+git-ignored and rebuilt on demand. You only need it locally when previewing your changes (see below).
+
+Publishing is handled by the
+[Publish Dev Docs Website](../../.github/workflows/regenerate-devdocs-website.yml) GitHub Action, which
+runs whenever files under `doc/devdocs` (or this folder) change on the `main` branch &mdash; it can also
+be triggered manually from the **Actions** tab. The action builds the site and deploys it straight to
+GitHub Pages as an artifact, so nothing is written back to the repository.
+
+> [!NOTE]
+> The action requires GitHub Pages to be enabled with **Source: GitHub Actions** under the repository
+> **Settings → Pages**.
+
+## Editing the docs
+
+To change the documentation, edit the Markdown files under [`doc/devdocs`](../devdocs). The remaining
+files in this folder are maintained by hand and are safe to edit:
+
+- `docmd.config.json` &mdash; docmd configuration (title, source, output, and so on)
+- `package.json` &mdash; pins the docmd version used to build the site
+
+## Building locally
+
+Requires [Node.js](https://nodejs.org/).
+
+```powershell
+npm install      # install dependencies (first time only)
+npm run dev      # start a local preview server at http://localhost:3000
+npm run build    # generate the static site into ./site
+```

--- a/doc/devdocs-website/README.md
+++ b/doc/devdocs-website/README.md
@@ -23,8 +23,15 @@ GitHub Pages as an artifact, so nothing is written back to the repository.
 To change the documentation, edit the Markdown files under [`doc/devdocs`](../devdocs). The remaining
 files in this folder are maintained by hand and are safe to edit:
 
-- `docmd.config.json` &mdash; docmd configuration (title, source, output, and so on)
+- `docmd.config.json` &mdash; docmd configuration (title, source, output, plugins)
 - `package.json` &mdash; pins the docmd version used to build the site
+- `docmd-plugins/` &mdash; local build-time docmd plugins
+
+> [!TIP]
+> Link to repository files with repo-root-relative paths such as `/src/modules/.../Foo.cpp`.
+> VS Code resolves these against the workspace root (so they open the local file), and the
+> bundled `github-source-links` plugin rewrites them to
+> `https://github.com/microsoft/PowerToys/blob/main/...` on the published site.
 
 ## Building locally
 

--- a/doc/devdocs-website/docmd-plugins/github-source-links/index.js
+++ b/doc/devdocs-website/docmd-plugins/github-source-links/index.js
@@ -1,0 +1,52 @@
+// docmd plugin: github-source-links
+//
+// The dev docs link to source files with repo-root-relative paths such as
+// "/src/modules/.../Foo.cpp". VS Code resolves those against the workspace root,
+// so they stay clickable while editing locally. On the published static site,
+// however, a "/src/..." link resolves against the site origin and 404s.
+//
+// This plugin rewrites those links to absolute GitHub blob URLs so they work on
+// the published site, while the Markdown sources stay untouched (keeping local
+// VS Code navigation intact).
+//
+// It hooks markdownSetup at the Markdown token level, so it only rewrites links
+// written in the docs' content. docmd's own generated links (sidebar, breadcrumbs,
+// canonical tags) are never seen here, which matters because an internal doc route
+// like "/tools/build-tools" is otherwise indistinguishable from a repo path like
+// "/tools/BugReportTool" once rendered to HTML.
+//
+// docmd appends a trailing slash to the rewritten links (".../Foo.cpp/"); GitHub
+// resolves that to the file anyway, so it is left as-is for simplicity.
+
+const REPO_BLOB_BASE = 'https://github.com/microsoft/PowerToys/blob/main';
+
+export default {
+  plugin: {
+    name: 'github-source-links',
+    version: '1.0.0',
+    capabilities: ['markdown'],
+  },
+
+  markdownSetup(md) {
+    const defaultRender =
+      md.renderer.rules.link_open ||
+      ((tokens, idx, options, env, self) => self.renderToken(tokens, idx, options));
+
+    md.renderer.rules.link_open = (tokens, idx, options, env, self) => {
+      const token = tokens[idx];
+      const hrefIndex = token.attrIndex('href');
+
+      if (hrefIndex >= 0) {
+        const href = token.attrs[hrefIndex][1];
+
+        // Only repo-root-relative links ("/src/..."). Leave protocol-relative
+        // ("//host"), absolute ("https://..."), relative and anchor links alone.
+        if (href.length > 1 && href[0] === '/' && href[1] !== '/') {
+          token.attrs[hrefIndex][1] = REPO_BLOB_BASE + href;
+        }
+      }
+
+      return defaultRender(tokens, idx, options, env, self);
+    };
+  },
+};

--- a/doc/devdocs-website/docmd-plugins/github-source-links/package.json
+++ b/doc/devdocs-website/docmd-plugins/github-source-links/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "docmd-plugin-github-source-links",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "main": "index.js",
+  "description": "docmd plugin that rewrites repo-root-relative doc links to GitHub blob URLs at build time."
+}

--- a/doc/devdocs-website/docmd.config.json
+++ b/doc/devdocs-website/docmd.config.json
@@ -1,0 +1,6 @@
+{
+  "title": "PowerToys Dev Docs",
+  "src": "../devdocs",
+  "out": "site",
+  "base": "/"
+}

--- a/doc/devdocs-website/docmd.config.json
+++ b/doc/devdocs-website/docmd.config.json
@@ -2,5 +2,8 @@
   "title": "PowerToys Dev Docs",
   "src": "../devdocs",
   "out": "site",
-  "base": "/"
+  "base": "/",
+  "plugins": {
+    "docmd-plugin-github-source-links": {}
+  }
 }

--- a/doc/devdocs-website/package.json
+++ b/doc/devdocs-website/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "powertoys-devdocs-website",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Static Dev Docs website generated from doc/devdocs with docmd.",
+  "scripts": {
+    "dev": "docmd dev",
+    "build": "docmd build"
+  },
+  "devDependencies": {
+    "@docmd/core": "0.8.6"
+  }
+}

--- a/doc/devdocs-website/package.json
+++ b/doc/devdocs-website/package.json
@@ -7,6 +7,9 @@
     "dev": "docmd dev",
     "build": "docmd build"
   },
+  "dependencies": {
+    "docmd-plugin-github-source-links": "file:./docmd-plugins/github-source-links"
+  },
   "devDependencies": {
     "@docmd/core": "0.8.6"
   }


### PR DESCRIPTION
**Custom docmd Plugin:**

* Implements a local docmd plugin (`docmd-plugins/github-source-links`) that rewrites repo-root-relative Markdown links (e.g., `/src/.../Foo.cpp`) to absolute GitHub blob URLs at build time, ensuring links to source files work correctly on the published site while remaining functional in local editing environments.