### PR TITLE
CmdPal: compact is supposed to be off by default

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsModel.cs
@@ -46,7 +46,7 @@ public record SettingsModel
 
     public bool AllowExternalReload { get; init; }
 
-    public bool CompactMode { get; set; } = false;
+    public bool CompactMode { get; set; }
 
     // When compact mode is on and the palette is centered on launch, this is the relative
     // height from the bottom of the screen (as a percentage) at which the collapsed search

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsModel.cs
@@ -46,7 +46,7 @@ public record SettingsModel
 
     public bool AllowExternalReload { get; init; }
 
-    public bool CompactMode { get; set; } = true;
+    public bool CompactMode { get; set; } = false;
 
     // When compact mode is on and the palette is centered on launch, this is the relative
     // height from the bottom of the screen (as a percentage) at which the collapsed search


### PR DESCRIPTION
Title. It should be off by default. Oops.