### PR TITLE
[Keyboard Manager] Search, filter and bulk-delete for the remapping list

### DIFF
--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/IToggleableShortcut.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/IToggleableShortcut.cs
@@ -19,5 +19,14 @@ namespace KeyboardManagerEditorUI.Helpers
         string Id { get; set; }
 
         string AppName { get; set; }
+
+        bool IsAllApps { get; set; }
+
+        // Raw virtual-key codes of the trigger (original) keys, kept so the search/filter
+        // bar can classify modifiers by VK code (locale-independent) instead of display name.
+        IReadOnlyList<int> TriggerKeyCodes { get; set; }
+
+        // Lowercased, pre-computed text used by the filter bar's text search.
+        string SearchableText { get; set; }
     }
 }

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/ProgramShortcut.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/ProgramShortcut.cs
@@ -34,5 +34,9 @@ namespace KeyboardManagerEditorUI.Helpers
         public string IfRunningAction { get; set; } = string.Empty;
 
         public string Visibility { get; set; } = string.Empty;
+
+        public IReadOnlyList<int> TriggerKeyCodes { get; set; } = Array.Empty<int>();
+
+        public string SearchableText { get; set; } = string.Empty;
     }
 }

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/Remapping.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/Remapping.cs
@@ -28,6 +28,10 @@ namespace KeyboardManagerEditorUI.Helpers
 
         public bool IsActive { get; set; } = true;
 
+        public IReadOnlyList<int> TriggerKeyCodes { get; set; } = Array.Empty<int>();
+
+        public string SearchableText { get; set; } = string.Empty;
+
         public event PropertyChangedEventHandler? PropertyChanged;
 
         public bool IsEnabled

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/Remapping.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/Remapping.cs
@@ -34,6 +34,10 @@ namespace KeyboardManagerEditorUI.Helpers
         // True when this single-key remap only fires on a solo tap; drives the "Alone" badge in the list.
         public bool IsAlone => Condition == Interop.SingleKeyRemapCondition.Alone;
 
+        public IReadOnlyList<int> TriggerKeyCodes { get; set; } = Array.Empty<int>();
+
+        public string SearchableText { get; set; } = string.Empty;
+
         public event PropertyChangedEventHandler? PropertyChanged;
 
         public bool IsEnabled

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/TextMapping.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/TextMapping.cs
@@ -23,5 +23,9 @@ namespace KeyboardManagerEditorUI.Helpers
         public bool IsActive { get; set; } = true;
 
         public string Id { get; set; } = string.Empty;
+
+        public IReadOnlyList<int> TriggerKeyCodes { get; set; } = Array.Empty<int>();
+
+        public string SearchableText { get; set; } = string.Empty;
     }
 }

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/URLShortcut.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/URLShortcut.cs
@@ -23,5 +23,9 @@ namespace KeyboardManagerEditorUI.Helpers
         public bool IsAllApps { get; set; } = true;
 
         public string AppName { get; set; } = string.Empty;
+
+        public IReadOnlyList<int> TriggerKeyCodes { get; set; } = Array.Empty<int>();
+
+        public string SearchableText { get; set; } = string.Empty;
     }
 }

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/KeyboardManagerEditorXAML/App.xaml
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/KeyboardManagerEditorXAML/App.xaml
@@ -15,6 +15,96 @@
                 <ResourceDictionary Source="ms-appx:///PowerToys.Common.UI.Controls/Controls/KeyVisual/KeyCharPresenter.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <x:Double x:Key="ContentDialogMaxWidth">960</x:Double>
+            <Style
+                x:Key="SubtleToggleButtonStyle"
+                BasedOn="{StaticResource DefaultToggleButtonStyle}"
+                TargetType="ToggleButton">
+                <Setter Property="Background" Value="{ThemeResource SubtleFillColorTransparentBrush}" />
+                <Setter Property="BorderBrush" Value="{ThemeResource SubtleFillColorTransparentBrush}" />
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="ToggleButton">
+                            <ContentPresenter
+                                x:Name="ContentPresenter"
+                                Padding="{TemplateBinding Padding}"
+                                HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                AutomationProperties.AccessibilityView="Raw"
+                                Background="{TemplateBinding Background}"
+                                BackgroundSizing="{TemplateBinding BackgroundSizing}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                Content="{TemplateBinding Content}"
+                                ContentTemplate="{TemplateBinding ContentTemplate}"
+                                ContentTransitions="{TemplateBinding ContentTransitions}"
+                                CornerRadius="{TemplateBinding CornerRadius}"
+                                Foreground="{TemplateBinding Foreground}">
+                                <ContentPresenter.BackgroundTransition>
+                                    <BrushTransition Duration="0:0:0.083" />
+                                </ContentPresenter.BackgroundTransition>
+                                <VisualStateManager.VisualStateGroups>
+                                    <VisualStateGroup x:Name="CommonStates">
+                                        <VisualState x:Name="Normal" />
+                                        <VisualState x:Name="PointerOver">
+                                            <VisualState.Setters>
+                                                <Setter Target="ContentPresenter.Background" Value="{ThemeResource SubtleFillColorSecondaryBrush}" />
+                                                <Setter Target="ContentPresenter.BorderBrush" Value="{ThemeResource SubtleFillColorTransparentBrush}" />
+                                                <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TextFillColorPrimaryBrush}" />
+                                            </VisualState.Setters>
+                                        </VisualState>
+                                        <VisualState x:Name="Pressed">
+                                            <VisualState.Setters>
+                                                <Setter Target="ContentPresenter.Background" Value="{ThemeResource SubtleFillColorTertiaryBrush}" />
+                                                <Setter Target="ContentPresenter.BorderBrush" Value="{ThemeResource SubtleFillColorTransparentBrush}" />
+                                                <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TextFillColorSecondaryBrush}" />
+                                            </VisualState.Setters>
+                                        </VisualState>
+                                        <VisualState x:Name="Disabled">
+                                            <VisualState.Setters>
+                                                <Setter Target="ContentPresenter.Background" Value="{ThemeResource SubtleFillColorTransparentBrush}" />
+                                                <Setter Target="ContentPresenter.BorderBrush" Value="{ThemeResource SubtleFillColorTransparentBrush}" />
+                                                <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TextFillColorDisabledBrush}" />
+                                            </VisualState.Setters>
+                                        </VisualState>
+                                        <VisualState x:Name="Checked">
+                                            <VisualState.Setters>
+                                                <Setter Target="ContentPresenter.Background" Value="{ThemeResource AccentFillColorDefaultBrush}" />
+                                                <Setter Target="ContentPresenter.BackgroundSizing" Value="OuterBorderEdge" />
+                                                <Setter Target="ContentPresenter.BorderBrush" Value="{ThemeResource AccentControlElevationBorderBrush}" />
+                                                <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TextOnAccentFillColorPrimaryBrush}" />
+                                            </VisualState.Setters>
+                                        </VisualState>
+                                        <VisualState x:Name="CheckedPointerOver">
+                                            <VisualState.Setters>
+                                                <Setter Target="ContentPresenter.Background" Value="{ThemeResource AccentFillColorSecondaryBrush}" />
+                                                <Setter Target="ContentPresenter.BackgroundSizing" Value="OuterBorderEdge" />
+                                                <Setter Target="ContentPresenter.BorderBrush" Value="{ThemeResource AccentControlElevationBorderBrush}" />
+                                                <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TextOnAccentFillColorPrimaryBrush}" />
+                                            </VisualState.Setters>
+                                        </VisualState>
+                                        <VisualState x:Name="CheckedPressed">
+                                            <VisualState.Setters>
+                                                <Setter Target="ContentPresenter.Background" Value="{ThemeResource AccentFillColorTertiaryBrush}" />
+                                                <Setter Target="ContentPresenter.BackgroundSizing" Value="OuterBorderEdge" />
+                                                <Setter Target="ContentPresenter.BorderBrush" Value="{ThemeResource ControlFillColorTransparentBrush}" />
+                                                <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TextOnAccentFillColorSecondaryBrush}" />
+                                            </VisualState.Setters>
+                                        </VisualState>
+                                        <VisualState x:Name="CheckedDisabled">
+                                            <VisualState.Setters>
+                                                <Setter Target="ContentPresenter.Background" Value="{ThemeResource AccentFillColorDisabledBrush}" />
+                                                <Setter Target="ContentPresenter.BackgroundSizing" Value="OuterBorderEdge" />
+                                                <Setter Target="ContentPresenter.BorderBrush" Value="{ThemeResource ControlFillColorTransparentBrush}" />
+                                                <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource TextOnAccentFillColorDisabled}" />
+                                            </VisualState.Setters>
+                                        </VisualState>
+                                    </VisualStateGroup>
+                                </VisualStateManager.VisualStateGroups>
+                            </ContentPresenter>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
             <!--  Icons  -->
             <x:String x:Key="ArrowIconData">M12.001 2C17.5238 2 22.001 6.47715 22.001 12C22.001 17.5228 17.5238 22 12.001 22C6.47813 22 2.00098 17.5228 2.00098 12C2.00098 6.47715 6.47813 2 12.001 2ZM12.7813 7.46897L12.6972 7.39635C12.4362 7.2027 12.078 7.20031 11.8146 7.38918L11.7206 7.46897L11.648 7.55308C11.4544 7.81407 11.452 8.17229 11.6409 8.43568L11.7206 8.52963L14.4403 11.2493H7.75027L7.6485 11.2561C7.31571 11.3013 7.05227 11.5647 7.00712 11.8975L7.00027 11.9993L7.00712 12.1011C7.05227 12.4339 7.31571 12.6973 7.6485 12.7424L7.75027 12.7493H14.4403L11.72 15.4697L11.6474 15.5538C11.4295 15.8474 11.4536 16.264 11.7198 16.5303C11.9861 16.7967 12.4027 16.8209 12.6964 16.6032L12.7805 16.5306L16.782 12.5306L16.8547 12.4464C17.0484 12.1854 17.0508 11.8272 16.8619 11.5638L16.7821 11.4698L12.7813 7.46897L12.6972 7.39635L12.7813 7.46897Z</x:String>
         </ResourceDictionary>

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/KeyboardManagerEditorXAML/MainWindow.xaml
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/KeyboardManagerEditorXAML/MainWindow.xaml
@@ -25,13 +25,35 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <TitleBar x:Name="titleBar" Title="Keyboard Manager">
+        <TitleBar
+            x:Name="titleBar"
+            Title="Keyboard Manager"
+            IsTabStop="False">
             <TitleBar.IconSource>
                 <ImageIconSource ImageSource="/Assets/KeyboardManagerEditor/FluentIconsKeyboardManager.png" />
             </TitleBar.IconSource>
+            <TitleBar.Content>
+                <AutoSuggestBox
+                    x:Name="SearchBox"
+                    x:Uid="FilterSearchBox"
+                    MinWidth="286"
+                    MaxWidth="360"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Center"
+                    QueryIcon="Find"
+                    Text="{x:Bind MainPageContent.SearchText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                    <AutoSuggestBox.KeyboardAccelerators>
+                        <KeyboardAccelerator
+                            Key="F"
+                            Invoked="SearchBox_FindInvoked"
+                            Modifiers="Control" />
+                    </AutoSuggestBox.KeyboardAccelerators>
+                </AutoSuggestBox>
+            </TitleBar.Content>
         </TitleBar>
 
         <pages:MainPage
+            x:Name="MainPageContent"
             Grid.Row="1"
             HorizontalAlignment="Stretch"
             VerticalAlignment="Stretch" />

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/KeyboardManagerEditorXAML/MainWindow.xaml.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/KeyboardManagerEditorXAML/MainWindow.xaml.cs
@@ -60,5 +60,11 @@ namespace KeyboardManagerEditorUI
             this.Activated -= MainWindow_Activated;
             this.Closed -= MainWindow_Closed;
         }
+
+        private void SearchBox_FindInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
+        {
+            SearchBox.Focus(FocusState.Programmatic);
+            args.Handled = true;
+        }
     }
 }

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/MainPage.xaml
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/MainPage.xaml
@@ -68,6 +68,7 @@
             x:Key="StringVisibilityConverter"
             EmptyValue="Collapsed"
             NotEmptyValue="Visible" />
+        <tkconverters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
     </Page.Resources>
 
     <Grid>
@@ -96,6 +97,7 @@
             <Grid RowSpacing="16">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="48" />
+                    <RowDefinition Height="Auto" />
                     <RowDefinition Height="*" />
                 </Grid.RowDefinitions>
                 <Grid VerticalAlignment="Top">
@@ -109,8 +111,83 @@
                         </StackPanel>
                     </Button>
                 </Grid>
+
+                <!--  Search / filter / bulk-select bar  -->
+                <Grid Grid.Row="1" Visibility="{x:Bind HasAnyData, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <ScrollViewer
+                        HorizontalScrollBarVisibility="Auto"
+                        HorizontalScrollMode="Auto"
+                        VerticalScrollMode="Disabled">
+                        <StackPanel
+                            Orientation="Horizontal"
+                            Spacing="8"
+                            VerticalAlignment="Center">
+                            <AutoSuggestBox
+                                x:Name="SearchBox"
+                                x:Uid="FilterSearchBox"
+                                MinWidth="220"
+                                VerticalAlignment="Center"
+                                QueryIcon="Find"
+                                TextChanged="SearchBox_TextChanged" />
+                            <ToggleButton
+                                x:Name="WinFilterToggle"
+                                x:Uid="FilterWinToggle"
+                                Checked="ModifierFilter_Changed"
+                                Unchecked="ModifierFilter_Changed" />
+                            <ToggleButton
+                                x:Name="CtrlFilterToggle"
+                                x:Uid="FilterCtrlToggle"
+                                Checked="ModifierFilter_Changed"
+                                Unchecked="ModifierFilter_Changed" />
+                            <ToggleButton
+                                x:Name="AltFilterToggle"
+                                x:Uid="FilterAltToggle"
+                                Checked="ModifierFilter_Changed"
+                                Unchecked="ModifierFilter_Changed" />
+                            <ToggleButton
+                                x:Name="ShiftFilterToggle"
+                                x:Uid="FilterShiftToggle"
+                                Checked="ModifierFilter_Changed"
+                                Unchecked="ModifierFilter_Changed" />
+                            <ComboBox
+                                x:Name="AppFilterCombo"
+                                MinWidth="150"
+                                VerticalAlignment="Center"
+                                ItemsSource="{x:Bind AppFilterOptions}"
+                                SelectedIndex="0"
+                                SelectionChanged="AppFilterCombo_SelectionChanged" />
+                            <Button
+                                x:Name="ClearFiltersBtn"
+                                x:Uid="FilterClearBtn"
+                                Click="ClearFilters_Click" />
+                        </StackPanel>
+                    </ScrollViewer>
+                    <StackPanel
+                        Grid.Column="1"
+                        Margin="8,0,0,0"
+                        Orientation="Horizontal"
+                        Spacing="8"
+                        VerticalAlignment="Center">
+                        <ToggleButton
+                            x:Name="SelectionModeToggle"
+                            x:Uid="SelectModeToggle"
+                            Click="SelectionModeToggle_Click" />
+                        <Button
+                            x:Name="DeleteSelectedBtn"
+                            Click="DeleteSelectedBtn_Click"
+                            Content="{x:Bind DeleteSelectedLabel, Mode=OneWay}"
+                            IsEnabled="{x:Bind HasSelection, Mode=OneWay}"
+                            Style="{StaticResource AccentButtonStyle}"
+                            Visibility="{x:Bind IsSelectionMode, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
+                    </StackPanel>
+                </Grid>
+
                 <Grid
-                    Grid.Row="1"
+                    Grid.Row="2"
                     Background="{ThemeResource LayerFillColorDefaultBrush}"
                     BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                     BorderThickness="1"
@@ -162,11 +239,13 @@
                                                 HorizontalAlignment="Stretch"
                                                 Fill="{ThemeResource CardStrokeColorDefaultBrush}" />
                                             <ListView
-                                                IsItemClickEnabled="True"
+                                                x:Name="RemappingsListView"
+                                                IsItemClickEnabled="{x:Bind IsNotSelectionMode, Mode=OneWay}"
                                                 ItemClick="RemappingsList_ItemClick"
                                                 ItemsSource="{x:Bind RemappingList}"
                                                 ScrollViewer.VerticalScrollMode="Disabled"
-                                                SelectionMode="None">
+                                                SelectionChanged="MappingList_SelectionChanged"
+                                                SelectionMode="{x:Bind ListSelectionMode, Mode=OneWay}">
                                                 <ListView.ItemTemplate>
                                                     <DataTemplate x:DataType="helper:Remapping">
                                                         <Grid MinHeight="48" Padding="0,8,0,8">
@@ -257,11 +336,13 @@
                                                 HorizontalAlignment="Stretch"
                                                 Fill="{ThemeResource CardStrokeColorDefaultBrush}" />
                                             <ListView
-                                                IsItemClickEnabled="True"
+                                                x:Name="TextListView"
+                                                IsItemClickEnabled="{x:Bind IsNotSelectionMode, Mode=OneWay}"
                                                 ItemClick="TextMappingsList_ItemClick"
                                                 ItemsSource="{x:Bind TextMappings}"
                                                 ScrollViewer.VerticalScrollMode="Disabled"
-                                                SelectionMode="None">
+                                                SelectionChanged="MappingList_SelectionChanged"
+                                                SelectionMode="{x:Bind ListSelectionMode, Mode=OneWay}">
                                                 <ListView.ItemTemplate>
                                                     <DataTemplate x:DataType="helper:TextMapping">
                                                         <Grid MinHeight="48" Padding="0,8,0,8">
@@ -346,11 +427,13 @@
                                                 Fill="{ThemeResource CardStrokeColorDefaultBrush}" />
 
                                             <ListView
-                                                IsItemClickEnabled="True"
+                                                x:Name="ProgramsListView"
+                                                IsItemClickEnabled="{x:Bind IsNotSelectionMode, Mode=OneWay}"
                                                 ItemClick="ProgramShortcutsList_ItemClick"
                                                 ItemsSource="{x:Bind ProgramShortcuts}"
                                                 ScrollViewer.VerticalScrollMode="Disabled"
-                                                SelectionMode="None">
+                                                SelectionChanged="MappingList_SelectionChanged"
+                                                SelectionMode="{x:Bind ListSelectionMode, Mode=OneWay}">
                                                 <ListView.ItemTemplate>
                                                     <DataTemplate x:DataType="helper:ProgramShortcut">
                                                         <Grid MinHeight="48" Padding="0,8,0,8">
@@ -463,11 +546,13 @@
                                                 HorizontalAlignment="Stretch"
                                                 Fill="{ThemeResource CardStrokeColorDefaultBrush}" />
                                             <ListView
-                                                IsItemClickEnabled="True"
+                                                x:Name="UrlsListView"
+                                                IsItemClickEnabled="{x:Bind IsNotSelectionMode, Mode=OneWay}"
                                                 ItemClick="UrlShortcutsList_ItemClick"
                                                 ItemsSource="{x:Bind UrlShortcuts}"
                                                 ScrollViewer.VerticalScrollMode="Disabled"
-                                                SelectionMode="None">
+                                                SelectionChanged="MappingList_SelectionChanged"
+                                                SelectionMode="{x:Bind ListSelectionMode, Mode=OneWay}">
                                                 <ListView.ItemTemplate>
                                                     <DataTemplate x:DataType="helper:URLShortcut">
                                                         <Grid MinHeight="48" Padding="0,8,0,8">
@@ -551,11 +636,13 @@
                                                 HorizontalAlignment="Stretch"
                                                 Fill="{ThemeResource CardStrokeColorDefaultBrush}" />
                                             <ListView
-                                                IsItemClickEnabled="True"
+                                                x:Name="DisabledListView"
+                                                IsItemClickEnabled="{x:Bind IsNotSelectionMode, Mode=OneWay}"
                                                 ItemClick="DisabledList_ItemClick"
                                                 ItemsSource="{x:Bind DisabledList}"
                                                 ScrollViewer.VerticalScrollMode="Disabled"
-                                                SelectionMode="None">
+                                                SelectionChanged="MappingList_SelectionChanged"
+                                                SelectionMode="{x:Bind ListSelectionMode, Mode=OneWay}">
                                                 <ListView.ItemTemplate>
                                                     <DataTemplate x:DataType="helper:Remapping">
                                                         <Grid MinHeight="48" Padding="0,8,0,8">
@@ -612,6 +699,33 @@
                                 </Grid>
                             </ScrollViewer>
                         </tkcontrols:Case>
+                        <tkcontrols:Case Value="NoResults">
+                            <StackPanel
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Center"
+                                Spacing="8">
+                                <FontIcon
+                                    HorizontalAlignment="Center"
+                                    FontSize="24"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    Glyph="&#xE721;" />
+                                <TextBlock
+                                    x:Uid="NoResultsTitle"
+                                    HorizontalAlignment="Center"
+                                    TextAlignment="Center" />
+                                <TextBlock
+                                    x:Uid="NoResultsDescription"
+                                    HorizontalAlignment="Center"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    Style="{StaticResource CaptionTextBlockStyle}"
+                                    TextAlignment="Center" />
+                                <Button
+                                    x:Uid="NoResultsClearBtn"
+                                    Margin="0,8,0,0"
+                                    HorizontalAlignment="Center"
+                                    Click="ClearFilters_Click" />
+                            </StackPanel>
+                        </tkcontrols:Case>
                     </tkcontrols:SwitchPresenter>
                 </Grid>
 
@@ -636,6 +750,14 @@
                     x:Uid="DeleteConfirmationDialog"
                     DefaultButton="Primary">
                     <TextBlock x:Uid="DeleteConfirmationDialogContent" TextWrapping="Wrap" />
+                </ContentDialog>
+
+                <!--  Confirmation Dialog for bulk delete  -->
+                <ContentDialog
+                    x:Name="BulkDeleteConfirmationDialog"
+                    x:Uid="BulkDeleteConfirmationDialog"
+                    DefaultButton="Close">
+                    <TextBlock x:Name="BulkDeleteConfirmationText" TextWrapping="Wrap" />
                 </ContentDialog>
             </Grid>
         </ContentControl>

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/MainPage.xaml
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/MainPage.xaml
@@ -100,7 +100,7 @@
                     <RowDefinition Height="*" />
                 </Grid.RowDefinitions>
 
-                <!--  Add remapping (always visible) + search / filter / bulk-select bar  -->
+                <!--  Add remapping (always visible) + filter / bulk-select toolbar  -->
                 <Grid Grid.Row="0">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto" />
@@ -124,75 +124,121 @@
                             <TextBlock x:Uid="NewRemappingBtn_Text" VerticalAlignment="Center" />
                         </StackPanel>
                     </Button>
-                    <ScrollViewer
-                        Grid.Column="1"
-                        HorizontalScrollBarVisibility="Auto"
-                        HorizontalScrollMode="Auto"
-                        VerticalScrollMode="Disabled"
-                        Visibility="{x:Bind HasAnyData, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
-                        <StackPanel
-                            VerticalAlignment="Center"
-                            Orientation="Horizontal"
-                            Spacing="8">
-                            <AutoSuggestBox
-                                x:Name="SearchBox"
-                                x:Uid="FilterSearchBox"
-                                MinWidth="220"
-                                VerticalAlignment="Center"
-                                QueryIcon="Find"
-                                TextChanged="SearchBox_TextChanged" />
-                            <ToggleButton
-                                x:Name="WinFilterToggle"
-                                x:Uid="FilterWinToggle"
-                                Checked="ModifierFilter_Changed"
-                                Unchecked="ModifierFilter_Changed" />
-                            <ToggleButton
-                                x:Name="CtrlFilterToggle"
-                                x:Uid="FilterCtrlToggle"
-                                Checked="ModifierFilter_Changed"
-                                Unchecked="ModifierFilter_Changed" />
-                            <ToggleButton
-                                x:Name="AltFilterToggle"
-                                x:Uid="FilterAltToggle"
-                                Checked="ModifierFilter_Changed"
-                                Unchecked="ModifierFilter_Changed" />
-                            <ToggleButton
-                                x:Name="ShiftFilterToggle"
-                                x:Uid="FilterShiftToggle"
-                                Checked="ModifierFilter_Changed"
-                                Unchecked="ModifierFilter_Changed" />
-                            <ComboBox
-                                x:Name="AppFilterCombo"
-                                MinWidth="150"
-                                VerticalAlignment="Center"
-                                ItemsSource="{x:Bind AppFilterOptions}"
-                                SelectedIndex="0"
-                                SelectionChanged="AppFilterCombo_SelectionChanged" />
-                            <Button
-                                x:Name="ClearFiltersBtn"
-                                x:Uid="FilterClearBtn"
-                                Click="ClearFilters_Click" />
-                        </StackPanel>
-                    </ScrollViewer>
                     <StackPanel
                         Grid.Column="2"
-                        Margin="8,0,0,0"
                         VerticalAlignment="Center"
                         Orientation="Horizontal"
                         Spacing="8"
                         Visibility="{x:Bind HasAnyData, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
-                        <ToggleButton
-                            x:Name="SelectionModeToggle"
-                            Click="SelectionModeToggle_Click"
-                            Content="{x:Bind SelectModeLabel, Mode=OneWay}"
-                            ToolTipService.ToolTip="{x:Bind SelectModeTooltip, Mode=OneWay}" />
+                        <Button
+                            x:Name="FilterButton"
+                            x:Uid="FilterButton"
+                            Width="36"
+                            Height="32"
+                            Padding="0"
+                            Style="{StaticResource SubtleButtonStyle}">
+                            <FontIcon FontSize="16" Glyph="&#xE71C;" />
+                            <Button.Flyout>
+                                <Flyout Placement="BottomEdgeAlignedRight">
+                                    <StackPanel
+                                        MinWidth="260"
+                                        Padding="4"
+                                        Spacing="16">
+                                        <StackPanel Spacing="8">
+                                            <TextBlock
+                                                x:Uid="FilterModifiersHeader"
+                                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                Style="{StaticResource CaptionTextBlockStyle}" />
+                                            <StackPanel Orientation="Horizontal" Spacing="8">
+                                                <ToggleButton
+                                                    x:Name="WinFilterToggle"
+                                                    x:Uid="FilterWinToggle"
+                                                    Checked="ModifierFilter_Changed"
+                                                    Style="{StaticResource SubtleToggleButtonStyle}"
+                                                    Unchecked="ModifierFilter_Changed" />
+                                                <ToggleButton
+                                                    x:Name="CtrlFilterToggle"
+                                                    x:Uid="FilterCtrlToggle"
+                                                    Checked="ModifierFilter_Changed"
+                                                    Style="{StaticResource SubtleToggleButtonStyle}"
+                                                    Unchecked="ModifierFilter_Changed" />
+                                                <ToggleButton
+                                                    x:Name="AltFilterToggle"
+                                                    x:Uid="FilterAltToggle"
+                                                    Checked="ModifierFilter_Changed"
+                                                    Style="{StaticResource SubtleToggleButtonStyle}"
+                                                    Unchecked="ModifierFilter_Changed" />
+                                                <ToggleButton
+                                                    x:Name="ShiftFilterToggle"
+                                                    x:Uid="FilterShiftToggle"
+                                                    Checked="ModifierFilter_Changed"
+                                                    Style="{StaticResource SubtleToggleButtonStyle}"
+                                                    Unchecked="ModifierFilter_Changed" />
+                                            </StackPanel>
+                                        </StackPanel>
+                                        <StackPanel Spacing="8">
+                                            <TextBlock
+                                                x:Uid="FilterApplicationsHeader"
+                                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                Style="{StaticResource CaptionTextBlockStyle}" />
+                                            <ComboBox
+                                                x:Name="AppFilterCombo"
+                                                HorizontalAlignment="Stretch"
+                                                ItemsSource="{x:Bind AppFilterOptions}"
+                                                SelectedIndex="0"
+                                                SelectionChanged="AppFilterCombo_SelectionChanged" />
+                                        </StackPanel>
+                                        <Button
+                                            x:Name="ClearFiltersBtn"
+                                            x:Uid="FilterClearBtn"
+                                            HorizontalAlignment="Right"
+                                            Click="ClearFilters_Click"
+                                            Style="{StaticResource SubtleButtonStyle}" />
+                                    </StackPanel>
+                                </Flyout>
+                            </Button.Flyout>
+                        </Button>
+                        <Rectangle
+                            Width="1"
+                            Height="20"
+                            Margin="4,0"
+                            VerticalAlignment="Center"
+                            Fill="{ThemeResource DividerStrokeColorDefaultBrush}" />
                         <Button
                             x:Name="DeleteSelectedBtn"
+                            MinWidth="0"
+                            Padding="10,0"
+                            AutomationProperties.Name="{x:Bind DeleteSelectedLabel, Mode=OneWay}"
                             Click="DeleteSelectedBtn_Click"
-                            Content="{x:Bind DeleteSelectedLabel, Mode=OneWay}"
                             IsEnabled="{x:Bind HasSelection, Mode=OneWay}"
-                            Style="{StaticResource AccentButtonStyle}"
-                            Visibility="{x:Bind IsSelectionMode, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
+                            Style="{StaticResource SubtleButtonStyle}"
+                            ToolTipService.ToolTip="{x:Bind DeleteSelectedLabel, Mode=OneWay}"
+                            Visibility="{x:Bind IsSelectionMode, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
+                            <StackPanel Orientation="Horizontal" Spacing="10">
+                                <FontIcon FontSize="16" Glyph="&#xE74D;" />
+                                <TextBlock VerticalAlignment="Center" Text="{x:Bind SelectedCount, Mode=OneWay}" />
+                            </StackPanel>
+                        </Button>
+                        <Button
+                            x:Name="SelectionModeButton"
+                            Width="36"
+                            Height="32"
+                            Padding="0"
+                            AutomationProperties.Name="{x:Bind SelectModeLabel, Mode=OneWay}"
+                            Click="SelectionModeButton_Click"
+                            Style="{StaticResource SubtleButtonStyle}"
+                            ToolTipService.ToolTip="{x:Bind SelectModeTooltip, Mode=OneWay}">
+                            <Grid>
+                                <FontIcon
+                                    FontSize="16"
+                                    Glyph="&#xE762;"
+                                    Visibility="{x:Bind IsNotSelectionMode, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
+                                <FontIcon
+                                    FontSize="16"
+                                    Glyph="&#xE711;"
+                                    Visibility="{x:Bind IsSelectionMode, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
+                            </Grid>
+                        </Button>
                     </StackPanel>
                 </Grid>
 
@@ -778,6 +824,7 @@
                 <ContentDialog
                     x:Name="RemappingDialog"
                     x:Uid="RemappingDialog"
+                    Grid.Row="1"
                     Width="760"
                     MinWidth="800"
                     MinHeight="500"
@@ -792,6 +839,7 @@
                 <ContentDialog
                     x:Name="DeleteConfirmationDialog"
                     x:Uid="DeleteConfirmationDialog"
+                    Grid.Row="1"
                     DefaultButton="Primary">
                     <TextBlock x:Uid="DeleteConfirmationDialogContent" TextWrapping="Wrap" />
                 </ContentDialog>
@@ -800,6 +848,7 @@
                 <ContentDialog
                     x:Name="BulkDeleteConfirmationDialog"
                     x:Uid="BulkDeleteConfirmationDialog"
+                    Grid.Row="1"
                     DefaultButton="Close">
                     <TextBlock x:Name="BulkDeleteConfirmationText" TextWrapping="Wrap" />
                 </ContentDialog>

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/MainPage.xaml
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/MainPage.xaml
@@ -97,6 +97,7 @@
             <Grid RowSpacing="16">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="48" />
+                    <RowDefinition Height="Auto" />
                     <RowDefinition Height="*" />
                 </Grid.RowDefinitions>
                 <Grid VerticalAlignment="Top">
@@ -110,8 +111,83 @@
                         </StackPanel>
                     </Button>
                 </Grid>
+
+                <!--  Search / filter / bulk-select bar  -->
+                <Grid Grid.Row="1" Visibility="{x:Bind HasAnyData, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <ScrollViewer
+                        HorizontalScrollBarVisibility="Auto"
+                        HorizontalScrollMode="Auto"
+                        VerticalScrollMode="Disabled">
+                        <StackPanel
+                            Orientation="Horizontal"
+                            Spacing="8"
+                            VerticalAlignment="Center">
+                            <AutoSuggestBox
+                                x:Name="SearchBox"
+                                x:Uid="FilterSearchBox"
+                                MinWidth="220"
+                                VerticalAlignment="Center"
+                                QueryIcon="Find"
+                                TextChanged="SearchBox_TextChanged" />
+                            <ToggleButton
+                                x:Name="WinFilterToggle"
+                                x:Uid="FilterWinToggle"
+                                Checked="ModifierFilter_Changed"
+                                Unchecked="ModifierFilter_Changed" />
+                            <ToggleButton
+                                x:Name="CtrlFilterToggle"
+                                x:Uid="FilterCtrlToggle"
+                                Checked="ModifierFilter_Changed"
+                                Unchecked="ModifierFilter_Changed" />
+                            <ToggleButton
+                                x:Name="AltFilterToggle"
+                                x:Uid="FilterAltToggle"
+                                Checked="ModifierFilter_Changed"
+                                Unchecked="ModifierFilter_Changed" />
+                            <ToggleButton
+                                x:Name="ShiftFilterToggle"
+                                x:Uid="FilterShiftToggle"
+                                Checked="ModifierFilter_Changed"
+                                Unchecked="ModifierFilter_Changed" />
+                            <ComboBox
+                                x:Name="AppFilterCombo"
+                                MinWidth="150"
+                                VerticalAlignment="Center"
+                                ItemsSource="{x:Bind AppFilterOptions}"
+                                SelectedIndex="0"
+                                SelectionChanged="AppFilterCombo_SelectionChanged" />
+                            <Button
+                                x:Name="ClearFiltersBtn"
+                                x:Uid="FilterClearBtn"
+                                Click="ClearFilters_Click" />
+                        </StackPanel>
+                    </ScrollViewer>
+                    <StackPanel
+                        Grid.Column="1"
+                        Margin="8,0,0,0"
+                        Orientation="Horizontal"
+                        Spacing="8"
+                        VerticalAlignment="Center">
+                        <ToggleButton
+                            x:Name="SelectionModeToggle"
+                            x:Uid="SelectModeToggle"
+                            Click="SelectionModeToggle_Click" />
+                        <Button
+                            x:Name="DeleteSelectedBtn"
+                            Click="DeleteSelectedBtn_Click"
+                            Content="{x:Bind DeleteSelectedLabel, Mode=OneWay}"
+                            IsEnabled="{x:Bind HasSelection, Mode=OneWay}"
+                            Style="{StaticResource AccentButtonStyle}"
+                            Visibility="{x:Bind IsSelectionMode, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
+                    </StackPanel>
+                </Grid>
+
                 <Grid
-                    Grid.Row="1"
+                    Grid.Row="2"
                     Background="{ThemeResource LayerFillColorDefaultBrush}"
                     BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                     BorderThickness="1"
@@ -163,11 +239,13 @@
                                                 HorizontalAlignment="Stretch"
                                                 Fill="{ThemeResource CardStrokeColorDefaultBrush}" />
                                             <ListView
-                                                IsItemClickEnabled="True"
+                                                x:Name="RemappingsListView"
+                                                IsItemClickEnabled="{x:Bind IsNotSelectionMode, Mode=OneWay}"
                                                 ItemClick="RemappingsList_ItemClick"
                                                 ItemsSource="{x:Bind RemappingList}"
                                                 ScrollViewer.VerticalScrollMode="Disabled"
-                                                SelectionMode="None">
+                                                SelectionChanged="MappingList_SelectionChanged"
+                                                SelectionMode="{x:Bind ListSelectionMode, Mode=OneWay}">
                                                 <ListView.ItemTemplate>
                                                     <DataTemplate x:DataType="helper:Remapping">
                                                         <Grid MinHeight="48" Padding="0,8,0,8">
@@ -272,11 +350,13 @@
                                                 HorizontalAlignment="Stretch"
                                                 Fill="{ThemeResource CardStrokeColorDefaultBrush}" />
                                             <ListView
-                                                IsItemClickEnabled="True"
+                                                x:Name="TextListView"
+                                                IsItemClickEnabled="{x:Bind IsNotSelectionMode, Mode=OneWay}"
                                                 ItemClick="TextMappingsList_ItemClick"
                                                 ItemsSource="{x:Bind TextMappings}"
                                                 ScrollViewer.VerticalScrollMode="Disabled"
-                                                SelectionMode="None">
+                                                SelectionChanged="MappingList_SelectionChanged"
+                                                SelectionMode="{x:Bind ListSelectionMode, Mode=OneWay}">
                                                 <ListView.ItemTemplate>
                                                     <DataTemplate x:DataType="helper:TextMapping">
                                                         <Grid MinHeight="48" Padding="0,8,0,8">
@@ -363,11 +443,13 @@
                                                 Fill="{ThemeResource CardStrokeColorDefaultBrush}" />
 
                                             <ListView
-                                                IsItemClickEnabled="True"
+                                                x:Name="ProgramsListView"
+                                                IsItemClickEnabled="{x:Bind IsNotSelectionMode, Mode=OneWay}"
                                                 ItemClick="ProgramShortcutsList_ItemClick"
                                                 ItemsSource="{x:Bind ProgramShortcuts}"
                                                 ScrollViewer.VerticalScrollMode="Disabled"
-                                                SelectionMode="None">
+                                                SelectionChanged="MappingList_SelectionChanged"
+                                                SelectionMode="{x:Bind ListSelectionMode, Mode=OneWay}">
                                                 <ListView.ItemTemplate>
                                                     <DataTemplate x:DataType="helper:ProgramShortcut">
                                                         <Grid MinHeight="48" Padding="0,8,0,8">
@@ -482,11 +564,13 @@
                                                 HorizontalAlignment="Stretch"
                                                 Fill="{ThemeResource CardStrokeColorDefaultBrush}" />
                                             <ListView
-                                                IsItemClickEnabled="True"
+                                                x:Name="UrlsListView"
+                                                IsItemClickEnabled="{x:Bind IsNotSelectionMode, Mode=OneWay}"
                                                 ItemClick="UrlShortcutsList_ItemClick"
                                                 ItemsSource="{x:Bind UrlShortcuts}"
                                                 ScrollViewer.VerticalScrollMode="Disabled"
-                                                SelectionMode="None">
+                                                SelectionChanged="MappingList_SelectionChanged"
+                                                SelectionMode="{x:Bind ListSelectionMode, Mode=OneWay}">
                                                 <ListView.ItemTemplate>
                                                     <DataTemplate x:DataType="helper:URLShortcut">
                                                         <Grid MinHeight="48" Padding="0,8,0,8">
@@ -572,11 +656,13 @@
                                                 HorizontalAlignment="Stretch"
                                                 Fill="{ThemeResource CardStrokeColorDefaultBrush}" />
                                             <ListView
-                                                IsItemClickEnabled="True"
+                                                x:Name="DisabledListView"
+                                                IsItemClickEnabled="{x:Bind IsNotSelectionMode, Mode=OneWay}"
                                                 ItemClick="DisabledList_ItemClick"
                                                 ItemsSource="{x:Bind DisabledList}"
                                                 ScrollViewer.VerticalScrollMode="Disabled"
-                                                SelectionMode="None">
+                                                SelectionChanged="MappingList_SelectionChanged"
+                                                SelectionMode="{x:Bind ListSelectionMode, Mode=OneWay}">
                                                 <ListView.ItemTemplate>
                                                     <DataTemplate x:DataType="helper:Remapping">
                                                         <Grid MinHeight="48" Padding="0,8,0,8">
@@ -647,6 +733,33 @@
                                 </Grid>
                             </ScrollViewer>
                         </tkcontrols:Case>
+                        <tkcontrols:Case Value="NoResults">
+                            <StackPanel
+                                HorizontalAlignment="Center"
+                                VerticalAlignment="Center"
+                                Spacing="8">
+                                <FontIcon
+                                    HorizontalAlignment="Center"
+                                    FontSize="24"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    Glyph="&#xE721;" />
+                                <TextBlock
+                                    x:Uid="NoResultsTitle"
+                                    HorizontalAlignment="Center"
+                                    TextAlignment="Center" />
+                                <TextBlock
+                                    x:Uid="NoResultsDescription"
+                                    HorizontalAlignment="Center"
+                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                    Style="{StaticResource CaptionTextBlockStyle}"
+                                    TextAlignment="Center" />
+                                <Button
+                                    x:Uid="NoResultsClearBtn"
+                                    Margin="0,8,0,0"
+                                    HorizontalAlignment="Center"
+                                    Click="ClearFilters_Click" />
+                            </StackPanel>
+                        </tkcontrols:Case>
                     </tkcontrols:SwitchPresenter>
                 </Grid>
 
@@ -671,6 +784,14 @@
                     x:Uid="DeleteConfirmationDialog"
                     DefaultButton="Primary">
                     <TextBlock x:Uid="DeleteConfirmationDialogContent" TextWrapping="Wrap" />
+                </ContentDialog>
+
+                <!--  Confirmation Dialog for bulk delete  -->
+                <ContentDialog
+                    x:Name="BulkDeleteConfirmationDialog"
+                    x:Uid="BulkDeleteConfirmationDialog"
+                    DefaultButton="Close">
+                    <TextBlock x:Name="BulkDeleteConfirmationText" TextWrapping="Wrap" />
                 </ContentDialog>
             </Grid>
         </ContentControl>

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/MainPage.xaml
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/MainPage.xaml
@@ -107,9 +107,11 @@
                         <ColumnDefinition Width="*" />
                         <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
-                    <!--  "Add new remapping" is a list-level action, so it sits at the leading edge of the list
-                          toolbar (aligned with the list below). Kept outside the HasAnyData filter cluster so the
-                          first remapping can still be added from the empty state.  -->
+                    <!--
+                        "Add new remapping" is a list-level action, so it sits at the leading edge of the list
+                        toolbar (aligned with the list below). Kept outside the HasAnyData filter cluster so the
+                        first remapping can still be added from the empty state.
+                    -->
                     <Button
                         x:Name="NewRemappingBtn"
                         Grid.Column="0"
@@ -129,9 +131,9 @@
                         VerticalScrollMode="Disabled"
                         Visibility="{x:Bind HasAnyData, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
                         <StackPanel
+                            VerticalAlignment="Center"
                             Orientation="Horizontal"
-                            Spacing="8"
-                            VerticalAlignment="Center">
+                            Spacing="8">
                             <AutoSuggestBox
                                 x:Name="SearchBox"
                                 x:Uid="FilterSearchBox"
@@ -175,9 +177,9 @@
                     <StackPanel
                         Grid.Column="2"
                         Margin="8,0,0,0"
+                        VerticalAlignment="Center"
                         Orientation="Horizontal"
                         Spacing="8"
-                        VerticalAlignment="Center"
                         Visibility="{x:Bind HasAnyData, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
                         <ToggleButton
                             x:Name="SelectionModeToggle"

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/MainPage.xaml
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/MainPage.xaml
@@ -96,32 +96,38 @@
             VerticalContentAlignment="Stretch">
             <Grid RowSpacing="16">
                 <Grid.RowDefinitions>
-                    <RowDefinition Height="48" />
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="*" />
                 </Grid.RowDefinitions>
-                <Grid VerticalAlignment="Top">
+
+                <!--  Add remapping (always visible) + search / filter / bulk-select bar  -->
+                <Grid Grid.Row="0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <!--  "Add new remapping" is a list-level action, so it sits at the leading edge of the list
+                          toolbar (aligned with the list below). Kept outside the HasAnyData filter cluster so the
+                          first remapping can still be added from the empty state.  -->
                     <Button
                         x:Name="NewRemappingBtn"
-                        VerticalAlignment="Top"
-                        Click="NewRemappingBtn_Click">
+                        Grid.Column="0"
+                        Margin="0,0,8,0"
+                        VerticalAlignment="Center"
+                        Click="NewRemappingBtn_Click"
+                        Style="{StaticResource AccentButtonStyle}">
                         <StackPanel Orientation="Horizontal" Spacing="8">
                             <FontIcon FontSize="14" Glyph="&#xE710;" />
                             <TextBlock x:Uid="NewRemappingBtn_Text" VerticalAlignment="Center" />
                         </StackPanel>
                     </Button>
-                </Grid>
-
-                <!--  Search / filter / bulk-select bar  -->
-                <Grid Grid.Row="1" Visibility="{x:Bind HasAnyData, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*" />
-                        <ColumnDefinition Width="Auto" />
-                    </Grid.ColumnDefinitions>
                     <ScrollViewer
+                        Grid.Column="1"
                         HorizontalScrollBarVisibility="Auto"
                         HorizontalScrollMode="Auto"
-                        VerticalScrollMode="Disabled">
+                        VerticalScrollMode="Disabled"
+                        Visibility="{x:Bind HasAnyData, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
                         <StackPanel
                             Orientation="Horizontal"
                             Spacing="8"
@@ -167,11 +173,12 @@
                         </StackPanel>
                     </ScrollViewer>
                     <StackPanel
-                        Grid.Column="1"
+                        Grid.Column="2"
                         Margin="8,0,0,0"
                         Orientation="Horizontal"
                         Spacing="8"
-                        VerticalAlignment="Center">
+                        VerticalAlignment="Center"
+                        Visibility="{x:Bind HasAnyData, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
                         <ToggleButton
                             x:Name="SelectionModeToggle"
                             x:Uid="SelectModeToggle"
@@ -187,7 +194,7 @@
                 </Grid>
 
                 <Grid
-                    Grid.Row="2"
+                    Grid.Row="1"
                     Background="{ThemeResource LayerFillColorDefaultBrush}"
                     BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                     BorderThickness="1"

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/MainPage.xaml
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/MainPage.xaml
@@ -181,8 +181,9 @@
                         Visibility="{x:Bind HasAnyData, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
                         <ToggleButton
                             x:Name="SelectionModeToggle"
-                            x:Uid="SelectModeToggle"
-                            Click="SelectionModeToggle_Click" />
+                            Click="SelectionModeToggle_Click"
+                            Content="{x:Bind SelectModeLabel, Mode=OneWay}"
+                            ToolTipService.ToolTip="{x:Bind SelectModeTooltip, Mode=OneWay}" />
                         <Button
                             x:Name="DeleteSelectedBtn"
                             Click="DeleteSelectedBtn_Click"

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/MainPage.xaml.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/MainPage.xaml.cs
@@ -71,6 +71,8 @@ namespace KeyboardManagerEditorUI.Pages
             }
         }
 
+        // Bound collections hold the CURRENTLY VISIBLE (filtered) rows. The full set lives in the
+        // backing lists below; ApplyFilter() rebuilds the bound collections from them.
         public ObservableCollection<Remapping> RemappingList { get; } = new();
 
         public ObservableCollection<Remapping> DisabledList { get; } = new();
@@ -80,6 +82,106 @@ namespace KeyboardManagerEditorUI.Pages
         public ObservableCollection<ProgramShortcut> ProgramShortcuts { get; } = new();
 
         public ObservableCollection<URLShortcut> UrlShortcuts { get; } = new();
+
+        // Backing (unfiltered) source lists. The bound collections above are views onto these.
+        private readonly List<Remapping> _allRemappings = new();
+        private readonly List<Remapping> _allDisabled = new();
+        private readonly List<TextMapping> _allTextMappings = new();
+        private readonly List<ProgramShortcut> _allProgramShortcuts = new();
+        private readonly List<URLShortcut> _allUrlShortcuts = new();
+
+        // Virtual-key codes for each modifier family (both generic and left/right specific).
+        private static readonly int[] _ctrlVkCodes = { 0x11, 0xA2, 0xA3 };
+        private static readonly int[] _altVkCodes = { 0x12, 0xA4, 0xA5 };
+        private static readonly int[] _shiftVkCodes = { 0x10, 0xA0, 0xA1 };
+        private static readonly int[] _winVkCodes = { 0x5B, 0x5C };
+
+        // Sentinel stored in _appFilter for the "Global only" option (item index 1 in the combo).
+        // Uses a control character so it can never collide with a real app name.
+        private const string GlobalOnlyToken = "global-only";
+
+        // Ephemeral (never persisted) filter state.
+        private string _searchText = string.Empty;
+        private bool _filterWin;
+        private bool _filterCtrl;
+        private bool _filterAlt;
+        private bool _filterShift;
+        private string? _appFilter; // null = all apps, GlobalOnlyToken = global only, else a specific app name.
+        private bool _suppressFilterEvents;
+
+        // Cached composite formats for the (localized) bulk-delete strings, parsed lazily on first use.
+        private CompositeFormat? _deleteSelectedFormat;
+        private CompositeFormat? _bulkDeleteConfirmationFormat;
+
+        // Options shown in the app-filter combo box: [All apps], [Global only], then each distinct app name.
+        public ObservableCollection<string> AppFilterOptions { get; } = new();
+
+        private bool _hasAnyData;
+        private bool _isSelectionMode;
+        private int _selectedCount;
+
+        // True when there is at least one remapping loaded (regardless of the active filter).
+        public bool HasAnyData
+        {
+            get => _hasAnyData;
+            private set
+            {
+                if (_hasAnyData != value)
+                {
+                    _hasAnyData = value;
+                    RaisePropertyChanged(nameof(HasAnyData));
+                }
+            }
+        }
+
+        // True while the user is multi-selecting rows for bulk deletion.
+        public bool IsSelectionMode
+        {
+            get => _isSelectionMode;
+            private set
+            {
+                if (_isSelectionMode != value)
+                {
+                    _isSelectionMode = value;
+                    RaisePropertyChanged(nameof(IsSelectionMode));
+                    RaisePropertyChanged(nameof(IsNotSelectionMode));
+                    RaisePropertyChanged(nameof(ListSelectionMode));
+                }
+            }
+        }
+
+        public bool IsNotSelectionMode => !_isSelectionMode;
+
+        public ListViewSelectionMode ListSelectionMode => _isSelectionMode ? ListViewSelectionMode.Multiple : ListViewSelectionMode.None;
+
+        // Number of rows selected across all sections while in selection mode.
+        public int SelectedCount
+        {
+            get => _selectedCount;
+            private set
+            {
+                if (_selectedCount != value)
+                {
+                    _selectedCount = value;
+                    RaisePropertyChanged(nameof(SelectedCount));
+                    RaisePropertyChanged(nameof(HasSelection));
+                    RaisePropertyChanged(nameof(DeleteSelectedLabel));
+                }
+            }
+        }
+
+        public bool HasSelection => _selectedCount > 0;
+
+        public string DeleteSelectedLabel
+        {
+            get
+            {
+                _deleteSelectedFormat ??= CompositeFormat.Parse(ResourceHelper.GetString("BulkDelete_SelectedFormat"));
+                return string.Format(CultureInfo.CurrentCulture, _deleteSelectedFormat, _selectedCount);
+            }
+        }
+
+        private void RaisePropertyChanged(string propertyName) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 
         [DllImport("PowerToys.KeyboardManagerEditorLibraryWrapper.dll", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
         private static extern void GetKeyDisplayName(int keyCode, [Out] StringBuilder keyName, int maxLength);
@@ -705,7 +807,8 @@ namespace KeyboardManagerEditorUI.Pages
                 {
                     case Remapping remapping:
                         HandleRemappingDelete(remapping);
-                        UpdateHasAnyMappings();
+                        RefreshAppFilterOptions();
+                        ApplyFilter();
                         break;
 
                     case IToggleableShortcut shortcut:
@@ -882,52 +985,59 @@ namespace KeyboardManagerEditorUI.Pages
             LoadTextMappings();
             LoadProgramShortcuts();
             LoadUrlShortcuts();
-            UpdateHasAnyMappings();
+            RefreshAppFilterOptions();
+            ApplyFilter();
         }
 
         private void UpdateHasAnyMappings()
         {
-            bool hasAny = RemappingList.Count > 0 || DisabledList.Count > 0 || TextMappings.Count > 0 || ProgramShortcuts.Count > 0 || UrlShortcuts.Count > 0;
-            MappingState = hasAny ? "HasMappings" : "Empty";
+            bool hasData = _allRemappings.Count > 0 || _allDisabled.Count > 0 || _allTextMappings.Count > 0 || _allProgramShortcuts.Count > 0 || _allUrlShortcuts.Count > 0;
+            bool hasVisible = RemappingList.Count > 0 || DisabledList.Count > 0 || TextMappings.Count > 0 || ProgramShortcuts.Count > 0 || UrlShortcuts.Count > 0;
+
+            HasAnyData = hasData;
+            MappingState = !hasData ? "Empty" : (hasVisible ? "HasMappings" : "NoResults");
         }
 
         private void LoadRemappings()
         {
             SettingsManager.EditorSettings.ShortcutsByOperationType.TryGetValue(ShortcutOperationType.RemapShortcut, out var remapShortcutIds);
 
+            _allRemappings.Clear();
+            _allDisabled.Clear();
+
             if (remapShortcutIds == null)
             {
                 return;
             }
-
-            RemappingList.Clear();
-            DisabledList.Clear();
 
             foreach (var id in remapShortcutIds)
             {
                 ShortcutSettings shortcutSettings = SettingsManager.EditorSettings.ShortcutSettingsDictionary[id];
                 ShortcutKeyMapping mapping = shortcutSettings.Shortcut;
                 var originalKeyNames = ParseKeyCodes(mapping.OriginalKeys);
+                var remappedKeyNames = ParseKeyCodes(mapping.TargetKeys);
 
                 bool isDisabled = mapping.TargetKeys == VkDisabledString;
 
                 var remapping = new Remapping
                 {
                     Shortcut = originalKeyNames,
-                    RemappedKeys = isDisabled ? new List<string>() : ParseKeyCodes(mapping.TargetKeys),
+                    RemappedKeys = isDisabled ? new List<string>() : remappedKeyNames,
                     IsAllApps = string.IsNullOrEmpty(mapping.TargetApp),
                     AppName = mapping.TargetApp ?? string.Empty,
                     Id = shortcutSettings.Id,
                     IsActive = shortcutSettings.IsActive,
+                    TriggerKeyCodes = ParseVkCodes(mapping.OriginalKeys),
+                    SearchableText = BuildSearchableText(originalKeyNames.Concat(isDisabled ? Enumerable.Empty<string>() : remappedKeyNames).Append(mapping.TargetApp ?? string.Empty)),
                 };
 
                 if (isDisabled)
                 {
-                    DisabledList.Add(remapping);
+                    _allDisabled.Add(remapping);
                 }
                 else
                 {
-                    RemappingList.Add(remapping);
+                    _allRemappings.Add(remapping);
                 }
             }
         }
@@ -936,12 +1046,12 @@ namespace KeyboardManagerEditorUI.Pages
         {
             SettingsManager.EditorSettings.ShortcutsByOperationType.TryGetValue(ShortcutOperationType.RemapText, out var remapShortcutIds);
 
+            _allTextMappings.Clear();
+
             if (remapShortcutIds == null)
             {
                 return;
             }
-
-            TextMappings.Clear();
 
             foreach (var id in remapShortcutIds)
             {
@@ -949,7 +1059,7 @@ namespace KeyboardManagerEditorUI.Pages
                 ShortcutKeyMapping mapping = shortcutSettings.Shortcut;
                 var originalKeyNames = ParseKeyCodes(mapping.OriginalKeys);
 
-                TextMappings.Add(new TextMapping
+                _allTextMappings.Add(new TextMapping
                 {
                     Shortcut = originalKeyNames,
                     Text = mapping.TargetText,
@@ -957,6 +1067,8 @@ namespace KeyboardManagerEditorUI.Pages
                     AppName = mapping.TargetApp ?? string.Empty,
                     Id = shortcutSettings.Id,
                     IsActive = shortcutSettings.IsActive,
+                    TriggerKeyCodes = ParseVkCodes(mapping.OriginalKeys),
+                    SearchableText = BuildSearchableText(originalKeyNames.Append(mapping.TargetText).Append(mapping.TargetApp ?? string.Empty)),
                 });
             }
         }
@@ -965,12 +1077,12 @@ namespace KeyboardManagerEditorUI.Pages
         {
             SettingsManager.EditorSettings.ShortcutsByOperationType.TryGetValue(ShortcutOperationType.RunProgram, out var remapShortcutIds);
 
+            _allProgramShortcuts.Clear();
+
             if (remapShortcutIds == null)
             {
                 return;
             }
-
-            ProgramShortcuts.Clear();
 
             foreach (var id in remapShortcutIds)
             {
@@ -978,7 +1090,7 @@ namespace KeyboardManagerEditorUI.Pages
                 ShortcutKeyMapping mapping = shortcutSettings.Shortcut;
                 var originalKeyNames = ParseKeyCodes(mapping.OriginalKeys);
 
-                ProgramShortcuts.Add(new ProgramShortcut
+                _allProgramShortcuts.Add(new ProgramShortcut
                 {
                     Shortcut = originalKeyNames,
                     AppToRun = mapping.ProgramPath,
@@ -991,6 +1103,8 @@ namespace KeyboardManagerEditorUI.Pages
                     Elevation = mapping.Elevation.ToString(),
                     IfRunningAction = mapping.IfRunningAction.ToString(),
                     Visibility = mapping.Visibility.ToString(),
+                    TriggerKeyCodes = ParseVkCodes(mapping.OriginalKeys),
+                    SearchableText = BuildSearchableText(originalKeyNames.Append(mapping.ProgramPath).Append(mapping.ProgramArgs).Append(mapping.TargetApp ?? string.Empty)),
                 });
             }
         }
@@ -999,12 +1113,12 @@ namespace KeyboardManagerEditorUI.Pages
         {
             SettingsManager.EditorSettings.ShortcutsByOperationType.TryGetValue(ShortcutOperationType.OpenUri, out var remapShortcutIds);
 
+            _allUrlShortcuts.Clear();
+
             if (remapShortcutIds == null)
             {
                 return;
             }
-
-            UrlShortcuts.Clear();
 
             foreach (var id in remapShortcutIds)
             {
@@ -1012,7 +1126,7 @@ namespace KeyboardManagerEditorUI.Pages
                 ShortcutKeyMapping mapping = shortcutSettings.Shortcut;
                 var originalKeyNames = ParseKeyCodes(mapping.OriginalKeys);
 
-                UrlShortcuts.Add(new URLShortcut
+                _allUrlShortcuts.Add(new URLShortcut
                 {
                     Shortcut = originalKeyNames,
                     URL = mapping.UriToOpen,
@@ -1020,6 +1134,8 @@ namespace KeyboardManagerEditorUI.Pages
                     IsActive = shortcutSettings.IsActive,
                     IsAllApps = string.IsNullOrEmpty(mapping.TargetApp),
                     AppName = mapping.TargetApp ?? string.Empty,
+                    TriggerKeyCodes = ParseVkCodes(mapping.OriginalKeys),
+                    SearchableText = BuildSearchableText(originalKeyNames.Append(mapping.UriToOpen).Append(mapping.TargetApp ?? string.Empty)),
                 });
             }
         }
@@ -1034,6 +1150,334 @@ namespace KeyboardManagerEditorUI.Pages
                     return _mappingService?.GetKeyDisplayName(code) ?? $"VK {code}";
                 })
                 .ToList();
+        }
+
+        // Parse the raw ";"-separated VK code string into integers (no display-name conversion),
+        // so modifier filtering can classify keys by code and stay locale-independent.
+        private static List<int> ParseVkCodes(string keyCodesString)
+        {
+            var codes = new List<int>();
+            foreach (var part in keyCodesString.Split(';'))
+            {
+                if (int.TryParse(part, NumberStyles.Integer, CultureInfo.InvariantCulture, out int code))
+                {
+                    codes.Add(code);
+                }
+            }
+
+            return codes;
+        }
+
+        // Combine a row's human-readable parts into a single lowercased string for text search.
+        private static string BuildSearchableText(IEnumerable<string> parts)
+        {
+            var sb = new StringBuilder();
+            foreach (var part in parts)
+            {
+                if (string.IsNullOrEmpty(part))
+                {
+                    continue;
+                }
+
+                if (sb.Length > 0)
+                {
+                    sb.Append(' ');
+                }
+
+                sb.Append(part);
+            }
+
+            return sb.ToString().ToLowerInvariant();
+        }
+
+        #endregion
+
+        #region Filter and Selection
+
+        // Rebuilds the five bound (visible) collections from their backing lists using the active filters.
+        private void ApplyFilter()
+        {
+            RebuildView(_allRemappings, RemappingList);
+            RebuildView(_allDisabled, DisabledList);
+            RebuildView(_allTextMappings, TextMappings);
+            RebuildView(_allProgramShortcuts, ProgramShortcuts);
+            RebuildView(_allUrlShortcuts, UrlShortcuts);
+            UpdateHasAnyMappings();
+        }
+
+        private void RebuildView<T>(List<T> source, ObservableCollection<T> view)
+            where T : IToggleableShortcut
+        {
+            view.Clear();
+            foreach (var item in source)
+            {
+                if (RowMatches(item))
+                {
+                    view.Add(item);
+                }
+            }
+        }
+
+        // Returns true when a row passes the active filters. Filter categories combine with AND;
+        // the modifier toggles combine with OR (selecting Win + Ctrl shows the Win OR Ctrl layers).
+        private bool RowMatches(IToggleableShortcut row)
+        {
+            if (_filterWin || _filterCtrl || _filterAlt || _filterShift)
+            {
+                bool modifierMatch =
+                    (_filterWin && ContainsAny(row.TriggerKeyCodes, _winVkCodes)) ||
+                    (_filterCtrl && ContainsAny(row.TriggerKeyCodes, _ctrlVkCodes)) ||
+                    (_filterAlt && ContainsAny(row.TriggerKeyCodes, _altVkCodes)) ||
+                    (_filterShift && ContainsAny(row.TriggerKeyCodes, _shiftVkCodes));
+
+                if (!modifierMatch)
+                {
+                    return false;
+                }
+            }
+
+            if (_appFilter == GlobalOnlyToken)
+            {
+                if (!row.IsAllApps)
+                {
+                    return false;
+                }
+            }
+            else if (_appFilter != null)
+            {
+                if (row.IsAllApps || !string.Equals(row.AppName, _appFilter, StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+            }
+
+            if (!string.IsNullOrEmpty(_searchText) &&
+                row.SearchableText.IndexOf(_searchText, StringComparison.OrdinalIgnoreCase) < 0)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        private static bool ContainsAny(IReadOnlyList<int> codes, int[] vkSet)
+        {
+            for (int i = 0; i < codes.Count; i++)
+            {
+                if (Array.IndexOf(vkSet, codes[i]) >= 0)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        // Recomputes the app-filter combo's items from the backing lists, preserving the current selection.
+        private void RefreshAppFilterOptions()
+        {
+            var apps = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+            AddApps(_allRemappings, apps);
+            AddApps(_allDisabled, apps);
+            AddApps(_allTextMappings, apps);
+            AddApps(_allProgramShortcuts, apps);
+            AddApps(_allUrlShortcuts, apps);
+
+            string? previous = _appFilter;
+
+            _suppressFilterEvents = true;
+
+            AppFilterOptions.Clear();
+            AppFilterOptions.Add(ResourceHelper.GetString("FilterApp_AllApps"));
+            AppFilterOptions.Add(ResourceHelper.GetString("FilterApp_GlobalOnly"));
+            foreach (var app in apps)
+            {
+                AppFilterOptions.Add(app);
+            }
+
+            int index = 0;
+            if (previous == GlobalOnlyToken)
+            {
+                index = 1;
+            }
+            else if (previous != null)
+            {
+                int found = AppFilterOptions.IndexOf(previous);
+                index = found >= 0 ? found : 0;
+            }
+
+            AppFilterCombo.SelectedIndex = index;
+            _appFilter = index == 0 ? null : (index == 1 ? GlobalOnlyToken : AppFilterOptions[index]);
+
+            _suppressFilterEvents = false;
+        }
+
+        private static void AddApps<T>(List<T> source, SortedSet<string> apps)
+            where T : IToggleableShortcut
+        {
+            foreach (var item in source)
+            {
+                if (!item.IsAllApps && !string.IsNullOrEmpty(item.AppName))
+                {
+                    apps.Add(item.AppName);
+                }
+            }
+        }
+
+        private void SearchBox_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
+        {
+            if (_suppressFilterEvents)
+            {
+                return;
+            }
+
+            _searchText = sender.Text?.Trim() ?? string.Empty;
+            ApplyFilter();
+        }
+
+        private void ModifierFilter_Changed(object sender, RoutedEventArgs e)
+        {
+            if (_suppressFilterEvents)
+            {
+                return;
+            }
+
+            _filterWin = WinFilterToggle.IsChecked == true;
+            _filterCtrl = CtrlFilterToggle.IsChecked == true;
+            _filterAlt = AltFilterToggle.IsChecked == true;
+            _filterShift = ShiftFilterToggle.IsChecked == true;
+            ApplyFilter();
+        }
+
+        private void AppFilterCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (_suppressFilterEvents)
+            {
+                return;
+            }
+
+            int index = AppFilterCombo.SelectedIndex;
+            _appFilter = index <= 0 ? null : (index == 1 ? GlobalOnlyToken : AppFilterOptions[index]);
+            ApplyFilter();
+        }
+
+        private void ClearFilters_Click(object sender, RoutedEventArgs e)
+        {
+            _suppressFilterEvents = true;
+
+            SearchBox.Text = string.Empty;
+            WinFilterToggle.IsChecked = false;
+            CtrlFilterToggle.IsChecked = false;
+            AltFilterToggle.IsChecked = false;
+            ShiftFilterToggle.IsChecked = false;
+            AppFilterCombo.SelectedIndex = 0;
+
+            _searchText = string.Empty;
+            _filterWin = false;
+            _filterCtrl = false;
+            _filterAlt = false;
+            _filterShift = false;
+            _appFilter = null;
+
+            _suppressFilterEvents = false;
+
+            ApplyFilter();
+        }
+
+        private void SelectionModeToggle_Click(object sender, RoutedEventArgs e)
+        {
+            IsSelectionMode = SelectionModeToggle.IsChecked == true;
+
+            if (!IsSelectionMode)
+            {
+                ClearAllSelections();
+            }
+
+            UpdateSelectedCount();
+        }
+
+        private void ClearAllSelections()
+        {
+            RemappingsListView.SelectedItems.Clear();
+            DisabledListView.SelectedItems.Clear();
+            TextListView.SelectedItems.Clear();
+            ProgramsListView.SelectedItems.Clear();
+            UrlsListView.SelectedItems.Clear();
+        }
+
+        private void MappingList_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            UpdateSelectedCount();
+        }
+
+        private void UpdateSelectedCount()
+        {
+            SelectedCount =
+                RemappingsListView.SelectedItems.Count +
+                DisabledListView.SelectedItems.Count +
+                TextListView.SelectedItems.Count +
+                ProgramsListView.SelectedItems.Count +
+                UrlsListView.SelectedItems.Count;
+        }
+
+        private async void DeleteSelectedBtn_Click(object sender, RoutedEventArgs e)
+        {
+            if (_mappingService == null || SelectedCount == 0)
+            {
+                return;
+            }
+
+            _bulkDeleteConfirmationFormat ??= CompositeFormat.Parse(ResourceHelper.GetString("BulkDeleteConfirmation_Format"));
+            BulkDeleteConfirmationText.Text = string.Format(CultureInfo.CurrentCulture, _bulkDeleteConfirmationFormat, SelectedCount);
+
+            if (await BulkDeleteConfirmationDialog.ShowAsync() != ContentDialogResult.Primary)
+            {
+                return;
+            }
+
+            try
+            {
+                // Snapshot the selection first; deletion mutates the collections and settings underneath.
+                var remappings = RemappingsListView.SelectedItems.OfType<Remapping>().ToList();
+                var disabled = DisabledListView.SelectedItems.OfType<Remapping>().ToList();
+                var texts = TextListView.SelectedItems.OfType<TextMapping>().ToList();
+                var programs = ProgramsListView.SelectedItems.OfType<ProgramShortcut>().ToList();
+                var urls = UrlsListView.SelectedItems.OfType<URLShortcut>().ToList();
+
+                foreach (var item in remappings)
+                {
+                    HandleRemappingDelete(item);
+                }
+
+                foreach (var item in disabled)
+                {
+                    HandleRemappingDelete(item);
+                }
+
+                foreach (var item in texts)
+                {
+                    HandleShortcutDelete(item);
+                }
+
+                foreach (var item in programs)
+                {
+                    HandleShortcutDelete(item);
+                }
+
+                foreach (var item in urls)
+                {
+                    HandleShortcutDelete(item);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError("Error during bulk delete: " + ex.Message);
+            }
+
+            IsSelectionMode = false;
+            SelectionModeToggle.IsChecked = false;
+            LoadAllMappings();
+            UpdateSelectedCount();
         }
 
         #endregion

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/MainPage.xaml.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/MainPage.xaml.cs
@@ -104,6 +104,7 @@ namespace KeyboardManagerEditorUI.Pages
 
         // Ephemeral (never persisted) filter state.
         private string _searchText = string.Empty;
+        private string _normalizedSearchText = string.Empty;
         private bool _filterWin;
         private bool _filterCtrl;
         private bool _filterAlt;
@@ -121,6 +122,26 @@ namespace KeyboardManagerEditorUI.Pages
         private bool _hasAnyData;
         private bool _isSelectionMode;
         private int _selectedCount;
+
+        public string SearchText
+        {
+            get => _searchText;
+            set
+            {
+                string newValue = value ?? string.Empty;
+                if (_searchText != newValue)
+                {
+                    _searchText = newValue;
+                    _normalizedSearchText = newValue.Trim();
+                    RaisePropertyChanged(nameof(SearchText));
+
+                    if (!_suppressFilterEvents)
+                    {
+                        ApplyFilter();
+                    }
+                }
+            }
+        }
 
         // True when there is at least one remapping loaded (regardless of the active filter).
         public bool HasAnyData
@@ -1325,8 +1346,8 @@ namespace KeyboardManagerEditorUI.Pages
                 }
             }
 
-            if (!string.IsNullOrEmpty(_searchText) &&
-                row.SearchableText.IndexOf(_searchText, StringComparison.OrdinalIgnoreCase) < 0)
+            if (!string.IsNullOrEmpty(_normalizedSearchText) &&
+                row.SearchableText.IndexOf(_normalizedSearchText, StringComparison.OrdinalIgnoreCase) < 0)
             {
                 return false;
             }
@@ -1398,17 +1419,6 @@ namespace KeyboardManagerEditorUI.Pages
             }
         }
 
-        private void SearchBox_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
-        {
-            if (_suppressFilterEvents)
-            {
-                return;
-            }
-
-            _searchText = sender.Text?.Trim() ?? string.Empty;
-            ApplyFilter();
-        }
-
         private void ModifierFilter_Changed(object sender, RoutedEventArgs e)
         {
             if (_suppressFilterEvents)
@@ -1439,14 +1449,13 @@ namespace KeyboardManagerEditorUI.Pages
         {
             _suppressFilterEvents = true;
 
-            SearchBox.Text = string.Empty;
+            SearchText = string.Empty;
             WinFilterToggle.IsChecked = false;
             CtrlFilterToggle.IsChecked = false;
             AltFilterToggle.IsChecked = false;
             ShiftFilterToggle.IsChecked = false;
             AppFilterCombo.SelectedIndex = 0;
 
-            _searchText = string.Empty;
             _filterWin = false;
             _filterCtrl = false;
             _filterAlt = false;
@@ -1458,9 +1467,9 @@ namespace KeyboardManagerEditorUI.Pages
             ApplyFilter();
         }
 
-        private void SelectionModeToggle_Click(object sender, RoutedEventArgs e)
+        private void SelectionModeButton_Click(object sender, RoutedEventArgs e)
         {
-            bool entering = SelectionModeToggle.IsChecked == true;
+            bool entering = !IsSelectionMode;
 
             // When leaving selection mode, clear the selection while the lists are still in Multiple
             // mode. ListView.SelectedItems is only valid for Multiple, so it must be touched before
@@ -1568,7 +1577,6 @@ namespace KeyboardManagerEditorUI.Pages
             }
 
             IsSelectionMode = false;
-            SelectionModeToggle.IsChecked = false;
             LoadAllMappings();
             UpdateSelectedCount();
         }

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/MainPage.xaml.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/MainPage.xaml.cs
@@ -73,6 +73,8 @@ namespace KeyboardManagerEditorUI.Pages
             }
         }
 
+        // Bound collections hold the CURRENTLY VISIBLE (filtered) rows. The full set lives in the
+        // backing lists below; ApplyFilter() rebuilds the bound collections from them.
         public ObservableCollection<Remapping> RemappingList { get; } = new();
 
         public ObservableCollection<Remapping> DisabledList { get; } = new();
@@ -82,6 +84,106 @@ namespace KeyboardManagerEditorUI.Pages
         public ObservableCollection<ProgramShortcut> ProgramShortcuts { get; } = new();
 
         public ObservableCollection<URLShortcut> UrlShortcuts { get; } = new();
+
+        // Backing (unfiltered) source lists. The bound collections above are views onto these.
+        private readonly List<Remapping> _allRemappings = new();
+        private readonly List<Remapping> _allDisabled = new();
+        private readonly List<TextMapping> _allTextMappings = new();
+        private readonly List<ProgramShortcut> _allProgramShortcuts = new();
+        private readonly List<URLShortcut> _allUrlShortcuts = new();
+
+        // Virtual-key codes for each modifier family (both generic and left/right specific).
+        private static readonly int[] _ctrlVkCodes = { 0x11, 0xA2, 0xA3 };
+        private static readonly int[] _altVkCodes = { 0x12, 0xA4, 0xA5 };
+        private static readonly int[] _shiftVkCodes = { 0x10, 0xA0, 0xA1 };
+        private static readonly int[] _winVkCodes = { 0x5B, 0x5C };
+
+        // Sentinel stored in _appFilter for the "Global only" option (item index 1 in the combo).
+        // Uses a control character so it can never collide with a real app name.
+        private const string GlobalOnlyToken = "global-only";
+
+        // Ephemeral (never persisted) filter state.
+        private string _searchText = string.Empty;
+        private bool _filterWin;
+        private bool _filterCtrl;
+        private bool _filterAlt;
+        private bool _filterShift;
+        private string? _appFilter; // null = all apps, GlobalOnlyToken = global only, else a specific app name.
+        private bool _suppressFilterEvents;
+
+        // Cached composite formats for the (localized) bulk-delete strings, parsed lazily on first use.
+        private CompositeFormat? _deleteSelectedFormat;
+        private CompositeFormat? _bulkDeleteConfirmationFormat;
+
+        // Options shown in the app-filter combo box: [All apps], [Global only], then each distinct app name.
+        public ObservableCollection<string> AppFilterOptions { get; } = new();
+
+        private bool _hasAnyData;
+        private bool _isSelectionMode;
+        private int _selectedCount;
+
+        // True when there is at least one remapping loaded (regardless of the active filter).
+        public bool HasAnyData
+        {
+            get => _hasAnyData;
+            private set
+            {
+                if (_hasAnyData != value)
+                {
+                    _hasAnyData = value;
+                    RaisePropertyChanged(nameof(HasAnyData));
+                }
+            }
+        }
+
+        // True while the user is multi-selecting rows for bulk deletion.
+        public bool IsSelectionMode
+        {
+            get => _isSelectionMode;
+            private set
+            {
+                if (_isSelectionMode != value)
+                {
+                    _isSelectionMode = value;
+                    RaisePropertyChanged(nameof(IsSelectionMode));
+                    RaisePropertyChanged(nameof(IsNotSelectionMode));
+                    RaisePropertyChanged(nameof(ListSelectionMode));
+                }
+            }
+        }
+
+        public bool IsNotSelectionMode => !_isSelectionMode;
+
+        public ListViewSelectionMode ListSelectionMode => _isSelectionMode ? ListViewSelectionMode.Multiple : ListViewSelectionMode.None;
+
+        // Number of rows selected across all sections while in selection mode.
+        public int SelectedCount
+        {
+            get => _selectedCount;
+            private set
+            {
+                if (_selectedCount != value)
+                {
+                    _selectedCount = value;
+                    RaisePropertyChanged(nameof(SelectedCount));
+                    RaisePropertyChanged(nameof(HasSelection));
+                    RaisePropertyChanged(nameof(DeleteSelectedLabel));
+                }
+            }
+        }
+
+        public bool HasSelection => _selectedCount > 0;
+
+        public string DeleteSelectedLabel
+        {
+            get
+            {
+                _deleteSelectedFormat ??= CompositeFormat.Parse(ResourceHelper.GetString("BulkDelete_SelectedFormat"));
+                return string.Format(CultureInfo.CurrentCulture, _deleteSelectedFormat, _selectedCount);
+            }
+        }
+
+        private void RaisePropertyChanged(string propertyName) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 
         [DllImport("PowerToys.KeyboardManagerEditorLibraryWrapper.dll", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
         private static extern void GetKeyDisplayName(int keyCode, [Out] StringBuilder keyName, int maxLength);
@@ -721,7 +823,8 @@ namespace KeyboardManagerEditorUI.Pages
                 {
                     case Remapping remapping:
                         HandleRemappingDelete(remapping);
-                        UpdateHasAnyMappings();
+                        RefreshAppFilterOptions();
+                        ApplyFilter();
                         break;
 
                     case IToggleableShortcut shortcut:
@@ -914,26 +1017,30 @@ namespace KeyboardManagerEditorUI.Pages
             LoadTextMappings();
             LoadProgramShortcuts();
             LoadUrlShortcuts();
-            UpdateHasAnyMappings();
+            RefreshAppFilterOptions();
+            ApplyFilter();
         }
 
         private void UpdateHasAnyMappings()
         {
-            bool hasAny = RemappingList.Count > 0 || DisabledList.Count > 0 || TextMappings.Count > 0 || ProgramShortcuts.Count > 0 || UrlShortcuts.Count > 0;
-            MappingState = hasAny ? "HasMappings" : "Empty";
+            bool hasData = _allRemappings.Count > 0 || _allDisabled.Count > 0 || _allTextMappings.Count > 0 || _allProgramShortcuts.Count > 0 || _allUrlShortcuts.Count > 0;
+            bool hasVisible = RemappingList.Count > 0 || DisabledList.Count > 0 || TextMappings.Count > 0 || ProgramShortcuts.Count > 0 || UrlShortcuts.Count > 0;
+
+            HasAnyData = hasData;
+            MappingState = !hasData ? "Empty" : (hasVisible ? "HasMappings" : "NoResults");
         }
 
         private void LoadRemappings()
         {
             SettingsManager.EditorSettings.ShortcutsByOperationType.TryGetValue(ShortcutOperationType.RemapShortcut, out var remapShortcutIds);
 
+            _allRemappings.Clear();
+            _allDisabled.Clear();
+
             if (remapShortcutIds == null)
             {
                 return;
             }
-
-            RemappingList.Clear();
-            DisabledList.Clear();
 
             foreach (var id in remapShortcutIds)
             {
@@ -945,13 +1052,14 @@ namespace KeyboardManagerEditorUI.Pages
 
                 ShortcutKeyMapping mapping = shortcutSettings.Shortcut;
                 var originalKeyNames = ParseKeyCodes(mapping.OriginalKeys);
+                var remappedKeyNames = ParseKeyCodes(mapping.TargetKeys);
 
                 bool isDisabled = mapping.TargetKeys == VkDisabledString;
 
                 var remapping = new Remapping
                 {
                     Shortcut = originalKeyNames,
-                    RemappedKeys = isDisabled ? new List<string>() : ParseKeyCodes(mapping.TargetKeys),
+                    RemappedKeys = isDisabled ? new List<string>() : remappedKeyNames,
                     IsAllApps = string.IsNullOrEmpty(mapping.TargetApp),
                     AppName = mapping.TargetApp ?? string.Empty,
                     Id = shortcutSettings.Id,
@@ -959,15 +1067,17 @@ namespace KeyboardManagerEditorUI.Pages
 
                     // Round-trip the dual-key condition so the list badge and edit dialog reflect Alone.
                     Condition = mapping.Condition,
+                    TriggerKeyCodes = ParseVkCodes(mapping.OriginalKeys),
+                    SearchableText = BuildSearchableText(originalKeyNames.Concat(isDisabled ? Enumerable.Empty<string>() : remappedKeyNames).Append(mapping.TargetApp ?? string.Empty)),
                 };
 
                 if (isDisabled)
                 {
-                    DisabledList.Add(remapping);
+                    _allDisabled.Add(remapping);
                 }
                 else
                 {
-                    RemappingList.Add(remapping);
+                    _allRemappings.Add(remapping);
                 }
             }
         }
@@ -976,12 +1086,12 @@ namespace KeyboardManagerEditorUI.Pages
         {
             SettingsManager.EditorSettings.ShortcutsByOperationType.TryGetValue(ShortcutOperationType.RemapText, out var remapShortcutIds);
 
+            _allTextMappings.Clear();
+
             if (remapShortcutIds == null)
             {
                 return;
             }
-
-            TextMappings.Clear();
 
             foreach (var id in remapShortcutIds)
             {
@@ -994,7 +1104,7 @@ namespace KeyboardManagerEditorUI.Pages
                 ShortcutKeyMapping mapping = shortcutSettings.Shortcut;
                 var originalKeyNames = ParseKeyCodes(mapping.OriginalKeys);
 
-                TextMappings.Add(new TextMapping
+                _allTextMappings.Add(new TextMapping
                 {
                     Shortcut = originalKeyNames,
                     Text = mapping.TargetText,
@@ -1002,6 +1112,8 @@ namespace KeyboardManagerEditorUI.Pages
                     AppName = mapping.TargetApp ?? string.Empty,
                     Id = shortcutSettings.Id,
                     IsActive = shortcutSettings.IsActive,
+                    TriggerKeyCodes = ParseVkCodes(mapping.OriginalKeys),
+                    SearchableText = BuildSearchableText(originalKeyNames.Append(mapping.TargetText).Append(mapping.TargetApp ?? string.Empty)),
                 });
             }
         }
@@ -1010,12 +1122,12 @@ namespace KeyboardManagerEditorUI.Pages
         {
             SettingsManager.EditorSettings.ShortcutsByOperationType.TryGetValue(ShortcutOperationType.RunProgram, out var remapShortcutIds);
 
+            _allProgramShortcuts.Clear();
+
             if (remapShortcutIds == null)
             {
                 return;
             }
-
-            ProgramShortcuts.Clear();
 
             foreach (var id in remapShortcutIds)
             {
@@ -1028,7 +1140,7 @@ namespace KeyboardManagerEditorUI.Pages
                 ShortcutKeyMapping mapping = shortcutSettings.Shortcut;
                 var originalKeyNames = ParseKeyCodes(mapping.OriginalKeys);
 
-                ProgramShortcuts.Add(new ProgramShortcut
+                _allProgramShortcuts.Add(new ProgramShortcut
                 {
                     Shortcut = originalKeyNames,
                     AppToRun = mapping.ProgramPath,
@@ -1041,6 +1153,8 @@ namespace KeyboardManagerEditorUI.Pages
                     Elevation = mapping.Elevation.ToString(),
                     IfRunningAction = mapping.IfRunningAction.ToString(),
                     Visibility = mapping.Visibility.ToString(),
+                    TriggerKeyCodes = ParseVkCodes(mapping.OriginalKeys),
+                    SearchableText = BuildSearchableText(originalKeyNames.Append(mapping.ProgramPath).Append(mapping.ProgramArgs).Append(mapping.TargetApp ?? string.Empty)),
                 });
             }
         }
@@ -1049,12 +1163,12 @@ namespace KeyboardManagerEditorUI.Pages
         {
             SettingsManager.EditorSettings.ShortcutsByOperationType.TryGetValue(ShortcutOperationType.OpenUri, out var remapShortcutIds);
 
+            _allUrlShortcuts.Clear();
+
             if (remapShortcutIds == null)
             {
                 return;
             }
-
-            UrlShortcuts.Clear();
 
             foreach (var id in remapShortcutIds)
             {
@@ -1067,7 +1181,7 @@ namespace KeyboardManagerEditorUI.Pages
                 ShortcutKeyMapping mapping = shortcutSettings.Shortcut;
                 var originalKeyNames = ParseKeyCodes(mapping.OriginalKeys);
 
-                UrlShortcuts.Add(new URLShortcut
+                _allUrlShortcuts.Add(new URLShortcut
                 {
                     Shortcut = originalKeyNames,
                     URL = mapping.UriToOpen,
@@ -1075,6 +1189,8 @@ namespace KeyboardManagerEditorUI.Pages
                     IsActive = shortcutSettings.IsActive,
                     IsAllApps = string.IsNullOrEmpty(mapping.TargetApp),
                     AppName = mapping.TargetApp ?? string.Empty,
+                    TriggerKeyCodes = ParseVkCodes(mapping.OriginalKeys),
+                    SearchableText = BuildSearchableText(originalKeyNames.Append(mapping.UriToOpen).Append(mapping.TargetApp ?? string.Empty)),
                 });
             }
         }
@@ -1089,6 +1205,334 @@ namespace KeyboardManagerEditorUI.Pages
                     return _mappingService?.GetKeyDisplayName(code) ?? $"VK {code}";
                 })
                 .ToList();
+        }
+
+        // Parse the raw ";"-separated VK code string into integers (no display-name conversion),
+        // so modifier filtering can classify keys by code and stay locale-independent.
+        private static List<int> ParseVkCodes(string keyCodesString)
+        {
+            var codes = new List<int>();
+            foreach (var part in keyCodesString.Split(';'))
+            {
+                if (int.TryParse(part, NumberStyles.Integer, CultureInfo.InvariantCulture, out int code))
+                {
+                    codes.Add(code);
+                }
+            }
+
+            return codes;
+        }
+
+        // Combine a row's human-readable parts into a single lowercased string for text search.
+        private static string BuildSearchableText(IEnumerable<string> parts)
+        {
+            var sb = new StringBuilder();
+            foreach (var part in parts)
+            {
+                if (string.IsNullOrEmpty(part))
+                {
+                    continue;
+                }
+
+                if (sb.Length > 0)
+                {
+                    sb.Append(' ');
+                }
+
+                sb.Append(part);
+            }
+
+            return sb.ToString().ToLowerInvariant();
+        }
+
+        #endregion
+
+        #region Filter and Selection
+
+        // Rebuilds the five bound (visible) collections from their backing lists using the active filters.
+        private void ApplyFilter()
+        {
+            RebuildView(_allRemappings, RemappingList);
+            RebuildView(_allDisabled, DisabledList);
+            RebuildView(_allTextMappings, TextMappings);
+            RebuildView(_allProgramShortcuts, ProgramShortcuts);
+            RebuildView(_allUrlShortcuts, UrlShortcuts);
+            UpdateHasAnyMappings();
+        }
+
+        private void RebuildView<T>(List<T> source, ObservableCollection<T> view)
+            where T : IToggleableShortcut
+        {
+            view.Clear();
+            foreach (var item in source)
+            {
+                if (RowMatches(item))
+                {
+                    view.Add(item);
+                }
+            }
+        }
+
+        // Returns true when a row passes the active filters. Filter categories combine with AND;
+        // the modifier toggles combine with OR (selecting Win + Ctrl shows the Win OR Ctrl layers).
+        private bool RowMatches(IToggleableShortcut row)
+        {
+            if (_filterWin || _filterCtrl || _filterAlt || _filterShift)
+            {
+                bool modifierMatch =
+                    (_filterWin && ContainsAny(row.TriggerKeyCodes, _winVkCodes)) ||
+                    (_filterCtrl && ContainsAny(row.TriggerKeyCodes, _ctrlVkCodes)) ||
+                    (_filterAlt && ContainsAny(row.TriggerKeyCodes, _altVkCodes)) ||
+                    (_filterShift && ContainsAny(row.TriggerKeyCodes, _shiftVkCodes));
+
+                if (!modifierMatch)
+                {
+                    return false;
+                }
+            }
+
+            if (_appFilter == GlobalOnlyToken)
+            {
+                if (!row.IsAllApps)
+                {
+                    return false;
+                }
+            }
+            else if (_appFilter != null)
+            {
+                if (row.IsAllApps || !string.Equals(row.AppName, _appFilter, StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+            }
+
+            if (!string.IsNullOrEmpty(_searchText) &&
+                row.SearchableText.IndexOf(_searchText, StringComparison.OrdinalIgnoreCase) < 0)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        private static bool ContainsAny(IReadOnlyList<int> codes, int[] vkSet)
+        {
+            for (int i = 0; i < codes.Count; i++)
+            {
+                if (Array.IndexOf(vkSet, codes[i]) >= 0)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        // Recomputes the app-filter combo's items from the backing lists, preserving the current selection.
+        private void RefreshAppFilterOptions()
+        {
+            var apps = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+            AddApps(_allRemappings, apps);
+            AddApps(_allDisabled, apps);
+            AddApps(_allTextMappings, apps);
+            AddApps(_allProgramShortcuts, apps);
+            AddApps(_allUrlShortcuts, apps);
+
+            string? previous = _appFilter;
+
+            _suppressFilterEvents = true;
+
+            AppFilterOptions.Clear();
+            AppFilterOptions.Add(ResourceHelper.GetString("FilterApp_AllApps"));
+            AppFilterOptions.Add(ResourceHelper.GetString("FilterApp_GlobalOnly"));
+            foreach (var app in apps)
+            {
+                AppFilterOptions.Add(app);
+            }
+
+            int index = 0;
+            if (previous == GlobalOnlyToken)
+            {
+                index = 1;
+            }
+            else if (previous != null)
+            {
+                int found = AppFilterOptions.IndexOf(previous);
+                index = found >= 0 ? found : 0;
+            }
+
+            AppFilterCombo.SelectedIndex = index;
+            _appFilter = index == 0 ? null : (index == 1 ? GlobalOnlyToken : AppFilterOptions[index]);
+
+            _suppressFilterEvents = false;
+        }
+
+        private static void AddApps<T>(List<T> source, SortedSet<string> apps)
+            where T : IToggleableShortcut
+        {
+            foreach (var item in source)
+            {
+                if (!item.IsAllApps && !string.IsNullOrEmpty(item.AppName))
+                {
+                    apps.Add(item.AppName);
+                }
+            }
+        }
+
+        private void SearchBox_TextChanged(AutoSuggestBox sender, AutoSuggestBoxTextChangedEventArgs args)
+        {
+            if (_suppressFilterEvents)
+            {
+                return;
+            }
+
+            _searchText = sender.Text?.Trim() ?? string.Empty;
+            ApplyFilter();
+        }
+
+        private void ModifierFilter_Changed(object sender, RoutedEventArgs e)
+        {
+            if (_suppressFilterEvents)
+            {
+                return;
+            }
+
+            _filterWin = WinFilterToggle.IsChecked == true;
+            _filterCtrl = CtrlFilterToggle.IsChecked == true;
+            _filterAlt = AltFilterToggle.IsChecked == true;
+            _filterShift = ShiftFilterToggle.IsChecked == true;
+            ApplyFilter();
+        }
+
+        private void AppFilterCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (_suppressFilterEvents)
+            {
+                return;
+            }
+
+            int index = AppFilterCombo.SelectedIndex;
+            _appFilter = index <= 0 ? null : (index == 1 ? GlobalOnlyToken : AppFilterOptions[index]);
+            ApplyFilter();
+        }
+
+        private void ClearFilters_Click(object sender, RoutedEventArgs e)
+        {
+            _suppressFilterEvents = true;
+
+            SearchBox.Text = string.Empty;
+            WinFilterToggle.IsChecked = false;
+            CtrlFilterToggle.IsChecked = false;
+            AltFilterToggle.IsChecked = false;
+            ShiftFilterToggle.IsChecked = false;
+            AppFilterCombo.SelectedIndex = 0;
+
+            _searchText = string.Empty;
+            _filterWin = false;
+            _filterCtrl = false;
+            _filterAlt = false;
+            _filterShift = false;
+            _appFilter = null;
+
+            _suppressFilterEvents = false;
+
+            ApplyFilter();
+        }
+
+        private void SelectionModeToggle_Click(object sender, RoutedEventArgs e)
+        {
+            IsSelectionMode = SelectionModeToggle.IsChecked == true;
+
+            if (!IsSelectionMode)
+            {
+                ClearAllSelections();
+            }
+
+            UpdateSelectedCount();
+        }
+
+        private void ClearAllSelections()
+        {
+            RemappingsListView.SelectedItems.Clear();
+            DisabledListView.SelectedItems.Clear();
+            TextListView.SelectedItems.Clear();
+            ProgramsListView.SelectedItems.Clear();
+            UrlsListView.SelectedItems.Clear();
+        }
+
+        private void MappingList_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            UpdateSelectedCount();
+        }
+
+        private void UpdateSelectedCount()
+        {
+            SelectedCount =
+                RemappingsListView.SelectedItems.Count +
+                DisabledListView.SelectedItems.Count +
+                TextListView.SelectedItems.Count +
+                ProgramsListView.SelectedItems.Count +
+                UrlsListView.SelectedItems.Count;
+        }
+
+        private async void DeleteSelectedBtn_Click(object sender, RoutedEventArgs e)
+        {
+            if (_mappingService == null || SelectedCount == 0)
+            {
+                return;
+            }
+
+            _bulkDeleteConfirmationFormat ??= CompositeFormat.Parse(ResourceHelper.GetString("BulkDeleteConfirmation_Format"));
+            BulkDeleteConfirmationText.Text = string.Format(CultureInfo.CurrentCulture, _bulkDeleteConfirmationFormat, SelectedCount);
+
+            if (await BulkDeleteConfirmationDialog.ShowAsync() != ContentDialogResult.Primary)
+            {
+                return;
+            }
+
+            try
+            {
+                // Snapshot the selection first; deletion mutates the collections and settings underneath.
+                var remappings = RemappingsListView.SelectedItems.OfType<Remapping>().ToList();
+                var disabled = DisabledListView.SelectedItems.OfType<Remapping>().ToList();
+                var texts = TextListView.SelectedItems.OfType<TextMapping>().ToList();
+                var programs = ProgramsListView.SelectedItems.OfType<ProgramShortcut>().ToList();
+                var urls = UrlsListView.SelectedItems.OfType<URLShortcut>().ToList();
+
+                foreach (var item in remappings)
+                {
+                    HandleRemappingDelete(item);
+                }
+
+                foreach (var item in disabled)
+                {
+                    HandleRemappingDelete(item);
+                }
+
+                foreach (var item in texts)
+                {
+                    HandleShortcutDelete(item);
+                }
+
+                foreach (var item in programs)
+                {
+                    HandleShortcutDelete(item);
+                }
+
+                foreach (var item in urls)
+                {
+                    HandleShortcutDelete(item);
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError("Error during bulk delete: " + ex.Message);
+            }
+
+            IsSelectionMode = false;
+            SelectionModeToggle.IsChecked = false;
+            LoadAllMappings();
+            UpdateSelectedCount();
         }
 
         #endregion

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/MainPage.xaml.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/MainPage.xaml.cs
@@ -873,6 +873,17 @@ namespace KeyboardManagerEditorUI.Pages
                 return;
             }
 
+            // Only act on a genuine user toggle, where the control's new state diverges from the model.
+            // ListView container recycling (heavy during filtering, bulk-delete reloads and scrolling of a
+            // long list) re-applies the OneTime IsOn binding to the recycled-in item, which also raises
+            // Toggled. Without this guard those spurious events call Enable/DisableShortcut, whose
+            // non-idempotent ToggleShortcutKeyMappingActiveState flips the wrong entry's persisted active
+            // state — making unrelated mappings silently turn OFF.
+            if (toggleSwitch.IsOn == shortcut.IsActive)
+            {
+                return;
+            }
+
             try
             {
                 bool desiredState = toggleSwitch.IsOn;

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/MainPage.xaml.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Pages/MainPage.xaml.cs
@@ -148,6 +148,8 @@ namespace KeyboardManagerEditorUI.Pages
                     RaisePropertyChanged(nameof(IsSelectionMode));
                     RaisePropertyChanged(nameof(IsNotSelectionMode));
                     RaisePropertyChanged(nameof(ListSelectionMode));
+                    RaisePropertyChanged(nameof(SelectModeLabel));
+                    RaisePropertyChanged(nameof(SelectModeTooltip));
                 }
             }
         }
@@ -155,6 +157,12 @@ namespace KeyboardManagerEditorUI.Pages
         public bool IsNotSelectionMode => !_isSelectionMode;
 
         public ListViewSelectionMode ListSelectionMode => _isSelectionMode ? ListViewSelectionMode.Multiple : ListViewSelectionMode.None;
+
+        // Label/tooltip for the selection-mode toggle. While in selection mode the toggle itself is
+        // the way out ("Cancel"), so the affordance to leave is always visible.
+        public string SelectModeLabel => ResourceHelper.GetString(_isSelectionMode ? "SelectModeToggle_Cancel" : "SelectModeToggle_Select");
+
+        public string SelectModeTooltip => ResourceHelper.GetString(_isSelectionMode ? "SelectModeToggle_CancelTooltip" : "SelectModeToggle_SelectTooltip");
 
         // Number of rows selected across all sections while in selection mode.
         public int SelectedCount
@@ -1452,23 +1460,38 @@ namespace KeyboardManagerEditorUI.Pages
 
         private void SelectionModeToggle_Click(object sender, RoutedEventArgs e)
         {
-            IsSelectionMode = SelectionModeToggle.IsChecked == true;
+            bool entering = SelectionModeToggle.IsChecked == true;
 
-            if (!IsSelectionMode)
+            // When leaving selection mode, clear the selection while the lists are still in Multiple
+            // mode. ListView.SelectedItems is only valid for Multiple, so it must be touched before
+            // ListSelectionMode flips to None below (otherwise it throws and takes the panel down).
+            if (!entering)
             {
                 ClearAllSelections();
             }
+
+            IsSelectionMode = entering;
 
             UpdateSelectedCount();
         }
 
         private void ClearAllSelections()
         {
-            RemappingsListView.SelectedItems.Clear();
-            DisabledListView.SelectedItems.Clear();
-            TextListView.SelectedItems.Clear();
-            ProgramsListView.SelectedItems.Clear();
-            UrlsListView.SelectedItems.Clear();
+            ClearSelectionIfMultiple(RemappingsListView);
+            ClearSelectionIfMultiple(DisabledListView);
+            ClearSelectionIfMultiple(TextListView);
+            ClearSelectionIfMultiple(ProgramsListView);
+            ClearSelectionIfMultiple(UrlsListView);
+        }
+
+        // ListView.SelectedItems is only valid while SelectionMode is Multiple; touching it in any
+        // other mode throws. Guard so selection housekeeping is safe whatever the current mode is.
+        private static void ClearSelectionIfMultiple(ListViewBase list)
+        {
+            if (list.SelectionMode == ListViewSelectionMode.Multiple)
+            {
+                list.SelectedItems.Clear();
+            }
         }
 
         private void MappingList_SelectionChanged(object sender, SelectionChangedEventArgs e)
@@ -1479,12 +1502,16 @@ namespace KeyboardManagerEditorUI.Pages
         private void UpdateSelectedCount()
         {
             SelectedCount =
-                RemappingsListView.SelectedItems.Count +
-                DisabledListView.SelectedItems.Count +
-                TextListView.SelectedItems.Count +
-                ProgramsListView.SelectedItems.Count +
-                UrlsListView.SelectedItems.Count;
+                SelectedCountIfMultiple(RemappingsListView) +
+                SelectedCountIfMultiple(DisabledListView) +
+                SelectedCountIfMultiple(TextListView) +
+                SelectedCountIfMultiple(ProgramsListView) +
+                SelectedCountIfMultiple(UrlsListView);
         }
+
+        // Mirrors ClearSelectionIfMultiple: SelectedItems.Count also throws outside Multiple mode.
+        private static int SelectedCountIfMultiple(ListViewBase list)
+            => list.SelectionMode == ListViewSelectionMode.Multiple ? list.SelectedItems.Count : 0;
 
         private async void DeleteSelectedBtn_Click(object sender, RoutedEventArgs e)
         {

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Strings/en-US/Resources.resw
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Strings/en-US/Resources.resw
@@ -501,4 +501,72 @@
   <data name="CheckServiceBtn.Content" xml:space="preserve">
     <value>Check service status</value>
   </data>
+  <data name="FilterSearchBox.PlaceholderText" xml:space="preserve">
+    <value>Search remappings</value>
+    <comment>Placeholder text for the search box that filters the remapping list</comment>
+  </data>
+  <data name="FilterWinToggle.Content" xml:space="preserve">
+    <value>Win</value>
+    <comment>Toggle button that filters the list to remappings using the Windows modifier key</comment>
+  </data>
+  <data name="FilterCtrlToggle.Content" xml:space="preserve">
+    <value>Ctrl</value>
+    <comment>Toggle button that filters the list to remappings using the Ctrl modifier key</comment>
+  </data>
+  <data name="FilterAltToggle.Content" xml:space="preserve">
+    <value>Alt</value>
+    <comment>Toggle button that filters the list to remappings using the Alt modifier key</comment>
+  </data>
+  <data name="FilterShiftToggle.Content" xml:space="preserve">
+    <value>Shift</value>
+    <comment>Toggle button that filters the list to remappings using the Shift modifier key</comment>
+  </data>
+  <data name="FilterClearBtn.Content" xml:space="preserve">
+    <value>Clear filters</value>
+    <comment>Button that clears all active search and filter selections</comment>
+  </data>
+  <data name="FilterClearBtn.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Clear all search and filter selections</value>
+  </data>
+  <data name="SelectModeToggle.Content" xml:space="preserve">
+    <value>Select</value>
+    <comment>Toggle button that turns on multi-select mode so several remappings can be deleted at once</comment>
+  </data>
+  <data name="SelectModeToggle.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Select multiple remappings to delete them together</value>
+  </data>
+  <data name="FilterApp_AllApps" xml:space="preserve">
+    <value>All apps</value>
+    <comment>App filter option that shows remappings for every app</comment>
+  </data>
+  <data name="FilterApp_GlobalOnly" xml:space="preserve">
+    <value>Global only</value>
+    <comment>App filter option that shows only remappings that are not tied to a specific app</comment>
+  </data>
+  <data name="BulkDelete_SelectedFormat" xml:space="preserve">
+    <value>Delete selected ({0})</value>
+    <comment>{0} is the number of selected remappings. Label of the button that deletes them.</comment>
+  </data>
+  <data name="BulkDeleteConfirmationDialog.Title" xml:space="preserve">
+    <value>Delete selected remappings?</value>
+  </data>
+  <data name="BulkDeleteConfirmationDialog.PrimaryButtonText" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="BulkDeleteConfirmationDialog.CloseButtonText" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="BulkDeleteConfirmation_Format" xml:space="preserve">
+    <value>You are about to delete {0} remappings. This cannot be undone.</value>
+    <comment>{0} is the number of remappings to delete</comment>
+  </data>
+  <data name="NoResultsTitle.Text" xml:space="preserve">
+    <value>No remappings match your filters</value>
+  </data>
+  <data name="NoResultsDescription.Text" xml:space="preserve">
+    <value>Try changing the search text or clearing the filters.</value>
+  </data>
+  <data name="NoResultsClearBtn.Content" xml:space="preserve">
+    <value>Clear filters</value>
+  </data>
 </root>

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Strings/en-US/Resources.resw
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Strings/en-US/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="NewRemappingBtn_Text.Text" xml:space="preserve">
-    <value>Add new remapping</value>
+    <value>New</value>
   </data>
   <data name="EmptyStateTitle.Text" xml:space="preserve">
     <value>Nothing mapped yet</value>
@@ -520,6 +520,21 @@
   <data name="FilterSearchBox.PlaceholderText" xml:space="preserve">
     <value>Search remappings</value>
     <comment>Placeholder text for the search box that filters the remapping list</comment>
+  </data>
+  <data name="FilterButton.AutomationProperties.Name" xml:space="preserve">
+    <value>Filter remappings</value>
+    <comment>Accessible name for the button that opens the remapping filters</comment>
+  </data>
+  <data name="FilterButton.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Filter remappings</value>
+  </data>
+  <data name="FilterModifiersHeader.Text" xml:space="preserve">
+    <value>Modifier keys</value>
+    <comment>Heading for the modifier-key filters</comment>
+  </data>
+  <data name="FilterApplicationsHeader.Text" xml:space="preserve">
+    <value>Application</value>
+    <comment>Heading for the application filter</comment>
   </data>
   <data name="FilterWinToggle.Content" xml:space="preserve">
     <value>Win</value>

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Strings/en-US/Resources.resw
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Strings/en-US/Resources.resw
@@ -517,4 +517,72 @@
   <data name="CheckServiceBtn.Content" xml:space="preserve">
     <value>Check service status</value>
   </data>
+  <data name="FilterSearchBox.PlaceholderText" xml:space="preserve">
+    <value>Search remappings</value>
+    <comment>Placeholder text for the search box that filters the remapping list</comment>
+  </data>
+  <data name="FilterWinToggle.Content" xml:space="preserve">
+    <value>Win</value>
+    <comment>Toggle button that filters the list to remappings using the Windows modifier key</comment>
+  </data>
+  <data name="FilterCtrlToggle.Content" xml:space="preserve">
+    <value>Ctrl</value>
+    <comment>Toggle button that filters the list to remappings using the Ctrl modifier key</comment>
+  </data>
+  <data name="FilterAltToggle.Content" xml:space="preserve">
+    <value>Alt</value>
+    <comment>Toggle button that filters the list to remappings using the Alt modifier key</comment>
+  </data>
+  <data name="FilterShiftToggle.Content" xml:space="preserve">
+    <value>Shift</value>
+    <comment>Toggle button that filters the list to remappings using the Shift modifier key</comment>
+  </data>
+  <data name="FilterClearBtn.Content" xml:space="preserve">
+    <value>Clear filters</value>
+    <comment>Button that clears all active search and filter selections</comment>
+  </data>
+  <data name="FilterClearBtn.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Clear all search and filter selections</value>
+  </data>
+  <data name="SelectModeToggle.Content" xml:space="preserve">
+    <value>Select</value>
+    <comment>Toggle button that turns on multi-select mode so several remappings can be deleted at once</comment>
+  </data>
+  <data name="SelectModeToggle.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Select multiple remappings to delete them together</value>
+  </data>
+  <data name="FilterApp_AllApps" xml:space="preserve">
+    <value>All apps</value>
+    <comment>App filter option that shows remappings for every app</comment>
+  </data>
+  <data name="FilterApp_GlobalOnly" xml:space="preserve">
+    <value>Global only</value>
+    <comment>App filter option that shows only remappings that are not tied to a specific app</comment>
+  </data>
+  <data name="BulkDelete_SelectedFormat" xml:space="preserve">
+    <value>Delete selected ({0})</value>
+    <comment>{0} is the number of selected remappings. Label of the button that deletes them.</comment>
+  </data>
+  <data name="BulkDeleteConfirmationDialog.Title" xml:space="preserve">
+    <value>Delete selected remappings?</value>
+  </data>
+  <data name="BulkDeleteConfirmationDialog.PrimaryButtonText" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="BulkDeleteConfirmationDialog.CloseButtonText" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="BulkDeleteConfirmation_Format" xml:space="preserve">
+    <value>You are about to delete {0} remappings. This cannot be undone.</value>
+    <comment>{0} is the number of remappings to delete</comment>
+  </data>
+  <data name="NoResultsTitle.Text" xml:space="preserve">
+    <value>No remappings match your filters</value>
+  </data>
+  <data name="NoResultsDescription.Text" xml:space="preserve">
+    <value>Try changing the search text or clearing the filters.</value>
+  </data>
+  <data name="NoResultsClearBtn.Content" xml:space="preserve">
+    <value>Clear filters</value>
+  </data>
 </root>

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Strings/en-US/Resources.resw
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Strings/en-US/Resources.resw
@@ -544,12 +544,19 @@
   <data name="FilterClearBtn.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Clear all search and filter selections</value>
   </data>
-  <data name="SelectModeToggle.Content" xml:space="preserve">
+  <data name="SelectModeToggle_Select" xml:space="preserve">
     <value>Select</value>
     <comment>Toggle button that turns on multi-select mode so several remappings can be deleted at once</comment>
   </data>
-  <data name="SelectModeToggle.[using:Microsoft.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+  <data name="SelectModeToggle_Cancel" xml:space="preserve">
+    <value>Cancel</value>
+    <comment>Same toggle button while multi-select mode is on; pressing it leaves selection mode</comment>
+  </data>
+  <data name="SelectModeToggle_SelectTooltip" xml:space="preserve">
     <value>Select multiple remappings to delete them together</value>
+  </data>
+  <data name="SelectModeToggle_CancelTooltip" xml:space="preserve">
+    <value>Exit selection mode</value>
   </data>
   <data name="FilterApp_AllApps" xml:space="preserve">
     <value>All apps</value>


### PR DESCRIPTION
## Summary of the Pull Request

Adds a **search / filter / bulk-delete bar** to the Keyboard Manager editor so that large remapping lists stay navigable. Once you accumulate many remaps the single flat list becomes hard to scan; this adds lightweight ways to narrow it down and to clean it up.

This is **editor-only** — the Keyboard Manager engine and the on-disk configuration schema are untouched. Filtering is a pure view concern and is never persisted.

Addresses #28434 ("Search in keyboard manager").

## Demo

Muted screen recording with on-screen captions:

https://github.com/user-attachments/assets/b7999b47-475b-44cb-9e31-baeeb924de82

It walks through: text search → the Win / Ctrl / Alt / Shift modifier toggles (OR within a group, AND across categories, including combining **Ctrl + Alt**) → the app filter → the "no results" empty state → **Select** mode → multi-select → **Cancel** → **Delete selected** → confirm → the rows are removed.

## Detailed Description of the PR

A filter bar is added above the mapping list:

- **Text search** — real-time, case-insensitive substring match over each row's key names, target (text / URL / program path) and target app.
- **Modifier toggles** (Win / Ctrl / Alt / Shift) — a row matches if its trigger contains that modifier. Classification is done on the raw virtual-key codes, so it is independent of the display language. Multiple toggles combine with **OR** (Win + Ctrl shows the Win *or* Ctrl rows).
- **App filter** — `All apps` / `Global only` / one entry per distinct target app.
- The categories above combine with **AND**. When nothing matches, a dedicated "no results" state is shown with a **Clear filters** action, kept distinct from the normal empty state.
- **Multi-select + bulk delete** — a `Select` toggle turns on multi-selection across all sections; `Delete selected (n)` removes them after a confirmation dialog. Only the currently **visible (filtered)** rows can be selected, so rows hidden by a filter can never be deleted by accident.

### Implementation notes

- Each section's list is already a data-bound `ListView` over an `ObservableCollection`. Those bound collections become **filtered views** over new backing lists; `ApplyFilter()` rebuilds them. Section visibility already keys off `.Count`, so filtered-empty sections collapse for free.
- Rows now carry their raw trigger VK codes and a precomputed lowercased search string.
- Bulk delete reuses the existing per-row delete handlers; no new deletion path.

## PR Checklist

- [ ] **Closes:** #28434
- [x] **Communication:** I've discussed this with core contributors in the issue.  <!-- issue is untriaged; opening as draft for feedback -->
- [x] **Tests:** Made sure tests pass and, if applicable, added new relevant tests. (Editor-only UI change; validated by building and manual testing.)
- [x] **Localization:** All end-user-facing strings are in the `.resw` resources.
- [ ] **Dev docs:** N/A
- [ ] **New binaries:** N/A
- [x] **Documentation updated:** N/A (no doc changes needed)

## Validation Steps Performed

- Built `KeyboardManagerEditorUI` (Debug/x64) — clean, analyzers/StyleCop green.
- Manually exercised search, each modifier toggle (incl. OR combinations), the app filter, combined AND filtering, the no-results/clear state, and multi-select bulk delete against a real ~80-entry configuration.

---

> Draft: opened for discussion on #28434.

