### PR TITLE
[CmdPal] Time-decayed frecency signal for main-page ranking

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/HistoryItem.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/HistoryItem.cs
@@ -2,7 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using CommunityToolkit.Mvvm.ComponentModel;
+using System;
 
 namespace Microsoft.CmdPal.UI.ViewModels;
 
@@ -11,4 +11,13 @@ public record HistoryItem
     public required string CommandId { get; init; }
 
     public required int Uses { get; init; }
+
+    /// <summary>
+    /// Gets the moment this command was last invoked. Persisted so ranking can apply real
+    /// time-decay instead of the previous list-position heuristic. History written before
+    /// this field existed deserializes to <c>default(DateTimeOffset)</c>;
+    /// <see cref="RecentCommandsManager"/> treats that sentinel as a mild backdate so
+    /// day-one ordering degrades gracefully to Uses-ordering rather than going all-equal.
+    /// </summary>
+    public DateTimeOffset LastUsed { get; init; }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/RecentCommandsManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/RecentCommandsManager.cs
@@ -3,13 +3,50 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
+using System.Text.Json.Serialization;
 
 namespace Microsoft.CmdPal.UI.ViewModels;
 
 public record RecentCommandsManager : IRecentCommandsManager
 {
+    // Recency half-life: a command's recency contribution halves every this many days. Three
+    // days balances an interactive launcher's usage rhythm - commands touched in the last few
+    // days still feel "recent", while month-old one-offs decay toward zero and stop crowding
+    // out newer habits.
+    internal const double HalfLifeDays = 3.0;
+
+    // Baseline points for a just-used command (recency == 1) before the frequency term. Kept
+    // near the previous top recency bucket so the frecency signal keeps roughly the same
+    // influence in the ranker's within-tier math (MainListRanker.FrecencyScale == 1.0).
+    internal const double BaseWeight = 10.0;
+
+    // Points added per unit of log2(uses + 1), scaled by recency. log() keeps heavy usage
+    // helpful without letting it dominate recency (uses 1 -> +10, 7 -> +30, 31 -> +50).
+    internal const double FrequencyWeight = 10.0;
+
+    // Upper bound on the returned weight. Holds the signal in the ~0..70 range the previous
+    // implementation produced, so tier ordering is unaffected (the tier always dominates and
+    // frecency only reorders within a tier).
+    internal const double MaxWeight = 70.0;
+
+    // Retain a few hundred commands. Large enough to remember habitual commands across weeks
+    // of use, small enough that the persisted JSON stays tiny (tens of KB). The old cap of 50
+    // evicted still-useful history within a single busy session on active machines.
+    internal const int MaxHistoryEntries = 500;
+
+    // Legacy history items (persisted before LastUsed existed) deserialize with a default
+    // timestamp. Treat them as used one day ago: recent enough that they still rank, mild
+    // enough that a single fresh use outranks them, and uniform so their relative order falls
+    // back to Uses (frequency) instead of collapsing to all-equal or zero.
+    internal static readonly TimeSpan LegacyBackdate = TimeSpan.FromDays(1);
+
     private ImmutableList<HistoryItem>? _history = ImmutableList<HistoryItem>.Empty;
 
+    // Persisted so recent-command frecency (including the LastUsed timestamps) survives a
+    // restart. [JsonInclude] is required because the property is internal; without it the
+    // source-generated serializer emits an empty object and history is silently dropped.
+    // Old persisted state (an empty object) still deserializes fine - History stays empty.
+    [JsonInclude]
     internal ImmutableList<HistoryItem> History
     {
         get => _history ?? ImmutableList<HistoryItem>.Empty;
@@ -21,43 +58,53 @@ public record RecentCommandsManager : IRecentCommandsManager
     }
 
     public int GetCommandHistoryWeight(string commandId)
+        => GetCommandHistoryWeight(commandId, DateTimeOffset.UtcNow);
+
+    /// <summary>
+    /// Computes the time-decayed frecency weight for a command relative to <paramref name="now"/>.
+    /// Recency uses an exponential half-life decay and frequency uses log(uses); the two are
+    /// combined so recency leads while frequency amplifies. The public overload evaluates at
+    /// the current time; this overload exists so tests can inject a fixed evaluation time.
+    /// </summary>
+    internal int GetCommandHistoryWeight(string commandId, DateTimeOffset now)
     {
-        var entry = History
-            .Index()
-            .Where(item => item.Item.CommandId == commandId)
-            .FirstOrDefault();
-
-        // These numbers are vaguely scaled so that "VS" will make "Visual Studio" the
-        // match after one use.
-        // Usually it has a weight of 84, compared to 109 for the VS cmd prompt
-        if (entry.Item is not null)
+        var entry = History.FirstOrDefault(item => item.CommandId == commandId);
+        if (entry is null)
         {
-            var index = entry.Index;
-
-            // First, add some weight based on how early in the list this appears
-            var bucket = index switch
-            {
-                _ when index <= 2 => 35,
-                _ when index <= 10 => 25,
-                _ when index <= 15 => 15,
-                _ when index <= 35 => 10,
-                _ => 5,
-            };
-
-            // Then, add weight for how often this is used, but cap the weight from usage.
-            var uses = Math.Min(entry.Item.Uses * 5, 35);
-
-            return bucket + uses;
+            return 0;
         }
 
-        return 0;
+        // Migrate legacy entries (no timestamp) to a mild backdate so they degrade to
+        // Uses-ordering instead of appearing brand-new or invisible.
+        var lastUsed = entry.LastUsed == default ? now - LegacyBackdate : entry.LastUsed;
+
+        // Clamp age at zero so a slightly-future timestamp (e.g. clock skew) can't amplify.
+        var ageDays = Math.Max(0.0, (now - lastUsed).TotalDays);
+
+        // Exponential time decay: recency in (0, 1], halving every HalfLifeDays.
+        var recency = Math.Pow(2.0, -ageDays / HalfLifeDays);
+
+        // Frequency via log2 so heavy usage helps but can't outrun recency.
+        var frequency = Math.Log(entry.Uses + 1, 2);
+
+        var weight = recency * (BaseWeight + (FrequencyWeight * frequency));
+
+        return (int)Math.Round(Math.Clamp(weight, 0.0, MaxWeight));
     }
 
     /// <summary>
     /// Returns a new RecentCommandsManager with the given command added/promoted in history.
-    /// Pure function — does not mutate this instance.
+    /// Pure function - does not mutate this instance.
     /// </summary>
     public RecentCommandsManager WithHistoryItem(string commandId)
+        => WithHistoryItem(commandId, DateTimeOffset.UtcNow);
+
+    /// <summary>
+    /// Records a use of <paramref name="commandId"/> at the explicit time <paramref name="now"/>.
+    /// The public overload uses the current time; this overload lets tests inject
+    /// strictly-increasing timestamps so time-decay behavior is deterministic.
+    /// </summary>
+    internal RecentCommandsManager WithHistoryItem(string commandId, DateTimeOffset now)
     {
         var existing = History.FirstOrDefault(item => item.CommandId == commandId);
         ImmutableList<HistoryItem> newHistory;
@@ -65,18 +112,18 @@ public record RecentCommandsManager : IRecentCommandsManager
         if (existing is not null)
         {
             newHistory = History.Remove(existing);
-            var updated = existing with { Uses = existing.Uses + 1 };
+            var updated = existing with { Uses = existing.Uses + 1, LastUsed = now };
             newHistory = newHistory.Insert(0, updated);
         }
         else
         {
-            var newItem = new HistoryItem { CommandId = commandId, Uses = 1 };
+            var newItem = new HistoryItem { CommandId = commandId, Uses = 1, LastUsed = now };
             newHistory = History.Insert(0, newItem);
         }
 
-        if (newHistory.Count > 50)
+        if (newHistory.Count > MaxHistoryEntries)
         {
-            newHistory = newHistory.RemoveRange(50, newHistory.Count - 50);
+            newHistory = newHistory.RemoveRange(MaxHistoryEntries, newHistory.Count - MaxHistoryEntries);
         }
 
         return this with { History = newHistory };

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/RecentCommandsManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/RecentCommandsManager.cs
@@ -34,13 +34,25 @@ public record RecentCommandsManager : IRecentCommandsManager
     // evicted still-useful history within a single busy session on active machines.
     internal const int MaxHistoryEntries = 500;
 
-    // Legacy history items (persisted before LastUsed existed) deserialize with a default
-    // timestamp. Treat them as used one day ago: recent enough that they still rank, mild
-    // enough that a single fresh use outranks them, and uniform so their relative order falls
-    // back to Uses (frequency) instead of collapsing to all-equal or zero.
+    // Defensive fallback for any history item that carries a default (missing) LastUsed - for
+    // example a value constructed without a timestamp, or state written by a build that predates
+    // the LastUsed field. Such an item is treated as used one day ago: recent enough that it
+    // still ranks, mild enough that a single fresh use outranks it, and uniform so a group of
+    // them falls back to Uses (frequency) ordering instead of collapsing to all-equal or zero.
+    // In practice this rarely fires: earlier builds never actually persisted history (the
+    // internal History property was dropped by the serializer, see [JsonInclude] below), so
+    // upgrading users start from an empty store rather than one full of timestamp-less items.
     internal static readonly TimeSpan LegacyBackdate = TimeSpan.FromDays(1);
 
     private ImmutableList<HistoryItem>? _history = ImmutableList<HistoryItem>.Empty;
+
+    // Cached commandId -> entry lookup over History, rebuilt lazily whenever History is
+    // (re)assigned and never persisted. ScoreTopLevelItem calls GetCommandHistoryWeight for
+    // every candidate item on every keystroke, and History can hold up to MaxHistoryEntries
+    // (500) entries, so a plain linear scan would be O(items x history) per keystroke. The
+    // dictionary keeps each lookup O(1) so the hot path stays cheap as the store grows.
+    [JsonIgnore]
+    private Dictionary<string, HistoryItem>? _index;
 
     // Persisted so recent-command frecency (including the LastUsed timestamps) survives a
     // restart. [JsonInclude] is required because the property is internal; without it the
@@ -50,7 +62,38 @@ public record RecentCommandsManager : IRecentCommandsManager
     internal ImmutableList<HistoryItem> History
     {
         get => _history ?? ImmutableList<HistoryItem>.Empty;
-        init => _history = value;
+        init
+        {
+            _history = value;
+
+            // Invalidate the cached lookup so it is rebuilt from the new list on next use.
+            // A record 'with' copy carries over the old field, so this reset is what keeps
+            // the index from going stale after History changes.
+            _index = null;
+        }
+    }
+
+    private Dictionary<string, HistoryItem> Index
+    {
+        get
+        {
+            if (_index is null)
+            {
+                // Ordinal to match the string '==' comparison the previous linear scan used.
+                var map = new Dictionary<string, HistoryItem>(StringComparer.Ordinal);
+                foreach (var item in History)
+                {
+                    // History is most-recent-first and command ids are unique in it, but keep
+                    // the first (most recent) occurrence if a duplicate ever slips in so the
+                    // lookup matches the old FirstOrDefault behavior.
+                    map.TryAdd(item.CommandId, item);
+                }
+
+                _index = map;
+            }
+
+            return _index;
+        }
     }
 
     public RecentCommandsManager()
@@ -68,14 +111,13 @@ public record RecentCommandsManager : IRecentCommandsManager
     /// </summary>
     internal int GetCommandHistoryWeight(string commandId, DateTimeOffset now)
     {
-        var entry = History.FirstOrDefault(item => item.CommandId == commandId);
-        if (entry is null)
+        if (!Index.TryGetValue(commandId, out var entry))
         {
             return 0;
         }
 
-        // Migrate legacy entries (no timestamp) to a mild backdate so they degrade to
-        // Uses-ordering instead of appearing brand-new or invisible.
+        // Migrate items with a default (missing) timestamp to a mild backdate so they degrade
+        // to Uses-ordering instead of appearing brand-new or invisible. See LegacyBackdate.
         var lastUsed = entry.LastUsed == default ? now - LegacyBackdate : entry.LastUsed;
 
         // Clamp age at zero so a slightly-future timestamp (e.g. clock skew) can't amplify.

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/RecentCommandsTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/RecentCommandsTests.cs
@@ -203,6 +203,38 @@ public partial class RecentCommandsTests : CommandPaletteUnitTestBase
     }
 
     [TestMethod]
+    public void ValidateLookupIndexStaysConsistentAcrossChanges()
+    {
+        // The commandId lookup is backed by a cached index that must be invalidated whenever
+        // history changes (WithHistoryItem returns a new record, and a 'with' copy carries the
+        // old cached field over). Force the index to build on one instance, then mutate, and
+        // confirm each instance reports exactly its own history.
+        var now = new DateTimeOffset(2025, 6, 1, 0, 0, 0, TimeSpan.Zero);
+        var first = new RecentCommandsManager().WithHistoryItem("alpha", now);
+
+        // Read once to build the cached index on 'first'.
+        var alphaFirst = first.GetCommandHistoryWeight("alpha", now);
+        Assert.IsTrue(alphaFirst > 0, "alpha should have weight on the first instance");
+        Assert.AreEqual(0, first.GetCommandHistoryWeight("beta", now), "beta is not in the first instance");
+
+        // Add a use of alpha and a brand-new beta, producing a new instance.
+        var second = first
+            .WithHistoryItem("alpha", now.AddDays(1))
+            .WithHistoryItem("beta", now.AddDays(1));
+
+        // The new instance sees the newer alpha (more recent + higher use) and the new beta.
+        Assert.IsTrue(
+            second.GetCommandHistoryWeight("alpha", now.AddDays(1)) > 0,
+            "alpha should still resolve on the updated instance");
+        Assert.IsTrue(
+            second.GetCommandHistoryWeight("beta", now.AddDays(1)) > 0,
+            "beta should resolve on the updated instance after its index rebuilds");
+
+        // The original instance is unchanged - its index never gained beta.
+        Assert.AreEqual(0, first.GetCommandHistoryWeight("beta", now), "the original instance must not see beta");
+    }
+
+    [TestMethod]
     public void ValidateHistoryCap()
     {
         // Insert well beyond the cap, each newer than the last. The store keeps the most-recent

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/RecentCommandsTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/RecentCommandsTests.cs
@@ -4,7 +4,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
+using System.Text.Json;
 using Microsoft.CmdPal.Common.Text;
 using Microsoft.CmdPal.Ext.UnitTestBase;
 using Microsoft.CmdPal.UI.ViewModels.MainPage;
@@ -33,20 +35,6 @@ public partial class RecentCommandsTests : CommandPaletteUnitTestBase
         return history;
     }
 
-    private static RecentCommandsManager CreateBasicHistoryService()
-    {
-        var commonCommands = new List<string>
-        {
-            "com.microsoft.cmdpal.shell",
-            "com.microsoft.cmdpal.windowwalker",
-            "Visual Studio 2022 Preview_6533433915015224980",
-            "com.microsoft.cmdpal.reload",
-            "com.microsoft.cmdpal.shell",
-        };
-
-        return CreateHistory(commonCommands);
-    }
-
     [TestMethod]
     public void ValidateHistoryFunctionality()
     {
@@ -63,21 +51,31 @@ public partial class RecentCommandsTests : CommandPaletteUnitTestBase
     [TestMethod]
     public void ValidateHistoryWeighting()
     {
-        // Setup
-        var history = CreateBasicHistoryService();
+        // Build history with explicit, strictly-increasing timestamps so time-decay is
+        // deterministic. "shell" is used twice (most uses) and most recently; the others are
+        // each used once, progressively more recently.
+        var t0 = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var history = new RecentCommandsManager();
+        history = history.WithHistoryItem("com.microsoft.cmdpal.shell", t0);
+        history = history.WithHistoryItem("com.microsoft.cmdpal.windowwalker", t0.AddDays(1));
+        history = history.WithHistoryItem("Visual Studio 2022 Preview_6533433915015224980", t0.AddDays(2));
+        history = history.WithHistoryItem("com.microsoft.cmdpal.reload", t0.AddDays(3));
+        history = history.WithHistoryItem("com.microsoft.cmdpal.shell", t0.AddDays(4));
+
+        var now = t0.AddDays(4);
 
         // Act
-        var shellWeight = history.GetCommandHistoryWeight("com.microsoft.cmdpal.shell");
-        var windowWalkerWeight = history.GetCommandHistoryWeight("com.microsoft.cmdpal.windowwalker");
-        var vsWeight = history.GetCommandHistoryWeight("Visual Studio 2022 Preview_6533433915015224980");
-        var reloadWeight = history.GetCommandHistoryWeight("com.microsoft.cmdpal.reload");
-        var nonExistentWeight = history.GetCommandHistoryWeight("non.existent.command");
+        var shellWeight = history.GetCommandHistoryWeight("com.microsoft.cmdpal.shell", now);
+        var windowWalkerWeight = history.GetCommandHistoryWeight("com.microsoft.cmdpal.windowwalker", now);
+        var vsWeight = history.GetCommandHistoryWeight("Visual Studio 2022 Preview_6533433915015224980", now);
+        var reloadWeight = history.GetCommandHistoryWeight("com.microsoft.cmdpal.reload", now);
+        var nonExistentWeight = history.GetCommandHistoryWeight("non.existent.command", now);
 
         // Assert
-        Assert.IsTrue(shellWeight > windowWalkerWeight, "Shell should be weighted higher than Window Walker, more uses");
-        Assert.IsTrue(vsWeight > windowWalkerWeight, "Visual Studio should be weighted higher than Window Walker, because recency");
-        Assert.AreEqual(reloadWeight, vsWeight, "both reload and VS were used in the last three commands, same weight");
-        Assert.IsTrue(shellWeight > vsWeight, "VS and run were both used in the last 3, but shell has 2 more frequency");
+        Assert.IsTrue(shellWeight > windowWalkerWeight, "Shell is both the most-used and most-recent command");
+        Assert.IsTrue(vsWeight > windowWalkerWeight, "Visual Studio was used more recently than Window Walker");
+        Assert.IsTrue(reloadWeight > vsWeight, "Reload was used more recently than Visual Studio");
+        Assert.IsTrue(shellWeight > vsWeight, "Shell is both more recent and more frequently used than Visual Studio");
         Assert.AreEqual(0, nonExistentWeight, "Nonexistent command should have zero weight");
     }
 
@@ -159,97 +157,131 @@ public partial class RecentCommandsTests : CommandPaletteUnitTestBase
     }
 
     [TestMethod]
-    public void ValidateHistoryBuckets()
+    public void ValidateRecencyDecay()
     {
-        // Setup
-        // (these will be checked in reverse order, so that A is the most recent)
-        var items = new List<ListItemMock>
-        {
-            new("Command A", "Subtitle A", GivenId: "idA"), // #0  -> bucket 0
-            new("Command B", "Subtitle B", GivenId: "idB"), // #1  -> bucket 0
-            new("Command C", "Subtitle C", GivenId: "idC"), // #2  -> bucket 0
-            new("Command D", "Subtitle D", GivenId: "idD"), // #3  -> bucket 1
-            new("Command E", "Subtitle E", GivenId: "idE"), // #4  -> bucket 1
-            new("Command F", "Subtitle F", GivenId: "idF"), // #5  -> bucket 1
-            new("Command G", "Subtitle G", GivenId: "idG"), // #6  -> bucket 1
-            new("Command H", "Subtitle H", GivenId: "idH"), // #7  -> bucket 1
-            new("Command I", "Subtitle I", GivenId: "idI"), // #8  -> bucket 1
-            new("Command J", "Subtitle J", GivenId: "idJ"), // #9  -> bucket 1
-            new("Command K", "Subtitle K", GivenId: "idK"), // #10 -> bucket 1
-            new("Command L", "Subtitle L", GivenId: "idL"), // #11 -> bucket 2
-            new("Command M", "Subtitle M", GivenId: "idM"), // #12 -> bucket 2
-            new("Command N", "Subtitle N", GivenId: "idN"), // #13 -> bucket 2
-            new("Command O", "Subtitle O", GivenId: "idO"), // #14 -> bucket 2
-        };
+        // Each command is used exactly once, at progressively older times. Weight must decay
+        // monotonically with age, and a 3-day-old use (one half-life) should weigh about half
+        // of a use that just happened.
+        var now = new DateTimeOffset(2025, 2, 1, 0, 0, 0, TimeSpan.Zero);
+        var history = new RecentCommandsManager()
+            .WithHistoryItem("today", now)
+            .WithHistoryItem("three-days", now.AddDays(-3))
+            .WithHistoryItem("ten-days", now.AddDays(-10))
+            .WithHistoryItem("thirty-days", now.AddDays(-30));
 
-        for (var i = items.Count; i <= 50; i++)
+        var today = history.GetCommandHistoryWeight("today", now);
+        var threeDays = history.GetCommandHistoryWeight("three-days", now);
+        var tenDays = history.GetCommandHistoryWeight("ten-days", now);
+        var thirtyDays = history.GetCommandHistoryWeight("thirty-days", now);
+
+        Assert.IsTrue(today > threeDays, "A more recent use must weigh more than an older one");
+        Assert.IsTrue(threeDays > tenDays, "Decay must be monotonic with age");
+        Assert.IsTrue(tenDays > thirtyDays, "Older uses keep decaying toward zero");
+        Assert.IsTrue(thirtyDays >= 0, "Weight must never go negative");
+
+        // The half-life is 3 days, so a 3-day-old single use is about half of a fresh one.
+        Assert.AreEqual(today / 2.0, threeDays, 1.0, "Three days should be a single half-life");
+    }
+
+    [TestMethod]
+    public void ValidateFrequencyWeighting()
+    {
+        // Hold recency constant (same timestamp) and vary only the use count. More uses must
+        // weigh more, but the log-scaled frequency term stays within the documented cap.
+        var now = new DateTimeOffset(2025, 2, 1, 0, 0, 0, TimeSpan.Zero);
+        var history = new RecentCommandsManager().WithHistoryItem("once", now);
+        for (var i = 0; i < 7; i++)
         {
-            items.Add(new ListItemMock($"Command #{i}", GivenId: $"id{i}"));
+            history = history.WithHistoryItem("many", now);
         }
 
-        // Act
-        var history = CreateHistory(items.Reverse<ListItemMock>().ToList());
+        var once = history.GetCommandHistoryWeight("once", now);
+        var many = history.GetCommandHistoryWeight("many", now);
 
-        // Assert
-        // First three items should be in the top bucket
-        var weightA = history.GetCommandHistoryWeight("idA");
-        var weightB = history.GetCommandHistoryWeight("idB");
-        var weightC = history.GetCommandHistoryWeight("idC");
+        Assert.IsTrue(many > once, "At equal recency, a more frequently used command weighs more");
+        Assert.IsTrue(many <= RecentCommandsManager.MaxWeight, "Weight stays within the documented cap");
+    }
 
-        Assert.AreEqual(weightA, weightB, "Items A and B were used in the last 3 commands");
-        Assert.AreEqual(weightB, weightC, "Items B and C were used in the last 3 commands");
+    [TestMethod]
+    public void ValidateHistoryCap()
+    {
+        // Insert well beyond the cap, each newer than the last. The store keeps the most-recent
+        // entries and evicts the oldest, replacing the previous 50-entry limit.
+        var now = new DateTimeOffset(2025, 2, 1, 0, 0, 0, TimeSpan.Zero);
+        var history = new RecentCommandsManager();
 
-        // Next eight items (3-10 inclusive) should be in the second bucket
-        var weightD = history.GetCommandHistoryWeight("idD");
-        var weightE = history.GetCommandHistoryWeight("idE");
-        var weightF = history.GetCommandHistoryWeight("idF");
-        var weightG = history.GetCommandHistoryWeight("idG");
-        var weightH = history.GetCommandHistoryWeight("idH");
-        var weightI = history.GetCommandHistoryWeight("idI");
-        var weightJ = history.GetCommandHistoryWeight("idJ");
-        var weightK = history.GetCommandHistoryWeight("idK");
+        var total = RecentCommandsManager.MaxHistoryEntries + 50;
+        for (var i = 0; i < total; i++)
+        {
+            history = history.WithHistoryItem($"cmd-{i}", now.AddMinutes(i));
+        }
 
-        Assert.AreEqual(weightD, weightE, "Items D and E were used in the last 10 commands");
-        Assert.AreEqual(weightE, weightF, "Items E and F were used in the last 10 commands");
-        Assert.AreEqual(weightF, weightG, "Items F and G were used in the last 10 commands");
-        Assert.AreEqual(weightG, weightH, "Items G and H were used in the last 10 commands");
-        Assert.AreEqual(weightH, weightI, "Items H and I were used in the last 10 commands");
-        Assert.AreEqual(weightI, weightJ, "Items I and J were used in the last 10 commands");
-        Assert.AreEqual(weightJ, weightK, "Items J and K were used in the last 10 commands");
+        var evaluatedAt = now.AddMinutes(total);
 
-        // Items up to the 15th should be in the third bucket
-        var weightL = history.GetCommandHistoryWeight("idL");
-        var weightM = history.GetCommandHistoryWeight("idM");
-        var weightN = history.GetCommandHistoryWeight("idN");
-        var weightO = history.GetCommandHistoryWeight("idO");
-        var weight15 = history.GetCommandHistoryWeight("id15");
-        Assert.AreEqual(weightL, weightM, "Items L and M were used in the last 15 commands");
-        Assert.AreEqual(weightM, weightN, "Items M and N were used in the last 15 commands");
-        Assert.AreEqual(weightN, weightO, "Items N and O were used in the last 15 commands");
-        Assert.AreEqual(weightO, weight15, "Items O and 15 were used in the last 15 commands");
+        Assert.IsTrue(
+            history.History.Count <= RecentCommandsManager.MaxHistoryEntries,
+            "History should be capped at MaxHistoryEntries");
 
-        // Items after that should be in the lowest buckets
-        var weight0 = history.GetCommandHistoryWeight(items[0].Id);
-        var weight3 = history.GetCommandHistoryWeight(items[3].Id);
-        var weight11 = history.GetCommandHistoryWeight(items[11].Id);
-        var weight16 = history.GetCommandHistoryWeight("id16");
-        var weight20 = history.GetCommandHistoryWeight("id20");
-        var weight30 = history.GetCommandHistoryWeight("id30");
-        var weight40 = history.GetCommandHistoryWeight("id40");
-        var weight49 = history.GetCommandHistoryWeight("id49");
+        // The earliest (now-evicted) entries have fallen out of the store.
+        Assert.AreEqual(0, history.GetCommandHistoryWeight("cmd-0", evaluatedAt), "The oldest entry should have been evicted");
 
-        Assert.IsTrue(weight0 > weight3);
-        Assert.IsTrue(weight3 > weight11);
-        Assert.IsTrue(weight11 > weight16);
+        // The most-recent entries survive and still carry weight.
+        Assert.IsTrue(
+            history.GetCommandHistoryWeight($"cmd-{total - 1}", evaluatedAt) > 0,
+            "The most recent entry should be retained");
+    }
 
-        Assert.AreEqual(weight16, weight20);
-        Assert.AreEqual(weight20, weight30);
-        Assert.IsTrue(weight30 > weight40);
-        Assert.AreEqual(weight40, weight49);
+    [TestMethod]
+    public void ValidateLegacyHistoryMigration()
+    {
+        // Legacy items persisted before LastUsed existed deserialize with a default timestamp.
+        // They should be mildly backdated so ordering falls back to Uses (frequency) rather
+        // than collapsing to all-equal or zero.
+        var now = new DateTimeOffset(2025, 5, 1, 0, 0, 0, TimeSpan.Zero);
+        var legacy = new RecentCommandsManager
+        {
+            History = ImmutableList.Create(
+                new HistoryItem { CommandId = "rare", Uses = 1 },
+                new HistoryItem { CommandId = "common", Uses = 8 }),
+        };
 
-        // The 50th item has fallen out of the list now
-        var weight50 = history.GetCommandHistoryWeight("id50");
-        Assert.AreEqual(0, weight50, "Item 50 should have fallen out of the history list");
+        var rare = legacy.GetCommandHistoryWeight("rare", now);
+        var common = legacy.GetCommandHistoryWeight("common", now);
+
+        Assert.IsTrue(rare > 0, "Legacy items should be mildly backdated, not zeroed out");
+        Assert.IsTrue(common > rare, "Legacy ordering should fall back to Uses (frequency)");
+
+        // A brand-new, single real use should outrank a backdated single-use legacy item.
+        var withFresh = legacy.WithHistoryItem("brand-new", now);
+        var fresh = withFresh.GetCommandHistoryWeight("brand-new", now);
+        Assert.IsTrue(fresh > rare, "A just-used command should outrank a backdated single-use legacy item");
+    }
+
+    [TestMethod]
+    public void ValidateHistorySerializationRoundTrips()
+    {
+        // The persisted history (see SettingsModel's JsonSerializable context) must round-trip,
+        // including the new LastUsed timestamp, so decay survives a save/load cycle.
+        var now = new DateTimeOffset(2025, 3, 15, 12, 30, 0, TimeSpan.Zero);
+        var original = new RecentCommandsManager()
+            .WithHistoryItem("alpha", now)
+            .WithHistoryItem("beta", now.AddMinutes(5));
+
+        var json = JsonSerializer.Serialize(original, JsonSerializationContext.Default.RecentCommandsManager);
+        var restored = JsonSerializer.Deserialize(json, JsonSerializationContext.Default.RecentCommandsManager);
+
+        Assert.IsNotNull(restored, "Round-tripped history should not be null");
+        Assert.AreEqual(2, restored!.History.Count, "All history entries should round-trip");
+
+        var beta = restored.History.First(h => h.CommandId == "beta");
+        Assert.AreEqual(now.AddMinutes(5), beta.LastUsed, "The LastUsed timestamp should round-trip");
+        Assert.AreEqual(1, beta.Uses, "The use count should round-trip");
+
+        // Weights computed from the restored state should match the original.
+        Assert.AreEqual(
+            original.GetCommandHistoryWeight("beta", now.AddMinutes(5)),
+            restored.GetCommandHistoryWeight("beta", now.AddMinutes(5)),
+            "Restored history should produce the same weight as the original");
     }
 
     [TestMethod]


### PR DESCRIPTION
>[!WARNING]
> This PR is one in a series of PRs focused on rearchitecting the search/scoring logic of the `MainListPage`. An explanation of the entire search/scoring logic can be found in the first PR of the change (#49189).
> 
> **This PR should not be merged until PR #49191 is merged into it.**

## Phase 2 of the CmdPal search overhaul (stacked)

> [!IMPORTANT]
> **User-facing behavior change (release notes):** recent-command history is now actually persisted across restarts. Previously the internal `History` property was silently dropped by the source-generated serializer, so frecency reset every launch. Marking it `[JsonInclude]` fixes that, which is what lets the new time-decay signal (and `LastUsed`) survive a restart. This is the highest-visibility change in the PR even though it rides along with the redesign (decay is pointless without persistence).

Base branch is `dev/mjolley/cmdpal-search-overhaul` (phase 1), NOT `main`. Phase 3 (provider weighting) will stack on this branch.

### What changed
Replaces the list-position frecency heuristic in `RecentCommandsManager` with a real time-decayed signal so recently- and frequently-used commands reorder correctly **within** their ranker tier. The tier always dominates; frecency only reorders within a tier, so overall ordering behavior is preserved.

- **Time-decay weight**: `recency = 2^(-ageDays / halfLife)` combined with `log2(uses + 1)` for frequency, clamped to the previous ~0..70 range so the ranker's within-tier math and `FrecencyScale = 1.0` are unaffected.
- **`HistoryItem.LastUsed`**: new persisted `DateTimeOffset` driving the decay.
- **Store cap** grown from 50 to 500 entries (frecency decays gracefully, so a larger store is cheap and improves recall of older-but-frequent commands).
- **Legacy migration**: items without `LastUsed` deserialize as `MinValue` and are treated as used one day ago, so ordering degrades to Uses-ordering rather than all-equal. (Defensive: earlier builds never persisted history, so this rarely fires on real data.)
- **Test seams**: internal `WithHistoryItem(commandId, now)` / `GetCommandHistoryWeight(commandId, now)` overloads let tests inject strictly-increasing timestamps. Public overloads pass `DateTimeOffset.UtcNow`; the public `IRecentCommandsManager` contract is unchanged, so `MainListPage` needed no changes.

### Design constants
- Half-life: **3 days**
- Base weight: **10**, frequency weight: **10**, max weight: **70**
- Store cap: **500**
- Legacy backdate: **1 day**

### Review follow-ups
- **O(1) frecency lookup**: `GetCommandHistoryWeight` is called for every candidate on every keystroke and the store now holds up to 500 entries, so the old `History.FirstOrDefault` linear scan was indexed by `commandId`. The cache is built lazily, invalidated whenever `History` is reassigned, and excluded from JSON.
- **Migration comment corrected**: because history was never persisted before this PR, the `LegacyBackdate` path is defensive handling for any timestamp-less item, not a common "upgrading from old builds" scenario. Comment reworded to match.
- **Int return kept intentionally**: `IRecentCommandsManager.GetCommandHistoryWeight` stays `int` to honor the existing contract. It buckets the continuous decay into ~70 within-tier levels (still far finer than the old handful of position buckets), and `WithinTierScore` widens it to `double` at the call site. Widening the contract to preserve full granularity is deferred to the ranker-focused phase to keep this change atomic.

### Tests
- Rewrote the position-bucket tests as explicit time-decay tests (recency decay, frequency weighting, cap, legacy migration, serialization round-trip, index invalidation).
- Kept the tier-invariant tests unchanged in spirit (tier still dominates; frecency only reorders within a tier).
- Build: x64 Debug, exit 0.
- `Microsoft.CmdPal.UI.ViewModels.UnitTests`: 153/153 pass.
