### PR TITLE
CmdPal: Stretch main window card vertically when in expanded mode

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CmdPalMainControl.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/CmdPalMainControl.xaml.cs
@@ -127,6 +127,16 @@ public sealed partial class CmdPalMainControl : UserControl
     }
 
     /// <summary>
+    /// When <paramref name="stretch"/> is <see langword="true"/>, the card stretches to fill
+    /// the entire window vertically (non-compact mode). When <see langword="false"/>, the card
+    /// sizes itself to its content and anchors to the top of the window (compact mode).
+    /// </summary>
+    public void SetCardStretch(bool stretch)
+    {
+        CardBorder.VerticalAlignment = stretch ? VerticalAlignment.Stretch : VerticalAlignment.Top;
+    }
+
+    /// <summary>
     /// Forwards the host window's activation state to the current backdrop so the system can
     /// render its active / inactive appearance correctly.
     /// </summary>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml.cs
@@ -1759,17 +1759,26 @@ public sealed partial class MainWindow : WindowEx,
     {
         var settings = App.Current.Services.GetRequiredService<ISettingsService>().Settings;
 
-        // Only the compact + centered configuration needs a screen-fit clamp. There the card
-        // is anchored near the vertical center of the display, so an expanded list could run
-        // off the bottom edge; cap its height so it always fits. In every other case the card
-        // is free to fill the (fixed-size) HWND as before.
-        if (expanded && settings.CompactMode && IsCenteringSummon(settings))
+        if (!settings.CompactMode)
         {
-            RootElement.SetCardMaxHeight(ComputeExpandedCardMaxHeightDip());
+            // When compact mode is off the card is always static and fills the entire window,
+            // regardless of how much content is currently displayed.
+            RootElement.SetCardStretch(true);
+            RootElement.SetCardMaxHeight(double.PositiveInfinity);
         }
         else
         {
-            RootElement.SetCardMaxHeight(double.PositiveInfinity);
+            // In compact mode the card sizes itself to its content and anchors to the top.
+            RootElement.SetCardStretch(false);
+
+            // Only the compact + centered configuration needs a screen-fit clamp. There the card
+            // is anchored near the vertical center of the display, so an expanded list could run
+            // off the bottom edge; cap its height so it always fits. In every other case the card
+            // is free to fill the (fixed-size) HWND as before.
+            var cardMaxHeight = expanded && IsCenteringSummon(settings)
+                ? ComputeExpandedCardMaxHeightDip()
+                : double.PositiveInfinity;
+            RootElement.SetCardMaxHeight(cardMaxHeight);
         }
     }
 


### PR DESCRIPTION
## Summary of the Pull Request

This PR updates the behavior of CmdPal's main window in expanded (non-compact) mode to match the previous behavior. The page content now stretches across the entire window instead of collapsing to the actual content height.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #48872 
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

