### PR TITLE
Add .opus support for Peek

### DIFF
--- a/src/modules/peek/Peek.FilePreviewer/Previewers/MediaPreviewer/AudioPreviewer.cs
+++ b/src/modules/peek/Peek.FilePreviewer/Previewers/MediaPreviewer/AudioPreviewer.cs
@@ -200,6 +200,7 @@ namespace Peek.FilePreviewer.Previewers.MediaPreviewer
             ".amr",
             ".flac",
             ".m4a",
+            ".opus",
             ".mp3",
             ".ogg",
             ".wav",


### PR DESCRIPTION
## Summary
- Add .opus to Peek audio preview supported file types.
- Enables .opus playback preview attempts instead of unsupported-format fallback.
- Directly implements the request in issue #42576.

Closes #42576