### PR TITLE
GrabAndMove drag maximized windows relative to the click point

### DIFF
--- a/src/modules/GrabAndMove/GrabAndMove/main.cpp
+++ b/src/modules/GrabAndMove/GrabAndMove/main.cpp
@@ -1359,6 +1359,7 @@ static void HandleDragMove(POINT pt)
             RECT maxRect;
             GetWindowRect(g_dragTarget, &maxRect);
             int maxW = maxRect.right - maxRect.left;
+            int maxH = maxRect.bottom - maxRect.top;
 
             ShowWindow(g_dragTarget, SW_RESTORE);
 
@@ -1366,9 +1367,12 @@ static void HandleDragMove(POINT pt)
             int restoredW = g_dragWndRect.right - g_dragWndRect.left;
             int restoredH = g_dragWndRect.bottom - g_dragWndRect.top;
 
-            float ratio = (maxW > 0) ? static_cast<float>(g_dragStart.x - maxRect.left) / maxW : 0.5f;
-            int newX = g_dragStart.x - static_cast<int>(restoredW * ratio);
-            int newY = g_dragStart.y - (GetSystemMetrics(SM_CYFRAME) + GetSystemMetrics(SM_CYCAPTION) / 2);
+            // Preserve the relative grab position in both axes so the cursor stays
+            // at the same proportional spot within the restored window.
+            float ratioL = (maxW > 0) ? static_cast<float>(g_dragStart.x - maxRect.left) / maxW : 0.5f;
+            float ratioT = (maxH > 0) ? static_cast<float>(g_dragStart.y - maxRect.top) / maxH : 0.5f;
+            int newX = g_dragStart.x - static_cast<int>(restoredW * ratioL);
+            int newY = g_dragStart.y - static_cast<int>(restoredH * ratioT);
             SetWindowPos(g_dragTarget, nullptr, newX, newY, 0, 0,
                          SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_ASYNCWINDOWPOS);
 


### PR DESCRIPTION
This aligns the behavior with resize.

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

When grabbing and moving a maximized icon, the old behavior was to first restore the window with its title bar under the cursor, then proceed with the move. Now the window is restored and moved proportionally around the cursor, exactly like in the case of the grab and resize behavior.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] Closes: #xxx
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Ensure the window geometry/coordinates change exactly the same as for grab and resize on it, when starting from a maximized state.