### PR TITLE
Add PowerAccent.Core unit tests (geometry + positioning)

### DIFF
--- a/PowerToys.slnx
+++ b/PowerToys.slnx
@@ -814,6 +814,10 @@
       <Platform Solution="*|ARM64" Project="ARM64" />
       <Platform Solution="*|x64" Project="x64" />
     </Project>
+    <Project Path="src/modules/poweraccent/PowerAccent.Core.UnitTests/PowerAccent.Core.UnitTests.csproj">
+      <Platform Solution="*|ARM64" Project="ARM64" />
+      <Platform Solution="*|x64" Project="x64" />
+    </Project>
     <Project Path="src/modules/poweraccent/PowerAccent.UI/PowerAccent.UI.csproj">
       <Platform Solution="*|ARM64" Project="ARM64" />
       <Platform Solution="*|x64" Project="x64" />

--- a/src/modules/poweraccent/PowerAccent.Core.UnitTests/CalculationTests.cs
+++ b/src/modules/poweraccent/PowerAccent.Core.UnitTests/CalculationTests.cs
@@ -1,0 +1,369 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PowerAccent.Core.Services;
+using PowerAccent.Core.Tools;
+
+namespace PowerAccent.Core.UnitTests
+{
+    [TestClass]
+    public class CalculationTests
+    {
+        // Screen representing a standard 1920x1080 monitor at position (0,0)
+        private static readonly Rect StandardScreen = new Rect(0, 0, 1920, 1080);
+
+        // A typical toolbar window size (300x50 in WPF DIPs)
+        private static readonly Size ToolbarWindow = new Size(300, 50);
+
+        /// <summary>
+        /// Product code: Calculation.GetRawCoordinatesFromCaret
+        /// What: Verifies toolbar is centered horizontally above the caret at screen center
+        /// Why: The most common placement scenario — regression here affects every user
+        /// </summary>
+        [TestMethod]
+        public void GetRawCoordinatesFromCaret_CenterOfScreen_ShouldCenterToolbar()
+        {
+            var caret = new Point(960, 540);
+            var result = Calculation.GetRawCoordinatesFromCaret(caret, StandardScreen, ToolbarWindow);
+
+            // X should be caret.X - window.Width/2 = 960 - 150 = 810
+            Assert.AreEqual(810.0, result.X);
+
+            // Y should be caret.Y - window.Height - 20 = 540 - 50 - 20 = 470
+            Assert.AreEqual(470.0, result.Y);
+        }
+
+        /// <summary>
+        /// Product code: Calculation.GetRawCoordinatesFromCaret — left edge clamping
+        /// What: Verifies toolbar is clamped to screen left when caret is near left edge
+        /// Why: Without clamping, toolbar would extend off-screen and be unusable
+        /// </summary>
+        [TestMethod]
+        public void GetRawCoordinatesFromCaret_NearLeftEdge_ShouldClampToScreenLeft()
+        {
+            var caret = new Point(50, 540);
+            var result = Calculation.GetRawCoordinatesFromCaret(caret, StandardScreen, ToolbarWindow);
+
+            // left = 50 - 150 = -100, which is < screen.X (0), so X should be clamped to 0
+            Assert.AreEqual(0.0, result.X);
+        }
+
+        /// <summary>
+        /// Product code: Calculation.GetRawCoordinatesFromCaret — right edge clamping
+        /// What: Verifies toolbar is clamped to screen right when caret is near right edge
+        /// Why: Toolbar extending past screen right would be clipped by the display
+        /// </summary>
+        [TestMethod]
+        public void GetRawCoordinatesFromCaret_NearRightEdge_ShouldClampToScreenRight()
+        {
+            var caret = new Point(1900, 540);
+            var result = Calculation.GetRawCoordinatesFromCaret(caret, StandardScreen, ToolbarWindow);
+
+            // left = 1900 - 150 = 1750, left + window.Width = 1750 + 300 = 2050 > 1920
+            // So X should be clamped to screen.X + screen.Width - window.Width = 1920 - 300 = 1620
+            Assert.AreEqual(1620.0, result.X);
+        }
+
+        /// <summary>
+        /// Product code: Calculation.GetRawCoordinatesFromCaret — top edge flip
+        /// What: Verifies toolbar is placed below the caret when there is no room above
+        /// Why: When caret is near top of screen, toolbar must flip below to remain visible
+        /// </summary>
+        [TestMethod]
+        public void GetRawCoordinatesFromCaret_NearTopEdge_ShouldPlaceBelow()
+        {
+            var caret = new Point(960, 30);
+            var result = Calculation.GetRawCoordinatesFromCaret(caret, StandardScreen, ToolbarWindow);
+
+            // top = 30 - 50 - 20 = -40, which is < screen.Y (0)
+            // So Y should be caret.Y + 20 = 50 (placed below caret)
+            Assert.AreEqual(50.0, result.Y);
+        }
+
+        /// <summary>
+        /// Product code: Calculation.GetRawCoordinatesFromCaret — normal above placement
+        /// What: Verifies toolbar is placed above the caret when there is sufficient space
+        /// Why: Default behavior — toolbar should appear above to avoid occluding text below
+        /// </summary>
+        [TestMethod]
+        public void GetRawCoordinatesFromCaret_SufficientSpaceAbove_ShouldPlaceAbove()
+        {
+            var caret = new Point(960, 200);
+            var result = Calculation.GetRawCoordinatesFromCaret(caret, StandardScreen, ToolbarWindow);
+
+            // top = 200 - 50 - 20 = 130, which is >= screen.Y (0)
+            Assert.AreEqual(130.0, result.Y);
+        }
+
+        /// <summary>
+        /// Product code: Calculation.GetRawCoordinatesFromCaret — multi-monitor offset
+        /// What: Verifies toolbar respects non-zero screen origin (second monitor at X=1920)
+        /// Why: Multi-monitor setups have offset screen coordinates — clamping must use screen.X
+        /// </summary>
+        [TestMethod]
+        public void GetRawCoordinatesFromCaret_OffsetScreen_ShouldRespectScreenOrigin()
+        {
+            var screen = new Rect(1920, 0, 1920, 1080);
+            var caret = new Point(1950, 540);
+            var result = Calculation.GetRawCoordinatesFromCaret(caret, screen, ToolbarWindow);
+
+            // left = 1950 - 150 = 1800, which is < screen.X (1920)
+            // So X should be clamped to 1920
+            Assert.AreEqual(1920.0, result.X);
+        }
+
+        /// <summary>
+        /// Product code: Calculation.GetRawCoordinatesFromCaret — exact boundary case
+        /// What: Verifies no clamping occurs when toolbar fits exactly at the boundary
+        /// Why: Off-by-one errors in boundary checks are common — this catches ≤ vs &lt; bugs
+        /// </summary>
+        [TestMethod]
+        public void GetRawCoordinatesFromCaret_ExactBoundary_ShouldNotClamp()
+        {
+            var caret = new Point(150, 100);
+            var result = Calculation.GetRawCoordinatesFromCaret(caret, StandardScreen, ToolbarWindow);
+
+            // left = 150 - 150 = 0, which == screen.X, so no left clamp needed
+            Assert.AreEqual(0.0, result.X);
+
+            // top = 100 - 50 - 20 = 30, which >= 0
+            Assert.AreEqual(30.0, result.Y);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(NotImplementedException))]
+        public void GetRawCoordinatesFromPosition_InvalidPosition_ShouldThrow()
+        {
+            Calculation.GetRawCoordinatesFromPosition((Position)999, StandardScreen, ToolbarWindow, 1.0);
+        }
+
+        /// <summary>
+        /// Product code: Calculation.GetRawCoordinatesFromPosition with Position.Top
+        /// What: Verifies toolbar is horizontally centered at the top of the screen with offset
+        /// Why: Exact value test — catches formula regressions in the Top positioning branch
+        /// </summary>
+        [TestMethod]
+        public void GetRawCoordinatesFromPosition_TopCenter_ShouldBeCenteredAtTop()
+        {
+            var result = Calculation.GetRawCoordinatesFromPosition(Position.Top, StandardScreen, ToolbarWindow, 1.0);
+
+            // X: screen.X + screen.Width/2 - window.Width*dpi/2 = 0 + 960 - 150 = 810
+            Assert.AreEqual(810.0, result.X);
+
+            // Y: screen.Y + offset = 0 + 24 = 24
+            Assert.AreEqual(24.0, result.Y);
+        }
+
+        /// <summary>
+        /// Product code: Calculation.GetRawCoordinatesFromPosition with Position.Bottom
+        /// What: Verifies toolbar is horizontally centered at the bottom of the screen
+        /// Why: Bottom placement subtracts window height + offset — easy to get wrong
+        /// </summary>
+        [TestMethod]
+        public void GetRawCoordinatesFromPosition_BottomCenter_ShouldBeCenteredAtBottom()
+        {
+            var result = Calculation.GetRawCoordinatesFromPosition(Position.Bottom, StandardScreen, ToolbarWindow, 1.0);
+
+            // X: centered = 810
+            Assert.AreEqual(810.0, result.X);
+
+            // Y: screen.Y + screen.Height - (window.Height*dpi + offset) = 0 + 1080 - (50 + 24) = 1006
+            Assert.AreEqual(1006.0, result.Y);
+        }
+
+        /// <summary>
+        /// Product code: Calculation.GetRawCoordinatesFromPosition with Position.Center
+        /// What: Verifies toolbar is centered both horizontally and vertically
+        /// Why: Center is the simplest case — validates the baseline formula for both axes
+        /// </summary>
+        [TestMethod]
+        public void GetRawCoordinatesFromPosition_Center_ShouldBeTrulyCentered()
+        {
+            var result = Calculation.GetRawCoordinatesFromPosition(Position.Center, StandardScreen, ToolbarWindow, 1.0);
+
+            // X: screen.X + screen.Width/2 - window.Width*dpi/2 = 0 + 960 - 150 = 810
+            Assert.AreEqual(810.0, result.X);
+
+            // Y: screen.Y + screen.Height/2 - window.Height*dpi/2 = 0 + 540 - 25 = 515
+            Assert.AreEqual(515.0, result.Y);
+        }
+
+        /// <summary>
+        /// Product code: Calculation.GetRawCoordinatesFromPosition with Position.TopLeft
+        /// What: Verifies toolbar is placed at top-left corner with offset margin
+        /// Why: Corner placements use raw offset — validates the simplest X/Y path
+        /// </summary>
+        [TestMethod]
+        public void GetRawCoordinatesFromPosition_TopLeft_ShouldBeAtTopLeftCorner()
+        {
+            var result = Calculation.GetRawCoordinatesFromPosition(Position.TopLeft, StandardScreen, ToolbarWindow, 1.0);
+
+            // X: screen.X + offset = 0 + 24 = 24
+            Assert.AreEqual(24.0, result.X);
+
+            // Y: screen.Y + offset = 0 + 24 = 24
+            Assert.AreEqual(24.0, result.Y);
+        }
+
+        /// <summary>
+        /// Product code: Calculation.GetRawCoordinatesFromPosition with Position.TopRight
+        /// What: Verifies exact coordinates for top-right corner placement
+        /// Why: TopRight combines right-aligned X with top Y — validates both formula branches
+        /// </summary>
+        [TestMethod]
+        public void GetRawCoordinatesFromPosition_TopRight_ShouldBeAtTopRightCorner()
+        {
+            var result = Calculation.GetRawCoordinatesFromPosition(Position.TopRight, StandardScreen, ToolbarWindow, 1.0);
+
+            // X: screen.X + screen.Width - (window.Width*dpi + offset) = 0 + 1920 - (300 + 24) = 1596
+            Assert.AreEqual(1596.0, result.X);
+
+            // Y: screen.Y + offset = 0 + 24 = 24
+            Assert.AreEqual(24.0, result.Y);
+        }
+
+        /// <summary>
+        /// Product code: Calculation.GetRawCoordinatesFromPosition with Position.BottomLeft
+        /// What: Verifies exact coordinates for bottom-left corner placement
+        /// Why: BottomLeft combines left-aligned X with bottom Y — validates both formula branches
+        /// </summary>
+        [TestMethod]
+        public void GetRawCoordinatesFromPosition_BottomLeft_ShouldBeAtBottomLeftCorner()
+        {
+            var result = Calculation.GetRawCoordinatesFromPosition(Position.BottomLeft, StandardScreen, ToolbarWindow, 1.0);
+
+            // X: screen.X + offset = 0 + 24 = 24
+            Assert.AreEqual(24.0, result.X);
+
+            // Y: screen.Y + screen.Height - (window.Height*dpi + offset) = 0 + 1080 - (50 + 24) = 1006
+            Assert.AreEqual(1006.0, result.Y);
+        }
+
+        /// <summary>
+        /// Product code: Calculation.GetRawCoordinatesFromPosition with Position.BottomRight
+        /// What: Verifies toolbar is placed at bottom-right corner with offset margin
+        /// Why: BottomRight uses the most complex formula (subtracts from both edges)
+        /// </summary>
+        [TestMethod]
+        public void GetRawCoordinatesFromPosition_BottomRight_ShouldBeAtBottomRightCorner()
+        {
+            var result = Calculation.GetRawCoordinatesFromPosition(Position.BottomRight, StandardScreen, ToolbarWindow, 1.0);
+
+            // X: screen.X + screen.Width - (window.Width*dpi + offset) = 0 + 1920 - (300 + 24) = 1596
+            Assert.AreEqual(1596.0, result.X);
+
+            // Y: screen.Y + screen.Height - (window.Height*dpi + offset) = 0 + 1080 - (50 + 24) = 1006
+            Assert.AreEqual(1006.0, result.Y);
+        }
+
+        /// <summary>
+        /// Product code: Calculation.GetRawCoordinatesFromPosition with Position.Left
+        /// What: Verifies toolbar is placed at left edge, vertically centered
+        /// Why: Left position uses offset for X and centering for Y — tests the mix
+        /// </summary>
+        [TestMethod]
+        public void GetRawCoordinatesFromPosition_Left_ShouldBeAtLeftMiddle()
+        {
+            var result = Calculation.GetRawCoordinatesFromPosition(Position.Left, StandardScreen, ToolbarWindow, 1.0);
+
+            // X: screen.X + offset = 0 + 24 = 24
+            Assert.AreEqual(24.0, result.X);
+
+            // Y: centered vertically = 0 + 540 - 25 = 515
+            Assert.AreEqual(515.0, result.Y);
+        }
+
+        /// <summary>
+        /// Product code: Calculation.GetRawCoordinatesFromPosition with Position.Right
+        /// What: Verifies toolbar is placed at right edge, vertically centered
+        /// Why: Right position subtracts window width from screen edge — tests the right-align formula
+        /// </summary>
+        [TestMethod]
+        public void GetRawCoordinatesFromPosition_Right_ShouldBeAtRightMiddle()
+        {
+            var result = Calculation.GetRawCoordinatesFromPosition(Position.Right, StandardScreen, ToolbarWindow, 1.0);
+
+            // X: screen.X + screen.Width - (window.Width*dpi + offset) = 1920 - 324 = 1596
+            Assert.AreEqual(1596.0, result.X);
+
+            // Y: centered vertically = 515
+            Assert.AreEqual(515.0, result.Y);
+        }
+
+        /// <summary>
+        /// Product code: Calculation.GetRawCoordinatesFromPosition with DPI=1.5
+        /// What: Verifies that DPI scaling is applied to window size in centering formula
+        /// Why: High-DPI monitors are common — incorrect scaling makes toolbar appear off-center
+        /// </summary>
+        [TestMethod]
+        public void GetRawCoordinatesFromPosition_WithHighDpi_ShouldScaleWindow()
+        {
+            double dpi = 1.5;
+            var result = Calculation.GetRawCoordinatesFromPosition(Position.Center, StandardScreen, ToolbarWindow, dpi);
+
+            // X: screen.X + screen.Width/2 - window.Width*dpi/2 = 0 + 960 - (300*1.5)/2 = 960 - 225 = 735
+            Assert.AreEqual(735.0, result.X);
+
+            // Y: screen.Y + screen.Height/2 - window.Height*dpi/2 = 0 + 540 - (50*1.5)/2 = 540 - 37.5 = 502.5
+            Assert.AreEqual(502.5, result.Y);
+        }
+
+        /// <summary>
+        /// Product code: Calculation.GetRawCoordinatesFromPosition with DPI=2.0, TopLeft
+        /// What: Verifies that offset is NOT DPI-scaled for corner positions
+        /// Why: The 24px offset is a fixed margin — DPI scaling only affects window size
+        /// </summary>
+        [TestMethod]
+        public void GetRawCoordinatesFromPosition_WithDpi2_TopLeft_ShouldUseOffset()
+        {
+            double dpi = 2.0;
+            var result = Calculation.GetRawCoordinatesFromPosition(Position.TopLeft, StandardScreen, ToolbarWindow, dpi);
+
+            // X: screen.X + offset = 0 + 24 = 24 (offset is not DPI-scaled)
+            Assert.AreEqual(24.0, result.X);
+
+            // Y: screen.Y + offset = 0 + 24 = 24
+            Assert.AreEqual(24.0, result.Y);
+        }
+
+        /// <summary>
+        /// Product code: Calculation.GetRawCoordinatesFromPosition with DPI=2.0, BottomRight
+        /// What: Verifies DPI scaling of window size in bottom-right corner formula
+        /// Why: At 2x DPI, the window occupies 600×100 pixels — offset from edge must account for this
+        /// </summary>
+        [TestMethod]
+        public void GetRawCoordinatesFromPosition_WithDpi2_BottomRight_ShouldScaleWindowSize()
+        {
+            double dpi = 2.0;
+            var result = Calculation.GetRawCoordinatesFromPosition(Position.BottomRight, StandardScreen, ToolbarWindow, dpi);
+
+            // X: screen.X + screen.Width - (window.Width*dpi + offset) = 0 + 1920 - (300*2 + 24) = 1920 - 624 = 1296
+            Assert.AreEqual(1296.0, result.X);
+
+            // Y: screen.Y + screen.Height - (window.Height*dpi + offset) = 0 + 1080 - (50*2 + 24) = 1080 - 124 = 956
+            Assert.AreEqual(956.0, result.Y);
+        }
+
+        /// <summary>
+        /// Product code: Calculation.GetRawCoordinatesFromPosition with offset screen origin
+        /// What: Verifies screen.X is added as the base for TopLeft on a secondary monitor
+        /// Why: Without adding screen origin, toolbar appears on the wrong monitor
+        /// </summary>
+        [TestMethod]
+        public void GetRawCoordinatesFromPosition_OffsetScreen_ShouldRespectScreenOrigin()
+        {
+            var screen = new Rect(1920, 0, 1920, 1080);
+            var result = Calculation.GetRawCoordinatesFromPosition(Position.TopLeft, screen, ToolbarWindow, 1.0);
+
+            // X: screen.X + offset = 1920 + 24 = 1944
+            Assert.AreEqual(1944.0, result.X);
+
+            // Y: screen.Y + offset = 0 + 24 = 24
+            Assert.AreEqual(24.0, result.Y);
+        }
+    }
+}

--- a/src/modules/poweraccent/PowerAccent.Core.UnitTests/PointTests.cs
+++ b/src/modules/poweraccent/PowerAccent.Core.UnitTests/PointTests.cs
@@ -1,0 +1,205 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace PowerAccent.Core.UnitTests
+{
+    [TestClass]
+    public class PointTests
+    {
+        /// <summary>
+        /// Product code: Point() default constructor
+        /// What: Verifies X and Y initialize to zero
+        /// Why: Default state must be deterministic — uninitialized coordinates cause misplacement
+        /// </summary>
+        [TestMethod]
+        public void DefaultConstructor_ShouldInitializeToZero()
+        {
+            var point = new Point();
+            Assert.AreEqual(0, point.X);
+            Assert.AreEqual(0, point.Y);
+        }
+
+        /// <summary>
+        /// Product code: Point(double, double) constructor
+        /// What: Verifies that fractional coordinates are preserved exactly
+        /// Why: Sub-pixel precision is needed for DPI-aware positioning
+        /// </summary>
+        [TestMethod]
+        public void DoubleConstructor_ShouldSetCoordinates()
+        {
+            var point = new Point(3.5, 7.2);
+            Assert.AreEqual(3.5, point.X);
+            Assert.AreEqual(7.2, point.Y);
+        }
+
+        /// <summary>
+        /// Product code: Point(int, int) constructor
+        /// What: Verifies integer coordinates are stored as doubles without loss
+        /// Why: Implicit int→double conversion must be exact for pixel-aligned positioning
+        /// </summary>
+        [TestMethod]
+        public void IntConstructor_ShouldSetCoordinates()
+        {
+            var point = new Point(10, 20);
+            Assert.AreEqual(10.0, point.X);
+            Assert.AreEqual(20.0, point.Y);
+        }
+
+        /// <summary>
+        /// Product code: Point(System.Drawing.Point) constructor
+        /// What: Verifies conversion from System.Drawing.Point preserves coordinates
+        /// Why: Win32 API interop uses System.Drawing.Point — conversion must be lossless
+        /// </summary>
+        [TestMethod]
+        public void DrawingPointConstructor_ShouldConvertCoordinates()
+        {
+            var drawingPoint = new System.Drawing.Point(15, 25);
+            var point = new Point(drawingPoint);
+            Assert.AreEqual(15.0, point.X);
+            Assert.AreEqual(25.0, point.Y);
+        }
+
+        /// <summary>
+        /// Product code: Point implicit operator from System.Drawing.Point
+        /// What: Verifies implicit conversion works at assignment sites
+        /// Why: Enables seamless interop without explicit casts in calling code
+        /// </summary>
+        [TestMethod]
+        public void ImplicitConversion_FromDrawingPoint_ShouldWork()
+        {
+            Point point = new System.Drawing.Point(100, 200);
+            Assert.AreEqual(100.0, point.X);
+            Assert.AreEqual(200.0, point.Y);
+        }
+
+        /// <summary>
+        /// Product code: Point operator /(Point, double)
+        /// What: Verifies scalar division halves both coordinates
+        /// Why: Core arithmetic for DPI normalization
+        /// </summary>
+        [TestMethod]
+        public void DivisionByScalar_ShouldDivideCoordinates()
+        {
+            var point = new Point(10.0, 20.0);
+            var result = point / 2.0;
+            Assert.AreEqual(5.0, result.X);
+            Assert.AreEqual(10.0, result.Y);
+        }
+
+        /// <summary>
+        /// Product code: Point operator /(Point, double) with negative divisor
+        /// What: Verifies negative divisor negates both coordinates
+        /// Why: Ensures correct sign propagation in coordinate math
+        /// </summary>
+        [TestMethod]
+        public void DivisionByScalar_WithNegativeDivider_ShouldNegateCoordinates()
+        {
+            var point = new Point(10.0, 20.0);
+            var result = point / -2.0;
+            Assert.AreEqual(-5.0, result.X);
+            Assert.AreEqual(-10.0, result.Y);
+        }
+
+        /// <summary>
+        /// Product code: Point operator /(Point, double) zero guard
+        /// What: Verifies that dividing by zero throws DivideByZeroException
+        /// Why: Prevents Infinity coordinates from corrupting toolbar placement
+        /// </summary>
+        [TestMethod]
+        [ExpectedException(typeof(DivideByZeroException))]
+        public void DivisionByScalar_WithZero_ShouldThrow()
+        {
+            var point = new Point(10.0, 20.0);
+            _ = point / 0.0;
+        }
+
+        /// <summary>
+        /// Product code: Point operator /(Point, Point)
+        /// What: Verifies component-wise division (X/X, Y/Y)
+        /// Why: Used for coordinate space transformations
+        /// </summary>
+        [TestMethod]
+        public void DivisionByPoint_ShouldDivideComponentwise()
+        {
+            var point = new Point(10.0, 20.0);
+            var divider = new Point(2.0, 5.0);
+            var result = point / divider;
+            Assert.AreEqual(5.0, result.X);
+            Assert.AreEqual(4.0, result.Y);
+        }
+
+        /// <summary>
+        /// Product code: Point operator /(Point, Point) zero guard for X
+        /// What: Verifies that a divider with X=0 throws DivideByZeroException
+        /// Why: X=0 in a divider would produce Infinity for the X coordinate
+        /// </summary>
+        [TestMethod]
+        [ExpectedException(typeof(DivideByZeroException))]
+        public void DivisionByPoint_WithZeroX_ShouldThrow()
+        {
+            var point = new Point(10.0, 20.0);
+            var divider = new Point(0.0, 5.0);
+            _ = point / divider;
+        }
+
+        /// <summary>
+        /// Product code: Point operator /(Point, Point) zero guard for Y
+        /// What: Verifies that a divider with Y=0 throws DivideByZeroException
+        /// Why: Y=0 in a divider would produce Infinity for the Y coordinate
+        /// </summary>
+        [TestMethod]
+        [ExpectedException(typeof(DivideByZeroException))]
+        public void DivisionByPoint_WithZeroY_ShouldThrow()
+        {
+            var point = new Point(10.0, 20.0);
+            var divider = new Point(5.0, 0.0);
+            _ = point / divider;
+        }
+
+        /// <summary>
+        /// Product code: Point(double, double) constructor with negatives
+        /// What: Verifies that negative coordinates are stored correctly
+        /// Why: Negative coordinates are valid in multi-monitor setups (left/above primary)
+        /// </summary>
+        [TestMethod]
+        public void NegativeCoordinates_ShouldBeAllowed()
+        {
+            var point = new Point(-5.5, -10.3);
+            Assert.AreEqual(-5.5, point.X);
+            Assert.AreEqual(-10.3, point.Y);
+        }
+
+        /// <summary>
+        /// Product code: Point operator /(Point, double) with fractional divisor
+        /// What: Verifies dividing by 0.5 effectively doubles coordinates
+        /// Why: Fractional DPI values (1.25x, 1.5x) are common in production
+        /// </summary>
+        [TestMethod]
+        public void DivisionByScalar_WithFractionalDivider_ShouldWork()
+        {
+            var point = new Point(10.0, 20.0);
+            var result = point / 0.5;
+            Assert.AreEqual(20.0, result.X);
+            Assert.AreEqual(40.0, result.Y);
+        }
+
+        /// <summary>
+        /// Product code: Point operator /(Point, Point) zero guard for both X and Y
+        /// What: Verifies that a divider with both X=0 and Y=0 throws
+        /// Why: Degenerate origin-point divider must be rejected — tests the first guard hit
+        /// </summary>
+        [TestMethod]
+        [ExpectedException(typeof(DivideByZeroException))]
+        public void DivisionByPoint_WithBothZero_ShouldThrow()
+        {
+            var point = new Point(10.0, 20.0);
+            var divider = new Point(0.0, 0.0);
+            _ = point / divider;
+        }
+    }
+}

--- a/src/modules/poweraccent/PowerAccent.Core.UnitTests/PowerAccent.Core.UnitTests.csproj
+++ b/src/modules/poweraccent/PowerAccent.Core.UnitTests/PowerAccent.Core.UnitTests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!-- Look at Directory.Build.props in root for common stuff as well -->
+  <Import Project="$(RepoRoot)src\Common.Dotnet.CsWinRT.props" />
+
+  <Import Project="$(RepoRoot)src\Common.SelfContained.props" />
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+    <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\tests\PowerAccent.Core.Tests\</OutputPath>
+    <RootNamespace>PowerAccent.Core.UnitTests</RootNamespace>
+    <AssemblyName>PowerToys.PowerAccent.Core.UnitTests</AssemblyName>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PowerAccent.Core\PowerAccent.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/modules/poweraccent/PowerAccent.Core.UnitTests/RectTests.cs
+++ b/src/modules/poweraccent/PowerAccent.Core.UnitTests/RectTests.cs
@@ -1,0 +1,223 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace PowerAccent.Core.UnitTests
+{
+    [TestClass]
+    public class RectTests
+    {
+        /// <summary>
+        /// Product code: Rect() default constructor
+        /// What: Verifies all properties initialize to zero
+        /// Why: Default state must be well-defined to avoid uninitialized geometry bugs
+        /// </summary>
+        [TestMethod]
+        public void DefaultConstructor_ShouldInitializeToZero()
+        {
+            var rect = new Rect();
+            Assert.AreEqual(0, rect.X);
+            Assert.AreEqual(0, rect.Y);
+            Assert.AreEqual(0, rect.Width);
+            Assert.AreEqual(0, rect.Height);
+        }
+
+        /// <summary>
+        /// Product code: Rect(int, int, int, int) constructor
+        /// What: Verifies that integer arguments are correctly stored as doubles
+        /// Why: Implicit int→double conversion must preserve exact values
+        /// </summary>
+        [TestMethod]
+        public void IntConstructor_ShouldSetAllProperties()
+        {
+            var rect = new Rect(10, 20, 800, 600);
+            Assert.AreEqual(10.0, rect.X);
+            Assert.AreEqual(20.0, rect.Y);
+            Assert.AreEqual(800.0, rect.Width);
+            Assert.AreEqual(600.0, rect.Height);
+        }
+
+        /// <summary>
+        /// Product code: Rect(double, double, double, double) constructor
+        /// What: Verifies that fractional double values are stored exactly
+        /// Why: Ensures no rounding or truncation occurs during construction
+        /// </summary>
+        [TestMethod]
+        public void DoubleConstructor_ShouldSetAllProperties()
+        {
+            var rect = new Rect(1.5, 2.5, 100.3, 200.7);
+            Assert.AreEqual(1.5, rect.X);
+            Assert.AreEqual(2.5, rect.Y);
+            Assert.AreEqual(100.3, rect.Width);
+            Assert.AreEqual(200.7, rect.Height);
+        }
+
+        /// <summary>
+        /// Product code: Rect(Point, Size) constructor
+        /// What: Verifies that Point and Size components map to correct Rect properties
+        /// Why: X/Y come from Point, Width/Height from Size — a swap would silently corrupt layout
+        /// </summary>
+        [TestMethod]
+        public void PointSizeConstructor_ShouldSetFromComponents()
+        {
+            var point = new Point(50.0, 100.0);
+            var size = new Size(400.0, 300.0);
+            var rect = new Rect(point, size);
+            Assert.AreEqual(50.0, rect.X);
+            Assert.AreEqual(100.0, rect.Y);
+            Assert.AreEqual(400.0, rect.Width);
+            Assert.AreEqual(300.0, rect.Height);
+        }
+
+        /// <summary>
+        /// Product code: Rect operator /(Rect, double)
+        /// What: Verifies component-wise division by a scalar
+        /// Why: Used for DPI scaling — incorrect division would misposition the toolbar
+        /// </summary>
+        [TestMethod]
+        public void DivisionByScalar_ShouldDivideAllComponents()
+        {
+            var rect = new Rect(10.0, 20.0, 100.0, 200.0);
+            var result = rect / 2.0;
+            Assert.AreEqual(5.0, result.X);
+            Assert.AreEqual(10.0, result.Y);
+            Assert.AreEqual(50.0, result.Width);
+            Assert.AreEqual(100.0, result.Height);
+        }
+
+        /// <summary>
+        /// Product code: Rect operator /(Rect, double) zero guard
+        /// What: Verifies that dividing by zero throws DivideByZeroException
+        /// Why: Prevents Infinity values from propagating through layout calculations
+        /// </summary>
+        [TestMethod]
+        [ExpectedException(typeof(DivideByZeroException))]
+        public void DivisionByScalar_WithZero_ShouldThrow()
+        {
+            var rect = new Rect(10.0, 20.0, 100.0, 200.0);
+            _ = rect / 0.0;
+        }
+
+        /// <summary>
+        /// Product code: Rect operator /(Rect, Rect)
+        /// What: Verifies component-wise division (X/X, Y/Y, Width/Width, Height/Height)
+        /// Why: Used for coordinate system transformations between screen and window space
+        /// </summary>
+        [TestMethod]
+        public void DivisionByRect_ShouldDivideComponentwise()
+        {
+            var rect = new Rect(10.0, 20.0, 100.0, 200.0);
+            var divider = new Rect(2.0, 5.0, 10.0, 20.0);
+            var result = rect / divider;
+            Assert.AreEqual(5.0, result.X);
+            Assert.AreEqual(4.0, result.Y);
+            Assert.AreEqual(10.0, result.Width);
+            Assert.AreEqual(10.0, result.Height);
+        }
+
+        /// <summary>
+        /// Product code: Rect operator /(Rect, Rect) zero guard for X component
+        /// What: Verifies that a divider with X=0 throws DivideByZeroException
+        /// Why: X=0 in a divider Rect would produce Infinity for the X coordinate
+        /// </summary>
+        [TestMethod]
+        [ExpectedException(typeof(DivideByZeroException))]
+        public void DivisionByRect_WithZeroX_ShouldThrow()
+        {
+            var rect = new Rect(10.0, 20.0, 100.0, 200.0);
+            var divider = new Rect(0.0, 5.0, 10.0, 20.0);
+            _ = rect / divider;
+        }
+
+        /// <summary>
+        /// Product code: Rect operator /(Rect, Rect) zero guard for Y component
+        /// What: Verifies that a divider with Y=0 throws DivideByZeroException
+        /// Why: Y=0 in a divider Rect would produce Infinity for the Y coordinate
+        /// </summary>
+        [TestMethod]
+        [ExpectedException(typeof(DivideByZeroException))]
+        public void DivisionByRect_WithZeroY_ShouldThrow()
+        {
+            var rect = new Rect(10.0, 20.0, 100.0, 200.0);
+            var divider = new Rect(5.0, 0.0, 10.0, 20.0);
+            _ = rect / divider;
+        }
+
+        /// <summary>
+        /// Product code: Rect operator /(Rect, Rect) zero guard for Width component
+        /// What: Verifies that a divider with Width=0 throws DivideByZeroException
+        /// Why: Guards against producing Infinity values that propagate through calculations
+        /// </summary>
+        [TestMethod]
+        [ExpectedException(typeof(DivideByZeroException))]
+        public void DivisionByRect_WithZeroWidth_ShouldThrow()
+        {
+            var rect = new Rect(10, 20, 100, 200);
+            var divider = new Rect(1, 1, 0, 1);
+            _ = rect / divider;
+        }
+
+        /// <summary>
+        /// Product code: Rect operator /(Rect, Rect) zero guard for Height component
+        /// What: Verifies that a divider with Height=0 throws DivideByZeroException
+        /// Why: Guards against producing Infinity values that propagate through calculations
+        /// </summary>
+        [TestMethod]
+        [ExpectedException(typeof(DivideByZeroException))]
+        public void DivisionByRect_WithZeroHeight_ShouldThrow()
+        {
+            var rect = new Rect(10, 20, 100, 200);
+            var divider = new Rect(1, 1, 1, 0);
+            _ = rect / divider;
+        }
+
+        /// <summary>
+        /// Product code: Rect operator /(Rect, Rect) zero guard for all components
+        /// What: Verifies that a divider with all zero components throws DivideByZeroException
+        /// Why: Degenerate all-zero divider must be caught — tests the first guard hit (X=0)
+        /// </summary>
+        [TestMethod]
+        [ExpectedException(typeof(DivideByZeroException))]
+        public void DivisionByRect_WithAllZeroComponents_ShouldThrow()
+        {
+            var rect = new Rect(10, 20, 100, 200);
+            var divider = new Rect(0, 0, 0, 0);
+            _ = rect / divider;
+        }
+
+        /// <summary>
+        /// Product code: Rect(double, double, double, double) constructor
+        /// What: Verifies that negative X/Y coordinates are allowed
+        /// Why: Multi-monitor setups can have negative screen coordinates (left/above primary)
+        /// </summary>
+        [TestMethod]
+        public void NegativeCoordinates_ShouldBeAllowed()
+        {
+            var rect = new Rect(-100.0, -200.0, 400.0, 300.0);
+            Assert.AreEqual(-100.0, rect.X);
+            Assert.AreEqual(-200.0, rect.Y);
+            Assert.AreEqual(400.0, rect.Width);
+            Assert.AreEqual(300.0, rect.Height);
+        }
+
+        /// <summary>
+        /// Product code: Rect operator /(Rect, double) with negative divisor
+        /// What: Verifies that negative divisor negates all components
+        /// Why: Ensures sign propagation is correct — used in coordinate flipping scenarios
+        /// </summary>
+        [TestMethod]
+        public void DivisionByScalar_WithNegativeDivider_ShouldNegateComponents()
+        {
+            var rect = new Rect(10.0, 20.0, 100.0, 200.0);
+            var result = rect / -1.0;
+            Assert.AreEqual(-10.0, result.X);
+            Assert.AreEqual(-20.0, result.Y);
+            Assert.AreEqual(-100.0, result.Width);
+            Assert.AreEqual(-200.0, result.Height);
+        }
+    }
+}

--- a/src/modules/poweraccent/PowerAccent.Core.UnitTests/SizeTests.cs
+++ b/src/modules/poweraccent/PowerAccent.Core.UnitTests/SizeTests.cs
@@ -1,0 +1,192 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace PowerAccent.Core.UnitTests
+{
+    [TestClass]
+    public class SizeTests
+    {
+        /// <summary>
+        /// Product code: Size() default constructor
+        /// What: Verifies Width and Height initialize to zero
+        /// Why: Default state must be deterministic to avoid layout corruption
+        /// </summary>
+        [TestMethod]
+        public void DefaultConstructor_ShouldInitializeToZero()
+        {
+            var size = new Size();
+            Assert.AreEqual(0, size.Width);
+            Assert.AreEqual(0, size.Height);
+        }
+
+        /// <summary>
+        /// Product code: Size(double, double) constructor
+        /// What: Verifies fractional values are preserved exactly
+        /// Why: Ensures no rounding during construction for sub-pixel precision
+        /// </summary>
+        [TestMethod]
+        public void DoubleConstructor_ShouldSetDimensions()
+        {
+            var size = new Size(100.5, 200.3);
+            Assert.AreEqual(100.5, size.Width);
+            Assert.AreEqual(200.3, size.Height);
+        }
+
+        /// <summary>
+        /// Product code: Size(int, int) constructor
+        /// What: Verifies integer dimensions are stored as doubles without loss
+        /// Why: Implicit int→double conversion must be exact
+        /// </summary>
+        [TestMethod]
+        public void IntConstructor_ShouldSetDimensions()
+        {
+            var size = new Size(800, 600);
+            Assert.AreEqual(800.0, size.Width);
+            Assert.AreEqual(600.0, size.Height);
+        }
+
+        /// <summary>
+        /// Product code: Size implicit operator from System.Drawing.Size
+        /// What: Verifies implicit conversion from System.Drawing.Size works
+        /// Why: Interop boundary — System.Drawing types are used by Win32 APIs
+        /// </summary>
+        [TestMethod]
+        public void ImplicitConversion_FromDrawingSize_ShouldWork()
+        {
+            Size size = new System.Drawing.Size(1920, 1080);
+            Assert.AreEqual(1920.0, size.Width);
+            Assert.AreEqual(1080.0, size.Height);
+        }
+
+        /// <summary>
+        /// Product code: Size operator /(Size, double)
+        /// What: Verifies scalar division halves both dimensions
+        /// Why: Core arithmetic used for DPI scaling — must produce exact results
+        /// </summary>
+        [TestMethod]
+        public void DivisionByScalar_ShouldDivideDimensions()
+        {
+            var size = new Size(100.0, 200.0);
+            var result = size / 2.0;
+            Assert.AreEqual(50.0, result.Width);
+            Assert.AreEqual(100.0, result.Height);
+        }
+
+        /// <summary>
+        /// Product code: Size operator /(Size, double) with fractional divisor
+        /// What: Verifies that dividing by 0.5 effectively doubles dimensions
+        /// Why: Fractional DPI values are real (e.g., 1.25x, 1.5x scaling)
+        /// </summary>
+        [TestMethod]
+        public void DivisionByScalar_WithFractionalDivider_ShouldWork()
+        {
+            var size = new Size(100.0, 200.0);
+            var result = size / 0.5;
+            Assert.AreEqual(200.0, result.Width);
+            Assert.AreEqual(400.0, result.Height);
+        }
+
+        /// <summary>
+        /// Product code: Size operator /(Size, double) zero guard
+        /// What: Verifies that dividing by zero throws DivideByZeroException
+        /// Why: Prevents Infinity dimensions that would corrupt window layout
+        /// </summary>
+        [TestMethod]
+        [ExpectedException(typeof(DivideByZeroException))]
+        public void DivisionByScalar_WithZero_ShouldThrow()
+        {
+            var size = new Size(100.0, 200.0);
+            _ = size / 0.0;
+        }
+
+        /// <summary>
+        /// Product code: Size operator /(Size, Size)
+        /// What: Verifies component-wise division (Width/Width, Height/Height)
+        /// Why: Used for computing scaling ratios between two rectangles
+        /// </summary>
+        [TestMethod]
+        public void DivisionBySize_ShouldDivideComponentwise()
+        {
+            var size = new Size(100.0, 200.0);
+            var divider = new Size(10.0, 20.0);
+            var result = size / divider;
+            Assert.AreEqual(10.0, result.Width);
+            Assert.AreEqual(10.0, result.Height);
+        }
+
+        /// <summary>
+        /// Product code: Size operator /(Size, Size) zero Width guard
+        /// What: Verifies that a divider with Width=0 throws DivideByZeroException
+        /// Why: Width=0 divider would produce Infinity — must be caught early
+        /// </summary>
+        [TestMethod]
+        [ExpectedException(typeof(DivideByZeroException))]
+        public void DivisionBySize_WithZeroWidth_ShouldThrow()
+        {
+            var size = new Size(100.0, 200.0);
+            var divider = new Size(0.0, 20.0);
+            _ = size / divider;
+        }
+
+        /// <summary>
+        /// Product code: Size operator /(Size, Size) zero Height guard
+        /// What: Verifies that a divider with Height=0 throws DivideByZeroException
+        /// Why: Height=0 divider would produce Infinity — must be caught early
+        /// </summary>
+        [TestMethod]
+        [ExpectedException(typeof(DivideByZeroException))]
+        public void DivisionBySize_WithZeroHeight_ShouldThrow()
+        {
+            var size = new Size(100.0, 200.0);
+            var divider = new Size(10.0, 0.0);
+            _ = size / divider;
+        }
+
+        /// <summary>
+        /// Product code: Size operator /(Size, double) with negative divisor
+        /// What: Verifies that negative divisor correctly negates both dimensions
+        /// Why: Ensures sign propagation is correct in arithmetic
+        /// </summary>
+        [TestMethod]
+        public void DivisionByScalar_WithNegativeDivider_ShouldWork()
+        {
+            var size = new Size(100.0, 200.0);
+            var result = size / -2.0;
+            Assert.AreEqual(-50.0, result.Width);
+            Assert.AreEqual(-100.0, result.Height);
+        }
+
+        /// <summary>
+        /// Product code: Size operator /(Size, double) with very small divisor
+        /// What: Verifies division by a small number produces expected large result
+        /// Why: Near-zero divisors (e.g., very low DPI) must not crash or produce NaN
+        /// </summary>
+        [TestMethod]
+        public void DivisionByScalar_WithVerySmallDivider_ShouldYieldLargeResult()
+        {
+            var size = new Size(1.0, 1.0);
+            var result = size / 0.001;
+            Assert.AreEqual(1000.0, result.Width, 0.01);
+            Assert.AreEqual(1000.0, result.Height, 0.01);
+        }
+
+        /// <summary>
+        /// Product code: Size operator /(Size, Size) zero guard for both dimensions
+        /// What: Verifies that a divider with both Width=0 and Height=0 throws
+        /// Why: Degenerate zero-size divider must be rejected — tests the first guard hit
+        /// </summary>
+        [TestMethod]
+        [ExpectedException(typeof(DivideByZeroException))]
+        public void DivisionBySize_WithBothZeroDimensions_ShouldThrow()
+        {
+            var size = new Size(100.0, 200.0);
+            var divider = new Size(0.0, 0.0);
+            _ = size / divider;
+        }
+    }
+}

--- a/src/modules/poweraccent/PowerAccent.Core/Models/Rect.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/Models/Rect.cs
@@ -58,7 +58,7 @@ public struct Rect
 
     public static Rect operator /(Rect rect, Rect divider)
     {
-        if (divider.X == 0 || divider.Y == 0)
+        if (divider.X == 0 || divider.Y == 0 || divider.Width == 0 || divider.Height == 0)
         {
             throw new DivideByZeroException();
         }

--- a/src/modules/poweraccent/PowerAccent.Core/Models/Size.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/Models/Size.cs
@@ -42,7 +42,7 @@ public struct Size
 
     public static Size operator /(Size size, Size divider)
     {
-        if (divider.Width == 0 || divider.Height == 0 || divider.Width == 0 || divider.Height == 0)
+        if (divider.Width == 0 || divider.Height == 0)
         {
             throw new DivideByZeroException();
         }

--- a/src/modules/poweraccent/PowerAccent.Core/PowerAccent.Core.csproj
+++ b/src/modules/poweraccent/PowerAccent.Core/PowerAccent.Core.csproj
@@ -33,4 +33,10 @@
     <ProjectReference Include="..\PowerAccent.Common\PowerAccent.Common.csproj" />
     <ProjectReference Include="..\PowerAccentKeyboardService\PowerAccentKeyboardService.vcxproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>PowerToys.PowerAccent.Core.UnitTests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

Adds `PowerAccent.Core.UnitTests` — new unit coverage for the Quick Accent (PowerAccent) core geometry and window-positioning logic. **62 tests, all passing.**

This is the clean, **tests-only** portion of #46684, rebased onto current `main` and split so it can land without that PR's global dependency bump (Microsoft.Extensions 9→10, SemanticKernel, OpenAI, forced `Directory.Build.props` package references, etc.). Nothing outside PowerAccent is touched.

## What's covered

- **`RectTests` / `SizeTests` / `PointTests`** — constructors, implicit conversions, component-wise and scalar division, and divide-by-zero guards.
- **`CalculationTests`** — `Calculation.GetRawCoordinatesFromCaret` and `GetRawCoordinatesFromPosition`: caret-relative placement, all nine anchor positions, horizontal/vertical clamping to screen edges, above/below flipping, **multi-monitor origin offsets**, and **DPI scaling** (1.0/1.5/2.0).

## Production changes (test-coupled, minimal)

- `Rect.operator /(Rect, Rect)` — the zero-divider guard previously checked only `X` and `Y`. Because the fields are `double`, a zero `Width`/`Height` divider silently produced `Infinity` instead of throwing. It now throws `DivideByZeroException` on any zero component (asserted by `RectTests`).
- `Size.operator /(Size, Size)` — drops a duplicated clause in the zero guard (no behavior change).
- `PowerAccent.Core.csproj` — `InternalsVisibleTo` for the test assembly (`Calculation` is `internal`).

## Why language tests from #46684 are omitted

The character/language mapping logic moved out of `PowerAccent.Core` into the new `PowerAccent.Common` project, which already has thorough, data-driven coverage in `PowerAccent.Common.UnitTests` (`CharacterMappingsTests`, `LetterKeyTests`). Porting the old `LanguagesTests` would have duplicated that against a deleted API, so it's intentionally left out.

Supersedes the PowerAccent portion of #46684.
