### PR TITLE
cmdpal: Support Enter key to submit FormContent (Adaptive Card) inputs

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContentFormControl.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContentFormControl.xaml.cs
@@ -305,7 +305,16 @@ public sealed partial class ContentFormControl : UserControl
             if (submitAction != null)
             {
                 e.Handled = true;
-                ViewModel?.HandleSubmit(submitAction, _renderedCard.UserInputs.AsJson());
+
+                // Validate (and gather) the inputs before submitting. AsJson() only
+                // returns the values cached by a successful ValidateInputs() call, so
+                // skipping this would submit an empty payload. This mirrors what the
+                // renderer does internally when a submit button is clicked.
+                var inputs = _renderedCard.UserInputs;
+                if (inputs.ValidateInputs(submitAction))
+                {
+                    ViewModel?.HandleSubmit(submitAction, inputs.AsJson());
+                }
             }
         }
     }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContentFormControl.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContentFormControl.xaml.cs
@@ -8,7 +8,9 @@ using Microsoft.CmdPal.UI.ViewModels;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
+using Windows.System;
 
 namespace Microsoft.CmdPal.UI.Controls;
 
@@ -22,6 +24,7 @@ public sealed partial class ContentFormControl : UserControl
     // tree. If this gets GC'ed, then it'll revoke our Action handler, and the
     // form will do seemingly nothing.
     private RenderedAdaptiveCard? _renderedCard;
+    private AdaptiveCard? _adaptiveCard;
 
     public ContentFormViewModel? ViewModel { get => _viewModel; set => AttachViewModel(value); }
 
@@ -95,9 +98,11 @@ public sealed partial class ContentFormControl : UserControl
     private void DisplayCard(AdaptiveCardParseResult result)
     {
         _renderedCard = _renderer.RenderAdaptiveCard(result.AdaptiveCard);
+        _adaptiveCard = result.AdaptiveCard;
         ContentGrid.Children.Clear();
         if (_renderedCard.FrameworkElement is not null)
         {
+            _renderedCard.FrameworkElement.KeyDown += OnFormKeyDown;
             ContentGrid.Children.Add(_renderedCard.FrameworkElement);
 
             // Use the Loaded event to ensure we focus after the card is in the visual tree
@@ -274,6 +279,35 @@ public sealed partial class ContentFormControl : UserControl
         }
 
         return null;
+    }
+
+    private void OnFormKeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        if (e.Key != VirtualKey.Enter || _renderedCard == null || _adaptiveCard == null)
+        {
+            return;
+        }
+
+        // Only submit when Enter is pressed inside a single-line TextBox
+        if (e.OriginalSource is TextBox textBox && !textBox.AcceptsReturn)
+        {
+            // Find the first Submit or Execute action on the card
+            IAdaptiveActionElement? submitAction = null;
+            foreach (var action in _adaptiveCard.Actions)
+            {
+                if (action is AdaptiveSubmitAction or AdaptiveExecuteAction)
+                {
+                    submitAction = action;
+                    break;
+                }
+            }
+
+            if (submitAction != null)
+            {
+                e.Handled = true;
+                ViewModel?.HandleSubmit(submitAction, _renderedCard.UserInputs.AsJson());
+            }
+        }
     }
 
     private void Rendered_Action(RenderedAdaptiveCard sender, AdaptiveActionEventArgs args) =>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContentFormControl.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContentFormControl.xaml.cs
@@ -283,7 +283,13 @@ public sealed partial class ContentFormControl : UserControl
 
     private void OnFormKeyDown(object sender, KeyRoutedEventArgs e)
     {
-        if (e.Key != VirtualKey.Enter || _renderedCard == null || _adaptiveCard == null)
+        // Snapshot the fields so a subsequent DisplayCard call can't swap the
+        // rendered/parsed card out from under us mid-method. This keeps the
+        // resolved submit action and the gathered inputs from the same card.
+        var renderedCard = _renderedCard;
+        var adaptiveCard = _adaptiveCard;
+
+        if (e.Key != VirtualKey.Enter || renderedCard == null || adaptiveCard == null)
         {
             return;
         }
@@ -293,7 +299,7 @@ public sealed partial class ContentFormControl : UserControl
         {
             // Find the first Submit or Execute action on the card
             IAdaptiveActionElement? submitAction = null;
-            foreach (var action in _adaptiveCard.Actions)
+            foreach (var action in adaptiveCard.Actions)
             {
                 if (action is AdaptiveSubmitAction or AdaptiveExecuteAction)
                 {
@@ -310,7 +316,7 @@ public sealed partial class ContentFormControl : UserControl
                 // returns the values cached by a successful ValidateInputs() call, so
                 // skipping this would submit an empty payload. This mirrors what the
                 // renderer does internally when a submit button is clicked.
-                var inputs = _renderedCard.UserInputs;
+                var inputs = renderedCard.UserInputs;
                 if (inputs.ValidateInputs(submitAction))
                 {
                     ViewModel?.HandleSubmit(submitAction, inputs.AsJson());


### PR DESCRIPTION
## Summary

Adds Enter key support for submitting Adaptive Card forms in the Command Palette. When a user presses Enter inside a single-line `Input.Text` field, the form is automatically submitted using the first `Action.Submit` or `Action.Execute` action on the card.

## Problem

When extensions use `FormContent` with Adaptive Cards, pressing Enter inside an `Input.Text` field does not trigger submission. Users must click the submit button with their mouse (or tab to it), breaking keyboard-only workflows like login/unlock forms.

## Solution

Added a `KeyDown` event handler on the rendered Adaptive Card's `FrameworkElement` in `ContentFormControl.xaml.cs`:

- Intercepts `VirtualKey.Enter` when the source is a `TextBox` that doesn't accept returns (single-line)
- Finds the first `AdaptiveSubmitAction` or `AdaptiveExecuteAction` on the card
- Calls `HandleSubmit` with that action and the current user inputs via `RenderedAdaptiveCard.UserInputs.AsJson()`

Multiline text inputs (`AcceptsReturn = true`) are excluded so Enter still inserts newlines.

## Validation

- Single file change in `ContentFormControl.xaml.cs`
- Uses existing `HandleSubmit` path — same behavior as clicking the submit button
- No impact on cards without submit/execute actions
- No impact on multiline text inputs

Fixes #46003