### PR TITLE
Fixing Windows.ImplementationLibrary between proj and package.config

### DIFF
--- a/src/common/COMUtils/packages.config
+++ b/src/common/COMUtils/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.250325.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.260126.7" targetFramework="native" />
 </packages>

--- a/src/modules/MouseWithoutBorders/ModuleInterface/MouseWithoutBordersModuleInterface.vcxproj.filters
+++ b/src/modules/MouseWithoutBorders/ModuleInterface/MouseWithoutBordersModuleInterface.vcxproj.filters
@@ -39,6 +39,7 @@
   </ItemGroup>
   <ItemGroup>
     <Natvis Include="$(MSBuildThisFileDirectory)..\..\natvis\wil.natvis" />
+    <Natvis Include="$(MSBuildThisFileDirectory)..\..\natvis\wil.natstepfilter" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/modules/MouseWithoutBorders/ModuleInterface/packages.config
+++ b/src/modules/MouseWithoutBorders/ModuleInterface/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.250325.1" targetFramework="native" />
+  <package id="Microsoft.Windows.ImplementationLibrary" version="1.0.260126.7" targetFramework="native" />
 </packages>


### PR DESCRIPTION
In the vcxproj files, it lists it correctly for Microsoft.Windows.ImplementationLibrary.1.0.260126.7 but the package files are incorrect

This fixes one of two drifts in package manager
<img width="1612" height="457" alt="Screenshot 2026-06-30 103348" src="https://github.com/user-attachments/assets/b4ff91c1-ca98-4833-92bf-4c647b5ea95c" />


The natstepfilter was brought in via clicking "install" in package manager