### PR TITLE
[CmdPal] Fix existing issue with fallback scoring 

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
@@ -64,19 +64,14 @@ public sealed partial class MainListPage : DynamicListPage,
     private RoScored<IListItem>[]? _filteredItems;
     private RoScored<IListItem>[]? _filteredApps;
 
-    // Global/special fallbacks are re-scored lazily on the render path (GetSearchViewItems)
-    // instead of being frozen at keystroke time. Their dynamic titles are resolved
-    // asynchronously off the typing path by the fallback update manager, so deferring the
-    // score lets slow fallback results fold into the already-rendered list with fresh, correct
-    // scores from the same ranker. Fallbacks always classify at the FallbackFloor tier, so this
-    // only reorders them among themselves and can never leapfrog deterministic command/app
-    // results. We snapshot the source list and the precomputed query together so a superseding
-    // keystroke atomically replaces both.
+    // Global/special fallbacks are scored on the render path, not at keystroke time, because
+    // their titles resolve asynchronously. We snapshot the source list and query together so a
+    // superseding keystroke replaces both atomically.
     private IReadOnlyList<IListItem>? _globalFallbackSources;
     private FuzzyQuery _globalFallbackQuery;
 
-    // Common fallbacks use rank-based (query-independent) scores, so freezing them is safe;
-    // only their live titles decide whether they render, so they still fold in as they resolve.
+    // Common fallbacks use query-independent scores, so freezing them is safe; only their live
+    // titles decide whether they render.
     private IEnumerable<RoScored<IListItem>>? _fallbackItems;
 
     private bool _includeApps;
@@ -274,11 +269,8 @@ public sealed partial class MainListPage : DynamicListPage,
 
     private IListItem[] GetSearchViewItems()
     {
-        // Re-score the global fallbacks against their current titles so that any fallback whose
-        // dynamic title resolved asynchronously (after first paint) folds into the list with a
-        // fresh score from the same ranker. This runs on the render path and is cheap because
-        // there are only a handful of configured global fallbacks. Deterministic command/app
-        // results below do not depend on this, so first paint never waits on the (async) fallbacks.
+        // Score global fallbacks against their current titles so a fallback whose title
+        // resolved after first paint gets the right score. Cheap: only a handful are configured.
         var validScoredFallbacks = ScoreDeferredFallbacks(_globalFallbackSources, _globalFallbackQuery, _scoringFunction);
 
         var validFallbacks = _fallbackItems?
@@ -295,11 +287,8 @@ public sealed partial class MainListPage : DynamicListPage,
             AppResultLimit);
     }
 
-    // Scores the current global-fallback snapshot against its query using the supplied ranker,
-    // dropping any whose (possibly still unresolved) title is empty. Extracted and made static
-    // so the fast-first-paint fold-in can be unit tested with a fake slow source: deterministic
-    // command/app results are produced entirely without this method, and re-scoring here always
-    // reflects the latest snapshot, so a superseding keystroke's snapshot replaces any stale one.
+    // Scores the current global-fallback snapshot against its query, dropping any whose title is
+    // still empty. Static so it can be unit tested with a fake slow source.
     internal static List<RoScored<IListItem>>? ScoreDeferredFallbacks(
         IReadOnlyList<IListItem>? sources,
         in FuzzyQuery query,
@@ -629,10 +618,8 @@ public sealed partial class MainListPage : DynamicListPage,
                 return;
             }
 
-            // Snapshot the global fallbacks and query, but do NOT score them here. Their dynamic
-            // titles are updated asynchronously by the fallback update manager (BeginUpdate, above),
-            // which runs off the typing path. Scoring is deferred to the render path so late fallback
-            // resolutions fold in with fresh scores instead of a value frozen against a stale title.
+            // Snapshot the global fallbacks and query, but score them later on the render path,
+            // since their titles are still resolving asynchronously (BeginUpdate, above).
             _globalFallbackSources = commands.Where(s => s.IsFallback && configuredGlobalFallbackIds.Contains(s.Id)).ToArray();
             _globalFallbackQuery = searchQuery;
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
@@ -64,9 +64,19 @@ public sealed partial class MainListPage : DynamicListPage,
     private RoScored<IListItem>[]? _filteredItems;
     private RoScored<IListItem>[]? _filteredApps;
 
-    // Keep as IEnumerable for deferred execution. Fallback item titles are updated
-    // asynchronously, so scoring must happen lazily when GetItems is called.
-    private IEnumerable<RoScored<IListItem>>? _scoredFallbackItems;
+    // Global/special fallbacks are re-scored lazily on the render path (GetSearchViewItems)
+    // instead of being frozen at keystroke time. Their dynamic titles are resolved
+    // asynchronously off the typing path by the fallback update manager, so deferring the
+    // score lets slow fallback results fold into the already-rendered list with fresh, correct
+    // scores from the same ranker. Fallbacks always classify at the FallbackFloor tier, so this
+    // only reorders them among themselves and can never leapfrog deterministic command/app
+    // results. We snapshot the source list and the precomputed query together so a superseding
+    // keystroke atomically replaces both.
+    private IReadOnlyList<IListItem>? _globalFallbackSources;
+    private FuzzyQuery _globalFallbackQuery;
+
+    // Common fallbacks use rank-based (query-independent) scores, so freezing them is safe;
+    // only their live titles decide whether they render, so they still fold in as they resolve.
     private IEnumerable<RoScored<IListItem>>? _fallbackItems;
 
     private bool _includeApps;
@@ -264,9 +274,12 @@ public sealed partial class MainListPage : DynamicListPage,
 
     private IListItem[] GetSearchViewItems()
     {
-        var validScoredFallbacks = _scoredFallbackItems?
-            .Where(s => !string.IsNullOrWhiteSpace(s.Item.Title))
-            .ToList();
+        // Re-score the global fallbacks against their current titles so that any fallback whose
+        // dynamic title resolved asynchronously (after first paint) folds into the list with a
+        // fresh score from the same ranker. This runs on the render path and is cheap because
+        // there are only a handful of configured global fallbacks. Deterministic command/app
+        // results below do not depend on this, so first paint never waits on the (async) fallbacks.
+        var validScoredFallbacks = ScoreDeferredFallbacks(_globalFallbackSources, _globalFallbackQuery, _scoringFunction);
 
         var validFallbacks = _fallbackItems?
             .Where(s => !string.IsNullOrWhiteSpace(s.Item.Title))
@@ -280,6 +293,42 @@ public sealed partial class MainListPage : DynamicListPage,
             _resultsSeparator,
             _fallbacksSeparator,
             AppResultLimit);
+    }
+
+    // Scores the current global-fallback snapshot against its query using the supplied ranker,
+    // dropping any whose (possibly still unresolved) title is empty. Extracted and made static
+    // so the fast-first-paint fold-in can be unit tested with a fake slow source: deterministic
+    // command/app results are produced entirely without this method, and re-scoring here always
+    // reflects the latest snapshot, so a superseding keystroke's snapshot replaces any stale one.
+    internal static List<RoScored<IListItem>>? ScoreDeferredFallbacks(
+        IReadOnlyList<IListItem>? sources,
+        in FuzzyQuery query,
+        ScoringFunction<IListItem> scoringFunction)
+    {
+        if (sources is null || sources.Count == 0)
+        {
+            return null;
+        }
+
+        var scored = InternalListHelpers.FilterListWithScores(sources, query, scoringFunction);
+        if (scored.Length == 0)
+        {
+            return null;
+        }
+
+        List<RoScored<IListItem>>? valid = null;
+        foreach (var s in scored)
+        {
+            if (string.IsNullOrWhiteSpace(s.Item.Title))
+            {
+                continue;
+            }
+
+            valid ??= new List<RoScored<IListItem>>(scored.Length);
+            valid.Add(s);
+        }
+
+        return valid;
     }
 
     private IListItem[] GetDefaultViewItems()
@@ -367,7 +416,7 @@ public sealed partial class MainListPage : DynamicListPage,
         _filteredItems = null;
         _filteredApps = null;
         _fallbackItems = null;
-        _scoredFallbackItems = null;
+        _globalFallbackSources = null;
     }
 
     public override void UpdateSearchText(string oldSearch, string newSearch)
@@ -577,8 +626,12 @@ public sealed partial class MainListPage : DynamicListPage,
                 return;
             }
 
-            IEnumerable<IListItem> newFallbacksForScoring = commands.Where(s => s.IsFallback && configuredGlobalFallbackIds.Contains(s.Id));
-            _scoredFallbackItems = InternalListHelpers.FilterListWithScores(newFallbacksForScoring, searchQuery, _scoringFunction);
+            // Snapshot the global fallbacks and query, but do NOT score them here. Their dynamic
+            // titles are updated asynchronously by the fallback update manager (BeginUpdate, above),
+            // which runs off the typing path. Scoring is deferred to the render path so late fallback
+            // resolutions fold in with fresh scores instead of a value frozen against a stale title.
+            _globalFallbackSources = commands.Where(s => s.IsFallback && configuredGlobalFallbackIds.Contains(s.Id)).ToArray();
+            _globalFallbackQuery = searchQuery;
 
             if (token.IsCancellationRequested)
             {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
@@ -417,6 +417,11 @@ public sealed partial class MainListPage : DynamicListPage,
         _filteredApps = null;
         _fallbackItems = null;
         _globalFallbackSources = null;
+
+        // Reset the paired query too. ScoreDeferredFallbacks already short-circuits on a null
+        // source list, so a stale query here is harmless, but clearing both keeps the snapshot
+        // pair symmetric and avoids a confusing leftover value.
+        _globalFallbackQuery = default;
     }
 
     public override void UpdateSearchText(string oldSearch, string newSearch)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
@@ -418,9 +418,7 @@ public sealed partial class MainListPage : DynamicListPage,
         _fallbackItems = null;
         _globalFallbackSources = null;
 
-        // Reset the paired query too. ScoreDeferredFallbacks already short-circuits on a null
-        // source list, so a stale query here is harmless, but clearing both keeps the snapshot
-        // pair symmetric and avoids a confusing leftover value.
+        // Clear the paired query too, so both are reset together.
         _globalFallbackQuery = default;
     }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelViewModel.cs
@@ -439,10 +439,9 @@ public sealed partial class TopLevelViewModel : ObservableObject, IListItem, IEx
             fallback.FallbackHandler.UpdateQuery(newQuery);
             var newTitle = Title;
 
-            // Report any title change, not just an empty <-> non-empty flip. The render path
-            // re-scores fallbacks off this signal, so a fallback whose title changes from one
-            // non-empty value to another (e.g. "server01" -> "server02") must still trigger a
-            // refresh or it would keep its stale score and position.
+            // Report any title change, not just an empty <-> non-empty flip: the render path
+            // re-scores fallbacks off this signal, so a change like "server01" -> "server02"
+            // must still trigger a refresh or the fallback keeps its stale score and position.
             return !string.Equals(oldTitle, newTitle, StringComparison.Ordinal);
         }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelViewModel.cs
@@ -433,12 +433,17 @@ public sealed partial class TopLevelViewModel : ObservableObject, IListItem, IEx
         // RPC to check type
         if (model is IFallbackCommandItem fallback)
         {
-            var wasEmpty = string.IsNullOrEmpty(Title);
+            var oldTitle = Title;
 
             // RPC for method
             fallback.FallbackHandler.UpdateQuery(newQuery);
-            var isEmpty = string.IsNullOrEmpty(Title);
-            return wasEmpty != isEmpty;
+            var newTitle = Title;
+
+            // Report any title change, not just an empty <-> non-empty flip. The render path
+            // re-scores fallbacks off this signal, so a fallback whose title changes from one
+            // non-empty value to another (e.g. "server01" -> "server02") must still trigger a
+            // refresh or it would keep its stale score and position.
+            return !string.Equals(oldTitle, newTitle, StringComparison.Ordinal);
         }
 
         return false;

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/FastFirstPaintTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/FastFirstPaintTests.cs
@@ -165,8 +165,13 @@ public sealed partial class FastFirstPaintTests
     }
 
     [TestMethod]
-    public void SupersedingQuery_ReplacesSnapshot_StaleStrongMatchNotApplied()
+    public void ReScoreUsesLatestSnapshot_StaleStrongMatchNotApplied()
     {
+        // This exercises the render-path re-score directly: it always scores whatever snapshot is
+        // current, so a superseding keystroke's query wins and the prior query's strong score is
+        // gone. In production the field pair (_globalFallbackSources + _globalFallbackQuery) is
+        // written under lock (commands) in UpdateSearchTextCore and read under the same lock in
+        // GetItems, so the swap is atomic; this test stands in for that behavior at the helper level.
         var fallback = new MutableListItem { Title = "Remote Desktop" };
         IReadOnlyList<IListItem> sources = new IListItem[] { fallback };
 

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/FastFirstPaintTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/FastFirstPaintTests.cs
@@ -1,0 +1,210 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.CmdPal.Common.Helpers;
+using Microsoft.CmdPal.Common.Text;
+using Microsoft.CmdPal.UI.ViewModels.Commands;
+using Microsoft.CmdPal.UI.ViewModels.MainPage;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.Foundation;
+
+namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
+
+/// <summary>
+/// Guardrail tests for the "fast first paint" behavior of the main/root page.
+///
+/// The typing path renders deterministic in-proc results (top-level commands + installed
+/// apps) immediately and folds in slow, out-of-proc fallback contributions asynchronously
+/// as they resolve. These tests pin the two invariants that make that safe:
+///   1. Deterministic results are produced without any fallback contribution present, so
+///      first paint never waits on a slow source.
+///   2. Late-arriving fallbacks are merged with a fresh score from the same ranker, always
+///      at the FallbackFloor tier, so they can never leapfrog deterministic matches, and a
+///      superseding query's snapshot replaces any stale one.
+/// </summary>
+[TestClass]
+public sealed partial class FastFirstPaintTests
+{
+    private static readonly Separator _resultsSeparator = new("Results");
+    private static readonly Separator _fallbacksSeparator = new("Fallbacks");
+
+    // A list item whose Title can be mutated to simulate an extension resolving a dynamic
+    // fallback title asynchronously, after first paint.
+    private sealed partial class MutableListItem : IListItem
+    {
+        public string Title { get; set; } = string.Empty;
+
+        public string Subtitle { get; set; } = string.Empty;
+
+        public ICommand Command => new NoOpCommand();
+
+        public IDetails? Details => null;
+
+        public IIconInfo? Icon => null;
+
+        public string Section => string.Empty;
+
+        public ITag[] Tags => [];
+
+        public string TextToSuggest => string.Empty;
+
+        public IContextItem[] MoreCommands => [];
+
+#pragma warning disable CS0067 // The event is never used
+        public event TypedEventHandler<object, IPropChangedEventArgs>? PropChanged;
+#pragma warning restore CS0067 // The event is never used
+
+        public override string ToString() => Title;
+    }
+
+    // A stand-in ranker that mirrors the real contract for fallbacks: an item with no
+    // (resolved) title scores 0 and is dropped; otherwise it lands at the FallbackFloor tier
+    // with a stronger within-floor score when its current title overlaps the query text.
+    private static ScoringFunction<IListItem> FloorScorerFor(string queryText)
+    {
+        return (in FuzzyQuery _, IListItem item) =>
+        {
+            var title = item.Title;
+            if (string.IsNullOrWhiteSpace(title))
+            {
+                return 0;
+            }
+
+            var within = title.Contains(queryText, StringComparison.OrdinalIgnoreCase) ? 100 : 1;
+            return MainListRanker.Pack(RankTier.FallbackFloor, within);
+        };
+    }
+
+    private static RoScored<IListItem> ScoredFuzzy(string title, int within)
+        => new(score: MainListRanker.Pack(RankTier.Fuzzy, within), item: new MutableListItem { Title = title });
+
+    private static RoScored<IListItem> ScoredFloorMax(string title)
+        => new(score: MainListRanker.Pack(RankTier.FallbackFloor, MainListRanker.TierStride - 1), item: new MutableListItem { Title = title });
+
+    [TestMethod]
+    public void FirstPaint_ProducesDeterministicResults_WithNoFallbackContribution()
+    {
+        var command = ScoredFuzzy("Notepad", within: 50);
+        var app = ScoredFuzzy("Notepad++", within: 40);
+        var filtered = new List<RoScored<IListItem>> { command };
+        var apps = new List<RoScored<IListItem>> { app };
+
+        // No scored fallbacks and no fallback items: this models first paint before any slow
+        // out-of-proc source has responded.
+        var result = MainListPageResultFactory.Create(
+            filtered,
+            scoredFallbackItems: null,
+            apps,
+            fallbackItems: null,
+            _resultsSeparator,
+            _fallbacksSeparator,
+            appResultLimit: 10);
+
+        CollectionAssert.AreEqual(
+            new IListItem[] { _resultsSeparator, command.Item, app.Item },
+            result,
+            "First paint must render the deterministic command/app results without any fallback contribution.");
+    }
+
+    [TestMethod]
+    public void UnresolvedFallback_IsAbsentAtFirstPaint()
+    {
+        var fallback = new MutableListItem { Title = string.Empty };
+        IReadOnlyList<IListItem> sources = new IListItem[] { fallback };
+
+        var scored = MainListPage.ScoreDeferredFallbacks(sources, default, FloorScorerFor("remote"));
+
+        Assert.IsNull(scored, "A fallback whose dynamic title has not resolved yet must not appear.");
+    }
+
+    [TestMethod]
+    public void SlowFallback_FoldsIn_WhenItsTitleResolves()
+    {
+        var fallback = new MutableListItem { Title = string.Empty };
+        IReadOnlyList<IListItem> sources = new IListItem[] { fallback };
+        var scorer = FloorScorerFor("remote");
+
+        // First paint: unresolved title -> not present.
+        Assert.IsNull(MainListPage.ScoreDeferredFallbacks(sources, default, scorer));
+
+        // The extension resolves the dynamic title asynchronously (off the typing path).
+        fallback.Title = "Remote Desktop: server01";
+
+        // A later refresh re-scores the same snapshot and folds the fallback in.
+        var after = MainListPage.ScoreDeferredFallbacks(sources, default, scorer);
+
+        Assert.IsNotNull(after);
+        Assert.AreEqual(1, after!.Count);
+        Assert.AreSame(fallback, after[0].Item);
+        Assert.AreEqual(RankTier.FallbackFloor, MainListRanker.TierOf(after[0].Score));
+    }
+
+    [TestMethod]
+    public void ReScore_ReflectsCurrentTitle_NotAFrozenValue()
+    {
+        var fallback = new MutableListItem { Title = "no match here" };
+        IReadOnlyList<IListItem> sources = new IListItem[] { fallback };
+        var scorer = FloorScorerFor("remote");
+
+        var weak = MainListPage.ScoreDeferredFallbacks(sources, default, scorer);
+        Assert.IsNotNull(weak);
+        var weakScore = weak![0].Score;
+
+        // The title resolves to a strong match. If scoring were frozen at keystroke time, the
+        // weak score would persist; deferred re-scoring must reflect the fresh title.
+        fallback.Title = "Remote host";
+        var strong = MainListPage.ScoreDeferredFallbacks(sources, default, scorer);
+
+        Assert.IsNotNull(strong);
+        Assert.IsTrue(strong![0].Score > weakScore, "Re-scoring must reflect the freshly resolved title, not a frozen value.");
+    }
+
+    [TestMethod]
+    public void SupersedingQuery_ReplacesSnapshot_StaleStrongMatchNotApplied()
+    {
+        var fallback = new MutableListItem { Title = "Remote Desktop" };
+        IReadOnlyList<IListItem> sources = new IListItem[] { fallback };
+
+        // Query A ("remote") is a strong match for the current title.
+        var a = MainListPage.ScoreDeferredFallbacks(sources, default, FloorScorerFor("remote"));
+        Assert.IsNotNull(a);
+        var strongScore = a![0].Score;
+
+        // A newer keystroke installs query B ("zzz"), which does not overlap the title. The
+        // render path always scores the latest snapshot, so query A's strong score is gone.
+        var b = MainListPage.ScoreDeferredFallbacks(sources, default, FloorScorerFor("zzz"));
+
+        Assert.IsNotNull(b);
+        Assert.IsTrue(b![0].Score < strongScore, "A superseding query must not inherit the prior query's stale score.");
+    }
+
+    [TestMethod]
+    public void LateFallback_MergesBelowDeterministicMatches_NoLeapfrog()
+    {
+        // A minimal deterministic Fuzzy match versus a fallback with the maximum possible
+        // within-floor score. The tier ladder must still keep the fallback below the command.
+        var command = ScoredFuzzy("Notepad", within: 1);
+        var fallback = ScoredFloorMax("Search the web for notepad");
+
+        var filtered = new List<RoScored<IListItem>> { command };
+        var scoredFallbacks = new List<RoScored<IListItem>> { fallback };
+
+        var result = MainListPageResultFactory.Create(
+            filtered,
+            scoredFallbacks,
+            filteredApps: null,
+            fallbackItems: null,
+            _resultsSeparator,
+            _fallbacksSeparator,
+            appResultLimit: 10);
+
+        Assert.AreEqual(_resultsSeparator, result[0]);
+        Assert.AreSame(command.Item, result[1], "Deterministic matches must sort above floor-tier fallbacks.");
+        Assert.AreSame(fallback.Item, result[2], "A late floor-tier fallback merges after deterministic results, never leapfrogging them.");
+    }
+}


### PR DESCRIPTION
>[!WARNING]
> This PR is one in a series of PRs focused on rearchitecting the search/scoring logic of the `MainListPage`. An explanation of the entire search/scoring logic can be found in the first PR of the change (#49189).
> 
> **This PR should not be merged until PR #49195 is merged into it.**

When you type, CmdPal shows two kinds of results: instant ones (your commands + installed apps) and "fallback" ones whose label is computed by an out-of-process extension and comes back a moment later.

The old code decided a fallback's ranking the instant you typed - before its label had arrived - so it scored the fallback as if it were blank, and then never re-scored it once the real label showed up. You'd *see* the correct label, but its position was frozen at the score it got while still empty.

This change stops scoring fallbacks at keystroke time and re-scores them each time the list repaints, using whatever label they have right then. So, a fallback's position always matches the label you're looking at.
