### PR TITLE
Fix VS Code workspace UNC paths

### DIFF
--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/WorkspacesHelper/VSCodeWorkspacesApi.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.VSCodeWorkspaces/WorkspacesHelper/VSCodeWorkspacesApi.cs
@@ -33,16 +33,40 @@ namespace Community.PowerToys.Run.Plugin.VSCodeWorkspaces.WorkspacesHelper
                 return null;
             }
 
-            var (workspaceEnv, machineName) = ParseVSCodeAuthority.GetWorkspaceEnvironment(authority ?? rfc3986Uri.Authority);
+            var isFileUri = string.Equals(
+                rfc3986Uri.Scheme,
+                Uri.UriSchemeFile,
+                StringComparison.OrdinalIgnoreCase);
+
+            var isUncFileUri =
+                isFileUri &&
+                string.IsNullOrEmpty(authority) &&
+                !string.IsNullOrEmpty(rfc3986Uri.Authority) &&
+                !string.Equals(
+                    rfc3986Uri.Authority,
+                    "localhost",
+                    StringComparison.OrdinalIgnoreCase);
+
+            // file://server/share is a local Windows UNC path, not a VS Code remote URI.
+            var effectiveAuthority =
+                isFileUri && string.IsNullOrEmpty(authority)
+                    ? string.Empty
+                    : authority ?? rfc3986Uri.Authority;
+
+            var (workspaceEnv, machineName) =
+                ParseVSCodeAuthority.GetWorkspaceEnvironment(effectiveAuthority);
+
             if (workspaceEnv is null)
             {
                 return null;
             }
 
-            var path = rfc3986Uri.Path;
+            var path = isUncFileUri
+                ? $@"\\{rfc3986Uri.Authority}{rfc3986Uri.Path.Replace('/', '\\')}"
+                : rfc3986Uri.Path;
 
-            // Remove preceding '/' from local (Windows) path
-            if (workspaceEnv == WorkspaceEnvironment.Local)
+            // file:///C:/... becomes C:/...
+            if (workspaceEnv == WorkspaceEnvironment.Local && !isUncFileUri)
             {
                 path = path[1..];
             }


### PR DESCRIPTION
## Summary of the Pull Request

Fixes #47719

VS Code stores recently opened workspaces as URIs. A workspace on a Windows network share can be stored as `file://server/share/workspace.code-workspace`.

The VS Code Workspaces plugin interpreted the server part of that URI as a VS Code remote authority. Because it was not a recognized remote authority, valid UNC workspaces were discarded.

This change recognizes file URIs with a server authority as local UNC paths and converts them to the Windows UNC format: `\\server\share\...`.

## PR Checklist

* [x] Closes #47719
* [x] **Communication:** This implementation follows the suggested direction in the issue discussion.
* [ ] **Tests:** No automated regression test added.
* [x] **Localization:** No user-facing strings were changed.
* [x] **New binaries:** No binaries were added.
* [x] **Documentation updated:** No documentation changes are required.

## Validation Steps Performed

* Built the full PowerToys solution locally in `Release | x64` with 0 errors.
* Started the locally built PowerToys instance.
* Verified that the VS Code Workspaces plugin finds local workspaces.
* Verified that UNC workspaces using both a hostname and an IP address appear in PowerToys Run.
* Opened a UNC workspace successfully from PowerToys Run.
