### PR TITLE
CmdPal: Hide separator between search bar and context grids when collapsed

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/BindTransformers.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/BindTransformers.cs
@@ -27,4 +27,7 @@ internal static class BindTransformers
 
     public static Visibility VisibleWhenAny(bool value1, bool value2)
         => (value1 || value2) ? Visibility.Visible : Visibility.Collapsed;
+
+    public static Thickness BottomBorderThicknessWhenAll(bool value1, bool value2)
+        => value1 && value2 ? new Thickness(0, 0, 0, 1) : new Thickness(0);
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml
@@ -206,7 +206,7 @@
                 HorizontalAlignment="Stretch"
                 VerticalAlignment="Stretch"
                 BorderBrush="{ThemeResource CmdPal.TopBarBorderBrush}"
-                BorderThickness="0,0,0,1">
+                BorderThickness="{x:Bind h:BindTransformers.BottomBorderThicknessWhenAll(ViewModel.IsSearchBoxVisible, ExpandedMode), Mode=OneWay}">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto" />
                     <ColumnDefinition Width="*" />
@@ -596,7 +596,6 @@
                     <VisualState.Setters>
                         <Setter Target="SearchBox.IsEnabled" Value="False" />
                         <Setter Target="SearchBox.Opacity" Value="0" />
-                        <Setter Target="TopBarGrid.BorderBrush" Value="Transparent" />
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>


### PR DESCRIPTION
## Summary of the Pull Request

This PR updates a conditional visibility of a border/separator line between search bar and page content to hide it when the ShellPage is in collapsed mode.

## Pictures? Pictures!

<img width="472" height="108" alt="image" src="https://github.com/user-attachments/assets/eebc6be2-7dbf-4861-812e-d06ab1d42257" />

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #49312
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

