### PR TITLE
CmdPal: Avoid unnecessary handler runs on settings changes (part 1)

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Dock/DockViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Dock/DockViewModel.cs
@@ -83,6 +83,11 @@ public sealed partial class DockViewModel : IDisposable
             return;
         }
 
+        if (_settings == settings)
+        {
+            return;
+        }
+
         _settings = settings;
         SetupBands();
     }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Settings/DockSettings.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Settings/DockSettings.cs
@@ -48,7 +48,10 @@ public record DockSettings
     public string? BackgroundImagePath { get; init; }
 
     // </Theme settings>
-    private ImmutableList<DockBandSettings>? _startBands = ImmutableList.Create(
+
+    // Band lists use EquatableList backing fields so the compiler-synthesized record equality
+    // compares them by content, not by reference. See EquatableList<T> for why this matters.
+    private readonly EquatableList<DockBandSettings> _startBands = new(ImmutableList.Create(
         new DockBandSettings
         {
             ProviderId = "com.microsoft.cmdpal.builtin.core",
@@ -59,23 +62,23 @@ public record DockSettings
             ProviderId = "WinGet",
             CommandId = "com.microsoft.cmdpal.winget",
             ShowTitles = false,
-        });
+        }));
 
     public ImmutableList<DockBandSettings> StartBands
     {
-        get => _startBands ?? ImmutableList<DockBandSettings>.Empty;
-        init => _startBands = value;
+        get => _startBands.List;
+        init => _startBands = new(value);
     }
 
-    private ImmutableList<DockBandSettings>? _centerBands = ImmutableList<DockBandSettings>.Empty;
+    private readonly EquatableList<DockBandSettings> _centerBands = new(ImmutableList<DockBandSettings>.Empty);
 
     public ImmutableList<DockBandSettings> CenterBands
     {
-        get => _centerBands ?? ImmutableList<DockBandSettings>.Empty;
-        init => _centerBands = value;
+        get => _centerBands.List;
+        init => _centerBands = new(value);
     }
 
-    private ImmutableList<DockBandSettings>? _endBands = ImmutableList.Create(
+    private readonly EquatableList<DockBandSettings> _endBands = new(ImmutableList.Create(
         new DockBandSettings
         {
             ProviderId = "PerformanceMonitor",
@@ -85,12 +88,12 @@ public record DockSettings
         {
             ProviderId = "com.microsoft.cmdpal.builtin.datetime",
             CommandId = "com.microsoft.cmdpal.timedate.dockBand",
-        });
+        }));
 
     public ImmutableList<DockBandSettings> EndBands
     {
-        get => _endBands ?? ImmutableList<DockBandSettings>.Empty;
-        init => _endBands = value;
+        get => _endBands.List;
+        init => _endBands = new(value);
     }
 
     public bool ShowLabels { get; init; } = true;
@@ -99,12 +102,12 @@ public record DockSettings
     /// Gets the per-monitor dock configurations. Each entry overrides global
     /// settings for a specific display. Empty by default (all monitors use global).
     /// </summary>
-    private ImmutableList<DockMonitorConfig>? _monitorConfigs = ImmutableList<DockMonitorConfig>.Empty;
+    private readonly EquatableList<DockMonitorConfig> _monitorConfigs = new(ImmutableList<DockMonitorConfig>.Empty);
 
     public ImmutableList<DockMonitorConfig> MonitorConfigs
     {
-        get => _monitorConfigs ?? ImmutableList<DockMonitorConfig>.Empty;
-        init => _monitorConfigs = value ?? ImmutableList<DockMonitorConfig>.Empty;
+        get => _monitorConfigs.List;
+        init => _monitorConfigs = new(value);
     }
 
     /// <summary>
@@ -192,20 +195,41 @@ public sealed record DockMonitorConfig
     /// </summary>
     public bool IsCustomized { get; init; }
 
+    // Nullable EquatableList backing fields give the synthesized record equality structural
+    // comparison of the per-monitor bands while preserving null ("inherit global") vs. an
+    // explicit (possibly empty) list. See EquatableList<T>.
+    private readonly EquatableList<DockBandSettings>? _startBands;
+
     /// <summary>
     /// Gets the per-monitor start bands. Only used when <see cref="IsCustomized"/> is <c>true</c>.
     /// </summary>
-    public ImmutableList<DockBandSettings>? StartBands { get; init; }
+    public ImmutableList<DockBandSettings>? StartBands
+    {
+        get => _startBands?.List;
+        init => _startBands = value is null ? null : new EquatableList<DockBandSettings>(value);
+    }
+
+    private readonly EquatableList<DockBandSettings>? _centerBands;
 
     /// <summary>
     /// Gets the per-monitor center bands. Only used when <see cref="IsCustomized"/> is <c>true</c>.
     /// </summary>
-    public ImmutableList<DockBandSettings>? CenterBands { get; init; }
+    public ImmutableList<DockBandSettings>? CenterBands
+    {
+        get => _centerBands?.List;
+        init => _centerBands = value is null ? null : new EquatableList<DockBandSettings>(value);
+    }
+
+    private readonly EquatableList<DockBandSettings>? _endBands;
 
     /// <summary>
     /// Gets the per-monitor end bands. Only used when <see cref="IsCustomized"/> is <c>true</c>.
     /// </summary>
-    public ImmutableList<DockBandSettings>? EndBands { get; init; }
+    public ImmutableList<DockBandSettings>? EndBands
+    {
+        get => _endBands?.List;
+        init => _endBands = value is null ? null : new EquatableList<DockBandSettings>(value);
+    }
 
     /// <summary>
     /// Gets the UTC timestamp when this monitor was last seen connected. Used for

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Settings/EquatableList`1.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Settings/EquatableList`1.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+
+namespace Microsoft.CmdPal.UI.ViewModels.Settings;
+
+/// <summary>
+/// A thin wrapper around <see cref="ImmutableList{T}"/> that provides <em>structural</em>
+/// (element-by-element) equality. <see cref="ImmutableList{T}"/> itself only implements
+/// reference equality, which means a record holding one compares unequal to an otherwise
+/// identical record whenever the list was rebuilt into a fresh instance (e.g. after loading
+/// settings from disk).
+/// </summary>
+/// <remarks>
+/// Used as the <em>backing field</em> type for record list properties (the public properties
+/// still expose <see cref="ImmutableList{T}"/>). Because the compiler-synthesized record
+/// equality compares backing fields, swapping the field type here makes that synthesized
+/// equality structural — with no hand-written <c>Equals</c> to keep in sync as new properties
+/// are added.
+/// </remarks>
+internal readonly struct EquatableList<T> : IEquatable<EquatableList<T>>
+{
+    private readonly ImmutableList<T>? _list;
+
+    public EquatableList(ImmutableList<T>? list) => _list = list;
+
+    public ImmutableList<T> List => _list ?? ImmutableList<T>.Empty;
+
+    public bool Equals(EquatableList<T> other)
+    {
+        var a = List;
+        var b = other.List;
+
+        if (ReferenceEquals(a, b))
+        {
+            return true;
+        }
+
+        if (a.Count != b.Count)
+        {
+            return false;
+        }
+
+        var comparer = EqualityComparer<T>.Default;
+        for (var i = 0; i < a.Count; i++)
+        {
+            if (!comparer.Equals(a[i], b[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public override bool Equals(object? obj) => obj is EquatableList<T> other && Equals(other);
+
+    public override int GetHashCode()
+    {
+        var hash = default(HashCode);
+        foreach (var item in List)
+        {
+            hash.Add(item);
+        }
+
+        return hash.ToHashCode();
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsModel.cs
@@ -11,6 +11,10 @@ namespace Microsoft.CmdPal.UI.ViewModels;
 
 public record SettingsModel
 {
+    // LOAD BEARNING: Some SettingsChanged subscribers react selectively (e.g.
+    // MainWindow.MainWindowSettingsComparer, DockWindowManager.OnSettingsChanged). If a new
+    // setting needs a live reaction, add it there too - otherwise it won't take effect.
+
     ///////////////////////////////////////////////////////////////////////////
     // SETTINGS HERE
     public static HotkeySettings DefaultActivationShortcut { get; } = new HotkeySettings(true, false, true, false, 0x20); // win+alt+space

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockWindow.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockWindow.xaml.cs
@@ -219,6 +219,11 @@ public sealed partial class DockWindow : WindowEx,
             return;
         }
 
+        if (_settings == args.DockSettings)
+        {
+            return;
+        }
+
         _settings = args.DockSettings;
         RefreshSideOverride();
         DispatcherQueue.TryEnqueue(UpdateSettingsOnUiThread);

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockWindowManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockWindowManager.cs
@@ -26,6 +26,9 @@ public sealed partial class DockWindowManager : IDisposable
     private bool _disposed;
     private int _syncing;
 
+    private bool? _lastSyncedEnableDock;
+    private DockSettings? _lastSyncedDockSettings;
+
     public DockWindowManager(
         IMonitorService monitorService,
         ISettingsService settingsService,
@@ -217,6 +220,14 @@ public sealed partial class DockWindowManager : IDisposable
 
     private void OnSettingsChanged(ISettingsService sender, SettingsModel args)
     {
+        if (args.EnableDock == _lastSyncedEnableDock && args.DockSettings == _lastSyncedDockSettings)
+        {
+            return;
+        }
+
+        _lastSyncedEnableDock = args.EnableDock;
+        _lastSyncedDockSettings = args.DockSettings;
+
         _dispatcherQueue.TryEnqueue(() =>
         {
             if (!_disposed)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using CmdPalKeyboardService;
@@ -80,6 +81,11 @@ public sealed partial class MainWindow : WindowEx,
     private bool _allowBreakthroughShortcut;
     private bool _suppressDpiChange;
     private bool _themeServiceInitialized;
+
+    // The snapshot of settings last consumed by HotReloadSettings. Used to skip redundant
+    // hot-reloads when a SettingsChanged notification touches settings this window doesn't
+    // care about (theme, provider config, aliases, and so on).
+    private SettingsModel? _lastAppliedSettings;
 
     // Session tracking for telemetry
     private Stopwatch? _sessionStopwatch;
@@ -239,6 +245,14 @@ public sealed partial class MainWindow : WindowEx,
 
     private void SettingsChangedHandler(ISettingsService sender, SettingsModel args)
     {
+        // Only rebuild window state when a setting HotReloadSettings actually consumes has
+        // changed. Most SettingsChanged notifications (theme, provider config, aliases, ...)
+        // don't affect the host window, so hot-reloading on every one is wasteful.
+        if (MainWindowSettingsComparer.Instance.Equals(_lastAppliedSettings, args))
+        {
+            return;
+        }
+
         DispatcherQueue.TryEnqueue(HotReloadSettings);
     }
 
@@ -464,7 +478,11 @@ public sealed partial class MainWindow : WindowEx,
 
     private void HotReloadSettings()
     {
+        // NOTE: SettingsChangedHandler skips this method when nothing relevant changed, using
+        // MainWindowSettingsComparer. When you start consuming a new setting below, add it to
+        // that comparer too — otherwise changes to it won't trigger a hot-reload.
         var settings = App.Current.Services.GetRequiredService<ISettingsService>().Settings;
+        _lastAppliedSettings = settings;
 
         SetupHotkey(settings);
         App.Current.Services.GetService<TrayIconService>()!.SetupTrayIcon(settings.ShowSystemTrayIcon);
@@ -488,6 +506,87 @@ public sealed partial class MainWindow : WindowEx,
     /// </summary>
     private static bool ShouldShowHwndFrame(SettingsModel settings) =>
         !BuildInfo.IsCiBuild && settings.ShowHwndFrame;
+
+    /// <summary>
+    /// Compares two <see cref="SettingsModel"/> instances by only the settings that
+    /// <see cref="HotReloadSettings"/> (and the methods it calls) actually consume. Any change
+    /// to a setting outside this set is invisible to the host window, so treating such models
+    /// as equal lets <see cref="SettingsChangedHandler"/> skip a redundant hot-reload.
+    /// </summary>
+    /// <remarks>
+    /// Keep this in sync with the settings read by <see cref="HotReloadSettings"/>,
+    /// <see cref="SetupHotkey"/>, <see cref="ShouldShowHwndFrame"/>, and
+    /// <see cref="HandleExpandCompactOnUiThread"/>.
+    /// </remarks>
+    private sealed class MainWindowSettingsComparer : IEqualityComparer<SettingsModel>
+    {
+        public static MainWindowSettingsComparer Instance { get; } = new();
+
+        public bool Equals(SettingsModel? x, SettingsModel? y)
+        {
+            if (ReferenceEquals(x, y))
+            {
+                return true;
+            }
+
+            if (x is null || y is null)
+            {
+                return false;
+            }
+
+            return x.UseLowLevelGlobalHotkey == y.UseLowLevelGlobalHotkey
+                && x.ShowSystemTrayIcon == y.ShowSystemTrayIcon
+                && x.IgnoreShortcutWhenFullscreen == y.IgnoreShortcutWhenFullscreen
+                && x.IgnoreShortcutWhenBusy == y.IgnoreShortcutWhenBusy
+                && x.AllowBreakthroughShortcut == y.AllowBreakthroughShortcut
+                && x.AutoGoHomeInterval == y.AutoGoHomeInterval
+                && x.ShowHwndFrame == y.ShowHwndFrame
+                && x.CompactMode == y.CompactMode
+                && x.Hotkey == y.Hotkey // HotkeySettings is a record (value equality)
+                && CommandHotkeysEqual(x.CommandHotkeys, y.CommandHotkeys);
+        }
+
+        // TopLevelHotkey is a record (value equality); compare element-wise. ImmutableList
+        // itself only implements reference equality, so we can't rely on ==.
+        private static bool CommandHotkeysEqual(ImmutableList<TopLevelHotkey> x, ImmutableList<TopLevelHotkey> y)
+        {
+            if (ReferenceEquals(x, y))
+            {
+                return true;
+            }
+
+            if (x.Count != y.Count)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < x.Count; i++)
+            {
+                if (x[i] != y[i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public int GetHashCode(SettingsModel obj)
+        {
+            var hash = default(HashCode);
+            hash.Add(obj.UseLowLevelGlobalHotkey);
+            hash.Add(obj.ShowSystemTrayIcon);
+            hash.Add(obj.IgnoreShortcutWhenFullscreen);
+            hash.Add(obj.IgnoreShortcutWhenBusy);
+            hash.Add(obj.AllowBreakthroughShortcut);
+            hash.Add(obj.AutoGoHomeInterval);
+            hash.Add(obj.ShowHwndFrame);
+            hash.Add(obj.CompactMode);
+            hash.Add(obj.Hotkey);
+            hash.Add(obj.CommandHotkeys.Count);
+            return hash.ToHashCode();
+        }
+    }
 
     /// <summary>
     /// Configures the HWND for the borderless / transparent main-window mode and (when

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/DockSettingsEqualityTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/DockSettingsEqualityTests.cs
@@ -1,0 +1,98 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using Microsoft.CmdPal.UI.ViewModels.Settings;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
+
+/// <summary>
+/// Verifies that <see cref="DockSettings"/> (and its nested <see cref="DockMonitorConfig"/>)
+/// compare by <em>content</em> rather than by list reference. Dock consumers guard their
+/// (expensive) reloads with <c>_settings == args.DockSettings</c>, so two settings that differ
+/// only by having freshly-rebuilt band lists — e.g. after loading from disk — must compare
+/// equal, otherwise the reload fires needlessly.
+/// </summary>
+[TestClass]
+public class DockSettingsEqualityTests
+{
+    private static DockBandSettings Band(string providerId, string commandId, bool? showTitles = null) =>
+        new() { ProviderId = providerId, CommandId = commandId, ShowTitles = showTitles };
+
+    [TestMethod]
+    public void Equal_WhenBandListsHaveSameContentButDifferentInstances()
+    {
+        var a = new DockSettings
+        {
+            StartBands = ImmutableList.Create(Band("p", "home"), Band("w", "winget", showTitles: false)),
+        };
+        var b = new DockSettings
+        {
+            StartBands = ImmutableList.Create(Band("p", "home"), Band("w", "winget", showTitles: false)),
+        };
+
+        // Distinct ImmutableList instances — would be reference-unequal without EquatableList.
+        Assert.AreNotSame(a.StartBands, b.StartBands);
+        Assert.AreEqual(a, b);
+        Assert.IsTrue(a == b);
+        Assert.AreEqual(a.GetHashCode(), b.GetHashCode());
+    }
+
+    [TestMethod]
+    public void NotEqual_WhenABandDiffers()
+    {
+        var a = new DockSettings { StartBands = ImmutableList.Create(Band("p", "home")) };
+        var b = new DockSettings { StartBands = ImmutableList.Create(Band("p", "settings")) };
+
+        Assert.AreNotEqual(a, b);
+        Assert.IsTrue(a != b);
+    }
+
+    [TestMethod]
+    public void NotEqual_WhenBandOrderDiffers()
+    {
+        var a = new DockSettings { StartBands = ImmutableList.Create(Band("p", "a"), Band("p", "b")) };
+        var b = new DockSettings { StartBands = ImmutableList.Create(Band("p", "b"), Band("p", "a")) };
+
+        Assert.AreNotEqual(a, b);
+    }
+
+    [TestMethod]
+    public void Equal_WhenMonitorConfigsHaveSameContentIncludingPerMonitorBands()
+    {
+        var a = new DockSettings
+        {
+            MonitorConfigs = ImmutableList.Create(new DockMonitorConfig
+            {
+                MonitorDeviceId = @"\\.\DISPLAY1",
+                IsCustomized = true,
+                StartBands = ImmutableList.Create(Band("p", "home")),
+            }),
+        };
+        var b = new DockSettings
+        {
+            MonitorConfigs = ImmutableList.Create(new DockMonitorConfig
+            {
+                MonitorDeviceId = @"\\.\DISPLAY1",
+                IsCustomized = true,
+                StartBands = ImmutableList.Create(Band("p", "home")),
+            }),
+        };
+
+        Assert.AreEqual(a, b);
+        Assert.AreEqual(a.GetHashCode(), b.GetHashCode());
+    }
+
+    [TestMethod]
+    public void NotEqual_WhenPerMonitorBandsIsNullVersusEmpty()
+    {
+        // null means "inherit global bands"; an explicit empty list does not. The two must
+        // stay distinguishable so a monitor can't silently switch between the two meanings.
+        var inherit = new DockMonitorConfig { MonitorDeviceId = "m", StartBands = null };
+        var explicitEmpty = new DockMonitorConfig { MonitorDeviceId = "m", StartBands = ImmutableList<DockBandSettings>.Empty };
+
+        Assert.AreNotEqual(inherit, explicitEmpty);
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/EquatableListTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/EquatableListTests.cs
@@ -1,0 +1,105 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using Microsoft.CmdPal.UI.ViewModels.Settings;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
+
+/// <summary>
+/// Tests for <see cref="EquatableList{T}"/> — the value-equality wrapper used as the backing
+/// field for record list properties so record equality compares list contents, not references.
+/// </summary>
+[TestClass]
+public class EquatableListTests
+{
+    private static EquatableList<string> Of(params string[] items) =>
+        new(ImmutableList.Create(items));
+
+    [TestMethod]
+    public void Equal_WhenSameContentDifferentInstances()
+    {
+        var a = Of("x", "y", "z");
+        var b = Of("x", "y", "z");
+
+        Assert.AreNotSame(a.List, b.List);
+        Assert.IsTrue(a.Equals(b));
+        Assert.AreEqual(a, b);
+        Assert.AreEqual(a.GetHashCode(), b.GetHashCode());
+    }
+
+    [TestMethod]
+    public void Equal_WhenSameUnderlyingReference()
+    {
+        var shared = ImmutableList.Create("a", "b");
+        var a = new EquatableList<string>(shared);
+        var b = new EquatableList<string>(shared);
+
+        Assert.IsTrue(a.Equals(b));
+    }
+
+    [TestMethod]
+    public void NotEqual_WhenAnElementDiffers()
+    {
+        Assert.AreNotEqual(Of("a", "b"), Of("a", "c"));
+    }
+
+    [TestMethod]
+    public void NotEqual_WhenOrderDiffers()
+    {
+        Assert.AreNotEqual(Of("a", "b"), Of("b", "a"));
+    }
+
+    [TestMethod]
+    public void NotEqual_WhenCountsDiffer()
+    {
+        Assert.AreNotEqual(Of("a"), Of("a", "b"));
+    }
+
+    [TestMethod]
+    public void EmptyLists_AreEqual()
+    {
+        var fromEmpty = new EquatableList<string>(ImmutableList<string>.Empty);
+        var fromNull = new EquatableList<string>(null);
+
+        Assert.IsTrue(fromEmpty.Equals(fromNull));
+        Assert.AreEqual(fromEmpty.GetHashCode(), fromNull.GetHashCode());
+    }
+
+    [TestMethod]
+    public void Default_ExposesEmptyListAndEqualsEmpty()
+    {
+        EquatableList<string> defaulted = default;
+
+        // A default(struct) has a null inner list; List must still surface an empty list
+        // (never null) and compare equal to an explicitly-empty instance.
+        Assert.IsNotNull(defaulted.List);
+        Assert.AreEqual(0, defaulted.List.Count);
+        Assert.IsTrue(defaulted.Equals(new EquatableList<string>(ImmutableList<string>.Empty)));
+    }
+
+    [TestMethod]
+    public void List_IsNeverNull()
+    {
+        Assert.IsNotNull(new EquatableList<string>(null).List);
+    }
+
+    [TestMethod]
+    public void EqualsObject_ReturnsFalse_ForOtherTypes()
+    {
+        object other = "not an equatable list";
+
+        Assert.IsFalse(Of("a").Equals(other));
+        Assert.IsFalse(Of("a").Equals(null!));
+    }
+
+    [TestMethod]
+    public void EqualsObject_ReturnsTrue_ForBoxedEqualValue()
+    {
+        object boxed = Of("a", "b");
+
+        Assert.IsTrue(Of("a", "b").Equals(boxed));
+    }
+}


### PR DESCRIPTION
## Summary of the Pull Request

This PR stops Command Palette subscribers from re-running their full hot-reload path on every SettingsChanged event. Previously any settings edit re-registered hotkeys, rebuilt the backdrop, and tore down/recreated dock windows even when nothing the subscriber consumed had changed.

- `MainWindow`: added `MainWindowSettingsComparer `(IEqualityComparer<SettingsModel>); skips HotReloadSettings unless a consumed setting changed.
- `DockWindowManager`: OnSettingsChanged bails unless EnableDock/DockSettings changed; monitor-topology path still always syncs.
- `DockWindow `/ `DockViewModel`: guard reloads with _settings == args.DockSettings.
- `DockSettings `/ `DockMonitorConfig`: list backing fields now use a new EquatableList<T> wrapper, giving record equality content-based (not reference-based) list comparison so guards hold after a reload rebuilds the lists.
- Tests: EquatableListTests and DockSettingsEqualityTests cover the wrapper and structural DockSettings equality.
- Public API and persisted JSON contract unchanged (EquatableList<T> is backing-field only; properties still expose ImmutableList<T>).

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #49168
- [ ] <!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

