### PR TITLE
Fix CmdPal gallery crash when extension has no homepage

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Gallery/ExtensionGalleryItemViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Gallery/ExtensionGalleryItemViewModel.cs
@@ -105,6 +105,13 @@ public sealed partial class ExtensionGalleryItemViewModel : ObservableObject
 
     public string? Homepage => _entry.Homepage;
 
+    // Validated, browser-openable homepage uri. Null when the entry has no
+    // homepage or it is not a web uri. NavigateUri bindings must use this
+    // (a Uri) rather than the raw Homepage string: x:Bind evaluates bindings
+    // regardless of element visibility, and converting a null/invalid string
+    // to Uri throws and crashes the page.
+    public Uri? HomepageUri => _homepageHttpUri;
+
     public Uri IconUri { get; }
 
     public ImageSource IconSource

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/ExtensionGalleryItemPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/ExtensionGalleryItemPage.xaml
@@ -232,7 +232,7 @@
                                 Grid.Row="3"
                                 Padding="0"
                                 AutomationProperties.AutomationId="CmdPal_GalleryItemPage_ViewRepository"
-                                NavigateUri="{x:Bind ViewModel.Homepage, Mode=OneWay}"
+                                NavigateUri="{x:Bind ViewModel.HomepageUri, Mode=OneWay}"
                                 ToolTipService.ToolTip="{x:Bind ViewModel.Homepage, Mode=OneWay}"
                                 Visibility="{x:Bind help:BindTransformers.BoolToVisibility(ViewModel.HasHomepage), Mode=OneWay, FallbackValue=Collapsed}">
                                 <StackPanel Orientation="Horizontal" Spacing="4">

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/ExtensionGalleryItemViewModelTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/ExtensionGalleryItemViewModelTests.cs
@@ -119,6 +119,7 @@ public class ExtensionGalleryItemViewModelTests
         var viewModel = CreateViewModel(entry);
 
         Assert.IsFalse(viewModel.HasHomepage);
+        Assert.IsNull(viewModel.HomepageUri);
         Assert.IsFalse(viewModel.HasAuthorUrl);
         Assert.IsFalse(viewModel.HasUrlSource);
         Assert.IsFalse(viewModel.HasActionableSourceDetails);
@@ -129,6 +130,32 @@ public class ExtensionGalleryItemViewModelTests
         Assert.IsFalse(viewModel.OpenHomepageCommand.CanExecute(null));
         Assert.IsFalse(viewModel.OpenAuthorPageCommand.CanExecute(null));
         Assert.IsFalse(viewModel.OpenInstallUrlCommand.CanExecute(null));
+    }
+
+    [TestMethod]
+    public void Constructor_SetsHomepageUri_WhenHomepageIsWebUri()
+    {
+        var entry = CreateEntry(iconUrl: null);
+        entry.Homepage = "https://example.com/extension";
+
+        var viewModel = CreateViewModel(entry);
+
+        Assert.IsTrue(viewModel.HasHomepage);
+        Assert.AreEqual(new Uri("https://example.com/extension"), viewModel.HomepageUri);
+        Assert.IsTrue(viewModel.OpenHomepageCommand.CanExecute(null));
+    }
+
+    [TestMethod]
+    public void Constructor_LeavesHomepageUriNull_WhenHomepageIsMissing()
+    {
+        var entry = CreateEntry(iconUrl: null);
+        entry.Homepage = null;
+
+        var viewModel = CreateViewModel(entry);
+
+        Assert.IsFalse(viewModel.HasHomepage);
+        Assert.IsNull(viewModel.HomepageUri);
+        Assert.IsFalse(viewModel.OpenHomepageCommand.CanExecute(null));
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary

Selecting an extension in the CmdPal Extension Gallery crashed the app when that extension had **no `homepage`** defined.

## Root cause

In `ExtensionGalleryItemPage.xaml`, the "View repository" `HyperlinkButton` bound its `NavigateUri` (a `System.Uri`) directly to the raw string property `ViewModel.Homepage`:

```xml
NavigateUri="{x:Bind ViewModel.Homepage, Mode=OneWay}"
```

`x:Bind` evaluates **all** bindings on an element regardless of `Visibility`, and to assign a `string` to a `Uri` target it generates a `new Uri(value)` conversion. When `homepage` is undefined, `Homepage` is `null`, so the binding executes `new Uri(null)` → `ArgumentNullException` → the page crashes on load. The `Visibility="{... HasHomepage}"` collapse did not help because the `NavigateUri` binding still runs.

Every other `NavigateUri` x:Bind in the codebase (`Link`, `LinkUri`) is already bound to a `Uri?`, so the homepage hyperlink was the lone offender.

## Fix

- **`ExtensionGalleryItemViewModel.cs`** — Added a validated `Uri? HomepageUri` property backed by the existing `_homepageHttpUri` (already `null` for missing or non-web homepages).
- **`ExtensionGalleryItemPage.xaml`** — Bound `NavigateUri` to `ViewModel.HomepageUri` instead of the raw string. `null` is valid for `NavigateUri`, so no conversion occurs. The tooltip still shows the `Homepage` string.
- **Tests** — Added coverage asserting `HomepageUri` is set for a web homepage and `null` when missing.

## Verification

- `Microsoft.CmdPal.UI.ViewModels`, `Microsoft.CmdPal.UI` (XAML compile), and the unit test project all built cleanly (x64/Release, exit code 0).
- All 24 `ExtensionGalleryItemViewModelTests` pass, including the two new cases.
- Manually verified in VS that opening an extension without a homepage no longer crashes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>


https://github.com/user-attachments/assets/b268bafb-6bee-4862-9fbf-7a0e06675e36
