### PR TITLE
[CmdPal] Golden-set relevance test harness for main-page ranking

### DIFF
--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/MainListRankerTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/MainListRankerTests.cs
@@ -1,0 +1,141 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.CmdPal.UI.ViewModels;
+using Microsoft.CmdPal.UI.ViewModels.MainPage;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
+
+/// <summary>
+/// Focused, per-tier unit tests for the <see cref="MainListRanker"/> primitives - tier
+/// classification, the tier/within-tier packing invariants, and the within-tier score inputs.
+/// These cover the pieces the end-to-end <see cref="RelevanceHarnessTests"/> cannot easily drive
+/// through app/command mocks (alias-exact and fallback-floor classification, and the packing
+/// guarantee that a higher tier always outranks a lower one regardless of within-tier score).
+/// </summary>
+[TestClass]
+public class MainListRankerTests
+{
+    [DataTestMethod]
+    [DataRow("gh", "GitHub", true, true, false, false, RankTier.AliasExact, DisplayName = "Alias-exact is the strongest, most explicit signal and beats even a fallback flag")]
+    [DataRow("anything", "Some Fallback", true, false, false, true, RankTier.FallbackFloor, DisplayName = "A fallback that is not alias-exact lands on the floor regardless of a lexical match")]
+    [DataRow("calculator", "Calculator", false, false, false, true, RankTier.ExactTitle, DisplayName = "Exact title match")]
+    [DataRow("cal", "Calculator", false, false, false, true, RankTier.Prefix, DisplayName = "Title prefix match")]
+    [DataRow("code", "Visual Studio Code", false, false, false, true, RankTier.AcronymWordBoundary, DisplayName = "Word-boundary match")]
+    [DataRow("vs", "Visual Studio Code", false, false, false, true, RankTier.AcronymWordBoundary, DisplayName = "Acronym match")]
+    [DataRow("cmd", "Command Prompt", false, false, false, true, RankTier.Fuzzy, DisplayName = "A lexical match that is not exact/prefix/word-boundary/acronym is fuzzy")]
+    [DataRow("zzz", "Command Prompt", false, false, false, false, RankTier.None, DisplayName = "Nothing matched")]
+    [DataRow("zz", "Some Command", false, false, true, false, RankTier.Fuzzy, DisplayName = "An alias-substring match keeps the item at the fuzzy floor even with no lexical match")]
+    public void ClassifyTier_ClassifiesEachSignalIntoItsTier(
+        string query,
+        string title,
+        bool isFallback,
+        bool isAliasExact,
+        bool isAliasSubstringMatch,
+        bool matchedLexically,
+        RankTier expected)
+    {
+        Assert.AreEqual(
+            expected,
+            MainListRanker.ClassifyTier(query, title, isFallback, isAliasExact, isAliasSubstringMatch, matchedLexically));
+    }
+
+    [TestMethod]
+    public void Pack_HigherTierAlwaysOutranksLowerTier()
+    {
+        // The core invariant: a higher tier with the WORST possible within-tier score still
+        // outranks a lower tier with the BEST possible within-tier score. This is what makes
+        // "an exact match always beats a fuzzy one" true no matter how much frecency piles up.
+        RankTier[] ascending =
+        {
+            RankTier.FallbackFloor,
+            RankTier.Fuzzy,
+            RankTier.AcronymWordBoundary,
+            RankTier.Prefix,
+            RankTier.ExactTitle,
+            RankTier.AliasExact,
+        };
+
+        for (var i = 0; i < ascending.Length - 1; i++)
+        {
+            var lower = MainListRanker.Pack(ascending[i], MainListRanker.TierStride - 1);
+            var higher = MainListRanker.Pack(ascending[i + 1], 0);
+            Assert.IsTrue(
+                higher > lower,
+                $"{ascending[i + 1]} (min within-tier) must outrank {ascending[i]} (max within-tier)");
+        }
+    }
+
+    [TestMethod]
+    public void Pack_NoneIsZeroAndFiltered()
+    {
+        Assert.AreEqual(0, MainListRanker.Pack(RankTier.None, 999_999));
+    }
+
+    [TestMethod]
+    public void Pack_WithinTierScoreIsClampedToItsBand()
+    {
+        // An absurd within-tier score must never spill into the next tier's band.
+        var packed = MainListRanker.Pack(RankTier.Fuzzy, double.MaxValue);
+        Assert.AreEqual(RankTier.Fuzzy, MainListRanker.TierOf(packed));
+
+        var nextTierFloor = MainListRanker.Pack(RankTier.AcronymWordBoundary, 0);
+        Assert.IsTrue(packed < nextTierFloor, "A clamped within-tier score must stay below the next tier");
+    }
+
+    [TestMethod]
+    public void Pack_WithinTierScoreOrdersItemsInTheSameTier()
+    {
+        var low = MainListRanker.Pack(RankTier.Prefix, 10);
+        var high = MainListRanker.Pack(RankTier.Prefix, 20);
+        Assert.IsTrue(high > low, "Within the same tier, a higher within-tier score sorts higher");
+        Assert.AreEqual(MainListRanker.TierOf(low), MainListRanker.TierOf(high), "Both remain in the same tier");
+    }
+
+    [TestMethod]
+    public void TierOf_RoundTripsEveryTier()
+    {
+        foreach (RankTier tier in Enum.GetValues(typeof(RankTier)))
+        {
+            if (tier == RankTier.None)
+            {
+                continue;
+            }
+
+            var packed = MainListRanker.Pack(tier, 42);
+            Assert.AreEqual(tier, MainListRanker.TierOf(packed), $"Packing then unpacking {tier} should round-trip");
+        }
+    }
+
+    [TestMethod]
+    public void WithinTierScore_LexicalQualityLeads()
+    {
+        // More lexical quality raises the within-tier score, all else equal.
+        var lowLexical = MainListRanker.WithinTierScore(lexicalQuality: 5, frecencyWeight: 0, aliasSubstringBonus: 0, providerBonus: 0);
+        var highLexical = MainListRanker.WithinTierScore(lexicalQuality: 6, frecencyWeight: 0, aliasSubstringBonus: 0, providerBonus: 0);
+        Assert.IsTrue(highLexical > lowLexical, "Higher lexical quality should raise the within-tier score");
+    }
+
+    [TestMethod]
+    public void WithinTierScore_FrecencyBreaksTies()
+    {
+        var noFrecency = MainListRanker.WithinTierScore(lexicalQuality: 5, frecencyWeight: 0, aliasSubstringBonus: 0, providerBonus: 0);
+        var withFrecency = MainListRanker.WithinTierScore(lexicalQuality: 5, frecencyWeight: 3, aliasSubstringBonus: 0, providerBonus: 0);
+        Assert.IsTrue(withFrecency > noFrecency, "Frecency should raise the within-tier score for otherwise-equal items");
+    }
+
+    [TestMethod]
+    public void ProviderBonus_LowerIsBelowNormalIsBelowHigher()
+    {
+        Assert.IsTrue(
+            MainListRanker.ProviderBonus(ProviderSearchWeight.Lower) < MainListRanker.ProviderBonus(ProviderSearchWeight.Normal),
+            "Lower should subtract relative to Normal");
+        Assert.IsTrue(
+            MainListRanker.ProviderBonus(ProviderSearchWeight.Normal) < MainListRanker.ProviderBonus(ProviderSearchWeight.Higher),
+            "Higher should add relative to Normal");
+        Assert.AreEqual(0.0, MainListRanker.ProviderBonus(ProviderSearchWeight.Normal), "Normal is the neutral default");
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/RelevanceHarnessTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/RelevanceHarnessTests.cs
@@ -1,0 +1,462 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CmdPal.Common.Text;
+using Microsoft.CmdPal.Ext.UnitTestBase;
+using Microsoft.CmdPal.UI.ViewModels;
+using Microsoft.CmdPal.UI.ViewModels.MainPage;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.Foundation;
+using WyHash;
+
+namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
+
+/// <summary>
+/// Golden-set relevance harness for the main/root page ranker. Every case is expressed as a
+/// realistic query paired with an ordering constraint (rank-1, or "X must rank above Y") and
+/// asserted against the REAL <see cref="MainListPage.ScoreTopLevelItem"/> scoring path, sorted
+/// exactly the way the product sorts (positive scores, descending). The intent is to lock in
+/// "results seem logical and relevant" as an objective, extendable yardstick: to add a new
+/// scenario, drop another entry in the fixture and another constraint in a test.
+///
+/// This file also carries focused per-tier unit tests for <see cref="MainListRanker"/> that
+/// cover the pieces the golden set cannot easily drive through app/command mocks - alias-exact
+/// and fallback-floor classification, and the packing invariants that guarantee a higher tier
+/// always outranks a lower one regardless of within-tier score.
+/// </summary>
+[TestClass]
+public partial class RelevanceHarnessTests : CommandPaletteUnitTestBase
+{
+    // A lightweight IListItem stand-in for a top-level command or installed app. Mirrors the
+    // mock used by RecentCommandsTests so the harness exercises the same real scoring path,
+    // not a reimplementation. ProviderId lets a test key a per-provider weight lookup.
+    private sealed partial record ListItemMock(
+        string Title,
+        string? Subtitle = "",
+        string? GivenId = "",
+        string? ProviderId = "") : IListItem
+    {
+        public string Id => string.IsNullOrEmpty(GivenId) ? GenerateId() : GivenId;
+
+        public IDetails Details => throw new NotImplementedException();
+
+        public string Section => throw new NotImplementedException();
+
+        public ITag[] Tags => throw new NotImplementedException();
+
+        public string TextToSuggest => throw new NotImplementedException();
+
+        public ICommand Command => new NoOpCommand() { Id = Id };
+
+        public IIconInfo Icon => throw new NotImplementedException();
+
+        public IContextItem[] MoreCommands => throw new NotImplementedException();
+
+#pragma warning disable CS0067
+        public event TypedEventHandler<object, IPropChangedEventArgs>? PropChanged;
+#pragma warning restore CS0067
+
+        private string GenerateId()
+        {
+            var result = WyHash64.ComputeHash64(ProviderId + Title + Subtitle, seed: 0);
+            return $"{ProviderId}{result}";
+        }
+    }
+
+    private static IPrecomputedFuzzyMatcher CreateMatcher() =>
+        new PrecomputedFuzzyMatcher(new PrecomputedFuzzyMatcherOptions());
+
+    private static RecentCommandsManager EmptyHistory() => new();
+
+    // A representative slice of the main page: installed apps + top-level commands with
+    // realistic titles, subtitles and shared prefixes/acronyms. Deliberately includes the
+    // "confusable" clusters users complain about (Calc*, Visual Studio *, Command Prompt vs
+    // Control Panel) so the golden constraints below have real competition to beat.
+    private static List<ListItemMock> Fixture() => new()
+    {
+        new("Command Prompt", "Run the classic command interpreter"),
+        new("Control Panel", "Adjust your computer's settings"),
+        new("Calculator", "Perform calculations"),
+        new("Calendar", "View your schedule"),
+        new("Visual Studio Code", "Code editing. Redefined."),
+        new("Visual Studio 2022", "Full-featured IDE"),
+        new("Windows Settings", "Change PC settings"),
+        new("Windows Terminal", "Modern terminal for command-line tools"),
+        new("Task Manager", "Monitor apps and processes"),
+        new("Notepad", "A simple text editor"),
+        new("Microsoft Edge", "Browse the web"),
+        new("Paint", "Draw and edit images"),
+        new("Paint 3D", "Create in three dimensions"),
+    };
+
+    // Scores every fixture item for a query through the real product scorer and returns the
+    // matched titles in the exact order the product would render them: positive scores only,
+    // sorted descending. Mirrors InternalListHelpers.FilterListWithScores and the existing
+    // RecentCommandsTests.GetMatches helper.
+    private static List<string> Rank(
+        string query,
+        IEnumerable<ListItemMock> items,
+        IRecentCommandsManager? history = null,
+        Func<IListItem, ProviderSearchWeight>? providerWeightLookup = null)
+    {
+        var matcher = CreateMatcher();
+        var q = matcher.PrecomputeQuery(query);
+        history ??= EmptyHistory();
+
+        return items
+            .Select(item => (item.Title, Score: MainListPage.ScoreTopLevelItem(q, item, history, matcher, providerWeightLookup)))
+            .Where(x => x.Score > 0)
+            .OrderByDescending(x => x.Score)
+            .Select(x => x.Title)
+            .ToList();
+    }
+
+    private static void AssertRank1(
+        string query,
+        string expectedTitle,
+        IRecentCommandsManager? history = null,
+        Func<IListItem, ProviderSearchWeight>? providerWeightLookup = null)
+    {
+        var ranked = Rank(query, Fixture(), history, providerWeightLookup);
+        Assert.IsTrue(ranked.Count > 0, $"Query '{query}' should return at least one match");
+        Assert.AreEqual(
+            expectedTitle,
+            ranked[0],
+            $"Query '{query}' should surface '{expectedTitle}' at rank 1. Actual order: [{string.Join(", ", ranked)}]");
+    }
+
+    private static void AssertRanksAbove(
+        string query,
+        string higher,
+        string lower,
+        IRecentCommandsManager? history = null,
+        Func<IListItem, ProviderSearchWeight>? providerWeightLookup = null)
+    {
+        var ranked = Rank(query, Fixture(), history, providerWeightLookup);
+        var higherIndex = ranked.IndexOf(higher);
+        var lowerIndex = ranked.IndexOf(lower);
+
+        Assert.IsTrue(higherIndex >= 0, $"Query '{query}' should match '{higher}'. Actual order: [{string.Join(", ", ranked)}]");
+        Assert.IsTrue(lowerIndex >= 0, $"Query '{query}' should match '{lower}'. Actual order: [{string.Join(", ", ranked)}]");
+        Assert.IsTrue(
+            higherIndex < lowerIndex,
+            $"Query '{query}' should rank '{higher}' above '{lower}'. Actual order: [{string.Join(", ", ranked)}]");
+    }
+
+    // Golden set: the tier ladder, end to end.
+    [TestMethod]
+    public void Golden_ExactTitleBeatsPrefix()
+    {
+        // "Paint" is an exact title; "Paint 3D" only has it as a prefix. Exact must win.
+        AssertRank1("paint", "Paint");
+        AssertRanksAbove("paint", "Paint", "Paint 3D");
+    }
+
+    [TestMethod]
+    public void Golden_PrefixBeatsWordBoundary()
+    {
+        // "co" is a title prefix of Command Prompt and Control Panel, but only a word-boundary
+        // match for "Code" inside Visual Studio Code. Prefix outranks word-boundary.
+        AssertRanksAbove("co", "Command Prompt", "Visual Studio Code");
+        AssertRanksAbove("co", "Control Panel", "Visual Studio Code");
+    }
+
+    [TestMethod]
+    public void Golden_WordBoundaryBeatsFuzzy()
+    {
+        // "man" starts the word "Manager" in Task Manager (word-boundary), but is only a loose
+        // subsequence (m..a..n) of "Command Prompt" (fuzzy). Word-boundary must win.
+        AssertRank1("man", "Task Manager");
+        AssertRanksAbove("man", "Task Manager", "Command Prompt");
+    }
+
+    [TestMethod]
+    public void Golden_AcronymSurfacesTheRightApp()
+    {
+        // "vsc" is the acronym of Visual Studio Code (V-S-C); Visual Studio 2022 (V-S-2) is not
+        // a match. The acronym should surface the obviously-right app at rank 1.
+        AssertRank1("vsc", "Visual Studio Code");
+    }
+
+    [TestMethod]
+    public void Golden_ComplaintCase_SingleLetterSurfacesFrecentApp()
+    {
+        // "c" prefixes several apps (Calculator, Calendar, Command Prompt, Control Panel). With
+        // no signal they tie; a user who keeps opening Calculator should see it at rank 1. This
+        // is the canonical "the thing I want is buried" complaint, fixed by within-tier frecency.
+        var history = EmptyHistory();
+        var calculatorId = Fixture().First(i => i.Title == "Calculator").Id;
+        for (var i = 0; i < 5; i++)
+        {
+            history = history.WithHistoryItem(calculatorId);
+        }
+
+        AssertRank1("c", "Calculator", history);
+    }
+
+    [TestMethod]
+    public void Golden_ComplaintCase_CodeSurfacesVsCode()
+    {
+        // Typing "code" should put Visual Studio Code first (word-boundary on "Code").
+        AssertRank1("code", "Visual Studio Code");
+    }
+
+    [TestMethod]
+    public void Golden_ComplaintCase_SetSurfacesSettings()
+    {
+        // Typing "set" should put Windows Settings first (word-boundary on "Settings").
+        AssertRank1("set", "Windows Settings");
+    }
+
+    [TestMethod]
+    public void Golden_FrecencyReordersWithinTierOnly()
+    {
+        // Heavy use of Visual Studio Code (a word-boundary match for "co") must NOT lift it over
+        // Command Prompt / Control Panel, which are prefix matches a whole tier above it.
+        // Frecency reorders within a tier; it can never cross a tier boundary.
+        var history = EmptyHistory();
+        var vsCodeId = Fixture().First(i => i.Title == "Visual Studio Code").Id;
+        for (var i = 0; i < 50; i++)
+        {
+            history = history.WithHistoryItem(vsCodeId);
+        }
+
+        AssertRanksAbove("co", "Command Prompt", "Visual Studio Code", history);
+        AssertRanksAbove("co", "Control Panel", "Visual Studio Code", history);
+    }
+
+    [TestMethod]
+    public void Golden_FrecencyBreaksTieWithinTier()
+    {
+        // "vs" is an acronym match for both Visual Studio Code and Visual Studio 2022 (same
+        // tier). With no history they tie; the recently/repeatedly used one should climb to the
+        // top of the tier.
+        var fixture = Fixture();
+        var vs2022Id = fixture.First(i => i.Title == "Visual Studio 2022").Id;
+
+        var history = EmptyHistory();
+        for (var i = 0; i < 5; i++)
+        {
+            history = history.WithHistoryItem(vs2022Id);
+        }
+
+        AssertRanksAbove("vs", "Visual Studio 2022", "Visual Studio Code", history);
+    }
+
+    [TestMethod]
+    public void Golden_ProviderHigherBreaksAnExactTie()
+    {
+        // Two providers surface an identically-titled "Settings" command. Everything else being
+        // equal (same tier, same lexical quality, no frecency), a provider marked Higher should
+        // sort above the Normal one. Provider weight is a within-tier nudge for near-ties only.
+        var alpha = new ListItemMock("Settings", "From provider Alpha", ProviderId: "alpha");
+        var bravo = new ListItemMock("Settings", "From provider Bravo", ProviderId: "bravo");
+        var items = new List<ListItemMock> { alpha, bravo };
+
+        var matcher = CreateMatcher();
+        var q = matcher.PrecomputeQuery("Settings");
+        var history = EmptyHistory();
+
+        // Baseline: with no provider weighting the two tie exactly.
+        var baseAlpha = MainListPage.ScoreTopLevelItem(q, alpha, history, matcher);
+        var baseBravo = MainListPage.ScoreTopLevelItem(q, bravo, history, matcher);
+        Assert.AreEqual(baseAlpha, baseBravo, "The two identically-titled items should tie before provider weighting");
+
+        Func<IListItem, ProviderSearchWeight> lookup = item =>
+            item is ListItemMock m && m.ProviderId == "bravo"
+                ? ProviderSearchWeight.Higher
+                : ProviderSearchWeight.Normal;
+
+        var ranked = items
+            .Select(item => (item.ProviderId, Score: MainListPage.ScoreTopLevelItem(q, item, history, matcher, lookup)))
+            .OrderByDescending(x => x.Score)
+            .Select(x => x.ProviderId)
+            .ToList();
+
+        Assert.AreEqual("bravo", ranked[0], "The Higher-weighted provider should win an otherwise exact tie");
+    }
+
+    [TestMethod]
+    public void Golden_ProviderWeightCannotCrossTierBoundary()
+    {
+        // Even marked Higher, a word-boundary match (Visual Studio Code for "co") must stay
+        // below a prefix match (Command Prompt). Provider weight is clamped within a tier.
+        Func<IListItem, ProviderSearchWeight> boostVsCode = item =>
+            item is ListItemMock m && m.Title == "Visual Studio Code"
+                ? ProviderSearchWeight.Higher
+                : ProviderSearchWeight.Normal;
+
+        AssertRanksAbove("co", "Command Prompt", "Visual Studio Code", providerWeightLookup: boostVsCode);
+    }
+
+    // Per-tier unit tests for MainListRanker.
+    [TestMethod]
+    public void ClassifyTier_AliasExact_WinsEvenOverFallback()
+    {
+        // Alias-exact is the strongest, most explicit signal - it beats even a fallback flag.
+        Assert.AreEqual(
+            RankTier.AliasExact,
+            MainListRanker.ClassifyTier("gh", "GitHub", isFallback: true, isAliasExact: true, matchedLexically: false));
+    }
+
+    [TestMethod]
+    public void ClassifyTier_Fallback_SitsAtTheFloor()
+    {
+        // A fallback that is not an alias-exact match lands on the floor tier regardless of any
+        // lexical match, so dynamic fallbacks appear after direct command/app matches.
+        Assert.AreEqual(
+            RankTier.FallbackFloor,
+            MainListRanker.ClassifyTier("anything", "Some Fallback", isFallback: true, isAliasExact: false, matchedLexically: true));
+    }
+
+    [TestMethod]
+    public void ClassifyTier_ExactTitle()
+    {
+        Assert.AreEqual(
+            RankTier.ExactTitle,
+            MainListRanker.ClassifyTier("calculator", "Calculator", isFallback: false, isAliasExact: false, matchedLexically: true));
+    }
+
+    [TestMethod]
+    public void ClassifyTier_Prefix()
+    {
+        Assert.AreEqual(
+            RankTier.Prefix,
+            MainListRanker.ClassifyTier("cal", "Calculator", isFallback: false, isAliasExact: false, matchedLexically: true));
+    }
+
+    [TestMethod]
+    public void ClassifyTier_WordBoundary()
+    {
+        Assert.AreEqual(
+            RankTier.AcronymWordBoundary,
+            MainListRanker.ClassifyTier("code", "Visual Studio Code", isFallback: false, isAliasExact: false, matchedLexically: true));
+    }
+
+    [TestMethod]
+    public void ClassifyTier_Acronym()
+    {
+        Assert.AreEqual(
+            RankTier.AcronymWordBoundary,
+            MainListRanker.ClassifyTier("vs", "Visual Studio Code", isFallback: false, isAliasExact: false, matchedLexically: true));
+    }
+
+    [TestMethod]
+    public void ClassifyTier_Fuzzy()
+    {
+        // Lexically matched, but not exact/prefix/word-boundary/acronym.
+        Assert.AreEqual(
+            RankTier.Fuzzy,
+            MainListRanker.ClassifyTier("cmd", "Command Prompt", isFallback: false, isAliasExact: false, matchedLexically: true));
+    }
+
+    [TestMethod]
+    public void ClassifyTier_None_WhenNothingMatched()
+    {
+        Assert.AreEqual(
+            RankTier.None,
+            MainListRanker.ClassifyTier("zzz", "Command Prompt", isFallback: false, isAliasExact: false, matchedLexically: false));
+    }
+
+    [TestMethod]
+    public void Pack_HigherTierAlwaysOutranksLowerTier()
+    {
+        // The core invariant: a higher tier with the WORST possible within-tier score still
+        // outranks a lower tier with the BEST possible within-tier score. This is what makes
+        // "an exact match always beats a fuzzy one" true no matter how much frecency piles up.
+        RankTier[] ascending =
+        {
+            RankTier.FallbackFloor,
+            RankTier.Fuzzy,
+            RankTier.AcronymWordBoundary,
+            RankTier.Prefix,
+            RankTier.ExactTitle,
+            RankTier.AliasExact,
+        };
+
+        for (var i = 0; i < ascending.Length - 1; i++)
+        {
+            var lower = MainListRanker.Pack(ascending[i], MainListRanker.TierStride - 1);
+            var higher = MainListRanker.Pack(ascending[i + 1], 0);
+            Assert.IsTrue(
+                higher > lower,
+                $"{ascending[i + 1]} (min within-tier) must outrank {ascending[i]} (max within-tier)");
+        }
+    }
+
+    [TestMethod]
+    public void Pack_NoneIsZeroAndFiltered()
+    {
+        Assert.AreEqual(0, MainListRanker.Pack(RankTier.None, 999_999));
+    }
+
+    [TestMethod]
+    public void Pack_WithinTierScoreIsClampedToItsBand()
+    {
+        // An absurd within-tier score must never spill into the next tier's band.
+        var packed = MainListRanker.Pack(RankTier.Fuzzy, double.MaxValue);
+        Assert.AreEqual(RankTier.Fuzzy, MainListRanker.TierOf(packed));
+
+        var nextTierFloor = MainListRanker.Pack(RankTier.AcronymWordBoundary, 0);
+        Assert.IsTrue(packed < nextTierFloor, "A clamped within-tier score must stay below the next tier");
+    }
+
+    [TestMethod]
+    public void Pack_WithinTierScoreOrdersItemsInTheSameTier()
+    {
+        var low = MainListRanker.Pack(RankTier.Prefix, 10);
+        var high = MainListRanker.Pack(RankTier.Prefix, 20);
+        Assert.IsTrue(high > low, "Within the same tier, a higher within-tier score sorts higher");
+        Assert.AreEqual(MainListRanker.TierOf(low), MainListRanker.TierOf(high), "Both remain in the same tier");
+    }
+
+    [TestMethod]
+    public void TierOf_RoundTripsEveryTier()
+    {
+        foreach (RankTier tier in Enum.GetValues(typeof(RankTier)))
+        {
+            if (tier == RankTier.None)
+            {
+                continue;
+            }
+
+            var packed = MainListRanker.Pack(tier, 42);
+            Assert.AreEqual(tier, MainListRanker.TierOf(packed), $"Packing then unpacking {tier} should round-trip");
+        }
+    }
+
+    [TestMethod]
+    public void WithinTierScore_LexicalQualityLeads()
+    {
+        // More lexical quality raises the within-tier score, all else equal.
+        var lowLexical = MainListRanker.WithinTierScore(lexicalQuality: 5, frecencyWeight: 0, aliasSubstringBonus: 0, providerBonus: 0);
+        var highLexical = MainListRanker.WithinTierScore(lexicalQuality: 6, frecencyWeight: 0, aliasSubstringBonus: 0, providerBonus: 0);
+        Assert.IsTrue(highLexical > lowLexical, "Higher lexical quality should raise the within-tier score");
+    }
+
+    [TestMethod]
+    public void WithinTierScore_FrecencyBreaksTies()
+    {
+        var noFrecency = MainListRanker.WithinTierScore(lexicalQuality: 5, frecencyWeight: 0, aliasSubstringBonus: 0, providerBonus: 0);
+        var withFrecency = MainListRanker.WithinTierScore(lexicalQuality: 5, frecencyWeight: 3, aliasSubstringBonus: 0, providerBonus: 0);
+        Assert.IsTrue(withFrecency > noFrecency, "Frecency should raise the within-tier score for otherwise-equal items");
+    }
+
+    [TestMethod]
+    public void ProviderBonus_LowerIsBelowNormalIsBelowHigher()
+    {
+        Assert.IsTrue(
+            MainListRanker.ProviderBonus(ProviderSearchWeight.Lower) < MainListRanker.ProviderBonus(ProviderSearchWeight.Normal),
+            "Lower should subtract relative to Normal");
+        Assert.IsTrue(
+            MainListRanker.ProviderBonus(ProviderSearchWeight.Normal) < MainListRanker.ProviderBonus(ProviderSearchWeight.Higher),
+            "Higher should add relative to Normal");
+        Assert.AreEqual(0.0, MainListRanker.ProviderBonus(ProviderSearchWeight.Normal), "Normal is the neutral default");
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/RelevanceHarnessTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/RelevanceHarnessTests.cs
@@ -302,7 +302,7 @@ public partial class RelevanceHarnessTests : CommandPaletteUnitTestBase
         // Alias-exact is the strongest, most explicit signal - it beats even a fallback flag.
         Assert.AreEqual(
             RankTier.AliasExact,
-            MainListRanker.ClassifyTier("gh", "GitHub", isFallback: true, isAliasExact: true, matchedLexically: false));
+            MainListRanker.ClassifyTier("gh", "GitHub", isFallback: true, isAliasExact: true, isAliasSubstringMatch: false, matchedLexically: false));
     }
 
     [TestMethod]
@@ -312,7 +312,7 @@ public partial class RelevanceHarnessTests : CommandPaletteUnitTestBase
         // lexical match, so dynamic fallbacks appear after direct command/app matches.
         Assert.AreEqual(
             RankTier.FallbackFloor,
-            MainListRanker.ClassifyTier("anything", "Some Fallback", isFallback: true, isAliasExact: false, matchedLexically: true));
+            MainListRanker.ClassifyTier("anything", "Some Fallback", isFallback: true, isAliasExact: false, isAliasSubstringMatch: false, matchedLexically: true));
     }
 
     [TestMethod]
@@ -320,7 +320,7 @@ public partial class RelevanceHarnessTests : CommandPaletteUnitTestBase
     {
         Assert.AreEqual(
             RankTier.ExactTitle,
-            MainListRanker.ClassifyTier("calculator", "Calculator", isFallback: false, isAliasExact: false, matchedLexically: true));
+            MainListRanker.ClassifyTier("calculator", "Calculator", isFallback: false, isAliasExact: false, isAliasSubstringMatch: false, matchedLexically: true));
     }
 
     [TestMethod]
@@ -328,7 +328,7 @@ public partial class RelevanceHarnessTests : CommandPaletteUnitTestBase
     {
         Assert.AreEqual(
             RankTier.Prefix,
-            MainListRanker.ClassifyTier("cal", "Calculator", isFallback: false, isAliasExact: false, matchedLexically: true));
+            MainListRanker.ClassifyTier("cal", "Calculator", isFallback: false, isAliasExact: false, isAliasSubstringMatch: false, matchedLexically: true));
     }
 
     [TestMethod]
@@ -336,7 +336,7 @@ public partial class RelevanceHarnessTests : CommandPaletteUnitTestBase
     {
         Assert.AreEqual(
             RankTier.AcronymWordBoundary,
-            MainListRanker.ClassifyTier("code", "Visual Studio Code", isFallback: false, isAliasExact: false, matchedLexically: true));
+            MainListRanker.ClassifyTier("code", "Visual Studio Code", isFallback: false, isAliasExact: false, isAliasSubstringMatch: false, matchedLexically: true));
     }
 
     [TestMethod]
@@ -344,7 +344,7 @@ public partial class RelevanceHarnessTests : CommandPaletteUnitTestBase
     {
         Assert.AreEqual(
             RankTier.AcronymWordBoundary,
-            MainListRanker.ClassifyTier("vs", "Visual Studio Code", isFallback: false, isAliasExact: false, matchedLexically: true));
+            MainListRanker.ClassifyTier("vs", "Visual Studio Code", isFallback: false, isAliasExact: false, isAliasSubstringMatch: false, matchedLexically: true));
     }
 
     [TestMethod]
@@ -353,7 +353,7 @@ public partial class RelevanceHarnessTests : CommandPaletteUnitTestBase
         // Lexically matched, but not exact/prefix/word-boundary/acronym.
         Assert.AreEqual(
             RankTier.Fuzzy,
-            MainListRanker.ClassifyTier("cmd", "Command Prompt", isFallback: false, isAliasExact: false, matchedLexically: true));
+            MainListRanker.ClassifyTier("cmd", "Command Prompt", isFallback: false, isAliasExact: false, isAliasSubstringMatch: false, matchedLexically: true));
     }
 
     [TestMethod]
@@ -361,7 +361,18 @@ public partial class RelevanceHarnessTests : CommandPaletteUnitTestBase
     {
         Assert.AreEqual(
             RankTier.None,
-            MainListRanker.ClassifyTier("zzz", "Command Prompt", isFallback: false, isAliasExact: false, matchedLexically: false));
+            MainListRanker.ClassifyTier("zzz", "Command Prompt", isFallback: false, isAliasExact: false, isAliasSubstringMatch: false, matchedLexically: false));
+    }
+
+    [TestMethod]
+    public void ClassifyTier_AliasSubstring_FloorsToFuzzyEvenWithNoLexicalMatch()
+    {
+        // A partial alias match (the alias starts with the query) keeps the item visible at the
+        // Fuzzy floor even when nothing matched lexically. Without this it would fall through to
+        // None and disappear. A stronger title relationship still wins over this floor.
+        Assert.AreEqual(
+            RankTier.Fuzzy,
+            MainListRanker.ClassifyTier("zz", "Some Command", isFallback: false, isAliasExact: false, isAliasSubstringMatch: true, matchedLexically: false));
     }
 
     [TestMethod]

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/RelevanceHarnessTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/RelevanceHarnessTests.cs
@@ -12,55 +12,42 @@ using Microsoft.CmdPal.UI.ViewModels.MainPage;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Windows.Foundation;
 using WyHash;
 
 namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
 
 /// <summary>
-/// Golden-set relevance harness for the main/root page ranker. Every case is expressed as a
+/// End-to-end relevance harness for the main/root page ranker. Every case is expressed as a
 /// realistic query paired with an ordering constraint (rank-1, or "X must rank above Y") and
 /// asserted against the REAL <see cref="MainListPage.ScoreTopLevelItem"/> scoring path, sorted
 /// exactly the way the product sorts (positive scores, descending). The intent is to lock in
 /// "results seem logical and relevant" as an objective, extendable yardstick: to add a new
 /// scenario, drop another entry in the fixture and another constraint in a test.
 ///
-/// This file also carries focused per-tier unit tests for <see cref="MainListRanker"/> that
-/// cover the pieces the golden set cannot easily drive through app/command mocks - alias-exact
-/// and fallback-floor classification, and the packing invariants that guarantee a higher tier
-/// always outranks a lower one regardless of within-tier score.
+/// Focused, per-tier unit tests for the <see cref="MainListRanker"/> primitives live alongside
+/// this harness in <see cref="MainListRankerTests"/>.
 /// </summary>
 [TestClass]
 public partial class RelevanceHarnessTests : CommandPaletteUnitTestBase
 {
-    // A lightweight IListItem stand-in for a top-level command or installed app. Mirrors the
-    // mock used by RecentCommandsTests so the harness exercises the same real scoring path,
-    // not a reimplementation. ProviderId lets a test key a per-provider weight lookup.
-    private sealed partial record ListItemMock(
-        string Title,
-        string? Subtitle = "",
-        string? GivenId = "",
-        string? ProviderId = "") : IListItem
+    // A lightweight top-level-command / installed-app stand-in built on the real ListItem
+    // toolkit type, so the harness drives the same scoring path as the product (as the sibling
+    // RecentCommandsTests does) rather than a reimplementation. ProviderId lets a test key a
+    // per-provider weight lookup; Id is derived deterministically so frecency history can target it.
+    private sealed partial class ListItemMock : ListItem
     {
-        public string Id => string.IsNullOrEmpty(GivenId) ? GenerateId() : GivenId;
+        public ListItemMock(string title, string? subtitle = "", string? givenId = "", string? providerId = "")
+        {
+            Title = title;
+            Subtitle = subtitle ?? string.Empty;
+            ProviderId = providerId ?? string.Empty;
+            Id = string.IsNullOrEmpty(givenId) ? GenerateId() : givenId;
+            Command = new NoOpCommand() { Id = Id };
+        }
 
-        public IDetails Details => throw new NotImplementedException();
+        public string Id { get; }
 
-        public string Section => throw new NotImplementedException();
-
-        public ITag[] Tags => throw new NotImplementedException();
-
-        public string TextToSuggest => throw new NotImplementedException();
-
-        public ICommand Command => new NoOpCommand() { Id = Id };
-
-        public IIconInfo Icon => throw new NotImplementedException();
-
-        public IContextItem[] MoreCommands => throw new NotImplementedException();
-
-#pragma warning disable CS0067
-        public event TypedEventHandler<object, IPropChangedEventArgs>? PropChanged;
-#pragma warning restore CS0067
+        public string ProviderId { get; }
 
         private string GenerateId()
         {
@@ -77,7 +64,7 @@ public partial class RelevanceHarnessTests : CommandPaletteUnitTestBase
     // A representative slice of the main page: installed apps + top-level commands with
     // realistic titles, subtitles and shared prefixes/acronyms. Deliberately includes the
     // "confusable" clusters users complain about (Calc*, Visual Studio *, Command Prompt vs
-    // Control Panel) so the golden constraints below have real competition to beat.
+    // Control Panel) so the ordering constraints below have real competition to beat.
     private static List<ListItemMock> Fixture() => new()
     {
         new("Command Prompt", "Run the classic command interpreter"),
@@ -149,9 +136,9 @@ public partial class RelevanceHarnessTests : CommandPaletteUnitTestBase
             $"Query '{query}' should rank '{higher}' above '{lower}'. Actual order: [{string.Join(", ", ranked)}]");
     }
 
-    // Golden set: the tier ladder, end to end.
+    // End-to-end cases: the tier ladder, exercised through the real scorer.
     [TestMethod]
-    public void Golden_ExactTitleBeatsPrefix()
+    public void EndToEnd_ExactTitleBeatsPrefix()
     {
         // "Paint" is an exact title; "Paint 3D" only has it as a prefix. Exact must win.
         AssertRank1("paint", "Paint");
@@ -159,7 +146,7 @@ public partial class RelevanceHarnessTests : CommandPaletteUnitTestBase
     }
 
     [TestMethod]
-    public void Golden_PrefixBeatsWordBoundary()
+    public void EndToEnd_PrefixBeatsWordBoundary()
     {
         // "co" is a title prefix of Command Prompt and Control Panel, but only a word-boundary
         // match for "Code" inside Visual Studio Code. Prefix outranks word-boundary.
@@ -168,7 +155,7 @@ public partial class RelevanceHarnessTests : CommandPaletteUnitTestBase
     }
 
     [TestMethod]
-    public void Golden_WordBoundaryBeatsFuzzy()
+    public void EndToEnd_WordBoundaryBeatsFuzzy()
     {
         // "man" starts the word "Manager" in Task Manager (word-boundary), but is only a loose
         // subsequence (m..a..n) of "Command Prompt" (fuzzy). Word-boundary must win.
@@ -177,7 +164,7 @@ public partial class RelevanceHarnessTests : CommandPaletteUnitTestBase
     }
 
     [TestMethod]
-    public void Golden_AcronymSurfacesTheRightApp()
+    public void EndToEnd_AcronymSurfacesTheRightApp()
     {
         // "vsc" is the acronym of Visual Studio Code (V-S-C); Visual Studio 2022 (V-S-2) is not
         // a match. The acronym should surface the obviously-right app at rank 1.
@@ -185,7 +172,7 @@ public partial class RelevanceHarnessTests : CommandPaletteUnitTestBase
     }
 
     [TestMethod]
-    public void Golden_ComplaintCase_SingleLetterSurfacesFrecentApp()
+    public void EndToEnd_ComplaintCase_SingleLetterSurfacesFrecentApp()
     {
         // "c" prefixes several apps (Calculator, Calendar, Command Prompt, Control Panel). With
         // no signal they tie; a user who keeps opening Calculator should see it at rank 1. This
@@ -201,21 +188,21 @@ public partial class RelevanceHarnessTests : CommandPaletteUnitTestBase
     }
 
     [TestMethod]
-    public void Golden_ComplaintCase_CodeSurfacesVsCode()
+    public void EndToEnd_ComplaintCase_CodeSurfacesVsCode()
     {
         // Typing "code" should put Visual Studio Code first (word-boundary on "Code").
         AssertRank1("code", "Visual Studio Code");
     }
 
     [TestMethod]
-    public void Golden_ComplaintCase_SetSurfacesSettings()
+    public void EndToEnd_ComplaintCase_SetSurfacesSettings()
     {
         // Typing "set" should put Windows Settings first (word-boundary on "Settings").
         AssertRank1("set", "Windows Settings");
     }
 
     [TestMethod]
-    public void Golden_FrecencyReordersWithinTierOnly()
+    public void EndToEnd_FrecencyReordersWithinTierOnly()
     {
         // Heavy use of Visual Studio Code (a word-boundary match for "co") must NOT lift it over
         // Command Prompt / Control Panel, which are prefix matches a whole tier above it.
@@ -232,7 +219,7 @@ public partial class RelevanceHarnessTests : CommandPaletteUnitTestBase
     }
 
     [TestMethod]
-    public void Golden_FrecencyBreaksTieWithinTier()
+    public void EndToEnd_FrecencyBreaksTieWithinTier()
     {
         // "vs" is an acronym match for both Visual Studio Code and Visual Studio 2022 (same
         // tier). With no history they tie; the recently/repeatedly used one should climb to the
@@ -250,13 +237,13 @@ public partial class RelevanceHarnessTests : CommandPaletteUnitTestBase
     }
 
     [TestMethod]
-    public void Golden_ProviderHigherBreaksAnExactTie()
+    public void EndToEnd_ProviderHigherBreaksAnExactTie()
     {
         // Two providers surface an identically-titled "Settings" command. Everything else being
         // equal (same tier, same lexical quality, no frecency), a provider marked Higher should
         // sort above the Normal one. Provider weight is a within-tier nudge for near-ties only.
-        var alpha = new ListItemMock("Settings", "From provider Alpha", ProviderId: "alpha");
-        var bravo = new ListItemMock("Settings", "From provider Bravo", ProviderId: "bravo");
+        var alpha = new ListItemMock("Settings", "From provider Alpha", providerId: "alpha");
+        var bravo = new ListItemMock("Settings", "From provider Bravo", providerId: "bravo");
         var items = new List<ListItemMock> { alpha, bravo };
 
         var matcher = CreateMatcher();
@@ -283,7 +270,7 @@ public partial class RelevanceHarnessTests : CommandPaletteUnitTestBase
     }
 
     [TestMethod]
-    public void Golden_ProviderWeightCannotCrossTierBoundary()
+    public void EndToEnd_ProviderWeightCannotCrossTierBoundary()
     {
         // Even marked Higher, a word-boundary match (Visual Studio Code for "co") must stay
         // below a prefix match (Command Prompt). Provider weight is clamped within a tier.
@@ -293,181 +280,5 @@ public partial class RelevanceHarnessTests : CommandPaletteUnitTestBase
                 : ProviderSearchWeight.Normal;
 
         AssertRanksAbove("co", "Command Prompt", "Visual Studio Code", providerWeightLookup: boostVsCode);
-    }
-
-    // Per-tier unit tests for MainListRanker.
-    [TestMethod]
-    public void ClassifyTier_AliasExact_WinsEvenOverFallback()
-    {
-        // Alias-exact is the strongest, most explicit signal - it beats even a fallback flag.
-        Assert.AreEqual(
-            RankTier.AliasExact,
-            MainListRanker.ClassifyTier("gh", "GitHub", isFallback: true, isAliasExact: true, isAliasSubstringMatch: false, matchedLexically: false));
-    }
-
-    [TestMethod]
-    public void ClassifyTier_Fallback_SitsAtTheFloor()
-    {
-        // A fallback that is not an alias-exact match lands on the floor tier regardless of any
-        // lexical match, so dynamic fallbacks appear after direct command/app matches.
-        Assert.AreEqual(
-            RankTier.FallbackFloor,
-            MainListRanker.ClassifyTier("anything", "Some Fallback", isFallback: true, isAliasExact: false, isAliasSubstringMatch: false, matchedLexically: true));
-    }
-
-    [TestMethod]
-    public void ClassifyTier_ExactTitle()
-    {
-        Assert.AreEqual(
-            RankTier.ExactTitle,
-            MainListRanker.ClassifyTier("calculator", "Calculator", isFallback: false, isAliasExact: false, isAliasSubstringMatch: false, matchedLexically: true));
-    }
-
-    [TestMethod]
-    public void ClassifyTier_Prefix()
-    {
-        Assert.AreEqual(
-            RankTier.Prefix,
-            MainListRanker.ClassifyTier("cal", "Calculator", isFallback: false, isAliasExact: false, isAliasSubstringMatch: false, matchedLexically: true));
-    }
-
-    [TestMethod]
-    public void ClassifyTier_WordBoundary()
-    {
-        Assert.AreEqual(
-            RankTier.AcronymWordBoundary,
-            MainListRanker.ClassifyTier("code", "Visual Studio Code", isFallback: false, isAliasExact: false, isAliasSubstringMatch: false, matchedLexically: true));
-    }
-
-    [TestMethod]
-    public void ClassifyTier_Acronym()
-    {
-        Assert.AreEqual(
-            RankTier.AcronymWordBoundary,
-            MainListRanker.ClassifyTier("vs", "Visual Studio Code", isFallback: false, isAliasExact: false, isAliasSubstringMatch: false, matchedLexically: true));
-    }
-
-    [TestMethod]
-    public void ClassifyTier_Fuzzy()
-    {
-        // Lexically matched, but not exact/prefix/word-boundary/acronym.
-        Assert.AreEqual(
-            RankTier.Fuzzy,
-            MainListRanker.ClassifyTier("cmd", "Command Prompt", isFallback: false, isAliasExact: false, isAliasSubstringMatch: false, matchedLexically: true));
-    }
-
-    [TestMethod]
-    public void ClassifyTier_None_WhenNothingMatched()
-    {
-        Assert.AreEqual(
-            RankTier.None,
-            MainListRanker.ClassifyTier("zzz", "Command Prompt", isFallback: false, isAliasExact: false, isAliasSubstringMatch: false, matchedLexically: false));
-    }
-
-    [TestMethod]
-    public void ClassifyTier_AliasSubstring_FloorsToFuzzyEvenWithNoLexicalMatch()
-    {
-        // A partial alias match (the alias starts with the query) keeps the item visible at the
-        // Fuzzy floor even when nothing matched lexically. Without this it would fall through to
-        // None and disappear. A stronger title relationship still wins over this floor.
-        Assert.AreEqual(
-            RankTier.Fuzzy,
-            MainListRanker.ClassifyTier("zz", "Some Command", isFallback: false, isAliasExact: false, isAliasSubstringMatch: true, matchedLexically: false));
-    }
-
-    [TestMethod]
-    public void Pack_HigherTierAlwaysOutranksLowerTier()
-    {
-        // The core invariant: a higher tier with the WORST possible within-tier score still
-        // outranks a lower tier with the BEST possible within-tier score. This is what makes
-        // "an exact match always beats a fuzzy one" true no matter how much frecency piles up.
-        RankTier[] ascending =
-        {
-            RankTier.FallbackFloor,
-            RankTier.Fuzzy,
-            RankTier.AcronymWordBoundary,
-            RankTier.Prefix,
-            RankTier.ExactTitle,
-            RankTier.AliasExact,
-        };
-
-        for (var i = 0; i < ascending.Length - 1; i++)
-        {
-            var lower = MainListRanker.Pack(ascending[i], MainListRanker.TierStride - 1);
-            var higher = MainListRanker.Pack(ascending[i + 1], 0);
-            Assert.IsTrue(
-                higher > lower,
-                $"{ascending[i + 1]} (min within-tier) must outrank {ascending[i]} (max within-tier)");
-        }
-    }
-
-    [TestMethod]
-    public void Pack_NoneIsZeroAndFiltered()
-    {
-        Assert.AreEqual(0, MainListRanker.Pack(RankTier.None, 999_999));
-    }
-
-    [TestMethod]
-    public void Pack_WithinTierScoreIsClampedToItsBand()
-    {
-        // An absurd within-tier score must never spill into the next tier's band.
-        var packed = MainListRanker.Pack(RankTier.Fuzzy, double.MaxValue);
-        Assert.AreEqual(RankTier.Fuzzy, MainListRanker.TierOf(packed));
-
-        var nextTierFloor = MainListRanker.Pack(RankTier.AcronymWordBoundary, 0);
-        Assert.IsTrue(packed < nextTierFloor, "A clamped within-tier score must stay below the next tier");
-    }
-
-    [TestMethod]
-    public void Pack_WithinTierScoreOrdersItemsInTheSameTier()
-    {
-        var low = MainListRanker.Pack(RankTier.Prefix, 10);
-        var high = MainListRanker.Pack(RankTier.Prefix, 20);
-        Assert.IsTrue(high > low, "Within the same tier, a higher within-tier score sorts higher");
-        Assert.AreEqual(MainListRanker.TierOf(low), MainListRanker.TierOf(high), "Both remain in the same tier");
-    }
-
-    [TestMethod]
-    public void TierOf_RoundTripsEveryTier()
-    {
-        foreach (RankTier tier in Enum.GetValues(typeof(RankTier)))
-        {
-            if (tier == RankTier.None)
-            {
-                continue;
-            }
-
-            var packed = MainListRanker.Pack(tier, 42);
-            Assert.AreEqual(tier, MainListRanker.TierOf(packed), $"Packing then unpacking {tier} should round-trip");
-        }
-    }
-
-    [TestMethod]
-    public void WithinTierScore_LexicalQualityLeads()
-    {
-        // More lexical quality raises the within-tier score, all else equal.
-        var lowLexical = MainListRanker.WithinTierScore(lexicalQuality: 5, frecencyWeight: 0, aliasSubstringBonus: 0, providerBonus: 0);
-        var highLexical = MainListRanker.WithinTierScore(lexicalQuality: 6, frecencyWeight: 0, aliasSubstringBonus: 0, providerBonus: 0);
-        Assert.IsTrue(highLexical > lowLexical, "Higher lexical quality should raise the within-tier score");
-    }
-
-    [TestMethod]
-    public void WithinTierScore_FrecencyBreaksTies()
-    {
-        var noFrecency = MainListRanker.WithinTierScore(lexicalQuality: 5, frecencyWeight: 0, aliasSubstringBonus: 0, providerBonus: 0);
-        var withFrecency = MainListRanker.WithinTierScore(lexicalQuality: 5, frecencyWeight: 3, aliasSubstringBonus: 0, providerBonus: 0);
-        Assert.IsTrue(withFrecency > noFrecency, "Frecency should raise the within-tier score for otherwise-equal items");
-    }
-
-    [TestMethod]
-    public void ProviderBonus_LowerIsBelowNormalIsBelowHigher()
-    {
-        Assert.IsTrue(
-            MainListRanker.ProviderBonus(ProviderSearchWeight.Lower) < MainListRanker.ProviderBonus(ProviderSearchWeight.Normal),
-            "Lower should subtract relative to Normal");
-        Assert.IsTrue(
-            MainListRanker.ProviderBonus(ProviderSearchWeight.Normal) < MainListRanker.ProviderBonus(ProviderSearchWeight.Higher),
-            "Higher should add relative to Normal");
-        Assert.AreEqual(0.0, MainListRanker.ProviderBonus(ProviderSearchWeight.Normal), "Normal is the neutral default");
     }
 }


### PR DESCRIPTION
>[!WARNING]
> This PR is one in a series of PRs focused on rearchitecting the search/scoring logic of the `MainListPage`. An explanation of the entire search/scoring logic can be found in the first PR of the change (#49189).
> 
> **This PR should not be merged until PR #49197 is merged into it.**

## Phase 5 of the CmdPal search overhaul (stacked)

Stacked PR. Base is `dev/mjolley/dev-mjolley-fast-first-paint` (phase 4), not `main`. Keep as a draft; the human marks it ready.

### What this adds
A golden-set relevance test harness that locks in main/root-page ranking quality and guards against regressions. It is the objective yardstick for "results seem logical and relevant." Test-only: no product code changed.

New file: `Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/RelevanceHarnessTests.cs`.

**Golden set (11 cases)** - each drives the REAL `MainListPage.ScoreTopLevelItem` over a representative fixture of apps + top-level commands, sorts exactly the way the product does (positive scores, descending, mirroring `InternalListHelpers.FilterListWithScores` / the existing `RecentCommandsTests.GetMatches`), and asserts ordering via readable `AssertRank1(query, expected)` / `AssertRanksAbove(query, higher, lower)` helpers. Easy to extend: add a fixture item and another constraint.
- Tier ladder end to end: exact > prefix > acronym/word-boundary > fuzzy (`paint`, `co`, `man`).
- Acronym surfaces the right app (`vsc` -> Visual Studio Code).
- Frecency reorders WITHIN a tier only, never across (heavy use of a word-boundary match still sits below a prefix match for `co`).
- Frecency breaks a within-tier tie (`vs` -> the used Visual Studio wins).
- Per-provider Higher breaks an otherwise exact tie, and CANNOT cross a tier boundary.
- Realistic "this was the complaint" cases: `c` (frecent Calculator at rank 1), `code`, `set`.

**Per-tier ranker unit tests (16)** for `MainListRanker` - the pieces the golden set cannot easily drive through mocks:
- `ClassifyTier` boundaries incl. alias-exact (beats fallback) and fallback-floor.
- `Pack` monotonicity: a higher tier with the worst within-tier score still outranks a lower tier with the best within-tier score.
- Within-tier clamping (an absurd score never spills into the next tier), within-tier ordering, `TierOf` round-trip.
- `WithinTierScore` ordering (lexical leads, frecency breaks ties) and `ProviderBonus` sign (Lower < Normal < Higher).

### Determinism
Frecency cases inject uses through the phase-2 `WithHistoryItem` seam; no reliance on real extensions, registry, wall-clock, or machine state.

### Test results (x64 host on this ARM64 box)
- `Microsoft.CmdPal.UI.ViewModels.UnitTests`: 190/190 pass (27 new here: 11 golden + 16 per-tier).
- All other CmdPal `*.UnitTests`: green (Common 225, Apps 28, Bookmarks 222, Indexer 35, Registry 66, RemoteDesktop 26, Shell 124/+1 skip, System 21, TimeDate 301, WebSearch 10, Toolkit 645/+1 skip).
- `WindowWalker`: "Zero tests ran" - known pre-existing, ignored per plan.

### Findings for human review
None. Every golden case matched the current ranker's behavior on the first run - no ranking bug surfaced, so nothing was changed and no case had to encode a known-bad ordering. If a future fixture reveals a genuine defect, prefer documenting it and asserting current behavior over silently changing ranking.

