### PR TITLE
CmdPal: Fix fallback results showing when disabled in Command Palette

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
@@ -436,7 +436,7 @@ public sealed partial class MainListPage : DynamicListPage,
                 {
                     specialFallbacks.Add(s);
                 }
-                else
+                else if (s.IsEnabled)
                 {
                     commonFallbacks.Add(s);
                 }


### PR DESCRIPTION
Fallback results were showing in Command Palette search results even when the user had disabled them in settings.

When a fallback command is disabled (e.g., VS Code for Command Palette with `IsEnabled = false`), it is excluded from `configuredGlobalFallbackIds` (which only contains enabled + global fallbacks). However, during search filtering, all fallbacks NOT in `configuredGlobalFallbackIds` were unconditionally added to `commonFallbacks`, which gets scored and displayed in results. This means disabled fallbacks still appeared.

To fix, I added an `IsEnabled` check when building the `commonFallbacks` list in `MainListPage.cs`. Disabled fallback commands are now properly excluded from search results.

Fixes #48504