### PR TITLE
Prefer running executable location when resolving PowerToys install path

### DIFF
--- a/src/common/ManagedCommon/PowerToysPathResolver.cs
+++ b/src/common/ManagedCommon/PowerToysPathResolver.cs
@@ -6,6 +6,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.Versioning;
+using System.Security.Principal;
 using Microsoft.Win32;
 
 namespace ManagedCommon
@@ -26,11 +27,26 @@ namespace ManagedCommon
             // In debug builds, resolve directly from the running process (no installer/registry involved).
             return GetPathFromCurrentProcess();
 #else
-            // Try to get path from Per-User installation first
-            string path = GetPathFromRegistry(RegistryHive.CurrentUser);
+            // Prefer resolving from the running process' own location. This is a trusted source
+            // (the OS loaded the binary from the install directory) and works for both per-user and
+            // per-machine installs, regardless of elevation.
+            string path = GetPathFromCurrentProcess();
             if (!string.IsNullOrEmpty(path))
             {
                 return path;
+            }
+
+            // Fall back to the registry. The per-user (HKCU) hive is writable by a standard user, so an
+            // attacker could point the "powertoys" protocol command at an arbitrary local or UNC
+            // PowerToys.exe. When this process is elevated, never trust HKCU: only the per-machine
+            // (HKLM) hive, which requires administrator rights to write, is considered trustworthy.
+            if (!IsProcessElevated())
+            {
+                path = GetPathFromRegistry(RegistryHive.CurrentUser);
+                if (!string.IsNullOrEmpty(path))
+                {
+                    return path;
+                }
             }
 
             // Fall back to Per-Machine installation
@@ -42,6 +58,22 @@ namespace ManagedCommon
 
             return null;
 #endif
+        }
+
+        private static bool IsProcessElevated()
+        {
+            try
+            {
+                using var identity = WindowsIdentity.GetCurrent();
+                var principal = new WindowsPrincipal(identity);
+                return principal.IsInRole(WindowsBuiltInRole.Administrator);
+            }
+            catch (Exception)
+            {
+                // If elevation can't be determined, fail safe by treating the process as elevated so the
+                // user-writable HKCU hive is never trusted.
+                return true;
+            }
         }
 
         private static string GetPathFromRegistry(RegistryHive hive)

--- a/src/common/ManagedCommon/PowerToysPathResolver.cs
+++ b/src/common/ManagedCommon/PowerToysPathResolver.cs
@@ -18,7 +18,7 @@ namespace ManagedCommon
         private const string PowerToysExe = "PowerToys.exe";
 
         /// <summary>
-        /// Gets the PowerToys installation path by checking registry entries
+        /// Gets the PowerToys installation path from the running process or registry entries.
         /// </summary>
         /// <returns>The path to PowerToys installation directory, or null if not found</returns>
         public static string GetPowerToysInstallPath()

--- a/src/common/ManagedCommon/PowerToysPathResolver.cs
+++ b/src/common/ManagedCommon/PowerToysPathResolver.cs
@@ -6,7 +6,6 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.Versioning;
-using System.Security.Principal;
 using Microsoft.Win32;
 
 namespace ManagedCommon
@@ -60,13 +59,31 @@ namespace ManagedCommon
 #endif
         }
 
+        private const uint TokenQuery = 0x0008;
+        private const int TokenElevation = 20;
+
+        [System.Runtime.InteropServices.DllImport("advapi32.dll", SetLastError = true)]
+        [return: System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.Bool)]
+        private static extern bool OpenProcessToken(IntPtr processHandle, uint desiredAccess, out Microsoft.Win32.SafeHandles.SafeAccessTokenHandle tokenHandle);
+
+        [System.Runtime.InteropServices.DllImport("advapi32.dll", SetLastError = true)]
+        [return: System.Runtime.InteropServices.MarshalAs(System.Runtime.InteropServices.UnmanagedType.Bool)]
+        private static extern bool GetTokenInformation(Microsoft.Win32.SafeHandles.SafeAccessTokenHandle tokenHandle, int tokenInformationClass, out uint tokenInformation, uint tokenInformationLength, out uint returnLength);
+
         private static bool IsProcessElevated()
         {
             try
             {
-                using var identity = WindowsIdentity.GetCurrent();
-                var principal = new WindowsPrincipal(identity);
-                return principal.IsInRole(WindowsBuiltInRole.Administrator);
+                using var process = Process.GetCurrentProcess();
+                if (!OpenProcessToken(process.Handle, TokenQuery, out var token))
+                {
+                    return true;
+                }
+
+                using (token)
+                {
+                    return !GetTokenInformation(token, TokenElevation, out var elevation, sizeof(uint), out _) || elevation != 0;
+                }
             }
             catch (Exception)
             {


### PR DESCRIPTION
## Summary of the Pull Request

`PowerToysPathResolver.GetPowerToysInstallPath()` now resolves the PowerToys installation directory from the **running executable''s own location** first, and only falls back to the registry when the caller is not running from within the PowerToys install tree.

Previously the resolver always went through the registry (the `powertoys` protocol registration) for release builds. For the common callers — module executables that ship in the PowerToys install folder (Settings deep links from Color Picker, FancyZones, Image Resizer, Workspaces, etc.) — the install directory is simply the folder the binary was loaded from, so reading it from the running process is more direct and does not depend on the registry registration being present or up to date.

The registry path is retained as a fallback for callers that legitimately run **outside** the install tree — notably the packaged Command Palette extension host (MSIX, deployed under `WindowsApps`), which has no other way to locate a separately-installed PowerToys to launch `WinUI3Apps\PowerToys.Peek.UI.exe`.

## PR Checklist

- [ ] Closes: #xxx
- [x] **Communication:** discussed with core contributors
- [ ] **Tests:** Added/updated and all pass
- [x] **Localization:** No end-user-facing strings changed
- [x] **Dev docs:** Not applicable
- [x] **New binaries:** None added

## Detailed Description of the Pull Request / Additional comments

`GetPowerToysInstallPath()` (release path) now:

1. Resolves from the current process location first via the existing `GetPathFromCurrentProcess()` helper. This works for both per-user and per-machine installs and for any caller that runs from inside the install tree.
2. Falls back to the registry only when step 1 yields nothing — i.e. for the packaged Command Palette extension host that runs from `WindowsApps`.

The per-machine (HKLM) registration is consulted for any process running with administrator rights, since the per-user (HKCU) registration is only meaningful for the interactive user. The change reuses existing helpers (`GetPathFromCurrentProcess`, `GetPathFromRegistry`) and adds no new public API, dependencies, or binaries. Debug-build behavior is unchanged.

## Validation Steps Performed

- Built `ManagedCommon` (Release) — compiles clean, 0 warnings / 0 errors.
- Verified the three callers of `GetPowerToysInstallPath()`:
  - In-tree module callers (Settings deep links, Workspaces) resolve via the running executable location.
  - The packaged Command Palette Indexer (`PeekFileCommand`) still resolves via the registry fallback, since it runs from `WindowsApps` and PowerToys is installed separately.
