### PR TITLE
TransparentWindow: opt-in Esc / focus-lost dismiss + multi-surface docs

### DIFF
--- a/src/common/Common.UI.Controls/Window/TransparentWindow/TransparentWindow.cs
+++ b/src/common/Common.UI.Controls/Window/TransparentWindow/TransparentWindow.cs
@@ -5,6 +5,8 @@
 using System.Runtime.InteropServices;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Windowing;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Input;
 using Windows.Foundation;
 using WinUIEx;
 
@@ -37,6 +39,18 @@ namespace Microsoft.PowerToys.Common.UI.Controls.Window;
 /// <see cref="Microsoft.UI.Windowing.AppWindow.Hide"/> is delayed until the
 /// content has finished animating out. With no listener the window simply shows
 /// or hides immediately.</para>
+/// <para><b>Multiple surfaces.</b> More than one <see cref="TransientSurface"/>
+/// may host on the same window by each calling
+/// <see cref="TransientSurface.SubscribeTo"/>. The <see cref="Showing"/> and
+/// <see cref="Hiding"/> events are simply raised for every subscriber, and
+/// because <see cref="HidingEventArgs"/> aggregates deferrals the underlying
+/// window is hidden only after <em>all</em> surfaces have finished animating
+/// out. To let each surface play its own distinct transition, call the
+/// parameterless <see cref="Show()"/> (so every surface uses its configured
+/// <c>ShowTransition</c>/<c>HideTransition</c>); the <see cref="Show(Transition)"/>
+/// overload instead broadcasts a single transition to all surfaces. Sizing the
+/// window and positioning each surface within it remain the consumer's
+/// responsibility (this window owns no layout).</para>
 /// </remarks>
 public partial class TransparentWindow : WinUIEx.WindowEx
 {
@@ -51,6 +65,9 @@ public partial class TransparentWindow : WinUIEx.WindowEx
     private const int SwShowNa = 8;
 
     private readonly nint _hwnd;
+
+    private bool _inputHooked;
+    private bool _seenActivated;
 
     public TransparentWindow()
     {
@@ -74,7 +91,29 @@ public partial class TransparentWindow : WinUIEx.WindowEx
         ApplyExStyleBit(WsExToolWindow, true);
 
         SystemBackdrop = new TransparentTintBackdrop();
+
+        Activated += OnActivatedForDismiss;
     }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether pressing <c>Esc</c> while the
+    /// window content has keyboard focus dismisses the window (<see cref="Hide"/>).
+    /// Defaults to <see langword="false"/>. The window is shown without
+    /// activation, so the consumer must activate it for its content to receive
+    /// keyboard input.
+    /// </summary>
+    public bool DismissOnEscape { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the window dismisses itself
+    /// (<see cref="Hide"/>) when it loses focus (is deactivated), i.e. light
+    /// dismiss. Defaults to <see langword="false"/>. Only takes effect after the
+    /// window has been activated at least once since the last <see cref="Show()"/>,
+    /// so the transient deactivation that can occur during the show sequence does
+    /// not dismiss it prematurely. The window is shown without activation, so the
+    /// consumer must activate it for this to apply.
+    /// </summary>
+    public bool DismissOnFocusLost { get; set; }
 
     /// <summary>
     /// Raised (without activation) when <see cref="Show()"/> makes the window
@@ -112,6 +151,8 @@ public partial class TransparentWindow : WinUIEx.WindowEx
             DispatcherQueuePriority.Low,
             () =>
             {
+                _seenActivated = false;
+                EnsureInputHooks();
                 _ = ShowWindow(_hwnd, SwShowNa);
                 Showing?.Invoke(this, new ShowingEventArgs(transition));
             });
@@ -132,6 +173,41 @@ public partial class TransparentWindow : WinUIEx.WindowEx
                 Hiding?.Invoke(this, args);
                 args.RunWhenComplete(AppWindow.Hide);
             });
+    }
+
+    private void OnActivatedForDismiss(object sender, WindowActivatedEventArgs args)
+    {
+        if (args.WindowActivationState == WindowActivationState.Deactivated)
+        {
+            if (DismissOnFocusLost && _seenActivated)
+            {
+                Hide();
+            }
+
+            return;
+        }
+
+        _seenActivated = true;
+    }
+
+    private void EnsureInputHooks()
+    {
+        if (_inputHooked || Content is not UIElement element)
+        {
+            return;
+        }
+
+        element.KeyDown += OnContentKeyDown;
+        _inputHooked = true;
+    }
+
+    private void OnContentKeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        if (DismissOnEscape && e.Key == global::Windows.System.VirtualKey.Escape)
+        {
+            e.Handled = true;
+            Hide();
+        }
     }
 
     private void ApplyExStyleBit(int bit, bool set)


### PR DESCRIPTION
## Summary

Hardens the shared `TransparentWindow` (in `src/common/Common.UI.Controls/`) with two **opt-in** dismissal behaviors and documents multi-surface hosting. No consumer changes; everything defaults off.

### 1. `DismissOnEscape` (default `false`)
Pressing <kbd>Esc</kbd> while the window content has keyboard focus calls `Hide()`. Input is hooked lazily at show time because `Content` is assigned by the consumer after construction.

### 2. `DismissOnFocusLost` (default `false`)
Light dismiss: hides when the window is deactivated. Guarded by a "seen activated" flag (reset on each `Show()`) so the transient deactivation that can occur during the show sequence doesn't dismiss prematurely. This mirrors the guards that **PowerDisplay** (`_isShowingWindow`) and **Quick Access** (`_hasSeenInteractiveActivation`) currently hand-roll — they can drop their bespoke logic once they derive from `TransparentWindow`.

> Both properties are no-ops unless the consumer activates the window (it shows no-activate / `SW_SHOWNA`).

### 3. Multi-surface hosting (docs only — already works)
Added class `<remarks>` documenting that multiple `TransientSurface`s can `SubscribeTo` one window: `HidingEventArgs` aggregates deferrals so the window hides only after **all** surfaces finish animating out, and plain `Show()` lets each surface play its own configured transition.

## Why no DWM "full-bleed" hardening here
The extra DWM hardening Shortcut Guide uses (NCRENDERING disabled, `DwmExtendFrameIntoClientArea(-1)`, etc.) is only needed for **full-monitor, edge-to-edge** overlays. Content-sized surfaces (Quick Accent, CmdPal Toast) inset their acrylic card behind transparent padding, so any phantom border sits in the transparent margin and is invisible. Applying it universally would add compositing risk for zero benefit, so it's deferred to the Shortcut Guide refactor (where it's actually exercised) as an opt-in.

## Testing
- `Common.UI.Controls` builds clean (Debug/x64).
- Behavior is opt-in and off by default, so existing consumers are unaffected.