### PR TITLE
System Tray Icons to match Windows Theme #48389

### DIFF
--- a/src/common/ManagedCommon/ThemeAdaptiveTrayIconHelper.cs
+++ b/src/common/ManagedCommon/ThemeAdaptiveTrayIconHelper.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace ManagedCommon
+{
+    // Loads white/dark tray icons based on system theme, matching runner/tray_icon.cpp get_icon().
+    public static class ThemeAdaptiveTrayIconHelper
+    {
+        private const uint LoadImageIcon = 1;
+        private const uint LrLoadFromFile = 0x00000010;
+        private const uint LrDefaultSize = 0x00000040;
+
+        public static IntPtr LoadIconHandle(
+            bool themeAdaptive,
+            string whiteIconPath,
+            string darkIconPath,
+            Func<IntPtr> fallbackLoadIcon)
+        {
+            if (themeAdaptive)
+            {
+                var iconPath = ThemeHelpers.GetSystemTheme() == AppTheme.Dark ? whiteIconPath : darkIconPath;
+                if (File.Exists(iconPath))
+                {
+                    var icon = LoadImage(IntPtr.Zero, iconPath, LoadImageIcon, 0, 0, LrLoadFromFile | LrDefaultSize);
+                    if (icon != IntPtr.Zero)
+                    {
+                        return icon;
+                    }
+                }
+            }
+
+            return fallbackLoadIcon();
+        }
+
+        public static void DestroyIconHandle(IntPtr iconHandle)
+        {
+            if (iconHandle != IntPtr.Zero)
+            {
+                DestroyIcon(iconHandle);
+            }
+        }
+
+        [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern IntPtr LoadImage(
+            IntPtr hInst,
+            string name,
+            uint type,
+            int cx,
+            int cy,
+            uint fuLoad);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern bool DestroyIcon(IntPtr hIcon);
+    }
+}

--- a/src/common/ManagedCommon/ThemeHelpers.cs
+++ b/src/common/ManagedCommon/ThemeHelpers.cs
@@ -19,12 +19,19 @@ namespace ManagedCommon
         internal const string HkeyWindowsTheme = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Themes";
         internal const string HkeyWindowsPersonalizeTheme = $@"{HkeyWindowsTheme}\Personalize";
         internal const string HValueAppTheme = "AppsUseLightTheme";
+        internal const string HValueSystemTheme = "SystemUsesLightTheme";
         internal const int DWMWAImmersiveDarkMode = 20;
 
         // based on https://stackoverflow.com/questions/51334674/how-to-detect-windows-10-light-dark-mode-in-win32-application
         public static AppTheme GetAppTheme()
         {
             int value = (int)Registry.GetValue($"{HKeyRoot}\\{HkeyWindowsPersonalizeTheme}", HValueAppTheme, 1);
+            return (AppTheme)value;
+        }
+
+        public static AppTheme GetSystemTheme()
+        {
+            int value = (int)Registry.GetValue($"{HKeyRoot}\\{HkeyWindowsPersonalizeTheme}", HValueSystemTheme, 1);
             return (AppTheme)value;
         }
 

--- a/src/common/ManagedCommon/ThemeListener.cs
+++ b/src/common/ManagedCommon/ThemeListener.cs
@@ -8,54 +8,71 @@ using System.Security.Principal;
 
 namespace ManagedCommon
 {
-    /// <summary>
-    /// The Delegate for a ThemeChanged Event.
-    /// </summary>
-    /// <param name="sender">Sender ThemeListener</param>
     public delegate void ThemeChangedEvent(ThemeListener sender);
 
+    public delegate void SystemThemeChangedEvent(ThemeListener sender);
+
+    // Mirrors common/Themes/theme_listener.h used by the Runner tray icon.
     public partial class ThemeListener : IDisposable
     {
-        /// <summary>
-        /// Gets the App Theme.
-        /// </summary>
         public AppTheme AppTheme { get; private set; }
 
-        /// <summary>
-        /// An event that fires if the Theme changes.
-        /// </summary>
+        public AppTheme SystemTheme { get; private set; }
+
         public event ThemeChangedEvent ThemeChanged;
 
-        private readonly ManagementEventWatcher watcher;
+        public event SystemThemeChangedEvent SystemThemeChanged;
+
+        private readonly ManagementEventWatcher appThemeWatcher;
+        private readonly ManagementEventWatcher systemThemeWatcher;
 
         public ThemeListener()
         {
             var currentUser = WindowsIdentity.GetCurrent();
-            var query = new WqlEventQuery(
+            var keyPath = $"{currentUser.User.Value}\\\\{ThemeHelpers.HkeyWindowsPersonalizeTheme.Replace("\\", "\\\\")}";
+
+            var appThemeQuery = new WqlEventQuery(
                 $"SELECT * FROM RegistryValueChangeEvent WHERE Hive='HKEY_USERS' AND " +
-                $"KeyPath='{currentUser.User.Value}\\\\{ThemeHelpers.HkeyWindowsPersonalizeTheme.Replace("\\", "\\\\")}' AND ValueName='{ThemeHelpers.HValueAppTheme}'");
-            watcher = new ManagementEventWatcher(query);
-            watcher.EventArrived += Watcher_EventArrived;
-            watcher.Start();
+                $"KeyPath='{keyPath}' AND ValueName='{ThemeHelpers.HValueAppTheme}'");
+            appThemeWatcher = new ManagementEventWatcher(appThemeQuery);
+            appThemeWatcher.EventArrived += OnAppThemeRegistryChanged;
+            appThemeWatcher.Start();
+
+            var systemThemeQuery = new WqlEventQuery(
+                $"SELECT * FROM RegistryValueChangeEvent WHERE Hive='HKEY_USERS' AND " +
+                $"KeyPath='{keyPath}' AND ValueName='{ThemeHelpers.HValueSystemTheme}'");
+            systemThemeWatcher = new ManagementEventWatcher(systemThemeQuery);
+            systemThemeWatcher.EventArrived += OnSystemThemeRegistryChanged;
+            systemThemeWatcher.Start();
 
             AppTheme = ThemeHelpers.GetAppTheme();
+            SystemTheme = ThemeHelpers.GetSystemTheme();
         }
 
-        private void Watcher_EventArrived(object sender, EventArrivedEventArgs e)
+        private void OnAppThemeRegistryChanged(object sender, EventArrivedEventArgs e)
         {
             var appTheme = ThemeHelpers.GetAppTheme();
-
             if (appTheme != AppTheme)
             {
                 AppTheme = appTheme;
-
                 ThemeChanged?.Invoke(this);
+            }
+        }
+
+        private void OnSystemThemeRegistryChanged(object sender, EventArrivedEventArgs e)
+        {
+            var systemTheme = ThemeHelpers.GetSystemTheme();
+            if (systemTheme != SystemTheme)
+            {
+                SystemTheme = systemTheme;
+                SystemThemeChanged?.Invoke(this);
             }
         }
 
         public void Dispose()
         {
-            watcher.Dispose();
+            appThemeWatcher.Dispose();
+            systemThemeWatcher.Dispose();
             GC.SuppressFinalize(this);
         }
     }

--- a/src/common/Themes/icon_helpers.cpp
+++ b/src/common/Themes/icon_helpers.cpp
@@ -3,6 +3,38 @@
 #include <shlwapi.h>
 #include <commctrl.h>
 
+HICON LoadThemeAdaptiveTrayIcon(
+    bool themeAdaptive,
+    _In_ PCWSTR whiteIconPath,
+    _In_ PCWSTR darkIconPath,
+    _In_ HINSTANCE fallbackInstance,
+    _In_ LPCWSTR fallbackResourceName)
+{
+    if (themeAdaptive)
+    {
+        const auto systemTheme = ThemeHelpers::GetSystemTheme();
+        const PCWSTR iconPath = systemTheme == Theme::Dark ? whiteIconPath : darkIconPath;
+
+        if (GetFileAttributes(iconPath) != INVALID_FILE_ATTRIBUTES)
+        {
+            HICON icon = static_cast<HICON>(LoadImage(
+                NULL,
+                iconPath,
+                IMAGE_ICON,
+                0,
+                0,
+                LR_LOADFROMFILE | LR_DEFAULTSIZE));
+
+            if (icon)
+            {
+                return icon;
+            }
+        }
+    }
+
+    return LoadIcon(fallbackInstance, fallbackResourceName);
+}
+
 HRESULT GetIconIndexFromPath(_In_ PCWSTR path, _Out_ int* index)
 {
     *index = 0;

--- a/src/common/Themes/icon_helpers.h
+++ b/src/common/Themes/icon_helpers.h
@@ -3,5 +3,18 @@
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 
+#include <string>
+
+#include "theme_helpers.h"
+
 HRESULT GetIconIndexFromPath(_In_ PCWSTR path, _Out_ int* index);
 HBITMAP CreateBitmapFromIcon(_In_ HICON hIcon, _In_opt_ UINT width = 0, _In_opt_ UINT height = 0);
+
+// Loads a tray icon handle. When themeAdaptive is true, loads whiteIconPath for dark shell
+// and darkIconPath for light shell. Falls back to the embedded resource icon on failure.
+HICON LoadThemeAdaptiveTrayIcon(
+    bool themeAdaptive,
+    _In_ PCWSTR whiteIconPath,
+    _In_ PCWSTR darkIconPath,
+    _In_ HINSTANCE fallbackInstance,
+    _In_ LPCWSTR fallbackResourceName);

--- a/src/modules/MouseWithoutBorders/App/Class/Setting.cs
+++ b/src/modules/MouseWithoutBorders/App/Class/Setting.cs
@@ -132,6 +132,18 @@ namespace MouseWithoutBorders.Class
                         {
                             SaveSettings();
                         }
+
+                        if (last_properties.ShowThemeAdaptiveTrayIcon != _settings.Properties.ShowThemeAdaptiveTrayIcon)
+                        {
+                            Common.DoSomethingInUIThread(() =>
+                            {
+                                if (Common.MainForm != null)
+                                {
+                                    Common.MainForm.ConfigureTrayThemeListener();
+                                    Common.MainForm.RefreshTrayIcon();
+                                }
+                            });
+                        }
                     }
                 }
             }
@@ -1130,6 +1142,25 @@ namespace MouseWithoutBorders.Class
                 lock (_loadingSettingsLock)
                 {
                     _properties.ShowOriginalUI = value;
+                }
+            }
+        }
+
+        internal bool ShowThemeAdaptiveTrayIcon
+        {
+            get
+            {
+                lock (_loadingSettingsLock)
+                {
+                    return _properties.ShowThemeAdaptiveTrayIcon;
+                }
+            }
+
+            set
+            {
+                lock (_loadingSettingsLock)
+                {
+                    _properties.ShowThemeAdaptiveTrayIcon = value;
                 }
             }
         }

--- a/src/modules/MouseWithoutBorders/App/Form/frmScreen.cs
+++ b/src/modules/MouseWithoutBorders/App/Form/frmScreen.cs
@@ -57,6 +57,8 @@ namespace MouseWithoutBorders
         private Cursor dropCur;
         private int[,] logonLogo;
         private Timer helperTimer;
+        private ManagedCommon.ThemeListener themeListener;
+        private int lastChangeIconCode = -1;
 #pragma warning restore CA2213
 
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
@@ -118,6 +120,7 @@ namespace MouseWithoutBorders
 
             NotifyIcon.Visible = false;
             NotifyIcon.Dispose();
+            DisposeTrayThemeListener();
             if (!Common.RunOnLogonDesktop && !Common.RunOnScrSaverDesktop)
             {
                 Helper.RunDDHelper(true);
@@ -251,6 +254,7 @@ namespace MouseWithoutBorders
                 // Common.HookClipboard();
                 CurIcon = Common.ICON_ONE;
                 ChangeIcon(-1);
+                ConfigureTrayThemeListener();
                 dotCur = CustomCursor.CreateDotCursor();
                 Cursor = dotCur;
                 dropCur = CustomCursor.CreateCursor(Icon.ToBitmap(), 0, 0);
@@ -623,9 +627,25 @@ namespace MouseWithoutBorders
         {
             try
             {
+                lastChangeIconCode = iconCode;
+                var themeAdaptive = Setting.Values.ShowThemeAdaptiveTrayIcon;
                 Graphics g;
                 Pen p;
                 Bitmap bm = Images.notify_default;
+                var disposeBitmap = false;
+
+                if (themeAdaptive)
+                {
+                    var iconPath = ManagedCommon.ThemeHelpers.GetSystemTheme() == ManagedCommon.AppTheme.Dark
+                        ? Path.Combine(Application.StartupPath, "LogoWhite.ico")
+                        : Path.Combine(Application.StartupPath, "LogoDark.ico");
+                    if (File.Exists(iconPath))
+                    {
+                        using Icon icon = new(iconPath);
+                        bm = icon.ToBitmap();
+                        disposeBitmap = true;
+                    }
+                }
 
                 /*
                 if (curIcon == Common.ICON_ONE)
@@ -649,30 +669,33 @@ namespace MouseWithoutBorders
                 }
                 */
 
+                var darkShell = ManagedCommon.ThemeHelpers.GetSystemTheme() == ManagedCommon.AppTheme.Dark;
+
                 if (CurIcon != Common.ICON_ONE)
                 {
-                    p = new Pen(Color.Red, 2);
+                    p = new Pen(themeAdaptive ? (darkShell ? Color.White : Color.Black) : Color.Red, 2);
                     g = Graphics.FromImage(bm);
                     g.DrawRectangle(p, 1, 1, bm.Width - 2, bm.Height - 2);
                     g.Dispose();
+                    p.Dispose();
                 }
 
                 if (iconCode == Common.ICON_SMALL_CLIPBOARD)
                 {
                     g = Graphics.FromImage(bm);
-                    g.FillEllipse(Brushes.Blue, 8, 8, 16, 16);
+                    g.FillEllipse(themeAdaptive ? (darkShell ? Brushes.White : Brushes.Black) : Brushes.Blue, 8, 8, 16, 16);
                     g.Dispose();
                 }
                 else if (iconCode == Common.ICON_BIG_CLIPBOARD)
                 {
                     g = Graphics.FromImage(bm);
-                    g.FillEllipse(Brushes.Yellow, 8, 8, 16, 16);
+                    g.FillEllipse(themeAdaptive ? (darkShell ? Brushes.LightGray : Brushes.DarkGray) : Brushes.Yellow, 8, 8, 16, 16);
                     g.Dispose();
                 }
                 else if (iconCode == Common.ICON_ERROR)
                 {
                     g = Graphics.FromImage(bm);
-                    g.FillEllipse(Brushes.Red, 8, 8, 16, 16);
+                    g.FillEllipse(themeAdaptive ? (darkShell ? Brushes.Gray : Brushes.DimGray) : Brushes.Red, 8, 8, 16, 16);
                     g.Dispose();
                 }
 
@@ -692,12 +715,53 @@ namespace MouseWithoutBorders
                 }
 
                 NotifyIcon.Icon = Icon.FromHandle(bm.GetHicon());
-                bm.Dispose();
+                if (disposeBitmap)
+                {
+                    bm.Dispose();
+                }
             }
             catch (Exception e)
             {
                 Logger.Log(e);
             }
+        }
+
+        internal void ConfigureTrayThemeListener()
+        {
+            DisposeTrayThemeListener();
+
+            if (!Setting.Values.ShowThemeAdaptiveTrayIcon)
+            {
+                return;
+            }
+
+            themeListener = new ManagedCommon.ThemeListener();
+            themeListener.SystemThemeChanged += OnTraySystemThemeChanged;
+        }
+
+        internal void RefreshTrayIcon()
+        {
+            ChangeIcon(lastChangeIconCode);
+        }
+
+        private void OnTraySystemThemeChanged(ManagedCommon.ThemeListener sender)
+        {
+            if (Setting.Values.ShowThemeAdaptiveTrayIcon)
+            {
+                Common.DoSomethingInUIThread(RefreshTrayIcon);
+            }
+        }
+
+        private void DisposeTrayThemeListener()
+        {
+            if (themeListener == null)
+            {
+                return;
+            }
+
+            themeListener.SystemThemeChanged -= OnTraySystemThemeChanged;
+            themeListener.Dispose();
+            themeListener = null;
         }
 
         internal void MenuAllPC_Click(object sender, EventArgs e)

--- a/src/modules/MouseWithoutBorders/App/MouseWithoutBorders.csproj
+++ b/src/modules/MouseWithoutBorders/App/MouseWithoutBorders.csproj
@@ -206,6 +206,8 @@
     <Content Include="Icon\yes_button_hover.png" />
     <Content Include="Icon\yes_button_normal.png" />
     <Content Include="Logo.ico" />
+    <Content Include="LogoWhite.ico" CopyToOutputDirectory="PreserveNewest" Condition="Exists('LogoWhite.ico')" />
+    <Content Include="LogoDark.ico" CopyToOutputDirectory="PreserveNewest" Condition="Exists('LogoDark.ico')" />
   </ItemGroup>
   <ItemGroup>
     <!-- Including MessagePack to force version, since it's used by StreamJsonRpc but contains vulnerabilities. After StreamJsonRpc updates the version of MessagePack, we can upgrade StreamJsonRpc instead. -->

--- a/src/modules/ZoomIt/ZoomIt/ZoomIt.vcxproj
+++ b/src/modules/ZoomIt/ZoomIt/ZoomIt.vcxproj
@@ -544,6 +544,9 @@
     <ProjectReference Include="..\..\..\common\Telemetry\EtwTrace\EtwTrace.vcxproj">
       <Project>{8f021b46-362b-485c-bfba-ccf83e820cbd}</Project>
     </ProjectReference>
+    <ProjectReference Include="..\..\..\common\Themes\Themes.vcxproj">
+      <Project>{98537082-0FDB-40DE-ABD8-0DC5A4269BAB}</Project>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <Import Project="..\..\..\..\deps\spdlog.props" />
@@ -559,4 +562,8 @@
   <Import Project="..\..\..\..\packages\robmikh.common.0.0.23-beta\build\native\robmikh.common.targets" Condition="Exists('..\..\..\..\packages\robmikh.common.0.0.23-beta\build\native\robmikh.common.targets')" />
   <Import Project="..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\..\..\..\packages\Microsoft.Windows.CppWinRT.2.0.250303.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
   <Import Project="..\..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.260126.7\build\native\Microsoft.Windows.ImplementationLibrary.targets" Condition="Exists('..\..\..\..\packages\Microsoft.Windows.ImplementationLibrary.1.0.260126.7\build\native\Microsoft.Windows.ImplementationLibrary.targets')" />
+  <Target Name="CopyThemeAdaptiveTrayIcons" AfterTargets="Build">
+    <Copy SourceFiles="appiconWhite.ico" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" Condition="Exists('appiconWhite.ico')" />
+    <Copy SourceFiles="appiconDark.ico" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" Condition="Exists('appiconDark.ico')" />
+  </Target>
 </Project>

--- a/src/modules/ZoomIt/ZoomIt/ZoomItSettings.h
+++ b/src/modules/ZoomIt/ZoomIt/ZoomItSettings.h
@@ -40,6 +40,7 @@ BOOLEAN	g_BreakBackgroundStretch = FALSE;
 TCHAR	g_BreakBackgroundFile[MAX_PATH] = {0};
 BOOLEAN	g_OptionsShown = FALSE;
 BOOLEAN	g_ShowTrayIcon = TRUE;
+BOOLEAN g_ShowThemeAdaptiveTrayIcon = FALSE;
 BOOLEAN g_SnapToGrid = TRUE;
 BOOLEAN	g_TelescopeZoomOut = TRUE;
 BOOLEAN	g_BreakOnSecondary = FALSE;
@@ -106,6 +107,7 @@ REG_SETTING RegSettings[] = {
     { L"FontScale", SETTING_TYPE_DWORD, 0, &g_FontScale, static_cast<DOUBLE>(g_FontScale) },
     { L"ShowExpiredTime", SETTING_TYPE_BOOLEAN, 0, &g_ShowExpiredTime, static_cast<DOUBLE>(g_ShowExpiredTime) },
     { L"ShowTrayIcon", SETTING_TYPE_BOOLEAN, 0, &g_ShowTrayIcon, static_cast<DOUBLE>(g_ShowTrayIcon) },
+    { L"ShowThemeAdaptiveTrayIcon", SETTING_TYPE_BOOLEAN, 0, &g_ShowThemeAdaptiveTrayIcon, static_cast<DOUBLE>(g_ShowThemeAdaptiveTrayIcon) },
     // NOTE: AnimateZoom is misspelled, but since it is a user setting stored in the registry we must continue to misspell it.
     { L"AnimnateZoom", SETTING_TYPE_BOOLEAN, 0, &g_AnimateZoom, static_cast<DOUBLE>(g_AnimateZoom) },
     { L"SmoothImage", SETTING_TYPE_BOOLEAN, 0, &g_SmoothImage, static_cast<DOUBLE>(g_SmoothImage) },

--- a/src/modules/ZoomIt/ZoomIt/Zoomit.cpp
+++ b/src/modules/ZoomIt/ZoomIt/Zoomit.cpp
@@ -28,6 +28,9 @@
 #include <common/interop/shared_constants.h>
 #include <common/utils/ProcessWaiter.h>
 #include <common/utils/process_path.h>
+#include <common/Themes/icon_helpers.h>
+#include <common/Themes/theme_listener.h>
+#include <Shlwapi.h>
 
 #include "../ZoomItModuleInterface/trace.h"
 #include <common/Telemetry/EtwTrace/EtwTrace.h>
@@ -1658,6 +1661,58 @@ std::wstring OcrFromHBITMAP( HBITMAP hBitmap )
 // EnableDisableTrayIcon
 //
 //----------------------------------------------------------------------------
+#ifdef __ZOOMIT_POWERTOYS__
+static BOOLEAN g_TrayIconVisible = FALSE;
+static ThemeListener g_trayThemeListener;
+
+static HICON GetZoomItTrayIconHandle()
+{
+    WCHAR modulePath[MAX_PATH];
+    GetModuleFileName(g_hInstance, modulePath, MAX_PATH);
+    PathRemoveFileSpec(modulePath);
+    std::wstring whiteIconPath = std::wstring(modulePath) + L"\\appiconWhite.ico";
+    std::wstring darkIconPath = std::wstring(modulePath) + L"\\appiconDark.ico";
+    return LoadThemeAdaptiveTrayIcon(
+        g_ShowThemeAdaptiveTrayIcon == TRUE,
+        whiteIconPath.c_str(),
+        darkIconPath.c_str(),
+        g_hInstance,
+        L"APPICON");
+}
+
+static void RefreshTrayIcon(HWND hWnd)
+{
+    if (!g_TrayIconVisible || hWnd == nullptr)
+    {
+        return;
+    }
+
+    NOTIFYICONDATA tNotifyIconData;
+    memset(&tNotifyIconData, 0, sizeof(tNotifyIconData));
+    tNotifyIconData.cbSize = sizeof(NOTIFYICONDATA);
+    tNotifyIconData.hWnd = hWnd;
+    tNotifyIconData.uID = 1;
+    tNotifyIconData.uFlags = NIF_MESSAGE | NIF_ICON | NIF_TIP;
+    tNotifyIconData.uCallbackMessage = WM_USER_TRAY_ACTIVATE;
+    tNotifyIconData.hIcon = GetZoomItTrayIconHandle();
+    lstrcpyn(tNotifyIconData.szTip, APPNAME, sizeof(APPNAME));
+    Shell_NotifyIcon(NIM_MODIFY, &tNotifyIconData);
+}
+
+static void HandleTraySystemThemeChange()
+{
+    if (g_ShowThemeAdaptiveTrayIcon && g_TrayIconVisible)
+    {
+        RefreshTrayIcon(g_hWndMain);
+    }
+}
+
+static void InitializeTrayThemeListener()
+{
+    g_trayThemeListener.AddSystemThemeChangedHandler(&HandleTraySystemThemeChange);
+}
+#endif
+
 void EnableDisableTrayIcon( HWND hWnd, BOOLEAN Enable )
 {
     NOTIFYICONDATA tNotifyIconData;
@@ -1668,9 +1723,27 @@ void EnableDisableTrayIcon( HWND hWnd, BOOLEAN Enable )
     tNotifyIconData.uID = 1;
     tNotifyIconData.uFlags = NIF_MESSAGE | NIF_ICON | NIF_TIP;
     tNotifyIconData.uCallbackMessage = WM_USER_TRAY_ACTIVATE;
+#ifdef __ZOOMIT_POWERTOYS__
+    tNotifyIconData.hIcon = GetZoomItTrayIconHandle();
+#else
     tNotifyIconData.hIcon = LoadIcon( g_hInstance, L"APPICON" );
+#endif
     lstrcpyn(tNotifyIconData.szTip, APPNAME, sizeof(APPNAME));
+
+#ifdef __ZOOMIT_POWERTOYS__
+    if (Enable)
+    {
+        const DWORD message = g_TrayIconVisible ? NIM_MODIFY : NIM_ADD;
+        g_TrayIconVisible = Shell_NotifyIcon(message, &tNotifyIconData) ? TRUE : FALSE;
+    }
+    else
+    {
+        Shell_NotifyIcon(NIM_DELETE, &tNotifyIconData);
+        g_TrayIconVisible = FALSE;
+    }
+#else
     Shell_NotifyIcon(Enable ? NIM_ADD : NIM_DELETE, &tNotifyIconData);
+#endif
 }
 
 //----------------------------------------------------------------------------
@@ -10238,7 +10311,21 @@ LRESULT APIENTRY MainWndProc(
         }
 
         // Apply tray icon setting
-        EnableDisableTrayIcon(hWnd, g_ShowTrayIcon);
+        if (g_ShowTrayIcon)
+        {
+            if (g_TrayIconVisible)
+            {
+                RefreshTrayIcon(hWnd);
+            }
+            else
+            {
+                EnableDisableTrayIcon(hWnd, TRUE);
+            }
+        }
+        else
+        {
+            EnableDisableTrayIcon(hWnd, FALSE);
+        }
 
         // This is also called by ZoomIt when it starts and loads the Settings. Opacity is added after loading from registry, so we use the same pattern.
         if ((g_PenColor >> 24) == 0)
@@ -11887,6 +11974,9 @@ HWND InitInstance( HINSTANCE hInstance, int nCmdShow )
 
     // Add tray icon
     EnableDisableTrayIcon( hWndMain, g_ShowTrayIcon );
+#ifdef __ZOOMIT_POWERTOYS__
+    InitializeTrayThemeListener();
+#endif
     return hWndMain;
 
 }

--- a/src/modules/awake/Awake/Awake.csproj
+++ b/src/modules/awake/Awake/Awake.csproj
@@ -84,6 +84,12 @@
     <Content Include="Assets\Awake\timed.ico">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="Assets\Awake\*White.ico">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Assets\Awake\*Dark.ico">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/modules/awake/Awake/Core/Manager.cs
+++ b/src/modules/awake/Awake/Core/Manager.cs
@@ -185,22 +185,22 @@ namespace Awake.Core
                         ? string.Empty
                         : $"\nPID: {ProcessId}";
                     iconText = $"{Constants.FullAppName}\n{Resources.AWAKE_TRAY_TEXT_INDEFINITE}\n{Resources.AWAKE_TRAY_DISPLAY}: {ScreenStateString}{pidLine}";
-                    icon = TrayHelper.IndefiniteIcon;
+                    icon = TrayHelper.GetIconForMode(AwakeMode.INDEFINITE);
                     break;
 
                 case AwakeMode.PASSIVE:
                     iconText = $"{Constants.FullAppName}\n{Resources.AWAKE_SCREEN_OFF}";
-                    icon = TrayHelper.DisabledIcon;
+                    icon = TrayHelper.GetIconForMode(AwakeMode.PASSIVE);
                     break;
 
                 case AwakeMode.EXPIRABLE:
                     iconText = $"{Constants.FullAppName}\n{Resources.AWAKE_TRAY_UNTIL} {ExpireAt:MMM d, h:mm tt}\n{Resources.AWAKE_TRAY_DISPLAY}: {ScreenStateString}";
-                    icon = TrayHelper.ExpirableIcon;
+                    icon = TrayHelper.GetIconForMode(AwakeMode.EXPIRABLE);
                     break;
 
                 case AwakeMode.TIMED:
                     iconText = $"{Constants.FullAppName}\n{Resources.AWAKE_TRAY_TEXT_TIMED}\n{Resources.AWAKE_TRAY_DISPLAY}: {ScreenStateString}";
-                    icon = TrayHelper.TimedIcon;
+                    icon = TrayHelper.GetIconForMode(AwakeMode.TIMED);
                     break;
             }
 

--- a/src/modules/awake/Awake/Core/TrayHelper.cs
+++ b/src/modules/awake/Awake/Core/TrayHelper.cs
@@ -45,6 +45,10 @@ namespace Awake.Core
         internal static readonly Icon IndefiniteIcon = new(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Assets/Awake/indefinite.ico"));
         internal static readonly Icon DisabledIcon = new(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Assets/Awake/disabled.ico"));
 
+        private static bool _showThemeAdaptiveTrayIcon;
+        private static ThemeListener? _themeListener;
+        private static IntPtr _ownedAdaptiveIconHandle;
+
         private const int TrayIconId = 1000;
 
         static TrayHelper()
@@ -58,11 +62,108 @@ namespace Awake.Core
         /// </summary>
         internal static void DisposeIcons()
         {
+            DisposeThemeListener();
+            ReleaseOwnedAdaptiveIconHandle();
             DefaultAwakeIcon?.Dispose();
             TimedIcon?.Dispose();
             ExpirableIcon?.Dispose();
             IndefiniteIcon?.Dispose();
             DisabledIcon?.Dispose();
+        }
+
+        internal static void ConfigureThemeAdaptiveTrayIcon(bool themeAdaptive)
+        {
+            _showThemeAdaptiveTrayIcon = themeAdaptive;
+
+            if (themeAdaptive)
+            {
+                if (_themeListener is null)
+                {
+                    _themeListener = new ThemeListener();
+                    _themeListener.SystemThemeChanged += OnSystemThemeChanged;
+                }
+            }
+            else
+            {
+                DisposeThemeListener();
+                ReleaseOwnedAdaptiveIconHandle();
+            }
+        }
+
+        internal static Icon GetIconForMode(AwakeMode mode)
+        {
+            if (!_showThemeAdaptiveTrayIcon)
+            {
+                return GetColoredModeIcon(mode);
+            }
+
+            var baseName = GetIconBaseName(mode);
+            var assetsDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Assets", "Awake");
+            ReleaseOwnedAdaptiveIconHandle();
+            _ownedAdaptiveIconHandle = ThemeAdaptiveTrayIconHelper.LoadIconHandle(
+                true,
+                Path.Combine(assetsDir, $"{baseName}White.ico"),
+                Path.Combine(assetsDir, $"{baseName}Dark.ico"),
+                () => IntPtr.Zero);
+
+            if (_ownedAdaptiveIconHandle == IntPtr.Zero)
+            {
+                return GetColoredModeIcon(mode);
+            }
+
+            return Icon.FromHandle(_ownedAdaptiveIconHandle);
+        }
+
+        private static void OnSystemThemeChanged(ThemeListener sender)
+        {
+            if (!_showThemeAdaptiveTrayIcon)
+            {
+                return;
+            }
+
+            Manager.SetModeShellIcon();
+        }
+
+        private static void DisposeThemeListener()
+        {
+            if (_themeListener is null)
+            {
+                return;
+            }
+
+            _themeListener.SystemThemeChanged -= OnSystemThemeChanged;
+            _themeListener.Dispose();
+            _themeListener = null;
+        }
+
+        private static void ReleaseOwnedAdaptiveIconHandle()
+        {
+            ThemeAdaptiveTrayIconHelper.DestroyIconHandle(_ownedAdaptiveIconHandle);
+            _ownedAdaptiveIconHandle = IntPtr.Zero;
+        }
+
+        private static Icon GetColoredModeIcon(AwakeMode mode)
+        {
+            return mode switch
+            {
+                AwakeMode.INDEFINITE => IndefiniteIcon,
+                AwakeMode.PASSIVE => DisabledIcon,
+                AwakeMode.EXPIRABLE => ExpirableIcon,
+                AwakeMode.TIMED => TimedIcon,
+                _ => DefaultAwakeIcon,
+            };
+        }
+
+        private static string GetIconBaseName(AwakeMode mode)
+        {
+            return mode switch
+            {
+                AwakeMode.INDEFINITE => "indefinite",
+                AwakeMode.PASSIVE => "disabled",
+                AwakeMode.EXPIRABLE => "expirable",
+                AwakeMode.TIMED => "timed",
+                _ => "awake",
+            };
         }
 
         private static void ShowContextMenu(IntPtr hWnd)

--- a/src/modules/awake/Awake/Program.cs
+++ b/src/modules/awake/Awake/Program.cs
@@ -524,6 +524,7 @@ namespace Awake
         private static void InitializeSettings()
         {
             AwakeSettings settings = Manager.ModuleSettings?.GetSettings<AwakeSettings>(Core.Constants.AppName) ?? new AwakeSettings();
+            TrayHelper.ConfigureThemeAdaptiveTrayIcon(settings.Properties.ShowThemeAdaptiveTrayIcon);
             TrayHelper.SetTray(settings, _startedFromPowerToys);
         }
 
@@ -548,6 +549,7 @@ namespace Awake
                     ?? throw new InvalidOperationException("Settings are null.");
 
                 Logger.LogInfo($"Identified custom time shortcuts for the tray: {settings.Properties.CustomTrayTimes.Count}");
+                TrayHelper.ConfigureThemeAdaptiveTrayIcon(settings.Properties.ShowThemeAdaptiveTrayIcon);
 
                 switch (settings.Properties.Mode)
                 {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsModel.cs
@@ -31,6 +31,8 @@ public record SettingsModel
 
     public bool ShowSystemTrayIcon { get; init; } = true;
 
+    public bool ShowThemeAdaptiveTrayIcon { get; init; }
+
     public bool IgnoreShortcutWhenFullscreen { get; init; } = true;
 
     public bool IgnoreShortcutWhenBusy { get; init; }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsViewModel.cs
@@ -129,6 +129,16 @@ public partial class SettingsViewModel : INotifyPropertyChanged,
         set
         {
             _settingsService.UpdateSettings(s => s with { ShowSystemTrayIcon = value });
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(ShowThemeAdaptiveTrayIcon)));
+        }
+    }
+
+    public bool ShowThemeAdaptiveTrayIcon
+    {
+        get => _settingsService.Settings.ShowThemeAdaptiveTrayIcon;
+        set
+        {
+            _settingsService.UpdateSettings(s => s with { ShowThemeAdaptiveTrayIcon = value });
         }
     }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/TrayIconService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/TrayIconService.cs
@@ -3,8 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Runtime.InteropServices;
 using CommunityToolkit.Mvvm.Messaging;
+using ManagedCommon;
 using Microsoft.CmdPal.UI.Messages;
 using Microsoft.CmdPal.UI.ViewModels.Messages;
 using Microsoft.CmdPal.UI.ViewModels.Services;
@@ -20,6 +22,7 @@ namespace Microsoft.CmdPal.UI.Helpers;
 
 [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1310:Field names should not contain underscore", Justification = "Stylistically, window messages are WM_*")]
 [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1306:Field names should begin with lower-case letter", Justification = "Stylistically, window messages are WM_*")]
+[SuppressMessage("Design", "CA1001:Types that own disposable fields should be disposable", Justification = "TrayIconService uses explicit Destroy() lifecycle matching other PowerToys tray helpers")]
 internal sealed partial class TrayIconService
 {
     private const uint MY_NOTIFY_ID = 1000;
@@ -27,18 +30,25 @@ internal sealed partial class TrayIconService
 
     private readonly ISettingsService _settingsService;
     private readonly uint WM_TASKBAR_RESTART;
+    private readonly string _whiteIconPath;
+    private readonly string _darkIconPath;
 
     private Window? _window;
     private HWND _hwnd;
     private WNDPROC? _originalWndProc;
     private WNDPROC? _trayWndProc;
     private NOTIFYICONDATAW? _trayIconData;
-    private DestroyIconSafeHandle? _largeIcon;
     private DestroyMenuSafeHandle? _popupMenu;
+    private nint _trayIconHandle;
+    private bool _themeAdaptiveEnabled;
+    private ThemeListener? _themeListener;
+    private bool _trayIconAdded;
 
     public TrayIconService(ISettingsService settingsService)
     {
         _settingsService = settingsService;
+        _whiteIconPath = Path.Combine(AppContext.BaseDirectory, "Assets", "iconWhite.ico");
+        _darkIconPath = Path.Combine(AppContext.BaseDirectory, "Assets", "iconDark.ico");
 
         // TaskbarCreated is the message that's broadcast when explorer.exe
         // restarts. We need to know when that happens to be able to bring our
@@ -50,27 +60,11 @@ internal sealed partial class TrayIconService
     {
         if (showSystemTrayIcon ?? _settingsService.Settings.ShowSystemTrayIcon)
         {
-            if (_window is null)
-            {
-                _window = new Window();
-                _hwnd = new HWND(WindowNative.GetWindowHandle(_window));
-
-                // LOAD BEARING: If you don't stick the pointer to HotKeyPrc into a
-                // member (and instead like, use a local), then the pointer we marshal
-                // into the WindowLongPtr will be useless after we leave this function,
-                // and our **WindProc will explode**.
-                _trayWndProc = WindowProc;
-                var hotKeyPrcPointer = Marshal.GetFunctionPointerForDelegate(_trayWndProc);
-                _originalWndProc = Marshal.GetDelegateForFunctionPointer<WNDPROC>(PInvoke.SetWindowLongPtr(_hwnd, WINDOW_LONG_PTR_INDEX.GWL_WNDPROC, hotKeyPrcPointer));
-            }
+            EnsureTrayWindow();
+            SetThemeAdaptiveTrayIcon(_settingsService.Settings.ShowThemeAdaptiveTrayIcon);
 
             if (_trayIconData is null)
             {
-                // We need to stash this handle, so it doesn't clean itself up. If
-                // explorer restarts, we'll come back through here, and we don't
-                // really need to re-load the icon in that case. We can just use
-                // the handle from the first time.
-                _largeIcon = GetAppIconHandle();
                 _trayIconData = new NOTIFYICONDATAW()
                 {
                     cbSize = (uint)Marshal.SizeOf<NOTIFYICONDATAW>(),
@@ -78,15 +72,22 @@ internal sealed partial class TrayIconService
                     uID = MY_NOTIFY_ID,
                     uFlags = NOTIFY_ICON_DATA_FLAGS.NIF_MESSAGE | NOTIFY_ICON_DATA_FLAGS.NIF_ICON | NOTIFY_ICON_DATA_FLAGS.NIF_TIP,
                     uCallbackMessage = WM_TRAY_ICON,
-                    hIcon = (HICON)_largeIcon.DangerousGetHandle(),
+                    hIcon = (HICON)_trayIconHandle,
                     szTip = RS_.GetString("AppStoreName"),
                 };
+            }
+            else
+            {
+                UpdateTrayIconHandle();
             }
 
             var d = (NOTIFYICONDATAW)_trayIconData;
 
-            // Add the notification icon
-            PInvoke.Shell_NotifyIcon(NOTIFY_ICON_MESSAGE.NIM_ADD, in d);
+            // Add or update the notification icon
+            PInvoke.Shell_NotifyIcon(
+                _trayIconAdded ? NOTIFY_ICON_MESSAGE.NIM_MODIFY : NOTIFY_ICON_MESSAGE.NIM_ADD,
+                in d);
+            _trayIconAdded = true;
 
             if (_popupMenu is null)
             {
@@ -109,6 +110,7 @@ internal sealed partial class TrayIconService
             if (PInvoke.Shell_NotifyIcon(NOTIFY_ICON_MESSAGE.NIM_DELETE, in d))
             {
                 _trayIconData = null;
+                _trayIconAdded = false;
             }
         }
 
@@ -118,11 +120,9 @@ internal sealed partial class TrayIconService
             _popupMenu = null;
         }
 
-        if (_largeIcon is not null)
-        {
-            _largeIcon.Close();
-            _largeIcon = null;
-        }
+        DisposeThemeListener();
+        ThemeAdaptiveTrayIconHelper.DestroyIconHandle(_trayIconHandle);
+        _trayIconHandle = 0;
 
         if (_window is not null)
         {
@@ -132,19 +132,103 @@ internal sealed partial class TrayIconService
         }
     }
 
-    private DestroyIconSafeHandle GetAppIconHandle()
+    private void EnsureTrayWindow()
     {
-        var exePath = Path.Combine(AppContext.BaseDirectory, "Microsoft.CmdPal.UI.exe");
-
-        Span<HICON> large = new([default]); // 1 size array to accept icon
-        var extractedIconCount = PInvoke.ExtractIconEx(exePath, 0, large);
-        if ((extractedIconCount < 1) || (large[0] == HICON.Null))
+        if (_window is not null)
         {
-            return new DestroyIconSafeHandle(HICON.Null);
+            return;
         }
 
-        return new DestroyIconSafeHandle(large[0]);
+        _window = new Window();
+        _hwnd = new HWND(WindowNative.GetWindowHandle(_window));
+
+        // LOAD BEARING: If you don't stick the pointer to HotKeyPrc into a
+        // member (and instead like, use a local), then the pointer we marshal
+        // into the WindowLongPtr will be useless after we leave this function,
+        // and our **WindProc will explode**.
+        _trayWndProc = WindowProc;
+        var hotKeyPrcPointer = Marshal.GetFunctionPointerForDelegate(_trayWndProc);
+        _originalWndProc = Marshal.GetDelegateForFunctionPointer<WNDPROC>(PInvoke.SetWindowLongPtr(_hwnd, WINDOW_LONG_PTR_INDEX.GWL_WNDPROC, hotKeyPrcPointer));
     }
+
+    private void SetThemeAdaptiveTrayIcon(bool themeAdaptive)
+    {
+        _themeAdaptiveEnabled = themeAdaptive;
+        ReloadTrayIconHandle();
+
+        if (themeAdaptive)
+        {
+            if (_themeListener == null)
+            {
+                _themeListener = new ThemeListener();
+                _themeListener.SystemThemeChanged += OnSystemThemeChanged;
+            }
+        }
+        else
+        {
+            DisposeThemeListener();
+        }
+    }
+
+    private void ReloadTrayIconHandle()
+    {
+        ThemeAdaptiveTrayIconHelper.DestroyIconHandle(_trayIconHandle);
+        _trayIconHandle = ThemeAdaptiveTrayIconHelper.LoadIconHandle(
+            _themeAdaptiveEnabled,
+            _whiteIconPath,
+            _darkIconPath,
+            ExtractAppIconHandle);
+    }
+
+    private void OnSystemThemeChanged(ThemeListener sender)
+    {
+        if (!_themeAdaptiveEnabled)
+        {
+            return;
+        }
+
+        ReloadTrayIconHandle();
+        UpdateTrayIconHandle();
+    }
+
+    private void DisposeThemeListener()
+    {
+        if (_themeListener == null)
+        {
+            return;
+        }
+
+        _themeListener.SystemThemeChanged -= OnSystemThemeChanged;
+        _themeListener.Dispose();
+        _themeListener = null;
+    }
+
+    private void UpdateTrayIconHandle()
+    {
+        if (_trayIconData is null || _trayIconHandle == 0)
+        {
+            return;
+        }
+
+        var d = (NOTIFYICONDATAW)_trayIconData;
+        d.hIcon = (HICON)_trayIconHandle;
+        _trayIconData = d;
+
+        if (_trayIconAdded)
+        {
+            PInvoke.Shell_NotifyIcon(NOTIFY_ICON_MESSAGE.NIM_MODIFY, in d);
+        }
+    }
+
+    private static nint ExtractAppIconHandle()
+    {
+        var exePath = Path.Combine(AppContext.BaseDirectory, "Microsoft.CmdPal.UI.exe");
+        _ = ExtractIconExNative(exePath, 0, out var largeIcon, out _, 1);
+        return largeIcon;
+    }
+
+    [LibraryImport("shell32.dll", EntryPoint = "ExtractIconExW", StringMarshalling = StringMarshalling.Utf16)]
+    private static partial uint ExtractIconExNative(string lpszFile, int nIconIndex, out nint phiconLarge, out nint phiconSmall, uint nIcons);
 
     private LRESULT WindowProc(
         HWND hwnd,

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/GeneralPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/GeneralPage.xaml
@@ -146,9 +146,16 @@
 
                     <TextBlock x:Uid="BehaviorSettingsHeader" Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" />
 
-                    <controls:SettingsCard x:Uid="Settings_GeneralPage_ShowSystemTrayIcon_SettingsCard" HeaderIcon="{ui:FontIcon Glyph=&#xE75B;}">
+                    <controls:SettingsExpander x:Uid="Settings_GeneralPage_ShowSystemTrayIcon_SettingsCard" HeaderIcon="{ui:FontIcon Glyph=&#xE75B;}">
                         <ToggleSwitch AutomationProperties.AutomationId="CmdPal_GeneralPage_ShowSystemTrayIcon" IsOn="{x:Bind viewModel.ShowSystemTrayIcon, Mode=TwoWay}" />
-                    </controls:SettingsCard>
+                        <controls:SettingsExpander.Items>
+                            <controls:SettingsCard
+                                ContentAlignment="Left"
+                                IsEnabled="{x:Bind viewModel.ShowSystemTrayIcon, Mode=OneWay}">
+                                <CheckBox x:Uid="ShowThemeAdaptiveTrayIcon" IsChecked="{x:Bind viewModel.ShowThemeAdaptiveTrayIcon, Mode=TwoWay}" />
+                            </controls:SettingsCard>
+                        </controls:SettingsExpander.Items>
+                    </controls:SettingsExpander>
 
                     <!--  'For Developers' section  -->
 

--- a/src/modules/powerdisplay/PowerDisplay/Helpers/TrayIconService.cs
+++ b/src/modules/powerdisplay/PowerDisplay/Helpers/TrayIconService.cs
@@ -28,6 +28,7 @@ namespace PowerDisplay.Helpers
     /// <returns>The result of the message processing.</returns>
     internal delegate nint WndProcDelegate(nint hwnd, uint msg, nuint wParam, nint lParam);
 
+    [SuppressMessage("Design", "CA1001:Types that own disposable fields should be disposable", Justification = "TrayIconService uses explicit Destroy() lifecycle matching other PowerToys tray helpers")]
     internal sealed partial class TrayIconService
     {
         private const uint MyNotifyId = 1001;
@@ -38,14 +39,19 @@ namespace PowerDisplay.Helpers
         private readonly Action _exitAction;
         private readonly Action _openSettingsAction;
         private readonly uint _wmTaskbarRestart;
+        private readonly string _whiteIconPath;
+        private readonly string _darkIconPath;
 
         private Window? _window;
         private nint _hwnd;
         private nint _originalWndProc;
         private WndProcDelegate? _trayWndProc;
         private NOTIFYICONDATAW? _trayIconData;
-        private nint _largeIcon;
         private nint _popupMenu;
+        private nint _trayIconHandle;
+        private bool _themeAdaptiveEnabled;
+        private ThemeListener? _themeListener;
+        private bool _trayIconAdded;
 
         public TrayIconService(
             SettingsUtils settingsUtils,
@@ -57,6 +63,10 @@ namespace PowerDisplay.Helpers
             _toggleWindowAction = toggleWindowAction;
             _exitAction = exitAction;
             _openSettingsAction = openSettingsAction;
+
+            var assetsDir = Path.Combine(AppContext.BaseDirectory, "Assets", "PowerDisplay");
+            _whiteIconPath = Path.Combine(assetsDir, "PowerDisplayWhite.ico");
+            _darkIconPath = Path.Combine(assetsDir, "PowerDisplayDark.ico");
 
             // TaskbarCreated is the message that's broadcast when explorer.exe
             // restarts. We need to know when that happens to be able to bring our
@@ -71,27 +81,11 @@ namespace PowerDisplay.Helpers
 
             if (shouldShow)
             {
-                if (_window is null)
-                {
-                    _window = new Window();
-                    _hwnd = WindowNative.GetWindowHandle(_window);
-
-                    // LOAD BEARING: If you don't stick the pointer to HotKeyPrc into a
-                    // member (and instead like, use a local), then the pointer we marshal
-                    // into the WindowLongPtr will be useless after we leave this function,
-                    // and our **WindProc will explode**.
-                    _trayWndProc = WindowProc;
-                    var hotKeyPrcPointer = Marshal.GetFunctionPointerForDelegate(_trayWndProc);
-                    _originalWndProc = SetWindowLongPtrNative(_hwnd, GwlWndproc, hotKeyPrcPointer);
-                }
+                EnsureTrayWindow();
+                SetThemeAdaptiveTrayIcon(settings.Properties.ShowThemeAdaptiveTrayIcon);
 
                 if (_trayIconData is null)
                 {
-                    // We need to stash this handle, so it doesn't clean itself up. If
-                    // explorer restarts, we'll come back through here, and we don't
-                    // really need to re-load the icon in that case. We can just use
-                    // the handle from the first time.
-                    _largeIcon = GetAppIconHandle();
                     unsafe
                     {
                         _trayIconData = new NOTIFYICONDATAW()
@@ -101,10 +95,14 @@ namespace PowerDisplay.Helpers
                             uID = MyNotifyId,
                             uFlags = NOTIFY_ICON_DATA_FLAGS.NIF_MESSAGE | NOTIFY_ICON_DATA_FLAGS.NIF_ICON | NOTIFY_ICON_DATA_FLAGS.NIF_TIP,
                             uCallbackMessage = WmTrayIcon,
-                            hIcon = new HICON(_largeIcon),
+                            hIcon = new HICON(_trayIconHandle),
                             szTip = GetString("AppName"),
                         };
                     }
+                }
+                else
+                {
+                    UpdateTrayIconHandle();
                 }
 
                 var d = (NOTIFYICONDATAW)_trayIconData;
@@ -112,15 +110,20 @@ namespace PowerDisplay.Helpers
                 // Add the notification icon
                 unsafe
                 {
-                    bool success = Shell_NotifyIconNative((uint)NOTIFY_ICON_MESSAGE.NIM_ADD, &d);
+                    bool success = Shell_NotifyIconNative(
+                        (uint)(_trayIconAdded ? NOTIFY_ICON_MESSAGE.NIM_MODIFY : NOTIFY_ICON_MESSAGE.NIM_ADD),
+                        &d);
                     if (!success)
                     {
                         // Shell_NotifyIcon can fail if explorer.exe isn't ready yet (e.g., during system startup)
                         // Reset _trayIconData to allow retry via WM_WINDOWPOSCHANGING or WM_TASKBAR_RESTART
-                        Logger.LogWarning("[TrayIcon] Shell_NotifyIcon(NIM_ADD) failed, will retry later");
+                        Logger.LogWarning("[TrayIcon] Shell_NotifyIcon failed, will retry later");
                         _trayIconData = null;
+                        _trayIconAdded = false;
                         return;
                     }
+
+                    _trayIconAdded = true;
                 }
 
                 if (_popupMenu == 0)
@@ -146,6 +149,7 @@ namespace PowerDisplay.Helpers
                     if (Shell_NotifyIconNative((uint)NOTIFY_ICON_MESSAGE.NIM_DELETE, &d))
                     {
                         _trayIconData = null;
+                        _trayIconAdded = false;
                     }
                 }
             }
@@ -156,11 +160,9 @@ namespace PowerDisplay.Helpers
                 _popupMenu = 0;
             }
 
-            if (_largeIcon != 0)
-            {
-                DestroyIcon(_largeIcon);
-                _largeIcon = 0;
-            }
+            DisposeThemeListener();
+            ThemeAdaptiveTrayIconHelper.DestroyIconHandle(_trayIconHandle);
+            _trayIconHandle = 0;
 
             if (_window is not null)
             {
@@ -168,6 +170,97 @@ namespace PowerDisplay.Helpers
                 _window = null;
                 _hwnd = 0;
             }
+        }
+
+        private void SetThemeAdaptiveTrayIcon(bool themeAdaptive)
+        {
+            _themeAdaptiveEnabled = themeAdaptive;
+            ReloadTrayIconHandle();
+
+            if (themeAdaptive)
+            {
+                if (_themeListener == null)
+                {
+                    _themeListener = new ThemeListener();
+                    _themeListener.SystemThemeChanged += OnSystemThemeChanged;
+                }
+            }
+            else
+            {
+                DisposeThemeListener();
+            }
+        }
+
+        private void ReloadTrayIconHandle()
+        {
+            ThemeAdaptiveTrayIconHelper.DestroyIconHandle(_trayIconHandle);
+            _trayIconHandle = ThemeAdaptiveTrayIconHelper.LoadIconHandle(
+                _themeAdaptiveEnabled,
+                _whiteIconPath,
+                _darkIconPath,
+                GetAppIconHandle);
+        }
+
+        private void OnSystemThemeChanged(ThemeListener sender)
+        {
+            if (!_themeAdaptiveEnabled)
+            {
+                return;
+            }
+
+            ReloadTrayIconHandle();
+            UpdateTrayIconHandle();
+        }
+
+        private void DisposeThemeListener()
+        {
+            if (_themeListener == null)
+            {
+                return;
+            }
+
+            _themeListener.SystemThemeChanged -= OnSystemThemeChanged;
+            _themeListener.Dispose();
+            _themeListener = null;
+        }
+
+        private void UpdateTrayIconHandle()
+        {
+            if (_trayIconData is null || _trayIconHandle == 0)
+            {
+                return;
+            }
+
+            var d = (NOTIFYICONDATAW)_trayIconData;
+            d.hIcon = new HICON(_trayIconHandle);
+            _trayIconData = d;
+
+            if (_trayIconAdded)
+            {
+                unsafe
+                {
+                    Shell_NotifyIconNative((uint)NOTIFY_ICON_MESSAGE.NIM_MODIFY, &d);
+                }
+            }
+        }
+
+        private void EnsureTrayWindow()
+        {
+            if (_window is not null)
+            {
+                return;
+            }
+
+            _window = new Window();
+            _hwnd = WindowNative.GetWindowHandle(_window);
+
+            // LOAD BEARING: If you don't stick the pointer to HotKeyPrc into a
+            // member (and instead like, use a local), then the pointer we marshal
+            // into the WindowLongPtr will be useless after we leave this function,
+            // and our **WindProc will explode**.
+            _trayWndProc = WindowProc;
+            var hotKeyPrcPointer = Marshal.GetFunctionPointerForDelegate(_trayWndProc);
+            _originalWndProc = SetWindowLongPtrNative(_hwnd, GwlWndproc, hotKeyPrcPointer);
         }
 
         private static string GetString(string key)

--- a/src/modules/powerdisplay/PowerDisplay/PowerDisplay.csproj
+++ b/src/modules/powerdisplay/PowerDisplay/PowerDisplay.csproj
@@ -96,7 +96,6 @@
     <ProjectReference Include="..\PowerDisplay.Lib\PowerDisplay.Lib.csproj" />
     <ProjectReference Include="..\PowerDisplay.Models\PowerDisplay.Models.csproj" />
   </ItemGroup>
-  <!-- Copy Assets folder to output directory -->
   <ItemGroup>
     <Content Include="Assets\PowerDisplay\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/settings-ui/Settings.UI.Library/AwakeProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/AwakeProperties.cs
@@ -40,5 +40,8 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         [JsonPropertyName("customTrayTimes")]
         [CmdConfigureIgnore]
         public Dictionary<string, uint> CustomTrayTimes { get; set; }
+
+        [JsonPropertyName("show_theme_adaptive_tray_icon")]
+        public bool ShowThemeAdaptiveTrayIcon { get; set; }
     }
 }

--- a/src/settings-ui/Settings.UI.Library/MouseWithoutBordersProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/MouseWithoutBordersProperties.cs
@@ -48,6 +48,10 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         [JsonConverter(typeof(BoolPropertyJsonConverter))]
         public bool ShowOriginalUI { get; set; }
 
+        [JsonPropertyName("show_theme_adaptive_tray_icon")]
+        [JsonConverter(typeof(BoolPropertyJsonConverter))]
+        public bool ShowThemeAdaptiveTrayIcon { get; set; }
+
         [JsonConverter(typeof(BoolPropertyJsonConverter))]
         public bool WrapMouse { get; set; }
 

--- a/src/settings-ui/Settings.UI.Library/PowerDisplayProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/PowerDisplayProperties.cs
@@ -74,6 +74,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         [JsonPropertyName("show_system_tray_icon")]
         public bool ShowSystemTrayIcon { get; set; }
 
+        [JsonPropertyName("show_theme_adaptive_tray_icon")]
+        public bool ShowThemeAdaptiveTrayIcon { get; set; }
+
         /// <summary>
         /// Gets or sets a value indicating whether to show the profile switcher button in the flyout UI.
         /// Default is true. When false, the profile switcher is hidden (but profiles still work via Settings).

--- a/src/settings-ui/Settings.UI.Library/ZoomItProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/ZoomItProperties.cs
@@ -88,6 +88,8 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 
         public BoolProperty ShowTrayIcon { get; set; }
 
+        public BoolProperty ShowThemeAdaptiveTrayIcon { get; set; }
+
         [JsonPropertyName("AnimnateZoom")]
         public BoolProperty AnimateZoom { get; set; }
 

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/AwakePage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/AwakePage.xaml
@@ -99,6 +99,10 @@
                         IsEnabled="{x:Bind ViewModel.IsScreenConfigurationPossibleEnabled, Mode=OneWay}">
                         <ToggleSwitch IsOn="{x:Bind ViewModel.KeepDisplayOn, Mode=TwoWay}" />
                     </tkcontrols:SettingsCard>
+
+                    <tkcontrols:SettingsCard ContentAlignment="Left" HeaderIcon="{ui:FontIcon Glyph=&#xE75B;}">
+                        <CheckBox x:Uid="ShowThemeAdaptiveTrayIcon" IsChecked="{x:Bind ViewModel.ShowThemeAdaptiveTrayIcon, Mode=TwoWay}" />
+                    </tkcontrols:SettingsCard>
                 </controls:SettingsGroup>
             </StackPanel>
         </controls:SettingsPageControl.ModuleContent>

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/MouseWithoutBordersPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/MouseWithoutBordersPage.xaml
@@ -487,12 +487,21 @@
                         Command="{x:Bind ViewModel.AddFirewallRuleEventHandler}"
                         IsClickEnabled="True" />
                     <controls:GPOInfoControl ShowWarning="{x:Bind ViewModel.ShowPolicyConfiguredInfoForOriginalUiSetting, Mode=OneWay}">
-                        <tkcontrols:SettingsCard
+                        <tkcontrols:SettingsExpander
                             Name="MouseWithoutBordersShowOriginalUI"
                             x:Uid="MouseWithoutBorders_ShowOriginalUI"
-                            IsEnabled="{x:Bind ViewModel.CardForOriginalUiSettingIsEnabled, Mode=OneWay}">
+                            HeaderIcon="{ui:FontIcon Glyph=&#xE75B;}"
+                            IsEnabled="{x:Bind ViewModel.CardForOriginalUiSettingIsEnabled, Mode=OneWay}"
+                            IsExpanded="False">
                             <ToggleSwitch x:Uid="MouseWithoutBorders_ShowOriginalUI_ToggleSwitch" IsOn="{x:Bind ViewModel.ShowOriginalUI, Mode=TwoWay}" />
-                        </tkcontrols:SettingsCard>
+                            <tkcontrols:SettingsExpander.Items>
+                                <tkcontrols:SettingsCard
+                                    ContentAlignment="Left"
+                                    IsEnabled="{x:Bind ViewModel.ShowOriginalUI, Mode=OneWay}">
+                                    <CheckBox x:Uid="ShowThemeAdaptiveTrayIcon" IsChecked="{x:Bind ViewModel.ShowThemeAdaptiveTrayIcon, Mode=TwoWay}" />
+                                </tkcontrols:SettingsCard>
+                            </tkcontrols:SettingsExpander.Items>
+                        </tkcontrols:SettingsExpander>
                     </controls:GPOInfoControl>
                 </controls:SettingsGroup>
             </StackPanel>

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerDisplayPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerDisplayPage.xaml
@@ -93,9 +93,19 @@
                                     <tkcontrols:SettingsCard ContentAlignment="Left">
                                         <CheckBox x:Uid="PowerDisplay_RestoreSettingsOnStartup" IsChecked="{x:Bind ViewModel.RestoreSettingsOnStartup, Mode=TwoWay}" />
                                     </tkcontrols:SettingsCard>
-                                    <tkcontrols:SettingsCard ContentAlignment="Left">
-                                        <CheckBox x:Uid="PowerDisplay_ShowSystemTrayIcon" IsChecked="{x:Bind ViewModel.ShowSystemTrayIcon, Mode=TwoWay}" />
-                                    </tkcontrols:SettingsCard>
+                                    <tkcontrols:SettingsExpander
+                                        x:Uid="PowerDisplay_ShowSystemTrayIcon"
+                                        HeaderIcon="{ui:FontIcon Glyph=&#xE75B;}"
+                                        IsExpanded="False">
+                                        <CheckBox IsChecked="{x:Bind ViewModel.ShowSystemTrayIcon, Mode=TwoWay}" />
+                                        <tkcontrols:SettingsExpander.Items>
+                                            <tkcontrols:SettingsCard
+                                                ContentAlignment="Left"
+                                                IsEnabled="{x:Bind ViewModel.ShowSystemTrayIcon, Mode=OneWay}">
+                                                <CheckBox x:Uid="ShowThemeAdaptiveTrayIcon" IsChecked="{x:Bind ViewModel.ShowThemeAdaptiveTrayIcon, Mode=TwoWay}" />
+                                            </tkcontrols:SettingsCard>
+                                        </tkcontrols:SettingsExpander.Items>
+                                    </tkcontrols:SettingsExpander>
                                     <tkcontrols:SettingsCard ContentAlignment="Left">
                                         <CheckBox x:Uid="PowerDisplay_ShowProfileSwitcher" IsChecked="{x:Bind ViewModel.ShowProfileSwitcher, Mode=TwoWay}" />
                                     </tkcontrols:SettingsCard>

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/ZoomItPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/ZoomItPage.xaml
@@ -39,9 +39,20 @@
                     </tkcontrols:SettingsCard>
                 </controls:GPOInfoControl>
                 <controls:SettingsGroup x:Uid="ZoomIt_BehaviorGroup" IsEnabled="{x:Bind ViewModel.IsEnabled, Mode=OneWay}">
-                    <tkcontrols:SettingsCard Name="ZoomItToggleShowTrayIcon" x:Uid="ZoomIt_Toggle_ShowTrayIcon">
+                    <tkcontrols:SettingsExpander
+                        Name="ZoomItToggleShowTrayIcon"
+                        x:Uid="ZoomIt_Toggle_ShowTrayIcon"
+                        HeaderIcon="{ui:FontIcon Glyph=&#xE75B;}"
+                        IsExpanded="False">
                         <ToggleSwitch x:Uid="ToggleSwitch" IsOn="{x:Bind ViewModel.ShowTrayIcon, Mode=TwoWay}" />
-                    </tkcontrols:SettingsCard>
+                        <tkcontrols:SettingsExpander.Items>
+                            <tkcontrols:SettingsCard
+                                ContentAlignment="Left"
+                                IsEnabled="{x:Bind ViewModel.ShowTrayIcon, Mode=OneWay}">
+                                <CheckBox x:Uid="ShowThemeAdaptiveTrayIcon" IsChecked="{x:Bind ViewModel.ShowThemeAdaptiveTrayIcon, Mode=TwoWay}" />
+                            </tkcontrols:SettingsCard>
+                        </tkcontrols:SettingsExpander.Items>
+                    </tkcontrols:SettingsExpander>
                 </controls:SettingsGroup>
                 <controls:SettingsGroup x:Uid="ZoomIt_ZoomGroup" IsEnabled="{x:Bind ViewModel.IsEnabled, Mode=OneWay}">
                     <tkcontrols:SettingsExpander

--- a/src/settings-ui/Settings.UI/ViewModels/AwakeViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/AwakeViewModel.cs
@@ -147,6 +147,19 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             }
         }
 
+        public bool ShowThemeAdaptiveTrayIcon
+        {
+            get => ModuleSettings.Properties.ShowThemeAdaptiveTrayIcon;
+            set
+            {
+                if (ModuleSettings.Properties.ShowThemeAdaptiveTrayIcon != value)
+                {
+                    ModuleSettings.Properties.ShowThemeAdaptiveTrayIcon = value;
+                    NotifyPropertyChanged();
+                }
+            }
+        }
+
         public uint IntervalHours
         {
             get => ModuleSettings.Properties.IntervalHours;

--- a/src/settings-ui/Settings.UI/ViewModels/MouseWithoutBordersViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/MouseWithoutBordersViewModel.cs
@@ -87,6 +87,20 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 {
                     Settings.Properties.ShowOriginalUI = value;
                     NotifyPropertyChanged(nameof(ShowOriginalUI));
+                    OnPropertyChanged(nameof(ShowThemeAdaptiveTrayIcon));
+                }
+            }
+        }
+
+        public bool ShowThemeAdaptiveTrayIcon
+        {
+            get => Settings.Properties.ShowThemeAdaptiveTrayIcon;
+            set
+            {
+                if (Settings.Properties.ShowThemeAdaptiveTrayIcon != value)
+                {
+                    Settings.Properties.ShowThemeAdaptiveTrayIcon = value;
+                    NotifyPropertyChanged(nameof(ShowThemeAdaptiveTrayIcon));
                 }
             }
         }

--- a/src/settings-ui/Settings.UI/ViewModels/PowerDisplayViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/PowerDisplayViewModel.cs
@@ -313,6 +313,20 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                     // This is needed because set_config() doesn't signal SettingsUpdatedEvent to avoid UI refresh issues
                     SignalSettingsUpdated();
                     Logger.LogInfo($"ShowSystemTrayIcon changed to {value}");
+                    OnPropertyChanged(nameof(ShowThemeAdaptiveTrayIcon));
+                }
+            }
+        }
+
+        public bool ShowThemeAdaptiveTrayIcon
+        {
+            get => _settings.Properties.ShowThemeAdaptiveTrayIcon;
+            set
+            {
+                if (SetSettingsProperty(_settings.Properties.ShowThemeAdaptiveTrayIcon, value, v => _settings.Properties.ShowThemeAdaptiveTrayIcon = v))
+                {
+                    SignalSettingsUpdated();
+                    Logger.LogInfo($"ShowThemeAdaptiveTrayIcon changed to {value}");
                 }
             }
         }

--- a/src/settings-ui/Settings.UI/ViewModels/ZoomItViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/ZoomItViewModel.cs
@@ -229,6 +229,21 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 {
                     _zoomItSettings.Properties.ShowTrayIcon.Value = value;
                     OnPropertyChanged(nameof(ShowTrayIcon));
+                    OnPropertyChanged(nameof(ShowThemeAdaptiveTrayIcon));
+                    NotifySettingsChanged();
+                }
+            }
+        }
+
+        public bool ShowThemeAdaptiveTrayIcon
+        {
+            get => _zoomItSettings.Properties.ShowThemeAdaptiveTrayIcon.Value;
+            set
+            {
+                if (_zoomItSettings.Properties.ShowThemeAdaptiveTrayIcon.Value != value)
+                {
+                    _zoomItSettings.Properties.ShowThemeAdaptiveTrayIcon.Value = value;
+                    OnPropertyChanged(nameof(ShowThemeAdaptiveTrayIcon));
                     NotifySettingsChanged();
                 }
             }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Making an option for the PowerToys tools that can have icons in the System Tray (_Awake_, _Command Palette_, _ZoomIt_, _Mouse Without Borders_ and _Power Display_) have an option for a monochrome version that matches the device's color theme (light/dark).

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [X] Closes: [#48389](https://github.com/microsoft/PowerToys/issues/48389)
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

