### PR TITLE
Fixing a WindowBase warning during compile

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -48,6 +48,26 @@
     <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="Restore" Properties="RestoreInProgress=true" BuildInParallel="false" />
   </Target>
 
+  <!--
+    The Microsoft.Web.WebView2 package's managed .targets unconditionally references the WPF
+    wrapper (Microsoft.Web.WebView2.Wpf.dll) for every non-WinRT .NET project. That wrapper
+    depends on WPF's WindowsBase, which only ships in the WPF profile of the WindowsDesktop
+    reference pack. WinForms-only or plain projects therefore resolve WindowsBase to the
+    4.0.0.0 facade from Microsoft.NETCore.App, producing an MSB3277 conflict against the
+    wrapper's 5.0.0.0 reference. A project that doesn't enable WPF can't use the WPF WebView2
+    control anyway, so drop that unused reference before RAR runs (WPF projects keep it).
+    WinUI/WinAppSDK projects use the CsWinRT projection and never get this reference, so this
+    is a no-op for them.
+  -->
+  <Target 
+	  Name="RemoveUnusedWebView2WpfReference"
+      BeforeTargets="ResolveAssemblyReferences"
+	  Condition="'$(UseWPF)' != 'true'">
+    <ItemGroup>
+      <Reference Remove="@(Reference)" Condition="'%(Reference.Filename)' == 'Microsoft.Web.WebView2.Wpf'" />
+    </ItemGroup>
+  </Target>
+	
   <PropertyGroup Condition="'$(IgnoreExperimentalWarnings)' == 'true'">
     <NoWarn>$(NoWarn);CS8305;SA1500;CA1852</NoWarn>
   </PropertyGroup>


### PR DESCRIPTION
Removing a warning that pops up a lot.

**With fix:**
<img width="694" height="674" alt="image" src="https://github.com/user-attachments/assets/2a496935-0d4b-45e6-97f2-62b8d4004faa" />

**Without fix:** here it is commented out to show the warning. 
<img width="1033" height="654" alt="Screenshot 2026-06-30 111523" src="https://github.com/user-attachments/assets/5d8f5df9-3c45-4155-a995-4b666df894fd" />

Found conflicts between different versions of "WindowsBase" that could not be resolved.
There was a conflict between "WindowsBase, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" and "WindowsBase, Version=5.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35".
    "WindowsBase, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" was chosen because it was primary and "WindowsBase, Version=5.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" was not.
    References which depend on "WindowsBase, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" [C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\10.0.8\ref\net10.0\WindowsBase.dll].
        C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\10.0.8\ref\net10.0\WindowsBase.dll
          Project file item includes which caused reference "C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\10.0.8\ref\net10.0\WindowsBase.dll".
            C:\Program Files\dotnet\packs\Microsoft.NETCore.App.Ref\10.0.8\ref/net10.0/WindowsBase.dll
    References which depend on or have been unified to "WindowsBase, Version=5.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" [].
        C:\Users\crutkas\.nuget\packages\microsoft.web.webview2\1.0.3719.77\lib_manual\net5.0-windows10.0.17763.0\Microsoft.Web.WebView2.Wpf.dll
          Project file item includes which caused reference "C:\Users\crutkas\.nuget\packages\microsoft.web.webview2\1.0.3719.77\lib_manual\net5.0-windows10.0.17763.0\Microsoft.Web.WebView2.Wpf.dll".
            C:\Users\crutkas\.nuget\packages\microsoft.web.webview2\1.0.3719.77\buildTransitive\..\\lib_manual\net5.0-windows10.0.17763.0\Microsoft.Web.WebView2.Wpf.dll