### PR TITLE
CmdPal: Ensure that directory paths passed from Bookmarks is quoted

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.Common/Helpers/ShellArgumentBuilder.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Common/Helpers/ShellArgumentBuilder.cs
@@ -1,0 +1,98 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text;
+
+namespace Microsoft.CmdPal.Common.Helpers;
+
+public static class ShellArgumentBuilder
+{
+    public static string BuildArguments(params string[] arguments)
+    {
+        if (arguments.Length <= 0)
+        {
+            return string.Empty;
+        }
+
+        var stringBuilder = new StringBuilder();
+        foreach (var argument in arguments)
+        {
+            AppendArgument(stringBuilder, argument);
+        }
+
+        return stringBuilder.ToString();
+    }
+
+    private static void AppendArgument(StringBuilder stringBuilder, string argument)
+    {
+        if (stringBuilder.Length > 0)
+        {
+            stringBuilder.Append(' ');
+        }
+
+        if (argument.Length == 0 || ShouldBeQuoted(argument))
+        {
+            stringBuilder.Append('"');
+            var index = 0;
+            while (index < argument.Length)
+            {
+                var c = argument[index++];
+                if (c == '\\')
+                {
+                    var numBackSlash = 1;
+                    while (index < argument.Length && argument[index] == '\\')
+                    {
+                        index++;
+                        numBackSlash++;
+                    }
+
+                    if (index == argument.Length)
+                    {
+                        stringBuilder.Append('\\', numBackSlash * 2);
+                    }
+                    else if (argument[index] == '"')
+                    {
+                        stringBuilder.Append('\\', (numBackSlash * 2) + 1);
+                        stringBuilder.Append('"');
+                        index++;
+                    }
+                    else
+                    {
+                        stringBuilder.Append('\\', numBackSlash);
+                    }
+
+                    continue;
+                }
+
+                if (c == '"')
+                {
+                    stringBuilder.Append('\\');
+                    stringBuilder.Append('"');
+                    continue;
+                }
+
+                stringBuilder.Append(c);
+            }
+
+            stringBuilder.Append('"');
+        }
+        else
+        {
+            stringBuilder.Append(argument);
+        }
+    }
+
+    private static bool ShouldBeQuoted(string argument)
+    {
+        foreach (var c in argument)
+        {
+            if (char.IsWhiteSpace(c) || c == '"')
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Common.UnitTests/Helpers/ShellArgumentBuilderTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Common.UnitTests/Helpers/ShellArgumentBuilderTests.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CmdPal.Common.Helpers;
+
+namespace Microsoft.CmdPal.Common.UnitTests.Helpers;
+
+[TestClass]
+public class ShellArgumentBuilderTests
+{
+    [DataTestMethod]
+    [DataRow("plain", "plain")]
+    [DataRow("C:\\Program Files\\PowerToys", "\"C:\\Program Files\\PowerToys\"")]
+    [DataRow("say \"hello\"", "\"say \\\"hello\\\"\"")]
+    [DataRow("", "\"\"")]
+    [DataRow("C:\\Program Files\\", "\"C:\\Program Files\\\\\"")]
+    public void BuildArguments_FormatsSingleArgument(string argument, string expected)
+    {
+        var actual = ShellArgumentBuilder.BuildArguments(argument);
+
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void BuildArguments_FormatsMultipleArguments()
+    {
+        var actual = ShellArgumentBuilder.BuildArguments("plain", "C:\\Program Files\\PowerToys", "two words");
+
+        Assert.AreEqual("plain \"C:\\Program Files\\PowerToys\" \"two words\"", actual);
+    }
+}

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Bookmark/Helpers/CommandLauncher.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Bookmark/Helpers/CommandLauncher.cs
@@ -5,6 +5,7 @@
 using System.ComponentModel;
 using System.Runtime.InteropServices;
 using ManagedCommon;
+using Microsoft.CmdPal.Common.Helpers;
 
 namespace Microsoft.CmdPal.Ext.Bookmarks.Helpers;
 
@@ -24,7 +25,7 @@ internal static class CommandLauncher
                 // You can notice the difference with Recycle Bin for example:
                 // - "explorer ::{645FF040-5081-101B-9F08-00AA002F954E}"
                 // - "::{645FF040-5081-101B-9F08-00AA002F954E}"
-                return ShellHelpers.OpenInShell("explorer.exe", classification.Target);
+                return ShellHelpers.OpenInShell("explorer.exe", ShellArgumentBuilder.BuildArguments(classification.Target));
 
             case LaunchMethod.ActivateAppId:
                 return ActivateAppId(classification.Target, classification.Arguments);

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Bookmark/Microsoft.CmdPal.Ext.Bookmarks.csproj
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Bookmark/Microsoft.CmdPal.Ext.Bookmarks.csproj
@@ -11,6 +11,7 @@
     <ProjectPriFileName>Microsoft.CmdPal.Ext.Bookmarks.pri</ProjectPriFileName>
   </PropertyGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\Microsoft.CmdPal.Common\Microsoft.CmdPal.Common.csproj" />
     <ProjectReference Include="..\..\extensionsdk\Microsoft.CommandPalette.Extensions.Toolkit\Microsoft.CommandPalette.Extensions.Toolkit.csproj" />
     <ProjectReference Include="..\..\ext\Microsoft.CmdPal.Ext.Indexer\Microsoft.CmdPal.Ext.Indexer.csproj" />
   </ItemGroup>

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Shell/Helpers/ShellListPageHelpers.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Shell/Helpers/ShellListPageHelpers.cs
@@ -2,7 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Text;
+using Microsoft.CmdPal.Common.Helpers;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 
 namespace Microsoft.CmdPal.Ext.Shell.Helpers;
@@ -42,98 +42,7 @@ public class ShellListPageHelpers
         executable = segments[0];
         if (segments.Length > 1)
         {
-            arguments = ArgumentBuilder.BuildArguments(segments[1..]);
-        }
-    }
-
-    private static class ArgumentBuilder
-    {
-        internal static string BuildArguments(string[] arguments)
-        {
-            if (arguments.Length <= 0)
-            {
-                return string.Empty;
-            }
-
-            var stringBuilder = new StringBuilder();
-            foreach (var argument in arguments)
-            {
-                AppendArgument(stringBuilder, argument);
-            }
-
-            return stringBuilder.ToString();
-        }
-
-        private static void AppendArgument(StringBuilder stringBuilder, string argument)
-        {
-            if (stringBuilder.Length > 0)
-            {
-                stringBuilder.Append(' ');
-            }
-
-            if (argument.Length == 0 || ShouldBeQuoted(argument))
-            {
-                stringBuilder.Append('\"');
-                var index = 0;
-                while (index < argument.Length)
-                {
-                    var c = argument[index++];
-                    if (c == '\\')
-                    {
-                        var numBackSlash = 1;
-                        while (index < argument.Length && argument[index] == '\\')
-                        {
-                            index++;
-                            numBackSlash++;
-                        }
-
-                        if (index == argument.Length)
-                        {
-                            stringBuilder.Append('\\', numBackSlash * 2);
-                        }
-                        else if (argument[index] == '\"')
-                        {
-                            stringBuilder.Append('\\', (numBackSlash * 2) + 1);
-                            stringBuilder.Append('\"');
-                            index++;
-                        }
-                        else
-                        {
-                            stringBuilder.Append('\\', numBackSlash);
-                        }
-
-                        continue;
-                    }
-
-                    if (c == '\"')
-                    {
-                        stringBuilder.Append('\\');
-                        stringBuilder.Append('\"');
-                        continue;
-                    }
-
-                    stringBuilder.Append(c);
-                }
-
-                stringBuilder.Append('\"');
-            }
-            else
-            {
-                stringBuilder.Append(argument);
-            }
-        }
-
-        private static bool ShouldBeQuoted(string s)
-        {
-            foreach (var c in s)
-            {
-                if (char.IsWhiteSpace(c) || c == '\"')
-                {
-                    return true;
-                }
-            }
-
-            return false;
+            arguments = ShellArgumentBuilder.BuildArguments(segments[1..]);
         }
     }
 }


### PR DESCRIPTION
This PR ensures that directory paths passed from Bookmarks through `CommandLauncher` to Windows Explorer are properly quoted. In current implementation the directory path that should be opened through Windows Explorer is not quoted and if it contains a space then Explorer will treat it as multiple arguments instead.

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #48672 
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

