### PR TITLE
Skip auto-labeling PRs that already have labels

### DIFF
--- a/.github/workflows/auto-labeler.yml
+++ b/.github/workflows/auto-labeler.yml
@@ -73,6 +73,13 @@ jobs:
 
               const itemType = issue.pull_request ? 'Pull request' : 'Issue';
 
+              // Skip pull requests that already have labels applied.
+              if (issue.pull_request && issue.labels && issue.labels.length > 0) {
+                const existingLabels = issue.labels.map(l => l.name).join(', ');
+                console.log(`${itemType} #${issueNumber} already has labels (${existingLabels}); skipping.`);
+                return;
+              }
+
               const title = issue.title ?? '';
               const body  = issue.body  ?? '';
 


### PR DESCRIPTION
## Summary

The auto-labeler workflow now skips pull requests that already have labels applied before running the AI classification. This avoids overwriting or duplicating labels that were manually set by contributors or maintainers.

## Changes

- Added a check in `labelIssue()` that returns early for PRs with existing labels, logging which labels are already present.
- Issues continue to be labeled regardless (only PRs get the skip logic).