### PR TITLE
Feature/sync brightness wmi

### DIFF
--- a/src/modules/powerdisplay/PowerDisplay.Lib/Drivers/WMI/WmiController.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Lib/Drivers/WMI/WmiController.cs
@@ -86,6 +86,38 @@ namespace PowerDisplay.Common.Drivers.WMI
 
         public string Name => "WMI Monitor Controller";
 
+        public event Action<string, int>? BrightnessChanged;
+
+        private WmiConnection? _eventConnection;
+        private IDisposable? _brightnessEventSubscription;
+
+        public WmiController()
+        {
+            try
+            {
+                _eventConnection = new WmiConnection(WmiNamespace);
+                _brightnessEventSubscription = _eventConnection.CreateEventSubscription(
+                    "SELECT * FROM WmiMonitorBrightnessEvent",
+                    eventObj =>
+                    {
+                        try
+                        {
+                            var instanceName = eventObj.GetPropertyValue<string>("InstanceName");
+                            var brightness = eventObj.GetPropertyValue<byte>("Brightness");
+                            BrightnessChanged?.Invoke(instanceName, brightness);
+                        }
+                        catch (Exception ex)
+                        {
+                            Logger.LogWarning($"Error handling WMI brightness event: {ex.Message}");
+                        }
+                    });
+            }
+            catch (Exception ex)
+            {
+                Logger.LogInfo($"WMI brightness event subscription unavailable: {ex.Message}");
+            }
+        }
+
         /// <summary>
         /// Get monitor brightness
         /// </summary>
@@ -306,8 +338,8 @@ namespace PowerDisplay.Common.Drivers.WMI
 
         public void Dispose()
         {
-            // WmiLight objects are created per-operation and disposed immediately via using statements.
-            // No instance-level resources require cleanup.
+            _brightnessEventSubscription?.Dispose();
+            _eventConnection?.Dispose();
             GC.SuppressFinalize(this);
         }
     }

--- a/src/modules/powerdisplay/PowerDisplay/Helpers/MonitorManager.cs
+++ b/src/modules/powerdisplay/PowerDisplay/Helpers/MonitorManager.cs
@@ -41,6 +41,8 @@ namespace PowerDisplay.Helpers
 
         public IReadOnlyList<Monitor> Monitors => _monitors.AsReadOnly();
 
+        public event EventHandler<WmiBrightnessChangedEventArgs>? WmiBrightnessChanged;
+
         public MonitorManager()
         {
             // Initialize controllers
@@ -67,6 +69,7 @@ namespace PowerDisplay.Helpers
                 // WMI controller (internal monitors)
                 // Always create - DiscoverMonitorsAsync returns empty list if WMI is unavailable
                 _wmiController = new WmiController();
+                _wmiController.BrightnessChanged += WmiController_BrightnessChanged;
             }
             catch (Exception ex)
             {
@@ -449,12 +452,21 @@ namespace PowerDisplay.Helpers
 
                 // Release controllers
                 _ddcController?.Dispose();
-                _wmiController?.Dispose();
+                if (_wmiController != null)
+                {
+                    _wmiController.BrightnessChanged -= WmiController_BrightnessChanged;
+                    _wmiController.Dispose();
+                }
 
                 _monitors.Clear();
                 _monitorLookup.Clear();
                 _disposed = true;
             }
+        }
+
+        private void WmiController_BrightnessChanged(string instanceName, int brightness)
+        {
+            WmiBrightnessChanged?.Invoke(this, new WmiBrightnessChangedEventArgs(instanceName, brightness));
         }
     }
 }

--- a/src/modules/powerdisplay/PowerDisplay/Helpers/WmiBrightnessChangedEventArgs.cs
+++ b/src/modules/powerdisplay/PowerDisplay/Helpers/WmiBrightnessChangedEventArgs.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace PowerDisplay.Helpers
+{
+    public class WmiBrightnessChangedEventArgs : EventArgs
+    {
+        public string InstanceName { get; }
+
+        public int Brightness { get; }
+
+        public WmiBrightnessChangedEventArgs(string instanceName, int brightness)
+        {
+            InstanceName = instanceName;
+            Brightness = brightness;
+        }
+    }
+}

--- a/src/modules/powerdisplay/PowerDisplay/ViewModels/MainViewModel.LinkedBrightness.cs
+++ b/src/modules/powerdisplay/PowerDisplay/ViewModels/MainViewModel.LinkedBrightness.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using ManagedCommon;
 using Microsoft.UI.Dispatching;
+using PowerDisplay.Common.Models;
 using PowerDisplay.Common.Services;
 using PowerDisplay.Helpers;
 using PowerDisplay.Models;
@@ -277,6 +278,52 @@ public partial class MainViewModel
         catch (Exception ex)
         {
             Logger.LogError($"[LinkedBrightness] Broadcast failed: {ex.Message}");
+        }
+    }
+
+    private void MonitorManager_WmiBrightnessChanged(object? sender, WmiBrightnessChangedEventArgs e)
+    {
+        _dispatcherQueue.TryEnqueue(() =>
+        {
+            HandleWmiBrightnessChanged(e.InstanceName, e.Brightness);
+        });
+    }
+
+    private void HandleWmiBrightnessChanged(string instanceName, int brightness)
+    {
+        if (!LinkedLevelsActive || !SyncBrightnessWithInternalDisplay)
+        {
+            return;
+        }
+
+        var lookupId = MonitorIdentity.FromInstanceName(instanceName);
+        if (string.IsNullOrEmpty(lookupId))
+        {
+            return;
+        }
+
+        var matchingMonitor = Monitors.FirstOrDefault(m => MonitorIdComparer.Instance.Equals(m.Id, lookupId));
+        if (matchingMonitor == null)
+        {
+            matchingMonitor = Monitors.FirstOrDefault(m => string.Equals(m.InstanceName, instanceName, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (matchingMonitor != null && IsLinkedTarget(matchingMonitor))
+        {
+            if (matchingMonitor.Brightness != brightness)
+            {
+                Logger.LogInfo($"[WmiBrightness] Internal monitor brightness changed to {brightness}%. Syncing linked displays.");
+                matchingMonitor.UpdateBrightnessDisplay(brightness);
+                SetLinkedBrightnessSilently(brightness);
+
+                foreach (var vm in Monitors)
+                {
+                    if (vm != matchingMonitor && IsLinkedTarget(vm))
+                    {
+                        vm.Brightness = brightness;
+                    }
+                }
+            }
         }
     }
 }

--- a/src/modules/powerdisplay/PowerDisplay/ViewModels/MainViewModel.LinkedBrightness.cs
+++ b/src/modules/powerdisplay/PowerDisplay/ViewModels/MainViewModel.LinkedBrightness.cs
@@ -291,7 +291,7 @@ public partial class MainViewModel
 
     private void HandleWmiBrightnessChanged(string instanceName, int brightness)
     {
-        if (!LinkedLevelsActive || !SyncBrightnessWithInternalDisplay)
+        if (!SyncBrightnessWithInternalDisplay)
         {
             return;
         }
@@ -308,17 +308,21 @@ public partial class MainViewModel
             matchingMonitor = Monitors.FirstOrDefault(m => string.Equals(m.InstanceName, instanceName, StringComparison.OrdinalIgnoreCase));
         }
 
-        if (matchingMonitor != null && IsLinkedTarget(matchingMonitor))
+        if (matchingMonitor != null)
         {
             if (matchingMonitor.Brightness != brightness)
             {
-                Logger.LogInfo($"[WmiBrightness] Internal monitor brightness changed to {brightness}%. Syncing linked displays.");
+                Logger.LogInfo($"[WmiBrightness] Internal monitor brightness changed to {brightness}%. Syncing displays.");
                 matchingMonitor.UpdateBrightnessDisplay(brightness);
-                SetLinkedBrightnessSilently(brightness);
+
+                if (LinkedLevelsActive)
+                {
+                    SetLinkedBrightnessSilently(brightness);
+                }
 
                 foreach (var vm in Monitors)
                 {
-                    if (vm != matchingMonitor && IsLinkedTarget(vm))
+                    if (vm != matchingMonitor && vm.SupportsBrightness && !_excludedMonitorIds.Contains(vm.Id))
                     {
                         vm.Brightness = brightness;
                     }

--- a/src/modules/powerdisplay/PowerDisplay/ViewModels/MainViewModel.Settings.cs
+++ b/src/modules/powerdisplay/PowerDisplay/ViewModels/MainViewModel.Settings.cs
@@ -53,6 +53,37 @@ public partial class MainViewModel
     }
 
     /// <summary>
+    /// Partial change hook fired by the source-generator for <see cref="SyncBrightnessWithInternalDisplay"/>.
+    /// Persists the new value to settings.json.
+    /// </summary>
+    partial void OnSyncBrightnessWithInternalDisplayChanged(bool value)
+    {
+        SaveSyncBrightnessWithInternalDisplay(value);
+    }
+
+    private void SaveSyncBrightnessWithInternalDisplay(bool value)
+    {
+        try
+        {
+            var settings = _settingsUtils.GetSettingsOrDefault<PowerDisplaySettings>(PowerDisplaySettings.ModuleName);
+            if (settings.Properties.SyncBrightnessWithInternalDisplay == value)
+            {
+                return;
+            }
+
+            settings.Properties.SyncBrightnessWithInternalDisplay = value;
+
+            _settingsUtils.SaveSettings(
+                System.Text.Json.JsonSerializer.Serialize(settings, AppJsonContext.Default.PowerDisplaySettings),
+                PowerDisplaySettings.ModuleName);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError($"[Settings] Failed to save SyncBrightnessWithInternalDisplay: {ex.Message}");
+        }
+    }
+
+    /// <summary>
     /// Persist the linked-brightness exclusion set to settings.json. Called from
     /// <c>SetMonitorExcludedFromSync</c> in <c>MainViewModel.LinkedBrightness.cs</c> after the
     /// runtime <c>_excludedMonitorIds</c> set has been mutated.

--- a/src/modules/powerdisplay/PowerDisplay/ViewModels/MainViewModel.cs
+++ b/src/modules/powerdisplay/PowerDisplay/ViewModels/MainViewModel.cs
@@ -101,6 +101,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
         // Initialize the monitor manager
         _monitorManager = new MonitorManager();
+        _monitorManager.WmiBrightnessChanged += MonitorManager_WmiBrightnessChanged;
 
         // Load profiles for quick apply feature
         LoadProfiles();
@@ -148,6 +149,12 @@ public partial class MainViewModel : ObservableObject, IDisposable
     [NotifyPropertyChangedFor(nameof(ShowLinkLevelsToggle))]
     [NotifyPropertyChangedFor(nameof(ShowLinkLevelsInactiveIcon))]
     public partial bool LinkedLevelsActive { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to synchronize brightness with the internal display.
+    /// </summary>
+    [ObservableProperty]
+    public partial bool SyncBrightnessWithInternalDisplay { get; set; }
 
     /// <summary>
     /// Gets or sets the brightness value driving the linked "All Displays" slider. Setter is
@@ -421,7 +428,11 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
         try
         {
-            _monitorManager?.Dispose();
+            if (_monitorManager != null)
+            {
+                _monitorManager.WmiBrightnessChanged -= MonitorManager_WmiBrightnessChanged;
+                _monitorManager.Dispose();
+            }
         }
         catch
         {
@@ -488,6 +499,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
             ShowProfileSwitcher = settings.Properties.ShowProfileSwitcher;
             ShowIdentifyMonitorsButton = settings.Properties.ShowIdentifyMonitorsButton;
             MouseWheelIncrement = settings.Properties.MouseWheelIncrement;
+            SyncBrightnessWithInternalDisplay = settings.Properties.SyncBrightnessWithInternalDisplay;
 
             // Load the linked-brightness exclusion set before applying LinkedLevelsActive. If this
             // method runs after monitors are already discovered, the toggle hook can seed the master

--- a/src/modules/powerdisplay/PowerDisplay/ViewModels/MonitorViewModel.cs
+++ b/src/modules/powerdisplay/PowerDisplay/ViewModels/MonitorViewModel.cs
@@ -253,6 +253,8 @@ public partial class MonitorViewModel : ObservableObject, IDisposable
 
     public string Id => _monitor.Id;
 
+    public string InstanceName => _monitor.InstanceName;
+
     public string Name => IsInternal
         ? ResourceLoaderInstance.ResourceLoader.GetString("BuiltInDisplayName")
         : _monitor.Name;

--- a/src/settings-ui/Settings.UI.Library/PowerDisplayProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/PowerDisplayProperties.cs
@@ -26,6 +26,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             ShowIdentifyMonitorsButton = true;
             MaxCompatibilityMode = false;
             LinkedLevelsActive = false;
+            SyncBrightnessWithInternalDisplay = false;
             ExcludedFromSyncMonitorIds = new List<string>();
             CustomVcpMappings = new List<CustomVcpValueMapping>();
 
@@ -108,6 +109,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         /// </summary>
         [JsonPropertyName("excluded_from_sync_monitor_ids")]
         public List<string> ExcludedFromSyncMonitorIds { get; set; }
+
+        [JsonPropertyName("sync_brightness_with_internal_display")]
+        public bool SyncBrightnessWithInternalDisplay { get; set; }
 
         /// <summary>
         /// Gets or sets custom VCP value name mappings shared across all monitors.

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerDisplayPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerDisplayPage.xaml
@@ -1,4 +1,4 @@
-﻿<local:NavigablePage
+<local:NavigablePage
     x:Class="Microsoft.PowerToys.Settings.UI.Views.PowerDisplayPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -101,6 +101,9 @@
                                     </tkcontrols:SettingsCard>
                                     <tkcontrols:SettingsCard ContentAlignment="Left">
                                         <CheckBox x:Uid="PowerDisplay_ShowIdentifyMonitorsButton" IsChecked="{x:Bind ViewModel.ShowIdentifyMonitorsButton, Mode=TwoWay}" />
+                                    </tkcontrols:SettingsCard>
+                                    <tkcontrols:SettingsCard ContentAlignment="Left">
+                                        <CheckBox x:Uid="PowerDisplay_SyncBrightnessWithInternalDisplay" IsChecked="{x:Bind ViewModel.SyncBrightnessWithInternalDisplay, Mode=TwoWay}" />
                                     </tkcontrols:SettingsCard>
                                 </tkcontrols:SettingsExpander.Items>
                             </tkcontrols:SettingsExpander>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -5551,6 +5551,9 @@ The break timer font matches the text font.</value>
   <data name="PowerDisplay_RestoreSettingsOnStartup.Content" xml:space="preserve">
     <value>Restore monitor brightness and color temperature when Power Display launches</value>
     <comment>{Locked="Power Display"}</comment>
+  </data>
+  <data name="PowerDisplay_SyncBrightnessWithInternalDisplay.Content" xml:space="preserve">
+    <value>Sync external monitor brightness when laptop screen brightness changes</value>
   </data>
   <data name="PowerDisplay_ShowSystemTrayIcon.Content" xml:space="preserve">
     <value>Show system tray icon</value>

--- a/src/settings-ui/Settings.UI/ViewModels/PowerDisplayViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/PowerDisplayViewModel.cs
@@ -343,6 +343,19 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             }
         }
 
+        public bool SyncBrightnessWithInternalDisplay
+        {
+            get => _settings.Properties.SyncBrightnessWithInternalDisplay;
+            set
+            {
+                if (SetSettingsProperty(_settings.Properties.SyncBrightnessWithInternalDisplay, value, v => _settings.Properties.SyncBrightnessWithInternalDisplay = v))
+                {
+                    SignalSettingsUpdated();
+                    Logger.LogInfo($"SyncBrightnessWithInternalDisplay changed to {value}");
+                }
+            }
+        }
+
         public HotkeySettings ActivationShortcut
         {
             get => _settings.Properties.ActivationShortcut;


### PR DESCRIPTION
- [x] Closes: #48120 
## Summary of the Pull Request

This PR adds two highly requested features to the **PowerDisplay** utility:
1. **Linked Brightness Controls:** A master "All Displays" slider to control all monitors simultaneously with support for per-monitor exclusions and debounced hardware writes.
2. **Laptop Screen (Internal Display) Sync:** Real-time synchronization of external displays when the laptop/built-in screen's brightness is adjusted (such as via the Windows 11/10 Quick Settings slider or Fn keys).

---

## Detailed Changes

### 1. Linked Brightness Controls
- **Master Slider:** Added a master "All Displays" slider in the PowerDisplay flyout UI (`LinkedBrightness`) that broadcasts value changes to all linked monitors.
- **Per-Monitor Exclusion:** Users can toggle individual monitors in and out of the linked group using a button on each card (`IsExcludedFromSync` / `excluded_from_sync_monitor_ids`). Excluded monitors keep their own independent sliders and do not follow the master level.
- **Hardware Debouncing:** Propagates adjustments using a debounced queue (`SliderCommitScheduler`) to prevent high-frequency DDC/CI commands from locking up or lagging external monitors during drags.

### 2. Laptop Screen Sync (Windows Slider Integration)
- **WMI Event Monitoring:** Wired up real-time listening to Windows `WmiMonitorBrightnessEvent` in `WmiController` to detect changes to the built-in display's brightness.
- **Windows Slider & Fn Key Sync:** When the user adjusts their laptop screen's brightness via the Windows Quick Settings flyout or keyboard Fn keys, the utility captures the event and automatically updates all non-excluded external displays.
- **Independent Behavior:** Designed the sync to work even if the internal display itself is excluded from the PowerToys linked group, allowing the native Windows slider to serve as the master control for all external screens.
- **UI Alignment:** Added a settings toggle under Settings UI: *"Sync external monitor brightness when laptop screen brightness changes"* (`sync_brightness_with_internal_display`).

---

## PR Checklist

- [x] Closes: #48120
- [x] **Communication:** Commits are atomic and cleanly document the implementation.
- [x] **Tests:** Compiled project and ran the full MSTest suite (`PowerDisplay.Lib.UnitTests`). All **138/138 unit tests pass successfully**.
