### PR TITLE
feat(shortcut-guide): add Claude Desktop manifest

### DIFF
--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/Assets/ShortcutGuide/Manifests/Anthropic.Claude.en-US.yml
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/Assets/ShortcutGuide/Manifests/Anthropic.Claude.en-US.yml
@@ -54,7 +54,7 @@ Shortcuts:
             Shift: false
             Alt: true
             Keys:
-              - '<Space>'
+              - "<Space>"
 
   - SectionName: In chats
     Properties:

--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/Assets/ShortcutGuide/Manifests/Anthropic.Claude.en-US.yml
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/Assets/ShortcutGuide/Manifests/Anthropic.Claude.en-US.yml
@@ -1,0 +1,108 @@
+PackageName: Anthropic.Claude
+Name: Claude
+WindowFilter: "Claude.exe"
+BackgroundProcess: false
+Shortcuts:
+  - SectionName: General
+    Properties:
+      - Name: Quick chat or search
+        Recommended: true
+        Shortcut:
+          - Win: false
+            Ctrl: true
+            Shift: false
+            Alt: false
+            Keys:
+              - K
+      - Name: Incognito chat
+        Shortcut:
+          - Win: false
+            Ctrl: true
+            Shift: true
+            Alt: false
+            Keys:
+              - I
+      - Name: Toggle sidebar
+        Shortcut:
+          - Win: false
+            Ctrl: true
+            Shift: false
+            Alt: false
+            Keys:
+              - .
+      - Name: Keyboard shortcuts
+        Shortcut:
+          - Win: false
+            Ctrl: true
+            Shift: false
+            Alt: false
+            Keys:
+              - /
+      - Name: Settings
+        Shortcut:
+          - Win: false
+            Ctrl: true
+            Shift: true
+            Alt: false
+            Keys:
+              - ','
+      - Name: Open Claude from anywhere
+        Recommended: true
+        Shortcut:
+          - Win: false
+            Ctrl: true
+            Shift: false
+            Alt: true
+            Keys:
+              - '<Space>'
+
+  - SectionName: In chats
+    Properties:
+      - Name: Send message
+        Shortcut:
+          - Win: false
+            Ctrl: false
+            Shift: false
+            Alt: false
+            Keys:
+              - '<Enter>'
+      - Name: New line in message
+        Shortcut:
+          - Win: false
+            Ctrl: false
+            Shift: true
+            Alt: false
+            Keys:
+              - '<Enter>'
+      - Name: Toggle extended thinking
+        Shortcut:
+          - Win: false
+            Ctrl: true
+            Shift: true
+            Alt: false
+            Keys:
+              - E
+      - Name: Upload file
+        Shortcut:
+          - Win: false
+            Ctrl: true
+            Shift: false
+            Alt: false
+            Keys:
+              - U
+      - Name: Open in external editor
+        Shortcut:
+          - Win: false
+            Ctrl: true
+            Shift: false
+            Alt: false
+            Keys:
+              - G
+      - Name: Stop Claude's response
+        Shortcut:
+          - Win: false
+            Ctrl: false
+            Shift: false
+            Alt: false
+            Keys:
+              - '<Esc>'

--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/Assets/ShortcutGuide/Manifests/Anthropic.Claude.en-US.yml
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/Assets/ShortcutGuide/Manifests/Anthropic.Claude.en-US.yml
@@ -65,7 +65,7 @@ Shortcuts:
             Shift: false
             Alt: false
             Keys:
-              - '<Enter>'
+              - "<Enter>"
       - Name: New line in message
         Shortcut:
           - Win: false
@@ -73,7 +73,7 @@ Shortcuts:
             Shift: true
             Alt: false
             Keys:
-              - '<Enter>'
+              - "<Enter>"
       - Name: Toggle extended thinking
         Shortcut:
           - Win: false
@@ -105,4 +105,4 @@ Shortcuts:
             Shift: false
             Alt: false
             Keys:
-              - '<Esc>'
+              - "<Escape>"


### PR DESCRIPTION
## Summary of the Pull Request
Adds a Shortcut Guide manifest for Claude Desktop (Claude.exe), covering
General (quick chat/search, incognito chat, sidebar toggle, keyboard
shortcuts, settings, open-from-anywhere) and In-chat actions (send, new
line, extended thinking toggle, file upload, stop generation), pulled
directly from the app's own in-app "Keyboard shortcuts" panel (Ctrl+/
inside Claude Desktop).

## PR Checklist

- [x] Closes: #49237
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments
Note: the "Open Claude from anywhere" global hotkey (Ctrl+Alt+Space) is
included since it's shown live in the app's shortcut panel on Windows,
though I haven't found it documented on support.claude.com as of this
writing — worth flagging in case Anthropic's docs are just behind.

Tests/Localization/Dev docs/New binaries/Documentation: N/A — this is a
data-only YAML manifest addition, no code changes, following the same
shape as the merged Postman manifest (#48461).

## Validation Steps Performed
Tested manually against a live build of Shortcut Guide with Claude
Desktop focused. Confirmed the Claude section renders with both
categories, and recommended shortcuts (Quick chat/search, Open Claude
from anywhere) are pinned at top. Screenshot attached below.

<img width="547" height="913" alt="Claude_Shortcut_Guide" src="https://github.com/user-attachments/assets/cd4b17ab-058b-4a64-ade9-e34122aa1eab" />
