### PR TITLE
CmdPal: Manually set the clock band icon to blank

### DIFF
--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/NowDockBand.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/NowDockBand.cs
@@ -14,6 +14,10 @@ internal sealed partial class NowDockBand : ListItem, IDisposable
     private static readonly TimeSpan PerSecondUpdateInterval = TimeSpan.FromSeconds(1);
     private static readonly TimeSpan PerMinuteUpdateInterval = TimeSpan.FromMinutes(1);
 
+    // Manually set the icon to blank, to override the "open link" icon on the
+    // command itself
+    public override IconInfo Icon => new(string.Empty);
+
     private readonly System.Timers.Timer _timer;
     private readonly Action? _onUpdated;
     private readonly Func<DateTime> _clock;


### PR DESCRIPTION
When we added a primary command to open the notification center, that changed the icon of the clock band. It now defaulted to using the "OpenLink" icon, from the command.

By manually setting the icon to blank, we remove that icon we didn't want.
