### PR TITLE
CmdPal: Fix compact mode not toggling the list/command bar at runtime

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
@@ -67,6 +67,12 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
 
     private readonly CompositeFormat _pageNavigatedAnnouncement;
 
+    private readonly ISettingsService _settingsService;
+
+    // The last compact-mode setting we reacted to. Lets us ignore hot-reloads of unrelated
+    // settings and only re-evaluate the layout when compact mode itself changes.
+    private bool _compactMode;
+
     private SettingsWindow? _settingsWindow;
     private DockWindowManager? _dockWindowManager;
 
@@ -91,8 +97,9 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
 
     public ShellPage()
     {
-        var settings = App.Current.Services.GetRequiredService<ISettingsService>().Settings;
-        this.ExpandedMode = !settings.CompactMode;
+        _settingsService = App.Current.Services.GetRequiredService<ISettingsService>();
+        _compactMode = _settingsService.Settings.CompactMode;
+        this.ExpandedMode = !_compactMode;
 
         this.InitializeComponent();
 
@@ -118,6 +125,11 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
         WeakReferenceMessenger.Default.Register<ShowPinToDockDialogMessage>(this);
 
         WeakReferenceMessenger.Default.Register<ExpandCompactModeMessage>(this);
+
+        // The compact-mode setting can be toggled while the palette is open. React to the
+        // hot-reload so the expanded/collapsed layout updates immediately instead of waiting
+        // for the next navigation or search-text change.
+        _settingsService.SettingsChanged += OnSettingsChanged;
 
         AddHandler(PreviewKeyDownEvent, new KeyEventHandler(ShellPage_OnPreviewKeyDown), true);
         AddHandler(KeyDownEvent, new KeyEventHandler(ShellPage_OnKeyDown), false);
@@ -674,6 +686,11 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
         var settings = App.Current.Services.GetRequiredService<ISettingsService>().Settings;
         if (!settings.CompactMode)
         {
+            // Compact mode is off: the shell always shows the full expanded UI. Set it
+            // explicitly (rather than trusting the constructor's initial value) so toggling
+            // the setting off at runtime restores the list and command bar when the palette
+            // was collapsed.
+            HandleExpandCompactOnUiThread(true);
             return;
         }
 
@@ -936,6 +953,24 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
         this.DispatcherQueue.TryEnqueue(UpdateCompactModeForCurrentPage);
     }
 
+    private void OnSettingsChanged(ISettingsService sender, SettingsModel args)
+    {
+        // Only the compact-mode setting affects the expanded/collapsed layout, so ignore
+        // hot-reloads that leave it unchanged. Comparing and updating _compactMode on the UI
+        // thread keeps it single-threaded regardless of which thread raises the event.
+        var compactMode = args.CompactMode;
+        this.DispatcherQueue.TryEnqueue(() =>
+        {
+            if (compactMode == _compactMode)
+            {
+                return;
+            }
+
+            _compactMode = compactMode;
+            UpdateCompactModeForCurrentPage();
+        });
+    }
+
     private void HandleExpandCompactOnUiThread(bool expanded)
     {
         var settings = App.Current.Services.GetRequiredService<ISettingsService>().Settings;
@@ -979,6 +1014,7 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
 
         _isDisposed = true;
         WeakReferenceMessenger.Default.UnregisterAll(this);
+        _settingsService.SettingsChanged -= OnSettingsChanged;
 
         _focusAfterLoadedCts?.Cancel();
         _focusAfterLoadedCts?.Dispose();


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This PR hooks `ShellPage` to `ISettingsService` and triggers update of expanded state when the Compact mode settings is changed.

Toggling the compact-mode setting while the palette was open neverre-evaluated `ShellPage.ExpandedMode`, so disabling compact mode left the palette collapsed (only the search box visible).

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #48933 
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

