### PR TITLE
[CmdPal] Phase 7b: parallel + off-lock search scoring throughput

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.Common/Helpers/InternalListHelpers.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Common/Helpers/InternalListHelpers.cs
@@ -60,6 +60,90 @@ public static partial class InternalListHelpers
         }
     }
 
+    // Minimum item count before the parallel path is worth its partitioning/merge overhead.
+    // Below this the serial path wins, so commands (hundreds) and small app sets stay serial.
+    private const int ParallelScoringThreshold = 512;
+
+    /// <summary>
+    /// Order-preserving parallel variant of <see cref="FilterListWithScores{T}"/>. Partitions the
+    /// input into contiguous index ranges, scores each range on a separate thread, then
+    /// concatenates the per-partition matched items back in partition order. This produces a
+    /// pre-sort buffer BYTE-IDENTICAL to the serial path (matched items in original enumeration
+    /// order), so the subsequent <see cref="Array.Sort(Array, int, int, IComparer)"/> - which is
+    /// deterministic for a given input - yields the exact same ordered result. The scoring
+    /// function must be pure over each item (each item is scored by exactly one thread, so any
+    /// per-item cached state is never touched concurrently). Falls back to the serial path for
+    /// small inputs where partitioning would not pay off.
+    /// </summary>
+    public static RoScored<T>[] FilterListWithScoresParallel<T>(
+        IReadOnlyList<T>? items,
+        in FuzzyQuery query,
+        in ScoringFunction<T> scoreFunction)
+    {
+        if (items is null || items.Count == 0)
+        {
+            return [];
+        }
+
+        var count = items.Count;
+        var partitions = Math.Min(Environment.ProcessorCount, Math.Max(1, count / ParallelScoringThreshold));
+
+        if (count < ParallelScoringThreshold || partitions <= 1)
+        {
+            return FilterListWithScores(items, query, scoreFunction);
+        }
+
+        // Copy the by-ref parameters into locals so they can be captured by the parallel body.
+        // FuzzyQuery is an immutable value read concurrently (never mutated), so sharing one copy
+        // across threads is safe.
+        var q = query;
+        var fn = scoreFunction;
+        var source = items;
+
+        var partitionResults = new List<RoScored<T>>[partitions];
+
+        System.Threading.Tasks.Parallel.For(0, partitions, p =>
+        {
+            var start = (int)((long)p * count / partitions);
+            var end = (int)((long)(p + 1) * count / partitions);
+
+            var local = new List<RoScored<T>>(end - start);
+            for (var i = start; i < end; i++)
+            {
+                var item = source[i];
+                var score = fn(in q, item);
+                if (score > 0)
+                {
+                    local.Add(new RoScored<T>(item, score));
+                }
+            }
+
+            partitionResults[p] = local;
+        });
+
+        var total = 0;
+        for (var p = 0; p < partitions; p++)
+        {
+            total += partitionResults[p].Count;
+        }
+
+        // Concatenate partitions in order. Contiguous ranges merged in partition order reproduce
+        // the exact original enumeration order of the matched items, matching the serial buffer.
+        var buffer = GC.AllocateUninitializedArray<RoScored<T>>(total);
+        var pos = 0;
+        for (var p = 0; p < partitions; p++)
+        {
+            var list = partitionResults[p];
+            for (var j = 0; j < list.Count; j++)
+            {
+                buffer[pos++] = list[j];
+            }
+        }
+
+        Array.Sort(buffer, 0, total, default(RoScoredDescendingComparer<T>));
+        return buffer;
+    }
+
     private static void GrowBuffer<T>(ref RoScored<T>[] buffer, int count)
     {
         var newBuffer = ArrayPool<RoScored<T>>.Shared.Rent(buffer.Length * 2);

--- a/src/modules/cmdpal/Microsoft.CmdPal.Common/Helpers/InternalListHelpers.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Common/Helpers/InternalListHelpers.cs
@@ -60,20 +60,15 @@ public static partial class InternalListHelpers
         }
     }
 
-    // Minimum item count before the parallel path is worth its partitioning/merge overhead.
-    // Below this the serial path wins, so commands (hundreds) and small app sets stay serial.
+    // Minimum item count before the parallel path earns back its partitioning and merge overhead,
+    // which keeps commands and small app sets on the serial path.
     private const int ParallelScoringThreshold = 512;
 
     /// <summary>
-    /// Order-preserving parallel variant of <see cref="FilterListWithScores{T}"/>. Partitions the
-    /// input into contiguous index ranges, scores each range on a separate thread, then
-    /// concatenates the per-partition matched items back in partition order. This produces a
-    /// pre-sort buffer BYTE-IDENTICAL to the serial path (matched items in original enumeration
-    /// order), so the subsequent <see cref="Array.Sort(Array, int, int, IComparer)"/> - which is
-    /// deterministic for a given input - yields the exact same ordered result. The scoring
-    /// function must be pure over each item (each item is scored by exactly one thread, so any
-    /// per-item cached state is never touched concurrently). Falls back to the serial path for
-    /// small inputs where partitioning would not pay off.
+    /// Order-preserving parallel variant of <see cref="FilterListWithScores{T}"/> that scores
+    /// contiguous index ranges on separate threads and concatenates them back in partition order,
+    /// producing a pre-sort buffer identical to the serial path. The scoring function has to be
+    /// pure per item, since each item is scored by exactly one thread.
     /// </summary>
     public static RoScored<T>[] FilterListWithScoresParallel<T>(
         IReadOnlyList<T>? items,
@@ -93,9 +88,8 @@ public static partial class InternalListHelpers
             return FilterListWithScores(items, query, scoreFunction);
         }
 
-        // Copy the by-ref parameters into locals so they can be captured by the parallel body.
-        // FuzzyQuery is an immutable value read concurrently (never mutated), so sharing one copy
-        // across threads is safe.
+        // Copy the by-ref parameters into locals so the parallel body can capture them. FuzzyQuery
+        // is immutable, so one shared copy is safe to read from every thread.
         var q = query;
         var fn = scoreFunction;
         var source = items;
@@ -127,8 +121,8 @@ public static partial class InternalListHelpers
             total += partitionResults[p].Count;
         }
 
-        // Concatenate partitions in order. Contiguous ranges merged in partition order reproduce
-        // the exact original enumeration order of the matched items, matching the serial buffer.
+        // Contiguous ranges merged in partition order reproduce the serial buffer's exact
+        // enumeration order.
         var buffer = GC.AllocateUninitializedArray<RoScored<T>>(total);
         var pos = 0;
         for (var p = 0; p < partitions; p++)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
@@ -639,9 +639,36 @@ public sealed partial class MainListPage : DynamicListPage,
         // ===== SCORING PHASE (OFF the lock) =====
         // The dominant apps pass is parallelized; commands and fallbacks stay serial. All of this
         // now runs without holding the TopLevelCommands lock, so it no longer blocks GetItems()/render.
-        var searchQuery = _fuzzyMatcherProvider.Current.PrecomputeQuery(SearchText);
+        //
+        // Snapshot every input the scoring pass depends on into immutable locals, ONCE, before any
+        // item is scored. The live fields (_appStateService.State.RecentCommands,
+        // _fuzzyMatcherProvider.Current, _settingsService.Settings) can be swapped concurrently - a
+        // selection calls WithHistoryItem on another thread - so re-reading them per item could mix
+        // two frecency snapshots in one pass or, worse, let a parallel thread observe a fresh,
+        // unwarmed history index and race on its lazy dictionary build. Capturing here pins one
+        // consistent context; each captured value equals what the first scored item would have read,
+        // so the settled order is unchanged (ScoringParallelEquivalenceTests is the guardrail).
+        var recent = _appStateService.State.RecentCommands;
+        recent.PrewarmIndex();
+        var matcher = _fuzzyMatcherProvider.Current;
+        var settings = _settingsService.Settings;
+        var scoringNow = DateTimeOffset.UtcNow;
 
-        var scoredFilteredItems = InternalListHelpers.FilterListWithScores(itemsSource, searchQuery, _scoringFunction);
+        var searchQuery = matcher.PrecomputeQuery(SearchText);
+
+        // Commands resolve their per-provider weight from the captured settings. Every installed app
+        // belongs to the well-known AllApps provider, so its weight is constant across the whole apps
+        // pass - resolve it once here instead of repeating a dictionary lookup for every app.
+        var appsProviderWeight = ResolveProviderSearchWeight(settings, AllAppsCommandProvider.WellKnownId);
+        Func<IListItem, ProviderSearchWeight> commandsProviderLookup = item => ResolveProviderSearchWeight(settings, item);
+        Func<IListItem, ProviderSearchWeight> appsProviderLookup = _ => appsProviderWeight;
+
+        ScoringFunction<IListItem> commandsScorer = (in FuzzyQuery q, IListItem item) =>
+            ScoreTopLevelItem(in q, item, recent, matcher, commandsProviderLookup, scoringNow);
+        ScoringFunction<IListItem> appsScorer = (in FuzzyQuery q, IListItem item) =>
+            ScoreTopLevelItem(in q, item, recent, matcher, appsProviderLookup, scoringNow);
+
+        var scoredFilteredItems = InternalListHelpers.FilterListWithScores(itemsSource, searchQuery, commandsScorer);
 
         if (token.IsCancellationRequested)
         {
@@ -658,11 +685,7 @@ public sealed partial class MainListPage : DynamicListPage,
         RoScored<IListItem>[]? scoredApps = null;
         if (appsSource.Count > 0)
         {
-            // Build the frecency lookup once, single-threaded, before the parallel pass reads it.
-            // The lazy dictionary build in RecentCommandsManager is not thread-safe.
-            _appStateService.State.RecentCommands.PrewarmIndex();
-
-            scoredApps = InternalListHelpers.FilterListWithScoresParallel(appsSource, searchQuery, _scoringFunction);
+            scoredApps = InternalListHelpers.FilterListWithScoresParallel(appsSource, searchQuery, appsScorer);
 
             if (token.IsCancellationRequested)
             {
@@ -675,6 +698,12 @@ public sealed partial class MainListPage : DynamicListPage,
 #endif
 
         // ===== PUBLISH PHASE (under lock): atomic swap, supersede-safe =====
+        // Keep the critical section to the field swaps only. Scheduling work (telemetry debounce and
+        // the refresh throttle) is done AFTER releasing the lock so we no longer nest
+        // _searchTelemetryLock under the commands lock, nor hold the TopLevelCommands lock across
+        // that bookkeeping. Only the deterministic result count is captured here for the post-lock
+        // telemetry payload.
+        var deterministicResultCount = 0;
         lock (commands)
         {
             // A newer keystroke cancels this token before doing its own work, so a stale snapshot's
@@ -702,40 +731,43 @@ public sealed partial class MainListPage : DynamicListPage,
             // null so a rebuild clears any stale set - matching the previous ClearResults behavior.
             _filteredApps = appsSource.Count > 0 ? scoredApps : null;
 
-            // Queue a settled-search telemetry event. This measures the deterministic first-paint
-            // results (commands + capped apps) and the latency to produce them, at this boundary -
-            // never inside the per-item scoring loop. The event is debounced so it is emitted only
-            // when the query settles, not on every keystroke, and it carries the query LENGTH only.
             if (isUserInput)
             {
-                var deterministicResultCount = (_filteredItems?.Length ?? 0)
+                deterministicResultCount = (_filteredItems?.Length ?? 0)
                     + Math.Min(_filteredApps?.Length ?? 0, AppResultLimit);
-                _searchTelemetry.QueueSearchResults(newSearch.Length, deterministicResultCount, stopwatch.ElapsedMilliseconds);
-            }
-
-            if (isUserInput)
-            {
-                // Make sure that the throttle delay is consistent from the user's perspective, even if filtering
-                // takes a long time. If we always use the full throttle duration, then a slow filter could make the UI feel sluggish.
-                var adjustedInterval = RaiseItemsChangedThrottleForUserInput - stopwatch.Elapsed;
-                if (adjustedInterval < TimeSpan.Zero)
-                {
-                    adjustedInterval = TimeSpan.Zero;
-                }
-
-                RequestRefresh(fullRefresh: true, adjustedInterval);
-            }
-            else
-            {
-                RequestRefresh(fullRefresh: true);
             }
 
 #if CMDPAL_FF_MAINPAGE_TIME_RAISE_ITEMS
             var listPageUpdatedTimestamp = stopwatch.ElapsedMilliseconds;
             Logger.LogDebug($"Render items with '{newSearch}' in {listPageUpdatedTimestamp}ms /d {listPageUpdatedTimestamp - filterDoneTimestamp}ms");
 #endif
+        }
 
-            stopwatch.Stop();
+        // Reaching here means the swap actually happened (the superseded path returns inside the
+        // lock). Do the telemetry/refresh scheduling now, outside the critical section.
+        stopwatch.Stop();
+
+        if (isUserInput)
+        {
+            // Queue a settled-search telemetry event. This measures the deterministic first-paint
+            // results (commands + capped apps) and the latency to produce them, at this boundary -
+            // never inside the per-item scoring loop. The event is debounced so it is emitted only
+            // when the query settles, not on every keystroke, and it carries the query LENGTH only.
+            _searchTelemetry.QueueSearchResults(newSearch.Length, deterministicResultCount, stopwatch.ElapsedMilliseconds);
+
+            // Make sure that the throttle delay is consistent from the user's perspective, even if filtering
+            // takes a long time. If we always use the full throttle duration, then a slow filter could make the UI feel sluggish.
+            var adjustedInterval = RaiseItemsChangedThrottleForUserInput - stopwatch.Elapsed;
+            if (adjustedInterval < TimeSpan.Zero)
+            {
+                adjustedInterval = TimeSpan.Zero;
+            }
+
+            RequestRefresh(fullRefresh: true, adjustedInterval);
+        }
+        else
+        {
+            RequestRefresh(fullRefresh: true);
         }
     }
 
@@ -760,7 +792,8 @@ public sealed partial class MainListPage : DynamicListPage,
         IListItem topLevelOrAppItem,
         IRecentCommandsManager history,
         IPrecomputedFuzzyMatcher precomputedFuzzyMatcher,
-        Func<IListItem, ProviderSearchWeight>? providerWeightLookup = null)
+        Func<IListItem, ProviderSearchWeight>? providerWeightLookup = null,
+        DateTimeOffset? now = null)
     {
         var title = topLevelOrAppItem.Title;
         if (string.IsNullOrWhiteSpace(title))
@@ -825,7 +858,7 @@ public sealed partial class MainListPage : DynamicListPage,
             return 0;
         }
 
-        var frecencyWeight = history.GetCommandHistoryWeight(id);
+        var frecencyWeight = history.GetCommandHistoryWeight(id, now ?? DateTimeOffset.UtcNow);
         var aliasSubstringBonus = isAliasSubstringMatch && !isAliasMatch ? MainListRanker.AliasSubstringBonus : 0.0;
 
         // Per-provider weight is a within-tier nudge only. Resolving it here (rather than in
@@ -896,19 +929,29 @@ public sealed partial class MainListPage : DynamicListPage,
 
     // Resolves the user-configured per-provider search weight for an item. Top-level commands
     // carry their own provider id; installed apps all belong to the well-known "AllApps"
-    // provider, so app items are weighted by that provider's setting.
+    // provider, so app items are weighted by that provider's setting. The static overloads take
+    // an explicit settings snapshot so the hot path can resolve weights against a single captured
+    // SettingsModel instead of re-reading the live settings service per item.
     private ProviderSearchWeight ResolveProviderSearchWeight(IListItem topLevelOrAppItem)
+        => ResolveProviderSearchWeight(_settingsService.Settings, topLevelOrAppItem);
+
+    private static ProviderSearchWeight ResolveProviderSearchWeight(SettingsModel settings, IListItem topLevelOrAppItem)
     {
         var providerId = topLevelOrAppItem is TopLevelViewModel topLevel
             ? topLevel.CommandProviderId
             : AllAppsCommandProvider.WellKnownId;
 
+        return ResolveProviderSearchWeight(settings, providerId);
+    }
+
+    private static ProviderSearchWeight ResolveProviderSearchWeight(SettingsModel settings, string providerId)
+    {
         if (string.IsNullOrEmpty(providerId))
         {
             return ProviderSearchWeight.Normal;
         }
 
-        return _settingsService.Settings.ProviderSettings.TryGetValue(providerId, out var providerSettings)
+        return settings.ProviderSettings.TryGetValue(providerId, out var providerSettings)
             ? providerSettings.SearchWeight
             : ProviderSearchWeight.Normal;
     }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
@@ -490,10 +490,8 @@ public sealed partial class MainListPage : DynamicListPage,
 
         var commands = _tlcManager.TopLevelCommands;
 
-        // Materialized inputs captured under the lock so the heavy scoring below can run OFF the
-        // lock. Scoring no longer converts directly into blocked settle/render time, because
-        // GetItems() takes the SAME lock and now only contends with the short snapshot/publish
-        // sections rather than the whole multi-thousand-item scoring pass.
+        // Inputs captured under the lock so the heavy scoring below can run off it. GetItems()
+        // takes the same lock, so it now only contends with the short snapshot and publish sections.
         IReadOnlyList<IListItem> itemsSource;
         IReadOnlyList<IListItem> appsSource;
         IReadOnlyList<IListItem> fallbackSource;
@@ -555,10 +553,9 @@ public sealed partial class MainListPage : DynamicListPage,
 
             includeAppsSnapshot = _includeApps;
 
-            // If the new string doesn't start with the old string we can't re-use previous
-            // results; likewise if the app-inclusion state changed. Either way we rebuild from the
-            // full catalog. On an extend (the new query starts with the old and app state is
-            // unchanged) we re-score only the previously matched subset, not the whole catalog.
+            // A query that doesn't extend the old one, or a change in app inclusion, means we
+            // can't re-use the previous results and have to rebuild from the full catalog. On an
+            // extend we re-score only the previously matched subset.
             var reset = !newSearch.StartsWith(oldSearch, StringComparison.CurrentCultureIgnoreCase)
                 || _filteredItemsIncludesApps != includeAppsSnapshot;
 
@@ -621,10 +618,8 @@ public sealed partial class MainListPage : DynamicListPage,
                 }
             }
 
-            // Materialize every source sequence while still under the lock. After this point the
-            // scoring passes never touch the live TopLevelCommands collection or the app provider,
-            // so they are free to run off the lock. globalFallbackSources reuses the specialFallbacks
-            // list already built above, dropping the redundant second commands.Where(...) pass.
+            // Materialize every source while still under the lock, so the scoring passes never
+            // touch the live TopLevelCommands collection or the app provider.
             itemsSource = MaterializeSource(newFilteredItems);
             appsSource = MaterializeSource(newApps);
             fallbackSource = MaterializeSource(newFallbacks);
@@ -636,18 +631,13 @@ public sealed partial class MainListPage : DynamicListPage,
             return;
         }
 
-        // ===== SCORING PHASE (OFF the lock) =====
-        // The dominant apps pass is parallelized; commands and fallbacks stay serial. All of this
-        // now runs without holding the TopLevelCommands lock, so it no longer blocks GetItems()/render.
+        // ===== SCORING PHASE (off the lock) =====
+        // The dominant apps pass is parallelized, commands and fallbacks stay serial, and none of
+        // it holds the TopLevelCommands lock any more, so it no longer blocks GetItems()/render.
         //
-        // Snapshot every input the scoring pass depends on into immutable locals, ONCE, before any
-        // item is scored. The live fields (_appStateService.State.RecentCommands,
-        // _fuzzyMatcherProvider.Current, _settingsService.Settings) can be swapped concurrently - a
-        // selection calls WithHistoryItem on another thread - so re-reading them per item could mix
-        // two frecency snapshots in one pass or, worse, let a parallel thread observe a fresh,
-        // unwarmed history index and race on its lazy dictionary build. Capturing here pins one
-        // consistent context; each captured value equals what the first scored item would have read,
-        // so the settled order is unchanged (ScoringParallelEquivalenceTests is the guardrail).
+        // Snapshot every scoring input once, up front: the live fields can be swapped mid-pass when
+        // a selection calls WithHistoryItem on another thread, which would mix two frecency
+        // snapshots into one pass or race a parallel thread against an unwarmed history index.
         var recent = _appStateService.State.RecentCommands;
         recent.PrewarmIndex();
         var matcher = _fuzzyMatcherProvider.Current;
@@ -656,9 +646,8 @@ public sealed partial class MainListPage : DynamicListPage,
 
         var searchQuery = matcher.PrecomputeQuery(SearchText);
 
-        // Commands resolve their per-provider weight from the captured settings. Every installed app
-        // belongs to the well-known AllApps provider, so its weight is constant across the whole apps
-        // pass - resolve it once here instead of repeating a dictionary lookup for every app.
+        // Every installed app belongs to the well-known AllApps provider, so its weight is constant
+        // for the whole pass and we resolve it once instead of once per app.
         var appsProviderWeight = ResolveProviderSearchWeight(settings, AllAppsCommandProvider.WellKnownId);
         Func<IListItem, ProviderSearchWeight> commandsProviderLookup = item => ResolveProviderSearchWeight(settings, item);
         Func<IListItem, ProviderSearchWeight> appsProviderLookup = _ => appsProviderWeight;
@@ -697,17 +686,14 @@ public sealed partial class MainListPage : DynamicListPage,
         var filterDoneTimestamp = stopwatch.ElapsedMilliseconds;
 #endif
 
-        // ===== PUBLISH PHASE (under lock): atomic swap, supersede-safe =====
-        // Keep the critical section to the field swaps only. Scheduling work (telemetry debounce and
-        // the refresh throttle) is done AFTER releasing the lock so we no longer nest
-        // _searchTelemetryLock under the commands lock, nor hold the TopLevelCommands lock across
-        // that bookkeeping. Only the deterministic result count is captured here for the post-lock
-        // telemetry payload.
+        // ===== PUBLISH PHASE (under lock) =====
+        // The critical section is the field swaps only. Telemetry debounce and refresh throttling
+        // happen after the lock so _searchTelemetryLock never nests under the commands lock.
         var deterministicResultCount = 0;
         lock (commands)
         {
-            // A newer keystroke cancels this token before doing its own work, so a stale snapshot's
-            // finished results can never overwrite a newer query's. Skip the swap when superseded.
+            // A newer keystroke cancels this token before doing its own work, so a stale snapshot
+            // can never overwrite a newer query's results.
             if (token.IsCancellationRequested)
             {
                 return;
@@ -726,9 +712,8 @@ public sealed partial class MainListPage : DynamicListPage,
             _globalFallbackSources = globalFallbackSources;
             _globalFallbackQuery = searchQuery;
 
-            // Apps are only re-scored when there is an apps source (either the full catalog with
-            // apps included, or a retained subset on the extend path). When there is none, publish
-            // null so a rebuild clears any stale set - matching the previous ClearResults behavior.
+            // With no apps source, publish null so a rebuild clears any stale set, matching the old
+            // ClearResults behavior.
             _filteredApps = appsSource.Count > 0 ? scoredApps : null;
 
             if (isUserInput)
@@ -743,16 +728,13 @@ public sealed partial class MainListPage : DynamicListPage,
 #endif
         }
 
-        // Reaching here means the swap actually happened (the superseded path returns inside the
-        // lock). Do the telemetry/refresh scheduling now, outside the critical section.
+        // Getting here means the swap happened, since the superseded path returns inside the lock.
         stopwatch.Stop();
 
         if (isUserInput)
         {
-            // Queue a settled-search telemetry event. This measures the deterministic first-paint
-            // results (commands + capped apps) and the latency to produce them, at this boundary -
-            // never inside the per-item scoring loop. The event is debounced so it is emitted only
-            // when the query settles, not on every keystroke, and it carries the query LENGTH only.
+            // Queue a settled-search telemetry event. It's debounced so it only fires once the
+            // query settles, and it carries the query LENGTH only, never the text.
             _searchTelemetry.QueueSearchResults(newSearch.Length, deterministicResultCount, stopwatch.ElapsedMilliseconds);
 
             // Make sure that the throttle delay is consistent from the user's perspective, even if filtering
@@ -771,10 +753,8 @@ public sealed partial class MainListPage : DynamicListPage,
         }
     }
 
-    // Materializes a source sequence into a stable, indexable snapshot so the scoring passes can
-    // run off the TopLevelCommands lock. Sequences that are already an IReadOnlyList (our own
-    // freshly built lists and empty arrays) are used as-is; lazy LINQ over the live collection or
-    // over previous results is copied so later mutation of the source can't affect scoring.
+    // Materializes a source into a stable, indexable snapshot so scoring can run off the lock.
+    // Anything already an IReadOnlyList passes through; lazy LINQ over live data gets copied.
     private static IReadOnlyList<IListItem> MaterializeSource(IEnumerable<IListItem> items)
         => items as IReadOnlyList<IListItem> ?? items.ToArray();
 
@@ -929,9 +909,8 @@ public sealed partial class MainListPage : DynamicListPage,
 
     // Resolves the user-configured per-provider search weight for an item. Top-level commands
     // carry their own provider id; installed apps all belong to the well-known "AllApps"
-    // provider, so app items are weighted by that provider's setting. The static overloads take
-    // an explicit settings snapshot so the hot path can resolve weights against a single captured
-    // SettingsModel instead of re-reading the live settings service per item.
+    // provider, so app items are weighted by that provider's setting. The static overloads take a
+    // settings snapshot so the hot path resolves against one captured SettingsModel.
     private ProviderSearchWeight ResolveProviderSearchWeight(IListItem topLevelOrAppItem)
         => ResolveProviderSearchWeight(_settingsService.Settings, topLevelOrAppItem);
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
@@ -489,6 +489,19 @@ public sealed partial class MainListPage : DynamicListPage,
         }
 
         var commands = _tlcManager.TopLevelCommands;
+
+        // Materialized inputs captured under the lock so the heavy scoring below can run OFF the
+        // lock. Scoring no longer converts directly into blocked settle/render time, because
+        // GetItems() takes the SAME lock and now only contends with the short snapshot/publish
+        // sections rather than the whole multi-thousand-item scoring pass.
+        IReadOnlyList<IListItem> itemsSource;
+        IReadOnlyList<IListItem> appsSource;
+        IReadOnlyList<IListItem> fallbackSource;
+        IListItem[] globalFallbackSources;
+        bool includeAppsSnapshot;
+        bool tookFullCatalog = false;
+
+        // ===== SNAPSHOT PHASE (under lock) =====
         lock (commands)
         {
             if (token.IsCancellationRequested)
@@ -540,52 +553,28 @@ public sealed partial class MainListPage : DynamicListPage,
                 return;
             }
 
-            // If the new string doesn't start with the old string, then we can't
-            // re-use previous results. Reset _filteredItems, and keep er moving.
-            if (!newSearch.StartsWith(oldSearch, StringComparison.CurrentCultureIgnoreCase))
-            {
-                ClearResults();
-            }
+            includeAppsSnapshot = _includeApps;
 
-            // If the internal state has changed, reset _filteredItems to reset the list.
-            if (_filteredItemsIncludesApps != _includeApps)
-            {
-                ClearResults();
-            }
+            // If the new string doesn't start with the old string we can't re-use previous
+            // results; likewise if the app-inclusion state changed. Either way we rebuild from the
+            // full catalog. On an extend (the new query starts with the old and app state is
+            // unchanged) we re-score only the previously matched subset, not the whole catalog.
+            var reset = !newSearch.StartsWith(oldSearch, StringComparison.CurrentCultureIgnoreCase)
+                || _filteredItemsIncludesApps != includeAppsSnapshot;
 
-            if (token.IsCancellationRequested)
-            {
-                return;
-            }
+            var prevFilteredItems = reset ? null : _filteredItems;
+            var prevApps = reset ? null : _filteredApps;
+            var prevFallbacks = reset ? null : _fallbackItems;
 
-            var newFilteredItems = Enumerable.Empty<IListItem>();
-            var newFallbacks = Enumerable.Empty<IListItem>();
-            var newApps = Enumerable.Empty<IListItem>();
-
-            if (_filteredItems is not null)
-            {
-                newFilteredItems = _filteredItems.Select(s => s.Item);
-            }
-
-            if (token.IsCancellationRequested)
-            {
-                return;
-            }
-
-            if (_filteredApps is not null)
-            {
-                newApps = _filteredApps.Select(s => s.Item);
-            }
-
-            if (token.IsCancellationRequested)
-            {
-                return;
-            }
-
-            if (_fallbackItems is not null)
-            {
-                newFallbacks = _fallbackItems.Select(s => s.Item);
-            }
+            IEnumerable<IListItem> newFilteredItems = prevFilteredItems is not null
+                ? prevFilteredItems.Select(s => s.Item)
+                : Enumerable.Empty<IListItem>();
+            IEnumerable<IListItem> newApps = prevApps is not null
+                ? prevApps.Select(s => s.Item)
+                : Enumerable.Empty<IListItem>();
+            IEnumerable<IListItem> newFallbacks = prevFallbacks is not null
+                ? prevFallbacks.Select(s => s.Item)
+                : Enumerable.Empty<IListItem>();
 
             if (token.IsCancellationRequested)
             {
@@ -596,6 +585,7 @@ public sealed partial class MainListPage : DynamicListPage,
             // with a list of all our commands & apps.
             if (!newFilteredItems.Any() && !newApps.Any())
             {
+                tookFullCatalog = true;
                 newFilteredItems = commands.Where(s => !s.IsFallback);
 
                 // Fallbacks are always included in the list, even if they
@@ -608,9 +598,7 @@ public sealed partial class MainListPage : DynamicListPage,
                     return;
                 }
 
-                _filteredItemsIncludesApps = _includeApps;
-
-                if (_includeApps)
+                if (includeAppsSnapshot)
                 {
                     var allNewApps = AllAppsCommandProvider.Page.GetItems().Cast<AppListItem>().ToList();
 
@@ -633,47 +621,86 @@ public sealed partial class MainListPage : DynamicListPage,
                 }
             }
 
-            var searchQuery = _fuzzyMatcherProvider.Current.PrecomputeQuery(SearchText);
+            // Materialize every source sequence while still under the lock. After this point the
+            // scoring passes never touch the live TopLevelCommands collection or the app provider,
+            // so they are free to run off the lock. globalFallbackSources reuses the specialFallbacks
+            // list already built above, dropping the redundant second commands.Where(...) pass.
+            itemsSource = MaterializeSource(newFilteredItems);
+            appsSource = MaterializeSource(newApps);
+            fallbackSource = MaterializeSource(newFallbacks);
+            globalFallbackSources = [.. specialFallbacks];
+        }
 
-            // Produce a list of everything that matches the current filter.
-            _filteredItems = InternalListHelpers.FilterListWithScores(newFilteredItems, searchQuery, _scoringFunction);
+        if (token.IsCancellationRequested)
+        {
+            return;
+        }
+
+        // ===== SCORING PHASE (OFF the lock) =====
+        // The dominant apps pass is parallelized; commands and fallbacks stay serial. All of this
+        // now runs without holding the TopLevelCommands lock, so it no longer blocks GetItems()/render.
+        var searchQuery = _fuzzyMatcherProvider.Current.PrecomputeQuery(SearchText);
+
+        var scoredFilteredItems = InternalListHelpers.FilterListWithScores(itemsSource, searchQuery, _scoringFunction);
+
+        if (token.IsCancellationRequested)
+        {
+            return;
+        }
+
+        var scoredFallbackItems = InternalListHelpers.FilterListWithScores(fallbackSource, searchQuery, _fallbackScoringFunction);
+
+        if (token.IsCancellationRequested)
+        {
+            return;
+        }
+
+        RoScored<IListItem>[]? scoredApps = null;
+        if (appsSource.Count > 0)
+        {
+            // Build the frecency lookup once, single-threaded, before the parallel pass reads it.
+            // The lazy dictionary build in RecentCommandsManager is not thread-safe.
+            _appStateService.State.RecentCommands.PrewarmIndex();
+
+            scoredApps = InternalListHelpers.FilterListWithScoresParallel(appsSource, searchQuery, _scoringFunction);
 
             if (token.IsCancellationRequested)
             {
                 return;
             }
+        }
+
+#if CMDPAL_FF_MAINPAGE_TIME_RAISE_ITEMS
+        var filterDoneTimestamp = stopwatch.ElapsedMilliseconds;
+#endif
+
+        // ===== PUBLISH PHASE (under lock): atomic swap, supersede-safe =====
+        lock (commands)
+        {
+            // A newer keystroke cancels this token before doing its own work, so a stale snapshot's
+            // finished results can never overwrite a newer query's. Skip the swap when superseded.
+            if (token.IsCancellationRequested)
+            {
+                return;
+            }
+
+            if (tookFullCatalog)
+            {
+                _filteredItemsIncludesApps = includeAppsSnapshot;
+            }
+
+            _filteredItems = scoredFilteredItems;
+            _fallbackItems = scoredFallbackItems;
 
             // Snapshot the global fallbacks and query, but score them later on the render path,
             // since their titles are still resolving asynchronously (BeginUpdate, above).
-            _globalFallbackSources = commands.Where(s => s.IsFallback && configuredGlobalFallbackIds.Contains(s.Id)).ToArray();
+            _globalFallbackSources = globalFallbackSources;
             _globalFallbackQuery = searchQuery;
 
-            if (token.IsCancellationRequested)
-            {
-                return;
-            }
-
-            _fallbackItems = InternalListHelpers.FilterListWithScores<IListItem>(newFallbacks ?? [], searchQuery, _fallbackScoringFunction);
-
-            if (token.IsCancellationRequested)
-            {
-                return;
-            }
-
-            // Produce a list of filtered apps with the appropriate limit
-            if (newApps.Any())
-            {
-                _filteredApps = InternalListHelpers.FilterListWithScores(newApps, searchQuery, _scoringFunction);
-
-                if (token.IsCancellationRequested)
-                {
-                    return;
-                }
-            }
-
-#if CMDPAL_FF_MAINPAGE_TIME_RAISE_ITEMS
-            var filterDoneTimestamp = stopwatch.ElapsedMilliseconds;
-#endif
+            // Apps are only re-scored when there is an apps source (either the full catalog with
+            // apps included, or a retained subset on the extend path). When there is none, publish
+            // null so a rebuild clears any stale set - matching the previous ClearResults behavior.
+            _filteredApps = appsSource.Count > 0 ? scoredApps : null;
 
             // Queue a settled-search telemetry event. This measures the deterministic first-paint
             // results (commands + capped apps) and the latency to produce them, at this boundary -
@@ -711,6 +738,13 @@ public sealed partial class MainListPage : DynamicListPage,
             stopwatch.Stop();
         }
     }
+
+    // Materializes a source sequence into a stable, indexable snapshot so the scoring passes can
+    // run off the TopLevelCommands lock. Sequences that are already an IReadOnlyList (our own
+    // freshly built lists and empty arrays) are used as-is; lazy LINQ over the live collection or
+    // over previous results is copied so later mutation of the source can't affect scoring.
+    private static IReadOnlyList<IListItem> MaterializeSource(IEnumerable<IListItem> items)
+        => items as IReadOnlyList<IListItem> ?? items.ToArray();
 
     private bool ActuallyLoading()
     {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/RecentCommandsManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/RecentCommandsManager.cs
@@ -115,10 +115,11 @@ public record RecentCommandsManager : IRecentCommandsManager
     /// <summary>
     /// Computes the time-decayed frecency weight for a command relative to <paramref name="now"/>.
     /// Recency uses an exponential half-life decay and frequency uses log(uses); the two are
-    /// combined so recency leads while frequency amplifies. The public overload evaluates at
-    /// the current time; this overload exists so tests can inject a fixed evaluation time.
+    /// combined so recency leads while frequency amplifies. The parameterless overload evaluates at
+    /// the current time; this overload lets callers pin a single evaluation time across a batch (and
+    /// tests inject a fixed time).
     /// </summary>
-    internal int GetCommandHistoryWeight(string commandId, DateTimeOffset now)
+    public int GetCommandHistoryWeight(string commandId, DateTimeOffset now)
     {
         if (!Index.TryGetValue(commandId, out var entry))
         {
@@ -184,6 +185,13 @@ public record RecentCommandsManager : IRecentCommandsManager
 public interface IRecentCommandsManager
 {
     int GetCommandHistoryWeight(string commandId);
+
+    /// <summary>
+    /// Computes the frecency weight for a command relative to an explicit evaluation time. Callers
+    /// that score a whole batch should capture a single <paramref name="now"/> once and pass it for
+    /// every item so the batch is scored against one consistent time snapshot.
+    /// </summary>
+    int GetCommandHistoryWeight(string commandId, DateTimeOffset now);
 
     RecentCommandsManager WithHistoryItem(string commandId);
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/RecentCommandsManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/RecentCommandsManager.cs
@@ -100,6 +100,15 @@ public record RecentCommandsManager : IRecentCommandsManager
     {
     }
 
+    /// <summary>
+    /// Forces the lazy command-id lookup (<see cref="Index"/>) to be built now, on the calling
+    /// thread. The build itself is not thread-safe (it populates a shared dictionary field without
+    /// locking), so callers that are about to score items in parallel MUST call this once,
+    /// single-threaded, before the parallel loop. Once built, <see cref="GetCommandHistoryWeight(string)"/>
+    /// only performs concurrent dictionary reads, which are safe.
+    /// </summary>
+    public void PrewarmIndex() => _ = Index;
+
     public int GetCommandHistoryWeight(string commandId)
         => GetCommandHistoryWeight(commandId, DateTimeOffset.UtcNow);
 
@@ -177,4 +186,12 @@ public interface IRecentCommandsManager
     int GetCommandHistoryWeight(string commandId);
 
     RecentCommandsManager WithHistoryItem(string commandId);
+
+    /// <summary>
+    /// Builds any lazily-initialized internal state (e.g. the command-id lookup) on the calling
+    /// thread so that subsequent <see cref="GetCommandHistoryWeight(string)"/> calls are safe to
+    /// issue concurrently. Callers that score items in parallel must invoke this once, single-
+    /// threaded, before the parallel loop.
+    /// </summary>
+    void PrewarmIndex();
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/RecentCommandsManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/RecentCommandsManager.cs
@@ -101,11 +101,8 @@ public record RecentCommandsManager : IRecentCommandsManager
     }
 
     /// <summary>
-    /// Forces the lazy command-id lookup (<see cref="Index"/>) to be built now, on the calling
-    /// thread. The build itself is not thread-safe (it populates a shared dictionary field without
-    /// locking), so callers that are about to score items in parallel MUST call this once,
-    /// single-threaded, before the parallel loop. Once built, <see cref="GetCommandHistoryWeight(string)"/>
-    /// only performs concurrent dictionary reads, which are safe.
+    /// Builds the lazy command-id lookup now, on the calling thread. The build isn't thread-safe,
+    /// so call this once before scoring items in parallel; the reads afterward are safe.
     /// </summary>
     public void PrewarmIndex() => _ = Index;
 
@@ -115,9 +112,8 @@ public record RecentCommandsManager : IRecentCommandsManager
     /// <summary>
     /// Computes the time-decayed frecency weight for a command relative to <paramref name="now"/>.
     /// Recency uses an exponential half-life decay and frequency uses log(uses); the two are
-    /// combined so recency leads while frequency amplifies. The parameterless overload evaluates at
-    /// the current time; this overload lets callers pin a single evaluation time across a batch (and
-    /// tests inject a fixed time).
+    /// combined so recency leads while frequency amplifies. The parameterless overload uses the
+    /// current time; this one lets a batch pin a single snapshot.
     /// </summary>
     public int GetCommandHistoryWeight(string commandId, DateTimeOffset now)
     {
@@ -187,19 +183,16 @@ public interface IRecentCommandsManager
     int GetCommandHistoryWeight(string commandId);
 
     /// <summary>
-    /// Computes the frecency weight for a command relative to an explicit evaluation time. Callers
-    /// that score a whole batch should capture a single <paramref name="now"/> once and pass it for
-    /// every item so the batch is scored against one consistent time snapshot.
+    /// Frecency weight for a command at an explicit evaluation time, so a whole batch can be
+    /// scored against one snapshot instead of a moving clock.
     /// </summary>
     int GetCommandHistoryWeight(string commandId, DateTimeOffset now);
 
     RecentCommandsManager WithHistoryItem(string commandId);
 
     /// <summary>
-    /// Builds any lazily-initialized internal state (e.g. the command-id lookup) on the calling
-    /// thread so that subsequent <see cref="GetCommandHistoryWeight(string)"/> calls are safe to
-    /// issue concurrently. Callers that score items in parallel must invoke this once, single-
-    /// threaded, before the parallel loop.
+    /// Builds any lazy internal state on the calling thread. Call it once before scoring items in
+    /// parallel, since the build itself isn't thread-safe.
     /// </summary>
     void PrewarmIndex();
 }

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/ScoringParallelEquivalenceTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/ScoringParallelEquivalenceTests.cs
@@ -324,4 +324,54 @@ public sealed partial class ScoringParallelEquivalenceTests
             AssertOrderedResultsIdentical($"determinism run {run}", first, again);
         }
     }
+
+    /// <summary>
+    /// Captured-context equivalence (FIX #1 + #5). The hot path snapshots the frecency manager, the
+    /// fuzzy matcher, the settings and a single evaluation time ONCE per query, then scores every
+    /// item against that immutable context - and, because every installed app resolves to the one
+    /// well-known apps provider, it feeds the apps pass a single constant provider weight instead of
+    /// a per-item lookup. This test proves that captured context produces a result BYTE-IDENTICAL in
+    /// order and score to the previous per-item live-read path: the reference scorer reads the time
+    /// per call (the old default overload) and delivers the weight through a per-item delegate, while
+    /// the candidate scorer threads a single captured <c>now</c> and a constant weight through the
+    /// parallel pass. Identical output confirms the optimization only changed HOW/WHERE the list is
+    /// computed, not WHAT it is.
+    /// </summary>
+    [TestMethod]
+    public void CapturedContext_ConstantWeightAndFixedNow_MatchesPerItemLiveRead()
+    {
+        var apps = BuildCatalog(AppCount, "app");
+        var matcher = CreateMatcher();
+        var history = SeedHistory(apps, HistorySeedCount);
+        var source = apps.Cast<IListItem>().ToArray();
+
+        history.PrewarmIndex();
+
+        // A non-default weight so the value must actually flow through to the packed score; if the
+        // constant path dropped or mis-carried it, the ordered result would diverge from the
+        // per-item reference.
+        const ProviderSearchWeight weight = ProviderSearchWeight.Higher;
+        Func<IListItem, ProviderSearchWeight> perItemLookup = _ => weight;
+        Func<IListItem, ProviderSearchWeight> constantLookup = _ => weight;
+
+        // Captured once, before the loop - exactly as the product captures scoringNow before its
+        // scoring passes. The reference path below omits it, so it reads the current time per call.
+        var capturedNow = DateTimeOffset.UtcNow;
+
+        ScoringFunction<IListItem> liveReadScorer = (in FuzzyQuery query, IListItem item) =>
+            MainListPage.ScoreTopLevelItem(query, item, history, matcher, perItemLookup);
+        ScoringFunction<IListItem> capturedContextScorer = (in FuzzyQuery query, IListItem item) =>
+            MainListPage.ScoreTopLevelItem(query, item, history, matcher, constantLookup, capturedNow);
+
+        foreach (var raw in Queries)
+        {
+            var query = matcher.PrecomputeQuery(raw);
+
+            var reference = InternalListHelpers.FilterListWithScores(source, query, liveReadScorer);
+            var candidate = InternalListHelpers.FilterListWithScoresParallel(source, query, capturedContextScorer);
+
+            TestContext.WriteLine($"captured-context '{raw}': {reference.Length} matches (per-item live read) vs {candidate.Length} (constant weight + fixed now).");
+            AssertOrderedResultsIdentical($"captured '{raw}'", reference, candidate);
+        }
+    }
 }

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/ScoringParallelEquivalenceTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/ScoringParallelEquivalenceTests.cs
@@ -1,0 +1,327 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CmdPal.Common.Helpers;
+using Microsoft.CmdPal.Common.Text;
+using Microsoft.CmdPal.UI.ViewModels.Commands;
+using Microsoft.CmdPal.UI.ViewModels.MainPage;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.Foundation;
+
+namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
+
+/// <summary>
+/// GUARDRAIL for the Phase 7b throughput work. The hot-path scoring pass was moved off the
+/// TopLevelCommands lock and the dominant apps pass was parallelized. The optimization is only
+/// permitted to change HOW FAST and WHERE the settled list is computed - never WHAT it is. This
+/// test locks that invariant in: for a representative synthetic catalog (a few thousand apps plus
+/// hundreds of commands) and several queries - including the 1-char pathological case, the extend
+/// (incremental narrowing) path, and the shrink/retype rebuild path - the parallel scorer
+/// (<see cref="InternalListHelpers.FilterListWithScoresParallel{T}"/>) must produce a result that
+/// is BYTE-IDENTICAL in order and score to the reference sequential scorer
+/// (<see cref="InternalListHelpers.FilterListWithScores{T}"/>).
+///
+/// The comparison is by item reference and packed score at every index, so any reordering - even a
+/// tie-break difference - fails the test. Everything here is deterministic (index-driven catalog,
+/// no RNG, no wall clock, order-preserving partition/merge), so it is CI-safe and never flakes on
+/// thread scheduling.
+/// </summary>
+[TestClass]
+public sealed partial class ScoringParallelEquivalenceTests
+{
+    // Large enough that the parallel path is actually taken (well over the internal sequential
+    // threshold) and multiple partitions are exercised, small enough to stay fast in CI.
+    private const int AppCount = 4000;
+    private const int CommandCount = 300;
+    private const int HistorySeedCount = 250;
+
+    // Queries chosen to exercise distinct scoring shapes: "c" is the pathological 1-char case that
+    // matches a large fraction of the catalog; the "ca"/"cal"/"calc" chain is the extend path; the
+    // acronym/word-boundary and multi-word cases stress the tier classifier.
+    private static readonly string[] Queries =
+        ["c", "ca", "cal", "calc", "vs", "vsc", "vs code", "term", "set", "e"];
+
+    public TestContext TestContext { get; set; } = null!;
+
+    private sealed partial class CatalogItem : IListItem, IPrecomputedListItem
+    {
+        private FuzzyTargetCache _titleCache;
+        private FuzzyTargetCache _subtitleCache;
+
+        public CatalogItem(string title, string subtitle, string id)
+        {
+            Title = title;
+            Subtitle = subtitle;
+            Id = id;
+            Command = new NoOpCommand() { Id = id };
+        }
+
+        public string Title { get; }
+
+        public string Subtitle { get; }
+
+        public string Id { get; }
+
+        public ICommand Command { get; }
+
+        public IDetails? Details => null;
+
+        public IIconInfo? Icon => null;
+
+        public string Section => string.Empty;
+
+        public ITag[] Tags => [];
+
+        public string TextToSuggest => string.Empty;
+
+        public IContextItem[] MoreCommands => [];
+
+#pragma warning disable CS0067 // The event is never used
+        public event TypedEventHandler<object, IPropChangedEventArgs>? PropChanged;
+#pragma warning restore CS0067
+
+        public FuzzyTarget GetTitleTarget(IPrecomputedFuzzyMatcher matcher) => _titleCache.GetOrUpdate(matcher, Title);
+
+        public FuzzyTarget GetSubtitleTarget(IPrecomputedFuzzyMatcher matcher) => _subtitleCache.GetOrUpdate(matcher, Subtitle);
+    }
+
+    private static readonly string[] Nouns =
+    [
+        "Calculator", "Calendar", "Camera", "Canvas", "Command", "Control", "Cloud", "Cast",
+        "Visual", "Studio", "Code", "Terminal", "Task", "Notepad", "Paint", "Photos", "Player",
+        "Panel", "Prompt", "Settings", "Store", "System", "Manager", "Monitor", "Editor", "Browser",
+        "Mail", "Maps", "Music", "Movies", "Network", "Office", "Onenote", "Outlook", "People",
+    ];
+
+    private static readonly string[] Qualifiers =
+    [
+        string.Empty, "Pro", "2022", "3D", "Preview", "X", "Lite", "Plus", "Home", "Enterprise",
+        "for Windows", "Insider", "Legacy", "New", "Classic",
+    ];
+
+    private static readonly string[] SubtitleWords =
+    [
+        "Perform calculations and conversions", "View and manage your schedule", "Edit and refine images",
+        "Modern terminal for command-line tools", "Full-featured integrated development environment",
+        "Browse the web quickly and securely", "Adjust your computer settings", "Monitor apps and processes",
+        "A simple and fast text editor", "Play and organize your media library",
+    ];
+
+    private static IPrecomputedFuzzyMatcher CreateMatcher() => new PrecomputedFuzzyMatcher(new PrecomputedFuzzyMatcherOptions());
+
+    private static CatalogItem[] BuildCatalog(int count, string idPrefix)
+    {
+        var items = new CatalogItem[count];
+        for (var i = 0; i < count; i++)
+        {
+            var noun = Nouns[i % Nouns.Length];
+            var qualifier = Qualifiers[(i / Nouns.Length) % Qualifiers.Length];
+            var title = string.IsNullOrEmpty(qualifier) ? noun : $"{noun} {qualifier}";
+
+            if (i >= Nouns.Length * Qualifiers.Length)
+            {
+                title = $"{title} {i}";
+            }
+
+            var subtitle = SubtitleWords[i % SubtitleWords.Length];
+            items[i] = new CatalogItem(title, subtitle, $"{idPrefix}.{i}");
+        }
+
+        return items;
+    }
+
+    private static RecentCommandsManager SeedHistory(CatalogItem[] apps, int seedCount)
+    {
+        var history = new RecentCommandsManager();
+        var n = Math.Min(seedCount, apps.Length);
+        for (var i = 0; i < n; i++)
+        {
+            var idx = (i * 7) % apps.Length;
+            history = history.WithHistoryItem(apps[idx].Command.Id);
+        }
+
+        return history;
+    }
+
+    private static ScoringFunction<IListItem> BuildScoringFunction(
+        IRecentCommandsManager history,
+        IPrecomputedFuzzyMatcher matcher)
+        => (in FuzzyQuery query, IListItem item) =>
+            MainListPage.ScoreTopLevelItem(query, item, history, matcher, null);
+
+    private static void AssertOrderedResultsIdentical(
+        string context,
+        RoScored<IListItem>[] reference,
+        RoScored<IListItem>[] candidate)
+    {
+        Assert.AreEqual(reference.Length, candidate.Length, $"[{context}] result count must match the sequential reference.");
+
+        for (var i = 0; i < reference.Length; i++)
+        {
+            // Same packed score at the same index.
+            Assert.AreEqual(
+                reference[i].Score,
+                candidate[i].Score,
+                $"[{context}] score at index {i} must match the sequential reference.");
+
+            // Same item reference at the same index - proves the ORDER is byte-identical, including
+            // tie-breaks, not merely that the same set of scores appears.
+            Assert.AreSame(
+                reference[i].Item,
+                candidate[i].Item,
+                $"[{context}] item at index {i} must be the exact same instance as the sequential reference.");
+        }
+    }
+
+    /// <summary>
+    /// Full-catalog scoring: for every query the parallel apps pass must produce a result
+    /// byte-identical in order and score to the sequential reference. This is the rebuild/retype
+    /// path (a fresh query scored against the whole catalog).
+    /// </summary>
+    [TestMethod]
+    public void ParallelScoring_FullCatalog_MatchesSequentialForEveryQuery()
+    {
+        var apps = BuildCatalog(AppCount, "app");
+        var matcher = CreateMatcher();
+        var history = SeedHistory(apps, HistorySeedCount);
+        var scoringFn = BuildScoringFunction(history, matcher);
+        var source = apps.Cast<IListItem>().ToArray();
+
+        // Mirror the product: build the frecency index once before the parallel pass reads it.
+        history.PrewarmIndex();
+
+        foreach (var raw in Queries)
+        {
+            var query = matcher.PrecomputeQuery(raw);
+
+            var sequential = InternalListHelpers.FilterListWithScores(source, query, scoringFn);
+            var parallel = InternalListHelpers.FilterListWithScoresParallel(source, query, scoringFn);
+
+            TestContext.WriteLine($"query '{raw}': {sequential.Length} matches (sequential) vs {parallel.Length} (parallel).");
+            AssertOrderedResultsIdentical($"full '{raw}'", sequential, parallel);
+        }
+    }
+
+    /// <summary>
+    /// Extend (incremental narrowing) path: score the whole catalog for the 1-char query, retain
+    /// the matched subset in its produced order, then re-score that subset for the extending query.
+    /// The parallel scorer over the retained subset must still match the sequential reference.
+    /// </summary>
+    [TestMethod]
+    public void ParallelScoring_ExtendPath_MatchesSequentialOverRetainedSubset()
+    {
+        var apps = BuildCatalog(AppCount, "app");
+        var matcher = CreateMatcher();
+        var history = SeedHistory(apps, HistorySeedCount);
+        var scoringFn = BuildScoringFunction(history, matcher);
+        var source = apps.Cast<IListItem>().ToArray();
+
+        history.PrewarmIndex();
+
+        // ("c" -> "ca" -> "cal" -> "calc") extend chain, each step narrowing the previous result.
+        var chain = new[] { "c", "ca", "cal", "calc" };
+
+        var retained = source;
+        for (var step = 1; step < chain.Length; step++)
+        {
+            // The retained subset is exactly what the product feeds the next keystroke: the items
+            // of the previous result, in the previous result's order.
+            var prevQuery = matcher.PrecomputeQuery(chain[step - 1]);
+            var prev = InternalListHelpers.FilterListWithScores(retained, prevQuery, scoringFn);
+            retained = prev.Select(s => s.Item).ToArray();
+
+            var query = matcher.PrecomputeQuery(chain[step]);
+            var sequential = InternalListHelpers.FilterListWithScores(retained, query, scoringFn);
+            var parallel = InternalListHelpers.FilterListWithScoresParallel(retained, query, scoringFn);
+
+            TestContext.WriteLine($"extend '{chain[step - 1]}' -> '{chain[step]}': retained {retained.Length}, kept {sequential.Length}.");
+            AssertOrderedResultsIdentical($"extend '{chain[step - 1]}'->'{chain[step]}'", sequential, parallel);
+
+            Assert.IsTrue(sequential.Length <= retained.Length, "Extending a query cannot add matches beyond the retained set.");
+        }
+    }
+
+    /// <summary>
+    /// Shrink/retype rebuild path: a query that does NOT extend the previous one forces a full
+    /// rebuild against the whole catalog. Verify the parallel scorer matches the sequential
+    /// reference for a sequence of unrelated queries scored fresh each time.
+    /// </summary>
+    [TestMethod]
+    public void ParallelScoring_RetypeRebuild_MatchesSequential()
+    {
+        var apps = BuildCatalog(AppCount, "app");
+        var matcher = CreateMatcher();
+        var history = SeedHistory(apps, HistorySeedCount);
+        var scoringFn = BuildScoringFunction(history, matcher);
+        var source = apps.Cast<IListItem>().ToArray();
+
+        history.PrewarmIndex();
+
+        // Unrelated queries (each a fresh rebuild, never an extend of the last).
+        foreach (var raw in new[] { "calc", "term", "vs code", "settings", "e" })
+        {
+            var query = matcher.PrecomputeQuery(raw);
+            var sequential = InternalListHelpers.FilterListWithScores(source, query, scoringFn);
+            var parallel = InternalListHelpers.FilterListWithScoresParallel(source, query, scoringFn);
+
+            AssertOrderedResultsIdentical($"retype '{raw}'", sequential, parallel);
+        }
+    }
+
+    /// <summary>
+    /// Commands (hundreds) stay on the serial path but the helper is still exercised over that
+    /// smaller catalog for completeness: the parallel entry point must fall back to - and match -
+    /// the sequential result even below its parallel threshold.
+    /// </summary>
+    [TestMethod]
+    public void ParallelScoring_Commands_MatchesSequential()
+    {
+        var commands = BuildCatalog(CommandCount, "cmd");
+        var matcher = CreateMatcher();
+        var history = SeedHistory(commands, HistorySeedCount);
+        var scoringFn = BuildScoringFunction(history, matcher);
+        var source = commands.Cast<IListItem>().ToArray();
+
+        history.PrewarmIndex();
+
+        foreach (var raw in Queries)
+        {
+            var query = matcher.PrecomputeQuery(raw);
+            var sequential = InternalListHelpers.FilterListWithScores(source, query, scoringFn);
+            var parallel = InternalListHelpers.FilterListWithScoresParallel(source, query, scoringFn);
+
+            AssertOrderedResultsIdentical($"commands '{raw}'", sequential, parallel);
+        }
+    }
+
+    /// <summary>
+    /// Determinism: repeatedly running the parallel scorer over the same catalog and query yields
+    /// the exact same ordered result each time, regardless of thread scheduling.
+    /// </summary>
+    [TestMethod]
+    public void ParallelScoring_IsDeterministicAcrossRuns()
+    {
+        var apps = BuildCatalog(AppCount, "app");
+        var matcher = CreateMatcher();
+        var history = SeedHistory(apps, HistorySeedCount);
+        var scoringFn = BuildScoringFunction(history, matcher);
+        var source = apps.Cast<IListItem>().ToArray();
+
+        history.PrewarmIndex();
+
+        var query = matcher.PrecomputeQuery("c");
+        var first = InternalListHelpers.FilterListWithScoresParallel(source, query, scoringFn);
+
+        for (var run = 0; run < 8; run++)
+        {
+            var again = InternalListHelpers.FilterListWithScoresParallel(source, query, scoringFn);
+            AssertOrderedResultsIdentical($"determinism run {run}", first, again);
+        }
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/ScoringParallelEquivalenceTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/ScoringParallelEquivalenceTests.cs
@@ -17,33 +17,23 @@ using Windows.Foundation;
 namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
 
 /// <summary>
-/// GUARDRAIL for the Phase 7b throughput work. The hot-path scoring pass was moved off the
-/// TopLevelCommands lock and the dominant apps pass was parallelized. The optimization is only
-/// permitted to change HOW FAST and WHERE the settled list is computed - never WHAT it is. This
-/// test locks that invariant in: for a representative synthetic catalog (a few thousand apps plus
-/// hundreds of commands) and several queries - including the 1-char pathological case, the extend
-/// (incremental narrowing) path, and the shrink/retype rebuild path - the parallel scorer
-/// (<see cref="InternalListHelpers.FilterListWithScoresParallel{T}"/>) must produce a result that
-/// is BYTE-IDENTICAL in order and score to the reference sequential scorer
-/// (<see cref="InternalListHelpers.FilterListWithScores{T}"/>).
-///
-/// The comparison is by item reference and packed score at every index, so any reordering - even a
-/// tie-break difference - fails the test. Everything here is deterministic (index-driven catalog,
-/// no RNG, no wall clock, order-preserving partition/merge), so it is CI-safe and never flakes on
-/// thread scheduling.
+/// Guardrail for the throughput work: moving scoring off the TopLevelCommands lock and
+/// parallelizing the apps pass may change how fast and where the settled list is computed, never
+/// what it is. Across a synthetic catalog and several queries (the 1-char pathological case, the
+/// extend chain, and the retype rebuild) the parallel scorer has to match the sequential one item
+/// for item and score for score.
 /// </summary>
 [TestClass]
 public sealed partial class ScoringParallelEquivalenceTests
 {
-    // Large enough that the parallel path is actually taken (well over the internal sequential
-    // threshold) and multiple partitions are exercised, small enough to stay fast in CI.
+    // Big enough that the parallel path is actually taken across multiple partitions, small enough
+    // to stay fast on CI.
     private const int AppCount = 4000;
     private const int CommandCount = 300;
     private const int HistorySeedCount = 250;
 
-    // Queries chosen to exercise distinct scoring shapes: "c" is the pathological 1-char case that
-    // matches a large fraction of the catalog; the "ca"/"cal"/"calc" chain is the extend path; the
-    // acronym/word-boundary and multi-word cases stress the tier classifier.
+    // "c" is the pathological 1-char case, the "ca"/"cal"/"calc" chain is the extend path, and the
+    // acronym and multi-word cases stress the tier classifier.
     private static readonly string[] Queries =
         ["c", "ca", "cal", "calc", "vs", "vsc", "vs code", "term", "set", "e"];
 
@@ -170,8 +160,8 @@ public sealed partial class ScoringParallelEquivalenceTests
                 candidate[i].Score,
                 $"[{context}] score at index {i} must match the sequential reference.");
 
-            // Same item reference at the same index - proves the ORDER is byte-identical, including
-            // tie-breaks, not merely that the same set of scores appears.
+            // Same item reference at the same index, which proves the order matches including
+            // tie-breaks, not just that the same scores turn up.
             Assert.AreSame(
                 reference[i].Item,
                 candidate[i].Item,
@@ -180,9 +170,8 @@ public sealed partial class ScoringParallelEquivalenceTests
     }
 
     /// <summary>
-    /// Full-catalog scoring: for every query the parallel apps pass must produce a result
-    /// byte-identical in order and score to the sequential reference. This is the rebuild/retype
-    /// path (a fresh query scored against the whole catalog).
+    /// The rebuild path: a fresh query scored against the whole catalog, where the parallel apps
+    /// pass has to match the sequential reference exactly.
     /// </summary>
     [TestMethod]
     public void ParallelScoring_FullCatalog_MatchesSequentialForEveryQuery()
@@ -209,9 +198,8 @@ public sealed partial class ScoringParallelEquivalenceTests
     }
 
     /// <summary>
-    /// Extend (incremental narrowing) path: score the whole catalog for the 1-char query, retain
-    /// the matched subset in its produced order, then re-score that subset for the extending query.
-    /// The parallel scorer over the retained subset must still match the sequential reference.
+    /// The extend path: score the whole catalog for a 1-char query, keep the matched subset in the
+    /// order it came back, then re-score that subset for the extending query.
     /// </summary>
     [TestMethod]
     public void ParallelScoring_ExtendPath_MatchesSequentialOverRetainedSubset()
@@ -224,14 +212,14 @@ public sealed partial class ScoringParallelEquivalenceTests
 
         history.PrewarmIndex();
 
-        // ("c" -> "ca" -> "cal" -> "calc") extend chain, each step narrowing the previous result.
+        // Each step narrows the previous result.
         var chain = new[] { "c", "ca", "cal", "calc" };
 
         var retained = source;
         for (var step = 1; step < chain.Length; step++)
         {
-            // The retained subset is exactly what the product feeds the next keystroke: the items
-            // of the previous result, in the previous result's order.
+            // This is exactly what the product feeds the next keystroke: the previous result's
+            // items, in the previous result's order.
             var prevQuery = matcher.PrecomputeQuery(chain[step - 1]);
             var prev = InternalListHelpers.FilterListWithScores(retained, prevQuery, scoringFn);
             retained = prev.Select(s => s.Item).ToArray();
@@ -248,9 +236,8 @@ public sealed partial class ScoringParallelEquivalenceTests
     }
 
     /// <summary>
-    /// Shrink/retype rebuild path: a query that does NOT extend the previous one forces a full
-    /// rebuild against the whole catalog. Verify the parallel scorer matches the sequential
-    /// reference for a sequence of unrelated queries scored fresh each time.
+    /// The retype path: a query that doesn't extend the previous one forces a full rebuild, so
+    /// check a run of unrelated queries scored fresh each time.
     /// </summary>
     [TestMethod]
     public void ParallelScoring_RetypeRebuild_MatchesSequential()
@@ -275,9 +262,8 @@ public sealed partial class ScoringParallelEquivalenceTests
     }
 
     /// <summary>
-    /// Commands (hundreds) stay on the serial path but the helper is still exercised over that
-    /// smaller catalog for completeness: the parallel entry point must fall back to - and match -
-    /// the sequential result even below its parallel threshold.
+    /// Commands (hundreds) stay serial, so the parallel entry point has to fall back below its
+    /// threshold and still match the sequential result.
     /// </summary>
     [TestMethod]
     public void ParallelScoring_Commands_MatchesSequential()
@@ -301,8 +287,8 @@ public sealed partial class ScoringParallelEquivalenceTests
     }
 
     /// <summary>
-    /// Determinism: repeatedly running the parallel scorer over the same catalog and query yields
-    /// the exact same ordered result each time, regardless of thread scheduling.
+    /// Running the parallel scorer over the same catalog and query repeatedly gives the same
+    /// ordered result every time, whatever the thread scheduling does.
     /// </summary>
     [TestMethod]
     public void ParallelScoring_IsDeterministicAcrossRuns()
@@ -326,16 +312,9 @@ public sealed partial class ScoringParallelEquivalenceTests
     }
 
     /// <summary>
-    /// Captured-context equivalence (FIX #1 + #5). The hot path snapshots the frecency manager, the
-    /// fuzzy matcher, the settings and a single evaluation time ONCE per query, then scores every
-    /// item against that immutable context - and, because every installed app resolves to the one
-    /// well-known apps provider, it feeds the apps pass a single constant provider weight instead of
-    /// a per-item lookup. This test proves that captured context produces a result BYTE-IDENTICAL in
-    /// order and score to the previous per-item live-read path: the reference scorer reads the time
-    /// per call (the old default overload) and delivers the weight through a per-item delegate, while
-    /// the candidate scorer threads a single captured <c>now</c> and a constant weight through the
-    /// parallel pass. Identical output confirms the optimization only changed HOW/WHERE the list is
-    /// computed, not WHAT it is.
+    /// The hot path snapshots the frecency manager, matcher, settings and one evaluation time per
+    /// query, and feeds the apps pass a single constant provider weight. This proves that captured
+    /// context lands on the same ordered result as the old per-item live reads.
     /// </summary>
     [TestMethod]
     public void CapturedContext_ConstantWeightAndFixedNow_MatchesPerItemLiveRead()
@@ -347,15 +326,13 @@ public sealed partial class ScoringParallelEquivalenceTests
 
         history.PrewarmIndex();
 
-        // A non-default weight so the value must actually flow through to the packed score; if the
-        // constant path dropped or mis-carried it, the ordered result would diverge from the
-        // per-item reference.
+        // A non-default weight, so the value has to actually flow through to the packed score.
         const ProviderSearchWeight weight = ProviderSearchWeight.Higher;
         Func<IListItem, ProviderSearchWeight> perItemLookup = _ => weight;
         Func<IListItem, ProviderSearchWeight> constantLookup = _ => weight;
 
-        // Captured once, before the loop - exactly as the product captures scoringNow before its
-        // scoring passes. The reference path below omits it, so it reads the current time per call.
+        // Captured once before the loop, exactly as the product captures scoringNow. The reference
+        // path below omits it, so it reads the current time per call.
         var capturedNow = DateTimeOffset.UtcNow;
 
         ScoringFunction<IListItem> liveReadScorer = (in FuzzyQuery query, IListItem item) =>

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/ScoringParallelEquivalenceTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/ScoringParallelEquivalenceTests.cs
@@ -3,16 +3,14 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CmdPal.Common.Helpers;
 using Microsoft.CmdPal.Common.Text;
 using Microsoft.CmdPal.UI.ViewModels.Commands;
 using Microsoft.CmdPal.UI.ViewModels.MainPage;
 using Microsoft.CommandPalette.Extensions;
-using Microsoft.CommandPalette.Extensions.Toolkit;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Windows.Foundation;
+using static Microsoft.CmdPal.UI.ViewModels.UnitTests.ScoringTestCatalog;
 
 namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
 
@@ -38,106 +36,6 @@ public sealed partial class ScoringParallelEquivalenceTests
         ["c", "ca", "cal", "calc", "vs", "vsc", "vs code", "term", "set", "e"];
 
     public TestContext TestContext { get; set; } = null!;
-
-    private sealed partial class CatalogItem : IListItem, IPrecomputedListItem
-    {
-        private FuzzyTargetCache _titleCache;
-        private FuzzyTargetCache _subtitleCache;
-
-        public CatalogItem(string title, string subtitle, string id)
-        {
-            Title = title;
-            Subtitle = subtitle;
-            Id = id;
-            Command = new NoOpCommand() { Id = id };
-        }
-
-        public string Title { get; }
-
-        public string Subtitle { get; }
-
-        public string Id { get; }
-
-        public ICommand Command { get; }
-
-        public IDetails? Details => null;
-
-        public IIconInfo? Icon => null;
-
-        public string Section => string.Empty;
-
-        public ITag[] Tags => [];
-
-        public string TextToSuggest => string.Empty;
-
-        public IContextItem[] MoreCommands => [];
-
-#pragma warning disable CS0067 // The event is never used
-        public event TypedEventHandler<object, IPropChangedEventArgs>? PropChanged;
-#pragma warning restore CS0067
-
-        public FuzzyTarget GetTitleTarget(IPrecomputedFuzzyMatcher matcher) => _titleCache.GetOrUpdate(matcher, Title);
-
-        public FuzzyTarget GetSubtitleTarget(IPrecomputedFuzzyMatcher matcher) => _subtitleCache.GetOrUpdate(matcher, Subtitle);
-    }
-
-    private static readonly string[] Nouns =
-    [
-        "Calculator", "Calendar", "Camera", "Canvas", "Command", "Control", "Cloud", "Cast",
-        "Visual", "Studio", "Code", "Terminal", "Task", "Notepad", "Paint", "Photos", "Player",
-        "Panel", "Prompt", "Settings", "Store", "System", "Manager", "Monitor", "Editor", "Browser",
-        "Mail", "Maps", "Music", "Movies", "Network", "Office", "Onenote", "Outlook", "People",
-    ];
-
-    private static readonly string[] Qualifiers =
-    [
-        string.Empty, "Pro", "2022", "3D", "Preview", "X", "Lite", "Plus", "Home", "Enterprise",
-        "for Windows", "Insider", "Legacy", "New", "Classic",
-    ];
-
-    private static readonly string[] SubtitleWords =
-    [
-        "Perform calculations and conversions", "View and manage your schedule", "Edit and refine images",
-        "Modern terminal for command-line tools", "Full-featured integrated development environment",
-        "Browse the web quickly and securely", "Adjust your computer settings", "Monitor apps and processes",
-        "A simple and fast text editor", "Play and organize your media library",
-    ];
-
-    private static IPrecomputedFuzzyMatcher CreateMatcher() => new PrecomputedFuzzyMatcher(new PrecomputedFuzzyMatcherOptions());
-
-    private static CatalogItem[] BuildCatalog(int count, string idPrefix)
-    {
-        var items = new CatalogItem[count];
-        for (var i = 0; i < count; i++)
-        {
-            var noun = Nouns[i % Nouns.Length];
-            var qualifier = Qualifiers[(i / Nouns.Length) % Qualifiers.Length];
-            var title = string.IsNullOrEmpty(qualifier) ? noun : $"{noun} {qualifier}";
-
-            if (i >= Nouns.Length * Qualifiers.Length)
-            {
-                title = $"{title} {i}";
-            }
-
-            var subtitle = SubtitleWords[i % SubtitleWords.Length];
-            items[i] = new CatalogItem(title, subtitle, $"{idPrefix}.{i}");
-        }
-
-        return items;
-    }
-
-    private static RecentCommandsManager SeedHistory(CatalogItem[] apps, int seedCount)
-    {
-        var history = new RecentCommandsManager();
-        var n = Math.Min(seedCount, apps.Length);
-        for (var i = 0; i < n; i++)
-        {
-            var idx = (i * 7) % apps.Length;
-            history = history.WithHistoryItem(apps[idx].Command.Id);
-        }
-
-        return history;
-    }
 
     private static ScoringFunction<IListItem> BuildScoringFunction(
         IRecentCommandsManager history,

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/ScoringTestCatalog.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/ScoringTestCatalog.cs
@@ -1,0 +1,92 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.CmdPal.Common.Helpers;
+using Microsoft.CmdPal.Common.Text;
+using Microsoft.CmdPal.UI.ViewModels.Commands;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+
+namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
+
+internal static partial class ScoringTestCatalog
+{
+    internal sealed partial class CatalogItem : ListItem, IPrecomputedListItem
+    {
+        private FuzzyTargetCache _titleCache;
+        private FuzzyTargetCache _subtitleCache;
+
+        internal CatalogItem(string title, string subtitle, string id)
+            : base(new NoOpCommand() { Id = id })
+        {
+            Title = title;
+            Subtitle = subtitle;
+            Id = id;
+        }
+
+        internal string Id { get; }
+
+        public FuzzyTarget GetTitleTarget(IPrecomputedFuzzyMatcher matcher) => _titleCache.GetOrUpdate(matcher, Title);
+
+        public FuzzyTarget GetSubtitleTarget(IPrecomputedFuzzyMatcher matcher) => _subtitleCache.GetOrUpdate(matcher, Subtitle);
+    }
+
+    private static readonly string[] Nouns =
+    [
+        "Calculator", "Calendar", "Camera", "Canvas", "Command", "Control", "Cloud", "Cast",
+        "Visual", "Studio", "Code", "Terminal", "Task", "Notepad", "Paint", "Photos", "Player",
+        "Panel", "Prompt", "Settings", "Store", "System", "Manager", "Monitor", "Editor", "Browser",
+        "Mail", "Maps", "Music", "Movies", "Network", "Office", "Onenote", "Outlook", "People",
+    ];
+
+    private static readonly string[] Qualifiers =
+    [
+        string.Empty, "Pro", "2022", "3D", "Preview", "X", "Lite", "Plus", "Home", "Enterprise",
+        "for Windows", "Insider", "Legacy", "New", "Classic",
+    ];
+
+    private static readonly string[] SubtitleWords =
+    [
+        "Perform calculations and conversions", "View and manage your schedule", "Edit and refine images",
+        "Modern terminal for command-line tools", "Full-featured integrated development environment",
+        "Browse the web quickly and securely", "Adjust your computer settings", "Monitor apps and processes",
+        "A simple and fast text editor", "Play and organize your media library",
+    ];
+
+    internal static IPrecomputedFuzzyMatcher CreateMatcher() => new PrecomputedFuzzyMatcher(new PrecomputedFuzzyMatcherOptions());
+
+    internal static CatalogItem[] BuildCatalog(int count, string idPrefix)
+    {
+        var items = new CatalogItem[count];
+        for (var i = 0; i < count; i++)
+        {
+            var noun = Nouns[i % Nouns.Length];
+            var qualifier = Qualifiers[(i / Nouns.Length) % Qualifiers.Length];
+            var title = string.IsNullOrEmpty(qualifier) ? noun : $"{noun} {qualifier}";
+
+            if (i >= Nouns.Length * Qualifiers.Length)
+            {
+                title = $"{title} {i}";
+            }
+
+            var subtitle = SubtitleWords[i % SubtitleWords.Length];
+            items[i] = new CatalogItem(title, subtitle, $"{idPrefix}.{i}");
+        }
+
+        return items;
+    }
+
+    internal static RecentCommandsManager SeedHistory(CatalogItem[] apps, int seedCount)
+    {
+        var history = new RecentCommandsManager();
+        var n = Math.Min(seedCount, apps.Length);
+        for (var i = 0; i < n; i++)
+        {
+            var idx = (i * 7) % apps.Length;
+            history = history.WithHistoryItem(apps[idx].Id);
+        }
+
+        return history;
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/ScoringThroughputHarnessTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/ScoringThroughputHarnessTests.cs
@@ -339,6 +339,55 @@ public sealed partial class ScoringThroughputHarnessTests
         }
     }
 
+    /// <summary>
+    /// BEFORE/AFTER throughput: times the dominant apps scoring pass on the sequential path
+    /// (before, <see cref="InternalListHelpers.FilterListWithScores{T}"/>) versus the Phase 7b
+    /// parallel path (after, <see cref="InternalListHelpers.FilterListWithScoresParallel{T}"/>) and
+    /// reports the speedup per query. The parallel path pre-warms the frecency index once before
+    /// measuring, mirroring the product. This is report-only; it asserts only that the parallel
+    /// path returns the same match count as the sequential one, never a wall-clock threshold, so it
+    /// stays CI-safe.
+    /// </summary>
+    [TestMethod]
+    public void AppScoring_BeforeAfter_SerialVsParallelThroughput()
+    {
+        var apps = BuildCatalog(AppCount, "app");
+        var matcher = CreateMatcher();
+        var history = SeedHistory(apps, HistorySeedCount);
+        var scoringFn = BuildScoringFunction(history, matcher);
+        var source = apps.Cast<IListItem>().ToArray();
+
+        // Build the frecency index once, single-threaded, before the parallel pass reads it.
+        history.PrewarmIndex();
+
+        TestContext.WriteLine($"CPU count: {Environment.ProcessorCount}. Catalog: {AppCount} apps.");
+        TestContext.WriteLine("query | serial ms (before) | parallel ms (after) | speedup | matches");
+
+        foreach (var raw in Queries)
+        {
+            var query = matcher.PrecomputeQuery(raw);
+
+            RoScored<IListItem>[] serialResult = [];
+            var serialMs = TimeAverageMs(() =>
+            {
+                serialResult = InternalListHelpers.FilterListWithScores(source, query, scoringFn);
+            });
+
+            RoScored<IListItem>[] parallelResult = [];
+            var parallelMs = TimeAverageMs(() =>
+            {
+                parallelResult = InternalListHelpers.FilterListWithScoresParallel(source, query, scoringFn);
+            });
+
+            var speedup = parallelMs > 0 ? serialMs / parallelMs : 0.0;
+            TestContext.WriteLine(
+                $"{raw,-8}| {serialMs,17:F3} | {parallelMs,18:F3} | {speedup,6:F2}x | {serialResult.Length,7}");
+
+            // Structural, machine-independent: the parallel path returns the same match count.
+            Assert.AreEqual(serialResult.Length, parallelResult.Length, $"Match count must match for query '{raw}'.");
+        }
+    }
+
     // Averaged per-item nanoseconds for a loop that internally iterates the whole app catalog once.
     private static double PerItemNs(Action loopOverCatalog)
     {

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/ScoringThroughputHarnessTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/ScoringThroughputHarnessTests.cs
@@ -11,8 +11,8 @@ using Microsoft.CmdPal.Common.Text;
 using Microsoft.CmdPal.UI.ViewModels.Commands;
 using Microsoft.CmdPal.UI.ViewModels.MainPage;
 using Microsoft.CommandPalette.Extensions;
-using Microsoft.CommandPalette.Extensions.Toolkit;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using static Microsoft.CmdPal.UI.ViewModels.UnitTests.ScoringTestCatalog;
 
 namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
 
@@ -45,92 +45,6 @@ public sealed partial class ScoringThroughputHarnessTests
     private static readonly string[] Queries = ["c", "ca", "cal", "calc", "vsc", "vs code"];
 
     public TestContext TestContext { get; set; } = null!;
-
-    // Stand-in for an installed app or a top-level command. It caches fuzzy targets exactly like
-    // AppListItem does, so what we measure is the cached path the product actually runs.
-    private sealed partial class CatalogItem : ListItem, IPrecomputedListItem
-    {
-        private FuzzyTargetCache _titleCache;
-        private FuzzyTargetCache _subtitleCache;
-
-        public CatalogItem(string title, string subtitle, string id)
-            : base(new NoOpCommand() { Id = id })
-        {
-            Title = title;
-            Subtitle = subtitle;
-            Id = id;
-        }
-
-        public string Id { get; }
-
-        public FuzzyTarget GetTitleTarget(IPrecomputedFuzzyMatcher matcher) => _titleCache.GetOrUpdate(matcher, Title);
-
-        public FuzzyTarget GetSubtitleTarget(IPrecomputedFuzzyMatcher matcher) => _subtitleCache.GetOrUpdate(matcher, Subtitle);
-    }
-
-    // Composition is index-driven, no RNG and no wall clock, so the catalog and its match counts
-    // are reproducible across runs and hosts.
-    private static readonly string[] Nouns =
-    [
-        "Calculator", "Calendar", "Camera", "Canvas", "Command", "Control", "Cloud", "Cast",
-        "Visual", "Studio", "Code", "Terminal", "Task", "Notepad", "Paint", "Photos", "Player",
-        "Panel", "Prompt", "Settings", "Store", "System", "Manager", "Monitor", "Editor", "Browser",
-        "Mail", "Maps", "Music", "Movies", "Network", "Office", "Onenote", "Outlook", "People",
-    ];
-
-    private static readonly string[] Qualifiers =
-    [
-        string.Empty, "Pro", "2022", "3D", "Preview", "X", "Lite", "Plus", "Home", "Enterprise",
-        "for Windows", "Insider", "Legacy", "New", "Classic",
-    ];
-
-    private static readonly string[] SubtitleWords =
-    [
-        "Perform calculations and conversions", "View and manage your schedule", "Edit and refine images",
-        "Modern terminal for command-line tools", "Full-featured integrated development environment",
-        "Browse the web quickly and securely", "Adjust your computer settings", "Monitor apps and processes",
-        "A simple and fast text editor", "Play and organize your media library",
-    ];
-
-    private static IPrecomputedFuzzyMatcher CreateMatcher() => new PrecomputedFuzzyMatcher(new PrecomputedFuzzyMatcherOptions());
-
-    // Titles cycle the word banks to build dense confusable clusters, which is the shape that makes
-    // a 1-char query match a big slice of the catalog.
-    private static CatalogItem[] BuildCatalog(int count, string idPrefix)
-    {
-        var items = new CatalogItem[count];
-        for (var i = 0; i < count; i++)
-        {
-            var noun = Nouns[i % Nouns.Length];
-            var qualifier = Qualifiers[(i / Nouns.Length) % Qualifiers.Length];
-            var title = string.IsNullOrEmpty(qualifier) ? noun : $"{noun} {qualifier}";
-
-            // Only disambiguate past the first cycle, so early titles stay realistic.
-            if (i >= Nouns.Length * Qualifiers.Length)
-            {
-                title = $"{title} {i}";
-            }
-
-            var subtitle = SubtitleWords[i % SubtitleWords.Length];
-            items[i] = new CatalogItem(title, subtitle, $"{idPrefix}.{i}");
-        }
-
-        return items;
-    }
-
-    private static RecentCommandsManager SeedHistory(CatalogItem[] apps, int seedCount)
-    {
-        var history = new RecentCommandsManager();
-        var n = Math.Min(seedCount, apps.Length);
-        for (var i = 0; i < n; i++)
-        {
-            // Spread the seeds across the catalog so hits are not all clustered at the front.
-            var idx = (i * 7) % apps.Length;
-            history = history.WithHistoryItem(apps[idx].Id);
-        }
-
-        return history;
-    }
 
     private static ScoringFunction<IListItem> BuildScoringFunction(
         IRecentCommandsManager history,

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/ScoringThroughputHarnessTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/ScoringThroughputHarnessTests.cs
@@ -340,13 +340,9 @@ public sealed partial class ScoringThroughputHarnessTests
     }
 
     /// <summary>
-    /// BEFORE/AFTER throughput: times the dominant apps scoring pass on the sequential path
-    /// (before, <see cref="InternalListHelpers.FilterListWithScores{T}"/>) versus the Phase 7b
-    /// parallel path (after, <see cref="InternalListHelpers.FilterListWithScoresParallel{T}"/>) and
-    /// reports the speedup per query. The parallel path pre-warms the frecency index once before
-    /// measuring, mirroring the product. This is report-only; it asserts only that the parallel
-    /// path returns the same match count as the sequential one, never a wall-clock threshold, so it
-    /// stays CI-safe.
+    /// Times the dominant apps pass serial versus parallel and reports the speedup per query.
+    /// Report-only: it asserts the two paths return the same match count, never a wall-clock
+    /// threshold.
     /// </summary>
     [TestMethod]
     public void AppScoring_BeforeAfter_SerialVsParallelThroughput()
@@ -383,7 +379,7 @@ public sealed partial class ScoringThroughputHarnessTests
             TestContext.WriteLine(
                 $"{raw,-8}| {serialMs,17:F3} | {parallelMs,18:F3} | {speedup,6:F2}x | {serialResult.Length,7}");
 
-            // Structural, machine-independent: the parallel path returns the same match count.
+            // The parallel path returns the same match count, on any machine.
             Assert.AreEqual(serialResult.Length, parallelResult.Length, $"Match count must match for query '{raw}'.");
         }
     }


### PR DESCRIPTION
>[!WARNING]
> One in a series rearchitecting the `MainListPage` search and scoring logic. The full explanation lives in the first PR of the change (#49189).
>
> **This PR should not be merged until PR #49249 is merged into it.**

## What's going on

Phase 7a (#49246) measured where the settle time goes. App scoring dominates, and it runs while holding the lock that also blocks `GetItems` and render. This PR acts on that.

It's a make it faster, same answer change. The settled result order is identical to what phase 6 and 7a produce. No ranking constant, tier rule, frecency value, or provider weight moved. Early frame behavior is untouched, since that's 7c's job.

## The plan

**Shrink the `TopLevelCommands` lock scope** in `UpdateSearchTextCore`. Sources get snapshotted under the lock, the multi thousand item scoring and sort run off it, and the lock comes back only long enough to publish the finished result. The existing cancellation token guard keeps the swap supersede safe, so a newer keystroke always wins and a stale snapshot never clobbers newer results.

**Parallelize the app scoring pass** with `FilterListWithScoresParallel`. Contiguous partitions score on separate threads and concatenate in partition order, which reproduces the serial pre sort buffer exactly, so the same `Array.Sort` gives the same output. Commands and fallbacks stay serial because they're small enough that the coordination cost isn't worth it.

**Drop a redundant** second `commands.Where(IsFallback)` pass by reusing the `specialFallbacks` list the prefilter loop already built.

**Add `ScoringParallelEquivalenceTests`** as the guardrail. It asserts the parallel path matches a sequential reference item for item and score for score across full catalog, extend, retype rebuild, commands, and determinism cases, using a few thousand synthetic apps and a few hundred commands. It's deterministic, so it's safe on CI.

Throughput on a 12 CPU box with 3000 apps:

| query | serial ms | parallel ms | speedup |
|-------|-----------|-------------|---------|
| c     | 8.376 | 3.681 | 2.28x |
| ca    | 7.826 | 3.274 | 2.39x |
| cal   | 6.522 | 2.142 | 3.04x |
| calc  | 4.593 | 3.193 | 1.44x |
| vsc   | 4.680 | 1.779 | 2.63x |

## Notes for reviewers

`RecentCommandsManager.Index` gets pre warmed on a single thread before the parallel loop kicks off. Its lazy dictionary build isn't thread safe, and I'd rather do one cheap warm up than add a lock inside the hot path.

Two optimizations from the 7a data got skipped on purpose. Skipping the subtitle DP and gating `ClassifyTier` would both be faster, and both change within tier scores. That breaks the same answer promise, so they're off the table until we're ready to argue about ranking changes on their own merits.