### PR TITLE
[CmdPal] Phase 7c: early-frame relevance (withhold weak fuzzy tail on ultra-short queries)

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
@@ -87,6 +87,24 @@ public sealed partial class MainListPage : DynamicListPage,
 
     private int AppResultLimit => AllAppsCommandProvider.TopLevelResultLimit;
 
+    // ===== Early-frame relevance (Phase 7c) =====
+    // Longest query, in characters, for which the low-confidence app tail is withheld on the
+    // render path. A 1-2 char query fuzzy-matches a huge fraction of the app catalog, so within
+    // that single giant Fuzzy tier the order is decided almost entirely by frecency and the
+    // most-frecent app can float to the top on a weak, mid-word subsequence match - the "wrong
+    // when I start typing" flash. While the query is this short we show only the letter-relevant
+    // apps and let the noisy tail fold in once the query is long enough to discriminate. This is
+    // a pure render-path view over the already-scored/sorted results: it never re-scores and
+    // never reorders, so the settled order of a discriminating (3+ char) query is untouched. Set
+    // to 0 to disable the gate entirely.
+    private const int ShortQueryAppTailGateMaxLength = 2;
+
+    // Minimum ranker tier an app must reach to be shown while the query is still ultra-short.
+    // Word-boundary, prefix, exact-title and alias matches are all relevant to the characters the
+    // user actually typed; the Fuzzy tier (a scattered subsequence match) is the noisy tail that
+    // is withheld until the query can discriminate.
+    private const RankTier ShortQueryAppGateMinTier = RankTier.AcronymWordBoundary;
+
     private InterlockedBoolean _fullRefreshRequested;
     private InterlockedBoolean _refreshRunning;
     private InterlockedBoolean _refreshRequested;
@@ -281,10 +299,16 @@ public sealed partial class MainListPage : DynamicListPage,
             .Where(s => !string.IsNullOrWhiteSpace(s.Item.Title))
             .ToList();
 
+        // Early-frame gate: while the query is still ultra-short, withhold the large low-confidence
+        // fuzzy app tail so a frecency-floated weak match cannot surface at the top mid-typing. For
+        // discriminating (longer) queries the scored apps are passed through unchanged, so the
+        // settled order of a meaningful query is never altered.
+        var gatedApps = ApplyShortQueryAppGate(_filteredApps, SearchText?.Length ?? 0);
+
         var result = MainListPageResultFactory.Create(
             _filteredItems,
             validScoredFallbacks,
-            _filteredApps,
+            gatedApps,
             validFallbacks,
             _resultsSeparator,
             _fallbacksSeparator,
@@ -335,6 +359,52 @@ public sealed partial class MainListPage : DynamicListPage,
         }
 
         return valid;
+    }
+
+    // Applies the Phase 7c early-frame short-query gate to the already-scored, already-sorted app
+    // results. For a discriminating query (empty, or longer than ShortQueryAppTailGateMaxLength) the
+    // input is returned unchanged, so the settled order of a meaningful query is byte-identical to
+    // before. For an ultra-short query only the letter-relevant apps (tier at or above
+    // ShortQueryAppGateMinTier) are kept; the noisy fuzzy tail is withheld until the query can
+    // discriminate. This is a pure view over the scored array - it slices a contiguous prefix and
+    // never re-scores or reorders - so it can never change the ranker's output. Extracted as a
+    // static so the early-frame behavior can be unit tested without constructing a MainListPage.
+    internal static IList<RoScored<IListItem>>? ApplyShortQueryAppGate(
+        RoScored<IListItem>[]? scoredApps,
+        int queryLength)
+    {
+        if (scoredApps is null || scoredApps.Length == 0)
+        {
+            return scoredApps;
+        }
+
+        if (queryLength <= 0 || queryLength > ShortQueryAppTailGateMaxLength)
+        {
+            return scoredApps;
+        }
+
+        var keep = HighConfidenceAppPrefixLength(scoredApps, ShortQueryAppGateMinTier);
+        return keep == scoredApps.Length
+            ? scoredApps
+            : new ArraySegment<RoScored<IListItem>>(scoredApps, 0, keep);
+    }
+
+    // Number of leading scored entries whose ranker tier is at or above minTier. The scored arrays
+    // are sorted descending by packed score and the tier occupies the high bits of that score, so
+    // all entries at or above a given tier form a contiguous prefix - a single forward scan to the
+    // first entry that falls below the tier yields the cutoff.
+    internal static int HighConfidenceAppPrefixLength(IReadOnlyList<RoScored<IListItem>> scored, RankTier minTier)
+    {
+        var min = (int)minTier;
+        for (var i = 0; i < scored.Count; i++)
+        {
+            if ((int)MainListRanker.TierOf(scored[i].Score) < min)
+            {
+                return i;
+            }
+        }
+
+        return scored.Count;
     }
 
     private IListItem[] GetDefaultViewItems()

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
@@ -68,6 +68,14 @@ public sealed partial class MainListPage : DynamicListPage,
     private RoScored<IListItem>[]? _filteredItems;
     private RoScored<IListItem>[]? _filteredApps;
 
+    // Length of the query that produced the currently published _filteredApps. Published atomically
+    // with _filteredApps under lock(commands) so the early-frame gate always decides on the length
+    // of the query that actually produced the app array it is gating. Gating on the live SearchText
+    // instead would be unsafe: SearchText is advanced on the UI thread ahead of the publish, so on a
+    // 2-to-3 char transition a throttled refresh could render the stale 2-char app array while the
+    // live length already reads 3, no-op the gate, and briefly expose the fuzzy tail 7c withholds.
+    private int _filteredAppsQueryLength;
+
     // Global/special fallbacks are scored on the render path, not at keystroke time, because
     // their titles resolve asynchronously. We snapshot the source list and query together so a
     // superseding keystroke replaces both atomically.
@@ -303,7 +311,7 @@ public sealed partial class MainListPage : DynamicListPage,
         // fuzzy app tail so a frecency-floated weak match cannot surface at the top mid-typing. For
         // discriminating (longer) queries the scored apps are passed through unchanged, so the
         // settled order of a meaningful query is never altered.
-        var gatedApps = ApplyShortQueryAppGate(_filteredApps, SearchText?.Length ?? 0);
+        var gatedApps = ApplyShortQueryAppGate(_filteredApps, _filteredAppsQueryLength);
 
         var result = MainListPageResultFactory.Create(
             _filteredItems,
@@ -407,6 +415,27 @@ public sealed partial class MainListPage : DynamicListPage,
         return scored.Count;
     }
 
+    // Number of app results that are actually visible for a given published query length, matching
+    // what ApplyShortQueryAppGate renders: the gated high-confidence prefix while the query is in the
+    // ultra-short window, otherwise the full set, in both cases capped by the app result limit. Used
+    // to keep the settled-search telemetry count consistent with what the user is shown, so a short
+    // query whose fuzzy tail is withheld does not report an inflated result count.
+    internal static int GatedVisibleAppCount(RoScored<IListItem>[]? scoredApps, int queryLength, int appResultLimit)
+    {
+        if (scoredApps is null || scoredApps.Length == 0)
+        {
+            return 0;
+        }
+
+        var count = scoredApps.Length;
+        if (queryLength > 0 && queryLength <= ShortQueryAppTailGateMaxLength)
+        {
+            count = HighConfidenceAppPrefixLength(scoredApps, ShortQueryAppGateMinTier);
+        }
+
+        return Math.Min(count, appResultLimit);
+    }
+
     private IListItem[] GetDefaultViewItems()
     {
         if (_defaultViewDirty)
@@ -491,6 +520,7 @@ public sealed partial class MainListPage : DynamicListPage,
     {
         _filteredItems = null;
         _filteredApps = null;
+        _filteredAppsQueryLength = 0;
         _fallbackItems = null;
         _globalFallbackSources = null;
 
@@ -786,10 +816,15 @@ public sealed partial class MainListPage : DynamicListPage,
             // ClearResults behavior.
             _filteredApps = appsSource.Count > 0 ? scoredApps : null;
 
+            // Publish the query length atomically with the array so the render-path gate (and the
+            // telemetry count below) always evaluate against the query that produced this app array,
+            // never the live SearchText which the UI thread may already have advanced past.
+            _filteredAppsQueryLength = _filteredApps is null ? 0 : newSearch.Length;
+
             if (isUserInput)
             {
                 deterministicResultCount = (_filteredItems?.Length ?? 0)
-                    + Math.Min(_filteredApps?.Length ?? 0, AppResultLimit);
+                    + GatedVisibleAppCount(_filteredApps, _filteredAppsQueryLength, AppResultLimit);
             }
 
 #if CMDPAL_FF_MAINPAGE_TIME_RAISE_ITEMS

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
@@ -68,12 +68,10 @@ public sealed partial class MainListPage : DynamicListPage,
     private RoScored<IListItem>[]? _filteredItems;
     private RoScored<IListItem>[]? _filteredApps;
 
-    // Length of the query that produced the currently published _filteredApps. Published atomically
-    // with _filteredApps under lock(commands) so the early-frame gate always decides on the length
-    // of the query that actually produced the app array it is gating. Gating on the live SearchText
-    // instead would be unsafe: SearchText is advanced on the UI thread ahead of the publish, so on a
-    // 2-to-3 char transition a throttled refresh could render the stale 2-char app array while the
-    // live length already reads 3, no-op the gate, and briefly expose the fuzzy tail 7c withholds.
+    // Length of the query that produced the current _filteredApps, set under lock(commands)
+    // alongside the array itself. SearchText won't work here: the UI thread advances it ahead of
+    // the publish, so the gate would judge a stale 2-char array against a 3-char query and flash
+    // the tail anyway.
     private int _filteredAppsQueryLength;
 
     // Global/special fallbacks are scored on the render path, not at keystroke time, because
@@ -95,22 +93,14 @@ public sealed partial class MainListPage : DynamicListPage,
 
     private int AppResultLimit => AllAppsCommandProvider.TopLevelResultLimit;
 
-    // ===== Early-frame relevance (Phase 7c) =====
-    // Longest query, in characters, for which the low-confidence app tail is withheld on the
-    // render path. A 1-2 char query fuzzy-matches a huge fraction of the app catalog, so within
-    // that single giant Fuzzy tier the order is decided almost entirely by frecency and the
-    // most-frecent app can float to the top on a weak, mid-word subsequence match - the "wrong
-    // when I start typing" flash. While the query is this short we show only the letter-relevant
-    // apps and let the noisy tail fold in once the query is long enough to discriminate. This is
-    // a pure render-path view over the already-scored/sorted results: it never re-scores and
-    // never reorders, so the settled order of a discriminating (3+ char) query is untouched. Set
-    // to 0 to disable the gate entirely.
+    // ===== Early-frame relevance =====
+    // Longest query we still hold back the weak fuzzy app tail for, since one letter matches most
+    // of the catalog and frecency floats your most-used app up on a match it barely earned. Set to
+    // 0 to turn the gate off.
     private const int ShortQueryAppTailGateMaxLength = 2;
 
-    // Minimum ranker tier an app must reach to be shown while the query is still ultra-short.
-    // Word-boundary, prefix, exact-title and alias matches are all relevant to the characters the
-    // user actually typed; the Fuzzy tier (a scattered subsequence match) is the noisy tail that
-    // is withheld until the query can discriminate.
+    // Minimum tier an app has to reach to show while the query is still that short, since
+    // word-boundary, prefix, exact-title and alias matches all relate to what you actually typed.
     private const RankTier ShortQueryAppGateMinTier = RankTier.AcronymWordBoundary;
 
     private InterlockedBoolean _fullRefreshRequested;
@@ -307,10 +297,8 @@ public sealed partial class MainListPage : DynamicListPage,
             .Where(s => !string.IsNullOrWhiteSpace(s.Item.Title))
             .ToList();
 
-        // Early-frame gate: while the query is still ultra-short, withhold the large low-confidence
-        // fuzzy app tail so a frecency-floated weak match cannot surface at the top mid-typing. For
-        // discriminating (longer) queries the scored apps are passed through unchanged, so the
-        // settled order of a meaningful query is never altered.
+        // Hold back the weak fuzzy tail while the query is still short, so a frecency-floated
+        // match can't surface at the top mid-typing.
         var gatedApps = ApplyShortQueryAppGate(_filteredApps, _filteredAppsQueryLength);
 
         var result = MainListPageResultFactory.Create(
@@ -369,14 +357,9 @@ public sealed partial class MainListPage : DynamicListPage,
         return valid;
     }
 
-    // Applies the Phase 7c early-frame short-query gate to the already-scored, already-sorted app
-    // results. For a discriminating query (empty, or longer than ShortQueryAppTailGateMaxLength) the
-    // input is returned unchanged, so the settled order of a meaningful query is byte-identical to
-    // before. For an ultra-short query only the letter-relevant apps (tier at or above
-    // ShortQueryAppGateMinTier) are kept; the noisy fuzzy tail is withheld until the query can
-    // discriminate. This is a pure view over the scored array - it slices a contiguous prefix and
-    // never re-scores or reorders - so it can never change the ranker's output. Extracted as a
-    // static so the early-frame behavior can be unit tested without constructing a MainListPage.
+    // Keeps only the letter-relevant apps while the query is short, and returns a longer query's
+    // results untouched. It slices a contiguous prefix of the already-scored, already-sorted array,
+    // so it can never re-score or reorder anything.
     internal static IList<RoScored<IListItem>>? ApplyShortQueryAppGate(
         RoScored<IListItem>[]? scoredApps,
         int queryLength)
@@ -397,10 +380,8 @@ public sealed partial class MainListPage : DynamicListPage,
             : new ArraySegment<RoScored<IListItem>>(scoredApps, 0, keep);
     }
 
-    // Number of leading scored entries whose ranker tier is at or above minTier. The scored arrays
-    // are sorted descending by packed score and the tier occupies the high bits of that score, so
-    // all entries at or above a given tier form a contiguous prefix - a single forward scan to the
-    // first entry that falls below the tier yields the cutoff.
+    // The array is sorted descending by packed score and the tier lives in that score's high bits,
+    // so everything at or above a tier forms a contiguous prefix that one forward scan can find.
     internal static int HighConfidenceAppPrefixLength(IReadOnlyList<RoScored<IListItem>> scored, RankTier minTier)
     {
         var min = (int)minTier;
@@ -415,11 +396,8 @@ public sealed partial class MainListPage : DynamicListPage,
         return scored.Count;
     }
 
-    // Number of app results that are actually visible for a given published query length, matching
-    // what ApplyShortQueryAppGate renders: the gated high-confidence prefix while the query is in the
-    // ultra-short window, otherwise the full set, in both cases capped by the app result limit. Used
-    // to keep the settled-search telemetry count consistent with what the user is shown, so a short
-    // query whose fuzzy tail is withheld does not report an inflated result count.
+    // How many apps the user actually sees, mirroring ApplyShortQueryAppGate and the app result
+    // limit, so telemetry doesn't report a count that includes the tail we withheld.
     internal static int GatedVisibleAppCount(RoScored<IListItem>[]? scoredApps, int queryLength, int appResultLimit)
     {
         if (scoredApps is null || scoredApps.Length == 0)
@@ -744,10 +722,8 @@ public sealed partial class MainListPage : DynamicListPage,
         var settings = _settingsService.Settings;
         var scoringNow = DateTimeOffset.UtcNow;
 
-        // Precompute from the snapshotted query (newSearch), not the live SearchText field, which a
-        // newer keystroke may already have advanced. Every other scoring input is pinned above for
-        // the same reason; using SearchText here would score this pass against a different query than
-        // the one it was launched for.
+        // Precompute from the snapshotted newSearch, not the live SearchText, which a newer
+        // keystroke may already have advanced past.
         var searchQuery = matcher.PrecomputeQuery(newSearch);
 
         // Every installed app belongs to the well-known AllApps provider, so its weight is constant
@@ -820,9 +796,8 @@ public sealed partial class MainListPage : DynamicListPage,
             // ClearResults behavior.
             _filteredApps = appsSource.Count > 0 ? scoredApps : null;
 
-            // Publish the query length atomically with the array so the render-path gate (and the
-            // telemetry count below) always evaluate against the query that produced this app array,
-            // never the live SearchText which the UI thread may already have advanced past.
+            // Publish the length with the array so the render gate and the telemetry count both
+            // judge against the query that actually produced it.
             _filteredAppsQueryLength = _filteredApps is null ? 0 : newSearch.Length;
 
             if (isUserInput)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
@@ -68,10 +68,7 @@ public sealed partial class MainListPage : DynamicListPage,
     private RoScored<IListItem>[]? _filteredItems;
     private RoScored<IListItem>[]? _filteredApps;
 
-    // Length of the query that produced the current _filteredApps, set under lock(commands)
-    // alongside the array itself. SearchText won't work here: the UI thread advances it ahead of
-    // the publish, so the gate would judge a stale 2-char array against a 3-char query and flash
-    // the tail anyway.
+    // Published with _filteredApps so filtering uses the query that produced the scores.
     private int _filteredAppsQueryLength;
 
     // Global/special fallbacks are scored on the render path, not at keystroke time, because
@@ -93,15 +90,11 @@ public sealed partial class MainListPage : DynamicListPage,
 
     private int AppResultLimit => AllAppsCommandProvider.TopLevelResultLimit;
 
-    // ===== Early-frame relevance =====
-    // Longest query we still hold back the weak fuzzy app tail for, since one letter matches most
-    // of the catalog and frecency floats your most-used app up on a match it barely earned. Set to
-    // 0 to turn the gate off.
-    private const int ShortQueryAppTailGateMaxLength = 2;
+    // Longest query to filter fuzzy app matches on. This prevents weak app matches on short queries.
+    private const int ShortQueryAppFilterMaxLength = 2;
 
-    // Minimum tier an app has to reach to show while the query is still that short, since
-    // word-boundary, prefix, exact-title and alias matches all relate to what you actually typed.
-    private const RankTier ShortQueryAppGateMinTier = RankTier.AcronymWordBoundary;
+    // Minimum tier an app must reach to appear for a short query.
+    private const RankTier ShortQueryAppFilterMinTier = RankTier.AcronymWordBoundary;
 
     private InterlockedBoolean _fullRefreshRequested;
     private InterlockedBoolean _refreshRunning;
@@ -297,14 +290,14 @@ public sealed partial class MainListPage : DynamicListPage,
             .Where(s => !string.IsNullOrWhiteSpace(s.Item.Title))
             .ToList();
 
-        // Hold back the weak fuzzy tail while the query is still short, so a frecency-floated
-        // match can't surface at the top mid-typing.
-        var gatedApps = ApplyShortQueryAppGate(_filteredApps, _filteredAppsQueryLength);
+        // Remove fuzzy-only app matches for short queries so frecency-boosted weak matches don't
+        // appear while typing.
+        var filteredApps = FilterAppsForShortQueries(_filteredApps, _filteredAppsQueryLength);
 
         var result = MainListPageResultFactory.Create(
             _filteredItems,
             validScoredFallbacks,
-            gatedApps,
+            filteredApps,
             validFallbacks,
             _resultsSeparator,
             _fallbacksSeparator,
@@ -357,10 +350,8 @@ public sealed partial class MainListPage : DynamicListPage,
         return valid;
     }
 
-    // Keeps only the letter-relevant apps while the query is short, and returns a longer query's
-    // results untouched. It slices a contiguous prefix of the already-scored, already-sorted array,
-    // so it can never re-score or reorder anything.
-    internal static IList<RoScored<IListItem>>? ApplyShortQueryAppGate(
+    // Returns a filtered view of the scored array without reordering it.
+    internal static IList<RoScored<IListItem>>? FilterAppsForShortQueries(
         RoScored<IListItem>[]? scoredApps,
         int queryLength)
     {
@@ -369,20 +360,19 @@ public sealed partial class MainListPage : DynamicListPage,
             return scoredApps;
         }
 
-        if (queryLength <= 0 || queryLength > ShortQueryAppTailGateMaxLength)
+        if (queryLength <= 0 || queryLength > ShortQueryAppFilterMaxLength)
         {
             return scoredApps;
         }
 
-        var keep = HighConfidenceAppPrefixLength(scoredApps, ShortQueryAppGateMinTier);
+        var keep = GetHighConfidenceAppsCount(scoredApps, ShortQueryAppFilterMinTier);
         return keep == scoredApps.Length
             ? scoredApps
             : new ArraySegment<RoScored<IListItem>>(scoredApps, 0, keep);
     }
 
-    // The array is sorted descending by packed score and the tier lives in that score's high bits,
-    // so everything at or above a tier forms a contiguous prefix that one forward scan can find.
-    internal static int HighConfidenceAppPrefixLength(IReadOnlyList<RoScored<IListItem>> scored, RankTier minTier)
+    // Qualifying apps form a contiguous prefix because the array is already sorted by score.
+    internal static int GetHighConfidenceAppsCount(IReadOnlyList<RoScored<IListItem>> scored, RankTier minTier)
     {
         var min = (int)minTier;
         for (var i = 0; i < scored.Count; i++)
@@ -396,9 +386,8 @@ public sealed partial class MainListPage : DynamicListPage,
         return scored.Count;
     }
 
-    // How many apps the user actually sees, mirroring ApplyShortQueryAppGate and the app result
-    // limit, so telemetry doesn't report a count that includes the tail we withheld.
-    internal static int GatedVisibleAppCount(RoScored<IListItem>[]? scoredApps, int queryLength, int appResultLimit)
+    // Applies the short-query filter and result limit to the telemetry count.
+    internal static int GetVisibleAppCount(RoScored<IListItem>[]? scoredApps, int queryLength, int appResultLimit)
     {
         if (scoredApps is null || scoredApps.Length == 0)
         {
@@ -406,9 +395,9 @@ public sealed partial class MainListPage : DynamicListPage,
         }
 
         var count = scoredApps.Length;
-        if (queryLength > 0 && queryLength <= ShortQueryAppTailGateMaxLength)
+        if (queryLength > 0 && queryLength <= ShortQueryAppFilterMaxLength)
         {
-            count = HighConfidenceAppPrefixLength(scoredApps, ShortQueryAppGateMinTier);
+            count = GetHighConfidenceAppsCount(scoredApps, ShortQueryAppFilterMinTier);
         }
 
         return Math.Min(count, appResultLimit);
@@ -796,14 +785,13 @@ public sealed partial class MainListPage : DynamicListPage,
             // ClearResults behavior.
             _filteredApps = appsSource.Count > 0 ? scoredApps : null;
 
-            // Publish the length with the array so the render gate and the telemetry count both
-            // judge against the query that actually produced it.
+            // Publish the length with the array so filtering and telemetry use the same query.
             _filteredAppsQueryLength = _filteredApps is null ? 0 : newSearch.Length;
 
             if (isUserInput)
             {
                 deterministicResultCount = (_filteredItems?.Length ?? 0)
-                    + GatedVisibleAppCount(_filteredApps, _filteredAppsQueryLength, AppResultLimit);
+                    + GetVisibleAppCount(_filteredApps, _filteredAppsQueryLength, AppResultLimit);
             }
 
 #if CMDPAL_FF_MAINPAGE_TIME_RAISE_ITEMS

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
@@ -744,7 +744,11 @@ public sealed partial class MainListPage : DynamicListPage,
         var settings = _settingsService.Settings;
         var scoringNow = DateTimeOffset.UtcNow;
 
-        var searchQuery = matcher.PrecomputeQuery(SearchText);
+        // Precompute from the snapshotted query (newSearch), not the live SearchText field, which a
+        // newer keystroke may already have advanced. Every other scoring input is pinned above for
+        // the same reason; using SearchText here would score this pass against a different query than
+        // the one it was launched for.
+        var searchQuery = matcher.PrecomputeQuery(newSearch);
 
         // Every installed app belongs to the well-known AllApps provider, so its weight is constant
         // for the whole pass and we resolve it once instead of once per app.

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/EarlyFrameRelevanceTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/EarlyFrameRelevanceTests.cs
@@ -307,4 +307,81 @@ public sealed partial class EarlyFrameRelevanceTests
         Assert.AreEqual(1, MainListPage.HighConfidenceAppPrefixLength(scored, RankTier.ExactTitle));
         Assert.AreEqual(0, MainListPage.HighConfidenceAppPrefixLength(scored, RankTier.AliasExact));
     }
+
+    /// <summary>
+    /// FIX #2 guardrail: the gate decision is driven entirely by the length it is handed - the query
+    /// length PUBLISHED atomically with the app array - not by any later value. Feeding the published
+    /// short length (2) withholds the fuzzy tail even though a longer length would pass it through,
+    /// which is exactly why MainListPage gates on the published _filteredAppsQueryLength rather than
+    /// the live SearchText the UI thread may already have advanced past on a 2-to-3 char transition.
+    /// </summary>
+    [TestMethod]
+    public void Gate_DecidesOnSuppliedPublishedLength_NotLiveText()
+    {
+        RoScored<IListItem> Fuzzy(int within)
+            => new(new CatalogItem($"fuzzy.{within}", string.Empty, $"fuzzy.{within}"), MainListRanker.Pack(RankTier.Fuzzy, within));
+
+        var scored = new[] { Fuzzy(30), Fuzzy(20), Fuzzy(10) };
+
+        // Published length 2 (the query that produced this array is still ultra-short): withhold.
+        var gatedByPublished = MainListPage.ApplyShortQueryAppGate(scored, queryLength: 2);
+        Assert.IsNotNull(gatedByPublished);
+        Assert.AreEqual(0, gatedByPublished!.Count, "Gating on the published short length (2) must withhold the fuzzy tail.");
+
+        // The SAME array gated on a longer length passes through, so gating on a stale/live longer
+        // length would wrongly expose the tail. That is the regression Fix #2 prevents.
+        Assert.AreSame(scored, MainListPage.ApplyShortQueryAppGate(scored, queryLength: 5), "A longer length would pass the tail through, proving the supplied length is what decides.");
+    }
+
+    /// <summary>
+    /// FIX #3 guardrail: the settled-search telemetry count reflects the GATED visible apps for an
+    /// ultra-short query, not the full ungated app array. For a discriminating query it is the full
+    /// (capped) count. This keeps the reported result count consistent with what the user is shown.
+    /// </summary>
+    [TestMethod]
+    public void GatedVisibleAppCount_ShortQuery_CountsOnlyGatedApps()
+    {
+        var matcher = CreateMatcher();
+        var apps = BuildMixedCatalogForC();
+        var scored = Score(apps, "c", new RecentCommandsManager(), matcher);
+
+        var full = scored.Length;
+        var confident = scored.Count(s => (int)MainListRanker.TierOf(s.Score) >= (int)RankTier.AcronymWordBoundary);
+        Assert.IsTrue(confident < full, "Precondition: a fuzzy tail exists so the gated count is strictly less than the full count.");
+
+        const int NoCap = 1000;
+
+        // Ultra-short published length: only the confident head is counted.
+        Assert.AreEqual(confident, MainListPage.GatedVisibleAppCount(scored, queryLength: 1, appResultLimit: NoCap));
+        Assert.AreEqual(confident, MainListPage.GatedVisibleAppCount(scored, queryLength: 2, appResultLimit: NoCap));
+
+        // Discriminating published length: the full set (capped) is counted.
+        Assert.AreEqual(full, MainListPage.GatedVisibleAppCount(scored, queryLength: 3, appResultLimit: NoCap));
+        Assert.AreEqual(full, MainListPage.GatedVisibleAppCount(scored, queryLength: 0, appResultLimit: NoCap), "A zero-length (default view) count is ungated.");
+    }
+
+    /// <summary>
+    /// FIX #3: the gated visible count is still capped by the app result limit, a fuzzy-only
+    /// ultra-short query reports zero visible apps (its whole tail is withheld), and null/empty
+    /// inputs report zero.
+    /// </summary>
+    [TestMethod]
+    public void GatedVisibleAppCount_RespectsCap_AndZeroForWithheldOrEmpty()
+    {
+        var matcher = CreateMatcher();
+
+        // Fuzzy-only ultra-short query: nothing confident, so the gated count is zero.
+        var fuzzyOnly = Score(BuildFuzzyOnlyCatalogForX(), "x", new RecentCommandsManager(), matcher);
+        Assert.IsTrue(fuzzyOnly.Length > 0, "Precondition: 'x' matches fuzzily.");
+        Assert.AreEqual(0, MainListPage.GatedVisibleAppCount(fuzzyOnly, queryLength: 1, appResultLimit: 1000));
+
+        // The cap applies on the ungated path.
+        var mixed = Score(BuildMixedCatalogForC(), "c", new RecentCommandsManager(), matcher);
+        Assert.IsTrue(mixed.Length > 2, "Precondition: the mixed catalog has more than two matches so the cap bites.");
+        Assert.AreEqual(2, MainListPage.GatedVisibleAppCount(mixed, queryLength: 3, appResultLimit: 2), "The full count is capped by the app result limit.");
+
+        // Null and empty report zero.
+        Assert.AreEqual(0, MainListPage.GatedVisibleAppCount(null, 1, 1000));
+        Assert.AreEqual(0, MainListPage.GatedVisibleAppCount(Array.Empty<RoScored<IListItem>>(), 1, 1000));
+    }
 }

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/EarlyFrameRelevanceTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/EarlyFrameRelevanceTests.cs
@@ -1,0 +1,310 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CmdPal.Common.Helpers;
+using Microsoft.CmdPal.Common.Text;
+using Microsoft.CmdPal.UI.ViewModels.Commands;
+using Microsoft.CmdPal.UI.ViewModels.MainPage;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.Foundation;
+
+namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
+
+/// <summary>
+/// GUARDRAIL for the Phase 7c early-frame relevance change. Phase 7c stops the "completely wrong
+/// when I start typing" flash by withholding, on the render path, the large low-confidence fuzzy
+/// app tail for ultra-short (1-2 char) queries. The change is confined to the transient early
+/// frame: it slices the already-scored, already-sorted app array and never re-scores or reorders,
+/// so the settled order of a discriminating (3+ char) query is byte-identical to before.
+///
+/// These tests lock two things:
+///  1. The confirmed mechanism (Mechanism A): a 1-char query drops a huge fraction of the catalog
+///     into the single Fuzzy tier, where within-tier order is decided almost entirely by frecency,
+///     so the most-frecent app floats to rank 1 on a weak, mid-word subsequence match.
+///  2. The fix: for an ultra-short query the gate withholds that Fuzzy tail (keeping only the
+///     letter-relevant word-boundary/prefix/exact matches), while for a 3+ char query the scored
+///     apps are passed through unchanged (same array reference).
+///
+/// Everything here is deterministic (index-driven catalog, injected frecency, no wall-clock
+/// ordering dependence), so it is CI-safe and never flakes.
+/// </summary>
+[TestClass]
+public sealed partial class EarlyFrameRelevanceTests
+{
+    public TestContext TestContext { get; set; } = null!;
+
+    private sealed partial class CatalogItem : IListItem, IPrecomputedListItem
+    {
+        private FuzzyTargetCache _titleCache;
+        private FuzzyTargetCache _subtitleCache;
+
+        public CatalogItem(string title, string subtitle, string id)
+        {
+            Title = title;
+            Subtitle = subtitle;
+            Id = id;
+            Command = new NoOpCommand() { Id = id };
+        }
+
+        public string Title { get; }
+
+        public string Subtitle { get; }
+
+        public string Id { get; }
+
+        public ICommand Command { get; }
+
+        public IDetails? Details => null;
+
+        public IIconInfo? Icon => null;
+
+        public string Section => string.Empty;
+
+        public ITag[] Tags => [];
+
+        public string TextToSuggest => string.Empty;
+
+        public IContextItem[] MoreCommands => [];
+
+#pragma warning disable CS0067 // The event is never used
+        public event TypedEventHandler<object, IPropChangedEventArgs>? PropChanged;
+#pragma warning restore CS0067
+
+        public FuzzyTarget GetTitleTarget(IPrecomputedFuzzyMatcher matcher) => _titleCache.GetOrUpdate(matcher, Title);
+
+        public FuzzyTarget GetSubtitleTarget(IPrecomputedFuzzyMatcher matcher) => _subtitleCache.GetOrUpdate(matcher, Subtitle);
+    }
+
+    private static IPrecomputedFuzzyMatcher CreateMatcher() => new PrecomputedFuzzyMatcher(new PrecomputedFuzzyMatcherOptions());
+
+    private static ScoringFunction<IListItem> BuildScoringFunction(IRecentCommandsManager history, IPrecomputedFuzzyMatcher matcher)
+        => (in FuzzyQuery query, IListItem item) => MainListPage.ScoreTopLevelItem(query, item, history, matcher, null);
+
+    private static RoScored<IListItem>[] Score(IReadOnlyList<CatalogItem> apps, string rawQuery, IRecentCommandsManager history, IPrecomputedFuzzyMatcher matcher)
+    {
+        var query = matcher.PrecomputeQuery(rawQuery);
+        var fn = BuildScoringFunction(history, matcher);
+        return InternalListHelpers.FilterListWithScores(apps.Cast<IListItem>().ToArray(), query, fn);
+    }
+
+    private static RecentCommandsManager SeedUses(RecentCommandsManager history, string commandId, int uses)
+    {
+        for (var i = 0; i < uses; i++)
+        {
+            history = history.WithHistoryItem(commandId);
+        }
+
+        return history;
+    }
+
+    // Apps that match the query "x" ONLY as a mid-word subsequence: no title starts with "x" and no
+    // word inside a title starts with "x", so every match classifies at the Fuzzy tier. This is the
+    // pathological ultra-short-query shape - a big weak-match set with no confident matches at all.
+    private static CatalogItem[] BuildFuzzyOnlyCatalogForX() =>
+    [
+        new CatalogItem("Galaxy Store", "Shop for apps", "app.galaxy"),
+        new CatalogItem("Nexus Mods", "Manage game mods", "app.nexus"),
+        new CatalogItem("Toolbox Companion", "Developer tools", "app.toolbox"),
+        new CatalogItem("Max Cleaner", "Free up disk space", "app.max"),
+        new CatalogItem("Voxel Editor", "Edit voxel art", "app.voxel"),
+    ];
+
+    // Apps for the query "c" spanning multiple tiers: some titles start with "c" (Prefix), some have
+    // a non-leading word starting with "c" (word boundary), and some only contain "c" mid-word
+    // (Fuzzy). Used to prove the gate keeps the confident head and drops only the fuzzy tail.
+    private static CatalogItem[] BuildMixedCatalogForC() =>
+    [
+        new CatalogItem("Calculator", "Perform calculations", "app.calc"),
+        new CatalogItem("Calendar", "View your schedule", "app.cal"),
+        new CatalogItem("Visual Studio Code", "Code editor", "app.vscode"),
+        new CatalogItem("Windows Camera", "Take photos", "app.camera"),
+        new CatalogItem("Microsoft Edge", "Browse the web", "app.edge"),
+        new CatalogItem("Office Hub", "Productivity apps", "app.office"),
+        new CatalogItem("Discord", "Chat with friends", "app.discord"),
+    ];
+
+    /// <summary>
+    /// Investigation evidence, locked as a test: for a 1-char query whose only matches are mid-word
+    /// subsequences, EVERY result classifies at the Fuzzy tier - so whatever sits at rank 1 is a
+    /// weak match, and seeding frecency on one such app floats it to the top of that weak tier. This
+    /// is Mechanism A that Phase 7c targets.
+    /// </summary>
+    [TestMethod]
+    public void ShortQuery_FrecencyFloatsWeakFuzzyMatchToTop()
+    {
+        var matcher = CreateMatcher();
+        var apps = BuildFuzzyOnlyCatalogForX();
+
+        // With no history, some app is at rank 1 purely on lexical quality.
+        var noHistory = Score(apps, "x", new RecentCommandsManager(), matcher);
+        Assert.IsTrue(noHistory.Length > 0, "The fuzzy-only catalog must still match 'x'.");
+        foreach (var s in noHistory)
+        {
+            Assert.AreEqual(
+                RankTier.Fuzzy,
+                MainListRanker.TierOf(s.Score),
+                $"Every 'x' match must be Fuzzy tier; '{s.Item.Title}' was {MainListRanker.TierOf(s.Score)}.");
+        }
+
+        // Seed heavy frecency on an app that was NOT already at the top, and confirm it floats up.
+        var seededId = noHistory[^1].Item is CatalogItem last ? last.Id : throw new InvalidOperationException();
+        var seededTitle = noHistory[^1].Item.Title;
+        var history = SeedUses(new RecentCommandsManager(), seededId, 40);
+
+        var withHistory = Score(apps, "x", history, matcher);
+
+        TestContext.WriteLine($"no-history rank1='{noHistory[0].Item.Title}', seeded '{seededTitle}' -> rank1='{withHistory[0].Item.Title}'.");
+
+        Assert.AreEqual(RankTier.Fuzzy, MainListRanker.TierOf(withHistory[0].Score), "The floated rank-1 item is still only a Fuzzy match.");
+        Assert.AreEqual(seededTitle, withHistory[0].Item.Title, "Frecency should float the seeded weak match to rank 1 within the Fuzzy tier.");
+    }
+
+    /// <summary>
+    /// The fix: for an ultra-short (1-char) query the gate withholds the ENTIRE Fuzzy tail, so the
+    /// frecency-floated weak match can no longer be surfaced at rank 1 while the user is still
+    /// typing. Here every match is Fuzzy, so the gated app set is empty (commands/fallbacks, added
+    /// by the result factory, still render).
+    /// </summary>
+    [TestMethod]
+    public void ShortQuery_Gate_WithholdsEntireFuzzyTail()
+    {
+        var matcher = CreateMatcher();
+        var apps = BuildFuzzyOnlyCatalogForX();
+
+        var seededId = apps[0].Id;
+        var history = SeedUses(new RecentCommandsManager(), seededId, 40);
+
+        var scored = Score(apps, "x", history, matcher);
+        Assert.IsTrue(scored.Length > 0, "Precondition: the ungated result surfaces weak fuzzy matches.");
+
+        var gated = MainListPage.ApplyShortQueryAppGate(scored, queryLength: 1);
+
+        Assert.IsNotNull(gated);
+        Assert.AreEqual(0, gated!.Count, "For a 1-char query with only fuzzy matches, the whole low-confidence tail is withheld.");
+    }
+
+    /// <summary>
+    /// The gate keeps the confident head (word-boundary / prefix / exact matches) and drops only the
+    /// Fuzzy tail for an ultra-short query. Verified against a mixed catalog for "c".
+    /// </summary>
+    [TestMethod]
+    public void ShortQuery_Gate_KeepsConfidentTiers_DropsFuzzyTail()
+    {
+        var matcher = CreateMatcher();
+        var apps = BuildMixedCatalogForC();
+
+        var scored = Score(apps, "c", new RecentCommandsManager(), matcher);
+
+        var fuzzyCount = scored.Count(s => MainListRanker.TierOf(s.Score) == RankTier.Fuzzy);
+        var confidentCount = scored.Count(s => (int)MainListRanker.TierOf(s.Score) >= (int)RankTier.AcronymWordBoundary);
+
+        Assert.IsTrue(fuzzyCount > 0, "Precondition: the mixed catalog produces some fuzzy-tail matches for 'c'.");
+        Assert.IsTrue(confidentCount > 0, "Precondition: the mixed catalog produces some confident matches for 'c'.");
+
+        var gated = MainListPage.ApplyShortQueryAppGate(scored, queryLength: 1);
+        Assert.IsNotNull(gated);
+
+        Assert.AreEqual(confidentCount, gated!.Count, "Only the confident (tier >= word-boundary) head is kept.");
+        foreach (var s in gated)
+        {
+            Assert.IsTrue(
+                (int)MainListRanker.TierOf(s.Score) >= (int)RankTier.AcronymWordBoundary,
+                $"Gated item '{s.Item.Title}' must be word-boundary tier or higher, was {MainListRanker.TierOf(s.Score)}.");
+        }
+
+        // The gated head is a contiguous prefix of the scored array, in the exact same order.
+        for (var i = 0; i < gated.Count; i++)
+        {
+            Assert.AreSame(scored[i].Item, gated[i].Item, $"Gated item at index {i} must be the same instance and position as the scored array.");
+        }
+    }
+
+    /// <summary>
+    /// INVARIANT: for a discriminating (3+ char) query the gate is a no-op - it returns the exact
+    /// same array instance, so the settled order of a meaningful query is byte-identical to the
+    /// pre-7c behavior and the Phase 7b equivalence guarantee is untouched.
+    /// </summary>
+    [TestMethod]
+    public void DiscriminatingQuery_Gate_ReturnsInputUnchanged()
+    {
+        var matcher = CreateMatcher();
+        var apps = BuildMixedCatalogForC();
+
+        foreach (var raw in new[] { "cal", "calc", "code" })
+        {
+            var scored = Score(apps, raw, new RecentCommandsManager(), matcher);
+            var gated = MainListPage.ApplyShortQueryAppGate(scored, raw.Length);
+
+            Assert.AreSame(scored, gated, $"A {raw.Length}-char query ('{raw}') must pass the scored apps through unchanged.");
+        }
+    }
+
+    /// <summary>
+    /// The gate fires for query lengths 1 and 2 (ultra-short) but not for length 3+. Confirmed
+    /// against the fuzzy-only catalog, where firing empties the set and not-firing passes it through.
+    /// </summary>
+    [TestMethod]
+    public void Gate_LengthBoundary_FiresForOneAndTwo_NotThree()
+    {
+        var matcher = CreateMatcher();
+        var apps = BuildFuzzyOnlyCatalogForX();
+        var scored = Score(apps, "x", new RecentCommandsManager(), matcher);
+        Assert.IsTrue(scored.Length > 0, "Precondition: 'x' matches fuzzily.");
+
+        Assert.AreEqual(0, MainListPage.ApplyShortQueryAppGate(scored, 1)!.Count, "Length 1 must gate.");
+        Assert.AreEqual(0, MainListPage.ApplyShortQueryAppGate(scored, 2)!.Count, "Length 2 must gate.");
+        Assert.AreSame(scored, MainListPage.ApplyShortQueryAppGate(scored, 3), "Length 3 must not gate.");
+    }
+
+    /// <summary>
+    /// The gate never touches an empty or null app set, and treats a zero-length query (the default
+    /// view, no search) as a pass-through.
+    /// </summary>
+    [TestMethod]
+    public void Gate_NullEmptyAndZeroLength_AreNoOps()
+    {
+        Assert.IsNull(MainListPage.ApplyShortQueryAppGate(null, 1));
+
+        var empty = Array.Empty<RoScored<IListItem>>();
+        Assert.AreSame(empty, MainListPage.ApplyShortQueryAppGate(empty, 1));
+
+        var matcher = CreateMatcher();
+        var scored = Score(BuildFuzzyOnlyCatalogForX(), "x", new RecentCommandsManager(), matcher);
+        Assert.AreSame(scored, MainListPage.ApplyShortQueryAppGate(scored, 0), "A zero-length query is a pass-through.");
+    }
+
+    /// <summary>
+    /// Unit-level check of the prefix-length helper: because the scored array is sorted descending
+    /// by packed score and the tier occupies the high bits, all entries at or above a tier form a
+    /// contiguous prefix, and the helper returns that prefix length.
+    /// </summary>
+    [TestMethod]
+    public void HighConfidenceAppPrefixLength_CountsLeadingHighTierEntries()
+    {
+        RoScored<IListItem> Make(RankTier tier, int within)
+            => new(new CatalogItem($"{tier}", string.Empty, $"{tier}.{within}"), MainListRanker.Pack(tier, within));
+
+        // Sorted descending by packed score: Exact(5) > Prefix(4) > WordBoundary(3) > Fuzzy(2) > Fallback(1).
+        var scored = new[]
+        {
+            Make(RankTier.ExactTitle, 100),
+            Make(RankTier.Prefix, 50),
+            Make(RankTier.AcronymWordBoundary, 20),
+            Make(RankTier.Fuzzy, 9000),
+            Make(RankTier.FallbackFloor, 5),
+        };
+
+        Assert.AreEqual(5, MainListPage.HighConfidenceAppPrefixLength(scored, RankTier.FallbackFloor));
+        Assert.AreEqual(4, MainListPage.HighConfidenceAppPrefixLength(scored, RankTier.Fuzzy));
+        Assert.AreEqual(3, MainListPage.HighConfidenceAppPrefixLength(scored, RankTier.AcronymWordBoundary));
+        Assert.AreEqual(2, MainListPage.HighConfidenceAppPrefixLength(scored, RankTier.Prefix));
+        Assert.AreEqual(1, MainListPage.HighConfidenceAppPrefixLength(scored, RankTier.ExactTitle));
+        Assert.AreEqual(0, MainListPage.HighConfidenceAppPrefixLength(scored, RankTier.AliasExact));
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/EarlyFrameRelevanceTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/EarlyFrameRelevanceTests.cs
@@ -16,12 +16,6 @@ using Windows.Foundation;
 
 namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
 
-/// <summary>
-/// Guardrail for the early-frame relevance change, which stops the "completely wrong when I start
-/// typing" flash by withholding the weak fuzzy app tail on short queries. These lock the mechanism
-/// (a 1-char query drops most of the catalog into one Fuzzy tier where frecency decides the order)
-/// and the fix (short queries keep only the confident head, longer queries pass through untouched).
-/// </summary>
 [TestClass]
 public sealed partial class EarlyFrameRelevanceTests
 {
@@ -91,8 +85,7 @@ public sealed partial class EarlyFrameRelevanceTests
         return history;
     }
 
-    // Apps that match "x" only as a mid-word subsequence, so every match lands at the Fuzzy tier.
-    // This is the pathological shape: a big weak-match set with no confident matches at all.
+    // Every app matches "x" only at the Fuzzy tier.
     private static CatalogItem[] BuildFuzzyOnlyCatalogForX() =>
     [
         new CatalogItem("Galaxy Store", "Shop for apps", "app.galaxy"),
@@ -150,12 +143,10 @@ public sealed partial class EarlyFrameRelevanceTests
     }
 
     /// <summary>
-    /// The fix: a 1-char query withholds the whole Fuzzy tail, so the frecency-floated weak match
-    /// can't reach rank 1 while you're still typing. Every match here is Fuzzy, so the gated app
-    /// set comes back empty and only commands and fallbacks render.
+    /// A short query filters every fuzzy-only app match.
     /// </summary>
     [TestMethod]
-    public void ShortQuery_Gate_WithholdsEntireFuzzyTail()
+    public void ShortQuery_Filter_RemovesEveryFuzzyMatch()
     {
         var matcher = CreateMatcher();
         var apps = BuildFuzzyOnlyCatalogForX();
@@ -166,18 +157,17 @@ public sealed partial class EarlyFrameRelevanceTests
         var scored = Score(apps, "x", history, matcher);
         Assert.IsTrue(scored.Length > 0, "Precondition: the ungated result surfaces weak fuzzy matches.");
 
-        var gated = MainListPage.ApplyShortQueryAppGate(scored, queryLength: 1);
+        var filtered = MainListPage.FilterAppsForShortQueries(scored, queryLength: 1);
 
-        Assert.IsNotNull(gated);
-        Assert.AreEqual(0, gated!.Count, "For a 1-char query with only fuzzy matches, the whole low-confidence tail is withheld.");
+        Assert.IsNotNull(filtered);
+        Assert.AreEqual(0, filtered!.Count, "A one-character query should filter fuzzy-only app matches.");
     }
 
     /// <summary>
-    /// The gate keeps the confident head and drops only the Fuzzy tail, checked against a mixed
-    /// catalog for "c".
+    /// The filter keeps high-confidence matches and removes fuzzy matches.
     /// </summary>
     [TestMethod]
-    public void ShortQuery_Gate_KeepsConfidentTiers_DropsFuzzyTail()
+    public void ShortQuery_Filter_KeepsHighConfidenceMatches()
     {
         var matcher = CreateMatcher();
         var apps = BuildMixedCatalogForC();
@@ -190,30 +180,29 @@ public sealed partial class EarlyFrameRelevanceTests
         Assert.IsTrue(fuzzyCount > 0, "Precondition: the mixed catalog produces some fuzzy-tail matches for 'c'.");
         Assert.IsTrue(confidentCount > 0, "Precondition: the mixed catalog produces some confident matches for 'c'.");
 
-        var gated = MainListPage.ApplyShortQueryAppGate(scored, queryLength: 1);
-        Assert.IsNotNull(gated);
+        var filtered = MainListPage.FilterAppsForShortQueries(scored, queryLength: 1);
+        Assert.IsNotNull(filtered);
 
-        Assert.AreEqual(confidentCount, gated!.Count, "Only the confident (tier >= word-boundary) head is kept.");
-        foreach (var s in gated)
+        Assert.AreEqual(confidentCount, filtered!.Count, "Only word-boundary or stronger matches should remain.");
+        foreach (var s in filtered)
         {
             Assert.IsTrue(
                 (int)MainListRanker.TierOf(s.Score) >= (int)RankTier.AcronymWordBoundary,
-                $"Gated item '{s.Item.Title}' must be word-boundary tier or higher, was {MainListRanker.TierOf(s.Score)}.");
+                $"Filtered item '{s.Item.Title}' must be word-boundary tier or higher, was {MainListRanker.TierOf(s.Score)}.");
         }
 
-        // The gated head is a contiguous prefix of the scored array, in the same order.
-        for (var i = 0; i < gated.Count; i++)
+        // Filtering preserves the scored order.
+        for (var i = 0; i < filtered.Count; i++)
         {
-            Assert.AreSame(scored[i].Item, gated[i].Item, $"Gated item at index {i} must be the same instance and position as the scored array.");
+            Assert.AreSame(scored[i].Item, filtered[i].Item, $"Filtered item at index {i} must keep its scored position.");
         }
     }
 
     /// <summary>
-    /// For a 3+ char query the gate is a no-op and hands back the same array instance, so a
-    /// meaningful query's settled order is exactly what it was before.
+    /// Queries longer than two characters return the original array.
     /// </summary>
     [TestMethod]
-    public void DiscriminatingQuery_Gate_ReturnsInputUnchanged()
+    public void LongerQuery_Filter_ReturnsInputUnchanged()
     {
         var matcher = CreateMatcher();
         var apps = BuildMixedCatalogForC();
@@ -221,52 +210,49 @@ public sealed partial class EarlyFrameRelevanceTests
         foreach (var raw in new[] { "cal", "calc", "code" })
         {
             var scored = Score(apps, raw, new RecentCommandsManager(), matcher);
-            var gated = MainListPage.ApplyShortQueryAppGate(scored, raw.Length);
+            var filtered = MainListPage.FilterAppsForShortQueries(scored, raw.Length);
 
-            Assert.AreSame(scored, gated, $"A {raw.Length}-char query ('{raw}') must pass the scored apps through unchanged.");
+            Assert.AreSame(scored, filtered, $"A {raw.Length}-character query ('{raw}') should return the original array.");
         }
     }
 
     /// <summary>
-    /// The gate fires for lengths 1 and 2 but not 3, checked against the fuzzy-only catalog where
-    /// firing empties the set and not firing passes it through.
+    /// The filter applies to query lengths one and two.
     /// </summary>
     [TestMethod]
-    public void Gate_LengthBoundary_FiresForOneAndTwo_NotThree()
+    public void Filter_LengthBoundary_AppliesToOneAndTwo_NotThree()
     {
         var matcher = CreateMatcher();
         var apps = BuildFuzzyOnlyCatalogForX();
         var scored = Score(apps, "x", new RecentCommandsManager(), matcher);
         Assert.IsTrue(scored.Length > 0, "Precondition: 'x' matches fuzzily.");
 
-        Assert.AreEqual(0, MainListPage.ApplyShortQueryAppGate(scored, 1)!.Count, "Length 1 must gate.");
-        Assert.AreEqual(0, MainListPage.ApplyShortQueryAppGate(scored, 2)!.Count, "Length 2 must gate.");
-        Assert.AreSame(scored, MainListPage.ApplyShortQueryAppGate(scored, 3), "Length 3 must not gate.");
+        Assert.AreEqual(0, MainListPage.FilterAppsForShortQueries(scored, 1)!.Count, "Length 1 should be filtered.");
+        Assert.AreEqual(0, MainListPage.FilterAppsForShortQueries(scored, 2)!.Count, "Length 2 should be filtered.");
+        Assert.AreSame(scored, MainListPage.FilterAppsForShortQueries(scored, 3), "Length 3 should not be filtered.");
     }
 
     /// <summary>
-    /// The gate leaves an empty or null app set alone, and treats a zero-length query (the default
-    /// view) as a pass-through.
+    /// Null, empty, and default-view inputs are unchanged.
     /// </summary>
     [TestMethod]
-    public void Gate_NullEmptyAndZeroLength_AreNoOps()
+    public void Filter_NullEmptyAndZeroLength_AreNoOps()
     {
-        Assert.IsNull(MainListPage.ApplyShortQueryAppGate(null, 1));
+        Assert.IsNull(MainListPage.FilterAppsForShortQueries(null, 1));
 
         var empty = Array.Empty<RoScored<IListItem>>();
-        Assert.AreSame(empty, MainListPage.ApplyShortQueryAppGate(empty, 1));
+        Assert.AreSame(empty, MainListPage.FilterAppsForShortQueries(empty, 1));
 
         var matcher = CreateMatcher();
         var scored = Score(BuildFuzzyOnlyCatalogForX(), "x", new RecentCommandsManager(), matcher);
-        Assert.AreSame(scored, MainListPage.ApplyShortQueryAppGate(scored, 0), "A zero-length query is a pass-through.");
+        Assert.AreSame(scored, MainListPage.FilterAppsForShortQueries(scored, 0), "A zero-length query should return the original array.");
     }
 
     /// <summary>
-    /// The prefix-length helper returns the run of entries at or above a tier, which works because
-    /// the array is sorted descending by packed score and the tier sits in the high bits.
+    /// Counts the leading entries at or above the requested tier.
     /// </summary>
     [TestMethod]
-    public void HighConfidenceAppPrefixLength_CountsLeadingHighTierEntries()
+    public void GetHighConfidenceAppsCount_CountsLeadingHighTierEntries()
     {
         RoScored<IListItem> Make(RankTier tier, int within)
             => new(new CatalogItem($"{tier}", string.Empty, $"{tier}.{within}"), MainListRanker.Pack(tier, within));
@@ -281,43 +267,37 @@ public sealed partial class EarlyFrameRelevanceTests
             Make(RankTier.FallbackFloor, 5),
         };
 
-        Assert.AreEqual(5, MainListPage.HighConfidenceAppPrefixLength(scored, RankTier.FallbackFloor));
-        Assert.AreEqual(4, MainListPage.HighConfidenceAppPrefixLength(scored, RankTier.Fuzzy));
-        Assert.AreEqual(3, MainListPage.HighConfidenceAppPrefixLength(scored, RankTier.AcronymWordBoundary));
-        Assert.AreEqual(2, MainListPage.HighConfidenceAppPrefixLength(scored, RankTier.Prefix));
-        Assert.AreEqual(1, MainListPage.HighConfidenceAppPrefixLength(scored, RankTier.ExactTitle));
-        Assert.AreEqual(0, MainListPage.HighConfidenceAppPrefixLength(scored, RankTier.AliasExact));
+        Assert.AreEqual(5, MainListPage.GetHighConfidenceAppsCount(scored, RankTier.FallbackFloor));
+        Assert.AreEqual(4, MainListPage.GetHighConfidenceAppsCount(scored, RankTier.Fuzzy));
+        Assert.AreEqual(3, MainListPage.GetHighConfidenceAppsCount(scored, RankTier.AcronymWordBoundary));
+        Assert.AreEqual(2, MainListPage.GetHighConfidenceAppsCount(scored, RankTier.Prefix));
+        Assert.AreEqual(1, MainListPage.GetHighConfidenceAppsCount(scored, RankTier.ExactTitle));
+        Assert.AreEqual(0, MainListPage.GetHighConfidenceAppsCount(scored, RankTier.AliasExact));
     }
 
     /// <summary>
-    /// The gate decides on the length it's handed, the one published with the array, not on
-    /// anything read later. That's why MainListPage gates on _filteredAppsQueryLength instead of
-    /// the live SearchText.
+    /// Uses the query length published with the scored array.
     /// </summary>
     [TestMethod]
-    public void Gate_DecidesOnSuppliedPublishedLength_NotLiveText()
+    public void Filter_UsesSuppliedPublishedLength()
     {
         RoScored<IListItem> Fuzzy(int within)
             => new(new CatalogItem($"fuzzy.{within}", string.Empty, $"fuzzy.{within}"), MainListRanker.Pack(RankTier.Fuzzy, within));
 
         var scored = new[] { Fuzzy(30), Fuzzy(20), Fuzzy(10) };
 
-        // The query that produced this array is still short, so withhold.
-        var gatedByPublished = MainListPage.ApplyShortQueryAppGate(scored, queryLength: 2);
-        Assert.IsNotNull(gatedByPublished);
-        Assert.AreEqual(0, gatedByPublished!.Count, "Gating on the published short length (2) must withhold the fuzzy tail.");
+        var filteredByPublished = MainListPage.FilterAppsForShortQueries(scored, queryLength: 2);
+        Assert.IsNotNull(filteredByPublished);
+        Assert.AreEqual(0, filteredByPublished!.Count, "The published short length should filter fuzzy matches.");
 
-        // The same array with a longer length passes through, which is the regression a stale
-        // length would cause.
-        Assert.AreSame(scored, MainListPage.ApplyShortQueryAppGate(scored, queryLength: 5), "A longer length would pass the tail through, proving the supplied length is what decides.");
+        Assert.AreSame(scored, MainListPage.FilterAppsForShortQueries(scored, queryLength: 5), "A longer published length should return the original array.");
     }
 
     /// <summary>
-    /// Telemetry counts the gated visible apps on a short query and the full capped set on a longer
-    /// one, so the reported count matches what you're actually looking at.
+    /// Telemetry counts only visible apps after filtering.
     /// </summary>
     [TestMethod]
-    public void GatedVisibleAppCount_ShortQuery_CountsOnlyGatedApps()
+    public void GetVisibleAppCount_ShortQuery_CountsOnlyFilteredApps()
     {
         var matcher = CreateMatcher();
         var apps = BuildMixedCatalogForC();
@@ -325,40 +305,34 @@ public sealed partial class EarlyFrameRelevanceTests
 
         var full = scored.Length;
         var confident = scored.Count(s => (int)MainListRanker.TierOf(s.Score) >= (int)RankTier.AcronymWordBoundary);
-        Assert.IsTrue(confident < full, "Precondition: a fuzzy tail exists so the gated count is strictly less than the full count.");
+        Assert.IsTrue(confident < full, "Precondition: fuzzy matches make the filtered count smaller.");
 
         const int NoCap = 1000;
 
-        // Short published length: only the confident head is counted.
-        Assert.AreEqual(confident, MainListPage.GatedVisibleAppCount(scored, queryLength: 1, appResultLimit: NoCap));
-        Assert.AreEqual(confident, MainListPage.GatedVisibleAppCount(scored, queryLength: 2, appResultLimit: NoCap));
+        Assert.AreEqual(confident, MainListPage.GetVisibleAppCount(scored, queryLength: 1, appResultLimit: NoCap));
+        Assert.AreEqual(confident, MainListPage.GetVisibleAppCount(scored, queryLength: 2, appResultLimit: NoCap));
 
-        // Longer published length: the full set (capped) is counted.
-        Assert.AreEqual(full, MainListPage.GatedVisibleAppCount(scored, queryLength: 3, appResultLimit: NoCap));
-        Assert.AreEqual(full, MainListPage.GatedVisibleAppCount(scored, queryLength: 0, appResultLimit: NoCap), "A zero-length (default view) count is ungated.");
+        Assert.AreEqual(full, MainListPage.GetVisibleAppCount(scored, queryLength: 3, appResultLimit: NoCap));
+        Assert.AreEqual(full, MainListPage.GetVisibleAppCount(scored, queryLength: 0, appResultLimit: NoCap), "A zero-length query should count the full set.");
     }
 
     /// <summary>
-    /// The gated count still respects the app result limit, reports zero when a short query's whole
-    /// tail is withheld, and reports zero for null or empty input.
+    /// The count respects the app limit and handles empty input.
     /// </summary>
     [TestMethod]
-    public void GatedVisibleAppCount_RespectsCap_AndZeroForWithheldOrEmpty()
+    public void GetVisibleAppCount_RespectsCap_AndEmptyInput()
     {
         var matcher = CreateMatcher();
 
-        // Nothing confident here, so the gated count is zero.
         var fuzzyOnly = Score(BuildFuzzyOnlyCatalogForX(), "x", new RecentCommandsManager(), matcher);
         Assert.IsTrue(fuzzyOnly.Length > 0, "Precondition: 'x' matches fuzzily.");
-        Assert.AreEqual(0, MainListPage.GatedVisibleAppCount(fuzzyOnly, queryLength: 1, appResultLimit: 1000));
+        Assert.AreEqual(0, MainListPage.GetVisibleAppCount(fuzzyOnly, queryLength: 1, appResultLimit: 1000));
 
-        // The cap applies on the ungated path.
         var mixed = Score(BuildMixedCatalogForC(), "c", new RecentCommandsManager(), matcher);
         Assert.IsTrue(mixed.Length > 2, "Precondition: the mixed catalog has more than two matches so the cap bites.");
-        Assert.AreEqual(2, MainListPage.GatedVisibleAppCount(mixed, queryLength: 3, appResultLimit: 2), "The full count is capped by the app result limit.");
+        Assert.AreEqual(2, MainListPage.GetVisibleAppCount(mixed, queryLength: 3, appResultLimit: 2), "The app result limit should cap the count.");
 
-        // Null and empty report zero.
-        Assert.AreEqual(0, MainListPage.GatedVisibleAppCount(null, 1, 1000));
-        Assert.AreEqual(0, MainListPage.GatedVisibleAppCount(Array.Empty<RoScored<IListItem>>(), 1, 1000));
+        Assert.AreEqual(0, MainListPage.GetVisibleAppCount(null, 1, 1000));
+        Assert.AreEqual(0, MainListPage.GetVisibleAppCount(Array.Empty<RoScored<IListItem>>(), 1, 1000));
     }
 }

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/EarlyFrameRelevanceTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/EarlyFrameRelevanceTests.cs
@@ -12,7 +12,6 @@ using Microsoft.CmdPal.UI.ViewModels.MainPage;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Windows.Foundation;
 
 namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
 
@@ -21,42 +20,20 @@ public sealed partial class EarlyFrameRelevanceTests
 {
     public TestContext TestContext { get; set; } = null!;
 
-    private sealed partial class CatalogItem : IListItem, IPrecomputedListItem
+    private sealed partial class CatalogItem : ListItem, IPrecomputedListItem
     {
         private FuzzyTargetCache _titleCache;
         private FuzzyTargetCache _subtitleCache;
 
         public CatalogItem(string title, string subtitle, string id)
+            : base(new NoOpCommand() { Id = id })
         {
             Title = title;
             Subtitle = subtitle;
             Id = id;
-            Command = new NoOpCommand() { Id = id };
         }
 
-        public string Title { get; }
-
-        public string Subtitle { get; }
-
         public string Id { get; }
-
-        public ICommand Command { get; }
-
-        public IDetails? Details => null;
-
-        public IIconInfo? Icon => null;
-
-        public string Section => string.Empty;
-
-        public ITag[] Tags => [];
-
-        public string TextToSuggest => string.Empty;
-
-        public IContextItem[] MoreCommands => [];
-
-#pragma warning disable CS0067 // The event is never used
-        public event TypedEventHandler<object, IPropChangedEventArgs>? PropChanged;
-#pragma warning restore CS0067
 
         public FuzzyTarget GetTitleTarget(IPrecomputedFuzzyMatcher matcher) => _titleCache.GetOrUpdate(matcher, Title);
 

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/EarlyFrameRelevanceTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/EarlyFrameRelevanceTests.cs
@@ -17,22 +17,10 @@ using Windows.Foundation;
 namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
 
 /// <summary>
-/// GUARDRAIL for the Phase 7c early-frame relevance change. Phase 7c stops the "completely wrong
-/// when I start typing" flash by withholding, on the render path, the large low-confidence fuzzy
-/// app tail for ultra-short (1-2 char) queries. The change is confined to the transient early
-/// frame: it slices the already-scored, already-sorted app array and never re-scores or reorders,
-/// so the settled order of a discriminating (3+ char) query is byte-identical to before.
-///
-/// These tests lock two things:
-///  1. The confirmed mechanism (Mechanism A): a 1-char query drops a huge fraction of the catalog
-///     into the single Fuzzy tier, where within-tier order is decided almost entirely by frecency,
-///     so the most-frecent app floats to rank 1 on a weak, mid-word subsequence match.
-///  2. The fix: for an ultra-short query the gate withholds that Fuzzy tail (keeping only the
-///     letter-relevant word-boundary/prefix/exact matches), while for a 3+ char query the scored
-///     apps are passed through unchanged (same array reference).
-///
-/// Everything here is deterministic (index-driven catalog, injected frecency, no wall-clock
-/// ordering dependence), so it is CI-safe and never flakes.
+/// Guardrail for the early-frame relevance change, which stops the "completely wrong when I start
+/// typing" flash by withholding the weak fuzzy app tail on short queries. These lock the mechanism
+/// (a 1-char query drops most of the catalog into one Fuzzy tier where frecency decides the order)
+/// and the fix (short queries keep only the confident head, longer queries pass through untouched).
 /// </summary>
 [TestClass]
 public sealed partial class EarlyFrameRelevanceTests
@@ -103,9 +91,8 @@ public sealed partial class EarlyFrameRelevanceTests
         return history;
     }
 
-    // Apps that match the query "x" ONLY as a mid-word subsequence: no title starts with "x" and no
-    // word inside a title starts with "x", so every match classifies at the Fuzzy tier. This is the
-    // pathological ultra-short-query shape - a big weak-match set with no confident matches at all.
+    // Apps that match "x" only as a mid-word subsequence, so every match lands at the Fuzzy tier.
+    // This is the pathological shape: a big weak-match set with no confident matches at all.
     private static CatalogItem[] BuildFuzzyOnlyCatalogForX() =>
     [
         new CatalogItem("Galaxy Store", "Shop for apps", "app.galaxy"),
@@ -115,9 +102,8 @@ public sealed partial class EarlyFrameRelevanceTests
         new CatalogItem("Voxel Editor", "Edit voxel art", "app.voxel"),
     ];
 
-    // Apps for the query "c" spanning multiple tiers: some titles start with "c" (Prefix), some have
-    // a non-leading word starting with "c" (word boundary), and some only contain "c" mid-word
-    // (Fuzzy). Used to prove the gate keeps the confident head and drops only the fuzzy tail.
+    // Apps spanning multiple tiers for "c": some titles start with it, some have a non-leading word
+    // that does, and some only contain it mid-word.
     private static CatalogItem[] BuildMixedCatalogForC() =>
     [
         new CatalogItem("Calculator", "Perform calculations", "app.calc"),
@@ -130,10 +116,8 @@ public sealed partial class EarlyFrameRelevanceTests
     ];
 
     /// <summary>
-    /// Investigation evidence, locked as a test: for a 1-char query whose only matches are mid-word
-    /// subsequences, EVERY result classifies at the Fuzzy tier - so whatever sits at rank 1 is a
-    /// weak match, and seeding frecency on one such app floats it to the top of that weak tier. This
-    /// is Mechanism A that Phase 7c targets.
+    /// The mechanism, locked as a test: when a 1-char query only matches mid-word, every result is
+    /// Fuzzy, so seeding frecency on any one of them floats it straight to rank 1.
     /// </summary>
     [TestMethod]
     public void ShortQuery_FrecencyFloatsWeakFuzzyMatchToTop()
@@ -166,10 +150,9 @@ public sealed partial class EarlyFrameRelevanceTests
     }
 
     /// <summary>
-    /// The fix: for an ultra-short (1-char) query the gate withholds the ENTIRE Fuzzy tail, so the
-    /// frecency-floated weak match can no longer be surfaced at rank 1 while the user is still
-    /// typing. Here every match is Fuzzy, so the gated app set is empty (commands/fallbacks, added
-    /// by the result factory, still render).
+    /// The fix: a 1-char query withholds the whole Fuzzy tail, so the frecency-floated weak match
+    /// can't reach rank 1 while you're still typing. Every match here is Fuzzy, so the gated app
+    /// set comes back empty and only commands and fallbacks render.
     /// </summary>
     [TestMethod]
     public void ShortQuery_Gate_WithholdsEntireFuzzyTail()
@@ -190,8 +173,8 @@ public sealed partial class EarlyFrameRelevanceTests
     }
 
     /// <summary>
-    /// The gate keeps the confident head (word-boundary / prefix / exact matches) and drops only the
-    /// Fuzzy tail for an ultra-short query. Verified against a mixed catalog for "c".
+    /// The gate keeps the confident head and drops only the Fuzzy tail, checked against a mixed
+    /// catalog for "c".
     /// </summary>
     [TestMethod]
     public void ShortQuery_Gate_KeepsConfidentTiers_DropsFuzzyTail()
@@ -218,7 +201,7 @@ public sealed partial class EarlyFrameRelevanceTests
                 $"Gated item '{s.Item.Title}' must be word-boundary tier or higher, was {MainListRanker.TierOf(s.Score)}.");
         }
 
-        // The gated head is a contiguous prefix of the scored array, in the exact same order.
+        // The gated head is a contiguous prefix of the scored array, in the same order.
         for (var i = 0; i < gated.Count; i++)
         {
             Assert.AreSame(scored[i].Item, gated[i].Item, $"Gated item at index {i} must be the same instance and position as the scored array.");
@@ -226,9 +209,8 @@ public sealed partial class EarlyFrameRelevanceTests
     }
 
     /// <summary>
-    /// INVARIANT: for a discriminating (3+ char) query the gate is a no-op - it returns the exact
-    /// same array instance, so the settled order of a meaningful query is byte-identical to the
-    /// pre-7c behavior and the Phase 7b equivalence guarantee is untouched.
+    /// For a 3+ char query the gate is a no-op and hands back the same array instance, so a
+    /// meaningful query's settled order is exactly what it was before.
     /// </summary>
     [TestMethod]
     public void DiscriminatingQuery_Gate_ReturnsInputUnchanged()
@@ -246,8 +228,8 @@ public sealed partial class EarlyFrameRelevanceTests
     }
 
     /// <summary>
-    /// The gate fires for query lengths 1 and 2 (ultra-short) but not for length 3+. Confirmed
-    /// against the fuzzy-only catalog, where firing empties the set and not-firing passes it through.
+    /// The gate fires for lengths 1 and 2 but not 3, checked against the fuzzy-only catalog where
+    /// firing empties the set and not firing passes it through.
     /// </summary>
     [TestMethod]
     public void Gate_LengthBoundary_FiresForOneAndTwo_NotThree()
@@ -263,8 +245,8 @@ public sealed partial class EarlyFrameRelevanceTests
     }
 
     /// <summary>
-    /// The gate never touches an empty or null app set, and treats a zero-length query (the default
-    /// view, no search) as a pass-through.
+    /// The gate leaves an empty or null app set alone, and treats a zero-length query (the default
+    /// view) as a pass-through.
     /// </summary>
     [TestMethod]
     public void Gate_NullEmptyAndZeroLength_AreNoOps()
@@ -280,9 +262,8 @@ public sealed partial class EarlyFrameRelevanceTests
     }
 
     /// <summary>
-    /// Unit-level check of the prefix-length helper: because the scored array is sorted descending
-    /// by packed score and the tier occupies the high bits, all entries at or above a tier form a
-    /// contiguous prefix, and the helper returns that prefix length.
+    /// The prefix-length helper returns the run of entries at or above a tier, which works because
+    /// the array is sorted descending by packed score and the tier sits in the high bits.
     /// </summary>
     [TestMethod]
     public void HighConfidenceAppPrefixLength_CountsLeadingHighTierEntries()
@@ -309,11 +290,9 @@ public sealed partial class EarlyFrameRelevanceTests
     }
 
     /// <summary>
-    /// FIX #2 guardrail: the gate decision is driven entirely by the length it is handed - the query
-    /// length PUBLISHED atomically with the app array - not by any later value. Feeding the published
-    /// short length (2) withholds the fuzzy tail even though a longer length would pass it through,
-    /// which is exactly why MainListPage gates on the published _filteredAppsQueryLength rather than
-    /// the live SearchText the UI thread may already have advanced past on a 2-to-3 char transition.
+    /// The gate decides on the length it's handed, the one published with the array, not on
+    /// anything read later. That's why MainListPage gates on _filteredAppsQueryLength instead of
+    /// the live SearchText.
     /// </summary>
     [TestMethod]
     public void Gate_DecidesOnSuppliedPublishedLength_NotLiveText()
@@ -323,20 +302,19 @@ public sealed partial class EarlyFrameRelevanceTests
 
         var scored = new[] { Fuzzy(30), Fuzzy(20), Fuzzy(10) };
 
-        // Published length 2 (the query that produced this array is still ultra-short): withhold.
+        // The query that produced this array is still short, so withhold.
         var gatedByPublished = MainListPage.ApplyShortQueryAppGate(scored, queryLength: 2);
         Assert.IsNotNull(gatedByPublished);
         Assert.AreEqual(0, gatedByPublished!.Count, "Gating on the published short length (2) must withhold the fuzzy tail.");
 
-        // The SAME array gated on a longer length passes through, so gating on a stale/live longer
-        // length would wrongly expose the tail. That is the regression Fix #2 prevents.
+        // The same array with a longer length passes through, which is the regression a stale
+        // length would cause.
         Assert.AreSame(scored, MainListPage.ApplyShortQueryAppGate(scored, queryLength: 5), "A longer length would pass the tail through, proving the supplied length is what decides.");
     }
 
     /// <summary>
-    /// FIX #3 guardrail: the settled-search telemetry count reflects the GATED visible apps for an
-    /// ultra-short query, not the full ungated app array. For a discriminating query it is the full
-    /// (capped) count. This keeps the reported result count consistent with what the user is shown.
+    /// Telemetry counts the gated visible apps on a short query and the full capped set on a longer
+    /// one, so the reported count matches what you're actually looking at.
     /// </summary>
     [TestMethod]
     public void GatedVisibleAppCount_ShortQuery_CountsOnlyGatedApps()
@@ -351,26 +329,25 @@ public sealed partial class EarlyFrameRelevanceTests
 
         const int NoCap = 1000;
 
-        // Ultra-short published length: only the confident head is counted.
+        // Short published length: only the confident head is counted.
         Assert.AreEqual(confident, MainListPage.GatedVisibleAppCount(scored, queryLength: 1, appResultLimit: NoCap));
         Assert.AreEqual(confident, MainListPage.GatedVisibleAppCount(scored, queryLength: 2, appResultLimit: NoCap));
 
-        // Discriminating published length: the full set (capped) is counted.
+        // Longer published length: the full set (capped) is counted.
         Assert.AreEqual(full, MainListPage.GatedVisibleAppCount(scored, queryLength: 3, appResultLimit: NoCap));
         Assert.AreEqual(full, MainListPage.GatedVisibleAppCount(scored, queryLength: 0, appResultLimit: NoCap), "A zero-length (default view) count is ungated.");
     }
 
     /// <summary>
-    /// FIX #3: the gated visible count is still capped by the app result limit, a fuzzy-only
-    /// ultra-short query reports zero visible apps (its whole tail is withheld), and null/empty
-    /// inputs report zero.
+    /// The gated count still respects the app result limit, reports zero when a short query's whole
+    /// tail is withheld, and reports zero for null or empty input.
     /// </summary>
     [TestMethod]
     public void GatedVisibleAppCount_RespectsCap_AndZeroForWithheldOrEmpty()
     {
         var matcher = CreateMatcher();
 
-        // Fuzzy-only ultra-short query: nothing confident, so the gated count is zero.
+        // Nothing confident here, so the gated count is zero.
         var fuzzyOnly = Score(BuildFuzzyOnlyCatalogForX(), "x", new RecentCommandsManager(), matcher);
         Assert.IsTrue(fuzzyOnly.Length > 0, "Precondition: 'x' matches fuzzily.");
         Assert.AreEqual(0, MainListPage.GatedVisibleAppCount(fuzzyOnly, queryLength: 1, appResultLimit: 1000));


### PR DESCRIPTION
>[!NOTE]
> Last in a series rearchitecting the `MainListPage` search and ranking logic. The design detail lives in the initial PR #49189.

## What's going on

Type one or two characters into Command Palette and you'll watch it show you obviously wrong stuff for a beat before the right results land. Everybody's seen it. This is the fix.

Here's the why. A single character query fuzzy matches a huge slice of the app catalog, and all of it lands in one `Fuzzy` tier. On a one character match the lexical quality is basically zero, so `FrecencyScale 1` beats `LexicalScale 10` times almost nothing. Frecency ends up deciding the order inside that giant tier, and your most used app floats to the top on a weak mid word match. There's a new test that reproduces exactly that: for a query that only matches mid word, every result lands in the Fuzzy tier, and seeding frecency on one app floats it to rank one.

Global fallbacks aren't the culprit, which surprised me. They always classify at `FallbackFloor` and can never leapfrog commands or apps. The rest of the reshuffle is a late async app batch folding in and floating a weak fuzzy app, same root cause.

## The plan

In `GetSearchViewItems`, when the query is one or two characters, hold back the low confidence app tail and show only apps at tier `AcronymWordBoundary` or better. That's word boundary, prefix, exact, and alias. Commands and fallbacks render exactly as they did.

The scored arrays are already sorted descending and the tier sits in the packed score's high bits, so the kept set is a contiguous prefix. That makes this one forward scan and an `ArraySegment` view handed to the result factory. Nothing gets re scored, nothing gets reordered, and no ranker constant, tier, or frecency value moves.

The same gate runs on a late async app batch, which is what stabilizes the short query fold in.

At three characters or more the gate is a no op that hands back the same array instance, so the settled order is byte for byte what 7b produced.

`EarlyFrameRelevanceTests` covers the frecency floats a weak match evidence, the gate withholding the fuzzy tail, the gate keeping confident tiers, three plus character pass through against the same reference, the length boundary, the null and empty and zero length no ops, and the prefix length helper. The 7b equivalence tests stay green and unchanged.

## Notes for reviewers

There's a more direct fix I didn't ship. Damping frecency or re gating tiers for short queries inside the ranker would attack the root cause instead of hiding it at render time. It would also change the settled order and break the 7b equivalence test, so it isn't something I want to sneak in under a perf PR. Worth a real conversation on its own.

This is a render path gate, and I want to be honest that it's a gate. The ranker still thinks your most frecent app is the best answer for `c`. We just stop drawing that opinion until the query says something.