### PR TITLE
feat(shortcut-guide): add 1Password manifest

### DIFF
--- a/doc/specs/WinGet Manifest Keyboard Shortcuts schema.md
+++ b/doc/specs/WinGet Manifest Keyboard Shortcuts schema.md
@@ -109,7 +109,7 @@ Per Application/Package one or more Keyboard manifests can be declared. Every ma
 <details>
  <summary><b>SectionName</b> - Name of the category of shortcuts</summary>
 
- Name of the section of shortcuts. 
+ Name of the section of shortcuts. Use sentence case, the same convention described under `Name` below.
 
 **Special sections**:
 
@@ -125,6 +125,10 @@ Special sections start with an identifier enclosed between `<` and `>`. This dec
  <summary><b>Name</b> - Name of the shortcut</summary>
 
  Name of the shortcut. This is the name that will be displayed in the interpreter.
+
+**Casing**:
+
+By convention, shortcut names (and `SectionName` values) use **sentence case**: capitalize only the first word plus any proper nouns or product/feature names. For example, prefer `Reopen last closed tab` over `Reopen Last Closed Tab`, but keep `Open History`, `Quit Slack`, and `Show Quick Access` capitalized because those are application feature names. Match the casing the application uses for its own features rather than copying the title-case styling some apps apply to their entire shortcut list.
 
 </details>
 

--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/Assets/ShortcutGuide/Manifests/AgileBits.1Password.en-US.yml
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/Assets/ShortcutGuide/Manifests/AgileBits.1Password.en-US.yml
@@ -1,0 +1,226 @@
+PackageName: AgileBits.1Password
+Name: 1Password
+WindowFilter: "1Password.exe"
+BackgroundProcess: false
+Shortcuts:
+  - SectionName: Basics
+    Properties:
+      - Name: View Keyboard Shortcuts
+        Shortcut:
+        - Win: false
+          Ctrl: true
+          Shift: true
+          Alt: false
+          Keys:
+            - "/"
+      - Name: Show Quick Access
+        Recommended: true
+        Shortcut:
+        - Win: false
+          Ctrl: true
+          Shift: true
+          Alt: false
+          Keys:
+            - "<Space>"
+      - Name: Lock 1Password
+        Recommended: true
+        Shortcut:
+        - Win: false
+          Ctrl: true
+          Shift: true
+          Alt: false
+          Keys:
+            - L
+  - SectionName: Navigation
+    Properties:
+      - Name: Find
+        Shortcut:
+        - Win: false
+          Ctrl: true
+          Shift: false
+          Alt: false
+          Keys:
+            - F
+      - Name: Switch to All Accounts
+        Shortcut:
+        - Win: false
+          Ctrl: true
+          Shift: false
+          Alt: false
+          Keys:
+            - "<1>"
+      - Name: "Switch Accounts & Collections"
+        Shortcut:
+        - Win: false
+          Ctrl: true
+          Shift: false
+          Alt: false
+          Keys:
+            - '2 - 9'
+      - Name: Back
+        Shortcut:
+        - Win: false
+          Ctrl: false
+          Shift: false
+          Alt: true
+          Keys:
+            - "<Left>"
+      - Name: Forward
+        Shortcut:
+        - Win: false
+          Ctrl: false
+          Shift: false
+          Alt: true
+          Keys:
+            - "<Right>"
+      - Name: Focus Next Row
+        Shortcut:
+        - Win: false
+          Ctrl: false
+          Shift: false
+          Alt: false
+          Keys:
+            - "<Down>"
+      - Name: Focus Previous Row
+        Shortcut:
+        - Win: false
+          Ctrl: false
+          Shift: false
+          Alt: false
+          Keys:
+            - "<Up>"
+      - Name: Focus Right Section
+        Shortcut:
+        - Win: false
+          Ctrl: false
+          Shift: false
+          Alt: false
+          Keys:
+            - "<Right>"
+      - Name: Focus Left Section
+        Shortcut:
+        - Win: false
+          Ctrl: false
+          Shift: false
+          Alt: false
+          Keys:
+            - "<Left>"
+  - SectionName: Selected Item
+    Properties:
+      - Name: Copy Primary Field
+        Recommended: true
+        Shortcut:
+        - Win: false
+          Ctrl: true
+          Shift: false
+          Alt: false
+          Keys:
+            - C
+      - Name: Copy Password
+        Recommended: true
+        Shortcut:
+        - Win: false
+          Ctrl: true
+          Shift: true
+          Alt: false
+          Keys:
+            - C
+      - Name: Copy One-Time Password
+        Recommended: true
+        Shortcut:
+        - Win: false
+          Ctrl: true
+          Shift: false
+          Alt: true
+          Keys:
+            - C
+      - Name: "Open & Fill in Web Browser"
+        Shortcut:
+        - Win: false
+          Ctrl: true
+          Shift: true
+          Alt: false
+          Keys:
+            - F
+      - Name: Open Item in New Window
+        Shortcut:
+        - Win: false
+          Ctrl: true
+          Shift: false
+          Alt: false
+          Keys:
+            - O
+      - Name: Edit Item
+        Shortcut:
+        - Win: false
+          Ctrl: true
+          Shift: false
+          Alt: false
+          Keys:
+            - E
+      - Name: Save Item
+        Shortcut:
+        - Win: false
+          Ctrl: true
+          Shift: false
+          Alt: false
+          Keys:
+            - S
+      - Name: Reveal Concealed Fields
+        Shortcut:
+        - Win: false
+          Ctrl: true
+          Shift: false
+          Alt: false
+          Keys:
+            - R
+      - Name: Archive Item
+        Shortcut:
+        - Win: false
+          Ctrl: false
+          Shift: false
+          Alt: false
+          Keys:
+            - "<Delete>"
+      - Name: Delete Item
+        Shortcut:
+        - Win: false
+          Ctrl: true
+          Shift: false
+          Alt: false
+          Keys:
+            - "<Delete>"
+  - SectionName: View
+    Properties:
+      - Name: Show/Hide Sidebar
+        Shortcut:
+        - Win: false
+          Ctrl: true
+          Shift: true
+          Alt: false
+          Keys:
+            - D
+      - Name: Zoom In
+        Shortcut:
+        - Win: false
+          Ctrl: true
+          Shift: false
+          Alt: false
+          Keys:
+            - "+"
+      - Name: Zoom Out
+        Shortcut:
+        - Win: false
+          Ctrl: true
+          Shift: false
+          Alt: false
+          Keys:
+            - "-"
+      - Name: Actual Size
+        Shortcut:
+        - Win: false
+          Ctrl: true
+          Shift: false
+          Alt: false
+          Keys:
+            - "<0>"

--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/Assets/ShortcutGuide/Manifests/AgileBits.1Password.en-US.yml
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/Assets/ShortcutGuide/Manifests/AgileBits.1Password.en-US.yml
@@ -5,7 +5,7 @@ BackgroundProcess: false
 Shortcuts:
   - SectionName: Basics
     Properties:
-      - Name: View Keyboard Shortcuts
+      - Name: View keyboard shortcuts
         Shortcut:
         - Win: false
           Ctrl: true
@@ -41,7 +41,7 @@ Shortcuts:
           Alt: false
           Keys:
             - F
-      - Name: Switch to All Accounts
+      - Name: Switch to all accounts
         Shortcut:
         - Win: false
           Ctrl: true
@@ -49,7 +49,7 @@ Shortcuts:
           Alt: false
           Keys:
             - "<1>"
-      - Name: "Switch Accounts & Collections"
+      - Name: "Switch accounts & collections"
         Shortcut:
         - Win: false
           Ctrl: true
@@ -73,7 +73,7 @@ Shortcuts:
           Alt: true
           Keys:
             - "<Right>"
-      - Name: Focus Next Row
+      - Name: Focus next row
         Shortcut:
         - Win: false
           Ctrl: false
@@ -81,7 +81,7 @@ Shortcuts:
           Alt: false
           Keys:
             - "<Down>"
-      - Name: Focus Previous Row
+      - Name: Focus previous row
         Shortcut:
         - Win: false
           Ctrl: false
@@ -89,7 +89,7 @@ Shortcuts:
           Alt: false
           Keys:
             - "<Up>"
-      - Name: Focus Right Section
+      - Name: Focus right section
         Shortcut:
         - Win: false
           Ctrl: false
@@ -97,7 +97,7 @@ Shortcuts:
           Alt: false
           Keys:
             - "<Right>"
-      - Name: Focus Left Section
+      - Name: Focus left section
         Shortcut:
         - Win: false
           Ctrl: false
@@ -105,9 +105,9 @@ Shortcuts:
           Alt: false
           Keys:
             - "<Left>"
-  - SectionName: Selected Item
+  - SectionName: Selected item
     Properties:
-      - Name: Copy Primary Field
+      - Name: Copy primary field
         Recommended: true
         Shortcut:
         - Win: false
@@ -116,7 +116,7 @@ Shortcuts:
           Alt: false
           Keys:
             - C
-      - Name: Copy Password
+      - Name: Copy password
         Recommended: true
         Shortcut:
         - Win: false
@@ -125,7 +125,7 @@ Shortcuts:
           Alt: false
           Keys:
             - C
-      - Name: Copy One-Time Password
+      - Name: Copy one-time password
         Recommended: true
         Shortcut:
         - Win: false
@@ -134,7 +134,7 @@ Shortcuts:
           Alt: true
           Keys:
             - C
-      - Name: "Open & Fill in Web Browser"
+      - Name: "Open & fill in web browser"
         Shortcut:
         - Win: false
           Ctrl: true
@@ -142,7 +142,7 @@ Shortcuts:
           Alt: false
           Keys:
             - F
-      - Name: Open Item in New Window
+      - Name: Open item in new window
         Shortcut:
         - Win: false
           Ctrl: true
@@ -150,7 +150,7 @@ Shortcuts:
           Alt: false
           Keys:
             - O
-      - Name: Edit Item
+      - Name: Edit item
         Shortcut:
         - Win: false
           Ctrl: true
@@ -158,7 +158,7 @@ Shortcuts:
           Alt: false
           Keys:
             - E
-      - Name: Save Item
+      - Name: Save item
         Shortcut:
         - Win: false
           Ctrl: true
@@ -166,7 +166,7 @@ Shortcuts:
           Alt: false
           Keys:
             - S
-      - Name: Reveal Concealed Fields
+      - Name: Reveal concealed fields
         Shortcut:
         - Win: false
           Ctrl: true
@@ -174,7 +174,7 @@ Shortcuts:
           Alt: false
           Keys:
             - R
-      - Name: Archive Item
+      - Name: Archive item
         Shortcut:
         - Win: false
           Ctrl: false
@@ -182,7 +182,7 @@ Shortcuts:
           Alt: false
           Keys:
             - "<Delete>"
-      - Name: Delete Item
+      - Name: Delete item
         Shortcut:
         - Win: false
           Ctrl: true
@@ -192,7 +192,7 @@ Shortcuts:
             - "<Delete>"
   - SectionName: View
     Properties:
-      - Name: Show/Hide Sidebar
+      - Name: Show/hide sidebar
         Shortcut:
         - Win: false
           Ctrl: true
@@ -200,7 +200,7 @@ Shortcuts:
           Alt: false
           Keys:
             - D
-      - Name: Zoom In
+      - Name: Zoom in
         Shortcut:
         - Win: false
           Ctrl: true
@@ -208,7 +208,7 @@ Shortcuts:
           Alt: false
           Keys:
             - "+"
-      - Name: Zoom Out
+      - Name: Zoom out
         Shortcut:
         - Win: false
           Ctrl: true
@@ -216,7 +216,7 @@ Shortcuts:
           Alt: false
           Keys:
             - "-"
-      - Name: Actual Size
+      - Name: Actual size
         Shortcut:
         - Win: false
           Ctrl: true


### PR DESCRIPTION
## Summary of the Pull Request

Adds a Shortcut Guide manifest for the **1Password** desktop app.

- **New manifest:** `src/modules/ShortcutGuide/ShortcutGuide.Ui/Assets/ShortcutGuide/Manifests/AgileBits.1Password.en-US.yml`: 26 shortcuts for `1Password.exe`, grouped into the same four sections 1Password uses in its in-app Keyboard Shortcuts reference:
  - **Basics:** View keyboard shortcuts, Show Quick Access, Lock 1Password
  - **Navigation:** Find, Switch to all accounts, Switch accounts & collections, Back, Forward, Focus next/previous row, Focus right/left section
  - **Selected item:** Copy primary field / password / one-time password, Open & fill in web browser, Open item in new window, Edit item, Save item, Reveal concealed fields, Archive item, Delete item
  - **View:** Show/hide sidebar, Zoom in, Zoom out, Actual size
- **No code changes.** The manifest is auto-included via the existing `Manifests/*.yml` glob in `ShortcutGuide.Ui.csproj`, exactly like the existing Postman, Slack, Discord, and browser manifests.
- The two literal-digit shortcuts (`Ctrl+1` switch to all accounts, `Ctrl+0` actual size) use the `<N>` token (`<1>` / `<0>`) per the manifest spec, and the "Switch accounts & collections" range renders as `2 - 9`.
- **Documentation:** Added a note in `doc/specs/WinGet Manifest Keyboard Shortcuts schema.md` documenting the existing **sentence-case** naming convention for `Name` and `SectionName` (capitalize only the first word plus proper nouns / product feature names), so future contributors do not copy an application's title-case shortcut-list styling. The 1Password names in this PR follow that convention, keeping only feature/product names capitalized (Show Quick Access, Lock 1Password).

## PR Checklist

- [x] Closes: #48792
- [ ] **Communication:** I've discussed this with core contributors already. <!-- Filed #48792; the v0.100 announcement invites app-shortcut contributions via PR. Follows the precedent set by #48461 (Postman). -->
- [ ] **Tests:** Added/updated and all pass <!-- N/A: data-only change, no new code paths. The manifest was validated by deserializing it with YamlDotNet (the same `Deserializer` used by `ManifestInterpreter`), confirming all 26 entries and key tokens parse into `ShortcutFile`. -->
- [x] **Localization:** All end-user-facing strings can be localized <!-- Shortcut names live in the per-language manifest (`*.en-US.yml`); other locales fall back to en-US, consistent with every existing manifest. -->
- [x] **Dev docs:** Added/updated <!-- Documented the sentence-case naming convention for Name / SectionName in doc/specs/WinGet Manifest Keyboard Shortcuts schema.md. -->
- [ ] **New binaries:** Added on the required places <!-- N/A: the new manifest is a data asset under an already-shipped, globbed folder. No new binaries or test projects. -->
- [ ] **Documentation updated:** <!-- N/A: user-facing docs unchanged. -->
- [x] **Local run:** Built the Shortcut Guide projects and ran the Debug build with 1Password focused (`Win+Shift+/`); screenshot of the rendered guide is attached below.

## Detailed Description of the Pull Request / Additional comments

The Shortcut Guide displays per-app shortcuts from YAML manifests, matched to the foreground window via `WindowFilter`. Adding support for an app is purely additive: drop a `<PackageName>.<locale>.yml` file in the `Manifests` folder and it is picked up by the existing build glob and the index generator.

- `PackageName: AgileBits.1Password` (the WinGet package identifier) and `WindowFilter: "1Password.exe"` (the desktop app process).
- `Name: 1Password` is the display name shown in the Shortcut Guide app picker.
- Shortcut names follow the repo's sentence-case convention (now documented in the schema spec). Recommended is set on the five highest-frequency / signature actions: Show Quick Access, Lock 1Password, Copy primary field, Copy password, Copy one-time password.

## Validation Steps Performed

- **Schema/parse:** Deserialized the manifest with `YamlDotNet.Serialization.Deserializer` (the same path `ManifestInterpreter.YamlToShortcutList` uses). All four sections and 26 entries parse, with 5 marked Recommended. No parse errors.
- **Key rendering:** Verified every key token against `KeyVisual` and `ShortcutDescriptionToKeysConverter`: `<Space>`/`<Delete>` strip to their labels, `<Left>`/`<Right>`/`<Up>`/`<Down>` map to arrow glyphs, `<1>`/`<0>` strip to the literal digit (matching the merged Postman `<9>`/`<0>` handling), `2 - 9` renders verbatim, and `+` / `-` render as the literal symbols (as in the bundled Windows Explorer and Shell manifests).
- **Source fidelity:** The section grouping and every shortcut/modifier combination match 1Password's in-app Keyboard Shortcuts reference one-to-one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1462" height="2260" alt="image" src="https://github.com/user-attachments/assets/e7824a38-cb56-4242-9a6a-31c7a93c03c9" />

