### PR TITLE
feat: autocomplete environment variables in CmdPal Run

### DIFF
--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Shell.UnitTests/RunPageTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Shell.UnitTests/RunPageTests.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CmdPal.Common.Services;
 using Microsoft.CmdPal.Ext.Run;
+using Microsoft.CmdPal.Ext.Shell.Helpers;
 using Microsoft.CmdPal.Ext.UnitTestBase;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -85,6 +86,68 @@ public class RunPageTests : CommandPaletteUnitTestBase
             IgnoreInaccessible = true,
         };
         return Directory.EnumerateFileSystemEntries(path, "*", o);
+    }
+
+    private static ScopeExit SetEnvironmentVariableForTest(string name, string value)
+    {
+        var originalValue = Environment.GetEnvironmentVariable(name);
+        Environment.SetEnvironmentVariable(name, value);
+        return new ScopeExit(() => Environment.SetEnvironmentVariable(name, originalValue));
+    }
+
+    [TestMethod]
+    public void TryGetEnvironmentVariableCompletionPrefix_OnlyMatchesUnterminatedTokens()
+    {
+        Assert.IsTrue(ShellListPageHelpers.TryGetEnvironmentVariableCompletionPrefix("%USE", out var tokenStart, out var prefix));
+        Assert.AreEqual(0, tokenStart);
+        Assert.AreEqual("USE", prefix);
+
+        Assert.IsTrue(ShellListPageHelpers.TryGetEnvironmentVariableCompletionPrefix("cmd %use", out tokenStart, out prefix));
+        Assert.AreEqual(4, tokenStart);
+        Assert.AreEqual("use", prefix);
+
+        Assert.IsFalse(ShellListPageHelpers.TryGetEnvironmentVariableCompletionPrefix("%USERPROFILE%", out _, out _));
+        Assert.IsFalse(ShellListPageHelpers.TryGetEnvironmentVariableCompletionPrefix("%", out _, out _));
+        Assert.IsFalse(ShellListPageHelpers.TryGetEnvironmentVariableCompletionPrefix("%%", out _, out _));
+        Assert.IsFalse(ShellListPageHelpers.TryGetEnvironmentVariableCompletionPrefix("C:\\Windows", out _, out _));
+    }
+
+    [TestMethod]
+    public void CompleteEnvironmentVariableToken_ReplacesUnterminatedToken()
+    {
+        var completed = ShellListPageHelpers.CompleteEnvironmentVariableToken("cmd %use", "USERPROFILE");
+
+        Assert.AreEqual("cmd %USERPROFILE%", completed);
+    }
+
+    [TestMethod]
+    public void ExpandEnvironmentVariablesForPath_ExpandsKnownCompletedToken()
+    {
+        const string envName = "CMDPAL_TEST_ENV_EXPAND";
+        var envValue = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        using var cleanup = SetEnvironmentVariableForTest(envName, envValue);
+
+        var expanded = ShellListPageHelpers.ExpandEnvironmentVariablesForPath($"%{envName}%\\Docs");
+        var lowerCaseExpanded = ShellListPageHelpers.ExpandEnvironmentVariablesForPath($"%{envName.ToLowerInvariant()}%\\Docs");
+
+        Assert.AreEqual(envValue + "\\Docs", expanded);
+        Assert.AreEqual(envValue + "\\Docs", lowerCaseExpanded);
+    }
+
+    [TestMethod]
+    public void ExpandEnvironmentVariablesForPath_LeavesUnknownAndEmptyTokensUnchanged()
+    {
+        const string unknownEnvName = "CMDPAL_TEST_ENV_UNKNOWN";
+        const string emptyEnvName = "CMDPAL_TEST_ENV_EMPTY";
+        Environment.SetEnvironmentVariable(unknownEnvName, null);
+        using var cleanup = SetEnvironmentVariableForTest(emptyEnvName, string.Empty);
+
+        var unknownInput = $"%{unknownEnvName}%\\Docs";
+        var emptyInput = $"%{emptyEnvName}%\\Docs";
+
+        Assert.AreEqual(unknownInput, ShellListPageHelpers.ExpandEnvironmentVariablesForPath(unknownInput));
+        Assert.AreEqual(emptyInput, ShellListPageHelpers.ExpandEnvironmentVariablesForPath(emptyInput));
+        Assert.AreEqual("C:\\Windows", ShellListPageHelpers.ExpandEnvironmentVariablesForPath("C:\\Windows"));
     }
 
     [TestMethod]
@@ -286,6 +349,67 @@ public class RunPageTests : CommandPaletteUnitTestBase
 
         var commandList = page.GetItems();
         Assert.IsNotNull(commandList);
+    }
+
+    [TestMethod]
+    public async Task TestEnvironmentVariableAutocompleteSuggestions()
+    {
+        const string envName = "CMDPAL_TEST_ENV_SUGGESTION";
+        using var cleanup = SetEnvironmentVariableForTest(envName, "autocomplete-value");
+
+        var nativeService = CreateMockHistoryService().Object;
+        using var page = new RunListPage(nativeService, telemetryService: null);
+
+        await UpdatePageAndWaitForItems(page, () => { page.SearchText = "%cmdpal_test_env_sugg"; });
+
+        var commandList = page.GetItems();
+        var envItem = commandList.FirstOrDefault(item => item.Title.Equals($"%{envName}%", StringComparison.OrdinalIgnoreCase));
+
+        Assert.IsNotNull(envItem);
+        Assert.AreEqual($"%{envName}%", envItem.TextToSuggest);
+    }
+
+    [TestMethod]
+    public async Task TestCompletedEnvironmentVariableEnumeratesDirectory()
+    {
+        const string envName = "CMDPAL_TEST_ENV_DIRECTORY";
+
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        using var cleanupDir = new ScopeExit(() => Directory.Delete(tempDir, recursive: true));
+        using var cleanupEnv = SetEnvironmentVariableForTest(envName, tempDir);
+
+        var testFile = Path.Combine(tempDir, "child.txt");
+        File.WriteAllText(testFile, "test content");
+        var testDirectory = Path.Combine(tempDir, "Docs");
+        Directory.CreateDirectory(testDirectory);
+
+        var nativeService = CreateMockHistoryService().Object;
+        using var page = new RunListPage(nativeService, telemetryService: null);
+
+        await UpdatePageAndWaitForItems(page, () => { page.SearchText = $"%{envName}%\\"; });
+
+        var commandList = page.GetItems();
+        Assert.AreEqual(2 + ExeItemCount, commandList.Length);
+
+        var childItem = commandList.FirstOrDefault(item => item.Title.Equals("child.txt", StringComparison.OrdinalIgnoreCase));
+        Assert.IsNotNull(childItem);
+        Assert.AreEqual($"%{envName}%\\child.txt", childItem.TextToSuggest);
+    }
+
+    [TestMethod]
+    public async Task TestUnknownEnvironmentVariableDoesNotEnumeratePath()
+    {
+        var envName = "CMDPAL_TEST_ENV_UNKNOWN_" + Guid.NewGuid().ToString("N");
+        Environment.SetEnvironmentVariable(envName, null);
+
+        var nativeService = CreateMockHistoryService().Object;
+        using var page = new RunListPage(nativeService, telemetryService: null);
+
+        await UpdatePageAndWaitForItems(page, () => { page.SearchText = $"%{envName}%\\"; });
+
+        var commandList = page.GetItems();
+        Assert.AreEqual(ExeItemCount, commandList.Length);
     }
 
     [TestMethod]

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Shell/Helpers/ShellListPageHelpers.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Shell/Helpers/ShellListPageHelpers.cs
@@ -2,6 +2,8 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections;
+using System.Text;
 using Microsoft.CmdPal.Common.Helpers;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 
@@ -9,6 +11,129 @@ namespace Microsoft.CmdPal.Ext.Shell.Helpers;
 
 public class ShellListPageHelpers
 {
+    internal static bool TryGetEnvironmentVariableCompletionPrefix(string input, out int tokenStart, out string prefix)
+    {
+        tokenStart = -1;
+        prefix = string.Empty;
+
+        if (string.IsNullOrEmpty(input))
+        {
+            return false;
+        }
+
+        var openTokenStart = -1;
+        for (var i = 0; i < input.Length; i++)
+        {
+            if (input[i] != '%')
+            {
+                continue;
+            }
+
+            if (openTokenStart == -1)
+            {
+                openTokenStart = i;
+            }
+            else
+            {
+                openTokenStart = -1;
+            }
+        }
+
+        if (openTokenStart == -1 || openTokenStart == input.Length - 1)
+        {
+            return false;
+        }
+
+        tokenStart = openTokenStart;
+        prefix = input.Substring(openTokenStart + 1);
+        return true;
+    }
+
+    internal static string CompleteEnvironmentVariableToken(string input, string variableName)
+    {
+        if (string.IsNullOrEmpty(variableName) ||
+            !TryGetEnvironmentVariableCompletionPrefix(input, out var tokenStart, out var _))
+        {
+            return input;
+        }
+
+        return string.Concat(input.AsSpan(0, tokenStart), "%", variableName, "%");
+    }
+
+    internal static string ExpandEnvironmentVariablesForPath(string input)
+    {
+        if (string.IsNullOrEmpty(input))
+        {
+            return input;
+        }
+
+        var expandedInput = new StringBuilder(input.Length);
+        var copiedIndex = 0;
+        var foundExpandableToken = false;
+        var openTokenStart = -1;
+
+        for (var i = 0; i < input.Length; i++)
+        {
+            if (input[i] != '%')
+            {
+                continue;
+            }
+
+            if (openTokenStart == -1)
+            {
+                openTokenStart = i;
+                continue;
+            }
+
+            var variableName = input.Substring(openTokenStart + 1, i - openTokenStart - 1);
+            if (string.IsNullOrEmpty(variableName))
+            {
+                openTokenStart = -1;
+                continue;
+            }
+
+            if (!TryFindEnvironmentVariable(variableName, out var canonicalName, out var variableValue) ||
+                string.IsNullOrEmpty(variableValue))
+            {
+                return input;
+            }
+
+            expandedInput.Append(input, copiedIndex, openTokenStart - copiedIndex);
+            expandedInput.Append('%');
+            expandedInput.Append(canonicalName);
+            expandedInput.Append('%');
+            copiedIndex = i + 1;
+            foundExpandableToken = true;
+            openTokenStart = -1;
+        }
+
+        if (!foundExpandableToken)
+        {
+            return input;
+        }
+
+        expandedInput.Append(input, copiedIndex, input.Length - copiedIndex);
+        return Environment.ExpandEnvironmentVariables(expandedInput.ToString());
+    }
+
+    private static bool TryFindEnvironmentVariable(string variableName, out string canonicalName, out string? variableValue)
+    {
+        foreach (DictionaryEntry variable in Environment.GetEnvironmentVariables())
+        {
+            if (variable.Key is string name &&
+                name.Equals(variableName, StringComparison.OrdinalIgnoreCase))
+            {
+                canonicalName = name;
+                variableValue = variable.Value as string;
+                return true;
+            }
+        }
+
+        canonicalName = string.Empty;
+        variableValue = null;
+        return false;
+    }
+
     internal static bool FileExistInPath(string filename)
     {
         return FileExistInPath(filename, out var _);

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Shell/Run/RunListPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Shell/Run/RunListPage.cs
@@ -2,10 +2,12 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Microsoft.CmdPal.Common.Services;
 using Microsoft.CmdPal.Ext.Shell;
+using Microsoft.CmdPal.Ext.Shell.Helpers;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 using Windows.Foundation.Collections;
@@ -57,11 +59,14 @@ public sealed partial class RunListPage : AsyncDynamicListPage
 
     private readonly Dictionary<string, RunExeItem> _currentPathItems = new();
     private readonly List<ListItem> _pathItems = [];
+    private readonly List<ListItem> _environmentVariableItems = [];
     private ListItem? _exeItem;
 
     private bool _loadedInitialHistory;
 
     private string _currentSubdir = string.Empty;
+    private string _currentTextToSuggestDirectory = string.Empty;
+    private bool _currentWithLeadingTilde;
 
     public RunListPage(
         IRunHistoryService runHistoryService,
@@ -104,10 +109,7 @@ public sealed partial class RunListPage : AsyncDynamicListPage
             correctedSearchText = string.Concat(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), searchText.AsSpan(1));
         }
 
-        // Previously, we were expanding environment variables before searching
-        // the filesystem. Now that we're using the IACListISF, we don't need to
-        // do that ourselves - it will handle it for us.
-        var expanded = correctedSearchText;
+        var expanded = ShellListPageHelpers.ExpandEnvironmentVariablesForPath(correctedSearchText);
 
         // Check for cancellation after environment expansion
         if (cancellationToken.IsCancellationRequested)
@@ -120,10 +122,15 @@ public sealed partial class RunListPage : AsyncDynamicListPage
         if (string.IsNullOrEmpty(searchText) || string.IsNullOrWhiteSpace(searchText))
         {
             _pathItems.Clear();
+            _environmentVariableItems.Clear();
             _currentHistoryItems.Clear();
             _currentHistoryItems.AddRange(_historyItems.Values);
             return;
         }
+
+        ListHelpers.InPlaceUpdateList(
+            _environmentVariableItems,
+            BuildEnvironmentVariableItems(searchText));
 
         var couldResolvePath = false;
         var isFile = false;
@@ -293,11 +300,13 @@ public sealed partial class RunListPage : AsyncDynamicListPage
         bool withLeadingTilde,
         CancellationToken cancellationToken)
     {
+        var browsingSearchText = ShellListPageHelpers.ExpandEnvironmentVariablesForPath(searchText);
+
         // The way AutoComplete handles "expanding" paths means passing the
         // entire string up to the last slash as the query to autocomplete on.
         //
         // we'll replicate that here
-        var lastSlash = searchText.LastIndexOfAny(['\\', '/']);
+        var lastSlash = browsingSearchText.LastIndexOfAny(['\\', '/']);
 
         // If the search text has no path separator (e.g. bare "c:"), there's
         // nothing to browse — RunDlg only enumerates directory contents when
@@ -308,7 +317,7 @@ public sealed partial class RunListPage : AsyncDynamicListPage
             return;
         }
 
-        var directoryPath = searchText.Substring(0, lastSlash);
+        var directoryPath = browsingSearchText.Substring(0, lastSlash);
 
         // AutoComplete is crazy, and will just append the child items to a full
         // path, without inserting a \. So you'll get things like
@@ -320,6 +329,8 @@ public sealed partial class RunListPage : AsyncDynamicListPage
             directoryPath += Path.DirectorySeparatorChar;
         }
 
+        var textToSuggestDirectoryPath = GetTextToSuggestDirectoryPath(searchText, browsingSearchText);
+
         // Check for cancellation before directory operations
         if (cancellationToken.IsCancellationRequested)
         {
@@ -330,7 +341,9 @@ public sealed partial class RunListPage : AsyncDynamicListPage
         {
             { "fullFilePath", fullFilePath },
             { "searchText", searchText },
+            { "browsingSearchText", browsingSearchText },
             { "directoryPath", directoryPath },
+            { "textToSuggestDirectoryPath", textToSuggestDirectoryPath ?? string.Empty },
         });
 
         // Check for cancellation before file system enumeration
@@ -341,9 +354,11 @@ public sealed partial class RunListPage : AsyncDynamicListPage
 
         // If the directory we're in changed, then first rebuild the cache
         // of all the items in the directory, _then_ filter them below.
-        if (!_currentSubdir.Equals(directoryPath, StringComparison.OrdinalIgnoreCase))
+        if (!_currentSubdir.Equals(directoryPath, StringComparison.OrdinalIgnoreCase) ||
+            _currentWithLeadingTilde != withLeadingTilde ||
+            !_currentTextToSuggestDirectory.Equals(textToSuggestDirectoryPath ?? string.Empty, StringComparison.Ordinal))
         {
-            var succeededWithoutBeingCancelled = await ChangeDirectory(directoryPath, withLeadingTilde, cancellationToken);
+            var succeededWithoutBeingCancelled = await ChangeDirectory(directoryPath, withLeadingTilde, textToSuggestDirectoryPath, cancellationToken);
             if (!succeededWithoutBeingCancelled)
             {
                 return;
@@ -356,7 +371,7 @@ public sealed partial class RunListPage : AsyncDynamicListPage
         // would lose the user's filter text — e.g. "c:\Windows\." resolves
         // to "c:\Windows", losing the "." prefix filter.
         var newMatchedPathItems = FilterCurrentDirectoryFiles(
-            searchText,
+            browsingSearchText,
             directoryPath,
             _currentSubdir,
             _currentPathItems.AsReadOnly(),
@@ -437,6 +452,28 @@ public sealed partial class RunListPage : AsyncDynamicListPage
         return haystack.StartsWith(needle, StringComparison.InvariantCultureIgnoreCase);
     }
 
+    private static string? GetTextToSuggestDirectoryPath(string searchText, string browsingSearchText)
+    {
+        if (searchText.Equals(browsingSearchText, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        var lastSlash = searchText.LastIndexOfAny(['\\', '/']);
+        if (lastSlash < 0)
+        {
+            return null;
+        }
+
+        var directoryPath = searchText.Substring(0, lastSlash);
+        if (!directoryPath.EndsWith(Path.DirectorySeparatorChar))
+        {
+            directoryPath += Path.DirectorySeparatorChar;
+        }
+
+        return directoryPath;
+    }
+
     /// <summary>
     /// Change the current directory that we are browsing to the specified
     /// directory. This will rebuild the cache of items in _currentPathItems,
@@ -444,10 +481,12 @@ public sealed partial class RunListPage : AsyncDynamicListPage
     /// It will also update _currentSubdir to the new path.
     ///
     /// Returns true if the directory change was successful, false if it was cancelled.
-    /// <param name="directoryPath">The path of the directory to change to.</param>
-    /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
     /// </summary>
-    private async Task<bool> ChangeDirectory(string directoryPath, bool withLeadingTilde, CancellationToken cancellationToken)
+    /// <param name="directoryPath">The path of the directory to change to.</param>
+    /// <param name="withLeadingTilde">Whether the user's input started with a tilde.</param>
+    /// <param name="textToSuggestDirectoryPath">The original directory prefix to use for suggestions.</param>
+    /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
+    private async Task<bool> ChangeDirectory(string directoryPath, bool withLeadingTilde, string? textToSuggestDirectoryPath, CancellationToken cancellationToken)
     {
         _telemetryService?.LogEvent("CreatePathItems_ChangedDirectory", new PropertySet()
         {
@@ -460,7 +499,8 @@ public sealed partial class RunListPage : AsyncDynamicListPage
             withLeadingTilde,
             _historyService,
             _telemetryService,
-            cancellationToken);
+            cancellationToken,
+            textToSuggestDirectoryPath);
 
         if (newPathItems is null)
         {
@@ -476,6 +516,8 @@ public sealed partial class RunListPage : AsyncDynamicListPage
         // Add the commands to the list
         _pathItems.Clear();
         _currentSubdir = directoryPath;
+        _currentTextToSuggestDirectory = textToSuggestDirectoryPath ?? string.Empty;
+        _currentWithLeadingTilde = withLeadingTilde;
         _currentPathItems.Clear();
         foreach ((var k, var v) in newPathItems)
         {
@@ -493,15 +535,19 @@ public sealed partial class RunListPage : AsyncDynamicListPage
     /// ACListISF API, which is what powers the AutoComplete in RunDlg.
     /// </summary>
     /// <param name="directoryPath">The path of the directory to build items for.</param>
+    /// <param name="withLeadingTilde">Whether the user's input started with a tilde.</param>
+    /// <param name="historyService">The run history service.</param>
     /// <param name="telemetryService">An optional telemetry service for logging events.</param>
     /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
+    /// <param name="textToSuggestDirectoryPath">The original directory prefix to use for suggestions.</param>
     /// <returns>A dictionary mapping file names to ListItems, or null if cancelled.</returns>
     internal static async Task<Dictionary<string, RunExeItem>?> BuildItemsForDirectory(
         string directoryPath,
         bool withLeadingTilde,
         IRunHistoryService historyService,
         ITelemetryService? telemetryService,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        string? textToSuggestDirectoryPath = null)
     {
         // Get all the files in the directory.
         // Run this on the OLE STA thread, because GetSuggestions needs OLE to work.
@@ -524,7 +570,12 @@ public sealed partial class RunListPage : AsyncDynamicListPage
         foreach (var f in files)
         {
             var textToSuggest = f;
-            if (withLeadingTilde)
+            if (!string.IsNullOrEmpty(textToSuggestDirectoryPath) &&
+                f.StartsWith(directoryPath, StringComparison.OrdinalIgnoreCase))
+            {
+                textToSuggest = string.Concat(textToSuggestDirectoryPath, f.AsSpan(directoryPath.Length));
+            }
+            else if (withLeadingTilde)
             {
                 var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
                 if (textToSuggest.StartsWith(userProfile, StringComparison.OrdinalIgnoreCase))
@@ -543,6 +594,44 @@ public sealed partial class RunListPage : AsyncDynamicListPage
         }
 
         return newPathItems;
+    }
+
+    private static List<ListItem> BuildEnvironmentVariableItems(string searchText)
+    {
+        if (!ShellListPageHelpers.TryGetEnvironmentVariableCompletionPrefix(searchText, out var _, out var prefix))
+        {
+            return [];
+        }
+
+        var variableNames = new List<string>();
+        var seenVariables = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (DictionaryEntry variable in Environment.GetEnvironmentVariables())
+        {
+            if (variable.Key is not string variableName ||
+                !variableName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) ||
+                !seenVariables.Add(variableName))
+            {
+                continue;
+            }
+
+            variableNames.Add(variableName);
+        }
+
+        variableNames.Sort(StringComparer.OrdinalIgnoreCase);
+
+        var items = new List<ListItem>(variableNames.Count);
+        foreach (var variableName in variableNames)
+        {
+            var variableToken = $"%{variableName}%";
+            items.Add(new ListItem()
+            {
+                Title = variableToken,
+                Subtitle = Environment.GetEnvironmentVariable(variableName) ?? string.Empty,
+                TextToSuggest = ShellListPageHelpers.CompleteEnvironmentVariableToken(searchText, variableName),
+            });
+        }
+
+        return items;
     }
 
     private void FilterHistoryItems(string newSearch, string searchText)
@@ -611,6 +700,7 @@ public sealed partial class RunListPage : AsyncDynamicListPage
 
         var totalCount =
             (_exeItem is not null ? 1 : 0) +
+            _environmentVariableItems.Count +
             _currentHistoryItems.Count +
             _pathItems.Count
             ;
@@ -621,6 +711,11 @@ public sealed partial class RunListPage : AsyncDynamicListPage
         if (_exeItem is not null)
         {
             combined[index++] = _exeItem;
+        }
+
+        for (var i = 0; i < _environmentVariableItems.Count; i++)
+        {
+            combined[index++] = _environmentVariableItems[i];
         }
 
         for (var i = 0; i < _currentHistoryItems.Count; i++)


### PR DESCRIPTION
## Summary of the Pull Request

Adds environment-variable autocomplete to the CmdPal Run page. Type `%USE` and the suggestion list now offers `%USERPROFILE%`, `%USERNAME%`, and so on; pick one and it completes the `%VAR%` token in the input box. A fully typed `%USERPROFILE%\` now resolves to the real directory so its children show up as path suggestions.

## PR Checklist

- [x] Closes: #44978
- [x] **Communication:** I've discussed this with core contributors already.
- [x] **Tests:** Added/updated and all pass
- [x] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
- [x] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects

## Detailed Description of the Pull Request / Additional comments

@zadjii-msft, you scoped #44978 down to just the env-var autocomplete half back in June (the path-expansion half being covered by #38877), so that is what this targets.

The token logic lives in three small static helpers in `ShellListPageHelpers` so it is testable without spinning up the WinUI page. `TryGetEnvironmentVariableCompletionPrefix` finds an unterminated `%` token like `%USE` and returns the prefix; it deliberately ignores a closed token such as `%USERPROFILE%` and a lone `%`, so it only fires while you are mid-typing. `CompleteEnvironmentVariableToken` turns that open token into a full `%VAR%` for the `TextToSuggest` value. `ExpandEnvironmentVariablesForPath` expands a closed token when resolving the current directory, and leaves the input untouched when the variable is unknown or empty, so a token like `%NOPE%\` does not enumerate a garbage path.

`RunListPage` ties these together. An open token produces one env suggestion per matching variable, and a closed token gets expanded before the directory is enumerated. Matching is case-insensitive throughout.

## Validation Steps Performed

Coverage lives in `RunPageTests.cs`. The prefix detection is verified so that open tokens match while closed tokens, a lone `%`, a `%%`, and plain paths do not. Typing a partial name is verified to surface the matching `%VAR%` with the correct `TextToSuggest`, and a completed token followed by a trailing slash is verified to enumerate the real directory's children. An unknown variable is verified to produce no file enumeration and to not throw, and the expansion helper is verified to expand known tokens case-insensitively while leaving unknown or empty tokens unchanged.

Closes #44978
