### PR TITLE
[PowerToys] Guard TitleBar windows against an empty window title (startup fault)

### DIFF
--- a/src/modules/EnvironmentVariables/EnvironmentVariables/EnvironmentVariablesXAML/MainWindow.xaml.cs
+++ b/src/modules/EnvironmentVariables/EnvironmentVariables/EnvironmentVariablesXAML/MainWindow.xaml.cs
@@ -32,6 +32,17 @@ namespace EnvironmentVariables
             var loader = ResourceLoaderInstance.ResourceLoader;
             var title = App.GetService<IElevationHelper>().IsElevated ? loader.GetString("WindowAdminTitle") : loader.GetString("WindowTitle");
 
+            // The WinUI TitleBar control reads the owning window's title (AppWindow.Title) during a
+            // deferred layout pass. If the native window title is empty at that instant, the windowing
+            // layer can fault while resolving it and terminate the process. ResourceLoader.GetString
+            // returns an empty string when the resource map can't be resolved at runtime, which would
+            // leave the title empty here, so fall back to a non-empty product name to keep the native
+            // window title populated.
+            if (string.IsNullOrEmpty(title))
+            {
+                title = "Environment Variables";
+            }
+
             Title = title;
             titleBar.Title = title;
 

--- a/src/modules/FileLocksmith/FileLocksmithUI/FileLocksmithXAML/MainWindow.xaml.cs
+++ b/src/modules/FileLocksmith/FileLocksmithUI/FileLocksmithXAML/MainWindow.xaml.cs
@@ -25,6 +25,15 @@ namespace FileLocksmithUI
 
             var loader = ResourceLoaderInstance.ResourceLoader;
             var title = isElevated ? loader.GetString("AppAdminTitle") : loader.GetString("AppTitle");
+
+            // Guard against an empty title: ResourceLoader.GetString returns "" when the resource
+            // map can't be resolved, and an empty native window title can fault the WinUI TitleBar
+            // control while it reads AppWindow.Title during a deferred layout pass.
+            if (string.IsNullOrEmpty(title))
+            {
+                title = "File Locksmith";
+            }
+
             Title = title;
             titleBar.Title = title;
         }

--- a/src/modules/Hosts/Hosts/HostsXAML/MainWindow.xaml.cs
+++ b/src/modules/Hosts/Hosts/HostsXAML/MainWindow.xaml.cs
@@ -33,6 +33,15 @@ namespace Hosts
             var loader = new ResourceLoader("PowerToys.HostsUILib.pri", "PowerToys.HostsUILib/Resources");
 
             var title = Host.GetService<IElevationHelper>().IsElevated ? loader.GetString("WindowAdminTitle") : loader.GetString("WindowTitle");
+
+            // Guard against an empty title: ResourceLoader.GetString returns "" when the resource
+            // map can't be resolved, and an empty native window title can fault the WinUI TitleBar
+            // control while it reads AppWindow.Title during a deferred layout pass.
+            if (string.IsNullOrEmpty(title))
+            {
+                title = "Hosts File Editor";
+            }
+
             Title = title;
             titleBar.Title = title;
 

--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuideXAML/MainWindow.xaml.cs
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuideXAML/MainWindow.xaml.cs
@@ -57,7 +57,17 @@ namespace ShortcutGuide
                 return _currentApplicationIds;
             });
 
-            Title = ResourceLoaderInstance.ResourceLoader.GetString("Title")!;
+            var title = ResourceLoaderInstance.ResourceLoader.GetString("Title")!;
+
+            // Guard against an empty title: ResourceLoader.GetString returns "" when the resource
+            // map can't be resolved, and an empty native window title can fault the WinUI TitleBar
+            // control while it reads AppWindow.Title during a deferred layout pass.
+            if (string.IsNullOrEmpty(title))
+            {
+                title = "Shortcut Guide";
+            }
+
+            Title = title;
             ExtendsContentIntoTitleBar = true;
 
 #if !DEBUG

--- a/src/modules/registrypreview/RegistryPreview/RegistryPreviewXAML/MainWindow.xaml.cs
+++ b/src/modules/registrypreview/RegistryPreview/RegistryPreviewXAML/MainWindow.xaml.cs
@@ -48,6 +48,13 @@ namespace RegistryPreview
             SetTitleBar(titleBar);
             AppWindow.SetIcon("Assets\\RegistryPreview\\RegistryPreview.ico");
 
+            // Ensure a non-empty window title before the title bar's first layout reads it.
+            // UpdateWindowTitle() only runs later (on file load), so without this the native
+            // window title would be empty during startup, which can fault the WinUI TitleBar
+            // control while it reads AppWindow.Title during a deferred layout pass.
+            titleBar.Title = APPNAME;
+            AppWindow.Title = APPNAME;
+
             // if have settings, update the location of the window
             if (jsonWindowPlacement != null)
             {

--- a/src/settings-ui/Settings.UI/SettingsXAML/Controls/Dashboard/ShortcutConflictWindow.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Controls/Dashboard/ShortcutConflictWindow.xaml.cs
@@ -45,7 +45,17 @@ namespace Microsoft.PowerToys.Settings.UI.SettingsXAML.Controls.Dashboard
             ExtendsContentIntoTitleBar = true;
             SetTitleBar(titleBar);
 
-            this.Title = resourceLoader.GetString("ShortcutConflictWindow_Title");
+            var windowTitle = resourceLoader.GetString("ShortcutConflictWindow_Title");
+
+            // Guard against an empty title: ResourceLoader.GetString returns "" when the resource
+            // map can't be resolved, and an empty native window title can fault the WinUI TitleBar
+            // control while it reads AppWindow.Title during a deferred layout pass.
+            if (string.IsNullOrEmpty(windowTitle))
+            {
+                windowTitle = "PowerToys shortcut conflicts";
+            }
+
+            this.Title = windowTitle;
             this.CenterOnScreen();
 
             ViewModel.OnPageLoaded();


### PR DESCRIPTION
## Summary

Guard PowerToys' WinUI windows against an empty native window title, so the WinUI `TitleBar` control can't read an empty title during startup and fault the process.  This fixes a class of bugs like https://github.com/microsoft/PowerToys/issues/48547

## Background

Spotted while reading through the Environment Variables `MainWindow` startup path. The WinUI `TitleBar` control (used with `ExtendsContentIntoTitleBar`) reads the owning window's `AppWindow.Title` during a deferred layout pass (`OnApplyTemplate` → `UpdateTitle`). When the native window title is empty at that instant, the windowing layer can fault while resolving the title and terminate the process during startup.

The native title ends up empty in two ways:
1. The title is computed from `ResourceLoader.GetString(...)`, which returns an **empty string** (it doesn't throw) when the resource map can't be resolved at runtime.
2. The window sets `AppWindow.Title` only *later*, not before the title bar's first layout.

## Windows fixed

Every PowerToys window that hosts the `TitleBar` control:

| Window | Fix |
|---|---|
| Environment Variables | Non-empty fallback for the resource-based title |
| Hosts | Non-empty fallback for the resource-based title |
| File Locksmith | Non-empty fallback for the resource-based title |
| Shortcut Guide | Non-empty fallback for the resource-based title |
| Settings — shortcut-conflict window | Non-empty fallback for the resource-based title |
| Registry Preview | Set `AppWindow.Title` to the app name in the constructor (previously only set later in `UpdateWindowTitle`) |
| Keyboard Manager Editor | No change — already sets a hardcoded non-empty `Title` |

## Risk

Very low. The only behavior change is that a previously-empty title becomes a non-empty fallback; the normal (resource-resolved) paths are unchanged.

## Validation

Each affected project builds clean (`x64 | Release`): EnvironmentVariables, Hosts, FileLocksmithUI, ShortcutGuide.Ui, RegistryPreview, PowerToys.Settings.

## Related

Root cause write-up (windowing/WinUI side): microsoft/microsoft-ui-xaml#11214.

---

ADO: https://microsoft.visualstudio.com/DefaultCollection/OS/_workitems/edit/62685601/
