### PR TITLE
[Keyboard Manager] Per-keyboard remap profiles (auto-switch + cycle hotkey)

### DIFF
--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/KeyboardAssignmentRow.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/KeyboardAssignmentRow.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace KeyboardManagerEditorUI.Helpers
+{
+    /// <summary>One row in the auto-switch dialog: a detected keyboard and its assigned profile.</summary>
+    public sealed class KeyboardAssignmentRow : INotifyPropertyChanged
+    {
+        private bool _isTyping;
+        private string _displayName = string.Empty;
+
+        public string DisplayName
+        {
+            get => _displayName;
+            set
+            {
+                if (_displayName != value)
+                {
+                    _displayName = value;
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(DisplayName)));
+                }
+            }
+        }
+
+        public string DevicePath { get; set; } = string.Empty;
+
+        public IReadOnlyList<string> Profiles { get; set; } = new List<string>();
+
+        public string SelectedProfile { get; set; } = string.Empty;
+
+        /// <summary>True while this keyboard is the one currently being typed on (for a highlight).</summary>
+        public bool IsTyping
+        {
+            get => _isTyping;
+            set
+            {
+                if (_isTyping != value)
+                {
+                    _isTyping = value;
+                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsTyping)));
+                }
+            }
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+    }
+}

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Interop/DetectedKeyboard.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Interop/DetectedKeyboard.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace KeyboardManagerEditorUI.Interop
+{
+    /// <summary>A physical keyboard discovered via Raw Input, for the per-keyboard profile UI.</summary>
+    public sealed class DetectedKeyboard
+    {
+        /// <summary>Normalized RIDI_DEVICENAME (stable prefix); the key matched by the engine.</summary>
+        public string DevicePath { get; init; } = string.Empty;
+
+        /// <summary>Human-readable name (HID product string, else VID/PID, else a short path).</summary>
+        public string DisplayName { get; init; } = string.Empty;
+    }
+}

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Interop/RawInputDeviceEnumerator.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Interop/RawInputDeviceEnumerator.cs
@@ -1,0 +1,243 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using ManagedCommon;
+
+namespace KeyboardManagerEditorUI.Interop
+{
+    /// <summary>
+    /// Enumerates connected keyboards using Raw Input (no window required). Mirrors the engine's
+    /// identity model: device paths are normalized to the stable prefix (up to the 2nd '#') and
+    /// de-duplicated, so the list matches what the engine writes into the device→profile map.
+    /// </summary>
+    internal static class RawInputDeviceEnumerator
+    {
+        private const uint RidiDeviceName = 0x20000007;
+        private const uint RimTypeKeyboard = 1;
+        private const uint FileShareRead = 0x1;
+        private const uint FileShareWrite = 0x2;
+        private const uint OpenExisting = 3;
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct RawInputDeviceList
+        {
+            public IntPtr HDevice;
+            public uint DwType;
+        }
+
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern uint GetRawInputDeviceList([In, Out] RawInputDeviceList[]? pRawInputDeviceList, ref uint puiNumDevices, uint cbSize);
+
+        [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        private static extern uint GetRawInputDeviceInfoW(IntPtr hDevice, uint uiCommand, IntPtr pData, ref uint pcbSize);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        private static extern IntPtr CreateFileW(string lpFileName, uint dwDesiredAccess, uint dwShareMode, IntPtr lpSecurityAttributes, uint dwCreationDisposition, uint dwFlagsAndAttributes, IntPtr hTemplateFile);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool CloseHandle(IntPtr hObject);
+
+        [DllImport("hid.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        [return: MarshalAs(UnmanagedType.U1)]
+        private static extern bool HidD_GetProductString(IntPtr hidDeviceObject, IntPtr buffer, uint bufferLength);
+
+        /// <summary>
+        /// Normalizes a RIDI_DEVICENAME to the stable prefix (everything before the 2nd '#'),
+        /// dropping the instance id that some virtual keyboards churn. Must match the engine's
+        /// NormalizeDevicePath so the UI and the engine agree on device identity.
+        /// </summary>
+        public static string NormalizeDevicePath(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+            {
+                return path;
+            }
+
+            int first = path.IndexOf('#', StringComparison.Ordinal);
+            if (first < 0)
+            {
+                return path;
+            }
+
+            int second = path.IndexOf('#', first + 1);
+            return second < 0 ? path : path.Substring(0, second);
+        }
+
+        public static List<DetectedKeyboard> EnumerateKeyboards()
+        {
+            var result = new List<DetectedKeyboard>();
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            try
+            {
+                uint count = 0;
+                uint structSize = (uint)Marshal.SizeOf<RawInputDeviceList>();
+                if (GetRawInputDeviceList(null, ref count, structSize) != 0 || count == 0)
+                {
+                    return result;
+                }
+
+                var list = new RawInputDeviceList[count];
+                if (GetRawInputDeviceList(list, ref count, structSize) == unchecked((uint)-1))
+                {
+                    return result;
+                }
+
+                for (int i = 0; i < count; i++)
+                {
+                    if (list[i].DwType != RimTypeKeyboard)
+                    {
+                        continue;
+                    }
+
+                    DetectedKeyboard? keyboard = DescribeDevice(list[i].HDevice);
+                    if (keyboard is null || !seen.Add(keyboard.DevicePath))
+                    {
+                        continue; // unreadable, or already listed (one entry per physical device)
+                    }
+
+                    result.Add(keyboard);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError("Failed to enumerate keyboards: " + ex.Message);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Describes a raw-input device handle (as delivered with WM_INPUT) as a keyboard entry, or
+        /// null if its name can't be read. Used to identify the keyboard a live keystroke came from.
+        /// </summary>
+        public static DetectedKeyboard? DescribeDevice(IntPtr hDevice)
+        {
+            string fullPath = GetDeviceName(hDevice);
+            if (string.IsNullOrEmpty(fullPath))
+            {
+                return null;
+            }
+
+            return new DetectedKeyboard
+            {
+                DevicePath = NormalizeDevicePath(fullPath),
+                DisplayName = BuildDisplayName(fullPath),
+            };
+        }
+
+        private static string GetDeviceName(IntPtr hDevice)
+        {
+            uint size = 0;
+            if (GetRawInputDeviceInfoW(hDevice, RidiDeviceName, IntPtr.Zero, ref size) != 0 || size == 0)
+            {
+                return string.Empty;
+            }
+
+            IntPtr buffer = Marshal.AllocHGlobal((int)size * sizeof(char));
+            try
+            {
+                if (GetRawInputDeviceInfoW(hDevice, RidiDeviceName, buffer, ref size) == unchecked((uint)-1))
+                {
+                    return string.Empty;
+                }
+
+                return Marshal.PtrToStringUni(buffer) ?? string.Empty;
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(buffer);
+            }
+        }
+
+        private static string BuildDisplayName(string fullPath)
+        {
+            string product = GetProductString(fullPath);
+            if (!string.IsNullOrEmpty(product))
+            {
+                return product;
+            }
+
+            string vid = ExtractToken(fullPath, "VID");
+            string pid = ExtractToken(fullPath, "PID");
+            if (!string.IsNullOrEmpty(vid))
+            {
+                return $"Keyboard (VID {vid}/PID {pid})";
+            }
+
+            // No friendly identity (e.g. virtualized provider): show the stable device token.
+            return ShortenPath(NormalizeDevicePath(fullPath));
+        }
+
+        private static string GetProductString(string devicePath)
+        {
+            IntPtr handle = CreateFileW(devicePath, 0, FileShareRead | FileShareWrite, IntPtr.Zero, OpenExisting, 0, IntPtr.Zero);
+            if (handle == IntPtr.Zero || handle == new IntPtr(-1))
+            {
+                return string.Empty;
+            }
+
+            const int bytes = 256 * sizeof(char);
+            IntPtr buffer = Marshal.AllocHGlobal(bytes);
+            try
+            {
+                if (!HidD_GetProductString(handle, buffer, bytes))
+                {
+                    return string.Empty;
+                }
+
+                return (Marshal.PtrToStringUni(buffer) ?? string.Empty).Trim();
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(buffer);
+                CloseHandle(handle);
+            }
+        }
+
+        private static string ExtractToken(string path, string key)
+        {
+            string upper = path.ToUpperInvariant();
+            foreach (char sep in new[] { '_', '&' })
+            {
+                int pos = upper.IndexOf(key + sep, StringComparison.Ordinal);
+                if (pos < 0)
+                {
+                    continue;
+                }
+
+                pos += key.Length + 1;
+                int start = pos;
+                while (pos < upper.Length && Uri.IsHexDigit(upper[pos]))
+                {
+                    pos++;
+                }
+
+                string hex = upper.Substring(start, pos - start);
+                if (hex.Length == 0)
+                {
+                    continue;
+                }
+
+                // Bluetooth encodes VID as "0002<realVid>"; keep the last 4 hex digits.
+                return hex.Length == 8 ? hex.Substring(4) : hex;
+            }
+
+            return string.Empty;
+        }
+
+        private static string ShortenPath(string path)
+        {
+            int hash = path.IndexOf('#', StringComparison.Ordinal);
+            string tail = hash >= 0 && hash + 1 < path.Length ? path[(hash + 1)..] : path;
+            return tail.Length > 40
+                ? string.Concat("Keyboard (", tail.AsSpan(0, 40), "…)")
+                : "Keyboard (" + tail + ")";
+        }
+    }
+}

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Interop/RawInputWatcher.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Interop/RawInputWatcher.cs
@@ -1,0 +1,253 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+using ManagedCommon;
+
+namespace KeyboardManagerEditorUI.Interop
+{
+    /// <summary>
+    /// Watches raw keyboard input on a dedicated hidden-window thread so the auto-switch dialog can
+    /// identify which physical keyboard the user is typing on (the same identity the engine sees).
+    /// Fires <see cref="DetectedKeyboard"/> for each key-down; ignores injected input (hDevice == 0).
+    /// The callback runs on the watcher thread — marshal to the UI thread before touching UI.
+    /// </summary>
+    internal sealed class RawInputWatcher : IDisposable
+    {
+        private const uint RidInput = 0x10000003;
+        private const uint RimTypeKeyboard = 1;
+        private const uint RidevInputSink = 0x00000100;
+        private const uint WmInput = 0x00FF;
+        private const uint WmQuit = 0x0012;
+        private const int WmKeyDown = 0x0100;
+        private const int WmSysKeyDown = 0x0104;
+
+        private delegate IntPtr WndProcDelegate(IntPtr hwnd, uint msg, IntPtr wParam, IntPtr lParam);
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct RawInputDevice
+        {
+            public ushort UsUsagePage;
+            public ushort UsUsage;
+            public uint DwFlags;
+            public IntPtr HwndTarget;
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        private struct WndClass
+        {
+            public uint Style;
+            public IntPtr LpfnWndProc;
+            public int CbClsExtra;
+            public int CbWndExtra;
+            public IntPtr HInstance;
+            public IntPtr HIcon;
+            public IntPtr HCursor;
+            public IntPtr HbrBackground;
+            public IntPtr LpszMenuName;
+            [MarshalAs(UnmanagedType.LPWStr)]
+            public string LpszClassName;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct NativeMessage
+        {
+            public IntPtr Hwnd;
+            public uint Message;
+            public IntPtr WParam;
+            public IntPtr LParam;
+            public uint Time;
+            public int PtX;
+            public int PtY;
+        }
+
+        [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern ushort RegisterClassW(ref WndClass lpWndClass);
+
+        [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern IntPtr CreateWindowExW(uint exStyle, string className, string windowName, uint style, int x, int y, int width, int height, IntPtr parent, IntPtr menu, IntPtr instance, IntPtr param);
+
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        private static extern IntPtr DefWindowProcW(IntPtr hwnd, uint msg, IntPtr wParam, IntPtr lParam);
+
+        [DllImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool DestroyWindow(IntPtr hwnd);
+
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool UnregisterClassW(string className, IntPtr instance);
+
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        private static extern int GetMessageW(out NativeMessage msg, IntPtr hwnd, uint filterMin, uint filterMax);
+
+        [DllImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool TranslateMessage(ref NativeMessage msg);
+
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        private static extern IntPtr DispatchMessageW(ref NativeMessage msg);
+
+        [DllImport("user32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool PostThreadMessageW(uint threadId, uint msg, IntPtr wParam, IntPtr lParam);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool RegisterRawInputDevices([In] RawInputDevice[] devices, uint count, uint size);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern uint GetRawInputData(IntPtr hRawInput, uint command, IntPtr data, ref uint size, uint headerSize);
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+        private static extern IntPtr GetModuleHandleW(string? name);
+
+        [DllImport("kernel32.dll")]
+        private static extern uint GetCurrentThreadId();
+
+        private readonly Action<DetectedKeyboard> _onKeyboard;
+        private readonly WndProcDelegate _wndProc;
+        private Thread? _thread;
+        private uint _threadId;
+
+        public RawInputWatcher(Action<DetectedKeyboard> onKeyboard)
+        {
+            _onKeyboard = onKeyboard;
+            _wndProc = WndProc; // hold a reference so the delegate isn't collected
+        }
+
+        public void Start()
+        {
+            if (_thread != null)
+            {
+                return;
+            }
+
+            _thread = new Thread(ThreadMain) { IsBackground = true, Name = "KbmRawInputWatcher" };
+            _thread.Start();
+        }
+
+        public void Stop()
+        {
+            Thread? thread = _thread;
+            if (thread == null)
+            {
+                return;
+            }
+
+            _thread = null;
+            if (_threadId != 0)
+            {
+                PostThreadMessageW(_threadId, WmQuit, IntPtr.Zero, IntPtr.Zero);
+            }
+
+            thread.Join();
+            _threadId = 0;
+        }
+
+        public void Dispose() => Stop();
+
+        private void ThreadMain()
+        {
+            _threadId = GetCurrentThreadId();
+            const string className = "KbmEditorRawInputWatcher";
+
+            var wc = new WndClass
+            {
+                LpfnWndProc = Marshal.GetFunctionPointerForDelegate(_wndProc),
+                HInstance = GetModuleHandleW(null),
+                LpszClassName = className,
+            };
+            RegisterClassW(ref wc);
+
+            IntPtr hwnd = CreateWindowExW(0, className, string.Empty, 0, 0, 0, 0, 0, IntPtr.Zero, IntPtr.Zero, wc.HInstance, IntPtr.Zero);
+            if (hwnd == IntPtr.Zero)
+            {
+                Logger.LogError("RawInputWatcher: CreateWindow failed");
+                return;
+            }
+
+            var devices = new[]
+            {
+                new RawInputDevice { UsUsagePage = 0x01, UsUsage = 0x06, DwFlags = RidevInputSink, HwndTarget = hwnd },
+            };
+            if (!RegisterRawInputDevices(devices, 1, (uint)Marshal.SizeOf<RawInputDevice>()))
+            {
+                Logger.LogError("RawInputWatcher: RegisterRawInputDevices failed");
+                DestroyWindow(hwnd);
+                UnregisterClassW(className, wc.HInstance);
+                return;
+            }
+
+            while (GetMessageW(out NativeMessage msg, IntPtr.Zero, 0, 0) > 0)
+            {
+                TranslateMessage(ref msg);
+                DispatchMessageW(ref msg);
+            }
+
+            DestroyWindow(hwnd);
+            UnregisterClassW(className, wc.HInstance);
+        }
+
+        private IntPtr WndProc(IntPtr hwnd, uint msg, IntPtr wParam, IntPtr lParam)
+        {
+            if (msg == WmInput)
+            {
+                HandleRawInput(lParam);
+            }
+
+            return DefWindowProcW(hwnd, msg, wParam, lParam);
+        }
+
+        private void HandleRawInput(IntPtr hRawInput)
+        {
+            uint headerSize = (uint)((2 * sizeof(uint)) + (2 * IntPtr.Size)); // RAWINPUTHEADER
+            uint size = 0;
+            if (GetRawInputData(hRawInput, RidInput, IntPtr.Zero, ref size, headerSize) != 0 || size == 0)
+            {
+                return;
+            }
+
+            IntPtr buffer = Marshal.AllocHGlobal((int)size);
+            try
+            {
+                if (GetRawInputData(hRawInput, RidInput, buffer, ref size, headerSize) != size)
+                {
+                    return;
+                }
+
+                if ((uint)Marshal.ReadInt32(buffer, 0) != RimTypeKeyboard)
+                {
+                    return;
+                }
+
+                IntPtr hDevice = Marshal.ReadIntPtr(buffer, 2 * sizeof(uint));
+                if (hDevice == IntPtr.Zero)
+                {
+                    return; // injected input (e.g. a remap's own output)
+                }
+
+                // RAWKEYBOARD.Message sits 8 bytes into the keyboard payload (after MakeCode/Flags/
+                // Reserved/VKey), which starts right after the header.
+                int message = Marshal.ReadInt32(buffer, (int)headerSize + 8);
+                if (message != WmKeyDown && message != WmSysKeyDown)
+                {
+                    return;
+                }
+
+                DetectedKeyboard? keyboard = RawInputDeviceEnumerator.DescribeDevice(hDevice);
+                if (keyboard != null)
+                {
+                    _onKeyboard(keyboard);
+                }
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(buffer);
+            }
+        }
+    }
+}

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/MainPage.xaml
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/MainPage.xaml
@@ -68,6 +68,7 @@
             x:Key="StringVisibilityConverter"
             EmptyValue="Collapsed"
             NotEmptyValue="Visible" />
+        <tkconverters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
     </Page.Resources>
 
     <Grid>
@@ -99,8 +100,45 @@
                     <RowDefinition Height="*" />
                 </Grid.RowDefinitions>
                 <Grid VerticalAlignment="Top">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <StackPanel
+                        VerticalAlignment="Center"
+                        Orientation="Horizontal"
+                        Spacing="8">
+                        <TextBlock
+                            x:Uid="ProfileLabel"
+                            VerticalAlignment="Center"
+                            Style="{StaticResource BodyStrongTextBlockStyle}" />
+                        <ComboBox
+                            x:Name="ProfileSelector"
+                            x:Uid="ProfileSelector"
+                            MinWidth="180"
+                            SelectionChanged="ProfileSelector_SelectionChanged" />
+                        <Button x:Name="NewProfileBtn" Click="NewProfileBtn_Click">
+                            <FontIcon FontSize="14" Glyph="&#xE710;" />
+                            <ToolTipService.ToolTip>
+                                <TextBlock x:Uid="NewProfileBtnTooltip" />
+                            </ToolTipService.ToolTip>
+                        </Button>
+                        <Button x:Name="DeleteProfileBtn" Click="DeleteProfileBtn_Click">
+                            <FontIcon FontSize="14" Glyph="&#xE74D;" />
+                            <ToolTipService.ToolTip>
+                                <TextBlock x:Uid="DeleteProfileBtnTooltip" />
+                            </ToolTipService.ToolTip>
+                        </Button>
+                        <Button x:Name="AutoSwitchBtn" Click="AutoSwitchBtn_Click">
+                            <StackPanel Orientation="Horizontal" Spacing="6">
+                                <FontIcon FontSize="14" Glyph="&#xE765;" />
+                                <TextBlock x:Uid="AutoSwitchBtn_Text" VerticalAlignment="Center" />
+                            </StackPanel>
+                        </Button>
+                    </StackPanel>
                     <Button
                         x:Name="NewRemappingBtn"
+                        Grid.Column="1"
                         VerticalAlignment="Top"
                         Click="NewRemappingBtn_Click">
                         <StackPanel Orientation="Horizontal" Spacing="8">
@@ -636,6 +674,75 @@
                     x:Uid="DeleteConfirmationDialog"
                     DefaultButton="Primary">
                     <TextBlock x:Uid="DeleteConfirmationDialogContent" TextWrapping="Wrap" />
+                </ContentDialog>
+
+                <!--  Dialog for creating a new profile  -->
+                <ContentDialog
+                    x:Name="NewProfileDialog"
+                    x:Uid="NewProfileDialog"
+                    DefaultButton="Primary">
+                    <StackPanel Spacing="12">
+                        <TextBox x:Name="NewProfileNameBox" x:Uid="NewProfileNameBox" />
+                        <CheckBox x:Name="CopyCurrentProfileCheckBox" x:Uid="CopyCurrentProfileCheckBox" />
+                    </StackPanel>
+                </ContentDialog>
+
+                <!--  Confirmation Dialog for deleting a profile  -->
+                <ContentDialog
+                    x:Name="DeleteProfileDialog"
+                    x:Uid="DeleteProfileDialog"
+                    DefaultButton="Close">
+                    <TextBlock x:Uid="DeleteProfileDialogContent" TextWrapping="Wrap" />
+                </ContentDialog>
+
+                <!--  Dialog for per-keyboard auto-switch settings  -->
+                <ContentDialog
+                    x:Name="AutoSwitchDialog"
+                    x:Uid="AutoSwitchDialog"
+                    DefaultButton="Primary">
+                    <StackPanel MinWidth="480" Spacing="12">
+                        <ToggleSwitch x:Name="AutoSwitchToggle" x:Uid="AutoSwitchToggle" />
+                        <TextBlock x:Uid="AutoSwitchKeyboardsHeader" Style="{StaticResource BodyStrongTextBlockStyle}" />
+                        <InfoBar
+                            x:Uid="AutoSwitchIdentifyHint"
+                            IsClosable="False"
+                            IsOpen="True"
+                            Severity="Informational" />
+                        <ItemsControl x:Name="KeyboardAssignmentsList">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate x:DataType="helper:KeyboardAssignmentRow">
+                                    <Grid Margin="0,4" ColumnSpacing="8">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="20" />
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
+                                        <FontIcon
+                                            VerticalAlignment="Center"
+                                            FontSize="14"
+                                            Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}"
+                                            Glyph="&#xE765;"
+                                            Visibility="{x:Bind IsTyping, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
+                                        <TextBlock
+                                            Grid.Column="1"
+                                            VerticalAlignment="Center"
+                                            Text="{x:Bind DisplayName, Mode=OneWay}"
+                                            TextTrimming="CharacterEllipsis" />
+                                        <ComboBox
+                                            Grid.Column="2"
+                                            MinWidth="150"
+                                            ItemsSource="{x:Bind Profiles}"
+                                            SelectedItem="{x:Bind SelectedProfile, Mode=TwoWay}" />
+                                    </Grid>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                        <TextBlock
+                            x:Uid="AutoSwitchHint"
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            Style="{StaticResource CaptionTextBlockStyle}"
+                            TextWrapping="Wrap" />
+                    </StackPanel>
                 </ContentDialog>
             </Grid>
         </ContentControl>

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/MainPage.xaml
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/MainPage.xaml
@@ -100,9 +100,10 @@
                     <RowDefinition Height="*" />
                 </Grid.RowDefinitions>
 
-                <!--  Add remapping (always visible) + filter / bulk-select toolbar  -->
+                <!--  Add remapping (always visible) + active profile + filter / bulk-select toolbar  -->
                 <Grid Grid.Row="0">
                     <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="*" />
                         <ColumnDefinition Width="Auto" />
@@ -124,8 +125,65 @@
                             <TextBlock x:Uid="NewRemappingBtn_Text" VerticalAlignment="Center" />
                         </StackPanel>
                     </Button>
+                    <!--
+                        The active profile scopes the whole list, so it shares the list toolbar instead of
+                        claiming a row of its own: the trailing filter cluster is right-aligned and left the
+                        middle of this row empty anyway.
+                    -->
                     <StackPanel
-                        Grid.Column="2"
+                        Grid.Column="1"
+                        VerticalAlignment="Center"
+                        Orientation="Horizontal"
+                        Spacing="8">
+                        <TextBlock
+                            x:Uid="ProfileLabel"
+                            VerticalAlignment="Center"
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                        <ComboBox
+                            x:Name="ProfileSelector"
+                            x:Uid="ProfileSelector"
+                            MinWidth="160"
+                            SelectionChanged="ProfileSelector_SelectionChanged" />
+                        <Button
+                            x:Name="NewProfileBtn"
+                            Width="36"
+                            Height="32"
+                            Padding="0"
+                            Click="NewProfileBtn_Click"
+                            Style="{StaticResource SubtleButtonStyle}">
+                            <FontIcon FontSize="14" Glyph="&#xE710;" />
+                            <ToolTipService.ToolTip>
+                                <TextBlock x:Uid="NewProfileBtnTooltip" />
+                            </ToolTipService.ToolTip>
+                        </Button>
+                        <Button
+                            x:Name="DeleteProfileBtn"
+                            Width="36"
+                            Height="32"
+                            Padding="0"
+                            Click="DeleteProfileBtn_Click"
+                            Style="{StaticResource SubtleButtonStyle}">
+                            <FontIcon FontSize="14" Glyph="&#xE74D;" />
+                            <ToolTipService.ToolTip>
+                                <TextBlock x:Uid="DeleteProfileBtnTooltip" />
+                            </ToolTipService.ToolTip>
+                        </Button>
+                        <!--
+                            Labelled and bordered, unlike the two subtle icon buttons: those act on the
+                            profile in the box next to them, while this opens the device-assignment dialog
+                            and needs to read as its own action. No glyph — the keyboard glyph's ink is a
+                            short band sitting high in its em box, so it looks misaligned beside the label
+                            however it is aligned.
+                        -->
+                        <Button
+                            x:Name="AutoSwitchBtn"
+                            Height="32"
+                            Click="AutoSwitchBtn_Click">
+                            <TextBlock x:Uid="AutoSwitchBtn_Text" VerticalAlignment="Center" />
+                        </Button>
+                    </StackPanel>
+                    <StackPanel
+                        Grid.Column="3"
                         VerticalAlignment="Center"
                         Orientation="Horizontal"
                         Spacing="8"
@@ -851,6 +909,81 @@
                     Grid.Row="1"
                     DefaultButton="Close">
                     <TextBlock x:Name="BulkDeleteConfirmationText" TextWrapping="Wrap" />
+                </ContentDialog>
+
+                <!--  Dialog for creating a new profile  -->
+                <ContentDialog
+                    x:Name="NewProfileDialog"
+                    x:Uid="NewProfileDialog"
+                    DefaultButton="Primary">
+                    <StackPanel Spacing="12">
+                        <TextBox x:Name="NewProfileNameBox" x:Uid="NewProfileNameBox" />
+                        <CheckBox x:Name="CopyCurrentProfileCheckBox" x:Uid="CopyCurrentProfileCheckBox" />
+                    </StackPanel>
+                </ContentDialog>
+
+                <!--  Confirmation Dialog for deleting a profile  -->
+                <ContentDialog
+                    x:Name="DeleteProfileDialog"
+                    x:Uid="DeleteProfileDialog"
+                    DefaultButton="Close">
+                    <StackPanel Spacing="6">
+                        <TextBlock x:Uid="DeleteProfileDialogContent" TextWrapping="Wrap" />
+                        <TextBlock
+                            x:Name="DeleteProfileDialogName"
+                            FontWeight="SemiBold"
+                            TextWrapping="Wrap" />
+                    </StackPanel>
+                </ContentDialog>
+
+                <!--  Dialog for per-keyboard auto-switch settings  -->
+                <ContentDialog
+                    x:Name="AutoSwitchDialog"
+                    x:Uid="AutoSwitchDialog"
+                    DefaultButton="Primary">
+                    <StackPanel MinWidth="480" Spacing="12">
+                        <ToggleSwitch x:Name="AutoSwitchToggle" x:Uid="AutoSwitchToggle" />
+                        <TextBlock x:Uid="AutoSwitchKeyboardsHeader" Style="{StaticResource BodyStrongTextBlockStyle}" />
+                        <InfoBar
+                            x:Uid="AutoSwitchIdentifyHint"
+                            IsClosable="False"
+                            IsOpen="True"
+                            Severity="Informational" />
+                        <ItemsControl x:Name="KeyboardAssignmentsList">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate x:DataType="helper:KeyboardAssignmentRow">
+                                    <Grid Margin="0,4" ColumnSpacing="8">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="20" />
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
+                                        <FontIcon
+                                            VerticalAlignment="Center"
+                                            FontSize="14"
+                                            Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}"
+                                            Glyph="&#xE765;"
+                                            Visibility="{x:Bind IsTyping, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
+                                        <TextBlock
+                                            Grid.Column="1"
+                                            VerticalAlignment="Center"
+                                            Text="{x:Bind DisplayName, Mode=OneWay}"
+                                            TextTrimming="CharacterEllipsis" />
+                                        <ComboBox
+                                            Grid.Column="2"
+                                            MinWidth="150"
+                                            ItemsSource="{x:Bind Profiles}"
+                                            SelectedItem="{x:Bind SelectedProfile, Mode=TwoWay}" />
+                                    </Grid>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                        <TextBlock
+                            x:Uid="AutoSwitchHint"
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            Style="{StaticResource CaptionTextBlockStyle}"
+                            TextWrapping="Wrap" />
+                    </StackPanel>
                 </ContentDialog>
             </Grid>
         </ContentControl>

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/MainPage.xaml.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/MainPage.xaml.cs
@@ -41,6 +41,11 @@ namespace KeyboardManagerEditorUI.Pages
         private EditingItem? _editingItem;
         private string _mappingState = "Empty";
         private bool _isServiceRunning = true;
+        private bool _suppressProfileSelection;
+        private RawInputWatcher? _autoSwitchWatcher;
+        private ObservableCollection<KeyboardAssignmentRow>? _keyboardRows;
+        private List<string> _autoSwitchProfiles = new();
+        private string _notAssignedLabel = string.Empty;
 
         public event PropertyChangedEventHandler? PropertyChanged;
 
@@ -122,6 +127,7 @@ namespace KeyboardManagerEditorUI.Pages
             if (_mappingService != null)
             {
                 LoadAllMappings();
+                LoadProfiles();
             }
             else
             {
@@ -152,6 +158,231 @@ namespace KeyboardManagerEditorUI.Pages
         {
             ServiceDownBanner.Visibility = IsServiceRunning ? Visibility.Collapsed : Visibility.Visible;
         }
+
+        #region Profile Management
+
+        private void LoadProfiles()
+        {
+            _suppressProfileSelection = true;
+            try
+            {
+                IReadOnlyList<string> profiles = ProfileManager.GetProfiles();
+                string active = ProfileManager.GetActiveProfile();
+
+                ProfileSelector.ItemsSource = profiles;
+                ProfileSelector.SelectedItem = profiles.Contains(active) ? active : (profiles.Count > 0 ? profiles[0] : null);
+                UpdateDeleteProfileButtonState();
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError("Failed to load profiles: " + ex.Message);
+            }
+            finally
+            {
+                _suppressProfileSelection = false;
+            }
+        }
+
+        private void UpdateDeleteProfileButtonState()
+        {
+            DeleteProfileBtn.IsEnabled = !string.Equals(
+                ProfileManager.GetActiveProfile(),
+                "default",
+                StringComparison.OrdinalIgnoreCase);
+        }
+
+        private void ProfileSelector_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (_suppressProfileSelection || _mappingService == null)
+            {
+                return;
+            }
+
+            if (ProfileSelector.SelectedItem is not string profile)
+            {
+                return;
+            }
+
+            if (string.Equals(profile, ProfileManager.GetActiveProfile(), StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            SwitchToActiveProfile(profile);
+        }
+
+        private void SwitchToActiveProfile(string profile)
+        {
+            try
+            {
+                if (!ProfileManager.SetActiveProfile(profile))
+                {
+                    Logger.LogWarning($"Failed to switch to profile '{profile}'");
+                    return;
+                }
+
+                RebuildForActiveProfile();
+                UpdateDeleteProfileButtonState();
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError("Error switching profile: " + ex.Message);
+            }
+        }
+
+        // Re-reads the now-active profile's config into a fresh native service and the editor cache.
+        private void RebuildForActiveProfile()
+        {
+            _mappingService?.Dispose();
+            _mappingService = new KeyboardMappingService();
+            SettingsManager.ReloadForActiveProfile();
+            LoadAllMappings();
+        }
+
+        private async void NewProfileBtn_Click(object sender, RoutedEventArgs e)
+        {
+            NewProfileNameBox.Text = string.Empty;
+            CopyCurrentProfileCheckBox.IsChecked = false;
+
+            if (await NewProfileDialog.ShowAsync() != ContentDialogResult.Primary)
+            {
+                return;
+            }
+
+            string name = NewProfileNameBox.Text.Trim();
+            if (string.IsNullOrEmpty(name))
+            {
+                return;
+            }
+
+            if (ProfileManager.CreateProfile(name, CopyCurrentProfileCheckBox.IsChecked == true))
+            {
+                LoadProfiles();
+
+                // Selecting the new profile triggers the switch through SelectionChanged.
+                ProfileSelector.SelectedItem = name;
+            }
+            else
+            {
+                Logger.LogWarning($"Could not create profile '{name}' (invalid name or already exists)");
+            }
+        }
+
+        private async void DeleteProfileBtn_Click(object sender, RoutedEventArgs e)
+        {
+            string active = ProfileManager.GetActiveProfile();
+            if (string.Equals(active, "default", StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            if (await DeleteProfileDialog.ShowAsync() != ContentDialogResult.Primary)
+            {
+                return;
+            }
+
+            if (ProfileManager.DeleteProfile(active))
+            {
+                // DeleteProfile falls back to the default profile; rebuild against it.
+                RebuildForActiveProfile();
+                LoadProfiles();
+            }
+        }
+
+        private async void AutoSwitchBtn_Click(object sender, RoutedEventArgs e)
+        {
+            _notAssignedLabel = ResourceHelper.GetString("AutoSwitch_NotAssigned");
+
+            // Available choices per keyboard: "(not assigned)" + existing profiles.
+            _autoSwitchProfiles = new List<string> { _notAssignedLabel };
+            _autoSwitchProfiles.AddRange(ProfileManager.GetProfiles());
+
+            // Start from previously-saved assignments only; live typing identifies/adds the rest.
+            // (Enumeration is not used: it surfaces virtual/synthetic keyboards the user never types
+            // on, and can miss the device seen at typing time on some machines.)
+            _keyboardRows = new ObservableCollection<KeyboardAssignmentRow>();
+            foreach (DeviceAssignment saved in DeviceProfileManager.GetSavedAssignments())
+            {
+                _keyboardRows.Add(new KeyboardAssignmentRow
+                {
+                    DevicePath = saved.Device,
+                    DisplayName = string.IsNullOrEmpty(saved.Name) ? saved.Device : saved.Name,
+                    Profiles = _autoSwitchProfiles,
+                    SelectedProfile = _autoSwitchProfiles.Contains(saved.Profile) ? saved.Profile : _notAssignedLabel,
+                });
+            }
+
+            KeyboardAssignmentsList.ItemsSource = _keyboardRows;
+            AutoSwitchToggle.IsOn = DeviceProfileManager.GetAutoSwitchEnabled();
+
+            // Watch live keystrokes so the user can identify a keyboard by typing on it (and so a
+            // keyboard that only shows up at typing time — not in enumeration — still gets a row).
+            _autoSwitchWatcher = new RawInputWatcher(OnKeyboardTyped);
+            _autoSwitchWatcher.Start();
+
+            ContentDialogResult result;
+            try
+            {
+                result = await AutoSwitchDialog.ShowAsync();
+            }
+            finally
+            {
+                _autoSwitchWatcher.Stop();
+                _autoSwitchWatcher = null;
+            }
+
+            if (result != ContentDialogResult.Primary)
+            {
+                return;
+            }
+
+            var toSave = _keyboardRows
+                .Where(r => !string.Equals(r.SelectedProfile, _notAssignedLabel, StringComparison.Ordinal))
+                .Select(r => new DeviceAssignment { Device = r.DevicePath, Profile = r.SelectedProfile, Name = r.DisplayName });
+
+            DeviceProfileManager.Save(AutoSwitchToggle.IsOn, toSave);
+        }
+
+        // Runs on the Raw Input watcher thread; marshal to the UI thread before touching rows.
+        private void OnKeyboardTyped(DetectedKeyboard keyboard)
+        {
+            DispatcherQueue.TryEnqueue(() =>
+            {
+                if (_keyboardRows == null)
+                {
+                    return;
+                }
+
+                KeyboardAssignmentRow? match = null;
+                foreach (KeyboardAssignmentRow row in _keyboardRows)
+                {
+                    bool isMatch = string.Equals(row.DevicePath, keyboard.DevicePath, StringComparison.OrdinalIgnoreCase);
+                    row.IsTyping = isMatch;
+                    if (isMatch)
+                    {
+                        match = row;
+                        if (!string.IsNullOrEmpty(keyboard.DisplayName))
+                        {
+                            row.DisplayName = keyboard.DisplayName; // refresh a placeholder name once identified
+                        }
+                    }
+                }
+
+                if (match == null)
+                {
+                    _keyboardRows.Add(new KeyboardAssignmentRow
+                    {
+                        DevicePath = keyboard.DevicePath,
+                        DisplayName = keyboard.DisplayName,
+                        Profiles = _autoSwitchProfiles,
+                        SelectedProfile = _notAssignedLabel,
+                        IsTyping = true,
+                    });
+                }
+            });
+        }
+
+        #endregion
 
         #region Dialog Show Methods
 
@@ -893,15 +1124,17 @@ namespace KeyboardManagerEditorUI.Pages
 
         private void LoadRemappings()
         {
+            // Clear first so switching to a profile with no remaps empties the list
+            // (rather than leaving the previous profile's entries on screen).
+            RemappingList.Clear();
+            DisabledList.Clear();
+
             SettingsManager.EditorSettings.ShortcutsByOperationType.TryGetValue(ShortcutOperationType.RemapShortcut, out var remapShortcutIds);
 
             if (remapShortcutIds == null)
             {
                 return;
             }
-
-            RemappingList.Clear();
-            DisabledList.Clear();
 
             foreach (var id in remapShortcutIds)
             {
@@ -934,14 +1167,14 @@ namespace KeyboardManagerEditorUI.Pages
 
         private void LoadTextMappings()
         {
+            TextMappings.Clear();
+
             SettingsManager.EditorSettings.ShortcutsByOperationType.TryGetValue(ShortcutOperationType.RemapText, out var remapShortcutIds);
 
             if (remapShortcutIds == null)
             {
                 return;
             }
-
-            TextMappings.Clear();
 
             foreach (var id in remapShortcutIds)
             {
@@ -963,14 +1196,14 @@ namespace KeyboardManagerEditorUI.Pages
 
         private void LoadProgramShortcuts()
         {
+            ProgramShortcuts.Clear();
+
             SettingsManager.EditorSettings.ShortcutsByOperationType.TryGetValue(ShortcutOperationType.RunProgram, out var remapShortcutIds);
 
             if (remapShortcutIds == null)
             {
                 return;
             }
-
-            ProgramShortcuts.Clear();
 
             foreach (var id in remapShortcutIds)
             {
@@ -997,14 +1230,14 @@ namespace KeyboardManagerEditorUI.Pages
 
         private void LoadUrlShortcuts()
         {
+            UrlShortcuts.Clear();
+
             SettingsManager.EditorSettings.ShortcutsByOperationType.TryGetValue(ShortcutOperationType.OpenUri, out var remapShortcutIds);
 
             if (remapShortcutIds == null)
             {
                 return;
             }
-
-            UrlShortcuts.Clear();
 
             foreach (var id in remapShortcutIds)
             {

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/MainPage.xaml.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/MainPage.xaml.cs
@@ -36,6 +36,8 @@ namespace KeyboardManagerEditorUI.Pages
         private const string VkDisabledString = "256";
 
         private DispatcherTimer? _serviceCheckTimer;
+        private FileSystemWatcher? _settingsWatcher;
+        private DispatcherTimer? _activeProfileDebounce;
         private KeyboardMappingService? _mappingService;
         private bool _disposed;
         private bool _isEditMode;
@@ -43,6 +45,11 @@ namespace KeyboardManagerEditorUI.Pages
         private string _mappingState = "Empty";
         private bool _isServiceRunning = true;
         private bool _isUpdatingToggle;
+        private bool _suppressProfileSelection;
+        private RawInputWatcher? _autoSwitchWatcher;
+        private ObservableCollection<KeyboardAssignmentRow>? _keyboardRows;
+        private List<string> _autoSwitchProfiles = new();
+        private string _notAssignedLabel = string.Empty;
 
         public event PropertyChangedEventHandler? PropertyChanged;
 
@@ -255,6 +262,8 @@ namespace KeyboardManagerEditorUI.Pages
             if (_mappingService != null)
             {
                 LoadAllMappings();
+                LoadProfiles();
+                StartActiveProfileWatcher();
             }
             else
             {
@@ -285,6 +294,328 @@ namespace KeyboardManagerEditorUI.Pages
         {
             ServiceDownBanner.Visibility = IsServiceRunning ? Visibility.Collapsed : Visibility.Visible;
         }
+
+        #region Profile Management
+
+        private void LoadProfiles()
+        {
+            _suppressProfileSelection = true;
+            try
+            {
+                IReadOnlyList<string> profiles = ProfileManager.GetProfiles();
+                string active = ProfileManager.GetActiveProfile();
+
+                ProfileSelector.ItemsSource = profiles;
+                ProfileSelector.SelectedItem = profiles.Contains(active) ? active : (profiles.Count > 0 ? profiles[0] : null);
+                UpdateDeleteProfileButtonState();
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError("Failed to load profiles: " + ex.Message);
+            }
+            finally
+            {
+                _suppressProfileSelection = false;
+            }
+        }
+
+        private void UpdateDeleteProfileButtonState()
+        {
+            // Track the profile shown in the picker, not the live active profile: auto-switch can
+            // change the active profile in the background, and Delete acts on the selected one.
+            DeleteProfileBtn.IsEnabled =
+                ProfileSelector.SelectedItem is string selected &&
+                !string.Equals(selected, "default", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private void ProfileSelector_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (_suppressProfileSelection || _mappingService == null)
+            {
+                return;
+            }
+
+            if (ProfileSelector.SelectedItem is not string profile)
+            {
+                return;
+            }
+
+            UpdateDeleteProfileButtonState();
+
+            if (string.Equals(profile, ProfileManager.GetActiveProfile(), StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            SwitchToActiveProfile(profile);
+        }
+
+        private void SwitchToActiveProfile(string profile)
+        {
+            try
+            {
+                if (!ProfileManager.SetActiveProfile(profile))
+                {
+                    Logger.LogWarning($"Failed to switch to profile '{profile}'");
+                    return;
+                }
+
+                RebuildForActiveProfile();
+                UpdateDeleteProfileButtonState();
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError("Error switching profile: " + ex.Message);
+            }
+        }
+
+        // Points the page at the now-active profile: a fresh native service reads that profile's
+        // configuration, and reconciling the editor settings against it re-tags the mappings so the
+        // list shows this profile's remappings and only those.
+        private void RebuildForActiveProfile()
+        {
+            _mappingService?.Dispose();
+            _mappingService = new KeyboardMappingService();
+            SettingsManager.ReloadForActiveProfile();
+            LoadAllMappings();
+        }
+
+        // The engine rewrites settings.json's activeConfiguration when it auto-switches profiles (or
+        // the cycle hotkey fires). Watch that file so the editor's profile picker + mapping view
+        // follow the engine instead of showing a stale profile.
+        private void StartActiveProfileWatcher()
+        {
+            try
+            {
+                string dir = ProfileManager.SettingsDirectory;
+                if (!Directory.Exists(dir))
+                {
+                    return;
+                }
+
+                _activeProfileDebounce = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(200) };
+                _activeProfileDebounce.Tick += (s, e) =>
+                {
+                    _activeProfileDebounce!.Stop();
+                    RefreshActiveProfileFromDisk();
+                };
+
+                _settingsWatcher = new FileSystemWatcher(dir, "settings.json")
+                {
+                    NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.Size,
+                    EnableRaisingEvents = true,
+                };
+                _settingsWatcher.Changed += OnSettingsFileChanged;
+                _settingsWatcher.Created += OnSettingsFileChanged;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning("Failed to start active-profile watcher: " + ex.Message);
+            }
+        }
+
+        // Raised on a thread-pool thread, often several times per write; hop to the UI thread and
+        // debounce so the reload happens at most once per settle.
+        private void OnSettingsFileChanged(object sender, FileSystemEventArgs e)
+        {
+            DispatcherQueue.TryEnqueue(() =>
+            {
+                _activeProfileDebounce?.Stop();
+                _activeProfileDebounce?.Start();
+            });
+        }
+
+        // If the on-disk active profile differs from what the picker shows (engine auto-switched
+        // under us), move the picker and reload the mapping view to match. Guarded with
+        // _suppressProfileSelection so it can't loop with the editor's own profile switches.
+        private void RefreshActiveProfileFromDisk()
+        {
+            if (_mappingService == null || _disposed)
+            {
+                return;
+            }
+
+            string active = ProfileManager.GetActiveProfile();
+            if (ProfileSelector.SelectedItem is string current &&
+                string.Equals(current, active, StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            _suppressProfileSelection = true;
+            try
+            {
+                IReadOnlyList<string> profiles = ProfileManager.GetProfiles();
+                if (ProfileSelector.ItemsSource is not IReadOnlyList<string> shown || !shown.SequenceEqual(profiles))
+                {
+                    ProfileSelector.ItemsSource = profiles;
+                }
+
+                ProfileSelector.SelectedItem = profiles.Contains(active)
+                    ? active
+                    : (profiles.Count > 0 ? profiles[0] : null);
+                UpdateDeleteProfileButtonState();
+            }
+            finally
+            {
+                _suppressProfileSelection = false;
+            }
+
+            RebuildForActiveProfile();
+        }
+
+        private async void NewProfileBtn_Click(object sender, RoutedEventArgs e)
+        {
+            NewProfileNameBox.Text = string.Empty;
+            CopyCurrentProfileCheckBox.IsChecked = false;
+
+            if (await NewProfileDialog.ShowAsync() != ContentDialogResult.Primary)
+            {
+                return;
+            }
+
+            string name = NewProfileNameBox.Text.Trim();
+            if (string.IsNullOrEmpty(name))
+            {
+                return;
+            }
+
+            if (ProfileManager.CreateProfile(name, CopyCurrentProfileCheckBox.IsChecked == true))
+            {
+                LoadProfiles();
+
+                // Selecting the new profile triggers the switch through SelectionChanged.
+                ProfileSelector.SelectedItem = name;
+            }
+            else
+            {
+                Logger.LogWarning($"Could not create profile '{name}' (invalid name or already exists)");
+            }
+        }
+
+        private async void DeleteProfileBtn_Click(object sender, RoutedEventArgs e)
+        {
+            // Delete exactly what the user has selected in the picker — NOT ProfileManager
+            // .GetActiveProfile(). Auto-switch can change the active profile in the background while
+            // this editor is open, so the live active profile may differ from the one shown here;
+            // using it deleted an unintended profile. Name the target in the prompt so any remaining
+            // mismatch is visible before the user confirms.
+            if (ProfileSelector.SelectedItem is not string selected ||
+                string.Equals(selected, "default", StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            DeleteProfileDialogName.Text = selected;
+
+            if (await DeleteProfileDialog.ShowAsync() != ContentDialogResult.Primary)
+            {
+                return;
+            }
+
+            if (ProfileManager.DeleteProfile(selected))
+            {
+                // DeleteProfile only falls back to "default" when the deleted profile was the active
+                // one; rebuild against whatever is active now and refresh the picker.
+                RebuildForActiveProfile();
+                LoadProfiles();
+            }
+        }
+
+        private async void AutoSwitchBtn_Click(object sender, RoutedEventArgs e)
+        {
+            _notAssignedLabel = ResourceHelper.GetString("AutoSwitch_NotAssigned");
+
+            // Available choices per keyboard: "(not assigned)" + existing profiles.
+            _autoSwitchProfiles = new List<string> { _notAssignedLabel };
+            _autoSwitchProfiles.AddRange(ProfileManager.GetProfiles());
+
+            // Start from previously-saved assignments only; live typing identifies/adds the rest.
+            // (Enumeration is not used: it surfaces virtual/synthetic keyboards the user never types
+            // on, and can miss the device seen at typing time on some machines.)
+            _keyboardRows = new ObservableCollection<KeyboardAssignmentRow>();
+            foreach (DeviceAssignment saved in DeviceProfileManager.GetSavedAssignments())
+            {
+                _keyboardRows.Add(new KeyboardAssignmentRow
+                {
+                    DevicePath = saved.Device,
+                    DisplayName = string.IsNullOrEmpty(saved.Name) ? saved.Device : saved.Name,
+                    Profiles = _autoSwitchProfiles,
+                    SelectedProfile = _autoSwitchProfiles.Contains(saved.Profile) ? saved.Profile : _notAssignedLabel,
+                });
+            }
+
+            KeyboardAssignmentsList.ItemsSource = _keyboardRows;
+            AutoSwitchToggle.IsOn = DeviceProfileManager.GetAutoSwitchEnabled();
+
+            // Watch live keystrokes so the user can identify a keyboard by typing on it (and so a
+            // keyboard that only shows up at typing time — not in enumeration — still gets a row).
+            _autoSwitchWatcher = new RawInputWatcher(OnKeyboardTyped);
+            _autoSwitchWatcher.Start();
+
+            ContentDialogResult result;
+            try
+            {
+                result = await AutoSwitchDialog.ShowAsync();
+            }
+            finally
+            {
+                _autoSwitchWatcher.Stop();
+                _autoSwitchWatcher = null;
+            }
+
+            if (result != ContentDialogResult.Primary)
+            {
+                return;
+            }
+
+            var toSave = _keyboardRows
+                .Where(r => !string.Equals(r.SelectedProfile, _notAssignedLabel, StringComparison.Ordinal))
+                .Select(r => new DeviceAssignment { Device = r.DevicePath, Profile = r.SelectedProfile, Name = r.DisplayName });
+
+            DeviceProfileManager.Save(AutoSwitchToggle.IsOn, toSave);
+        }
+
+        // Runs on the Raw Input watcher thread; marshal to the UI thread before touching rows.
+        private void OnKeyboardTyped(DetectedKeyboard keyboard)
+        {
+            DispatcherQueue.TryEnqueue(() =>
+            {
+                if (_keyboardRows == null)
+                {
+                    return;
+                }
+
+                KeyboardAssignmentRow? match = null;
+                foreach (KeyboardAssignmentRow row in _keyboardRows)
+                {
+                    bool isMatch = string.Equals(row.DevicePath, keyboard.DevicePath, StringComparison.OrdinalIgnoreCase);
+                    row.IsTyping = isMatch;
+                    if (isMatch)
+                    {
+                        match = row;
+                        if (!string.IsNullOrEmpty(keyboard.DisplayName))
+                        {
+                            row.DisplayName = keyboard.DisplayName; // refresh a placeholder name once identified
+                        }
+                    }
+                }
+
+                if (match == null)
+                {
+                    _keyboardRows.Add(new KeyboardAssignmentRow
+                    {
+                        DevicePath = keyboard.DevicePath,
+                        DisplayName = keyboard.DisplayName,
+                        Profiles = _autoSwitchProfiles,
+                        SelectedProfile = _notAssignedLabel,
+                        IsTyping = true,
+                    });
+                }
+            });
+        }
+
+        #endregion
 
         #region Dialog Show Methods
 
@@ -1072,6 +1403,11 @@ namespace KeyboardManagerEditorUI.Pages
 
         private void LoadRemappings()
         {
+            // Clear first so switching to a profile with no remaps empties the list
+            // (rather than leaving the previous profile's entries on screen).
+            RemappingList.Clear();
+            DisabledList.Clear();
+
             SettingsManager.EditorSettings.ShortcutsByOperationType.TryGetValue(ShortcutOperationType.RemapShortcut, out var remapShortcutIds);
 
             _allRemappings.Clear();
@@ -1124,6 +1460,8 @@ namespace KeyboardManagerEditorUI.Pages
 
         private void LoadTextMappings()
         {
+            TextMappings.Clear();
+
             SettingsManager.EditorSettings.ShortcutsByOperationType.TryGetValue(ShortcutOperationType.RemapText, out var remapShortcutIds);
 
             _allTextMappings.Clear();
@@ -1160,6 +1498,8 @@ namespace KeyboardManagerEditorUI.Pages
 
         private void LoadProgramShortcuts()
         {
+            ProgramShortcuts.Clear();
+
             SettingsManager.EditorSettings.ShortcutsByOperationType.TryGetValue(ShortcutOperationType.RunProgram, out var remapShortcutIds);
 
             _allProgramShortcuts.Clear();
@@ -1201,6 +1541,8 @@ namespace KeyboardManagerEditorUI.Pages
 
         private void LoadUrlShortcuts()
         {
+            UrlShortcuts.Clear();
+
             SettingsManager.EditorSettings.ShortcutsByOperationType.TryGetValue(ShortcutOperationType.OpenUri, out var remapShortcutIds);
 
             _allUrlShortcuts.Clear();
@@ -1602,6 +1944,17 @@ namespace KeyboardManagerEditorUI.Pages
             {
                 _serviceCheckTimer?.Stop();
                 _serviceCheckTimer = null;
+                _activeProfileDebounce?.Stop();
+                _activeProfileDebounce = null;
+                if (_settingsWatcher != null)
+                {
+                    _settingsWatcher.EnableRaisingEvents = false;
+                    _settingsWatcher.Changed -= OnSettingsFileChanged;
+                    _settingsWatcher.Created -= OnSettingsFileChanged;
+                    _settingsWatcher.Dispose();
+                    _settingsWatcher = null;
+                }
+
                 _mappingService?.Dispose();
                 _mappingService = null;
             }

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Settings/DeviceAssignment.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Settings/DeviceAssignment.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace KeyboardManagerEditorUI.Settings
+{
+    /// <summary>A saved keyboard→profile assignment (with a friendly name for display).</summary>
+    public sealed class DeviceAssignment
+    {
+        public string Device { get; set; } = string.Empty;
+
+        public string Profile { get; set; } = string.Empty;
+
+        public string Name { get; set; } = string.Empty;
+    }
+}

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Settings/DeviceProfileManager.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Settings/DeviceProfileManager.cs
@@ -1,0 +1,116 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using ManagedCommon;
+
+namespace KeyboardManagerEditorUI.Settings
+{
+    /// <summary>
+    /// Reads and writes deviceProfiles.json — the device→profile map and the auto-switch enable
+    /// flag consumed by the engine for per-keyboard profile auto-switching. Saving signals the
+    /// engine (via <see cref="ProfileManager.SignalEngineReload"/>) so it reloads the map.
+    /// </summary>
+    internal static class DeviceProfileManager
+    {
+        private static readonly string _filePath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "Microsoft",
+            "PowerToys",
+            "Keyboard Manager",
+            "deviceProfiles.json");
+
+        private static readonly JsonSerializerOptions _jsonOptions = new()
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+        };
+
+        private sealed class DeviceProfilesFile
+        {
+            public bool AutoSwitchEnabled { get; set; }
+
+            public List<DeviceProfileEntry> Map { get; set; } = new();
+
+            // The engine's profile-cycle hotkey definition. The editor doesn't own this (yet);
+            // keep it as a raw node so saving from the editor round-trips it unchanged.
+            public System.Text.Json.Nodes.JsonNode? CycleHotkey { get; set; }
+        }
+
+        private sealed class DeviceProfileEntry
+        {
+            public string Device { get; set; } = string.Empty;
+
+            public string Profile { get; set; } = string.Empty;
+
+            // Display name only; the engine ignores this field.
+            public string Name { get; set; } = string.Empty;
+        }
+
+        public static bool GetAutoSwitchEnabled() => Load().AutoSwitchEnabled;
+
+        /// <summary>Returns the saved keyboard→profile assignments (with display names).</summary>
+        public static IReadOnlyList<DeviceAssignment> GetSavedAssignments()
+        {
+            return Load().Map
+                .Where(e => !string.IsNullOrEmpty(e.Device) && !string.IsNullOrEmpty(e.Profile))
+                .Select(e => new DeviceAssignment { Device = e.Device, Profile = e.Profile, Name = e.Name })
+                .ToList();
+        }
+
+        /// <summary>
+        /// Persists the auto-switch flag and assignments, then signals the engine to reload.
+        /// Assignments with an empty device or profile are dropped (unassigned keyboards).
+        /// </summary>
+        public static bool Save(bool autoSwitchEnabled, IEnumerable<DeviceAssignment> assignments)
+        {
+            try
+            {
+                var file = new DeviceProfilesFile
+                {
+                    AutoSwitchEnabled = autoSwitchEnabled,
+                    Map = assignments
+                        .Where(a => !string.IsNullOrEmpty(a.Device) && !string.IsNullOrEmpty(a.Profile))
+                        .Select(a => new DeviceProfileEntry { Device = a.Device, Profile = a.Profile, Name = a.Name })
+                        .ToList(),
+                    CycleHotkey = Load().CycleHotkey, // preserve the engine's hotkey definition
+                };
+
+                Directory.CreateDirectory(Path.GetDirectoryName(_filePath)!);
+                File.WriteAllText(_filePath, JsonSerializer.Serialize(file, _jsonOptions));
+
+                ProfileManager.SignalEngineReload();
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError("Failed to save deviceProfiles.json: " + ex.Message);
+                return false;
+            }
+        }
+
+        private static DeviceProfilesFile Load()
+        {
+            try
+            {
+                if (File.Exists(_filePath))
+                {
+                    return JsonSerializer.Deserialize<DeviceProfilesFile>(File.ReadAllText(_filePath), _jsonOptions)
+                           ?? new DeviceProfilesFile();
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning("Failed to read deviceProfiles.json: " + ex.Message);
+            }
+
+            return new DeviceProfilesFile();
+        }
+    }
+}

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Settings/ProfileManager.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Settings/ProfileManager.cs
@@ -1,0 +1,369 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading;
+using ManagedCommon;
+
+namespace KeyboardManagerEditorUI.Settings
+{
+    /// <summary>
+    /// Manages Keyboard Manager profiles. Each profile is one engine config file "{name}.json"
+    /// in the Keyboard Manager folder; the active profile is recorded in settings.json under
+    /// "activeConfiguration" and listed in "keyboardConfigurations". Switching the active profile
+    /// rewrites those values and signals the engine's reload event, which live-swaps the whole
+    /// active remap set (verified: the engine re-reads activeConfiguration on that event).
+    /// </summary>
+    internal static class ProfileManager
+    {
+        private const string DefaultProfile = "default";
+
+        // Named event the KBM engine waits on; signaling it makes the engine reload its settings.
+        private const string SettingsChangedEventName = "PowerToys_KeyboardManager_Event_Settings";
+
+        // A valid but empty engine config, used when creating a fresh profile.
+        private const string EmptyConfigJson =
+            "{\"remapKeys\":{\"inProcess\":[]},\"remapKeysToText\":{\"inProcess\":[]}," +
+            "\"remapShortcuts\":{\"global\":[],\"appSpecific\":[]}," +
+            "\"remapShortcutsToText\":{\"global\":[],\"appSpecific\":[]}}";
+
+        private static readonly string _settingsDirectory = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "Microsoft",
+            "PowerToys",
+            "Keyboard Manager");
+
+        private static string SettingsJsonPath => Path.Combine(_settingsDirectory, "settings.json");
+
+        private static string ConfigPath(string profile) => Path.Combine(_settingsDirectory, profile + ".json");
+
+        /// <summary>
+        /// Returns the known profile names. Reads "keyboardConfigurations" from settings.json and
+        /// also scans "{name}.json" files so externally created profiles are picked up. Always
+        /// includes the built-in "default".
+        /// </summary>
+        public static IReadOnlyList<string> GetProfiles()
+        {
+            var names = new List<string>();
+
+            try
+            {
+                if (ReadSettingsRoot()?["properties"]?["keyboardConfigurations"]?["value"] is JsonArray configs)
+                {
+                    foreach (JsonNode? item in configs)
+                    {
+                        string? name = item?.GetValue<string>();
+                        if (!string.IsNullOrEmpty(name) && !names.Contains(name))
+                        {
+                            names.Add(name);
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning($"ProfileManager.GetProfiles: failed reading settings.json: {ex.Message}");
+            }
+
+            try
+            {
+                if (Directory.Exists(_settingsDirectory))
+                {
+                    foreach (string file in Directory.EnumerateFiles(_settingsDirectory, "*.json"))
+                    {
+                        string stem = Path.GetFileNameWithoutExtension(file);
+
+                        // Skip settings.json, editor caches, and backups like "default.backup-...".
+                        if (stem.Equals("settings", StringComparison.OrdinalIgnoreCase) ||
+                            stem.StartsWith("editorSettings", StringComparison.OrdinalIgnoreCase) ||
+                            stem.Contains('.'))
+                        {
+                            continue;
+                        }
+
+                        if (!names.Contains(stem))
+                        {
+                            names.Add(stem);
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning($"ProfileManager.GetProfiles: failed scanning config files: {ex.Message}");
+            }
+
+            if (!names.Contains(DefaultProfile))
+            {
+                names.Insert(0, DefaultProfile);
+            }
+
+            return names;
+        }
+
+        /// <summary>Gets the active profile name (defaults to "default").</summary>
+        public static string GetActiveProfile()
+        {
+            try
+            {
+                string? active = ReadSettingsRoot()?["properties"]?["activeConfiguration"]?["value"]?.GetValue<string>();
+                return string.IsNullOrEmpty(active) ? DefaultProfile : active;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning($"ProfileManager.GetActiveProfile: {ex.Message}");
+                return DefaultProfile;
+            }
+        }
+
+        /// <summary>
+        /// Makes <paramref name="profile"/> the active profile and signals the engine to reload.
+        /// Returns false if the profile's config file does not exist.
+        /// </summary>
+        public static bool SetActiveProfile(string profile)
+        {
+            if (string.IsNullOrWhiteSpace(profile))
+            {
+                return false;
+            }
+
+            try
+            {
+                if (!File.Exists(ConfigPath(profile)))
+                {
+                    Logger.LogWarning($"ProfileManager.SetActiveProfile: '{profile}.json' does not exist");
+                    return false;
+                }
+
+                JsonObject root = (ReadSettingsRoot() as JsonObject) ?? CreateDefaultSettingsRoot();
+                JsonObject properties = EnsureObject(root, "properties");
+                SetValueProperty(properties, "activeConfiguration", profile);
+                AddToConfigurationList(properties, profile);
+                WriteSettingsRoot(root);
+
+                SignalEngineReload();
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError($"ProfileManager.SetActiveProfile('{profile}'): {ex.Message}");
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Creates a new profile config file (empty, or copied from the current active profile) and
+        /// registers it in settings.json. Does not switch to it. Returns false on invalid name or if
+        /// a profile with that name already exists.
+        /// </summary>
+        public static bool CreateProfile(string profile, bool copyFromActive)
+        {
+            if (!IsValidProfileName(profile))
+            {
+                Logger.LogWarning($"ProfileManager.CreateProfile: invalid name '{profile}'");
+                return false;
+            }
+
+            try
+            {
+                string target = ConfigPath(profile);
+                if (File.Exists(target))
+                {
+                    Logger.LogWarning($"ProfileManager.CreateProfile: '{profile}' already exists");
+                    return false;
+                }
+
+                if (copyFromActive && File.Exists(ConfigPath(GetActiveProfile())))
+                {
+                    File.Copy(ConfigPath(GetActiveProfile()), target, overwrite: false);
+                }
+                else
+                {
+                    File.WriteAllText(target, EmptyConfigJson);
+                }
+
+                JsonObject root = (ReadSettingsRoot() as JsonObject) ?? CreateDefaultSettingsRoot();
+                JsonObject properties = EnsureObject(root, "properties");
+                AddToConfigurationList(properties, profile);
+                WriteSettingsRoot(root);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError($"ProfileManager.CreateProfile('{profile}'): {ex.Message}");
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Deletes a profile's config file and its editor cache, and unregisters it. The built-in
+        /// "default" profile cannot be deleted. If the deleted profile was active, switches to
+        /// "default" and signals a reload.
+        /// </summary>
+        public static bool DeleteProfile(string profile)
+        {
+            if (string.IsNullOrWhiteSpace(profile) || profile.Equals(DefaultProfile, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            try
+            {
+                bool wasActive = GetActiveProfile().Equals(profile, StringComparison.OrdinalIgnoreCase);
+
+                TryDeleteFile(ConfigPath(profile));
+                TryDeleteFile(Path.Combine(_settingsDirectory, $"editorSettings.{profile}.json"));
+
+                JsonObject root = (ReadSettingsRoot() as JsonObject) ?? CreateDefaultSettingsRoot();
+                JsonObject properties = EnsureObject(root, "properties");
+                RemoveFromConfigurationList(properties, profile);
+                if (wasActive)
+                {
+                    SetValueProperty(properties, "activeConfiguration", DefaultProfile);
+                }
+
+                WriteSettingsRoot(root);
+
+                if (wasActive)
+                {
+                    SignalEngineReload();
+                }
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError($"ProfileManager.DeleteProfile('{profile}'): {ex.Message}");
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Signals the KBM engine to reload its settings (picking up a changed activeConfiguration).
+        /// A missing event is not fatal: the engine reads settings on next start.
+        /// </summary>
+        public static void SignalEngineReload()
+        {
+            try
+            {
+                using EventWaitHandle handle = EventWaitHandle.OpenExisting(SettingsChangedEventName);
+                handle.Set();
+            }
+            catch (WaitHandleCannotBeOpenedException)
+            {
+                Logger.LogInfo("ProfileManager.SignalEngineReload: engine reload event not present (engine not running?)");
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning($"ProfileManager.SignalEngineReload: {ex.Message}");
+            }
+        }
+
+        private static bool IsValidProfileName(string profile)
+        {
+            if (string.IsNullOrWhiteSpace(profile))
+            {
+                return false;
+            }
+
+            // Dots are reserved to distinguish backups / editor caches from profile configs.
+            if (profile.Contains('.') || profile.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+            {
+                return false;
+            }
+
+            return !profile.Equals("settings", StringComparison.OrdinalIgnoreCase) &&
+                   !profile.StartsWith("editorSettings", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static JsonNode? ReadSettingsRoot()
+        {
+            return File.Exists(SettingsJsonPath) ? JsonNode.Parse(File.ReadAllText(SettingsJsonPath)) : null;
+        }
+
+        private static JsonObject CreateDefaultSettingsRoot()
+        {
+            return new JsonObject
+            {
+                ["properties"] = new JsonObject(),
+                ["name"] = "Keyboard Manager",
+                ["version"] = "1.0",
+            };
+        }
+
+        private static void WriteSettingsRoot(JsonNode root)
+        {
+            Directory.CreateDirectory(_settingsDirectory);
+            File.WriteAllText(SettingsJsonPath, root.ToJsonString(new JsonSerializerOptions { WriteIndented = false }));
+        }
+
+        private static JsonObject EnsureObject(JsonObject parent, string key)
+        {
+            if (parent[key] is JsonObject existing)
+            {
+                return existing;
+            }
+
+            var created = new JsonObject();
+            parent[key] = created;
+            return created;
+        }
+
+        private static void SetValueProperty(JsonObject properties, string key, string value)
+        {
+            EnsureObject(properties, key)["value"] = value;
+        }
+
+        private static void AddToConfigurationList(JsonObject properties, string profile)
+        {
+            JsonObject holder = EnsureObject(properties, "keyboardConfigurations");
+            if (holder["value"] is not JsonArray array)
+            {
+                array = new JsonArray();
+                holder["value"] = array;
+            }
+
+            if (!array.Any(n => string.Equals(n?.GetValue<string>(), profile, StringComparison.Ordinal)))
+            {
+                array.Add(profile);
+            }
+        }
+
+        private static void RemoveFromConfigurationList(JsonObject properties, string profile)
+        {
+            if (properties["keyboardConfigurations"]?["value"] is not JsonArray array)
+            {
+                return;
+            }
+
+            for (int i = array.Count - 1; i >= 0; i--)
+            {
+                if (string.Equals(array[i]?.GetValue<string>(), profile, StringComparison.Ordinal))
+                {
+                    array.RemoveAt(i);
+                }
+            }
+        }
+
+        private static void TryDeleteFile(string path)
+        {
+            try
+            {
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning($"ProfileManager: failed deleting '{path}': {ex.Message}");
+            }
+        }
+    }
+}

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Settings/ProfileManager.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Settings/ProfileManager.cs
@@ -1,0 +1,373 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading;
+using ManagedCommon;
+
+namespace KeyboardManagerEditorUI.Settings
+{
+    /// <summary>
+    /// Manages Keyboard Manager profiles. Each profile is one engine config file "{name}.json"
+    /// in the Keyboard Manager folder; the active profile is recorded in settings.json under
+    /// "activeConfiguration" and listed in "keyboardConfigurations". Switching the active profile
+    /// rewrites those values and signals the engine's reload event, which live-swaps the whole
+    /// active remap set (verified: the engine re-reads activeConfiguration on that event).
+    /// </summary>
+    internal static class ProfileManager
+    {
+        private const string DefaultProfile = "default";
+
+        // Named event the KBM engine waits on; signaling it makes the engine reload its settings.
+        private const string SettingsChangedEventName = "PowerToys_KeyboardManager_Event_Settings";
+
+        // A valid but empty engine config, used when creating a fresh profile.
+        private const string EmptyConfigJson =
+            "{\"remapKeys\":{\"inProcess\":[]},\"remapKeysToText\":{\"inProcess\":[]}," +
+            "\"remapShortcuts\":{\"global\":[],\"appSpecific\":[]}," +
+            "\"remapShortcutsToText\":{\"global\":[],\"appSpecific\":[]}}";
+
+        private static readonly string _settingsDirectory = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "Microsoft",
+            "PowerToys",
+            "Keyboard Manager");
+
+        private static string SettingsJsonPath => Path.Combine(_settingsDirectory, "settings.json");
+
+        /// <summary>Folder holding the profile configs + settings.json — exposed so the editor can
+        /// watch settings.json for engine-driven active-profile changes (auto-switch / cycle hotkey).</summary>
+        public static string SettingsDirectory => _settingsDirectory;
+
+        private static string ConfigPath(string profile) => Path.Combine(_settingsDirectory, profile + ".json");
+
+        /// <summary>
+        /// Returns the known profile names. Reads "keyboardConfigurations" from settings.json and
+        /// also scans "{name}.json" files so externally created profiles are picked up. Always
+        /// includes the built-in "default".
+        /// </summary>
+        public static IReadOnlyList<string> GetProfiles()
+        {
+            var names = new List<string>();
+
+            try
+            {
+                if (ReadSettingsRoot()?["properties"]?["keyboardConfigurations"]?["value"] is JsonArray configs)
+                {
+                    foreach (JsonNode? item in configs)
+                    {
+                        string? name = item?.GetValue<string>();
+                        if (!string.IsNullOrEmpty(name) && !names.Contains(name))
+                        {
+                            names.Add(name);
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning($"ProfileManager.GetProfiles: failed reading settings.json: {ex.Message}");
+            }
+
+            try
+            {
+                if (Directory.Exists(_settingsDirectory))
+                {
+                    foreach (string file in Directory.EnumerateFiles(_settingsDirectory, "*.json"))
+                    {
+                        string stem = Path.GetFileNameWithoutExtension(file);
+
+                        // Skip settings.json, editor caches, and backups like "default.backup-...".
+                        if (stem.Equals("settings", StringComparison.OrdinalIgnoreCase) ||
+                            stem.StartsWith("editorSettings", StringComparison.OrdinalIgnoreCase) ||
+                            stem.Contains('.'))
+                        {
+                            continue;
+                        }
+
+                        if (!names.Contains(stem))
+                        {
+                            names.Add(stem);
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning($"ProfileManager.GetProfiles: failed scanning config files: {ex.Message}");
+            }
+
+            if (!names.Contains(DefaultProfile))
+            {
+                names.Insert(0, DefaultProfile);
+            }
+
+            return names;
+        }
+
+        /// <summary>Gets the active profile name (defaults to "default").</summary>
+        public static string GetActiveProfile()
+        {
+            try
+            {
+                string? active = ReadSettingsRoot()?["properties"]?["activeConfiguration"]?["value"]?.GetValue<string>();
+                return string.IsNullOrEmpty(active) ? DefaultProfile : active;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning($"ProfileManager.GetActiveProfile: {ex.Message}");
+                return DefaultProfile;
+            }
+        }
+
+        /// <summary>
+        /// Makes <paramref name="profile"/> the active profile and signals the engine to reload.
+        /// Returns false if the profile's config file does not exist.
+        /// </summary>
+        public static bool SetActiveProfile(string profile)
+        {
+            if (string.IsNullOrWhiteSpace(profile))
+            {
+                return false;
+            }
+
+            try
+            {
+                if (!File.Exists(ConfigPath(profile)))
+                {
+                    Logger.LogWarning($"ProfileManager.SetActiveProfile: '{profile}.json' does not exist");
+                    return false;
+                }
+
+                JsonObject root = (ReadSettingsRoot() as JsonObject) ?? CreateDefaultSettingsRoot();
+                JsonObject properties = EnsureObject(root, "properties");
+                SetValueProperty(properties, "activeConfiguration", profile);
+                AddToConfigurationList(properties, profile);
+                WriteSettingsRoot(root);
+
+                SignalEngineReload();
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError($"ProfileManager.SetActiveProfile('{profile}'): {ex.Message}");
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Creates a new profile config file (empty, or copied from the current active profile) and
+        /// registers it in settings.json. Does not switch to it. Returns false on invalid name or if
+        /// a profile with that name already exists.
+        /// </summary>
+        public static bool CreateProfile(string profile, bool copyFromActive)
+        {
+            if (!IsValidProfileName(profile))
+            {
+                Logger.LogWarning($"ProfileManager.CreateProfile: invalid name '{profile}'");
+                return false;
+            }
+
+            try
+            {
+                string target = ConfigPath(profile);
+                if (File.Exists(target))
+                {
+                    Logger.LogWarning($"ProfileManager.CreateProfile: '{profile}' already exists");
+                    return false;
+                }
+
+                if (copyFromActive && File.Exists(ConfigPath(GetActiveProfile())))
+                {
+                    File.Copy(ConfigPath(GetActiveProfile()), target, overwrite: false);
+                }
+                else
+                {
+                    File.WriteAllText(target, EmptyConfigJson);
+                }
+
+                JsonObject root = (ReadSettingsRoot() as JsonObject) ?? CreateDefaultSettingsRoot();
+                JsonObject properties = EnsureObject(root, "properties");
+                AddToConfigurationList(properties, profile);
+                WriteSettingsRoot(root);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError($"ProfileManager.CreateProfile('{profile}'): {ex.Message}");
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Deletes a profile's config file and unregisters it, dropping the profile from the editor
+        /// settings' membership as well. The built-in "default" profile cannot be deleted. If the
+        /// deleted profile was active, switches to "default" and signals a reload.
+        /// </summary>
+        public static bool DeleteProfile(string profile)
+        {
+            if (string.IsNullOrWhiteSpace(profile) || profile.Equals(DefaultProfile, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            try
+            {
+                bool wasActive = GetActiveProfile().Equals(profile, StringComparison.OrdinalIgnoreCase);
+
+                TryDeleteFile(ConfigPath(profile));
+                SettingsManager.RemoveProfileMembership(profile);
+
+                JsonObject root = (ReadSettingsRoot() as JsonObject) ?? CreateDefaultSettingsRoot();
+                JsonObject properties = EnsureObject(root, "properties");
+                RemoveFromConfigurationList(properties, profile);
+                if (wasActive)
+                {
+                    SetValueProperty(properties, "activeConfiguration", DefaultProfile);
+                }
+
+                WriteSettingsRoot(root);
+
+                if (wasActive)
+                {
+                    SignalEngineReload();
+                }
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError($"ProfileManager.DeleteProfile('{profile}'): {ex.Message}");
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Signals the KBM engine to reload its settings (picking up a changed activeConfiguration).
+        /// A missing event is not fatal: the engine reads settings on next start.
+        /// </summary>
+        public static void SignalEngineReload()
+        {
+            try
+            {
+                using EventWaitHandle handle = EventWaitHandle.OpenExisting(SettingsChangedEventName);
+                handle.Set();
+            }
+            catch (WaitHandleCannotBeOpenedException)
+            {
+                Logger.LogInfo("ProfileManager.SignalEngineReload: engine reload event not present (engine not running?)");
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning($"ProfileManager.SignalEngineReload: {ex.Message}");
+            }
+        }
+
+        private static bool IsValidProfileName(string profile)
+        {
+            if (string.IsNullOrWhiteSpace(profile))
+            {
+                return false;
+            }
+
+            // Dots are reserved to distinguish backups / editor caches from profile configs.
+            if (profile.Contains('.') || profile.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+            {
+                return false;
+            }
+
+            return !profile.Equals("settings", StringComparison.OrdinalIgnoreCase) &&
+                   !profile.StartsWith("editorSettings", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static JsonNode? ReadSettingsRoot()
+        {
+            return File.Exists(SettingsJsonPath) ? JsonNode.Parse(File.ReadAllText(SettingsJsonPath)) : null;
+        }
+
+        private static JsonObject CreateDefaultSettingsRoot()
+        {
+            return new JsonObject
+            {
+                ["properties"] = new JsonObject(),
+                ["name"] = "Keyboard Manager",
+                ["version"] = "1.0",
+            };
+        }
+
+        private static void WriteSettingsRoot(JsonNode root)
+        {
+            Directory.CreateDirectory(_settingsDirectory);
+            File.WriteAllText(SettingsJsonPath, root.ToJsonString(new JsonSerializerOptions { WriteIndented = false }));
+        }
+
+        private static JsonObject EnsureObject(JsonObject parent, string key)
+        {
+            if (parent[key] is JsonObject existing)
+            {
+                return existing;
+            }
+
+            var created = new JsonObject();
+            parent[key] = created;
+            return created;
+        }
+
+        private static void SetValueProperty(JsonObject properties, string key, string value)
+        {
+            EnsureObject(properties, key)["value"] = value;
+        }
+
+        private static void AddToConfigurationList(JsonObject properties, string profile)
+        {
+            JsonObject holder = EnsureObject(properties, "keyboardConfigurations");
+            if (holder["value"] is not JsonArray array)
+            {
+                array = new JsonArray();
+                holder["value"] = array;
+            }
+
+            if (!array.Any(n => string.Equals(n?.GetValue<string>(), profile, StringComparison.Ordinal)))
+            {
+                array.Add(profile);
+            }
+        }
+
+        private static void RemoveFromConfigurationList(JsonObject properties, string profile)
+        {
+            if (properties["keyboardConfigurations"]?["value"] is not JsonArray array)
+            {
+                return;
+            }
+
+            for (int i = array.Count - 1; i >= 0; i--)
+            {
+                if (string.Equals(array[i]?.GetValue<string>(), profile, StringComparison.Ordinal))
+                {
+                    array.RemoveAt(i);
+                }
+            }
+        }
+
+        private static void TryDeleteFile(string path)
+        {
+            try
+            {
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning($"ProfileManager: failed deleting '{path}': {ex.Message}");
+            }
+        }
+    }
+}

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Settings/SettingsManager.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Settings/SettingsManager.cs
@@ -20,7 +20,18 @@ namespace KeyboardManagerEditorUI.Settings
             "PowerToys",
             "Keyboard Manager");
 
-        private static readonly string _settingsFilePath = Path.Combine(_settingsDirectory, "editorSettings.json");
+        // The editor cache is per-profile so switching profiles never mixes mappings.
+        // The built-in "default" profile keeps the legacy "editorSettings.json" name for back-compat.
+        private static string CurrentCacheFilePath
+        {
+            get
+            {
+                string profile = ProfileManager.GetActiveProfile();
+                return profile.Equals("default", StringComparison.OrdinalIgnoreCase)
+                    ? Path.Combine(_settingsDirectory, "editorSettings.json")
+                    : Path.Combine(_settingsDirectory, $"editorSettings.{profile}.json");
+            }
+        }
 
         private static readonly JsonSerializerOptions _jsonOptions = new JsonSerializerOptions { WriteIndented = true };
 
@@ -53,11 +64,11 @@ namespace KeyboardManagerEditorUI.Settings
         {
             try
             {
-                if (!File.Exists(_settingsFilePath))
+                if (!File.Exists(CurrentCacheFilePath))
                 {
                     if (_mappingService is not null)
                     {
-                        EditorSettings createdSettings = CreateSettingsFromKeyboardManagerService();
+                        EditorSettings createdSettings = CreateSettingsFromKeyboardManagerService(_mappingService);
                         WriteSettings(createdSettings);
                         return createdSettings;
                     }
@@ -65,7 +76,7 @@ namespace KeyboardManagerEditorUI.Settings
                     return new EditorSettings();
                 }
 
-                string json = File.ReadAllText(_settingsFilePath);
+                string json = File.ReadAllText(CurrentCacheFilePath);
                 return JsonSerializer.Deserialize<EditorSettings>(json, _jsonOptions) ?? new EditorSettings();
             }
             catch (Exception)
@@ -80,7 +91,7 @@ namespace KeyboardManagerEditorUI.Settings
             {
                 Directory.CreateDirectory(_settingsDirectory);
                 string json = JsonSerializer.Serialize(editorSettings, _jsonOptions);
-                File.WriteAllText(_settingsFilePath, json);
+                File.WriteAllText(CurrentCacheFilePath, json);
                 return true;
             }
             catch (Exception)
@@ -91,18 +102,18 @@ namespace KeyboardManagerEditorUI.Settings
 
         public static bool WriteSettings() => WriteSettings(EditorSettings);
 
-        private static EditorSettings CreateSettingsFromKeyboardManagerService()
+        private static EditorSettings CreateSettingsFromKeyboardManagerService(KeyboardMappingService service)
         {
             EditorSettings settings = new EditorSettings();
 
             // Process all shortcut mappings (RunProgram, OpenUri, RemapShortcut, RemapText)
-            foreach (ShortcutKeyMapping mapping in _mappingService!.GetShortcutMappings())
+            foreach (ShortcutKeyMapping mapping in service.GetShortcutMappings())
             {
                 AddShortcutMapping(settings, mapping);
             }
 
             // Process single key to key mappings
-            foreach (var mapping in _mappingService!.GetSingleKeyMappings())
+            foreach (var mapping in service.GetSingleKeyMappings())
             {
                 var shortcutMapping = new ShortcutKeyMapping
                 {
@@ -114,7 +125,7 @@ namespace KeyboardManagerEditorUI.Settings
             }
 
             // Process single key to text mappings
-            foreach (var mapping in _mappingService!.GetKeyToTextMappings())
+            foreach (var mapping in service.GetKeyToTextMappings())
             {
                 var shortcutMapping = new ShortcutKeyMapping
                 {
@@ -127,6 +138,32 @@ namespace KeyboardManagerEditorUI.Settings
             }
 
             return settings;
+        }
+
+        /// <summary>
+        /// Reloads the editor cache to reflect whatever profile is currently active (call after
+        /// <see cref="ProfileManager.SetActiveProfile"/>). Rebuilds from the now-active profile's
+        /// native config so the editor shows exactly what the engine will apply, and persists it to
+        /// that profile's cache file. No-op when the native service is unavailable (preview mode).
+        /// </summary>
+        public static void ReloadForActiveProfile()
+        {
+            if (_mappingService is null)
+            {
+                return;
+            }
+
+            try
+            {
+                using var service = new KeyboardMappingService();
+                EditorSettings = CreateSettingsFromKeyboardManagerService(service);
+                WriteSettings();
+            }
+            catch (Exception ex)
+            {
+                ManagedCommon.Logger.LogError($"SettingsManager.ReloadForActiveProfile failed: {ex.Message}");
+                EditorSettings = new EditorSettings();
+            }
         }
 
         public static void CorrelateServiceAndEditorMappings()

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Settings/SettingsManager.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Settings/SettingsManager.cs
@@ -37,6 +37,19 @@ namespace KeyboardManagerEditorUI.Settings
         /// </summary>
         internal static bool IsNativeServiceAvailable => _mappingService is not null;
 
+        /// <summary>
+        /// Gets the profile the engine is currently applying, or <see langword="null"/> when the native
+        /// service is unavailable (preview mode), which keeps the settings operations profile-agnostic.
+        /// </summary>
+        /// <remarks>
+        /// Read live rather than taken from <see cref="KeyboardMappingService.ConfigurationName"/>: that
+        /// property is captured in the service constructor, so it goes stale as soon as the profile is
+        /// switched while the editor is open (by the picker, the cycle hotkey, or device auto-switch).
+        /// Both come from the same place — "activeConfiguration" in the Keyboard Manager settings.json.
+        /// </remarks>
+        private static string? CurrentProfileName =>
+            _mappingService is null ? null : ProfileManager.GetActiveProfile();
+
         public static EditorSettings EditorSettings { get; set; }
 
         static SettingsManager()
@@ -177,6 +190,97 @@ namespace KeyboardManagerEditorUI.Settings
         {
             int errorCode = exception.HResult & 0xFFFF;
             return errorCode is 32 or 33;
+        }
+
+        /// <summary>
+        /// Brings the editor settings in line with whatever profile is now active — call after
+        /// <see cref="ProfileManager.SetActiveProfile"/>, or after the engine switched profiles on its
+        /// own (device auto-switch, cycle hotkey). Reconciling against a freshly loaded configuration
+        /// tags that profile's mappings and leaves the other profiles' entries inactive, so
+        /// <see cref="IsMappingInActiveProfile"/> filters them out of the list without the settings
+        /// having to be split per profile. No-op when the native service is unavailable (preview mode).
+        /// </summary>
+        public static void ReloadForActiveProfile()
+        {
+            if (_mappingService is null)
+            {
+                return;
+            }
+
+            CorrelateServiceAndEditorMappings();
+        }
+
+        /// <summary>
+        /// Drops <paramref name="profileName"/> from every mapping's profile membership, so deleting a
+        /// profile leaves no dangling references behind. A mapping that belonged to this profile and to
+        /// no other is deleted with it; one that is still named by another profile is kept and stays in
+        /// that profile. Mappings carrying no profile at all are left alone — an untagged mapping
+        /// predates profiles and is treated as belonging everywhere, so a deletion must not adopt it.
+        /// </summary>
+        public static void RemoveProfileMembership(string profileName)
+        {
+            if (string.IsNullOrWhiteSpace(profileName))
+            {
+                return;
+            }
+
+            try
+            {
+                EditorSettings updatedSettings = CloneSettings();
+                bool changed = false;
+                var orphanedIds = new List<string>();
+
+                foreach (KeyValuePair<string, ShortcutSettings> entry in updatedSettings.ShortcutSettingsDictionary)
+                {
+                    if (!RemoveProfile(entry.Value, profileName))
+                    {
+                        continue;
+                    }
+
+                    changed = true;
+                    if (GetProfiles(entry.Value).Count == 0)
+                    {
+                        orphanedIds.Add(entry.Key);
+                    }
+                }
+
+                foreach (string id in orphanedIds)
+                {
+                    ShortcutOperationType operationType = updatedSettings.ShortcutSettingsDictionary[id].Shortcut.OperationType;
+                    updatedSettings.ShortcutSettingsDictionary.Remove(id);
+                    if (updatedSettings.ShortcutsByOperationType.TryGetValue(operationType, out List<string>? operationIds))
+                    {
+                        operationIds.Remove(id);
+                    }
+                }
+
+                foreach (string profile in updatedSettings.ProfileDictionary.Keys
+                    .Where(profile => profile.Equals(profileName, StringComparison.OrdinalIgnoreCase))
+                    .ToList())
+                {
+                    changed |= updatedSettings.ProfileDictionary.Remove(profile);
+                }
+
+                if (!changed)
+                {
+                    return;
+                }
+
+                updatedSettings.ProfileDictionary = BuildProfileIndex(updatedSettings);
+                if (string.Equals(updatedSettings.ActiveProfile, profileName, StringComparison.OrdinalIgnoreCase))
+                {
+                    updatedSettings.ActiveProfile = string.Empty;
+                }
+
+                if (WriteSettings(updatedSettings))
+                {
+                    EditorSettings = updatedSettings;
+                }
+            }
+            catch (Exception exception)
+            {
+                ManagedCommon.Logger.LogError($"SettingsManager.RemoveProfileMembership('{profileName}'): {exception.Message}");
+            }
         }
 
         private static EditorSettings CreateSettingsFromKeyboardManagerService(KeyboardMappingService service)
@@ -386,7 +490,7 @@ namespace KeyboardManagerEditorUI.Settings
             {
                 EditorSettings updatedSettings = CloneSettings();
 
-                if (!TryApplyShortcutKeyMapping(updatedSettings, shortcutKeyMapping, replacingId, _mappingService?.ConfigurationName))
+                if (!TryApplyShortcutKeyMapping(updatedSettings, shortcutKeyMapping, replacingId, CurrentProfileName))
                 {
                     return false;
                 }
@@ -476,7 +580,7 @@ namespace KeyboardManagerEditorUI.Settings
             try
             {
                 EditorSettings updatedSettings = CloneSettings();
-                if (!TryApplyShortcutKeyMappingRemoval(updatedSettings, guid, _mappingService?.ConfigurationName) ||
+                if (!TryApplyShortcutKeyMappingRemoval(updatedSettings, guid, CurrentProfileName) ||
                     !WriteSettings(updatedSettings))
                 {
                     return false;
@@ -536,7 +640,7 @@ namespace KeyboardManagerEditorUI.Settings
                         updatedSettings,
                         guid,
                         isActive,
-                        _mappingService?.ConfigurationName) ||
+                        CurrentProfileName) ||
                     !WriteSettings(updatedSettings))
                 {
                     return false;
@@ -581,7 +685,7 @@ namespace KeyboardManagerEditorUI.Settings
 
         internal static bool IsMappingInActiveProfile(ShortcutSettings shortcutSettings)
         {
-            string? profileName = _mappingService?.ConfigurationName;
+            string? profileName = CurrentProfileName;
             if (string.IsNullOrWhiteSpace(profileName))
             {
                 profileName = EditorSettings.ActiveProfile;

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Strings/en-US/Resources.resw
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Strings/en-US/Resources.resw
@@ -501,4 +501,73 @@
   <data name="CheckServiceBtn.Content" xml:space="preserve">
     <value>Check service status</value>
   </data>
+  <data name="ProfileLabel.Text" xml:space="preserve">
+    <value>Profile</value>
+  </data>
+  <data name="ProfileSelector.AutomationProperties.Name" xml:space="preserve">
+    <value>Active profile</value>
+  </data>
+  <data name="NewProfileBtnTooltip.Text" xml:space="preserve">
+    <value>Create a new profile</value>
+  </data>
+  <data name="DeleteProfileBtnTooltip.Text" xml:space="preserve">
+    <value>Delete the current profile</value>
+  </data>
+  <data name="NewProfileDialog.Title" xml:space="preserve">
+    <value>New profile</value>
+  </data>
+  <data name="NewProfileDialog.PrimaryButtonText" xml:space="preserve">
+    <value>Create</value>
+  </data>
+  <data name="NewProfileDialog.CloseButtonText" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="NewProfileNameBox.Header" xml:space="preserve">
+    <value>Profile name</value>
+  </data>
+  <data name="NewProfileNameBox.PlaceholderText" xml:space="preserve">
+    <value>e.g., Mac keyboard</value>
+  </data>
+  <data name="CopyCurrentProfileCheckBox.Content" xml:space="preserve">
+    <value>Start from a copy of the current profile</value>
+  </data>
+  <data name="DeleteProfileDialog.Title" xml:space="preserve">
+    <value>Delete profile?</value>
+  </data>
+  <data name="DeleteProfileDialog.PrimaryButtonText" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="DeleteProfileDialog.CloseButtonText" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="DeleteProfileDialogContent.Text" xml:space="preserve">
+    <value>This permanently deletes the selected profile and all of its mappings. This cannot be undone.</value>
+  </data>
+  <data name="AutoSwitchBtn_Text.Text" xml:space="preserve">
+    <value>Auto-switch</value>
+  </data>
+  <data name="AutoSwitchDialog.Title" xml:space="preserve">
+    <value>Per-keyboard auto-switch</value>
+  </data>
+  <data name="AutoSwitchDialog.PrimaryButtonText" xml:space="preserve">
+    <value>Save</value>
+  </data>
+  <data name="AutoSwitchDialog.CloseButtonText" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="AutoSwitchToggle.Header" xml:space="preserve">
+    <value>Automatically switch the active profile based on the keyboard being used</value>
+  </data>
+  <data name="AutoSwitchKeyboardsHeader.Text" xml:space="preserve">
+    <value>Assign a profile to each keyboard</value>
+  </data>
+  <data name="AutoSwitchHint.Text" xml:space="preserve">
+    <value>When enabled, typing on a keyboard switches to its assigned profile. Unassigned keyboards keep the current profile. Note: some virtual/remote input layers may prevent reliable per-keyboard detection.</value>
+  </data>
+  <data name="AutoSwitch_NotAssigned" xml:space="preserve">
+    <value>(not assigned)</value>
+  </data>
+  <data name="AutoSwitchIdentifyHint.Title" xml:space="preserve">
+    <value>Press a key on a keyboard to highlight its row (and add it if it isn't listed).</value>
+  </data>
 </root>

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Strings/en-US/Resources.resw
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Strings/en-US/Resources.resw
@@ -607,4 +607,73 @@
   <data name="NoResultsClearBtn.Content" xml:space="preserve">
     <value>Clear filters</value>
   </data>
+  <data name="ProfileLabel.Text" xml:space="preserve">
+    <value>Profile</value>
+  </data>
+  <data name="ProfileSelector.AutomationProperties.Name" xml:space="preserve">
+    <value>Active profile</value>
+  </data>
+  <data name="NewProfileBtnTooltip.Text" xml:space="preserve">
+    <value>Create a new profile</value>
+  </data>
+  <data name="DeleteProfileBtnTooltip.Text" xml:space="preserve">
+    <value>Delete the current profile</value>
+  </data>
+  <data name="NewProfileDialog.Title" xml:space="preserve">
+    <value>New profile</value>
+  </data>
+  <data name="NewProfileDialog.PrimaryButtonText" xml:space="preserve">
+    <value>Create</value>
+  </data>
+  <data name="NewProfileDialog.CloseButtonText" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="NewProfileNameBox.Header" xml:space="preserve">
+    <value>Profile name</value>
+  </data>
+  <data name="NewProfileNameBox.PlaceholderText" xml:space="preserve">
+    <value>e.g., Mac keyboard</value>
+  </data>
+  <data name="CopyCurrentProfileCheckBox.Content" xml:space="preserve">
+    <value>Start from a copy of the current profile</value>
+  </data>
+  <data name="DeleteProfileDialog.Title" xml:space="preserve">
+    <value>Delete profile?</value>
+  </data>
+  <data name="DeleteProfileDialog.PrimaryButtonText" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="DeleteProfileDialog.CloseButtonText" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="DeleteProfileDialogContent.Text" xml:space="preserve">
+    <value>This profile and all of its mappings will be permanently deleted. This cannot be undone:</value>
+  </data>
+  <data name="AutoSwitchBtn_Text.Text" xml:space="preserve">
+    <value>Auto-switch</value>
+  </data>
+  <data name="AutoSwitchDialog.Title" xml:space="preserve">
+    <value>Per-keyboard auto-switch</value>
+  </data>
+  <data name="AutoSwitchDialog.PrimaryButtonText" xml:space="preserve">
+    <value>Save</value>
+  </data>
+  <data name="AutoSwitchDialog.CloseButtonText" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="AutoSwitchToggle.Header" xml:space="preserve">
+    <value>Automatically switch the active profile based on the keyboard being used</value>
+  </data>
+  <data name="AutoSwitchKeyboardsHeader.Text" xml:space="preserve">
+    <value>Assign a profile to each keyboard</value>
+  </data>
+  <data name="AutoSwitchHint.Text" xml:space="preserve">
+    <value>When enabled, typing on a keyboard switches to its assigned profile. Unassigned keyboards keep the current profile. Note: some virtual/remote input layers may prevent reliable per-keyboard detection.</value>
+  </data>
+  <data name="AutoSwitch_NotAssigned" xml:space="preserve">
+    <value>(not assigned)</value>
+  </data>
+  <data name="AutoSwitchIdentifyHint.Title" xml:space="preserve">
+    <value>Press a key on a keyboard to highlight its row (and add it if it isn't listed).</value>
+  </data>
 </root>

--- a/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardManager.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardManager.cpp
@@ -2,9 +2,11 @@
 #include "KeyboardManager.h"
 #include <interface/powertoy_module_interface.h>
 #include <common/SettingsAPI/settings_objects.h>
+#include <common/SettingsAPI/settings_helpers.h>
 #include <common/interop/shared_constants.h>
 #include <common/debug_control.h>
 #include <common/utils/winapi_error.h>
+#include <common/utils/json.h>
 #include <common/logger/logger_settings.h>
 
 #include <keyboardmanager/common/KeyboardManagerConstants.h>
@@ -18,6 +20,30 @@
 HHOOK KeyboardManager::hookHandleCopy;
 HHOOK KeyboardManager::hookHandle;
 KeyboardManager* KeyboardManager::keyboardManagerObjectPtr;
+
+namespace
+{
+    // A RIDI_DEVICENAME path looks like "\\?\HID#<deviceId>#<instanceId>#<interfaceGuid>". Some
+    // virtual keyboards (e.g. Target_KIP) are assigned a fresh <instanceId> over time, which would
+    // break an exact-path match. Match on the stable prefix instead: everything up to the instance
+    // (the 2nd '#'). This keeps distinct keyboards apart while tolerating instance-id churn.
+    std::wstring NormalizeDevicePath(const std::wstring& path)
+    {
+        const size_t first = path.find(L'#');
+        if (first == std::wstring::npos)
+        {
+            return path;
+        }
+
+        const size_t second = path.find(L'#', first + 1);
+        if (second == std::wstring::npos)
+        {
+            return path;
+        }
+
+        return path.substr(0, second);
+    }
+}
 
 namespace
 {
@@ -71,6 +97,288 @@ KeyboardManager::KeyboardManager()
 
     editorIsRunningEvent = CreateEvent(nullptr, true, false, KeyboardManagerConstants::EditorWindowEventName.c_str());
     settingsEventWaiter.start(KeyboardManagerConstants::SettingsEventName, changeSettingsCallback);
+
+    // Start detecting which physical keyboard is being typed on (for per-keyboard profile switching).
+    rawInputTracker = std::make_unique<RawInputKeyboardTracker>(
+        [this](const RawInputKeyboardTracker::KeyEvent& keyEvent) { OnRawKeyEvent(keyEvent); });
+    rawInputTracker->Start();
+
+    // Global profile-cycle hotkey. Re-read the config so the definition parsed before this object
+    // existed is applied (LoadDeviceProfiles guards on the pointer).
+    profileCycleHotkey = std::make_unique<ProfileCycleHotkey>([this] { CycleActiveProfile(); });
+    profileCycleHotkey->Start();
+    LoadDeviceProfiles();
+}
+
+void KeyboardManager::OnRawKeyEvent(const RawInputKeyboardTracker::KeyEvent& keyEvent)
+{
+    // Ignore injected input (hDevice == NULL, incl. KBM's own remap output) and key-ups.
+    if (keyEvent.injected || !keyEvent.keyDown)
+    {
+        return;
+    }
+
+    // Ignore modifier keys: they lead every chord (including the profile-cycle hotkey, whose own
+    // Shift/Alt key-downs would otherwise feed the hysteresis and fight the cycle), and a lone
+    // modifier is weak evidence that the user moved to this keyboard.
+    switch (keyEvent.vkey)
+    {
+    case VK_SHIFT:
+    case VK_CONTROL:
+    case VK_MENU:
+    case VK_LSHIFT:
+    case VK_RSHIFT:
+    case VK_LCONTROL:
+    case VK_RCONTROL:
+    case VK_LMENU:
+    case VK_RMENU:
+    case VK_LWIN:
+    case VK_RWIN:
+        return;
+    default:
+        break;
+    }
+
+    // A physical keystroke whose device path can't be resolved (observed on Surface Type Cover
+    // right after idle, when its KIP device node re-enumerates). Log it so drops are visible.
+    if (keyEvent.devicePath.empty())
+    {
+        Logger::trace(L"[autosw] keydown vk=0x{:x} with unresolvable device — skipped", keyEvent.vkey);
+        return;
+    }
+
+    // Log the active keyboard when it changes (helps discover device paths for the profile map).
+    if (keyEvent.devicePath != lastSeenDevice)
+    {
+        lastSeenDevice = keyEvent.devicePath;
+        Logger::trace(L"Detected keyboard: {}", keyEvent.devicePath);
+    }
+
+    if (!autoSwitchEnabled.load())
+    {
+        return;
+    }
+
+    // Which profile is this keyboard bound to? Unmapped keyboards keep the current profile.
+    std::wstring target;
+    {
+        std::lock_guard<std::mutex> lock(deviceMapMutex);
+        auto it = deviceProfileMap.find(NormalizeDevicePath(keyEvent.devicePath));
+        if (it == deviceProfileMap.end())
+        {
+            return;
+        }
+
+        target = it->second;
+    }
+
+    std::wstring current;
+    {
+        std::lock_guard<std::mutex> lock(activeProfileMutex);
+        current = activeProfileName;
+    }
+
+    if (target == current)
+    {
+        // Already on the right profile; reset any pending switch.
+        pendingTarget.clear();
+        pendingCount = 0;
+        requestedProfile.clear();
+        return;
+    }
+
+    // A switch to this profile was already requested; wait for the reload to take effect.
+    if (target == requestedProfile)
+    {
+        return;
+    }
+
+    // Hysteresis: require a few consecutive keystrokes on the new keyboard before switching.
+    if (target == pendingTarget)
+    {
+        ++pendingCount;
+    }
+    else
+    {
+        pendingTarget = target;
+        pendingCount = 1;
+    }
+
+    if (pendingCount < AutoSwitchThreshold)
+    {
+        return;
+    }
+
+    pendingCount = 0;
+    requestedProfile = target;
+    Logger::trace(L"Auto-switch: keyboard {} -> profile '{}'", keyEvent.devicePath, target);
+    SwitchActiveProfile(target);
+}
+
+void KeyboardManager::LoadDeviceProfiles()
+{
+    bool enabled = false;
+    std::unordered_map<std::wstring, std::wstring> map;
+    UINT hotkeyModifiers = 0;
+    UINT hotkeyVk = 0;
+
+    try
+    {
+        const auto path = PTSettingsHelper::get_module_save_folder_location(moduleName) + L"\\deviceProfiles.json";
+        auto parsed = json::from_file(path);
+        if (parsed.has_value())
+        {
+            const json::JsonObject& obj = parsed.value();
+            if (obj.HasKey(L"autoSwitchEnabled"))
+            {
+                enabled = obj.GetNamedBoolean(L"autoSwitchEnabled", false);
+            }
+
+            if (obj.HasKey(L"map"))
+            {
+                const auto arr = obj.GetNamedArray(L"map");
+                for (uint32_t i = 0; i < arr.Size(); ++i)
+                {
+                    const auto entry = arr.GetObjectAt(i);
+                    std::wstring device{ entry.GetNamedString(L"device", L"") };
+                    std::wstring profile{ entry.GetNamedString(L"profile", L"") };
+                    if (!device.empty() && !profile.empty())
+                    {
+                        map[NormalizeDevicePath(device)] = profile;
+                    }
+                }
+            }
+
+            if (obj.HasKey(L"cycleHotkey"))
+            {
+                const auto hotkey = obj.GetNamedObject(L"cycleHotkey");
+                hotkeyVk = static_cast<UINT>(hotkey.GetNamedNumber(L"code", 0));
+                if (hotkey.GetNamedBoolean(L"win", false))
+                {
+                    hotkeyModifiers |= MOD_WIN;
+                }
+                if (hotkey.GetNamedBoolean(L"ctrl", false))
+                {
+                    hotkeyModifiers |= MOD_CONTROL;
+                }
+                if (hotkey.GetNamedBoolean(L"alt", false))
+                {
+                    hotkeyModifiers |= MOD_ALT;
+                }
+                if (hotkey.GetNamedBoolean(L"shift", false))
+                {
+                    hotkeyModifiers |= MOD_SHIFT;
+                }
+            }
+        }
+    }
+    catch (...)
+    {
+        Logger::error(L"Failed to load deviceProfiles.json");
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(deviceMapMutex);
+        deviceProfileMap = std::move(map);
+    }
+
+    autoSwitchEnabled.store(enabled);
+
+    if (profileCycleHotkey)
+    {
+        profileCycleHotkey->Update(hotkeyModifiers, hotkeyVk);
+    }
+}
+
+void KeyboardManager::CycleActiveProfile()
+{
+    try
+    {
+        const auto path = PTSettingsHelper::get_module_save_folder_location(moduleName) + L"\\settings.json";
+        auto parsed = json::from_file(path);
+        if (!parsed.has_value())
+        {
+            return;
+        }
+
+        const auto properties = parsed.value().GetNamedObject(L"properties");
+        const std::wstring current{ properties.GetNamedObject(KeyboardManagerConstants::ActiveConfigurationSettingName).GetNamedString(L"value", KeyboardManagerConstants::DefaultConfiguration) };
+
+        std::vector<std::wstring> profiles;
+        if (properties.HasKey(L"keyboardConfigurations"))
+        {
+            const auto arr = properties.GetNamedObject(L"keyboardConfigurations").GetNamedArray(L"value");
+            for (uint32_t i = 0; i < arr.Size(); ++i)
+            {
+                profiles.emplace_back(arr.GetStringAt(i));
+            }
+        }
+
+        if (profiles.size() < 2)
+        {
+            return; // nothing to cycle to
+        }
+
+        size_t currentIndex = 0;
+        for (size_t i = 0; i < profiles.size(); ++i)
+        {
+            if (profiles[i] == current)
+            {
+                currentIndex = i;
+                break;
+            }
+        }
+
+        const std::wstring& next = profiles[(currentIndex + 1) % profiles.size()];
+        Logger::trace(L"CycleActiveProfile: '{}' -> '{}'", current, next);
+        SwitchActiveProfile(next);
+
+        // Audible feedback that the profile changed (no UI surface in the engine).
+        MessageBeep(MB_OK);
+    }
+    catch (...)
+    {
+        Logger::error(L"CycleActiveProfile failed");
+    }
+}
+
+void KeyboardManager::SwitchActiveProfile(const std::wstring& profile)
+{
+    // Tracker thread and hotkey thread can both land here; serialize the read-modify-write.
+    std::lock_guard<std::mutex> lock(switchProfileMutex);
+
+    try
+    {
+        const auto path = PTSettingsHelper::get_module_save_folder_location(moduleName) + L"\\settings.json";
+        auto parsed = json::from_file(path);
+        json::JsonObject root = parsed.has_value() ? parsed.value() : json::JsonObject{};
+
+        json::JsonObject properties = root.HasKey(L"properties") ? root.GetNamedObject(L"properties") : json::JsonObject{};
+
+        json::JsonObject activeConfiguration;
+        activeConfiguration.SetNamedValue(L"value", json::JsonValue::CreateStringValue(profile));
+        properties.SetNamedValue(KeyboardManagerConstants::ActiveConfigurationSettingName, activeConfiguration);
+        root.SetNamedValue(L"properties", properties);
+
+        json::to_file(path, root);
+    }
+    catch (...)
+    {
+        Logger::error(L"Failed to write activeConfiguration for auto-switch");
+        return;
+    }
+
+    // Reuse the existing reload path: the engine's own settings watcher will apply the new profile.
+    HANDLE hEvent = CreateEvent(nullptr, false, false, KeyboardManagerConstants::SettingsEventName.c_str());
+    if (hEvent)
+    {
+        SetEvent(hEvent);
+        CloseHandle(hEvent);
+    }
+    else
+    {
+        Logger::error(L"Auto-switch: failed to signal settings event");
+    }
 }
 
 void KeyboardManager::LoadSettings()
@@ -83,6 +391,14 @@ void KeyboardManager::LoadSettings()
         // retry once
         state.LoadSettings();
     }
+
+    // Track the active profile (for auto-switch decisions) and refresh the device->profile map.
+    {
+        std::lock_guard<std::mutex> lock(activeProfileMutex);
+        activeProfileName = state.currentConfig;
+    }
+    LoadDeviceProfiles();
+
     try
     {
         // Send telemetry about configured key/shortcut to key/shortcut mappings, OS an app specific level.

--- a/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardManager.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardManager.cpp
@@ -2,9 +2,11 @@
 #include "KeyboardManager.h"
 #include <interface/powertoy_module_interface.h>
 #include <common/SettingsAPI/settings_objects.h>
+#include <common/SettingsAPI/settings_helpers.h>
 #include <common/interop/shared_constants.h>
 #include <common/debug_control.h>
 #include <common/utils/winapi_error.h>
+#include <common/utils/json.h>
 #include <common/logger/logger_settings.h>
 
 #include <keyboardmanager/common/KeyboardManagerConstants.h>
@@ -20,6 +22,30 @@ HHOOK KeyboardManager::hookHandle;
 HHOOK KeyboardManager::mouseHookHandle;
 HHOOK KeyboardManager::mouseHookHandleCopy;
 KeyboardManager* KeyboardManager::keyboardManagerObjectPtr;
+
+namespace
+{
+    // A RIDI_DEVICENAME path looks like "\\?\HID#<deviceId>#<instanceId>#<interfaceGuid>". Some
+    // virtual keyboards (e.g. Target_KIP) are assigned a fresh <instanceId> over time, which would
+    // break an exact-path match. Match on the stable prefix instead: everything up to the instance
+    // (the 2nd '#'). This keeps distinct keyboards apart while tolerating instance-id churn.
+    std::wstring NormalizeDevicePath(const std::wstring& path)
+    {
+        const size_t first = path.find(L'#');
+        if (first == std::wstring::npos)
+        {
+            return path;
+        }
+
+        const size_t second = path.find(L'#', first + 1);
+        if (second == std::wstring::npos)
+        {
+            return path;
+        }
+
+        return path.substr(0, second);
+    }
+}
 
 namespace
 {
@@ -83,6 +109,288 @@ KeyboardManager::KeyboardManager()
 
     editorIsRunningEvent = CreateEvent(nullptr, true, false, KeyboardManagerConstants::EditorWindowEventName.c_str());
     settingsEventWaiter.start(KeyboardManagerConstants::SettingsEventName, changeSettingsCallback);
+
+    // Start detecting which physical keyboard is being typed on (for per-keyboard profile switching).
+    rawInputTracker = std::make_unique<RawInputKeyboardTracker>(
+        [this](const RawInputKeyboardTracker::KeyEvent& keyEvent) { OnRawKeyEvent(keyEvent); });
+    rawInputTracker->Start();
+
+    // Global profile-cycle hotkey. Re-read the config so the definition parsed before this object
+    // existed is applied (LoadDeviceProfiles guards on the pointer).
+    profileCycleHotkey = std::make_unique<ProfileCycleHotkey>([this] { CycleActiveProfile(); });
+    profileCycleHotkey->Start();
+    LoadDeviceProfiles();
+}
+
+void KeyboardManager::OnRawKeyEvent(const RawInputKeyboardTracker::KeyEvent& keyEvent)
+{
+    // Ignore injected input (hDevice == NULL, incl. KBM's own remap output) and key-ups.
+    if (keyEvent.injected || !keyEvent.keyDown)
+    {
+        return;
+    }
+
+    // Ignore modifier keys: they lead every chord (including the profile-cycle hotkey, whose own
+    // Shift/Alt key-downs would otherwise feed the hysteresis and fight the cycle), and a lone
+    // modifier is weak evidence that the user moved to this keyboard.
+    switch (keyEvent.vkey)
+    {
+    case VK_SHIFT:
+    case VK_CONTROL:
+    case VK_MENU:
+    case VK_LSHIFT:
+    case VK_RSHIFT:
+    case VK_LCONTROL:
+    case VK_RCONTROL:
+    case VK_LMENU:
+    case VK_RMENU:
+    case VK_LWIN:
+    case VK_RWIN:
+        return;
+    default:
+        break;
+    }
+
+    // A physical keystroke whose device path can't be resolved (observed on Surface Type Cover
+    // right after idle, when its KIP device node re-enumerates). Log it so drops are visible.
+    if (keyEvent.devicePath.empty())
+    {
+        Logger::trace(L"[autosw] keydown vk=0x{:x} with unresolvable device — skipped", keyEvent.vkey);
+        return;
+    }
+
+    // Log the active keyboard when it changes (helps discover device paths for the profile map).
+    if (keyEvent.devicePath != lastSeenDevice)
+    {
+        lastSeenDevice = keyEvent.devicePath;
+        Logger::trace(L"Detected keyboard: {}", keyEvent.devicePath);
+    }
+
+    if (!autoSwitchEnabled.load())
+    {
+        return;
+    }
+
+    // Which profile is this keyboard bound to? Unmapped keyboards keep the current profile.
+    std::wstring target;
+    {
+        std::lock_guard<std::mutex> lock(deviceMapMutex);
+        auto it = deviceProfileMap.find(NormalizeDevicePath(keyEvent.devicePath));
+        if (it == deviceProfileMap.end())
+        {
+            return;
+        }
+
+        target = it->second;
+    }
+
+    std::wstring current;
+    {
+        std::lock_guard<std::mutex> lock(activeProfileMutex);
+        current = activeProfileName;
+    }
+
+    if (target == current)
+    {
+        // Already on the right profile; reset any pending switch.
+        pendingTarget.clear();
+        pendingCount = 0;
+        requestedProfile.clear();
+        return;
+    }
+
+    // A switch to this profile was already requested; wait for the reload to take effect.
+    if (target == requestedProfile)
+    {
+        return;
+    }
+
+    // Hysteresis: require a few consecutive keystrokes on the new keyboard before switching.
+    if (target == pendingTarget)
+    {
+        ++pendingCount;
+    }
+    else
+    {
+        pendingTarget = target;
+        pendingCount = 1;
+    }
+
+    if (pendingCount < AutoSwitchThreshold)
+    {
+        return;
+    }
+
+    pendingCount = 0;
+    requestedProfile = target;
+    Logger::trace(L"Auto-switch: keyboard {} -> profile '{}'", keyEvent.devicePath, target);
+    SwitchActiveProfile(target);
+}
+
+void KeyboardManager::LoadDeviceProfiles()
+{
+    bool enabled = false;
+    std::unordered_map<std::wstring, std::wstring> map;
+    UINT hotkeyModifiers = 0;
+    UINT hotkeyVk = 0;
+
+    try
+    {
+        const auto path = PTSettingsHelper::get_module_save_folder_location(moduleName) + L"\\deviceProfiles.json";
+        auto parsed = json::from_file(path);
+        if (parsed.has_value())
+        {
+            const json::JsonObject& obj = parsed.value();
+            if (obj.HasKey(L"autoSwitchEnabled"))
+            {
+                enabled = obj.GetNamedBoolean(L"autoSwitchEnabled", false);
+            }
+
+            if (obj.HasKey(L"map"))
+            {
+                const auto arr = obj.GetNamedArray(L"map");
+                for (uint32_t i = 0; i < arr.Size(); ++i)
+                {
+                    const auto entry = arr.GetObjectAt(i);
+                    std::wstring device{ entry.GetNamedString(L"device", L"") };
+                    std::wstring profile{ entry.GetNamedString(L"profile", L"") };
+                    if (!device.empty() && !profile.empty())
+                    {
+                        map[NormalizeDevicePath(device)] = profile;
+                    }
+                }
+            }
+
+            if (obj.HasKey(L"cycleHotkey"))
+            {
+                const auto hotkey = obj.GetNamedObject(L"cycleHotkey");
+                hotkeyVk = static_cast<UINT>(hotkey.GetNamedNumber(L"code", 0));
+                if (hotkey.GetNamedBoolean(L"win", false))
+                {
+                    hotkeyModifiers |= MOD_WIN;
+                }
+                if (hotkey.GetNamedBoolean(L"ctrl", false))
+                {
+                    hotkeyModifiers |= MOD_CONTROL;
+                }
+                if (hotkey.GetNamedBoolean(L"alt", false))
+                {
+                    hotkeyModifiers |= MOD_ALT;
+                }
+                if (hotkey.GetNamedBoolean(L"shift", false))
+                {
+                    hotkeyModifiers |= MOD_SHIFT;
+                }
+            }
+        }
+    }
+    catch (...)
+    {
+        Logger::error(L"Failed to load deviceProfiles.json");
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(deviceMapMutex);
+        deviceProfileMap = std::move(map);
+    }
+
+    autoSwitchEnabled.store(enabled);
+
+    if (profileCycleHotkey)
+    {
+        profileCycleHotkey->Update(hotkeyModifiers, hotkeyVk);
+    }
+}
+
+void KeyboardManager::CycleActiveProfile()
+{
+    try
+    {
+        const auto path = PTSettingsHelper::get_module_save_folder_location(moduleName) + L"\\settings.json";
+        auto parsed = json::from_file(path);
+        if (!parsed.has_value())
+        {
+            return;
+        }
+
+        const auto properties = parsed.value().GetNamedObject(L"properties");
+        const std::wstring current{ properties.GetNamedObject(KeyboardManagerConstants::ActiveConfigurationSettingName).GetNamedString(L"value", KeyboardManagerConstants::DefaultConfiguration) };
+
+        std::vector<std::wstring> profiles;
+        if (properties.HasKey(L"keyboardConfigurations"))
+        {
+            const auto arr = properties.GetNamedObject(L"keyboardConfigurations").GetNamedArray(L"value");
+            for (uint32_t i = 0; i < arr.Size(); ++i)
+            {
+                profiles.emplace_back(arr.GetStringAt(i));
+            }
+        }
+
+        if (profiles.size() < 2)
+        {
+            return; // nothing to cycle to
+        }
+
+        size_t currentIndex = 0;
+        for (size_t i = 0; i < profiles.size(); ++i)
+        {
+            if (profiles[i] == current)
+            {
+                currentIndex = i;
+                break;
+            }
+        }
+
+        const std::wstring& next = profiles[(currentIndex + 1) % profiles.size()];
+        Logger::trace(L"CycleActiveProfile: '{}' -> '{}'", current, next);
+        SwitchActiveProfile(next);
+
+        // Audible feedback that the profile changed (no UI surface in the engine).
+        MessageBeep(MB_OK);
+    }
+    catch (...)
+    {
+        Logger::error(L"CycleActiveProfile failed");
+    }
+}
+
+void KeyboardManager::SwitchActiveProfile(const std::wstring& profile)
+{
+    // Tracker thread and hotkey thread can both land here; serialize the read-modify-write.
+    std::lock_guard<std::mutex> lock(switchProfileMutex);
+
+    try
+    {
+        const auto path = PTSettingsHelper::get_module_save_folder_location(moduleName) + L"\\settings.json";
+        auto parsed = json::from_file(path);
+        json::JsonObject root = parsed.has_value() ? parsed.value() : json::JsonObject{};
+
+        json::JsonObject properties = root.HasKey(L"properties") ? root.GetNamedObject(L"properties") : json::JsonObject{};
+
+        json::JsonObject activeConfiguration;
+        activeConfiguration.SetNamedValue(L"value", json::JsonValue::CreateStringValue(profile));
+        properties.SetNamedValue(KeyboardManagerConstants::ActiveConfigurationSettingName, activeConfiguration);
+        root.SetNamedValue(L"properties", properties);
+
+        json::to_file(path, root);
+    }
+    catch (...)
+    {
+        Logger::error(L"Failed to write activeConfiguration for auto-switch");
+        return;
+    }
+
+    // Reuse the existing reload path: the engine's own settings watcher will apply the new profile.
+    HANDLE hEvent = CreateEvent(nullptr, false, false, KeyboardManagerConstants::SettingsEventName.c_str());
+    if (hEvent)
+    {
+        SetEvent(hEvent);
+        CloseHandle(hEvent);
+    }
+    else
+    {
+        Logger::error(L"Auto-switch: failed to signal settings event");
+    }
 }
 
 void KeyboardManager::LoadSettings()
@@ -100,6 +408,14 @@ void KeyboardManager::LoadSettings()
     // that was physically held across the reload can't leave a stale pending/combination entry (which a
     // later event would promote, injecting an unmatched original key-down). No-op on the initial load.
     state.ClearAllAloneKeyState();
+
+    // Track the active profile (for auto-switch decisions) and refresh the device->profile map.
+    {
+        std::lock_guard<std::mutex> lock(activeProfileMutex);
+        activeProfileName = state.currentConfig;
+    }
+    LoadDeviceProfiles();
+
     try
     {
         // Send telemetry about configured key/shortcut to key/shortcut mappings, OS an app specific level.

--- a/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardManager.h
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardManager.h
@@ -1,8 +1,16 @@
 #pragma once
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
 #include <common/hooks/LowlevelKeyboardEvent.h>
 #include <common/utils/EventWaiter.h>
 #include <keyboardmanager/common/Input.h>
 #include "State.h"
+#include "RawInputKeyboardTracker.h"
+#include "ProfileCycleHotkey.h"
 
 class KeyboardManager
 {
@@ -14,6 +22,17 @@ public:
 
     ~KeyboardManager()
     {
+        // Stop the worker threads first so they can't call back into a half-destroyed object.
+        if (rawInputTracker)
+        {
+            rawInputTracker->Stop();
+        }
+
+        if (profileCycleHotkey)
+        {
+            profileCycleHotkey->Stop();
+        }
+
         if (editorIsRunningEvent)
         {
             CloseHandle(editorIsRunningEvent);
@@ -54,6 +73,50 @@ private:
     std::atomic_bool loadingSettings = false;
 
     HANDLE editorIsRunningEvent = nullptr;
+
+    // Detects which physical keyboard is being typed on, for per-keyboard profile auto-switching.
+    std::unique_ptr<RawInputKeyboardTracker> rawInputTracker;
+
+    // Global hotkey that cycles through the profiles (definition in deviceProfiles.json).
+    std::unique_ptr<ProfileCycleHotkey> profileCycleHotkey;
+
+    // Serializes profile switches (tracker thread and hotkey thread both call SwitchActiveProfile).
+    std::mutex switchProfileMutex;
+
+    // Called (on the tracker thread) for each raw keyboard event.
+    void OnRawKeyEvent(const RawInputKeyboardTracker::KeyEvent& keyEvent);
+
+    // Reload the device->profile map, the auto-switch enable flag, and the cycle-hotkey
+    // definition from deviceProfiles.json.
+    void LoadDeviceProfiles();
+
+    // Make the given profile active by writing settings.json + signaling the settings-changed
+    // event, so the existing reload path applies it (avoids a second thread mutating `state`).
+    void SwitchActiveProfile(const std::wstring& profile);
+
+    // Advance to the next profile in settings.json's keyboardConfigurations list (hotkey action).
+    void CycleActiveProfile();
+
+    // Number of consecutive clean keystrokes on a keyboard before its profile is auto-selected
+    // (hysteresis to avoid thrashing when two keyboards are used in quick alternation).
+    static constexpr int AutoSwitchThreshold = 2;
+
+    // Auto-switch config (shared with the tracker thread; guarded).
+    std::atomic_bool autoSwitchEnabled{ false };
+    std::unordered_map<std::wstring, std::wstring> deviceProfileMap;
+    std::mutex deviceMapMutex;
+
+    // The currently active profile name, updated on every settings load. Read on the tracker thread.
+    std::wstring activeProfileName;
+    std::mutex activeProfileMutex;
+
+    // Tracker-thread-only auto-switch policy state.
+    std::wstring pendingTarget;
+    int pendingCount = 0;
+    std::wstring requestedProfile;
+
+    // Last keyboard seen, logged on change to help discover device paths for the profile map.
+    std::wstring lastSeenDevice;
 
     // Hook procedure definition
     static LRESULT CALLBACK HookProc(int nCode, WPARAM wParam, LPARAM lParam);

--- a/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardManager.h
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardManager.h
@@ -1,8 +1,16 @@
 #pragma once
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
 #include <common/hooks/LowlevelKeyboardEvent.h>
 #include <common/utils/EventWaiter.h>
 #include <keyboardmanager/common/Input.h>
 #include "State.h"
+#include "RawInputKeyboardTracker.h"
+#include "ProfileCycleHotkey.h"
 
 class KeyboardManager
 {
@@ -14,6 +22,17 @@ public:
 
     ~KeyboardManager()
     {
+        // Stop the worker threads first so they can't call back into a half-destroyed object.
+        if (rawInputTracker)
+        {
+            rawInputTracker->Stop();
+        }
+
+        if (profileCycleHotkey)
+        {
+            profileCycleHotkey->Stop();
+        }
+
         if (editorIsRunningEvent)
         {
             CloseHandle(editorIsRunningEvent);
@@ -66,6 +85,50 @@ private:
     std::atomic_bool loadingSettings = false;
 
     HANDLE editorIsRunningEvent = nullptr;
+
+    // Detects which physical keyboard is being typed on, for per-keyboard profile auto-switching.
+    std::unique_ptr<RawInputKeyboardTracker> rawInputTracker;
+
+    // Global hotkey that cycles through the profiles (definition in deviceProfiles.json).
+    std::unique_ptr<ProfileCycleHotkey> profileCycleHotkey;
+
+    // Serializes profile switches (tracker thread and hotkey thread both call SwitchActiveProfile).
+    std::mutex switchProfileMutex;
+
+    // Called (on the tracker thread) for each raw keyboard event.
+    void OnRawKeyEvent(const RawInputKeyboardTracker::KeyEvent& keyEvent);
+
+    // Reload the device->profile map, the auto-switch enable flag, and the cycle-hotkey
+    // definition from deviceProfiles.json.
+    void LoadDeviceProfiles();
+
+    // Make the given profile active by writing settings.json + signaling the settings-changed
+    // event, so the existing reload path applies it (avoids a second thread mutating `state`).
+    void SwitchActiveProfile(const std::wstring& profile);
+
+    // Advance to the next profile in settings.json's keyboardConfigurations list (hotkey action).
+    void CycleActiveProfile();
+
+    // Number of consecutive clean keystrokes on a keyboard before its profile is auto-selected
+    // (hysteresis to avoid thrashing when two keyboards are used in quick alternation).
+    static constexpr int AutoSwitchThreshold = 2;
+
+    // Auto-switch config (shared with the tracker thread; guarded).
+    std::atomic_bool autoSwitchEnabled{ false };
+    std::unordered_map<std::wstring, std::wstring> deviceProfileMap;
+    std::mutex deviceMapMutex;
+
+    // The currently active profile name, updated on every settings load. Read on the tracker thread.
+    std::wstring activeProfileName;
+    std::mutex activeProfileMutex;
+
+    // Tracker-thread-only auto-switch policy state.
+    std::wstring pendingTarget;
+    int pendingCount = 0;
+    std::wstring requestedProfile;
+
+    // Last keyboard seen, logged on change to help discover device paths for the profile map.
+    std::wstring lastSeenDevice;
 
     // Hook procedure definition
     static LRESULT CALLBACK HookProc(int nCode, WPARAM wParam, LPARAM lParam);

--- a/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardManagerEngineLibrary.vcxproj
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardManagerEngineLibrary.vcxproj
@@ -36,12 +36,16 @@
     <ClInclude Include="KeyboardEventHandlers.h" />
     <ClInclude Include="KeyboardManager.h" />
     <ClInclude Include="pch.h" />
+    <ClInclude Include="ProfileCycleHotkey.h" />
+    <ClInclude Include="RawInputKeyboardTracker.h" />
     <ClInclude Include="State.h" />
     <ClInclude Include="trace.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="KeyboardEventHandlers.cpp" />
     <ClCompile Include="KeyboardManager.cpp" />
+    <ClCompile Include="ProfileCycleHotkey.cpp" />
+    <ClCompile Include="RawInputKeyboardTracker.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(UsePrecompiledHeaders)' != 'false'">Create</PrecompiledHeader>
     </ClCompile>

--- a/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/ProfileCycleHotkey.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/ProfileCycleHotkey.cpp
@@ -1,0 +1,159 @@
+#include "pch.h"
+#include "ProfileCycleHotkey.h"
+
+#include <common/logger/logger.h>
+
+namespace
+{
+    const wchar_t* const HotkeyWindowClassName = L"KbmProfileCycleHotkey";
+}
+
+ProfileCycleHotkey::ProfileCycleHotkey(Callback callback) :
+    m_callback(std::move(callback))
+{
+}
+
+ProfileCycleHotkey::~ProfileCycleHotkey()
+{
+    Stop();
+}
+
+void ProfileCycleHotkey::Start()
+{
+    bool expected = false;
+    if (!m_started.compare_exchange_strong(expected, true))
+    {
+        return;
+    }
+
+    m_thread = std::thread([this] { ThreadMain(); });
+}
+
+void ProfileCycleHotkey::Stop()
+{
+    if (!m_started.exchange(false))
+    {
+        return;
+    }
+
+    const DWORD threadId = m_threadId.load();
+    if (threadId != 0)
+    {
+        PostThreadMessageW(threadId, WM_QUIT, 0, 0);
+    }
+
+    if (m_thread.joinable())
+    {
+        m_thread.join();
+    }
+
+    m_threadId.store(0);
+    m_hwnd.store(nullptr);
+}
+
+void ProfileCycleHotkey::Update(UINT modifiers, UINT vk)
+{
+    m_pendingModifiers.store(modifiers);
+    m_pendingVk.store(vk);
+
+    // If the window exists, apply on its thread; otherwise ThreadMain applies it after creation.
+    const HWND hwnd = m_hwnd.load();
+    if (hwnd != nullptr)
+    {
+        PostMessageW(hwnd, ApplyHotkeyMessage, 0, 0);
+    }
+}
+
+LRESULT CALLBACK ProfileCycleHotkey::WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+    if (msg == WM_NCCREATE)
+    {
+        auto* create = reinterpret_cast<CREATESTRUCTW*>(lParam);
+        SetWindowLongPtrW(hwnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(create->lpCreateParams));
+        return DefWindowProcW(hwnd, msg, wParam, lParam);
+    }
+
+    auto* self = reinterpret_cast<ProfileCycleHotkey*>(GetWindowLongPtrW(hwnd, GWLP_USERDATA));
+    if (self != nullptr)
+    {
+        if (msg == ApplyHotkeyMessage)
+        {
+            self->ApplyPendingRegistration(hwnd);
+            return 0;
+        }
+
+        if (msg == WM_HOTKEY && wParam == HotkeyId && self->m_callback)
+        {
+            self->m_callback();
+            return 0;
+        }
+    }
+
+    return DefWindowProcW(hwnd, msg, wParam, lParam);
+}
+
+void ProfileCycleHotkey::ApplyPendingRegistration(HWND hwnd)
+{
+    if (m_registered)
+    {
+        UnregisterHotKey(hwnd, HotkeyId);
+        m_registered = false;
+    }
+
+    const UINT vk = m_pendingVk.load();
+    if (vk == 0)
+    {
+        return; // hotkey disabled
+    }
+
+    // MOD_NOREPEAT: holding the chord fires once, not repeatedly.
+    if (RegisterHotKey(hwnd, HotkeyId, m_pendingModifiers.load() | MOD_NOREPEAT, vk))
+    {
+        m_registered = true;
+        Logger::trace(L"ProfileCycleHotkey: registered (modifiers=0x{:x}, vk=0x{:x})", m_pendingModifiers.load(), vk);
+    }
+    else
+    {
+        Logger::warn(L"ProfileCycleHotkey: RegisterHotKey failed ({}) — hotkey in use by another app?", GetLastError());
+    }
+}
+
+void ProfileCycleHotkey::ThreadMain()
+{
+    m_threadId.store(GetCurrentThreadId());
+
+    WNDCLASSEXW wc = {};
+    wc.cbSize = sizeof(wc);
+    wc.lpfnWndProc = &ProfileCycleHotkey::WndProc;
+    wc.hInstance = GetModuleHandleW(nullptr);
+    wc.lpszClassName = HotkeyWindowClassName;
+    RegisterClassExW(&wc);
+
+    HWND hwnd = CreateWindowExW(0, HotkeyWindowClassName, L"", 0, 0, 0, 0, 0, nullptr, nullptr, wc.hInstance, this);
+    if (hwnd == nullptr)
+    {
+        Logger::error(L"ProfileCycleHotkey: CreateWindow failed ({})", GetLastError());
+        UnregisterClassW(HotkeyWindowClassName, wc.hInstance);
+        return;
+    }
+
+    m_hwnd.store(hwnd);
+    ApplyPendingRegistration(hwnd);
+
+    MSG msg;
+    while (GetMessageW(&msg, nullptr, 0, 0) > 0)
+    {
+        TranslateMessage(&msg);
+        DispatchMessageW(&msg);
+    }
+
+    if (m_registered)
+    {
+        UnregisterHotKey(hwnd, HotkeyId);
+        m_registered = false;
+    }
+
+    m_hwnd.store(nullptr);
+    DestroyWindow(hwnd);
+    UnregisterClassW(HotkeyWindowClassName, wc.hInstance);
+}

--- a/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/ProfileCycleHotkey.h
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/ProfileCycleHotkey.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <atomic>
+#include <functional>
+#include <thread>
+
+#include <Windows.h>
+
+// Registers a global hotkey (on its own hidden-window thread) that cycles the active per-keyboard
+// profile. The hotkey definition comes from deviceProfiles.json ("cycleHotkey"); when absent the
+// hotkey is unregistered and the feature is inert. RegisterHotKey needs a thread with a message
+// loop, and the engine's main loop is thread-message-only, so this owns a window like the tracker.
+class ProfileCycleHotkey
+{
+public:
+    using Callback = std::function<void()>;
+
+    explicit ProfileCycleHotkey(Callback callback);
+    ~ProfileCycleHotkey();
+
+    ProfileCycleHotkey(const ProfileCycleHotkey&) = delete;
+    ProfileCycleHotkey& operator=(const ProfileCycleHotkey&) = delete;
+
+    // Starts the listener thread. Safe to call once; subsequent calls are ignored.
+    void Start();
+
+    // Signals the listener thread to exit and joins it. Safe to call multiple times.
+    void Stop();
+
+    // Applies a new hotkey (fsModifiers per RegisterHotKey semantics; vk == 0 unregisters).
+    // Thread-safe; takes effect on the listener thread.
+    void Update(UINT modifiers, UINT vk);
+
+private:
+    static const inline UINT ApplyHotkeyMessage = WM_APP + 2;
+    static const inline int HotkeyId = 1;
+
+    static LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
+
+    void ThreadMain();
+    void ApplyPendingRegistration(HWND hwnd);
+
+    Callback m_callback;
+    std::thread m_thread;
+    std::atomic<HWND> m_hwnd{ nullptr };
+    std::atomic<DWORD> m_threadId{ 0 };
+    std::atomic_bool m_started{ false };
+    std::atomic<UINT> m_pendingModifiers{ 0 };
+    std::atomic<UINT> m_pendingVk{ 0 };
+    bool m_registered = false; // listener-thread only
+};

--- a/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/RawInputKeyboardTracker.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/RawInputKeyboardTracker.cpp
@@ -1,0 +1,187 @@
+#include "pch.h"
+#include "RawInputKeyboardTracker.h"
+
+#include <vector>
+
+#include <common/logger/logger.h>
+
+namespace
+{
+    const wchar_t* const RawInputWindowClassName = L"KbmPerKeyboardRawInputSink";
+
+    std::wstring ResolveDevicePath(HANDLE hDevice)
+    {
+        if (hDevice == nullptr)
+        {
+            return {};
+        }
+
+        UINT size = 0;
+        if (GetRawInputDeviceInfoW(hDevice, RIDI_DEVICENAME, nullptr, &size) != 0 || size == 0)
+        {
+            return {};
+        }
+
+        std::wstring path(size, L'\0');
+        UINT written = GetRawInputDeviceInfoW(hDevice, RIDI_DEVICENAME, path.data(), &size);
+        if (written == static_cast<UINT>(-1))
+        {
+            return {};
+        }
+
+        // RIDI_DEVICENAME returns the count including the null terminator; trim to actual length.
+        path.resize(wcsnlen(path.c_str(), path.size()));
+        return path;
+    }
+}
+
+RawInputKeyboardTracker::RawInputKeyboardTracker(Callback callback) :
+    m_callback(std::move(callback))
+{
+}
+
+RawInputKeyboardTracker::~RawInputKeyboardTracker()
+{
+    Stop();
+}
+
+void RawInputKeyboardTracker::Start()
+{
+    bool expected = false;
+    if (!m_started.compare_exchange_strong(expected, true))
+    {
+        return;
+    }
+
+    m_thread = std::thread([this] { ThreadMain(); });
+}
+
+void RawInputKeyboardTracker::Stop()
+{
+    if (!m_started.exchange(false))
+    {
+        return;
+    }
+
+    const DWORD threadId = m_threadId.load();
+    if (threadId != 0)
+    {
+        PostThreadMessageW(threadId, WM_QUIT, 0, 0);
+    }
+
+    if (m_thread.joinable())
+    {
+        m_thread.join();
+    }
+
+    m_threadId.store(0);
+}
+
+LRESULT CALLBACK RawInputKeyboardTracker::WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+    if (msg == WM_NCCREATE)
+    {
+        auto* create = reinterpret_cast<CREATESTRUCTW*>(lParam);
+        SetWindowLongPtrW(hwnd, GWLP_USERDATA, reinterpret_cast<LONG_PTR>(create->lpCreateParams));
+        return DefWindowProcW(hwnd, msg, wParam, lParam);
+    }
+
+    if (msg == WM_INPUT)
+    {
+        auto* self = reinterpret_cast<RawInputKeyboardTracker*>(GetWindowLongPtrW(hwnd, GWLP_USERDATA));
+        if (self != nullptr)
+        {
+            self->HandleRawInput(reinterpret_cast<HRAWINPUT>(lParam));
+        }
+
+        return DefWindowProcW(hwnd, msg, wParam, lParam);
+    }
+
+    return DefWindowProcW(hwnd, msg, wParam, lParam);
+}
+
+void RawInputKeyboardTracker::HandleRawInput(HRAWINPUT hRawInput)
+{
+    UINT size = 0;
+    if (GetRawInputData(hRawInput, RID_INPUT, nullptr, &size, sizeof(RAWINPUTHEADER)) != 0 || size == 0)
+    {
+        return;
+    }
+
+    std::vector<BYTE> buffer(size);
+    if (GetRawInputData(hRawInput, RID_INPUT, buffer.data(), &size, sizeof(RAWINPUTHEADER)) != size)
+    {
+        return;
+    }
+
+    const auto* raw = reinterpret_cast<const RAWINPUT*>(buffer.data());
+    if (raw->header.dwType != RIM_TYPEKEYBOARD)
+    {
+        return;
+    }
+
+    const RAWKEYBOARD& kb = raw->data.keyboard;
+    if (kb.VKey == 0xFF)
+    {
+        // Part of an escaped sequence / overrun; not a real key.
+        return;
+    }
+
+    KeyEvent ev;
+    ev.vkey = kb.VKey;
+    ev.keyDown = (kb.Message == WM_KEYDOWN || kb.Message == WM_SYSKEYDOWN);
+    ev.injected = (raw->header.hDevice == nullptr);
+    ev.devicePath = ResolveDevicePath(raw->header.hDevice);
+
+    if (m_callback)
+    {
+        m_callback(ev);
+    }
+}
+
+void RawInputKeyboardTracker::ThreadMain()
+{
+    m_threadId.store(GetCurrentThreadId());
+
+    WNDCLASSEXW wc = {};
+    wc.cbSize = sizeof(wc);
+    wc.lpfnWndProc = &RawInputKeyboardTracker::WndProc;
+    wc.hInstance = GetModuleHandleW(nullptr);
+    wc.lpszClassName = RawInputWindowClassName;
+    RegisterClassExW(&wc);
+
+    // Hidden top-level window (never shown). RIDEV_INPUTSINK is most reliable with a real window.
+    HWND hwnd = CreateWindowExW(0, RawInputWindowClassName, L"", 0, 0, 0, 0, 0, nullptr, nullptr, wc.hInstance, this);
+    if (hwnd == nullptr)
+    {
+        Logger::error(L"RawInputKeyboardTracker: CreateWindow failed ({})", GetLastError());
+        UnregisterClassW(RawInputWindowClassName, wc.hInstance);
+        return;
+    }
+
+    RAWINPUTDEVICE rid = {};
+    rid.usUsagePage = 0x01; // Generic Desktop
+    rid.usUsage = 0x06; // Keyboard
+    rid.dwFlags = RIDEV_INPUTSINK; // receive input even when not in the foreground; never suppresses
+    rid.hwndTarget = hwnd;
+    if (!RegisterRawInputDevices(&rid, 1, sizeof(rid)))
+    {
+        Logger::error(L"RawInputKeyboardTracker: RegisterRawInputDevices failed ({})", GetLastError());
+        DestroyWindow(hwnd);
+        UnregisterClassW(RawInputWindowClassName, wc.hInstance);
+        return;
+    }
+
+    Logger::trace(L"RawInputKeyboardTracker: listening for raw keyboard input");
+
+    MSG msg;
+    while (GetMessageW(&msg, nullptr, 0, 0) > 0)
+    {
+        TranslateMessage(&msg);
+        DispatchMessageW(&msg);
+    }
+
+    DestroyWindow(hwnd);
+    UnregisterClassW(RawInputWindowClassName, wc.hInstance);
+    Logger::trace(L"RawInputKeyboardTracker: stopped");
+}

--- a/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/RawInputKeyboardTracker.h
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/RawInputKeyboardTracker.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <atomic>
+#include <functional>
+#include <string>
+#include <thread>
+
+#include <Windows.h>
+
+// Receives raw keyboard input on a dedicated hidden-window thread so the engine can tell which
+// physical keyboard produced a keystroke. This is the detection half of per-keyboard profile
+// auto-switching; the switching policy lives in the callback owner (KeyboardManager).
+//
+// The engine's main loop is a thread-message loop (no window), and WM_INPUT is only delivered to a
+// window's WndProc, so this runs its own window + message pump on a separate thread. Uses
+// RIDEV_INPUTSINK to observe keystrokes regardless of foreground focus, and never suppresses input.
+class RawInputKeyboardTracker
+{
+public:
+    struct KeyEvent
+    {
+        // RIDI_DEVICENAME device interface path: stable, unique per physical device, and the
+        // identity key we match against the device->profile map. Empty when injected.
+        std::wstring devicePath;
+        USHORT vkey = 0;
+        bool keyDown = false;
+
+        // hDevice == NULL: synthetic/injected input (including KBM's own remap output). The policy
+        // layer must ignore these for switching, or self-injected keys would trigger switches.
+        bool injected = false;
+    };
+
+    using Callback = std::function<void(const KeyEvent&)>;
+
+    explicit RawInputKeyboardTracker(Callback callback);
+    ~RawInputKeyboardTracker();
+
+    RawInputKeyboardTracker(const RawInputKeyboardTracker&) = delete;
+    RawInputKeyboardTracker& operator=(const RawInputKeyboardTracker&) = delete;
+
+    // Starts the listener thread. Safe to call once; subsequent calls are ignored.
+    void Start();
+
+    // Signals the listener thread to exit and joins it. Safe to call multiple times.
+    void Stop();
+
+private:
+    static LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
+
+    void ThreadMain();
+    void HandleRawInput(HRAWINPUT hRawInput);
+
+    Callback m_callback;
+    std::thread m_thread;
+    std::atomic<DWORD> m_threadId{ 0 };
+    std::atomic_bool m_started{ false };
+};


### PR DESCRIPTION
## Summary

Adds **per-keyboard remap profiles** to Keyboard Manager: keep several profiles and switch the active one based on which physical keyboard you're typing on.

Related to #12349 (and to #1460 / #35632) — but worth being precise, because that issue has collected two different asks over the years. Its original request is switching the **Windows keyboard layout** per device (US-Intl ↔ RUS, the way RightKeyboard does it), and this PR does **not** do that. What it implements is the other half the discussion converged on: per-device **remap profiles** with manual, automatic and hotkey switching — what @908875137 asked for there as "group management and a shortcut for quick switching". So there is deliberately no closing keyword here; #12349 should stay open for the layout case.

## Demo

Muted screen recording with on-screen captions:

https://github.com/user-attachments/assets/bbb35212-e5d8-4e45-838b-6413c10531f0

The clip shows two profiles — **"demo Type Cover"** and **"demo mac"** (the latter remaps `8 → 9`) — the **auto-switch** dialog identifying each keyboard by typing on it and assigning a profile, then live switching: typing on the **Type Cover** keeps `8` as `8`, switching to the **Apple keyboard** (`demo mac`) makes `8` become `9`, and the editor's profile picker follows the engine's auto-switch live. Known limitation shown: keys remapped by the *active* profile are suppressed by the low-level hook and never reach Raw Input, so auto-switch reacts to ordinary (non-remapped) keystrokes; the profile-cycle hotkey covers press-only-remapped-keys cases.

> The recording predates the storage rework and the toolbar layout below, so its editor screenshots are a version behind; the behaviour it shows is unchanged.

## What's included

**Engine (`KeyboardManagerEngineLibrary`)**
- `RawInputKeyboardTracker` — a dedicated hidden-window thread that uses Raw Input (`RIDEV_INPUTSINK`) to identify which physical keyboard produced each keystroke. It never suppresses input.
- Per-keyboard auto-switch in `KeyboardManager` — a `device -> profile` map plus an enable flag (`deviceProfiles.json`) drive switching the active profile. Switching reuses the existing settings-reload path (write `activeConfiguration` + signal the settings event), so remap state is never mutated off the reload thread. Device paths are matched on a normalized prefix (tolerant of instance-id churn seen on some virtual keyboards); injected input and modifier key-downs are excluded from the decision; a short hysteresis avoids thrashing.
- `ProfileCycleHotkey` — an optional global hotkey (`RegisterHotKey` + `MOD_NOREPEAT`) that cycles the active profile, as a reliable manual alternative to auto-switch.

**Editor (`KeyboardManagerEditorUI`)**
- Profile selector (create / delete / switch) in the list toolbar, built on the existing named-configuration mechanism.
- An **Auto-switch** dialog that identifies keyboards by having you type on them (`RawInputWatcher`), lets you assign a profile per keyboard, and writes `deviceProfiles.json`.

## How it works

Profiles are existing `{name}.json` config files listed in `keyboardConfigurations`; the active one is `activeConfiguration` in `settings.json`. Switching a profile writes that value and signals the engine's existing reload event — no new config plumbing.

## Editor storage: built on the model already in `main`

Following @niels9001's feedback, this PR **no longer keeps its own per-profile editor cache**. An earlier revision split `editorSettings.json` into `editorSettings.<profile>.json`, which duplicated the profile support `main` already has. It now uses that support directly:

- membership stays in `ShortcutSettings.Profiles` / `EditorSettings.ProfileDictionary`,
- the list is filtered by the existing `IsMappingInActiveProfile()`,
- switching a profile just runs the existing `ReconcileMappings(..., profileName)` against the newly loaded configuration.

Two things surfaced while doing this, and both are fixed here:

1. `KeyboardMappingService.ConfigurationName` is captured in the service constructor, and `SettingsManager` holds one service for the lifetime of the editor. With a profile picker in the UI, switching profiles with the editor open left that name stale, so a newly added remapping was tagged into the *previous* profile. `SettingsManager` now reads the active profile live (same source: `activeConfiguration`), and falls back to the old behaviour when the native service is unavailable.
2. `IsMappingInActiveProfile()` treats "no profiles" as "belongs everywhere" — correct for settings written before profiles existed. That means deleting a profile cannot simply untag its mappings, or they resurface in *every* profile. Deleting a profile now removes the mappings that belonged to it and to nothing else, and leaves never-tagged mappings alone.

Net effect on this PR: `SettingsManager.cs` gains two members and swaps four call sites instead of reworking the storage layer.

**Shared vs. copied remappings** — as discussed, the storage already expresses both, so this is a UI decision rather than a format one. With today's `ReconcileMappings`, duplicating a profile produces independent copies (the "hard copy" option) with no extra code, so that is what this PR ships. Sharing one remapping across profiles needs UI that doesn't exist yet (including an "update everywhere / only in this profile" prompt when editing a shared row) — happy to do that as a follow-up once we've settled the UX.

## Known limitation

Keys remapped by the *active* profile are suppressed by the low-level keyboard hook and therefore never reach Raw Input. So auto-switch reacts to ordinary (non-remapped) keystrokes; the profile-cycle hotkey covers cases where you only press remapped keys. This is documented in the code.

## Status / open items

- Rebased onto current `main` (post #49287); single commit, no conflicts.
- Profile picker lives in the KBM editor, per @niels9001. It shares the list toolbar rather than taking a row of its own, since the trailing filter cluster left that row's middle empty.
- Ready for review. The shared-vs-copied UX above is the one open design question, but per @niels9001's "I can help make tweaks to that later as well" it seemed better to get the mechanics reviewed and refine the UX on top, rather than keep the PR parked. Happy to put it back to draft if you'd rather settle that first.
- Auto-switch defaults to **off**; manual profile switching and the cycle hotkey are the primary paths.
- Editor UI for configuring the cycle hotkey is a follow-up (currently the definition lives in `deviceProfiles.json`).

## Testing

Built and exercised on a real machine (Apple Wireless Keyboard + Surface Type Cover) with a 6-profile, 84-remapping configuration:

- creating / switching / deleting profiles from the editor, assigning keyboards by typing, auto-switching on ordinary typing, and cycling profiles via the hotkey;
- engine-driven switches (auto-switch and the cycle hotkey) move the editor's picker and mapping list while it is open;
- a remapping added after switching profiles is tagged to the profile that is active at that moment (fix 1 above);
- deleting a profile removes exactly its own mappings — no leftover membership, no mappings orphaned into other profiles, and the operation-type index stays consistent (fix 2 above);
- "alone"/tap remaps (#49136) round-trip through the profile-aware reconcile unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

