### PR TITLE
CmdPal: Fix stale fallback scores by re-scoring global fallbacks at read time

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
@@ -63,10 +63,14 @@ public sealed partial class MainListPage : DynamicListPage,
     private RoScored<IListItem>[]? _filteredItems;
     private RoScored<IListItem>[]? _filteredApps;
 
-    // Keep as IEnumerable for deferred execution. Fallback item titles are updated
-    // asynchronously, so scoring must happen lazily when GetItems is called.
-    private IEnumerable<RoScored<IListItem>>? _scoredFallbackItems;
-    private IEnumerable<RoScored<IListItem>>? _fallbackItems;
+    // Global fallback titles are updated asynchronously while a query is active, so their
+    // title-based scores go stale. Keep the unscored candidates and re-score on every GetItems.
+    private TopLevelViewModel[]? _globalFallbackCandidates;
+
+    private RoScored<IListItem>[]? _fallbackItems;
+
+    private FuzzyQuery _searchQuery;
+    private IPrecomputedFuzzyMatcher _queryMatcher;
 
     private bool _includeApps;
     private bool _filteredItemsIncludesApps;
@@ -100,7 +104,8 @@ public sealed partial class MainListPage : DynamicListPage,
         _appStateService = appStateService;
         _tlcManager = topLevelCommandManager;
         _fuzzyMatcherProvider = fuzzyMatcherProvider;
-        _scoringFunction = (in query, item) => ScoreTopLevelItem(in query, item, _appStateService.State.RecentCommands, _fuzzyMatcherProvider.Current);
+        _queryMatcher = fuzzyMatcherProvider.Current;
+        _scoringFunction = (in query, item) => ScoreTopLevelItem(in query, item, _appStateService.State.RecentCommands, _queryMatcher);
         _fallbackScoringFunction = (in _, item) => ScoreFallbackItem(item, _settingsService.Settings.FallbackRanks);
 
         _tlcManager.PropertyChanged += TlcManager_PropertyChanged;
@@ -259,9 +264,9 @@ public sealed partial class MainListPage : DynamicListPage,
 
     private IListItem[] GetSearchViewItems()
     {
-        var validScoredFallbacks = _scoredFallbackItems?
-            .Where(s => !string.IsNullOrWhiteSpace(s.Item.Title))
-            .ToList();
+        // Re-score global fallbacks on every read so late-arriving titles get fresh scores
+        var scoredFallbacks = InternalListHelpers.FilterListWithScores<IListItem>(
+            _globalFallbackCandidates, in _searchQuery, _scoringFunction);
 
         var validFallbacks = _fallbackItems?
             .Where(s => !string.IsNullOrWhiteSpace(s.Item.Title))
@@ -269,7 +274,7 @@ public sealed partial class MainListPage : DynamicListPage,
 
         return MainListPageResultFactory.Create(
             _filteredItems,
-            validScoredFallbacks,
+            scoredFallbacks,
             _filteredApps,
             validFallbacks,
             _resultsSeparator,
@@ -362,7 +367,7 @@ public sealed partial class MainListPage : DynamicListPage,
         _filteredItems = null;
         _filteredApps = null;
         _fallbackItems = null;
-        _scoredFallbackItems = null;
+        _globalFallbackCandidates = null;
     }
 
     public override void UpdateSearchText(string oldSearch, string newSearch)
@@ -562,7 +567,9 @@ public sealed partial class MainListPage : DynamicListPage,
                 }
             }
 
-            var searchQuery = _fuzzyMatcherProvider.Current.PrecomputeQuery(SearchText);
+            _queryMatcher = _fuzzyMatcherProvider.Current;
+            var searchQuery = _queryMatcher.PrecomputeQuery(SearchText);
+            _searchQuery = searchQuery;
 
             // Produce a list of everything that matches the current filter.
             _filteredItems = InternalListHelpers.FilterListWithScores(newFilteredItems, searchQuery, _scoringFunction);
@@ -572,8 +579,8 @@ public sealed partial class MainListPage : DynamicListPage,
                 return;
             }
 
-            IEnumerable<IListItem> newFallbacksForScoring = commands.Where(s => s.IsFallback && configuredGlobalFallbackIds.Contains(s.Id));
-            _scoredFallbackItems = InternalListHelpers.FilterListWithScores(newFallbacksForScoring, searchQuery, _scoringFunction);
+            // Global fallbacks are scored at read time in GetSearchViewItems; just snapshot them.
+            _globalFallbackCandidates = [.. specialFallbacks];
 
             if (token.IsCancellationRequested)
             {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPageResultFactory.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPageResultFactory.cs
@@ -39,16 +39,16 @@ internal static class MainListPageResultFactory
         // Apps are pre-sorted, so we just need to take the top N, limited by appResultLimit.
         int len3 = Math.Min(filteredApps?.Count ?? 0, appResultLimit);
 
-        int nonEmptyFallbackCount = fallbackItems?.Count ?? 0;
+        int fallbackCount = fallbackItems?.Count ?? 0;
 
         // Allocate the exact size of the result array.
         // We'll add an extra slot for the fallbacks section header if needed,
         // and another for the "Results" section header when merged results exist.
         int mergedCount = len1 + len2 + len3;
         bool needsResultsHeader = mergedCount > 0;
-        int totalCount = mergedCount + nonEmptyFallbackCount
+        int totalCount = mergedCount + fallbackCount
             + (needsResultsHeader ? 1 : 0)
-            + (nonEmptyFallbackCount > 0 ? 1 : 0);
+            + (fallbackCount > 0 ? 1 : 0);
 
         var result = new IListItem[totalCount];
 
@@ -158,25 +158,9 @@ internal static class MainListPageResultFactory
             }
         }
 
-        return result;
-    }
-
-    private static int GetNonEmptyFallbackItemsCount(IList<RoScored<IListItem>>? fallbackItems)
-    {
-        int fallbackItemsCount = 0;
-
-        if (fallbackItems is not null)
-        {
-            for (int i = 0; i < fallbackItems.Count; i++)
-            {
-                if (!string.IsNullOrWhiteSpace(fallbackItems[i].Item.Title))
-                {
-                    fallbackItemsCount++;
-                }
-            }
-        }
-
-        return fallbackItemsCount;
+        // Fallback titles can be cleared by background updates between sizing and the append
+        // loop above; trim any unwritten tail so callers never see null slots.
+        return writePos == totalCount ? result : result[..writePos];
     }
 }
 #pragma warning restore IDE0007 // Use implicit type

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/MainListPageResultFactoryTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/MainListPageResultFactoryTests.cs
@@ -232,6 +232,32 @@ public partial class MainListPageResultFactoryTests
     }
 
     [TestMethod]
+    public void Merge_FallbackTitleClearedConcurrently_ResultHasNoNullSlots()
+    {
+        // Simulates a background fallback update clearing a title after the caller's
+        // visibility filter ran: the array is sized for both items but only one is written.
+        var fallbacks = new List<RoScored<IListItem>>
+        {
+            S("FB1", 0),
+            S(string.Empty, 0),
+        };
+
+        var result = MainListPageResultFactory.Create(
+            null,
+            null,
+            null,
+            fallbacks,
+            _resultsSeparator,
+            _fallbacksSeparator,
+            appResultLimit: 10);
+
+        CollectionAssert.AllItemsAreNotNull(result);
+        Assert.AreEqual(2, result.Length);
+        Assert.AreEqual("Fallbacks", result[0].Title);
+        Assert.AreEqual("FB1", result[1].Title);
+    }
+
+    [TestMethod]
     public void Merge_HandlesNullLists()
     {
         var result = MainListPageResultFactory.Create(


### PR DESCRIPTION
## Summary of the Pull Request

This PR fixes issue with search scores of fallback items being stale and calculated from the old value.

- Replaces eager scoring of global fallback items with re-scoring on every GetItems call, so asynchronously updated titles get fresh scores and items with momentarily empty titles are no longer dropped for the rest of the query
- Captures the fuzzy query together with the matcher that precomputed it, so read-time scoring always uses a schema-consistent query/target pair even if settings hot-swap the matcher
- Reuses the already prefiltered global fallback list instead of recomputing it with a second LINQ pass
- Trims the result array in MainListPageResultFactory when a concurrently cleared title reduces the written item count, so callers never see null slots
- Removes the dead GetNonEmptyFallbackItemsCount helper and corrects the misleading deferred-execution comments on the fallback fields
- Adds a factory test covering a fallback title cleared between visibility filtering and the merge
- Changes the type of `_fallbackItems` from `IEnumerable` to an array to emphasize that it is not lazily evaluated. There is no change in semantics; the list was already materialized. This only changes the type to make that explicit to developers.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #46547
- [x] Closes: #46365
- [x] Ensures: world peace
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

