### PR TITLE
fix(shortcut-guide): use <N> token for literal digit keys in manifests

### DIFF
--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/Assets/ShortcutGuide/Manifests/+WindowsNT.Notepad.en-US.yml
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/Assets/ShortcutGuide/Manifests/+WindowsNT.Notepad.en-US.yml
@@ -210,7 +210,7 @@ Shortcuts:
           Shift: false
           Alt: false
           Keys:
-            - 0
+            - "<0>"
   - SectionName: Formatting
     Properties:
       - Name: Bold

--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/Assets/ShortcutGuide/Manifests/Adobe.AfterEffects.en-US.yml
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/Assets/ShortcutGuide/Manifests/Adobe.AfterEffects.en-US.yml
@@ -1542,7 +1542,7 @@ Shortcuts:
           Shift: false
           Alt: false
           Keys:
-            - 3
+            - "<3>"
       - Name: Move earlier or later by number of frames specified for stroke Duration
         Shortcut:
         - Win: false

--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/Assets/ShortcutGuide/Manifests/Adobe.Illustrator.en-US.yml
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/Assets/ShortcutGuide/Manifests/Adobe.Illustrator.en-US.yml
@@ -642,7 +642,7 @@ Shortcuts:
           Shift: true
           Alt: true
           Keys:
-            - 3
+            - "<3>"
       - Name: Show document template
         Shortcut:
         - Win: false
@@ -810,7 +810,7 @@ Shortcuts:
           Shift: false
           Alt: false
           Keys:
-            - 5
+            - "<5>"
       - Name: Release guides
         Shortcut:
         - Win: false
@@ -818,7 +818,7 @@ Shortcuts:
           Shift: false
           Alt: true
           Keys:
-            - 5
+            - "<5>"
       - Name: Show/ hide smart guides
         Shortcut:
         - Win: false
@@ -925,7 +925,7 @@ Shortcuts:
           Shift: false
           Alt: false
           Keys:
-            - 6
+            - "<6>"
       - Name: Select the object above the current selection
         Shortcut:
         - Win: false
@@ -965,7 +965,7 @@ Shortcuts:
           Shift: false
           Alt: false
           Keys:
-            - 2
+            - "<2>"
       - Name: Unlock a selection
         Shortcut:
         - Win: false
@@ -973,7 +973,7 @@ Shortcuts:
           Shift: false
           Alt: true
           Keys:
-            - 2
+            - "<2>"
       - Name: Hide a selection
         Shortcut:
         - Win: false
@@ -981,7 +981,7 @@ Shortcuts:
           Shift: false
           Alt: false
           Keys:
-            - 3
+            - "<3>"
       - Name: Show all selections
         Shortcut:
         - Win: false
@@ -989,7 +989,7 @@ Shortcuts:
           Shift: false
           Alt: true
           Keys:
-            - 3
+            - "<3>"
       - Name: Move selection in user-defined increments
         Shortcut:
         - Win: false
@@ -1013,7 +1013,7 @@ Shortcuts:
           Shift: true
           Alt: true
           Keys:
-            - 2
+            - "<2>"
       - Name: Bring a selection forward
         Shortcut:
         - Win: false
@@ -1071,7 +1071,7 @@ Shortcuts:
           Shift: false
           Alt: false
           Keys:
-            - 8
+            - "<8>"
       - Name: Release a compound path
         Shortcut:
         - Win: false
@@ -1079,7 +1079,7 @@ Shortcuts:
           Shift: true
           Alt: true
           Keys:
-            - 8
+            - "<8>"
       - Name: Edit a pattern
         Shortcut:
         - Win: false
@@ -1261,7 +1261,7 @@ Shortcuts:
           Shift: false
           Alt: false
           Keys:
-            - 4
+            - "<4>"
       - Name: Move an object
         Shortcut:
         - Win: false
@@ -1285,7 +1285,7 @@ Shortcuts:
           Shift: false
           Alt: false
           Keys:
-            - 7
+            - "<7>"
       - Name: Release a clipping mask
         Shortcut:
         - Win: false
@@ -1293,7 +1293,7 @@ Shortcuts:
           Shift: false
           Alt: true
           Keys:
-            - 7
+            - "<7>"
       - Name: Toggle between fill and stroke
         Shortcut:
         - Win: false
@@ -1641,7 +1641,7 @@ Shortcuts:
           Shift: false
           Alt: true
           Keys:
-            - 8
+            - "<8>"
       - Name: Insert copyright symbol
         Shortcut:
         - Win: false
@@ -1665,7 +1665,7 @@ Shortcuts:
           Shift: false
           Alt: true
           Keys:
-            - 7
+            - "<7>"
       - Name: Insert section symbol
         Shortcut:
         - Win: false
@@ -1673,7 +1673,7 @@ Shortcuts:
           Shift: false
           Alt: true
           Keys:
-            - 6
+            - "<6>"
       - Name: Insert trademark symbol
         Shortcut:
         - Win: false
@@ -1681,7 +1681,7 @@ Shortcuts:
           Shift: false
           Alt: true
           Keys:
-            - 2
+            - "<2>"
       - Name: Insert registered trademark symbol
         Shortcut:
         - Win: false

--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/Assets/ShortcutGuide/Manifests/Adobe.InDesign.en-US.yml
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/Assets/ShortcutGuide/Manifests/Adobe.InDesign.en-US.yml
@@ -1036,7 +1036,7 @@ Shortcuts:
           Shift: false
           Alt: false
           Keys:
-            - 5
+            - "<5>"
       - Name: Redraw screen
         Shortcut:
         - Win: false
@@ -1060,7 +1060,7 @@ Shortcuts:
           Shift: false
           Alt: true
           Keys:
-            - 2
+            - "<2>"
       - Name: Switch to next/previous document window
         Shortcut:
         - Win: false
@@ -1155,7 +1155,7 @@ Shortcuts:
           Shift: false
           Alt: false
           Keys:
-            - 6
+            - "<6>"
       - Name: Toggle Character/Paragraph text attributes mode
         Shortcut:
         - Win: false
@@ -1163,7 +1163,7 @@ Shortcuts:
           Shift: false
           Alt: true
           Keys:
-            - 7
+            - "<7>"
       - Name: Display the pop-up menu that has focus
         Shortcut:
         - Win: false
@@ -1301,7 +1301,7 @@ Shortcuts:
           Shift: true
           Alt: true
           Keys:
-            - 1
+            - "<1>"
       - Name: Show Magenta plate
         Shortcut:
         - Win: false
@@ -1309,7 +1309,7 @@ Shortcuts:
           Shift: true
           Alt: true
           Keys:
-            - 2
+            - "<2>"
       - Name: Show Yellow plate
         Shortcut:
         - Win: false
@@ -1317,7 +1317,7 @@ Shortcuts:
           Shift: true
           Alt: true
           Keys:
-            - 3
+            - "<3>"
       - Name: Show Black plate
         Shortcut:
         - Win: false
@@ -1325,7 +1325,7 @@ Shortcuts:
           Shift: true
           Alt: true
           Keys:
-            - 4
+            - "<4>"
       - Name: Show 1st Spot plate
         Shortcut:
         - Win: false
@@ -1333,7 +1333,7 @@ Shortcuts:
           Shift: true
           Alt: true
           Keys:
-            - 5
+            - "<5>"
       - Name: Show 2nd Spot plate
         Shortcut:
         - Win: false
@@ -1341,7 +1341,7 @@ Shortcuts:
           Shift: true
           Alt: true
           Keys:
-            - 6
+            - "<6>"
       - Name: Show 3rd Spot plate
         Shortcut:
         - Win: false
@@ -1349,7 +1349,7 @@ Shortcuts:
           Shift: true
           Alt: true
           Keys:
-            - 7
+            - "<7>"
   - SectionName: Transform panel
     Properties:
       - Name: Apply value and copy object

--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/Assets/ShortcutGuide/Manifests/Adobe.Photoshop.en-US.yml
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/Assets/ShortcutGuide/Manifests/Adobe.Photoshop.en-US.yml
@@ -803,7 +803,7 @@ Shortcuts:
           Shift: false
           Alt: false
           Keys:
-            - 1
+            - "<1>"
       - Name: Switch to Hand tool (when not in text-edit mode)
         Shortcut:
         - Win: false
@@ -1309,7 +1309,7 @@ Shortcuts:
           Shift: false
           Alt: true
           Keys:
-            - 1
+            - "<1>"
       - Name: Tone Curve panel
         Shortcut:
         - Win: false
@@ -1317,7 +1317,7 @@ Shortcuts:
           Shift: false
           Alt: true
           Keys:
-            - 2
+            - "<2>"
       - Name: Detail panel
         Shortcut:
         - Win: false
@@ -1325,7 +1325,7 @@ Shortcuts:
           Shift: false
           Alt: true
           Keys:
-            - 3
+            - "<3>"
       - Name: HSL/Grayscale panel
         Shortcut:
         - Win: false
@@ -1333,7 +1333,7 @@ Shortcuts:
           Shift: false
           Alt: true
           Keys:
-            - 4
+            - "<4>"
       - Name: Split Toning panel
         Shortcut:
         - Win: false
@@ -1341,7 +1341,7 @@ Shortcuts:
           Shift: false
           Alt: true
           Keys:
-            - 5
+            - "<5>"
       - Name: Lens Corrections panel
         Shortcut:
         - Win: false
@@ -1349,7 +1349,7 @@ Shortcuts:
           Shift: false
           Alt: true
           Keys:
-            - 6
+            - "<6>"
       - Name: Camera Calibration panel
         Shortcut:
         - Win: false
@@ -1357,7 +1357,7 @@ Shortcuts:
           Shift: false
           Alt: true
           Keys:
-            - 7
+            - "<7>"
       - Name: Presets panel
         Shortcut:
         - Win: false
@@ -1365,7 +1365,7 @@ Shortcuts:
           Shift: false
           Alt: true
           Keys:
-            - 9
+            - "<9>"
       - Name: Open Snapshots panel
         Shortcut:
         - Win: false
@@ -1373,7 +1373,7 @@ Shortcuts:
           Shift: false
           Alt: true
           Keys:
-            - 9
+            - "<9>"
       - Name: Parametric Curve Targeted Adjustment tool
         Shortcut:
         - Win: false
@@ -1665,7 +1665,7 @@ Shortcuts:
           Shift: false
           Alt: false
           Keys:
-            - 6
+            - "<6>"
       - Name: (Filmstrip mode) Add yellow label
         Shortcut:
         - Win: false
@@ -1673,7 +1673,7 @@ Shortcuts:
           Shift: false
           Alt: false
           Keys:
-            - 7
+            - "<7>"
       - Name: (Filmstrip mode) Add green label
         Shortcut:
         - Win: false
@@ -1681,7 +1681,7 @@ Shortcuts:
           Shift: false
           Alt: false
           Keys:
-            - 8
+            - "<8>"
       - Name: (Filmstrip mode) Add blue label
         Shortcut:
         - Win: false
@@ -1689,7 +1689,7 @@ Shortcuts:
           Shift: false
           Alt: false
           Keys:
-            - 9
+            - "<9>"
       - Name: (Filmstrip mode) Add purple label
         Shortcut:
         - Win: false
@@ -1697,7 +1697,7 @@ Shortcuts:
           Shift: true
           Alt: false
           Keys:
-            - 0
+            - "<0>"
       - Name: Camera Raw preferences
         Shortcut:
         - Win: false
@@ -1936,7 +1936,7 @@ Shortcuts:
           Shift: false
           Alt: false
           Keys:
-            - 0
+            - "<0>"
       - Name: Cycle through blending modes
         Shortcut:
         - Win: false
@@ -2433,7 +2433,7 @@ Shortcuts:
           Shift: false
           Alt: true
           Keys:
-            - 2
+            - "<2>"
       - Name: Delete adjustment layer
         Shortcut:
         - Win: false

--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/Assets/ShortcutGuide/Manifests/BlenderFoundation.Blender.en-US.yml
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/Assets/ShortcutGuide/Manifests/BlenderFoundation.Blender.en-US.yml
@@ -407,7 +407,7 @@ Shortcuts:
           Shift: false
           Alt: false
           Keys:
-            - 1
+            - "<1>"
       - Name: Edge select mode
         Shortcut:
         - Win: false
@@ -415,7 +415,7 @@ Shortcuts:
           Shift: false
           Alt: false
           Keys:
-            - 2
+            - "<2>"
       - Name: Face select mode
         Shortcut:
         - Win: false
@@ -423,7 +423,7 @@ Shortcuts:
           Shift: false
           Alt: false
           Keys:
-            - 3
+            - "<3>"
       - Name: Extrude region
         Shortcut:
         - Win: false

--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/Assets/ShortcutGuide/Manifests/Figma.Figma.en-US.yml
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/Assets/ShortcutGuide/Manifests/Figma.Figma.en-US.yml
@@ -806,7 +806,7 @@ Shortcuts:
           Shift: false
           Alt: false
           Keys:
-            - 1
+            - "<1>"
       - Name: Set opacity to 50
         Shortcut:
         - Win: false
@@ -814,7 +814,7 @@ Shortcuts:
           Shift: false
           Alt: false
           Keys:
-            - 5
+            - "<5>"
       - Name: Set opacity to 100
         Shortcut:
         - Win: false
@@ -822,7 +822,7 @@ Shortcuts:
           Shift: false
           Alt: false
           Keys:
-            - 0
+            - "<0>"
   - SectionName: Arrange
     Properties:
       - Name: Bring forward

--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/Assets/ShortcutGuide/Manifests/GIMP.GIMP.en-US.yml
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/Assets/ShortcutGuide/Manifests/GIMP.GIMP.en-US.yml
@@ -489,7 +489,7 @@ Shortcuts:
           Shift: false
           Alt: false
           Keys:
-            - 1
+            - "<1>"
   - SectionName: Edit
     Properties:
       - Name: Undo

--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/Assets/ShortcutGuide/Manifests/Google.Chrome.en-US.yml
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/Assets/ShortcutGuide/Manifests/Google.Chrome.en-US.yml
@@ -63,7 +63,7 @@ Shortcuts:
           Shift: false
           Alt: false
           Keys:
-            - 1
+            - "<1>"
       - Name: Jump to rightmost tab
         Shortcut:
         - Win: false
@@ -71,7 +71,7 @@ Shortcuts:
           Shift: false
           Alt: false
           Keys:
-            - 9
+            - "<9>"
       - Name: Open home page in current tab
         Shortcut:
         - Win: false
@@ -424,7 +424,7 @@ Shortcuts:
           Shift: false
           Alt: false
           Keys:
-            - 0
+            - "<0>"
       - Name: Scroll down a screen
         Shortcut:
         - Win: false

--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/Assets/ShortcutGuide/Manifests/JetBrains.IntelliJIDEA.Community.en-US.yml
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/Assets/ShortcutGuide/Manifests/JetBrains.IntelliJIDEA.Community.en-US.yml
@@ -21,7 +21,7 @@ Shortcuts:
           Shift: false
           Alt: true
           Keys:
-            - 1
+            - "<1>"
       - Name: Show Intention Actions
         Recommended: true
         Shortcut:
@@ -778,7 +778,7 @@ Shortcuts:
           Shift: false
           Alt: true
           Keys:
-            - 1
+            - "<1>"
       - Name: Show Bookmarks window
         Shortcut:
         - Win: false
@@ -786,7 +786,7 @@ Shortcuts:
           Shift: false
           Alt: true
           Keys:
-            - 2
+            - "<2>"
       - Name: Show Find window
         Shortcut:
         - Win: false
@@ -794,7 +794,7 @@ Shortcuts:
           Shift: false
           Alt: true
           Keys:
-            - 3
+            - "<3>"
       - Name: Show Run window
         Shortcut:
         - Win: false
@@ -802,7 +802,7 @@ Shortcuts:
           Shift: false
           Alt: true
           Keys:
-            - 4
+            - "<4>"
       - Name: Show Debug window
         Shortcut:
         - Win: false
@@ -810,7 +810,7 @@ Shortcuts:
           Shift: false
           Alt: true
           Keys:
-            - 5
+            - "<5>"
       - Name: Show Problems window
         Shortcut:
         - Win: false
@@ -818,7 +818,7 @@ Shortcuts:
           Shift: false
           Alt: true
           Keys:
-            - 6
+            - "<6>"
       - Name: Show Structure window
         Shortcut:
         - Win: false
@@ -826,7 +826,7 @@ Shortcuts:
           Shift: false
           Alt: true
           Keys:
-            - 7
+            - "<7>"
       - Name: Show Services window
         Shortcut:
         - Win: false
@@ -834,7 +834,7 @@ Shortcuts:
           Shift: false
           Alt: true
           Keys:
-            - 8
+            - "<8>"
       - Name: Show Version Control window
         Shortcut:
         - Win: false
@@ -842,7 +842,7 @@ Shortcuts:
           Shift: false
           Alt: true
           Keys:
-            - 9
+            - "<9>"
       - Name: Show Commit window
         Shortcut:
         - Win: false
@@ -850,7 +850,7 @@ Shortcuts:
           Shift: false
           Alt: true
           Keys:
-            - 0
+            - "<0>"
       - Name: Show Terminal window
         Shortcut:
         - Win: false

--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/Assets/ShortcutGuide/Manifests/Microsoft.Edge.en-US.yml
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/Assets/ShortcutGuide/Manifests/Microsoft.Edge.en-US.yml
@@ -45,7 +45,7 @@ Shortcuts:
           Shift: false
           Alt: false
           Keys:
-            - 1
+            - "<1>"
       - Name: Switch to the last tab
         Shortcut:
         - Win: false
@@ -53,7 +53,7 @@ Shortcuts:
           Shift: false
           Alt: false
           Keys:
-            - 9
+            - "<9>"
       - Name: Close the current tab
         Shortcut:
         - Win: false
@@ -479,7 +479,7 @@ Shortcuts:
           Shift: false
           Alt: false
           Keys:
-            - 0
+            - "<0>"
       - Name: Stop loading page; close dialog or pop-up
         Shortcut:
         - Win: false

--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/Assets/ShortcutGuide/Manifests/Microsoft.VisualStudioCode.en-US.yml
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/Assets/ShortcutGuide/Manifests/Microsoft.VisualStudioCode.en-US.yml
@@ -492,7 +492,7 @@ Shortcuts:
           Shift: false
           Alt: false
           Keys:
-            - 1
+            - "<1>"
       - Name: Focus into Second Editor Group
         Shortcut:
         - Win: false
@@ -500,7 +500,7 @@ Shortcuts:
           Shift: false
           Alt: false
           Keys:
-            - 2
+            - "<2>"
       - Name: Focus into Third Editor Group
         Shortcut:
         - Win: false
@@ -508,7 +508,7 @@ Shortcuts:
           Shift: false
           Alt: false
           Keys:
-            - 3
+            - "<3>"
       - Name: Move Editor Left
         Shortcut:
         - Win: false

--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/Assets/ShortcutGuide/Manifests/Mozilla.Firefox.en-US.yml
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/Assets/ShortcutGuide/Manifests/Mozilla.Firefox.en-US.yml
@@ -202,7 +202,7 @@ Shortcuts:
           Shift: false
           Alt: false
           Keys:
-            - 0
+            - "<0>"
   - SectionName: Editing
     Properties:
       - Name: Copy
@@ -485,7 +485,7 @@ Shortcuts:
           Shift: false
           Alt: false
           Keys:
-            - 1
+            - "<1>"
       - Name: Go to last tab
         Shortcut:
         - Win: false
@@ -493,7 +493,7 @@ Shortcuts:
           Shift: false
           Alt: false
           Keys:
-            - 9
+            - "<9>"
       - Name: Move tab left
         Shortcut:
         - Win: false

--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/Assets/ShortcutGuide/Manifests/SlackTechnologies.Slack.en-US.yml
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/Assets/ShortcutGuide/Manifests/SlackTechnologies.Slack.en-US.yml
@@ -241,7 +241,7 @@ Shortcuts:
           Shift: true
           Alt: false
           Keys:
-            - 1
+            - "<1>"
       - Name: Browse DMs
         Shortcut:
         - Win: false
@@ -249,7 +249,7 @@ Shortcuts:
           Shift: true
           Alt: false
           Keys:
-            - 2
+            - "<2>"
       - Name: Open the Activity view
         Shortcut:
         - Win: false
@@ -265,7 +265,7 @@ Shortcuts:
           Shift: true
           Alt: false
           Keys:
-            - 0
+            - "<0>"
       - Name: Open the Threads view
         Shortcut:
         - Win: false
@@ -525,7 +525,7 @@ Shortcuts:
           Shift: true
           Alt: false
           Keys:
-            - 9
+            - "<9>"
       - Name: Inline code selected text
         Shortcut:
         - Win: false
@@ -549,7 +549,7 @@ Shortcuts:
           Shift: true
           Alt: false
           Keys:
-            - 8
+            - "<8>"
       - Name: Numbered list
         Shortcut:
         - Win: false
@@ -557,7 +557,7 @@ Shortcuts:
           Shift: true
           Alt: false
           Keys:
-            - 7
+            - "<7>"
       - Name: Apply markdown formatting
         Shortcut:
         - Win: false
@@ -583,7 +583,7 @@ Shortcuts:
           Shift: false
           Alt: true
           Keys:
-            - 0
+            - "<0>"
       - Name: Big heading
         Shortcut:
         - Win: false
@@ -591,7 +591,7 @@ Shortcuts:
           Shift: false
           Alt: true
           Keys:
-            - 1
+            - "<1>"
       - Name: Medium heading
         Shortcut:
         - Win: false
@@ -599,7 +599,7 @@ Shortcuts:
           Shift: false
           Alt: true
           Keys:
-            - 2
+            - "<2>"
       - Name: Small heading
         Shortcut:
         - Win: false
@@ -607,7 +607,7 @@ Shortcuts:
           Shift: false
           Alt: true
           Keys:
-            - 3
+            - "<3>"
       - Name: Checklist
         Shortcut:
         - Win: false
@@ -615,7 +615,7 @@ Shortcuts:
           Shift: true
           Alt: false
           Keys:
-            - 0
+            - "<0>"
       - Name: Bulleted list
         Shortcut:
         - Win: false
@@ -623,7 +623,7 @@ Shortcuts:
           Shift: true
           Alt: false
           Keys:
-            - 8
+            - "<8>"
       - Name: Numbered list
         Shortcut:
         - Win: false
@@ -631,7 +631,7 @@ Shortcuts:
           Shift: true
           Alt: false
           Keys:
-            - 7
+            - "<7>"
       - Name: Toggle heading and list styles
         Shortcut:
         - Win: false


### PR DESCRIPTION
## Summary of the Pull Request

Converts the literal-digit shortcut keys in the bundled Shortcut Guide manifests to the `<N>` special-key convention, so they render as the correct number.

Per the manifest spec, a bare number in `Keys:` is a virtual-key code. A literal digit key authored as a bare number is therefore misread (VK `9` is Tab, VK `1` is the left mouse button, VK `0` is undefined) and renders incorrectly. The fix authors these as the `<N>` token (for example `"<9>"`), which `KeyVisual` strips to display the digit.

This is a data-only change: **91 literal-digit keys across 14 manifests** become `<N>` tokens. No code or doc changes; the renderer and converter already support `<N>`, and the convention is documented in the spec.

Follow-up to #48461, which introduced and documented the `<N>` convention (per @noraa-junker's request for a separate PR to fix the remaining manifests). Together with #48461 this resolves the rendering reported in #48460.

Files touched (all under `src/modules/ShortcutGuide/ShortcutGuide.Ui/Assets/ShortcutGuide/Manifests/`): Adobe.Illustrator (18), Adobe.Photoshop (17), SlackTechnologies.Slack (13), Adobe.InDesign (11), JetBrains.IntelliJIDEA.Community (11), BlenderFoundation.Blender (3), Figma.Figma (3), Google.Chrome (3), Microsoft.Edge (3), Microsoft.VisualStudioCode (3), Mozilla.Firefox (3), +WindowsNT.Notepad (1), Adobe.AfterEffects (1), GIMP.GIMP (1).

## PR Checklist

- [ ] **Closes:** N/A (follow-up to #48461; contributes to #48460)
- [ ] **Communication:** discussed in #48461; @noraa-junker requested this separate PR.
- [ ] **Tests:** N/A for data; the converter and `<N>` convention are unit-tested in #48461. Validated here by deserializing every manifest with YamlDotNet (see below).
- [x] **Localization:** unchanged; these are per-language manifest files.
- [ ] **Dev docs:** N/A (the `<N>` convention is documented in the spec via #48461).
- [ ] **New binaries:** N/A.
- [ ] **Documentation updated:** N/A.

## Detailed Description of the Pull Request / Additional comments

Each change wraps a single bare digit in angle brackets, for example:

```yaml
          Keys:
-            - 9
+            - "<9>"
```

Quoted tokens (`"<9>"`) are used to match the dominant special-token style already in the manifests (`"<Enter>"`, `"<Down>"`, etc.).

Note (out of scope): `Adobe.Photoshop.en-US.yml` has a shortcut with an empty `Name: ""` (around line 799). That is a pre-existing data issue unrelated to digit rendering; the digit is still converted, and the empty name is left as-is.

## Validation Steps Performed

- Confirmed the diff touches only the 14 manifests, 91 insertions and 91 deletions, with each changed line being a digit wrapped as `"<N>"` (no whitespace, indentation, or encoding churn).
- Confirmed zero bare-digit `Keys` entries remain and exactly 91 new `"<N>"` tokens exist.
- Deserialized all 32 manifests with YamlDotNet (the same library the app uses at runtime): 0 parse errors.
- Rendering behavior for `<N>` is already verified in #48461 (the renderer strips the brackets to show the digit).
