### PR TITLE
Add PR Needs-Author-Feedback lifecycle to fabricbot configuration

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -56,7 +56,44 @@ configuration:
       - addReply:
           reply: This issue has been marked as duplicate and has not had any activity for **1 day**. It will be closed for housekeeping purposes.
       - closeIssue
+    # ─── PR Needs-Author-Feedback: close after 7+7 days of inactivity ───
+    - description: Close PRs with Needs-Author-Feedback + Status-No recent activity after 7 more days
+      frequencies:
+      - hourly:
+          hour: 6
+      filters:
+      - isPullRequest
+      - isOpen
+      - hasLabel:
+          label: Needs-Author-Feedback
+      - hasLabel:
+          label: Status-No recent activity
+      - noActivitySince:
+          days: 7
+      actions:
+      - addReply:
+          reply: This pull request has been automatically closed because it has been marked as requiring author feedback but has not had any activity for **14 days**. If you would like to continue working on this, please reopen the PR and push your changes.
+      - closeIssue
+    - description: Warn PRs with Needs-Author-Feedback after 7 days of no activity
+      frequencies:
+      - hourly:
+          hour: 6
+      filters:
+      - isPullRequest
+      - isOpen
+      - hasLabel:
+          label: Needs-Author-Feedback
+      - noActivitySince:
+          days: 7
+      - isNotLabeledWith:
+          label: Status-No recent activity
+      actions:
+      - addLabel:
+          label: Status-No recent activity
+      - addReply:
+          reply: This pull request has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **7 days**. It will be closed if no further activity occurs **within 7 days of this comment**. To keep this PR active, please push your changes or leave a comment.
     eventResponderTasks:
+    # ─── When issue/PR author comments, swap Needs-Author-Feedback → Needs-Triage ───
     - if:
       - payloadType: Issue_Comment
       - isAction:
@@ -74,6 +111,23 @@ configuration:
       - addLabel:
           label: Needs-Team-Response
       description: 
+    # ─── When PR author pushes commits, swap Needs-Author-Feedback → Needs-Triage ───
+    - if:
+      - payloadType: Pull_Request
+      - isAction:
+          action: Synchronize
+      - isActivitySender:
+          issueAuthor: True
+      - hasLabel:
+          label: Needs-Author-Feedback
+      - isOpen
+      then:
+      - addLabel:
+          label: Needs-Triage
+      - removeLabel:
+          label: Needs-Author-Feedback
+      description: 
+    # ─── Remove "Status-No recent activity" on any issue update (not close) ───
     - if:
       - payloadType: Issues
       - not:
@@ -85,10 +139,21 @@ configuration:
       - removeLabel:
           label: Status-No recent activity
       description: 
+    # ─── Remove "Status-No recent activity" on any issue comment ───
     - if:
       - payloadType: Issue_Comment
       - hasLabel:
           label: Status-No recent activity
+      then:
+      - removeLabel:
+          label: Status-No recent activity
+      description: 
+    # ─── Remove "Status-No recent activity" on PR updates (push, review, etc.) ───
+    - if:
+      - payloadType: Pull_Request
+      - hasLabel:
+          label: Status-No recent activity
+      - isOpen
       then:
       - removeLabel:
           label: Status-No recent activity


### PR DESCRIPTION
## Summary

Adds fabricbot rules to manage the `Needs-Author-Feedback` label lifecycle for **pull requests**, complementing the existing issue management rules in `resourceManagement.yml`.

This is a **simpler alternative** to the GitHub Actions workflow approach (PR #48812), trading advanced features (draft conversion, author-specific activity tracking) for zero-maintenance fabricbot automation.

## Behavior

### Flow diagram

```
┌──────────────────────────────────────────────────────────────────────┐
│  Maintainer adds "Needs-Author-Feedback" label to a PR              │
└──────────────────────────────────────────────────────────────────────┘
         │
         ▼
┌─────────────────────────────────────┐     ┌──────────────────────────────────┐
│  7 days, no activity                │────►│  Add "Status-No recent activity" │
│                                     │     │  + post warning comment          │
└─────────────────────────────────────┘     └──────────────────────────────────┘
         │                                               │
         ▼                                               ▼
┌─────────────────────────────────────┐     ┌──────────────────────────────────┐
│  7 more days (14 total), no activity│────►│  Close PR + post closing comment │
└─────────────────────────────────────┘     └──────────────────────────────────┘

┌──────────────────────────────────────────────────────────────────────┐
│  Author pushes commits OR comments on PR (at any point)              │
└──────────────────────────────────────────────────────────────────────┘
         │
         ▼
    Remove "Needs-Author-Feedback" → Add "Needs-Triage"
    Remove "Status-No recent activity" (if present)
```

### Scheduled searches (every 6 hours)

| Condition | Action |
|-----------|--------|
| PR + `Needs-Author-Feedback` + 7 days inactive + no `Status-No recent activity` | Add `Status-No recent activity` label + warning comment |
| PR + `Needs-Author-Feedback` + `Status-No recent activity` + 7 more days inactive | Post closing comment + close PR |

### Event responders

| Trigger | Action |
|---------|--------|
| Author comments on PR (`Issue_Comment` + `issueAuthor`) | Remove `Needs-Author-Feedback`, add `Needs-Triage` + `Needs-Team-Response` |
| Author pushes commits (`Pull_Request` + `Synchronize` + `issueAuthor`) | Remove `Needs-Author-Feedback`, add `Needs-Triage` |
| Any PR update activity | Remove `Status-No recent activity` |

### Bot messages

**Warning (at 7 days):**
> This pull request has been automatically marked as stale because it has been marked as requiring author feedback but has not had any activity for **7 days**. It will be closed if no further activity occurs **within 7 days of this comment**. To keep this PR active, please push your changes or leave a comment.

**Closing (at 14 days):**
> This pull request has been automatically closed because it has been marked as requiring author feedback but has not had any activity for **14 days**. If you would like to continue working on this, please reopen the PR and push your changes.

## Comparison with GitHub Actions workflow (PR #48812)

| Feature | This PR (fabricbot) | PR #48812 (Actions) |
|---------|-------------------|-------------------|
| Convert to draft at 7 days | ❌ Not supported | ✅ Via GraphQL |
| Close at 14 days | ✅ | ✅ |
| Author-specific activity tracking | ❌ Any activity resets timer | ✅ Only author activity counts |
| Bot comment resets timer | ⚠️ Yes (fabricbot limitation) | ✅ No (filtered out) |
| Maintenance burden | None (fabricbot managed) | Low (workflow file) |
| Testing before merge | ❌ No local testing | ✅ `workflow_dispatch` + dry-run |
| Review comment detection | ❌ Only issue comments | ✅ Reviews + inline comments |

## Trade-offs

**Pros:**
- Zero maintenance — fabricbot is a managed service
- Consistent with existing issue management patterns in the same file
- No workflow YAML to debug or maintain

**Cons:**
- No draft conversion (fabricbot cannot call GraphQL)
- `noActivitySince` counts **all** activity — bot comments, maintainer comments, and label changes all reset the inactivity timer
- Cannot distinguish author activity from other activity
- No way to test locally or with dry-run before merge

## Relationship to existing automation

Mirrors the existing issue rules (lines 11-43) which use the same pattern:
- Issues: 5 days → warning, 5 more days → close
- PRs (this change): 7 days → warning, 7 more days → close