### PR TITLE
Fix dev setup .vsconfig component IDs for Visual Studio 2026

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -6,10 +6,8 @@
     "Microsoft.VisualStudio.Workload.NativeDesktop",
     "Microsoft.VisualStudio.Workload.ManagedDesktop",
     "Microsoft.VisualStudio.Workload.Universal",
-    "Microsoft.VisualStudio.Component.Windows10SDK.19041",
-    "Microsoft.VisualStudio.Component.Windows10SDK.20348",
-    "Microsoft.VisualStudio.Component.Windows10SDK.22621",
-    "Microsoft.VisualStudio.Component.Windows10SDK.26100",
+    "Microsoft.VisualStudio.Component.Windows11SDK.22621",
+    "Microsoft.VisualStudio.Component.Windows11SDK.26100",
     "Microsoft.VisualStudio.ComponentGroup.UWP.VC",
     "Microsoft.VisualStudio.Component.UWP.VC.ARM64",
     "Microsoft.VisualStudio.Component.VC.Runtimes.ARM64.Spectre",
@@ -19,6 +17,7 @@
     "Microsoft.VisualStudio.Component.VC.ATL",
     "Microsoft.VisualStudio.Component.VC.ATL.Spectre",
     "Microsoft.VisualStudio.Component.Vcpkg",
-    "Microsoft.VisualStudio.ComponentGroup.WindowsAppSDK.Cs"
+    "Microsoft.VisualStudio.Component.WindowsAppSdkSupport.CSharp",
+    "Microsoft.VisualStudio.Component.WindowsAppSdkSupport.Cpp"
   ]
 }

--- a/doc/devdocs/readme.md
+++ b/doc/devdocs/readme.md
@@ -11,7 +11,7 @@ Welcome to the PowerToys developer documentation. This documentation provides in
    - Desktop Development with C++
    - WinUI application development
    - .NET desktop development
-   - Windows 10 SDK (10.0.22621.0)
+   - Windows 11 SDK (10.0.22621.0)
    - Windows 11 SDK (10.0.26100.3916)
 1. .NET 8 SDK
 1. Enable long paths in Windows (see [Enable Long Paths](https://docs.microsoft.com/windows/win32/fileio/maximum-file-path-limitation#enabling-long-paths-in-windows-10-version-1607-and-later) for details)


### PR DESCRIPTION
## Summary

Fixes #48778 — the automated developer setup (`winget configure .config\configuration.winget`) provisions **Visual Studio 2026** but feeds it a `.vsconfig` containing **Visual Studio 2022-era component IDs** that were renamed or removed in VS 2026. The `VSComponents` DSC resource silently skips the invalid IDs, so the **Windows 11 SDK (26100)** and **WindowsAppSDK C# support** never install — breaking the build with cppwinrt (exit code 3) and WindowsAppSDK target failures, exactly as reported.

## Root cause

PR #45534 bumped `.config/configuration.winget` from VS 2022 → VS 2026 (`Microsoft.VisualStudio.Community`, `channelId: VisualStudio.18.Release`) but left `.vsconfig` untouched. Five component IDs in `.vsconfig` are invalid in the VS 2026 (Dev18) catalog:

| `.vsconfig` (old, VS 2022) | VS 2026 reality |
|---|---|
| `Component.Windows10SDK.22621` | renamed → `Component.Windows11SDK.22621` |
| `Component.Windows10SDK.26100` | renamed → `Component.Windows11SDK.26100` (the build's target SDK) |
| `ComponentGroup.WindowsAppSDK.Cs` | renamed → `WindowsAppSdkSupport.CSharp` |
| `Component.Windows10SDK.19041` | removed from VS 2026 (only a `WindowsTargetPlatformMinVersion` floor — never a real install requirement) |
| `Component.Windows10SDK.20348` | removed from VS 2026 (not referenced by the build) |

A single `.vsconfig` is the source of truth for all three winget variants (`configuration.winget`, `configuration.vsProfessional.winget`, `configuration.vsEnterprise.winget`), which reference it via `${WinGetConfigRoot}\..\.vsconfig`, so this one edit fixes every automated path.

## Changes

- `Windows10SDK.22621/26100` → `Windows11SDK.22621/26100`
- `ComponentGroup.WindowsAppSDK.Cs` → `WindowsAppSdkSupport.CSharp`, and added `WindowsAppSdkSupport.Cpp` (PowerToys' C++/WinRT projects need it)
- Removed `Windows10SDK.19041` and `Windows10SDK.20348`
- `doc/devdocs/readme.md`: corrected the `10.0.22621.0` SDK label from "Windows 10 SDK" to "Windows 11 SDK"

## Validation

- All 18 resulting component IDs validated against a live VS 2026 (18.7.0) installation via `vswhere -include packages` — all present/valid.
- `.vsconfig` parses as valid JSON.
- Build target requirements confirmed from `Cpp.Build.props` (`WindowsTargetPlatformVersion = 10.0.26100.0`, min `10.0.19041.0`) and `Common.Dotnet.CsWinRT.props`.

## Notes

The docs still list "VS 2022 17.4+" as an alternative; this `.vsconfig` is aligned to the recommended/automated VS 2026 path. The VS Installer treats any unrecognized component IDs in `.vsconfig` gracefully (shown as unavailable, non-blocking) for VS 2022 users.