### PR TITLE
CmdPal: Add keyboard shortcuts to manually expand compact mode palette

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
@@ -950,6 +950,17 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
                 ((ShellPage)sender).ToggleFilterFocus();
                 e.Handled = true;
                 break;
+            case VirtualKey.Down when modifiers.None:
+            case VirtualKey.Tab when modifiers.None:
+                // In a collapsed compact palette, Down/Tab reveals the top-level items so the
+                // user can browse and discover them. Only swallow the key when we actually
+                // expand; otherwise let it fall through to normal list navigation / focus move.
+                if (((ShellPage)sender).TryExpandCollapsedCompact())
+                {
+                    e.Handled = true;
+                }
+
+                break;
             default:
                 {
                     // The CommandBar is responsible for handling all the item keybindings,
@@ -1053,6 +1064,23 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
 
         this.ExpandedMode = newExpanded;
         PropertyChanged?.Invoke(this, new(nameof(ExpandedMode)));
+    }
+
+    /// <summary>
+    /// Expands a collapsed compact palette on demand (via Down/Tab) so the user can browse the
+    /// top-level items. Returns <see langword="false"/> and does nothing unless compact mode is
+    /// on and the palette is currently collapsed, letting the caller keep the key's normal
+    /// meaning (list navigation / focus traversal) in every other case.
+    /// </summary>
+    private bool TryExpandCollapsedCompact()
+    {
+        if (!_compactMode || ExpandedMode)
+        {
+            return false;
+        }
+
+        HandleExpandCompactOnUiThread(true);
+        return true;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary of the Pull Request

This PR adds support for new keyboard shortcuts to expand CmdPal when in Compact mode. Both of them are "natural" 
- Down arrow key
- Tab key

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #49112
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

