### PR TITLE
Fix EnvironmentVariables profile fallback and add-variable focus stability

### DIFF
--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Converters/EnvironmentStateToBoolConverter.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Converters/EnvironmentStateToBoolConverter.cs
@@ -13,7 +13,11 @@ public partial class EnvironmentStateToBoolConverter : IValueConverter
 {
     public object Convert(object value, Type targetType, object parameter, string language)
     {
-        var type = (EnvironmentState)value;
+        if (value is not EnvironmentState type)
+        {
+            return true;
+        }
+
         return type switch
         {
             EnvironmentState.Unchanged => false,
@@ -23,6 +27,6 @@ public partial class EnvironmentStateToBoolConverter : IValueConverter
 
     public object ConvertBack(object value, Type targetType, object parameter, string language)
     {
-        throw new NotImplementedException();
+        return null;
     }
 }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Converters/EnvironmentStateToMessageConverter.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Converters/EnvironmentStateToMessageConverter.cs
@@ -15,14 +15,18 @@ public partial class EnvironmentStateToMessageConverter : IValueConverter
     public object Convert(object value, Type targetType, object parameter, string language)
     {
         var resourceLoader = ResourceLoaderInstance.ResourceLoader;
-        var type = (EnvironmentState)value;
+        if (value is not EnvironmentState type)
+        {
+            return string.Empty;
+        }
+
         return type switch
         {
             EnvironmentState.Unchanged => string.Empty,
             EnvironmentState.ChangedOnStartup => resourceLoader.GetString("StateNotUpToDateOnStartupMsg"),
             EnvironmentState.EnvironmentMessageReceived => resourceLoader.GetString("StateNotUpToDateEnvironmentMessageReceivedMsg"),
             EnvironmentState.ProfileNotApplicable => resourceLoader.GetString("StateProfileNotApplicableMsg"),
-            _ => throw new NotImplementedException(),
+            _ => string.Empty,
         };
     }
 

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Converters/EnvironmentStateToMessageConverter.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Converters/EnvironmentStateToMessageConverter.cs
@@ -32,6 +32,6 @@ public partial class EnvironmentStateToMessageConverter : IValueConverter
 
     public object ConvertBack(object value, Type targetType, object parameter, string language)
     {
-        throw new NotImplementedException();
+        return null;
     }
 }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Converters/EnvironmentStateToTitleConverter.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Converters/EnvironmentStateToTitleConverter.cs
@@ -15,6 +15,11 @@ public partial class EnvironmentStateToTitleConverter : IValueConverter
     public object Convert(object value, Type targetType, object parameter, string language)
     {
         var resourceLoader = ResourceLoaderInstance.ResourceLoader;
+        if (value is not EnvironmentState)
+        {
+            return resourceLoader.GetString("StateNotUpToDateTitle");
+        }
+
         var type = (EnvironmentState)value;
         return type switch
         {
@@ -25,6 +30,6 @@ public partial class EnvironmentStateToTitleConverter : IValueConverter
 
     public object ConvertBack(object value, Type targetType, object parameter, string language)
     {
-        throw new NotImplementedException();
+        return null;
     }
 }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Converters/EnvironmentStateToVisibilityConverter.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Converters/EnvironmentStateToVisibilityConverter.cs
@@ -14,7 +14,11 @@ public partial class EnvironmentStateToVisibilityConverter : IValueConverter
 {
     public object Convert(object value, Type targetType, object parameter, string language)
     {
-        var type = (EnvironmentState)value;
+        if (value is not EnvironmentState type)
+        {
+            return Visibility.Visible;
+        }
+
         return type switch
         {
             EnvironmentState.Unchanged => Visibility.Collapsed,
@@ -24,6 +28,6 @@ public partial class EnvironmentStateToVisibilityConverter : IValueConverter
 
     public object ConvertBack(object value, Type targetType, object parameter, string language)
     {
-        throw new NotImplementedException();
+        return null;
     }
 }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Converters/VariableTypeToGlyphConverter.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Converters/VariableTypeToGlyphConverter.cs
@@ -13,7 +13,11 @@ public partial class VariableTypeToGlyphConverter : IValueConverter
 {
     public object Convert(object value, Type targetType, object parameter, string language)
     {
-        var type = (VariablesSetType)value;
+        if (value is not VariablesSetType type)
+        {
+            return "\uE10A"; // Generic symbol for unknown types
+        }
+
         return type switch
         {
             VariablesSetType.User => "\uE77B",
@@ -21,7 +25,7 @@ public partial class VariableTypeToGlyphConverter : IValueConverter
             VariablesSetType.Profile => "\uEDE3",
             VariablesSetType.Path => "\uE8AC",
             VariablesSetType.Duplicate => "\uE8C8",
-            _ => throw new NotImplementedException(),
+            _ => "\uE10A",
         };
     }
 

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Converters/VariableTypeToGlyphConverter.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Converters/VariableTypeToGlyphConverter.cs
@@ -31,6 +31,6 @@ public partial class VariableTypeToGlyphConverter : IValueConverter
 
     public object ConvertBack(object value, Type targetType, object parameter, string language)
     {
-        throw new NotImplementedException();
+        return null;
     }
 }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml
@@ -703,48 +703,56 @@
                         </tkcontrols:Case>
                         <tkcontrols:Case Value="ExistingVariable">
                             <!--  Adding existing variables  -->
-                            <ListView
-                                x:Name="ExistingVariablesListView"
-                                Grid.Row="1"
-                                Margin="-12,12,0,12"
-                                HorizontalAlignment="Stretch"
-                                ItemsSource="{x:Bind ViewModel.DefaultVariables.Variables, Mode=OneWay}"
-                                Loaded="ExistingVariablesListView_Loaded"
-                                SelectionChanged="ExistingVariablesListView_SelectionChanged"
-                                SelectionMode="Multiple">
+                            <StackPanel>
+                                <TextBox
+                                    x:Name="DefaultVariablesSearchBox"
+                                    x:Uid="SearchExistingVariable"
+                                    Margin="0,8,0,4"
+                                    TextChanged="DefaultVariablesSearchBox_TextChanged"
+                                    VerticalAlignment="Center" />
+                                <ListView
+                                    x:Name="ExistingVariablesListView"
+                                    Grid.Row="1"
+                                    Margin="-12,0,0,12"
+                                    HorizontalAlignment="Stretch"
+                                    ItemsSource="{x:Bind ViewModel.FilteredDefaultVariables, Mode=OneWay}"
+                                    Loaded="ExistingVariablesListView_Loaded"
+                                    SelectionChanged="ExistingVariablesListView_SelectionChanged"
+                                    SelectionMode="Multiple">
 
-                                <ListView.ItemTemplate>
-                                    <DataTemplate x:DataType="models:Variable">
-                                        <Grid Height="48" ColumnSpacing="8">
-                                            <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="20" />
-                                                <ColumnDefinition />
-                                            </Grid.ColumnDefinitions>
-                                            <FontIcon
-                                                Grid.Column="0"
-                                                VerticalAlignment="Center"
-                                                FontSize="14"
-                                                Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}"
-                                                Glyph="{x:Bind ParentType, Mode=OneWay, Converter={StaticResource VariableTypeToGlyphConverter}}" />
-                                            <StackPanel
-                                                Grid.Column="1"
-                                                VerticalAlignment="Center"
-                                                Orientation="Vertical">
-                                                <TextBlock
-                                                    Text="{x:Bind Name}"
-                                                    TextTrimming="CharacterEllipsis"
-                                                    TextWrapping="NoWrap" />
-                                                <TextBlock
-                                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                                    Style="{StaticResource CaptionTextBlockStyle}"
-                                                    Text="{x:Bind Values}"
-                                                    TextTrimming="CharacterEllipsis"
-                                                    TextWrapping="NoWrap" />
-                                            </StackPanel>
-                                        </Grid>
-                                    </DataTemplate>
-                                </ListView.ItemTemplate>
-                            </ListView>
+                                    <ListView.ItemTemplate>
+                                        <DataTemplate x:DataType="models:Variable">
+                                            <Grid Height="48" ColumnSpacing="8">
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="20" />
+                                                    <ColumnDefinition />
+                                                </Grid.ColumnDefinitions>
+                                                <FontIcon
+                                                    Grid.Column="0"
+                                                    VerticalAlignment="Center"
+                                                    FontSize="14"
+                                                    Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}"
+                                                    Glyph="{x:Bind ParentType, Mode=OneWay, Converter={StaticResource VariableTypeToGlyphConverter}}" />
+                                                <StackPanel
+                                                    Grid.Column="1"
+                                                    VerticalAlignment="Center"
+                                                    Orientation="Vertical">
+                                                    <TextBlock
+                                                        Text="{x:Bind Name}"
+                                                        TextTrimming="CharacterEllipsis"
+                                                        TextWrapping="NoWrap" />
+                                                    <TextBlock
+                                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                        Style="{StaticResource CaptionTextBlockStyle}"
+                                                        Text="{x:Bind Values}"
+                                                        TextTrimming="CharacterEllipsis"
+                                                        TextWrapping="NoWrap" />
+                                                </StackPanel>
+                                            </Grid>
+                                        </DataTemplate>
+                                    </ListView.ItemTemplate>
+                                </ListView>
+                            </StackPanel>
 
                         </tkcontrols:Case>
                     </tkcontrols:SwitchPresenter>

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml
@@ -635,7 +635,7 @@
 
                     </Grid>
 
-                    <Button>
+                    <Button Click="AddVariableBtn_Click">
                         <StackPanel Orientation="Horizontal" Spacing="8">
                             <FontIcon
                                 x:Name="AddVariableIcon"
@@ -644,131 +644,111 @@
                                 Glyph="&#xe710;" />
                             <TextBlock x:Uid="AddVariableBtn" />
                         </StackPanel>
-                        <Button.Flyout>
-                            <Flyout
-                                x:Name="AddVariableFlyout"
-                                Closed="AddVariableFlyout_Closed"
-                                Placement="Right"
-                                ShouldConstrainToRootBounds="False">
-                                <Grid Width="320" Height="480">
-                                    <Grid.RowDefinitions>
-                                        <RowDefinition Height="Auto" />
-                                        <RowDefinition Height="*" />
-                                        <RowDefinition Height="Auto" />
-                                    </Grid.RowDefinitions>
-
-                                    <tkcontrols:Segmented
-                                        x:Name="SwitchViewsSegmentedView"
-                                        MaxWidth="500"
-                                        HorizontalAlignment="Stretch"
-                                        SelectionMode="Single">
-                                        <tkcontrols:SegmentedItem
-                                            x:Name="AddNewVariableSegmentedItem"
-                                            x:Uid="NewVariableSegmentedButton"
-                                            Tag="NewVariable" />
-                                        <tkcontrols:SegmentedItem
-                                            x:Name="AddExistingVariableSegmentedItem"
-                                            x:Uid="ExistingVariableSegmentedButton"
-                                            Tag="ExistingVariable" />
-                                    </tkcontrols:Segmented>
-
-                                    <tkcontrols:SwitchPresenter
-                                        x:Name="AddVariableSwitchPresenter"
-                                        Grid.Row="1"
-                                        Value="{Binding SelectedItem.Tag, ElementName=SwitchViewsSegmentedView}">
-                                        <tkcontrols:Case Value="NewVariable">
-                                            <StackPanel Grid.Row="1" Orientation="Vertical">
-
-                                                <!--  Adding new variable  -->
-                                                <TextBox
-                                                    x:Name="AddNewVariableName"
-                                                    x:Uid="AddNewVariableName"
-                                                    Margin="0,16,0,0"
-                                                    TextChanged="AddNewVariableName_TextChanged" />
-
-                                                <TextBox
-                                                    x:Name="AddNewVariableValue"
-                                                    x:Uid="AddNewVariableValue"
-                                                    Margin="0,16,0,0" />
-                                            </StackPanel>
-                                        </tkcontrols:Case>
-                                        <tkcontrols:Case Value="ExistingVariable">
-                                            <!--  Adding existing variables  -->
-                                            <ListView
-                                                x:Name="ExistingVariablesListView"
-                                                Grid.Row="1"
-                                                Margin="-12,12,0,12"
-                                                HorizontalAlignment="Stretch"
-                                                ItemsSource="{x:Bind ViewModel.DefaultVariables.Variables, Mode=OneWay}"
-                                                Loaded="ExistingVariablesListView_Loaded"
-                                                SelectionChanged="ExistingVariablesListView_SelectionChanged"
-                                                SelectionMode="Multiple">
-
-                                                <ListView.ItemTemplate>
-                                                    <DataTemplate x:DataType="models:Variable">
-                                                        <Grid Height="48" ColumnSpacing="8">
-                                                            <Grid.ColumnDefinitions>
-                                                                <ColumnDefinition Width="20" />
-                                                                <ColumnDefinition />
-                                                            </Grid.ColumnDefinitions>
-                                                            <FontIcon
-                                                                Grid.Column="0"
-                                                                VerticalAlignment="Center"
-                                                                FontSize="14"
-                                                                Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}"
-                                                                Glyph="{x:Bind ParentType, Mode=OneWay, Converter={StaticResource VariableTypeToGlyphConverter}}" />
-                                                            <StackPanel
-                                                                Grid.Column="1"
-                                                                VerticalAlignment="Center"
-                                                                Orientation="Vertical">
-                                                                <TextBlock
-                                                                    Text="{x:Bind Name}"
-                                                                    TextTrimming="CharacterEllipsis"
-                                                                    TextWrapping="NoWrap" />
-                                                                <TextBlock
-                                                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                                                    Style="{StaticResource CaptionTextBlockStyle}"
-                                                                    Text="{x:Bind Values}"
-                                                                    TextTrimming="CharacterEllipsis"
-                                                                    TextWrapping="NoWrap" />
-                                                            </StackPanel>
-                                                        </Grid>
-                                                    </DataTemplate>
-                                                </ListView.ItemTemplate>
-                                            </ListView>
-
-                                        </tkcontrols:Case>
-                                    </tkcontrols:SwitchPresenter>
-                                    <Grid Grid.Row="2" HorizontalAlignment="Stretch">
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="*" />
-                                            <ColumnDefinition Width="*" />
-                                        </Grid.ColumnDefinitions>
-
-                                        <Button
-                                            x:Name="ConfirmAddVariableBtn"
-                                            x:Uid="ConfirmAddVariableBtn"
-                                            Margin="4,0,4,0"
-                                            HorizontalAlignment="Stretch"
-                                            Command="{x:Bind AddVariableCommand}"
-                                            IsEnabled="False"
-                                            Style="{StaticResource AccentButtonStyle}" />
-
-                                        <Button
-                                            x:Name="CancelAddVariableBtn"
-                                            x:Uid="CancelAddVariableBtn"
-                                            Grid.Column="1"
-                                            Margin="4,0,4,0"
-                                            HorizontalAlignment="Stretch"
-                                            Command="{x:Bind CancelAddVariableCommand}" />
-
-                                    </Grid>
-                                </Grid>
-
-                            </Flyout>
-                        </Button.Flyout>
                     </Button>
                 </StackPanel>
+            </ScrollViewer>
+        </ContentDialog>
+
+        <ContentDialog
+            x:Name="AddVariableDialog"
+            x:Uid="AddVariableDialog"
+            IsPrimaryButtonEnabled="False"
+            IsSecondaryButtonEnabled="True"
+            PrimaryButtonStyle="{StaticResource AccentButtonStyle}"
+            Closed="AddVariableDialog_Closed">
+            <ContentDialog.DataContext>
+                <models:ProfileVariablesSet />
+            </ContentDialog.DataContext>
+            <ScrollViewer>
+                <Grid Width="320" Height="480">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+
+                    <tkcontrols:Segmented
+                        x:Name="SwitchViewsSegmentedView"
+                        MaxWidth="500"
+                        HorizontalAlignment="Stretch"
+                        SelectionMode="Single">
+                        <tkcontrols:SegmentedItem
+                            x:Name="AddNewVariableSegmentedItem"
+                            x:Uid="NewVariableSegmentedButton"
+                            Tag="NewVariable" />
+                        <tkcontrols:SegmentedItem
+                            x:Name="AddExistingVariableSegmentedItem"
+                            x:Uid="ExistingVariableSegmentedButton"
+                            Tag="ExistingVariable" />
+                    </tkcontrols:Segmented>
+
+                    <tkcontrols:SwitchPresenter
+                        x:Name="AddVariableSwitchPresenter"
+                        Grid.Row="1"
+                        Value="{Binding SelectedItem.Tag, ElementName=SwitchViewsSegmentedView}">
+                        <tkcontrols:Case Value="NewVariable">
+                            <StackPanel Grid.Row="1" Orientation="Vertical">
+
+                                <!--  Adding new variable  -->
+                                <TextBox
+                                    x:Name="AddNewVariableName"
+                                    x:Uid="AddNewVariableName"
+                                    Margin="0,16,0,0"
+                                    TextChanged="AddNewVariableName_TextChanged" />
+
+                                <TextBox
+                                    x:Name="AddNewVariableValue"
+                                    x:Uid="AddNewVariableValue"
+                                    Margin="0,16,0,0" />
+                            </StackPanel>
+                        </tkcontrols:Case>
+                        <tkcontrols:Case Value="ExistingVariable">
+                            <!--  Adding existing variables  -->
+                            <ListView
+                                x:Name="ExistingVariablesListView"
+                                Grid.Row="1"
+                                Margin="-12,12,0,12"
+                                HorizontalAlignment="Stretch"
+                                ItemsSource="{x:Bind ViewModel.DefaultVariables.Variables, Mode=OneWay}"
+                                Loaded="ExistingVariablesListView_Loaded"
+                                SelectionChanged="ExistingVariablesListView_SelectionChanged"
+                                SelectionMode="Multiple">
+
+                                <ListView.ItemTemplate>
+                                    <DataTemplate x:DataType="models:Variable">
+                                        <Grid Height="48" ColumnSpacing="8">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="20" />
+                                                <ColumnDefinition />
+                                            </Grid.ColumnDefinitions>
+                                            <FontIcon
+                                                Grid.Column="0"
+                                                VerticalAlignment="Center"
+                                                FontSize="14"
+                                                Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}"
+                                                Glyph="{x:Bind ParentType, Mode=OneWay, Converter={StaticResource VariableTypeToGlyphConverter}}" />
+                                            <StackPanel
+                                                Grid.Column="1"
+                                                VerticalAlignment="Center"
+                                                Orientation="Vertical">
+                                                <TextBlock
+                                                    Text="{x:Bind Name}"
+                                                    TextTrimming="CharacterEllipsis"
+                                                    TextWrapping="NoWrap" />
+                                                <TextBlock
+                                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                    Style="{StaticResource CaptionTextBlockStyle}"
+                                                    Text="{x:Bind Values}"
+                                                    TextTrimming="CharacterEllipsis"
+                                                    TextWrapping="NoWrap" />
+                                            </StackPanel>
+                                        </Grid>
+                                    </DataTemplate>
+                                </ListView.ItemTemplate>
+                            </ListView>
+
+                        </tkcontrols:Case>
+                    </tkcontrols:SwitchPresenter>
+                </Grid>
             </ScrollViewer>
         </ContentDialog>
     </Grid>

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml
@@ -437,7 +437,8 @@
             x:Uid="AddDefaultVariableDialog"
             IsPrimaryButtonEnabled="{Binding Valid, Mode=OneWay}"
             IsSecondaryButtonEnabled="True"
-            PrimaryButtonStyle="{StaticResource AccentButtonStyle}">
+            PrimaryButtonStyle="{StaticResource AccentButtonStyle}"
+            IsLightDismissEnabled="False">
             <ContentDialog.DataContext>
                 <models:Variable />
             </ContentDialog.DataContext>
@@ -469,7 +470,8 @@
             x:Uid="EditVariableDialog"
             IsPrimaryButtonEnabled="{Binding Valid, Mode=OneWay}"
             IsSecondaryButtonEnabled="True"
-            PrimaryButtonStyle="{StaticResource AccentButtonStyle}">
+            PrimaryButtonStyle="{StaticResource AccentButtonStyle}"
+            IsLightDismissEnabled="False">
             <ContentDialog.DataContext>
                 <models:Variable />
             </ContentDialog.DataContext>
@@ -568,7 +570,8 @@
             x:Uid="AddProfileDialog"
             IsPrimaryButtonEnabled="{Binding Valid, Mode=OneWay}"
             IsSecondaryButtonEnabled="True"
-            PrimaryButtonStyle="{StaticResource AccentButtonStyle}">
+            PrimaryButtonStyle="{StaticResource AccentButtonStyle}"
+            IsLightDismissEnabled="False">
             <ContentDialog.DataContext>
                 <models:ProfileVariablesSet />
             </ContentDialog.DataContext>

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml
@@ -675,6 +675,8 @@
             IsPrimaryButtonEnabled="False"
             IsSecondaryButtonEnabled="True"
             PrimaryButtonStyle="{StaticResource AccentButtonStyle}"
+            IsLightDismissEnabled="False"
+            Opened="AddVariableDialog_Opened"
             Closed="AddVariableDialog_Closed">
             <ContentDialog.DataContext>
                 <models:ProfileVariablesSet />

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml
@@ -83,6 +83,16 @@
                                     Click="EditVariable_Click"
                                     CommandParameter="{x:Bind (models:Variable)}"
                                     Icon="{ui:FontIcon Glyph=&#xE70F;}" />
+                                <MenuFlyoutItem
+                                    x:Uid="CopyName"
+                                    Click="CopyVariableName_Click"
+                                    CommandParameter="{x:Bind (models:Variable)}"
+                                    Icon="{ui:FontIcon Glyph=&#xE8C8;}" />
+                                <MenuFlyoutItem
+                                    x:Uid="CopyValue"
+                                    Click="CopyVariableValue_Click"
+                                    CommandParameter="{x:Bind (models:Variable)}"
+                                    Icon="{ui:FontIcon Glyph=&#xE8C8;}" />
                                 <MenuFlyoutSeparator />
                                 <MenuFlyoutItem
                                     x:Uid="RemoveItem"

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml
@@ -506,6 +506,10 @@
                                                     x:Uid="RemoveListItem"
                                                     Click="RemoveListVariableButton_Click"
                                                     Icon="{ui:FontIcon Glyph=&#xE74D;}" />
+                                                <MenuFlyoutItem
+                                                    x:Uid="RemoveDuplicateListItem"
+                                                    Click="RemoveListVariableDuplicatesButton_Click"
+                                                    Icon="{ui:FontIcon Glyph=&#xE74D;}" />
                                                 <MenuFlyoutSeparator />
                                                 <MenuFlyoutItem
                                                     x:Uid="InsertListEntryBefore"

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml
@@ -89,6 +89,11 @@
                                     CommandParameter="{x:Bind (models:Variable)}"
                                     Icon="{ui:FontIcon Glyph=&#xE8C8;}" />
                                 <MenuFlyoutItem
+                                    x:Uid="CopyNameAndValue"
+                                    Click="CopyVariableNameAndValue_Click"
+                                    CommandParameter="{x:Bind (models:Variable)}"
+                                    Icon="{ui:FontIcon Glyph=&#xE8C8;}" />
+                                <MenuFlyoutItem
                                     x:Uid="CopyValue"
                                     Click="CopyVariableValue_Click"
                                     CommandParameter="{x:Bind (models:Variable)}"

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml
@@ -708,6 +708,7 @@
                                     x:Name="DefaultVariablesSearchBox"
                                     x:Uid="SearchExistingVariable"
                                     Margin="0,8,0,4"
+                                    IsClearButtonVisible="True"
                                     TextChanged="DefaultVariablesSearchBox_TextChanged"
                                     VerticalAlignment="Center" />
                                 <ListView
@@ -752,6 +753,13 @@
                                         </DataTemplate>
                                     </ListView.ItemTemplate>
                                 </ListView>
+                                <TextBlock
+                                    x:Name="NoMatchingDefaultVariablesText"
+                                    x:Uid="NoMatchingDefaultVariables"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    Style="{StaticResource CaptionTextBlockStyle}"
+                                    Visibility="Collapsed"
+                                    TextWrapping="WrapWholeWords" />
                             </StackPanel>
 
                         </tkcontrols:Case>

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml
@@ -710,6 +710,7 @@
                                     Margin="0,8,0,4"
                                     IsClearButtonVisible="True"
                                     TextChanged="DefaultVariablesSearchBox_TextChanged"
+                                    KeyDown="DefaultVariablesSearchBox_KeyDown"
                                     VerticalAlignment="Center" />
                                 <ListView
                                     x:Name="ExistingVariablesListView"

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml
@@ -382,6 +382,7 @@
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="24" />
                                             <ColumnDefinition />
+                                            <ColumnDefinition Width="24" />
                                         </Grid.ColumnDefinitions>
                                         <FontIcon
                                             Grid.Column="0"
@@ -390,11 +391,11 @@
                                             Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}"
                                             Glyph="{x:Bind ParentType, Mode=OneWay, Converter={StaticResource VariableTypeToGlyphConverter}}" />
 
-                                        <StackPanel Grid.Column="1" VerticalAlignment="Center">
-                                            <TextBlock
-                                                Text="{x:Bind Name}"
-                                                TextTrimming="CharacterEllipsis"
-                                                TextWrapping="NoWrap" />
+                                         <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                                             <TextBlock
+                                                 Text="{x:Bind Name}"
+                                                 TextTrimming="CharacterEllipsis"
+                                                 TextWrapping="NoWrap" />
                                             <TextBlock
                                                 Grid.Row="1"
                                                 Foreground="{ThemeResource TextFillColorSecondaryBrush}"
@@ -402,13 +403,27 @@
                                                 Text="{x:Bind Values}"
                                                 TextTrimming="CharacterEllipsis"
                                                 TextWrapping="NoWrap">
-                                                <ToolTipService.ToolTip>
-                                                    <TextBlock Text="{x:Bind Values}" TextWrapping="WrapWholeWords" />
-                                                </ToolTipService.ToolTip>
-                                            </TextBlock>
-                                        </StackPanel>
-                                    </Grid>
-                                </DataTemplate>
+                                                 <ToolTipService.ToolTip>
+                                                     <TextBlock Text="{x:Bind Values}" TextWrapping="WrapWholeWords" />
+                                                 </ToolTipService.ToolTip>
+                                             </TextBlock>
+                                         </StackPanel>
+                                         <Button
+                                             x:Uid="CopyNameAndValue"
+                                             Grid.Column="2"
+                                             VerticalAlignment="Center"
+                                             Style="{StaticResource SubtleButtonStyle}"
+                                             CommandParameter="{x:Bind (models:Variable)}"
+                                             Click="CopyAppliedVariableNameAndValue_Click">
+                                             <Button.Content>
+                                                 <FontIcon
+                                                     FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                                     Glyph="&#xE8C8;"
+                                                     FontSize="14" />
+                                             </Button.Content>
+                                         </Button>
+                                     </Grid>
+                                 </DataTemplate>
                             </ItemsControl.ItemTemplate>
                         </ItemsControl>
                     </ScrollViewer>

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -164,24 +164,25 @@ namespace EnvironmentVariablesUILib
                 }
             }
 
-            AddNewVariableName.Text = string.Empty;
-            AddNewVariableValue.Text = string.Empty;
-            ExistingVariablesListView.SelectionChanged -= ExistingVariablesListView_SelectionChanged;
-            ExistingVariablesListView.SelectedItems.Clear();
-            ExistingVariablesListView.SelectionChanged += ExistingVariablesListView_SelectionChanged;
-            AddVariableFlyout.Hide();
+            ResetAddVariableInputs();
+            AddVariableDialog.Hide();
         }
 
         private void CancelAddVariable()
         {
+            ResetAddVariableInputs();
+            AddVariableDialog.Hide();
+        }
+
+        private void ResetAddVariableInputs()
+        {
             AddNewVariableName.Text = string.Empty;
             AddNewVariableValue.Text = string.Empty;
+            AddVariableDialog.IsPrimaryButtonEnabled = false;
 
             ExistingVariablesListView.SelectionChanged -= ExistingVariablesListView_SelectionChanged;
             ExistingVariablesListView.SelectedItems.Clear();
             ExistingVariablesListView.SelectionChanged += ExistingVariablesListView_SelectionChanged;
-
-            AddVariableFlyout.Hide();
         }
 
         private void AddDefaultVariable(DefaultVariablesSet set)
@@ -263,11 +264,11 @@ namespace EnvironmentVariablesUILib
             {
                 if (nameTxtBox.Text.Length == 0 || nameTxtBox.Text.Length >= 255 || profile.Variables.Where(x => x.Name.Equals(nameTxtBox.Text, StringComparison.OrdinalIgnoreCase)).Any())
                 {
-                    ConfirmAddVariableBtn.IsEnabled = false;
+                    AddVariableDialog.IsPrimaryButtonEnabled = false;
                 }
                 else
                 {
-                    ConfirmAddVariableBtn.IsEnabled = true;
+                    AddVariableDialog.IsPrimaryButtonEnabled = true;
                 }
             }
         }
@@ -315,14 +316,14 @@ namespace EnvironmentVariablesUILib
                 }
             }
 
-            ConfirmAddVariableBtn.IsEnabled = false;
+            AddVariableDialog.IsPrimaryButtonEnabled = false;
             foreach (Variable variable in ExistingVariablesListView.SelectedItems)
             {
                 if (variable != null)
                 {
                     if (!profile.Variables.Where(x => x.Name.Equals(variable.Name, StringComparison.Ordinal) && x.Values.Equals(variable.Values, StringComparison.Ordinal)).Any())
                     {
-                        ConfirmAddVariableBtn.IsEnabled = true;
+                        AddVariableDialog.IsPrimaryButtonEnabled = true;
                         break;
                     }
                 }
@@ -346,6 +347,20 @@ namespace EnvironmentVariablesUILib
                 AddProfileDialog.DataContext = profile.Clone();
                 await AddProfileDialog.ShowAsync();
             }
+        }
+
+        private async void AddVariableBtn_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+        {
+            var resourceLoader = Helpers.ResourceLoaderInstance.ResourceLoader;
+            AddVariableDialog.Title = resourceLoader.GetString("AddVariable_Title");
+            AddVariableDialog.PrimaryButtonText = resourceLoader.GetString("AddBtn");
+            AddVariableDialog.SecondaryButtonText = resourceLoader.GetString("CancelBtn");
+            AddVariableDialog.PrimaryButtonCommand = AddVariableCommand;
+            AddVariableDialog.SecondaryButtonCommand = CancelAddVariableCommand;
+            ResetAddVariableInputs();
+            SwitchViewsSegmentedView.SelectedIndex = 0;
+            AddVariableDialog.DataContext = AddProfileDialog.DataContext;
+            await AddVariableDialog.ShowAsync();
         }
 
         private void ExistingVariablesListView_Loaded(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
@@ -620,10 +635,9 @@ namespace EnvironmentVariablesUILib
             ViewModel.EnvironmentState = EnvironmentState.Unchanged;
         }
 
-        private void AddVariableFlyout_Closed(object sender, object e)
+        private void AddVariableDialog_Closed(ContentDialog sender, ContentDialogClosedEventArgs args)
         {
-            CancelAddVariable();
-            ConfirmAddVariableBtn.IsEnabled = false;
+            ResetAddVariableInputs();
         }
     }
 }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -569,31 +569,33 @@ namespace EnvironmentVariablesUILib
 
             int toRemove = -1;
 
-            if (e.AddedItems.Count > 0)
-            {
-                var list = sender as ListView;
-                if (list == null)
+                if (e.AddedItems.Count > 0)
                 {
-                    return;
-                }
+                    var list = sender as ListView;
+                    if (list == null)
+                    {
+                        return;
+                    }
 
-                var duplicates = list.SelectedItems
-                    .OfType<Variable>()
-                    .GroupBy(x => $"{(x.Name ?? string.Empty).Trim().ToUpperInvariant()}|{x.Values}|{x.ParentType}")
-                    .Where(g => g.Count() > 1)
-                    .ToList();
+                    var selectedVariables = list.SelectedItems.OfType<Variable>().ToList();
+                    var dedupedSelections = new List<Variable>();
 
-                foreach (var dup in duplicates)
-                {
+                    foreach (var selected in selectedVariables)
+                    {
+                        if (dedupedSelections.Any(x => AreEquivalentVariables(x, selected)))
+                        {
+                            continue;
+                        }
+
+                        dedupedSelections.Add(selected);
+                    }
+
                     ExistingVariablesListView.SelectionChanged -= ExistingVariablesListView_SelectionChanged;
-                    var duplicatedItems = dup
-                        .OrderBy(x => list.SelectedItems.IndexOf(x))
-                        .Skip(1)
-                        .ToList();
-                    foreach (var item in duplicatedItems)
+                    foreach (var item in selectedVariables.Except(dedupedSelections).ToList())
                     {
                         list.SelectedItems.Remove(item);
                     }
+
                     ExistingVariablesListView.SelectionChanged += ExistingVariablesListView_SelectionChanged;
                 }
             }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -779,7 +779,13 @@ namespace EnvironmentVariablesUILib
 
         private void ReorderButtonUp_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
         {
-            var listItem = ((MenuFlyoutItem)sender).DataContext as Variable.ValuesListItem;
+            var menuFlyoutItem = sender as MenuFlyoutItem;
+            if (menuFlyoutItem == null)
+            {
+                return;
+            }
+
+            var listItem = menuFlyoutItem.DataContext as Variable.ValuesListItem;
             if (listItem == null)
             {
                 return;
@@ -802,7 +808,13 @@ namespace EnvironmentVariablesUILib
 
         private void ReorderButtonDown_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
         {
-            var listItem = ((MenuFlyoutItem)sender).DataContext as Variable.ValuesListItem;
+            var menuFlyoutItem = sender as MenuFlyoutItem;
+            if (menuFlyoutItem == null)
+            {
+                return;
+            }
+
+            var listItem = menuFlyoutItem.DataContext as Variable.ValuesListItem;
             if (listItem == null)
             {
                 return;
@@ -825,7 +837,13 @@ namespace EnvironmentVariablesUILib
 
         private void RemoveListVariableButton_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
         {
-            var listItem = ((MenuFlyoutItem)sender).DataContext as Variable.ValuesListItem;
+            var menuFlyoutItem = sender as MenuFlyoutItem;
+            if (menuFlyoutItem == null)
+            {
+                return;
+            }
+
+            var listItem = menuFlyoutItem.DataContext as Variable.ValuesListItem;
             if (listItem == null)
             {
                 return;
@@ -886,7 +904,13 @@ namespace EnvironmentVariablesUILib
 
         private void InsertListEntryBeforeButton_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
         {
-            var listItem = (sender as MenuFlyoutItem)?.DataContext as Variable.ValuesListItem;
+            var menuFlyoutItem = sender as MenuFlyoutItem;
+            if (menuFlyoutItem == null)
+            {
+                return;
+            }
+
+            var listItem = menuFlyoutItem.DataContext as Variable.ValuesListItem;
             if (listItem == null)
             {
                 return;
@@ -911,7 +935,13 @@ namespace EnvironmentVariablesUILib
 
         private void InsertListEntryAfterButton_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
         {
-            var listItem = (sender as MenuFlyoutItem)?.DataContext as Variable.ValuesListItem;
+            var menuFlyoutItem = sender as MenuFlyoutItem;
+            if (menuFlyoutItem == null)
+            {
+                return;
+            }
+
+            var listItem = menuFlyoutItem.DataContext as Variable.ValuesListItem;
             if (listItem == null)
             {
                 return;
@@ -966,6 +996,11 @@ namespace EnvironmentVariablesUILib
         private void RefreshEditVariableDialogValueTextFromList(Variable variable)
         {
             if (variable?.ValuesList == null)
+            {
+                return;
+            }
+
+            if (EditVariableDialogValueTxtBox == null)
             {
                 return;
             }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -639,9 +639,14 @@ namespace EnvironmentVariablesUILib
             }
 
             var variable = EditVariableDialog.DataContext as Variable;
+            if (variable?.ValuesList == null)
+            {
+                return;
+            }
+
             variable.ValuesList.Remove(listItem);
 
-            var newValues = string.Join(";", variable.ValuesList?.Select(x => x.Text).ToArray());
+            var newValues = string.Join(";", variable.ValuesList?.Select(x => x?.Text).ToArray());
             EditVariableDialogValueTxtBox.Text = newValues;
         }
 
@@ -659,9 +664,17 @@ namespace EnvironmentVariablesUILib
 
             for (int i = variable.ValuesList.Count - 1; i >= 0; i--)
             {
-                var originalValue = variable.ValuesList[i].Text ?? string.Empty;
+                var item = variable.ValuesList[i];
+                if (item == null)
+                {
+                    variable.ValuesList.RemoveAt(i);
+                    hasDuplicates = true;
+                    continue;
+                }
+
+                var originalValue = item.Text ?? string.Empty;
                 var trimmedValue = originalValue.Trim();
-                variable.ValuesList[i].Text = trimmedValue;
+                item.Text = trimmedValue;
                 if (!seenValues.Add(trimmedValue))
                 {
                     variable.ValuesList.RemoveAt(i);

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -422,6 +422,15 @@ namespace EnvironmentVariablesUILib
                 return;
             }
 
+            if (variable.ParentType == VariablesSetType.Profile)
+            {
+                variableSet = ResolveVariableSetFromVariable(variable) as ProfileVariablesSet;
+                if (variableSet == null)
+                {
+                    return;
+                }
+            }
+
             var resourceLoader = Helpers.ResourceLoaderInstance.ResourceLoader;
             ContentDialog dialog = new ContentDialog();
             dialog.XamlRoot = RootPage.XamlRoot;

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
@@ -478,6 +479,43 @@ namespace EnvironmentVariablesUILib
 
             var newValues = string.Join(";", variable.ValuesList?.Select(x => x.Text).ToArray());
             EditVariableDialogValueTxtBox.Text = newValues;
+        }
+
+        private void RemoveListVariableDuplicatesButton_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+        {
+            var variable = EditVariableDialog.DataContext as Variable;
+            if (variable?.ValuesList == null)
+            {
+                return;
+            }
+
+            var seenValues = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var hasDuplicates = false;
+            var hasValueChanges = false;
+
+            for (int i = variable.ValuesList.Count - 1; i >= 0; i--)
+            {
+                var originalValue = variable.ValuesList[i].Text ?? string.Empty;
+                var trimmedValue = originalValue.Trim();
+                variable.ValuesList[i].Text = trimmedValue;
+                if (!seenValues.Add(trimmedValue))
+                {
+                    variable.ValuesList.RemoveAt(i);
+                    hasDuplicates = true;
+                }
+                else if (!string.Equals(originalValue, trimmedValue, StringComparison.Ordinal))
+                {
+                    hasValueChanges = true;
+                }
+            }
+
+            if (hasDuplicates || hasValueChanges)
+            {
+                var newValues = string.Join(";", variable.ValuesList?.Select(x => x.Text).ToArray());
+                EditVariableDialogValueTxtBox.TextChanged -= EditVariableDialogValueTxtBox_TextChanged;
+                EditVariableDialogValueTxtBox.Text = newValues;
+                EditVariableDialogValueTxtBox.TextChanged += EditVariableDialogValueTxtBox_TextChanged;
+            }
         }
 
         private void InsertListEntryBeforeButton_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -247,6 +247,7 @@ namespace EnvironmentVariablesUILib
                 var dataPackage = new DataPackage();
                 dataPackage.SetText(text ?? string.Empty);
                 Clipboard.SetContent(dataPackage);
+                Clipboard.Flush();
             }
             catch
             {

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -567,27 +567,24 @@ namespace EnvironmentVariablesUILib
                 return;
             }
 
-            int toRemove = -1;
-
-                if (e.AddedItems.Count > 0)
+            if (e.AddedItems.Count > 0)
+            {
+                var list = sender as ListView;
+                if (list == null)
                 {
-                    var list = sender as ListView;
-                    if (list == null)
-                    {
-                        return;
-                    }
-
-                    var selectedVariables = list.SelectedItems.OfType<Variable>().ToList();
-                    var dedupedSelections = DeduplicateVariablesByEquivalence(selectedVariables);
-
-                    ExistingVariablesListView.SelectionChanged -= ExistingVariablesListView_SelectionChanged;
-                    foreach (var item in selectedVariables.Except(dedupedSelections).ToList())
-                    {
-                        list.SelectedItems.Remove(item);
-                    }
-
-                    ExistingVariablesListView.SelectionChanged += ExistingVariablesListView_SelectionChanged;
+                    return;
                 }
+
+                var selectedVariables = list.SelectedItems.OfType<Variable>().ToList();
+                var dedupedSelections = DeduplicateVariablesByEquivalence(selectedVariables);
+
+                ExistingVariablesListView.SelectionChanged -= ExistingVariablesListView_SelectionChanged;
+                foreach (var item in selectedVariables.Except(dedupedSelections).ToList())
+                {
+                    list.SelectedItems.Remove(item);
+                }
+
+                ExistingVariablesListView.SelectionChanged += ExistingVariablesListView_SelectionChanged;
             }
 
             if (e.RemovedItems.Count > 0)
@@ -600,13 +597,7 @@ namespace EnvironmentVariablesUILib
                         continue;
                     }
 
-                    for (int i = profile.Variables.Count - 1; i >= 0; i--)
-                    {
-                        if (AreEquivalentVariables(profile.Variables[i], removedVariable))
-                        {
-                            profile.Variables.RemoveAt(i);
-                        }
-                    }
+                    RemoveEquivalentProfileVariables(profile.Variables, removedVariable);
                 }
             }
 
@@ -778,6 +769,22 @@ namespace EnvironmentVariablesUILib
             }
 
             return deduped;
+        }
+
+        private static void RemoveEquivalentProfileVariables(IList<Variable> variables, Variable targetVariable)
+        {
+            if (variables == null || targetVariable == null)
+            {
+                return;
+            }
+
+            for (int i = variables.Count - 1; i >= 0; i--)
+            {
+                if (AreEquivalentVariables(variables[i], targetVariable))
+                {
+                    variables.RemoveAt(i);
+                }
+            }
         }
 
         private async Task ShowAddDefaultVariableDialogAsync(DefaultVariablesSet set)

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -93,7 +93,7 @@ namespace EnvironmentVariablesUILib
 
         private void EditVariable(RelayCommandParameter param)
         {
-            if (param == null)
+            if (param == null || ViewModel == null)
             {
                 return;
             }
@@ -129,7 +129,7 @@ namespace EnvironmentVariablesUILib
 
         private void AddProfile()
         {
-            if (AddProfileDialog == null)
+            if (AddProfileDialog == null || ViewModel == null)
             {
                 return;
             }
@@ -145,7 +145,7 @@ namespace EnvironmentVariablesUILib
 
         private void UpdateProfile()
         {
-            if (AddProfileDialog == null)
+            if (AddProfileDialog == null || ViewModel == null)
             {
                 return;
             }
@@ -161,6 +161,11 @@ namespace EnvironmentVariablesUILib
 
         private async void RemoveProfileBtn_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
         {
+            if (ViewModel == null)
+            {
+                return;
+            }
+
             var button = sender as MenuFlyoutItem;
             if (button == null)
             {
@@ -308,7 +313,7 @@ namespace EnvironmentVariablesUILib
 
         private void AddDefaultVariable(DefaultVariablesSet set)
         {
-            if (AddDefaultVariableDialog == null)
+            if (AddDefaultVariableDialog == null || ViewModel == null)
             {
                 return;
             }
@@ -330,6 +335,11 @@ namespace EnvironmentVariablesUILib
 
         private async void Delete_Variable_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
         {
+            if (ViewModel == null)
+            {
+                return;
+            }
+
             MenuFlyoutItem selectedItem = sender as MenuFlyoutItem;
             if (selectedItem == null || RootPage == null)
             {
@@ -423,6 +433,11 @@ namespace EnvironmentVariablesUILib
 
         private void ReloadButton_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
         {
+            if (ViewModel == null)
+            {
+                return;
+            }
+
             ViewModel.LoadEnvironmentVariables();
             ViewModel.EnvironmentState = EnvironmentState.Unchanged;
         }
@@ -1013,6 +1028,11 @@ namespace EnvironmentVariablesUILib
 
         private void InvalidStateInfoBar_CloseButtonClick(InfoBar sender, object args)
         {
+            if (ViewModel == null)
+            {
+                return;
+            }
+
             ViewModel.EnvironmentState = EnvironmentState.Unchanged;
         }
 

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -786,6 +786,7 @@ namespace EnvironmentVariablesUILib
             var variable = EditVariableDialog.DataContext as Variable;
             var param = EditVariableDialog.PrimaryButtonCommandParameter as RelayCommandParameter;
             var variableSet = param?.Set;
+            var originalVariable = param?.Variable;
             if (variable == null)
             {
                 EditVariableDialog.IsPrimaryButtonEnabled = false;
@@ -801,7 +802,11 @@ namespace EnvironmentVariablesUILib
             if (variableSet != null)
             {
                 var normalizedName = EditVariableDialogNameTxtBox.Text?.Trim();
-                if (string.IsNullOrWhiteSpace(normalizedName) || variableSet.Variables == null || variableSet.Variables.Any(x => string.Equals((x?.Name ?? string.Empty).Trim(), normalizedName, StringComparison.OrdinalIgnoreCase)) || !variable.Valid)
+                bool hasDuplicateName = variableSet.Variables != null &&
+                    variableSet.Variables.Any(x => !ReferenceEquals(x, originalVariable)
+                        && string.Equals((x?.Name ?? string.Empty).Trim(), normalizedName, StringComparison.OrdinalIgnoreCase));
+
+                if (string.IsNullOrWhiteSpace(normalizedName) || variableSet.Variables == null || hasDuplicateName || !variable.Valid)
                 {
                     EditVariableDialog.IsPrimaryButtonEnabled = false;
                 }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -156,7 +156,9 @@ namespace EnvironmentVariablesUILib
                     foreach (Variable variable in ExistingVariablesListView.SelectedItems)
                     {
                         if (!profile.Variables
-                            .Where(x => x.Name.Equals(variable.Name, StringComparison.OrdinalIgnoreCase) && x.Values == variable.Values)
+                            .Where(x => x.Name.Equals(variable.Name, StringComparison.OrdinalIgnoreCase)
+                                     && x.Values == variable.Values
+                                     && x.ParentType == variable.ParentType)
                             .Any())
                         {
                             var clone = variable.Clone(true);
@@ -326,7 +328,11 @@ namespace EnvironmentVariablesUILib
             {
                 if (variable != null)
                 {
-                    if (!profile.Variables.Where(x => x.Name.Equals(variable.Name, StringComparison.Ordinal) && x.Values.Equals(variable.Values, StringComparison.Ordinal)).Any())
+                    if (!profile.Variables
+                        .Where(x => x.Name.Equals(variable.Name, StringComparison.Ordinal)
+                                 && x.Values.Equals(variable.Values, StringComparison.Ordinal)
+                                 && x.ParentType == variable.ParentType)
+                        .Any())
                     {
                         AddVariableDialog.IsPrimaryButtonEnabled = true;
                         break;

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -125,20 +125,12 @@ namespace EnvironmentVariablesUILib
 
                 var normalizedName = (variable.Name ?? string.Empty).Trim();
 
-                if (ViewModel.AppliedProfile != null && ViewModel.AppliedProfile.Variables != null &&
-                    ViewModel.AppliedProfile.Variables.Any(x => x != null &&
-                        string.Equals((x.Name ?? string.Empty).Trim(), normalizedName, StringComparison.OrdinalIgnoreCase) &&
-                        EnvironmentVariablesHelper.IsEquivalentVariableValue(x.Values, variable.Values)))
-                {
-                    return ViewModel.AppliedProfile;
-                }
-
                 var matchingProfiles = ViewModel.Profiles?
                     .Where(profile => profile?.Variables != null &&
                         profile.Variables.Any(x => x != null &&
-                             string.Equals((x.Name ?? string.Empty).Trim(), normalizedName, StringComparison.OrdinalIgnoreCase) &&
-                             EnvironmentVariablesHelper.IsEquivalentVariableValue(x.Values, variable.Values) &&
-                             x.ParentType == VariablesSetType.Profile))
+                            string.Equals((x.Name ?? string.Empty).Trim(), normalizedName, StringComparison.OrdinalIgnoreCase) &&
+                            EnvironmentVariablesHelper.IsEquivalentVariableValue(x.Values, variable.Values) &&
+                            x.ParentType == VariablesSetType.Profile))
                     .ToList();
 
                 if (matchingProfiles == null || matchingProfiles.Count != 1)

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -86,14 +86,35 @@ namespace EnvironmentVariablesUILib
                 return;
             }
 
-            var variablesSet = btn.DataContext as VariablesSet;
             var variable = btn.CommandParameter as Variable;
             if (variable == null)
             {
                 return;
             }
 
+            var variablesSet = ResolveVariableSetFromVariable(variable);
             await ShowEditDialogAsync(variable, variablesSet);
+        }
+
+        private VariablesSet ResolveVariableSetFromVariable(Variable variable)
+        {
+            if (variable == null || ViewModel == null)
+            {
+                return null;
+            }
+
+            if (variable.ParentType == VariablesSetType.User)
+            {
+                return ViewModel.UserDefaultSet;
+            }
+
+            if (variable.ParentType == VariablesSetType.System)
+            {
+                return ViewModel.SystemDefaultSet;
+            }
+
+            return ViewModel.Profiles?
+                .FirstOrDefault(profile => profile?.Variables != null && profile.Variables.Contains(variable));
         }
 
         private void EditVariable(RelayCommandParameter param)

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -83,11 +83,12 @@ namespace EnvironmentVariablesUILib
 
             var variablesSet = btn.DataContext as VariablesSet;
             var variable = btn.CommandParameter as Variable;
-
-            if (variable != null)
+            if (variable == null)
             {
-                await ShowEditDialogAsync(variable, variablesSet);
+                return;
             }
+
+            await ShowEditDialogAsync(variable, variablesSet);
         }
 
         private void EditVariable(RelayCommandParameter param)
@@ -109,6 +110,11 @@ namespace EnvironmentVariablesUILib
 
         private async Task AddProfileAsync()
         {
+            if (AddProfileDialog == null || SwitchViewsSegmentedView == null)
+            {
+                return;
+            }
+
             SwitchViewsSegmentedView.SelectedIndex = 0;
 
             var resourceLoader = Helpers.ResourceLoaderInstance.ResourceLoader;
@@ -123,6 +129,11 @@ namespace EnvironmentVariablesUILib
 
         private void AddProfile()
         {
+            if (AddProfileDialog == null)
+            {
+                return;
+            }
+
             var profile = AddProfileDialog.DataContext as ProfileVariablesSet;
             if (profile == null)
             {
@@ -134,6 +145,11 @@ namespace EnvironmentVariablesUILib
 
         private void UpdateProfile()
         {
+            if (AddProfileDialog == null)
+            {
+                return;
+            }
+
             var updatedProfile = AddProfileDialog.DataContext as ProfileVariablesSet;
             if (updatedProfile == null)
             {
@@ -181,10 +197,10 @@ namespace EnvironmentVariablesUILib
         private void AddVariable()
         {
             var profile = AddProfileDialog.DataContext as ProfileVariablesSet;
-            if (profile == null || profile.Variables == null || AddNewVariableName == null || AddNewVariableValue == null || ExistingVariablesListView == null || AddVariableSwitchPresenter == null)
+            if (AddVariableDialog == null || AddProfileDialog == null || profile == null || profile.Variables == null || AddNewVariableName == null || AddNewVariableValue == null || ExistingVariablesListView == null || AddVariableSwitchPresenter == null)
             {
                 ResetAddVariableInputs();
-                AddVariableDialog.Hide();
+                AddVariableDialog?.Hide();
                 return;
             }
 
@@ -213,12 +229,22 @@ namespace EnvironmentVariablesUILib
 
         private void CancelAddVariable()
         {
+            if (AddVariableDialog == null)
+            {
+                return;
+            }
+
             ResetAddVariableInputs();
             AddVariableDialog.Hide();
         }
 
         private void ClearAddVariableSearchFilter()
         {
+            if (ViewModel == null)
+            {
+                return;
+            }
+
             if (DefaultVariablesSearchBox != null)
             {
                 DefaultVariablesSearchBox.TextChanged -= DefaultVariablesSearchBox_TextChanged;
@@ -232,6 +258,11 @@ namespace EnvironmentVariablesUILib
 
         private void UpdateNoMatchingDefaultVariablesText()
         {
+            if (ViewModel == null)
+            {
+                return;
+            }
+
             if (NoMatchingDefaultVariablesText == null || DefaultVariablesSearchBox == null)
             {
                 return;
@@ -250,18 +281,38 @@ namespace EnvironmentVariablesUILib
 
         private void ResetAddVariableInputs()
         {
-            AddNewVariableName.Text = string.Empty;
-            AddNewVariableValue.Text = string.Empty;
-            AddVariableDialog.IsPrimaryButtonEnabled = false;
+            if (AddNewVariableName != null)
+            {
+                AddNewVariableName.Text = string.Empty;
+            }
+
+            if (AddNewVariableValue != null)
+            {
+                AddNewVariableValue.Text = string.Empty;
+            }
+
+            if (AddVariableDialog != null)
+            {
+                AddVariableDialog.IsPrimaryButtonEnabled = false;
+            }
+
             ClearAddVariableSearchFilter();
 
-            ExistingVariablesListView.SelectionChanged -= ExistingVariablesListView_SelectionChanged;
-            ExistingVariablesListView.SelectedItems.Clear();
-            ExistingVariablesListView.SelectionChanged += ExistingVariablesListView_SelectionChanged;
+            if (ExistingVariablesListView != null)
+            {
+                ExistingVariablesListView.SelectionChanged -= ExistingVariablesListView_SelectionChanged;
+                ExistingVariablesListView.SelectedItems.Clear();
+                ExistingVariablesListView.SelectionChanged += ExistingVariablesListView_SelectionChanged;
+            }
         }
 
         private void AddDefaultVariable(DefaultVariablesSet set)
         {
+            if (AddDefaultVariableDialog == null)
+            {
+                return;
+            }
+
             if (set == null)
             {
                 return;
@@ -347,15 +398,20 @@ namespace EnvironmentVariablesUILib
 
         private void AddNewVariableName_TextChanged(object sender, TextChangedEventArgs e)
         {
+            if (AddProfileDialog == null || AddVariableDialog == null)
+            {
+                return;
+            }
+
             TextBox nameTxtBox = sender as TextBox;
             var profile = AddProfileDialog.DataContext as ProfileVariablesSet;
-            if (nameTxtBox == null || profile == null)
+            if (nameTxtBox == null || profile == null || profile.Variables == null)
             {
                 AddVariableDialog.IsPrimaryButtonEnabled = false;
                 return;
             }
 
-            if (nameTxtBox.Text.Length == 0 || nameTxtBox.Text.Length >= 255 || profile.Variables.Where(x => x.Name.Equals(nameTxtBox.Text, StringComparison.OrdinalIgnoreCase)).Any())
+            if (nameTxtBox.Text.Length == 0 || nameTxtBox.Text.Length >= 255 || profile.Variables.Where(x => string.Equals(x?.Name, nameTxtBox.Text, StringComparison.OrdinalIgnoreCase)).Any())
             {
                 AddVariableDialog.IsPrimaryButtonEnabled = false;
             }
@@ -373,9 +429,20 @@ namespace EnvironmentVariablesUILib
 
         private void ExistingVariablesListView_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
+            if (AddVariableDialog == null)
+            {
+                return;
+            }
+
             var profile = AddProfileDialog.DataContext as ProfileVariablesSet;
             if (profile == null)
             {
+                return;
+            }
+
+            if (profile.Variables == null)
+            {
+                AddVariableDialog.IsPrimaryButtonEnabled = false;
                 return;
             }
 
@@ -455,6 +522,11 @@ namespace EnvironmentVariablesUILib
 
         private async void EditProfileBtn_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
         {
+            if (SwitchViewsSegmentedView == null || AddProfileDialog == null)
+            {
+                return;
+            }
+
             SwitchViewsSegmentedView.SelectedIndex = 0;
 
             var button = sender as MenuFlyoutItem;
@@ -480,6 +552,11 @@ namespace EnvironmentVariablesUILib
 
         private async void AddVariableBtn_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
         {
+            if (AddVariableDialog == null || SwitchViewsSegmentedView == null || AddProfileDialog == null)
+            {
+                return;
+            }
+
             var resourceLoader = Helpers.ResourceLoaderInstance.ResourceLoader;
             AddVariableDialog.Title = resourceLoader.GetString("AddVariable_Title");
             AddVariableDialog.PrimaryButtonText = resourceLoader.GetString("AddBtn");
@@ -494,6 +571,11 @@ namespace EnvironmentVariablesUILib
 
         private void DefaultVariablesSearchBox_TextChanged(object sender, TextChangedEventArgs e)
         {
+            if (DefaultVariablesSearchBox == null || ExistingVariablesListView == null || AddVariableDialog == null || ViewModel == null)
+            {
+                return;
+            }
+
             var searchText = (sender as TextBox)?.Text;
             ViewModel.SetDefaultVariablesFilter(searchText);
 
@@ -507,6 +589,11 @@ namespace EnvironmentVariablesUILib
 
         private void DefaultVariablesSearchBox_KeyDown(object sender, Microsoft.UI.Xaml.Input.KeyRoutedEventArgs e)
         {
+            if (DefaultVariablesSearchBox == null || e == null)
+            {
+                return;
+            }
+
             if (e.Key == VirtualKey.Escape && !string.IsNullOrEmpty(DefaultVariablesSearchBox.Text))
             {
                 e.Handled = true;
@@ -519,6 +606,11 @@ namespace EnvironmentVariablesUILib
         {
             var profile = AddProfileDialog.DataContext as ProfileVariablesSet;
             if (profile == null)
+            {
+                return;
+            }
+
+            if (profile.Variables == null || ExistingVariablesListView == null)
             {
                 return;
             }
@@ -564,6 +656,11 @@ namespace EnvironmentVariablesUILib
 
         private async Task ShowAddDefaultVariableDialogAsync(DefaultVariablesSet set)
         {
+            if (set == null || AddDefaultVariableDialog == null)
+            {
+                return;
+            }
+
             var resourceLoader = Helpers.ResourceLoaderInstance.ResourceLoader;
 
             AddDefaultVariableDialog.Title = resourceLoader.GetString("AddVariable_Title");
@@ -581,6 +678,11 @@ namespace EnvironmentVariablesUILib
         private async void AddDefaultVariableBtn_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
         {
             var button = sender as Button;
+            if (button == null)
+            {
+                return;
+            }
+
             var defaultVariableSet = button.CommandParameter as DefaultVariablesSet;
 
             if (defaultVariableSet != null)
@@ -608,7 +710,7 @@ namespace EnvironmentVariablesUILib
 
             if (variableSet != null)
             {
-                if (variableSet.Variables.Where(x => x.Name.Equals(EditVariableDialogNameTxtBox.Text, StringComparison.OrdinalIgnoreCase)).Any() || !variable.Valid)
+                if (variableSet.Variables == null || variableSet.Variables.Where(x => string.Equals(x?.Name, EditVariableDialogNameTxtBox.Text, StringComparison.OrdinalIgnoreCase)).Any() || !variable.Valid)
                 {
                     EditVariableDialog.IsPrimaryButtonEnabled = false;
                 }
@@ -626,6 +728,11 @@ namespace EnvironmentVariablesUILib
 
         private void AddDefaultVariableNameTxtBox_TextChanged(object sender, TextChangedEventArgs e)
         {
+            if (AddDefaultVariableDialog == null)
+            {
+                return;
+            }
+
             TextBox nameTxtBox = sender as TextBox;
             var variable = AddDefaultVariableDialog.DataContext as Variable;
             if (nameTxtBox == null || variable == null)
@@ -641,7 +748,7 @@ namespace EnvironmentVariablesUILib
                 return;
             }
 
-            if (nameTxtBox.Text.Length == 0 || defaultSet.Variables.Where(x => x.Name.Equals(nameTxtBox.Text, StringComparison.OrdinalIgnoreCase)).Any())
+            if (defaultSet.Variables == null || nameTxtBox.Text.Length == 0 || defaultSet.Variables.Where(x => string.Equals(x?.Name, nameTxtBox.Text, StringComparison.OrdinalIgnoreCase)).Any())
             {
                 AddDefaultVariableDialog.IsPrimaryButtonEnabled = false;
             }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -76,6 +76,7 @@ namespace EnvironmentVariablesUILib
             var clone = variable.Clone();
             EditVariableDialog.DataContext = clone;
 
+            SetDialogXamlRoot(EditVariableDialog);
             await EditVariableDialog.ShowAsync();
         }
 
@@ -183,6 +184,7 @@ namespace EnvironmentVariablesUILib
             AddProfileDialog.PrimaryButtonCommand = AddProfileCommand;
             AddProfileDialog.DataContext = new ProfileVariablesSet(Guid.NewGuid(), string.Empty);
 
+            SetDialogXamlRoot(AddProfileDialog);
             await AddProfileDialog.ShowAsync();
         }
 
@@ -647,6 +649,7 @@ namespace EnvironmentVariablesUILib
             AddProfileDialog.SecondaryButtonText = resourceLoader.GetString("CancelBtn");
             AddProfileDialog.PrimaryButtonCommand = UpdateProfileCommand;
             AddProfileDialog.DataContext = profile.Clone();
+            SetDialogXamlRoot(AddProfileDialog);
             await AddProfileDialog.ShowAsync();
         }
 
@@ -666,7 +669,7 @@ namespace EnvironmentVariablesUILib
             ResetAddVariableInputs();
             SwitchViewsSegmentedView.SelectedIndex = 0;
             AddVariableDialog.DataContext = AddProfileDialog.DataContext;
-            AddVariableDialog.XamlRoot = RootPage.XamlRoot;
+            SetDialogXamlRoot(AddVariableDialog);
             await AddVariableDialog.ShowAsync();
         }
 
@@ -748,6 +751,16 @@ namespace EnvironmentVariablesUILib
             UpdateNoMatchingDefaultVariablesText();
         }
 
+        private void SetDialogXamlRoot(ContentDialog dialog)
+        {
+            if (dialog == null || RootPage == null)
+            {
+                return;
+            }
+
+            dialog.XamlRoot = RootPage.XamlRoot;
+        }
+
         private static bool AreEquivalentVariables(Variable left, Variable right)
         {
             if (left == null || right == null)
@@ -808,6 +821,7 @@ namespace EnvironmentVariablesUILib
 
             var variableType = set.Id == VariablesSet.SystemGuid ? VariablesSetType.System : VariablesSetType.User;
             AddDefaultVariableDialog.DataContext = new Variable(string.Empty, string.Empty, variableType);
+            SetDialogXamlRoot(AddDefaultVariableDialog);
 
             await AddDefaultVariableDialog.ShowAsync();
         }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -584,6 +584,11 @@ namespace EnvironmentVariablesUILib
         {
             var txtBox = sender as TextBox;
             var variable = EditVariableDialog.DataContext as Variable;
+            if (txtBox == null || variable == null)
+            {
+                return;
+            }
+
             EditVariableDialog.IsPrimaryButtonEnabled = true;
 
             variable.ValuesList = Variable.ValuesStringToValuesListItemCollection(txtBox.Text);
@@ -609,10 +614,7 @@ namespace EnvironmentVariablesUILib
                 variable.ValuesList.Move(index, index - 1);
             }
 
-            var newValues = string.Join(";", variable.ValuesList?.Select(x => x.Text).ToArray());
-            EditVariableDialogValueTxtBox.TextChanged -= EditVariableDialogValueTxtBox_TextChanged;
-            EditVariableDialogValueTxtBox.Text = newValues;
-            EditVariableDialogValueTxtBox.TextChanged += EditVariableDialogValueTxtBox_TextChanged;
+            RefreshEditVariableDialogValueTextFromList(variable);
         }
 
         private void ReorderButtonDown_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
@@ -635,10 +637,7 @@ namespace EnvironmentVariablesUILib
                 variable.ValuesList.Move(index, index + 1);
             }
 
-            var newValues = string.Join(";", variable.ValuesList?.Select(x => x.Text).ToArray());
-            EditVariableDialogValueTxtBox.TextChanged -= EditVariableDialogValueTxtBox_TextChanged;
-            EditVariableDialogValueTxtBox.Text = newValues;
-            EditVariableDialogValueTxtBox.TextChanged += EditVariableDialogValueTxtBox_TextChanged;
+            RefreshEditVariableDialogValueTextFromList(variable);
         }
 
         private void RemoveListVariableButton_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
@@ -657,10 +656,7 @@ namespace EnvironmentVariablesUILib
 
             variable.ValuesList.Remove(listItem);
 
-            var newValues = string.Join(";", variable.ValuesList?.Select(x => x?.Text).ToArray());
-            EditVariableDialogValueTxtBox.TextChanged -= EditVariableDialogValueTxtBox_TextChanged;
-            EditVariableDialogValueTxtBox.Text = newValues;
-            EditVariableDialogValueTxtBox.TextChanged += EditVariableDialogValueTxtBox_TextChanged;
+            RefreshEditVariableDialogValueTextFromList(variable);
         }
 
         private void RemoveListVariableDuplicatesButton_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
@@ -701,10 +697,7 @@ namespace EnvironmentVariablesUILib
 
             if (hasDuplicates || hasValueChanges)
             {
-                var newValues = string.Join(";", variable.ValuesList?.Select(x => x.Text).ToArray());
-                EditVariableDialogValueTxtBox.TextChanged -= EditVariableDialogValueTxtBox_TextChanged;
-                EditVariableDialogValueTxtBox.Text = newValues;
-                EditVariableDialogValueTxtBox.TextChanged += EditVariableDialogValueTxtBox_TextChanged;
+                RefreshEditVariableDialogValueTextFromList(variable);
             }
         }
 
@@ -717,13 +710,20 @@ namespace EnvironmentVariablesUILib
             }
 
             var variable = EditVariableDialog.DataContext as Variable;
+            if (variable?.ValuesList == null)
+            {
+                return;
+            }
+
             var index = variable.ValuesList.IndexOf(listItem);
+            if (index < 0)
+            {
+                return;
+            }
+
             variable.ValuesList.Insert(index, new Variable.ValuesListItem { Text = string.Empty });
 
-            var newValues = string.Join(";", variable.ValuesList?.Select(x => x.Text).ToArray());
-            EditVariableDialogValueTxtBox.TextChanged -= EditVariableDialogValueTxtBox_TextChanged;
-            EditVariableDialogValueTxtBox.Text = newValues;
-            EditVariableDialogValueTxtBox.TextChanged += EditVariableDialogValueTxtBox_TextChanged;
+            RefreshEditVariableDialogValueTextFromList(variable);
         }
 
         private void InsertListEntryAfterButton_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
@@ -735,32 +735,59 @@ namespace EnvironmentVariablesUILib
             }
 
             var variable = EditVariableDialog.DataContext as Variable;
+            if (variable?.ValuesList == null)
+            {
+                return;
+            }
+
             var index = variable.ValuesList.IndexOf(listItem);
+            if (index < 0)
+            {
+                return;
+            }
+
             variable.ValuesList.Insert(index + 1, new Variable.ValuesListItem { Text = string.Empty });
 
-            var newValues = string.Join(";", variable.ValuesList?.Select(x => x.Text).ToArray());
-            EditVariableDialogValueTxtBox.TextChanged -= EditVariableDialogValueTxtBox_TextChanged;
-            EditVariableDialogValueTxtBox.Text = newValues;
-            EditVariableDialogValueTxtBox.TextChanged += EditVariableDialogValueTxtBox_TextChanged;
+            RefreshEditVariableDialogValueTextFromList(variable);
         }
 
         private void EditVariableValuesListTextBox_LostFocus(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
         {
-            var listItem = (sender as TextBox)?.DataContext as Variable.ValuesListItem;
+            var textBox = sender as TextBox;
+            if (textBox == null)
+            {
+                return;
+            }
+
+            var listItem = textBox.DataContext as Variable.ValuesListItem;
             if (listItem == null)
             {
                 return;
             }
 
-            if (listItem.Text == (sender as TextBox)?.Text)
+            if (listItem.Text == textBox.Text)
             {
                 return;
             }
 
-            listItem.Text = (sender as TextBox)?.Text;
+            listItem.Text = textBox.Text;
             var variable = EditVariableDialog.DataContext as Variable;
+            if (variable?.ValuesList == null)
+            {
+                return;
+            }
 
-            var newValues = string.Join(";", variable.ValuesList?.Select(x => x.Text).ToArray());
+            RefreshEditVariableDialogValueTextFromList(variable);
+        }
+
+        private void RefreshEditVariableDialogValueTextFromList(Variable variable)
+        {
+            if (variable?.ValuesList == null)
+            {
+                return;
+            }
+
+            var newValues = string.Join(";", variable.ValuesList.Select(x => x?.Text).ToArray());
             EditVariableDialogValueTxtBox.TextChanged -= EditVariableDialogValueTxtBox_TextChanged;
             EditVariableDialogValueTxtBox.Text = newValues;
             EditVariableDialogValueTxtBox.TextChanged += EditVariableDialogValueTxtBox_TextChanged;

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -11,6 +11,7 @@ using Windows.System;
 using Windows.ApplicationModel.DataTransfer;
 
 using CommunityToolkit.Mvvm.Input;
+using EnvironmentVariablesUILib.Helpers;
 using EnvironmentVariablesUILib.Models;
 using EnvironmentVariablesUILib.ViewModels;
 using Microsoft.UI.Xaml.Controls;
@@ -796,20 +797,7 @@ namespace EnvironmentVariablesUILib
             }
 
             return string.Equals((left.Name ?? string.Empty).Trim(), (right.Name ?? string.Empty).Trim(), StringComparison.OrdinalIgnoreCase)
-                && IsEquivalentVariableValue(left.Values, right.Values);
-        }
-
-        private static bool IsEquivalentVariableValue(string candidateValue, string compareValue)
-        {
-            var candidate = candidateValue ?? string.Empty;
-            var compare = compareValue ?? string.Empty;
-            var expandedCandidate = Environment.ExpandEnvironmentVariables(candidate);
-            var expandedCompare = Environment.ExpandEnvironmentVariables(compare);
-
-            return string.Equals(candidate, compare, StringComparison.Ordinal) ||
-                string.Equals(expandedCandidate, compare, StringComparison.Ordinal) ||
-                string.Equals(candidate, expandedCompare, StringComparison.Ordinal) ||
-                string.Equals(expandedCandidate, expandedCompare, StringComparison.Ordinal);
+                && EnvironmentVariablesHelper.IsEquivalentVariableValue(left.Values, right.Values);
         }
 
         private async Task ShowAddDefaultVariableDialogAsync(DefaultVariablesSet set)

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
+using Windows.ApplicationModel.DataTransfer;
 
 using CommunityToolkit.Mvvm.Input;
 using EnvironmentVariablesUILib.Models;
@@ -212,6 +213,43 @@ namespace EnvironmentVariablesUILib
                     ViewModel.DeleteVariable(variable, variableSet);
                 };
                 var result = await dialog.ShowAsync();
+            }
+        }
+
+        private void CopyVariableName_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+        {
+            var selectedItem = sender as MenuFlyoutItem;
+            var variable = selectedItem?.CommandParameter as Variable;
+            if (variable == null)
+            {
+                return;
+            }
+
+            CopyToClipboard(variable.Name);
+        }
+
+        private void CopyVariableValue_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+        {
+            var selectedItem = sender as MenuFlyoutItem;
+            var variable = selectedItem?.CommandParameter as Variable;
+            if (variable == null)
+            {
+                return;
+            }
+
+            CopyToClipboard(variable.Values);
+        }
+
+        private static void CopyToClipboard(string text)
+        {
+            try
+            {
+                var dataPackage = new DataPackage();
+                dataPackage.SetText(text ?? string.Empty);
+                Clipboard.SetContent(dataPackage);
+            }
+            catch
+            {
             }
         }
 

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -619,9 +619,9 @@ namespace EnvironmentVariablesUILib
             {
                 if (variable != null)
                 {
+                    var candidateName = (variable.Name ?? string.Empty).Trim();
                     if (!profile.Variables
-                        .Where(x => AreEquivalentVariables(x, variable))
-                        .Any())
+                        .Any(x => string.Equals((x?.Name ?? string.Empty).Trim(), candidateName, StringComparison.OrdinalIgnoreCase)))
                     {
                         AddVariableDialog.IsPrimaryButtonEnabled = true;
                         break;

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -76,6 +76,11 @@ namespace EnvironmentVariablesUILib
         private async void EditVariable_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
         {
             var btn = sender as MenuFlyoutItem;
+            if (btn == null)
+            {
+                return;
+            }
+
             var variablesSet = btn.DataContext as VariablesSet;
             var variable = btn.CommandParameter as Variable;
 
@@ -87,9 +92,18 @@ namespace EnvironmentVariablesUILib
 
         private void EditVariable(RelayCommandParameter param)
         {
+            if (param == null)
+            {
+                return;
+            }
+
             var variableSet = param.Set as ProfileVariablesSet;
             var original = param.Variable;
             var edited = EditVariableDialog.DataContext as Variable;
+            if (original == null || edited == null)
+            {
+                return;
+            }
             ViewModel.EditVariable(original, edited, variableSet);
         }
 
@@ -122,25 +136,36 @@ namespace EnvironmentVariablesUILib
         private async void RemoveProfileBtn_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
         {
             var button = sender as MenuFlyoutItem;
-            var profile = button.CommandParameter as ProfileVariablesSet;
-
-            if (profile != null)
+            if (button == null)
             {
-                var resourceLoader = Helpers.ResourceLoaderInstance.ResourceLoader;
-                ContentDialog dialog = new ContentDialog();
-                dialog.XamlRoot = RootPage.XamlRoot;
-                dialog.Title = profile.Name;
-                dialog.PrimaryButtonText = resourceLoader.GetString("Yes");
-                dialog.CloseButtonText = resourceLoader.GetString("No");
-                dialog.DefaultButton = ContentDialogButton.Primary;
-                dialog.Content = new TextBlock() { Text = resourceLoader.GetString("Delete_Dialog_Description"), TextWrapping = Microsoft.UI.Xaml.TextWrapping.WrapWholeWords };
-                dialog.PrimaryButtonClick += (s, args) =>
-                {
-                    ViewModel.RemoveProfile(profile);
-                };
-
-                var result = await dialog.ShowAsync();
+                return;
             }
+
+            var profile = button.CommandParameter as ProfileVariablesSet;
+            if (profile == null)
+            {
+                return;
+            }
+
+            if (RootPage == null)
+            {
+                return;
+            }
+
+            var resourceLoader = Helpers.ResourceLoaderInstance.ResourceLoader;
+            ContentDialog dialog = new ContentDialog();
+            dialog.XamlRoot = RootPage.XamlRoot;
+            dialog.Title = profile.Name;
+            dialog.PrimaryButtonText = resourceLoader.GetString("Yes");
+            dialog.CloseButtonText = resourceLoader.GetString("No");
+            dialog.DefaultButton = ContentDialogButton.Primary;
+            dialog.Content = new TextBlock() { Text = resourceLoader.GetString("Delete_Dialog_Description"), TextWrapping = Microsoft.UI.Xaml.TextWrapping.WrapWholeWords };
+            dialog.PrimaryButtonClick += (s, args) =>
+            {
+                ViewModel.RemoveProfile(profile);
+            };
+
+            var result = await dialog.ShowAsync();
         }
 
         private void AddVariable()
@@ -222,7 +247,16 @@ namespace EnvironmentVariablesUILib
 
         private void AddDefaultVariable(DefaultVariablesSet set)
         {
+            if (set == null)
+            {
+                return;
+            }
+
             var variable = AddDefaultVariableDialog.DataContext as Variable;
+            if (variable == null)
+            {
+                return;
+            }
             var type = set.Type;
 
             ViewModel.AddDefaultVariable(variable, type);
@@ -231,25 +265,31 @@ namespace EnvironmentVariablesUILib
         private async void Delete_Variable_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
         {
             MenuFlyoutItem selectedItem = sender as MenuFlyoutItem;
+            if (selectedItem == null || RootPage == null)
+            {
+                return;
+            }
+
             var variableSet = selectedItem.DataContext as ProfileVariablesSet;
             var variable = selectedItem.CommandParameter as Variable;
-
-            if (variable != null)
+            if (variable == null)
             {
-                var resourceLoader = Helpers.ResourceLoaderInstance.ResourceLoader;
-                ContentDialog dialog = new ContentDialog();
-                dialog.XamlRoot = RootPage.XamlRoot;
-                dialog.Title = variable.Name;
-                dialog.PrimaryButtonText = resourceLoader.GetString("Yes");
-                dialog.CloseButtonText = resourceLoader.GetString("No");
-                dialog.DefaultButton = ContentDialogButton.Primary;
-                dialog.Content = new TextBlock() { Text = resourceLoader.GetString("Delete_Variable_Description"), TextWrapping = Microsoft.UI.Xaml.TextWrapping.WrapWholeWords };
-                dialog.PrimaryButtonClick += (s, args) =>
-                {
-                    ViewModel.DeleteVariable(variable, variableSet);
-                };
-                var result = await dialog.ShowAsync();
+                return;
             }
+
+            var resourceLoader = Helpers.ResourceLoaderInstance.ResourceLoader;
+            ContentDialog dialog = new ContentDialog();
+            dialog.XamlRoot = RootPage.XamlRoot;
+            dialog.Title = variable.Name;
+            dialog.PrimaryButtonText = resourceLoader.GetString("Yes");
+            dialog.CloseButtonText = resourceLoader.GetString("No");
+            dialog.DefaultButton = ContentDialogButton.Primary;
+            dialog.Content = new TextBlock() { Text = resourceLoader.GetString("Delete_Variable_Description"), TextWrapping = Microsoft.UI.Xaml.TextWrapping.WrapWholeWords };
+            dialog.PrimaryButtonClick += (s, args) =>
+            {
+                ViewModel.DeleteVariable(variable, variableSet);
+            };
+            var result = await dialog.ShowAsync();
         }
 
         private void CopyVariableName_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
@@ -403,18 +443,24 @@ namespace EnvironmentVariablesUILib
             SwitchViewsSegmentedView.SelectedIndex = 0;
 
             var button = sender as MenuFlyoutItem;
-            var profile = button.CommandParameter as ProfileVariablesSet;
-
-            if (profile != null)
+            if (button == null)
             {
-                var resourceLoader = Helpers.ResourceLoaderInstance.ResourceLoader;
-                AddProfileDialog.Title = resourceLoader.GetString("EditProfileDialog_Title");
-                AddProfileDialog.PrimaryButtonText = resourceLoader.GetString("SaveBtn");
-                AddProfileDialog.SecondaryButtonText = resourceLoader.GetString("CancelBtn");
-                AddProfileDialog.PrimaryButtonCommand = UpdateProfileCommand;
-                AddProfileDialog.DataContext = profile.Clone();
-                await AddProfileDialog.ShowAsync();
+                return;
             }
+
+            var profile = button.CommandParameter as ProfileVariablesSet;
+            if (profile == null)
+            {
+                return;
+            }
+
+            var resourceLoader = Helpers.ResourceLoaderInstance.ResourceLoader;
+            AddProfileDialog.Title = resourceLoader.GetString("EditProfileDialog_Title");
+            AddProfileDialog.PrimaryButtonText = resourceLoader.GetString("SaveBtn");
+            AddProfileDialog.SecondaryButtonText = resourceLoader.GetString("CancelBtn");
+            AddProfileDialog.PrimaryButtonCommand = UpdateProfileCommand;
+            AddProfileDialog.DataContext = profile.Clone();
+            await AddProfileDialog.ShowAsync();
         }
 
         private async void AddVariableBtn_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -371,6 +371,7 @@ namespace EnvironmentVariablesUILib
         private void ExistingVariablesListView_Loaded(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
         {
             var profile = AddProfileDialog.DataContext as ProfileVariablesSet;
+            var remainingItems = ExistingVariablesListView.Items.Cast<Variable>().ToList();
 
             foreach (Variable item in ExistingVariablesListView.Items)
             {
@@ -380,10 +381,7 @@ namespace EnvironmentVariablesUILib
                     {
                         if (profileItem.Name == item.Name && profileItem.Values == item.Values)
                         {
-                            if (ExistingVariablesListView.SelectedItems
-                                .Where(x => ((Variable)x).Name.Equals(profileItem.Name, StringComparison.OrdinalIgnoreCase) &&
-                                            ((Variable)x).Values.Equals(profileItem.Values, StringComparison.Ordinal))
-                                .Any())
+                            if (!remainingItems.Remove(item))
                             {
                                 continue;
                             }
@@ -391,6 +389,7 @@ namespace EnvironmentVariablesUILib
                             ExistingVariablesListView.SelectionChanged -= ExistingVariablesListView_SelectionChanged;
                             ExistingVariablesListView.SelectedItems.Add(item);
                             ExistingVariablesListView.SelectionChanged += ExistingVariablesListView_SelectionChanged;
+                            break;
                         }
                     }
                 }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -340,21 +340,24 @@ namespace EnvironmentVariablesUILib
 
             if (e.RemovedItems.Count > 0)
             {
-                Variable removedVariable = e.RemovedItems[0] as Variable;
-                for (int i = 0; i < profile.Variables.Count; i++)
+                foreach (var removedItem in e.RemovedItems.Cast<Variable>())
                 {
-                    if (profile.Variables[i].Name.Equals(removedVariable.Name, StringComparison.OrdinalIgnoreCase)
-                        && profile.Variables[i].Values == removedVariable.Values
-                        && profile.Variables[i].ParentType == removedVariable.ParentType)
+                    toRemove = -1;
+                    for (int i = 0; i < profile.Variables.Count; i++)
                     {
-                        toRemove = i;
-                        break;
+                        if (profile.Variables[i].Name.Equals(removedItem.Name, StringComparison.OrdinalIgnoreCase)
+                            && profile.Variables[i].Values == removedItem.Values
+                            && profile.Variables[i].ParentType == removedItem.ParentType)
+                        {
+                            toRemove = i;
+                            break;
+                        }
                     }
-                }
 
-                if (toRemove != -1)
-                {
-                    profile.Variables.RemoveAt(toRemove);
+                    if (toRemove != -1)
+                    {
+                        profile.Variables.RemoveAt(toRemove);
+                    }
                 }
             }
 

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -774,8 +774,7 @@ namespace EnvironmentVariablesUILib
             }
 
             return string.Equals((left.Name ?? string.Empty).Trim(), (right.Name ?? string.Empty).Trim(), StringComparison.OrdinalIgnoreCase)
-                && string.Equals(left.Values, right.Values, StringComparison.Ordinal)
-                && left.ParentType == right.ParentType;
+                && string.Equals(left.Values, right.Values, StringComparison.Ordinal);
         }
 
         private async Task ShowAddDefaultVariableDialogAsync(DefaultVariablesSet set)

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -123,13 +123,21 @@ namespace EnvironmentVariablesUILib
                 }
 
                 var normalizedName = (variable.Name ?? string.Empty).Trim();
-                return ViewModel.Profiles?
-                    .FirstOrDefault(profile =>
-                        profile?.Variables != null &&
+                var matchingProfiles = ViewModel.Profiles?
+                    .Where(profile => profile?.Variables != null &&
                         profile.Variables.Any(x => x != null &&
                             string.Equals((x.Name ?? string.Empty).Trim(), normalizedName, StringComparison.OrdinalIgnoreCase) &&
                             string.Equals(x.Values, variable.Values, StringComparison.Ordinal) &&
-                            x.ParentType == VariablesSetType.Profile));
+                            x.ParentType == VariablesSetType.Profile))
+                    .ToList();
+
+                if (matchingProfiles == null || matchingProfiles.Count != 1)
+                {
+                    LoggerInstance.Logger.LogError("Unable to uniquely resolve profile owner for edited variable.");
+                    return null;
+                }
+
+                return matchingProfiles[0];
             }
 
             return null;

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -156,10 +156,8 @@ namespace EnvironmentVariablesUILib
                 {
                     foreach (Variable variable in ExistingVariablesListView.SelectedItems)
                     {
-                        if (!profile.Variables
-                            .Where(x => x.Name.Equals(variable.Name, StringComparison.OrdinalIgnoreCase)
-                                     && x.Values == variable.Values
-                                     && x.ParentType == variable.ParentType)
+                        if (variable != null && !profile.Variables
+                            .Where(x => AreEquivalentVariables(x, variable))
                             .Any())
                         {
                             var clone = variable.Clone(true);
@@ -329,8 +327,14 @@ namespace EnvironmentVariablesUILib
             if (e.AddedItems.Count > 0)
             {
                 var list = sender as ListView;
+                if (list == null)
+                {
+                    return;
+                }
+
                 var duplicates = list.SelectedItems
-                    .GroupBy(x => $"{((Variable)x).Name?.ToUpperInvariant()}|{((Variable)x).Values}|{((Variable)x).ParentType}")
+                    .OfType<Variable>()
+                    .GroupBy(x => $"{x.Name?.ToUpperInvariant()}|{x.Values}|{x.ParentType}")
                     .Where(g => g.Count() > 1)
                     .ToList();
 
@@ -355,9 +359,7 @@ namespace EnvironmentVariablesUILib
                     toRemove = -1;
                     for (int i = 0; i < profile.Variables.Count; i++)
                     {
-                        if (string.Equals(profile.Variables[i].Name, removedVariable.Name, StringComparison.OrdinalIgnoreCase)
-                            && profile.Variables[i].Values == removedVariable.Values
-                            && profile.Variables[i].ParentType == removedVariable.ParentType)
+                        if (AreEquivalentVariables(profile.Variables[i], removedVariable))
                         {
                             toRemove = i;
                             break;
@@ -377,9 +379,7 @@ namespace EnvironmentVariablesUILib
                 if (variable != null)
                 {
                     if (!profile.Variables
-                        .Where(x => string.Equals(x.Name, variable.Name, StringComparison.OrdinalIgnoreCase)
-                                 && x.Values.Equals(variable.Values, StringComparison.Ordinal)
-                                 && x.ParentType == variable.ParentType)
+                        .Where(x => AreEquivalentVariables(x, variable))
                         .Any())
                     {
                         AddVariableDialog.IsPrimaryButtonEnabled = true;
@@ -461,9 +461,7 @@ namespace EnvironmentVariablesUILib
                 {
                     foreach (var profileItem in profile.Variables)
                     {
-                        if (string.Equals(profileItem.Name, item.Name, StringComparison.OrdinalIgnoreCase)
-                            && profileItem.Values == item.Values
-                            && profileItem.ParentType == item.ParentType)
+                        if (AreEquivalentVariables(profileItem, item))
                         {
                             if (!remainingItems.Remove(item))
                             {
@@ -480,6 +478,18 @@ namespace EnvironmentVariablesUILib
             }
 
             UpdateNoMatchingDefaultVariablesText();
+        }
+
+        private static bool AreEquivalentVariables(Variable left, Variable right)
+        {
+            if (left == null || right == null)
+            {
+                return false;
+            }
+
+            return string.Equals(left.Name, right.Name, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(left.Values, right.Values, StringComparison.Ordinal)
+                && left.ParentType == right.ParentType;
         }
 
         private async Task ShowAddDefaultVariableDialogAsync(DefaultVariablesSet set)

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -340,14 +340,20 @@ namespace EnvironmentVariablesUILib
 
             if (e.RemovedItems.Count > 0)
             {
-                foreach (var removedItem in e.RemovedItems.Cast<Variable>())
+                foreach (var removedObject in e.RemovedItems)
                 {
+                    var removedVariable = removedObject as Variable;
+                    if (removedVariable == null)
+                    {
+                        continue;
+                    }
+
                     toRemove = -1;
                     for (int i = 0; i < profile.Variables.Count; i++)
                     {
-                        if (profile.Variables[i].Name.Equals(removedItem.Name, StringComparison.OrdinalIgnoreCase)
-                            && profile.Variables[i].Values == removedItem.Values
-                            && profile.Variables[i].ParentType == removedItem.ParentType)
+                        if (string.Equals(profile.Variables[i].Name, removedVariable.Name, StringComparison.OrdinalIgnoreCase)
+                            && profile.Variables[i].Values == removedVariable.Values
+                            && profile.Variables[i].ParentType == removedVariable.ParentType)
                         {
                             toRemove = i;
                             break;
@@ -367,7 +373,7 @@ namespace EnvironmentVariablesUILib
                 if (variable != null)
                 {
                     if (!profile.Variables
-                        .Where(x => x.Name.Equals(variable.Name, StringComparison.OrdinalIgnoreCase)
+                        .Where(x => string.Equals(x.Name, variable.Name, StringComparison.OrdinalIgnoreCase)
                                  && x.Values.Equals(variable.Values, StringComparison.Ordinal)
                                  && x.ParentType == variable.ParentType)
                         .Any())
@@ -443,16 +449,16 @@ namespace EnvironmentVariablesUILib
             foreach (Variable item in ExistingVariablesListView.Items)
             {
                 if (item != null)
+                {
+                    foreach (var profileItem in profile.Variables)
                     {
-                        foreach (var profileItem in profile.Variables)
+                        if (string.Equals(profileItem.Name, item.Name, StringComparison.OrdinalIgnoreCase)
+                            && profileItem.Values == item.Values
+                            && profileItem.ParentType == item.ParentType)
                         {
-                            if (profileItem.Name.Equals(item.Name, StringComparison.OrdinalIgnoreCase)
-                                && profileItem.Values == item.Values
-                                && profileItem.ParentType == item.ParentType)
+                            if (!remainingItems.Remove(item))
                             {
-                                if (!remainingItems.Remove(item))
-                                {
-                                    continue;
+                                continue;
                             }
 
                             ExistingVariablesListView.SelectionChanged -= ExistingVariablesListView_SelectionChanged;

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -758,7 +758,7 @@ namespace EnvironmentVariablesUILib
 
         private void AddDefaultVariableNameTxtBox_TextChanged(object sender, TextChangedEventArgs e)
         {
-            if (AddDefaultVariableDialog == null)
+            if (AddDefaultVariableDialog == null || ViewModel == null)
             {
                 return;
             }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -863,7 +863,7 @@ namespace EnvironmentVariablesUILib
                     }
 
                     return string.Equals((candidate.Name ?? string.Empty).Trim(), (reference.Name ?? string.Empty).Trim(), StringComparison.OrdinalIgnoreCase)
-                        && string.Equals(candidate.Values, reference.Values, StringComparison.Ordinal)
+                        && EnvironmentVariablesHelper.IsEquivalentVariableValue(candidate.Values, reference.Values)
                         && candidate.ParentType == reference.ParentType;
                 }
 

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -796,7 +796,20 @@ namespace EnvironmentVariablesUILib
             }
 
             return string.Equals((left.Name ?? string.Empty).Trim(), (right.Name ?? string.Empty).Trim(), StringComparison.OrdinalIgnoreCase)
-                && string.Equals(left.Values, right.Values, StringComparison.Ordinal);
+                && IsEquivalentVariableValue(left.Values, right.Values);
+        }
+
+        private static bool IsEquivalentVariableValue(string candidateValue, string compareValue)
+        {
+            var candidate = candidateValue ?? string.Empty;
+            var compare = compareValue ?? string.Empty;
+            var expandedCandidate = Environment.ExpandEnvironmentVariables(candidate);
+            var expandedCompare = Environment.ExpandEnvironmentVariables(compare);
+
+            return string.Equals(candidate, compare, StringComparison.Ordinal) ||
+                string.Equals(expandedCandidate, compare, StringComparison.Ordinal) ||
+                string.Equals(candidate, expandedCompare, StringComparison.Ordinal) ||
+                string.Equals(expandedCandidate, expandedCompare, StringComparison.Ordinal);
         }
 
         private async Task ShowAddDefaultVariableDialogAsync(DefaultVariablesSet set)

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -244,20 +244,10 @@ namespace EnvironmentVariablesUILib
                 return;
             }
 
-            var resourceLoader = Helpers.ResourceLoaderInstance.ResourceLoader;
-            ContentDialog dialog = new ContentDialog();
-            dialog.XamlRoot = RootPage.XamlRoot;
-            dialog.Title = profile.Name;
-            dialog.PrimaryButtonText = resourceLoader.GetString("Yes");
-            dialog.CloseButtonText = resourceLoader.GetString("No");
-            dialog.DefaultButton = ContentDialogButton.Primary;
-            dialog.Content = new TextBlock() { Text = resourceLoader.GetString("Delete_Dialog_Description"), TextWrapping = Microsoft.UI.Xaml.TextWrapping.WrapWholeWords };
-            dialog.PrimaryButtonClick += (s, args) =>
-            {
-                ViewModel.RemoveProfile(profile);
-            };
-
-            var result = await dialog.ShowAsync();
+            await ShowDeleteConfirmationDialogAsync(
+                profile.Name,
+                "Delete_Dialog_Description",
+                () => ViewModel.RemoveProfile(profile));
         }
 
         private void AddVariable()
@@ -439,19 +429,40 @@ namespace EnvironmentVariablesUILib
                 }
             }
 
-            var resourceLoader = Helpers.ResourceLoaderInstance.ResourceLoader;
-            ContentDialog dialog = new ContentDialog();
-            dialog.XamlRoot = RootPage.XamlRoot;
-            dialog.Title = variable.Name;
-            dialog.PrimaryButtonText = resourceLoader.GetString("Yes");
-            dialog.CloseButtonText = resourceLoader.GetString("No");
-            dialog.DefaultButton = ContentDialogButton.Primary;
-            dialog.Content = new TextBlock() { Text = resourceLoader.GetString("Delete_Variable_Description"), TextWrapping = Microsoft.UI.Xaml.TextWrapping.WrapWholeWords };
-            dialog.PrimaryButtonClick += (s, args) =>
+            await ShowDeleteConfirmationDialogAsync(
+                variable.Name,
+                "Delete_Variable_Description",
+                () => ViewModel.DeleteVariable(variable, variableSet));
+        }
+
+        private async Task ShowDeleteConfirmationDialogAsync(string title, string descriptionKey, Action onConfirm)
+        {
+            if (RootPage == null || onConfirm == null || string.IsNullOrWhiteSpace(descriptionKey))
             {
-                ViewModel.DeleteVariable(variable, variableSet);
+                return;
+            }
+
+            var resourceLoader = Helpers.ResourceLoaderInstance.ResourceLoader;
+            var dialog = new ContentDialog
+            {
+                Title = title,
+                PrimaryButtonText = resourceLoader.GetString("Yes"),
+                CloseButtonText = resourceLoader.GetString("No"),
+                DefaultButton = ContentDialogButton.Primary,
+                IsLightDismissEnabled = false,
+                Content = new TextBlock()
+                {
+                    Text = resourceLoader.GetString(descriptionKey),
+                    TextWrapping = Microsoft.UI.Xaml.TextWrapping.WrapWholeWords
+                }
             };
+
+            SetDialogXamlRoot(dialog);
             var result = await dialog.ShowAsync();
+            if (result == ContentDialogResult.Primary)
+            {
+                onConfirm();
+            }
         }
 
         private void CopyVariableName_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -124,24 +124,11 @@ namespace EnvironmentVariablesUILib
                 }
 
                 var normalizedName = (variable.Name ?? string.Empty).Trim();
-                var normalizedValue = variable.Values ?? string.Empty;
-                var expandedValue = Environment.ExpandEnvironmentVariables(normalizedValue);
-
-                bool IsValueMatch(string candidateValue)
-                {
-                    var candidate = candidateValue ?? string.Empty;
-                    var expandedCandidate = Environment.ExpandEnvironmentVariables(candidate);
-
-                    return string.Equals(candidate, normalizedValue, StringComparison.Ordinal) ||
-                        string.Equals(expandedCandidate, normalizedValue, StringComparison.Ordinal) ||
-                        string.Equals(candidate, expandedValue, StringComparison.Ordinal) ||
-                        string.Equals(expandedCandidate, expandedValue, StringComparison.Ordinal);
-                }
 
                 if (ViewModel.AppliedProfile != null && ViewModel.AppliedProfile.Variables != null &&
                     ViewModel.AppliedProfile.Variables.Any(x => x != null &&
                         string.Equals((x.Name ?? string.Empty).Trim(), normalizedName, StringComparison.OrdinalIgnoreCase) &&
-                        IsValueMatch(x.Values)))
+                        EnvironmentVariablesHelper.IsEquivalentVariableValue(x.Values, variable.Values)))
                 {
                     return ViewModel.AppliedProfile;
                 }
@@ -150,7 +137,7 @@ namespace EnvironmentVariablesUILib
                     .Where(profile => profile?.Variables != null &&
                         profile.Variables.Any(x => x != null &&
                              string.Equals((x.Name ?? string.Empty).Trim(), normalizedName, StringComparison.OrdinalIgnoreCase) &&
-                             IsValueMatch(x.Values) &&
+                             EnvironmentVariablesHelper.IsEquivalentVariableValue(x.Values, variable.Values) &&
                              x.ParentType == VariablesSetType.Profile))
                     .ToList();
 

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -224,7 +224,7 @@ namespace EnvironmentVariablesUILib
                     return;
                 }
 
-                if (newVariableName.Length >= 255 || profile.Variables.Any(x => string.Equals(x?.Name, newVariableName, StringComparison.OrdinalIgnoreCase)))
+                if (newVariableName.Length >= 255 || profile.Variables.Any(x => string.Equals((x?.Name ?? string.Empty).Trim(), newVariableName, StringComparison.OrdinalIgnoreCase)))
                 {
                     AddVariableDialog.IsPrimaryButtonEnabled = false;
                     return;

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -343,7 +343,9 @@ namespace EnvironmentVariablesUILib
                 Variable removedVariable = e.RemovedItems[0] as Variable;
                 for (int i = 0; i < profile.Variables.Count; i++)
                 {
-                    if (profile.Variables[i].Name == removedVariable.Name && profile.Variables[i].Values == removedVariable.Values && profile.Variables[i].ParentType == removedVariable.ParentType)
+                    if (profile.Variables[i].Name.Equals(removedVariable.Name, StringComparison.OrdinalIgnoreCase)
+                        && profile.Variables[i].Values == removedVariable.Values
+                        && profile.Variables[i].ParentType == removedVariable.ParentType)
                     {
                         toRemove = i;
                         break;
@@ -362,7 +364,7 @@ namespace EnvironmentVariablesUILib
                 if (variable != null)
                 {
                     if (!profile.Variables
-                        .Where(x => x.Name.Equals(variable.Name, StringComparison.Ordinal)
+                        .Where(x => x.Name.Equals(variable.Name, StringComparison.OrdinalIgnoreCase)
                                  && x.Values.Equals(variable.Values, StringComparison.Ordinal)
                                  && x.ParentType == variable.ParentType)
                         .Any())
@@ -438,14 +440,16 @@ namespace EnvironmentVariablesUILib
             foreach (Variable item in ExistingVariablesListView.Items)
             {
                 if (item != null)
-                {
-                    foreach (var profileItem in profile.Variables)
                     {
-                        if (profileItem.Name == item.Name && profileItem.Values == item.Values && profileItem.ParentType == item.ParentType)
+                        foreach (var profileItem in profile.Variables)
                         {
-                            if (!remainingItems.Remove(item))
+                            if (profileItem.Name.Equals(item.Name, StringComparison.OrdinalIgnoreCase)
+                                && profileItem.Values == item.Values
+                                && profileItem.ParentType == item.ParentType)
                             {
-                                continue;
+                                if (!remainingItems.Remove(item))
+                                {
+                                    continue;
                             }
 
                             ExistingVariablesListView.SelectionChanged -= ExistingVariablesListView_SelectionChanged;

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -598,6 +598,10 @@ namespace EnvironmentVariablesUILib
             }
 
             var variable = EditVariableDialog.DataContext as Variable;
+            if (variable?.ValuesList == null)
+            {
+                return;
+            }
 
             var index = variable.ValuesList.IndexOf(listItem);
             if (index > 0)
@@ -606,7 +610,9 @@ namespace EnvironmentVariablesUILib
             }
 
             var newValues = string.Join(";", variable.ValuesList?.Select(x => x.Text).ToArray());
+            EditVariableDialogValueTxtBox.TextChanged -= EditVariableDialogValueTxtBox_TextChanged;
             EditVariableDialogValueTxtBox.Text = newValues;
+            EditVariableDialogValueTxtBox.TextChanged += EditVariableDialogValueTxtBox_TextChanged;
         }
 
         private void ReorderButtonDown_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
@@ -618,7 +624,10 @@ namespace EnvironmentVariablesUILib
             }
 
             var variable = EditVariableDialog.DataContext as Variable;
-            var btn = EditVariableDialog.PrimaryButtonCommandParameter as Button;
+            if (variable?.ValuesList == null)
+            {
+                return;
+            }
 
             var index = variable.ValuesList.IndexOf(listItem);
             if (index < variable.ValuesList.Count - 1)
@@ -627,7 +636,9 @@ namespace EnvironmentVariablesUILib
             }
 
             var newValues = string.Join(";", variable.ValuesList?.Select(x => x.Text).ToArray());
+            EditVariableDialogValueTxtBox.TextChanged -= EditVariableDialogValueTxtBox_TextChanged;
             EditVariableDialogValueTxtBox.Text = newValues;
+            EditVariableDialogValueTxtBox.TextChanged += EditVariableDialogValueTxtBox_TextChanged;
         }
 
         private void RemoveListVariableButton_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
@@ -647,7 +658,9 @@ namespace EnvironmentVariablesUILib
             variable.ValuesList.Remove(listItem);
 
             var newValues = string.Join(";", variable.ValuesList?.Select(x => x?.Text).ToArray());
+            EditVariableDialogValueTxtBox.TextChanged -= EditVariableDialogValueTxtBox_TextChanged;
             EditVariableDialogValueTxtBox.Text = newValues;
+            EditVariableDialogValueTxtBox.TextChanged += EditVariableDialogValueTxtBox_TextChanged;
         }
 
         private void RemoveListVariableDuplicatesButton_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -188,6 +188,25 @@ namespace EnvironmentVariablesUILib
             }
 
             ViewModel.ClearDefaultVariablesFilter();
+            UpdateNoMatchingDefaultVariablesText();
+        }
+
+        private void UpdateNoMatchingDefaultVariablesText()
+        {
+            if (NoMatchingDefaultVariablesText == null || DefaultVariablesSearchBox == null)
+            {
+                return;
+            }
+
+            var hasActiveFilter = !string.IsNullOrWhiteSpace(DefaultVariablesSearchBox.Text);
+            if (hasActiveFilter && ViewModel.FilteredDefaultVariables.Count == 0)
+            {
+                NoMatchingDefaultVariablesText.Visibility = Microsoft.UI.Xaml.Visibility.Visible;
+            }
+            else
+            {
+                NoMatchingDefaultVariablesText.Visibility = Microsoft.UI.Xaml.Visibility.Collapsed;
+            }
         }
 
         private void ResetAddVariableInputs()
@@ -397,6 +416,7 @@ namespace EnvironmentVariablesUILib
             ExistingVariablesListView.SelectionChanged += ExistingVariablesListView_SelectionChanged;
 
             AddVariableDialog.IsPrimaryButtonEnabled = false;
+            UpdateNoMatchingDefaultVariablesText();
         }
 
         private void ExistingVariablesListView_Loaded(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
@@ -425,6 +445,8 @@ namespace EnvironmentVariablesUILib
                     }
                 }
             }
+
+            UpdateNoMatchingDefaultVariablesText();
         }
 
         private async Task ShowAddDefaultVariableDialogAsync(DefaultVariablesSet set)

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -113,8 +113,26 @@ namespace EnvironmentVariablesUILib
                 return ViewModel.SystemDefaultSet;
             }
 
-            return ViewModel.Profiles?
-                .FirstOrDefault(profile => profile?.Variables != null && profile.Variables.Contains(variable));
+            if (variable.ParentType == VariablesSetType.Profile)
+            {
+                var exactMatch = ViewModel.Profiles?
+                    .FirstOrDefault(profile => profile?.Variables != null && profile.Variables.Contains(variable));
+                if (exactMatch != null)
+                {
+                    return exactMatch;
+                }
+
+                var normalizedName = (variable.Name ?? string.Empty).Trim();
+                return ViewModel.Profiles?
+                    .FirstOrDefault(profile =>
+                        profile?.Variables != null &&
+                        profile.Variables.Any(x => x != null &&
+                            string.Equals((x.Name ?? string.Empty).Trim(), normalizedName, StringComparison.OrdinalIgnoreCase) &&
+                            string.Equals(x.Values, variable.Values, StringComparison.Ordinal) &&
+                            x.ParentType == VariablesSetType.Profile));
+            }
+
+            return null;
         }
 
         private void EditVariable(RelayCommandParameter param)

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -606,9 +606,8 @@ namespace EnvironmentVariablesUILib
             {
                 if (variable != null)
                 {
-                    var candidateName = (variable.Name ?? string.Empty).Trim();
                     if (!profile.Variables
-                        .Any(x => string.Equals((x?.Name ?? string.Empty).Trim(), candidateName, StringComparison.OrdinalIgnoreCase)))
+                        .Any(x => AreEquivalentVariables(x, variable)))
                     {
                         AddVariableDialog.IsPrimaryButtonEnabled = true;
                         break;

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -749,6 +749,10 @@ namespace EnvironmentVariablesUILib
                     EditVariableDialog.IsPrimaryButtonEnabled = true;
                 }
             }
+            else
+            {
+                EditVariableDialog.IsPrimaryButtonEnabled = false;
+            }
 
             if (!variable.Validate())
             {

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -283,9 +283,13 @@ namespace EnvironmentVariablesUILib
             {
                 foreach (Variable variable in ExistingVariablesListView.SelectedItems)
                 {
-                    if (variable != null && !profile.Variables
-                        .Where(x => AreEquivalentVariables(x, variable))
-                        .Any())
+                    if (variable == null || string.IsNullOrWhiteSpace(variable.Name))
+                    {
+                        continue;
+                    }
+
+                    var candidateName = (variable.Name ?? string.Empty).Trim();
+                    if (!profile.Variables.Any(x => string.Equals((x?.Name ?? string.Empty).Trim(), candidateName, StringComparison.OrdinalIgnoreCase)))
                     {
                         var clone = variable.Clone(true);
                         profile.Variables.Add(clone);

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -124,6 +124,11 @@ namespace EnvironmentVariablesUILib
                 }
 
                 var normalizedName = (variable.Name ?? string.Empty).Trim();
+                if (string.IsNullOrWhiteSpace(normalizedName))
+                {
+                    LoggerInstance.Logger.LogError("Unable to resolve profile owner for invalid edited variable name.");
+                    return null;
+                }
 
                 var matchingProfiles = ViewModel.Profiles?
                     .Where(profile => profile?.Variables != null &&

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -578,17 +578,7 @@ namespace EnvironmentVariablesUILib
                     }
 
                     var selectedVariables = list.SelectedItems.OfType<Variable>().ToList();
-                    var dedupedSelections = new List<Variable>();
-
-                    foreach (var selected in selectedVariables)
-                    {
-                        if (dedupedSelections.Any(x => AreEquivalentVariables(x, selected)))
-                        {
-                            continue;
-                        }
-
-                        dedupedSelections.Add(selected);
-                    }
+                    var dedupedSelections = DeduplicateVariablesByEquivalence(selectedVariables);
 
                     ExistingVariablesListView.SelectionChanged -= ExistingVariablesListView_SelectionChanged;
                     foreach (var item in selectedVariables.Except(dedupedSelections).ToList())
@@ -779,6 +769,22 @@ namespace EnvironmentVariablesUILib
 
             return string.Equals((left.Name ?? string.Empty).Trim(), (right.Name ?? string.Empty).Trim(), StringComparison.OrdinalIgnoreCase)
                 && EnvironmentVariablesHelper.IsEquivalentVariableValue(left.Values, right.Values);
+        }
+
+        private static List<Variable> DeduplicateVariablesByEquivalence(IList<Variable> variables)
+        {
+            var deduped = new List<Variable>();
+            foreach (var variable in variables)
+            {
+                if (deduped.Any(existing => AreEquivalentVariables(existing, variable)))
+                {
+                    continue;
+                }
+
+                deduped.Add(variable);
+            }
+
+            return deduped;
         }
 
         private async Task ShowAddDefaultVariableDialogAsync(DefaultVariablesSet set)

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -802,8 +802,25 @@ namespace EnvironmentVariablesUILib
             if (variableSet != null)
             {
                 var normalizedName = EditVariableDialogNameTxtBox.Text?.Trim();
+                static bool IsCurrentVariable(Variable candidate, Variable reference)
+                {
+                    if (candidate == null || reference == null)
+                    {
+                        return false;
+                    }
+
+                    if (ReferenceEquals(candidate, reference))
+                    {
+                        return true;
+                    }
+
+                    return string.Equals((candidate.Name ?? string.Empty).Trim(), (reference.Name ?? string.Empty).Trim(), StringComparison.OrdinalIgnoreCase)
+                        && string.Equals(candidate.Values, reference.Values, StringComparison.Ordinal)
+                        && candidate.ParentType == reference.ParentType;
+                }
+
                 bool hasDuplicateName = variableSet.Variables != null &&
-                    variableSet.Variables.Any(x => !ReferenceEquals(x, originalVariable)
+                    variableSet.Variables.Any(x => !IsCurrentVariable(x, originalVariable)
                         && string.Equals((x?.Name ?? string.Empty).Trim(), normalizedName, StringComparison.OrdinalIgnoreCase));
 
                 if (string.IsNullOrWhiteSpace(normalizedName) || variableSet.Variables == null || hasDuplicateName || !variable.Valid)

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -319,6 +319,10 @@ namespace EnvironmentVariablesUILib
         private void ExistingVariablesListView_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             var profile = AddProfileDialog.DataContext as ProfileVariablesSet;
+            if (profile == null)
+            {
+                return;
+            }
 
             int toRemove = -1;
 
@@ -444,6 +448,11 @@ namespace EnvironmentVariablesUILib
         private void ExistingVariablesListView_Loaded(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
         {
             var profile = AddProfileDialog.DataContext as ProfileVariablesSet;
+            if (profile == null)
+            {
+                return;
+            }
+
             var remainingItems = ExistingVariablesListView.Items.Cast<Variable>().ToList();
 
             foreach (Variable item in ExistingVariablesListView.Items)

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -178,11 +178,24 @@ namespace EnvironmentVariablesUILib
             AddVariableDialog.Hide();
         }
 
+        private void ClearAddVariableSearchFilter()
+        {
+            if (DefaultVariablesSearchBox != null)
+            {
+                DefaultVariablesSearchBox.TextChanged -= DefaultVariablesSearchBox_TextChanged;
+                DefaultVariablesSearchBox.Text = string.Empty;
+                DefaultVariablesSearchBox.TextChanged += DefaultVariablesSearchBox_TextChanged;
+            }
+
+            ViewModel.ClearDefaultVariablesFilter();
+        }
+
         private void ResetAddVariableInputs()
         {
             AddNewVariableName.Text = string.Empty;
             AddNewVariableValue.Text = string.Empty;
             AddVariableDialog.IsPrimaryButtonEnabled = false;
+            ClearAddVariableSearchFilter();
 
             ExistingVariablesListView.SelectionChanged -= ExistingVariablesListView_SelectionChanged;
             ExistingVariablesListView.SelectedItems.Clear();
@@ -372,6 +385,18 @@ namespace EnvironmentVariablesUILib
             SwitchViewsSegmentedView.SelectedIndex = 0;
             AddVariableDialog.DataContext = AddProfileDialog.DataContext;
             await AddVariableDialog.ShowAsync();
+        }
+
+        private void DefaultVariablesSearchBox_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            var searchText = (sender as TextBox)?.Text;
+            ViewModel.SetDefaultVariablesFilter(searchText);
+
+            ExistingVariablesListView.SelectionChanged -= ExistingVariablesListView_SelectionChanged;
+            ExistingVariablesListView.SelectedItems.Clear();
+            ExistingVariablesListView.SelectionChanged += ExistingVariablesListView_SelectionChanged;
+
+            AddVariableDialog.IsPrimaryButtonEnabled = false;
         }
 
         private void ExistingVariablesListView_Loaded(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -492,7 +492,7 @@ namespace EnvironmentVariablesUILib
 
                 var duplicates = list.SelectedItems
                     .OfType<Variable>()
-                    .GroupBy(x => $"{x.Name?.ToUpperInvariant()}|{x.Values}|{x.ParentType}")
+                    .GroupBy(x => $"{(x.Name ?? string.Empty).Trim().ToUpperInvariant()}|{x.Values}|{x.ParentType}")
                     .Where(g => g.Count() > 1)
                     .ToList();
 

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -600,19 +600,12 @@ namespace EnvironmentVariablesUILib
                         continue;
                     }
 
-                    toRemove = -1;
-                    for (int i = 0; i < profile.Variables.Count; i++)
+                    for (int i = profile.Variables.Count - 1; i >= 0; i--)
                     {
                         if (AreEquivalentVariables(profile.Variables[i], removedVariable))
                         {
-                            toRemove = i;
-                            break;
+                            profile.Variables.RemoveAt(i);
                         }
-                    }
-
-                    if (toRemove != -1)
-                    {
-                        profile.Variables.RemoveAt(toRemove);
                     }
                 }
             }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -124,12 +124,22 @@ namespace EnvironmentVariablesUILib
         private void AddProfile()
         {
             var profile = AddProfileDialog.DataContext as ProfileVariablesSet;
+            if (profile == null)
+            {
+                return;
+            }
+
             ViewModel.AddProfile(profile);
         }
 
         private void UpdateProfile()
         {
             var updatedProfile = AddProfileDialog.DataContext as ProfileVariablesSet;
+            if (updatedProfile == null)
+            {
+                return;
+            }
+
             ViewModel.UpdateProfile(updatedProfile);
         }
 
@@ -171,23 +181,28 @@ namespace EnvironmentVariablesUILib
         private void AddVariable()
         {
             var profile = AddProfileDialog.DataContext as ProfileVariablesSet;
-            if (profile != null)
+            if (profile == null || profile.Variables == null || AddNewVariableName == null || AddNewVariableValue == null || ExistingVariablesListView == null || AddVariableSwitchPresenter == null)
             {
-                if (AddVariableSwitchPresenter.Value as string == "NewVariable")
+                ResetAddVariableInputs();
+                AddVariableDialog.Hide();
+                return;
+            }
+
+            var activePanel = AddVariableSwitchPresenter.Value as string;
+            if (activePanel == "NewVariable")
+            {
+                profile.Variables.Add(new Variable(AddNewVariableName.Text, AddNewVariableValue.Text, VariablesSetType.Profile));
+            }
+            else
+            {
+                foreach (Variable variable in ExistingVariablesListView.SelectedItems)
                 {
-                    profile.Variables.Add(new Variable(AddNewVariableName.Text, AddNewVariableValue.Text, VariablesSetType.Profile));
-                }
-                else
-                {
-                    foreach (Variable variable in ExistingVariablesListView.SelectedItems)
+                    if (variable != null && !profile.Variables
+                        .Where(x => AreEquivalentVariables(x, variable))
+                        .Any())
                     {
-                        if (variable != null && !profile.Variables
-                            .Where(x => AreEquivalentVariables(x, variable))
-                            .Any())
-                        {
-                            var clone = variable.Clone(true);
-                            profile.Variables.Add(clone);
-                        }
+                        var clone = variable.Clone(true);
+                        profile.Variables.Add(clone);
                     }
                 }
             }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -917,6 +917,8 @@ namespace EnvironmentVariablesUILib
             }
 
             var normalizedDefaultName = nameTxtBox.Text?.Trim();
+            variable.Name = normalizedDefaultName;
+
             if (defaultSet.Variables == null || string.IsNullOrWhiteSpace(normalizedDefaultName) || defaultSet.Variables.Any(x => string.Equals((x?.Name ?? string.Empty).Trim(), normalizedDefaultName, StringComparison.OrdinalIgnoreCase)) || !variable.Validate())
             {
                 AddDefaultVariableDialog.IsPrimaryButtonEnabled = false;
@@ -924,11 +926,6 @@ namespace EnvironmentVariablesUILib
             else
             {
                 AddDefaultVariableDialog.IsPrimaryButtonEnabled = true;
-            }
-
-            if (!variable.Validate())
-            {
-                AddDefaultVariableDialog.IsPrimaryButtonEnabled = false;
             }
         }
 

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -123,12 +123,34 @@ namespace EnvironmentVariablesUILib
                 }
 
                 var normalizedName = (variable.Name ?? string.Empty).Trim();
+                var normalizedValue = variable.Values ?? string.Empty;
+                var expandedValue = Environment.ExpandEnvironmentVariables(normalizedValue);
+
+                bool IsValueMatch(string candidateValue)
+                {
+                    var candidate = candidateValue ?? string.Empty;
+                    var expandedCandidate = Environment.ExpandEnvironmentVariables(candidate);
+
+                    return string.Equals(candidate, normalizedValue, StringComparison.Ordinal) ||
+                        string.Equals(expandedCandidate, normalizedValue, StringComparison.Ordinal) ||
+                        string.Equals(candidate, expandedValue, StringComparison.Ordinal) ||
+                        string.Equals(expandedCandidate, expandedValue, StringComparison.Ordinal);
+                }
+
+                if (ViewModel.AppliedProfile != null && ViewModel.AppliedProfile.Variables != null &&
+                    ViewModel.AppliedProfile.Variables.Any(x => x != null &&
+                        string.Equals((x.Name ?? string.Empty).Trim(), normalizedName, StringComparison.OrdinalIgnoreCase) &&
+                        IsValueMatch(x.Values)))
+                {
+                    return ViewModel.AppliedProfile;
+                }
+
                 var matchingProfiles = ViewModel.Profiles?
                     .Where(profile => profile?.Variables != null &&
                         profile.Variables.Any(x => x != null &&
-                            string.Equals((x.Name ?? string.Empty).Trim(), normalizedName, StringComparison.OrdinalIgnoreCase) &&
-                            string.Equals(x.Values, variable.Values, StringComparison.Ordinal) &&
-                            x.ParentType == VariablesSetType.Profile))
+                             string.Equals((x.Name ?? string.Empty).Trim(), normalizedName, StringComparison.OrdinalIgnoreCase) &&
+                             IsValueMatch(x.Values) &&
+                             x.ParentType == VariablesSetType.Profile))
                     .ToList();
 
                 if (matchingProfiles == null || matchingProfiles.Count != 1)

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -440,7 +440,7 @@ namespace EnvironmentVariablesUILib
             }
 
             var normalizedName = nameTxtBox.Text?.Trim();
-            if (string.IsNullOrWhiteSpace(normalizedName) || normalizedName.Length >= 255 || profile.Variables.Where(x => string.Equals(x?.Name, normalizedName, StringComparison.OrdinalIgnoreCase)).Any())
+            if (string.IsNullOrWhiteSpace(normalizedName) || normalizedName.Length >= 255 || profile.Variables.Any(x => string.Equals((x?.Name ?? string.Empty).Trim(), normalizedName, StringComparison.OrdinalIgnoreCase)))
             {
                 AddVariableDialog.IsPrimaryButtonEnabled = false;
             }
@@ -688,7 +688,7 @@ namespace EnvironmentVariablesUILib
                 return false;
             }
 
-            return string.Equals(left.Name, right.Name, StringComparison.OrdinalIgnoreCase)
+            return string.Equals((left.Name ?? string.Empty).Trim(), (right.Name ?? string.Empty).Trim(), StringComparison.OrdinalIgnoreCase)
                 && string.Equals(left.Values, right.Values, StringComparison.Ordinal)
                 && left.ParentType == right.ParentType;
         }
@@ -754,7 +754,8 @@ namespace EnvironmentVariablesUILib
 
             if (variableSet != null)
             {
-                if (variableSet.Variables == null || variableSet.Variables.Where(x => string.Equals(x?.Name, EditVariableDialogNameTxtBox.Text, StringComparison.OrdinalIgnoreCase)).Any() || !variable.Valid)
+                var normalizedName = EditVariableDialogNameTxtBox.Text?.Trim();
+                if (string.IsNullOrWhiteSpace(normalizedName) || variableSet.Variables == null || variableSet.Variables.Any(x => string.Equals((x?.Name ?? string.Empty).Trim(), normalizedName, StringComparison.OrdinalIgnoreCase)) || !variable.Valid)
                 {
                     EditVariableDialog.IsPrimaryButtonEnabled = false;
                 }
@@ -796,7 +797,8 @@ namespace EnvironmentVariablesUILib
                 return;
             }
 
-            if (defaultSet.Variables == null || nameTxtBox.Text.Length == 0 || defaultSet.Variables.Where(x => string.Equals(x?.Name, nameTxtBox.Text, StringComparison.OrdinalIgnoreCase)).Any())
+            var normalizedDefaultName = nameTxtBox.Text?.Trim();
+            if (defaultSet.Variables == null || string.IsNullOrWhiteSpace(normalizedDefaultName) || defaultSet.Variables.Any(x => string.Equals((x?.Name ?? string.Empty).Trim(), normalizedDefaultName, StringComparison.OrdinalIgnoreCase)) || !variable.Validate())
             {
                 AddDefaultVariableDialog.IsPrimaryButtonEnabled = false;
             }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -343,7 +343,7 @@ namespace EnvironmentVariablesUILib
                 Variable removedVariable = e.RemovedItems[0] as Variable;
                 for (int i = 0; i < profile.Variables.Count; i++)
                 {
-                    if (profile.Variables[i].Name == removedVariable.Name && profile.Variables[i].Values == removedVariable.Values)
+                    if (profile.Variables[i].Name == removedVariable.Name && profile.Variables[i].Values == removedVariable.Values && profile.Variables[i].ParentType == removedVariable.ParentType)
                     {
                         toRemove = i;
                         break;
@@ -441,7 +441,7 @@ namespace EnvironmentVariablesUILib
                 {
                     foreach (var profileItem in profile.Variables)
                     {
-                        if (profileItem.Name == item.Name && profileItem.Values == item.Values)
+                        if (profileItem.Name == item.Name && profileItem.Values == item.Values && profileItem.ParentType == item.ParentType)
                         {
                             if (!remainingItems.Remove(item))
                             {

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -290,8 +290,7 @@ namespace EnvironmentVariablesUILib
                         continue;
                     }
 
-                    var candidateName = (variable.Name ?? string.Empty).Trim();
-                    if (!profile.Variables.Any(x => string.Equals((x?.Name ?? string.Empty).Trim(), candidateName, StringComparison.OrdinalIgnoreCase)))
+                    if (!profile.Variables.Any(x => AreEquivalentVariables(x, variable)))
                     {
                         var clone = variable.Clone(true);
                         profile.Variables.Add(clone);

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -294,17 +294,19 @@ namespace EnvironmentVariablesUILib
         {
             TextBox nameTxtBox = sender as TextBox;
             var profile = AddProfileDialog.DataContext as ProfileVariablesSet;
-
-            if (nameTxtBox != null)
+            if (nameTxtBox == null || profile == null)
             {
-                if (nameTxtBox.Text.Length == 0 || nameTxtBox.Text.Length >= 255 || profile.Variables.Where(x => x.Name.Equals(nameTxtBox.Text, StringComparison.OrdinalIgnoreCase)).Any())
-                {
-                    AddVariableDialog.IsPrimaryButtonEnabled = false;
-                }
-                else
-                {
-                    AddVariableDialog.IsPrimaryButtonEnabled = true;
-                }
+                AddVariableDialog.IsPrimaryButtonEnabled = false;
+                return;
+            }
+
+            if (nameTxtBox.Text.Length == 0 || nameTxtBox.Text.Length >= 255 || profile.Variables.Where(x => x.Name.Equals(nameTxtBox.Text, StringComparison.OrdinalIgnoreCase)).Any())
+            {
+                AddVariableDialog.IsPrimaryButtonEnabled = false;
+            }
+            else
+            {
+                AddVariableDialog.IsPrimaryButtonEnabled = true;
             }
         }
 
@@ -530,7 +532,12 @@ namespace EnvironmentVariablesUILib
         {
             var variable = EditVariableDialog.DataContext as Variable;
             var param = EditVariableDialog.PrimaryButtonCommandParameter as RelayCommandParameter;
-            var variableSet = param.Set;
+            var variableSet = param?.Set;
+            if (variable == null)
+            {
+                EditVariableDialog.IsPrimaryButtonEnabled = false;
+                return;
+            }
 
             if (variableSet == null)
             {
@@ -560,18 +567,26 @@ namespace EnvironmentVariablesUILib
         {
             TextBox nameTxtBox = sender as TextBox;
             var variable = AddDefaultVariableDialog.DataContext as Variable;
-            var defaultSet = variable.ParentType == VariablesSetType.User ? ViewModel.UserDefaultSet : ViewModel.SystemDefaultSet;
-
-            if (nameTxtBox != null)
+            if (nameTxtBox == null || variable == null)
             {
-                if (nameTxtBox.Text.Length == 0 || defaultSet.Variables.Where(x => x.Name.Equals(nameTxtBox.Text, StringComparison.OrdinalIgnoreCase)).Any())
-                {
-                    AddDefaultVariableDialog.IsPrimaryButtonEnabled = false;
-                }
-                else
-                {
-                    AddDefaultVariableDialog.IsPrimaryButtonEnabled = true;
-                }
+                AddDefaultVariableDialog.IsPrimaryButtonEnabled = false;
+                return;
+            }
+
+            var defaultSet = variable.ParentType == VariablesSetType.User ? ViewModel.UserDefaultSet : ViewModel.SystemDefaultSet;
+            if (defaultSet == null)
+            {
+                AddDefaultVariableDialog.IsPrimaryButtonEnabled = false;
+                return;
+            }
+
+            if (nameTxtBox.Text.Length == 0 || defaultSet.Variables.Where(x => x.Name.Equals(nameTxtBox.Text, StringComparison.OrdinalIgnoreCase)).Any())
+            {
+                AddDefaultVariableDialog.IsPrimaryButtonEnabled = false;
+            }
+            else
+            {
+                AddDefaultVariableDialog.IsPrimaryButtonEnabled = true;
             }
 
             if (!variable.Validate())

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -444,7 +444,7 @@ namespace EnvironmentVariablesUILib
 
         private void ExistingVariablesListView_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            if (AddVariableDialog == null)
+            if (AddVariableDialog == null || AddProfileDialog == null)
             {
                 return;
             }
@@ -619,6 +619,11 @@ namespace EnvironmentVariablesUILib
 
         private void ExistingVariablesListView_Loaded(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
         {
+            if (AddProfileDialog == null)
+            {
+                return;
+            }
+
             var profile = AddProfileDialog.DataContext as ProfileVariablesSet;
             if (profile == null)
             {
@@ -782,7 +787,7 @@ namespace EnvironmentVariablesUILib
         {
             var txtBox = sender as TextBox;
             var variable = EditVariableDialog.DataContext as Variable;
-            if (txtBox == null || variable == null)
+            if (EditVariableDialog == null || txtBox == null || variable == null)
             {
                 return;
             }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -341,7 +341,14 @@ namespace EnvironmentVariablesUILib
                 foreach (var dup in duplicates)
                 {
                     ExistingVariablesListView.SelectionChanged -= ExistingVariablesListView_SelectionChanged;
-                    list.SelectedItems.Remove(dup.ElementAt(1));
+                    var duplicatedItems = dup
+                        .OrderBy(x => list.SelectedItems.IndexOf(x))
+                        .Skip(1)
+                        .ToList();
+                    foreach (var item in duplicatedItems)
+                    {
+                        list.SelectedItems.Remove(item);
+                    }
                     ExistingVariablesListView.SelectionChanged += ExistingVariablesListView_SelectionChanged;
                 }
             }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -59,6 +59,11 @@ namespace EnvironmentVariablesUILib
 
         private async Task ShowEditDialogAsync(Variable variable, VariablesSet parentSet)
         {
+            if (EditVariableDialog == null || variable == null)
+            {
+                return;
+            }
+
             var resourceLoader = Helpers.ResourceLoaderInstance.ResourceLoader;
 
             EditVariableDialog.Title = resourceLoader.GetString("EditVariableDialog_Title");
@@ -93,7 +98,7 @@ namespace EnvironmentVariablesUILib
 
         private void EditVariable(RelayCommandParameter param)
         {
-            if (param == null || ViewModel == null)
+            if (param == null || ViewModel == null || EditVariableDialog == null)
             {
                 return;
             }
@@ -713,6 +718,11 @@ namespace EnvironmentVariablesUILib
 
         private void EditVariableDialogNameTxtBox_TextChanged(object sender, TextChangedEventArgs e)
         {
+            if (EditVariableDialog == null || EditVariableDialogNameTxtBox == null || ViewModel == null)
+            {
+                return;
+            }
+
             var variable = EditVariableDialog.DataContext as Variable;
             var param = EditVariableDialog.PrimaryButtonCommandParameter as RelayCommandParameter;
             var variableSet = param?.Set;
@@ -785,9 +795,14 @@ namespace EnvironmentVariablesUILib
 
         private void EditVariableDialogValueTxtBox_TextChanged(object sender, TextChangedEventArgs e)
         {
+            if (EditVariableDialog == null)
+            {
+                return;
+            }
+
             var txtBox = sender as TextBox;
             var variable = EditVariableDialog.DataContext as Variable;
-            if (EditVariableDialog == null || txtBox == null || variable == null)
+            if (txtBox == null || variable == null)
             {
                 return;
             }
@@ -799,6 +814,11 @@ namespace EnvironmentVariablesUILib
 
         private void ReorderButtonUp_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
         {
+            if (EditVariableDialog == null)
+            {
+                return;
+            }
+
             var menuFlyoutItem = sender as MenuFlyoutItem;
             if (menuFlyoutItem == null)
             {
@@ -828,6 +848,11 @@ namespace EnvironmentVariablesUILib
 
         private void ReorderButtonDown_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
         {
+            if (EditVariableDialog == null)
+            {
+                return;
+            }
+
             var menuFlyoutItem = sender as MenuFlyoutItem;
             if (menuFlyoutItem == null)
             {
@@ -857,6 +882,11 @@ namespace EnvironmentVariablesUILib
 
         private void RemoveListVariableButton_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
         {
+            if (EditVariableDialog == null)
+            {
+                return;
+            }
+
             var menuFlyoutItem = sender as MenuFlyoutItem;
             if (menuFlyoutItem == null)
             {
@@ -882,6 +912,11 @@ namespace EnvironmentVariablesUILib
 
         private void RemoveListVariableDuplicatesButton_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
         {
+            if (EditVariableDialog == null)
+            {
+                return;
+            }
+
             var variable = EditVariableDialog.DataContext as Variable;
             if (variable?.ValuesList == null)
             {
@@ -924,6 +959,11 @@ namespace EnvironmentVariablesUILib
 
         private void InsertListEntryBeforeButton_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
         {
+            if (EditVariableDialog == null)
+            {
+                return;
+            }
+
             var menuFlyoutItem = sender as MenuFlyoutItem;
             if (menuFlyoutItem == null)
             {
@@ -955,6 +995,11 @@ namespace EnvironmentVariablesUILib
 
         private void InsertListEntryAfterButton_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
         {
+            if (EditVariableDialog == null)
+            {
+                return;
+            }
+
             var menuFlyoutItem = sender as MenuFlyoutItem;
             if (menuFlyoutItem == null)
             {
@@ -986,6 +1031,11 @@ namespace EnvironmentVariablesUILib
 
         private void EditVariableValuesListTextBox_LostFocus(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
         {
+            if (EditVariableDialog == null)
+            {
+                return;
+            }
+
             var textBox = sender as TextBox;
             if (textBox == null)
             {

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -1231,5 +1231,15 @@ namespace EnvironmentVariablesUILib
         {
             ResetAddVariableInputs();
         }
+
+        private void AddVariableDialog_Opened(ContentDialog sender, Microsoft.UI.Xaml.Controls.ContentDialogOpenedEventArgs args)
+        {
+            if (AddNewVariableName == null)
+            {
+                return;
+            }
+
+            AddNewVariableName.Focus(Microsoft.UI.Xaml.FocusState.Programmatic);
+        }
     }
 }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -652,7 +652,7 @@ namespace EnvironmentVariablesUILib
 
         private async void AddVariableBtn_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
         {
-            if (AddVariableDialog == null || SwitchViewsSegmentedView == null || AddProfileDialog == null)
+            if (AddVariableDialog == null || SwitchViewsSegmentedView == null || AddProfileDialog == null || RootPage == null)
             {
                 return;
             }
@@ -666,6 +666,7 @@ namespace EnvironmentVariablesUILib
             ResetAddVariableInputs();
             SwitchViewsSegmentedView.SelectedIndex = 0;
             AddVariableDialog.DataContext = AddProfileDialog.DataContext;
+            AddVariableDialog.XamlRoot = RootPage.XamlRoot;
             await AddVariableDialog.ShowAsync();
         }
 

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -155,7 +155,9 @@ namespace EnvironmentVariablesUILib
                 {
                     foreach (Variable variable in ExistingVariablesListView.SelectedItems)
                     {
-                        if (!profile.Variables.Where(x => x.Name == variable.Name).Any())
+                        if (!profile.Variables
+                            .Where(x => x.Name.Equals(variable.Name, StringComparison.OrdinalIgnoreCase) && x.Values == variable.Values)
+                            .Any())
                         {
                             var clone = variable.Clone(true);
                             profile.Variables.Add(clone);
@@ -288,7 +290,10 @@ namespace EnvironmentVariablesUILib
             if (e.AddedItems.Count > 0)
             {
                 var list = sender as ListView;
-                var duplicates = list.SelectedItems.GroupBy(x => ((Variable)x).Name.ToLowerInvariant()).Where(g => g.Count() > 1).ToList();
+                var duplicates = list.SelectedItems
+                    .GroupBy(x => $"{((Variable)x).Name?.ToUpperInvariant()}|{((Variable)x).Values}|{((Variable)x).ParentType}")
+                    .Where(g => g.Count() > 1)
+                    .ToList();
 
                 foreach (var dup in duplicates)
                 {
@@ -375,7 +380,10 @@ namespace EnvironmentVariablesUILib
                     {
                         if (profileItem.Name == item.Name && profileItem.Values == item.Values)
                         {
-                            if (ExistingVariablesListView.SelectedItems.Where(x => ((Variable)x).Name.Equals(profileItem.Name, StringComparison.OrdinalIgnoreCase)).Any())
+                            if (ExistingVariablesListView.SelectedItems
+                                .Where(x => ((Variable)x).Name.Equals(profileItem.Name, StringComparison.OrdinalIgnoreCase) &&
+                                            ((Variable)x).Values.Equals(profileItem.Values, StringComparison.Ordinal))
+                                .Any())
                             {
                                 continue;
                             }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -217,10 +217,16 @@ namespace EnvironmentVariablesUILib
             var activePanel = AddVariableSwitchPresenter.Value as string;
             if (activePanel == "NewVariable")
             {
-                var newVariableName = AddNewVariableName.Text?.Trim();
-                var newVariable = new Variable(newVariableName, AddNewVariableValue.Text, VariablesSetType.Profile);
+                var newVariableName = AddNewVariableName?.Text?.Trim();
+                var newVariable = new Variable(newVariableName, AddNewVariableValue?.Text, VariablesSetType.Profile);
                 if (!newVariable.Valid)
                 {
+                    return;
+                }
+
+                if (newVariableName.Length >= 255 || profile.Variables.Any(x => string.Equals(x?.Name, newVariableName, StringComparison.OrdinalIgnoreCase)))
+                {
+                    AddVariableDialog.IsPrimaryButtonEnabled = false;
                     return;
                 }
 

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -217,7 +217,14 @@ namespace EnvironmentVariablesUILib
             var activePanel = AddVariableSwitchPresenter.Value as string;
             if (activePanel == "NewVariable")
             {
-                profile.Variables.Add(new Variable(AddNewVariableName.Text, AddNewVariableValue.Text, VariablesSetType.Profile));
+                var newVariableName = AddNewVariableName.Text?.Trim();
+                var newVariable = new Variable(newVariableName, AddNewVariableValue.Text, VariablesSetType.Profile);
+                if (!newVariable.Valid)
+                {
+                    return;
+                }
+
+                profile.Variables.Add(newVariable);
             }
             else
             {
@@ -426,7 +433,8 @@ namespace EnvironmentVariablesUILib
                 return;
             }
 
-            if (nameTxtBox.Text.Length == 0 || nameTxtBox.Text.Length >= 255 || profile.Variables.Where(x => string.Equals(x?.Name, nameTxtBox.Text, StringComparison.OrdinalIgnoreCase)).Any())
+            var normalizedName = nameTxtBox.Text?.Trim();
+            if (string.IsNullOrWhiteSpace(normalizedName) || normalizedName.Length >= 255 || profile.Variables.Where(x => string.Equals(x?.Name, normalizedName, StringComparison.OrdinalIgnoreCase)).Any())
             {
                 AddVariableDialog.IsPrimaryButtonEnabled = false;
             }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -410,6 +410,19 @@ namespace EnvironmentVariablesUILib
             CopyToClipboard(variable.Values);
         }
 
+        private void CopyVariableNameAndValue_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+        {
+            var selectedItem = sender as MenuFlyoutItem;
+            var variable = selectedItem?.CommandParameter as Variable;
+            if (variable == null)
+            {
+                return;
+            }
+
+            var value = variable.Values ?? string.Empty;
+            CopyToClipboard($"{variable.Name}={value}");
+        }
+
         private static void CopyToClipboard(string text)
         {
             try

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
+using Windows.System;
 using Windows.ApplicationModel.DataTransfer;
 
 using CommunityToolkit.Mvvm.Input;
@@ -417,6 +418,16 @@ namespace EnvironmentVariablesUILib
 
             AddVariableDialog.IsPrimaryButtonEnabled = false;
             UpdateNoMatchingDefaultVariablesText();
+        }
+
+        private void DefaultVariablesSearchBox_KeyDown(object sender, Microsoft.UI.Xaml.Input.KeyRoutedEventArgs e)
+        {
+            if (e.Key == VirtualKey.Escape && !string.IsNullOrEmpty(DefaultVariablesSearchBox.Text))
+            {
+                e.Handled = true;
+                ClearAddVariableSearchFilter();
+                DefaultVariablesSearchBox.Focus(Microsoft.UI.Xaml.FocusState.Programmatic);
+            }
         }
 
         private void ExistingVariablesListView_Loaded(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/EnvironmentVariablesMainPage.xaml.cs
@@ -423,6 +423,18 @@ namespace EnvironmentVariablesUILib
             CopyToClipboard($"{variable.Name}={value}");
         }
 
+        private void CopyAppliedVariableNameAndValue_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+        {
+            var button = sender as Button;
+            var variable = button?.CommandParameter as Variable;
+            if (variable == null)
+            {
+                return;
+            }
+
+            CopyToClipboard($"{variable.Name}={variable.Values ?? string.Empty}");
+        }
+
         private static void CopyToClipboard(string text)
         {
             try
@@ -453,7 +465,7 @@ namespace EnvironmentVariablesUILib
             }
 
             var normalizedName = nameTxtBox.Text?.Trim();
-            if (string.IsNullOrWhiteSpace(normalizedName) || normalizedName.Length >= 255 || profile.Variables.Any(x => string.Equals((x?.Name ?? string.Empty).Trim(), normalizedName, StringComparison.OrdinalIgnoreCase)))
+            if (string.IsNullOrWhiteSpace(normalizedName) || normalizedName.Contains('=') || normalizedName.Length >= 255 || profile.Variables.Any(x => string.Equals((x?.Name ?? string.Empty).Trim(), normalizedName, StringComparison.OrdinalIgnoreCase)))
             {
                 AddVariableDialog.IsPrimaryButtonEnabled = false;
             }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesHelper.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesHelper.cs
@@ -21,17 +21,18 @@ namespace EnvironmentVariablesUILib.Helpers
 
         internal static Variable GetExisting(string variableName)
         {
-            if (string.IsNullOrEmpty(variableName))
+            if (string.IsNullOrWhiteSpace(variableName))
             {
                 return null;
             }
 
             DefaultVariablesSet userSet = new DefaultVariablesSet(Guid.NewGuid(), "tmpUser", VariablesSetType.User);
             GetVariables(EnvironmentVariableTarget.User, userSet);
+            var normalizedName = variableName?.Trim();
 
             foreach (var variable in userSet.Variables)
             {
-                if (string.Equals(variable?.Name, variableName, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals((variable?.Name ?? string.Empty).Trim(), normalizedName, StringComparison.OrdinalIgnoreCase))
                 {
                     return new Variable(variable.Name, variable.Values, VariablesSetType.User);
                 }
@@ -42,7 +43,7 @@ namespace EnvironmentVariablesUILib.Helpers
 
             foreach (var variable in systemSet.Variables)
             {
-                if (string.Equals(variable?.Name, variableName, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals((variable?.Name ?? string.Empty).Trim(), normalizedName, StringComparison.OrdinalIgnoreCase))
                 {
                     return new Variable(variable.Name, variable.Values, VariablesSetType.System);
                 }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesHelper.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesHelper.cs
@@ -82,6 +82,12 @@ namespace EnvironmentVariablesUILib.Helpers
                 return;
             }
 
+            if (variable.Contains('='))
+            {
+                LoggerInstance.Logger.LogError("Can't apply variable - invalid name.");
+                return;
+            }
+
             const int MaxUserEnvVariableLength = 255; // User-wide env vars stored in the registry have names limited to 255 chars
             if (!fromMachine && variable.Length >= MaxUserEnvVariableLength)
             {

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesHelper.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesHelper.cs
@@ -75,6 +75,12 @@ namespace EnvironmentVariablesUILib.Helpers
         // When applying profile, this would take num_of_variables * 1s to propagate the changes. We do manually SendNotifyMessage with no timeout where needed.
         private static void SetEnvironmentVariableFromRegistryWithoutNotify(string variable, string value, bool fromMachine)
         {
+            if (string.IsNullOrWhiteSpace(variable))
+            {
+                LoggerInstance.Logger.LogError("Can't apply variable - invalid name.");
+                return;
+            }
+
             const int MaxUserEnvVariableLength = 255; // User-wide env vars stored in the registry have names limited to 255 chars
             if (!fromMachine && variable.Length >= MaxUserEnvVariableLength)
             {
@@ -86,6 +92,7 @@ namespace EnvironmentVariablesUILib.Helpers
             {
                 if (environmentKey != null)
                 {
+                    var environmentValue = value ?? string.Empty;
                     if (value == null)
                     {
                         environmentKey.DeleteValue(variable, throwOnMissingValue: false);
@@ -93,13 +100,13 @@ namespace EnvironmentVariablesUILib.Helpers
                     else
                     {
                         // If a variable contains %, we save it as a REG_EXPAND_SZ, which is the same behavior as the Windows default environment variables editor.
-                        if (value.Contains('%'))
+                        if (environmentValue.Contains('%'))
                         {
-                            environmentKey.SetValue(variable, value, RegistryValueKind.ExpandString);
+                            environmentKey.SetValue(variable, environmentValue, RegistryValueKind.ExpandString);
                         }
                         else
                         {
-                            environmentKey.SetValue(variable, value, RegistryValueKind.String);
+                            environmentKey.SetValue(variable, environmentValue, RegistryValueKind.String);
                         }
                     }
                 }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesHelper.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesHelper.cs
@@ -19,6 +19,19 @@ namespace EnvironmentVariablesUILib.Helpers
             return (variable?.Name ?? string.Empty) + "_PowerToys_" + (profileName ?? string.Empty);
         }
 
+        internal static bool IsEquivalentVariableValue(string candidateValue, string compareValue)
+        {
+            var candidate = candidateValue ?? string.Empty;
+            var compare = compareValue ?? string.Empty;
+            var expandedCandidate = Environment.ExpandEnvironmentVariables(candidate);
+            var expandedCompare = Environment.ExpandEnvironmentVariables(compare);
+
+            return string.Equals(candidate, compare, StringComparison.Ordinal) ||
+                string.Equals(expandedCandidate, compare, StringComparison.Ordinal) ||
+                string.Equals(candidate, expandedCompare, StringComparison.Ordinal) ||
+                string.Equals(expandedCandidate, expandedCompare, StringComparison.Ordinal);
+        }
+
         internal static Variable GetExisting(string variableName)
         {
             if (string.IsNullOrWhiteSpace(variableName))

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesHelper.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesHelper.cs
@@ -16,17 +16,22 @@ namespace EnvironmentVariablesUILib.Helpers
     {
         internal static string GetBackupVariableName(Variable variable, string profileName)
         {
-            return variable.Name + "_PowerToys_" + profileName;
+            return (variable?.Name ?? string.Empty) + "_PowerToys_" + (profileName ?? string.Empty);
         }
 
         internal static Variable GetExisting(string variableName)
         {
+            if (string.IsNullOrEmpty(variableName))
+            {
+                return null;
+            }
+
             DefaultVariablesSet userSet = new DefaultVariablesSet(Guid.NewGuid(), "tmpUser", VariablesSetType.User);
             GetVariables(EnvironmentVariableTarget.User, userSet);
 
             foreach (var variable in userSet.Variables)
             {
-                if (variable.Name.Equals(variableName, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(variable?.Name, variableName, StringComparison.OrdinalIgnoreCase))
                 {
                     return new Variable(variable.Name, variable.Values, VariablesSetType.User);
                 }
@@ -37,7 +42,7 @@ namespace EnvironmentVariablesUILib.Helpers
 
             foreach (var variable in systemSet.Variables)
             {
-                if (variable.Name.Equals(variableName, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(variable?.Name, variableName, StringComparison.OrdinalIgnoreCase))
                 {
                     return new Variable(variable.Name, variable.Values, VariablesSetType.System);
                 }
@@ -149,6 +154,11 @@ namespace EnvironmentVariablesUILib.Helpers
         // variable's ParentType. These helpers centralize that behavior for the apply/unapply/edit paths.
         internal static bool SetProfileVariableWithoutNotify(Variable variable)
         {
+            if (variable == null || string.IsNullOrEmpty(variable.Name))
+            {
+                return false;
+            }
+
             SetEnvironmentVariableFromRegistryWithoutNotify(variable.Name, variable.Values, fromMachine: false);
 
             return true;
@@ -156,6 +166,11 @@ namespace EnvironmentVariablesUILib.Helpers
 
         internal static bool UnsetProfileVariableWithoutNotify(Variable variable)
         {
+            if (variable == null || string.IsNullOrEmpty(variable.Name))
+            {
+                return false;
+            }
+
             SetEnvironmentVariableFromRegistryWithoutNotify(variable.Name, null, fromMachine: false);
 
             return true;
@@ -163,6 +178,11 @@ namespace EnvironmentVariablesUILib.Helpers
 
         internal static bool SetVariable(Variable variable)
         {
+            if (variable == null || string.IsNullOrEmpty(variable.Name))
+            {
+                return false;
+            }
+
             bool fromMachine = variable.ParentType switch
             {
                 VariablesSetType.Profile => false,
@@ -179,6 +199,11 @@ namespace EnvironmentVariablesUILib.Helpers
 
         internal static bool UnsetVariable(Variable variable)
         {
+            if (variable == null || string.IsNullOrEmpty(variable.Name))
+            {
+                return false;
+            }
+
             bool fromMachine = variable.ParentType switch
             {
                 VariablesSetType.Profile => false,

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesHelper.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesHelper.cs
@@ -161,7 +161,7 @@ namespace EnvironmentVariablesUILib.Helpers
         // variable's ParentType. These helpers centralize that behavior for the apply/unapply/edit paths.
         internal static bool SetProfileVariableWithoutNotify(Variable variable)
         {
-            if (variable == null || string.IsNullOrEmpty(variable.Name))
+            if (variable == null || string.IsNullOrWhiteSpace(variable.Name))
             {
                 return false;
             }
@@ -173,7 +173,7 @@ namespace EnvironmentVariablesUILib.Helpers
 
         internal static bool UnsetProfileVariableWithoutNotify(Variable variable)
         {
-            if (variable == null || string.IsNullOrEmpty(variable.Name))
+            if (variable == null || string.IsNullOrWhiteSpace(variable.Name))
             {
                 return false;
             }
@@ -185,7 +185,12 @@ namespace EnvironmentVariablesUILib.Helpers
 
         internal static bool SetVariable(Variable variable)
         {
-            if (variable == null || string.IsNullOrEmpty(variable.Name))
+            if (variable == null || string.IsNullOrWhiteSpace(variable.Name))
+            {
+                return false;
+            }
+
+            if (variable.ParentType != VariablesSetType.Profile && variable.ParentType != VariablesSetType.User && variable.ParentType != VariablesSetType.System)
             {
                 return false;
             }
@@ -195,8 +200,15 @@ namespace EnvironmentVariablesUILib.Helpers
                 VariablesSetType.Profile => false,
                 VariablesSetType.User => false,
                 VariablesSetType.System => true,
-                _ => throw new NotImplementedException(),
+                _ => false,
             };
+
+            const int MaxUserEnvVariableLength = 255; // User-wide env vars stored in the registry have names limited to 255 chars
+            if (!fromMachine && variable.Name.Length >= MaxUserEnvVariableLength)
+            {
+                LoggerInstance.Logger.LogError("Can't apply variable - name too long.");
+                return false;
+            }
 
             SetEnvironmentVariableFromRegistryWithoutNotify(variable.Name, variable.Values, fromMachine);
             NotifyEnvironmentChange();
@@ -206,7 +218,12 @@ namespace EnvironmentVariablesUILib.Helpers
 
         internal static bool UnsetVariable(Variable variable)
         {
-            if (variable == null || string.IsNullOrEmpty(variable.Name))
+            if (variable == null || string.IsNullOrWhiteSpace(variable.Name))
+            {
+                return false;
+            }
+
+            if (variable.ParentType != VariablesSetType.Profile && variable.ParentType != VariablesSetType.User && variable.ParentType != VariablesSetType.System)
             {
                 return false;
             }
@@ -216,7 +233,7 @@ namespace EnvironmentVariablesUILib.Helpers
                 VariablesSetType.Profile => false,
                 VariablesSetType.User => false,
                 VariablesSetType.System => true,
-                _ => throw new NotImplementedException(),
+                _ => false,
             };
 
             SetEnvironmentVariableFromRegistryWithoutNotify(variable.Name, null, fromMachine);

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
@@ -85,21 +85,15 @@ namespace EnvironmentVariablesUILib.Helpers
             _fileAccessLock.Wait();
             try
             {
-                List<ProfileVariablesSet> profiles;
                 try
                 {
-                    profiles = ReadProfilesFromPath(ProfilesJsonFilePath);
+                    var profiles = ReadProfilesFromPath(ProfilesJsonFilePath);
                     if (profiles != null)
                     {
                         return profiles;
                     }
 
-                    var backupProfiles = ReadProfilesFromLatestBackup(out var backupPath);
-                    if (backupProfiles != null && !string.IsNullOrWhiteSpace(backupPath))
-                    {
-                        RestoreProfilesJsonFromBackup(backupPath);
-                    }
-
+                    var backupProfiles = TryRestoreProfilesFromLatestBackup();
                     if (backupProfiles != null)
                     {
                         return backupProfiles;
@@ -107,12 +101,7 @@ namespace EnvironmentVariablesUILib.Helpers
                 }
                 catch (JsonException)
                 {
-                    var backupProfiles = ReadProfilesFromLatestBackup(out var backupPath);
-                    if (backupProfiles != null && !string.IsNullOrWhiteSpace(backupPath))
-                    {
-                        RestoreProfilesJsonFromBackup(backupPath);
-                    }
-
+                    var backupProfiles = TryRestoreProfilesFromLatestBackup();
                     if (backupProfiles != null)
                     {
                         return backupProfiles;
@@ -122,7 +111,7 @@ namespace EnvironmentVariablesUILib.Helpers
                 }
                 catch (Exception)
                 {
-                    var backupProfiles = ReadProfilesFromLatestBackup(out _);
+                    var backupProfiles = TryRestoreProfilesFromLatestBackup();
                     if (backupProfiles != null)
                     {
                         return backupProfiles;
@@ -286,6 +275,17 @@ namespace EnvironmentVariablesUILib.Helpers
             }
 
             return null;
+        }
+
+        private List<ProfileVariablesSet> TryRestoreProfilesFromLatestBackup()
+        {
+            var backupProfiles = ReadProfilesFromLatestBackup(out var backupPath);
+            if (backupProfiles != null && !string.IsNullOrWhiteSpace(backupPath))
+            {
+                RestoreProfilesJsonFromBackup(backupPath);
+            }
+
+            return backupProfiles;
         }
 
         private void RestoreProfilesJsonFromBackup(string backupPath)

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
@@ -76,7 +76,24 @@ namespace EnvironmentVariablesUILib.Helpers
                 _fileSystem.Directory.CreateDirectory(directoryPath);
             }
 
-            await _fileSystem.File.WriteAllTextAsync(ProfilesJsonFilePath, jsonData);
+            var tempFilePath = $"{ProfilesJsonFilePath}.{Guid.NewGuid():N}.tmp";
+            try
+            {
+                await _fileSystem.File.WriteAllTextAsync(tempFilePath, jsonData);
+                if (_fileSystem.File.Exists(ProfilesJsonFilePath))
+                {
+                    _fileSystem.File.Delete(ProfilesJsonFilePath);
+                }
+
+                _fileSystem.File.Move(tempFilePath, ProfilesJsonFilePath);
+            }
+            finally
+            {
+                if (_fileSystem.File.Exists(tempFilePath))
+                {
+                    _fileSystem.File.Delete(tempFilePath);
+                }
+            }
         }
 
         private static List<ProfileVariablesSet> SanitizeProfilesForPersistence(IEnumerable<ProfileVariablesSet> profiles)

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
@@ -60,8 +60,17 @@ namespace EnvironmentVariablesUILib.Helpers
                 return;
             }
 
-            _fileAccessLock.Wait();
-            _fileAccessLock.Dispose();
+            try
+            {
+                _fileAccessLock.Wait();
+            }
+            finally
+            {
+                if (_fileAccessLock.CurrentCount == 0)
+                {
+                    _fileAccessLock.Dispose();
+                }
+            }
         }
 
         public List<ProfileVariablesSet> ReadProfiles()

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
@@ -55,6 +55,13 @@ namespace EnvironmentVariablesUILib.Helpers
         public async Task WriteAsync(IEnumerable<ProfileVariablesSet> profiles)
         {
             string jsonData = JsonSerializer.Serialize(profiles, _serializerOptions);
+
+            var directoryPath = Path.GetDirectoryName(_profilesJsonFilePath);
+            if (!string.IsNullOrWhiteSpace(directoryPath))
+            {
+                _fileSystem.Directory.CreateDirectory(directoryPath);
+            }
+
             await _fileSystem.File.WriteAllTextAsync(ProfilesJsonFilePath, jsonData);
         }
     }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
@@ -93,6 +93,17 @@ namespace EnvironmentVariablesUILib.Helpers
                     {
                         return profiles;
                     }
+
+                    var backupProfiles = ReadProfilesFromLatestBackup(out var backupPath);
+                    if (backupProfiles != null && !string.IsNullOrWhiteSpace(backupPath))
+                    {
+                        RestoreProfilesJsonFromBackup(backupPath);
+                    }
+
+                    if (backupProfiles != null)
+                    {
+                        return backupProfiles;
+                    }
                 }
                 catch (JsonException)
                 {

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
@@ -6,6 +6,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions;
+using System.Collections.ObjectModel;
+using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 
@@ -65,7 +67,8 @@ namespace EnvironmentVariablesUILib.Helpers
 
         public async Task WriteAsync(IEnumerable<ProfileVariablesSet> profiles)
         {
-            string jsonData = JsonSerializer.Serialize(profiles, _serializerOptions);
+            var persistedProfiles = SanitizeProfilesForPersistence(profiles);
+            string jsonData = JsonSerializer.Serialize(persistedProfiles, _serializerOptions);
 
             var directoryPath = Path.GetDirectoryName(_profilesJsonFilePath);
             if (!string.IsNullOrWhiteSpace(directoryPath))
@@ -74,6 +77,54 @@ namespace EnvironmentVariablesUILib.Helpers
             }
 
             await _fileSystem.File.WriteAllTextAsync(ProfilesJsonFilePath, jsonData);
+        }
+
+        private static List<ProfileVariablesSet> SanitizeProfilesForPersistence(IEnumerable<ProfileVariablesSet> profiles)
+        {
+            var result = new List<ProfileVariablesSet>();
+            if (profiles == null)
+            {
+                return result;
+            }
+
+            var profileIds = new HashSet<Guid>();
+            foreach (var profile in profiles.Where(p => p != null && p.Id != Guid.Empty))
+            {
+                if (!profileIds.Add(profile.Id))
+                {
+                    continue;
+                }
+
+                var profileName = (profile.Name ?? string.Empty).Trim();
+                if (string.IsNullOrWhiteSpace(profileName))
+                {
+                    continue;
+                }
+
+                var persistedVariables = profile.Variables == null
+                    ? new List<Variable>()
+                    : profile.Variables
+                        .Where(v => v != null && !string.IsNullOrWhiteSpace(v.Name))
+                        .Select(v =>
+                        {
+                            var variableClone = v.Clone();
+                            variableClone.Name = v.Name?.Trim();
+                            variableClone.ParentType = VariablesSetType.Profile;
+                            variableClone.ApplyToSystem = v.ApplyToSystem;
+                            return variableClone;
+                        })
+                        .ToList();
+
+                var persistedProfile = new ProfileVariablesSet(profile.Id, profileName)
+                {
+                    IsEnabled = profile.IsEnabled,
+                    Variables = new ObservableCollection<Variable>(persistedVariables),
+                };
+
+                result.Add(persistedProfile);
+            }
+
+            return result;
         }
     }
 }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
@@ -24,6 +24,8 @@ namespace EnvironmentVariablesUILib.Helpers
 
         private readonly SemaphoreSlim _fileAccessLock = new (1, 1);
 
+        private bool _disposed;
+
         private readonly IFileSystem _fileSystem;
 
         private readonly JsonSerializerOptions _serializerOptions = new JsonSerializerOptions
@@ -42,10 +44,18 @@ namespace EnvironmentVariablesUILib.Helpers
 
         public void Dispose()
         {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            _fileAccessLock.Dispose();
         }
 
         public List<ProfileVariablesSet> ReadProfiles()
         {
+            ThrowIfDisposed();
             _fileAccessLock.Wait();
             try
             {
@@ -78,6 +88,7 @@ namespace EnvironmentVariablesUILib.Helpers
 
         public async Task WriteAsync(IEnumerable<ProfileVariablesSet> profiles)
         {
+            ThrowIfDisposed();
             await _fileAccessLock.WaitAsync();
             try
             {
@@ -122,6 +133,13 @@ namespace EnvironmentVariablesUILib.Helpers
             finally
             {
                 _fileAccessLock.Release();
+            }
+        }
+        private void ThrowIfDisposed()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(EnvironmentVariablesService));
             }
         }
 

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
@@ -151,10 +151,7 @@ namespace EnvironmentVariablesUILib.Helpers
                             }
                             finally
                             {
-                                if (_fileSystem.File.Exists(backupFilePath))
-                                {
-                                    _fileSystem.File.Delete(backupFilePath);
-                                }
+                                 DeleteIfExists(backupFilePath);
                             }
                         }
                     }
@@ -165,10 +162,7 @@ namespace EnvironmentVariablesUILib.Helpers
                 }
                 finally
                 {
-                    if (_fileSystem.File.Exists(tempFilePath))
-                    {
-                        _fileSystem.File.Delete(tempFilePath);
-                    }
+                    DeleteIfExists(tempFilePath);
                 }
             }
             finally
@@ -181,6 +175,20 @@ namespace EnvironmentVariablesUILib.Helpers
             if (System.Threading.Volatile.Read(ref _disposed) == 1)
             {
                 throw new ObjectDisposedException(nameof(EnvironmentVariablesService));
+            }
+        }
+
+        private void DeleteIfExists(string filePath)
+        {
+            try
+            {
+                if (_fileSystem.File.Exists(filePath))
+                {
+                    _fileSystem.File.Delete(filePath);
+                }
+            }
+            catch
+            {
             }
         }
 

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
@@ -47,9 +47,20 @@ namespace EnvironmentVariablesUILib.Helpers
             }
 
             var fileContent = _fileSystem.File.ReadAllText(ProfilesJsonFilePath);
-            var profiles = JsonSerializer.Deserialize<List<ProfileVariablesSet>>(fileContent);
+            if (string.IsNullOrWhiteSpace(fileContent))
+            {
+                return new List<ProfileVariablesSet>();
+            }
 
-            return profiles;
+            try
+            {
+                var profiles = JsonSerializer.Deserialize<List<ProfileVariablesSet>>(fileContent);
+                return profiles ?? new List<ProfileVariablesSet>();
+            }
+            catch (JsonException)
+            {
+                return new List<ProfileVariablesSet>();
+            }
         }
 
         public async Task WriteAsync(IEnumerable<ProfileVariablesSet> profiles)

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
@@ -133,8 +133,29 @@ namespace EnvironmentVariablesUILib.Helpers
                         }
                         catch (Exception)
                         {
-                            _fileSystem.File.Delete(ProfilesJsonFilePath);
-                            _fileSystem.File.Move(tempFilePath, ProfilesJsonFilePath);
+                            var backupFilePath = $"{ProfilesJsonFilePath}.{Guid.NewGuid():N}.bak";
+                            try
+                            {
+                                _fileSystem.File.Copy(ProfilesJsonFilePath, backupFilePath);
+                                _fileSystem.File.Delete(ProfilesJsonFilePath);
+                                _fileSystem.File.Move(tempFilePath, ProfilesJsonFilePath);
+                            }
+                            catch (Exception)
+                            {
+                                if (_fileSystem.File.Exists(backupFilePath) && !_fileSystem.File.Exists(ProfilesJsonFilePath))
+                                {
+                                    _fileSystem.File.Move(backupFilePath, ProfilesJsonFilePath);
+                                }
+
+                                throw;
+                            }
+                            finally
+                            {
+                                if (_fileSystem.File.Exists(backupFilePath))
+                                {
+                                    _fileSystem.File.Delete(backupFilePath);
+                                }
+                            }
                         }
                     }
                     else

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
@@ -221,6 +221,12 @@ namespace EnvironmentVariablesUILib.Helpers
                     if (extension.Equals(".tmp", StringComparison.OrdinalIgnoreCase)
                         || extension.Equals(".bak", StringComparison.OrdinalIgnoreCase))
                     {
+                        var artifactIdLength = fileName.Length - expectedPrefix.Length - extension.Length;
+                        if (artifactIdLength <= 0)
+                        {
+                            continue;
+                        }
+
                         var artifactId = fileName.Substring(expectedPrefix.Length, fileName.Length - expectedPrefix.Length - extension.Length);
                         if (artifactId.Length == 32 && Guid.TryParseExact(artifactId, "N", out _))
                         {

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
@@ -85,13 +85,23 @@ namespace EnvironmentVariablesUILib.Helpers
             _fileAccessLock.Wait();
             try
             {
+                List<ProfileVariablesSet> profiles;
                 try
                 {
-                    return ReadProfilesFromPath(ProfilesJsonFilePath) ?? ReadProfilesFromLatestBackup();
+                    profiles = ReadProfilesFromPath(ProfilesJsonFilePath);
+                    if (profiles != null)
+                    {
+                        return profiles;
+                    }
                 }
                 catch (JsonException)
                 {
-                    var backupProfiles = ReadProfilesFromLatestBackup();
+                    var backupProfiles = ReadProfilesFromLatestBackup(out var backupPath);
+                    if (backupProfiles != null && !string.IsNullOrWhiteSpace(backupPath))
+                    {
+                        RestoreProfilesJsonFromBackup(backupPath);
+                    }
+
                     if (backupProfiles != null)
                     {
                         return backupProfiles;
@@ -99,6 +109,18 @@ namespace EnvironmentVariablesUILib.Helpers
 
                     return new List<ProfileVariablesSet>();
                 }
+                catch (Exception)
+                {
+                    var backupProfiles = ReadProfilesFromLatestBackup(out _);
+                    if (backupProfiles != null)
+                    {
+                        return backupProfiles;
+                    }
+
+                    return new List<ProfileVariablesSet>();
+                }
+
+                return new List<ProfileVariablesSet>();
             }
             finally
             {
@@ -198,7 +220,7 @@ namespace EnvironmentVariablesUILib.Helpers
         {
             if (!_fileSystem.File.Exists(filePath))
             {
-                return new List<ProfileVariablesSet>();
+                return null;
             }
 
             var fileContent = _fileSystem.File.ReadAllText(filePath);
@@ -211,8 +233,9 @@ namespace EnvironmentVariablesUILib.Helpers
             return profiles ?? new List<ProfileVariablesSet>();
         }
 
-        private List<ProfileVariablesSet> ReadProfilesFromLatestBackup()
+        private List<ProfileVariablesSet> ReadProfilesFromLatestBackup(out string backupPath)
         {
+            backupPath = null;
             var directoryPath = Path.GetDirectoryName(_profilesJsonFilePath);
             if (string.IsNullOrWhiteSpace(directoryPath) || !_fileSystem.Directory.Exists(directoryPath))
             {
@@ -228,11 +251,16 @@ namespace EnvironmentVariablesUILib.Helpers
                     .Where(filePath => IsProfileArtifact(filePath, baseFileName, ".bak"))
                     .OrderByDescending(filePath => _fileSystem.File.GetLastWriteTimeUtc(filePath));
 
-                foreach (var backupPath in backupPaths)
+                foreach (var backupCandidatePath in backupPaths)
                 {
                     try
                     {
-                        return ReadProfilesFromPath(backupPath);
+                        var profiles = ReadProfilesFromPath(backupCandidatePath);
+                        if (profiles != null)
+                        {
+                            backupPath = backupCandidatePath;
+                            return profiles;
+                        }
                     }
                     catch (JsonException)
                     {
@@ -247,6 +275,24 @@ namespace EnvironmentVariablesUILib.Helpers
             }
 
             return null;
+        }
+
+        private void RestoreProfilesJsonFromBackup(string backupPath)
+        {
+            try
+            {
+                var directoryPath = Path.GetDirectoryName(_profilesJsonFilePath);
+                if (!string.IsNullOrWhiteSpace(directoryPath))
+                {
+                    _fileSystem.Directory.CreateDirectory(directoryPath);
+                }
+
+                _fileSystem.File.Copy(backupPath, ProfilesJsonFilePath, true);
+                DeleteIfExists(backupPath);
+            }
+            catch
+            {
+            }
         }
 
         private static bool IsProfileArtifact(string filePath, string baseFileName, string extension)

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
@@ -85,24 +85,18 @@ namespace EnvironmentVariablesUILib.Helpers
             _fileAccessLock.Wait();
             try
             {
-                if (!_fileSystem.File.Exists(ProfilesJsonFilePath))
-                {
-                    return new List<ProfileVariablesSet>();
-                }
-
                 try
                 {
-                    var fileContent = _fileSystem.File.ReadAllText(ProfilesJsonFilePath);
-                    if (string.IsNullOrWhiteSpace(fileContent))
-                    {
-                        return new List<ProfileVariablesSet>();
-                    }
-
-                    var profiles = JsonSerializer.Deserialize<List<ProfileVariablesSet>>(fileContent);
-                    return profiles ?? new List<ProfileVariablesSet>();
+                    return ReadProfilesFromPath(ProfilesJsonFilePath) ?? ReadProfilesFromLatestBackup();
                 }
                 catch (JsonException)
                 {
+                    var backupProfiles = ReadProfilesFromLatestBackup();
+                    if (backupProfiles != null)
+                    {
+                        return backupProfiles;
+                    }
+
                     return new List<ProfileVariablesSet>();
                 }
             }
@@ -200,6 +194,84 @@ namespace EnvironmentVariablesUILib.Helpers
             }
         }
 
+        private List<ProfileVariablesSet> ReadProfilesFromPath(string filePath)
+        {
+            if (!_fileSystem.File.Exists(filePath))
+            {
+                return new List<ProfileVariablesSet>();
+            }
+
+            var fileContent = _fileSystem.File.ReadAllText(filePath);
+            if (string.IsNullOrWhiteSpace(fileContent))
+            {
+                return new List<ProfileVariablesSet>();
+            }
+
+            var profiles = JsonSerializer.Deserialize<List<ProfileVariablesSet>>(fileContent);
+            return profiles ?? new List<ProfileVariablesSet>();
+        }
+
+        private List<ProfileVariablesSet> ReadProfilesFromLatestBackup()
+        {
+            var directoryPath = Path.GetDirectoryName(_profilesJsonFilePath);
+            if (string.IsNullOrWhiteSpace(directoryPath) || !_fileSystem.Directory.Exists(directoryPath))
+            {
+                return null;
+            }
+
+            try
+            {
+                var baseFileName = Path.GetFileName(ProfilesJsonFilePath);
+                var wildcardPattern = $"{baseFileName}.*.bak";
+
+                var backupPaths = _fileSystem.Directory.EnumerateFiles(directoryPath, wildcardPattern)
+                    .Where(filePath => IsProfileArtifact(filePath, baseFileName, ".bak"))
+                    .OrderByDescending(filePath => _fileSystem.File.GetLastWriteTimeUtc(filePath));
+
+                foreach (var backupPath in backupPaths)
+                {
+                    try
+                    {
+                        return ReadProfilesFromPath(backupPath);
+                    }
+                    catch (JsonException)
+                    {
+                    }
+                    catch (Exception)
+                    {
+                    }
+                }
+            }
+            catch
+            {
+            }
+
+            return null;
+        }
+
+        private static bool IsProfileArtifact(string filePath, string baseFileName, string extension)
+        {
+            var fileName = Path.GetFileName(filePath);
+            if (!fileName.StartsWith(baseFileName + ".", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            if (!Path.GetExtension(filePath).Equals(extension, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            var artifactIdLength = fileName.Length - baseFileName.Length - 1 - extension.Length;
+            if (artifactIdLength != 32)
+            {
+                return false;
+            }
+
+            var artifactId = fileName.Substring(baseFileName.Length + 1, artifactIdLength);
+            return Guid.TryParseExact(artifactId, "N", out _);
+        }
+
         private void CleanupStaleProfileJsonArtifacts()
         {
             var directoryPath = Path.GetDirectoryName(_profilesJsonFilePath);
@@ -211,27 +283,20 @@ namespace EnvironmentVariablesUILib.Helpers
             try
             {
                 var baseFileName = Path.GetFileName(ProfilesJsonFilePath);
-                var expectedPrefix = baseFileName + ".";
                 var wildcardPattern = $"{baseFileName}.*";
 
                 foreach (var filePath in _fileSystem.Directory.EnumerateFiles(directoryPath, wildcardPattern))
                 {
-                    var fileName = Path.GetFileName(filePath);
                     var extension = Path.GetExtension(filePath);
                     if (extension.Equals(".tmp", StringComparison.OrdinalIgnoreCase)
                         || extension.Equals(".bak", StringComparison.OrdinalIgnoreCase))
                     {
-                        var artifactIdLength = fileName.Length - expectedPrefix.Length - extension.Length;
-                        if (artifactIdLength <= 0)
+                        if (!IsProfileArtifact(filePath, baseFileName, extension))
                         {
                             continue;
                         }
 
-                        var artifactId = fileName.Substring(expectedPrefix.Length, fileName.Length - expectedPrefix.Length - extension.Length);
-                        if (artifactId.Length == 32 && Guid.TryParseExact(artifactId, "N", out _))
-                        {
-                            DeleteIfExists(filePath);
-                        }
+                        DeleteIfExists(filePath);
                     }
                 }
             }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
@@ -137,7 +137,9 @@ namespace EnvironmentVariablesUILib.Helpers
                 result.Add(persistedProfile);
             }
 
-            return result;
+            return result
+                .OrderBy(profile => (profile.Name ?? string.Empty).Trim(), StringComparer.OrdinalIgnoreCase)
+                .ToList();
         }
 
         private static List<Variable> SanitizeProfileVariables(IEnumerable<Variable> variables)
@@ -175,7 +177,9 @@ namespace EnvironmentVariablesUILib.Helpers
                 persistedVariables.Add(variableClone);
             }
 
-            return persistedVariables;
+            return persistedVariables
+                .OrderBy(variable => (variable.Name ?? string.Empty).Trim(), StringComparer.OrdinalIgnoreCase)
+                .ToList();
         }
     }
 }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
@@ -82,10 +82,12 @@ namespace EnvironmentVariablesUILib.Helpers
                 await _fileSystem.File.WriteAllTextAsync(tempFilePath, jsonData);
                 if (_fileSystem.File.Exists(ProfilesJsonFilePath))
                 {
-                    _fileSystem.File.Delete(ProfilesJsonFilePath);
+                    _fileSystem.File.Replace(tempFilePath, ProfilesJsonFilePath, null);
                 }
-
-                _fileSystem.File.Move(tempFilePath, ProfilesJsonFilePath);
+                else
+                {
+                    _fileSystem.File.Move(tempFilePath, ProfilesJsonFilePath);
+                }
             }
             finally
             {

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
@@ -82,7 +82,15 @@ namespace EnvironmentVariablesUILib.Helpers
                 await _fileSystem.File.WriteAllTextAsync(tempFilePath, jsonData);
                 if (_fileSystem.File.Exists(ProfilesJsonFilePath))
                 {
-                    _fileSystem.File.Replace(tempFilePath, ProfilesJsonFilePath, null);
+                    try
+                    {
+                        _fileSystem.File.Replace(tempFilePath, ProfilesJsonFilePath, null);
+                    }
+                    catch (Exception)
+                    {
+                        _fileSystem.File.Delete(ProfilesJsonFilePath);
+                        _fileSystem.File.Move(tempFilePath, ProfilesJsonFilePath);
+                    }
                 }
                 else
                 {

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
@@ -44,7 +44,13 @@ namespace EnvironmentVariablesUILib.Helpers
 
             _fileSystem = fileSystem;
 
-            _profilesJsonFilePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), ProfilesJsonFileSubPath, "profiles.json");
+            var localApplicationDataPath = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            if (string.IsNullOrWhiteSpace(localApplicationDataPath))
+            {
+                localApplicationDataPath = Path.GetTempPath();
+            }
+
+            _profilesJsonFilePath = Path.Combine(localApplicationDataPath, ProfilesJsonFileSubPath, "profiles.json");
         }
 
         public void Dispose()

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
@@ -211,15 +211,21 @@ namespace EnvironmentVariablesUILib.Helpers
             try
             {
                 var baseFileName = Path.GetFileName(ProfilesJsonFilePath);
+                var expectedPrefix = baseFileName + ".";
                 var wildcardPattern = $"{baseFileName}.*";
 
                 foreach (var filePath in _fileSystem.Directory.EnumerateFiles(directoryPath, wildcardPattern))
                 {
+                    var fileName = Path.GetFileName(filePath);
                     var extension = Path.GetExtension(filePath);
                     if (extension.Equals(".tmp", StringComparison.OrdinalIgnoreCase)
                         || extension.Equals(".bak", StringComparison.OrdinalIgnoreCase))
                     {
-                        DeleteIfExists(filePath);
+                        var artifactId = fileName.Substring(expectedPrefix.Length, fileName.Length - expectedPrefix.Length - extension.Length);
+                        if (artifactId.Length == 32 && Guid.TryParseExact(artifactId, "N", out _))
+                        {
+                            DeleteIfExists(filePath);
+                        }
                     }
                 }
             }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
@@ -9,6 +9,7 @@ using System.IO.Abstractions;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 
 using EnvironmentVariablesUILib.Models;
@@ -20,6 +21,8 @@ namespace EnvironmentVariablesUILib.Helpers
         private const string ProfilesJsonFileSubPath = "Microsoft\\PowerToys\\EnvironmentVariables\\";
 
         private readonly string _profilesJsonFilePath;
+
+        private readonly SemaphoreSlim _fileAccessLock = new (1, 1);
 
         private readonly IFileSystem _fileSystem;
 
@@ -43,66 +46,82 @@ namespace EnvironmentVariablesUILib.Helpers
 
         public List<ProfileVariablesSet> ReadProfiles()
         {
-            if (!_fileSystem.File.Exists(ProfilesJsonFilePath))
-            {
-                return new List<ProfileVariablesSet>();
-            }
-
+            _fileAccessLock.Wait();
             try
             {
-                var fileContent = _fileSystem.File.ReadAllText(ProfilesJsonFilePath);
-                if (string.IsNullOrWhiteSpace(fileContent))
+                if (!_fileSystem.File.Exists(ProfilesJsonFilePath))
                 {
                     return new List<ProfileVariablesSet>();
                 }
 
-                var profiles = JsonSerializer.Deserialize<List<ProfileVariablesSet>>(fileContent);
-                return profiles ?? new List<ProfileVariablesSet>();
+                try
+                {
+                    var fileContent = _fileSystem.File.ReadAllText(ProfilesJsonFilePath);
+                    if (string.IsNullOrWhiteSpace(fileContent))
+                    {
+                        return new List<ProfileVariablesSet>();
+                    }
+
+                    var profiles = JsonSerializer.Deserialize<List<ProfileVariablesSet>>(fileContent);
+                    return profiles ?? new List<ProfileVariablesSet>();
+                }
+                catch (Exception)
+                {
+                    return new List<ProfileVariablesSet>();
+                }
             }
-            catch (Exception)
+            finally
             {
-                return new List<ProfileVariablesSet>();
+                _fileAccessLock.Release();
             }
         }
 
         public async Task WriteAsync(IEnumerable<ProfileVariablesSet> profiles)
         {
-            var persistedProfiles = SanitizeProfilesForPersistence(profiles);
-            string jsonData = JsonSerializer.Serialize(persistedProfiles, _serializerOptions);
-
-            var directoryPath = Path.GetDirectoryName(_profilesJsonFilePath);
-            if (!string.IsNullOrWhiteSpace(directoryPath))
-            {
-                _fileSystem.Directory.CreateDirectory(directoryPath);
-            }
-
-            var tempFilePath = $"{ProfilesJsonFilePath}.{Guid.NewGuid():N}.tmp";
+            await _fileAccessLock.WaitAsync();
             try
             {
-                await _fileSystem.File.WriteAllTextAsync(tempFilePath, jsonData);
-                if (_fileSystem.File.Exists(ProfilesJsonFilePath))
+                var persistedProfiles = SanitizeProfilesForPersistence(profiles);
+                string jsonData = JsonSerializer.Serialize(persistedProfiles, _serializerOptions);
+
+                var directoryPath = Path.GetDirectoryName(_profilesJsonFilePath);
+                if (!string.IsNullOrWhiteSpace(directoryPath))
                 {
-                    try
+                    _fileSystem.Directory.CreateDirectory(directoryPath);
+                }
+
+                var tempFilePath = $"{ProfilesJsonFilePath}.{Guid.NewGuid():N}.tmp";
+                try
+                {
+                    await _fileSystem.File.WriteAllTextAsync(tempFilePath, jsonData);
+                    if (_fileSystem.File.Exists(ProfilesJsonFilePath))
                     {
-                        _fileSystem.File.Replace(tempFilePath, ProfilesJsonFilePath, null);
+                        try
+                        {
+                            _fileSystem.File.Replace(tempFilePath, ProfilesJsonFilePath, null);
+                        }
+                        catch (Exception)
+                        {
+                            _fileSystem.File.Delete(ProfilesJsonFilePath);
+                            _fileSystem.File.Move(tempFilePath, ProfilesJsonFilePath);
+                        }
                     }
-                    catch (Exception)
+                    else
                     {
-                        _fileSystem.File.Delete(ProfilesJsonFilePath);
                         _fileSystem.File.Move(tempFilePath, ProfilesJsonFilePath);
                     }
                 }
-                else
+                finally
                 {
-                    _fileSystem.File.Move(tempFilePath, ProfilesJsonFilePath);
+                    if (_fileSystem.File.Exists(tempFilePath))
+                    {
+                        _fileSystem.File.Delete(tempFilePath);
+                    }
                 }
             }
             finally
             {
-                if (_fileSystem.File.Exists(tempFilePath))
-                {
-                    _fileSystem.File.Delete(tempFilePath);
-                }
+                _fileAccessLock.Release();
             }
         }
 

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
@@ -24,7 +24,7 @@ namespace EnvironmentVariablesUILib.Helpers
 
         private readonly SemaphoreSlim _fileAccessLock = new (1, 1);
 
-        private bool _disposed;
+        private int _disposed;
 
         private readonly IFileSystem _fileSystem;
 
@@ -44,12 +44,12 @@ namespace EnvironmentVariablesUILib.Helpers
 
         public void Dispose()
         {
-            if (_disposed)
+            if (System.Threading.Interlocked.Exchange(ref _disposed, 1) == 1)
             {
                 return;
             }
 
-            _disposed = true;
+            _fileAccessLock.Wait();
             _fileAccessLock.Dispose();
         }
 
@@ -137,7 +137,7 @@ namespace EnvironmentVariablesUILib.Helpers
         }
         private void ThrowIfDisposed()
         {
-            if (_disposed)
+            if (System.Threading.Volatile.Read(ref _disposed) == 1)
             {
                 throw new ObjectDisposedException(nameof(EnvironmentVariablesService));
             }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
@@ -60,9 +60,11 @@ namespace EnvironmentVariablesUILib.Helpers
                 return;
             }
 
+            var lockAcquired = false;
             try
             {
                 _fileAccessLock.Wait();
+                lockAcquired = true;
             }
             catch (ObjectDisposedException)
             {
@@ -70,7 +72,7 @@ namespace EnvironmentVariablesUILib.Helpers
             }
             finally
             {
-                if (_fileAccessLock.CurrentCount == 0)
+                if (lockAcquired && _fileAccessLock.CurrentCount == 0)
                 {
                     _fileAccessLock.Dispose();
                 }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
@@ -118,6 +118,8 @@ namespace EnvironmentVariablesUILib.Helpers
             await _fileAccessLock.WaitAsync();
             try
             {
+                CleanupStaleProfileJsonArtifacts();
+
                 var persistedProfiles = SanitizeProfilesForPersistence(profiles);
                 string jsonData = JsonSerializer.Serialize(persistedProfiles, _serializerOptions);
 
@@ -191,6 +193,34 @@ namespace EnvironmentVariablesUILib.Helpers
                 if (_fileSystem.File.Exists(filePath))
                 {
                     _fileSystem.File.Delete(filePath);
+                }
+            }
+            catch
+            {
+            }
+        }
+
+        private void CleanupStaleProfileJsonArtifacts()
+        {
+            var directoryPath = Path.GetDirectoryName(_profilesJsonFilePath);
+            if (string.IsNullOrWhiteSpace(directoryPath) || !_fileSystem.Directory.Exists(directoryPath))
+            {
+                return;
+            }
+
+            try
+            {
+                var baseFileName = Path.GetFileName(ProfilesJsonFilePath);
+                var wildcardPattern = $"{baseFileName}.*";
+
+                foreach (var filePath in _fileSystem.Directory.EnumerateFiles(directoryPath, wildcardPattern))
+                {
+                    var extension = Path.GetExtension(filePath);
+                    if (extension.Equals(".tmp", StringComparison.OrdinalIgnoreCase)
+                        || extension.Equals(".bak", StringComparison.OrdinalIgnoreCase))
+                    {
+                        DeleteIfExists(filePath);
+                    }
                 }
             }
             catch

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
@@ -105,6 +105,7 @@ namespace EnvironmentVariablesUILib.Helpers
             }
 
             var profileIds = new HashSet<Guid>();
+            var profileNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             foreach (var profile in profiles.Where(p => p != null && p.Id != Guid.Empty))
             {
                 if (!profileIds.Add(profile.Id))
@@ -118,19 +119,14 @@ namespace EnvironmentVariablesUILib.Helpers
                     continue;
                 }
 
+                if (!profileNames.Add(profileName))
+                {
+                    continue;
+                }
+
                 var persistedVariables = profile.Variables == null
                     ? new List<Variable>()
-                    : profile.Variables
-                        .Where(v => v != null && !string.IsNullOrWhiteSpace(v.Name))
-                        .Select(v =>
-                        {
-                            var variableClone = v.Clone();
-                            variableClone.Name = v.Name?.Trim();
-                            variableClone.ParentType = VariablesSetType.Profile;
-                            variableClone.ApplyToSystem = v.ApplyToSystem;
-                            return variableClone;
-                        })
-                        .ToList();
+                    : SanitizeProfileVariables(profile.Variables);
 
                 var persistedProfile = new ProfileVariablesSet(profile.Id, profileName)
                 {
@@ -142,6 +138,44 @@ namespace EnvironmentVariablesUILib.Helpers
             }
 
             return result;
+        }
+
+        private static List<Variable> SanitizeProfileVariables(IEnumerable<Variable> variables)
+        {
+            var persistedVariables = new List<Variable>();
+            var variableNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            if (variables == null)
+            {
+                return persistedVariables;
+            }
+
+            foreach (var variable in variables)
+            {
+                if (variable == null)
+                {
+                    continue;
+                }
+
+                var variableName = variable.Name?.Trim();
+                if (string.IsNullOrWhiteSpace(variableName))
+                {
+                    continue;
+                }
+
+                if (!variableNames.Add(variableName))
+                {
+                    continue;
+                }
+
+                var variableClone = variable.Clone();
+                variableClone.Name = variableName;
+                variableClone.ParentType = VariablesSetType.Profile;
+                variableClone.ApplyToSystem = variable.ApplyToSystem;
+
+                persistedVariables.Add(variableClone);
+            }
+
+            return persistedVariables;
         }
     }
 }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
@@ -48,18 +48,18 @@ namespace EnvironmentVariablesUILib.Helpers
                 return new List<ProfileVariablesSet>();
             }
 
-            var fileContent = _fileSystem.File.ReadAllText(ProfilesJsonFilePath);
-            if (string.IsNullOrWhiteSpace(fileContent))
-            {
-                return new List<ProfileVariablesSet>();
-            }
-
             try
             {
+                var fileContent = _fileSystem.File.ReadAllText(ProfilesJsonFilePath);
+                if (string.IsNullOrWhiteSpace(fileContent))
+                {
+                    return new List<ProfileVariablesSet>();
+                }
+
                 var profiles = JsonSerializer.Deserialize<List<ProfileVariablesSet>>(fileContent);
                 return profiles ?? new List<ProfileVariablesSet>();
             }
-            catch (JsonException)
+            catch (Exception)
             {
                 return new List<ProfileVariablesSet>();
             }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
@@ -64,6 +64,10 @@ namespace EnvironmentVariablesUILib.Helpers
             {
                 _fileAccessLock.Wait();
             }
+            catch (ObjectDisposedException)
+            {
+                return;
+            }
             finally
             {
                 if (_fileAccessLock.CurrentCount == 0)

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
@@ -75,7 +75,7 @@ namespace EnvironmentVariablesUILib.Helpers
                     var profiles = JsonSerializer.Deserialize<List<ProfileVariablesSet>>(fileContent);
                     return profiles ?? new List<ProfileVariablesSet>();
                 }
-                catch (Exception)
+                catch (JsonException)
                 {
                     return new List<ProfileVariablesSet>();
                 }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
@@ -37,6 +37,11 @@ namespace EnvironmentVariablesUILib.Helpers
 
         public EnvironmentVariablesService(IFileSystem fileSystem)
         {
+            if (fileSystem == null)
+            {
+                throw new ArgumentNullException(nameof(fileSystem));
+            }
+
             _fileSystem = fileSystem;
 
             _profilesJsonFilePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), ProfilesJsonFileSubPath, "profiles.json");

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Helpers/EnvironmentVariablesService.cs
@@ -226,7 +226,7 @@ namespace EnvironmentVariablesUILib.Helpers
             var fileContent = _fileSystem.File.ReadAllText(filePath);
             if (string.IsNullOrWhiteSpace(fileContent))
             {
-                return new List<ProfileVariablesSet>();
+                return null;
             }
 
             var profiles = JsonSerializer.Deserialize<List<ProfileVariablesSet>>(fileContent);

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/ProfileVariablesSet.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/ProfileVariablesSet.cs
@@ -202,8 +202,13 @@ namespace EnvironmentVariablesUILib.Models
                 // It exists. Backup is needed.
                 if (variableToOverride != null && variableToOverride.ParentType == VariablesSetType.User)
                 {
-                    variableToOverride.Name = EnvironmentVariablesHelper.GetBackupVariableName(variableToOverride, (Name ?? string.Empty).Trim());
-                    if (!variableToOverride.Validate())
+                    var backupName = EnvironmentVariablesHelper.GetBackupVariableName(variableToOverride, (Name ?? string.Empty).Trim());
+                    var backupVariable = new Variable(variableToOverride.Name, variableToOverride.Values, variableToOverride.ParentType)
+                    {
+                        Name = backupName,
+                    };
+
+                    if (!backupVariable.Validate())
                     {
                         return false;
                     }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/ProfileVariablesSet.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/ProfileVariablesSet.cs
@@ -36,6 +36,8 @@ namespace EnvironmentVariablesUILib.Models
                 return Task.CompletedTask;
             }
 
+            var profileName = (Name ?? string.Empty).Trim();
+
             return Task.Run(() =>
             {
                 foreach (var variable in Variables)
@@ -46,12 +48,12 @@ namespace EnvironmentVariablesUILib.Models
                     }
 
                     // Get existing variable with the same name if it exist
-                    var variableToOverride = EnvironmentVariablesHelper.GetExisting(variable.Name);
+                    var variableToOverride = EnvironmentVariablesHelper.GetExisting((variable.Name ?? string.Empty).Trim());
 
                     // It exists. Rename it to preserve it.
                     if (variableToOverride != null && variableToOverride.ParentType == VariablesSetType.User)
                     {
-                        variableToOverride.Name = EnvironmentVariablesHelper.GetBackupVariableName(variableToOverride, this.Name);
+                        variableToOverride.Name = EnvironmentVariablesHelper.GetBackupVariableName(variableToOverride, profileName);
 
                         // Backup the variable
                         if (!EnvironmentVariablesHelper.SetProfileVariableWithoutNotify(variableToOverride))
@@ -107,7 +109,7 @@ namespace EnvironmentVariablesUILib.Models
             }
 
             var originalName = variable.Name;
-            var backupName = EnvironmentVariablesHelper.GetBackupVariableName(variable, this.Name);
+            var backupName = EnvironmentVariablesHelper.GetBackupVariableName(variable, (Name ?? string.Empty).Trim());
 
             // Get backup variable if it exist
             var backupVariable = EnvironmentVariablesHelper.GetExisting(backupName);
@@ -147,7 +149,7 @@ namespace EnvironmentVariablesUILib.Models
                     continue;
                 }
 
-                var applied = EnvironmentVariablesHelper.GetExisting(variable.Name);
+                var applied = EnvironmentVariablesHelper.GetExisting((variable.Name ?? string.Empty).Trim());
                 if (applied != null && applied.Values == variable.Values && applied.ParentType == VariablesSetType.User)
                 {
                     continue;
@@ -179,12 +181,12 @@ namespace EnvironmentVariablesUILib.Models
                 }
 
                 // Get existing variable with the same name if it exist
-                var variableToOverride = EnvironmentVariablesHelper.GetExisting(variable.Name);
+                var variableToOverride = EnvironmentVariablesHelper.GetExisting((variable.Name ?? string.Empty).Trim());
 
                 // It exists. Backup is needed.
                 if (variableToOverride != null && variableToOverride.ParentType == VariablesSetType.User)
                 {
-                    variableToOverride.Name = EnvironmentVariablesHelper.GetBackupVariableName(variableToOverride, this.Name);
+                    variableToOverride.Name = EnvironmentVariablesHelper.GetBackupVariableName(variableToOverride, (Name ?? string.Empty).Trim());
                     if (!variableToOverride.Validate())
                     {
                         return false;
@@ -197,7 +199,7 @@ namespace EnvironmentVariablesUILib.Models
 
         public ProfileVariablesSet Clone()
         {
-            var clone = new ProfileVariablesSet(this.Id, this.Name);
+            var clone = new ProfileVariablesSet(this.Id, (this.Name ?? string.Empty).Trim());
             clone.Variables = new ObservableCollection<Variable>(this.Variables ?? new System.Collections.Generic.List<Variable>());
             clone.IsEnabled = this.IsEnabled;
 

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/ProfileVariablesSet.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/ProfileVariablesSet.cs
@@ -53,12 +53,25 @@ namespace EnvironmentVariablesUILib.Models
                     // It exists. Rename it to preserve it.
                     if (variableToOverride != null && variableToOverride.ParentType == VariablesSetType.User)
                     {
-                        variableToOverride.Name = EnvironmentVariablesHelper.GetBackupVariableName(variableToOverride, profileName);
+                        var backupName = EnvironmentVariablesHelper.GetBackupVariableName(variableToOverride, profileName);
 
-                        // Backup the variable
-                        if (!EnvironmentVariablesHelper.SetProfileVariableWithoutNotify(variableToOverride))
+                        // Only create a backup variable if there isn't one already for this profile.
+                        if (EnvironmentVariablesHelper.GetExisting(backupName) == null)
                         {
-                            LoggerInstance.Logger.LogError("Failed to set backup variable.");
+                            var backupVariable = new Variable(variableToOverride.Name, variableToOverride.Values, variableToOverride.ParentType)
+                            {
+                                Name = backupName,
+                            };
+
+                            // Backup the variable
+                            if (!EnvironmentVariablesHelper.SetProfileVariableWithoutNotify(backupVariable))
+                            {
+                                LoggerInstance.Logger.LogError("Failed to set backup variable.");
+                            }
+                        }
+                        else
+                        {
+                            LoggerInstance.Logger.LogError("Cannot back up user variable because backup already exists.");
                         }
                     }
 

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/ProfileVariablesSet.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/ProfileVariablesSet.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
@@ -227,8 +228,9 @@ namespace EnvironmentVariablesUILib.Models
         {
             var clone = new ProfileVariablesSet(this.Id, (this.Name ?? string.Empty).Trim());
             var variables = this.Variables
-                ?.Select(variable => variable == null ? null : variable.Clone(profile: true))
-                .ToList() ?? new System.Collections.Generic.List<Variable>();
+                ?.Where(variable => variable != null)
+                .Select(variable => variable.Clone(profile: true))
+                .ToList() ?? new List<Variable>();
             clone.Variables = new ObservableCollection<Variable>(variables);
             clone.IsEnabled = this.IsEnabled;
 

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/ProfileVariablesSet.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/ProfileVariablesSet.cs
@@ -35,6 +35,11 @@ namespace EnvironmentVariablesUILib.Models
             {
                 foreach (var variable in Variables)
                 {
+                    if (variable == null)
+                    {
+                        continue;
+                    }
+
                     // Get existing variable with the same name if it exist
                     var variableToOverride = EnvironmentVariablesHelper.GetExisting(variable.Name);
 
@@ -66,6 +71,11 @@ namespace EnvironmentVariablesUILib.Models
             {
                 foreach (var variable in Variables)
                 {
+                    if (variable == null)
+                    {
+                        continue;
+                    }
+
                     UnapplyVariable(variable);
                 }
 
@@ -75,6 +85,11 @@ namespace EnvironmentVariablesUILib.Models
 
         public void UnapplyVariable(Variable variable)
         {
+            if (variable == null)
+            {
+                return;
+            }
+
             // Unset the variable
             if (!EnvironmentVariablesHelper.UnsetProfileVariableWithoutNotify(variable))
             {
@@ -112,6 +127,11 @@ namespace EnvironmentVariablesUILib.Models
 
             foreach (var variable in Variables)
             {
+                if (variable == null)
+                {
+                    continue;
+                }
+
                 var applied = EnvironmentVariablesHelper.GetExisting(variable.Name);
                 if (applied != null && applied.Values == variable.Values && applied.ParentType == VariablesSetType.User)
                 {
@@ -128,6 +148,11 @@ namespace EnvironmentVariablesUILib.Models
         {
             foreach (var variable in Variables)
             {
+                if (variable == null)
+                {
+                    continue;
+                }
+
                 if (!variable.Validate())
                 {
                     return false;
@@ -153,7 +178,7 @@ namespace EnvironmentVariablesUILib.Models
         public ProfileVariablesSet Clone()
         {
             var clone = new ProfileVariablesSet(this.Id, this.Name);
-            clone.Variables = new ObservableCollection<Variable>(this.Variables);
+            clone.Variables = new ObservableCollection<Variable>(this.Variables ?? new System.Collections.Generic.List<Variable>());
             clone.IsEnabled = this.IsEnabled;
 
             return clone;

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/ProfileVariablesSet.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/ProfileVariablesSet.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Threading.Tasks;
 
 using CommunityToolkit.Mvvm.ComponentModel;

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/ProfileVariablesSet.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/ProfileVariablesSet.cs
@@ -31,6 +31,11 @@ namespace EnvironmentVariablesUILib.Models
 
         public Task Apply()
         {
+            if (Variables == null)
+            {
+                return Task.CompletedTask;
+            }
+
             return Task.Run(() =>
             {
                 foreach (var variable in Variables)
@@ -67,6 +72,11 @@ namespace EnvironmentVariablesUILib.Models
 
         public Task UnApply()
         {
+            if (Variables == null)
+            {
+                return Task.CompletedTask;
+            }
+
             return Task.Run(() =>
             {
                 foreach (var variable in Variables)
@@ -125,6 +135,11 @@ namespace EnvironmentVariablesUILib.Models
                 return false;
             }
 
+            if (Variables == null)
+            {
+                return false;
+            }
+
             foreach (var variable in Variables)
             {
                 if (variable == null)
@@ -146,6 +161,11 @@ namespace EnvironmentVariablesUILib.Models
 
         public bool IsApplicable()
         {
+            if (Variables == null)
+            {
+                return true;
+            }
+
             foreach (var variable in Variables)
             {
                 if (variable == null)

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/ProfileVariablesSet.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/ProfileVariablesSet.cs
@@ -54,17 +54,21 @@ namespace EnvironmentVariablesUILib.Models
                     if (variableToOverride != null && variableToOverride.ParentType == VariablesSetType.User)
                     {
                         var backupName = EnvironmentVariablesHelper.GetBackupVariableName(variableToOverride, profileName);
+                        var backupVariableToSave = new Variable(variableToOverride.Name, variableToOverride.Values, variableToOverride.ParentType)
+                        {
+                            Name = backupName,
+                        };
+
+                        if (!backupVariableToSave.Validate())
+                        {
+                            LoggerInstance.Logger.LogError("Invalid backup variable name. Skipping profile backup.");
+                        }
 
                         // Only create a backup variable if there isn't one already for this profile.
-                        if (EnvironmentVariablesHelper.GetExisting(backupName) == null)
+                        else if (EnvironmentVariablesHelper.GetExisting(backupName) == null)
                         {
-                            var backupVariable = new Variable(variableToOverride.Name, variableToOverride.Values, variableToOverride.ParentType)
-                            {
-                                Name = backupName,
-                            };
-
                             // Backup the variable
-                            if (!EnvironmentVariablesHelper.SetProfileVariableWithoutNotify(backupVariable))
+                            if (!EnvironmentVariablesHelper.SetProfileVariableWithoutNotify(backupVariableToSave))
                             {
                                 LoggerInstance.Logger.LogError("Failed to set backup variable.");
                             }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/ProfileVariablesSet.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/ProfileVariablesSet.cs
@@ -150,7 +150,10 @@ namespace EnvironmentVariablesUILib.Models
                 }
 
                 var applied = EnvironmentVariablesHelper.GetExisting((variable.Name ?? string.Empty).Trim());
-                if (applied != null && applied.Values == variable.Values && applied.ParentType == VariablesSetType.User)
+                if (applied != null
+                    && string.Equals((applied.Name ?? string.Empty).Trim(), (variable.Name ?? string.Empty).Trim(), StringComparison.OrdinalIgnoreCase)
+                    && EnvironmentVariablesHelper.IsEquivalentVariableValue(applied.Values, variable.Values)
+                    && applied.ParentType == VariablesSetType.User)
                 {
                     continue;
                 }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/ProfileVariablesSet.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/ProfileVariablesSet.cs
@@ -225,7 +225,10 @@ namespace EnvironmentVariablesUILib.Models
         public ProfileVariablesSet Clone()
         {
             var clone = new ProfileVariablesSet(this.Id, (this.Name ?? string.Empty).Trim());
-            clone.Variables = new ObservableCollection<Variable>(this.Variables ?? new System.Collections.Generic.List<Variable>());
+            var variables = this.Variables
+                ?.Select(variable => variable == null ? null : variable.Clone(profile: true))
+                .ToList() ?? new System.Collections.Generic.List<Variable>();
+            clone.Variables = new ObservableCollection<Variable>(variables);
             clone.IsEnabled = this.IsEnabled;
 
             return clone;

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/Variable.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/Variable.cs
@@ -64,6 +64,11 @@ namespace EnvironmentVariablesUILib.Models
 
         private bool IsList()
         {
+            if (string.IsNullOrWhiteSpace(Name))
+            {
+                return false;
+            }
+
             List<string> listVariables = new()
             {
                 "_NT_ALT_SYMBOL_PATH",
@@ -106,7 +111,8 @@ namespace EnvironmentVariablesUILib.Models
 
         internal static ObservableCollection<ValuesListItem> ValuesStringToValuesListItemCollection(string values)
         {
-            return new ObservableCollection<ValuesListItem>(values.Split(';').Select(x => new ValuesListItem { Text = x }));
+            var source = string.IsNullOrWhiteSpace(values) ? string.Empty : values;
+            return new ObservableCollection<ValuesListItem>(source.Split(';').Select(x => new ValuesListItem { Text = x }));
         }
 
         internal Task Update(Variable edited, bool propagateChange, ProfileVariablesSet parentProfile)

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/Variable.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/Variable.cs
@@ -176,16 +176,26 @@ namespace EnvironmentVariablesUILib.Models
                     // It exists. Rename it to preserve it.
                     if (variableToOverride != null && variableToOverride.ParentType == VariablesSetType.User && parentProfile != null)
                     {
-                        // Gets which name the backup variable should have.
-                        variableToOverride.Name = EnvironmentVariablesHelper.GetBackupVariableName(variableToOverride, parentProfile.Name);
-
-                        // Only create a backup variable if there's not one already, to avoid overriding. (solves Path nuking errors, for example, after editing path on an enabled profile)
-                        if (EnvironmentVariablesHelper.GetExisting(variableToOverride.Name) == null)
+                        var backupName = EnvironmentVariablesHelper.GetBackupVariableName(variableToOverride, parentProfile.Name);
+                        var backupVariable = new Variable(variableToOverride.Name, variableToOverride.Values, variableToOverride.ParentType)
                         {
-                            // Backup the variable
-                            if (!EnvironmentVariablesHelper.SetProfileVariableWithoutNotify(variableToOverride))
+                            Name = backupName,
+                        };
+
+                        if (!backupVariable.Validate())
+                        {
+                            LoggerInstance.Logger.LogError("Cannot create backup variable due to invalid backup name.");
+                        }
+                        else
+                        {
+                            // Only create a backup variable if there's not one already, to avoid overriding. (solves Path nuking errors, for example, after editing path on an enabled profile)
+                            if (EnvironmentVariablesHelper.GetExisting(backupVariable.Name) == null)
                             {
-                                LoggerInstance.Logger.LogError("Failed to set backup variable.");
+                                // Backup the variable
+                                if (!EnvironmentVariablesHelper.SetProfileVariableWithoutNotify(backupVariable))
+                                {
+                                    LoggerInstance.Logger.LogError("Failed to set backup variable.");
+                                }
                             }
                         }
                     }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/Variable.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/Variable.cs
@@ -117,6 +117,12 @@ namespace EnvironmentVariablesUILib.Models
 
         internal Task Update(Variable edited, bool propagateChange, ProfileVariablesSet parentProfile)
         {
+            if (edited == null || string.IsNullOrWhiteSpace(edited.Name))
+            {
+                LoggerInstance.Logger.LogError("Invalid edited variable.");
+                return Task.CompletedTask;
+            }
+
             bool nameChanged = Name != edited.Name;
 
             var clone = this.Clone();

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/Variable.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/Variable.cs
@@ -217,6 +217,12 @@ namespace EnvironmentVariablesUILib.Models
                 return false;
             }
 
+            if (normalizedName.Contains('='))
+            {
+                LoggerInstance.Logger.LogError("Variable name contains invalid '=' character.");
+                return false;
+            }
+
             const int MaxUserEnvVariableLength = 255; // User-wide env vars stored in the registry have names limited to 255 chars
             if (ParentType != VariablesSetType.System && normalizedName.Length >= MaxUserEnvVariableLength)
             {

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/Variable.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/Variable.cs
@@ -69,6 +69,7 @@ namespace EnvironmentVariablesUILib.Models
                 return false;
             }
 
+            var normalizedName = (Name ?? string.Empty).Trim();
             List<string> listVariables = new()
             {
                 "_NT_ALT_SYMBOL_PATH",
@@ -81,7 +82,7 @@ namespace EnvironmentVariablesUILib.Models
 
             foreach (var name in listVariables)
             {
-                if (Name.Equals(name, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(normalizedName, name, StringComparison.OrdinalIgnoreCase))
                 {
                     return true;
                 }
@@ -102,7 +103,7 @@ namespace EnvironmentVariablesUILib.Models
 
         public Variable(string name, string values, VariablesSetType parentType)
         {
-            Name = name;
+            Name = name?.Trim();
             Values = values;
             ParentType = parentType;
 
@@ -117,18 +118,19 @@ namespace EnvironmentVariablesUILib.Models
 
         internal Task Update(Variable edited, bool propagateChange, ProfileVariablesSet parentProfile)
         {
-            if (edited == null || string.IsNullOrWhiteSpace(edited.Name))
+            var normalizedEditedName = edited?.Name?.Trim();
+            if (edited == null || string.IsNullOrWhiteSpace(normalizedEditedName))
             {
                 LoggerInstance.Logger.LogError("Invalid edited variable.");
                 return Task.CompletedTask;
             }
 
-            bool nameChanged = Name != edited.Name;
+            bool nameChanged = !string.Equals((Name ?? string.Empty).Trim(), normalizedEditedName, StringComparison.OrdinalIgnoreCase);
 
             var clone = this.Clone();
 
             // Update state
-            Name = edited.Name;
+            Name = normalizedEditedName;
             Values = edited.Values;
 
             ValuesList = ValuesStringToValuesListItemCollection(Values);
@@ -209,13 +211,14 @@ namespace EnvironmentVariablesUILib.Models
 
         public bool Validate()
         {
-            if (string.IsNullOrWhiteSpace(Name))
+            var normalizedName = Name?.Trim();
+            if (string.IsNullOrWhiteSpace(normalizedName))
             {
                 return false;
             }
 
             const int MaxUserEnvVariableLength = 255; // User-wide env vars stored in the registry have names limited to 255 chars
-            if (ParentType != VariablesSetType.System && Name.Length >= MaxUserEnvVariableLength)
+            if (ParentType != VariablesSetType.System && normalizedName.Length >= MaxUserEnvVariableLength)
             {
                 LoggerInstance.Logger.LogError("Variable name too long.");
                 return false;

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/VariablesSet.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/VariablesSet.cs
@@ -54,7 +54,7 @@ namespace EnvironmentVariablesUILib.Models
                 VariablesSetType.User => UserIconPath,
                 VariablesSetType.System => SystemIconPath,
                 VariablesSetType.Profile => ProfileIconPath,
-                _ => throw new NotImplementedException(),
+                _ => string.Empty,
             };
         }
 

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/VariablesSet.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Models/VariablesSet.cs
@@ -45,7 +45,7 @@ namespace EnvironmentVariablesUILib.Models
         public VariablesSet(Guid id, string name, VariablesSetType type)
         {
             Id = id;
-            Name = name;
+            Name = name?.Trim();
             Type = type;
             Variables = new ObservableCollection<Variable>();
 
@@ -60,7 +60,7 @@ namespace EnvironmentVariablesUILib.Models
 
         private bool Validate()
         {
-            if (string.IsNullOrWhiteSpace(Name))
+            if (string.IsNullOrWhiteSpace(Name?.Trim()))
             {
                 return false;
             }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Strings/en-us/Resources.resw
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Strings/en-us/Resources.resw
@@ -229,6 +229,9 @@
   <data name="StateNotUpToDateEnvironmentMessageReceivedMsg" xml:space="preserve">
     <value>Variables have been modified. Reload to get the latest changes.</value>
   </data>
+  <data name="SearchExistingVariable.PlaceholderText" xml:space="preserve">
+    <value>Search variables by name or value</value>
+  </data>
   <data name="AddVariable_Title" xml:space="preserve">
     <value>Add variable</value>
   </data>

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Strings/en-us/Resources.resw
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Strings/en-us/Resources.resw
@@ -256,6 +256,9 @@
   <data name="CopyName.Text" xml:space="preserve">
     <value>Copy Name</value>
   </data>
+  <data name="CopyNameAndValue.Text" xml:space="preserve">
+    <value>Copy Name = Value</value>
+  </data>
   <data name="CopyValue.Text" xml:space="preserve">
     <value>Copy Value</value>
   </data>

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Strings/en-us/Resources.resw
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Strings/en-us/Resources.resw
@@ -268,6 +268,9 @@
   <data name="RemoveListItem.Text" xml:space="preserve">
     <value>Delete</value>
   </data>
+  <data name="RemoveDuplicateListItem.Text" xml:space="preserve">
+    <value>Remove duplicates</value>
+  </data>
   <data name="RemoveItem.Text" xml:space="preserve">
     <value>Remove</value>
   </data>

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Strings/en-us/Resources.resw
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Strings/en-us/Resources.resw
@@ -247,6 +247,12 @@
   <data name="EditItem.Text" xml:space="preserve">
     <value>Edit</value>
   </data>
+  <data name="CopyName.Text" xml:space="preserve">
+    <value>Copy Name</value>
+  </data>
+  <data name="CopyValue.Text" xml:space="preserve">
+    <value>Copy Value</value>
+  </data>
   <data name="More_Options_ButtonTooltip.Text" xml:space="preserve">
     <value>More options</value>
   </data>

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Strings/en-us/Resources.resw
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/Strings/en-us/Resources.resw
@@ -232,6 +232,9 @@
   <data name="SearchExistingVariable.PlaceholderText" xml:space="preserve">
     <value>Search variables by name or value</value>
   </data>
+  <data name="NoMatchingDefaultVariables.Text" xml:space="preserve">
+    <value>No matching variables found.</value>
+  </data>
   <data name="AddVariable_Title" xml:space="preserve">
     <value>Add variable</value>
   </data>

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
@@ -665,6 +665,8 @@ namespace EnvironmentVariablesUILib.ViewModels
 
             bool propagateChange = true;
 
+            var variableToProcess = variable;
+
             if (profile != null)
             {
                 if (profile.Variables == null)
@@ -686,6 +688,8 @@ namespace EnvironmentVariablesUILib.ViewModels
                     LoggerInstance.Logger.LogError("Failed to remove profile variable from profile list.");
                     return;
                 }
+
+                variableToProcess = targetVariable;
 
                 if (!profile.IsEnabled)
                 {
@@ -716,7 +720,7 @@ namespace EnvironmentVariablesUILib.ViewModels
                     }
                     else
                     {
-                        profile.UnapplyVariable(variable);
+                        profile.UnapplyVariable(variableToProcess);
                     }
                 });
                 task.ContinueWith((a) =>

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
@@ -108,15 +108,28 @@ namespace EnvironmentVariablesUILib.ViewModels
         {
             try
             {
-                var profiles = _environmentVariablesService.ReadProfiles();
+                var profiles = _environmentVariablesService?.ReadProfiles() ?? new List<ProfileVariablesSet>();
+                if (profiles == null)
+                {
+                    profiles = new List<ProfileVariablesSet>();
+                }
+
                 foreach (var profile in profiles)
                 {
+                    if (profile == null || profile.Variables == null)
+                    {
+                        continue;
+                    }
+
                     DeduplicateProfileVariables(profile);
                     profile.PropertyChanged += Profile_PropertyChanged;
 
                     foreach (var variable in profile.Variables)
                     {
-                        variable.ParentType = VariablesSetType.Profile;
+                        if (variable != null)
+                        {
+                            variable.ParentType = VariablesSetType.Profile;
+                        }
                     }
                 }
 
@@ -262,6 +275,11 @@ namespace EnvironmentVariablesUILib.ViewModels
                 return;
             }
 
+            if (Profiles == null)
+            {
+                Profiles = new ObservableCollection<ProfileVariablesSet>();
+            }
+
             DeduplicateProfileVariables(profile);
             profile.PropertyChanged += Profile_PropertyChanged;
             if (profile.IsEnabled)
@@ -278,6 +296,11 @@ namespace EnvironmentVariablesUILib.ViewModels
         internal void UpdateProfile(ProfileVariablesSet updatedProfile)
         {
             if (updatedProfile == null)
+            {
+                return;
+            }
+
+            if (Profiles == null)
             {
                 return;
             }
@@ -459,6 +482,11 @@ namespace EnvironmentVariablesUILib.ViewModels
                 return;
             }
 
+            if (Profiles == null)
+            {
+                return;
+            }
+
             if (profile.IsEnabled)
             {
                 UnsetAppliedProfile();
@@ -497,11 +525,11 @@ namespace EnvironmentVariablesUILib.ViewModels
             }
             else
             {
-                if (variable.ParentType == VariablesSetType.User)
+                if (variable.ParentType == VariablesSetType.User && UserDefaultSet?.Variables != null)
                 {
                     UserDefaultSet.Variables.Remove(variable);
                 }
-                else if (variable.ParentType == VariablesSetType.System)
+                else if (variable.ParentType == VariablesSetType.System && SystemDefaultSet?.Variables != null)
                 {
                     SystemDefaultSet.Variables.Remove(variable);
                 }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
@@ -94,6 +94,11 @@ namespace EnvironmentVariablesUILib.ViewModels
 
             foreach (var variable in SystemDefaultSet.Variables)
             {
+                if (variable == null)
+                {
+                    continue;
+                }
+
                 DefaultVariables.Variables.Add(variable);
             }
 

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
@@ -310,23 +310,27 @@ namespace EnvironmentVariablesUILib.ViewModels
 
             if (type == VariablesSetType.User)
             {
-                if (UserDefaultSet.Variables != null && UserDefaultSet.Variables.Any(x => string.Equals((x?.Name ?? string.Empty).Trim(), normalizedName, StringComparison.OrdinalIgnoreCase)))
+                if (UserDefaultSet.Variables != null && UserDefaultSet.Variables.Any(x =>
+                    x != null &&
+                    string.Equals((x.Name ?? string.Empty).Trim(), normalizedName, StringComparison.OrdinalIgnoreCase)))
                 {
                     return;
                 }
 
                 UserDefaultSet.Variables.Add(variable);
-                UserDefaultSet.Variables = new ObservableCollection<Variable>(UserDefaultSet.Variables.OrderBy(x => x.Name).ToList());
+                UserDefaultSet.Variables = new ObservableCollection<Variable>(UserDefaultSet.Variables.Where(x => x != null).OrderBy(x => x.Name).ToList());
             }
             else if (type == VariablesSetType.System)
             {
-                if (SystemDefaultSet.Variables != null && SystemDefaultSet.Variables.Any(x => string.Equals((x?.Name ?? string.Empty).Trim(), normalizedName, StringComparison.OrdinalIgnoreCase)))
+                if (SystemDefaultSet.Variables != null && SystemDefaultSet.Variables.Any(x =>
+                    x != null &&
+                    string.Equals((x.Name ?? string.Empty).Trim(), normalizedName, StringComparison.OrdinalIgnoreCase)))
                 {
                     return;
                 }
 
                 SystemDefaultSet.Variables.Add(variable);
-                SystemDefaultSet.Variables = new ObservableCollection<Variable>(SystemDefaultSet.Variables.OrderBy(x => x.Name).ToList());
+                SystemDefaultSet.Variables = new ObservableCollection<Variable>(SystemDefaultSet.Variables.Where(x => x != null).OrderBy(x => x.Name).ToList());
             }
 
             EnvironmentVariablesHelper.SetVariable(variable);

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
@@ -290,7 +290,7 @@ namespace EnvironmentVariablesUILib.ViewModels
 
             if (type == VariablesSetType.User)
             {
-                if (UserDefaultSet.Variables != null && UserDefaultSet.Variables.Any(x => string.Equals(x?.Name, variable.Name, StringComparison.OrdinalIgnoreCase)))
+                if (UserDefaultSet.Variables != null && UserDefaultSet.Variables.Any(x => string.Equals((x?.Name ?? string.Empty).Trim(), variable.Name, StringComparison.OrdinalIgnoreCase)))
                 {
                     return;
                 }
@@ -300,7 +300,7 @@ namespace EnvironmentVariablesUILib.ViewModels
             }
             else if (type == VariablesSetType.System)
             {
-                if (SystemDefaultSet.Variables != null && SystemDefaultSet.Variables.Any(x => string.Equals(x?.Name, variable.Name, StringComparison.OrdinalIgnoreCase)))
+                if (SystemDefaultSet.Variables != null && SystemDefaultSet.Variables.Any(x => string.Equals((x?.Name ?? string.Empty).Trim(), variable.Name, StringComparison.OrdinalIgnoreCase)))
                 {
                     return;
                 }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
@@ -325,9 +325,9 @@ namespace EnvironmentVariablesUILib.ViewModels
             var originalName = (original.Name ?? string.Empty).Trim();
             var editedName = (edited.Name ?? string.Empty).Trim();
             bool changed = !string.Equals(originalName, editedName, StringComparison.OrdinalIgnoreCase) || original.Values != edited.Values;
-            if (changed && variablesSet == null && string.IsNullOrEmpty(edited.Values) && string.Equals(originalName, editedName, StringComparison.OrdinalIgnoreCase))
+            if (changed && string.IsNullOrEmpty(edited.Values) && string.Equals(originalName, editedName, StringComparison.OrdinalIgnoreCase))
             {
-                DeleteVariable(original, null);
+                DeleteVariable(original, variablesSet);
                 return;
             }
 

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
@@ -325,7 +325,7 @@ namespace EnvironmentVariablesUILib.ViewModels
             var originalName = (original.Name ?? string.Empty).Trim();
             var editedName = (edited.Name ?? string.Empty).Trim();
             bool changed = !string.Equals(originalName, editedName, StringComparison.OrdinalIgnoreCase) || original.Values != edited.Values;
-            if (changed && string.IsNullOrEmpty(edited.Values) && string.Equals(originalName, editedName, StringComparison.OrdinalIgnoreCase))
+            if (changed && string.IsNullOrEmpty(edited.Values))
             {
                 DeleteVariable(original, variablesSet);
                 return;

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
@@ -132,9 +132,34 @@ namespace EnvironmentVariablesUILib.ViewModels
                     profiles = new List<ProfileVariablesSet>();
                 }
 
+                var validProfiles = new List<ProfileVariablesSet>();
+                var loadedProfileIds = new HashSet<Guid>();
+                var loadedProfileNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
                 foreach (var profile in profiles)
                 {
-                    if (profile == null || profile.Variables == null)
+                    if (profile == null || profile.Id == Guid.Empty)
+                    {
+                        continue;
+                    }
+
+                    profile.Name = (profile.Name ?? string.Empty).Trim();
+                    if (string.IsNullOrWhiteSpace(profile.Name))
+                    {
+                        continue;
+                    }
+
+                    if (profile.Variables == null)
+                    {
+                        profile.Variables = new ObservableCollection<Variable>();
+                    }
+
+                    if (!loadedProfileIds.Add(profile.Id))
+                    {
+                        continue;
+                    }
+
+                    if (!loadedProfileNames.Add(profile.Name))
                     {
                         continue;
                     }
@@ -149,9 +174,11 @@ namespace EnvironmentVariablesUILib.ViewModels
                             variable.ParentType = VariablesSetType.Profile;
                         }
                     }
+
+                    validProfiles.Add(profile);
                 }
 
-                var appliedProfiles = profiles.Where(x => x != null && x.IsEnabled).ToList();
+                var appliedProfiles = validProfiles.Where(x => x != null && x.IsEnabled).ToList();
                 if (appliedProfiles.Count > 0)
                 {
                     var appliedProfile = appliedProfiles.First();
@@ -167,7 +194,7 @@ namespace EnvironmentVariablesUILib.ViewModels
                     }
                 }
 
-                Profiles = new ObservableCollection<ProfileVariablesSet>(profiles);
+                Profiles = new ObservableCollection<ProfileVariablesSet>(validProfiles);
             }
             catch (Exception ex)
             {

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
@@ -107,12 +107,12 @@ namespace EnvironmentVariablesUILib.ViewModels
                 return false;
             }
 
-            if (string.Equals(defaultVariable.Name, profileVariable.Name, StringComparison.OrdinalIgnoreCase))
+            if (string.Equals((defaultVariable.Name ?? string.Empty).Trim(), (profileVariable.Name ?? string.Empty).Trim(), StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }
 
-            return string.Equals(defaultVariable.Name, EnvironmentVariablesHelper.GetBackupVariableName(profileVariable, profileName), StringComparison.OrdinalIgnoreCase);
+            return string.Equals((defaultVariable.Name ?? string.Empty).Trim(), EnvironmentVariablesHelper.GetBackupVariableName(profileVariable, profileName).Trim(), StringComparison.OrdinalIgnoreCase);
         }
 
         public void LoadEnvironmentVariables()

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
@@ -82,7 +82,7 @@ namespace EnvironmentVariablesUILib.ViewModels
                 }
 
                 DefaultVariables.Variables.Add(variable);
-                if (AppliedProfile != null && AppliedProfile.Variables != null && AppliedProfile.Variables.Any())
+                if (AppliedProfile?.Variables != null && AppliedProfile.Variables.Any())
                 {
                     if (AppliedProfile.Variables.Any(profileVariable => IsVariableAppliedToProfile(variable, profileVariable, AppliedProfile.Name)))
                     {

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
@@ -249,19 +249,28 @@ namespace EnvironmentVariablesUILib.ViewModels
 
             // Find duplicates
             var duplicates = variables.Where(x => x != null && !string.Equals("PATH", (x.Name ?? string.Empty).Trim(), StringComparison.OrdinalIgnoreCase))
-                                     .GroupBy(x => (x.Name ?? string.Empty).Trim().ToLowerInvariant())
-                                     .Where(g => g.Count() > 1);
+                                      .GroupBy(x => (x.Name ?? string.Empty).Trim().ToLowerInvariant())
+                                      .Where(g => g.Count() > 1);
             foreach (var duplicate in duplicates)
             {
-                var userVar = duplicate.ElementAt(0);
-                var systemVar = duplicate.ElementAt(1);
+                var duplicateItems = duplicate.ToList();
+                var representative = duplicateItems.First();
 
-                var clone = userVar.Clone();
+                var clone = representative.Clone();
                 clone.ParentType = VariablesSetType.Duplicate;
-                clone.Name = systemVar.Name;
-                variables.Insert(variables.IndexOf(userVar), clone);
-                variables.Remove(userVar);
-                variables.Remove(systemVar);
+                clone.Name = representative.Name;
+                var insertionIndex = variables.IndexOf(representative);
+                if (insertionIndex < 0)
+                {
+                    insertionIndex = 0;
+                }
+
+                foreach (var item in duplicateItems)
+                {
+                    variables.Remove(item);
+                }
+
+                variables.Insert(insertionIndex, clone);
             }
 
             variables = variables.OrderBy(x => x.ParentType).ToList();

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
@@ -76,12 +76,19 @@ namespace EnvironmentVariablesUILib.ViewModels
 
             foreach (var variable in UserDefaultSet.Variables)
             {
+                if (variable == null)
+                {
+                    continue;
+                }
+
                 DefaultVariables.Variables.Add(variable);
-                if (AppliedProfile != null)
+                if (AppliedProfile != null && AppliedProfile.Variables != null && AppliedProfile.Variables.Any())
                 {
                     if (AppliedProfile.Variables.Where(
-                        x => (x.Name.Equals(variable.Name, StringComparison.OrdinalIgnoreCase) && x.Values.Equals(variable.Values, StringComparison.OrdinalIgnoreCase))
-                            || variable.Name.Equals(EnvironmentVariablesHelper.GetBackupVariableName(x, AppliedProfile.Name), StringComparison.OrdinalIgnoreCase)).Any())
+                        x => x != null
+                            && (!string.IsNullOrWhiteSpace(variable.Name)
+                                && (!string.IsNullOrWhiteSpace(x.Name) && variable.Name.Equals(x.Name, StringComparison.OrdinalIgnoreCase))
+                                || string.Equals(variable.Name, EnvironmentVariablesHelper.GetBackupVariableName(x, AppliedProfile.Name), StringComparison.OrdinalIgnoreCase))).Any())
                     {
                         // If it's a user variable that's also in the profile or is a backup variable, mark it as applied from profile.
                         variable.IsAppliedFromProfile = true;
@@ -133,7 +140,7 @@ namespace EnvironmentVariablesUILib.ViewModels
                     }
                 }
 
-                var appliedProfiles = profiles.Where(x => x.IsEnabled).ToList();
+                var appliedProfiles = profiles.Where(x => x != null && x.IsEnabled).ToList();
                 if (appliedProfiles.Count > 0)
                 {
                     var appliedProfile = appliedProfiles.First();
@@ -165,20 +172,20 @@ namespace EnvironmentVariablesUILib.ViewModels
             LoadDefaultVariables();
 
             var variables = new List<Variable>();
-            if (AppliedProfile != null)
+            if (AppliedProfile != null && AppliedProfile.Variables != null)
             {
-                variables = variables.Concat(AppliedProfile.Variables.Select(x => new Variable(x.Name, Environment.ExpandEnvironmentVariables(x.Values), VariablesSetType.Profile)).OrderBy(x => x.Name)).ToList();
+                variables = variables.Concat(AppliedProfile.Variables.Where(x => x != null).Select(x => new Variable(x.Name, Environment.ExpandEnvironmentVariables(x.Values), VariablesSetType.Profile)).OrderBy(x => x.Name)).ToList();
             }
 
             // Variables are expanded to be shown in the applied variables section, so the user sees their actual values.
-            variables = variables.Concat(UserDefaultSet.Variables.Select(x => new Variable(x.Name, Environment.ExpandEnvironmentVariables(x.Values), VariablesSetType.User)).OrderBy(x => x.Name))
-                                 .Concat(SystemDefaultSet.Variables.Select(x => new Variable(x.Name, Environment.ExpandEnvironmentVariables(x.Values), VariablesSetType.System)).OrderBy(x => x.Name))
+            variables = variables.Concat(UserDefaultSet.Variables.Where(x => x != null).Select(x => new Variable(x.Name, Environment.ExpandEnvironmentVariables(x.Values), VariablesSetType.User)).OrderBy(x => x.Name))
+                                 .Concat(SystemDefaultSet.Variables.Where(x => x != null).Select(x => new Variable(x.Name, Environment.ExpandEnvironmentVariables(x.Values), VariablesSetType.System)).OrderBy(x => x.Name))
                                  .ToList();
 
             // Handle PATH variable - add USER value to the end of the SYSTEM value
-            var profilePath = variables.Where(x => x.Name.Equals("PATH", StringComparison.OrdinalIgnoreCase) && x.ParentType == VariablesSetType.Profile).FirstOrDefault();
-            var userPath = variables.Where(x => x.Name.Equals("PATH", StringComparison.OrdinalIgnoreCase) && x.ParentType == VariablesSetType.User).FirstOrDefault();
-            var systemPath = variables.Where(x => x.Name.Equals("PATH", StringComparison.OrdinalIgnoreCase) && x.ParentType == VariablesSetType.System).FirstOrDefault();
+            var profilePath = variables.Where(x => x != null && "PATH".Equals(x.Name, StringComparison.OrdinalIgnoreCase) && x.ParentType == VariablesSetType.Profile).FirstOrDefault();
+            var userPath = variables.Where(x => x != null && "PATH".Equals(x.Name, StringComparison.OrdinalIgnoreCase) && x.ParentType == VariablesSetType.User).FirstOrDefault();
+            var systemPath = variables.Where(x => x != null && "PATH".Equals(x.Name, StringComparison.OrdinalIgnoreCase) && x.ParentType == VariablesSetType.System).FirstOrDefault();
 
             if (systemPath != null)
             {
@@ -203,7 +210,9 @@ namespace EnvironmentVariablesUILib.ViewModels
             variables = variables.GroupBy(x => x.Name).Select(y => y.First()).ToList();
 
             // Find duplicates
-            var duplicates = variables.Where(x => !x.Name.Equals("PATH", StringComparison.OrdinalIgnoreCase)).GroupBy(x => x.Name.ToLower(CultureInfo.InvariantCulture)).Where(g => g.Count() > 1);
+            var duplicates = variables.Where(x => x != null && !string.Equals("PATH", x.Name, StringComparison.OrdinalIgnoreCase))
+                                     .GroupBy(x => x.Name?.ToLower(CultureInfo.InvariantCulture) ?? string.Empty)
+                                     .Where(g => g.Count() > 1);
             foreach (var duplicate in duplicates)
             {
                 var userVar = duplicate.ElementAt(0);

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
@@ -342,7 +342,8 @@ namespace EnvironmentVariablesUILib.ViewModels
             bool propagateChange = !isProfileVariable || variablesSet.Id.Equals(AppliedProfile?.Id);
             var originalName = (targetVariable.Name ?? string.Empty).Trim();
             var editedName = (edited.Name ?? string.Empty).Trim();
-            bool changed = !string.Equals(originalName, editedName, StringComparison.OrdinalIgnoreCase) || !IsEquivalentVariableValue(targetVariable.Values, edited.Values);
+            bool changed = !string.Equals(originalName, editedName, StringComparison.OrdinalIgnoreCase) ||
+                !EnvironmentVariablesHelper.IsEquivalentVariableValue(targetVariable.Values, edited.Values);
             if (changed && string.IsNullOrEmpty(edited.Values))
             {
                 DeleteVariable(targetVariable, variablesSet);
@@ -744,21 +745,8 @@ namespace EnvironmentVariablesUILib.ViewModels
             var normalizedName = (target.Name ?? string.Empty).Trim();
             return variables
                 .Where(x => x != null && string.Equals((x.Name ?? string.Empty).Trim(), normalizedName, StringComparison.OrdinalIgnoreCase))
-                .Where(x => IsEquivalentVariableValue(x?.Values, target.Values))
+                .Where(x => EnvironmentVariablesHelper.IsEquivalentVariableValue(x?.Values, target.Values))
                 .FirstOrDefault();
-        }
-
-        private static bool IsEquivalentVariableValue(string candidateValue, string compareValue)
-        {
-            var candidate = candidateValue ?? string.Empty;
-            var compare = compareValue ?? string.Empty;
-            var expandedCandidate = Environment.ExpandEnvironmentVariables(candidate);
-            var expandedCompare = Environment.ExpandEnvironmentVariables(compare);
-
-            return string.Equals(candidate, compare, StringComparison.Ordinal) ||
-                string.Equals(expandedCandidate, compare, StringComparison.Ordinal) ||
-                string.Equals(candidate, expandedCompare, StringComparison.Ordinal) ||
-                string.Equals(expandedCandidate, expandedCompare, StringComparison.Ordinal);
         }
     }
 }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
@@ -367,7 +367,7 @@ namespace EnvironmentVariablesUILib.ViewModels
                 return;
             }
 
-            if (Profiles.Any(p => p != null && string.Equals(p.Name, profile.Name, StringComparison.OrdinalIgnoreCase) && p.Id != profile.Id))
+            if (Profiles.Any(p => p != null && string.Equals((p.Name ?? string.Empty).Trim(), profile.Name, StringComparison.OrdinalIgnoreCase) && p.Id != profile.Id))
             {
                 return;
             }
@@ -412,7 +412,7 @@ namespace EnvironmentVariablesUILib.ViewModels
                     updatedProfile.Variables = new ObservableCollection<Variable>();
                 }
 
-                if (Profiles.Any(x => x != null && x.Id != updatedProfile.Id && string.Equals(x.Name, updatedProfile.Name, StringComparison.OrdinalIgnoreCase)))
+                if (Profiles.Any(x => x != null && x.Id != updatedProfile.Id && string.Equals((x.Name ?? string.Empty).Trim(), updatedProfile.Name, StringComparison.OrdinalIgnoreCase)))
                 {
                     return;
                 }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
@@ -325,6 +325,11 @@ namespace EnvironmentVariablesUILib.ViewModels
 
             profile.Name = profile.Name.Trim();
 
+            if (profile.Variables == null)
+            {
+                profile.Variables = new ObservableCollection<Variable>();
+            }
+
             if (Profiles == null)
             {
                 Profiles = new ObservableCollection<ProfileVariablesSet>();
@@ -375,6 +380,11 @@ namespace EnvironmentVariablesUILib.ViewModels
             var existingProfile = Profiles.Where(x => x.Id == updatedProfile.Id).FirstOrDefault();
             if (existingProfile != null)
             {
+                if (updatedProfile.Variables == null)
+                {
+                    updatedProfile.Variables = new ObservableCollection<Variable>();
+                }
+
                 if (Profiles.Any(x => x != null && x.Id != updatedProfile.Id && string.Equals(x.Name, updatedProfile.Name, StringComparison.OrdinalIgnoreCase)))
                 {
                     return;

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
@@ -330,6 +330,16 @@ namespace EnvironmentVariablesUILib.ViewModels
                 Profiles = new ObservableCollection<ProfileVariablesSet>();
             }
 
+            if (Profiles.Any(p => p != null && p.Id == profile.Id))
+            {
+                return;
+            }
+
+            if (Profiles.Any(p => p != null && string.Equals(p.Name, profile.Name, StringComparison.OrdinalIgnoreCase) && p.Id != profile.Id))
+            {
+                return;
+            }
+
             DeduplicateProfileVariables(profile);
             profile.PropertyChanged += Profile_PropertyChanged;
             if (profile.IsEnabled)
@@ -365,6 +375,11 @@ namespace EnvironmentVariablesUILib.ViewModels
             var existingProfile = Profiles.Where(x => x.Id == updatedProfile.Id).FirstOrDefault();
             if (existingProfile != null)
             {
+                if (Profiles.Any(x => x != null && x.Id != updatedProfile.Id && string.Equals(x.Name, updatedProfile.Name, StringComparison.OrdinalIgnoreCase)))
+                {
+                    return;
+                }
+
                 DeduplicateProfileVariables(updatedProfile);
                 if (updatedProfile.IsEnabled)
                 {

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
@@ -227,6 +227,11 @@ namespace EnvironmentVariablesUILib.ViewModels
 
         internal void EditVariable(Variable original, Variable edited, ProfileVariablesSet variablesSet)
         {
+            if (original == null || edited == null)
+            {
+                return;
+            }
+
             bool propagateChange = variablesSet == null /* not a profile */ || variablesSet.Id.Equals(AppliedProfile?.Id);
             bool changed = original.Name != edited.Name || original.Values != edited.Values;
             if (changed)
@@ -247,6 +252,11 @@ namespace EnvironmentVariablesUILib.ViewModels
 
         internal void AddProfile(ProfileVariablesSet profile)
         {
+            if (profile == null)
+            {
+                return;
+            }
+
             DeduplicateProfileVariables(profile);
             profile.PropertyChanged += Profile_PropertyChanged;
             if (profile.IsEnabled)
@@ -262,6 +272,11 @@ namespace EnvironmentVariablesUILib.ViewModels
 
         internal void UpdateProfile(ProfileVariablesSet updatedProfile)
         {
+            if (updatedProfile == null)
+            {
+                return;
+            }
+
             var existingProfile = Profiles.Where(x => x.Id == updatedProfile.Id).FirstOrDefault();
             if (existingProfile != null)
             {
@@ -322,18 +337,20 @@ namespace EnvironmentVariablesUILib.ViewModels
 
         private void SetAppliedProfile(ProfileVariablesSet profile)
         {
-            if (profile != null)
+            if (profile == null)
             {
-                if (!profile.IsApplicable())
-                {
-                    profile.PropertyChanged -= Profile_PropertyChanged;
-                    profile.IsEnabled = false;
-                    profile.PropertyChanged += Profile_PropertyChanged;
+                return;
+            }
 
-                    EnvironmentState = EnvironmentState.ProfileNotApplicable;
+            if (!profile.IsApplicable())
+            {
+                profile.PropertyChanged -= Profile_PropertyChanged;
+                profile.IsEnabled = false;
+                profile.PropertyChanged += Profile_PropertyChanged;
 
-                    return;
-                }
+                EnvironmentState = EnvironmentState.ProfileNotApplicable;
+
+                return;
             }
 
             var task = profile.Apply();
@@ -432,6 +449,11 @@ namespace EnvironmentVariablesUILib.ViewModels
 
         internal void RemoveProfile(ProfileVariablesSet profile)
         {
+            if (profile == null)
+            {
+                return;
+            }
+
             if (profile.IsEnabled)
             {
                 UnsetAppliedProfile();

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
@@ -229,10 +229,21 @@ namespace EnvironmentVariablesUILib.ViewModels
             {
                 var clone = systemPath.Clone();
                 clone.ParentType = VariablesSetType.Path;
+                clone.Values = systemPath.Values ?? string.Empty;
 
                 if (userPath != null)
                 {
-                    clone.Values += ";" + userPath.Values;
+                    var userPathValue = userPath.Values ?? string.Empty;
+                    if (!string.IsNullOrEmpty(userPathValue))
+                    {
+                        if (!string.IsNullOrEmpty(clone.Values))
+                        {
+                            clone.Values += ";";
+                        }
+
+                        clone.Values += userPathValue;
+                    }
+
                     variables.Remove(userPath);
                 }
 
@@ -248,7 +259,8 @@ namespace EnvironmentVariablesUILib.ViewModels
             // Find duplicates
             var duplicates = variables.Where(x => x != null && !string.Equals("PATH", (x.Name ?? string.Empty).Trim(), StringComparison.OrdinalIgnoreCase))
                                       .GroupBy(x => (x.Name ?? string.Empty).Trim().ToLowerInvariant())
-                                      .Where(g => g.Count() > 1);
+                                      .Where(g => g.Count() > 1)
+                                      .ToList();
             foreach (var duplicate in duplicates)
             {
                 var duplicateItems = duplicate.ToList();

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
@@ -212,12 +212,12 @@ namespace EnvironmentVariablesUILib.ViewModels
             var variables = new List<Variable>();
             if (AppliedProfile != null && AppliedProfile.Variables != null)
             {
-                variables = variables.Concat(AppliedProfile.Variables.Where(x => x != null).Select(x => new Variable(x.Name, Environment.ExpandEnvironmentVariables(x.Values), VariablesSetType.Profile)).OrderBy(x => x.Name)).ToList();
+                variables = variables.Concat(AppliedProfile.Variables.Where(x => x != null).Select(x => new Variable(x.Name, Environment.ExpandEnvironmentVariables(x.Values ?? string.Empty), VariablesSetType.Profile)).OrderBy(x => x.Name)).ToList();
             }
 
             // Variables are expanded to be shown in the applied variables section, so the user sees their actual values.
-            variables = variables.Concat(UserDefaultSet.Variables.Where(x => x != null).Select(x => new Variable(x.Name, Environment.ExpandEnvironmentVariables(x.Values), VariablesSetType.User)).OrderBy(x => x.Name))
-                                 .Concat(SystemDefaultSet.Variables.Where(x => x != null).Select(x => new Variable(x.Name, Environment.ExpandEnvironmentVariables(x.Values), VariablesSetType.System)).OrderBy(x => x.Name))
+            variables = variables.Concat(UserDefaultSet.Variables.Where(x => x != null).Select(x => new Variable(x.Name, Environment.ExpandEnvironmentVariables(x.Values ?? string.Empty), VariablesSetType.User)).OrderBy(x => x.Name))
+                                 .Concat(SystemDefaultSet.Variables.Where(x => x != null).Select(x => new Variable(x.Name, Environment.ExpandEnvironmentVariables(x.Values ?? string.Empty), VariablesSetType.System)).OrderBy(x => x.Name))
                                  .ToList();
 
             // Handle PATH variable - add USER value to the end of the SYSTEM value

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
@@ -245,8 +245,6 @@ namespace EnvironmentVariablesUILib.ViewModels
                 variables.Remove(systemPath);
             }
 
-            variables = variables.GroupBy(x => (x.Name ?? string.Empty).Trim()).Select(y => y.First()).ToList();
-
             // Find duplicates
             var duplicates = variables.Where(x => x != null && !string.Equals("PATH", (x.Name ?? string.Empty).Trim(), StringComparison.OrdinalIgnoreCase))
                                       .GroupBy(x => (x.Name ?? string.Empty).Trim().ToLowerInvariant())

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
@@ -210,6 +210,11 @@ namespace EnvironmentVariablesUILib.ViewModels
 
         internal void AddDefaultVariable(Variable variable, VariablesSetType type)
         {
+            if (variable == null)
+            {
+                return;
+            }
+
             if (type == VariablesSetType.User)
             {
                 UserDefaultSet.Variables.Add(variable);
@@ -466,10 +471,20 @@ namespace EnvironmentVariablesUILib.ViewModels
 
         internal void DeleteVariable(Variable variable, ProfileVariablesSet profile)
         {
+            if (variable == null)
+            {
+                return;
+            }
+
             bool propagateChange = true;
 
             if (profile != null)
             {
+                if (profile.Variables == null)
+                {
+                    return;
+                }
+
                 // Profile variable
                 profile.Variables.Remove(variable);
 

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
@@ -221,9 +221,9 @@ namespace EnvironmentVariablesUILib.ViewModels
                                  .ToList();
 
             // Handle PATH variable - add USER value to the end of the SYSTEM value
-            var profilePath = variables.Where(x => x != null && "PATH".Equals(x.Name, StringComparison.OrdinalIgnoreCase) && x.ParentType == VariablesSetType.Profile).FirstOrDefault();
-            var userPath = variables.Where(x => x != null && "PATH".Equals(x.Name, StringComparison.OrdinalIgnoreCase) && x.ParentType == VariablesSetType.User).FirstOrDefault();
-            var systemPath = variables.Where(x => x != null && "PATH".Equals(x.Name, StringComparison.OrdinalIgnoreCase) && x.ParentType == VariablesSetType.System).FirstOrDefault();
+            var profilePath = variables.Where(x => x != null && "PATH".Equals((x.Name ?? string.Empty).Trim(), StringComparison.OrdinalIgnoreCase) && x.ParentType == VariablesSetType.Profile).FirstOrDefault();
+            var userPath = variables.Where(x => x != null && "PATH".Equals((x.Name ?? string.Empty).Trim(), StringComparison.OrdinalIgnoreCase) && x.ParentType == VariablesSetType.User).FirstOrDefault();
+            var systemPath = variables.Where(x => x != null && "PATH".Equals((x.Name ?? string.Empty).Trim(), StringComparison.OrdinalIgnoreCase) && x.ParentType == VariablesSetType.System).FirstOrDefault();
 
             if (systemPath != null)
             {
@@ -285,12 +285,13 @@ namespace EnvironmentVariablesUILib.ViewModels
                 return;
             }
 
-            variable.Name = variable.Name.Trim();
+            var normalizedName = (variable.Name ?? string.Empty).Trim();
+            variable.Name = normalizedName;
             variable.ParentType = type;
 
             if (type == VariablesSetType.User)
             {
-                if (UserDefaultSet.Variables != null && UserDefaultSet.Variables.Any(x => string.Equals((x?.Name ?? string.Empty).Trim(), variable.Name, StringComparison.OrdinalIgnoreCase)))
+                if (UserDefaultSet.Variables != null && UserDefaultSet.Variables.Any(x => string.Equals((x?.Name ?? string.Empty).Trim(), normalizedName, StringComparison.OrdinalIgnoreCase)))
                 {
                     return;
                 }
@@ -300,7 +301,7 @@ namespace EnvironmentVariablesUILib.ViewModels
             }
             else if (type == VariablesSetType.System)
             {
-                if (SystemDefaultSet.Variables != null && SystemDefaultSet.Variables.Any(x => string.Equals((x?.Name ?? string.Empty).Trim(), variable.Name, StringComparison.OrdinalIgnoreCase)))
+                if (SystemDefaultSet.Variables != null && SystemDefaultSet.Variables.Any(x => string.Equals((x?.Name ?? string.Empty).Trim(), normalizedName, StringComparison.OrdinalIgnoreCase)))
                 {
                     return;
                 }
@@ -321,7 +322,9 @@ namespace EnvironmentVariablesUILib.ViewModels
             }
 
             bool propagateChange = variablesSet == null /* not a profile */ || variablesSet.Id.Equals(AppliedProfile?.Id);
-            bool changed = original.Name != edited.Name || original.Values != edited.Values;
+            var originalName = (original.Name ?? string.Empty).Trim();
+            var editedName = (edited.Name ?? string.Empty).Trim();
+            bool changed = !string.Equals(originalName, editedName, StringComparison.OrdinalIgnoreCase) || original.Values != edited.Values;
             if (changed)
             {
                 var task = original.Update(edited, propagateChange, variablesSet);

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
@@ -743,10 +743,19 @@ namespace EnvironmentVariablesUILib.ViewModels
             }
 
             var normalizedName = (target.Name ?? string.Empty).Trim();
-            return variables
+            var matches = variables
                 .Where(x => x != null && string.Equals((x.Name ?? string.Empty).Trim(), normalizedName, StringComparison.OrdinalIgnoreCase))
                 .Where(x => EnvironmentVariablesHelper.IsEquivalentVariableValue(x?.Values, target.Values))
-                .FirstOrDefault();
+                .ToList();
+
+            if (matches.Count != 1)
+            {
+                LoggerInstance.Logger.LogError(
+                    $"Invalid profile variable resolution: expected one match for '{normalizedName}' but found {matches.Count}.");
+                return null;
+            }
+
+            return matches[0];
         }
     }
 }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
@@ -759,13 +759,19 @@ namespace EnvironmentVariablesUILib.ViewModels
                 return null;
             }
 
+            var normalizedTargetName = (target.Name ?? string.Empty).Trim();
+            if (string.IsNullOrWhiteSpace(normalizedTargetName))
+            {
+                return null;
+            }
+
             var exactMatch = variables.FirstOrDefault(x => ReferenceEquals(x, target));
             if (exactMatch != null)
             {
                 return exactMatch;
             }
 
-            var normalizedName = (target.Name ?? string.Empty).Trim();
+            var normalizedName = normalizedTargetName;
             var matches = variables
                 .Where(x => x != null && string.Equals((x.Name ?? string.Empty).Trim(), normalizedName, StringComparison.OrdinalIgnoreCase))
                 .Where(x => EnvironmentVariablesHelper.IsEquivalentVariableValue(x?.Values, target.Values))

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
@@ -528,8 +528,24 @@ namespace EnvironmentVariablesUILib.ViewModels
                 return;
             }
 
-            var deduped = profile.Variables
-                .Where(variable => !string.IsNullOrWhiteSpace(variable?.Name))
+            var cleanedVariables = new List<Variable>();
+            foreach (var variable in profile.Variables)
+            {
+                if (variable == null)
+                {
+                    continue;
+                }
+
+                variable.Name = variable.Name?.Trim();
+                if (string.IsNullOrWhiteSpace(variable.Name))
+                {
+                    continue;
+                }
+
+                cleanedVariables.Add(variable);
+            }
+
+            var deduped = cleanedVariables
                 .GroupBy(variable => $"{variable.Name?.ToUpperInvariant()}|{variable.Values}|{variable.ParentType}")
                 .Select(group => group.First())
                 .ToList();

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
@@ -295,6 +295,13 @@ namespace EnvironmentVariablesUILib.ViewModels
                 return;
             }
 
+            if (string.IsNullOrWhiteSpace(profile.Name))
+            {
+                return;
+            }
+
+            profile.Name = profile.Name.Trim();
+
             if (Profiles == null)
             {
                 Profiles = new ObservableCollection<ProfileVariablesSet>();
@@ -319,6 +326,13 @@ namespace EnvironmentVariablesUILib.ViewModels
             {
                 return;
             }
+
+            if (string.IsNullOrWhiteSpace(updatedProfile.Name))
+            {
+                return;
+            }
+
+            updatedProfile.Name = updatedProfile.Name.Trim();
 
             if (Profiles == null)
             {

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
@@ -645,6 +645,12 @@ namespace EnvironmentVariablesUILib.ViewModels
                 return;
             }
 
+            if (variable.ParentType == VariablesSetType.Profile && profile == null)
+            {
+                LoggerInstance.Logger.LogError("Invalid delete: cannot delete profile variable without owning profile set.");
+                return;
+            }
+
             bool propagateChange = true;
 
             if (profile != null)

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
@@ -325,6 +325,12 @@ namespace EnvironmentVariablesUILib.ViewModels
             var originalName = (original.Name ?? string.Empty).Trim();
             var editedName = (edited.Name ?? string.Empty).Trim();
             bool changed = !string.Equals(originalName, editedName, StringComparison.OrdinalIgnoreCase) || original.Values != edited.Values;
+            if (changed && variablesSet == null && string.IsNullOrEmpty(edited.Values) && string.Equals(originalName, editedName, StringComparison.OrdinalIgnoreCase))
+            {
+                DeleteVariable(original, null);
+                return;
+            }
+
             if (changed)
             {
                 var task = original.Update(edited, propagateChange, variablesSet);

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
@@ -245,11 +245,11 @@ namespace EnvironmentVariablesUILib.ViewModels
                 variables.Remove(systemPath);
             }
 
-            variables = variables.GroupBy(x => x.Name).Select(y => y.First()).ToList();
+            variables = variables.GroupBy(x => (x.Name ?? string.Empty).Trim()).Select(y => y.First()).ToList();
 
             // Find duplicates
-            var duplicates = variables.Where(x => x != null && !string.Equals("PATH", x.Name, StringComparison.OrdinalIgnoreCase))
-                                     .GroupBy(x => x.Name?.ToLower(CultureInfo.InvariantCulture) ?? string.Empty)
+            var duplicates = variables.Where(x => x != null && !string.Equals("PATH", (x.Name ?? string.Empty).Trim(), StringComparison.OrdinalIgnoreCase))
+                                     .GroupBy(x => (x.Name ?? string.Empty).Trim().ToLowerInvariant())
                                      .Where(g => g.Count() > 1);
             foreach (var duplicate in duplicates)
             {

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
@@ -368,7 +368,7 @@ namespace EnvironmentVariablesUILib.ViewModels
 
             var deduped = profile.Variables
                 .Where(variable => !string.IsNullOrWhiteSpace(variable?.Name))
-                .GroupBy(variable => variable.Name, StringComparer.OrdinalIgnoreCase)
+                .GroupBy(variable => $"{variable.Name?.ToUpperInvariant()}|{variable.Values}|{variable.ParentType}")
                 .Select(group => group.First())
                 .ToList();
 

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
@@ -321,7 +321,14 @@ namespace EnvironmentVariablesUILib.ViewModels
                 return;
             }
 
-            bool propagateChange = variablesSet == null /* not a profile */ || variablesSet.Id.Equals(AppliedProfile?.Id);
+            bool isProfileVariable = original.ParentType == VariablesSetType.Profile;
+            if (isProfileVariable && variablesSet == null)
+            {
+                LoggerInstance.Logger.LogError("Invalid edit: cannot edit profile variable without owning profile set.");
+                return;
+            }
+
+            bool propagateChange = !isProfileVariable || variablesSet.Id.Equals(AppliedProfile?.Id);
             var originalName = (original.Name ?? string.Empty).Trim();
             var editedName = (edited.Name ?? string.Empty).Trim();
             bool changed = !string.Equals(originalName, editedName, StringComparison.OrdinalIgnoreCase) || original.Values != edited.Values;

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
@@ -84,11 +84,7 @@ namespace EnvironmentVariablesUILib.ViewModels
                 DefaultVariables.Variables.Add(variable);
                 if (AppliedProfile != null && AppliedProfile.Variables != null && AppliedProfile.Variables.Any())
                 {
-                    if (AppliedProfile.Variables.Where(
-                        x => x != null
-                            && (!string.IsNullOrWhiteSpace(variable.Name)
-                                && (!string.IsNullOrWhiteSpace(x.Name) && variable.Name.Equals(x.Name, StringComparison.OrdinalIgnoreCase))
-                                || string.Equals(variable.Name, EnvironmentVariablesHelper.GetBackupVariableName(x, AppliedProfile.Name), StringComparison.OrdinalIgnoreCase))).Any())
+                    if (AppliedProfile.Variables.Any(profileVariable => IsVariableAppliedToProfile(variable, profileVariable, AppliedProfile.Name)))
                     {
                         // If it's a user variable that's also in the profile or is a backup variable, mark it as applied from profile.
                         variable.IsAppliedFromProfile = true;
@@ -102,6 +98,21 @@ namespace EnvironmentVariablesUILib.ViewModels
             }
 
             ApplyDefaultVariablesFilter();
+        }
+
+        private static bool IsVariableAppliedToProfile(Variable defaultVariable, Variable profileVariable, string profileName)
+        {
+            if (defaultVariable == null || profileVariable == null || string.IsNullOrWhiteSpace(defaultVariable.Name))
+            {
+                return false;
+            }
+
+            if (string.Equals(defaultVariable.Name, profileVariable.Name, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            return string.Equals(defaultVariable.Name, EnvironmentVariablesHelper.GetBackupVariableName(profileVariable, profileName), StringComparison.OrdinalIgnoreCase);
         }
 
         public void LoadEnvironmentVariables()

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
@@ -37,6 +37,12 @@ namespace EnvironmentVariablesUILib.ViewModels
         private ObservableCollection<Variable> _appliedVariables = new ObservableCollection<Variable>();
 
         [ObservableProperty]
+        private ObservableCollection<Variable> _filteredDefaultVariables = new ObservableCollection<Variable>();
+
+        [ObservableProperty]
+        private string _defaultVariablesFilterText = string.Empty;
+
+        [ObservableProperty]
         private bool _isElevated;
 
         [ObservableProperty]
@@ -87,6 +93,8 @@ namespace EnvironmentVariablesUILib.ViewModels
             {
                 DefaultVariables.Variables.Add(variable);
             }
+
+            ApplyDefaultVariablesFilter();
         }
 
         public void LoadEnvironmentVariables()
@@ -381,6 +389,45 @@ namespace EnvironmentVariablesUILib.ViewModels
                     variable.ParentType = VariablesSetType.Profile;
                 }
             }
+        }
+
+        partial void OnDefaultVariablesFilterTextChanged(string value)
+        {
+            ApplyDefaultVariablesFilter();
+        }
+
+        internal void SetDefaultVariablesFilter(string filterText)
+        {
+            DefaultVariablesFilterText = filterText;
+        }
+
+        internal void ClearDefaultVariablesFilter()
+        {
+            DefaultVariablesFilterText = string.Empty;
+        }
+
+        private void ApplyDefaultVariablesFilter()
+        {
+            if (DefaultVariables == null || DefaultVariables.Variables == null)
+            {
+                FilteredDefaultVariables = new ObservableCollection<Variable>();
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(DefaultVariablesFilterText))
+            {
+                FilteredDefaultVariables = new ObservableCollection<Variable>(DefaultVariables.Variables);
+                return;
+            }
+
+            var query = DefaultVariablesFilterText.Trim();
+            var filtered = DefaultVariables.Variables
+                .Where(variable =>
+                    (!string.IsNullOrWhiteSpace(variable?.Name) && variable.Name.IndexOf(query, StringComparison.OrdinalIgnoreCase) >= 0)
+                    || (!string.IsNullOrWhiteSpace(variable?.Values) && variable.Values.IndexOf(query, StringComparison.OrdinalIgnoreCase) >= 0))
+                .ToList();
+
+            FilteredDefaultVariables = new ObservableCollection<Variable>(filtered);
         }
 
         internal void RemoveProfile(ProfileVariablesSet profile)

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
@@ -328,19 +328,30 @@ namespace EnvironmentVariablesUILib.ViewModels
                 return;
             }
 
+            Variable targetVariable = original;
+            if (isProfileVariable)
+            {
+                targetVariable = ResolveProfileVariable(variablesSet?.Variables, original);
+                if (targetVariable == null)
+                {
+                    LoggerInstance.Logger.LogError("Invalid edit: cannot resolve owning profile variable.");
+                    return;
+                }
+            }
+
             bool propagateChange = !isProfileVariable || variablesSet.Id.Equals(AppliedProfile?.Id);
-            var originalName = (original.Name ?? string.Empty).Trim();
+            var originalName = (targetVariable.Name ?? string.Empty).Trim();
             var editedName = (edited.Name ?? string.Empty).Trim();
-            bool changed = !string.Equals(originalName, editedName, StringComparison.OrdinalIgnoreCase) || original.Values != edited.Values;
+            bool changed = !string.Equals(originalName, editedName, StringComparison.OrdinalIgnoreCase) || !IsEquivalentVariableValue(targetVariable.Values, edited.Values);
             if (changed && string.IsNullOrEmpty(edited.Values))
             {
-                DeleteVariable(original, variablesSet);
+                DeleteVariable(targetVariable, variablesSet);
                 return;
             }
 
             if (changed)
             {
-                var task = original.Update(edited, propagateChange, variablesSet);
+                var task = targetVariable.Update(edited, propagateChange, variablesSet);
                 task.ContinueWith(x =>
                 {
                     _dispatcherQueue.TryEnqueue(() =>
@@ -660,8 +671,20 @@ namespace EnvironmentVariablesUILib.ViewModels
                     return;
                 }
 
+                var targetVariable = ResolveProfileVariable(profile.Variables, variable);
+                if (targetVariable == null)
+                {
+                    LoggerInstance.Logger.LogError("Invalid delete: unable to resolve owning profile variable.");
+                    return;
+                }
+
                 // Profile variable
-                profile.Variables.Remove(variable);
+                var removed = profile.Variables.Remove(targetVariable);
+                if (!removed)
+                {
+                    LoggerInstance.Logger.LogError("Failed to remove profile variable from profile list.");
+                    return;
+                }
 
                 if (!profile.IsEnabled)
                 {
@@ -703,6 +726,39 @@ namespace EnvironmentVariablesUILib.ViewModels
                     });
                 });
             }
+        }
+
+        private static Variable ResolveProfileVariable(ObservableCollection<Variable> variables, Variable target)
+        {
+            if (variables == null || target == null)
+            {
+                return null;
+            }
+
+            var exactMatch = variables.FirstOrDefault(x => ReferenceEquals(x, target));
+            if (exactMatch != null)
+            {
+                return exactMatch;
+            }
+
+            var normalizedName = (target.Name ?? string.Empty).Trim();
+            return variables
+                .Where(x => x != null && string.Equals((x.Name ?? string.Empty).Trim(), normalizedName, StringComparison.OrdinalIgnoreCase))
+                .Where(x => IsEquivalentVariableValue(x?.Values, target.Values))
+                .FirstOrDefault();
+        }
+
+        private static bool IsEquivalentVariableValue(string candidateValue, string compareValue)
+        {
+            var candidate = candidateValue ?? string.Empty;
+            var compare = compareValue ?? string.Empty;
+            var expandedCandidate = Environment.ExpandEnvironmentVariables(candidate);
+            var expandedCompare = Environment.ExpandEnvironmentVariables(compare);
+
+            return string.Equals(candidate, compare, StringComparison.Ordinal) ||
+                string.Equals(expandedCandidate, compare, StringComparison.Ordinal) ||
+                string.Equals(candidate, expandedCompare, StringComparison.Ordinal) ||
+                string.Equals(expandedCandidate, expandedCompare, StringComparison.Ordinal);
         }
     }
 }

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
@@ -562,7 +562,7 @@ namespace EnvironmentVariablesUILib.ViewModels
             }
 
             var deduped = cleanedVariables
-                .GroupBy(variable => $"{variable.Name?.ToUpperInvariant()}|{variable.Values}|{variable.ParentType}")
+                .GroupBy(variable => $"{variable.Name?.Trim().ToUpperInvariant()}")
                 .Select(group => group.First())
                 .ToList();
 

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
@@ -103,6 +103,7 @@ namespace EnvironmentVariablesUILib.ViewModels
                 var profiles = _environmentVariablesService.ReadProfiles();
                 foreach (var profile in profiles)
                 {
+                    DeduplicateProfileVariables(profile);
                     profile.PropertyChanged += Profile_PropertyChanged;
 
                     foreach (var variable in profile.Variables)
@@ -238,6 +239,7 @@ namespace EnvironmentVariablesUILib.ViewModels
 
         internal void AddProfile(ProfileVariablesSet profile)
         {
+            DeduplicateProfileVariables(profile);
             profile.PropertyChanged += Profile_PropertyChanged;
             if (profile.IsEnabled)
             {
@@ -255,6 +257,7 @@ namespace EnvironmentVariablesUILib.ViewModels
             var existingProfile = Profiles.Where(x => x.Id == updatedProfile.Id).FirstOrDefault();
             if (existingProfile != null)
             {
+                DeduplicateProfileVariables(updatedProfile);
                 if (updatedProfile.IsEnabled)
                 {
                     // Let's unset the profile before applying the update. Even if this one is the one that's currently set.
@@ -353,6 +356,30 @@ namespace EnvironmentVariablesUILib.ViewModels
                 AppliedProfile.IsEnabled = false;
                 AppliedProfile = null;
                 appliedProfile.PropertyChanged += Profile_PropertyChanged;
+            }
+        }
+
+        private static void DeduplicateProfileVariables(ProfileVariablesSet profile)
+        {
+            if (profile?.Variables == null)
+            {
+                return;
+            }
+
+            var deduped = profile.Variables
+                .Where(variable => !string.IsNullOrWhiteSpace(variable?.Name))
+                .GroupBy(variable => variable.Name, StringComparer.OrdinalIgnoreCase)
+                .Select(group => group.First())
+                .ToList();
+
+            if (deduped.Count != profile.Variables.Count)
+            {
+                profile.Variables = new ObservableCollection<Variable>(deduped);
+
+                foreach (var variable in profile.Variables)
+                {
+                    variable.ParentType = VariablesSetType.Profile;
+                }
             }
         }
 

--- a/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariablesUILib/ViewModels/MainViewModel.cs
@@ -248,13 +248,36 @@ namespace EnvironmentVariablesUILib.ViewModels
                 return;
             }
 
+            if (type != VariablesSetType.User && type != VariablesSetType.System)
+            {
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(variable.Name) || !variable.Valid)
+            {
+                return;
+            }
+
+            variable.Name = variable.Name.Trim();
+            variable.ParentType = type;
+
             if (type == VariablesSetType.User)
             {
+                if (UserDefaultSet.Variables != null && UserDefaultSet.Variables.Any(x => string.Equals(x?.Name, variable.Name, StringComparison.OrdinalIgnoreCase)))
+                {
+                    return;
+                }
+
                 UserDefaultSet.Variables.Add(variable);
                 UserDefaultSet.Variables = new ObservableCollection<Variable>(UserDefaultSet.Variables.OrderBy(x => x.Name).ToList());
             }
             else if (type == VariablesSetType.System)
             {
+                if (SystemDefaultSet.Variables != null && SystemDefaultSet.Variables.Any(x => string.Equals(x?.Name, variable.Name, StringComparison.OrdinalIgnoreCase)))
+                {
+                    return;
+                }
+
                 SystemDefaultSet.Variables.Add(variable);
                 SystemDefaultSet.Variables = new ObservableCollection<Variable>(SystemDefaultSet.Variables.OrderBy(x => x.Name).ToList());
             }


### PR DESCRIPTION
## Summary
- Improve profile load fallback behavior in `EnvironmentVariablesService` so both missing profile store and empty profile JSON files fallback to the latest valid backup, including restoration of the backup file for consistency.
- Add `AddVariableDialog` resiliency for issue #30659 (Environment Variables: cannot copy-paste values while creating profiles): keep the add-variable content dialog from being closed by focus loss (`IsLightDismissEnabled="False"`) and auto-focus the variable-name field when opened.

## Validation
- Changes are scoped to the Environment Variables module and do not alter runtime behavior when valid profile JSON is available.
- Manual scenario coverage to validate:
  - `profiles.json` missing/empty -> latest `.bak` is selected and restored.
  - Opening add-variable dialog, switching to another app to copy text, and returning to paste value without dialog dismissal.

## Related
- Target issue: https://github.com/microsoft/PowerToys/issues/30659
