### PR TITLE
chore(cmdpal-sdk): log extension host forwarding failures

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.Common/Helpers/ExtensionHostInstance.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Common/Helpers/ExtensionHostInstance.cs
@@ -2,6 +2,8 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
+
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 
@@ -30,8 +32,9 @@ public partial class ExtensionHostInstance
                 {
                     await Host.LogMessage(message);
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
+                    LogHostForwardingFailure("Failed to send log message to extension host.", ex);
                 }
             });
         }
@@ -53,8 +56,9 @@ public partial class ExtensionHostInstance
                 {
                     await Host.ShowStatus(message, context);
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
+                    LogHostForwardingFailure("Failed to send show status message to extension host.", ex);
                 }
             });
         }
@@ -70,10 +74,16 @@ public partial class ExtensionHostInstance
                 {
                     await Host.HideStatus(message);
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
+                    LogHostForwardingFailure("Failed to send hide status message to extension host.", ex);
                 }
             });
         }
+    }
+
+    private static void LogHostForwardingFailure(string message, Exception ex)
+    {
+        Trace.WriteLine($"[CmdPal][ExtensionHostInstance] {message} ({ex.GetType().Name}): {ex.Message}");
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.Common/Services/ApplicationInfoService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Common/Services/ApplicationInfoService.cs
@@ -148,8 +148,9 @@ public sealed class ApplicationInfoService : IApplicationInfoService
             var isElevated = new WindowsPrincipal(WindowsIdentity.GetCurrent()).IsInRole(WindowsBuiltInRole.Administrator);
             return isElevated;
         }
-        catch (Exception)
+        catch (Exception ex)
         {
+            CoreLogger.LogError("Failed to determine process elevation status", ex);
             return false;
         }
     }

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/ExtensionHost.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/ExtensionHost.cs
@@ -2,6 +2,8 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
+
 namespace Microsoft.CommandPalette.Extensions.Toolkit;
 
 public partial class ExtensionHost
@@ -17,6 +19,11 @@ public partial class ExtensionHost
     /// the host app is gone.
     /// </summary>
     /// <param name="message">The log message to send</param>
+    private static void LogHostForwardingFailure(string message, Exception ex)
+    {
+        Trace.WriteLine($"CmdPal extension host forwarding failed: {message}\n{ex}");
+    }
+
     public static void LogMessage(ILogMessage message)
     {
         if (Host is not null)
@@ -27,8 +34,9 @@ public partial class ExtensionHost
                 {
                     await Host.LogMessage(message);
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
+                    LogHostForwardingFailure("LogMessage", ex);
                 }
             });
         }
@@ -50,8 +58,9 @@ public partial class ExtensionHost
                 {
                     await Host.ShowStatus(message, context);
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
+                    LogHostForwardingFailure("ShowStatus", ex);
                 }
             });
         }
@@ -67,8 +76,9 @@ public partial class ExtensionHost
                 {
                     await Host.HideStatus(message);
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
+                    LogHostForwardingFailure("HideStatus", ex);
                 }
             });
         }


### PR DESCRIPTION
### Summary
- Log exceptions when forwarding extension host messages instead of swallowing failures.
- Added diagnostics logging to LogMessage, ShowStatus, and HideStatus paths in ExtensionHost.
- Kept behavior unchanged besides observability to aid debugging and reduce silent failures.

### Testing
- None run (code-only change, no functional behavior change).
