### PR TITLE
Grab and Move: square overlay corners in remote sessions

### DIFF
--- a/src/modules/GrabAndMove/GrabAndMove/main.cpp
+++ b/src/modules/GrabAndMove/GrabAndMove/main.cpp
@@ -373,6 +373,13 @@ static int g_overlayRenderedH = 0;
 // Always On Top (WindowCornerUtils::CornersRadius).
 static int CornerRadiusForWindow(HWND hwnd)
 {
+    // Remote sessions draw square windows even on Win11, yet still report DWMWCP_DEFAULT. Match the
+    // window: a remote session gets square (radius 0) so the overlay border doesn't round off the corner.
+    if (GetSystemMetrics(SM_REMOTESESSION))
+    {
+        return 0;
+    }
+
     int pref = 0; // DWMWCP_DEFAULT
     if (DwmGetWindowAttribute(hwnd, DWMWA_WINDOW_CORNER_PREFERENCE, &pref, sizeof(pref)) != S_OK)
     {


### PR DESCRIPTION
Follow-up to the Grab and Move corner-matched overlay border. `CornerRadiusForWindow` rounded from `DWMWA_WINDOW_CORNER_PREFERENCE` but ignored remote sessions, where Windows draws **square** windows even on Win11 (the preference still reports `DWMWCP_DEFAULT`). The rounded overlay then curved off the square corner.

Now returns radius 0 when `GetSystemMetrics(SM_REMOTESESSION)` is set — square overlay to match the square window. Uses the same guard already present elsewhere in this file. Local Win11 is unchanged (8/4px).