### PR TITLE
[CmdPal] Fix excessive Narrator announcements on More button open

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml.cs
@@ -156,8 +156,8 @@ public sealed partial class CommandBar : UserControl,
 
     private void ContextMenuFlyout_Opened(object sender, object e)
     {
-        // We need to wait until our flyout is opened to try and toss focus
-        // at its search box. The control isn't in the UI tree before that
-        ContextControl.FocusSearchBox();
+        // Focus the filter box and fire a single consolidated Narrator
+        // announcement replacing the default cascade of UIA events.
+        ContextControl.AnnounceOpened();
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CommandBar.xaml.cs
@@ -156,8 +156,9 @@ public sealed partial class CommandBar : UserControl,
 
     private void ContextMenuFlyout_Opened(object sender, object e)
     {
-        // Focus the filter box and fire a single consolidated Narrator
-        // announcement replacing the default cascade of UIA events.
+        // Focus the filter box so the flyout captures keyboard input,
+        // then fire a single consolidated Narrator announcement.
+        ContextControl.FocusSearchBox();
         ContextControl.AnnounceOpened();
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContextMenu.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContextMenu.xaml
@@ -140,8 +140,10 @@
             <RowDefinition />
         </Grid.RowDefinitions>
 
-        <!--  Hidden element used solely for raising Narrator notifications.
-              It must be Content-visible in UIA but has no visual presence.  -->
+        <!--
+            Hidden element used solely for raising Narrator notifications.
+            It must be Content-visible in UIA but has no visual presence.
+        -->
         <TextBlock
             x:Name="NarratorAnnouncer"
             Width="0"
@@ -177,9 +179,9 @@
         <TextBox
             x:Name="ContextFilterBox"
             x:Uid="ContextFilterBox"
-            AutomationProperties.AccessibilityView="Raw"
             Margin="0"
             Padding="10,7,6,8"
+            AutomationProperties.AccessibilityView="Raw"
             Background="{ThemeResource AcrylicBackgroundFillColorBaseBrush}"
             BorderThickness="0,0,0,2"
             CornerRadius="8, 8, 0, 0"

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContextMenu.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContextMenu.xaml
@@ -139,10 +139,21 @@
             <RowDefinition />
             <RowDefinition />
         </Grid.RowDefinitions>
+
+        <!--  Hidden element used solely for raising Narrator notifications.
+              It must be Content-visible in UIA but has no visual presence.  -->
+        <TextBlock
+            x:Name="NarratorAnnouncer"
+            Width="0"
+            Height="0"
+            AutomationProperties.AccessibilityView="Content"
+            AutomationProperties.LiveSetting="Assertive" />
+
         <ListView
             x:Name="CommandsDropdown"
             MinWidth="248"
             Margin="0,4,0,2"
+            AutomationProperties.AccessibilityView="Raw"
             IsItemClickEnabled="True"
             ItemClick="CommandsDropdown_ItemClick"
             ItemTemplateSelector="{StaticResource ContextItemTemplateSelector}"
@@ -166,6 +177,7 @@
         <TextBox
             x:Name="ContextFilterBox"
             x:Uid="ContextFilterBox"
+            AutomationProperties.AccessibilityView="Raw"
             Margin="0"
             Padding="10,7,6,8"
             Background="{ThemeResource AcrylicBackgroundFillColorBaseBrush}"

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContextMenu.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContextMenu.xaml.cs
@@ -2,6 +2,8 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Globalization;
+using System.Text;
 using CommunityToolkit.Mvvm.Messaging;
 using CommunityToolkit.WinUI;
 using Microsoft.CmdPal.Common.Text;
@@ -11,6 +13,7 @@ using Microsoft.CmdPal.UI.ViewModels;
 using Microsoft.CmdPal.UI.ViewModels.Messages;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Windows.System;
@@ -26,6 +29,15 @@ public sealed partial class ContextMenu : UserControl,
 
     public static readonly DependencyProperty SubscribeToCommandBarProperty =
         DependencyProperty.Register(nameof(SubscribeToCommandBar), typeof(bool), typeof(ContextMenu), new PropertyMetadata(true, OnSubscribeToCommandBarChanged));
+
+    private static readonly CompositeFormat _contextMenuOpenedFormat =
+        CompositeFormat.Parse(ResourceLoaderInstance.GetString("ScreenReader_Announcement_ContextMenuOpened"));
+
+    /// <summary>
+    /// True while the context menu is transitioning from PrepareForOpen to AnnounceOpened.
+    /// Prevents ViewModel_PropertyChanged from triggering UIA-visible selection changes.
+    /// </summary>
+    private bool _isOpening;
 
     public bool ShowFilterBox
     {
@@ -103,10 +115,51 @@ public sealed partial class ContextMenu : UserControl,
 
     internal void PrepareForOpen(ContextMenuFilterLocation filterLocation)
     {
+        _isOpening = true;
+
         ViewModel.FilterOnTop = filterLocation == ContextMenuFilterLocation.Top;
         ViewModel.ResetContextMenu();
 
         UpdateUiForStackChange();
+    }
+
+    /// <summary>
+    /// Fires a single consolidated Narrator announcement.
+    /// Call this after the flyout is opened.
+    /// </summary>
+    internal void AnnounceOpened()
+    {
+        // Focus the search box immediately so the flyout captures keyboard input.
+        FocusSearchBox();
+
+        // Defer the announcement to the next dispatcher cycle. This ensures
+        // any pending FilteredItems updates have completed.
+        DispatcherQueue.TryEnqueue(() =>
+        {
+            _isOpening = false;
+
+            var commandItems = ViewModel.FilteredItems.OfType<CommandContextItemViewModel>().ToList();
+            var itemCount = commandItems.Count;
+            var selectedItem = CommandsDropdown.SelectedItem as CommandContextItemViewModel;
+            var selectedName = selectedItem?.Title ?? string.Empty;
+            var selectedIndex = selectedItem is not null ? commandItems.IndexOf(selectedItem) + 1 : 0;
+
+            var announcement = string.Format(
+                CultureInfo.CurrentCulture,
+                _contextMenuOpenedFormat,
+                itemCount,
+                selectedName,
+                selectedIndex);
+
+            // Raise from the dedicated announcer element which is
+            // Content-visible in UIA but has no visual presence.
+            var peer = FrameworkElementAutomationPeer.CreatePeerForElement(NarratorAnnouncer);
+            peer?.RaiseNotificationEvent(
+                AutomationNotificationKind.ActionCompleted,
+                AutomationNotificationProcessing.ImportantMostRecent,
+                announcement,
+                "ContextMenuOpened");
+        });
     }
 
     public void Receive(UpdateCommandBarMessage message)
@@ -197,7 +250,7 @@ public sealed partial class ContextMenu : UserControl,
     {
         var prop = e.PropertyName;
 
-        if (prop == nameof(ContextMenuViewModel.FilteredItems))
+        if (prop == nameof(ContextMenuViewModel.FilteredItems) && !_isOpening)
         {
             UpdateUiForStackChange();
         }
@@ -255,12 +308,14 @@ public sealed partial class ContextMenu : UserControl,
         if (e.Key == VirtualKey.Up)
         {
             NavigateUp();
+            AnnounceSelectedItem();
 
             e.Handled = true;
         }
         else if (e.Key == VirtualKey.Down)
         {
             NavigateDown();
+            AnnounceSelectedItem();
 
             e.Handled = true;
         }
@@ -345,6 +400,26 @@ public sealed partial class ContextMenu : UserControl,
     private bool IsSeparator(object item)
     {
         return item is SeparatorViewModel;
+    }
+
+    private void AnnounceSelectedItem()
+    {
+        if (CommandsDropdown.SelectedItem is not CommandContextItemViewModel selected)
+        {
+            return;
+        }
+
+        var commandItems = ViewModel.FilteredItems.OfType<CommandContextItemViewModel>().ToList();
+        var position = commandItems.IndexOf(selected) + 1;
+        var total = commandItems.Count;
+        var announcement = $"{selected.Title}, {position} of {total}";
+
+        var peer = FrameworkElementAutomationPeer.CreatePeerForElement(NarratorAnnouncer);
+        peer?.RaiseNotificationEvent(
+            AutomationNotificationKind.ItemAdded,
+            AutomationNotificationProcessing.ImportantMostRecent,
+            announcement,
+            "ContextMenuSelectionChanged");
     }
 
     private void UpdateUiForStackChange()

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContextMenu.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContextMenu.xaml.cs
@@ -125,15 +125,13 @@ public sealed partial class ContextMenu : UserControl,
 
     /// <summary>
     /// Fires a single consolidated Narrator announcement.
-    /// Call this after the flyout is opened.
+    /// Call this after the flyout is opened and focus has been set.
     /// </summary>
     internal void AnnounceOpened()
     {
-        // Focus the search box immediately so the flyout captures keyboard input.
-        FocusSearchBox();
-
         // Defer the announcement to the next dispatcher cycle. This ensures
-        // any pending FilteredItems updates have completed.
+        // any pending FilteredItems updates have completed and the flyout
+        // content is fully materialized in the UIA tree.
         DispatcherQueue.TryEnqueue(() =>
         {
             _isOpening = false;
@@ -151,12 +149,8 @@ public sealed partial class ContextMenu : UserControl,
                 selectedName,
                 selectedIndex);
 
-            // Raise from the dedicated announcer element which is
-            // Content-visible in UIA but has no visual presence.
-            var peer = FrameworkElementAutomationPeer.CreatePeerForElement(NarratorAnnouncer);
-            peer?.RaiseNotificationEvent(
+            RaiseNarratorNotification(
                 AutomationNotificationKind.ActionCompleted,
-                AutomationNotificationProcessing.ImportantMostRecent,
                 announcement,
                 "ContextMenuOpened");
         });
@@ -414,12 +408,32 @@ public sealed partial class ContextMenu : UserControl,
         var total = commandItems.Count;
         var announcement = $"{selected.Title}, {position} of {total}";
 
-        var peer = FrameworkElementAutomationPeer.CreatePeerForElement(NarratorAnnouncer);
-        peer?.RaiseNotificationEvent(
+        RaiseNarratorNotification(
             AutomationNotificationKind.ItemAdded,
-            AutomationNotificationProcessing.ImportantMostRecent,
             announcement,
             "ContextMenuSelectionChanged");
+    }
+
+    /// <summary>
+    /// Raises a UIA notification via the dedicated NarratorAnnouncer element.
+    /// Ensures the element has a peer (forcing layout if needed on first use).
+    /// </summary>
+    private void RaiseNarratorNotification(AutomationNotificationKind kind, string announcement, string activityId)
+    {
+        // On first flyout open the announcer may not have a peer yet.
+        // UpdateLayout ensures the element is materialized in the UIA tree.
+        var peer = FrameworkElementAutomationPeer.FromElement(NarratorAnnouncer);
+        if (peer is null)
+        {
+            NarratorAnnouncer.UpdateLayout();
+            peer = FrameworkElementAutomationPeer.CreatePeerForElement(NarratorAnnouncer);
+        }
+
+        peer?.RaiseNotificationEvent(
+            kind,
+            AutomationNotificationProcessing.ImportantMostRecent,
+            announcement,
+            activityId);
     }
 
     private void UpdateUiForStackChange()

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockControl.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockControl.xaml.cs
@@ -500,8 +500,9 @@ public sealed partial class DockControl : UserControl, IRecipient<CloseContextMe
 
     private void ContextMenuFlyout_Opened(object sender, object e)
     {
-        // Focus the filter box and fire a single consolidated Narrator
-        // announcement replacing the default cascade of UIA events.
+        // Focus the filter box so the flyout captures keyboard input,
+        // then fire a single consolidated Narrator announcement.
+        ContextControl.FocusSearchBox();
         ContextControl.AnnounceOpened();
     }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockControl.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockControl.xaml.cs
@@ -500,9 +500,9 @@ public sealed partial class DockControl : UserControl, IRecipient<CloseContextMe
 
     private void ContextMenuFlyout_Opened(object sender, object e)
     {
-        // We need to wait until our flyout is opened to try and toss focus
-        // at its search box. The control isn't in the UI tree before that
-        ContextControl.FocusSearchBox();
+        // Focus the filter box and fire a single consolidated Narrator
+        // announcement replacing the default cascade of UIA events.
+        ContextControl.AnnounceOpened();
     }
 
     public void Receive(CloseContextMenuMessage message)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Strings/en-us/Resources.resw
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Strings/en-us/Resources.resw
@@ -560,7 +560,7 @@ Right-click to remove the key combination, thereby deactivating the shortcut.</v
     <value>Navigated to {0} page</value>
   </data>
   <data name="ScreenReader_Announcement_ContextMenuOpened" xml:space="preserve">
-    <value>More actions, {0} commands. {1}, {2} of {0}.</value>
+    <value>Menu, {0} commands. {1}, {2} of {0}.</value>
   </data>
   <data name="SettingsButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Settings (Ctrl+,)</value>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Strings/en-us/Resources.resw
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Strings/en-us/Resources.resw
@@ -559,6 +559,9 @@ Right-click to remove the key combination, thereby deactivating the shortcut.</v
   <data name="ScreenReader_Announcement_NavigatedToPage0" xml:space="preserve">
     <value>Navigated to {0} page</value>
   </data>
+  <data name="ScreenReader_Announcement_ContextMenuOpened" xml:space="preserve">
+    <value>More actions, {0} commands. {1}, {2} of {0}.</value>
+  </data>
   <data name="SettingsButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Settings (Ctrl+,)</value>
   </data>


### PR DESCRIPTION

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Opening the More button caused Narrator to read a long cascade of overlapping announcements — popup window, filter TextBox placeholder, ListView item name, position ("1 of 4"), keyboard shortcut text — all from a single keypress with no further input.

This PR replaces that cascade with a single, clean announcement:
**"More actions, {0} commands. {1}, {2} of {0}"**
(num of commands, first item in list, num of order in list, num of commands)
**"More actions, 3 commands. Calculator, 1 of 3."**


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #48899
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [x] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments


| File | Change |
|------|--------|
| `ContextMenu.xaml` | Set `AccessibilityView="Raw"` on ListView and TextBox; added `NarratorAnnouncer` TextBlock for raising UIA notifications |
| `ContextMenu.xaml.cs` | Added `AnnounceOpened()`, `AnnounceSelectedItem()`, and `_isOpening` guard to prevent programmatic selection changes from triggering UIA events during the flyout transition |
| `CommandBar.xaml.cs` | Call `AnnounceOpened()` on flyout open |
| `DockControl.xaml.cs` | Same for dock context menu |
| `Resources.resw` | Added `ScreenReader_Announcement_ContextMenuOpened` localized format string |

## How it works

- ListView and TextBox are permanently `AccessibilityView="Raw"` — invisible
  to Narrator, preventing all system-driven UIA announcements
- A zero-size `NarratorAnnouncer` TextBlock (`AccessibilityView="Content"`,
  `LiveSetting="Assertive"`) serves as the sole notification source
- On open: a deferred `RaiseNotificationEvent` fires one consolidated announcement
- On arrow navigation: `AnnounceSelectedItem()` fires item name and position


<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed


https://github.com/user-attachments/assets/4660741f-6b91-4a32-9a56-83c64343b67a



- [x] Build succeeds (0 errors)
- [x] 124 ViewModel unit tests pass
- [x] Manual Narrator testing: open, arrow navigate, close, reopen
- [x] Keyboard filtering (type to filter) still works
- [x] Enter to invoke selected command still works
- [x] Escape to close still works