### PR TITLE
Cancel stale Quick Accent toolbar render timer

### DIFF
--- a/src/modules/poweraccent/PowerAccent.Core/PowerAccent.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/PowerAccent.cs
@@ -22,6 +22,7 @@ public partial class PowerAccent : IDisposable
     private const double ScreenMinPadding = 150;
 
     private bool _visible;
+    private int _showGeneration;
     private string[] _characters = Array.Empty<string>();
     private string[] _characterDescriptions = Array.Empty<string>();
     private int _selectedIndex = -1;
@@ -98,6 +99,10 @@ public partial class PowerAccent : IDisposable
         _initialShiftState = WindowsFunctions.IsShiftState();
         _visible = true;
 
+        // Each summon gets a generation id so a delayed render queued by an earlier
+        // press can't fire for a newer one (or after the toolbar was hidden).
+        int generation = ++_showGeneration;
+
         _characters = GetCharacters(letterKey);
         _characterDescriptions = GetCharacterDescriptions(_characters);
         _showUnicodeDescription = _settingService.ShowUnicodeDescription;
@@ -105,7 +110,7 @@ public partial class PowerAccent : IDisposable
         Task.Delay(_settingService.InputTime).ContinueWith(
         t =>
         {
-            if (_visible)
+            if (_visible && generation == _showGeneration)
             {
                 OnChangeDisplay?.Invoke(true, _characters);
             }
@@ -237,6 +242,7 @@ public partial class PowerAccent : IDisposable
         OnChangeDisplay?.Invoke(false, null);
         _selectedIndex = -1;
         _visible = false;
+        _showGeneration++;
     }
 
     private void ProcessNextChar(TriggerKey triggerKey, bool shiftPressed)


### PR DESCRIPTION
## Summary

Quick Accent's ShowToolbar queues a delayed render of the accent menu through Task.Delay(...).ContinueWith(...). The continuation only checked _visible before rendering, so a timer started by an earlier key press could still fire for a **newer** summon — or one that had already been hidden — popping the accent menu earlier than the configured delay intended.

This was surfaced while reviewing the press-and-hold work in #48937, but it is a pre-existing race independent of that feature, so it ships on its own.

## Fix

- Tag each `ShowToolbar` summon with an incrementing `_showGeneration` id and capture it in the local closure.
- The delayed continuation now renders only when it is still the most recent summon (`generation == _showGeneration`) **and** `_visible`.
- Bump the generation when the toolbar hides, so any in-flight timer queued before the hide is cancelled.

Everything runs on the UI thread (the dispatcher marshals `ShowToolbar`/hide and the continuation uses `FromCurrentSynchronizationContext`), so the counter needs no locking.

## Validation

- Built `PowerAccent.UI` (C++ hook + Core) Debug|x64 — 0 warnings, 0 errors.
- Manual: rapid repeated taps of an accent-capable letter no longer flash the menu early from a leftover timer; normal hold-to-open and navigation/commit are unchanged.