### PR TITLE
feat: setting for graph icons on CmdPal performance monitor bands

### DIFF
--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/DevHome/Helpers/ChartHelper.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/DevHome/Helpers/ChartHelper.cs
@@ -2,10 +2,13 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
 using System.Xml.Linq;
+using Windows.Graphics.Imaging;
+using Windows.Storage.Streams;
 
 namespace CoreWidgetProvider.Helpers;
 
@@ -17,10 +20,13 @@ internal sealed class ChartHelper
         GPU,
         Mem,
         Net,
+        Battery,
     }
 
     public const int ChartHeight = 86;
     public const int ChartWidth = 268;
+    public const int IconHeight = 32;
+    public const int IconWidth = 32;
 
     private const string LightGrayBoxStyle = "fill:none;stroke:lightgrey;stroke-width:1";
 
@@ -28,6 +34,7 @@ internal sealed class ChartHelper
     private const string GPULineStyle = "fill:none;stroke:rgb(222,104,242);stroke-width:1";
     private const string MemLineStyle = "fill:none;stroke:rgb(92,158,250);stroke-width:1";
     private const string NetLineStyle = "fill:none;stroke:rgb(245,98,142);stroke-width:1";
+    private const string BatteryLineStyle = "fill:none;stroke:rgb(78,203,113);stroke-width:1";
 
     private const string FillStyle = "fill:url(#gradientId);stroke:transparent";
 
@@ -42,6 +49,9 @@ internal sealed class ChartHelper
 
     private const string NetBrushStop1Style = "stop-color:rgb(245,98,142);stop-opacity:0.4";
     private const string NetBrushStop2Style = "stop-color:rgb(130,0,47);stop-opacity:0.25";
+
+    private const string BatteryBrushStop1Style = "stop-color:rgb(78,203,113);stop-opacity:0.4";
+    private const string BatteryBrushStop2Style = "stop-color:rgb(19,95,48);stop-opacity:0.25";
 
     private const string SvgElement = "svg";
     private const string RectElement = "rect";
@@ -62,11 +72,44 @@ internal sealed class ChartHelper
     private const string IdAttr = "id";
 
     private const int MaxChartValues = 34;
+    private const int IconPadding = 3;
+    private const int IconStrokeRadius = 1;
+    private const byte IconFillAlpha = 44;
+    private const byte IconLineAlpha = 255;
 
     public static string CreateImageUrl(List<float> chartValues, ChartType type)
     {
         var chartStr = CreateChart(chartValues, type);
         return "data:image/svg+xml;utf8," + chartStr;
+    }
+
+    public static IRandomAccessStream CreateIconStream(List<float> chartValues, ChartType type)
+    {
+        var values = SnapshotIconValues(chartValues);
+        var pixelBytes = RenderIconPixels(values, type);
+        var stream = new InMemoryRandomAccessStream();
+
+        try
+        {
+            var encoder = BitmapEncoder.CreateAsync(BitmapEncoder.PngEncoderId, stream).GetAwaiter().GetResult();
+            encoder.SetPixelData(
+                BitmapPixelFormat.Bgra8,
+                BitmapAlphaMode.Premultiplied,
+                (uint)IconWidth,
+                (uint)IconHeight,
+                96,
+                96,
+                pixelBytes);
+            encoder.FlushAsync().GetAwaiter().GetResult();
+
+            stream.Seek(0);
+            return stream;
+        }
+        catch
+        {
+            stream.Dispose();
+            throw;
+        }
     }
 
     /// <summary>
@@ -174,6 +217,10 @@ internal sealed class ChartHelper
                 stop1Style = NetBrushStop1Style;
                 stop2Style = NetBrushStop2Style;
                 break;
+            case ChartType.Battery:
+                stop1Style = BatteryBrushStop1Style;
+                stop2Style = BatteryBrushStop2Style;
+                break;
             case ChartType.CPU:
             default:
                 stop1Style = CPUBrushStop1Style;
@@ -213,10 +260,179 @@ internal sealed class ChartHelper
             ChartType.GPU => GPULineStyle,
             ChartType.Mem => MemLineStyle,
             ChartType.Net => NetLineStyle,
+            ChartType.Battery => BatteryLineStyle,
             _ => CPULineStyle,
         };
 
         return lineStyle;
+    }
+
+    private static float[] SnapshotIconValues(List<float> chartValues)
+    {
+        lock (chartValues)
+        {
+            if (chartValues.Count == 0)
+            {
+                return [0, 0];
+            }
+
+            if (chartValues.Count == 1)
+            {
+                var value = ClampChartValue(chartValues[0]);
+                return [value, value];
+            }
+
+            var values = new float[chartValues.Count];
+            for (var index = 0; index < chartValues.Count; index++)
+            {
+                values[index] = ClampChartValue(chartValues[index]);
+            }
+
+            return values;
+        }
+    }
+
+    private static byte[] RenderIconPixels(float[] values, ChartType type)
+    {
+        var pixels = new byte[IconWidth * IconHeight * 4];
+        var (red, green, blue) = GetIconColor(type);
+        CreateIconPoints(values, out var xPoints, out var yPoints);
+
+        FillIconArea(pixels, xPoints, yPoints, red, green, blue);
+        DrawIconLine(pixels, xPoints, yPoints, red, green, blue);
+
+        return pixels;
+    }
+
+    private static void CreateIconPoints(float[] values, out int[] xPoints, out int[] yPoints)
+    {
+        var count = values.Length;
+        xPoints = new int[count];
+        yPoints = new int[count];
+
+        var drawableWidth = IconWidth - (IconPadding * 2) - 1;
+        var drawableHeight = IconHeight - (IconPadding * 2) - 1;
+        var bottom = IconHeight - IconPadding - 1;
+
+        for (var index = 0; index < count; index++)
+        {
+            xPoints[index] = IconPadding + (int)Math.Round(index * drawableWidth / (double)(count - 1));
+            yPoints[index] = bottom - (int)Math.Round(values[index] * drawableHeight / 100.0);
+        }
+    }
+
+    private static void FillIconArea(byte[] pixels, int[] xPoints, int[] yPoints, byte red, byte green, byte blue)
+    {
+        var bottom = IconHeight - IconPadding - 1;
+
+        for (var index = 0; index < xPoints.Length - 1; index++)
+        {
+            var startX = xPoints[index];
+            var endX = xPoints[index + 1];
+            var startY = yPoints[index];
+            var endY = yPoints[index + 1];
+            var segmentWidth = Math.Max(1, endX - startX);
+
+            for (var x = startX; x <= endX; x++)
+            {
+                var position = (x - startX) / (double)segmentWidth;
+                var y = (int)Math.Round(startY + ((endY - startY) * position));
+                for (var fillY = Math.Max(IconPadding, y); fillY <= bottom; fillY++)
+                {
+                    SetPixel(pixels, x, fillY, red, green, blue, IconFillAlpha);
+                }
+            }
+        }
+    }
+
+    private static void DrawIconLine(byte[] pixels, int[] xPoints, int[] yPoints, byte red, byte green, byte blue)
+    {
+        for (var index = 0; index < xPoints.Length - 1; index++)
+        {
+            DrawLine(pixels, xPoints[index], yPoints[index], xPoints[index + 1], yPoints[index + 1], red, green, blue);
+        }
+    }
+
+    private static void DrawLine(byte[] pixels, int startX, int startY, int endX, int endY, byte red, byte green, byte blue)
+    {
+        var deltaX = Math.Abs(endX - startX);
+        var stepX = startX < endX ? 1 : -1;
+        var deltaY = -Math.Abs(endY - startY);
+        var stepY = startY < endY ? 1 : -1;
+        var error = deltaX + deltaY;
+
+        while (true)
+        {
+            DrawLinePoint(pixels, startX, startY, red, green, blue);
+
+            if (startX == endX && startY == endY)
+            {
+                break;
+            }
+
+            var error2 = error * 2;
+            if (error2 >= deltaY)
+            {
+                error += deltaY;
+                startX += stepX;
+            }
+
+            if (error2 <= deltaX)
+            {
+                error += deltaX;
+                startY += stepY;
+            }
+        }
+    }
+
+    private static void DrawLinePoint(byte[] pixels, int centerX, int centerY, byte red, byte green, byte blue)
+    {
+        for (var y = centerY - IconStrokeRadius; y <= centerY + IconStrokeRadius; y++)
+        {
+            for (var x = centerX - IconStrokeRadius; x <= centerX + IconStrokeRadius; x++)
+            {
+                if (Math.Abs(centerX - x) + Math.Abs(centerY - y) <= IconStrokeRadius)
+                {
+                    SetPixel(pixels, x, y, red, green, blue, IconLineAlpha);
+                }
+            }
+        }
+    }
+
+    private static void SetPixel(byte[] pixels, int x, int y, byte red, byte green, byte blue, byte alpha)
+    {
+        if (x < 0 || x >= IconWidth || y < 0 || y >= IconHeight)
+        {
+            return;
+        }
+
+        var offset = ((y * IconWidth) + x) * 4;
+        pixels[offset] = Premultiply(blue, alpha);
+        pixels[offset + 1] = Premultiply(green, alpha);
+        pixels[offset + 2] = Premultiply(red, alpha);
+        pixels[offset + 3] = alpha;
+    }
+
+    private static byte Premultiply(byte value, byte alpha)
+    {
+        return (byte)((value * alpha) / 255);
+    }
+
+    private static float ClampChartValue(float value)
+    {
+        return Math.Clamp(value, 0, 100);
+    }
+
+    private static (byte Red, byte Green, byte Blue) GetIconColor(ChartType type)
+    {
+        return type switch
+        {
+            ChartType.GPU => (222, 104, 242),
+            ChartType.Mem => (92, 158, 250),
+            ChartType.Net => (245, 98, 142),
+            ChartType.Battery => (78, 203, 113),
+            _ => (57, 184, 227),
+        };
     }
 
     private static StringBuilder TransformPointsToLine(List<float> chartValues, out int startX, out int finalX)

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/DevHome/Helpers/ChartHelper.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/DevHome/Helpers/ChartHelper.cs
@@ -113,6 +113,36 @@ internal sealed class ChartHelper
     }
 
     /// <summary>
+    /// Builds a cache key that changes only when the rendered icon would change.
+    /// </summary>
+    /// <remarks>
+    /// The icon bitmap is fully determined by the chart type and the integer
+    /// (x, y) points produced by <see cref="CreateIconPoints"/>; everything
+    /// downstream (<see cref="FillIconArea"/>, <see cref="DrawIconLine"/>) is a
+    /// pure function of those points and the type's color. Because each pixel
+    /// row spans several percent of the value range, small idle fluctuations map
+    /// to the same points and therefore the same bitmap. Callers compare this
+    /// signature to skip regenerating an identical icon, which keeps a live but
+    /// near-flat metric from allocating a fresh icon on every refresh tick.
+    /// This reuses the same snapshot and point math as <see cref="CreateIconStream"/>
+    /// so the key can never disagree with the bitmap it represents.
+    /// </remarks>
+    public static string CreateIconSignature(List<float> chartValues, ChartType type)
+    {
+        var values = SnapshotIconValues(chartValues);
+        CreateIconPoints(values, out var xPoints, out var yPoints);
+
+        var builder = new StringBuilder();
+        builder.Append((int)type).Append(':');
+        for (var index = 0; index < yPoints.Length; index++)
+        {
+            builder.Append(xPoints[index]).Append(',').Append(yPoints[index]).Append(';');
+        }
+
+        return builder.ToString();
+    }
+
+    /// <summary>
     /// Creates an SVG image for the chart.
     /// </summary>
     /// <param name="chartValues">The values to plot on the chart</param>

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceWidgetsPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceWidgetsPage.cs
@@ -460,7 +460,7 @@ internal abstract partial class WidgetPage : OnLoadContentPage
             string signature;
             lock (GraphIconValues)
             {
-                signature = BuildGraphIconSignature(chartType, GraphIconValues);
+                signature = ChartHelper.CreateIconSignature(GraphIconValues, chartType);
 
                 // Nothing visible changed since the last render: hand back the same
                 // IconInfo so the host icon cache sees a hit, not a new entry.
@@ -479,18 +479,6 @@ internal abstract partial class WidgetPage : OnLoadContentPage
         {
             return null;
         }
-    }
-
-    private static string BuildGraphIconSignature(ChartHelper.ChartType chartType, List<float> values)
-    {
-        var builder = new StringBuilder();
-        builder.Append((int)chartType).Append(':');
-        foreach (var value in values)
-        {
-            builder.Append(value.ToString("R", CultureInfo.InvariantCulture)).Append(',');
-        }
-
-        return builder.ToString();
     }
 
     protected void AddGraphIconValue(float value)

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceWidgetsPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceWidgetsPage.cs
@@ -67,6 +67,7 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
     private readonly string _id;
     private readonly bool _isBandPage;
     private readonly PerformanceMetricKind? _singleMetric;
+    private readonly SettingsManager _settingsManager;
 
     private readonly SystemCPUUsageWidgetPage? _cpuPage;
     private readonly ListItem? _cpuItem;
@@ -91,6 +92,7 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
 
     public PerformanceWidgetsPage(SettingsManager settingsManager, bool isBandPage = false, PerformanceMetricKind? singleMetric = null)
     {
+        _settingsManager = settingsManager;
         _isBandPage = isBandPage;
         _singleMetric = singleMetric;
         _id = singleMetric is null ? BaseId : $"{BaseId}.{GetMetricSuffix(singleMetric.Value)}";
@@ -107,6 +109,7 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
             _cpuPage.Updated += (s, e) =>
             {
                 _cpuItem.Title = _cpuPage.GetItemTitle(isBandPage);
+                UpdateMetricIcon(PerformanceMetricKind.Cpu);
             };
         }
 
@@ -122,6 +125,7 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
             _memoryPage.Updated += (s, e) =>
             {
                 _memoryItem.Title = _memoryPage.GetItemTitle(isBandPage);
+                UpdateMetricIcon(PerformanceMetricKind.Memory);
             };
         }
 
@@ -141,6 +145,7 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
                 _networkDownSpeed = _networkPage.GetDownSpeed();
                 _networkDownItem?.Title = $"{_networkDownSpeed}";
                 _networkUpItem?.Title = $"{_networkUpSpeed}";
+                UpdateMetricIcon(PerformanceMetricKind.Network);
             };
         }
 
@@ -156,6 +161,7 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
             _gpuPage.Updated += (s, e) =>
             {
                 _gpuItem.Title = _gpuPage.GetItemTitle(isBandPage);
+                UpdateMetricIcon(PerformanceMetricKind.Gpu);
             };
         }
 
@@ -175,7 +181,7 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
                 _batteryPage.Updated += (s, e) =>
                 {
                     _batteryItem.Title = _batteryPage.GetItemTitle(isBandPage);
-                    _batteryItem.Icon = _batteryPage.CurrentIcon;
+                    UpdateMetricIcon(PerformanceMetricKind.Battery);
                 };
             }
         }
@@ -208,6 +214,8 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
                 _batteryItem.Subtitle = Resources.GetResource("Battery_Usage_Subtitle");
             }
         }
+
+        UpdateAllMetricIcons();
     }
 
     protected override void Loaded()
@@ -284,6 +292,76 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
         _batteryPage?.Dispose();
     }
 
+    private void UpdateAllMetricIcons()
+    {
+        UpdateMetricIcon(PerformanceMetricKind.Cpu);
+        UpdateMetricIcon(PerformanceMetricKind.Memory);
+        UpdateMetricIcon(PerformanceMetricKind.Network);
+        UpdateMetricIcon(PerformanceMetricKind.Gpu);
+        UpdateMetricIcon(PerformanceMetricKind.Battery);
+    }
+
+    private void UpdateMetricIcon(PerformanceMetricKind metric)
+    {
+        var item = GetMetricItem(metric);
+        if (item is null)
+        {
+            return;
+        }
+
+        item.Icon = GetMetricIcon(metric);
+    }
+
+    private ListItem? GetMetricItem(PerformanceMetricKind metric)
+    {
+        return metric switch
+        {
+            PerformanceMetricKind.Cpu => _cpuItem,
+            PerformanceMetricKind.Memory => _memoryItem,
+            PerformanceMetricKind.Network => _networkItem,
+            PerformanceMetricKind.Gpu => _gpuItem,
+            PerformanceMetricKind.Battery => _batteryItem,
+            _ => null,
+        };
+    }
+
+    private IconInfo? GetMetricIcon(PerformanceMetricKind metric)
+    {
+        if (ShouldUseGraphIcon(metric))
+        {
+            var graphIcon = metric switch
+            {
+                PerformanceMetricKind.Cpu => _cpuPage?.CreateGraphIcon(ChartHelper.ChartType.CPU),
+                PerformanceMetricKind.Memory => _memoryPage?.CreateGraphIcon(ChartHelper.ChartType.Mem),
+                PerformanceMetricKind.Network => _networkPage?.CreateGraphIcon(ChartHelper.ChartType.Net),
+                PerformanceMetricKind.Gpu => _gpuPage?.CreateGraphIcon(ChartHelper.ChartType.GPU),
+                PerformanceMetricKind.Battery => _batteryPage?.CreateGraphIcon(ChartHelper.ChartType.Battery),
+                _ => null,
+            };
+
+            if (graphIcon is not null)
+            {
+                return graphIcon;
+            }
+        }
+
+        return GetStaticMetricIcon(metric);
+    }
+
+    private bool ShouldUseGraphIcon(PerformanceMetricKind metric)
+    {
+        return _isBandPage && _singleMetric == metric && _settingsManager.UseGraphIcons;
+    }
+
+    private IconInfo? GetStaticMetricIcon(PerformanceMetricKind metric)
+    {
+        return metric switch
+        {
+            PerformanceMetricKind.Battery => _batteryPage?.CurrentIcon ?? Icons.BatteryIcon,
+            _ => null,
+        };
+    }
+
     private bool IncludesMetric(PerformanceMetricKind metric)
     {
         return _singleMetric is null || _singleMetric == metric;
@@ -313,6 +391,8 @@ internal abstract partial class WidgetPage : OnLoadContentPage
     internal event EventHandler? Updated;
 
     protected Dictionary<string, string> ContentData { get; } = new();
+
+    protected List<float> GraphIconValues { get; } = new();
 
     protected WidgetPageState Page { get; set; } = WidgetPageState.Unknown;
 
@@ -355,6 +435,34 @@ internal abstract partial class WidgetPage : OnLoadContentPage
     protected abstract void LoadContentData();
 
     protected abstract string GetTemplatePath(WidgetPageState page);
+
+    internal IconInfo? CreateGraphIcon(ChartHelper.ChartType chartType)
+    {
+        try
+        {
+            return IconInfo.FromStream(ChartHelper.CreateIconStream(GraphIconValues, chartType));
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+
+    protected void AddGraphIconValue(float value)
+    {
+        lock (GraphIconValues)
+        {
+            ChartHelper.AddNextChartValue(value, GraphIconValues);
+        }
+    }
+
+    protected void ClearGraphIconValues()
+    {
+        lock (GraphIconValues)
+        {
+            GraphIconValues.Clear();
+        }
+    }
 
     protected string GetTemplateForPage(WidgetPageState page)
     {
@@ -456,6 +564,8 @@ internal sealed partial class SystemCPUUsageWidgetPage : WidgetPage, IDisposable
             var currentData = _dataManager.GetCPUStats();
 
             var dataDuration = timer.ElapsedMilliseconds;
+
+            AddGraphIconValue(currentData.CpuUsage * 100);
 
             ContentData["cpuUsage"] = FloatToPercentString(currentData.CpuUsage);
             ContentData["cpuSpeed"] = SpeedToString(currentData.CpuSpeed);
@@ -564,6 +674,8 @@ internal sealed partial class SystemMemoryUsageWidgetPage : WidgetPage, IDisposa
             var currentData = _dataManager.GetMemoryStats();
 
             var dataDuration = timer.ElapsedMilliseconds;
+
+            AddGraphIconValue(currentData.MemUsage * 100);
 
             ContentData["allMem"] = MemUlongToString(currentData.AllMem);
             ContentData["usedMem"] = MemUlongToString(currentData.UsedMem);
@@ -696,6 +808,8 @@ internal sealed partial class SystemNetworkUsageWidgetPage : WidgetPage, IDispos
 
             var netName = currentData.GetNetworkName(_networkIndex);
             var networkStats = currentData.GetNetworkUsage(_networkIndex);
+
+            AddGraphIconValue(networkStats.Usage * 100);
 
             ContentData["networkUsage"] = FloatToPercentString(networkStats.Usage);
             ContentData["netSent"] = SpeedToString(networkStats.Sent);
@@ -906,12 +1020,14 @@ internal sealed partial class SystemNetworkUsageWidgetPage : WidgetPage, IDispos
     private void HandlePrevNetwork()
     {
         _networkIndex = _dataManager.GetNetworkStats().GetPrevNetworkIndex(_networkIndex);
+        ClearGraphIconValues();
         UpdateWidget();
     }
 
     private void HandleNextNetwork()
     {
         _networkIndex = _dataManager.GetNetworkStats().GetNextNetworkIndex(_networkIndex);
+        ClearGraphIconValues();
         UpdateWidget();
     }
 
@@ -998,8 +1114,11 @@ internal sealed partial class SystemGPUUsageWidgetPage : WidgetPage, IDisposable
             var dataDuration = timer.ElapsedMilliseconds;
 
             var gpuName = stats.GetGPUName(_gpuActiveIndex);
+            var gpuUsage = stats.GetGPUUsage(_gpuActiveIndex, _gpuActiveEngType);
 
-            ContentData["gpuUsage"] = FloatToPercentString(stats.GetGPUUsage(_gpuActiveIndex, _gpuActiveEngType));
+            AddGraphIconValue(gpuUsage * 100);
+
+            ContentData["gpuUsage"] = FloatToPercentString(gpuUsage);
             ContentData["gpuName"] = gpuName;
             ContentData["gpuTemp"] = stats.GetGPUTemperature(_gpuActiveIndex);
             ContentData["gpuGraphUrl"] = stats.CreateGPUImageUrl(_gpuActiveIndex);
@@ -1061,12 +1180,14 @@ internal sealed partial class SystemGPUUsageWidgetPage : WidgetPage, IDisposable
     private void HandlePrevGPU()
     {
         _gpuActiveIndex = _dataManager.GetGPUStats().GetPrevGPUIndex(_gpuActiveIndex);
+        ClearGraphIconValues();
         UpdateWidget();
     }
 
     private void HandleNextGPU()
     {
         _gpuActiveIndex = _dataManager.GetGPUStats().GetNextGPUIndex(_gpuActiveIndex);
+        ClearGraphIconValues();
         UpdateWidget();
     }
 
@@ -1142,6 +1263,15 @@ internal sealed partial class SystemBatteryUsageWidgetPage : WidgetPage, IDispos
             var stats = _dataManager.GetBatteryStats();
 
             CurrentIcon = Icons.BatteryGlyph(stats.ChargePercent, stats.IsCharging, stats.HasBattery);
+
+            if (stats.HasBattery && stats.ChargePercent >= 0)
+            {
+                AddGraphIconValue(stats.ChargePercent * 100);
+            }
+            else
+            {
+                ClearGraphIconValues();
+            }
 
             if (!stats.HasBattery)
             {

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceWidgetsPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceWidgetsPage.cs
@@ -420,6 +420,16 @@ internal abstract partial class WidgetPage : OnLoadContentPage
 
     private readonly FormContent _formContent = new();
 
+    // The live graph icon is rebuilt on every metric refresh tick. Each
+    // IconInfo.FromStream(...) produces a distinct stream, and the host's
+    // CachedIconSourceProvider keys its cache on the stream's reference identity,
+    // so a fresh icon every tick adds a fresh cache entry every tick. Reuse the
+    // last IconInfo when the chart values have not changed since the last render:
+    // the same reference yields a cache hit instead of a new entry, which keeps
+    // idle and unchanged metrics from accumulating cache entries.
+    private IconInfo? _lastGraphIcon;
+    private string? _lastGraphIconSignature;
+
     public void UpdateWidget()
     {
         lock (ContentData)
@@ -440,12 +450,40 @@ internal abstract partial class WidgetPage : OnLoadContentPage
     {
         try
         {
-            return IconInfo.FromStream(ChartHelper.CreateIconStream(GraphIconValues, chartType));
+            string signature;
+            lock (GraphIconValues)
+            {
+                signature = BuildGraphIconSignature(chartType, GraphIconValues);
+
+                // Nothing visible changed since the last render: hand back the same
+                // IconInfo so the host icon cache sees a hit, not a new entry.
+                if (_lastGraphIcon is not null && signature == _lastGraphIconSignature)
+                {
+                    return _lastGraphIcon;
+                }
+
+                var icon = IconInfo.FromStream(ChartHelper.CreateIconStream(GraphIconValues, chartType));
+                _lastGraphIcon = icon;
+                _lastGraphIconSignature = signature;
+                return icon;
+            }
         }
         catch (Exception)
         {
             return null;
         }
+    }
+
+    private static string BuildGraphIconSignature(ChartHelper.ChartType chartType, List<float> values)
+    {
+        var builder = new StringBuilder();
+        builder.Append((int)chartType).Append(':');
+        foreach (var value in values)
+        {
+            builder.Append(value.ToString("R", CultureInfo.InvariantCulture)).Append(',');
+        }
+
+        return builder.ToString();
     }
 
     protected void AddGraphIconValue(float value)

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceWidgetsPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceWidgetsPage.cs
@@ -350,7 +350,14 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
 
     private bool ShouldUseGraphIcon(PerformanceMetricKind metric)
     {
-        return _isBandPage && _singleMetric == metric && _settingsManager.UseGraphIcons;
+        // Graph icons replace a metric's list-item icon on dock bands when the
+        // setting is on. This covers single-metric bands (_singleMetric set) and
+        // the all-metrics band (_singleMetric null, so every metric qualifies).
+        // The previous _singleMetric == metric test excluded the all-metrics
+        // band, which made enabling the setting look like a no-op there.
+        return _isBandPage
+            && _settingsManager.UseGraphIcons
+            && (_singleMetric is null || _singleMetric == metric);
     }
 
     private IconInfo? GetStaticMetricIcon(PerformanceMetricKind metric)

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/SettingsManager.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/SettingsManager.cs
@@ -25,10 +25,18 @@ internal sealed class SettingsManager : JsonSettingsManager
             new ChoiceSetSetting.Choice(Resources.GetResource("Network_Speed_Unit_BinaryBytesPerSec"), NetworkSpeedUnit.BinaryBytesPerSecond.ToString("G")),
         ]);
 
+    private readonly ToggleSetting _useGraphIcons = new(
+        Namespaced(nameof(UseGraphIcons)),
+        Resources.GetResource("Graph_Icons_Setting_Title"),
+        Resources.GetResource("Graph_Icons_Setting_Description"),
+        false);
+
     public NetworkSpeedUnit NetworkSpeedUnit =>
         Enum.TryParse<NetworkSpeedUnit>(_networkSpeedUnit.Value, out var unit)
             ? unit
             : NetworkSpeedUnit.BitsPerSecond;
+
+    public bool UseGraphIcons => _useGraphIcons.Value;
 
     private static string SettingsJsonPath()
     {
@@ -42,6 +50,7 @@ internal sealed class SettingsManager : JsonSettingsManager
         FilePath = SettingsJsonPath();
 
         Settings.Add(_networkSpeedUnit);
+        Settings.Add(_useGraphIcons);
 
         LoadSettings();
 

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/Strings/en-US/Resources.resw
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/Strings/en-US/Resources.resw
@@ -346,4 +346,10 @@
   <data name="Network_Speed_Unit_BinaryBytesPerSec" xml:space="preserve">
     <value>Binary bytes per second (KiB/s, MiB/s, GiB/s)</value>
   </data>
+  <data name="Graph_Icons_Setting_Title" xml:space="preserve">
+    <value>Use graph icons for dock bands</value>
+  </data>
+  <data name="Graph_Icons_Setting_Description" xml:space="preserve">
+    <value>Show live sparkline icons for single-metric Performance Monitor dock bands</value>
+  </data>
 </root>


### PR DESCRIPTION
## Summary of the Pull Request

Add a boolean `ToggleSetting` (e.g. `useGraphIcons`) to `SettingsManager.cs`, following the existing `_networkSpeedUnit` `ChoiceSetSetting` pattern (register in the constructor, expose a typed getter, add title/description strings to `Resources.resw`). In `PerformanceWidgetsPage.cs`, when the setting is enabled and the page is scoped to a single `PerformanceMetricKind` (dock band), generate a small sparkline icon from the metric's recent sample history instead of the static asset, and refresh it on the existing data-update tick.

The Command Palette Performance Monitor exposes per-metric dock "bands" (CPU, Memory, Network, GPU, Battery) but the bands show a static icon rather than a live graph. The issue asks for a setting that gives the bands "graph" icons resembling the Task Manager system-tray graph icons. Maintainer @zadjii-msft (MEMBER) confirmed scope on 2026-06-03: the taskbar piece is tracked separately by #46705, "but we can leave this open for 'enable the perf monitor items to have an icon similar to the task manager tray graph icons.'" The issue is open, unassigned, labeled `Idea-Enhancement` / `Help Wanted` / `CmdPal - Performance monitor`, with no competing claim or PR.

Closes #47009

## PR Checklist

- [x] Closes: #47009
- [x] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [x] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [x] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [x] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments

The Command Palette Performance Monitor exposes per-metric dock "bands" (CPU, Memory, Network, GPU, Battery) but the bands show a static icon rather than a live graph. The issue asks for a setting that gives the bands "graph" icons resembling the Task Manager system-tray graph icons. Maintainer @zadjii-msft (MEMBER) confirmed scope on 2026-06-03: the taskbar piece is tracked separately by #46705, "but we can leave this open for 'enable the perf monitor items to have an icon similar to the task manager tray graph icons.'" The issue is open, unassigned, labeled `Idea-Enhancement` / `Help Wanted` / `CmdPal - Performance monitor`, with no competing claim or PR.

Add a boolean `ToggleSetting` (e.g. `useGraphIcons`) to `SettingsManager.cs`, following the existing `_networkSpeedUnit` `ChoiceSetSetting` pattern (register in the constructor, expose a typed getter, add title/description strings to `Resources.resw`). In `PerformanceWidgetsPage.cs`, when the setting is enabled and the page is scoped to a single `PerformanceMetricKind` (dock band), generate a small sparkline icon from the metric's recent sample history instead of the static asset, and refresh it on the existing data-update tick. Reuse/extend `DevHome/Helpers/ChartHelper.cs` (already renders chart imagery for the widget templates) to emit a compact PNG/stream suitable for an `IconInfo`/`IconData`, then assign it to the band `ListItem.Icon`.

## Validation Steps Performed

With the setting off (default), bands render the existing static icons exactly as today (regression).
With the setting on, each single-metric dock band renders a sparkline icon derived from that metric's sample buffer.
The graph icon updates as new samples arrive on the data-gathering tick without leaking GDI/stream handles.
A band with insufficient sample history (just loaded) renders a sane empty/flat sparkline rather than throwing.
Toggling the setting at runtime switches icon style on the next refresh without requiring a restart.
