### PR TITLE
Add Peek.Common unit tests (MathHelper, PathHelper)

### DIFF
--- a/PowerToys.slnx
+++ b/PowerToys.slnx
@@ -786,6 +786,10 @@
       <Platform Solution="*|ARM64" Project="ARM64" />
       <Platform Solution="*|x64" Project="x64" />
     </Project>
+    <Project Path="src/modules/peek/Peek.Common.UnitTests/Peek.Common.UnitTests.csproj">
+      <Platform Solution="*|ARM64" Project="ARM64" />
+      <Platform Solution="*|x64" Project="x64" />
+    </Project>
     <Project Path="src/modules/peek/Peek.FilePreviewer/Peek.FilePreviewer.csproj">
       <Platform Solution="*|ARM64" Project="ARM64" />
       <Platform Solution="*|x64" Project="x64" />

--- a/src/modules/peek/Peek.Common.UnitTests/MathHelperTests.cs
+++ b/src/modules/peek/Peek.Common.UnitTests/MathHelperTests.cs
@@ -1,0 +1,283 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Peek.Common.Helpers;
+
+namespace Peek.Common.UnitTests
+{
+    [TestClass]
+    public class MathHelperTests
+    {
+        /// <summary>
+        /// Product code: MathHelper.Modulo(int, int)
+        /// What: Verifies standard modulo for positive numbers (7 mod 3 = 1)
+        /// Why: Baseline correctness — ensures the positive path matches C# % operator
+        /// </summary>
+        [TestMethod]
+        public void Modulo_PositiveNumbers_ShouldReturnStandardModulo()
+        {
+            Assert.AreEqual(1, MathHelper.Modulo(7, 3));
+        }
+
+        /// <summary>
+        /// Product code: MathHelper.Modulo(int, int)
+        /// What: Verifies that 0 mod n = 0
+        /// Why: Zero dividend is a common boundary — must not throw or return non-zero
+        /// </summary>
+        [TestMethod]
+        public void Modulo_ZeroDividend_ShouldReturnZero()
+        {
+            Assert.AreEqual(0, MathHelper.Modulo(0, 5));
+        }
+
+        /// <summary>
+        /// Product code: MathHelper.Modulo(int, int)
+        /// What: Verifies that exact division yields zero remainder
+        /// Why: Guards against off-by-one in the modulo formula
+        /// </summary>
+        [TestMethod]
+        public void Modulo_ExactDivision_ShouldReturnZero()
+        {
+            Assert.AreEqual(0, MathHelper.Modulo(6, 3));
+        }
+
+        /// <summary>
+        /// Product code: MathHelper.Modulo(int, int) — negative dividend path
+        /// What: Verifies that -1 mod 3 = 2 (mathematical modulo, not C# remainder)
+        /// Why: C# % returns -1 for negative dividends; Modulo wraps to positive range
+        /// </summary>
+        [TestMethod]
+        public void Modulo_NegativeDividend_ShouldReturnPositiveResult()
+        {
+            Assert.AreEqual(2, MathHelper.Modulo(-1, 3));
+        }
+
+        /// <summary>
+        /// Product code: MathHelper.Modulo(int, int) — negative dividend with larger magnitude
+        /// What: Verifies -7 mod 3 = 2 (wraps correctly for larger negative values)
+        /// Why: Tests the full formula: ((-7 % 3) + 3) % 3 = (-1 + 3) % 3 = 2
+        /// </summary>
+        [TestMethod]
+        public void Modulo_NegativeDividend_LargerMagnitude_ShouldWrapCorrectly()
+        {
+            Assert.AreEqual(2, MathHelper.Modulo(-7, 3));
+        }
+
+        /// <summary>
+        /// Product code: MathHelper.Modulo(int, int)
+        /// What: Verifies -6 mod 3 = 0 (exact negative multiple)
+        /// Why: Edge case where negative dividend is an exact multiple of divisor
+        /// </summary>
+        [TestMethod]
+        public void Modulo_NegativeDividend_ExactMultiple_ShouldReturnZero()
+        {
+            Assert.AreEqual(0, MathHelper.Modulo(-6, 3));
+        }
+
+        /// <summary>
+        /// Product code: MathHelper.Modulo(int, int)
+        /// What: Verifies n mod 1 = 0 for positive n
+        /// Why: Divisor of 1 always yields 0 — guards against divide-by-zero edge case
+        /// </summary>
+        [TestMethod]
+        public void Modulo_PositiveDividend_DivisorOne_ShouldReturnZero()
+        {
+            Assert.AreEqual(0, MathHelper.Modulo(5, 1));
+        }
+
+        /// <summary>
+        /// Product code: MathHelper.Modulo(int, int)
+        /// What: Verifies -n mod 1 = 0 for negative n
+        /// Why: Tests the negative path with divisor=1 (simplest negative case)
+        /// </summary>
+        [TestMethod]
+        public void Modulo_NegativeDividend_DivisorOne_ShouldReturnZero()
+        {
+            Assert.AreEqual(0, MathHelper.Modulo(-5, 1));
+        }
+
+        /// <summary>
+        /// Product code: MathHelper.Modulo(int, int)
+        /// What: Verifies modulo works with large numbers (1000001 mod 1000000 = 1)
+        /// Why: Tests that no integer overflow occurs in the formula for large operands
+        /// </summary>
+        [TestMethod]
+        public void Modulo_LargePositiveNumbers_ShouldWork()
+        {
+            Assert.AreEqual(1, MathHelper.Modulo(1000001, 1000000));
+        }
+
+        /// <summary>
+        /// Product code: MathHelper.Modulo(int, int)
+        /// What: Verifies that dividend less than divisor returns the dividend itself
+        /// Why: 2 mod 5 = 2 — no division happens, just returns the dividend
+        /// </summary>
+        [TestMethod]
+        public void Modulo_DividendLessThanDivisor_ShouldReturnDividend()
+        {
+            Assert.AreEqual(2, MathHelper.Modulo(2, 5));
+        }
+
+        /// <summary>
+        /// Product code: MathHelper.Modulo(int, int) — negative dividend
+        /// What: Verifies -2 mod 3 = 1 (mathematical modulo)
+        /// Why: Tests another negative wrap case: ((-2 % 3) + 3) % 3 = (-2 + 3) % 3 = 1
+        /// </summary>
+        [TestMethod]
+        public void Modulo_NegativeDividend_MinusTwo_ModThree_ShouldReturnOne()
+        {
+            Assert.AreEqual(1, MathHelper.Modulo(-2, 3));
+        }
+
+        /// <summary>
+        /// Product code: MathHelper.Modulo(int, int) — zero divisor
+        /// What: Documents that dividing by zero throws DivideByZeroException
+        /// Why: Edge case — callers must handle zero divisor; the method does not guard against it
+        /// </summary>
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void Modulo_ZeroDivisor_ShouldThrow()
+        {
+            MathHelper.Modulo(5, 0);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void Modulo_NegativeDivisor_ShouldThrow()
+        {
+            MathHelper.Modulo(-1, -3);
+        }
+
+        /// <summary>
+        /// Product code: MathHelper.NumberOfDigits(int)
+        /// What: Verifies that 0 has 1 digit
+        /// Why: Zero is a special case — Math.Abs(0).ToString() = "0" which has length 1
+        /// </summary>
+        [TestMethod]
+        public void NumberOfDigits_Zero_ShouldReturnOne()
+        {
+            Assert.AreEqual(1, MathHelper.NumberOfDigits(0));
+        }
+
+        /// <summary>
+        /// Product code: MathHelper.NumberOfDigits(int)
+        /// What: Verifies single-digit number returns 1
+        /// Why: Baseline case for the simplest positive input
+        /// </summary>
+        [TestMethod]
+        public void NumberOfDigits_SingleDigit_ShouldReturnOne()
+        {
+            Assert.AreEqual(1, MathHelper.NumberOfDigits(5));
+        }
+
+        /// <summary>
+        /// Product code: MathHelper.NumberOfDigits(int)
+        /// What: Verifies two-digit number returns 2
+        /// Why: Tests the transition from single to multi-digit
+        /// </summary>
+        [TestMethod]
+        public void NumberOfDigits_TwoDigits_ShouldReturnTwo()
+        {
+            Assert.AreEqual(2, MathHelper.NumberOfDigits(42));
+        }
+
+        /// <summary>
+        /// Product code: MathHelper.NumberOfDigits(int)
+        /// What: Verifies three-digit number (100) returns 3
+        /// Why: Tests exact power of 10 boundary (100 vs 99)
+        /// </summary>
+        [TestMethod]
+        public void NumberOfDigits_ThreeDigits_ShouldReturnThree()
+        {
+            Assert.AreEqual(3, MathHelper.NumberOfDigits(100));
+        }
+
+        /// <summary>
+        /// Product code: MathHelper.NumberOfDigits(int) — negative number
+        /// What: Verifies that sign is ignored via Math.Abs
+        /// Why: Negative sign is not a digit — only magnitude matters
+        /// </summary>
+        [TestMethod]
+        public void NumberOfDigits_NegativeNumber_ShouldIgnoreSign()
+        {
+            Assert.AreEqual(3, MathHelper.NumberOfDigits(-123));
+        }
+
+        /// <summary>
+        /// Product code: MathHelper.NumberOfDigits(int) — int.MaxValue
+        /// What: Verifies int.MaxValue (2147483647) returns 10 digits
+        /// Why: Upper boundary of int range — ensures no overflow in Math.Abs path
+        /// </summary>
+        [TestMethod]
+        public void NumberOfDigits_MaxValue_ShouldReturnTenDigits()
+        {
+            Assert.AreEqual(10, MathHelper.NumberOfDigits(int.MaxValue));
+        }
+
+        /// <summary>
+        /// Product code: MathHelper.NumberOfDigits(int) — near int.MinValue
+        /// What: Verifies int.MinValue + 1 (-2147483647) returns 10 digits
+        /// Why: int.MinValue itself overflows Math.Abs — this tests the safe boundary
+        /// </summary>
+        [TestMethod]
+        public void NumberOfDigits_MinValue_ShouldHandleAbsoluteValue()
+        {
+            Assert.AreEqual(10, MathHelper.NumberOfDigits(int.MinValue + 1));
+        }
+
+        /// <summary>
+        /// Product code: MathHelper.NumberOfDigits(int) — int.MinValue
+        /// What: Documents that int.MinValue causes OverflowException due to Math.Abs
+        /// Why: Edge case — Math.Abs(-2147483648) has no positive int representation
+        /// </summary>
+        [TestMethod]
+        [ExpectedException(typeof(OverflowException))]
+        public void NumberOfDigits_MinValue_ShouldThrowOverflow()
+        {
+            MathHelper.NumberOfDigits(int.MinValue);
+        }
+
+        /// <summary>
+        /// Product code: MathHelper.NumberOfDigits(int) — powers of 10
+        /// What: Verifies digit count at each power-of-10 boundary (1, 10, 100, 1000, 10000)
+        /// Why: Powers of 10 are the exact transition points — off-by-one bugs surface here
+        /// </summary>
+        [TestMethod]
+        public void NumberOfDigits_PowerOfTen_ShouldReturnCorrectCount()
+        {
+            Assert.AreEqual(1, MathHelper.NumberOfDigits(1));
+            Assert.AreEqual(2, MathHelper.NumberOfDigits(10));
+            Assert.AreEqual(3, MathHelper.NumberOfDigits(100));
+            Assert.AreEqual(4, MathHelper.NumberOfDigits(1000));
+            Assert.AreEqual(5, MathHelper.NumberOfDigits(10000));
+        }
+
+        /// <summary>
+        /// Product code: MathHelper.NumberOfDigits(int) — 9→10 boundary
+        /// What: Verifies that 9 returns 1 digit and 10 returns 2 digits
+        /// Why: Tests the first single-to-double digit transition
+        /// </summary>
+        [TestMethod]
+        public void NumberOfDigits_BoundaryValues_NineAndTen()
+        {
+            Assert.AreEqual(1, MathHelper.NumberOfDigits(9));
+            Assert.AreEqual(2, MathHelper.NumberOfDigits(10));
+        }
+
+        /// <summary>
+        /// Product code: MathHelper.NumberOfDigits(int) — 99→100 boundary
+        /// What: Verifies that 99 returns 2 digits and 100 returns 3 digits
+        /// Why: Tests the double-to-triple digit transition
+        /// </summary>
+        [TestMethod]
+        public void NumberOfDigits_BoundaryValues_NinetyNineAndHundred()
+        {
+            Assert.AreEqual(2, MathHelper.NumberOfDigits(99));
+            Assert.AreEqual(3, MathHelper.NumberOfDigits(100));
+        }
+    }
+}

--- a/src/modules/peek/Peek.Common.UnitTests/PathHelperTests.cs
+++ b/src/modules/peek/Peek.Common.UnitTests/PathHelperTests.cs
@@ -1,0 +1,156 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Peek.Common.Helpers;
+
+namespace Peek.Common.UnitTests
+{
+    [TestClass]
+    public class PathHelperTests
+    {
+        /// <summary>
+        /// Product code: PathHelper.IsUncPath(string)
+        /// What: Verifies a standard UNC path (\\server\share) is recognized
+        /// Why: Baseline positive case — the most common UNC format
+        /// </summary>
+        [TestMethod]
+        public void IsUncPath_StandardUncPath_ShouldReturnTrue()
+        {
+            Assert.IsTrue(PathHelper.IsUncPath(@"\\server\share"));
+        }
+
+        /// <summary>
+        /// Product code: PathHelper.IsUncPath(string)
+        /// What: Verifies a UNC path with nested subfolders and file is recognized
+        /// Why: Real-world UNC paths include subfolders — must not fail on deeper paths
+        /// </summary>
+        [TestMethod]
+        public void IsUncPath_UncPathWithSubfolder_ShouldReturnTrue()
+        {
+            Assert.IsTrue(PathHelper.IsUncPath(@"\\server\share\folder\file.txt"));
+        }
+
+        /// <summary>
+        /// Product code: PathHelper.IsUncPath(string)
+        /// What: Verifies a UNC path with dotted server name (FQDN) is recognized
+        /// Why: Enterprise environments use FQDN server names (e.g., server.corp.com)
+        /// </summary>
+        [TestMethod]
+        public void IsUncPath_UncPathWithDottedServer_ShouldReturnTrue()
+        {
+            Assert.IsTrue(PathHelper.IsUncPath(@"\\server.domain.com\share"));
+        }
+
+        /// <summary>
+        /// Product code: PathHelper.IsUncPath(string)
+        /// What: Verifies a UNC path with IP address is recognized
+        /// Why: Some network shares use IP addresses instead of hostnames
+        /// </summary>
+        [TestMethod]
+        public void IsUncPath_UncPathWithIPAddress_ShouldReturnTrue()
+        {
+            Assert.IsTrue(PathHelper.IsUncPath(@"\\192.168.1.1\share"));
+        }
+
+        /// <summary>
+        /// Product code: PathHelper.IsUncPath(string)
+        /// What: Verifies a local drive path (C:\...) is not classified as UNC
+        /// Why: Drive-letter paths are local — confusing them with UNC would break file access
+        /// </summary>
+        [TestMethod]
+        public void IsUncPath_LocalDrivePath_ShouldReturnFalse()
+        {
+            Assert.IsFalse(PathHelper.IsUncPath(@"C:\Users\test\file.txt"));
+        }
+
+        /// <summary>
+        /// Product code: PathHelper.IsUncPath(string)
+        /// What: Verifies a bare drive root (D:\) is not classified as UNC
+        /// Why: Drive roots are local paths — shortest possible local absolute path
+        /// </summary>
+        [TestMethod]
+        public void IsUncPath_LocalRootPath_ShouldReturnFalse()
+        {
+            Assert.IsFalse(PathHelper.IsUncPath(@"D:\"));
+        }
+
+        /// <summary>
+        /// Product code: PathHelper.IsUncPath(string)
+        /// What: Verifies a relative path is not classified as UNC
+        /// Why: Relative paths have no server component — Uri.TryCreate fails for them
+        /// </summary>
+        [TestMethod]
+        public void IsUncPath_RelativePath_ShouldReturnFalse()
+        {
+            Assert.IsFalse(PathHelper.IsUncPath(@"folder\file.txt"));
+        }
+
+        /// <summary>
+        /// Product code: PathHelper.IsUncPath(string)
+        /// What: Verifies an empty string returns false without throwing
+        /// Why: Empty input is a common edge case — must not crash
+        /// </summary>
+        [TestMethod]
+        public void IsUncPath_EmptyString_ShouldReturnFalse()
+        {
+            Assert.IsFalse(PathHelper.IsUncPath(string.Empty));
+        }
+
+        /// <summary>
+        /// Product code: PathHelper.IsUncPath(string)
+        /// What: Verifies an HTTP URL is not classified as UNC
+        /// Why: HTTP URLs are not file paths — Uri.IsUnc must return false for them
+        /// </summary>
+        [TestMethod]
+        public void IsUncPath_HttpUrl_ShouldReturnFalse()
+        {
+            Assert.IsFalse(PathHelper.IsUncPath("http://example.com/path"));
+        }
+
+        /// <summary>
+        /// Product code: PathHelper.IsUncPath(string)
+        /// What: Verifies a file:/// URI (local file) is not classified as UNC
+        /// Why: file:///C:/... is a local file URI, not a network UNC path
+        /// </summary>
+        [TestMethod]
+        public void IsUncPath_FileUri_ShouldReturnFalse()
+        {
+            Assert.IsFalse(PathHelper.IsUncPath("file:///C:/Users/test/file.txt"));
+        }
+
+        /// <summary>
+        /// Product code: PathHelper.IsUncPath(string)
+        /// What: Verifies a standard UNC path with a file component (\\server\share\file.txt)
+        /// Why: Tests UNC with a trailing file name — distinct from share-only paths
+        /// </summary>
+        [TestMethod]
+        public void IsUncPath_StandardUncWithFile_ShouldReturnTrue()
+        {
+            Assert.IsTrue(PathHelper.IsUncPath(@"\\server\share\file.txt"));
+        }
+
+        /// <summary>
+        /// Product code: PathHelper.IsUncPath(string)
+        /// What: Verifies a single-backslash prefix is not classified as UNC
+        /// Why: UNC requires exactly two leading backslashes — one backslash is not UNC
+        /// </summary>
+        [TestMethod]
+        public void IsUncPath_SingleBackslash_ShouldReturnFalse()
+        {
+            Assert.IsFalse(PathHelper.IsUncPath(@"\server\share"));
+        }
+
+        /// <summary>
+        /// Product code: PathHelper.IsUncPath(string)
+        /// What: Verifies null input returns false without throwing
+        /// Why: Null is a common edge case — Uri.TryCreate handles null gracefully
+        /// </summary>
+        [TestMethod]
+        public void IsUncPath_NullInput_ShouldReturnFalse()
+        {
+            Assert.IsFalse(PathHelper.IsUncPath(null));
+        }
+    }
+}

--- a/src/modules/peek/Peek.Common.UnitTests/Peek.Common.UnitTests.csproj
+++ b/src/modules/peek/Peek.Common.UnitTests/Peek.Common.UnitTests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!-- Look at Directory.Build.props in root for common stuff as well -->
+  <Import Project="$(RepoRoot)src\Common.Dotnet.CsWinRT.props" />
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+    <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\tests\Peek.Common.Tests\</OutputPath>
+    <RootNamespace>Peek.Common.UnitTests</RootNamespace>
+    <AssemblyName>PowerToys.Peek.Common.UnitTests</AssemblyName>
+    <OutputType>Exe</OutputType>
+    <!-- Pull in the WindowsDesktop shared framework so that runtime DLLs (System.CodeDom,
+         Microsoft.VisualBasic, WindowsBase, etc.) resolve to the same version as all other
+         projects in the solution. Without this, transitive NuGet packages provide older
+         versions that fail the verifyDepsJsonLibraryVersions CI check. -->
+    <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Peek.Common\Peek.Common.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/modules/peek/Peek.Common/Helpers/MathHelper.cs
+++ b/src/modules/peek/Peek.Common/Helpers/MathHelper.cs
@@ -11,6 +11,11 @@ namespace Peek.Common.Helpers
     {
         public static int Modulo(int a, int b)
         {
+            if (b <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(b), b, "Divisor must be positive.");
+            }
+
             return a < 0 ? ((a % b) + b) % b : a % b;
         }
 


### PR DESCRIPTION
## Summary

Adds a **Peek.Common.UnitTests** project (MSTest) with unit coverage for Peek.Common.Helpers:

- **MathHelper.Modulo** — positive/zero results, negative-dividend wrap-around, large values, and the new non-positive-divisor guard.
- **MathHelper.NumberOfDigits** — single/multi-digit, negative, and 9/10 & 99/100 boundary values.
- **PathHelper.IsUncPath** — standard UNC, subfolders, dotted-server and IP hosts, plus negatives: drive-letter, relative, empty, HTTP URL, ile:// URI, single backslash, and null.

Also adds a small correctness guard to MathHelper.Modulo: a non-positive divisor now throws ArgumentOutOfRangeException instead of silently throwing DivideByZeroException (b == 0) or returning a misleading result (b < 0). Registers the test project in `PowerToys.slnx` (ARM64 + x64).

**37 tests pass** locally (x64 Debug).

## Context

This is a clean, **tests-only split of #46684** (the Peek.Common portion), intentionally **without** the bundled global dependency bump from that PR. The PowerAccent.Core portion of #46684 was shipped separately in #49104.

## Test coverage

| Area | Tests |
|------|-------|
| MathHelper.Modulo / NumberOfDigits | included |
| PathHelper.IsUncPath | included |

No production behavior changes beyond the Modulo argument guard, which is covered by the new tests.
