### PR TITLE
Mouse Without Borders: create received files in the logged-on user's context

### DIFF
--- a/src/modules/MouseWithoutBorders/App/Core/Clipboard.cs
+++ b/src/modules/MouseWithoutBorders/App/Core/Clipboard.cs
@@ -574,8 +574,30 @@ internal static class Clipboard
             }
             else
             {
+                // Create received files in the same context that the destination folder is created
+                // in. For per-user storage (the user's Desktop) that means as the logged-on user, so
+                // the file ends up owned by that user and inherits the folder's permissions. On the
+                // logon/screen-saver desktop the storage lives under Program Files where there is no
+                // interactive user to impersonate, so create the file directly.
+                void CreateDestinationFile(string path)
+                {
+                    if (Common.RunOnLogonDesktop || Common.RunOnScrSaverDesktop)
+                    {
+                        m = new FileStream(path, FileMode.Create);
+                    }
+                    else
+                    {
+                        _ = Launch.ImpersonateLoggedOnUserAndDoSomething(() =>
+                        {
+                            m = new FileStream(path, FileMode.Create);
+                        });
+                    }
+                }
+
                 if (postAct.Equals("desktop", StringComparison.OrdinalIgnoreCase))
                 {
+                    // Create the folder and open the file in a single impersonated scope so both
+                    // are owned by the logged-on user. This branch always targets the user's Desktop.
                     _ = Launch.ImpersonateLoggedOnUserAndDoSomething(() =>
                     {
                         savingFolder = Environment.GetFolderPath(Environment.SpecialFolder.Desktop) + "\\MouseWithoutBorders\\";
@@ -584,22 +606,22 @@ internal static class Clipboard
                         {
                             _ = Directory.CreateDirectory(savingFolder);
                         }
-                    });
 
-                    tempFile = savingFolder + Path.GetFileName(fileName);
-                    m = new FileStream(tempFile, FileMode.Create);
+                        tempFile = savingFolder + Path.GetFileName(fileName);
+                        m = new FileStream(tempFile, FileMode.Create);
+                    });
                 }
                 else if (postAct.Contains("mspaint"))
                 {
                     tempFile = Common.GetMyStorageDir() + @"ScreenCapture-" +
                         remoteMachine + ".png";
-                    m = new FileStream(tempFile, FileMode.Create);
+                    CreateDestinationFile(tempFile);
                 }
                 else
                 {
                     tempFile = Common.GetMyStorageDir();
                     tempFile += Path.GetFileName(fileName);
-                    m = new FileStream(tempFile, FileMode.Create);
+                    CreateDestinationFile(tempFile);
                 }
 
                 Logger.Log("==> " + tempFile);

--- a/src/modules/MouseWithoutBorders/App/Core/Clipboard.cs
+++ b/src/modules/MouseWithoutBorders/App/Core/Clipboard.cs
@@ -600,6 +600,8 @@ internal static class Clipboard
                     }
                 }
 
+                if (postAct.Equals("desktop", StringComparison.OrdinalIgnoreCase))
+                {
                     // Create the folder and open the file in a single impersonated scope so both
                     // are owned by the logged-on user. This branch always targets the user's Desktop.
                     bool success = Launch.ImpersonateLoggedOnUserAndDoSomething(() =>

--- a/src/modules/MouseWithoutBorders/App/Core/Clipboard.cs
+++ b/src/modules/MouseWithoutBorders/App/Core/Clipboard.cs
@@ -587,10 +587,16 @@ internal static class Clipboard
                     }
                     else
                     {
-                        _ = Launch.ImpersonateLoggedOnUserAndDoSomething(() =>
+                        bool success = Launch.ImpersonateLoggedOnUserAndDoSomething(() =>
                         {
                             m = new FileStream(path, FileMode.Create);
                         });
+
+                        if (!success || m == null)
+                        {
+                            Logger.Log("Impersonation failed for file creation, falling back to direct creation.");
+                            m = new FileStream(path, FileMode.Create);
+                        }
                     }
                 }
 

--- a/src/modules/MouseWithoutBorders/App/Core/Clipboard.cs
+++ b/src/modules/MouseWithoutBorders/App/Core/Clipboard.cs
@@ -600,11 +600,9 @@ internal static class Clipboard
                     }
                 }
 
-                if (postAct.Equals("desktop", StringComparison.OrdinalIgnoreCase))
-                {
                     // Create the folder and open the file in a single impersonated scope so both
                     // are owned by the logged-on user. This branch always targets the user's Desktop.
-                    _ = Launch.ImpersonateLoggedOnUserAndDoSomething(() =>
+                    bool success = Launch.ImpersonateLoggedOnUserAndDoSomething(() =>
                     {
                         savingFolder = Environment.GetFolderPath(Environment.SpecialFolder.Desktop) + "\\MouseWithoutBorders\\";
 
@@ -616,6 +614,19 @@ internal static class Clipboard
                         tempFile = savingFolder + Path.GetFileName(fileName);
                         m = new FileStream(tempFile, FileMode.Create);
                     });
+
+                    if (!success || m == null)
+                    {
+                        Logger.Log("Impersonation failed for desktop file creation, falling back to direct creation.");
+                        savingFolder = Environment.GetFolderPath(Environment.SpecialFolder.Desktop) + "\\MouseWithoutBorders\\";
+                        if (!Directory.Exists(savingFolder))
+                        {
+                            _ = Directory.CreateDirectory(savingFolder);
+                        }
+
+                        tempFile = savingFolder + Path.GetFileName(fileName);
+                        m = new FileStream(tempFile, FileMode.Create);
+                    }
                 }
                 else if (postAct.Contains("mspaint"))
                 {

--- a/src/modules/MouseWithoutBorders/App/Core/Clipboard.cs
+++ b/src/modules/MouseWithoutBorders/App/Core/Clipboard.cs
@@ -546,9 +546,28 @@ internal static class Clipboard
             }
         }
 
+        void CommitDestinationFile(string sourcePath, string destinationPath)
+        {
+            bool success;
+            if (Common.RunOnLogonDesktop || Common.RunOnScrSaverDesktop)
+            {
+                File.Move(sourcePath, destinationPath, overwrite: true);
+                success = true;
+            }
+            else
+            {
+                success = Launch.ImpersonateLoggedOnUserAndDoSomething(() => File.Move(sourcePath, destinationPath, overwrite: true));
+            }
+
+            if (!success)
+            {
+                throw new IOException($"Could not replace destination file: {destinationPath}");
+            }
+        }
+
         void CreateDestinationFile(string path)
         {
-            destinationFile = new ReceivedDestinationFile(path, DeleteDestinationFile);
+            destinationFile = new ReceivedDestinationFile(path, DeleteDestinationFile, CommitDestinationFile);
             m = destinationFile.Stream;
         }
 
@@ -785,6 +804,7 @@ internal static class Clipboard
 
             if (m != null && fileName != null)
             {
+                long receivedLength = m.Length;
                 if (destinationFile != null)
                 {
                     destinationFile.Complete();
@@ -794,12 +814,12 @@ internal static class Clipboard
                     m.Flush();
                 }
 
-                Logger.LogDebug(m.Length.ToString(CultureInfo.CurrentCulture) + " bytes received.");
+                Logger.LogDebug(receivedLength.ToString(CultureInfo.CurrentCulture) + " bytes received.");
                 Clipboard.LastClipboardEventTime = Common.GetTick();
                 string toolTipText = null;
-                string sizeText = m.Length >= 1024
-                    ? (m.Length / 1024).ToString(CultureInfo.CurrentCulture) + "KB"
-                    : m.Length.ToString(CultureInfo.CurrentCulture) + "Bytes";
+                string sizeText = receivedLength >= 1024
+                    ? (receivedLength / 1024).ToString(CultureInfo.CurrentCulture) + "KB"
+                    : receivedLength.ToString(CultureInfo.CurrentCulture) + "Bytes";
 
                 PowerToysTelemetry.Log.WriteEvent(new MouseWithoutBorders.Telemetry.MouseWithoutBordersClipboardFileTransferEvent());
 

--- a/src/modules/MouseWithoutBorders/App/Core/Clipboard.cs
+++ b/src/modules/MouseWithoutBorders/App/Core/Clipboard.cs
@@ -579,68 +579,115 @@ internal static class Clipboard
                 // the file ends up owned by that user and inherits the folder's permissions. On the
                 // logon/screen-saver desktop the storage lives under Program Files where there is no
                 // interactive user to impersonate, so create the file directly.
-                void CreateDestinationFile(string path)
+                void CloseDestinationFile()
                 {
-                    if (Common.RunOnLogonDesktop || Common.RunOnScrSaverDesktop)
+                    m?.Close();
+                    m = null;
+                }
+
+                bool TryCreateDestinationFile(string path)
+                {
+                    CloseDestinationFile();
+
+                    bool success = false;
+                    try
                     {
-                        m = new FileStream(path, FileMode.Create);
-                    }
-                    else
-                    {
-                        bool success = Launch.ImpersonateLoggedOnUserAndDoSomething(() =>
+                        if (Common.RunOnLogonDesktop || Common.RunOnScrSaverDesktop)
                         {
                             m = new FileStream(path, FileMode.Create);
-                        });
+                            success = true;
+                        }
+                        else
+                        {
+                            success = Launch.ImpersonateLoggedOnUserAndDoSomething(() =>
+                            {
+                                m = new FileStream(path, FileMode.Create);
+                            });
+                        }
 
                         if (!success || m == null)
                         {
-                            Logger.Log("Impersonation failed for file creation, falling back to direct creation.");
-                            m = new FileStream(path, FileMode.Create);
+                            Logger.Log(string.Format(
+                                CultureInfo.CurrentCulture,
+                                "Could not create destination file while impersonating the logged-on user: {0}",
+                                path));
                         }
                     }
+                    catch (Exception e)
+                    {
+                        Logger.Log(e);
+                        CloseDestinationFile();
+                    }
+
+                    return success && m != null;
                 }
 
                 if (postAct.Equals("desktop", StringComparison.OrdinalIgnoreCase))
                 {
                     // Create the folder and open the file in a single impersonated scope so both
                     // are owned by the logged-on user. This branch always targets the user's Desktop.
-                    bool success = Launch.ImpersonateLoggedOnUserAndDoSomething(() =>
+                    CloseDestinationFile();
+                    bool success = false;
+                    try
                     {
-                        savingFolder = Environment.GetFolderPath(Environment.SpecialFolder.Desktop) + "\\MouseWithoutBorders\\";
-
-                        if (!Directory.Exists(savingFolder))
+                        success = Launch.ImpersonateLoggedOnUserAndDoSomething(() =>
                         {
-                            _ = Directory.CreateDirectory(savingFolder);
-                        }
+                            savingFolder = Environment.GetFolderPath(Environment.SpecialFolder.Desktop) + "\\MouseWithoutBorders\\";
+                            tempFile = savingFolder + Path.GetFileName(fileName);
 
-                        tempFile = savingFolder + Path.GetFileName(fileName);
-                        m = new FileStream(tempFile, FileMode.Create);
-                    });
+                            if (!Directory.Exists(savingFolder))
+                            {
+                                _ = Directory.CreateDirectory(savingFolder);
+                            }
+
+                            m = new FileStream(tempFile, FileMode.Create);
+                        });
+                    }
+                    catch (Exception e)
+                    {
+                        Logger.Log(e);
+                        CloseDestinationFile();
+                    }
 
                     if (!success || m == null)
                     {
-                        Logger.Log("Impersonation failed for desktop file creation, falling back to direct creation.");
-                        savingFolder = Environment.GetFolderPath(Environment.SpecialFolder.Desktop) + "\\MouseWithoutBorders\\";
-                        if (!Directory.Exists(savingFolder))
-                        {
-                            _ = Directory.CreateDirectory(savingFolder);
-                        }
-
-                        tempFile = savingFolder + Path.GetFileName(fileName);
-                        m = new FileStream(tempFile, FileMode.Create);
+                        CloseDestinationFile();
+                        string destinationPath = tempFile.Equals("data", StringComparison.Ordinal)
+                            ? Path.GetFileName(fileName)
+                            : tempFile;
+                        Logger.Log(string.Format(
+                            CultureInfo.CurrentCulture,
+                            "Could not create desktop destination file while impersonating the logged-on user: {0}",
+                            destinationPath));
+                        Common.SetToggleIcon(new int[Common.TOGGLE_ICONS_SIZE] { Common.ICON_ERROR, -1, Common.ICON_ERROR, -1 });
+                        Common.ShowToolTip("Could not create the destination file.", 1000, ToolTipIcon.Warning, Setting.Values.ShowClipNetStatus);
+                        s.Close();
+                        return;
                     }
                 }
                 else if (postAct.Contains("mspaint"))
                 {
                     tempFile = Common.GetMyStorageDir() + @"ScreenCapture-" +
                         remoteMachine + ".png";
-                    CreateDestinationFile(tempFile);
+                    if (!TryCreateDestinationFile(tempFile))
+                    {
+                        Common.SetToggleIcon(new int[Common.TOGGLE_ICONS_SIZE] { Common.ICON_ERROR, -1, Common.ICON_ERROR, -1 });
+                        Common.ShowToolTip("Could not create the destination file.", 1000, ToolTipIcon.Warning, Setting.Values.ShowClipNetStatus);
+                        s.Close();
+                        return;
+                    }
                 }
                 else
                 {
                     tempFile = Common.GetMyStorageDir();
                     tempFile += Path.GetFileName(fileName);
-                    CreateDestinationFile(tempFile);
+                    if (!TryCreateDestinationFile(tempFile))
+                    {
+                        Common.SetToggleIcon(new int[Common.TOGGLE_ICONS_SIZE] { Common.ICON_ERROR, -1, Common.ICON_ERROR, -1 });
+                        Common.ShowToolTip("Could not create the destination file.", 1000, ToolTipIcon.Warning, Setting.Values.ShowClipNetStatus);
+                        s.Close();
+                        return;
+                    }
                 }
 
                 Logger.Log("==> " + tempFile);

--- a/src/modules/MouseWithoutBorders/App/Core/Clipboard.cs
+++ b/src/modules/MouseWithoutBorders/App/Core/Clipboard.cs
@@ -510,6 +510,48 @@ internal static class Clipboard
             clipboardThreadOld = Thread.CurrentThread;
         }
 
+        ReceivedDestinationFile destinationFile = null;
+
+        void CloseDestinationFile()
+        {
+            destinationFile?.Dispose();
+            destinationFile = null;
+            m?.Close();
+            m = null;
+        }
+
+        void DeleteDestinationFile(string path)
+        {
+            try
+            {
+                bool success;
+                if (Common.RunOnLogonDesktop || Common.RunOnScrSaverDesktop)
+                {
+                    File.Delete(path);
+                    success = true;
+                }
+                else
+                {
+                    success = Launch.ImpersonateLoggedOnUserAndDoSomething(() => File.Delete(path));
+                }
+
+                if (!success)
+                {
+                    Logger.Log($"Could not delete incomplete destination file: {path}");
+                }
+            }
+            catch (Exception e)
+            {
+                Logger.Log(e);
+            }
+        }
+
+        void CreateDestinationFile(string path)
+        {
+            destinationFile = new ReceivedDestinationFile(path, DeleteDestinationFile);
+            m = destinationFile.Stream;
+        }
+
         try
         {
             byte[] header = new byte[1024];
@@ -579,12 +621,6 @@ internal static class Clipboard
                 // the file ends up owned by that user and inherits the folder's permissions. On the
                 // logon/screen-saver desktop the storage lives under Program Files where there is no
                 // interactive user to impersonate, so create the file directly.
-                void CloseDestinationFile()
-                {
-                    m?.Close();
-                    m = null;
-                }
-
                 bool TryCreateDestinationFile(string path)
                 {
                     CloseDestinationFile();
@@ -594,14 +630,14 @@ internal static class Clipboard
                     {
                         if (Common.RunOnLogonDesktop || Common.RunOnScrSaverDesktop)
                         {
-                            m = new FileStream(path, FileMode.Create);
+                            CreateDestinationFile(path);
                             success = true;
                         }
                         else
                         {
                             success = Launch.ImpersonateLoggedOnUserAndDoSomething(() =>
                             {
-                                m = new FileStream(path, FileMode.Create);
+                                CreateDestinationFile(path);
                             });
                         }
 
@@ -640,7 +676,7 @@ internal static class Clipboard
                                 _ = Directory.CreateDirectory(savingFolder);
                             }
 
-                            m = new FileStream(tempFile, FileMode.Create);
+                            CreateDestinationFile(tempFile);
                         });
                     }
                     catch (Exception e)
@@ -737,9 +773,27 @@ internal static class Clipboard
             }
             while (rv > 0);
 
+            if (receivedCount != dataSize)
+            {
+                Logger.Log($"Received incomplete file: expected {dataSize} bytes, received {receivedCount} bytes.");
+                CloseDestinationFile();
+                Common.SetToggleIcon(new int[Common.TOGGLE_ICONS_SIZE] { Common.ICON_ERROR, -1, Common.ICON_ERROR, -1 });
+                Common.ShowToolTip("Could not receive the complete destination file.", 1000, ToolTipIcon.Warning, Setting.Values.ShowClipNetStatus);
+                s.Close();
+                return;
+            }
+
             if (m != null && fileName != null)
             {
-                m.Flush();
+                if (destinationFile != null)
+                {
+                    destinationFile.Complete();
+                }
+                else
+                {
+                    m.Flush();
+                }
+
                 Logger.LogDebug(m.Length.ToString(CultureInfo.CurrentCulture) + " bytes received.");
                 Clipboard.LastClipboardEventTime = Common.GetTick();
                 string toolTipText = null;
@@ -829,20 +883,14 @@ internal static class Clipboard
                     Common.MainForm.UpdateNotifyIcon();
                 });
 
-                m?.Close();
-                m = null;
+                CloseDestinationFile();
             }
         }
         catch (ThreadAbortException)
         {
             Logger.Log("The current thread is being aborted (3).");
             s.Close();
-
-            if (m != null)
-            {
-                m.Close();
-                m = null;
-            }
+            CloseDestinationFile();
 
             return;
         }
@@ -864,12 +912,7 @@ internal static class Clipboard
                 -1, Common.ICON_BIG_CLIPBOARD, -1,
             });
             Common.ShowToolTip(e.Message, 1000, ToolTipIcon.Info, Setting.Values.ShowClipNetStatus);
-
-            if (m != null)
-            {
-                m.Close();
-                m = null;
-            }
+            CloseDestinationFile();
 
             return;
         }

--- a/src/modules/MouseWithoutBorders/App/Core/Clipboard.cs
+++ b/src/modules/MouseWithoutBorders/App/Core/Clipboard.cs
@@ -399,8 +399,6 @@ internal static class Clipboard
         }
     }
 
-    private static Stream m;
-
     private static void ConnectAndGetData(object postAction)
     {
         if (Common.Sk == null)
@@ -491,23 +489,76 @@ internal static class Clipboard
     {
         lock (ClipboardThreadOldLock)
         {
-            // Do not enable two connections at the same time.
-            if (clipboardThreadOld != null && clipboardThreadOld.ThreadState != System.Threading.ThreadState.AbortRequested
-                && clipboardThreadOld.ThreadState != System.Threading.ThreadState.Aborted && clipboardThreadOld.IsAlive
-                && clipboardThreadOld.ManagedThreadId != Thread.CurrentThread.ManagedThreadId)
+            if (!CanStartClipboardReceive(clipboardThreadOld, Thread.CurrentThread, 3000))
             {
-                if (clipboardThreadOld.Join(3000))
-                {
-                    if (m != null)
-                    {
-                        m.Flush();
-                        m.Close();
-                        m = null;
-                    }
-                }
+                Logger.Log("Rejecting clipboard transfer because the previous transfer is still active.");
+                s.Close();
+                return;
             }
 
             clipboardThreadOld = Thread.CurrentThread;
+        }
+
+        ReceivedDestinationFile destinationFile = null;
+        Stream m = null;
+
+        void CloseDestinationFile()
+        {
+            destinationFile?.Dispose();
+            destinationFile = null;
+            m?.Close();
+            m = null;
+        }
+
+        void DeleteDestinationFile(string path)
+        {
+            try
+            {
+                bool success;
+                if (Common.RunOnLogonDesktop || Common.RunOnScrSaverDesktop)
+                {
+                    File.Delete(path);
+                    success = true;
+                }
+                else
+                {
+                    success = Launch.ImpersonateLoggedOnUserAndDoSomething(() => File.Delete(path));
+                }
+
+                if (!success)
+                {
+                    Logger.Log($"Could not delete incomplete destination file: {path}");
+                }
+            }
+            catch (Exception e)
+            {
+                Logger.Log(e);
+            }
+        }
+
+        void CommitDestinationFile(string sourcePath, string destinationPath)
+        {
+            bool success;
+            if (Common.RunOnLogonDesktop || Common.RunOnScrSaverDesktop)
+            {
+                File.Move(sourcePath, destinationPath, overwrite: true);
+                success = true;
+            }
+            else
+            {
+                success = Launch.ImpersonateLoggedOnUserAndDoSomething(() => File.Move(sourcePath, destinationPath, overwrite: true));
+            }
+
+            if (!success)
+            {
+                throw new IOException($"Could not replace destination file: {destinationPath}");
+            }
+        }
+
+        void CreateDestinationFile(string path)
+        {
+            destinationFile = new ReceivedDestinationFile(path, DeleteDestinationFile, CommitDestinationFile);
+            m = destinationFile.Stream;
         }
 
         try
@@ -574,32 +625,115 @@ internal static class Clipboard
             }
             else
             {
+                // Create received files in the same context that the destination folder is created
+                // in. For per-user storage (the user's Desktop) that means as the logged-on user, so
+                // the file ends up owned by that user and inherits the folder's permissions. On the
+                // logon/screen-saver desktop the storage lives under Program Files where there is no
+                // interactive user to impersonate, so create the file directly.
+                bool TryCreateDestinationFile(string path)
+                {
+                    CloseDestinationFile();
+
+                    bool success = false;
+                    try
+                    {
+                        if (Common.RunOnLogonDesktop || Common.RunOnScrSaverDesktop)
+                        {
+                            CreateDestinationFile(path);
+                            success = true;
+                        }
+                        else
+                        {
+                            success = Launch.ImpersonateLoggedOnUserAndDoSomething(() =>
+                            {
+                                CreateDestinationFile(path);
+                            });
+                        }
+
+                        if (!success || m == null)
+                        {
+                            CloseDestinationFile();
+                            Logger.Log(string.Format(
+                                CultureInfo.CurrentCulture,
+                                "Could not create destination file: {0}",
+                                path));
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        Logger.Log(e);
+                        CloseDestinationFile();
+                    }
+
+                    return success && m != null;
+                }
+
                 if (postAct.Equals("desktop", StringComparison.OrdinalIgnoreCase))
                 {
-                    _ = Launch.ImpersonateLoggedOnUserAndDoSomething(() =>
+                    // Create the folder and open the file in a single impersonated scope so both
+                    // are owned by the logged-on user. This branch always targets the user's Desktop.
+                    CloseDestinationFile();
+                    bool success = false;
+                    try
                     {
-                        savingFolder = Environment.GetFolderPath(Environment.SpecialFolder.Desktop) + "\\MouseWithoutBorders\\";
-
-                        if (!Directory.Exists(savingFolder))
+                        success = Launch.ImpersonateLoggedOnUserAndDoSomething(() =>
                         {
-                            _ = Directory.CreateDirectory(savingFolder);
-                        }
-                    });
+                            savingFolder = Environment.GetFolderPath(Environment.SpecialFolder.Desktop) + "\\MouseWithoutBorders\\";
+                            tempFile = savingFolder + Path.GetFileName(fileName);
 
-                    tempFile = savingFolder + Path.GetFileName(fileName);
-                    m = new FileStream(tempFile, FileMode.Create);
+                            if (!Directory.Exists(savingFolder))
+                            {
+                                _ = Directory.CreateDirectory(savingFolder);
+                            }
+
+                            CreateDestinationFile(tempFile);
+                        });
+                    }
+                    catch (Exception e)
+                    {
+                        Logger.Log(e);
+                        CloseDestinationFile();
+                    }
+
+                    if (!success || m == null)
+                    {
+                        CloseDestinationFile();
+                        string destinationPath = tempFile.Equals("data", StringComparison.Ordinal)
+                            ? Path.GetFileName(fileName)
+                            : tempFile;
+                        Logger.Log(string.Format(
+                            CultureInfo.CurrentCulture,
+                            "Could not create desktop destination file while impersonating the logged-on user: {0}",
+                            destinationPath));
+                        Common.SetToggleIcon(new int[Common.TOGGLE_ICONS_SIZE] { Common.ICON_ERROR, -1, Common.ICON_ERROR, -1 });
+                        Common.ShowToolTip("Could not create the destination file.", 1000, ToolTipIcon.Warning, Setting.Values.ShowClipNetStatus);
+                        s.Close();
+                        return;
+                    }
                 }
                 else if (postAct.Contains("mspaint"))
                 {
                     tempFile = Common.GetMyStorageDir() + @"ScreenCapture-" +
                         remoteMachine + ".png";
-                    m = new FileStream(tempFile, FileMode.Create);
+                    if (!TryCreateDestinationFile(tempFile))
+                    {
+                        Common.SetToggleIcon(new int[Common.TOGGLE_ICONS_SIZE] { Common.ICON_ERROR, -1, Common.ICON_ERROR, -1 });
+                        Common.ShowToolTip("Could not create the destination file.", 1000, ToolTipIcon.Warning, Setting.Values.ShowClipNetStatus);
+                        s.Close();
+                        return;
+                    }
                 }
                 else
                 {
                     tempFile = Common.GetMyStorageDir();
                     tempFile += Path.GetFileName(fileName);
-                    m = new FileStream(tempFile, FileMode.Create);
+                    if (!TryCreateDestinationFile(tempFile))
+                    {
+                        Common.SetToggleIcon(new int[Common.TOGGLE_ICONS_SIZE] { Common.ICON_ERROR, -1, Common.ICON_ERROR, -1 });
+                        Common.ShowToolTip("Could not create the destination file.", 1000, ToolTipIcon.Warning, Setting.Values.ShowClipNetStatus);
+                        s.Close();
+                        return;
+                    }
                 }
 
                 Logger.Log("==> " + tempFile);
@@ -621,14 +755,7 @@ internal static class Clipboard
 
                 if (rv > 0)
                 {
-                    receivedCount += rv;
-
-                    if (receivedCount > dataSize)
-                    {
-                        rv -= (int)(receivedCount - dataSize);
-                    }
-
-                    m.Write(buf, 0, rv);
+                    rv = WriteReceivedData(m, buf, rv, dataSize, ref receivedCount);
                 }
 
                 if (Common.ToggleIcons == null)
@@ -649,15 +776,34 @@ internal static class Clipboard
             }
             while (rv > 0);
 
+            if (!HasExpectedReceivedDataLength(m, dataSize))
+            {
+                Logger.Log($"Received incomplete file: expected {dataSize} bytes, wrote {m.Length} bytes.");
+                CloseDestinationFile();
+                Common.SetToggleIcon(new int[Common.TOGGLE_ICONS_SIZE] { Common.ICON_ERROR, -1, Common.ICON_ERROR, -1 });
+                Common.ShowToolTip("Could not receive the complete destination file.", 1000, ToolTipIcon.Warning, Setting.Values.ShowClipNetStatus);
+                s.Close();
+                return;
+            }
+
             if (m != null && fileName != null)
             {
-                m.Flush();
-                Logger.LogDebug(m.Length.ToString(CultureInfo.CurrentCulture) + " bytes received.");
+                long receivedLength = m.Length;
+                if (destinationFile != null)
+                {
+                    destinationFile.Complete();
+                }
+                else
+                {
+                    m.Flush();
+                }
+
+                Logger.LogDebug(receivedLength.ToString(CultureInfo.CurrentCulture) + " bytes received.");
                 Clipboard.LastClipboardEventTime = Common.GetTick();
                 string toolTipText = null;
-                string sizeText = m.Length >= 1024
-                    ? (m.Length / 1024).ToString(CultureInfo.CurrentCulture) + "KB"
-                    : m.Length.ToString(CultureInfo.CurrentCulture) + "Bytes";
+                string sizeText = receivedLength >= 1024
+                    ? (receivedLength / 1024).ToString(CultureInfo.CurrentCulture) + "KB"
+                    : receivedLength.ToString(CultureInfo.CurrentCulture) + "Bytes";
 
                 PowerToysTelemetry.Log.WriteEvent(new MouseWithoutBorders.Telemetry.MouseWithoutBordersClipboardFileTransferEvent());
 
@@ -741,20 +887,14 @@ internal static class Clipboard
                     Common.MainForm.UpdateNotifyIcon();
                 });
 
-                m?.Close();
-                m = null;
+                CloseDestinationFile();
             }
         }
         catch (ThreadAbortException)
         {
             Logger.Log("The current thread is being aborted (3).");
             s.Close();
-
-            if (m != null)
-            {
-                m.Close();
-                m = null;
-            }
+            CloseDestinationFile();
 
             return;
         }
@@ -776,17 +916,40 @@ internal static class Clipboard
                 -1, Common.ICON_BIG_CLIPBOARD, -1,
             });
             Common.ShowToolTip(e.Message, 1000, ToolTipIcon.Info, Setting.Values.ShowClipNetStatus);
-
-            if (m != null)
-            {
-                m.Close();
-                m = null;
-            }
+            CloseDestinationFile();
 
             return;
         }
 
         s.Close();
+    }
+
+    internal static bool CanStartClipboardReceive(System.Threading.Thread previousReceiveThread, System.Threading.Thread currentReceiveThread, int waitMilliseconds)
+    {
+        return previousReceiveThread == null ||
+            previousReceiveThread.ThreadState == System.Threading.ThreadState.AbortRequested ||
+            previousReceiveThread.ThreadState == System.Threading.ThreadState.Aborted ||
+            !previousReceiveThread.IsAlive ||
+            previousReceiveThread.ManagedThreadId == currentReceiveThread.ManagedThreadId ||
+            previousReceiveThread.Join(waitMilliseconds);
+    }
+
+    internal static bool HasExpectedReceivedDataLength(Stream destination, long expectedLength)
+    {
+        return destination.Length == expectedLength;
+    }
+
+    internal static int WriteReceivedData(Stream destination, byte[] buffer, int bytesReceived, long expectedLength, ref long receivedCount)
+    {
+        receivedCount += bytesReceived;
+
+        if (receivedCount > expectedLength)
+        {
+            bytesReceived -= (int)(receivedCount - expectedLength);
+        }
+
+        destination.Write(buffer, 0, bytesReceived);
+        return bytesReceived;
     }
 
     internal static bool ShakeHand(ref string remoteName, Socket s, out Stream enStream, out Stream deStream, ref bool clientPushData, ref ClipboardPostAction postAction)
@@ -891,12 +1054,6 @@ internal static class Clipboard
             });
             Common.MainForm.UpdateNotifyIcon();
             Common.ShowToolTip(e.Message + "\r\n\r\nMake sure you run the same version in all machines.", 1000, ToolTipIcon.Warning, Setting.Values.ShowClipNetStatus);
-
-            if (m != null)
-            {
-                m.Close();
-                m = null;
-            }
         }
 
         return handShaken;

--- a/src/modules/MouseWithoutBorders/App/Core/Clipboard.cs
+++ b/src/modules/MouseWithoutBorders/App/Core/Clipboard.cs
@@ -372,8 +372,7 @@ internal static class Clipboard
         }
     }
 
-    private static readonly Lock ClipboardThreadOldLock = new();
-    private static System.Threading.Thread clipboardThreadOld;
+    private static readonly SemaphoreSlim ClipboardReceiveGate = new(initialCount: 1, maxCount: 1);
 
     internal static void GetRemoteClipboard(string postAction)
     {
@@ -487,18 +486,17 @@ internal static class Clipboard
 
     internal static void ReceiveAndProcessClipboardData(string remoteMachine, Socket s, Stream enStream, Stream deStream, string postAct)
     {
-        lock (ClipboardThreadOldLock)
+        if (!ExecuteClipboardReceive(
+                () => ReceiveAndProcessClipboardDataCore(remoteMachine, s, enStream, deStream, postAct),
+                waitMilliseconds: 3000))
         {
-            if (!CanStartClipboardReceive(clipboardThreadOld, Thread.CurrentThread, 3000))
-            {
-                Logger.Log("Rejecting clipboard transfer because the previous transfer is still active.");
-                s.Close();
-                return;
-            }
-
-            clipboardThreadOld = Thread.CurrentThread;
+            Logger.Log("Rejecting clipboard transfer because the previous transfer is still active.");
+            s.Close();
         }
+    }
 
+    private static void ReceiveAndProcessClipboardDataCore(string remoteMachine, Socket s, Stream enStream, Stream deStream, string postAct)
+    {
         ReceivedDestinationFile destinationFile = null;
         Stream m = null;
 
@@ -924,14 +922,22 @@ internal static class Clipboard
         s.Close();
     }
 
-    internal static bool CanStartClipboardReceive(System.Threading.Thread previousReceiveThread, System.Threading.Thread currentReceiveThread, int waitMilliseconds)
+    internal static bool ExecuteClipboardReceive(Action receiveAction, int waitMilliseconds)
     {
-        return previousReceiveThread == null ||
-            previousReceiveThread.ThreadState == System.Threading.ThreadState.AbortRequested ||
-            previousReceiveThread.ThreadState == System.Threading.ThreadState.Aborted ||
-            !previousReceiveThread.IsAlive ||
-            previousReceiveThread.ManagedThreadId == currentReceiveThread.ManagedThreadId ||
-            previousReceiveThread.Join(waitMilliseconds);
+        if (!ClipboardReceiveGate.Wait(waitMilliseconds))
+        {
+            return false;
+        }
+
+        try
+        {
+            receiveAction();
+            return true;
+        }
+        finally
+        {
+            ClipboardReceiveGate.Release();
+        }
     }
 
     internal static bool HasExpectedReceivedDataLength(Stream destination, long expectedLength)

--- a/src/modules/MouseWithoutBorders/App/Core/Launch.cs
+++ b/src/modules/MouseWithoutBorders/App/Core/Launch.cs
@@ -41,13 +41,12 @@ internal static class Launch
             // on subsequent calls. The reason appears to be an unknown issue with reverting the impersonation,
             // meaning that subsequent impersonation attempts run as the logged-on user and fail.
             // This is a workaround.
-            using var asyncFlowControl = System.Threading.ExecutionContext.SuppressFlow();
-
-            uint dwSessionId;
             IntPtr hUserToken = IntPtr.Zero, hUserTokenDup = IntPtr.Zero;
             try
             {
-                dwSessionId = (uint)Process.GetCurrentProcess().SessionId;
+                using var asyncFlowControl = System.Threading.ExecutionContext.SuppressFlow();
+
+                uint dwSessionId = (uint)Process.GetCurrentProcess().SessionId;
                 uint rv = NativeMethods.WTSQueryUserToken(dwSessionId, ref hUserToken);
                 var lastError = rv == 0 ? Marshal.GetLastWin32Error() : 0;
 
@@ -62,32 +61,77 @@ internal static class Launch
                 if (!NativeMethods.DuplicateToken(hUserToken, (int)NativeMethods.SECURITY_IMPERSONATION_LEVEL.SecurityImpersonation, ref hUserTokenDup))
                 {
                     Logger.TelemetryLogTrace($"{nameof(NativeMethods.DuplicateToken)} Failed! {Logger.GetStackTrace(new StackTrace())}", SeverityLevel.Warning);
-                    _ = NativeMethods.CloseHandle(hUserToken);
-                    _ = NativeMethods.CloseHandle(hUserTokenDup);
                     return false;
                 }
 
-                if (NativeMethods.ImpersonateLoggedOnUser(hUserTokenDup))
-                {
-                    targetFunc();
-                    _ = NativeMethods.RevertToSelf();
-                    _ = NativeMethods.CloseHandle(hUserToken);
-                    _ = NativeMethods.CloseHandle(hUserTokenDup);
-                    return true;
-                }
-                else
+                if (!NativeMethods.ImpersonateLoggedOnUser(hUserTokenDup))
                 {
                     Logger.Log("ImpersonateLoggedOnUser Failed!");
-                    _ = NativeMethods.CloseHandle(hUserToken);
-                    _ = NativeMethods.CloseHandle(hUserTokenDup);
                     return false;
                 }
+
+                ExecuteImpersonatedAction(
+                    targetFunc,
+                    NativeMethods.RevertToSelf,
+                    Marshal.GetLastWin32Error,
+                    Environment.FailFast);
+                return true;
             }
             catch (Exception e)
             {
                 Logger.Log(e);
                 return false;
             }
+            finally
+            {
+                if (hUserToken != IntPtr.Zero)
+                {
+                    _ = NativeMethods.CloseHandle(hUserToken);
+                }
+
+                if (hUserTokenDup != IntPtr.Zero)
+                {
+                    _ = NativeMethods.CloseHandle(hUserTokenDup);
+                }
+            }
+        }
+    }
+
+    internal static void ExecuteImpersonatedAction(Action targetFunc, Func<bool> revertToSelf, Func<int> getLastWin32Error, Action<string, Exception> failFast)
+    {
+        var impersonating = true;
+        try
+        {
+            ExecuteImpersonatedAction(targetFunc, () =>
+            {
+                if (!revertToSelf())
+                {
+                    throw new Win32Exception(getLastWin32Error(), $"{nameof(NativeMethods.RevertToSelf)} failed.");
+                }
+
+                impersonating = false;
+            });
+        }
+        finally
+        {
+            if (impersonating && !revertToSelf())
+            {
+                failFast(
+                    $"{nameof(NativeMethods.RevertToSelf)} failed; terminating to avoid continuing under the impersonated token.",
+                    new Win32Exception(getLastWin32Error()));
+            }
+        }
+    }
+
+    internal static void ExecuteImpersonatedAction(Action targetFunc, Action revertToSelf)
+    {
+        try
+        {
+            targetFunc();
+        }
+        finally
+        {
+            revertToSelf();
         }
     }
 

--- a/src/modules/MouseWithoutBorders/App/Core/Launch.cs
+++ b/src/modules/MouseWithoutBorders/App/Core/Launch.cs
@@ -72,7 +72,11 @@ internal static class Launch
                 }
 
                 impersonating = true;
-                targetFunc();
+                ExecuteImpersonatedAction(targetFunc, () =>
+                {
+                    _ = NativeMethods.RevertToSelf();
+                    impersonating = false;
+                });
                 return true;
             }
             catch (Exception e)
@@ -97,6 +101,18 @@ internal static class Launch
                     _ = NativeMethods.CloseHandle(hUserTokenDup);
                 }
             }
+        }
+    }
+
+    internal static void ExecuteImpersonatedAction(Action targetFunc, Action revertToSelf)
+    {
+        try
+        {
+            targetFunc();
+        }
+        finally
+        {
+            revertToSelf();
         }
     }
 

--- a/src/modules/MouseWithoutBorders/App/Core/Launch.cs
+++ b/src/modules/MouseWithoutBorders/App/Core/Launch.cs
@@ -41,13 +41,13 @@ internal static class Launch
             // on subsequent calls. The reason appears to be an unknown issue with reverting the impersonation,
             // meaning that subsequent impersonation attempts run as the logged-on user and fail.
             // This is a workaround.
-            using var asyncFlowControl = System.Threading.ExecutionContext.SuppressFlow();
-
-            uint dwSessionId;
             IntPtr hUserToken = IntPtr.Zero, hUserTokenDup = IntPtr.Zero;
+            bool impersonating = false;
             try
             {
-                dwSessionId = (uint)Process.GetCurrentProcess().SessionId;
+                using var asyncFlowControl = System.Threading.ExecutionContext.SuppressFlow();
+
+                uint dwSessionId = (uint)Process.GetCurrentProcess().SessionId;
                 uint rv = NativeMethods.WTSQueryUserToken(dwSessionId, ref hUserToken);
                 var lastError = rv == 0 ? Marshal.GetLastWin32Error() : 0;
 
@@ -62,31 +62,40 @@ internal static class Launch
                 if (!NativeMethods.DuplicateToken(hUserToken, (int)NativeMethods.SECURITY_IMPERSONATION_LEVEL.SecurityImpersonation, ref hUserTokenDup))
                 {
                     Logger.TelemetryLogTrace($"{nameof(NativeMethods.DuplicateToken)} Failed! {Logger.GetStackTrace(new StackTrace())}", SeverityLevel.Warning);
-                    _ = NativeMethods.CloseHandle(hUserToken);
-                    _ = NativeMethods.CloseHandle(hUserTokenDup);
                     return false;
                 }
 
-                if (NativeMethods.ImpersonateLoggedOnUser(hUserTokenDup))
-                {
-                    targetFunc();
-                    _ = NativeMethods.RevertToSelf();
-                    _ = NativeMethods.CloseHandle(hUserToken);
-                    _ = NativeMethods.CloseHandle(hUserTokenDup);
-                    return true;
-                }
-                else
+                if (!NativeMethods.ImpersonateLoggedOnUser(hUserTokenDup))
                 {
                     Logger.Log("ImpersonateLoggedOnUser Failed!");
-                    _ = NativeMethods.CloseHandle(hUserToken);
-                    _ = NativeMethods.CloseHandle(hUserTokenDup);
                     return false;
                 }
+
+                impersonating = true;
+                targetFunc();
+                return true;
             }
             catch (Exception e)
             {
                 Logger.Log(e);
                 return false;
+            }
+            finally
+            {
+                if (impersonating)
+                {
+                    _ = NativeMethods.RevertToSelf();
+                }
+
+                if (hUserToken != IntPtr.Zero)
+                {
+                    _ = NativeMethods.CloseHandle(hUserToken);
+                }
+
+                if (hUserTokenDup != IntPtr.Zero)
+                {
+                    _ = NativeMethods.CloseHandle(hUserTokenDup);
+                }
             }
         }
     }

--- a/src/modules/MouseWithoutBorders/App/Core/ReceivedDestinationFile.cs
+++ b/src/modules/MouseWithoutBorders/App/Core/ReceivedDestinationFile.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+
+namespace MouseWithoutBorders.Core;
+
+internal sealed class ReceivedDestinationFile : IDisposable
+{
+    private readonly Action<string, string> commitFile;
+    private readonly Action<string> deleteFile;
+    private readonly string destinationPath;
+    private readonly string stagingPath;
+    private bool completed;
+
+    internal ReceivedDestinationFile(string destinationPath, Action<string> deleteFile, Action<string, string> commitFile)
+    {
+        this.destinationPath = destinationPath;
+        this.deleteFile = deleteFile;
+        this.commitFile = commitFile;
+
+        stagingPath = Path.Combine(
+            Path.GetDirectoryName(destinationPath) ?? ".",
+            $".{Guid.NewGuid():N}.partial");
+        Stream = new FileStream(stagingPath, FileMode.CreateNew);
+    }
+
+    internal FileStream Stream { get; }
+
+    internal void Complete()
+    {
+        Stream.Flush();
+        Stream.Dispose();
+        commitFile(stagingPath, destinationPath);
+        completed = true;
+    }
+
+    public void Dispose()
+    {
+        Stream.Dispose();
+
+        if (!completed)
+        {
+            deleteFile(stagingPath);
+        }
+    }
+}

--- a/src/modules/MouseWithoutBorders/App/Core/ReceivedDestinationFile.cs
+++ b/src/modules/MouseWithoutBorders/App/Core/ReceivedDestinationFile.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+
+namespace MouseWithoutBorders.Core;
+
+internal sealed class ReceivedDestinationFile : IDisposable
+{
+    private readonly Action<string> deleteFile;
+    private readonly string path;
+    private bool completed;
+
+    internal ReceivedDestinationFile(string path, Action<string> deleteFile)
+    {
+        this.path = path;
+        this.deleteFile = deleteFile;
+
+        try
+        {
+            Stream = new FileStream(path, FileMode.CreateNew);
+            DeleteOnFailure = true;
+        }
+        catch (IOException)
+        {
+            Stream = new FileStream(path, FileMode.Create);
+        }
+    }
+
+    internal FileStream Stream { get; }
+
+    internal bool DeleteOnFailure { get; }
+
+    internal void Complete()
+    {
+        Stream.Flush();
+        completed = true;
+    }
+
+    public void Dispose()
+    {
+        Stream.Dispose();
+
+        if (DeleteOnFailure && !completed)
+        {
+            deleteFile(path);
+        }
+    }
+}

--- a/src/modules/MouseWithoutBorders/App/Core/ReceivedDestinationFile.cs
+++ b/src/modules/MouseWithoutBorders/App/Core/ReceivedDestinationFile.cs
@@ -9,33 +9,31 @@ namespace MouseWithoutBorders.Core;
 
 internal sealed class ReceivedDestinationFile : IDisposable
 {
+    private readonly Action<string, string> commitFile;
     private readonly Action<string> deleteFile;
-    private readonly string path;
+    private readonly string destinationPath;
+    private readonly string stagingPath;
     private bool completed;
 
-    internal ReceivedDestinationFile(string path, Action<string> deleteFile)
+    internal ReceivedDestinationFile(string destinationPath, Action<string> deleteFile, Action<string, string> commitFile)
     {
-        this.path = path;
+        this.destinationPath = destinationPath;
         this.deleteFile = deleteFile;
+        this.commitFile = commitFile;
 
-        try
-        {
-            Stream = new FileStream(path, FileMode.CreateNew);
-            DeleteOnFailure = true;
-        }
-        catch (IOException)
-        {
-            Stream = new FileStream(path, FileMode.Create);
-        }
+        stagingPath = Path.Combine(
+            Path.GetDirectoryName(destinationPath) ?? ".",
+            $".{Path.GetFileName(destinationPath)}.{Guid.NewGuid():N}.partial");
+        Stream = new FileStream(stagingPath, FileMode.CreateNew);
     }
 
     internal FileStream Stream { get; }
 
-    internal bool DeleteOnFailure { get; }
-
     internal void Complete()
     {
         Stream.Flush();
+        Stream.Dispose();
+        commitFile(stagingPath, destinationPath);
         completed = true;
     }
 
@@ -43,9 +41,9 @@ internal sealed class ReceivedDestinationFile : IDisposable
     {
         Stream.Dispose();
 
-        if (DeleteOnFailure && !completed)
+        if (!completed)
         {
-            deleteFile(path);
+            deleteFile(stagingPath);
         }
     }
 }

--- a/src/modules/MouseWithoutBorders/MouseWithoutBorders.UnitTests/Core/ReceivedDestinationFileTests.cs
+++ b/src/modules/MouseWithoutBorders/MouseWithoutBorders.UnitTests/Core/ReceivedDestinationFileTests.cs
@@ -1,0 +1,87 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MouseWithoutBorders.Core;
+
+namespace MouseWithoutBorders.UnitTests.Core;
+
+[TestClass]
+public sealed class ReceivedDestinationFileTests
+{
+    [TestMethod]
+    public void ExecuteImpersonatedActionRevertsWhenCallbackThrows()
+    {
+        var reverted = false;
+
+        Assert.ThrowsException<InvalidOperationException>(() => Launch.ExecuteImpersonatedAction(
+            () => throw new InvalidOperationException(),
+            () => reverted = true));
+
+        Assert.IsTrue(reverted);
+    }
+
+    [TestMethod]
+    public void IncompleteNewDestinationIsDeletedAfterWriteFailure()
+    {
+        var directory = CreateTestDirectory();
+        var path = Path.Combine(directory, "received.txt");
+
+        try
+        {
+            try
+            {
+                using var destination = new ReceivedDestinationFile(path, File.Delete);
+                destination.Stream.WriteByte(1);
+                throw new IOException("Simulated write failure.");
+            }
+            catch (IOException)
+            {
+            }
+
+            Assert.IsFalse(File.Exists(path));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public void IncompleteExistingDestinationIsNotDeletedAfterWriteFailure()
+    {
+        var directory = CreateTestDirectory();
+        var path = Path.Combine(directory, "received.txt");
+        File.WriteAllText(path, "existing");
+
+        try
+        {
+            try
+            {
+                using var destination = new ReceivedDestinationFile(path, File.Delete);
+                destination.Stream.WriteByte(1);
+                throw new IOException("Simulated write failure.");
+            }
+            catch (IOException)
+            {
+            }
+
+            Assert.IsTrue(File.Exists(path));
+            Assert.AreEqual(1L, new FileInfo(path).Length);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private static string CreateTestDirectory()
+    {
+        var directory = Path.Combine(AppContext.BaseDirectory, Guid.NewGuid().ToString("N"));
+        _ = Directory.CreateDirectory(directory);
+        return directory;
+    }
+}

--- a/src/modules/MouseWithoutBorders/MouseWithoutBorders.UnitTests/Core/ReceivedDestinationFileTests.cs
+++ b/src/modules/MouseWithoutBorders/MouseWithoutBorders.UnitTests/Core/ReceivedDestinationFileTests.cs
@@ -34,7 +34,7 @@ public sealed class ReceivedDestinationFileTests
         {
             try
             {
-                using var destination = new ReceivedDestinationFile(path, File.Delete);
+                using var destination = CreateDestinationFile(path);
                 destination.Stream.WriteByte(1);
                 throw new IOException("Simulated write failure.");
             }
@@ -43,6 +43,7 @@ public sealed class ReceivedDestinationFileTests
             }
 
             Assert.IsFalse(File.Exists(path));
+            Assert.AreEqual(0, Directory.GetFiles(directory).Length);
         }
         finally
         {
@@ -51,7 +52,7 @@ public sealed class ReceivedDestinationFileTests
     }
 
     [TestMethod]
-    public void IncompleteExistingDestinationIsNotDeletedAfterWriteFailure()
+    public void IncompleteExistingDestinationPreservesOriginalContents()
     {
         var directory = CreateTestDirectory();
         var path = Path.Combine(directory, "received.txt");
@@ -61,7 +62,7 @@ public sealed class ReceivedDestinationFileTests
         {
             try
             {
-                using var destination = new ReceivedDestinationFile(path, File.Delete);
+                using var destination = CreateDestinationFile(path);
                 destination.Stream.WriteByte(1);
                 throw new IOException("Simulated write failure.");
             }
@@ -70,12 +71,42 @@ public sealed class ReceivedDestinationFileTests
             }
 
             Assert.IsTrue(File.Exists(path));
-            Assert.AreEqual(1L, new FileInfo(path).Length);
+            Assert.AreEqual("existing", File.ReadAllText(path));
+            Assert.AreEqual(1, Directory.GetFiles(directory).Length);
         }
         finally
         {
             Directory.Delete(directory, recursive: true);
         }
+    }
+
+    [TestMethod]
+    public void CompleteExistingDestinationReplacesOriginalContents()
+    {
+        var directory = CreateTestDirectory();
+        var path = Path.Combine(directory, "received.txt");
+        File.WriteAllText(path, "existing");
+
+        try
+        {
+            using (var destination = CreateDestinationFile(path))
+            {
+                destination.Stream.WriteByte(1);
+                destination.Complete();
+            }
+
+            CollectionAssert.AreEqual(new byte[] { 1 }, File.ReadAllBytes(path));
+            Assert.AreEqual(1, Directory.GetFiles(directory).Length);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private static ReceivedDestinationFile CreateDestinationFile(string path)
+    {
+        return new ReceivedDestinationFile(path, File.Delete, (source, destination) => File.Move(source, destination, overwrite: true));
     }
 
     private static string CreateTestDirectory()

--- a/src/modules/MouseWithoutBorders/MouseWithoutBorders.UnitTests/Core/ReceivedDestinationFileTests.cs
+++ b/src/modules/MouseWithoutBorders/MouseWithoutBorders.UnitTests/Core/ReceivedDestinationFileTests.cs
@@ -1,0 +1,224 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.ComponentModel;
+using System.IO;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MouseWithoutBorders.Core;
+
+using SystemThread = System.Threading.Thread;
+
+namespace MouseWithoutBorders.UnitTests.Core;
+
+[TestClass]
+public sealed class ReceivedDestinationFileTests
+{
+    [TestMethod]
+    public void ExecuteImpersonatedActionRevertsWhenCallbackThrows()
+    {
+        var reverted = false;
+
+        Assert.ThrowsException<InvalidOperationException>(() => Launch.ExecuteImpersonatedAction(
+            () => throw new InvalidOperationException(),
+            () => reverted = true));
+
+        Assert.IsTrue(reverted);
+    }
+
+    [TestMethod]
+    public void ExecuteImpersonatedActionRetriesRevertAfterFirstFailure()
+    {
+        var reversionAttempts = 0;
+        var failFastCalled = false;
+
+        _ = Assert.ThrowsException<Win32Exception>(() => Launch.ExecuteImpersonatedAction(
+            () => { },
+            () => ++reversionAttempts == 2,
+            () => 5,
+            (_, _) => failFastCalled = true));
+
+        Assert.AreEqual(2, reversionAttempts);
+        Assert.IsFalse(failFastCalled);
+    }
+
+    [TestMethod]
+    public void ExecuteImpersonatedActionFailsFastWhenRevertRetryFails()
+    {
+        var reversionAttempts = 0;
+        Exception? failFastException = null;
+
+        _ = Assert.ThrowsException<Win32Exception>(() => Launch.ExecuteImpersonatedAction(
+            () => { },
+            () =>
+            {
+                reversionAttempts++;
+                return false;
+            },
+            () => 5,
+            (_, exception) => failFastException = exception));
+
+        Assert.AreEqual(2, reversionAttempts);
+        Assert.IsInstanceOfType<Win32Exception>(failFastException!);
+    }
+
+    [TestMethod]
+    public void PaddedPayloadIsAcceptedWhenExpectedBytesWereWritten()
+    {
+        using var destination = new MemoryStream();
+        var receivedCount = 0L;
+        var paddedPayload = new byte[] { 1, 2, 3, 4, 0, 0, 0, 0 };
+
+        var writtenCount = Clipboard.WriteReceivedData(
+            destination,
+            paddedPayload,
+            paddedPayload.Length,
+            expectedLength: 4,
+            ref receivedCount);
+
+        Assert.AreEqual(paddedPayload.Length, receivedCount);
+        Assert.AreEqual(4, writtenCount);
+        Assert.IsTrue(Clipboard.HasExpectedReceivedDataLength(destination, expectedLength: 4));
+        CollectionAssert.AreEqual(new byte[] { 1, 2, 3, 4 }, destination.ToArray());
+    }
+
+    [TestMethod]
+    public void SecondReceiveIsRejectedWhenFirstDoesNotFinishWithinWaitTimeout()
+    {
+        using var firstReceiveStarted = new ManualResetEventSlim();
+        using var allowFirstReceiveToFinish = new ManualResetEventSlim();
+        var firstReceiveThread = new SystemThread(() =>
+        {
+            firstReceiveStarted.Set();
+            allowFirstReceiveToFinish.Wait();
+        });
+
+        firstReceiveThread.Start();
+        Assert.IsTrue(firstReceiveStarted.Wait(millisecondsTimeout: 1000));
+
+        try
+        {
+            Assert.IsFalse(Clipboard.CanStartClipboardReceive(firstReceiveThread, SystemThread.CurrentThread, waitMilliseconds: 1));
+        }
+        finally
+        {
+            allowFirstReceiveToFinish.Set();
+            Assert.IsTrue(firstReceiveThread.Join(millisecondsTimeout: 1000));
+        }
+    }
+
+    [TestMethod]
+    public void IncompleteNewDestinationIsDeletedAfterWriteFailure()
+    {
+        var directory = CreateTestDirectory();
+        var path = Path.Combine(directory, "received.txt");
+
+        try
+        {
+            try
+            {
+                using var destination = CreateDestinationFile(path);
+                destination.Stream.WriteByte(1);
+                throw new IOException("Simulated write failure.");
+            }
+            catch (IOException)
+            {
+            }
+
+            Assert.IsFalse(File.Exists(path));
+            Assert.AreEqual(0, Directory.GetFiles(directory).Length);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public void IncompleteExistingDestinationPreservesOriginalContents()
+    {
+        var directory = CreateTestDirectory();
+        var path = Path.Combine(directory, "received.txt");
+        File.WriteAllText(path, "existing");
+
+        try
+        {
+            try
+            {
+                using var destination = CreateDestinationFile(path);
+                destination.Stream.WriteByte(1);
+                throw new IOException("Simulated write failure.");
+            }
+            catch (IOException)
+            {
+            }
+
+            Assert.IsTrue(File.Exists(path));
+            Assert.AreEqual("existing", File.ReadAllText(path));
+            Assert.AreEqual(1, Directory.GetFiles(directory).Length);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public void CompleteExistingDestinationReplacesOriginalContents()
+    {
+        var directory = CreateTestDirectory();
+        var path = Path.Combine(directory, "received.txt");
+        File.WriteAllText(path, "existing");
+
+        try
+        {
+            using (var destination = CreateDestinationFile(path))
+            {
+                destination.Stream.WriteByte(1);
+                destination.Complete();
+            }
+
+            CollectionAssert.AreEqual(new byte[] { 1 }, File.ReadAllBytes(path));
+            Assert.AreEqual(1, Directory.GetFiles(directory).Length);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public void MaximumLengthDestinationNameCanBeStaged()
+    {
+        var directory = CreateTestDirectory();
+        var path = Path.Combine(directory, new string('a', 255));
+
+        try
+        {
+            using (var destination = CreateDestinationFile(path))
+            {
+                destination.Stream.WriteByte(1);
+                destination.Complete();
+            }
+
+            CollectionAssert.AreEqual(new byte[] { 1 }, File.ReadAllBytes(path));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private static ReceivedDestinationFile CreateDestinationFile(string path)
+    {
+        return new ReceivedDestinationFile(path, File.Delete, (source, destination) => File.Move(source, destination, overwrite: true));
+    }
+
+    private static string CreateTestDirectory()
+    {
+        var directory = Path.Combine(AppContext.BaseDirectory, Guid.NewGuid().ToString("N"));
+        _ = Directory.CreateDirectory(directory);
+        return directory;
+    }
+}

--- a/src/modules/MouseWithoutBorders/MouseWithoutBorders.UnitTests/Core/ReceivedDestinationFileTests.cs
+++ b/src/modules/MouseWithoutBorders/MouseWithoutBorders.UnitTests/Core/ReceivedDestinationFileTests.cs
@@ -8,11 +8,10 @@ using System.IO;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MouseWithoutBorders.Core;
 
-using SystemThread = System.Threading.Thread;
-
 namespace MouseWithoutBorders.UnitTests.Core;
 
 [TestClass]
+[DoNotParallelize]
 public sealed class ReceivedDestinationFileTests
 {
     [TestMethod]
@@ -84,28 +83,88 @@ public sealed class ReceivedDestinationFileTests
     }
 
     [TestMethod]
-    public void SecondReceiveIsRejectedWhenFirstDoesNotFinishWithinWaitTimeout()
+    public async Task SequentialClipboardReceivesAreAcceptedAfterPriorTransferCompletes()
+    {
+        using var firstTransferCompleted = new ManualResetEventSlim();
+        using var allowFirstWorkerToFinish = new ManualResetEventSlim();
+        var firstReceive = Task.Run(() =>
+        {
+            var accepted = Clipboard.ExecuteClipboardReceive(() => { }, waitMilliseconds: 1000);
+            firstTransferCompleted.Set();
+            allowFirstWorkerToFinish.Wait();
+            return accepted;
+        });
+
+        Assert.IsTrue(firstTransferCompleted.Wait(millisecondsTimeout: 1000));
+
+        try
+        {
+            var secondReceiveAccepted = await Task.Run(() => Clipboard.ExecuteClipboardReceive(
+                () => { },
+                waitMilliseconds: 1000));
+
+            Assert.IsTrue(secondReceiveAccepted);
+        }
+        finally
+        {
+            allowFirstWorkerToFinish.Set();
+            Assert.IsTrue(await firstReceive);
+        }
+    }
+
+    [TestMethod]
+    public async Task OverlappingClipboardReceiveIsRejectedWithoutRunningSecondCallback()
     {
         using var firstReceiveStarted = new ManualResetEventSlim();
         using var allowFirstReceiveToFinish = new ManualResetEventSlim();
-        var firstReceiveThread = new SystemThread(() =>
-        {
-            firstReceiveStarted.Set();
-            allowFirstReceiveToFinish.Wait();
-        });
+        var firstReceive = Task.Run(
+            () => Clipboard.ExecuteClipboardReceive(
+                () =>
+                {
+                    firstReceiveStarted.Set();
+                    allowFirstReceiveToFinish.Wait();
+                },
+                waitMilliseconds: 1000));
 
-        firstReceiveThread.Start();
         Assert.IsTrue(firstReceiveStarted.Wait(millisecondsTimeout: 1000));
 
         try
         {
-            Assert.IsFalse(Clipboard.CanStartClipboardReceive(firstReceiveThread, SystemThread.CurrentThread, waitMilliseconds: 1));
+            var secondCallbackRan = false;
+            var secondReceiveAccepted = await Task.Run(() => Clipboard.ExecuteClipboardReceive(
+                () => secondCallbackRan = true,
+                waitMilliseconds: 1));
+
+            Assert.IsFalse(secondReceiveAccepted);
+            Assert.IsFalse(secondCallbackRan);
         }
         finally
         {
             allowFirstReceiveToFinish.Set();
-            Assert.IsTrue(firstReceiveThread.Join(millisecondsTimeout: 1000));
+            Assert.IsTrue(await firstReceive);
         }
+    }
+
+    [TestMethod]
+    public void ClipboardReceiveGateIsReleasedAfterCallbackException()
+    {
+        _ = Assert.ThrowsException<InvalidOperationException>(() => Clipboard.ExecuteClipboardReceive(
+            () => throw new InvalidOperationException(),
+            waitMilliseconds: 1000));
+
+        Assert.IsTrue(Clipboard.ExecuteClipboardReceive(() => { }, waitMilliseconds: 1000));
+    }
+
+    [TestMethod]
+    public void ClipboardReceiveGateIsReleasedAfterCallbackReturnsEarly()
+    {
+        static void ReturnEarly()
+        {
+            return;
+        }
+
+        Assert.IsTrue(Clipboard.ExecuteClipboardReceive(ReturnEarly, waitMilliseconds: 1000));
+        Assert.IsTrue(Clipboard.ExecuteClipboardReceive(() => { }, waitMilliseconds: 1000));
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary

When Mouse Without Borders receives a file (clipboard / file transfer) while the
service is running elevated, the destination folder is created while impersonating
the logged-on user, but the file itself was created outside of that context. As a
result, the received file's ownership and permissions did not match the folder it
lives in.

This change creates the received file in the same context as its destination folder:

- For per-user storage (the user's Desktop), the file is created while impersonating
  the logged-on user, so it is owned by that user and inherits the folder's
  permissions.
- On the logon / screen-saver desktop the storage lives under `Program Files`, where
  there is no interactive user to impersonate, so the file continues to be created
  directly — existing behavior is preserved.

## Scope

- Single file: `src/modules/MouseWithoutBorders/App/Core/Clipboard.cs`.
- Reuses the existing `Launch.ImpersonateLoggedOnUserAndDoSomething` helper; no new
  dependencies, no API / IPC / schema changes.
- Folder-creation logic is unchanged. Only the context of the file creation changes,
  and only for the per-user storage path. The `Program Files` path keeps its current
  behavior.

## Validation

- Built `MouseWithoutBorders.csproj` (Release | x64) — succeeds (exit code 0).
