### PR TITLE
CmdPal: Stop item action being executed when CmdPal is compact and collapsed

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
@@ -121,6 +121,9 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
 
     public bool ExpandedMode { get; set; }
 
+    // Item keybindings act on the selected item, which is hidden while collapsed — only honor them when expanded.
+    private bool ItemActionsAllowed => !_compactMode || ExpandedMode;
+
     public ShellPage()
     {
         _settingsService = App.Current.Services.GetRequiredService<ISettingsService>();
@@ -952,12 +955,14 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
                 break;
             default:
                 {
-                    // The CommandBar is responsible for handling all the item keybindings,
-                    // since the bound context item may need to then show another
-                    // context menu
-                    TryCommandKeybindingMessage msg = new(modifiers.Ctrl, modifiers.Alt, modifiers.Shift, modifiers.Win, e.Key);
-                    WeakReferenceMessenger.Default.Send(msg);
-                    e.Handled = msg.Handled;
+                    // The CommandBar handles item keybindings; skip them while collapsed so a chord can't hit the hidden selection.
+                    if (((ShellPage)sender).ItemActionsAllowed)
+                    {
+                        TryCommandKeybindingMessage msg = new(modifiers.Ctrl, modifiers.Alt, modifiers.Shift, modifiers.Win, e.Key);
+                        WeakReferenceMessenger.Default.Send(msg);
+                        e.Handled = msg.Handled;
+                    }
+
                     break;
                 }
         }
@@ -965,10 +970,7 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
 
     private void ShellPage_OnKeyDown(object sender, KeyRoutedEventArgs e)
     {
-        // Item actions are only forwarded when the palette is expanded. In compact mode the
-        // user can't see which item is active, so activating one would be surprising.
-        var itemActionsAllowed = !_compactMode || ExpandedMode;
-        if (itemActionsAllowed && TryHandleItemAction(e))
+        if (ItemActionsAllowed && TryHandleItemAction(e))
         {
             return;
         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
@@ -963,31 +963,48 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
         }
     }
 
-    private static void ShellPage_OnKeyDown(object sender, KeyRoutedEventArgs e)
+    private void ShellPage_OnKeyDown(object sender, KeyRoutedEventArgs e)
     {
-        var mods = KeyModifiers.GetCurrent();
-        if (mods.Ctrl && e.Key == VirtualKey.Enter)
+        // Item actions are only forwarded when the palette is expanded. In compact mode the
+        // user can't see which item is active, so activating one would be surprising.
+        var itemActionsAllowed = !_compactMode || ExpandedMode;
+        if (itemActionsAllowed && TryHandleItemAction(e))
         {
-            // ctrl+enter
-            WeakReferenceMessenger.Default.Send<ActivateSecondaryCommandMessage>();
-            e.Handled = true;
+            return;
         }
-        else if (e.Key == VirtualKey.Enter)
-        {
-            WeakReferenceMessenger.Default.Send<ActivateSelectedListItemMessage>();
-            e.Handled = true;
-        }
-        else if (mods.Ctrl && e.Key == VirtualKey.K)
-        {
-            // ctrl+k
-            WeakReferenceMessenger.Default.Send<OpenContextMenuMessage>(new OpenContextMenuMessage(null, null, null, ContextMenuFilterLocation.Bottom));
-            e.Handled = true;
-        }
-        else if (e.Key == VirtualKey.Escape)
+
+        if (e.Key == VirtualKey.Escape)
         {
             WeakReferenceMessenger.Default.Send<NavigateBackMessage>(new());
             e.Handled = true;
         }
+    }
+
+    private static bool TryHandleItemAction(KeyRoutedEventArgs e)
+    {
+        var mods = KeyModifiers.GetCurrent();
+        switch (e.Key)
+        {
+            // Ctrl+Enter
+            case VirtualKey.Enter when mods.OnlyCtrl:
+                WeakReferenceMessenger.Default.Send<ActivateSecondaryCommandMessage>();
+                break;
+
+            // Enter
+            case VirtualKey.Enter when mods.None:
+                WeakReferenceMessenger.Default.Send<ActivateSelectedListItemMessage>();
+                break;
+
+            // Ctrl+K
+            case VirtualKey.K when mods.OnlyCtrl:
+                WeakReferenceMessenger.Default.Send<OpenContextMenuMessage>(new(null, null, null, ContextMenuFilterLocation.Bottom));
+                break;
+            default:
+                return false;
+        }
+
+        e.Handled = true;
+        return true;
     }
 
     private void ShellPage_OnPointerPressed(object sender, PointerRoutedEventArgs e)


### PR DESCRIPTION
## Summary of the Pull Request

This PR prevents Command Palette in collapsed compact mode executing actions on a selected item. Since user is not aware what item is selected or what action are

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #49113
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

