### PR TITLE
CmdPal: Add Control Panel tasks to Windows Settings search

### DIFF
--- a/PowerToys.slnx
+++ b/PowerToys.slnx
@@ -361,6 +361,10 @@
       <Platform Solution="*|ARM64" Project="ARM64" />
       <Platform Solution="*|x64" Project="x64" />
     </Project>
+    <Project Path="src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.WindowsSettings.UnitTests/Microsoft.CmdPal.Ext.WindowsSettings.UnitTests.csproj">
+      <Platform Solution="*|ARM64" Project="ARM64" />
+      <Platform Solution="*|x64" Project="x64" />
+    </Project>
     <Project Path="src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.WindowWalker.UnitTests/Microsoft.CmdPal.Ext.WindowWalker.UnitTests.csproj">
       <Platform Solution="*|ARM64" Project="ARM64" />
       <Platform Solution="*|x64" Project="x64" />

--- a/src/modules/cmdpal/CommandPalette - no UI tests.slnf
+++ b/src/modules/cmdpal/CommandPalette - no UI tests.slnf
@@ -1,4 +1,4 @@
-{
+﻿{
   "solution": {
     "path": "..\\..\\..\\PowerToys.slnx",
     "projects": [
@@ -21,6 +21,7 @@
       "src\\modules\\cmdpal\\Tests\\Microsoft.CmdPal.Ext.Calc.UnitTests\\Microsoft.CmdPal.Ext.Calc.UnitTests.csproj",
       "src\\modules\\cmdpal\\Tests\\Microsoft.CmdPal.Ext.ClipboardHistory.UnitTests\\Microsoft.CmdPal.Ext.ClipboardHistory.UnitTests.csproj",
       "src\\modules\\cmdpal\\Tests\\Microsoft.CmdPal.Ext.Registry.UnitTests\\Microsoft.CmdPal.Ext.Registry.UnitTests.csproj",
+      "src\\modules\\cmdpal\\Tests\\Microsoft.CmdPal.Ext.WindowsSettings.UnitTests\\Microsoft.CmdPal.Ext.WindowsSettings.UnitTests.csproj",
       "src\\modules\\cmdpal\\Tests\\Microsoft.CmdPal.Ext.RemoteDesktop.UnitTests\\Microsoft.CmdPal.Ext.RemoteDesktop.UnitTests.csproj",
       "src\\modules\\cmdpal\\Tests\\Microsoft.CmdPal.Ext.Shell.UnitTests\\Microsoft.CmdPal.Ext.Shell.UnitTests.csproj",
       "src\\modules\\cmdpal\\Tests\\Microsoft.CmdPal.Ext.System.UnitTests\\Microsoft.CmdPal.Ext.System.UnitTests.csproj",

--- a/src/modules/cmdpal/CommandPalette.slnf
+++ b/src/modules/cmdpal/CommandPalette.slnf
@@ -1,4 +1,4 @@
-{
+﻿{
   "solution": {
     "path": "..\\..\\..\\PowerToys.slnx",
     "projects": [
@@ -25,6 +25,7 @@
       "src\\modules\\cmdpal\\Tests\\Microsoft.CmdPal.Ext.ClipboardHistory.UnitTests\\Microsoft.CmdPal.Ext.ClipboardHistory.UnitTests.csproj",
       "src\\modules\\cmdpal\\Tests\\Microsoft.CmdPal.Ext.Indexer.UnitTests\\Microsoft.CmdPal.Ext.Indexer.UnitTests.csproj",
       "src\\modules\\cmdpal\\Tests\\Microsoft.CmdPal.Ext.Registry.UnitTests\\Microsoft.CmdPal.Ext.Registry.UnitTests.csproj",
+      "src\\modules\\cmdpal\\Tests\\Microsoft.CmdPal.Ext.WindowsSettings.UnitTests\\Microsoft.CmdPal.Ext.WindowsSettings.UnitTests.csproj",
       "src\\modules\\cmdpal\\Tests\\Microsoft.CmdPal.Ext.RemoteDesktop.UnitTests\\Microsoft.CmdPal.Ext.RemoteDesktop.UnitTests.csproj",
       "src\\modules\\cmdpal\\Tests\\Microsoft.CmdPal.Ext.Shell.UnitTests\\Microsoft.CmdPal.Ext.Shell.UnitTests.csproj",
       "src\\modules\\cmdpal\\Tests\\Microsoft.CmdPal.Ext.System.UnitTests\\Microsoft.CmdPal.Ext.System.UnitTests.csproj",

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.WindowsSettings.UnitTests/ControlPanelTasksEnumerationTest.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.WindowsSettings.UnitTests/ControlPanelTasksEnumerationTest.cs
@@ -15,6 +15,11 @@ namespace Microsoft.CmdPal.Ext.WindowsSettings.UnitTests;
 [TestClass]
 public class ControlPanelTasksEnumerationTest
 {
+    /// <summary>
+    /// The path delimiter used by <see cref="WindowsSettingsPathHelper"/>.
+    /// </summary>
+    private const string PathDelimiterSequence = "\u0020\u0020\u02C3\u0020\u0020"; // = "<space><space><arrow><space><space>"
+
     [TestMethod]
     public void EnumerationReturnsWellFormedTasks()
     {
@@ -37,14 +42,45 @@ public class ControlPanelTasksEnumerationTest
             Assert.IsNotNull(task.TaskIdList);
             Assert.IsTrue(task.TaskIdList.Length > 0);
 
-            // the settings path shown as the result subtitle is filled in
-            // during enumeration, not by a later pass over the whole list
-            Assert.AreEqual(task.Type, task.JoinedFullSettingsPath);
+            // The settings path shown as the result subtitle (and searched by
+            // ">" path queries) must be consistent with the task's areas: with
+            // an area it is "<Type>  ˃  <Area>", without it is just the type.
+            if (task.Areas is null)
+            {
+                Assert.AreEqual(task.Type, task.JoinedFullSettingsPath);
+            }
+            else
+            {
+                Assert.IsTrue(task.Areas.Count > 0);
+                Assert.IsFalse(task.Areas.Any(string.IsNullOrWhiteSpace));
+                Assert.AreEqual(
+                    $"{task.Type}{PathDelimiterSequence}{string.Join(PathDelimiterSequence, task.Areas)}",
+                    task.JoinedFullSettingsPath);
+            }
+
+            // alternative names (Control Panel search keywords) are optional,
+            // but when present they must be usable for search matching
+            if (task.AltNames is not null)
+            {
+                Assert.IsTrue(task.AltNames.Any());
+                Assert.IsFalse(task.AltNames.Any(string.IsNullOrWhiteSpace));
+            }
         }
 
-        // The enumerated names are distinct enough to be useful for search
-        // results deduplication.
+        // The overwhelming majority of task names must be distinct — the
+        // merge dedupes by name, so a name collapse (e.g. a localization
+        // fallback bug) would silently drop most of the tasks from search.
         var distinctNames = tasks.Select(x => x.Name).Distinct(System.StringComparer.OrdinalIgnoreCase).Count();
-        Assert.IsTrue(distinctNames > 0);
+        Assert.IsTrue(distinctNames > tasks.Count / 2);
+
+        // Control Panel tasks belong to an applet (e.g. "Devices and
+        // Printers") and carry the keywords Control Panel's own search uses.
+        // Both are expected on client SKUs, but the extension degrades
+        // gracefully without them, so their absence on a reduced shell
+        // environment must not fail the suite.
+        if (!tasks.Any(x => x.Areas is not null) || !tasks.Any(x => x.AltNames is not null))
+        {
+            Assert.Inconclusive("The shell provided no category or keyword properties for the enumerated tasks on this machine.");
+        }
     }
 }

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.WindowsSettings.UnitTests/ControlPanelTasksEnumerationTest.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.WindowsSettings.UnitTests/ControlPanelTasksEnumerationTest.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using Microsoft.CmdPal.Ext.WindowsSettings.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CmdPal.Ext.WindowsSettings.UnitTests;
+
+/// <summary>
+/// Functional test for the shell enumeration of Control Panel tasks. Runs
+/// against the real shell of the test machine.
+/// </summary>
+[TestClass]
+public class ControlPanelTasksEnumerationTest
+{
+    [TestMethod]
+    public void EnumerationReturnsWellFormedTasks()
+    {
+        var tasks = ControlPanelTasksHelper.GetAllControlPanelTasks();
+
+        if (tasks.Count == 0)
+        {
+            // The All Tasks shell folder may be unavailable on some SKUs; the
+            // extension degrades gracefully in that case.
+            Assert.Inconclusive("The shell returned no Control Panel tasks on this machine.");
+        }
+
+        foreach (var task in tasks)
+        {
+            Assert.IsFalse(string.IsNullOrWhiteSpace(task.Name));
+            Assert.IsTrue(task.Command.StartsWith(ControlPanelTasksHelper.ShellItemCommandPrefix, System.StringComparison.Ordinal));
+            Assert.IsFalse(string.IsNullOrWhiteSpace(task.Type));
+
+            // every enumerated task must carry the id list used to launch it
+            Assert.IsNotNull(task.TaskIdList);
+            Assert.IsTrue(task.TaskIdList.Length > 0);
+
+            // the settings path shown as the result subtitle is filled in
+            // during enumeration, not by a later pass over the whole list
+            Assert.AreEqual(task.Type, task.JoinedFullSettingsPath);
+        }
+
+        // The enumerated names are distinct enough to be useful for search
+        // results deduplication.
+        var distinctNames = tasks.Select(x => x.Name).Distinct(System.StringComparer.OrdinalIgnoreCase).Count();
+        Assert.IsTrue(distinctNames > 0);
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.WindowsSettings.UnitTests/ControlPanelTasksHelperTest.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.WindowsSettings.UnitTests/ControlPanelTasksHelperTest.cs
@@ -1,0 +1,139 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CmdPal.Ext.WindowsSettings.Classes;
+using Microsoft.CmdPal.Ext.WindowsSettings.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CmdPal.Ext.WindowsSettings.UnitTests;
+
+[TestClass]
+public class ControlPanelTasksHelperTest
+{
+    private static WindowsSettings.Classes.WindowsSettings CreateSettings(params WindowsSetting[] settings)
+    {
+        return new WindowsSettings.Classes.WindowsSettings()
+        {
+            Settings = settings.ToList(),
+        };
+    }
+
+    private static WindowsSetting CreateTask(string name, string command = "::{26EE0668-A00A-44D7-9371-BEB064C98683}\\0\\::{ED7BA470-8E54-465E-825C-99712043E01C}\\{00000000-0000-0000-0000-000000000001}")
+    {
+        return new WindowsSetting()
+        {
+            Name = name,
+            Command = command,
+            Type = "Control Panel",
+        };
+    }
+
+    [TestMethod]
+    public void MergeAddsNewTasks()
+    {
+        var settings = CreateSettings(CreateTask("Existing setting"));
+        var tasks = new List<WindowsSetting>()
+        {
+            CreateTask("Set up USB game controllers"),
+            CreateTask("Restore your files with File History"),
+        };
+
+        var added = ControlPanelTasksHelper.MergeIntoSettings(settings, tasks);
+
+        Assert.AreEqual(2, added);
+        Assert.AreEqual(3, settings.Settings.Count());
+    }
+
+    [TestMethod]
+    public void MergeSkipsDuplicateNamesCaseInsensitive()
+    {
+        var settings = CreateSettings(CreateTask("File History"));
+        var tasks = new List<WindowsSetting>()
+        {
+            CreateTask("file history"),
+            CreateTask("FILE HISTORY"),
+        };
+
+        var added = ControlPanelTasksHelper.MergeIntoSettings(settings, tasks);
+
+        Assert.AreEqual(0, added);
+        Assert.AreEqual(1, settings.Settings.Count());
+    }
+
+    [TestMethod]
+    public void MergeSkipsNamesMatchingAlternativeNames()
+    {
+        var existing = CreateTask("Device Manager");
+        existing.AltNames = new List<string>() { "Hardware Manager" };
+        var settings = CreateSettings(existing);
+
+        var tasks = new List<WindowsSetting>()
+        {
+            CreateTask("Hardware Manager"),
+        };
+
+        var added = ControlPanelTasksHelper.MergeIntoSettings(settings, tasks);
+
+        Assert.AreEqual(0, added);
+        Assert.AreEqual(1, settings.Settings.Count());
+    }
+
+    [TestMethod]
+    public void MergeSkipsEntriesWithoutNameOrCommand()
+    {
+        var settings = CreateSettings();
+        var tasks = new List<WindowsSetting>()
+        {
+            CreateTask(string.Empty),
+            CreateTask("Valid name", command: string.Empty),
+            CreateTask("Another valid name"),
+        };
+
+        var added = ControlPanelTasksHelper.MergeIntoSettings(settings, tasks);
+
+        Assert.AreEqual(1, added);
+        Assert.AreEqual("Another valid name", settings.Settings.Single().Name);
+    }
+
+    [TestMethod]
+    public void MergeReturnsZeroForEmptyTaskList()
+    {
+        var settings = CreateSettings(CreateTask("Existing setting"));
+
+        var added = ControlPanelTasksHelper.MergeIntoSettings(settings, new List<WindowsSetting>());
+
+        Assert.AreEqual(0, added);
+        Assert.AreEqual(1, settings.Settings.Count());
+    }
+
+    [TestMethod]
+    public void MergeDeduplicatesWithinTaskList()
+    {
+        var settings = CreateSettings();
+        var tasks = new List<WindowsSetting>()
+        {
+            CreateTask("Mouse settings"),
+            CreateTask("Mouse settings"),
+        };
+
+        var added = ControlPanelTasksHelper.MergeIntoSettings(settings, tasks);
+
+        Assert.AreEqual(1, added);
+        Assert.AreEqual(1, settings.Settings.Count());
+    }
+
+    [TestMethod]
+    public void MergedTasksKeepShellItemCommandPrefix()
+    {
+        var settings = CreateSettings();
+        var tasks = new List<WindowsSetting>() { CreateTask("Set up USB game controllers") };
+
+        ControlPanelTasksHelper.MergeIntoSettings(settings, tasks);
+
+        var merged = settings.Settings.Single();
+        Assert.IsTrue(merged.Command.StartsWith(ControlPanelTasksHelper.ShellItemCommandPrefix, System.StringComparison.Ordinal));
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.WindowsSettings.UnitTests/ControlPanelTasksHelperTest.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.WindowsSettings.UnitTests/ControlPanelTasksHelperTest.cs
@@ -136,4 +136,49 @@ public class ControlPanelTasksHelperTest
         var merged = settings.Settings.Single();
         Assert.IsTrue(merged.Command.StartsWith(ControlPanelTasksHelper.ShellItemCommandPrefix, System.StringComparison.Ordinal));
     }
+
+    [TestMethod]
+    public void MergePublishesANewListInsteadOfMutatingTheOldOne()
+    {
+        // The merge runs on a background task while the search page may be
+        // enumerating the current list, so it has to publish a new list
+        // instead of mutating the visible one.
+        var settings = CreateSettings(CreateTask("Existing setting"));
+        var published = settings.Settings;
+
+        var added = ControlPanelTasksHelper.MergeIntoSettings(settings, new List<WindowsSetting>() { CreateTask("New task") });
+
+        Assert.AreEqual(1, added);
+        Assert.AreEqual(1, published.Count());
+        Assert.AreNotSame(published, settings.Settings);
+    }
+
+    [TestMethod]
+    public void ParseKeywordsSplitsAndTrims()
+    {
+        var result = ControlPanelTasksHelper.ParseKeywords("adjust; joystick;controllers ; devices;");
+
+        Assert.IsNotNull(result);
+        CollectionAssert.AreEqual(
+            new List<string>() { "adjust", "joystick", "controllers", "devices" },
+            result.ToList());
+    }
+
+    [TestMethod]
+    public void ParseKeywordsDeduplicatesCaseInsensitive()
+    {
+        var result = ControlPanelTasksHelper.ParseKeywords("back;Back;BACK;restore");
+
+        Assert.IsNotNull(result);
+        CollectionAssert.AreEqual(new List<string>() { "back", "restore" }, result.ToList());
+    }
+
+    [TestMethod]
+    public void ParseKeywordsReturnsNullWhenNothingUsable()
+    {
+        Assert.IsNull(ControlPanelTasksHelper.ParseKeywords(null));
+        Assert.IsNull(ControlPanelTasksHelper.ParseKeywords(string.Empty));
+        Assert.IsNull(ControlPanelTasksHelper.ParseKeywords("   "));
+        Assert.IsNull(ControlPanelTasksHelper.ParseKeywords(";; ; ;"));
+    }
 }

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.WindowsSettings.UnitTests/Microsoft.CmdPal.Ext.WindowsSettings.UnitTests.csproj
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.WindowsSettings.UnitTests/Microsoft.CmdPal.Ext.WindowsSettings.UnitTests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!-- Look at Directory.Build.props in root for common stuff as well -->
+  <Import Project="$(RepoRoot)src\Common.Dotnet.CsWinRT.props" />
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <RootNamespace>Microsoft.CmdPal.Ext.WindowsSettings.UnitTests</RootNamespace>
+    <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\WinUI3Apps\CmdPal\tests\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\ext\Microsoft.CmdPal.Ext.WindowsSettings\Microsoft.CmdPal.Ext.WindowsSettings.csproj" />
+    <ProjectReference Include="..\Microsoft.CmdPal.Ext.UnitTestsBase\Microsoft.CmdPal.Ext.UnitTestBase.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.WindowsSettings.UnitTests/WindowsSettingsPathHelperTest.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.WindowsSettings.UnitTests/WindowsSettingsPathHelperTest.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Microsoft.CmdPal.Ext.WindowsSettings.Classes;
+using Microsoft.CmdPal.Ext.WindowsSettings.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CmdPal.Ext.WindowsSettings.UnitTests;
+
+[TestClass]
+public class WindowsSettingsPathHelperTest
+{
+    /// <summary>
+    /// The path delimiter used by <see cref="WindowsSettingsPathHelper"/>.
+    /// </summary>
+    private const string PathDelimiterSequence = "\u0020\u0020\u02C3\u0020\u0020"; // = "<space><space><arrow><space><space>"
+
+    [TestMethod]
+    public void GeneratePathValuesWithSingleArea()
+    {
+        var setting = new WindowsSetting()
+        {
+            Name = "Set up USB game controllers",
+            Type = "Control Panel",
+            Areas = new List<string>() { "Devices and Printers" },
+        };
+
+        WindowsSettingsPathHelper.GeneratePathValues(setting);
+
+        Assert.AreEqual("Devices and Printers", setting.JoinedAreaPath);
+        Assert.AreEqual($"Control Panel{PathDelimiterSequence}Devices and Printers", setting.JoinedFullSettingsPath);
+    }
+
+    [TestMethod]
+    public void GeneratePathValuesWithMultipleAreas()
+    {
+        var setting = new WindowsSetting()
+        {
+            Name = "Administrative Tools",
+            Type = "Control Panel",
+            Areas = new List<string>() { "System and Security", "Administrative Tools" },
+        };
+
+        WindowsSettingsPathHelper.GeneratePathValues(setting);
+
+        Assert.AreEqual($"System and Security{PathDelimiterSequence}Administrative Tools", setting.JoinedAreaPath);
+        Assert.AreEqual($"Control Panel{PathDelimiterSequence}System and Security{PathDelimiterSequence}Administrative Tools", setting.JoinedFullSettingsPath);
+    }
+
+    [TestMethod]
+    public void GeneratePathValuesWithoutAreas()
+    {
+        var setting = new WindowsSetting()
+        {
+            Name = "File History",
+            Type = "Control Panel",
+        };
+
+        WindowsSettingsPathHelper.GeneratePathValues(setting);
+
+        Assert.AreEqual(string.Empty, setting.JoinedAreaPath);
+        Assert.AreEqual("Control Panel", setting.JoinedFullSettingsPath);
+    }
+
+    [TestMethod]
+    public void GeneratePathValuesSkipsSettingWithoutType()
+    {
+        var setting = new WindowsSetting()
+        {
+            Name = "Nameless",
+            Areas = new List<string>() { "Some area" },
+        };
+
+        WindowsSettingsPathHelper.GeneratePathValues(setting);
+
+        Assert.IsNull(setting.JoinedAreaPath);
+        Assert.IsNull(setting.JoinedFullSettingsPath);
+    }
+}

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/Classes/WindowsSetting.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/Classes/WindowsSetting.cs
@@ -82,5 +82,14 @@ internal sealed class WindowsSetting
     /// This property will be filled on runtime by "WindowsSettingsPathHelper".
     /// </summary>
     public string? JoinedFullSettingsPath { get; set; }
+
+    /// <summary>
+    /// Gets or sets the shell item id list (PIDL) of a Control Panel task.
+    /// This Property IS NOT PART OF THE DATA IN "WindowsSettings.json".
+    /// It is filled on runtime by "ControlPanelTasksHelper" for entries
+    /// enumerated from the shell, and is used to launch them — these items
+    /// have no executable command line and cannot be re-parsed by name.
+    /// </summary>
+    internal byte[]? TaskIdList { get; set; }
 #pragma warning restore CS8632
 }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/Commands/OpenSettingsCommand.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/Commands/OpenSettingsCommand.cs
@@ -36,6 +36,14 @@ internal sealed partial class OpenSettingsCommand : InvokableCommand
 
         var command = entry.Command;
 
+        // Control Panel task items enumerated from the shell have no
+        // executable command line and cannot be re-parsed by name — they are
+        // launched from the shell id list captured during enumeration.
+        if (entry.TaskIdList is { Length: > 0 })
+        {
+            return Helpers.ShellInterop.InvokeShellItemByIdList(entry.TaskIdList);
+        }
+
         if (command.Contains("%windir%", StringComparison.InvariantCultureIgnoreCase))
         {
             var windowsFolder = Environment.GetFolderPath(Environment.SpecialFolder.Windows);

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/Helpers/ControlPanelTasksHelper.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/Helpers/ControlPanelTasksHelper.cs
@@ -1,0 +1,195 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Runtime.InteropServices;
+
+using ManagedCommon;
+using Microsoft.CmdPal.Ext.WindowsSettings.Classes;
+using Microsoft.CmdPal.Ext.WindowsSettings.Properties;
+
+namespace Microsoft.CmdPal.Ext.WindowsSettings.Helpers;
+
+/// <summary>
+/// Helper class to enumerate the Control Panel tasks that Windows exposes via
+/// the shell "All Tasks" folder. These are the same entries Control Panel's
+/// own search offers (e.g. "Set up USB game controllers"), most of which are
+/// not part of the static <c>WindowsSettings.json</c> list. Names come from
+/// the shell already localized in the user's display language.
+/// </summary>
+internal static class ControlPanelTasksHelper
+{
+    /// <summary>
+    /// Marker prefix identifying commands that are shell parsing names of
+    /// Control Panel task items (instead of executable command lines).
+    /// </summary>
+    internal const string ShellItemCommandPrefix = "::{";
+
+    /// <summary>
+    /// Enumerates all Control Panel tasks exposed by the shell.
+    /// Returns an empty list when enumeration is not possible (e.g. server
+    /// SKUs without the Control Panel namespace, or shell errors).
+    /// </summary>
+    internal static List<WindowsSetting> GetAllControlPanelTasks()
+    {
+        var result = new List<WindowsSetting>();
+
+        var settingType = Resources.ResourceManager.GetString("AppControlPanel", CultureInfo.CurrentUICulture)
+            ?? "Control Panel";
+
+        try
+        {
+            var folder = ShellInterop.CreateItemFromParsingName(ShellInterop.AllTasksFolderParsingName);
+            if (folder is null)
+            {
+                Logger.LogWarning("Could not open the shell All Tasks folder; Control Panel tasks will not be available in search.");
+                return result;
+            }
+
+            var enumerator = ShellInterop.GetItemEnumerator(folder);
+            if (enumerator is null)
+            {
+                Logger.LogWarning("Could not enumerate the shell All Tasks folder; Control Panel tasks will not be available in search.");
+                return result;
+            }
+
+            while (enumerator.Next(1, out var itemPtr, out var fetched) == 0 && fetched == 1)
+            {
+                try
+                {
+                    var setting = CreateSettingFromShellItem(itemPtr, settingType);
+                    if (setting is not null)
+                    {
+                        result.Add(setting);
+                    }
+                }
+                finally
+                {
+                    if (itemPtr != IntPtr.Zero)
+                    {
+                        Marshal.Release(itemPtr);
+                    }
+                }
+            }
+        }
+        catch (Exception exception)
+        {
+            Logger.LogError($"Failed to enumerate Control Panel tasks: {exception.Message}");
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Merges dynamically enumerated Control Panel tasks into the given
+    /// settings list, skipping entries whose name is already known (either as
+    /// a name or an alternative name of an existing setting). Returns the
+    /// number of entries added.
+    /// </summary>
+    internal static int MergeIntoSettings(Classes.WindowsSettings windowsSettings, IReadOnlyCollection<WindowsSetting> controlPanelTasks)
+    {
+        if (windowsSettings?.Settings is null || controlPanelTasks is null || controlPanelTasks.Count == 0)
+        {
+            return 0;
+        }
+
+        var existingSettings = windowsSettings.Settings.ToList();
+
+        var knownNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var setting in existingSettings)
+        {
+            knownNames.Add(setting.Name);
+
+            if (setting.AltNames is not null)
+            {
+                foreach (var altName in setting.AltNames)
+                {
+                    knownNames.Add(altName);
+                }
+            }
+        }
+
+        var added = 0;
+        foreach (var task in controlPanelTasks)
+        {
+            if (string.IsNullOrWhiteSpace(task.Name) || string.IsNullOrWhiteSpace(task.Command))
+            {
+                continue;
+            }
+
+            if (!knownNames.Add(task.Name))
+            {
+                continue;
+            }
+
+            existingSettings.Add(task);
+            added++;
+        }
+
+        if (added > 0)
+        {
+            windowsSettings.Settings = existingSettings;
+        }
+
+        return added;
+    }
+
+    private static WindowsSetting CreateSettingFromShellItem(IntPtr itemPtr, string settingType)
+    {
+        var item = ShellInterop.CreateShellItemFromPointer(itemPtr);
+        if (item is null)
+        {
+            return null;
+        }
+
+        if (item.GetDisplayName(ShellInterop.SIGDNNormalDisplay, out var displayName) != 0
+            || string.IsNullOrWhiteSpace(displayName))
+        {
+            return null;
+        }
+
+        if (item.GetDisplayName(ShellInterop.SIGDNDesktopAbsoluteParsing, out var parsingName) != 0
+            || string.IsNullOrWhiteSpace(parsingName)
+            || !parsingName.StartsWith(ShellItemCommandPrefix, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        // Task items cannot be re-parsed from their parsing name later, so
+        // their id list has to be captured now — it is the only way to launch
+        // them when the user selects the result.
+        if (ShellInterop.SHGetIDListFromObject(itemPtr, out var pidl) != 0 || pidl == IntPtr.Zero)
+        {
+            return null;
+        }
+
+        byte[] idList;
+        try
+        {
+            idList = ShellInterop.CopyIdList(pidl);
+        }
+        finally
+        {
+            Marshal.FreeCoTaskMem(pidl);
+        }
+
+        return new WindowsSetting()
+        {
+            Name = displayName,
+            Command = parsingName,
+            Type = settingType,
+            TaskIdList = idList,
+
+            // Control Panel tasks have no areas, so their settings path is
+            // just the type. Filled here rather than by re-running
+            // WindowsSettingsPathHelper over the whole list, which would
+            // mutate entries the search page may be reading concurrently.
+            JoinedAreaPath = string.Empty,
+            JoinedFullSettingsPath = settingType,
+        };
+    }
+}

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/Helpers/ControlPanelTasksHelper.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/Helpers/ControlPanelTasksHelper.cs
@@ -177,19 +177,74 @@ internal static class ControlPanelTasksHelper
             Marshal.FreeCoTaskMem(pidl);
         }
 
-        return new WindowsSetting()
+        // The applet the task belongs to (e.g. "Devices and Printers") becomes
+        // the area, and the keywords Control Panel's own search matches (e.g.
+        // "joystick") become alternative names — so the entries take part in
+        // area, path and alternative name search like any static entry. Both
+        // come from the shell already localized.
+        IList<string> areas = null;
+        IEnumerable<string> altNames = null;
+        if (item is IShellItem2 item2)
+        {
+            if (item2.GetString(in ShellInterop.PKeyApplicationName, out var appName) == 0
+                && !string.IsNullOrWhiteSpace(appName))
+            {
+                areas = new List<string>(1) { appName };
+            }
+
+            if (item2.GetString(in ShellInterop.PKeyKeywords, out var keywords) == 0
+                && !string.IsNullOrWhiteSpace(keywords))
+            {
+                altNames = ParseKeywords(keywords);
+            }
+        }
+
+        var setting = new WindowsSetting()
         {
             Name = displayName,
             Command = parsingName,
             Type = settingType,
+            Areas = areas,
+            AltNames = altNames,
             TaskIdList = idList,
-
-            // Control Panel tasks have no areas, so their settings path is
-            // just the type. Filled here rather than by re-running
-            // WindowsSettingsPathHelper over the whole list, which would
-            // mutate entries the search page may be reading concurrently.
-            JoinedAreaPath = string.Empty,
-            JoinedFullSettingsPath = settingType,
         };
+
+        // Generate the settings path (subtitle and ">" path search) the same
+        // way it is generated for the static entries. Done here per setting
+        // rather than by re-running the helper over the whole merged list,
+        // which would mutate entries the search page may be reading
+        // concurrently.
+        WindowsSettingsPathHelper.GeneratePathValues(setting);
+
+        return setting;
+    }
+
+    /// <summary>
+    /// Splits the semicolon separated keyword string of a Control Panel task
+    /// into distinct, trimmed alternative names. Returns null when no usable
+    /// keyword remains.
+    /// </summary>
+    internal static IEnumerable<string> ParseKeywords(string keywords)
+    {
+        if (string.IsNullOrWhiteSpace(keywords))
+        {
+            return null;
+        }
+
+        var result = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var keyword in keywords.Split(';'))
+        {
+            var trimmed = keyword.Trim();
+            if (trimmed.Length == 0 || !seen.Add(trimmed))
+            {
+                continue;
+            }
+
+            result.Add(trimmed);
+        }
+
+        return result.Count > 0 ? result : null;
     }
 }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/Helpers/ControlPanelTasksHelper.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/Helpers/ControlPanelTasksHelper.cs
@@ -78,7 +78,7 @@ internal static class ControlPanelTasksHelper
         }
         catch (Exception exception)
         {
-            Logger.LogError($"Failed to enumerate Control Panel tasks: {exception.Message}");
+            Logger.LogError($"Failed to enumerate Control Panel tasks", exception);
         }
 
         return result;

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/Helpers/ShellInterop.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/Helpers/ShellInterop.cs
@@ -29,6 +29,21 @@ internal static partial class ShellInterop
     internal static readonly Guid IShellItemIid = new("43826d1e-e718-42ee-bc55-a1e261c37bfe");
     internal static readonly Guid IEnumShellItemsIid = new("70629033-e363-4a28-a567-0db78006e6d7");
 
+    /// <summary>
+    /// PKEY_ApplicationName — for Control Panel task items this is the name
+    /// of the Control Panel applet the task belongs to (e.g. "Power Options"),
+    /// localized by the shell. Shown in Explorer's All Tasks folder as the
+    /// group heading.
+    /// </summary>
+    internal static readonly PropertyKey PKeyApplicationName = new() { FmtId = new Guid("F29F85E0-4FF9-1068-AB91-08002B27B3D9"), Pid = 18 };
+
+    /// <summary>
+    /// PKEY_Keywords — the localized search keywords Control Panel's own
+    /// search uses to match a task (e.g. "joystick" for "Set up USB game
+    /// controllers"). IShellItem2.GetString returns them joined with "; ".
+    /// </summary>
+    internal static readonly PropertyKey PKeyKeywords = new() { FmtId = new Guid("F29F85E0-4FF9-1068-AB91-08002B27B3D9"), Pid = 5 };
+
     // SIGDN values (https://learn.microsoft.com/windows/win32/api/shobjidl_core/ne-shobjidl_core-sigdn)
     internal const uint SIGDNNormalDisplay = 0x00000000;
     internal const uint SIGDNDesktopAbsoluteParsing = 0x80028000;
@@ -169,6 +184,16 @@ internal static partial class ShellInterop
         return (IShellItem)ComWrappers.GetOrCreateObjectForComInstance(ptr, CreateObjectFlags.None);
     }
 
+    /// <summary>
+    /// A shell property key (PROPERTYKEY from wtypes.h).
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct PropertyKey
+    {
+        public Guid FmtId;
+        public uint Pid;
+    }
+
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
     internal struct SHELLEXECUTEINFOW
     {
@@ -208,6 +233,55 @@ internal partial interface IShellItem
 
     [PreserveSig]
     int Compare(IntPtr psi, uint hint, out int piOrder);
+}
+
+/// <summary>
+/// IShellItem2 — extends IShellItem with property access. Only GetString is
+/// used; the other methods are declared to keep the vtable layout of
+/// ShObjIdl_core.h intact.
+/// </summary>
+[GeneratedComInterface(StringMarshalling = StringMarshalling.Utf16)]
+[Guid("7e9fb0d3-919f-4307-ab2e-9b1860310c93")]
+internal partial interface IShellItem2 : IShellItem
+{
+    [PreserveSig]
+    int GetPropertyStore(uint flags, in Guid riid, out IntPtr ppv);
+
+    [PreserveSig]
+    int GetPropertyStoreWithCreateObject(uint flags, IntPtr punkCreateObject, in Guid riid, out IntPtr ppv);
+
+    [PreserveSig]
+    int GetPropertyStoreForKeys(IntPtr rgKeys, uint cKeys, uint flags, in Guid riid, out IntPtr ppv);
+
+    [PreserveSig]
+    int GetPropertyDescriptionList(in ShellInterop.PropertyKey keyType, in Guid riid, out IntPtr ppv);
+
+    [PreserveSig]
+    int Update(IntPtr pbc);
+
+    [PreserveSig]
+    int GetProperty(in ShellInterop.PropertyKey key, IntPtr ppropvar);
+
+    [PreserveSig]
+    int GetCLSID(in ShellInterop.PropertyKey key, out Guid pclsid);
+
+    [PreserveSig]
+    int GetFileTime(in ShellInterop.PropertyKey key, out ulong pft);
+
+    [PreserveSig]
+    int GetInt32(in ShellInterop.PropertyKey key, out int pi);
+
+    [PreserveSig]
+    int GetString(in ShellInterop.PropertyKey key, out string ppsz);
+
+    [PreserveSig]
+    int GetUInt32(in ShellInterop.PropertyKey key, out uint pui);
+
+    [PreserveSig]
+    int GetUInt64(in ShellInterop.PropertyKey key, out ulong pull);
+
+    [PreserveSig]
+    int GetBool(in ShellInterop.PropertyKey key, out int pf);
 }
 
 [GeneratedComInterface(StringMarshalling = StringMarshalling.Utf16)]

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/Helpers/ShellInterop.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/Helpers/ShellInterop.cs
@@ -1,0 +1,228 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+
+namespace Microsoft.CmdPal.Ext.WindowsSettings.Helpers;
+
+/// <summary>
+/// Minimal AOT-compatible shell interop used to enumerate and invoke
+/// Control Panel task items (the same items Control Panel's own search and
+/// the shell "All Tasks" folder expose).
+/// </summary>
+internal static partial class ShellInterop
+{
+    /// <summary>
+    /// Shell "All Tasks" folder containing every Control Panel task. The
+    /// "shell:" prefix is required — this namespace cannot be parsed as a
+    /// plain desktop-relative name (SHCreateItemFromParsingName returns
+    /// E_INVALIDARG without it).
+    /// </summary>
+    internal const string AllTasksFolderParsingName = "shell:::{ED7BA470-8E54-465E-825C-99712043E01C}";
+
+    /// <summary>BHID_EnumItems binding handler id.</summary>
+    internal static readonly Guid BHIDEnumItems = new("94f60519-2850-4924-aa5a-d15e84868039");
+
+    internal static readonly Guid IShellItemIid = new("43826d1e-e718-42ee-bc55-a1e261c37bfe");
+    internal static readonly Guid IEnumShellItemsIid = new("70629033-e363-4a28-a567-0db78006e6d7");
+
+    // SIGDN values (https://learn.microsoft.com/windows/win32/api/shobjidl_core/ne-shobjidl_core-sigdn)
+    internal const uint SIGDNNormalDisplay = 0x00000000;
+    internal const uint SIGDNDesktopAbsoluteParsing = 0x80028000;
+
+    // SHELLEXECUTEINFOW.fMask flags
+    internal const uint SEEMaskIdList = 0x00000004;
+    internal const uint SEEMaskNoAsync = 0x00000100;
+
+    internal const int SWShowNormal = 1;
+
+    private static readonly StrategyBasedComWrappers ComWrappers = new();
+
+    [LibraryImport("shell32.dll", StringMarshalling = StringMarshalling.Utf16)]
+    private static partial int SHCreateItemFromParsingName(string pszPath, IntPtr pbc, in Guid riid, out IntPtr ppv);
+
+    [LibraryImport("shell32.dll")]
+    internal static partial int SHGetIDListFromObject(IntPtr punk, out IntPtr ppidl);
+
+    [LibraryImport("shell32.dll", EntryPoint = "ShellExecuteExW", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static partial bool ShellExecuteEx(ref SHELLEXECUTEINFOW lpExecInfo);
+
+    /// <summary>
+    /// Creates an <see cref="IShellItem"/> from a shell parsing name (e.g. "::{CLSID}\...").
+    /// Returns null when the item cannot be created.
+    /// </summary>
+    internal static IShellItem CreateItemFromParsingName(string parsingName)
+    {
+        var hr = SHCreateItemFromParsingName(parsingName, IntPtr.Zero, IShellItemIid, out var ptr);
+        if (hr != 0 || ptr == IntPtr.Zero)
+        {
+            return null;
+        }
+
+        try
+        {
+            return (IShellItem)ComWrappers.GetOrCreateObjectForComInstance(ptr, CreateObjectFlags.None);
+        }
+        finally
+        {
+            Marshal.Release(ptr);
+        }
+    }
+
+    /// <summary>
+    /// Binds the given shell folder item to its item enumerator.
+    /// Returns null when the folder cannot be enumerated.
+    /// </summary>
+    internal static IEnumShellItems GetItemEnumerator(IShellItem folder)
+    {
+        var hr = folder.BindToHandler(IntPtr.Zero, BHIDEnumItems, IEnumShellItemsIid, out var ptr);
+        if (hr != 0 || ptr == IntPtr.Zero)
+        {
+            return null;
+        }
+
+        try
+        {
+            return (IEnumShellItems)ComWrappers.GetOrCreateObjectForComInstance(ptr, CreateObjectFlags.None);
+        }
+        finally
+        {
+            Marshal.Release(ptr);
+        }
+    }
+
+    /// <summary>
+    /// Copies a native item id list (PIDL) into a managed byte array. A PIDL
+    /// is a sequence of SHITEMID blocks { ushort cb; byte[cb - 2]; }
+    /// terminated by cb == 0.
+    /// </summary>
+    internal static byte[] CopyIdList(IntPtr pidl)
+    {
+        var size = 0;
+        while (true)
+        {
+            var cb = (ushort)Marshal.ReadInt16(pidl, size);
+            if (cb == 0)
+            {
+                size += sizeof(ushort);
+                break;
+            }
+
+            size += cb;
+        }
+
+        var bytes = new byte[size];
+        Marshal.Copy(pidl, bytes, 0, size);
+        return bytes;
+    }
+
+    /// <summary>
+    /// Invokes a shell item from its stored id list bytes via ShellExecuteEx.
+    /// Control Panel task items have no file-system path or executable
+    /// command line and cannot be re-parsed by name, so their id list is
+    /// captured during enumeration and used here to launch them.
+    /// </summary>
+    internal static bool InvokeShellItemByIdList(byte[] idList)
+    {
+        if (idList is null || idList.Length == 0)
+        {
+            return false;
+        }
+
+        var pidl = Marshal.AllocCoTaskMem(idList.Length);
+        try
+        {
+            Marshal.Copy(idList, 0, pidl, idList.Length);
+
+            var info = new SHELLEXECUTEINFOW
+            {
+                CbSize = (uint)Marshal.SizeOf<SHELLEXECUTEINFOW>(),
+                FMask = SEEMaskIdList | SEEMaskNoAsync,
+                LpIDList = pidl,
+                Show = SWShowNormal,
+            };
+
+            return ShellExecuteEx(ref info);
+        }
+        finally
+        {
+            Marshal.FreeCoTaskMem(pidl);
+        }
+    }
+
+    /// <summary>
+    /// Wraps a raw IShellItem pointer (e.g. from IEnumShellItems.Next) into a
+    /// managed <see cref="IShellItem"/>. Does not consume the caller's
+    /// reference — the caller still has to release the raw pointer.
+    /// </summary>
+    internal static IShellItem CreateShellItemFromPointer(IntPtr ptr)
+    {
+        if (ptr == IntPtr.Zero)
+        {
+            return null;
+        }
+
+        return (IShellItem)ComWrappers.GetOrCreateObjectForComInstance(ptr, CreateObjectFlags.None);
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    internal struct SHELLEXECUTEINFOW
+    {
+        public uint CbSize;
+        public uint FMask;
+        public IntPtr Hwnd;
+        public IntPtr LpVerb;
+        public IntPtr LpFile;
+        public IntPtr LpParameters;
+        public IntPtr LpDirectory;
+        public int Show;
+        public IntPtr HInstApp;
+        public IntPtr LpIDList;
+        public IntPtr LpClass;
+        public IntPtr HkeyClass;
+        public uint DwHotKey;
+        public IntPtr HIconOrMonitor;
+        public IntPtr Process;
+    }
+}
+
+[GeneratedComInterface(StringMarshalling = StringMarshalling.Utf16)]
+[Guid("43826d1e-e718-42ee-bc55-a1e261c37bfe")]
+internal partial interface IShellItem
+{
+    [PreserveSig]
+    int BindToHandler(IntPtr pbc, in Guid bhid, in Guid riid, out IntPtr ppv);
+
+    [PreserveSig]
+    int GetParent(out IntPtr ppsi);
+
+    [PreserveSig]
+    int GetDisplayName(uint sigdnName, out string ppszName);
+
+    [PreserveSig]
+    int GetAttributes(uint sfgaoMask, out uint psfgaoAttribs);
+
+    [PreserveSig]
+    int Compare(IntPtr psi, uint hint, out int piOrder);
+}
+
+[GeneratedComInterface(StringMarshalling = StringMarshalling.Utf16)]
+[Guid("70629033-e363-4a28-a567-0db78006e6d7")]
+internal partial interface IEnumShellItems
+{
+    [PreserveSig]
+    int Next(uint celt, out IntPtr rgelt, out uint pceltFetched);
+
+    [PreserveSig]
+    int Skip(uint celt);
+
+    [PreserveSig]
+    int Reset();
+
+    [PreserveSig]
+    int Clone(out IntPtr ppenum);
+}

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/Helpers/WindowsSettingsPathHelper.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/Helpers/WindowsSettingsPathHelper.cs
@@ -30,41 +30,50 @@ internal static class WindowsSettingsPathHelper
 
         foreach (var settings in windowsSettings.Settings)
         {
-            // Check if type value is filled. If not, then write log warning.
-            if (string.IsNullOrEmpty(settings.Type))
-            {
-                // TODO GH #108 Logging is something we have to take care of
-                // Log.Warn($"The type property is not set for setting [{settings.Name}] in json. Skipping generating of settings path.", typeof(WindowsSettingsPathHelper));
-                Logger.LogWarning($"The type property is not set for setting [{settings.Name}] in json. Skipping generating of settings path.");
-                continue;
-            }
+            GeneratePathValues(settings);
+        }
+    }
 
-            // Check if "JoinedAreaPath" and "JoinedFullSettingsPath" are filled. Then log debug message.
-            if (!string.IsNullOrEmpty(settings.JoinedAreaPath))
-            {
-                // Log.Debug($"The property [JoinedAreaPath] of setting [{settings.Name}] was filled from the json. This value is not used and will be overwritten.", typeof(WindowsSettingsPathHelper));
-                Logger.LogDebug($"The property [JoinedAreaPath] of setting [{settings.Name}] was filled from the json. This value is not used and will be overwritten.");
-            }
+    /// <summary>
+    /// Generates the values for <see cref="WindowsSetting.JoinedAreaPath"/> and <see cref="WindowsSetting.JoinedFullSettingsPath"/> on a single setting.
+    /// </summary>
+    /// <param name="setting">The setting to generate the path values for.</param>
+    internal static void GeneratePathValues(Classes.WindowsSetting setting)
+    {
+        // Check if type value is filled. If not, then write log warning.
+        if (string.IsNullOrEmpty(setting.Type))
+        {
+            // TODO GH #108 Logging is something we have to take care of
+            // Log.Warn($"The type property is not set for setting [{setting.Name}]. Skipping generating of settings path.", typeof(WindowsSettingsPathHelper));
+            Logger.LogWarning($"The type property is not set for setting [{setting.Name}]. Skipping generating of settings path.");
+            return;
+        }
 
-            if (!string.IsNullOrEmpty(settings.JoinedFullSettingsPath))
-            {
-                // TODO GH #108 Logging is something we have to take care of
-                // Log.Debug($"The property [JoinedFullSettingsPath] of setting [{settings.Name}] was filled from the json. This value is not used and will be overwritten.", typeof(WindowsSettingsPathHelper));
-                Logger.LogDebug($"The property [JoinedFullSettingsPath] of setting [{settings.Name}] was filled from the json. This value is not used and will be overwritten.");
-            }
+        // Check if "JoinedAreaPath" and "JoinedFullSettingsPath" are filled. Then log debug message.
+        if (!string.IsNullOrEmpty(setting.JoinedAreaPath))
+        {
+            // Log.Debug($"The property [JoinedAreaPath] of setting [{setting.Name}] was filled from the json. This value is not used and will be overwritten.", typeof(WindowsSettingsPathHelper));
+            Logger.LogDebug($"The property [JoinedAreaPath] of setting [{setting.Name}] was filled from the json. This value is not used and will be overwritten.");
+        }
 
-            // Generating path values.
-            if (!(settings.Areas is null) && settings.Areas.Any())
-            {
-                var areaValue = string.Join(_pathDelimiterSequence, settings.Areas);
-                settings.JoinedAreaPath = areaValue;
-                settings.JoinedFullSettingsPath = $"{settings.Type}{_pathDelimiterSequence}{areaValue}";
-            }
-            else
-            {
-                settings.JoinedAreaPath = string.Empty;
-                settings.JoinedFullSettingsPath = settings.Type;
-            }
+        if (!string.IsNullOrEmpty(setting.JoinedFullSettingsPath))
+        {
+            // TODO GH #108 Logging is something we have to take care of
+            // Log.Debug($"The property [JoinedFullSettingsPath] of setting [{setting.Name}] was filled from the json. This value is not used and will be overwritten.", typeof(WindowsSettingsPathHelper));
+            Logger.LogDebug($"The property [JoinedFullSettingsPath] of setting [{setting.Name}] was filled from the json. This value is not used and will be overwritten.");
+        }
+
+        // Generating path values.
+        if (!(setting.Areas is null) && setting.Areas.Any())
+        {
+            var areaValue = string.Join(_pathDelimiterSequence, setting.Areas);
+            setting.JoinedAreaPath = areaValue;
+            setting.JoinedFullSettingsPath = $"{setting.Type}{_pathDelimiterSequence}{areaValue}";
+        }
+        else
+        {
+            setting.JoinedAreaPath = string.Empty;
+            setting.JoinedFullSettingsPath = setting.Type;
         }
     }
 }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/Properties/AssemblyInfo.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/Properties/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Microsoft.CmdPal.Ext.WindowsSettings.UnitTests")]

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/WindowsSettingsCommandsProvider.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/WindowsSettingsCommandsProvider.cs
@@ -2,6 +2,10 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Threading.Tasks;
+
+using ManagedCommon;
 using Microsoft.CmdPal.Ext.WindowsSettings.Helpers;
 using Microsoft.CmdPal.Ext.WindowsSettings.Pages;
 using Microsoft.CmdPal.Ext.WindowsSettings.Properties;
@@ -37,6 +41,24 @@ public sealed partial class WindowsSettingsCommandsProvider : CommandProvider
 
         TranslationHelper.TranslateAllSettings(_windowsSettings);
         WindowsSettingsPathHelper.GenerateSettingsPathValues(_windowsSettings);
+
+        // Merge in the Control Panel tasks the shell exposes (see #48539) in
+        // the background — shell enumeration must not delay provider startup.
+        // Runs after TranslateAllSettings on purpose: shell display names are
+        // already localized and must not go through resource translation.
+        var windowsSettings = _windowsSettings;
+        _ = Task.Run(() =>
+        {
+            try
+            {
+                var controlPanelTasks = ControlPanelTasksHelper.GetAllControlPanelTasks();
+                ControlPanelTasksHelper.MergeIntoSettings(windowsSettings, controlPanelTasks);
+            }
+            catch (Exception exception)
+            {
+                Logger.LogError($"Failed to merge Control Panel tasks into settings search: {exception.Message}");
+            }
+        });
     }
 
     public override ICommandItem[] TopLevelCommands()

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/WindowsSettingsCommandsProvider.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/WindowsSettingsCommandsProvider.cs
@@ -56,7 +56,7 @@ public sealed partial class WindowsSettingsCommandsProvider : CommandProvider
             }
             catch (Exception exception)
             {
-                Logger.LogError($"Failed to merge Control Panel tasks into settings search: {exception.Message}");
+                Logger.LogError($"Failed to merge Control Panel tasks into settings search", exception);
             }
         });
     }


### PR DESCRIPTION
## Summary of the Pull Request

The Command Palette's Windows Settings extension only matches queries against the
static `WindowsSettings.json` list, so Control Panel tasks that Windows itself
exposes — "Set up USB game controllers", "File History", "Adjust the appearance and
performance of Windows" — can never be found, even though Control Panel's own
search finds them instantly.

This adds a second, dynamic source. At startup the extension enumerates the Control
Panel tasks from the shell's "All Tasks" folder (the same data Control Panel search
uses, ~150 tasks) and merges them into the searchable set, de-duplicated against the
existing entries.

## PR Checklist

- [x] Closes: #48539
- [x] **Communication:** Discussed in #48539
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places

## Detailed Description of the Pull Request / Additional comments

**Enumeration.** `ControlPanelTasksHelper` binds the shell "All Tasks" folder
(`shell:::{ED7BA470-8E54-465E-825C-99712043E01C}`) to `IEnumShellItems` and reads each
item's display name. Those names come from the shell **already localized**, so the merge
deliberately runs *after* `TranslationHelper.TranslateAllSettings` — they must not go
through resx translation. Merged entries are typed as Control Panel, so their subtitle
reuses the existing localized string.

**Launching.** Control Panel task items have no executable command line, and they cannot
be re-parsed from their parsing name (`SHParseDisplayName` fails on them). Their shell id
list (PIDL) is therefore captured during enumeration via `SHGetIDListFromObject` and
stored on the entry; invoking the result launches it with `ShellExecuteEx(SEE_MASK_IDLIST)`.

**AOT.** All interop is source-generated (`LibraryImport` + `GeneratedComInterface` with
`StrategyBasedComWrappers`), so the extension stays `IsAotCompatible`.

**Startup.** Enumeration runs on a background task so the provider constructor never
blocks, and it degrades gracefully — if the shell namespace is unavailable the helper logs
a warning and returns an empty list, leaving search exactly as it is today.

**UX.** Merged entries get `AppHomepageScore = 0`, so they never appear on an empty query.
De-duplication checks both `Name` and `AltNames` of existing settings.

**No pipeline changes needed:** the new unit test project follows the same pattern as
`Microsoft.CmdPal.Ext.Registry.UnitTests` — registered in `PowerToys.slnx` and the CmdPal
solution filters, and picked up by the existing `**\*UnitTest*.dll` glob. No sibling CmdPal
unit test project is listed in `.pipelines`.

## Validation Steps Performed

**Automated** — added `Microsoft.CmdPal.Ext.WindowsSettings.UnitTests` (this extension's
first test project). 8 tests, all passing:
- 7 unit tests over the merge: adds new tasks; skips duplicate names case-insensitively;
  skips names matching an existing entry's `AltNames`; skips entries missing a name or
  command; de-duplicates within the incoming list; returns 0 for an empty list; preserves
  the shell command prefix.
- 1 functional test that enumerates the real shell folder and asserts every task has a
  name, a `::{`-prefixed parsing name, a non-empty id list, and the expected settings path.

**Manual (Windows 11, x64 Debug)** — built `Microsoft.CmdPal.UI` and drove the real palette:
- `Windows Settings` → `game controllers` returns **Set up USB game controllers**,
  subtitle **Control Panel**.
- The File History and "appearance and performance" tasks are found.
- Invoking the result opens the real Windows **Game Controllers** dialog; the performance
  task opens **Performance Options**.
- Typing the exact task name at the root surfaces it via the fallback item, without
  entering the page.
- Regression: existing `power` → **Power and sleep** still resolves, the empty query still
  shows only the homepage entries, and there are no duplicate rows.
- No perceptible delay — results were available as soon as CmdPal finished loading.

<img width="1000" height="600" alt="01-windows-settings-game-controllers" src="https://github.com/user-attachments/assets/04d6ad8e-a69d-4c95-b480-05146aef8784" />
<img width="1000" height="600" alt="02-existing-power-result" src="https://github.com/user-attachments/assets/62e75ea8-4a99-489a-8e7c-f7bf5813185f" />
<img width="1000" height="600" alt="03-root-fallback-game-controllers" src="https://github.com/user-attachments/assets/03eb8908-b8f9-4635-a02e-29b413f0ff24" />
<img width="581" height="1080" alt="04-game-controllers-dialog" src="https://github.com/user-attachments/assets/c8fa24ec-7e41-4da4-b862-e888a88dab7b" />

