### PR TITLE
[CmdPal] Per-provider search weight (Lower/Normal/Higher)

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
@@ -100,7 +100,7 @@ public sealed partial class MainListPage : DynamicListPage,
         _appStateService = appStateService;
         _tlcManager = topLevelCommandManager;
         _fuzzyMatcherProvider = fuzzyMatcherProvider;
-        _scoringFunction = (in query, item) => ScoreTopLevelItem(in query, item, _appStateService.State.RecentCommands, _fuzzyMatcherProvider.Current);
+        _scoringFunction = (in query, item) => ScoreTopLevelItem(in query, item, _appStateService.State.RecentCommands, _fuzzyMatcherProvider.Current, ResolveProviderSearchWeight);
         _fallbackScoringFunction = (in _, item) => ScoreFallbackItem(item, _settingsService.Settings.FallbackRanks);
 
         _tlcManager.PropertyChanged += TlcManager_PropertyChanged;
@@ -640,7 +640,8 @@ public sealed partial class MainListPage : DynamicListPage,
         in FuzzyQuery query,
         IListItem topLevelOrAppItem,
         IRecentCommandsManager history,
-        IPrecomputedFuzzyMatcher precomputedFuzzyMatcher)
+        IPrecomputedFuzzyMatcher precomputedFuzzyMatcher,
+        Func<IListItem, ProviderSearchWeight>? providerWeightLookup = null)
     {
         var title = topLevelOrAppItem.Title;
         if (string.IsNullOrWhiteSpace(title))
@@ -708,11 +709,16 @@ public sealed partial class MainListPage : DynamicListPage,
         var frecencyWeight = history.GetCommandHistoryWeight(id);
         var aliasSubstringBonus = isAliasSubstringMatch && !isAliasMatch ? MainListRanker.AliasSubstringBonus : 0.0;
 
+        // Per-provider weight is a within-tier nudge only. Resolving it here (rather than in
+        // the tier classifier) guarantees it can never promote an item across a tier boundary.
+        var providerWeight = providerWeightLookup?.Invoke(topLevelOrAppItem) ?? ProviderSearchWeight.Normal;
+        var providerBonus = MainListRanker.ProviderBonus(providerWeight);
+
         var withinTier = MainListRanker.WithinTierScore(
             lexicalQuality,
             frecencyWeight,
             aliasSubstringBonus,
-            providerBonus: 0.0);
+            providerBonus: providerBonus);
 
         return MainListRanker.Pack(tier, withinTier);
     }
@@ -765,6 +771,25 @@ public sealed partial class MainListPage : DynamicListPage,
             // we've got an app here
             return topLevelOrAppItem.Command?.Id ?? string.Empty;
         }
+    }
+
+    // Resolves the user-configured per-provider search weight for an item. Top-level commands
+    // carry their own provider id; installed apps all belong to the well-known "AllApps"
+    // provider, so app items are weighted by that provider's setting.
+    private ProviderSearchWeight ResolveProviderSearchWeight(IListItem topLevelOrAppItem)
+    {
+        var providerId = topLevelOrAppItem is TopLevelViewModel topLevel
+            ? topLevel.CommandProviderId
+            : AllAppsCommandProvider.WellKnownId;
+
+        if (string.IsNullOrEmpty(providerId))
+        {
+            return ProviderSearchWeight.Normal;
+        }
+
+        return _settingsService.Settings.ProviderSettings.TryGetValue(providerId, out var providerSettings)
+            ? providerSettings.SearchWeight
+            : ProviderSearchWeight.Normal;
     }
 
     public void Receive(ClearSearchMessage message) => SearchText = string.Empty;

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
@@ -6,6 +6,7 @@
  #define CMDPAL_FF_MAINPAGE_TIME_RAISE_ITEMS
 */
 
+using System.Collections.Immutable;
 using System.Collections.Specialized;
 using System.Diagnostics;
 using CommunityToolkit.Mvvm.Messaging;
@@ -70,6 +71,10 @@ public sealed partial class MainListPage : DynamicListPage,
 
     private bool _includeApps;
     private bool _filteredItemsIncludesApps;
+
+    // Last per-provider settings we reacted to, so a settings reload can tell whether any
+    // provider's search weight actually changed and only then re-rank the active query.
+    private ImmutableDictionary<string, ProviderSettings>? _lastProviderSettingsSnapshot;
 
     private int AppResultLimit => AllAppsCommandProvider.TopLevelResultLimit;
 
@@ -803,7 +808,65 @@ public sealed partial class MainListPage : DynamicListPage,
 
     private void SettingsChangedHandler(ISettingsService sender, SettingsModel args) => HotReloadSettings(args);
 
-    private void HotReloadSettings(SettingsModel settings) => ShowDetails = settings.ShowAppDetails;
+    private void HotReloadSettings(SettingsModel settings)
+    {
+        ShowDetails = settings.ShowAppDetails;
+
+        // A per-provider search-weight change has to reorder the query that is already on screen.
+        // Scoring reads the weight live, but scored results are cached, so without an explicit
+        // re-score the active query keeps its old order until the next keystroke. Detect a weight
+        // change and re-rank the current search in place.
+        var providerSettings = settings.ProviderSettings;
+        var weightsChanged = ProviderWeightsChanged(_lastProviderSettingsSnapshot, providerSettings);
+        _lastProviderSettingsSnapshot = providerSettings;
+
+        if (weightsChanged && !string.IsNullOrEmpty(SearchText))
+        {
+            RerankActiveSearch();
+        }
+    }
+
+    // Re-scores the current query off the UI thread so a settings change (e.g. a per-provider
+    // search-weight change) reorders the results already shown. This reuses the same non-reset
+    // re-score path as an app-inclusion refresh: the retained matches are re-scored with the new
+    // weights, which is sufficient because provider weight only nudges order within a tier and
+    // never changes which items match.
+    private void RerankActiveSearch()
+    {
+        var current = SearchText;
+        if (!string.IsNullOrEmpty(current))
+        {
+            _ = Task.Run(() => UpdateSearchTextCore(current, current, isUserInput: false));
+        }
+    }
+
+    // True when the effective per-provider search weight differs between two snapshots. A provider
+    // absent from a snapshot is treated as Normal, so adding or removing an entry whose weight is
+    // Normal does not count as a change.
+    private static bool ProviderWeightsChanged(
+        ImmutableDictionary<string, ProviderSettings>? previous,
+        ImmutableDictionary<string, ProviderSettings> current)
+    {
+        previous ??= ImmutableDictionary<string, ProviderSettings>.Empty;
+        if (ReferenceEquals(previous, current))
+        {
+            return false;
+        }
+
+        var keys = new HashSet<string>(previous.Keys, StringComparer.Ordinal);
+        keys.UnionWith(current.Keys);
+        foreach (var key in keys)
+        {
+            var previousWeight = previous.TryGetValue(key, out var p) ? p.SearchWeight : ProviderSearchWeight.Normal;
+            var currentWeight = current.TryGetValue(key, out var c) ? c.SearchWeight : ProviderSearchWeight.Normal;
+            if (previousWeight != currentWeight)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     public void Dispose()
     {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListRanker.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListRanker.cs
@@ -31,6 +31,23 @@ internal static class MainListRanker
     // exact alias, which gets its own top tier). Mirrors the previous +1-before-x10 boost.
     internal const double AliasSubstringBonus = 10.0;
 
+    // Magnitude of the per-provider within-tier nudge. Deliberately small - half a point of
+    // lexical quality (LexicalScale = 10) - so a Higher/Lower provider only breaks near-ties
+    // and reorders items that already share a tier. It can NEVER move an item across a tier
+    // boundary because the packed within-tier score is clamped to a single tier's band.
+    internal const double ProviderWeightBonus = 5.0;
+
+    /// <summary>
+    /// Maps a per-provider <see cref="ProviderSearchWeight"/> to an additive within-tier
+    /// bonus. Lower subtracts, Normal is neutral, Higher adds. The enum's underlying value is
+    /// the sign of the nudge, so the result is simply the weight times
+    /// <see cref="ProviderWeightBonus"/>. Note the nudge is slightly asymmetric at the tier
+    /// floor: <see cref="Pack"/> clamps the within-tier score to a non-negative band, so a
+    /// Lower nudge on an item already scoring near 0 (weak match, no history) can clamp to 0
+    /// and read the same as Normal, whereas Higher always applies.
+    /// </summary>
+    public static double ProviderBonus(ProviderSearchWeight weight) => (int)weight * ProviderWeightBonus;
+
     /// <summary>
     /// Packs a tier and within-tier score into a single descending-sortable integer.
     /// Returns 0 for <see cref="RankTier.None"/> so non-matches are filtered by the

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ProviderSettings.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ProviderSettings.cs
@@ -7,6 +7,25 @@ using System.Text.Json.Serialization;
 
 namespace Microsoft.CmdPal.UI.ViewModels;
 
+/// <summary>
+/// Per-provider relevance nudge applied to main/root page search results. The value is a
+/// within-tier bonus only: it can reorder items that already share a relevance tier but can
+/// never move an item across a tier boundary. The underlying integer values are the sign of
+/// the bonus (Lower subtracts, Higher adds), and <see cref="Normal"/> is 0 so a missing or
+/// legacy setting deserializes to the neutral default.
+/// </summary>
+public enum ProviderSearchWeight
+{
+    /// <summary>De-prioritize this provider's results within their tier.</summary>
+    Lower = -1,
+
+    /// <summary>Default. No provider nudge.</summary>
+    Normal = 0,
+
+    /// <summary>Prioritize this provider's results within their tier.</summary>
+    Higher = 1,
+}
+
 public record ProviderSettings
 {
     // List of built-in fallbacks that should not have global results enabled by default
@@ -17,6 +36,12 @@ public record ProviderSettings
         ];
 
     public bool IsEnabled { get; init; } = true;
+
+    /// <summary>
+    /// Per-provider within-tier ranking nudge for main-page search. Defaults to
+    /// <see cref="ProviderSearchWeight.Normal"/>; missing/legacy values deserialize to Normal.
+    /// </summary>
+    public ProviderSearchWeight SearchWeight { get; init; } = ProviderSearchWeight.Normal;
 
     private ImmutableDictionary<string, FallbackSettings>? _fallbackCommands
         = ImmutableDictionary<string, FallbackSettings>.Empty;

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ProviderSettingsViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ProviderSettingsViewModel.cs
@@ -135,6 +135,41 @@ public partial class ProviderSettingsViewModel : ObservableObject
     }
 
     /// <summary>
+    /// Per-provider search weight surfaced as a 0/1/2 ComboBox index (Lower / Normal /
+    /// Higher) so it can bind to <c>ComboBox.SelectedIndex</c> in the same style as the
+    /// other per-provider options. Persists to <see cref="ProviderSettings.SearchWeight"/>.
+    /// </summary>
+    public int SearchWeightIndex
+    {
+        get => _providerSettings.SearchWeight switch
+        {
+            ProviderSearchWeight.Lower => 0,
+            ProviderSearchWeight.Higher => 2,
+            _ => 1,
+        };
+        set
+        {
+            var newWeight = value switch
+            {
+                0 => ProviderSearchWeight.Lower,
+                2 => ProviderSearchWeight.Higher,
+                _ => ProviderSearchWeight.Normal,
+            };
+
+            if (newWeight != _providerSettings.SearchWeight)
+            {
+                var newSettings = _providerSettings with { SearchWeight = newWeight };
+                _settingsService.UpdateSettings(s => s with
+                {
+                    ProviderSettings = s.ProviderSettings.SetItem(_provider.ProviderId, newSettings),
+                });
+                _providerSettings = newSettings;
+                OnPropertyChanged(nameof(SearchWeightIndex));
+            }
+        }
+    }
+
+    /// <summary>
     /// Gets a value indicating whether returns true if we have a settings page
     /// that's initialized, or we are still working on initializing that
     /// settings page. If we don't have a settings object, or that settings

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/ExtensionPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/ExtensionPage.xaml
@@ -79,6 +79,17 @@
                         Value="{x:Bind ViewModel.IsEnabled, Mode=OneWay}">
                         <controls:Case Value="True">
                             <StackPanel Orientation="Vertical">
+                                <controls:SettingsCard x:Name="SearchWeightSettingsCard" x:Uid="Settings_ExtensionPage_SearchWeight_SettingsCard">
+                                    <ComboBox
+                                        MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                        AutomationProperties.AutomationId="CmdPal_ExtensionPage_SearchWeight"
+                                        AutomationProperties.LabeledBy="{x:Bind SearchWeightSettingsCard}"
+                                        SelectedIndex="{x:Bind ViewModel.SearchWeightIndex, Mode=TwoWay}">
+                                        <ComboBoxItem x:Uid="Settings_ExtensionPage_SearchWeight_Lower" />
+                                        <ComboBoxItem x:Uid="Settings_ExtensionPage_SearchWeight_Normal" />
+                                        <ComboBoxItem x:Uid="Settings_ExtensionPage_SearchWeight_Higher" />
+                                    </ComboBox>
+                                </controls:SettingsCard>
                                 <TextBlock x:Uid="ExtensionCommandsHeader" Style="{StaticResource SettingsSectionHeaderTextBlockStyle}" />
                                 <ItemsRepeater ItemsSource="{x:Bind ViewModel.TopLevelCommands, Mode=OneWay}" Layout="{StaticResource VerticalStackLayout}">
                                     <ItemsRepeater.ItemTemplate>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Strings/en-us/Resources.resw
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Strings/en-us/Resources.resw
@@ -352,7 +352,7 @@ Right-click to remove the key combination, thereby deactivating the shortcut.</v
     <value>Search weight</value>
   </data>
   <data name="Settings_ExtensionPage_SearchWeight_SettingsCard.Description" xml:space="preserve">
-    <value>Nudge this provider's results up or down among equally-relevant matches. It never overrides a stronger text match.</value>
+    <value>Nudge this provider's results up or down among equally-relevant matches.</value>
   </data>
   <data name="Settings_ExtensionPage_SearchWeight_SettingsCard.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Search weight</value>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Strings/en-us/Resources.resw
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Strings/en-us/Resources.resw
@@ -348,6 +348,24 @@ Right-click to remove the key combination, thereby deactivating the shortcut.</v
   <data name="Settings_ExtensionPage_AliasActivation_SettingsCard.Description" xml:space="preserve">
     <value>Choose when the alias runs. Direct runs as soon as you type the alias. Indirect runs after a trailing space.</value>
   </data>
+  <data name="Settings_ExtensionPage_SearchWeight_SettingsCard.Header" xml:space="preserve">
+    <value>Search weight</value>
+  </data>
+  <data name="Settings_ExtensionPage_SearchWeight_SettingsCard.Description" xml:space="preserve">
+    <value>Nudge this provider's results up or down among equally-relevant matches. It never overrides a stronger text match.</value>
+  </data>
+  <data name="Settings_ExtensionPage_SearchWeight_SettingsCard.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Search weight</value>
+  </data>
+  <data name="Settings_ExtensionPage_SearchWeight_Lower.Content" xml:space="preserve">
+    <value>Lower</value>
+  </data>
+  <data name="Settings_ExtensionPage_SearchWeight_Normal.Content" xml:space="preserve">
+    <value>Normal</value>
+  </data>
+  <data name="Settings_ExtensionPage_SearchWeight_Higher.Content" xml:space="preserve">
+    <value>Higher</value>
+  </data>
   <data name="Settings_ExtensionPage_Builtin_SettingsCard.Header" xml:space="preserve">
     <value>Built-in</value>
   </data>

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/ProviderWeightingTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/ProviderWeightingTests.cs
@@ -1,0 +1,214 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Text.Json;
+using Microsoft.CmdPal.Common.Text;
+using Microsoft.CmdPal.Ext.UnitTestBase;
+using Microsoft.CmdPal.UI.ViewModels.MainPage;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.Foundation;
+using WyHash;
+
+namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
+
+[TestClass]
+public partial class ProviderWeightingTests : CommandPaletteUnitTestBase
+{
+    private static IPrecomputedFuzzyMatcher CreateMatcher()
+        => new PrecomputedFuzzyMatcher(new PrecomputedFuzzyMatcherOptions());
+
+    private static RecentCommandsManager EmptyHistory() => new();
+
+    // Maps each item to the weight configured for its provider id.
+    private static Func<IListItem, ProviderSearchWeight> LookupBy(IReadOnlyDictionary<string, ProviderSearchWeight> byProvider)
+        => item =>
+        {
+            var providerId = item is WeightItemMock mock ? mock.ProviderId ?? string.Empty : string.Empty;
+            return byProvider.TryGetValue(providerId, out var weight) ? weight : ProviderSearchWeight.Normal;
+        };
+
+    [TestMethod]
+    public void ProviderBonus_MapsSignedMagnitude()
+    {
+        Assert.AreEqual(-MainListRanker.ProviderWeightBonus, MainListRanker.ProviderBonus(ProviderSearchWeight.Lower));
+        Assert.AreEqual(0.0, MainListRanker.ProviderBonus(ProviderSearchWeight.Normal));
+        Assert.AreEqual(MainListRanker.ProviderWeightBonus, MainListRanker.ProviderBonus(ProviderSearchWeight.Higher));
+    }
+
+    [TestMethod]
+    public void ProviderWeight_ReordersWithinTier()
+    {
+        // Two items that land in the SAME tier (exact-title) with identical lexical quality
+        // and no history. The only differentiator is the per-provider weight.
+        var fuzzyMatcher = CreateMatcher();
+        var q = fuzzyMatcher.PrecomputeQuery("git");
+
+        var itemA = new WeightItemMock("git", ProviderId: "providerA");
+        var itemB = new WeightItemMock("git", ProviderId: "providerB");
+
+        // Baseline: both Normal -> equal scores.
+        var neutral = LookupBy(new Dictionary<string, ProviderSearchWeight>());
+        var baseA = MainListPage.ScoreTopLevelItem(q, itemA, EmptyHistory(), fuzzyMatcher, neutral);
+        var baseB = MainListPage.ScoreTopLevelItem(q, itemB, EmptyHistory(), fuzzyMatcher, neutral);
+        Assert.AreEqual(baseA, baseB, "With both providers Normal, tied items should score equally");
+
+        // A Higher, B Lower -> A must now sort above B.
+        var lookup = LookupBy(new Dictionary<string, ProviderSearchWeight>
+        {
+            ["providerA"] = ProviderSearchWeight.Higher,
+            ["providerB"] = ProviderSearchWeight.Lower,
+        });
+        var higherA = MainListPage.ScoreTopLevelItem(q, itemA, EmptyHistory(), fuzzyMatcher, lookup);
+        var lowerB = MainListPage.ScoreTopLevelItem(q, itemB, EmptyHistory(), fuzzyMatcher, lookup);
+
+        Assert.IsTrue(higherA > baseA, "Higher weight should raise the score");
+        Assert.IsTrue(lowerB < baseB, "Lower weight should reduce the score");
+        Assert.IsTrue(higherA > lowerB, "Higher-weighted provider should outrank the lower-weighted one within the tier");
+
+        // Same tier the whole time - the nudge only reordered within it.
+        Assert.AreEqual(MainListRanker.TierOf(baseA), MainListRanker.TierOf(higherA));
+        Assert.AreEqual(MainListRanker.TierOf(baseB), MainListRanker.TierOf(lowerB));
+    }
+
+    [TestMethod]
+    public void ProviderWeight_NeverCrossesTierBoundary()
+    {
+        var fuzzyMatcher = CreateMatcher();
+        var q = fuzzyMatcher.PrecomputeQuery("code");
+
+        // "code" exactly matches -> ExactTitle tier. Give it the WORST weight.
+        var exact = new WeightItemMock("code", ProviderId: "weak");
+
+        // "Visual Studio Code" only matches "code" at a word boundary -> lower tier. Give it
+        // the BEST weight, plus a pile of history, to try to jump the tier boundary.
+        var lowerTier = new WeightItemMock("Visual Studio Code", ProviderId: "strong");
+
+        var lookup = LookupBy(new Dictionary<string, ProviderSearchWeight>
+        {
+            ["weak"] = ProviderSearchWeight.Lower,
+            ["strong"] = ProviderSearchWeight.Higher,
+        });
+
+        var history = EmptyHistory();
+        for (var i = 0; i < 50; i++)
+        {
+            history = history.WithHistoryItem(lowerTier.Id);
+        }
+
+        var exactScore = MainListPage.ScoreTopLevelItem(q, exact, EmptyHistory(), fuzzyMatcher, lookup);
+        var lowerScore = MainListPage.ScoreTopLevelItem(q, lowerTier, history, fuzzyMatcher, lookup);
+
+        Assert.IsTrue(
+            MainListRanker.TierOf(exactScore) > MainListRanker.TierOf(lowerScore),
+            "The exact match must live in a strictly higher tier");
+        Assert.IsTrue(
+            exactScore > lowerScore,
+            "A within-tier nudge (even Higher + heavy history) must never promote an item across a tier boundary");
+    }
+
+    [TestMethod]
+    public void ProviderWeight_DefaultNormalMatchesNoLookup()
+    {
+        var fuzzyMatcher = CreateMatcher();
+        var q = fuzzyMatcher.PrecomputeQuery("term");
+        var item = new WeightItemMock("Terminal", ProviderId: "providerA");
+
+        // No lookup at all should behave exactly like an all-Normal lookup, which should
+        // behave exactly like the previous (provider-unaware) scoring.
+        var noLookup = MainListPage.ScoreTopLevelItem(q, item, EmptyHistory(), fuzzyMatcher);
+        var normalLookup = MainListPage.ScoreTopLevelItem(
+            q,
+            item,
+            EmptyHistory(),
+            fuzzyMatcher,
+            LookupBy(new Dictionary<string, ProviderSearchWeight> { ["providerA"] = ProviderSearchWeight.Normal }));
+
+        Assert.AreEqual(noLookup, normalLookup, "Normal weight must be a no-op relative to the default path");
+    }
+
+    [TestMethod]
+    public void ProviderWeight_AppliesToAnyProviderItem()
+    {
+        // App items are plain IListItems (not TopLevelViewModel). This asserts the scorer
+        // honors the provider weight for ANY item, which is how installed apps (the "AllApps"
+        // provider) get nudged.
+        var fuzzyMatcher = CreateMatcher();
+        var q = fuzzyMatcher.PrecomputeQuery("note");
+        var appItem = new WeightItemMock("Notepad", ProviderId: "AllApps");
+
+        var normal = MainListPage.ScoreTopLevelItem(q, appItem, EmptyHistory(), fuzzyMatcher);
+        var higher = MainListPage.ScoreTopLevelItem(
+            q,
+            appItem,
+            EmptyHistory(),
+            fuzzyMatcher,
+            LookupBy(new Dictionary<string, ProviderSearchWeight> { ["AllApps"] = ProviderSearchWeight.Higher }));
+
+        Assert.IsTrue(higher > normal, "An app-style item should also respond to its provider's Higher weight");
+    }
+
+    [TestMethod]
+    public void SearchWeight_SerializationRoundTrips()
+    {
+        var dict = ImmutableDictionary<string, ProviderSettings>.Empty
+            .SetItem("p", new ProviderSettings { SearchWeight = ProviderSearchWeight.Higher });
+
+        var json = JsonSerializer.Serialize(dict, JsonSerializationContext.Default.ImmutableProviderSettingsDictionary);
+        var restored = JsonSerializer.Deserialize(json, JsonSerializationContext.Default.ImmutableProviderSettingsDictionary);
+
+        Assert.IsNotNull(restored);
+        Assert.AreEqual(ProviderSearchWeight.Higher, restored!["p"].SearchWeight);
+    }
+
+    [TestMethod]
+    public void SearchWeight_LegacyJsonDeserializesToNormal()
+    {
+        // Legacy persisted settings predate SearchWeight; the missing property must default
+        // to Normal rather than throwing or landing on Lower.
+        const string legacyJson = "{\"p\":{\"IsEnabled\":true}}";
+
+        var restored = JsonSerializer.Deserialize(legacyJson, JsonSerializationContext.Default.ImmutableProviderSettingsDictionary);
+
+        Assert.IsNotNull(restored);
+        Assert.AreEqual(ProviderSearchWeight.Normal, restored!["p"].SearchWeight);
+    }
+
+    private sealed partial record WeightItemMock(
+        string Title,
+        string? Subtitle = "",
+        string? GivenId = "",
+        string? ProviderId = "") : IListItem
+    {
+        public string Id => string.IsNullOrEmpty(GivenId) ? GenerateId() : GivenId;
+
+        public IDetails Details => throw new NotImplementedException();
+
+        public string Section => throw new NotImplementedException();
+
+        public ITag[] Tags => throw new NotImplementedException();
+
+        public string TextToSuggest => throw new NotImplementedException();
+
+        public ICommand Command => new NoOpCommand() { Id = Id };
+
+        public IIconInfo Icon => throw new NotImplementedException();
+
+        public IContextItem[] MoreCommands => throw new NotImplementedException();
+
+#pragma warning disable CS0067
+        public event TypedEventHandler<object, IPropChangedEventArgs>? PropChanged;
+#pragma warning restore CS0067
+
+        private string GenerateId()
+        {
+            var result = WyHash64.ComputeHash64(ProviderId + Title + Subtitle, seed: 0);
+            return $"{ProviderId}{result}";
+        }
+    }
+}


### PR DESCRIPTION
>[!WARNING]
> This PR is one in a series of PRs focused on rearchitecting the search/scoring logic of the `MainListPage`. An explanation of the entire search/scoring logic can be found in the first PR of the change (#49189).
> 
> **This PR should not be merged until PR #49194 is merged into it.**

Phase 3 of the stacked CmdPal search overhaul. Based on and targeting `dev/mjolley/frecency-redesign` (phase 2), NOT main.

## What
Adds a per-provider **Search weight** (Lower / Normal / Higher, default Normal) that nudges main-page search results **within their relevance tier only**. Tier always dominates; the weight can reorder near-ties but can never move an item across a tier boundary.

## Changes
- `ProviderSettings`: new `ProviderSearchWeight` enum (Lower = -1, Normal = 0, Higher = 1) + `SearchWeight` property. Missing/legacy JSON deserializes to Normal.
- `MainListRanker`: `ProviderWeightBonus = 5.0` constant and `ProviderBonus(weight)` mapping (signed magnitude). Half a point of lexical quality (LexicalScale = 10), so it only breaks near-ties.
- `MainListPage.ScoreTopLevelItem`: resolves each item's provider weight (top-level commands by their provider id, installed apps by the well-known `AllApps` provider) and feeds it into the within-tier score. Backward-compatible optional parameter.
- `ProviderSettingsViewModel` + `ExtensionPage.xaml`: a Lower/Normal/Higher ComboBox per provider (shown for built-ins and apps too). New resw strings. Ran `applyXamlStyling`.

## Design constant
- Provider bonus per level: **+/- 5.0** points (Higher = +5, Normal = 0, Lower = -5), vs LexicalScale = 10 per lexical point and FrecencyScale = 1. Modest by design.

## Tests (all green, x64 host)
- Provider weight reorders within a tier; never crosses a tier boundary (even Higher + heavy history vs a Lower exact match).
- Default Normal == the previous provider-unaware behavior (no-op).
- Applies to app-style (non-TopLevel) items.
- Serialization round-trips; legacy JSON without the property defaults to Normal.
- Build `CommandPalette.slnf` x64/Debug = exit 0. ViewModels 157/157. All other CmdPal unit suites pass (Registry + WindowWalker not run - known pre-existing non-green).

Atomic to phase 3; host-side only, no extension SDK changes.