### PR TITLE
[ColorPicker] Fix the main window UI appearing in the zoomed-in view

### DIFF
--- a/src/modules/colorPicker/ColorPickerUI/Helpers/AppStateHandler.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/AppStateHandler.cs
@@ -243,5 +243,7 @@ namespace ColorPicker.Helpers
             lpPoint.Y += yOffset;
             SetCursorPos(lpPoint.X, lpPoint.Y);
         }
+
+        internal IntPtr GetMainWindowHandle() => _hwndSource?.Handle ?? IntPtr.Zero;
     }
 }

--- a/src/modules/colorPicker/ColorPickerUI/Helpers/WindowCaptureExclusionHelper.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/WindowCaptureExclusionHelper.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using ManagedCommon;
+
+namespace ColorPicker.Helpers;
+
+internal static class WindowCaptureExclusionHelper
+{
+    // Windows 10 version 2004 (build 19041) is the minimum supported version. PowerToys
+    // itself requires the same version, so this check is not strictly required, but is
+    // useful as a safeguard.
+    private static readonly bool IsSupported =
+        Environment.OSVersion.Version >= new Version(10, 0, 19041);
+
+    // Only logging once per session to avoid repeated identical warnings, as the zoom
+    // window may be used very often.
+    private static bool hasLoggedFailure;
+
+    internal static bool Exclude(IntPtr hwnd) =>
+        SetWindowAffinity(hwnd, NativeMethods.WDA_EXCLUDEFROMCAPTURE);
+
+    internal static bool Include(IntPtr hwnd) =>
+        SetWindowAffinity(hwnd, NativeMethods.WDA_NONE);
+
+    private static bool SetWindowAffinity(nint hwnd, uint affinity)
+    {
+        if (!IsSupported)
+        {
+            return false;
+        }
+
+        bool success = NativeMethods.SetWindowDisplayAffinity(hwnd, affinity);
+
+        if (!success)
+        {
+            int errorCode = Marshal.GetLastWin32Error();
+            if (!hasLoggedFailure)
+            {
+                Logger.LogWarning(
+                    $"Failed to set window display affinity. Error code: {errorCode}");
+                hasLoggedFailure = true;
+            }
+        }
+
+        return success;
+    }
+}

--- a/src/modules/colorPicker/ColorPickerUI/Helpers/ZoomWindowHelper.cs
+++ b/src/modules/colorPicker/ColorPickerUI/Helpers/ZoomWindowHelper.cs
@@ -79,12 +79,30 @@ namespace ColorPicker.Helpers
             // we just started zooming, copy screen area
             if (_previousZoomLevel == 0)
             {
-                var x = (int)point.X - (BaseZoomImageSize / 2);
-                var y = (int)point.Y - (BaseZoomImageSize / 2);
+                // First, exclude the color picker window from the capture; otherwise its
+                // corner will be included in the zoomed-in image.
+                var mainWindowHandle = _appStateHandler.GetMainWindowHandle();
+                bool exclusionSuccess =
+                    WindowCaptureExclusionHelper.Exclude(mainWindowHandle);
 
-                _graphics.CopyFromScreen(x, y, 0, 0, _bmp.Size, CopyPixelOperation.SourceCopy);
+                try
+                {
+                    var x = (int)point.X - (BaseZoomImageSize / 2);
+                    var y = (int)point.Y - (BaseZoomImageSize / 2);
 
-                _zoomViewModel.ZoomArea = BitmapToImageSource(_bmp);
+                    _graphics.CopyFromScreen(x, y, 0, 0, _bmp.Size, CopyPixelOperation.SourceCopy);
+
+                    _zoomViewModel.ZoomArea = BitmapToImageSource(_bmp);
+                }
+                finally
+                {
+                    // Restore the color picker window to normal display affinity so that
+                    // it can be captured again.
+                    if (exclusionSuccess)
+                    {
+                        WindowCaptureExclusionHelper.Include(mainWindowHandle);
+                    }
+                }
             }
 
             _zoomViewModel.ZoomFactor = Math.Pow(ZoomFactor, _currentZoomLevel - 1);

--- a/src/modules/colorPicker/ColorPickerUI/NativeMethods.cs
+++ b/src/modules/colorPicker/ColorPickerUI/NativeMethods.cs
@@ -231,5 +231,17 @@ namespace ColorPicker
             var hwnd = new WindowInteropHelper(win).Handle;
             _ = SetWindowLong(hwnd, GWL_EX_STYLE, GetWindowLong(hwnd, GWL_EX_STYLE) | WS_EX_TOOLWINDOW);
         }
+
+        /// <summary>
+        /// Sets the display affinity of a window, which controls how the window is
+        /// displayed on a monitor. Used to exclude the picker window from ZoomWindow's
+        /// source bitmap.
+        /// </summary>
+        [DllImport("user32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool SetWindowDisplayAffinity(IntPtr hwnd, uint dwAffinity);
+
+        internal const uint WDA_NONE = 0x00000000;
+        internal const uint WDA_EXCLUDEFROMCAPTURE = 0x00000011;
     }
 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #37801
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [x] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
This uses `SetWindowAffinity()` with the `WDA_EXCLUDEFROMCAPTURE` constant on the main Color Picker window to ensure the ZoomWindow bitmap creation excludes the corner of the picker UI. The ability to capture the picker window is restored immediately after, so it's still visible in Snipping Tool, Remote Desktop and other tools.

The fix uses a new helper with simple `Include()` / `Exclude()` methods as an adapter to the native code. This may potentially be included in Common if other utilities needed it.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
1. Repro'd the original issue on the current Color Picker release:
<img width="262" height="263" alt="image" src="https://github.com/user-attachments/assets/bc12b2f8-b67f-4b56-a803-57ab2fe0fa17" />

2. Confirmed that the fix worked and normal window affinity was restored (otherwise I would not have been able to snip this):
<img width="262" height="262" alt="image" src="https://github.com/user-attachments/assets/bc336ad0-4114-49fa-8440-b78466de363f" />

3. Repeated zooming in and out over a normal session.