### PR TITLE
[CmdPal] Fix memory leak in PerformanceWidgetsPage network band items

### DIFF
--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceWidgetsPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceWidgetsPage.cs
@@ -134,13 +134,32 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
                 MoreCommands = _networkPage.Commands,
             };
 
+            if (isBandPage)
+            {
+                _networkUpItem = new ListItem(_networkPage)
+                {
+                    Title = $"{_networkUpSpeed}",
+                    Subtitle = Resources.GetResource("Network_Send_Subtitle"),
+                    Icon = Icons.NetworkUpIcon,
+                    MoreCommands = _networkPage.Commands,
+                };
+
+                _networkDownItem = new ListItem(_networkPage)
+                {
+                    Title = $"{_networkDownSpeed}",
+                    Subtitle = Resources.GetResource("Network_Receive_Subtitle"),
+                    Icon = Icons.NetworkDownIcon,
+                    MoreCommands = _networkPage.Commands,
+                };
+            }
+
             _networkPage.Updated += (s, e) =>
             {
                 _networkItem.Title = _networkPage.GetItemTitle(isBandPage);
                 _networkUpSpeed = _networkPage.GetUpSpeed();
                 _networkDownSpeed = _networkPage.GetDownSpeed();
-                _networkDownItem?.Title = $"{_networkDownSpeed}";
                 _networkUpItem?.Title = $"{_networkUpSpeed}";
+                _networkDownItem?.Title = $"{_networkDownSpeed}";
             };
         }
 
@@ -253,22 +272,6 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
         }
         else
         {
-            _networkUpItem = new ListItem(_networkPage!)
-            {
-                Title = $"{_networkUpSpeed}",
-                Subtitle = Resources.GetResource("Network_Send_Subtitle"),
-                Icon = Icons.NetworkUpIcon,
-                MoreCommands = _networkPage!.Commands,
-            };
-
-            _networkDownItem = new ListItem(_networkPage!)
-            {
-                Title = $"{_networkDownSpeed}",
-                Subtitle = Resources.GetResource("Network_Receive_Subtitle"),
-                Icon = Icons.NetworkDownIcon,
-                MoreCommands = _networkPage!.Commands,
-            };
-
             return _batteryItem is not null
                 ? new[] { _cpuItem!, _memoryItem!, _networkUpItem!, _networkDownItem!, _gpuItem!, _batteryItem! }
                 : new[] { _cpuItem!, _memoryItem!, _networkUpItem!, _networkDownItem!, _gpuItem! };

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceWidgetsPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceWidgetsPage.cs
@@ -158,8 +158,8 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
                 _networkItem.Title = _networkPage.GetItemTitle(isBandPage);
                 _networkUpSpeed = _networkPage.GetUpSpeed();
                 _networkDownSpeed = _networkPage.GetDownSpeed();
-                _networkUpItem?.Title = $"{_networkUpSpeed}";
                 _networkDownItem?.Title = $"{_networkDownSpeed}";
+                _networkUpItem?.Title = $"{_networkUpSpeed}";
             };
         }
 


### PR DESCRIPTION
## Summary

Fixes a memory leak in the Performance Monitor dock extension where `GetItems()` created **new** `ListItem` instances for `_networkUpItem` and `_networkDownItem` on every call.

## Problem

When the dock subscribes to `ItemsChanged` and calls `GetItems()` to refresh, the band page path allocates 2 new `ListItem` objects each time — the old ones are replaced in the fields but never collected (they remain referenced by the `DockItemViewModel` wrappers until the next refresh cycle). Under normal operation this leaks ~2 objects/second indefinitely.

## Fix

Move `_networkUpItem`/`_networkDownItem` creation into the constructor (matching the pattern used by CPU, Memory, GPU, and Battery items). `GetItems()` now returns stable references. The `Updated` event handler already updates their `.Title` properties, which propagates to the UI via `PropChanged` → `CommandItemViewModel.Model_PropChanged`.

## Validation

- Build succeeds (`Microsoft.CmdPal.Ext.PerformanceMonitor.csproj`)
- Network up/down band items still receive title updates via the existing `Updated` handler
- No `RaiseItemsChanged()` needed — `ListItem.Title` setter fires `PropChanged`, which `DockItemViewModel` already observes