### PR TITLE
CmdPal JS/TS Extensions - Phase 5: gallery npm install/uninstall

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.Common/ExtensionGallery/Models/GalleryInstallSource.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Common/ExtensionGallery/Models/GalleryInstallSource.cs
@@ -11,4 +11,10 @@ public sealed class GalleryInstallSource
     public string? Id { get; set; }
 
     public string? Uri { get; set; }
+
+    /// <summary>
+    /// Gets or sets the npm metadata for a JavaScript/TypeScript ("jsonrpc") extension.
+    /// Present only when <see cref="Type"/> is "jsonrpc".
+    /// </summary>
+    public GalleryNpmPackage? Npm { get; set; }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.Common/ExtensionGallery/Models/GalleryInstallSource.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Common/ExtensionGallery/Models/GalleryInstallSource.cs
@@ -13,8 +13,8 @@ public sealed class GalleryInstallSource
     public string? Uri { get; set; }
 
     /// <summary>
-    /// Gets or sets the npm metadata for a JavaScript/TypeScript ("jsonrpc") extension.
-    /// Present only when <see cref="Type"/> is "jsonrpc".
+    /// Gets or sets the npm package details for a JavaScript/TypeScript ("jsonrpc") extension.
+    /// Only present when <see cref="Type"/> is "jsonrpc".
     /// </summary>
     public GalleryNpmPackage? Npm { get; set; }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.Common/ExtensionGallery/Models/GalleryNpmPackage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Common/ExtensionGallery/Models/GalleryNpmPackage.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CmdPal.Common.ExtensionGallery.Models;
+
+/// <summary>
+/// npm metadata for a JavaScript/TypeScript ("jsonrpc") gallery extension. Describes the
+/// package to install and, optionally, the registry it should be pulled from.
+/// </summary>
+public sealed class GalleryNpmPackage
+{
+    /// <summary>
+    /// Gets or sets the npm package identifier (for example, "@publisher/cmdpal-my-extension").
+    /// </summary>
+    public string Package { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the exact package version to install (for example, "1.4.2"). The install
+    /// flow requires an exact version; ranges and dist-tags (such as "latest") are rejected so
+    /// the artifact that is installed always matches the one the catalog approved.
+    /// </summary>
+    public string Version { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the Subresource Integrity value (for example, "sha512-...") of the approved
+    /// package tarball. The install flow verifies the resolved package against this value before
+    /// promoting it, so a registry that serves different bytes for the same version is rejected.
+    /// </summary>
+    public string Integrity { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the npm registry URL to install from. When null or empty, the default
+    /// registry configured on the machine is used. When present it must be an absolute HTTPS URL
+    /// on the approved allowlist.
+    /// </summary>
+    public string? Registry { get; set; }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.Common/ExtensionGallery/Models/GalleryNpmPackage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Common/ExtensionGallery/Models/GalleryNpmPackage.cs
@@ -5,8 +5,8 @@
 namespace Microsoft.CmdPal.Common.ExtensionGallery.Models;
 
 /// <summary>
-/// npm metadata for a JavaScript/TypeScript ("jsonrpc") gallery extension. Describes the
-/// package to install and, optionally, the registry it should be pulled from.
+/// npm package details for a JavaScript/TypeScript ("jsonrpc") gallery extension. Describes the
+/// package to install and the optional registry to use.
 /// </summary>
 public sealed class GalleryNpmPackage
 {
@@ -16,23 +16,21 @@ public sealed class GalleryNpmPackage
     public string Package { get; set; } = string.Empty;
 
     /// <summary>
-    /// Gets or sets the exact package version to install (for example, "1.4.2"). The install
-    /// flow requires an exact version; ranges and dist-tags (such as "latest") are rejected so
-    /// the artifact that is installed always matches the one the catalog approved.
+    /// Gets or sets the exact package version to install (for example, "1.4.2"). The installer
+    /// rejects ranges and dist tags such as "latest" so the installed artifact matches the catalog.
     /// </summary>
     public string Version { get; set; } = string.Empty;
 
     /// <summary>
-    /// Gets or sets the Subresource Integrity value (for example, "sha512-...") of the approved
-    /// package tarball. The install flow verifies the resolved package against this value before
+    /// Gets or sets the Subresource Integrity value (for example, "sha512-...") for the approved
+    /// package tarball. The installer checks npm's resolved package against this value before
     /// promoting it, so a registry that serves different bytes for the same version is rejected.
     /// </summary>
     public string Integrity { get; set; } = string.Empty;
 
     /// <summary>
-    /// Gets or sets the npm registry URL to install from. When null or empty, the default
-    /// registry configured on the machine is used. When present it must be an absolute HTTPS URL
-    /// on the approved allowlist.
+    /// Gets or sets the npm registry URL to install from. When null or empty, npm uses the
+    /// machine default. When present, it must be an absolute HTTPS URL on the approved allowlist.
     /// </summary>
     public string? Registry { get; set; }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Gallery/ExtensionGalleryItemViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Gallery/ExtensionGalleryItemViewModel.cs
@@ -4,12 +4,14 @@
 
 using System.Collections.ObjectModel;
 using System.Text;
+using System.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.CmdPal.Common.ExtensionGallery.Models;
 using Microsoft.CmdPal.Common.WinGet.Models;
 using Microsoft.CmdPal.Common.WinGet.Services;
 using Microsoft.CmdPal.UI.ViewModels.Properties;
+using Microsoft.CmdPal.UI.ViewModels.Services;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 using Microsoft.Extensions.Logging;
 using Microsoft.UI.Xaml.Media;
@@ -39,6 +41,7 @@ public sealed partial class ExtensionGalleryItemViewModel : ObservableObject
     private const string SourceTypeUrl = "url";
     private const string SourceTypeGitHub = "github";
     private const string SourceTypeWebsite = "website";
+    private const string SourceTypeJsonRpc = "jsonrpc";
     private const string SourceTypeUnknown = "unknown";
 
     private readonly GalleryExtensionEntry _entry;
@@ -46,6 +49,7 @@ public sealed partial class ExtensionGalleryItemViewModel : ObservableObject
     private readonly IWinGetPackageManagerService? _winGetPackageManagerService;
     private readonly IWinGetOperationTrackerService? _winGetOperationTrackerService;
     private readonly IWinGetPackageStatusService? _winGetPackageStatusService;
+    private readonly IJsExtensionInstaller? _jsExtensionInstaller;
     private readonly IReadOnlyDictionary<string, GalleryInstallSource> _installSourcesByType;
     private readonly IReadOnlyDictionary<string, GallerySourceViewModel> _sourcesByKind;
 
@@ -54,18 +58,24 @@ public sealed partial class ExtensionGalleryItemViewModel : ObservableObject
     private readonly Uri? _authorPageHttpUri;
     private readonly Uri? _installLinkHttpUri;
 
+    // Drives the cancel affordance for an in-flight jsonrpc install or uninstall. Non-null only while
+    // an operation is running.
+    private CancellationTokenSource? _jsonRpcActionCts;
+
     public ExtensionGalleryItemViewModel(
         GalleryExtensionEntry entry,
         ILogger<ExtensionGalleryItemViewModel> logger,
         IWinGetPackageManagerService? winGetPackageManagerService = null,
         IWinGetPackageStatusService? winGetPackageStatusService = null,
-        IWinGetOperationTrackerService? winGetOperationTrackerService = null)
+        IWinGetOperationTrackerService? winGetOperationTrackerService = null,
+        IJsExtensionInstaller? jsExtensionInstaller = null)
     {
         _entry = entry;
         _logger = logger;
         _winGetPackageManagerService = winGetPackageManagerService;
         _winGetPackageStatusService = winGetPackageStatusService;
         _winGetOperationTrackerService = winGetOperationTrackerService;
+        _jsExtensionInstaller = jsExtensionInstaller;
         _installSourcesByType = BuildInstallSourceLookup(entry.InstallSources);
         (Sources, _sourcesByKind) = BuildSourceInfos(_installSourcesByType, entry.Homepage);
         _homepageHttpUri = TryCreateWebUri(entry.Homepage);
@@ -75,6 +85,19 @@ public sealed partial class ExtensionGalleryItemViewModel : ObservableObject
 
         var resolvedIconUri = ResolveIconUri();
         IconUri = resolvedIconUri ?? PlaceholderIconUri;
+
+        // Derive the installed state for a jsonrpc gallery item from the host truth (a validated,
+        // loadable manifest) rather than the catalog, so reopening the gallery shows Uninstall for
+        // packages that are actually installed and blocks reinstalling into an active directory.
+        if (_jsExtensionInstaller is not null && HasJsonRpcSource)
+        {
+            if (_jsExtensionInstaller.IsInstalled(Id))
+            {
+                IsInstalled = true;
+            }
+
+            IsInstalledStateKnown = true;
+        }
     }
 
     public string Id => _entry.Id;
@@ -146,6 +169,8 @@ public sealed partial class ExtensionGalleryItemViewModel : ObservableObject
 
     public bool HasWebsiteSource => HasSource(SourceTypeWebsite);
 
+    public bool HasJsonRpcSource => HasSource(SourceTypeJsonRpc) && !string.IsNullOrWhiteSpace(JsonRpcPackageId);
+
     public bool HasUnknownSource => HasSource(SourceTypeUnknown);
 
     public bool HasAnySourceDetails => Sources.Count > 0;
@@ -173,7 +198,7 @@ public sealed partial class ExtensionGalleryItemViewModel : ObservableObject
 
     public bool ShowUnknownSourceIndicator => HasUnknownSource || !HasKnownSourceIndicator;
 
-    public bool HasActionableSourceDetails => HasStoreSource || HasWinGetSource || HasHomepage || HasUrlSource;
+    public bool HasActionableSourceDetails => HasStoreSource || HasWinGetSource || HasJsonRpcSource || HasHomepage || HasUrlSource;
 
     public bool ShowNoSourceDetails => !HasActionableSourceDetails;
 
@@ -188,6 +213,18 @@ public sealed partial class ExtensionGalleryItemViewModel : ObservableObject
     public string? WinGetId => GetSource(SourceTypeWinGet)?.Id;
 
     public string? StoreId => GetSource(SourceTypeStore)?.Id;
+
+    public string? JsonRpcPackageId =>
+        _installSourcesByType.TryGetValue(SourceTypeJsonRpc, out var source) ? source.Npm?.Package : null;
+
+    public string? JsonRpcRegistry =>
+        _installSourcesByType.TryGetValue(SourceTypeJsonRpc, out var source) ? source.Npm?.Registry : null;
+
+    public string? JsonRpcVersion =>
+        _installSourcesByType.TryGetValue(SourceTypeJsonRpc, out var source) ? source.Npm?.Version : null;
+
+    public string? JsonRpcIntegrity =>
+        _installSourcesByType.TryGetValue(SourceTypeJsonRpc, out var source) ? source.Npm?.Integrity : null;
 
     public string? InstallUrl => _installLinkHttpUri?.AbsoluteUri;
 
@@ -300,6 +337,35 @@ public sealed partial class ExtensionGalleryItemViewModel : ObservableObject
 
     public bool HasWinGetActionMessage => !string.IsNullOrWhiteSpace(WinGetActionMessage);
 
+    [ObservableProperty]
+    public partial bool IsJsonRpcActionInProgress { get; set; }
+
+    [ObservableProperty]
+    public partial string? JsonRpcActionMessage { get; set; }
+
+    public bool ShowInstallViaNpmButton => HasJsonRpcSource && !IsInstalled;
+
+    public bool CanInstallViaNpm => ShowInstallViaNpmButton && _jsExtensionInstaller is not null && !IsJsonRpcActionInProgress;
+
+    public bool ShowUninstallJsonRpcButton => HasJsonRpcSource && IsInstalled;
+
+    public bool CanUninstallJsonRpc => ShowUninstallJsonRpcButton && _jsExtensionInstaller is not null && !IsJsonRpcActionInProgress;
+
+    public bool CanCancelJsonRpcAction =>
+        IsJsonRpcActionInProgress && _jsonRpcActionCts is { IsCancellationRequested: false };
+
+    public bool ShowCancelJsonRpcActionButton => IsJsonRpcActionInProgress && CanCancelJsonRpcAction;
+
+    public bool ShowJsonRpcActionControls => HasJsonRpcSource && (ShowInstallViaNpmButton || ShowUninstallJsonRpcButton || IsJsonRpcActionInProgress);
+
+    public bool HasJsonRpcActionMessage => !string.IsNullOrWhiteSpace(JsonRpcActionMessage);
+
+    public string InstallViaNpmText => Resources.gallery_item_install_action;
+
+    public string UninstallJsonRpcText => Resources.gallery_item_jsonrpc_uninstall_action;
+
+    public string CancelJsonRpcActionText => Resources.gallery_item_jsonrpc_cancel_action;
+
     public void ApplyWinGetPackageInfo(WinGetPackageInfo packageInfo)
     {
         IsInstalled = IsInstalled || packageInfo.Status.IsInstalled;
@@ -366,6 +432,100 @@ public sealed partial class ExtensionGalleryItemViewModel : ObservableObject
         }
 
         ClipboardHelper.SetText(WinGetInstallCommand);
+    }
+
+    [RelayCommand(CanExecute = nameof(CanInstallViaNpm))]
+    private async Task InstallViaNpmAsync()
+    {
+        if (_jsExtensionInstaller is null || string.IsNullOrWhiteSpace(JsonRpcPackageId))
+        {
+            return;
+        }
+
+        IsJsonRpcActionInProgress = true;
+        JsonRpcActionMessage = Resources.gallery_item_jsonrpc_action_installing;
+
+        using var cts = new CancellationTokenSource();
+        _jsonRpcActionCts = cts;
+        NotifyJsonRpcActionStateChanged();
+
+        try
+        {
+            var result = await _jsExtensionInstaller.InstallAsync(Id, JsonRpcPackageId, JsonRpcVersion, JsonRpcIntegrity, JsonRpcRegistry, cts.Token).ConfigureAwait(true);
+            if (result.Succeeded)
+            {
+                IsInstalled = true;
+                IsInstalledStateKnown = true;
+                JsonRpcActionMessage = Resources.gallery_item_jsonrpc_action_installed;
+            }
+            else
+            {
+                JsonRpcActionMessage = result.ErrorMessage ?? Resources.gallery_item_jsonrpc_action_install_failed;
+            }
+        }
+        finally
+        {
+            _jsonRpcActionCts = null;
+            IsJsonRpcActionInProgress = false;
+        }
+    }
+
+    [RelayCommand(CanExecute = nameof(CanUninstallJsonRpc))]
+    private async Task UninstallJsonRpcAsync()
+    {
+        if (_jsExtensionInstaller is null)
+        {
+            return;
+        }
+
+        IsJsonRpcActionInProgress = true;
+        JsonRpcActionMessage = Resources.gallery_item_jsonrpc_action_uninstalling;
+
+        using var cts = new CancellationTokenSource();
+        _jsonRpcActionCts = cts;
+        NotifyJsonRpcActionStateChanged();
+
+        try
+        {
+            var result = await _jsExtensionInstaller.UninstallAsync(Id, cts.Token).ConfigureAwait(true);
+            if (result.Succeeded)
+            {
+                IsInstalled = false;
+                IsInstalledStateKnown = true;
+                JsonRpcActionMessage = Resources.gallery_item_jsonrpc_action_uninstalled;
+            }
+            else
+            {
+                JsonRpcActionMessage = result.ErrorMessage ?? Resources.gallery_item_jsonrpc_action_uninstall_failed;
+            }
+        }
+        finally
+        {
+            _jsonRpcActionCts = null;
+            IsJsonRpcActionInProgress = false;
+        }
+    }
+
+    [RelayCommand(CanExecute = nameof(CanCancelJsonRpcAction))]
+    private void CancelJsonRpcAction()
+    {
+        var cts = _jsonRpcActionCts;
+        if (cts is null || cts.IsCancellationRequested)
+        {
+            return;
+        }
+
+        try
+        {
+            cts.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+            // The operation completed and disposed the source between the guard and here; nothing to do.
+        }
+
+        JsonRpcActionMessage = Resources.gallery_item_jsonrpc_action_canceling;
+        NotifyJsonRpcActionStateChanged();
     }
 
     [RelayCommand(CanExecute = nameof(CanInstallViaWinGet))]
@@ -633,8 +793,9 @@ public sealed partial class ExtensionGalleryItemViewModel : ObservableObject
         {
             SourceTypeStore => 0,
             SourceTypeWinGet => 1,
-            SourceTypeGitHub => 2,
-            SourceTypeWebsite => 3,
+            SourceTypeJsonRpc => 2,
+            SourceTypeGitHub => 3,
+            SourceTypeWebsite => 4,
             SourceTypeUnknown => 99,
             _ => 98,
         };
@@ -699,6 +860,12 @@ public sealed partial class ExtensionGalleryItemViewModel : ObservableObject
                 uri: null,
                 isKnown: true),
             SourceTypeUrl => CreateSourceFromUrl(installSource.Uri),
+            SourceTypeJsonRpc => CreateSourceViewModel(
+                SourceTypeJsonRpc,
+                Resources.gallery_item_source_name_jsonrpc,
+                installSource.Npm?.Package,
+                uri: installSource.Npm?.Registry,
+                isKnown: true),
             _ => CreateSourceViewModel(
                 SourceTypeUnknown,
                 FormatResource(Resources.gallery_item_source_name_unknown, normalizedType),
@@ -940,6 +1107,31 @@ public sealed partial class ExtensionGalleryItemViewModel : ObservableObject
         OnPropertyChanged(nameof(InstallViaWinGetText));
         OnPropertyChanged(nameof(ShowWinGetActionControls));
         InstallViaWinGetCommand.NotifyCanExecuteChanged();
+        NotifyJsonRpcActionStateChanged();
+    }
+
+    private void NotifyJsonRpcActionStateChanged()
+    {
+        OnPropertyChanged(nameof(ShowInstallViaNpmButton));
+        OnPropertyChanged(nameof(CanInstallViaNpm));
+        OnPropertyChanged(nameof(ShowUninstallJsonRpcButton));
+        OnPropertyChanged(nameof(CanUninstallJsonRpc));
+        OnPropertyChanged(nameof(CanCancelJsonRpcAction));
+        OnPropertyChanged(nameof(ShowCancelJsonRpcActionButton));
+        OnPropertyChanged(nameof(ShowJsonRpcActionControls));
+        InstallViaNpmCommand.NotifyCanExecuteChanged();
+        UninstallJsonRpcCommand.NotifyCanExecuteChanged();
+        CancelJsonRpcActionCommand.NotifyCanExecuteChanged();
+    }
+
+    partial void OnIsJsonRpcActionInProgressChanged(bool value)
+    {
+        NotifyJsonRpcActionStateChanged();
+    }
+
+    partial void OnJsonRpcActionMessageChanged(string? value)
+    {
+        OnPropertyChanged(nameof(HasJsonRpcActionMessage));
     }
 
     partial void OnIsInstalledStateKnownChanged(bool value)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Gallery/ExtensionGalleryItemViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Gallery/ExtensionGalleryItemViewModel.cs
@@ -57,6 +57,9 @@ public sealed partial class ExtensionGalleryItemViewModel : ObservableObject
     private readonly Uri? _homepageHttpUri;
     private readonly Uri? _authorPageHttpUri;
     private readonly Uri? _installLinkHttpUri;
+    private bool _isDetectedInstalled;
+    private bool _isWinGetInstalled;
+    private bool _isWinGetInstalledStateKnown;
 
     // Backs Cancel while a jsonrpc install or uninstall is running.
     private CancellationTokenSource? _jsonRpcActionCts;
@@ -89,11 +92,7 @@ public sealed partial class ExtensionGalleryItemViewModel : ObservableObject
         // packages that are installed and blocks reinstall into an active directory.
         if (_jsExtensionInstaller is not null && HasJsonRpcSource)
         {
-            if (_jsExtensionInstaller.IsInstalled(Id))
-            {
-                IsInstalled = true;
-            }
-
+            IsJsonRpcInstalled = _jsExtensionInstaller.IsInstalled(Id);
             IsInstalledStateKnown = true;
         }
     }
@@ -262,7 +261,7 @@ public sealed partial class ExtensionGalleryItemViewModel : ObservableObject
 
     public bool ShowWinGetUnavailableMessage => !string.IsNullOrWhiteSpace(WinGetUnavailableMessage);
 
-    public bool ShowInstallViaWinGetButton => HasWinGetSource && (!IsInstalled || IsUpdateAvailable);
+    public bool ShowInstallViaWinGetButton => HasWinGetSource && (!_isWinGetInstalled || IsUpdateAvailable);
 
     public bool CanInstallViaWinGet => ShowInstallViaWinGetButton && IsWinGetAvailable && !IsWinGetActionInProgress;
 
@@ -325,9 +324,9 @@ public sealed partial class ExtensionGalleryItemViewModel : ObservableObject
             ? string.Empty
             : IsUpdateAvailable
                 ? Resources.gallery_item_winget_status_update_available
-                : IsInstalled
+                : _isWinGetInstalled
                     ? Resources.gallery_item_winget_status_installed
-                    : IsInstalledStateKnown
+                    : _isWinGetInstalledStateKnown
                         ? Resources.gallery_item_winget_status_not_installed
                         : Resources.gallery_item_winget_status_unavailable;
 
@@ -341,11 +340,14 @@ public sealed partial class ExtensionGalleryItemViewModel : ObservableObject
     [ObservableProperty]
     public partial string? JsonRpcActionMessage { get; set; }
 
-    public bool ShowInstallViaNpmButton => HasJsonRpcSource && !IsInstalled;
+    [ObservableProperty]
+    public partial bool IsJsonRpcInstalled { get; set; }
+
+    public bool ShowInstallViaNpmButton => HasJsonRpcSource && !IsJsonRpcInstalled;
 
     public bool CanInstallViaNpm => ShowInstallViaNpmButton && _jsExtensionInstaller is not null && !IsJsonRpcActionInProgress;
 
-    public bool ShowUninstallJsonRpcButton => HasJsonRpcSource && IsInstalled;
+    public bool ShowUninstallJsonRpcButton => HasJsonRpcSource && IsJsonRpcInstalled;
 
     public bool CanUninstallJsonRpc => ShowUninstallJsonRpcButton && _jsExtensionInstaller is not null && !IsJsonRpcActionInProgress;
 
@@ -366,10 +368,13 @@ public sealed partial class ExtensionGalleryItemViewModel : ObservableObject
 
     public void ApplyWinGetPackageInfo(WinGetPackageInfo packageInfo)
     {
-        IsInstalled = IsInstalled || packageInfo.Status.IsInstalled;
+        _isWinGetInstalled = packageInfo.Status.IsInstalled;
+        _isWinGetInstalledStateKnown = packageInfo.Status.IsInstalledStateKnown;
+        UpdateAggregateInstalledState();
         IsInstalledStateKnown = IsInstalledStateKnown || packageInfo.Status.IsInstalledStateKnown;
         IsUpdateAvailable = packageInfo.Status.IsUpdateAvailable;
         IsUpdateStateKnown = packageInfo.Status.IsUpdateStateKnown;
+        NotifyWinGetInstallStateChanged();
 
         if (packageInfo.Details is null)
         {
@@ -377,6 +382,13 @@ public sealed partial class ExtensionGalleryItemViewModel : ObservableObject
         }
 
         ApplySourceDetails(SourceTypeWinGet, CreateSourceDetails(packageInfo.Details));
+    }
+
+    public void ApplyDetectedInstallationState(bool isInstalled)
+    {
+        _isDetectedInstalled = isInstalled;
+        UpdateAggregateInstalledState();
+        IsInstalledStateKnown = true;
     }
 
     [RelayCommand(CanExecute = nameof(HasHomepage))]
@@ -452,12 +464,14 @@ public sealed partial class ExtensionGalleryItemViewModel : ObservableObject
             var result = await _jsExtensionInstaller.InstallAsync(Id, JsonRpcPackageId, JsonRpcVersion, JsonRpcIntegrity, JsonRpcRegistry, cts.Token).ConfigureAwait(true);
             if (result.Succeeded)
             {
-                IsInstalled = true;
+                IsJsonRpcInstalled = true;
                 IsInstalledStateKnown = true;
                 JsonRpcActionMessage = Resources.gallery_item_jsonrpc_action_installed;
             }
             else
             {
+                IsJsonRpcInstalled = _jsExtensionInstaller.IsInstalled(Id);
+                IsInstalledStateKnown = true;
                 JsonRpcActionMessage = result.ErrorMessage ?? Resources.gallery_item_jsonrpc_action_install_failed;
             }
         }
@@ -488,12 +502,14 @@ public sealed partial class ExtensionGalleryItemViewModel : ObservableObject
             var result = await _jsExtensionInstaller.UninstallAsync(Id, cts.Token).ConfigureAwait(true);
             if (result.Succeeded)
             {
-                IsInstalled = false;
+                IsJsonRpcInstalled = false;
                 IsInstalledStateKnown = true;
                 JsonRpcActionMessage = Resources.gallery_item_jsonrpc_action_uninstalled;
             }
             else
             {
+                IsJsonRpcInstalled = _jsExtensionInstaller.IsInstalled(Id);
+                IsInstalledStateKnown = true;
                 JsonRpcActionMessage = result.ErrorMessage ?? Resources.gallery_item_jsonrpc_action_uninstall_failed;
             }
         }
@@ -1056,18 +1072,24 @@ public sealed partial class ExtensionGalleryItemViewModel : ObservableObject
             }
         }
 
-        IsInstalled = completedOperationKind != WinGetPackageOperationKind.Uninstall;
+        _isWinGetInstalled = completedOperationKind != WinGetPackageOperationKind.Uninstall;
+        _isWinGetInstalledStateKnown = true;
+        UpdateAggregateInstalledState();
         IsInstalledStateKnown = true;
         IsUpdateAvailable = false;
         IsUpdateStateKnown = true;
+        NotifyWinGetInstallStateChanged();
     }
 
     private void ApplyOptimisticTrackedCompletion(WinGetPackageOperationKind completedOperationKind)
     {
-        IsInstalled = completedOperationKind != WinGetPackageOperationKind.Uninstall;
+        _isWinGetInstalled = completedOperationKind != WinGetPackageOperationKind.Uninstall;
+        _isWinGetInstalledStateKnown = true;
+        UpdateAggregateInstalledState();
         IsInstalledStateKnown = true;
         IsUpdateAvailable = false;
         IsUpdateStateKnown = true;
+        NotifyWinGetInstallStateChanged();
     }
 
     private ImageSource CreateImageSource(Uri iconUri)
@@ -1122,8 +1144,29 @@ public sealed partial class ExtensionGalleryItemViewModel : ObservableObject
         CancelJsonRpcActionCommand.NotifyCanExecuteChanged();
     }
 
+    private void NotifyWinGetInstallStateChanged()
+    {
+        OnPropertyChanged(nameof(ShowInstallViaWinGetButton));
+        OnPropertyChanged(nameof(CanInstallViaWinGet));
+        OnPropertyChanged(nameof(WinGetStatusText));
+        OnPropertyChanged(nameof(ShowWinGetStatusDetails));
+        OnPropertyChanged(nameof(ShowWinGetActionControls));
+        InstallViaWinGetCommand.NotifyCanExecuteChanged();
+    }
+
+    private void UpdateAggregateInstalledState()
+    {
+        IsInstalled = _isDetectedInstalled || _isWinGetInstalled || IsJsonRpcInstalled;
+    }
+
     partial void OnIsJsonRpcActionInProgressChanged(bool value)
     {
+        NotifyJsonRpcActionStateChanged();
+    }
+
+    partial void OnIsJsonRpcInstalledChanged(bool value)
+    {
+        UpdateAggregateInstalledState();
         NotifyJsonRpcActionStateChanged();
     }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Gallery/ExtensionGalleryItemViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Gallery/ExtensionGalleryItemViewModel.cs
@@ -58,8 +58,7 @@ public sealed partial class ExtensionGalleryItemViewModel : ObservableObject
     private readonly Uri? _authorPageHttpUri;
     private readonly Uri? _installLinkHttpUri;
 
-    // Drives the cancel affordance for an in-flight jsonrpc install or uninstall. Non-null only while
-    // an operation is running.
+    // Backs Cancel while a jsonrpc install or uninstall is running.
     private CancellationTokenSource? _jsonRpcActionCts;
 
     public ExtensionGalleryItemViewModel(
@@ -86,9 +85,8 @@ public sealed partial class ExtensionGalleryItemViewModel : ObservableObject
         var resolvedIconUri = ResolveIconUri();
         IconUri = resolvedIconUri ?? PlaceholderIconUri;
 
-        // Derive the installed state for a jsonrpc gallery item from the host truth (a validated,
-        // loadable manifest) rather than the catalog, so reopening the gallery shows Uninstall for
-        // packages that are actually installed and blocks reinstalling into an active directory.
+        // Seed jsonrpc install state from the host, not the catalog. That keeps Uninstall visible for
+        // packages that are installed and blocks reinstall into an active directory.
         if (_jsExtensionInstaller is not null && HasJsonRpcSource)
         {
             if (_jsExtensionInstaller.IsInstalled(Id))
@@ -521,7 +519,7 @@ public sealed partial class ExtensionGalleryItemViewModel : ObservableObject
         }
         catch (ObjectDisposedException)
         {
-            // The operation completed and disposed the source between the guard and here; nothing to do.
+            // The operation finished and disposed the source after the guard but before Cancel.
         }
 
         JsonRpcActionMessage = Resources.gallery_item_jsonrpc_action_canceling;

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Gallery/ExtensionGalleryItemViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Gallery/ExtensionGalleryItemViewModel.cs
@@ -36,6 +36,18 @@ public sealed partial class ExtensionGalleryItemViewModel : ObservableObject
             new EventId(2, nameof(LogIconLoadFailed)),
             "Failed to load icon from '{IconUri}'.");
 
+    private static readonly Action<ILogger, Exception?> LogJsonRpcInstallFailedMessage =
+        LoggerMessage.Define(
+            LogLevel.Error,
+            new EventId(3, nameof(LogJsonRpcInstallFailed)),
+            "JavaScript extension install failed.");
+
+    private static readonly Action<ILogger, Exception?> LogJsonRpcUninstallFailedMessage =
+        LoggerMessage.Define(
+            LogLevel.Error,
+            new EventId(4, nameof(LogJsonRpcUninstallFailed)),
+            "JavaScript extension uninstall failed.");
+
     private const string SourceTypeWinGet = "winget";
     private const string SourceTypeStore = "msstore";
     private const string SourceTypeUrl = "url";
@@ -475,6 +487,15 @@ public sealed partial class ExtensionGalleryItemViewModel : ObservableObject
                 JsonRpcActionMessage = result.ErrorMessage ?? Resources.gallery_item_jsonrpc_action_install_failed;
             }
         }
+        catch (OperationCanceledException)
+        {
+            JsonRpcActionMessage = Resources.npm_installer_canceled;
+        }
+        catch (Exception ex)
+        {
+            LogJsonRpcInstallFailed(_logger, ex);
+            JsonRpcActionMessage = Resources.gallery_item_jsonrpc_action_install_failed;
+        }
         finally
         {
             _jsonRpcActionCts = null;
@@ -512,6 +533,15 @@ public sealed partial class ExtensionGalleryItemViewModel : ObservableObject
                 IsInstalledStateKnown = true;
                 JsonRpcActionMessage = result.ErrorMessage ?? Resources.gallery_item_jsonrpc_action_uninstall_failed;
             }
+        }
+        catch (OperationCanceledException)
+        {
+            JsonRpcActionMessage = Resources.npm_installer_canceled;
+        }
+        catch (Exception ex)
+        {
+            LogJsonRpcUninstallFailed(_logger, ex);
+            JsonRpcActionMessage = Resources.gallery_item_jsonrpc_action_uninstall_failed;
         }
         finally
         {
@@ -1113,6 +1143,16 @@ public sealed partial class ExtensionGalleryItemViewModel : ObservableObject
     private static void LogIconLoadFailed(ILogger logger, string iconUri, Exception exception)
     {
         LogIconLoadFailedMessage(logger, iconUri, exception);
+    }
+
+    private static void LogJsonRpcInstallFailed(ILogger logger, Exception exception)
+    {
+        LogJsonRpcInstallFailedMessage(logger, exception);
+    }
+
+    private static void LogJsonRpcUninstallFailed(ILogger logger, Exception exception)
+    {
+        LogJsonRpcUninstallFailedMessage(logger, exception);
     }
 
     partial void OnIsInstalledChanged(bool value)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Gallery/ExtensionGalleryItemViewModelFactory.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Gallery/ExtensionGalleryItemViewModelFactory.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.CmdPal.Common.ExtensionGallery.Models;
 using Microsoft.CmdPal.Common.WinGet.Services;
+using Microsoft.CmdPal.UI.ViewModels.Services;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.CmdPal.UI.ViewModels.Gallery;
@@ -14,17 +15,20 @@ public sealed class ExtensionGalleryItemViewModelFactory
     private readonly IWinGetPackageManagerService? _winGetPackageManagerService;
     private readonly IWinGetOperationTrackerService? _winGetOperationTrackerService;
     private readonly IWinGetPackageStatusService? _winGetPackageStatusService;
+    private readonly IJsExtensionInstaller? _jsExtensionInstaller;
 
     public ExtensionGalleryItemViewModelFactory(
         ILogger<ExtensionGalleryItemViewModel> logger,
         IWinGetPackageManagerService? winGetPackageManagerService = null,
         IWinGetPackageStatusService? winGetPackageStatusService = null,
-        IWinGetOperationTrackerService? winGetOperationTrackerService = null)
+        IWinGetOperationTrackerService? winGetOperationTrackerService = null,
+        IJsExtensionInstaller? jsExtensionInstaller = null)
     {
         _logger = logger;
         _winGetPackageManagerService = winGetPackageManagerService;
         _winGetPackageStatusService = winGetPackageStatusService;
         _winGetOperationTrackerService = winGetOperationTrackerService;
+        _jsExtensionInstaller = jsExtensionInstaller;
     }
 
     public ExtensionGalleryItemViewModel Create(GalleryExtensionEntry entry)
@@ -36,6 +40,7 @@ public sealed class ExtensionGalleryItemViewModelFactory
             _logger,
             _winGetPackageManagerService,
             _winGetPackageStatusService,
-            _winGetOperationTrackerService);
+            _winGetOperationTrackerService,
+            _jsExtensionInstaller);
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Gallery/ExtensionGalleryViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Gallery/ExtensionGalleryViewModel.cs
@@ -391,8 +391,7 @@ public sealed partial class ExtensionGalleryViewModel : ObservableObject, IDispo
             {
                 if (!string.IsNullOrEmpty(entry.PackageFamilyName))
                 {
-                    entry.IsInstalled = installedPfns.Contains(entry.PackageFamilyName);
-                    entry.IsInstalledStateKnown = true;
+                    entry.ApplyDetectedInstallationState(installedPfns.Contains(entry.PackageFamilyName));
                 }
             }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Models/JSExtensionWrapper.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Models/JSExtensionWrapper.cs
@@ -213,7 +213,9 @@ public sealed partial class JSExtensionWrapper : IExtensionWrapper, IDisposable
         }
     }
 
-    public Task StartExtensionAsync()
+    public Task StartExtensionAsync() => StartExtensionAsync(CancellationToken.None);
+
+    internal Task StartExtensionAsync(CancellationToken cancellationToken)
     {
         lock (_lock)
         {
@@ -229,16 +231,16 @@ public sealed partial class JSExtensionWrapper : IExtensionWrapper, IDisposable
             // instead of spawning a second Node process. The start body runs on the thread
             // pool so no process is spawned while this lock is held; the task is cleared
             // when it completes so a later restart can start again.
-            _startInProgress ??= Task.Run(RunStartAsync);
+            _startInProgress ??= Task.Run(() => RunStartAsync(cancellationToken), CancellationToken.None);
             return _startInProgress;
         }
     }
 
-    private async Task RunStartAsync()
+    private async Task RunStartAsync(CancellationToken cancellationToken)
     {
         try
         {
-            await StartCoreAsync().ConfigureAwait(false);
+            await StartCoreAsync(cancellationToken).ConfigureAwait(false);
         }
         finally
         {
@@ -249,8 +251,10 @@ public sealed partial class JSExtensionWrapper : IExtensionWrapper, IDisposable
         }
     }
 
-    private async Task StartCoreAsync()
+    private async Task StartCoreAsync(CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         lock (_lock)
         {
             // The wrapper may have been disposed, or another start may have completed,
@@ -361,7 +365,7 @@ public sealed partial class JSExtensionWrapper : IExtensionWrapper, IDisposable
             var initResponse = await connection.SendRequestAsync(
                 "initialize",
                 new JsonObject { ["extensionId"] = _manifest.Name },
-                CancellationToken.None).ConfigureAwait(false);
+                cancellationToken).ConfigureAwait(false);
 
             if (initResponse.Error is not null)
             {
@@ -393,7 +397,11 @@ public sealed partial class JSExtensionWrapper : IExtensionWrapper, IDisposable
         }
         catch (Exception ex)
         {
-            Logger.LogError($"Failed to start JS extension {_manifest.Name}: {ex.Message}");
+            var canceled = ex is OperationCanceledException && cancellationToken.IsCancellationRequested;
+            if (!canceled)
+            {
+                Logger.LogError($"Failed to start JS extension {_manifest.Name}: {ex.Message}");
+            }
 
             try
             {
@@ -408,6 +416,10 @@ public sealed partial class JSExtensionWrapper : IExtensionWrapper, IDisposable
             }
 
             SignalDispose();
+            if (canceled)
+            {
+                throw;
+            }
         }
     }
 
@@ -443,6 +455,22 @@ public sealed partial class JSExtensionWrapper : IExtensionWrapper, IDisposable
 
     public void SignalDispose()
     {
+        var (process, connection, proxy) = DetachForDispose();
+        TearDown(process, connection, proxy);
+    }
+
+    public Task SignalDisposeAsync()
+    {
+        var (process, connection, proxy) = DetachForDispose();
+        return process is null && connection is null && proxy is null
+            ? Task.CompletedTask
+            : Task.Run(() => TearDown(process, connection, proxy));
+    }
+
+    public void Dispose() => SignalDispose();
+
+    private (Process? Process, JsonRpcConnection? Connection, JSCommandProviderProxy? Proxy) DetachForDispose()
+    {
         Process? process;
         JsonRpcConnection? connection;
         JSCommandProviderProxy? proxy;
@@ -459,10 +487,8 @@ public sealed partial class JSExtensionWrapper : IExtensionWrapper, IDisposable
             _commandProviderProxy = null;
         }
 
-        TearDown(process, connection, proxy);
+        return (process, connection, proxy);
     }
-
-    public void Dispose() => SignalDispose();
 
     public IExtension? GetExtensionObject()
     {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Properties/Resources.Designer.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Properties/Resources.Designer.cs
@@ -727,6 +727,321 @@ namespace Microsoft.CmdPal.UI.ViewModels.Properties {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to npm.
+        /// </summary>
+        public static string gallery_item_source_name_jsonrpc {
+            get {
+                return ResourceManager.GetString("gallery_item_source_name_jsonrpc", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Installing....
+        /// </summary>
+        public static string gallery_item_jsonrpc_action_installing {
+            get {
+                return ResourceManager.GetString("gallery_item_jsonrpc_action_installing", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Uninstalling....
+        /// </summary>
+        public static string gallery_item_jsonrpc_action_uninstalling {
+            get {
+                return ResourceManager.GetString("gallery_item_jsonrpc_action_uninstalling", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Extension installed.
+        /// </summary>
+        public static string gallery_item_jsonrpc_action_installed {
+            get {
+                return ResourceManager.GetString("gallery_item_jsonrpc_action_installed", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Extension uninstalled.
+        /// </summary>
+        public static string gallery_item_jsonrpc_action_uninstalled {
+            get {
+                return ResourceManager.GetString("gallery_item_jsonrpc_action_uninstalled", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The installation failed.
+        /// </summary>
+        public static string gallery_item_jsonrpc_action_install_failed {
+            get {
+                return ResourceManager.GetString("gallery_item_jsonrpc_action_install_failed", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The uninstall failed.
+        /// </summary>
+        public static string gallery_item_jsonrpc_action_uninstall_failed {
+            get {
+                return ResourceManager.GetString("gallery_item_jsonrpc_action_uninstall_failed", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Uninstall.
+        /// </summary>
+        public static string gallery_item_jsonrpc_uninstall_action {
+            get {
+                return ResourceManager.GetString("gallery_item_jsonrpc_uninstall_action", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Cancel.
+        /// </summary>
+        public static string gallery_item_jsonrpc_cancel_action {
+            get {
+                return ResourceManager.GetString("gallery_item_jsonrpc_cancel_action", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Canceling....
+        /// </summary>
+        public static string gallery_item_jsonrpc_action_canceling {
+            get {
+                return ResourceManager.GetString("gallery_item_jsonrpc_action_canceling", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The extension name is not valid.
+        /// </summary>
+        public static string npm_installer_invalid_name {
+            get {
+                return ResourceManager.GetString("npm_installer_invalid_name", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to This extension cannot be installed because its listing does not specify an npm package.
+        /// </summary>
+        public static string npm_installer_package_missing {
+            get {
+                return ResourceManager.GetString("npm_installer_package_missing", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to This extension cannot be installed because its npm package name is not valid.
+        /// </summary>
+        public static string npm_installer_package_invalid {
+            get {
+                return ResourceManager.GetString("npm_installer_package_invalid", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to This extension cannot be installed because its listing does not specify an exact version.
+        /// </summary>
+        public static string npm_installer_version_missing {
+            get {
+                return ResourceManager.GetString("npm_installer_version_missing", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to This extension cannot be installed because its listing does not specify a single exact version.
+        /// </summary>
+        public static string npm_installer_version_invalid {
+            get {
+                return ResourceManager.GetString("npm_installer_version_invalid", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to This extension cannot be installed because its listing does not include an integrity hash.
+        /// </summary>
+        public static string npm_installer_integrity_missing {
+            get {
+                return ResourceManager.GetString("npm_installer_integrity_missing", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to This extension cannot be installed because its integrity hash is not a supported format.
+        /// </summary>
+        public static string npm_installer_integrity_invalid {
+            get {
+                return ResourceManager.GetString("npm_installer_integrity_invalid", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to This extension cannot be installed because it requests a registry that is not allowed.
+        /// </summary>
+        public static string npm_installer_registry_invalid {
+            get {
+                return ResourceManager.GetString("npm_installer_registry_invalid", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to This extension is already installed. Uninstall it first to install a different version.
+        /// </summary>
+        public static string npm_installer_already_installed {
+            get {
+                return ResourceManager.GetString("npm_installer_already_installed", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The downloaded package did not match the expected integrity hash and was not installed.
+        /// </summary>
+        public static string npm_installer_integrity_mismatch {
+            get {
+                return ResourceManager.GetString("npm_installer_integrity_mismatch", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The downloaded package did not match the expected extension and was not installed.
+        /// </summary>
+        public static string npm_installer_identity_mismatch {
+            get {
+                return ResourceManager.GetString("npm_installer_identity_mismatch", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The downloaded package did not match the expected version and was not installed.
+        /// </summary>
+        public static string npm_installer_version_mismatch {
+            get {
+                return ResourceManager.GetString("npm_installer_version_mismatch", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The package was downloaded but does not contain a usable Command Palette extension.
+        /// </summary>
+        public static string npm_installer_not_an_extension {
+            get {
+                return ResourceManager.GetString("npm_installer_not_an_extension", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The extension was installed but could not be loaded, so it was removed.
+        /// </summary>
+        public static string npm_installer_not_discoverable {
+            get {
+                return ResourceManager.GetString("npm_installer_not_discoverable", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The operation was canceled.
+        /// </summary>
+        public static string npm_installer_canceled {
+            get {
+                return ResourceManager.GetString("npm_installer_canceled", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The extension files could not be removed. Close anything using them and try again.
+        /// </summary>
+        public static string npm_installer_remove_failed {
+            get {
+                return ResourceManager.GetString("npm_installer_remove_failed", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The installation failed.
+        /// </summary>
+        public static string npm_installer_install_failed {
+            get {
+                return ResourceManager.GetString("npm_installer_install_failed", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to npm was not found. Install Node.js to add JavaScript extensions.
+        /// </summary>
+        public static string npm_runner_npm_not_found {
+            get {
+                return ResourceManager.GetString("npm_runner_npm_not_found", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to npm could not be started.
+        /// </summary>
+        public static string npm_runner_start_failed {
+            get {
+                return ResourceManager.GetString("npm_runner_start_failed", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to A temporary install folder could not be created: {0}.
+        /// </summary>
+        public static string npm_runner_create_staging_failed {
+            get {
+                return ResourceManager.GetString("npm_runner_create_staging_failed", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The install timed out after {0} minutes.
+        /// </summary>
+        public static string npm_runner_timed_out {
+            get {
+                return ResourceManager.GetString("npm_runner_timed_out", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to npm failed with exit code {0}.
+        /// </summary>
+        public static string npm_runner_failed_exit {
+            get {
+                return ResourceManager.GetString("npm_runner_failed_exit", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The install was blocked because a dependency was not resolved from the approved registry with a verified integrity hash.
+        /// </summary>
+        public static string npm_runner_lockfile_untrusted {
+            get {
+                return ResourceManager.GetString("npm_runner_lockfile_untrusted", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The install was blocked because the package does not include a published npm-shrinkwrap.json. Command Palette only installs packages whose publisher has frozen the full dependency tree.
+        /// </summary>
+        public static string npm_runner_shrinkwrap_required {
+            get {
+                return ResourceManager.GetString("npm_runner_shrinkwrap_required", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The install was blocked because the downloaded package could not be read.
+        /// </summary>
+        public static string npm_runner_extract_failed {
+            get {
+                return ResourceManager.GetString("npm_runner_extract_failed", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to WinGet.
         /// </summary>
         public static string gallery_item_source_name_winget {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Properties/Resources.resx
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Properties/Resources.resx
@@ -492,6 +492,121 @@
   <data name="gallery_item_source_name_website" xml:space="preserve">
     <value>Website</value>
   </data>
+  <data name="gallery_item_source_name_jsonrpc" xml:space="preserve">
+    <value>npm</value>
+    <comment>Name of the npm install source for JavaScript/TypeScript extensions. Do not translate "npm".</comment>
+  </data>
+  <data name="gallery_item_jsonrpc_action_installing" xml:space="preserve">
+    <value>Installing...</value>
+  </data>
+  <data name="gallery_item_jsonrpc_action_uninstalling" xml:space="preserve">
+    <value>Uninstalling...</value>
+  </data>
+  <data name="gallery_item_jsonrpc_action_installed" xml:space="preserve">
+    <value>Extension installed.</value>
+  </data>
+  <data name="gallery_item_jsonrpc_action_uninstalled" xml:space="preserve">
+    <value>Extension uninstalled.</value>
+  </data>
+  <data name="gallery_item_jsonrpc_action_install_failed" xml:space="preserve">
+    <value>The installation failed.</value>
+  </data>
+  <data name="gallery_item_jsonrpc_action_uninstall_failed" xml:space="preserve">
+    <value>The uninstall failed.</value>
+  </data>
+  <data name="gallery_item_jsonrpc_uninstall_action" xml:space="preserve">
+    <value>Uninstall</value>
+  </data>
+  <data name="gallery_item_jsonrpc_cancel_action" xml:space="preserve">
+    <value>Cancel</value>
+    <comment>Button that cancels an in-progress extension install or uninstall.</comment>
+  </data>
+  <data name="gallery_item_jsonrpc_action_canceling" xml:space="preserve">
+    <value>Canceling...</value>
+  </data>
+  <data name="npm_installer_invalid_name" xml:space="preserve">
+    <value>The extension name is not valid.</value>
+  </data>
+  <data name="npm_installer_package_missing" xml:space="preserve">
+    <value>This extension cannot be installed because its listing does not specify an npm package.</value>
+  </data>
+  <data name="npm_installer_package_invalid" xml:space="preserve">
+    <value>This extension cannot be installed because its npm package name is not valid.</value>
+  </data>
+  <data name="npm_installer_version_missing" xml:space="preserve">
+    <value>This extension cannot be installed because its listing does not specify an exact version.</value>
+  </data>
+  <data name="npm_installer_version_invalid" xml:space="preserve">
+    <value>This extension cannot be installed because its listing does not specify a single exact version.</value>
+  </data>
+  <data name="npm_installer_integrity_missing" xml:space="preserve">
+    <value>This extension cannot be installed because its listing does not include an integrity hash.</value>
+  </data>
+  <data name="npm_installer_integrity_invalid" xml:space="preserve">
+    <value>This extension cannot be installed because its integrity hash is not a supported format.</value>
+  </data>
+  <data name="npm_installer_registry_invalid" xml:space="preserve">
+    <value>This extension cannot be installed because it requests a registry that is not allowed.</value>
+  </data>
+  <data name="npm_installer_already_installed" xml:space="preserve">
+    <value>This extension is already installed. Uninstall it first to install a different version.</value>
+  </data>
+  <data name="npm_installer_integrity_mismatch" xml:space="preserve">
+    <value>The downloaded package did not match the expected integrity hash and was not installed.</value>
+  </data>
+  <data name="npm_installer_identity_mismatch" xml:space="preserve">
+    <value>The downloaded package did not match the expected extension and was not installed.</value>
+  </data>
+  <data name="npm_installer_version_mismatch" xml:space="preserve">
+    <value>The downloaded package did not match the expected version and was not installed.</value>
+  </data>
+  <data name="npm_installer_not_an_extension" xml:space="preserve">
+    <value>The package was downloaded but does not contain a usable Command Palette extension.</value>
+  </data>
+  <data name="npm_installer_not_discoverable" xml:space="preserve">
+    <value>The extension was installed but could not be loaded, so it was removed.</value>
+  </data>
+  <data name="npm_installer_canceled" xml:space="preserve">
+    <value>The operation was canceled.</value>
+  </data>
+  <data name="npm_installer_remove_failed" xml:space="preserve">
+    <value>The extension files could not be removed. Close anything using them and try again.</value>
+  </data>
+  <data name="npm_installer_install_failed" xml:space="preserve">
+    <value>The installation failed.</value>
+  </data>
+  <data name="npm_runner_npm_not_found" xml:space="preserve">
+    <value>npm was not found. Install Node.js to add JavaScript extensions.</value>
+    <comment>Do not translate "npm" or "Node.js".</comment>
+  </data>
+  <data name="npm_runner_start_failed" xml:space="preserve">
+    <value>npm could not be started.</value>
+    <comment>Do not translate "npm".</comment>
+  </data>
+  <data name="npm_runner_create_staging_failed" xml:space="preserve">
+    <value>A temporary install folder could not be created: {0}</value>
+    <comment>{0}=underlying error message</comment>
+  </data>
+  <data name="npm_runner_timed_out" xml:space="preserve">
+    <value>The install timed out after {0} minutes.</value>
+    <comment>{0}=number of minutes</comment>
+  </data>
+  <data name="npm_runner_failed_exit" xml:space="preserve">
+    <value>npm failed with exit code {0}.</value>
+    <comment>{0}=process exit code. Do not translate "npm".</comment>
+  </data>
+  <data name="npm_runner_lockfile_untrusted" xml:space="preserve">
+    <value>The install was blocked because a dependency was not resolved from the approved registry with a verified integrity hash.</value>
+    <comment>Shown when a transitive dependency in the generated lockfile lacks an approved HTTPS registry source or an integrity hash.</comment>
+  </data>
+  <data name="npm_runner_shrinkwrap_required" xml:space="preserve">
+    <value>The install was blocked because the package does not include a published npm-shrinkwrap.json. Command Palette only installs packages whose publisher has frozen the full dependency tree.</value>
+    <comment>Shown when a package tarball is missing the publisher-provided npm-shrinkwrap.json that freezes the transitive dependency closure. Do not translate "npm-shrinkwrap.json".</comment>
+  </data>
+  <data name="npm_runner_extract_failed" xml:space="preserve">
+    <value>The install was blocked because the downloaded package could not be read.</value>
+    <comment>Shown when the downloaded npm package tarball could not be unpacked for inspection.</comment>
+  </data>
   <data name="gallery_item_source_name_unknown" xml:space="preserve">
     <value>Source: {0}</value>
     <comment>{0}=unsupported source type name from the gallery feed</comment>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/CrashRecoveryTracker.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/CrashRecoveryTracker.cs
@@ -209,8 +209,8 @@ internal sealed partial class CrashRecoveryTracker : IDisposable
     }
 
     /// <summary>
-    /// Reopens a directory after its uninstall finishes. The caller must first drain recovery,
-    /// then keep the directory blocked until the extension and its watcher are gone.
+    /// Reopens a directory after its uninstall finishes or is abandoned. The caller must first
+    /// drain recovery, then keep the directory blocked until removal completes or is canceled.
     /// </summary>
     public void CompleteDirectoryRemoval(string directory)
     {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/IJsExtensionHost.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/IJsExtensionHost.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.CmdPal.UI.ViewModels.Services;
+
+/// <summary>
+/// Narrow hook exposed by the Phase 4 <see cref="JsonRpcExtensionService"/> so the gallery
+/// install/uninstall flow can share the JSExtensions root directory, terminate a running
+/// extension's Node.js process before its directory is removed, learn which extensions are
+/// actually loaded, and ask the host to load a freshly promoted directory.
+/// </summary>
+public interface IJsExtensionHost
+{
+    /// <summary>
+    /// Gets the absolute path of the directory where JavaScript/TypeScript extensions live.
+    /// Each extension occupies its own subdirectory under this path.
+    /// </summary>
+    string ExtensionsRootPath { get; }
+
+    /// <summary>
+    /// Stops the extension loaded from <paramref name="extensionDirectory"/>, terminating its
+    /// Node.js process and unloading its provider. Safe to call when no extension is loaded from
+    /// that directory. Callers use this before deleting the directory so file handles are
+    /// released.
+    /// </summary>
+    /// <param name="extensionDirectory">The extension's directory under the JSExtensions root.</param>
+    /// <param name="cancellationToken">A token to cancel a bounded wait while the provider is stopped.</param>
+    void StopExtension(string extensionDirectory, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Determines whether <paramref name="extensionDirectory"/> contains a valid CmdPal manifest
+    /// that the Phase 4 discovery scan can load (a package.json with a cmdpal section at the
+    /// directory root). Used after an install so success is only reported when the extension is
+    /// actually loadable.
+    /// </summary>
+    /// <param name="extensionDirectory">The extension's directory under the JSExtensions root.</param>
+    /// <returns><see langword="true"/> when a loadable manifest is present; otherwise, <see langword="false"/>.</returns>
+    bool IsExtensionDiscoverable(string extensionDirectory);
+
+    /// <summary>
+    /// Determines whether an extension named <paramref name="extensionName"/> is currently loaded by
+    /// the host from JSExtensions/&lt;extensionName&gt;/. This reflects the live host state (a validated,
+    /// loadable manifest that was actually registered) rather than any catalog status, so the gallery
+    /// can show Uninstall for packages that are really installed.
+    /// </summary>
+    /// <param name="extensionName">The directory name for the extension under the JSExtensions root.</param>
+    /// <returns><see langword="true"/> when the extension is loaded; otherwise, <see langword="false"/>.</returns>
+    bool IsExtensionInstalled(string extensionName);
+
+    /// <summary>
+    /// Asks the host to discover and load the extension in <paramref name="extensionDirectory"/> and
+    /// waits, up to <paramref name="timeout"/>, until its provider has been registered. Called after a
+    /// freshly staged extension is promoted into the JSExtensions root so success is only reported once
+    /// the extension is actually loadable and registered.
+    /// </summary>
+    /// <param name="extensionDirectory">The promoted extension's directory under the JSExtensions root.</param>
+    /// <param name="timeout">The maximum time to wait for provider registration.</param>
+    /// <param name="cancellationToken">A token to cancel the wait.</param>
+    /// <returns><see langword="true"/> when the provider registered within the timeout; otherwise, <see langword="false"/>.</returns>
+    Task<bool> RefreshAndAwaitProviderAsync(string extensionDirectory, TimeSpan timeout, CancellationToken cancellationToken);
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/IJsExtensionHost.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/IJsExtensionHost.cs
@@ -9,10 +9,9 @@ using System.Threading.Tasks;
 namespace Microsoft.CmdPal.UI.ViewModels.Services;
 
 /// <summary>
-/// Narrow hook exposed by the Phase 4 <see cref="JsonRpcExtensionService"/> so the gallery
-/// install/uninstall flow can share the JSExtensions root directory, terminate a running
-/// extension's Node.js process before its directory is removed, learn which extensions are
-/// actually loaded, and ask the host to load a freshly promoted directory.
+/// Small hook used by the gallery install flow to share the JSExtensions root, stop a running
+/// Node.js process before delete, check what is installed, and ask the host to load a promoted
+/// directory.
 /// </summary>
 public interface IJsExtensionHost
 {
@@ -23,30 +22,26 @@ public interface IJsExtensionHost
     string ExtensionsRootPath { get; }
 
     /// <summary>
-    /// Stops the extension loaded from <paramref name="extensionDirectory"/>, terminating its
-    /// Node.js process and unloading its provider. Safe to call when no extension is loaded from
-    /// that directory. Callers use this before deleting the directory so file handles are
-    /// released.
+    /// Stops the extension loaded from <paramref name="extensionDirectory"/> and unloads its
+    /// provider. Safe to call when no extension is loaded from that directory. Callers use this before
+    /// deleting the directory so file handles are released.
     /// </summary>
     /// <param name="extensionDirectory">The extension's directory under the JSExtensions root.</param>
     /// <param name="cancellationToken">A token to cancel a bounded wait while the provider is stopped.</param>
     void StopExtension(string extensionDirectory, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Determines whether <paramref name="extensionDirectory"/> contains a valid CmdPal manifest
-    /// that the Phase 4 discovery scan can load (a package.json with a cmdpal section at the
-    /// directory root). Used after an install so success is only reported when the extension is
-    /// actually loadable.
+    /// Determines whether <paramref name="extensionDirectory"/> contains a CmdPal manifest the host
+    /// can load. Used after install so success is only reported when the extension is loadable.
     /// </summary>
     /// <param name="extensionDirectory">The extension's directory under the JSExtensions root.</param>
     /// <returns><see langword="true"/> when a loadable manifest is present; otherwise, <see langword="false"/>.</returns>
     bool IsExtensionDiscoverable(string extensionDirectory);
 
     /// <summary>
-    /// Determines whether an extension named <paramref name="extensionName"/> is currently loaded by
-    /// the host from JSExtensions/&lt;extensionName&gt;/. This reflects the live host state (a validated,
-    /// loadable manifest that was actually registered) rather than any catalog status, so the gallery
-    /// can show Uninstall for packages that are really installed.
+    /// Determines whether an extension named <paramref name="extensionName"/> is currently loaded from
+    /// JSExtensions/&lt;extensionName&gt;/. This follows the host state, not the catalog, so the gallery
+    /// shows Uninstall only for packages the host knows about.
     /// </summary>
     /// <param name="extensionName">The directory name for the extension under the JSExtensions root.</param>
     /// <returns><see langword="true"/> when the extension is loaded; otherwise, <see langword="false"/>.</returns>
@@ -54,9 +49,8 @@ public interface IJsExtensionHost
 
     /// <summary>
     /// Asks the host to discover and load the extension in <paramref name="extensionDirectory"/> and
-    /// waits, up to <paramref name="timeout"/>, until its provider has been registered. Called after a
-    /// freshly staged extension is promoted into the JSExtensions root so success is only reported once
-    /// the extension is actually loadable and registered.
+    /// waits, up to <paramref name="timeout"/>, for provider registration. Called after promotion so
+    /// install success means the extension loaded, not just copied to disk.
     /// </summary>
     /// <param name="extensionDirectory">The promoted extension's directory under the JSExtensions root.</param>
     /// <param name="timeout">The maximum time to wait for provider registration.</param>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/IJsExtensionHost.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/IJsExtensionHost.cs
@@ -28,7 +28,8 @@ public interface IJsExtensionHost
     /// </summary>
     /// <param name="extensionDirectory">The extension's directory under the JSExtensions root.</param>
     /// <param name="cancellationToken">A token to cancel a bounded wait while the provider is stopped.</param>
-    void StopExtension(string extensionDirectory, CancellationToken cancellationToken = default);
+    /// <returns>A task that completes after the extension and provider are stopped.</returns>
+    Task StopExtensionAsync(string extensionDirectory, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Determines whether <paramref name="extensionDirectory"/> contains a CmdPal manifest the host

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/IJsExtensionInstaller.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/IJsExtensionInstaller.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.CmdPal.UI.ViewModels.Services;
+
+/// <summary>
+/// Installs and uninstalls gallery JavaScript/TypeScript ("jsonrpc") extensions into the Phase 4
+/// JSExtensions directory. Implementations delegate the actual npm invocation and filesystem
+/// side effects to injected abstractions so the flow can be tested without running npm.
+/// </summary>
+public interface IJsExtensionInstaller
+{
+    /// <summary>
+    /// Installs the approved npm artifact for a jsonrpc extension into JSExtensions/&lt;extensionName&gt;/.
+    /// The install is a fail-closed transaction: the package, exact version, integrity, and optional
+    /// registry are validated up front, the package is installed into a staging directory outside the
+    /// watched root, verified, and only then atomically promoted and awaited for registration. A failed
+    /// or cancelled install never corrupts an existing install of the same extension.
+    /// </summary>
+    /// <param name="extensionName">The directory name for the extension under the JSExtensions root.</param>
+    /// <param name="npmPackage">The npm package identifier to install.</param>
+    /// <param name="version">The exact version to install.</param>
+    /// <param name="integrity">The sha512 Subresource Integrity value of the approved tarball.</param>
+    /// <param name="registry">Optional npm registry URL. When null or empty, the default registry is used.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>The result of the install.</returns>
+    Task<JsExtensionInstallResult> InstallAsync(string extensionName, string npmPackage, string? version, string? integrity, string? registry, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Terminates the extension's Node.js process and deletes JSExtensions/&lt;extensionName&gt;/.
+    /// The Phase 4 FileSystemWatcher then unloads the extension automatically.
+    /// </summary>
+    /// <param name="extensionName">The directory name for the extension under the JSExtensions root.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>The result of the uninstall.</returns>
+    Task<JsExtensionInstallResult> UninstallAsync(string extensionName, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Determines whether an extension named <paramref name="extensionName"/> is currently installed
+    /// and loaded by the host. Used to seed the gallery item's installed state from the host truth
+    /// rather than the catalog status.
+    /// </summary>
+    /// <param name="extensionName">The directory name for the extension under the JSExtensions root.</param>
+    /// <returns><see langword="true"/> when the extension is installed; otherwise, <see langword="false"/>.</returns>
+    bool IsInstalled(string extensionName);
+}
+
+/// <summary>
+/// The outcome of a JavaScript/TypeScript extension install or uninstall operation.
+/// </summary>
+/// <param name="Succeeded">Whether the operation completed successfully.</param>
+/// <param name="ErrorMessage">A user-visible error message when the operation failed; otherwise null.</param>
+public readonly record struct JsExtensionInstallResult(bool Succeeded, string? ErrorMessage)
+{
+    public static JsExtensionInstallResult Ok() => new(true, null);
+
+    public static JsExtensionInstallResult Fail(string errorMessage) => new(false, errorMessage);
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/IJsExtensionInstaller.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/IJsExtensionInstaller.cs
@@ -8,18 +8,17 @@ using System.Threading.Tasks;
 namespace Microsoft.CmdPal.UI.ViewModels.Services;
 
 /// <summary>
-/// Installs and uninstalls gallery JavaScript/TypeScript ("jsonrpc") extensions into the Phase 4
-/// JSExtensions directory. Implementations delegate the actual npm invocation and filesystem
-/// side effects to injected abstractions so the flow can be tested without running npm.
+/// Installs and uninstalls gallery JavaScript/TypeScript ("jsonrpc") extensions in the
+/// JSExtensions directory. Implementations keep npm and file changes behind injected services so
+/// tests can cover the flow without running npm.
 /// </summary>
 public interface IJsExtensionInstaller
 {
     /// <summary>
     /// Installs the approved npm artifact for a jsonrpc extension into JSExtensions/&lt;extensionName&gt;/.
-    /// The install is a fail-closed transaction: the package, exact version, integrity, and optional
-    /// registry are validated up front, the package is installed into a staging directory outside the
-    /// watched root, verified, and only then atomically promoted and awaited for registration. A failed
-    /// or cancelled install never corrupts an existing install of the same extension.
+    /// The install fails closed: catalog fields are validated first, the package is staged outside the
+    /// watched root, and only a verified package is promoted and awaited for registration. A failed or
+    /// canceled install leaves any existing install alone.
     /// </summary>
     /// <param name="extensionName">The directory name for the extension under the JSExtensions root.</param>
     /// <param name="npmPackage">The npm package identifier to install.</param>
@@ -40,9 +39,8 @@ public interface IJsExtensionInstaller
     Task<JsExtensionInstallResult> UninstallAsync(string extensionName, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Determines whether an extension named <paramref name="extensionName"/> is currently installed
-    /// and loaded by the host. Used to seed the gallery item's installed state from the host truth
-    /// rather than the catalog status.
+    /// Determines whether an extension named <paramref name="extensionName"/> is installed and loaded
+    /// by the host. Used to seed gallery state from the host instead of the catalog.
     /// </summary>
     /// <param name="extensionName">The directory name for the extension under the JSExtensions root.</param>
     /// <returns><see langword="true"/> when the extension is installed; otherwise, <see langword="false"/>.</returns>
@@ -50,10 +48,10 @@ public interface IJsExtensionInstaller
 }
 
 /// <summary>
-/// The outcome of a JavaScript/TypeScript extension install or uninstall operation.
+/// The result of a JavaScript/TypeScript extension install or uninstall operation.
 /// </summary>
 /// <param name="Succeeded">Whether the operation completed successfully.</param>
-/// <param name="ErrorMessage">A user-visible error message when the operation failed; otherwise null.</param>
+/// <param name="ErrorMessage">A message to show when the operation failed; otherwise null.</param>
 public readonly record struct JsExtensionInstallResult(bool Succeeded, string? ErrorMessage)
 {
     public static JsExtensionInstallResult Ok() => new(true, null);

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/INpmCommandRunner.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/INpmCommandRunner.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.CmdPal.UI.ViewModels.Services;
+
+/// <summary>
+/// Abstracts the npm command line and the directory side effects the installer relies on. This
+/// is the seam that lets tests exercise the install/uninstall transaction without invoking npm
+/// or touching a real registry.
+/// </summary>
+public interface INpmCommandRunner
+{
+    /// <summary>
+    /// Gets a value indicating whether the npm executable can be found on the machine.
+    /// </summary>
+    /// <returns><see langword="true"/> when npm is available; otherwise, <see langword="false"/>.</returns>
+    bool IsNpmAvailable();
+
+    /// <summary>
+    /// Installs the approved artifact into <paramref name="stagingDirectory"/> using npm. The exact
+    /// spec "name@version" is passed as a single argument, package lifecycle scripts are disabled, and
+    /// the exact version is pinned. On success the result carries the integrity value npm resolved for
+    /// the top-level package so the caller can verify it against the approved value before promoting.
+    /// </summary>
+    /// <param name="stagingDirectory">A directory outside the watched extensions root that npm installs into.</param>
+    /// <param name="artifact">The validated artifact to install.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>The result of running npm, including the resolved integrity on success.</returns>
+    Task<NpmCommandResult> InstallAsync(string stagingDirectory, NpmArtifact artifact, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Deletes <paramref name="targetDirectory"/> and everything under it. Refuses to delete when the
+    /// top-level directory is a symbolic link or junction (a reparse point), and retries briefly to
+    /// tolerate a file handle that is still being released. Safe to call when the directory does not
+    /// exist.
+    /// </summary>
+    /// <param name="targetDirectory">The directory to remove.</param>
+    /// <param name="cancellationToken">A token to cancel the retry loop between attempts.</param>
+    /// <returns>
+    /// <see langword="true"/> when the directory no longer exists after the call (either it was
+    /// deleted or it never existed); <see langword="false"/> when deletion failed or was refused and
+    /// the directory remains on disk.
+    /// </returns>
+    bool RemoveDirectory(string targetDirectory, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// The outcome of running an npm command.
+/// </summary>
+/// <param name="Succeeded">Whether the command exited successfully.</param>
+/// <param name="ErrorMessage">A user-visible error message when the command failed; otherwise null.</param>
+/// <param name="ResolvedIntegrity">
+/// The Subresource Integrity value npm resolved for the installed top-level package, read from the
+/// generated lockfile. Null when the command failed or the value could not be determined.
+/// </param>
+public readonly record struct NpmCommandResult(bool Succeeded, string? ErrorMessage, string? ResolvedIntegrity)
+{
+    public static NpmCommandResult Ok(string? resolvedIntegrity) => new(true, null, resolvedIntegrity);
+
+    public static NpmCommandResult Fail(string errorMessage) => new(false, errorMessage, null);
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/INpmCommandRunner.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/INpmCommandRunner.cs
@@ -8,9 +8,8 @@ using System.Threading.Tasks;
 namespace Microsoft.CmdPal.UI.ViewModels.Services;
 
 /// <summary>
-/// Abstracts the npm command line and the directory side effects the installer relies on. This
-/// is the seam that lets tests exercise the install/uninstall transaction without invoking npm
-/// or touching a real registry.
+/// Wraps npm and the directory changes the installer relies on. Tests use this seam to cover
+/// the install and uninstall flow without running npm or touching a real registry.
 /// </summary>
 public interface INpmCommandRunner
 {
@@ -21,10 +20,9 @@ public interface INpmCommandRunner
     bool IsNpmAvailable();
 
     /// <summary>
-    /// Installs the approved artifact into <paramref name="stagingDirectory"/> using npm. The exact
-    /// spec "name@version" is passed as a single argument, package lifecycle scripts are disabled, and
-    /// the exact version is pinned. On success the result carries the integrity value npm resolved for
-    /// the top-level package so the caller can verify it against the approved value before promoting.
+    /// Installs the approved artifact into <paramref name="stagingDirectory"/> using npm. The
+    /// "name@version" spec is passed as one argument, package lifecycle scripts are disabled, and the
+    /// result carries npm's resolved integrity so the caller can compare it before promoting.
     /// </summary>
     /// <param name="stagingDirectory">A directory outside the watched extensions root that npm installs into.</param>
     /// <param name="artifact">The validated artifact to install.</param>
@@ -34,9 +32,8 @@ public interface INpmCommandRunner
 
     /// <summary>
     /// Deletes <paramref name="targetDirectory"/> and everything under it. Refuses to delete when the
-    /// top-level directory is a symbolic link or junction (a reparse point), and retries briefly to
-    /// tolerate a file handle that is still being released. Safe to call when the directory does not
-    /// exist.
+    /// directory itself is a symbolic link or junction, and retries briefly when a file handle is still
+    /// being released. Safe to call when the directory does not exist.
     /// </summary>
     /// <param name="targetDirectory">The directory to remove.</param>
     /// <param name="cancellationToken">A token to cancel the retry loop between attempts.</param>
@@ -49,13 +46,13 @@ public interface INpmCommandRunner
 }
 
 /// <summary>
-/// The outcome of running an npm command.
+/// The result of running an npm command.
 /// </summary>
 /// <param name="Succeeded">Whether the command exited successfully.</param>
-/// <param name="ErrorMessage">A user-visible error message when the command failed; otherwise null.</param>
+/// <param name="ErrorMessage">A message to show when the command failed; otherwise null.</param>
 /// <param name="ResolvedIntegrity">
-/// The Subresource Integrity value npm resolved for the installed top-level package, read from the
-/// generated lockfile. Null when the command failed or the value could not be determined.
+/// The Subresource Integrity value npm resolved for the installed package, read from the generated
+/// lockfile. Null when the command failed or the value could not be found.
 /// </param>
 public readonly record struct NpmCommandResult(bool Succeeded, string? ErrorMessage, string? ResolvedIntegrity)
 {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/JsonRpcExtensionService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/JsonRpcExtensionService.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CmdPal.UI.ViewModels.Services;
 /// only guards in-memory collection mutations and is never held across an await or a
 /// process launch.
 /// </remarks>
-public sealed partial class JsonRpcExtensionService : IExtensionService, IDisposable
+public sealed partial class JsonRpcExtensionService : IExtensionService, IJsExtensionHost, IDisposable
 {
     // Consecutive crashes above this threshold disable an extension instead of restarting it.
     private const int MaxRestartAttempts = 3;
@@ -114,6 +114,117 @@ public sealed partial class JsonRpcExtensionService : IExtensionService, IDispos
 
         /// <summary>Stop restarting the extension and leave it disabled.</summary>
         Disable,
+    }
+
+    /// <inheritdoc />
+    public string ExtensionsRootPath => ExtensionsPath;
+
+    /// <inheritdoc />
+    public void StopExtension(string extensionDirectory, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(extensionDirectory))
+        {
+            return;
+        }
+
+        // Route through the per-directory gate so an uninstall serializes against any
+        // in-flight load, refresh, crash-restart, or hot-reload for the same directory
+        // and releases every resource (wrapper, process, source watcher, crash count,
+        // gate entry). The gallery calls this synchronously before deleting the
+        // directory, so block until the removal completes; all awaits on this path use
+        // ConfigureAwait(false) and the path is never entered from within a held gate,
+        // so there is no reentrant deadlock. The token lets an uninstall Cancel abandon
+        // the wait for a contended gate.
+        var removed = RemoveExtensionByDirectoryGatedAsync(extensionDirectory, cancellationToken).GetAwaiter().GetResult();
+        if (removed is not null)
+        {
+            OnProviderRemoved?.Invoke(this, [removed]);
+        }
+    }
+
+    /// <inheritdoc />
+    public bool IsExtensionDiscoverable(string extensionDirectory)
+    {
+        if (string.IsNullOrEmpty(extensionDirectory))
+        {
+            return false;
+        }
+
+        var manifestPath = Path.Combine(extensionDirectory, "package.json");
+        if (!File.Exists(manifestPath))
+        {
+            return false;
+        }
+
+        var parseResult = JSExtensionManifest.TryParseFile(manifestPath);
+        return parseResult.IsValid && parseResult.Manifest is not null;
+    }
+
+    /// <inheritdoc />
+    public bool IsExtensionInstalled(string extensionName)
+    {
+        if (string.IsNullOrEmpty(extensionName))
+        {
+            return false;
+        }
+
+        var directory = Path.Combine(ExtensionsPath, extensionName);
+
+        // Report installed when the extension is either live in the host or merely present on disk.
+        // A crash-disabled or corrupt install can leave the directory in place without a loaded
+        // provider; treating that as installed lets the gallery still offer Uninstall (and therefore
+        // repair-by-reinstall) instead of stranding the package with no way to remove it.
+        return IsExtensionLoadedInDirectory(directory) || IsExtensionPresentOnDisk(directory);
+    }
+
+    internal static bool IsExtensionPresentOnDisk(string extensionDirectory) =>
+        !string.IsNullOrEmpty(extensionDirectory) && Directory.Exists(extensionDirectory);
+
+    /// <inheritdoc />
+    public async Task<bool> RefreshAndAwaitProviderAsync(string extensionDirectory, TimeSpan timeout, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(extensionDirectory))
+        {
+            return false;
+        }
+
+        if (!EnsureExtensionsDirectory())
+        {
+            return false;
+        }
+
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        if (timeout > TimeSpan.Zero)
+        {
+            timeoutCts.CancelAfter(timeout);
+        }
+
+        try
+        {
+            // Loading is awaited synchronously per directory through the lifecycle gate, so by the
+            // time this returns the promoted directory is either loaded and registered or it failed.
+            // Firing OnProviderAdded keeps the rest of the host (and the gallery) in sync.
+            var added = await AddDiscoveredNotLoadedAsync(timeoutCts.Token).ConfigureAwait(false);
+            foreach (var wrapper in added)
+            {
+                OnProviderAdded?.Invoke(this, [wrapper]);
+            }
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            // The timeout elapsed before the extension finished loading.
+            return false;
+        }
+
+        return IsExtensionLoadedInDirectory(extensionDirectory);
+    }
+
+    private bool IsExtensionLoadedInDirectory(string extensionDirectory)
+    {
+        lock (_extensionsLock)
+        {
+            return _extensions.Any(e => PathsEqual(e.ManifestDirectory, extensionDirectory));
+        }
     }
 
     /// <summary>
@@ -1396,12 +1507,12 @@ public sealed partial class JsonRpcExtensionService : IExtensionService, IDispos
         }
     }
 
-    private async Task<CommandProviderWrapper?> RemoveExtensionByDirectoryGatedAsync(string directory)
+    private async Task<CommandProviderWrapper?> RemoveExtensionByDirectoryGatedAsync(string directory, CancellationToken cancellationToken = default)
     {
         IDisposable? gate = null;
         try
         {
-            gate = await _directoryGate.AcquireAsync(directory, CancellationToken.None).ConfigureAwait(false);
+            gate = await _directoryGate.AcquireAsync(directory, cancellationToken).ConfigureAwait(false);
         }
         catch (ObjectDisposedException)
         {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/JsonRpcExtensionService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/JsonRpcExtensionService.cs
@@ -254,6 +254,12 @@ public sealed partial class JsonRpcExtensionService : IExtensionService, IJsExte
             {
                 RaiseProviderAdded(wrapper);
             }
+
+            if (timeoutCts.IsCancellationRequested)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                return false;
+            }
         }
         catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
         {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/JsonRpcExtensionService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/JsonRpcExtensionService.cs
@@ -55,6 +55,8 @@ namespace Microsoft.CmdPal.UI.ViewModels.Services;
 /// </remarks>
 public sealed partial class JsonRpcExtensionService : IExtensionService, IJsExtensionHost, IDisposable
 {
+    internal const string GalleryInstallMarkerFileName = ".cmdpal-gallery-installing";
+
     // Consecutive crashes above this threshold disable an extension instead of restarting it.
     private const int MaxRestartAttempts = 3;
 
@@ -169,7 +171,7 @@ public sealed partial class JsonRpcExtensionService : IExtensionService, IJsExte
     public string ExtensionsRootPath => ExtensionsPath;
 
     /// <inheritdoc />
-    public void StopExtension(string extensionDirectory, CancellationToken cancellationToken = default)
+    public async Task StopExtensionAsync(string extensionDirectory, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrEmpty(extensionDirectory))
         {
@@ -178,13 +180,13 @@ public sealed partial class JsonRpcExtensionService : IExtensionService, IJsExte
 
         // Use the lifecycle gate so uninstall waits behind any load, refresh, restart, or hot reload
         // for this directory and cleans every owned resource. The gallery calls this before deleting
-        // files, so wait synchronously. Awaited work on this path uses ConfigureAwait(false), and we
-        // never enter while holding the same gate, so we avoid a reentrant deadlock. The token lets
-        // Cancel stop waiting for a busy gate.
-        var removed = RemoveExtensionByDirectoryGatedAsync(extensionDirectory, cancellationToken).GetAwaiter().GetResult();
+        // files. Awaited work on this path uses ConfigureAwait(false), and we never enter while holding
+        // the same gate, so we avoid a reentrant deadlock. The token lets Cancel stop waiting for a
+        // busy gate.
+        var removed = await RemoveExtensionByDirectoryGatedAsync(extensionDirectory, cancellationToken).ConfigureAwait(false);
         if (removed is not null)
         {
-            OnProviderRemoved?.Invoke(this, [removed]);
+            RaiseProviderRemoved(removed);
         }
     }
 
@@ -250,7 +252,7 @@ public sealed partial class JsonRpcExtensionService : IExtensionService, IJsExte
             var added = await AddDiscoveredNotLoadedAsync(timeoutCts.Token).ConfigureAwait(false);
             foreach (var wrapper in added)
             {
-                OnProviderAdded?.Invoke(this, [wrapper]);
+                RaiseProviderAdded(wrapper);
             }
         }
         catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
@@ -1022,7 +1024,7 @@ public sealed partial class JsonRpcExtensionService : IExtensionService, IJsExte
         {
             gate = await _directoryGate.AcquireAsync(directory, ct).ConfigureAwait(false);
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (_disposed || _reload.IsStopRequested)
         {
             return null;
         }
@@ -1094,7 +1096,7 @@ public sealed partial class JsonRpcExtensionService : IExtensionService, IJsExte
         {
             extensionWrapper = new JSExtensionWrapper(manifest, directory);
 
-            await extensionWrapper.StartExtensionAsync().ConfigureAwait(false);
+            await extensionWrapper.StartExtensionAsync(ct).ConfigureAwait(false);
 
             if (!extensionWrapper.IsRunning())
             {
@@ -1121,6 +1123,11 @@ public sealed partial class JsonRpcExtensionService : IExtensionService, IJsExte
 
             var wrapper = CommandProviderWrapper.CreateForJsonRpcExtension(extensionWrapper, provider, _taskScheduler);
             return new StartedInstance(extensionWrapper, wrapper);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            extensionWrapper?.SignalDispose();
+            throw;
         }
         catch (Exception ex)
         {
@@ -1541,6 +1548,11 @@ public sealed partial class JsonRpcExtensionService : IExtensionService, IJsExte
             return;
         }
 
+        if (File.Exists(Path.Combine(extensionDirectory, GalleryInstallMarkerFileName)))
+        {
+            return;
+        }
+
         var token = _reload.Token;
         StartObservedBackgroundTask(
             () => HandleDirectoryEntryUpsertAsync(extensionDirectory, token),
@@ -1693,10 +1705,17 @@ public sealed partial class JsonRpcExtensionService : IExtensionService, IJsExte
         {
             // The gate is being torn down; fall through and remove best-effort.
         }
+        catch (OperationCanceledException)
+        {
+            // The uninstall never acquired the lifecycle gate, so this directory is staying put.
+            // Reopen crash recovery before handing cancellation back to the caller.
+            _recovery.CompleteDirectoryRemoval(directory);
+            throw;
+        }
 
         try
         {
-            return RemoveExtensionByDirectoryCore(directory);
+            return await RemoveExtensionByDirectoryCoreAsync(directory).ConfigureAwait(false);
         }
         finally
         {
@@ -1708,7 +1727,7 @@ public sealed partial class JsonRpcExtensionService : IExtensionService, IJsExte
         }
     }
 
-    private CommandProviderWrapper? RemoveExtensionByDirectoryCore(string directory)
+    private async Task<CommandProviderWrapper?> RemoveExtensionByDirectoryCoreAsync(string directory)
     {
         JSExtensionWrapper? extensionToRemove;
         CommandProviderWrapper? wrapperToRemove;
@@ -1743,7 +1762,7 @@ public sealed partial class JsonRpcExtensionService : IExtensionService, IJsExte
         if (extensionToRemove is not null)
         {
             extensionToRemove.ProcessExited -= OnExtensionProcessExited;
-            extensionToRemove.SignalDispose();
+            await extensionToRemove.SignalDisposeAsync().ConfigureAwait(false);
         }
 
         return wrapperToRemove;

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/JsonRpcExtensionService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/JsonRpcExtensionService.cs
@@ -176,14 +176,11 @@ public sealed partial class JsonRpcExtensionService : IExtensionService, IJsExte
             return;
         }
 
-        // Route through the per-directory gate so an uninstall serializes against any
-        // in-flight load, refresh, crash-restart, or hot-reload for the same directory
-        // and releases every resource (wrapper, process, source watcher, crash count,
-        // gate entry). The gallery calls this synchronously before deleting the
-        // directory, so block until the removal completes; all awaits on this path use
-        // ConfigureAwait(false) and the path is never entered from within a held gate,
-        // so there is no reentrant deadlock. The token lets an uninstall Cancel abandon
-        // the wait for a contended gate.
+        // Use the lifecycle gate so uninstall waits behind any load, refresh, restart, or hot reload
+        // for this directory and cleans every owned resource. The gallery calls this before deleting
+        // files, so wait synchronously. Awaited work on this path uses ConfigureAwait(false), and we
+        // never enter while holding the same gate, so we avoid a reentrant deadlock. The token lets
+        // Cancel stop waiting for a busy gate.
         var removed = RemoveExtensionByDirectoryGatedAsync(extensionDirectory, cancellationToken).GetAwaiter().GetResult();
         if (removed is not null)
         {
@@ -219,10 +216,8 @@ public sealed partial class JsonRpcExtensionService : IExtensionService, IJsExte
 
         var directory = Path.Combine(ExtensionsPath, extensionName);
 
-        // Report installed when the extension is either live in the host or merely present on disk.
-        // A crash-disabled or corrupt install can leave the directory in place without a loaded
-        // provider; treating that as installed lets the gallery still offer Uninstall (and therefore
-        // repair-by-reinstall) instead of stranding the package with no way to remove it.
+        // Treat a directory on disk as installed even when the provider never loaded. That lets the
+        // gallery offer Uninstall for a crash disabled or corrupt install instead of stranding it.
         return IsExtensionLoadedInDirectory(directory) || IsExtensionPresentOnDisk(directory);
     }
 
@@ -250,9 +245,8 @@ public sealed partial class JsonRpcExtensionService : IExtensionService, IJsExte
 
         try
         {
-            // Loading is awaited synchronously per directory through the lifecycle gate, so by the
-            // time this returns the promoted directory is either loaded and registered or it failed.
-            // Firing OnProviderAdded keeps the rest of the host (and the gallery) in sync.
+            // The lifecycle gate waits for the promoted directory to load or fail. Raise OnProviderAdded
+            // for anything that registered so the host and gallery see the same state.
             var added = await AddDiscoveredNotLoadedAsync(timeoutCts.Token).ConfigureAwait(false);
             foreach (var wrapper in added)
             {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/JsonRpcExtensionService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/JsonRpcExtensionService.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CmdPal.UI.ViewModels.Services;
 /// and <see cref="Dispose"/> each cancel the affected recovery before awaiting it, so a
 /// drain never waits on work that is blocked behind the gate the caller is about to take.
 /// </remarks>
-public sealed partial class JsonRpcExtensionService : IExtensionService, IDisposable
+public sealed partial class JsonRpcExtensionService : IExtensionService, IJsExtensionHost, IDisposable
 {
     // Consecutive crashes above this threshold disable an extension instead of restarting it.
     private const int MaxRestartAttempts = 3;
@@ -163,6 +163,117 @@ public sealed partial class JsonRpcExtensionService : IExtensionService, IDispos
 
         /// <summary>Stop restarting the extension and leave it disabled.</summary>
         Disable,
+    }
+
+    /// <inheritdoc />
+    public string ExtensionsRootPath => ExtensionsPath;
+
+    /// <inheritdoc />
+    public void StopExtension(string extensionDirectory, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(extensionDirectory))
+        {
+            return;
+        }
+
+        // Route through the per-directory gate so an uninstall serializes against any
+        // in-flight load, refresh, crash-restart, or hot-reload for the same directory
+        // and releases every resource (wrapper, process, source watcher, crash count,
+        // gate entry). The gallery calls this synchronously before deleting the
+        // directory, so block until the removal completes; all awaits on this path use
+        // ConfigureAwait(false) and the path is never entered from within a held gate,
+        // so there is no reentrant deadlock. The token lets an uninstall Cancel abandon
+        // the wait for a contended gate.
+        var removed = RemoveExtensionByDirectoryGatedAsync(extensionDirectory, cancellationToken).GetAwaiter().GetResult();
+        if (removed is not null)
+        {
+            OnProviderRemoved?.Invoke(this, [removed]);
+        }
+    }
+
+    /// <inheritdoc />
+    public bool IsExtensionDiscoverable(string extensionDirectory)
+    {
+        if (string.IsNullOrEmpty(extensionDirectory))
+        {
+            return false;
+        }
+
+        var manifestPath = Path.Combine(extensionDirectory, "package.json");
+        if (!File.Exists(manifestPath))
+        {
+            return false;
+        }
+
+        var parseResult = JSExtensionManifest.TryParseFile(manifestPath);
+        return parseResult.IsValid && parseResult.Manifest is not null;
+    }
+
+    /// <inheritdoc />
+    public bool IsExtensionInstalled(string extensionName)
+    {
+        if (string.IsNullOrEmpty(extensionName))
+        {
+            return false;
+        }
+
+        var directory = Path.Combine(ExtensionsPath, extensionName);
+
+        // Report installed when the extension is either live in the host or merely present on disk.
+        // A crash-disabled or corrupt install can leave the directory in place without a loaded
+        // provider; treating that as installed lets the gallery still offer Uninstall (and therefore
+        // repair-by-reinstall) instead of stranding the package with no way to remove it.
+        return IsExtensionLoadedInDirectory(directory) || IsExtensionPresentOnDisk(directory);
+    }
+
+    internal static bool IsExtensionPresentOnDisk(string extensionDirectory) =>
+        !string.IsNullOrEmpty(extensionDirectory) && Directory.Exists(extensionDirectory);
+
+    /// <inheritdoc />
+    public async Task<bool> RefreshAndAwaitProviderAsync(string extensionDirectory, TimeSpan timeout, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(extensionDirectory))
+        {
+            return false;
+        }
+
+        if (!EnsureExtensionsDirectory())
+        {
+            return false;
+        }
+
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        if (timeout > TimeSpan.Zero)
+        {
+            timeoutCts.CancelAfter(timeout);
+        }
+
+        try
+        {
+            // Loading is awaited synchronously per directory through the lifecycle gate, so by the
+            // time this returns the promoted directory is either loaded and registered or it failed.
+            // Firing OnProviderAdded keeps the rest of the host (and the gallery) in sync.
+            var added = await AddDiscoveredNotLoadedAsync(timeoutCts.Token).ConfigureAwait(false);
+            foreach (var wrapper in added)
+            {
+                OnProviderAdded?.Invoke(this, [wrapper]);
+            }
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            // The timeout elapsed before the extension finished loading.
+            return false;
+        }
+
+        return IsExtensionLoadedInDirectory(extensionDirectory);
+    }
+
+    private bool IsExtensionLoadedInDirectory(string extensionDirectory)
+    {
+        lock (_extensionsLock)
+        {
+            return _extensions.Any(e => PathsEqual(e.ManifestDirectory, extensionDirectory));
+        }
     }
 
     /// <summary>
@@ -1570,7 +1681,7 @@ public sealed partial class JsonRpcExtensionService : IExtensionService, IDispos
         }
     }
 
-    private async Task<CommandProviderWrapper?> RemoveExtensionByDirectoryGatedAsync(string directory)
+    private async Task<CommandProviderWrapper?> RemoveExtensionByDirectoryGatedAsync(string directory, CancellationToken cancellationToken = default)
     {
         // Cancel and await this directory's crash recovery before taking the gate. Order
         // matters both ways: canceling first releases recovery that is waiting on (or
@@ -1582,7 +1693,7 @@ public sealed partial class JsonRpcExtensionService : IExtensionService, IDispos
         IDisposable? gate = null;
         try
         {
-            gate = await _directoryGate.AcquireAsync(directory, CancellationToken.None).ConfigureAwait(false);
+            gate = await _directoryGate.AcquireAsync(directory, cancellationToken).ConfigureAwait(false);
         }
         catch (ObjectDisposedException)
         {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/JsonRpcExtensionService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/JsonRpcExtensionService.cs
@@ -327,10 +327,9 @@ public sealed partial class JsonRpcExtensionService : IExtensionService, IJsExte
             return [];
         }
 
-        // Start the watcher before scanning so a package installed while the scan runs
-        // is still observed (the per-directory gate and the already-loaded check make a
-        // watcher-driven load and a scan-driven load for the same directory idempotent).
         RecoverStaleGalleryInstallMarkersOnce();
+
+        // Start the watcher before scanning so installs during the scan are still observed.
         StartDirectoryWatcher();
 
         var accepted = DiscoverAcceptedManifests(ExtensionsPath);

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/JsonRpcExtensionService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/JsonRpcExtensionService.cs
@@ -247,12 +247,12 @@ public sealed partial class JsonRpcExtensionService : IExtensionService, IJsExte
 
         try
         {
-            // The lifecycle gate waits for the promoted directory to load or fail. Raise OnProviderAdded
-            // for anything that registered so the host and gallery see the same state.
-            var added = await AddDiscoveredNotLoadedAsync(timeoutCts.Token).ConfigureAwait(false);
-            foreach (var wrapper in added)
+            // Keep the gallery timeout scoped to the promoted extension. A slow extension
+            // elsewhere should not make this install roll back.
+            var added = await AddDiscoveredExtensionAsync(extensionDirectory, timeoutCts.Token).ConfigureAwait(false);
+            if (added is not null)
             {
-                RaiseProviderAdded(wrapper);
+                RaiseProviderAdded(added);
             }
 
             if (timeoutCts.IsCancellationRequested)
@@ -1011,6 +1011,32 @@ public sealed partial class JsonRpcExtensionService : IExtensionService, IJsExte
             .ConfigureAwait(false);
 
         return [.. added];
+    }
+
+    private async Task<CommandProviderWrapper?> AddDiscoveredExtensionAsync(string extensionDirectory, CancellationToken ct)
+    {
+        var candidate = FindManifestByDirectory(DiscoverAcceptedManifests(ExtensionsPath), extensionDirectory);
+        if (candidate is null)
+        {
+            return null;
+        }
+
+        return await AddExtensionGatedAsync(candidate.Value.Directory, candidate.Value.Manifest, ct).ConfigureAwait(false);
+    }
+
+    internal static (string Directory, JSExtensionManifest Manifest)? FindManifestByDirectory(
+        IReadOnlyList<(string Directory, JSExtensionManifest Manifest)> manifests,
+        string extensionDirectory)
+    {
+        foreach (var manifest in manifests)
+        {
+            if (PathsEqual(manifest.Directory, extensionDirectory))
+            {
+                return manifest;
+            }
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/JsonRpcExtensionService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/JsonRpcExtensionService.cs
@@ -140,6 +140,7 @@ public sealed partial class JsonRpcExtensionService : IExtensionService, IJsExte
     // that completes after this point must not register its extension (which would leak a
     // Node process and watcher past shutdown); it tears the fresh instance down instead.
     private bool _shuttingDown;
+    private int _startupMarkerRecoveryCompleted;
 
     public JsonRpcExtensionService(TaskScheduler taskScheduler)
     {
@@ -329,6 +330,7 @@ public sealed partial class JsonRpcExtensionService : IExtensionService, IJsExte
         // Start the watcher before scanning so a package installed while the scan runs
         // is still observed (the per-directory gate and the already-loaded check make a
         // watcher-driven load and a scan-driven load for the same directory idempotent).
+        RecoverStaleGalleryInstallMarkersOnce();
         StartDirectoryWatcher();
 
         var accepted = DiscoverAcceptedManifests(ExtensionsPath);
@@ -414,6 +416,11 @@ public sealed partial class JsonRpcExtensionService : IExtensionService, IJsExte
             var (_, toRemove) = ReconcileDirectories(accepted.Select(a => a.Directory), loadedDirectories);
             foreach (var directory in toRemove)
             {
+                if (!ShouldRemoveExtensionDuringReconciliation(directory))
+                {
+                    continue;
+                }
+
                 var removed = await RemoveExtensionByDirectoryGatedAsync(directory).ConfigureAwait(false);
                 if (removed is not null)
                 {
@@ -542,7 +549,9 @@ public sealed partial class JsonRpcExtensionService : IExtensionService, IJsExte
     /// </summary>
     /// <param name="root">The extensions root directory to scan.</param>
     /// <returns>The valid extensions found, as (directory, manifest) pairs.</returns>
-    internal static IReadOnlyList<(string Directory, JSExtensionManifest Manifest)> DiscoverManifests(string root)
+    internal static IReadOnlyList<(string Directory, JSExtensionManifest Manifest)> DiscoverManifests(
+        string root,
+        bool includeGalleryInstalling = false)
     {
         var results = new List<(string, JSExtensionManifest)>();
 
@@ -564,6 +573,11 @@ public sealed partial class JsonRpcExtensionService : IExtensionService, IJsExte
 
         foreach (var subdir in subdirectories)
         {
+            if (!includeGalleryInstalling && HasGalleryInstallMarker(subdir))
+            {
+                continue;
+            }
+
             var manifestPath = Path.Combine(subdir, "package.json");
             if (!File.Exists(manifestPath))
             {
@@ -581,6 +595,83 @@ public sealed partial class JsonRpcExtensionService : IExtensionService, IJsExte
         }
 
         return results;
+    }
+
+    internal static IReadOnlyList<string> RecoverStaleGalleryInstallMarkers(
+        string root,
+        Action<string>? deleteMarker = null)
+    {
+        var failures = new List<string>();
+        if (string.IsNullOrEmpty(root) || !Directory.Exists(root))
+        {
+            return failures;
+        }
+
+        string[] subdirectories;
+        try
+        {
+            subdirectories = Directory.GetDirectories(root);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            Logger.LogError($"Failed to enumerate stale gallery install markers in {root}: {ex.Message}");
+            return failures;
+        }
+
+        deleteMarker ??= File.Delete;
+        foreach (var subdirectory in subdirectories)
+        {
+            var markerPath = Path.Combine(subdirectory, GalleryInstallMarkerFileName);
+            if (!File.Exists(markerPath))
+            {
+                continue;
+            }
+
+            if (!IsSafeStaleGalleryMarkerPath(root, subdirectory))
+            {
+                Logger.LogError($"Refusing to remove stale gallery install marker '{markerPath}' because its directory is outside the trusted extensions root or is a reparse point.");
+                failures.Add(subdirectory);
+                continue;
+            }
+
+            try
+            {
+                deleteMarker(markerPath);
+                Logger.LogInfo($"Removed stale gallery install marker '{markerPath}'.");
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                Logger.LogError($"Failed to remove stale gallery install marker '{markerPath}': {ex.Message}");
+                failures.Add(subdirectory);
+            }
+        }
+
+        return failures;
+    }
+
+    internal static bool HasGalleryInstallMarker(string extensionDirectory) =>
+        File.Exists(Path.Combine(extensionDirectory, GalleryInstallMarkerFileName));
+
+    internal static bool ShouldRemoveExtensionDuringReconciliation(string extensionDirectory) =>
+        !HasGalleryInstallMarker(extensionDirectory);
+
+    internal static bool IsSafeStaleGalleryMarkerPath(string root, string extensionDirectory)
+    {
+        try
+        {
+            var normalizedRoot = Path.TrimEndingDirectorySeparator(Path.GetFullPath(root));
+            var normalizedDirectory = Path.TrimEndingDirectorySeparator(Path.GetFullPath(extensionDirectory));
+            var markerPath = Path.Combine(normalizedDirectory, GalleryInstallMarkerFileName);
+
+            return string.Equals(Path.GetDirectoryName(normalizedDirectory), normalizedRoot, StringComparison.OrdinalIgnoreCase)
+                && IsUnderDirectory(markerPath, normalizedRoot)
+                && (File.GetAttributes(normalizedRoot) & FileAttributes.ReparsePoint) == 0
+                && (File.GetAttributes(normalizedDirectory) & FileAttributes.ReparsePoint) == 0;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException or PathTooLongException or System.Security.SecurityException)
+        {
+            return false;
+        }
     }
 
     /// <summary>
@@ -923,9 +1014,11 @@ public sealed partial class JsonRpcExtensionService : IExtensionService, IJsExte
     /// rejected duplicates. All full (re)load and reconciliation paths go through here so
     /// they agree on the same deterministic winner.
     /// </summary>
-    private static IReadOnlyList<(string Directory, JSExtensionManifest Manifest)> DiscoverAcceptedManifests(string root)
+    private static IReadOnlyList<(string Directory, JSExtensionManifest Manifest)> DiscoverAcceptedManifests(
+        string root,
+        bool includeGalleryInstalling = false)
     {
-        var discovered = DiscoverManifests(root);
+        var discovered = DiscoverManifests(root, includeGalleryInstalling);
         var (accepted, rejected) = ResolveIdCollisions(discovered);
 
         foreach (var (directory, manifest, winnerDirectory) in rejected)
@@ -938,6 +1031,14 @@ public sealed partial class JsonRpcExtensionService : IExtensionService, IJsExte
     }
 
     private bool IsStopping(CancellationToken ct) => _disposed || _reload.IsStopRequested || ct.IsCancellationRequested;
+
+    private void RecoverStaleGalleryInstallMarkersOnce()
+    {
+        if (Interlocked.Exchange(ref _startupMarkerRecoveryCompleted, 1) == 0)
+        {
+            RecoverStaleGalleryInstallMarkers(ExtensionsPath);
+        }
+    }
 
     // Provider add/remove notifications are raised through a single ordered dispatcher so a
     // consumer never observes an addition ahead of a removal that was raised before it.
@@ -1015,7 +1116,9 @@ public sealed partial class JsonRpcExtensionService : IExtensionService, IJsExte
 
     private async Task<CommandProviderWrapper?> AddDiscoveredExtensionAsync(string extensionDirectory, CancellationToken ct)
     {
-        var candidate = FindManifestByDirectory(DiscoverAcceptedManifests(ExtensionsPath), extensionDirectory);
+        var candidate = FindManifestByDirectory(
+            DiscoverAcceptedManifests(ExtensionsPath, includeGalleryInstalling: true),
+            extensionDirectory);
         if (candidate is null)
         {
             return null;
@@ -1580,7 +1683,7 @@ public sealed partial class JsonRpcExtensionService : IExtensionService, IJsExte
             return;
         }
 
-        if (File.Exists(Path.Combine(extensionDirectory, GalleryInstallMarkerFileName)))
+        if (HasGalleryInstallMarker(extensionDirectory))
         {
             return;
         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/NpmArtifact.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/NpmArtifact.cs
@@ -1,0 +1,253 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.CmdPal.UI.ViewModels.Services;
+
+/// <summary>
+/// The reason an <see cref="NpmArtifact"/> failed validation. The installer maps each value to a
+/// localized, user-facing message; keeping the reason as an enum keeps validation free of any
+/// presentation concern and lets tests assert the exact failure.
+/// </summary>
+public enum NpmArtifactValidationError
+{
+    /// <summary>No error; the artifact is valid.</summary>
+    None,
+
+    /// <summary>The package name is missing.</summary>
+    PackageMissing,
+
+    /// <summary>The package name is not a valid npm package name.</summary>
+    PackageInvalid,
+
+    /// <summary>The version is missing.</summary>
+    VersionMissing,
+
+    /// <summary>The version is not an exact semantic version (a range or dist-tag was supplied).</summary>
+    VersionInvalid,
+
+    /// <summary>The integrity value is missing.</summary>
+    IntegrityMissing,
+
+    /// <summary>The integrity value is not a supported Subresource Integrity (sha512) hash.</summary>
+    IntegrityInvalid,
+
+    /// <summary>The registry is present but is not an approved canonical HTTPS origin.</summary>
+    RegistryInvalid,
+}
+
+/// <summary>
+/// An immutable, validated description of the npm artifact the gallery is allowed to install. The
+/// only way to obtain one is through <see cref="TryCreate"/>, so any instance is guaranteed to carry
+/// a package name that matches the npm grammar, an exact version (never a range or dist-tag), a
+/// sha512 Subresource Integrity value, and, when present, an approved HTTPS registry. The npm install
+/// spec is always the literal "name@version" and can never be read as a flag, path, URL, git ref, or
+/// tarball.
+/// </summary>
+public sealed class NpmArtifact
+{
+    // The default public npm registry. When a catalog entry omits a registry this host is used
+    // implicitly by npm; when it specifies one it must be on this allowlist.
+    private static readonly HashSet<string> ApprovedRegistryHosts = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "registry.npmjs.org",
+    };
+
+    // npm package name grammar (RFC-ish): an optional @scope/ prefix, then a name segment. Each
+    // segment starts with an ASCII letter or digit and otherwise allows only letters, digits, and
+    // the '.', '_', '-' characters. This forbids whitespace, path separators, ':', '#', and a
+    // leading '-' or '@' in the name segment, so the value can never be a path, URL, git ref, or flag.
+    private static readonly Regex PackageNameRegex = new(
+        "^(?:@[a-z0-9][a-z0-9._-]*/)?[a-z0-9][a-z0-9._-]*$",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    // Exact semantic version: major.minor.patch with optional pre-release and build metadata. Range
+    // operators (^, ~, >, <, =, *, x, ||, -) and dist-tags (such as "latest") do not match, so only a
+    // single concrete version is ever accepted.
+    private static readonly Regex ExactVersionRegex = new(
+        @"^\d+\.\d+\.\d+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?(?:\+[0-9A-Za-z][0-9A-Za-z.-]*)?$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    // Subresource Integrity for a sha512 digest: the "sha512-" prefix followed by standard base64.
+    private static readonly Regex IntegrityRegex = new(
+        "^sha512-[A-Za-z0-9+/]+={0,2}$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    private const int MaxPackageNameLength = 214;
+
+    private NpmArtifact(string package, string version, string integrity, string? registry)
+    {
+        Package = package;
+        Version = version;
+        Integrity = integrity;
+        Registry = registry;
+    }
+
+    /// <summary>Gets the validated npm package name.</summary>
+    public string Package { get; }
+
+    /// <summary>Gets the exact version to install.</summary>
+    public string Version { get; }
+
+    /// <summary>Gets the sha512 Subresource Integrity value of the approved tarball.</summary>
+    public string Integrity { get; }
+
+    /// <summary>Gets the approved canonical registry origin ("https://host/"), or null to use the machine default.</summary>
+    public string? Registry { get; }
+
+    /// <summary>
+    /// Gets the exact npm install spec, always the literal "name@version". Because both halves were
+    /// validated, this can never be interpreted by npm as anything other than a registry package at a
+    /// single version.
+    /// </summary>
+    public string InstallSpec => $"{Package}@{Version}";
+
+    /// <summary>
+    /// Validates the parts of an approved artifact and, on success, returns an immutable
+    /// <see cref="NpmArtifact"/>. Fails closed: any missing or malformed part yields a specific
+    /// <see cref="NpmArtifactValidationError"/> and no artifact.
+    /// </summary>
+    /// <param name="package">The npm package name.</param>
+    /// <param name="version">The exact version.</param>
+    /// <param name="integrity">The sha512 Subresource Integrity value.</param>
+    /// <param name="registry">The optional registry URL.</param>
+    /// <param name="artifact">The validated artifact when the method returns true; otherwise null.</param>
+    /// <param name="error">The reason validation failed when the method returns false; otherwise <see cref="NpmArtifactValidationError.None"/>.</param>
+    /// <returns><see langword="true"/> when the artifact is valid; otherwise, <see langword="false"/>.</returns>
+    public static bool TryCreate(
+        string? package,
+        string? version,
+        string? integrity,
+        string? registry,
+        out NpmArtifact? artifact,
+        out NpmArtifactValidationError error)
+    {
+        artifact = null;
+
+        var trimmedPackage = package?.Trim() ?? string.Empty;
+        if (trimmedPackage.Length == 0)
+        {
+            error = NpmArtifactValidationError.PackageMissing;
+            return false;
+        }
+
+        if (trimmedPackage.Length > MaxPackageNameLength || !PackageNameRegex.IsMatch(trimmedPackage))
+        {
+            error = NpmArtifactValidationError.PackageInvalid;
+            return false;
+        }
+
+        var trimmedVersion = version?.Trim() ?? string.Empty;
+        if (trimmedVersion.Length == 0)
+        {
+            error = NpmArtifactValidationError.VersionMissing;
+            return false;
+        }
+
+        if (!ExactVersionRegex.IsMatch(trimmedVersion))
+        {
+            error = NpmArtifactValidationError.VersionInvalid;
+            return false;
+        }
+
+        var trimmedIntegrity = integrity?.Trim() ?? string.Empty;
+        if (trimmedIntegrity.Length == 0)
+        {
+            error = NpmArtifactValidationError.IntegrityMissing;
+            return false;
+        }
+
+        if (!IntegrityRegex.IsMatch(trimmedIntegrity))
+        {
+            error = NpmArtifactValidationError.IntegrityInvalid;
+            return false;
+        }
+
+        string? normalizedRegistry = null;
+        var trimmedRegistry = registry?.Trim();
+        if (!string.IsNullOrEmpty(trimmedRegistry))
+        {
+            if (!TryCanonicalizeRegistry(trimmedRegistry, out normalizedRegistry))
+            {
+                error = NpmArtifactValidationError.RegistryInvalid;
+                return false;
+            }
+        }
+
+        // Defense in depth: the join must not resolve to a flag even if the regexes ever loosen.
+        var spec = $"{trimmedPackage}@{trimmedVersion}";
+        if (spec.StartsWith('-'))
+        {
+            error = NpmArtifactValidationError.PackageInvalid;
+            return false;
+        }
+
+        artifact = new NpmArtifact(trimmedPackage, trimmedVersion, trimmedIntegrity, normalizedRegistry);
+        error = NpmArtifactValidationError.None;
+        return true;
+    }
+
+    private static bool TryCanonicalizeRegistry(string registry, out string? canonical)
+    {
+        canonical = null;
+
+        if (!Uri.TryCreate(registry, UriKind.Absolute, out var uri))
+        {
+            return false;
+        }
+
+        // A registry value is later passed to npm as the "--registry" argument. Restricting it to a
+        // canonical origin (scheme, host, and nothing else) closes the door on a value that smuggles
+        // shell metacharacters or extra request parts through a userinfo, port, path, query, or
+        // fragment. Anything richer than "https://<approved-host>/" is rejected, and the value that is
+        // stored is reconstructed from the host alone rather than echoing the caller's raw string.
+        var pathIsRoot = uri.AbsolutePath.Length == 0 || uri.AbsolutePath == "/";
+        var isCanonicalOrigin =
+            string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)
+            && ApprovedRegistryHosts.Contains(uri.Host)
+            && string.IsNullOrEmpty(uri.UserInfo)
+            && uri.IsDefaultPort
+            && string.IsNullOrEmpty(uri.Query)
+            && string.IsNullOrEmpty(uri.Fragment)
+            && pathIsRoot;
+
+        if (!isCanonicalOrigin)
+        {
+            return false;
+        }
+
+        canonical = $"https://{uri.Host}/";
+        return true;
+    }
+
+    /// <summary>
+    /// Determines whether <paramref name="url"/> is an absolute HTTPS URL served by an approved
+    /// registry host. Unlike <see cref="TryCanonicalizeRegistry"/> this accepts any path, because a
+    /// resolved tarball URL in a lockfile carries the package path (for example
+    /// "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz"). Used by the lockfile-integrity
+    /// gate to reject a dependency resolved from file:, git:, http:, or any host that is not on the
+    /// allowlist.
+    /// </summary>
+    internal static bool IsRegistrySourcedHttps(string? url)
+    {
+        if (string.IsNullOrWhiteSpace(url) || !Uri.TryCreate(url, UriKind.Absolute, out var uri))
+        {
+            return false;
+        }
+
+        return string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)
+            && ApprovedRegistryHosts.Contains(uri.Host);
+    }
+
+    /// <summary>
+    /// Determines whether <paramref name="integrity"/> is a supported sha512 Subresource Integrity
+    /// value. Used by the lockfile-integrity gate to reject a dependency that npm resolved without an
+    /// integrity hash.
+    /// </summary>
+    internal static bool IsSupportedIntegrity(string? integrity) =>
+        !string.IsNullOrWhiteSpace(integrity) && IntegrityRegex.IsMatch(integrity.Trim());
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/NpmArtifact.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/NpmArtifact.cs
@@ -10,8 +10,8 @@ namespace Microsoft.CmdPal.UI.ViewModels.Services;
 
 /// <summary>
 /// The reason an <see cref="NpmArtifact"/> failed validation. The installer maps each value to a
-/// localized, user-facing message; keeping the reason as an enum keeps validation free of any
-/// presentation concern and lets tests assert the exact failure.
+/// localized message. Keeping the reason as an enum keeps validation free of UI concerns and gives
+/// tests one exact failure to assert.
 /// </summary>
 public enum NpmArtifactValidationError
 {
@@ -27,7 +27,7 @@ public enum NpmArtifactValidationError
     /// <summary>The version is missing.</summary>
     VersionMissing,
 
-    /// <summary>The version is not an exact semantic version (a range or dist-tag was supplied).</summary>
+    /// <summary>The version is not an exact semantic version (a range or dist tag was supplied).</summary>
     VersionInvalid,
 
     /// <summary>The integrity value is missing.</summary>
@@ -41,33 +41,31 @@ public enum NpmArtifactValidationError
 }
 
 /// <summary>
-/// An immutable, validated description of the npm artifact the gallery is allowed to install. The
-/// only way to obtain one is through <see cref="TryCreate"/>, so any instance is guaranteed to carry
-/// a package name that matches the npm grammar, an exact version (never a range or dist-tag), a
-/// sha512 Subresource Integrity value, and, when present, an approved HTTPS registry. The npm install
-/// spec is always the literal "name@version" and can never be read as a flag, path, URL, git ref, or
-/// tarball.
+/// A validated description of the npm package the gallery may install. Instances only come from
+/// <see cref="TryCreate"/>, so callers get npm grammar, an exact version, a sha512 Subresource
+/// Integrity value, and an approved HTTPS registry when one is supplied. The install spec is the
+/// literal "name@version", not a flag, path, URL, git ref, or tarball.
 /// </summary>
 public sealed class NpmArtifact
 {
-    // The default public npm registry. When a catalog entry omits a registry this host is used
-    // implicitly by npm; when it specifies one it must be on this allowlist.
+    // The default public npm registry. If the catalog omits a registry, npm uses this host
+    // implicitly. If it specifies one, the host must be on this allowlist.
     private static readonly HashSet<string> ApprovedRegistryHosts = new(StringComparer.OrdinalIgnoreCase)
     {
         "registry.npmjs.org",
     };
 
-    // npm package name grammar (RFC-ish): an optional @scope/ prefix, then a name segment. Each
-    // segment starts with an ASCII letter or digit and otherwise allows only letters, digits, and
-    // the '.', '_', '-' characters. This forbids whitespace, path separators, ':', '#', and a
-    // leading '-' or '@' in the name segment, so the value can never be a path, URL, git ref, or flag.
+    // npm package name grammar: optional @scope/ prefix, then a name segment. Each segment starts
+    // with an ASCII letter or digit and otherwise allows only letters, digits, '.', '_', and '-'.
+    // This blocks whitespace, path separators, ':', '#', and a leading '-' or '@' in the name
+    // segment, so the value cannot become a path, URL, git ref, or flag.
     private static readonly Regex PackageNameRegex = new(
         "^(?:@[a-z0-9][a-z0-9._-]*/)?[a-z0-9][a-z0-9._-]*$",
         RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
 
-    // Exact semantic version: major.minor.patch with optional pre-release and build metadata. Range
-    // operators (^, ~, >, <, =, *, x, ||, -) and dist-tags (such as "latest") do not match, so only a
-    // single concrete version is ever accepted.
+    // Exact semantic version: major.minor.patch with optional prerelease and build metadata. Range
+    // operators (^, ~, >, <, =, *, x, ||, -) and dist tags such as "latest" do not match, so only one
+    // concrete version is accepted.
     private static readonly Regex ExactVersionRegex = new(
         @"^\d+\.\d+\.\d+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?(?:\+[0-9A-Za-z][0-9A-Za-z.-]*)?$",
         RegexOptions.CultureInvariant | RegexOptions.Compiled);
@@ -96,7 +94,7 @@ public sealed class NpmArtifact
     /// <summary>Gets the sha512 Subresource Integrity value of the approved tarball.</summary>
     public string Integrity { get; }
 
-    /// <summary>Gets the approved canonical registry origin ("https://host/"), or null to use the machine default.</summary>
+    /// <summary>Gets the approved canonical registry origin ("https://host/"), or null to use npm's machine default.</summary>
     public string? Registry { get; }
 
     /// <summary>
@@ -107,8 +105,8 @@ public sealed class NpmArtifact
     public string InstallSpec => $"{Package}@{Version}";
 
     /// <summary>
-    /// Validates the parts of an approved artifact and, on success, returns an immutable
-    /// <see cref="NpmArtifact"/>. Fails closed: any missing or malformed part yields a specific
+    /// Validates the parts of an approved artifact and returns an immutable <see cref="NpmArtifact"/>
+    /// when they pass. Any missing or malformed part fails closed with a specific
     /// <see cref="NpmArtifactValidationError"/> and no artifact.
     /// </summary>
     /// <param name="package">The npm package name.</param>
@@ -200,11 +198,9 @@ public sealed class NpmArtifact
             return false;
         }
 
-        // A registry value is later passed to npm as the "--registry" argument. Restricting it to a
-        // canonical origin (scheme, host, and nothing else) closes the door on a value that smuggles
-        // shell metacharacters or extra request parts through a userinfo, port, path, query, or
-        // fragment. Anything richer than "https://<approved-host>/" is rejected, and the value that is
-        // stored is reconstructed from the host alone rather than echoing the caller's raw string.
+        // npm later receives this value as the "--registry" argument. Keep it to a canonical origin
+        // so userinfo, ports, paths, query strings, fragments, and shell metacharacters cannot ride
+        // along. Store a rebuilt value from the host instead of echoing the caller's raw string.
         var pathIsRoot = uri.AbsolutePath.Length == 0 || uri.AbsolutePath == "/";
         var isCanonicalOrigin =
             string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)
@@ -226,11 +222,9 @@ public sealed class NpmArtifact
 
     /// <summary>
     /// Determines whether <paramref name="url"/> is an absolute HTTPS URL served by an approved
-    /// registry host. Unlike <see cref="TryCanonicalizeRegistry"/> this accepts any path, because a
-    /// resolved tarball URL in a lockfile carries the package path (for example
-    /// "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz"). Used by the lockfile-integrity
-    /// gate to reject a dependency resolved from file:, git:, http:, or any host that is not on the
-    /// allowlist.
+    /// registry host. Unlike <see cref="TryCanonicalizeRegistry"/>, this accepts package paths from
+    /// lockfiles (for example, "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz"). The
+    /// lockfile check uses it to reject file:, git:, http:, and any host outside the allowlist.
     /// </summary>
     internal static bool IsRegistrySourcedHttps(string? url)
     {
@@ -245,8 +239,7 @@ public sealed class NpmArtifact
 
     /// <summary>
     /// Determines whether <paramref name="integrity"/> is a supported sha512 Subresource Integrity
-    /// value. Used by the lockfile-integrity gate to reject a dependency that npm resolved without an
-    /// integrity hash.
+    /// value. The lockfile check uses it to reject dependencies without an integrity hash.
     /// </summary>
     internal static bool IsSupportedIntegrity(string? integrity) =>
         !string.IsNullOrWhiteSpace(integrity) && IntegrityRegex.IsMatch(integrity.Trim());

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/NpmCommandRunner.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/NpmCommandRunner.cs
@@ -1,0 +1,757 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Formats.Tar;
+using System.Globalization;
+using System.IO;
+using System.IO.Compression;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using ManagedCommon;
+using Microsoft.CmdPal.UI.ViewModels.Properties;
+
+namespace Microsoft.CmdPal.UI.ViewModels.Services;
+
+/// <summary>
+/// Default <see cref="INpmCommandRunner"/> that shells out to the npm executable found on PATH.
+/// The runner never installs the approved package as a dependency, because npm would then re-resolve
+/// its transitive semver ranges and ignore the publisher's embedded npm-shrinkwrap.json. Instead it
+/// downloads the exact tarball with <c>npm pack</c>, extracts it so the published package is the root
+/// project, requires the publisher to have shipped an npm-shrinkwrap.json that freezes the whole
+/// dependency closure, and runs <c>npm ci</c>, which installs that frozen closure verbatim and never
+/// re-resolves a range. npm is always invoked with lifecycle scripts disabled. The resolved package
+/// integrity is the Subresource Integrity of the downloaded tarball, and the frozen lockfile is
+/// re-checked so every resolved entry came from an approved registry over HTTPS with an integrity
+/// hash before the caller promotes the package.
+/// </summary>
+public sealed class NpmCommandRunner : INpmCommandRunner
+{
+    // npm on Windows ships as an npm.cmd batch shim. Passing an argument that contains a shell
+    // metacharacter to a .cmd file can let cmd.exe reinterpret it, even through ProcessStartInfo's
+    // ArgumentList. To keep untrusted arguments off any batch/cmd command line, the runner instead
+    // resolves node.exe and npm's JavaScript entry point (npm-cli.js) and launches
+    // "node.exe npm-cli.js install ...". node.exe is a real executable, so its ArgumentList is passed
+    // verbatim with no shell in the middle.
+    private const string NodeExecutableName = "node.exe";
+
+    // npm-cli.js relative to a directory that contains node.exe, and to a global npm prefix.
+    private static readonly string NpmCliRelativePath = Path.Combine("node_modules", "npm", "bin", "npm-cli.js");
+
+    // The directory (under the caller's staging directory) that the downloaded tarball is unpacked
+    // into. npm tarballs always root their entries under "package/", so the extracted project root is
+    // this well-known path and the installer promotes it directly.
+    internal const string PackageRootDirectoryName = "package";
+
+    // A private subdirectory of staging that only holds the downloaded .tgz, kept separate from the
+    // extracted package root so a single tarball is easy to locate.
+    internal const string PackDirectoryName = "__cmdpal_pack";
+
+    // The publisher-provided lockfile that must be present inside the package tarball. It freezes the
+    // full transitive dependency closure so npm ci installs an exact set rather than re-resolving
+    // mutable semver ranges at install time.
+    internal const string ShrinkwrapFileName = "npm-shrinkwrap.json";
+
+    // The lockfile npm consults, in precedence order. npm-shrinkwrap.json is the publishable form and
+    // takes precedence over package-lock.json.
+    private static readonly string[] LockfileNames = [ShrinkwrapFileName, "package-lock.json"];
+
+    // Upper bound on a single npm operation so the gallery cannot stay on "Installing..."
+    // forever when npm hangs (for example, an unreachable registry with no output).
+    private static readonly TimeSpan InstallTimeout = TimeSpan.FromMinutes(5);
+
+    // A directory whose handles are still being released briefly rejects a delete; retry a few
+    // times with a short backoff before giving up so an uninstall does not fail spuriously.
+    private const int DeleteAttempts = 5;
+    private static readonly TimeSpan DeleteRetryDelay = TimeSpan.FromMilliseconds(100);
+
+    // Cached composite formats for the localized runner messages that take arguments (CA1863).
+    private static readonly CompositeFormat CreateStagingFailedFormat = CompositeFormat.Parse(Resources.npm_runner_create_staging_failed);
+    private static readonly CompositeFormat TimedOutFormat = CompositeFormat.Parse(Resources.npm_runner_timed_out);
+    private static readonly CompositeFormat FailedExitFormat = CompositeFormat.Parse(Resources.npm_runner_failed_exit);
+
+    public bool IsNpmAvailable() => ResolveNpmInvocation() is not null;
+
+    public async Task<NpmCommandResult> InstallAsync(string stagingDirectory, NpmArtifact artifact, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(artifact);
+
+        var invocation = ResolveNpmInvocation();
+        if (invocation is null)
+        {
+            return NpmCommandResult.Fail(Resources.npm_runner_npm_not_found);
+        }
+
+        try
+        {
+            Directory.CreateDirectory(stagingDirectory);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            Logger.LogError($"Failed to create npm staging directory {stagingDirectory}: {ex.Message}");
+            return NpmCommandResult.Fail(string.Format(CultureInfo.CurrentCulture, CreateStagingFailedFormat, ex.Message));
+        }
+
+        try
+        {
+            // 1) Download the exact "name@version" tarball with no lifecycle scripts. npm pack fetches
+            //    the immutable published artifact; it does not resolve or install any dependency.
+            var packDirectory = Path.Combine(stagingDirectory, PackDirectoryName);
+            Directory.CreateDirectory(packDirectory);
+
+            var packResult = await RunNpmAsync(invocation.Value, BuildPackArguments(artifact, packDirectory), stagingDirectory, artifact.InstallSpec, cancellationToken).ConfigureAwait(false);
+            if (!packResult.Succeeded)
+            {
+                return NpmCommandResult.Fail(packResult.ErrorMessage ?? Resources.npm_runner_extract_failed);
+            }
+
+            var tarballPath = FindPackedTarball(packDirectory);
+            if (tarballPath is null)
+            {
+                Logger.LogError($"npm pack {artifact.InstallSpec} produced no tarball in {packDirectory}.");
+                return NpmCommandResult.Fail(Resources.npm_runner_extract_failed);
+            }
+
+            // 2) The resolved integrity is the Subresource Integrity of the downloaded tarball. The
+            //    caller compares this to the catalog-approved integrity before promoting anything.
+            var resolvedIntegrity = ComputeTarballIntegrity(tarballPath);
+            if (resolvedIntegrity is null)
+            {
+                return NpmCommandResult.Fail(Resources.npm_runner_extract_failed);
+            }
+
+            // 3) Treat the published package as the ROOT project by extracting its tarball. npm only
+            //    honors an embedded npm-shrinkwrap.json for the root project, not for a package
+            //    installed as a dependency, so this extraction is what makes the shrinkwrap
+            //    authoritative rather than silently ignored.
+            var packageRoot = Path.Combine(stagingDirectory, PackageRootDirectoryName);
+            var extractError = TryExtractPackage(tarballPath, packageRoot);
+            if (extractError is not null)
+            {
+                return NpmCommandResult.Fail(extractError);
+            }
+
+            // 4) Fail closed unless the publisher shipped a shrinkwrap that freezes the full transitive
+            //    closure. Without it, npm ci would have nothing to install from deterministically and
+            //    the closure would still be resolved from mutable ranges.
+            var shrinkwrapError = RequirePublisherShrinkwrap(packageRoot);
+            if (shrinkwrapError is not null)
+            {
+                Logger.LogError($"npm package {artifact.InstallSpec} does not include a published {ShrinkwrapFileName}; refusing to install.");
+                return NpmCommandResult.Fail(shrinkwrapError);
+            }
+
+            // 5) npm ci installs the exact closure named in the shrinkwrap and never re-resolves a
+            //    semver range. It fails closed when the lockfile is missing or out of sync with
+            //    package.json, so the frozen tree is the only thing that can be installed.
+            var ciResult = await RunNpmAsync(invocation.Value, BuildCiArguments(artifact), packageRoot, artifact.InstallSpec, cancellationToken).ConfigureAwait(false);
+            if (!ciResult.Succeeded)
+            {
+                return NpmCommandResult.Fail(ciResult.ErrorMessage ?? Resources.npm_runner_lockfile_untrusted);
+            }
+
+            // 6) Second gate: every resolved entry in the frozen lockfile must come from an approved
+            //    registry over HTTPS and carry a Subresource Integrity hash. This fails closed: a
+            //    lockfile that is missing, malformed, or contains a file:/git:/http:/integrity-less
+            //    resolution is rejected.
+            var lockfileError = VerifyLockfileIntegrity(packageRoot);
+            if (lockfileError is not null)
+            {
+                Logger.LogError($"npm ci {artifact.InstallSpec} produced an untrusted lockfile: {lockfileError}");
+                return NpmCommandResult.Fail(lockfileError);
+            }
+
+            return NpmCommandResult.Ok(resolvedIntegrity);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError($"npm operation for {artifact.InstallSpec} threw: {ex.Message}");
+            return NpmCommandResult.Fail(ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Builds the immutable <c>npm pack</c> argument list for an approved artifact. The first real
+    /// token is the validated "name@version" spec, passed through ArgumentList so npm can never read
+    /// it as a flag. The tarball is written to <paramref name="packDestination"/>, lifecycle scripts
+    /// are disabled, and a registry, when present, is passed only through its own flag pair.
+    /// </summary>
+    internal static IReadOnlyList<string> BuildPackArguments(NpmArtifact artifact, string packDestination)
+    {
+        var arguments = new List<string>
+        {
+            "pack",
+            artifact.InstallSpec,
+            "--ignore-scripts",
+            "--no-audit",
+            "--no-fund",
+            "--loglevel=error",
+            "--pack-destination",
+            packDestination,
+        };
+
+        if (!string.IsNullOrWhiteSpace(artifact.Registry))
+        {
+            arguments.Add("--registry");
+            arguments.Add(artifact.Registry);
+        }
+
+        return arguments;
+    }
+
+    /// <summary>
+    /// Builds the immutable <c>npm ci</c> argument list. npm ci installs the exact closure named in
+    /// the project's npm-shrinkwrap.json/package-lock.json and never re-resolves a semver range, so it
+    /// takes no package spec. Lifecycle scripts are disabled, and a registry, when present, is passed
+    /// only through its own flag pair.
+    /// </summary>
+    internal static IReadOnlyList<string> BuildCiArguments(NpmArtifact artifact)
+    {
+        var arguments = new List<string>
+        {
+            "ci",
+            "--ignore-scripts",
+            "--no-audit",
+            "--no-fund",
+            "--loglevel=error",
+        };
+
+        if (!string.IsNullOrWhiteSpace(artifact.Registry))
+        {
+            arguments.Add("--registry");
+            arguments.Add(artifact.Registry);
+        }
+
+        return arguments;
+    }
+
+    /// <summary>
+    /// Returns null when the extracted package root contains the publisher-provided
+    /// <c>npm-shrinkwrap.json</c> that freezes the whole dependency closure; otherwise returns a
+    /// localized error. This is the fail-closed gate that rejects any package whose publisher did not
+    /// freeze its transitive dependencies.
+    /// </summary>
+    internal static string? RequirePublisherShrinkwrap(string packageRoot)
+    {
+        var shrinkwrapPath = Path.Combine(packageRoot, ShrinkwrapFileName);
+        return File.Exists(shrinkwrapPath) ? null : Resources.npm_runner_shrinkwrap_required;
+    }
+
+    /// <summary>
+    /// Computes the sha512 Subresource Integrity value ("sha512-" + base64 digest) of the tarball at
+    /// <paramref name="tarballPath"/>. This matches the integrity npm publishes for a registry
+    /// tarball, so the caller can compare it to the catalog-approved value. Returns null when the file
+    /// cannot be read.
+    /// </summary>
+    internal static string? ComputeTarballIntegrity(string tarballPath)
+    {
+        try
+        {
+            using var stream = File.OpenRead(tarballPath);
+            var hash = SHA512.HashData(stream);
+            return "sha512-" + Convert.ToBase64String(hash);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            Logger.LogError($"Failed to read tarball {tarballPath} for integrity: {ex.Message}");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Locates the single tarball <c>npm pack</c> wrote into <paramref name="packDirectory"/>. The
+    /// directory is created fresh per install, so exactly one .tgz is expected. Returns null when none
+    /// is found.
+    /// </summary>
+    internal static string? FindPackedTarball(string packDirectory)
+    {
+        if (!Directory.Exists(packDirectory))
+        {
+            return null;
+        }
+
+        foreach (var candidate in Directory.EnumerateFiles(packDirectory, "*.tgz"))
+        {
+            return candidate;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Extracts the gzip-compressed npm tarball at <paramref name="tarballPath"/> so the published
+    /// package becomes the root project at <paramref name="packageRoot"/>. npm tarballs root every
+    /// entry under "package/", so the archive is unpacked into a temporary directory and that inner
+    /// folder is moved to <paramref name="packageRoot"/>. Returns null on success, or a localized
+    /// error when the tarball cannot be read or does not contain a package root.
+    /// </summary>
+    internal static string? TryExtractPackage(string tarballPath, string packageRoot)
+    {
+        var extractRoot = packageRoot + ".extract";
+        try
+        {
+            if (Directory.Exists(extractRoot))
+            {
+                Directory.Delete(extractRoot, recursive: true);
+            }
+
+            Directory.CreateDirectory(extractRoot);
+
+            using (var fileStream = File.OpenRead(tarballPath))
+            using (var gzipStream = new GZipStream(fileStream, CompressionMode.Decompress))
+            {
+                // ExtractToDirectory refuses to write an entry outside extractRoot, so a malicious
+                // "../" path in the tarball cannot escape the staging tree.
+                TarFile.ExtractToDirectory(gzipStream, extractRoot, overwriteFiles: true);
+            }
+
+            var innerPackage = Path.Combine(extractRoot, PackageRootDirectoryName);
+            if (!Directory.Exists(innerPackage))
+            {
+                // Some publishers root the tarball under a different folder name; fall back to the
+                // single top-level directory when there is exactly one.
+                innerPackage = ResolveSingleTopLevelDirectory(extractRoot) ?? string.Empty;
+            }
+
+            if (string.IsNullOrEmpty(innerPackage) || !Directory.Exists(innerPackage))
+            {
+                Logger.LogError($"Tarball {tarballPath} did not contain a package root.");
+                return Resources.npm_runner_extract_failed;
+            }
+
+            if (Directory.Exists(packageRoot))
+            {
+                Directory.Delete(packageRoot, recursive: true);
+            }
+
+            Directory.Move(innerPackage, packageRoot);
+            return null;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidDataException)
+        {
+            Logger.LogError($"Failed to extract tarball {tarballPath}: {ex.Message}");
+            return Resources.npm_runner_extract_failed;
+        }
+        finally
+        {
+            try
+            {
+                if (Directory.Exists(extractRoot))
+                {
+                    Directory.Delete(extractRoot, recursive: true);
+                }
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                Logger.LogWarning($"Failed to clean tarball extract directory {extractRoot}: {ex.Message}");
+            }
+        }
+    }
+
+    private static string? ResolveSingleTopLevelDirectory(string root)
+    {
+        string? only = null;
+        foreach (var directory in Directory.EnumerateDirectories(root))
+        {
+            if (only is not null)
+            {
+                return null;
+            }
+
+            only = directory;
+        }
+
+        return only;
+    }
+
+    /// <summary>
+    /// Runs npm (through node.exe and npm-cli.js so the npm.cmd batch shim is never involved) with the
+    /// given arguments and working directory, bounding the wait so a hung npm cannot stall the UI.
+    /// Returns success, a timeout message, or the captured stderr on a non-zero exit. Rethrows
+    /// <see cref="OperationCanceledException"/> only for a caller-driven cancel, not the timeout.
+    /// </summary>
+    private static async Task<NpmProcessResult> RunNpmAsync(NpmInvocation invocation, IReadOnlyList<string> arguments, string workingDirectory, string installSpec, CancellationToken cancellationToken)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = invocation.FileName,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+            WorkingDirectory = workingDirectory,
+        };
+
+        // Launcher arguments first (npm-cli.js), so node.exe runs npm itself. These are trusted,
+        // runner-resolved paths. Every following argument is passed through ArgumentList (never string
+        // concatenation) so npm cannot reinterpret an untrusted token as a flag.
+        foreach (var launcherArgument in invocation.LauncherArguments)
+        {
+            psi.ArgumentList.Add(launcherArgument);
+        }
+
+        foreach (var argument in arguments)
+        {
+            psi.ArgumentList.Add(argument);
+        }
+
+        using var process = Process.Start(psi);
+        if (process is null)
+        {
+            return NpmProcessResult.Fail(Resources.npm_runner_start_failed);
+        }
+
+        var stderrBuilder = new StringBuilder();
+        process.ErrorDataReceived += (_, e) =>
+        {
+            if (e.Data is not null)
+            {
+                stderrBuilder.AppendLine(e.Data);
+            }
+        };
+        process.BeginErrorReadLine();
+        process.BeginOutputReadLine();
+
+        // Bound the wait so a hung npm does not leave the UI stuck. A caller-driven cancel and the
+        // timeout share one linked source; the catch below tells the two apart.
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(InstallTimeout);
+
+        try
+        {
+            await process.WaitForExitAsync(timeoutCts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            await TerminateAndWaitAsync(process).ConfigureAwait(false);
+            Logger.LogError($"npm {installSpec} timed out after {InstallTimeout.TotalMinutes:0} minutes.");
+            return NpmProcessResult.Fail(string.Format(CultureInfo.CurrentCulture, TimedOutFormat, InstallTimeout.TotalMinutes.ToString("0", CultureInfo.CurrentCulture)));
+        }
+        catch (OperationCanceledException)
+        {
+            await TerminateAndWaitAsync(process).ConfigureAwait(false);
+            throw;
+        }
+
+        if (process.ExitCode != 0)
+        {
+            var error = stderrBuilder.ToString().Trim();
+            Logger.LogError($"npm {installSpec} failed (exit {process.ExitCode}): {error}");
+            return NpmProcessResult.Fail(string.IsNullOrEmpty(error)
+                ? string.Format(CultureInfo.CurrentCulture, FailedExitFormat, process.ExitCode)
+                : error);
+        }
+
+        return NpmProcessResult.Ok();
+    }
+
+    /// <summary>
+    /// The outcome of a single npm invocation: success, or a localized/captured error message.
+    /// </summary>
+    private readonly record struct NpmProcessResult(bool Succeeded, string? ErrorMessage)
+    {
+        public static NpmProcessResult Ok() => new(true, null);
+
+        public static NpmProcessResult Fail(string errorMessage) => new(false, errorMessage);
+    }
+
+    public bool RemoveDirectory(string targetDirectory, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(targetDirectory) || !Directory.Exists(targetDirectory))
+        {
+            return true;
+        }
+
+        // Never recurse through a junction or symbolic link: deleting recursively could reach files
+        // outside the extensions tree. If the directory itself is a reparse point, refuse.
+        if (IsReparsePoint(targetDirectory))
+        {
+            Logger.LogError($"Refusing to delete '{targetDirectory}' because it is a reparse point (junction or symbolic link).");
+            return false;
+        }
+
+        for (var attempt = 1; attempt <= DeleteAttempts; attempt++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                Directory.Delete(targetDirectory, recursive: true);
+                return true;
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                if (attempt == DeleteAttempts)
+                {
+                    Logger.LogError($"Failed to delete directory {targetDirectory} after {DeleteAttempts} attempts: {ex.Message}");
+                    return false;
+                }
+
+                Thread.Sleep(DeleteRetryDelay);
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Resolves the lockfile npm consults inside <paramref name="projectRoot"/>, preferring the
+    /// publishable npm-shrinkwrap.json over package-lock.json. Returns null when neither exists.
+    /// </summary>
+    private static string? ResolveLockfilePath(string projectRoot)
+    {
+        foreach (var lockfileName in LockfileNames)
+        {
+            var candidate = Path.Combine(projectRoot, lockfileName);
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+
+    private static async Task TerminateAndWaitAsync(Process process)
+    {
+        try
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+
+                // Give the OS a bounded moment to tear the tree down so file handles are released
+                // before the staging directory is cleaned up.
+                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+                await process.WaitForExitAsync(cts.Token).ConfigureAwait(false);
+            }
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or System.ComponentModel.Win32Exception or NotSupportedException or OperationCanceledException)
+        {
+            Logger.LogError($"Failed to terminate npm process: {ex.Message}");
+        }
+    }
+
+    private static bool IsReparsePoint(string path)
+    {
+        try
+        {
+            return (File.GetAttributes(path) & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or System.Security.SecurityException)
+        {
+            // If the attributes cannot be read, err on the side of caution and treat it as unsafe.
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// A resolved npm launcher: the executable to start (node.exe) and the leading arguments that
+    /// make it run npm (the path to npm-cli.js). The install spec and flags are appended after these.
+    /// </summary>
+    internal readonly record struct NpmInvocation(string FileName, IReadOnlyList<string> LauncherArguments);
+
+    /// <summary>
+    /// Verifies that every resolved dependency in the frozen lockfile inside
+    /// <paramref name="projectRoot"/> was fetched from an approved registry over HTTPS and carries a
+    /// supported Subresource Integrity hash. The publisher's npm-shrinkwrap.json is preferred over
+    /// package-lock.json. Returns null when the whole tree is trusted, or a localized error message
+    /// describing the first untrusted resolution. Fails closed: a missing or unreadable lockfile is
+    /// treated as untrusted.
+    /// </summary>
+    internal static string? VerifyLockfileIntegrity(string projectRoot)
+    {
+        var lockfilePath = ResolveLockfilePath(projectRoot);
+        if (lockfilePath is null)
+        {
+            return Resources.npm_runner_lockfile_untrusted;
+        }
+
+        try
+        {
+            using var stream = File.OpenRead(lockfilePath);
+            using var document = JsonDocument.Parse(stream);
+            var root = document.RootElement;
+
+            // lockfileVersion 2/3: a "packages" map keyed by install path. The root package has an
+            // empty key and no resolution of its own; a "link": true entry points at a local
+            // workspace and is skipped. Every other entry must carry a trusted resolved URL + hash.
+            if (root.TryGetProperty("packages", out var packages) && packages.ValueKind == JsonValueKind.Object)
+            {
+                foreach (var package in packages.EnumerateObject())
+                {
+                    if (package.Name.Length == 0)
+                    {
+                        continue;
+                    }
+
+                    if (package.Value.TryGetProperty("link", out var link)
+                        && link.ValueKind == JsonValueKind.True)
+                    {
+                        continue;
+                    }
+
+                    if (!IsTrustedResolution(package.Value))
+                    {
+                        return Resources.npm_runner_lockfile_untrusted;
+                    }
+                }
+
+                return null;
+            }
+
+            // lockfileVersion 1: a nested "dependencies" tree. Walk it recursively.
+            if (root.TryGetProperty("dependencies", out var dependencies) && dependencies.ValueKind == JsonValueKind.Object)
+            {
+                return VerifyLegacyDependencies(dependencies) ? null : Resources.npm_runner_lockfile_untrusted;
+            }
+
+            // Neither shape present: nothing was pinned, so the tree cannot be trusted.
+            return Resources.npm_runner_lockfile_untrusted;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException)
+        {
+            Logger.LogError($"Failed to verify lockfile integrity at {lockfilePath}: {ex.Message}");
+            return Resources.npm_runner_lockfile_untrusted;
+        }
+    }
+
+    private static bool VerifyLegacyDependencies(JsonElement dependencies)
+    {
+        foreach (var dependency in dependencies.EnumerateObject())
+        {
+            var entry = dependency.Value;
+            if (entry.ValueKind != JsonValueKind.Object)
+            {
+                return false;
+            }
+
+            // A "bundled" dependency ships inside its parent's tarball and has no resolution of its
+            // own; it was already covered by the parent's integrity. Anything else must be trusted.
+            var isBundled = entry.TryGetProperty("bundled", out var bundled) && bundled.ValueKind == JsonValueKind.True;
+            if (!isBundled && !IsTrustedResolution(entry))
+            {
+                return false;
+            }
+
+            if (entry.TryGetProperty("dependencies", out var nested) && nested.ValueKind == JsonValueKind.Object
+                && !VerifyLegacyDependencies(nested))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool IsTrustedResolution(JsonElement entry)
+    {
+        var resolved = entry.TryGetProperty("resolved", out var resolvedElement) && resolvedElement.ValueKind == JsonValueKind.String
+            ? resolvedElement.GetString()
+            : null;
+        var integrity = entry.TryGetProperty("integrity", out var integrityElement) && integrityElement.ValueKind == JsonValueKind.String
+            ? integrityElement.GetString()
+            : null;
+
+        return NpmArtifact.IsRegistrySourcedHttps(resolved) && NpmArtifact.IsSupportedIntegrity(integrity);
+    }
+
+    /// <summary>
+    /// Resolves node.exe and npm's npm-cli.js so npm can be launched without the npm.cmd batch shim.
+    /// Probes PATH for node.exe, then looks for npm-cli.js next to node.exe (a standard Node.js
+    /// install) and under the global npm prefix reported by the environment. Returns null when either
+    /// piece cannot be located.
+    /// </summary>
+    internal static NpmInvocation? ResolveNpmInvocation() =>
+        ResolveNpmInvocation(GetPathDirectories());
+
+    internal static NpmInvocation? ResolveNpmInvocation(IReadOnlyList<string> pathDirectories)
+    {
+        ArgumentNullException.ThrowIfNull(pathDirectories);
+
+        foreach (var directory in pathDirectories)
+        {
+            string nodeCandidate;
+            try
+            {
+                nodeCandidate = Path.Combine(directory, NodeExecutableName);
+            }
+            catch (ArgumentException)
+            {
+                // Malformed PATH entry; skip it.
+                continue;
+            }
+
+            if (!File.Exists(nodeCandidate))
+            {
+                continue;
+            }
+
+            var npmCli = FindNpmCli(directory);
+            if (npmCli is not null)
+            {
+                return new NpmInvocation(nodeCandidate, new[] { npmCli });
+            }
+        }
+
+        return null;
+    }
+
+    private static string? FindNpmCli(string nodeDirectory)
+    {
+        // Standard Windows Node.js layout: npm-cli.js sits under the same directory as node.exe.
+        foreach (var candidateRoot in EnumerateNpmPrefixCandidates(nodeDirectory))
+        {
+            string npmCli;
+            try
+            {
+                npmCli = Path.Combine(candidateRoot, NpmCliRelativePath);
+            }
+            catch (ArgumentException)
+            {
+                continue;
+            }
+
+            if (File.Exists(npmCli))
+            {
+                return npmCli;
+            }
+        }
+
+        return null;
+    }
+
+    private static IEnumerable<string> EnumerateNpmPrefixCandidates(string nodeDirectory)
+    {
+        // node.exe's own directory (Program Files\nodejs) is the usual prefix on Windows.
+        yield return nodeDirectory;
+
+        // A user-level npm prefix (npm config's default on Windows) lives under APPDATA\npm.
+        var appData = Environment.GetEnvironmentVariable("APPDATA");
+        if (!string.IsNullOrEmpty(appData))
+        {
+            yield return Path.Combine(appData, "npm");
+        }
+    }
+
+    private static IReadOnlyList<string> GetPathDirectories()
+    {
+        var pathVariable = Environment.GetEnvironmentVariable("PATH");
+        if (string.IsNullOrEmpty(pathVariable))
+        {
+            return [];
+        }
+
+        return pathVariable.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/NpmCommandRunner.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/NpmCommandRunner.cs
@@ -20,54 +20,44 @@ using Microsoft.CmdPal.UI.ViewModels.Properties;
 namespace Microsoft.CmdPal.UI.ViewModels.Services;
 
 /// <summary>
-/// Default <see cref="INpmCommandRunner"/> that shells out to the npm executable found on PATH.
-/// The runner never installs the approved package as a dependency, because npm would then re-resolve
-/// its transitive semver ranges and ignore the publisher's embedded npm-shrinkwrap.json. Instead it
-/// downloads the exact tarball with <c>npm pack</c>, extracts it so the published package is the root
-/// project, requires the publisher to have shipped an npm-shrinkwrap.json that freezes the whole
-/// dependency closure, and runs <c>npm ci</c>, which installs that frozen closure verbatim and never
-/// re-resolves a range. npm is always invoked with lifecycle scripts disabled. The resolved package
-/// integrity is the Subresource Integrity of the downloaded tarball, and the frozen lockfile is
-/// re-checked so every resolved entry came from an approved registry over HTTPS with an integrity
-/// hash before the caller promotes the package.
+/// Default <see cref="INpmCommandRunner"/>. It finds node.exe on PATH and runs npm through
+/// npm-cli.js instead of npm.cmd. The runner uses <c>npm pack</c> to download the exact approved
+/// tarball, treats that package as the project root, requires a shipped npm-shrinkwrap.json, then
+/// runs <c>npm ci</c> with lifecycle scripts off. Before the installer promotes anything, the runner
+/// checks the tarball integrity and the frozen lockfile.
 /// </summary>
 public sealed class NpmCommandRunner : INpmCommandRunner
 {
-    // npm on Windows ships as an npm.cmd batch shim. Passing an argument that contains a shell
-    // metacharacter to a .cmd file can let cmd.exe reinterpret it, even through ProcessStartInfo's
-    // ArgumentList. To keep untrusted arguments off any batch/cmd command line, the runner instead
-    // resolves node.exe and npm's JavaScript entry point (npm-cli.js) and launches
-    // "node.exe npm-cli.js install ...". node.exe is a real executable, so its ArgumentList is passed
-    // verbatim with no shell in the middle.
+    // npm on Windows ships as an npm.cmd batch shim. A shell metacharacter passed to a .cmd file can
+    // be reinterpreted by cmd.exe, even through ProcessStartInfo.ArgumentList. Keep untrusted
+    // arguments off any batch command line by running node.exe with npm-cli.js directly.
     private const string NodeExecutableName = "node.exe";
 
     // npm-cli.js relative to a directory that contains node.exe, and to a global npm prefix.
     private static readonly string NpmCliRelativePath = Path.Combine("node_modules", "npm", "bin", "npm-cli.js");
 
-    // The directory (under the caller's staging directory) that the downloaded tarball is unpacked
-    // into. npm tarballs always root their entries under "package/", so the extracted project root is
-    // this well-known path and the installer promotes it directly.
+    // The directory under staging where the downloaded tarball is unpacked. npm tarballs root their
+    // entries under "package/", so the installer can promote this path directly.
     internal const string PackageRootDirectoryName = "package";
 
     // A private subdirectory of staging that only holds the downloaded .tgz, kept separate from the
     // extracted package root so a single tarball is easy to locate.
     internal const string PackDirectoryName = "__cmdpal_pack";
 
-    // The publisher-provided lockfile that must be present inside the package tarball. It freezes the
-    // full transitive dependency closure so npm ci installs an exact set rather than re-resolving
-    // mutable semver ranges at install time.
+    // The lockfile that must be present inside the package tarball. It freezes the full dependency
+    // closure so npm ci installs an exact set instead of resolving mutable ranges at install time.
     internal const string ShrinkwrapFileName = "npm-shrinkwrap.json";
 
-    // The lockfile npm consults, in precedence order. npm-shrinkwrap.json is the publishable form and
-    // takes precedence over package-lock.json.
+    // The lockfiles npm consults, in precedence order. npm-shrinkwrap.json is the publishable form
+    // and takes precedence over package-lock.json.
     private static readonly string[] LockfileNames = [ShrinkwrapFileName, "package-lock.json"];
 
-    // Upper bound on a single npm operation so the gallery cannot stay on "Installing..."
-    // forever when npm hangs (for example, an unreachable registry with no output).
+    // Upper bound on one npm operation so the gallery cannot stay on "Installing..." forever when
+    // npm hangs, such as an unreachable registry with no output.
     private static readonly TimeSpan InstallTimeout = TimeSpan.FromMinutes(5);
 
-    // A directory whose handles are still being released briefly rejects a delete; retry a few
-    // times with a short backoff before giving up so an uninstall does not fail spuriously.
+    // A directory with handles still closing can briefly reject a delete. Retry a few times so an
+    // uninstall does not fail just because the OS needed another moment.
     private const int DeleteAttempts = 5;
     private static readonly TimeSpan DeleteRetryDelay = TimeSpan.FromMilliseconds(100);
 
@@ -100,8 +90,8 @@ public sealed class NpmCommandRunner : INpmCommandRunner
 
         try
         {
-            // 1) Download the exact "name@version" tarball with no lifecycle scripts. npm pack fetches
-            //    the immutable published artifact; it does not resolve or install any dependency.
+            // 1) Download the exact "name@version" tarball with lifecycle scripts off. npm pack fetches
+            //    the published artifact without resolving dependencies.
             var packDirectory = Path.Combine(stagingDirectory, PackDirectoryName);
             Directory.CreateDirectory(packDirectory);
 
@@ -118,18 +108,15 @@ public sealed class NpmCommandRunner : INpmCommandRunner
                 return NpmCommandResult.Fail(Resources.npm_runner_extract_failed);
             }
 
-            // 2) The resolved integrity is the Subresource Integrity of the downloaded tarball. The
-            //    caller compares this to the catalog-approved integrity before promoting anything.
+            // 2) The caller compares this tarball hash to the catalog value before promotion.
             var resolvedIntegrity = ComputeTarballIntegrity(tarballPath);
             if (resolvedIntegrity is null)
             {
                 return NpmCommandResult.Fail(Resources.npm_runner_extract_failed);
             }
 
-            // 3) Treat the published package as the ROOT project by extracting its tarball. npm only
-            //    honors an embedded npm-shrinkwrap.json for the root project, not for a package
-            //    installed as a dependency, so this extraction is what makes the shrinkwrap
-            //    authoritative rather than silently ignored.
+            // 3) Make the published package the root project before npm ci runs. npm only honors an
+            //    embedded npm-shrinkwrap.json at the project root, not inside a dependency.
             var packageRoot = Path.Combine(stagingDirectory, PackageRootDirectoryName);
             var extractError = TryExtractPackage(tarballPath, packageRoot);
             if (extractError is not null)
@@ -137,9 +124,8 @@ public sealed class NpmCommandRunner : INpmCommandRunner
                 return NpmCommandResult.Fail(extractError);
             }
 
-            // 4) Fail closed unless the publisher shipped a shrinkwrap that freezes the full transitive
-            //    closure. Without it, npm ci would have nothing to install from deterministically and
-            //    the closure would still be resolved from mutable ranges.
+            // 4) Fail closed unless the publisher shipped a shrinkwrap that freezes the full dependency
+            //    closure. Without it, npm ci has no fixed tree to install.
             var shrinkwrapError = RequirePublisherShrinkwrap(packageRoot);
             if (shrinkwrapError is not null)
             {
@@ -147,19 +133,16 @@ public sealed class NpmCommandRunner : INpmCommandRunner
                 return NpmCommandResult.Fail(shrinkwrapError);
             }
 
-            // 5) npm ci installs the exact closure named in the shrinkwrap and never re-resolves a
-            //    semver range. It fails closed when the lockfile is missing or out of sync with
-            //    package.json, so the frozen tree is the only thing that can be installed.
+            // 5) npm ci installs the exact closure named in the shrinkwrap. It fails when the lockfile
+            //    is missing or out of sync with package.json.
             var ciResult = await RunNpmAsync(invocation.Value, BuildCiArguments(artifact), packageRoot, artifact.InstallSpec, cancellationToken).ConfigureAwait(false);
             if (!ciResult.Succeeded)
             {
                 return NpmCommandResult.Fail(ciResult.ErrorMessage ?? Resources.npm_runner_lockfile_untrusted);
             }
 
-            // 6) Second gate: every resolved entry in the frozen lockfile must come from an approved
-            //    registry over HTTPS and carry a Subresource Integrity hash. This fails closed: a
-            //    lockfile that is missing, malformed, or contains a file:/git:/http:/integrity-less
-            //    resolution is rejected.
+            // 6) Check every lockfile entry before promotion. Anything outside an approved HTTPS
+            //    registry, or missing a Subresource Integrity hash, is rejected.
             var lockfileError = VerifyLockfileIntegrity(packageRoot);
             if (lockfileError is not null)
             {
@@ -181,10 +164,9 @@ public sealed class NpmCommandRunner : INpmCommandRunner
     }
 
     /// <summary>
-    /// Builds the immutable <c>npm pack</c> argument list for an approved artifact. The first real
-    /// token is the validated "name@version" spec, passed through ArgumentList so npm can never read
-    /// it as a flag. The tarball is written to <paramref name="packDestination"/>, lifecycle scripts
-    /// are disabled, and a registry, when present, is passed only through its own flag pair.
+    /// Builds the <c>npm pack</c> arguments for an approved artifact. The validated "name@version"
+    /// spec goes through ArgumentList as one token so npm cannot read it as a flag. Lifecycle scripts
+    /// are disabled, and any registry is passed as its own flag value pair.
     /// </summary>
     internal static IReadOnlyList<string> BuildPackArguments(NpmArtifact artifact, string packDestination)
     {
@@ -210,10 +192,9 @@ public sealed class NpmCommandRunner : INpmCommandRunner
     }
 
     /// <summary>
-    /// Builds the immutable <c>npm ci</c> argument list. npm ci installs the exact closure named in
-    /// the project's npm-shrinkwrap.json/package-lock.json and never re-resolves a semver range, so it
-    /// takes no package spec. Lifecycle scripts are disabled, and a registry, when present, is passed
-    /// only through its own flag pair.
+    /// Builds the <c>npm ci</c> arguments. npm ci installs the exact closure named in the lockfile and
+    /// does not take a package spec, so it cannot resolve a range again. Lifecycle scripts are disabled,
+    /// and any registry is passed as its own flag value pair.
     /// </summary>
     internal static IReadOnlyList<string> BuildCiArguments(NpmArtifact artifact)
     {
@@ -236,10 +217,9 @@ public sealed class NpmCommandRunner : INpmCommandRunner
     }
 
     /// <summary>
-    /// Returns null when the extracted package root contains the publisher-provided
-    /// <c>npm-shrinkwrap.json</c> that freezes the whole dependency closure; otherwise returns a
-    /// localized error. This is the fail-closed gate that rejects any package whose publisher did not
-    /// freeze its transitive dependencies.
+    /// Returns null when the extracted package root contains the <c>npm-shrinkwrap.json</c> that
+    /// freezes the dependency closure; otherwise returns a localized error. This gate rejects packages
+    /// that did not freeze their transitive dependencies.
     /// </summary>
     internal static string? RequirePublisherShrinkwrap(string packageRoot)
     {
@@ -248,10 +228,9 @@ public sealed class NpmCommandRunner : INpmCommandRunner
     }
 
     /// <summary>
-    /// Computes the sha512 Subresource Integrity value ("sha512-" + base64 digest) of the tarball at
-    /// <paramref name="tarballPath"/>. This matches the integrity npm publishes for a registry
-    /// tarball, so the caller can compare it to the catalog-approved value. Returns null when the file
-    /// cannot be read.
+    /// Computes the sha512 Subresource Integrity value ("sha512-" + base64 digest) for the tarball at
+    /// <paramref name="tarballPath"/>. This matches the value npm publishes for a registry tarball, so
+    /// the caller can compare it to the catalog. Returns null when the file cannot be read.
     /// </summary>
     internal static string? ComputeTarballIntegrity(string tarballPath)
     {
@@ -269,9 +248,8 @@ public sealed class NpmCommandRunner : INpmCommandRunner
     }
 
     /// <summary>
-    /// Locates the single tarball <c>npm pack</c> wrote into <paramref name="packDirectory"/>. The
-    /// directory is created fresh per install, so exactly one .tgz is expected. Returns null when none
-    /// is found.
+    /// Locates the tarball <c>npm pack</c> wrote into <paramref name="packDirectory"/>. The directory
+    /// is new for each install, so one .tgz is expected. Returns null when none is found.
     /// </summary>
     internal static string? FindPackedTarball(string packDirectory)
     {
@@ -289,11 +267,11 @@ public sealed class NpmCommandRunner : INpmCommandRunner
     }
 
     /// <summary>
-    /// Extracts the gzip-compressed npm tarball at <paramref name="tarballPath"/> so the published
-    /// package becomes the root project at <paramref name="packageRoot"/>. npm tarballs root every
-    /// entry under "package/", so the archive is unpacked into a temporary directory and that inner
-    /// folder is moved to <paramref name="packageRoot"/>. Returns null on success, or a localized
-    /// error when the tarball cannot be read or does not contain a package root.
+    /// Extracts the gzip compressed npm tarball at <paramref name="tarballPath"/> so the published
+    /// package becomes the root project at <paramref name="packageRoot"/>. npm tarballs place entries
+    /// under "package/", so the archive is unpacked aside and that inner folder is moved into place.
+    /// Returns null on success, or a localized error when the tarball cannot be read or lacks a package
+    /// root.
     /// </summary>
     internal static string? TryExtractPackage(string tarballPath, string packageRoot)
     {
@@ -310,16 +288,16 @@ public sealed class NpmCommandRunner : INpmCommandRunner
             using (var fileStream = File.OpenRead(tarballPath))
             using (var gzipStream = new GZipStream(fileStream, CompressionMode.Decompress))
             {
-                // ExtractToDirectory refuses to write an entry outside extractRoot, so a malicious
-                // "../" path in the tarball cannot escape the staging tree.
+                // ExtractToDirectory refuses to write outside extractRoot, so a malicious "../" path in
+                // the tarball cannot escape staging.
                 TarFile.ExtractToDirectory(gzipStream, extractRoot, overwriteFiles: true);
             }
 
             var innerPackage = Path.Combine(extractRoot, PackageRootDirectoryName);
             if (!Directory.Exists(innerPackage))
             {
-                // Some publishers root the tarball under a different folder name; fall back to the
-                // single top-level directory when there is exactly one.
+                // Some publishers root the tarball under a different folder name. Use the single top
+                // level directory when there is exactly one.
                 innerPackage = ResolveSingleTopLevelDirectory(extractRoot) ?? string.Empty;
             }
 
@@ -375,10 +353,10 @@ public sealed class NpmCommandRunner : INpmCommandRunner
     }
 
     /// <summary>
-    /// Runs npm (through node.exe and npm-cli.js so the npm.cmd batch shim is never involved) with the
-    /// given arguments and working directory, bounding the wait so a hung npm cannot stall the UI.
-    /// Returns success, a timeout message, or the captured stderr on a non-zero exit. Rethrows
-    /// <see cref="OperationCanceledException"/> only for a caller-driven cancel, not the timeout.
+    /// Runs npm through node.exe and npm-cli.js so the npm.cmd batch shim stays out of the path.
+    /// Bounds the wait so a hung npm cannot stall the UI. Returns success, a timeout message, or the
+    /// captured stderr on a nonzero exit. Rethrows <see cref="OperationCanceledException"/> only for a
+    /// caller cancel, not the timeout.
     /// </summary>
     private static async Task<NpmProcessResult> RunNpmAsync(NpmInvocation invocation, IReadOnlyList<string> arguments, string workingDirectory, string installSpec, CancellationToken cancellationToken)
     {
@@ -392,9 +370,8 @@ public sealed class NpmCommandRunner : INpmCommandRunner
             WorkingDirectory = workingDirectory,
         };
 
-        // Launcher arguments first (npm-cli.js), so node.exe runs npm itself. These are trusted,
-        // runner-resolved paths. Every following argument is passed through ArgumentList (never string
-        // concatenation) so npm cannot reinterpret an untrusted token as a flag.
+        // Launcher arguments first so node.exe runs npm itself. These paths were resolved by the
+        // runner. Every untrusted argument goes through ArgumentList, not string concatenation.
         foreach (var launcherArgument in invocation.LauncherArguments)
         {
             psi.ArgumentList.Add(launcherArgument);
@@ -422,8 +399,8 @@ public sealed class NpmCommandRunner : INpmCommandRunner
         process.BeginErrorReadLine();
         process.BeginOutputReadLine();
 
-        // Bound the wait so a hung npm does not leave the UI stuck. A caller-driven cancel and the
-        // timeout share one linked source; the catch below tells the two apart.
+        // Bound the wait so a hung npm does not leave the UI stuck. The caller token and timeout share
+        // one linked source; the catch below tells them apart.
         using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         timeoutCts.CancelAfter(InstallTimeout);
 
@@ -456,7 +433,7 @@ public sealed class NpmCommandRunner : INpmCommandRunner
     }
 
     /// <summary>
-    /// The outcome of a single npm invocation: success, or a localized/captured error message.
+    /// The result of one npm invocation: success, or a localized or captured error message.
     /// </summary>
     private readonly record struct NpmProcessResult(bool Succeeded, string? ErrorMessage)
     {
@@ -472,8 +449,8 @@ public sealed class NpmCommandRunner : INpmCommandRunner
             return true;
         }
 
-        // Never recurse through a junction or symbolic link: deleting recursively could reach files
-        // outside the extensions tree. If the directory itself is a reparse point, refuse.
+        // Never recurse through a junction or symbolic link. Recursive delete could reach files outside
+        // the extensions tree, so refuse when the directory itself is a reparse point.
         if (IsReparsePoint(targetDirectory))
         {
             Logger.LogError($"Refusing to delete '{targetDirectory}' because it is a reparse point (junction or symbolic link).");
@@ -506,7 +483,7 @@ public sealed class NpmCommandRunner : INpmCommandRunner
 
     /// <summary>
     /// Resolves the lockfile npm consults inside <paramref name="projectRoot"/>, preferring the
-    /// publishable npm-shrinkwrap.json over package-lock.json. Returns null when neither exists.
+    /// publishable npm-shrinkwrap.json over package-lock.json. Returns null when neither file exists.
     /// </summary>
     private static string? ResolveLockfilePath(string projectRoot)
     {
@@ -530,8 +507,8 @@ public sealed class NpmCommandRunner : INpmCommandRunner
             {
                 process.Kill(entireProcessTree: true);
 
-                // Give the OS a bounded moment to tear the tree down so file handles are released
-                // before the staging directory is cleaned up.
+                // Give the OS a bounded moment to tear the tree down before staging cleanup tries to
+                // delete files that still have handles open.
                 using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
                 await process.WaitForExitAsync(cts.Token).ConfigureAwait(false);
             }
@@ -550,24 +527,23 @@ public sealed class NpmCommandRunner : INpmCommandRunner
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or System.Security.SecurityException)
         {
-            // If the attributes cannot be read, err on the side of caution and treat it as unsafe.
+            // If the attributes cannot be read, play it safe and treat the path as unsafe.
             return true;
         }
     }
 
     /// <summary>
-    /// A resolved npm launcher: the executable to start (node.exe) and the leading arguments that
-    /// make it run npm (the path to npm-cli.js). The install spec and flags are appended after these.
+    /// A resolved npm launcher: node.exe plus the leading arguments that make it run npm. The install
+    /// spec and flags are appended after these.
     /// </summary>
     internal readonly record struct NpmInvocation(string FileName, IReadOnlyList<string> LauncherArguments);
 
     /// <summary>
-    /// Verifies that every resolved dependency in the frozen lockfile inside
-    /// <paramref name="projectRoot"/> was fetched from an approved registry over HTTPS and carries a
-    /// supported Subresource Integrity hash. The publisher's npm-shrinkwrap.json is preferred over
-    /// package-lock.json. Returns null when the whole tree is trusted, or a localized error message
-    /// describing the first untrusted resolution. Fails closed: a missing or unreadable lockfile is
-    /// treated as untrusted.
+    /// Verifies that every dependency in the frozen lockfile inside <paramref name="projectRoot"/>
+    /// came from an approved registry over HTTPS and carries a supported Subresource Integrity hash.
+    /// The publisher's npm-shrinkwrap.json is preferred over package-lock.json. Returns null when the
+    /// tree is trusted, or a localized error for the first untrusted resolution. A missing or unreadable
+    /// lockfile is treated as untrusted.
     /// </summary>
     internal static string? VerifyLockfileIntegrity(string projectRoot)
     {
@@ -583,9 +559,9 @@ public sealed class NpmCommandRunner : INpmCommandRunner
             using var document = JsonDocument.Parse(stream);
             var root = document.RootElement;
 
-            // lockfileVersion 2/3: a "packages" map keyed by install path. The root package has an
-            // empty key and no resolution of its own; a "link": true entry points at a local
-            // workspace and is skipped. Every other entry must carry a trusted resolved URL + hash.
+            // lockfileVersion 2 and 3 use a "packages" map keyed by install path. The root package has
+            // an empty key and no resolution of its own. A "link": true entry points at a local
+            // workspace and is skipped. Every other entry must carry a trusted resolved URL and hash.
             if (root.TryGetProperty("packages", out var packages) && packages.ValueKind == JsonValueKind.Object)
             {
                 foreach (var package in packages.EnumerateObject())
@@ -610,13 +586,13 @@ public sealed class NpmCommandRunner : INpmCommandRunner
                 return null;
             }
 
-            // lockfileVersion 1: a nested "dependencies" tree. Walk it recursively.
+            // lockfileVersion 1 uses a nested "dependencies" tree. Walk it recursively.
             if (root.TryGetProperty("dependencies", out var dependencies) && dependencies.ValueKind == JsonValueKind.Object)
             {
                 return VerifyLegacyDependencies(dependencies) ? null : Resources.npm_runner_lockfile_untrusted;
             }
 
-            // Neither shape present: nothing was pinned, so the tree cannot be trusted.
+            // Neither shape is present. Nothing was pinned, so the tree cannot be trusted.
             return Resources.npm_runner_lockfile_untrusted;
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or JsonException)
@@ -636,8 +612,8 @@ public sealed class NpmCommandRunner : INpmCommandRunner
                 return false;
             }
 
-            // A "bundled" dependency ships inside its parent's tarball and has no resolution of its
-            // own; it was already covered by the parent's integrity. Anything else must be trusted.
+            // A "bundled" dependency ships inside its parent's tarball and has no resolution of its own.
+            // The parent's integrity already covers it. Anything else must be trusted.
             var isBundled = entry.TryGetProperty("bundled", out var bundled) && bundled.ValueKind == JsonValueKind.True;
             if (!isBundled && !IsTrustedResolution(entry))
             {
@@ -667,10 +643,9 @@ public sealed class NpmCommandRunner : INpmCommandRunner
     }
 
     /// <summary>
-    /// Resolves node.exe and npm's npm-cli.js so npm can be launched without the npm.cmd batch shim.
-    /// Probes PATH for node.exe, then looks for npm-cli.js next to node.exe (a standard Node.js
-    /// install) and under the global npm prefix reported by the environment. Returns null when either
-    /// piece cannot be located.
+    /// Resolves node.exe and npm-cli.js so npm can run without the npm.cmd batch shim. Probes PATH for
+    /// node.exe, then looks for npm-cli.js next to node.exe and under the global npm prefix reported by
+    /// the environment. Returns null when either piece cannot be found.
     /// </summary>
     internal static NpmInvocation? ResolveNpmInvocation() =>
         ResolveNpmInvocation(GetPathDirectories());
@@ -688,7 +663,7 @@ public sealed class NpmCommandRunner : INpmCommandRunner
             }
             catch (ArgumentException)
             {
-                // Malformed PATH entry; skip it.
+                // Malformed PATH entry. Skip it.
                 continue;
             }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/NpmCommandRunner.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/NpmCommandRunner.cs
@@ -108,11 +108,18 @@ public sealed class NpmCommandRunner : INpmCommandRunner
                 return NpmCommandResult.Fail(Resources.npm_runner_extract_failed);
             }
 
-            // 2) The caller compares this tarball hash to the catalog value before promotion.
+            // 2) Verify the downloaded tarball before extracting or executing npm against anything it
+            //    contains. A mismatched artifact must not get a chance to choose dependency URLs.
             var resolvedIntegrity = ComputeTarballIntegrity(tarballPath);
             if (resolvedIntegrity is null)
             {
                 return NpmCommandResult.Fail(Resources.npm_runner_extract_failed);
+            }
+
+            if (!string.Equals(resolvedIntegrity, artifact.Integrity, StringComparison.Ordinal))
+            {
+                Logger.LogError($"Integrity mismatch installing '{artifact.InstallSpec}': expected {artifact.Integrity}, npm resolved {resolvedIntegrity}.");
+                return NpmCommandResult.Fail(Resources.npm_installer_integrity_mismatch);
             }
 
             // 3) Make the published package the root project before npm ci runs. npm only honors an
@@ -133,7 +140,15 @@ public sealed class NpmCommandRunner : INpmCommandRunner
                 return NpmCommandResult.Fail(shrinkwrapError);
             }
 
-            // 5) npm ci installs the exact closure named in the shrinkwrap. It fails when the lockfile
+            // 5) Validate every dependency URL and integrity hash before npm can fetch the closure.
+            var lockfileError = VerifyLockfileIntegrity(packageRoot);
+            if (lockfileError is not null)
+            {
+                Logger.LogError($"npm package {artifact.InstallSpec} contains an untrusted lockfile: {lockfileError}");
+                return NpmCommandResult.Fail(lockfileError);
+            }
+
+            // 6) npm ci installs the exact closure named in the shrinkwrap. It fails when the lockfile
             //    is missing or out of sync with package.json.
             var ciResult = await RunNpmAsync(invocation.Value, BuildCiArguments(artifact), packageRoot, artifact.InstallSpec, cancellationToken).ConfigureAwait(false);
             if (!ciResult.Succeeded)
@@ -141,9 +156,8 @@ public sealed class NpmCommandRunner : INpmCommandRunner
                 return NpmCommandResult.Fail(ciResult.ErrorMessage ?? Resources.npm_runner_lockfile_untrusted);
             }
 
-            // 6) Check every lockfile entry before promotion. Anything outside an approved HTTPS
-            //    registry, or missing a Subresource Integrity hash, is rejected.
-            var lockfileError = VerifyLockfileIntegrity(packageRoot);
+            // 7) Check the lockfile again after npm exits so promotion only uses the closure we approved.
+            lockfileError = VerifyLockfileIntegrity(packageRoot);
             if (lockfileError is not null)
             {
                 Logger.LogError($"npm ci {artifact.InstallSpec} produced an untrusted lockfile: {lockfileError}");
@@ -648,9 +662,12 @@ public sealed class NpmCommandRunner : INpmCommandRunner
     /// the environment. Returns null when either piece cannot be found.
     /// </summary>
     internal static NpmInvocation? ResolveNpmInvocation() =>
-        ResolveNpmInvocation(GetPathDirectories());
+        ResolveNpmInvocation(GetPathDirectories(), includeUserPrefix: true);
 
-    internal static NpmInvocation? ResolveNpmInvocation(IReadOnlyList<string> pathDirectories)
+    internal static NpmInvocation? ResolveNpmInvocation(IReadOnlyList<string> pathDirectories) =>
+        ResolveNpmInvocation(pathDirectories, includeUserPrefix: false);
+
+    private static NpmInvocation? ResolveNpmInvocation(IReadOnlyList<string> pathDirectories, bool includeUserPrefix)
     {
         ArgumentNullException.ThrowIfNull(pathDirectories);
 
@@ -672,7 +689,7 @@ public sealed class NpmCommandRunner : INpmCommandRunner
                 continue;
             }
 
-            var npmCli = FindNpmCli(directory);
+            var npmCli = FindNpmCli(directory, includeUserPrefix);
             if (npmCli is not null)
             {
                 return new NpmInvocation(nodeCandidate, new[] { npmCli });
@@ -682,10 +699,10 @@ public sealed class NpmCommandRunner : INpmCommandRunner
         return null;
     }
 
-    private static string? FindNpmCli(string nodeDirectory)
+    private static string? FindNpmCli(string nodeDirectory, bool includeUserPrefix)
     {
         // Standard Windows Node.js layout: npm-cli.js sits under the same directory as node.exe.
-        foreach (var candidateRoot in EnumerateNpmPrefixCandidates(nodeDirectory))
+        foreach (var candidateRoot in EnumerateNpmPrefixCandidates(nodeDirectory, includeUserPrefix))
         {
             string npmCli;
             try
@@ -706,10 +723,15 @@ public sealed class NpmCommandRunner : INpmCommandRunner
         return null;
     }
 
-    private static IEnumerable<string> EnumerateNpmPrefixCandidates(string nodeDirectory)
+    private static IEnumerable<string> EnumerateNpmPrefixCandidates(string nodeDirectory, bool includeUserPrefix)
     {
         // node.exe's own directory (Program Files\nodejs) is the usual prefix on Windows.
         yield return nodeDirectory;
+
+        if (!includeUserPrefix)
+        {
+            yield break;
+        }
 
         // A user-level npm prefix (npm config's default on Windows) lives under APPDATA\npm.
         var appData = Environment.GetEnvironmentVariable("APPDATA");

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/NpmCommandRunner.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/NpmCommandRunner.cs
@@ -513,24 +513,45 @@ public sealed class NpmCommandRunner : INpmCommandRunner
         return null;
     }
 
-    private static async Task TerminateAndWaitAsync(Process process)
+    private static Task TerminateAndWaitAsync(Process process) =>
+        TerminateAndWaitAsync(
+            () => process.HasExited,
+            () => process.Kill(entireProcessTree: true),
+            process.WaitForExitAsync);
+
+    internal static async Task TerminateAndWaitAsync(
+        Func<bool> hasExited,
+        Action terminateProcess,
+        Func<CancellationToken, Task> waitForExitAsync)
     {
         try
         {
-            if (!process.HasExited)
+            if (!hasExited())
             {
-                process.Kill(entireProcessTree: true);
+                terminateProcess();
 
                 // Give the OS a bounded moment to tear the tree down before staging cleanup tries to
                 // delete files that still have handles open.
                 using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-                await process.WaitForExitAsync(cts.Token).ConfigureAwait(false);
+                await waitForExitAsync(cts.Token).ConfigureAwait(false);
             }
         }
-        catch (Exception ex) when (ex is InvalidOperationException or System.ComponentModel.Win32Exception or NotSupportedException or OperationCanceledException)
+        catch (Exception ex) when (IsExpectedTerminationException(ex))
         {
             Logger.LogError($"Failed to terminate npm process: {ex.Message}");
         }
+    }
+
+    private static bool IsExpectedTerminationException(Exception exception)
+    {
+        if (exception is InvalidOperationException or System.ComponentModel.Win32Exception or NotSupportedException or OperationCanceledException)
+        {
+            return true;
+        }
+
+        return exception is AggregateException aggregateException
+            && aggregateException.Flatten().InnerExceptions.Count > 0
+            && aggregateException.Flatten().InnerExceptions.All(IsExpectedTerminationException);
     }
 
     private static bool IsReparsePoint(string path)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/NpmCommandRunner.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/NpmCommandRunner.cs
@@ -549,9 +549,14 @@ public sealed class NpmCommandRunner : INpmCommandRunner
             return true;
         }
 
-        return exception is AggregateException aggregateException
-            && aggregateException.Flatten().InnerExceptions.Count > 0
-            && aggregateException.Flatten().InnerExceptions.All(IsExpectedTerminationException);
+        if (exception is not AggregateException aggregateException)
+        {
+            return false;
+        }
+
+        var flattenedException = aggregateException.Flatten();
+        return flattenedException.InnerExceptions.Count > 0
+            && flattenedException.InnerExceptions.All(IsExpectedTerminationException);
     }
 
     private static bool IsReparsePoint(string path)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/NpmJsExtensionInstaller.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/NpmJsExtensionInstaller.cs
@@ -156,7 +156,8 @@ public sealed class NpmJsExtensionInstaller : IJsExtensionInstaller
         }
     }
 
-    public bool IsInstalled(string extensionName) => _host.IsExtensionInstalled(extensionName);
+    public bool IsInstalled(string extensionName) =>
+        TryResolveTargetDirectory(extensionName, out _) && _host.IsExtensionInstalled(extensionName);
 
     private async Task<JsExtensionInstallResult> InstallLockedAsync(string extensionName, string targetDirectory, NpmArtifact artifact, CancellationToken cancellationToken)
     {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/NpmJsExtensionInstaller.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/NpmJsExtensionInstaller.cs
@@ -1,0 +1,413 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using ManagedCommon;
+using Microsoft.CmdPal.UI.ViewModels.Models;
+using Microsoft.CmdPal.UI.ViewModels.Properties;
+
+namespace Microsoft.CmdPal.UI.ViewModels.Services;
+
+/// <summary>
+/// Installs and uninstalls gallery jsonrpc extensions as a fail-closed transaction over an
+/// immutable, approved artifact. The package, exact version, integrity, and optional registry are
+/// validated up front; the runner downloads the exact tarball, requires the publisher-provided
+/// npm-shrinkwrap.json that freezes the whole dependency closure, and installs that frozen closure
+/// with npm ci into a unique staging directory outside the watched JSExtensions root with lifecycle
+/// scripts disabled; the resolved integrity, package identity, and manifest are verified; and only
+/// then is the extension atomically promoted into JSExtensions/&lt;name&gt;/ and awaited for host
+/// registration. Staging is always cleaned up, and a failed, timed-out, or cancelled install never
+/// deletes or corrupts an existing install.
+/// </summary>
+public sealed class NpmJsExtensionInstaller : IJsExtensionInstaller
+{
+    // Upper bound on how long to wait for the host to load and register a freshly promoted extension.
+    private static readonly TimeSpan RegistrationTimeout = TimeSpan.FromSeconds(30);
+
+    private readonly IJsExtensionHost _host;
+    private readonly INpmCommandRunner _npmCommandRunner;
+
+    // Per-canonical-directory locks so an install and an uninstall of the same extension are
+    // serialized while different extensions install in parallel.
+    private readonly Dictionary<string, SemaphoreSlim> _directoryLocks = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, int> _lockReferenceCounts = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Lock _directoryLocksGate = new();
+
+    public NpmJsExtensionInstaller(IJsExtensionHost host, INpmCommandRunner npmCommandRunner)
+    {
+        ArgumentNullException.ThrowIfNull(host);
+        ArgumentNullException.ThrowIfNull(npmCommandRunner);
+
+        _host = host;
+        _npmCommandRunner = npmCommandRunner;
+    }
+
+    public async Task<JsExtensionInstallResult> InstallAsync(string extensionName, string npmPackage, string? version, string? integrity, string? registry, CancellationToken cancellationToken = default)
+    {
+        if (!TryResolveTargetDirectory(extensionName, out var targetDirectory))
+        {
+            return JsExtensionInstallResult.Fail(Resources.npm_installer_invalid_name);
+        }
+
+        // Fail closed: an incomplete or malformed catalog entry is never installable.
+        if (!NpmArtifact.TryCreate(npmPackage, version, integrity, registry, out var artifact, out var validationError)
+            || artifact is null)
+        {
+            return JsExtensionInstallResult.Fail(MapValidationError(validationError));
+        }
+
+        if (!_npmCommandRunner.IsNpmAvailable())
+        {
+            return JsExtensionInstallResult.Fail(Resources.npm_runner_npm_not_found);
+        }
+
+        var lockKey = CanonicalKey(targetDirectory);
+        var gate = AcquireDirectoryLock(lockKey);
+        try
+        {
+            await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                return await InstallLockedAsync(extensionName, targetDirectory, artifact, cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                gate.Release();
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            return JsExtensionInstallResult.Fail(Resources.npm_installer_canceled);
+        }
+        finally
+        {
+            ReleaseDirectoryLock(lockKey);
+        }
+    }
+
+    public async Task<JsExtensionInstallResult> UninstallAsync(string extensionName, CancellationToken cancellationToken = default)
+    {
+        if (!TryResolveTargetDirectory(extensionName, out var targetDirectory))
+        {
+            return JsExtensionInstallResult.Fail(Resources.npm_installer_invalid_name);
+        }
+
+        var lockKey = CanonicalKey(targetDirectory);
+        var gate = AcquireDirectoryLock(lockKey);
+        try
+        {
+            await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                // Terminate the Node.js process and wait for its handles to be released before
+                // deleting; the Phase 4 StopExtension blocks until the process has exited. The token
+                // lets Cancel abandon a wait for a contended lifecycle gate.
+                _host.StopExtension(targetDirectory, cancellationToken);
+
+                // RemoveDirectory refuses to follow a junction or symbolic link out of the root and
+                // retries briefly to tolerate a handle that is still being released. The token stops
+                // the retry loop so Cancel is honored between attempts.
+                if (!_npmCommandRunner.RemoveDirectory(targetDirectory, cancellationToken))
+                {
+                    Logger.LogError($"Uninstall of JS extension '{extensionName}' failed: could not delete {targetDirectory}.");
+                    return JsExtensionInstallResult.Fail(Resources.npm_installer_remove_failed);
+                }
+
+                Logger.LogInfo($"Uninstalled JS extension '{extensionName}'.");
+                return JsExtensionInstallResult.Ok();
+            }
+            finally
+            {
+                gate.Release();
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            return JsExtensionInstallResult.Fail(Resources.npm_installer_canceled);
+        }
+        finally
+        {
+            ReleaseDirectoryLock(lockKey);
+        }
+    }
+
+    public bool IsInstalled(string extensionName) => _host.IsExtensionInstalled(extensionName);
+
+    private async Task<JsExtensionInstallResult> InstallLockedAsync(string extensionName, string targetDirectory, NpmArtifact artifact, CancellationToken cancellationToken)
+    {
+        // Upgrade policy: block installing over an existing or loaded extension. The user uninstalls
+        // and reinstalls to change versions, which guarantees an existing install is never touched by
+        // a failed upgrade.
+        if (Directory.Exists(targetDirectory) || _host.IsExtensionInstalled(extensionName))
+        {
+            return JsExtensionInstallResult.Fail(Resources.npm_installer_already_installed);
+        }
+
+        var stagingRoot = GetStagingRoot();
+        var stagingDirectory = Path.Combine(stagingRoot, Guid.NewGuid().ToString("N"));
+        var promoted = false;
+
+        try
+        {
+            var result = await _npmCommandRunner.InstallAsync(stagingDirectory, artifact, cancellationToken).ConfigureAwait(false);
+            if (!result.Succeeded)
+            {
+                return JsExtensionInstallResult.Fail(result.ErrorMessage ?? Resources.npm_installer_install_failed);
+            }
+
+            // Verify the tarball npm resolved is exactly the approved one before anything is promoted.
+            if (string.IsNullOrEmpty(result.ResolvedIntegrity)
+                || !string.Equals(result.ResolvedIntegrity, artifact.Integrity, StringComparison.Ordinal))
+            {
+                Logger.LogError($"Integrity mismatch installing '{artifact.InstallSpec}': expected {artifact.Integrity}, npm resolved {result.ResolvedIntegrity ?? "(none)"}.");
+                return JsExtensionInstallResult.Fail(Resources.npm_installer_integrity_mismatch);
+            }
+
+            var packageDirectory = Path.Combine(stagingDirectory, NpmCommandRunner.PackageRootDirectoryName);
+            if (!Directory.Exists(packageDirectory))
+            {
+                Logger.LogError($"Installed npm package '{artifact.Package}' but its extracted root was not found under {stagingDirectory}.");
+                return JsExtensionInstallResult.Fail(Resources.npm_installer_not_an_extension);
+            }
+
+            // Validate that this is the approved package and version, and that it is a loadable
+            // CmdPal manifest (the parser enforces the entry point, the .js/.mjs/.cjs allowlist, and
+            // reparse/canonical containment).
+            var manifestPath = Path.Combine(packageDirectory, "package.json");
+            var parseResult = JSExtensionManifest.TryParseFile(manifestPath);
+            if (!parseResult.IsValid || parseResult.Manifest is null)
+            {
+                Logger.LogError($"Installed package '{artifact.Package}' is not a usable CmdPal extension: {parseResult.FailureReason}");
+                return JsExtensionInstallResult.Fail(Resources.npm_installer_not_an_extension);
+            }
+
+            var manifest = parseResult.Manifest;
+            if (!string.Equals(manifest.Name?.Trim(), artifact.Package, StringComparison.OrdinalIgnoreCase))
+            {
+                Logger.LogError($"Manifest identity mismatch: approved package '{artifact.Package}' but manifest declares '{manifest.Name}'.");
+                return JsExtensionInstallResult.Fail(Resources.npm_installer_identity_mismatch);
+            }
+
+            if (!string.Equals(manifest.Version?.Trim(), artifact.Version, StringComparison.Ordinal))
+            {
+                Logger.LogError($"Manifest version mismatch: approved version '{artifact.Version}' but manifest declares '{manifest.Version}'.");
+                return JsExtensionInstallResult.Fail(Resources.npm_installer_version_mismatch);
+            }
+
+            // The extracted package root already has the discovery layout npm ci produced: package.json
+            // at the root with the publisher-frozen dependency closure under its own node_modules.
+            // Promote it directly.
+            //
+            // Atomic promote onto the same volume. The target does not exist (blocked above), so this
+            // is a plain rename; the watched root only ever sees the fully validated tree.
+            Directory.CreateDirectory(_host.ExtensionsRootPath);
+            Directory.Move(packageDirectory, targetDirectory);
+            promoted = true;
+
+            // Only report success once the host has actually loaded and registered the provider.
+            var registered = await _host.RefreshAndAwaitProviderAsync(targetDirectory, RegistrationTimeout, cancellationToken).ConfigureAwait(false);
+            if (!registered)
+            {
+                Logger.LogError($"Promoted '{extensionName}' but the host did not register a provider within {RegistrationTimeout.TotalSeconds:0} seconds.");
+                if (RollbackPromotedInstall(targetDirectory))
+                {
+                    promoted = false;
+                }
+
+                return JsExtensionInstallResult.Fail(Resources.npm_installer_not_discoverable);
+            }
+
+            Logger.LogInfo($"Installed JS extension '{extensionName}' from npm package '{artifact.InstallSpec}'.");
+            return JsExtensionInstallResult.Ok();
+        }
+        catch (OperationCanceledException)
+        {
+            // A cancel after promotion must not leave a half-registered extension behind: stop the
+            // host process/provider first, then remove the promoted tree.
+            if (promoted)
+            {
+                RollbackPromotedInstall(targetDirectory);
+            }
+
+            return JsExtensionInstallResult.Fail(Resources.npm_installer_canceled);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            if (promoted)
+            {
+                RollbackPromotedInstall(targetDirectory);
+            }
+
+            Logger.LogError($"Install of '{extensionName}' failed: {ex.Message}");
+            return JsExtensionInstallResult.Fail(Resources.npm_installer_install_failed);
+        }
+        finally
+        {
+            // Clean the staging tree on every path, even when the install was canceled, so the staging
+            // cleanup must not observe the caller's token: pass CancellationToken.None explicitly.
+            if (!_npmCommandRunner.RemoveDirectory(stagingDirectory, CancellationToken.None))
+            {
+                Logger.LogWarning($"Failed to clean up staging directory {stagingDirectory}.");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Rolls back a promoted install. Stops the host process/provider that may have started for the
+    /// promoted directory, then removes the promoted tree, in that order, so a canceled or failed
+    /// install can never leave the extension both installed on disk and running. Uses no cancellation
+    /// token so cleanup always runs to completion, even on the cancel path.
+    /// </summary>
+    /// <returns><see langword="true"/> when the promoted directory was removed; otherwise, <see langword="false"/>.</returns>
+    private bool RollbackPromotedInstall(string targetDirectory)
+    {
+        _host.StopExtension(targetDirectory);
+        return _npmCommandRunner.RemoveDirectory(targetDirectory);
+    }
+
+    /// <summary>
+    /// Gets the staging root, a sibling of the JSExtensions root that the FileSystemWatcher does not
+    /// watch. Keeping it a sibling (same volume) makes the final promote a rename rather than a copy.
+    /// </summary>
+    private string GetStagingRoot()
+    {
+        var root = Path.GetFullPath(_host.ExtensionsRootPath);
+        var parent = Path.GetDirectoryName(Path.TrimEndingDirectorySeparator(root));
+        var rootName = Path.GetFileName(Path.TrimEndingDirectorySeparator(root));
+
+        if (string.IsNullOrEmpty(parent) || string.IsNullOrEmpty(rootName))
+        {
+            // Degenerate path (root of a volume); fall back to a sibling under the same directory.
+            return Path.Combine(root + ".staging");
+        }
+
+        return Path.Combine(parent, rootName + ".staging");
+    }
+
+    private static string CanonicalKey(string directory) =>
+        Path.TrimEndingDirectorySeparator(Path.GetFullPath(directory)).ToLowerInvariant();
+
+    private SemaphoreSlim AcquireDirectoryLock(string canonicalKey)
+    {
+        lock (_directoryLocksGate)
+        {
+            if (!_directoryLocks.TryGetValue(canonicalKey, out var entry))
+            {
+                entry = new SemaphoreSlim(1, 1);
+                _directoryLocks[canonicalKey] = entry;
+            }
+
+            // Track a reference count in the semaphore's current use so the dictionary entry is only
+            // removed when no operation holds or waits on it.
+            _lockReferenceCounts.TryGetValue(canonicalKey, out var count);
+            _lockReferenceCounts[canonicalKey] = count + 1;
+            return entry;
+        }
+    }
+
+    private void ReleaseDirectoryLock(string canonicalKey)
+    {
+        lock (_directoryLocksGate)
+        {
+            if (!_lockReferenceCounts.TryGetValue(canonicalKey, out var count))
+            {
+                return;
+            }
+
+            if (count <= 1)
+            {
+                _lockReferenceCounts.Remove(canonicalKey);
+                if (_directoryLocks.Remove(canonicalKey, out var entry))
+                {
+                    entry.Dispose();
+                }
+            }
+            else
+            {
+                _lockReferenceCounts[canonicalKey] = count - 1;
+            }
+        }
+    }
+
+    private static string MapValidationError(NpmArtifactValidationError error) => error switch
+    {
+        NpmArtifactValidationError.PackageMissing => Resources.npm_installer_package_missing,
+        NpmArtifactValidationError.PackageInvalid => Resources.npm_installer_package_invalid,
+        NpmArtifactValidationError.VersionMissing => Resources.npm_installer_version_missing,
+        NpmArtifactValidationError.VersionInvalid => Resources.npm_installer_version_invalid,
+        NpmArtifactValidationError.IntegrityMissing => Resources.npm_installer_integrity_missing,
+        NpmArtifactValidationError.IntegrityInvalid => Resources.npm_installer_integrity_invalid,
+        NpmArtifactValidationError.RegistryInvalid => Resources.npm_installer_registry_invalid,
+        _ => Resources.npm_installer_install_failed,
+    };
+
+    private bool TryResolveTargetDirectory(string extensionName, out string targetDirectory)
+    {
+        targetDirectory = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(extensionName))
+        {
+            return false;
+        }
+
+        // Guard against path traversal or absolute paths escaping the JSExtensions root.
+        var trimmed = extensionName.Trim();
+        if (trimmed.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0
+            || trimmed is "." or ".."
+            || Path.IsPathRooted(trimmed))
+        {
+            return false;
+        }
+
+        var root = _host.ExtensionsRootPath;
+        var normalizedRoot = Path.TrimEndingDirectorySeparator(Path.GetFullPath(root));
+
+        // The extensions root must be a real directory, not a reparse point. If a junction or symbolic
+        // link is used as the root, a candidate that passes the textual containment check below can
+        // still resolve on disk to a path outside the intended tree, so an uninstall delete could
+        // escape containment. Resolve reparse points on the root and refuse when it does not resolve
+        // to itself.
+        if (!RootResolvesToItself(normalizedRoot))
+        {
+            Logger.LogError($"Refusing to resolve a target under extensions root '{normalizedRoot}' because the root is a reparse point (junction or symbolic link).");
+            return false;
+        }
+
+        var candidate = Path.GetFullPath(Path.Combine(normalizedRoot, trimmed));
+        if (!candidate.StartsWith(normalizedRoot + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        targetDirectory = candidate;
+        return true;
+    }
+
+    private static bool RootResolvesToItself(string normalizedRoot)
+    {
+        // A root that does not exist yet cannot redirect anywhere; install creates it as a real
+        // directory before promoting into it.
+        if (!Directory.Exists(normalizedRoot))
+        {
+            return true;
+        }
+
+        try
+        {
+            // ResolveLinkTarget returns null when the path is not a reparse point, and the final
+            // target otherwise. Any reparse point on the root is treated as unsafe.
+            return Directory.ResolveLinkTarget(normalizedRoot, returnFinalTarget: true) is null;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or System.Security.SecurityException)
+        {
+            // If the root cannot be inspected, err on the side of caution and refuse.
+            Logger.LogError($"Failed to inspect extensions root '{normalizedRoot}' for reparse points: {ex.Message}");
+            return false;
+        }
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/NpmJsExtensionInstaller.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/NpmJsExtensionInstaller.cs
@@ -25,6 +25,32 @@ public sealed class NpmJsExtensionInstaller : IJsExtensionInstaller
     // Upper bound on how long to wait for the host to load and register a freshly promoted extension.
     private static readonly TimeSpan RegistrationTimeout = TimeSpan.FromSeconds(30);
 
+    private static readonly HashSet<string> ReservedWindowsNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "CON",
+        "PRN",
+        "AUX",
+        "NUL",
+        "COM1",
+        "COM2",
+        "COM3",
+        "COM4",
+        "COM5",
+        "COM6",
+        "COM7",
+        "COM8",
+        "COM9",
+        "LPT1",
+        "LPT2",
+        "LPT3",
+        "LPT4",
+        "LPT5",
+        "LPT6",
+        "LPT7",
+        "LPT8",
+        "LPT9",
+    };
+
     private readonly IJsExtensionHost _host;
     private readonly INpmCommandRunner _npmCommandRunner;
 
@@ -100,14 +126,14 @@ public sealed class NpmJsExtensionInstaller : IJsExtensionInstaller
             await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
-                // Stop the Node.js process before delete so file handles are released. StopExtension
-                // blocks until the process exits, and the token lets Cancel stop waiting on a busy gate.
-                _host.StopExtension(targetDirectory, cancellationToken);
+                // Stop the Node.js process before delete so file handles are released. The token lets
+                // Cancel stop waiting on a busy lifecycle gate without blocking the UI thread.
+                await _host.StopExtensionAsync(targetDirectory, cancellationToken).ConfigureAwait(false);
 
-                // RemoveDirectory refuses to follow a junction or symbolic link and retries briefly when
-                // handles are still closing. The token stops the retry loop between attempts.
-                if (!_npmCommandRunner.RemoveDirectory(targetDirectory, cancellationToken))
+                // Delete on a worker thread since process handles can take a moment to close.
+                if (!await RemoveDirectoryAsync(targetDirectory).ConfigureAwait(false))
                 {
+                    await _host.RefreshAndAwaitProviderAsync(targetDirectory, RegistrationTimeout, CancellationToken.None).ConfigureAwait(false);
                     Logger.LogError($"Uninstall of JS extension '{extensionName}' failed: could not delete {targetDirectory}.");
                     return JsExtensionInstallResult.Fail(Resources.npm_installer_remove_failed);
                 }
@@ -191,6 +217,8 @@ public sealed class NpmJsExtensionInstaller : IJsExtensionInstaller
                 return JsExtensionInstallResult.Fail(Resources.npm_installer_version_mismatch);
             }
 
+            File.WriteAllText(Path.Combine(packageDirectory, JsonRpcExtensionService.GalleryInstallMarkerFileName), string.Empty);
+
             // The extracted package root already has the layout discovery expects: package.json at the
             // root with the frozen dependency closure under its own node_modules. Promote it directly.
             //
@@ -205,7 +233,7 @@ public sealed class NpmJsExtensionInstaller : IJsExtensionInstaller
             if (!registered)
             {
                 Logger.LogError($"Promoted '{extensionName}' but the host did not register a provider within {RegistrationTimeout.TotalSeconds:0} seconds.");
-                if (RollbackPromotedInstall(targetDirectory))
+                if (await RollbackPromotedInstallAsync(targetDirectory).ConfigureAwait(false))
                 {
                     promoted = false;
                 }
@@ -213,6 +241,7 @@ public sealed class NpmJsExtensionInstaller : IJsExtensionInstaller
                 return JsExtensionInstallResult.Fail(Resources.npm_installer_not_discoverable);
             }
 
+            TryRemoveInstallMarker(targetDirectory);
             Logger.LogInfo($"Installed JS extension '{extensionName}' from npm package '{artifact.InstallSpec}'.");
             return JsExtensionInstallResult.Ok();
         }
@@ -222,7 +251,7 @@ public sealed class NpmJsExtensionInstaller : IJsExtensionInstaller
             // process and provider first, then remove the promoted tree.
             if (promoted)
             {
-                RollbackPromotedInstall(targetDirectory);
+                await RollbackPromotedInstallAsync(targetDirectory).ConfigureAwait(false);
             }
 
             return JsExtensionInstallResult.Fail(Resources.npm_installer_canceled);
@@ -231,7 +260,7 @@ public sealed class NpmJsExtensionInstaller : IJsExtensionInstaller
         {
             if (promoted)
             {
-                RollbackPromotedInstall(targetDirectory);
+                await RollbackPromotedInstallAsync(targetDirectory).ConfigureAwait(false);
             }
 
             Logger.LogError($"Install of '{extensionName}' failed: {ex.Message}");
@@ -241,7 +270,7 @@ public sealed class NpmJsExtensionInstaller : IJsExtensionInstaller
         {
             // Clean the staging tree on every path, even after cancel. Do not observe the caller token
             // here, because cleanup still needs to run.
-            if (!_npmCommandRunner.RemoveDirectory(stagingDirectory, CancellationToken.None))
+            if (!await RemoveDirectoryAsync(stagingDirectory).ConfigureAwait(false))
             {
                 Logger.LogWarning($"Failed to clean up staging directory {stagingDirectory}.");
             }
@@ -254,10 +283,32 @@ public sealed class NpmJsExtensionInstaller : IJsExtensionInstaller
     /// extension both installed and running. Uses no cancellation token so cleanup can finish.
     /// </summary>
     /// <returns><see langword="true"/> when the promoted directory was removed; otherwise, <see langword="false"/>.</returns>
-    private bool RollbackPromotedInstall(string targetDirectory)
+    private async Task<bool> RollbackPromotedInstallAsync(string targetDirectory)
     {
-        _host.StopExtension(targetDirectory);
-        return _npmCommandRunner.RemoveDirectory(targetDirectory);
+        await _host.StopExtensionAsync(targetDirectory, CancellationToken.None).ConfigureAwait(false);
+        var removed = await RemoveDirectoryAsync(targetDirectory).ConfigureAwait(false);
+        if (!removed)
+        {
+            TryRemoveInstallMarker(targetDirectory);
+        }
+
+        return removed;
+    }
+
+    private Task<bool> RemoveDirectoryAsync(string targetDirectory) =>
+        Task.Run(() => _npmCommandRunner.RemoveDirectory(targetDirectory, CancellationToken.None));
+
+    private static void TryRemoveInstallMarker(string targetDirectory)
+    {
+        var markerPath = Path.Combine(targetDirectory, JsonRpcExtensionService.GalleryInstallMarkerFileName);
+        try
+        {
+            File.Delete(markerPath);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            Logger.LogWarning($"Failed to remove gallery install marker '{markerPath}': {ex.Message}");
+        }
     }
 
     /// <summary>
@@ -346,8 +397,13 @@ public sealed class NpmJsExtensionInstaller : IJsExtensionInstaller
 
         // Guard against path traversal or absolute paths escaping the JSExtensions root.
         var trimmed = extensionName.Trim();
-        if (trimmed.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0
+        var separatorIndex = trimmed.IndexOf('.');
+        var deviceName = separatorIndex >= 0 ? trimmed[..separatorIndex] : trimmed;
+        if (!string.Equals(trimmed, extensionName, StringComparison.Ordinal)
+            || trimmed.EndsWith('.')
+            || trimmed.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0
             || trimmed is "." or ".."
+            || ReservedWindowsNames.Contains(deviceName)
             || Path.IsPathRooted(trimmed))
         {
             return false;
@@ -365,8 +421,23 @@ public sealed class NpmJsExtensionInstaller : IJsExtensionInstaller
             return false;
         }
 
-        var candidate = Path.GetFullPath(Path.Combine(normalizedRoot, trimmed));
+        string candidate;
+        try
+        {
+            candidate = Path.GetFullPath(Path.Combine(normalizedRoot, trimmed));
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            return false;
+        }
+
         if (!candidate.StartsWith(normalizedRoot + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (!string.Equals(Path.GetFileName(candidate), trimmed, StringComparison.OrdinalIgnoreCase)
+            || (Directory.Exists(candidate) && !DirectoryResolvesToItself(candidate)))
         {
             return false;
         }
@@ -375,11 +446,13 @@ public sealed class NpmJsExtensionInstaller : IJsExtensionInstaller
         return true;
     }
 
-    private static bool RootResolvesToItself(string normalizedRoot)
+    private static bool RootResolvesToItself(string normalizedRoot) => DirectoryResolvesToItself(normalizedRoot);
+
+    private static bool DirectoryResolvesToItself(string directory)
     {
         // A root that does not exist yet cannot redirect anywhere. Install creates it as a real
         // directory before promoting into it.
-        if (!Directory.Exists(normalizedRoot))
+        if (!Directory.Exists(directory))
         {
             return true;
         }
@@ -388,12 +461,12 @@ public sealed class NpmJsExtensionInstaller : IJsExtensionInstaller
         {
             // ResolveLinkTarget returns null when the path is not a reparse point. Any reparse point on
             // the root is treated as unsafe.
-            return Directory.ResolveLinkTarget(normalizedRoot, returnFinalTarget: true) is null;
+            return Directory.ResolveLinkTarget(directory, returnFinalTarget: true) is null;
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or System.Security.SecurityException)
         {
             // If the root cannot be inspected, play it safe and refuse.
-            Logger.LogError($"Failed to inspect extensions root '{normalizedRoot}' for reparse points: {ex.Message}");
+            Logger.LogError($"Failed to inspect extension directory '{directory}' for reparse points: {ex.Message}");
             return false;
         }
     }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/NpmJsExtensionInstaller.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Services/NpmJsExtensionInstaller.cs
@@ -14,15 +14,11 @@ using Microsoft.CmdPal.UI.ViewModels.Properties;
 namespace Microsoft.CmdPal.UI.ViewModels.Services;
 
 /// <summary>
-/// Installs and uninstalls gallery jsonrpc extensions as a fail-closed transaction over an
-/// immutable, approved artifact. The package, exact version, integrity, and optional registry are
-/// validated up front; the runner downloads the exact tarball, requires the publisher-provided
-/// npm-shrinkwrap.json that freezes the whole dependency closure, and installs that frozen closure
-/// with npm ci into a unique staging directory outside the watched JSExtensions root with lifecycle
-/// scripts disabled; the resolved integrity, package identity, and manifest are verified; and only
-/// then is the extension atomically promoted into JSExtensions/&lt;name&gt;/ and awaited for host
-/// registration. Staging is always cleaned up, and a failed, timed-out, or cancelled install never
-/// deletes or corrupts an existing install.
+/// Installs and uninstalls gallery jsonrpc extensions as a transaction around an approved artifact.
+/// The installer validates the catalog data, stages the package outside JSExtensions, asks the runner
+/// to install the frozen dependency tree, verifies identity and integrity, promotes the ready tree,
+/// and waits for host registration. Staging is cleaned every time. Failed, timed out, and canceled
+/// installs leave any existing install alone.
 /// </summary>
 public sealed class NpmJsExtensionInstaller : IJsExtensionInstaller
 {
@@ -32,8 +28,8 @@ public sealed class NpmJsExtensionInstaller : IJsExtensionInstaller
     private readonly IJsExtensionHost _host;
     private readonly INpmCommandRunner _npmCommandRunner;
 
-    // Per-canonical-directory locks so an install and an uninstall of the same extension are
-    // serialized while different extensions install in parallel.
+    // Per directory locks keep install and uninstall for the same extension serialized while
+    // different extensions can still install in parallel.
     private readonly Dictionary<string, SemaphoreSlim> _directoryLocks = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<string, int> _lockReferenceCounts = new(StringComparer.OrdinalIgnoreCase);
     private readonly Lock _directoryLocksGate = new();
@@ -54,7 +50,7 @@ public sealed class NpmJsExtensionInstaller : IJsExtensionInstaller
             return JsExtensionInstallResult.Fail(Resources.npm_installer_invalid_name);
         }
 
-        // Fail closed: an incomplete or malformed catalog entry is never installable.
+        // Fail closed. An incomplete or malformed catalog entry is never installable.
         if (!NpmArtifact.TryCreate(npmPackage, version, integrity, registry, out var artifact, out var validationError)
             || artifact is null)
         {
@@ -104,14 +100,12 @@ public sealed class NpmJsExtensionInstaller : IJsExtensionInstaller
             await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
-                // Terminate the Node.js process and wait for its handles to be released before
-                // deleting; the Phase 4 StopExtension blocks until the process has exited. The token
-                // lets Cancel abandon a wait for a contended lifecycle gate.
+                // Stop the Node.js process before delete so file handles are released. StopExtension
+                // blocks until the process exits, and the token lets Cancel stop waiting on a busy gate.
                 _host.StopExtension(targetDirectory, cancellationToken);
 
-                // RemoveDirectory refuses to follow a junction or symbolic link out of the root and
-                // retries briefly to tolerate a handle that is still being released. The token stops
-                // the retry loop so Cancel is honored between attempts.
+                // RemoveDirectory refuses to follow a junction or symbolic link and retries briefly when
+                // handles are still closing. The token stops the retry loop between attempts.
                 if (!_npmCommandRunner.RemoveDirectory(targetDirectory, cancellationToken))
                 {
                     Logger.LogError($"Uninstall of JS extension '{extensionName}' failed: could not delete {targetDirectory}.");
@@ -140,9 +134,8 @@ public sealed class NpmJsExtensionInstaller : IJsExtensionInstaller
 
     private async Task<JsExtensionInstallResult> InstallLockedAsync(string extensionName, string targetDirectory, NpmArtifact artifact, CancellationToken cancellationToken)
     {
-        // Upgrade policy: block installing over an existing or loaded extension. The user uninstalls
-        // and reinstalls to change versions, which guarantees an existing install is never touched by
-        // a failed upgrade.
+        // Upgrade policy: do not install over an existing or loaded extension. The user uninstalls and
+        // reinstalls to change versions, so a failed upgrade cannot damage a working install.
         if (Directory.Exists(targetDirectory) || _host.IsExtensionInstalled(extensionName))
         {
             return JsExtensionInstallResult.Fail(Resources.npm_installer_already_installed);
@@ -175,9 +168,8 @@ public sealed class NpmJsExtensionInstaller : IJsExtensionInstaller
                 return JsExtensionInstallResult.Fail(Resources.npm_installer_not_an_extension);
             }
 
-            // Validate that this is the approved package and version, and that it is a loadable
-            // CmdPal manifest (the parser enforces the entry point, the .js/.mjs/.cjs allowlist, and
-            // reparse/canonical containment).
+            // Validate that this is the approved package and version, with a manifest the host can load.
+            // The parser enforces the entry point, extension allowlist, and canonical containment.
             var manifestPath = Path.Combine(packageDirectory, "package.json");
             var parseResult = JSExtensionManifest.TryParseFile(manifestPath);
             if (!parseResult.IsValid || parseResult.Manifest is null)
@@ -199,17 +191,16 @@ public sealed class NpmJsExtensionInstaller : IJsExtensionInstaller
                 return JsExtensionInstallResult.Fail(Resources.npm_installer_version_mismatch);
             }
 
-            // The extracted package root already has the discovery layout npm ci produced: package.json
-            // at the root with the publisher-frozen dependency closure under its own node_modules.
-            // Promote it directly.
+            // The extracted package root already has the layout discovery expects: package.json at the
+            // root with the frozen dependency closure under its own node_modules. Promote it directly.
             //
-            // Atomic promote onto the same volume. The target does not exist (blocked above), so this
-            // is a plain rename; the watched root only ever sees the fully validated tree.
+            // Keep the promote on the same volume. The target does not exist, so this is a plain rename,
+            // and the watched root only sees the fully validated tree.
             Directory.CreateDirectory(_host.ExtensionsRootPath);
             Directory.Move(packageDirectory, targetDirectory);
             promoted = true;
 
-            // Only report success once the host has actually loaded and registered the provider.
+            // Only report success after the host loads and registers the provider.
             var registered = await _host.RefreshAndAwaitProviderAsync(targetDirectory, RegistrationTimeout, cancellationToken).ConfigureAwait(false);
             if (!registered)
             {
@@ -227,8 +218,8 @@ public sealed class NpmJsExtensionInstaller : IJsExtensionInstaller
         }
         catch (OperationCanceledException)
         {
-            // A cancel after promotion must not leave a half-registered extension behind: stop the
-            // host process/provider first, then remove the promoted tree.
+            // A cancel after promotion must not leave a half registered extension behind. Stop the host
+            // process and provider first, then remove the promoted tree.
             if (promoted)
             {
                 RollbackPromotedInstall(targetDirectory);
@@ -248,8 +239,8 @@ public sealed class NpmJsExtensionInstaller : IJsExtensionInstaller
         }
         finally
         {
-            // Clean the staging tree on every path, even when the install was canceled, so the staging
-            // cleanup must not observe the caller's token: pass CancellationToken.None explicitly.
+            // Clean the staging tree on every path, even after cancel. Do not observe the caller token
+            // here, because cleanup still needs to run.
             if (!_npmCommandRunner.RemoveDirectory(stagingDirectory, CancellationToken.None))
             {
                 Logger.LogWarning($"Failed to clean up staging directory {stagingDirectory}.");
@@ -258,10 +249,9 @@ public sealed class NpmJsExtensionInstaller : IJsExtensionInstaller
     }
 
     /// <summary>
-    /// Rolls back a promoted install. Stops the host process/provider that may have started for the
-    /// promoted directory, then removes the promoted tree, in that order, so a canceled or failed
-    /// install can never leave the extension both installed on disk and running. Uses no cancellation
-    /// token so cleanup always runs to completion, even on the cancel path.
+    /// Rolls back a promoted install. Stops any host process and provider for the promoted directory,
+    /// then removes the promoted tree, in that order, so a canceled or failed install cannot leave the
+    /// extension both installed and running. Uses no cancellation token so cleanup can finish.
     /// </summary>
     /// <returns><see langword="true"/> when the promoted directory was removed; otherwise, <see langword="false"/>.</returns>
     private bool RollbackPromotedInstall(string targetDirectory)
@@ -271,8 +261,8 @@ public sealed class NpmJsExtensionInstaller : IJsExtensionInstaller
     }
 
     /// <summary>
-    /// Gets the staging root, a sibling of the JSExtensions root that the FileSystemWatcher does not
-    /// watch. Keeping it a sibling (same volume) makes the final promote a rename rather than a copy.
+    /// Gets the staging root, a sibling of JSExtensions that the FileSystemWatcher does not watch.
+    /// Keeping it on the same volume makes the final promote a rename instead of a copy.
     /// </summary>
     private string GetStagingRoot()
     {
@@ -282,7 +272,7 @@ public sealed class NpmJsExtensionInstaller : IJsExtensionInstaller
 
         if (string.IsNullOrEmpty(parent) || string.IsNullOrEmpty(rootName))
         {
-            // Degenerate path (root of a volume); fall back to a sibling under the same directory.
+            // Root of a volume. Fall back to a sibling under the same directory.
             return Path.Combine(root + ".staging");
         }
 
@@ -302,8 +292,7 @@ public sealed class NpmJsExtensionInstaller : IJsExtensionInstaller
                 _directoryLocks[canonicalKey] = entry;
             }
 
-            // Track a reference count in the semaphore's current use so the dictionary entry is only
-            // removed when no operation holds or waits on it.
+            // Keep the semaphore until no operation holds it or waits on it.
             _lockReferenceCounts.TryGetValue(canonicalKey, out var count);
             _lockReferenceCounts[canonicalKey] = count + 1;
             return entry;
@@ -367,11 +356,9 @@ public sealed class NpmJsExtensionInstaller : IJsExtensionInstaller
         var root = _host.ExtensionsRootPath;
         var normalizedRoot = Path.TrimEndingDirectorySeparator(Path.GetFullPath(root));
 
-        // The extensions root must be a real directory, not a reparse point. If a junction or symbolic
-        // link is used as the root, a candidate that passes the textual containment check below can
-        // still resolve on disk to a path outside the intended tree, so an uninstall delete could
-        // escape containment. Resolve reparse points on the root and refuse when it does not resolve
-        // to itself.
+        // The extensions root must be a real directory, not a reparse point. A junction or symbolic
+        // link can pass the text containment check and still resolve outside the intended tree, letting
+        // uninstall delete escape containment. Refuse roots that resolve somewhere else.
         if (!RootResolvesToItself(normalizedRoot))
         {
             Logger.LogError($"Refusing to resolve a target under extensions root '{normalizedRoot}' because the root is a reparse point (junction or symbolic link).");
@@ -390,7 +377,7 @@ public sealed class NpmJsExtensionInstaller : IJsExtensionInstaller
 
     private static bool RootResolvesToItself(string normalizedRoot)
     {
-        // A root that does not exist yet cannot redirect anywhere; install creates it as a real
+        // A root that does not exist yet cannot redirect anywhere. Install creates it as a real
         // directory before promoting into it.
         if (!Directory.Exists(normalizedRoot))
         {
@@ -399,13 +386,13 @@ public sealed class NpmJsExtensionInstaller : IJsExtensionInstaller
 
         try
         {
-            // ResolveLinkTarget returns null when the path is not a reparse point, and the final
-            // target otherwise. Any reparse point on the root is treated as unsafe.
+            // ResolveLinkTarget returns null when the path is not a reparse point. Any reparse point on
+            // the root is treated as unsafe.
             return Directory.ResolveLinkTarget(normalizedRoot, returnFinalTarget: true) is null;
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or System.Security.SecurityException)
         {
-            // If the root cannot be inspected, err on the side of caution and refuse.
+            // If the root cannot be inspected, play it safe and refuse.
             Logger.LogError($"Failed to inspect extensions root '{normalizedRoot}' for reparse points: {ex.Message}");
             return false;
         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/App.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/App.xaml.cs
@@ -267,7 +267,9 @@ public partial class App : Application, IDisposable
         // Load IExtensionServices here
         services.AddSingleton<IExtensionService, BuiltInExtensionService>();
         services.AddSingleton<IExtensionService, WinRTExtensionService>();
-        services.AddSingleton<IExtensionService, JsonRpcExtensionService>();
+        services.AddSingleton<JsonRpcExtensionService>();
+        services.AddSingleton<IExtensionService>(static sp => sp.GetRequiredService<JsonRpcExtensionService>());
+        services.AddSingleton<IJsExtensionHost>(static sp => sp.GetRequiredService<JsonRpcExtensionService>());
 
         services.AddSingleton<IRunHistoryService, RunHistoryService>();
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/App.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/App.xaml.cs
@@ -301,7 +301,9 @@ public partial class App : Application, IDisposable
         // Load IExtensionServices here
         services.AddSingleton<IExtensionService, BuiltInExtensionService>();
         services.AddSingleton<IExtensionService, WinRTExtensionService>();
-        services.AddSingleton<IExtensionService, JsonRpcExtensionService>();
+        services.AddSingleton<JsonRpcExtensionService>();
+        services.AddSingleton<IExtensionService>(static sp => sp.GetRequiredService<JsonRpcExtensionService>());
+        services.AddSingleton<IJsExtensionHost>(static sp => sp.GetRequiredService<JsonRpcExtensionService>());
 
         services.AddSingleton<IRunHistoryService, RunHistoryService>();
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/GalleryServiceRegistration.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/GalleryServiceRegistration.cs
@@ -30,6 +30,9 @@ internal static class GalleryServiceRegistration
         });
         services.AddSingleton<IExtensionGalleryService, ExtensionGalleryService>();
 
+        services.AddSingleton<INpmCommandRunner, NpmCommandRunner>();
+        services.AddSingleton<IJsExtensionInstaller, NpmJsExtensionInstaller>();
+
         services.AddTransient<ExtensionGalleryItemViewModelFactory>();
         services.AddTransient<ExtensionGalleryViewModel>();
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/ExtensionGalleryItemPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/ExtensionGalleryItemPage.xaml
@@ -320,6 +320,47 @@
                         FontSize="12"
                         Visibility="{x:Bind help:BindTransformers.BoolToVisibility(ViewModel.ShowInstalledBadge), Mode=OneWay, FallbackValue=Collapsed}" />
 
+                    <Button
+                        MinWidth="172"
+                        Padding="12"
+                        HorizontalContentAlignment="Left"
+                        AutomationProperties.AutomationId="CmdPal_GalleryItemPage_InstallViaNpm"
+                        Command="{x:Bind ViewModel.InstallViaNpmCommand, Mode=OneWay}"
+                        Content="{x:Bind ViewModel.InstallViaNpmText, Mode=OneWay}"
+                        FontWeight="SemiBold"
+                        IsEnabled="{x:Bind ViewModel.CanInstallViaNpm, Mode=OneWay}"
+                        Style="{StaticResource AccentButtonStyle}"
+                        Visibility="{x:Bind help:BindTransformers.BoolToVisibility(ViewModel.ShowInstallViaNpmButton), Mode=OneWay, FallbackValue=Collapsed}" />
+
+                    <Button
+                        MinWidth="172"
+                        Padding="12"
+                        HorizontalContentAlignment="Left"
+                        AutomationProperties.AutomationId="CmdPal_GalleryItemPage_UninstallJsonRpc"
+                        Command="{x:Bind ViewModel.UninstallJsonRpcCommand, Mode=OneWay}"
+                        Content="{x:Bind ViewModel.UninstallJsonRpcText, Mode=OneWay}"
+                        FontWeight="SemiBold"
+                        IsEnabled="{x:Bind ViewModel.CanUninstallJsonRpc, Mode=OneWay}"
+                        Visibility="{x:Bind help:BindTransformers.BoolToVisibility(ViewModel.ShowUninstallJsonRpcButton), Mode=OneWay, FallbackValue=Collapsed}" />
+
+                    <Button
+                        MinWidth="172"
+                        Padding="12"
+                        HorizontalContentAlignment="Left"
+                        AutomationProperties.AutomationId="CmdPal_GalleryItemPage_CancelJsonRpcAction"
+                        Command="{x:Bind ViewModel.CancelJsonRpcActionCommand, Mode=OneWay}"
+                        Content="{x:Bind ViewModel.CancelJsonRpcActionText, Mode=OneWay}"
+                        IsEnabled="{x:Bind ViewModel.CanCancelJsonRpcAction, Mode=OneWay}"
+                        Visibility="{x:Bind help:BindTransformers.BoolToVisibility(ViewModel.ShowCancelJsonRpcActionButton), Mode=OneWay, FallbackValue=Collapsed}" />
+
+                    <TextBlock
+                        VerticalAlignment="Center"
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        Style="{StaticResource CaptionTextBlockStyle}"
+                        Text="{x:Bind ViewModel.JsonRpcActionMessage, Mode=OneWay}"
+                        TextWrapping="WrapWholeWords"
+                        Visibility="{x:Bind help:BindTransformers.BoolToVisibility(ViewModel.HasJsonRpcActionMessage), Mode=OneWay, FallbackValue=Collapsed}" />
+
                 </StackPanel>
                 <ScrollViewer Grid.Row="4">
                     <StackPanel Spacing="16">

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/ExtensionGalleryItemViewModelTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/ExtensionGalleryItemViewModelTests.cs
@@ -6,10 +6,13 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.CmdPal.Common.ExtensionGallery.Models;
 using Microsoft.CmdPal.Common.WinGet.Models;
 using Microsoft.CmdPal.Common.WinGet.Services;
 using Microsoft.CmdPal.UI.ViewModels.Gallery;
+using Microsoft.CmdPal.UI.ViewModels.Services;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -674,6 +677,168 @@ public class ExtensionGalleryItemViewModelTests
         Assert.IsTrue(viewModel.OpenInstalledAppsCommand.CanExecute(null));
     }
 
+    [TestMethod]
+    public void JsonRpcSource_IsRecognized_WithPackageAndRegistry()
+    {
+        var entry = new GalleryExtensionEntry
+        {
+            Id = "sample-js-extension",
+            Title = "Sample JS",
+            Description = "Sample jsonrpc extension",
+            Author = new GalleryAuthor { Name = "Sample Author" },
+            InstallSources =
+            [
+                new GalleryInstallSource
+                {
+                    Type = "jsonrpc",
+                    Npm = new GalleryNpmPackage
+                    {
+                        Package = "@contoso/sample",
+                        Version = "1.2.3",
+                        Integrity = "sha512-abc123==",
+                        Registry = "https://registry.example.com",
+                    },
+                },
+            ],
+        };
+
+        var viewModel = CreateViewModel(entry);
+
+        Assert.IsTrue(viewModel.HasJsonRpcSource);
+        Assert.AreEqual("@contoso/sample", viewModel.JsonRpcPackageId);
+        Assert.AreEqual("1.2.3", viewModel.JsonRpcVersion);
+        Assert.AreEqual("sha512-abc123==", viewModel.JsonRpcIntegrity);
+        Assert.AreEqual("https://registry.example.com", viewModel.JsonRpcRegistry);
+        Assert.IsTrue(viewModel.Sources.Any(s => s.Kind == "jsonrpc"));
+    }
+
+    [TestMethod]
+    public void JsonRpcSource_IsNotRecognized_WhenPackageMissing()
+    {
+        var entry = new GalleryExtensionEntry
+        {
+            Id = "sample-js-extension",
+            Title = "Sample JS",
+            Description = "Sample jsonrpc extension",
+            Author = new GalleryAuthor { Name = "Sample Author" },
+            InstallSources =
+            [
+                new GalleryInstallSource
+                {
+                    Type = "jsonrpc",
+                    Npm = new GalleryNpmPackage { Package = string.Empty },
+                },
+            ],
+        };
+
+        var viewModel = CreateViewModel(entry);
+
+        Assert.IsFalse(viewModel.HasJsonRpcSource);
+    }
+
+    [TestMethod]
+    public void InstallViaNpm_ShowsButton_WhenNotInstalled()
+    {
+        var viewModel = CreateJsonRpcViewModel(out _);
+
+        Assert.IsTrue(viewModel.ShowInstallViaNpmButton);
+        Assert.IsTrue(viewModel.CanInstallViaNpm);
+        Assert.IsFalse(viewModel.ShowUninstallJsonRpcButton);
+    }
+
+    [TestMethod]
+    public void CanInstallViaNpm_IsFalse_WhenNoInstaller()
+    {
+        var entry = CreateJsonRpcEntry();
+        var viewModel = CreateViewModel(entry);
+
+        Assert.IsTrue(viewModel.ShowInstallViaNpmButton);
+        Assert.IsFalse(viewModel.CanInstallViaNpm);
+    }
+
+    [TestMethod]
+    public async Task InstallViaNpmCommand_InstallsPackage_AndMarksInstalled()
+    {
+        var viewModel = CreateJsonRpcViewModel(out var installer);
+        installer
+            .Setup(x => x.InstallAsync("sample-js-extension", "@contoso/sample", "1.2.3", "sha512-abc123==", "https://registry.example.com", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(JsExtensionInstallResult.Ok());
+
+        await viewModel.InstallViaNpmCommand.ExecuteAsync(null);
+
+        installer.Verify(
+            x => x.InstallAsync("sample-js-extension", "@contoso/sample", "1.2.3", "sha512-abc123==", "https://registry.example.com", It.IsAny<CancellationToken>()),
+            Times.Once);
+        Assert.IsTrue(viewModel.IsInstalled);
+        Assert.IsTrue(viewModel.ShowUninstallJsonRpcButton);
+        Assert.IsFalse(viewModel.ShowInstallViaNpmButton);
+    }
+
+    [TestMethod]
+    public async Task InstallViaNpmCommand_SurfacesError_OnFailure()
+    {
+        var viewModel = CreateJsonRpcViewModel(out var installer);
+        installer
+            .Setup(x => x.InstallAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(JsExtensionInstallResult.Fail("npm was not found"));
+
+        await viewModel.InstallViaNpmCommand.ExecuteAsync(null);
+
+        Assert.IsFalse(viewModel.IsInstalled);
+        Assert.IsTrue(viewModel.HasJsonRpcActionMessage);
+        Assert.AreEqual("npm was not found", viewModel.JsonRpcActionMessage);
+    }
+
+    [TestMethod]
+    public async Task UninstallJsonRpcCommand_Uninstalls_AndMarksNotInstalled()
+    {
+        var viewModel = CreateJsonRpcViewModel(out var installer);
+        viewModel.IsInstalled = true;
+        viewModel.IsInstalledStateKnown = true;
+        installer
+            .Setup(x => x.UninstallAsync("sample-js-extension", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(JsExtensionInstallResult.Ok());
+
+        Assert.IsTrue(viewModel.ShowUninstallJsonRpcButton);
+
+        await viewModel.UninstallJsonRpcCommand.ExecuteAsync(null);
+
+        installer.Verify(x => x.UninstallAsync("sample-js-extension", It.IsAny<CancellationToken>()), Times.Once);
+        Assert.IsFalse(viewModel.IsInstalled);
+        Assert.IsTrue(viewModel.ShowInstallViaNpmButton);
+    }
+
+    private static GalleryExtensionEntry CreateJsonRpcEntry()
+    {
+        return new GalleryExtensionEntry
+        {
+            Id = "sample-js-extension",
+            Title = "Sample JS",
+            Description = "Sample jsonrpc extension",
+            Author = new GalleryAuthor { Name = "Sample Author" },
+            InstallSources =
+            [
+                new GalleryInstallSource
+                {
+                    Type = "jsonrpc",
+                    Npm = new GalleryNpmPackage
+                    {
+                        Package = "@contoso/sample",
+                        Version = "1.2.3",
+                        Integrity = "sha512-abc123==",
+                        Registry = "https://registry.example.com",
+                    },
+                },
+            ],
+        };
+    }
+
+    private static ExtensionGalleryItemViewModel CreateJsonRpcViewModel(out Mock<IJsExtensionInstaller> installer)
+    {
+        installer = new Mock<IJsExtensionInstaller>();
+        return CreateViewModel(CreateJsonRpcEntry(), jsExtensionInstaller: installer.Object);
+    }
+
     private static GalleryExtensionEntry CreateEntry(string? iconUrl)
     {
         return new GalleryExtensionEntry
@@ -691,14 +856,16 @@ public class ExtensionGalleryItemViewModelTests
         GalleryExtensionEntry entry,
         IWinGetPackageManagerService? winGetPackageManagerService = null,
         IWinGetPackageStatusService? winGetPackageStatusService = null,
-        IWinGetOperationTrackerService? winGetOperationTrackerService = null)
+        IWinGetOperationTrackerService? winGetOperationTrackerService = null,
+        IJsExtensionInstaller? jsExtensionInstaller = null)
     {
         return new ExtensionGalleryItemViewModel(
             entry,
             NullLogger<ExtensionGalleryItemViewModel>.Instance,
             winGetPackageManagerService,
             winGetPackageStatusService,
-            winGetOperationTrackerService);
+            winGetOperationTrackerService,
+            jsExtensionInstaller);
     }
 
     private static WinGetPackageDetails CreatePackageDetails()

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/ExtensionGalleryItemViewModelTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/ExtensionGalleryItemViewModelTests.cs
@@ -13,6 +13,7 @@ using Microsoft.CmdPal.Common.WinGet.Models;
 using Microsoft.CmdPal.Common.WinGet.Services;
 using Microsoft.CmdPal.UI.ViewModels.Gallery;
 using Microsoft.CmdPal.UI.ViewModels.Services;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -809,6 +810,46 @@ public class ExtensionGalleryItemViewModelTests
     }
 
     [TestMethod]
+    public async Task InstallViaNpmCommand_UnexpectedFailure_ShowsErrorAndReenablesButton()
+    {
+        var installer = new Mock<IJsExtensionInstaller>();
+        installer.Setup(x => x.IsInstalled("sample-js-extension")).Returns(false);
+        installer
+            .Setup(x => x.InstallAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("unexpected"));
+        var logger = new Mock<ILogger<ExtensionGalleryItemViewModel>>();
+        logger.Setup(x => x.IsEnabled(LogLevel.Error)).Returns(true);
+        var viewModel = CreateViewModel(CreateJsonRpcEntry(), jsExtensionInstaller: installer.Object, logger: logger.Object);
+
+        await viewModel.InstallViaNpmCommand.ExecuteAsync(null);
+
+        Assert.AreEqual(
+            Microsoft.CmdPal.UI.ViewModels.Properties.Resources.gallery_item_jsonrpc_action_install_failed,
+            viewModel.JsonRpcActionMessage);
+        Assert.IsFalse(viewModel.IsJsonRpcActionInProgress);
+        Assert.IsTrue(viewModel.CanInstallViaNpm);
+        installer.Verify(x => x.IsInstalled("sample-js-extension"), Times.Once);
+        VerifyErrorLogged(logger);
+    }
+
+    [TestMethod]
+    public async Task InstallViaNpmCommand_Cancellation_ShowsLocalizedStatusAndReenablesButton()
+    {
+        var viewModel = CreateJsonRpcViewModel(out var installer);
+        installer
+            .Setup(x => x.InstallAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
+
+        await viewModel.InstallViaNpmCommand.ExecuteAsync(null);
+
+        Assert.AreEqual(
+            Microsoft.CmdPal.UI.ViewModels.Properties.Resources.npm_installer_canceled,
+            viewModel.JsonRpcActionMessage);
+        Assert.IsFalse(viewModel.IsJsonRpcActionInProgress);
+        Assert.IsTrue(viewModel.CanInstallViaNpm);
+    }
+
+    [TestMethod]
     public async Task CancelJsonRpcActionCommand_NotifiesActionStateImmediately()
     {
         var operationStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -857,6 +898,46 @@ public class ExtensionGalleryItemViewModelTests
         installer.Verify(x => x.UninstallAsync("sample-js-extension", It.IsAny<CancellationToken>()), Times.Once);
         Assert.IsFalse(viewModel.IsInstalled);
         Assert.IsTrue(viewModel.ShowInstallViaNpmButton);
+    }
+
+    [TestMethod]
+    public async Task UninstallJsonRpcCommand_UnexpectedFailure_ShowsErrorAndReenablesButton()
+    {
+        var installer = new Mock<IJsExtensionInstaller>();
+        installer.Setup(x => x.IsInstalled("sample-js-extension")).Returns(true);
+        installer
+            .Setup(x => x.UninstallAsync("sample-js-extension", It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("unexpected"));
+        var logger = new Mock<ILogger<ExtensionGalleryItemViewModel>>();
+        logger.Setup(x => x.IsEnabled(LogLevel.Error)).Returns(true);
+        var viewModel = CreateViewModel(CreateJsonRpcEntry(), jsExtensionInstaller: installer.Object, logger: logger.Object);
+
+        await viewModel.UninstallJsonRpcCommand.ExecuteAsync(null);
+
+        Assert.AreEqual(
+            Microsoft.CmdPal.UI.ViewModels.Properties.Resources.gallery_item_jsonrpc_action_uninstall_failed,
+            viewModel.JsonRpcActionMessage);
+        Assert.IsFalse(viewModel.IsJsonRpcActionInProgress);
+        Assert.IsTrue(viewModel.CanUninstallJsonRpc);
+        installer.Verify(x => x.IsInstalled("sample-js-extension"), Times.Once);
+        VerifyErrorLogged(logger);
+    }
+
+    [TestMethod]
+    public async Task UninstallJsonRpcCommand_Cancellation_ShowsLocalizedStatusAndReenablesButton()
+    {
+        var viewModel = CreateJsonRpcViewModel(out var installer, isInstalled: true);
+        installer
+            .Setup(x => x.UninstallAsync("sample-js-extension", It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
+
+        await viewModel.UninstallJsonRpcCommand.ExecuteAsync(null);
+
+        Assert.AreEqual(
+            Microsoft.CmdPal.UI.ViewModels.Properties.Resources.npm_installer_canceled,
+            viewModel.JsonRpcActionMessage);
+        Assert.IsFalse(viewModel.IsJsonRpcActionInProgress);
+        Assert.IsTrue(viewModel.CanUninstallJsonRpc);
     }
 
     [TestMethod]
@@ -1037,15 +1118,28 @@ public class ExtensionGalleryItemViewModelTests
         IWinGetPackageManagerService? winGetPackageManagerService = null,
         IWinGetPackageStatusService? winGetPackageStatusService = null,
         IWinGetOperationTrackerService? winGetOperationTrackerService = null,
-        IJsExtensionInstaller? jsExtensionInstaller = null)
+        IJsExtensionInstaller? jsExtensionInstaller = null,
+        ILogger<ExtensionGalleryItemViewModel>? logger = null)
     {
         return new ExtensionGalleryItemViewModel(
             entry,
-            NullLogger<ExtensionGalleryItemViewModel>.Instance,
+            logger ?? NullLogger<ExtensionGalleryItemViewModel>.Instance,
             winGetPackageManagerService,
             winGetPackageStatusService,
             winGetOperationTrackerService,
             jsExtensionInstaller);
+    }
+
+    private static void VerifyErrorLogged(Mock<ILogger<ExtensionGalleryItemViewModel>> logger)
+    {
+        logger.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
     }
 
     private static WinGetPackageDetails CreatePackageDetails()

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/ExtensionGalleryItemViewModelTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/ExtensionGalleryItemViewModelTests.cs
@@ -790,11 +790,62 @@ public class ExtensionGalleryItemViewModelTests
     }
 
     [TestMethod]
+    public async Task InstallViaNpmCommand_RefreshesInstalledState_OnFailure()
+    {
+        var installer = new Mock<IJsExtensionInstaller>();
+        installer
+            .SetupSequence(x => x.IsInstalled("sample-js-extension"))
+            .Returns(false)
+            .Returns(true);
+        installer
+            .Setup(x => x.InstallAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(JsExtensionInstallResult.Fail("rollback failed"));
+        var viewModel = CreateViewModel(CreateJsonRpcEntry(), jsExtensionInstaller: installer.Object);
+
+        await viewModel.InstallViaNpmCommand.ExecuteAsync(null);
+
+        Assert.IsTrue(viewModel.IsJsonRpcInstalled);
+        Assert.IsTrue(viewModel.ShowUninstallJsonRpcButton);
+    }
+
+    [TestMethod]
+    public async Task CancelJsonRpcActionCommand_NotifiesActionStateImmediately()
+    {
+        var operationStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var installer = new Mock<IJsExtensionInstaller>();
+        installer.Setup(x => x.IsInstalled("sample-js-extension")).Returns(false);
+        installer
+            .Setup(x => x.InstallAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Returns(async (string _, string _, string? _, string? _, string? _, CancellationToken token) =>
+            {
+                operationStarted.SetResult();
+                try
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                    return JsExtensionInstallResult.Ok();
+                }
+                catch (OperationCanceledException)
+                {
+                    return JsExtensionInstallResult.Fail("canceled");
+                }
+            });
+        var viewModel = CreateViewModel(CreateJsonRpcEntry(), jsExtensionInstaller: installer.Object);
+
+        var installTask = viewModel.InstallViaNpmCommand.ExecuteAsync(null);
+        await operationStarted.Task;
+        Assert.IsTrue(viewModel.ShowCancelJsonRpcActionButton);
+
+        viewModel.CancelJsonRpcActionCommand.Execute(null);
+
+        Assert.IsFalse(viewModel.ShowCancelJsonRpcActionButton);
+        Assert.IsFalse(viewModel.CancelJsonRpcActionCommand.CanExecute(null));
+        await installTask;
+    }
+
+    [TestMethod]
     public async Task UninstallJsonRpcCommand_Uninstalls_AndMarksNotInstalled()
     {
-        var viewModel = CreateJsonRpcViewModel(out var installer);
-        viewModel.IsInstalled = true;
-        viewModel.IsInstalledStateKnown = true;
+        var viewModel = CreateJsonRpcViewModel(out var installer, isInstalled: true);
         installer
             .Setup(x => x.UninstallAsync("sample-js-extension", It.IsAny<CancellationToken>()))
             .ReturnsAsync(JsExtensionInstallResult.Ok());
@@ -806,6 +857,134 @@ public class ExtensionGalleryItemViewModelTests
         installer.Verify(x => x.UninstallAsync("sample-js-extension", It.IsAny<CancellationToken>()), Times.Once);
         Assert.IsFalse(viewModel.IsInstalled);
         Assert.IsTrue(viewModel.ShowInstallViaNpmButton);
+    }
+
+    [TestMethod]
+    public void WinGetInstall_DoesNotHideJsonRpcInstall()
+    {
+        var installer = new Mock<IJsExtensionInstaller>();
+        var entry = CreateJsonRpcEntry();
+        entry.InstallSources.Add(new GalleryInstallSource { Type = "winget", Id = "Contoso.Sample" });
+        var viewModel = CreateViewModel(entry, jsExtensionInstaller: installer.Object);
+
+        viewModel.ApplyWinGetPackageInfo(
+            new WinGetPackageInfo(
+                new WinGetPackageStatus(
+                    IsInstalled: true,
+                    IsInstalledStateKnown: true,
+                    IsUpdateAvailable: false,
+                    IsUpdateStateKnown: true),
+                Details: null));
+
+        Assert.IsTrue(viewModel.IsInstalled);
+        Assert.IsTrue(viewModel.ShowInstallViaNpmButton);
+        Assert.IsFalse(viewModel.ShowUninstallJsonRpcButton);
+    }
+
+    [TestMethod]
+    public void JsonRpcInstall_DoesNotHideWinGetInstall()
+    {
+        var installer = new Mock<IJsExtensionInstaller>();
+        installer.Setup(x => x.IsInstalled("sample-js-extension")).Returns(true);
+        var entry = CreateJsonRpcEntry();
+        entry.InstallSources.Add(new GalleryInstallSource { Type = "winget", Id = "Contoso.Sample" });
+        var viewModel = CreateViewModel(entry, jsExtensionInstaller: installer.Object);
+        List<string> propertyNames = [];
+        viewModel.PropertyChanged += (_, args) =>
+        {
+            if (args.PropertyName is not null)
+            {
+                propertyNames.Add(args.PropertyName);
+            }
+        };
+
+        viewModel.ApplyWinGetPackageInfo(
+            new WinGetPackageInfo(
+                new WinGetPackageStatus(
+                    IsInstalled: false,
+                    IsInstalledStateKnown: true,
+                    IsUpdateAvailable: false,
+                    IsUpdateStateKnown: true),
+                Details: null));
+
+        Assert.IsTrue(viewModel.IsInstalled);
+        Assert.IsTrue(viewModel.ShowInstallViaWinGetButton);
+        Assert.IsTrue(viewModel.ShowWinGetStatusDetails);
+        CollectionAssert.Contains(propertyNames, nameof(viewModel.ShowInstallViaWinGetButton));
+        CollectionAssert.Contains(propertyNames, nameof(viewModel.WinGetStatusText));
+    }
+
+    [TestMethod]
+    public void TrackedWinGetUninstall_PreservesJsonRpcInstalledState()
+    {
+        var installer = new Mock<IJsExtensionInstaller>();
+        installer.Setup(x => x.IsInstalled("sample-js-extension")).Returns(true);
+        var entry = CreateJsonRpcEntry();
+        entry.InstallSources.Add(new GalleryInstallSource { Type = "winget", Id = "Contoso.Sample" });
+        var viewModel = CreateViewModel(entry, jsExtensionInstaller: installer.Object);
+
+        viewModel.ApplyTrackedOperation(CreateCompletedWinGetOperation(WinGetPackageOperationKind.Uninstall));
+
+        Assert.IsTrue(viewModel.IsInstalled);
+        Assert.IsTrue(viewModel.IsJsonRpcInstalled);
+    }
+
+    [TestMethod]
+    public async Task RefreshWinGetInstall_PreservesWinGetStateAfterJsonRpcRemoval()
+    {
+        var installer = new Mock<IJsExtensionInstaller>();
+        installer.Setup(x => x.IsInstalled("sample-js-extension")).Returns(true);
+        var entry = CreateJsonRpcEntry();
+        entry.InstallSources.Add(new GalleryInstallSource { Type = "winget", Id = "Contoso.Sample" });
+        var viewModel = CreateViewModel(entry, jsExtensionInstaller: installer.Object);
+
+        await viewModel.RefreshWinGetPackageInfoAsync(WinGetPackageOperationKind.Install);
+        viewModel.IsJsonRpcInstalled = false;
+
+        Assert.IsTrue(viewModel.IsInstalled);
+    }
+
+    [TestMethod]
+    public void DetectedInstall_PersistsAcrossOtherSourceUpdates()
+    {
+        var installer = new Mock<IJsExtensionInstaller>();
+        installer.Setup(x => x.IsInstalled("sample-js-extension")).Returns(true);
+        var entry = CreateJsonRpcEntry();
+        entry.InstallSources.Add(new GalleryInstallSource { Type = "winget", Id = "Contoso.Sample" });
+        var viewModel = CreateViewModel(entry, jsExtensionInstaller: installer.Object);
+
+        viewModel.ApplyDetectedInstallationState(true);
+        viewModel.ApplyWinGetPackageInfo(
+            new WinGetPackageInfo(
+                new WinGetPackageStatus(
+                    IsInstalled: false,
+                    IsInstalledStateKnown: true,
+                    IsUpdateAvailable: false,
+                    IsUpdateStateKnown: true),
+                Details: null));
+        viewModel.IsJsonRpcInstalled = false;
+
+        Assert.IsTrue(viewModel.IsInstalled);
+    }
+
+    private static WinGetPackageOperation CreateCompletedWinGetOperation(WinGetPackageOperationKind kind)
+    {
+        var now = DateTimeOffset.UtcNow;
+        return new WinGetPackageOperation(
+            OperationId: Guid.NewGuid(),
+            PackageId: "Contoso.Sample",
+            PackageName: "Contoso Sample",
+            Kind: kind,
+            State: WinGetPackageOperationState.Succeeded,
+            CanCancel: false,
+            IsIndeterminate: false,
+            ProgressPercent: 100,
+            BytesDownloaded: 0,
+            BytesRequired: 0,
+            ErrorMessage: null,
+            StartedAt: now,
+            UpdatedAt: now,
+            CompletedAt: now);
     }
 
     private static GalleryExtensionEntry CreateJsonRpcEntry()
@@ -833,9 +1012,10 @@ public class ExtensionGalleryItemViewModelTests
         };
     }
 
-    private static ExtensionGalleryItemViewModel CreateJsonRpcViewModel(out Mock<IJsExtensionInstaller> installer)
+    private static ExtensionGalleryItemViewModel CreateJsonRpcViewModel(out Mock<IJsExtensionInstaller> installer, bool isInstalled = false)
     {
         installer = new Mock<IJsExtensionInstaller>();
+        installer.Setup(x => x.IsInstalled("sample-js-extension")).Returns(isInstalled);
         return CreateViewModel(CreateJsonRpcEntry(), jsExtensionInstaller: installer.Object);
     }
 

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/JSExtensionWrapperTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/JSExtensionWrapperTests.cs
@@ -4,6 +4,8 @@
 
 using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.CmdPal.JsonRpc;
 using Microsoft.CmdPal.UI.ViewModels.Models;
 using Microsoft.CommandPalette.Extensions;
@@ -184,5 +186,18 @@ public class JSExtensionWrapperTests
                 Icon = icon,
             },
             extensionDirectory);
+    }
+
+    [TestMethod]
+    public async Task StartExtensionAsync_StopsBeforeLaunch_WhenCanceled()
+    {
+        var wrapper = CreateWrapper();
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        await Assert.ThrowsExactlyAsync<OperationCanceledException>(
+            () => wrapper.StartExtensionAsync(cancellation.Token));
+
+        Assert.IsFalse(wrapper.IsRunning());
     }
 }

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/JsonRpcExtensionServiceDiscoveryTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/JsonRpcExtensionServiceDiscoveryTests.cs
@@ -133,6 +133,19 @@ public class JsonRpcExtensionServiceDiscoveryTests
         Assert.IsFalse(JsonRpcExtensionService.IsUnderDirectory(_root, string.Empty));
     }
 
+    [TestMethod]
+    public void IsExtensionPresentOnDisk_ReportsPresentDirectory()
+    {
+        // A crash-disabled or corrupt install leaves the directory on disk even when the provider
+        // never loaded. Present-on-disk detection is what lets the gallery still offer Uninstall.
+        var present = Path.Combine(_root, "present-but-unloaded");
+        Directory.CreateDirectory(present);
+
+        Assert.IsTrue(JsonRpcExtensionService.IsExtensionPresentOnDisk(present));
+        Assert.IsFalse(JsonRpcExtensionService.IsExtensionPresentOnDisk(Path.Combine(_root, "missing")));
+        Assert.IsFalse(JsonRpcExtensionService.IsExtensionPresentOnDisk(string.Empty));
+    }
+
     private void CreateExtension(string dirName, string packageJson, string? entryPointRelativePath)
     {
         var dir = Path.Combine(_root, dirName);

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/JsonRpcExtensionServiceDiscoveryTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/JsonRpcExtensionServiceDiscoveryTests.cs
@@ -136,8 +136,8 @@ public class JsonRpcExtensionServiceDiscoveryTests
     [TestMethod]
     public void IsExtensionPresentOnDisk_ReportsPresentDirectory()
     {
-        // A crash-disabled or corrupt install leaves the directory on disk even when the provider
-        // never loaded. Present-on-disk detection is what lets the gallery still offer Uninstall.
+        // A crash disabled or corrupt install can leave the directory on disk even when the provider
+        // never loaded. Disk detection keeps Uninstall available.
         var present = Path.Combine(_root, "present-but-unloaded");
         Directory.CreateDirectory(present);
 

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/JsonRpcExtensionServiceDiscoveryTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/JsonRpcExtensionServiceDiscoveryTests.cs
@@ -87,6 +87,88 @@ public class JsonRpcExtensionServiceDiscoveryTests
     }
 
     [TestMethod]
+    public void RecoverStaleGalleryInstallMarkers_RemovesMarkerAndRestoresDiscovery()
+    {
+        const string PackageJson = """
+        {
+            "name": "recovered-ext",
+            "main": "index.js",
+            "cmdpal": { "displayName": "Recovered" }
+        }
+        """;
+        CreateExtension("recovered", PackageJson, "index.js");
+        var directory = Path.Combine(_root, "recovered");
+        File.WriteAllText(Path.Combine(directory, JsonRpcExtensionService.GalleryInstallMarkerFileName), string.Empty);
+
+        Assert.AreEqual(0, JsonRpcExtensionService.DiscoverManifests(_root).Count);
+
+        var failures = JsonRpcExtensionService.RecoverStaleGalleryInstallMarkers(_root);
+
+        Assert.AreEqual(0, failures.Count);
+        Assert.IsFalse(JsonRpcExtensionService.HasGalleryInstallMarker(directory));
+        Assert.AreEqual(1, JsonRpcExtensionService.DiscoverManifests(_root).Count);
+    }
+
+    [TestMethod]
+    public void DiscoverManifests_ActiveGalleryInstallMarker_IsOnlyIncludedForInstaller()
+    {
+        const string PackageJson = """
+        {
+            "name": "active-ext",
+            "main": "index.js",
+            "cmdpal": { "displayName": "Active" }
+        }
+        """;
+        CreateExtension("active", PackageJson, "index.js");
+        var directory = Path.Combine(_root, "active");
+        File.WriteAllText(Path.Combine(directory, JsonRpcExtensionService.GalleryInstallMarkerFileName), string.Empty);
+
+        Assert.IsTrue(JsonRpcExtensionService.HasGalleryInstallMarker(directory));
+        Assert.AreEqual(0, JsonRpcExtensionService.DiscoverManifests(_root).Count);
+        Assert.AreEqual(1, JsonRpcExtensionService.DiscoverManifests(_root, includeGalleryInstalling: true).Count);
+        Assert.IsFalse(JsonRpcExtensionService.ShouldRemoveExtensionDuringReconciliation(directory));
+    }
+
+    [TestMethod]
+    public void RecoverStaleGalleryInstallMarkers_DeleteFailure_LeavesExtensionSuppressed()
+    {
+        const string PackageJson = """
+        {
+            "name": "blocked-ext",
+            "main": "index.js",
+            "cmdpal": { "displayName": "Blocked" }
+        }
+        """;
+        CreateExtension("blocked", PackageJson, "index.js");
+        var directory = Path.Combine(_root, "blocked");
+        File.WriteAllText(Path.Combine(directory, JsonRpcExtensionService.GalleryInstallMarkerFileName), string.Empty);
+
+        var failures = JsonRpcExtensionService.RecoverStaleGalleryInstallMarkers(
+            _root,
+            _ => throw new IOException("marker is locked"));
+
+        Assert.AreEqual(1, failures.Count);
+        Assert.AreEqual(directory, failures[0]);
+        Assert.IsTrue(JsonRpcExtensionService.HasGalleryInstallMarker(directory));
+        Assert.AreEqual(0, JsonRpcExtensionService.DiscoverManifests(_root).Count);
+    }
+
+    [TestMethod]
+    public void IsSafeStaleGalleryMarkerPath_RejectsDirectoryOutsideRoot()
+    {
+        var outsideDirectory = Path.Combine(Path.GetTempPath(), $"JSExtOutside_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(outsideDirectory);
+        try
+        {
+            Assert.IsFalse(JsonRpcExtensionService.IsSafeStaleGalleryMarkerPath(_root, outsideDirectory));
+        }
+        finally
+        {
+            Directory.Delete(outsideDirectory);
+        }
+    }
+
+    [TestMethod]
     public void DecideCrashAction_AtOrBelowLimit_Restarts()
     {
         Assert.AreEqual(JsonRpcExtensionService.CrashAction.Restart, JsonRpcExtensionService.DecideCrashAction(1, 3));

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/JsonRpcExtensionServiceReconciliationTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/JsonRpcExtensionServiceReconciliationTests.cs
@@ -197,6 +197,23 @@ public class JsonRpcExtensionServiceReconciliationTests
     }
 
     [TestMethod]
+    public void FindManifestByDirectory_ReturnsOnlyRequestedExtension()
+    {
+        var targetDirectory = Path.Combine(_root, "target");
+        var manifests = new[]
+        {
+            (Path.Combine(_root, "other"), new JSExtensionManifest { Name = "other" }),
+            (targetDirectory, new JSExtensionManifest { Name = "target" }),
+        };
+
+        var result = JsonRpcExtensionService.FindManifestByDirectory(manifests, targetDirectory + Path.DirectorySeparatorChar);
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual(targetDirectory, result.Value.Directory);
+        Assert.AreEqual("target", result.Value.Manifest.Name);
+    }
+
+    [TestMethod]
     public void GetExtensionDirectoryForPath_ReturnsOwningTopLevelDirectory()
     {
         var manifestPath = Path.Combine(_root, "my-ext", "package.json");

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/JsonRpcExtensionServiceReconciliationTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/JsonRpcExtensionServiceReconciliationTests.cs
@@ -183,6 +183,20 @@ public class JsonRpcExtensionServiceReconciliationTests
     }
 
     [TestMethod]
+    public async Task RefreshAndAwaitProviderAsync_CallerCancellation_Throws()
+    {
+        using var service = new JsonRpcExtensionService(TaskScheduler.Default);
+        using var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.Cancel();
+
+        await Assert.ThrowsExactlyAsync<OperationCanceledException>(() =>
+            service.RefreshAndAwaitProviderAsync(
+                Path.Combine(_root, "missing"),
+                TimeSpan.FromSeconds(1),
+                cancellationTokenSource.Token));
+    }
+
+    [TestMethod]
     public void GetExtensionDirectoryForPath_ReturnsOwningTopLevelDirectory()
     {
         var manifestPath = Path.Combine(_root, "my-ext", "package.json");

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/NpmArtifactTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/NpmArtifactTests.cs
@@ -1,0 +1,185 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CmdPal.UI.ViewModels.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
+
+[TestClass]
+public class NpmArtifactTests
+{
+    private const string ValidIntegrity = "sha512-abc123==";
+
+    [TestMethod]
+    public void TryCreate_UnscopedPackage_Succeeds()
+    {
+        var ok = NpmArtifact.TryCreate("left-pad", "1.3.0", ValidIntegrity, null, out var artifact, out var error);
+
+        Assert.IsTrue(ok);
+        Assert.IsNotNull(artifact);
+        Assert.AreEqual(NpmArtifactValidationError.None, error);
+        Assert.AreEqual("left-pad", artifact!.Package);
+        Assert.AreEqual("1.3.0", artifact.Version);
+        Assert.AreEqual(ValidIntegrity, artifact.Integrity);
+        Assert.IsNull(artifact.Registry);
+        Assert.AreEqual("left-pad@1.3.0", artifact.InstallSpec);
+    }
+
+    [TestMethod]
+    public void TryCreate_ScopedPackage_Succeeds()
+    {
+        var ok = NpmArtifact.TryCreate("@contoso/sample", "2.0.1", ValidIntegrity, null, out var artifact, out var error);
+
+        Assert.IsTrue(ok);
+        Assert.AreEqual(NpmArtifactValidationError.None, error);
+        Assert.AreEqual("@contoso/sample@2.0.1", artifact!.InstallSpec);
+    }
+
+    [TestMethod]
+    public void TryCreate_ApprovedRegistry_Succeeds()
+    {
+        var ok = NpmArtifact.TryCreate("left-pad", "1.3.0", ValidIntegrity, "https://registry.npmjs.org/", out var artifact, out var error);
+
+        Assert.IsTrue(ok);
+        Assert.AreEqual(NpmArtifactValidationError.None, error);
+        Assert.AreEqual("https://registry.npmjs.org/", artifact!.Registry);
+    }
+
+    [TestMethod]
+    public void TryCreate_PrereleaseAndBuildMetadata_Succeeds()
+    {
+        var ok = NpmArtifact.TryCreate("left-pad", "1.3.0-beta.1+build.5", ValidIntegrity, null, out var artifact, out var error);
+
+        Assert.IsTrue(ok);
+        Assert.AreEqual(NpmArtifactValidationError.None, error);
+        Assert.AreEqual("1.3.0-beta.1+build.5", artifact!.Version);
+    }
+
+    [TestMethod]
+    public void TryCreate_MissingPackage_FailsClosed()
+    {
+        var ok = NpmArtifact.TryCreate("   ", "1.3.0", ValidIntegrity, null, out var artifact, out var error);
+
+        Assert.IsFalse(ok);
+        Assert.IsNull(artifact);
+        Assert.AreEqual(NpmArtifactValidationError.PackageMissing, error);
+    }
+
+    [DataTestMethod]
+    [DataRow("-flag")]
+    [DataRow("../escape")]
+    [DataRow("has space")]
+    [DataRow("https://evil.example/pkg.tgz")]
+    [DataRow("git+https://example.com/x.git")]
+    [DataRow("./local/path")]
+    [DataRow("@scope")]
+    public void TryCreate_InvalidPackage_FailsClosed(string package)
+    {
+        var ok = NpmArtifact.TryCreate(package, "1.3.0", ValidIntegrity, null, out var artifact, out var error);
+
+        Assert.IsFalse(ok);
+        Assert.IsNull(artifact);
+        Assert.AreEqual(NpmArtifactValidationError.PackageInvalid, error);
+    }
+
+    [TestMethod]
+    public void TryCreate_MissingVersion_FailsClosed()
+    {
+        var ok = NpmArtifact.TryCreate("left-pad", null, ValidIntegrity, null, out _, out var error);
+
+        Assert.IsFalse(ok);
+        Assert.AreEqual(NpmArtifactValidationError.VersionMissing, error);
+    }
+
+    [DataTestMethod]
+    [DataRow("latest")]
+    [DataRow("^1.3.0")]
+    [DataRow("~1.3.0")]
+    [DataRow(">=1.0.0")]
+    [DataRow("1.x")]
+    [DataRow("1.2")]
+    [DataRow("*")]
+    [DataRow("1.2.3 || 2.0.0")]
+    public void TryCreate_RangeOrDistTagVersion_FailsClosed(string version)
+    {
+        var ok = NpmArtifact.TryCreate("left-pad", version, ValidIntegrity, null, out _, out var error);
+
+        Assert.IsFalse(ok);
+        Assert.AreEqual(NpmArtifactValidationError.VersionInvalid, error);
+    }
+
+    [TestMethod]
+    public void TryCreate_MissingIntegrity_FailsClosed()
+    {
+        var ok = NpmArtifact.TryCreate("left-pad", "1.3.0", string.Empty, null, out _, out var error);
+
+        Assert.IsFalse(ok);
+        Assert.AreEqual(NpmArtifactValidationError.IntegrityMissing, error);
+    }
+
+    [DataTestMethod]
+    [DataRow("sha1-abc123==")]
+    [DataRow("sha256-abc123==")]
+    [DataRow("abc123")]
+    [DataRow("sha512-")]
+    public void TryCreate_UnsupportedIntegrity_FailsClosed(string integrity)
+    {
+        var ok = NpmArtifact.TryCreate("left-pad", "1.3.0", integrity, null, out _, out var error);
+
+        Assert.IsFalse(ok);
+        Assert.AreEqual(NpmArtifactValidationError.IntegrityInvalid, error);
+    }
+
+    [DataTestMethod]
+    [DataRow("http://registry.npmjs.org/")]
+    [DataRow("https://evil.example.com/")]
+    [DataRow("ftp://registry.npmjs.org/")]
+    [DataRow("registry.npmjs.org")]
+    [DataRow("not a url")]
+    [DataRow("https://registry.npmjs.org/?x=1&calc")]
+    [DataRow("https://registry.npmjs.org/#frag")]
+    [DataRow("https://user:pass@registry.npmjs.org/")]
+    [DataRow("https://registry.npmjs.org:8443/")]
+    [DataRow("https://registry.npmjs.org/some/path")]
+    public void TryCreate_UnapprovedRegistry_FailsClosed(string registry)
+    {
+        var ok = NpmArtifact.TryCreate("left-pad", "1.3.0", ValidIntegrity, registry, out _, out var error);
+
+        Assert.IsFalse(ok);
+        Assert.AreEqual(NpmArtifactValidationError.RegistryInvalid, error);
+    }
+
+    [DataTestMethod]
+    [DataRow("https://registry.npmjs.org/", "https://registry.npmjs.org/")]
+    [DataRow("https://registry.npmjs.org", "https://registry.npmjs.org/")]
+    [DataRow("  https://registry.npmjs.org/  ", "https://registry.npmjs.org/")]
+    [DataRow("https://REGISTRY.NPMJS.ORG/", "https://registry.npmjs.org/")]
+    public void TryCreate_ApprovedRegistry_IsCanonicalized(string registry, string expected)
+    {
+        var ok = NpmArtifact.TryCreate("left-pad", "1.3.0", ValidIntegrity, registry, out var artifact, out var error);
+
+        Assert.IsTrue(ok);
+        Assert.AreEqual(NpmArtifactValidationError.None, error);
+        Assert.AreEqual(expected, artifact!.Registry);
+    }
+
+    [DataTestMethod]
+    [DataRow("https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz", true)]
+    [DataRow("http://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz", false)]
+    [DataRow("https://evil.example.com/left-pad/-/left-pad-1.3.0.tgz", false)]
+    [DataRow("git+https://github.com/foo/bar.git", false)]
+    [DataRow("file:../local", false)]
+    [DataRow("", false)]
+    public void IsRegistrySourcedHttps_AcceptsOnlyApprovedHttpsHosts(string url, bool expected) =>
+        Assert.AreEqual(expected, NpmArtifact.IsRegistrySourcedHttps(url));
+
+    [DataTestMethod]
+    [DataRow("sha512-abc123==", true)]
+    [DataRow("sha1-abc123=", false)]
+    [DataRow("abc123", false)]
+    [DataRow("", false)]
+    public void IsSupportedIntegrity_AcceptsOnlySha512(string integrity, bool expected) =>
+        Assert.AreEqual(expected, NpmArtifact.IsSupportedIntegrity(integrity));
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/NpmCommandRunnerTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/NpmCommandRunnerTests.cs
@@ -48,7 +48,7 @@ public class NpmCommandRunnerTests
 
         var args = NpmCommandRunner.BuildPackArguments(artifact!, "C:\\stage\\pack").ToArray();
 
-        // The spec token (second argument) must never begin with '-', so npm cannot read it as a flag.
+        // The spec token must not begin with '-', or npm could read it as a flag.
         Assert.IsFalse(args[1].StartsWith('-'));
     }
 
@@ -77,8 +77,8 @@ public class NpmCommandRunnerTests
         CollectionAssert.Contains(args, "--no-fund");
         CollectionAssert.Contains(args, "--loglevel=error");
 
-        // npm ci installs the frozen closure named in the shrinkwrap; it must never carry a package
-        // spec or version, because doing so would re-open range resolution at install time.
+        // npm ci installs the frozen closure named in the shrinkwrap. Do not pass a package spec or
+        // version, because that would open range resolution again.
         CollectionAssert.DoesNotContain(args, artifact!.InstallSpec);
         CollectionAssert.DoesNotContain(args, "install");
         CollectionAssert.DoesNotContain(args, "--save-exact");
@@ -108,7 +108,7 @@ public class NpmCommandRunnerTests
     [TestMethod]
     public void RequirePublisherShrinkwrap_ReturnsError_WhenShrinkwrapMissing()
     {
-        // Fail closed: a package that only ships a package.json but no frozen closure is rejected.
+        // Fail closed when a package ships package.json but no frozen closure.
         var packageRoot = CreateTempDirectory();
         File.WriteAllText(Path.Combine(packageRoot, "package.json"), "{\"name\":\"x\",\"version\":\"1.0.0\"}");
         File.WriteAllText(Path.Combine(packageRoot, "package-lock.json"), "{}");
@@ -153,9 +153,9 @@ public class NpmCommandRunnerTests
     [TestMethod]
     public void TryExtractPackage_ExtractsPublishedRoot_WithEmbeddedShrinkwrap()
     {
-        // Build a real npm-style tarball (gzip tar rooted under "package/") that embeds a shrinkwrap,
-        // then prove the runner unpacks it so the published package becomes the root project and the
-        // shrinkwrap gate can see the frozen closure. No network is involved.
+        // Build a real npm tarball (gzip tar rooted under "package/") with a shrinkwrap, then prove
+        // the runner makes the published package the root project so the gate can see the frozen
+        // closure. No network needed.
         var dir = CreateTempDirectory();
         var tarball = Path.Combine(dir, "sample.tgz");
         WriteNpmTarball(tarball, new[]
@@ -195,8 +195,8 @@ public class NpmCommandRunnerTests
     [TestMethod]
     public void VerifyLockfileIntegrity_ReadsPublisherShrinkwrap_WhenNoPackageLock()
     {
-        // Only the shrinkwrap is present (as it would be after npm ci consumes it). The trusted
-        // URL + SRI gate must read it and accept a fully pinned, registry-sourced closure.
+        // Only the shrinkwrap is present, as it would be after npm ci consumes it. The trusted URL and
+        // SRI gate must accept a fully pinned closure from the registry.
         var dir = CreateTempDirectory();
         var shrinkwrap = """
         {
@@ -258,8 +258,8 @@ public class NpmCommandRunnerTests
         {
             var removed = runner.RemoveDirectory(junction);
 
-            // The runner must refuse to recurse through the reparse point, and the real target's
-            // contents must be untouched.
+            // The runner must refuse to recurse through the reparse point, and the real target must stay
+            // untouched.
             Assert.IsFalse(removed);
             Assert.IsTrue(File.Exists(sentinel));
         }
@@ -279,7 +279,7 @@ public class NpmCommandRunnerTests
     [TestMethod]
     public void ResolveNpmInvocation_UsesNodeExeAndNpmCliJs_NotNpmCmd()
     {
-        // Lay out a fake Node.js install: node.exe on PATH with npm-cli.js under its node_modules.
+        // Lay out a fake Node.js install: node.exe on PATH with npm-cli.js under node_modules.
         var nodeDir = CreateTempDirectory();
         var nodeExe = Path.Combine(nodeDir, "node.exe");
         File.WriteAllText(nodeExe, "binary");
@@ -410,8 +410,8 @@ public class NpmCommandRunnerTests
     }
 
     /// <summary>
-    /// Writes a gzip-compressed tar archive (the format npm publishes) containing the given entries,
-    /// so extraction can be exercised without any network access.
+    /// Writes a gzip compressed tar archive in npm's published format so extraction can be tested
+    /// without network access.
     /// </summary>
     private static void WriteNpmTarball(string tarballPath, (string Name, string Content)[] entries)
     {

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/NpmCommandRunnerTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/NpmCommandRunnerTests.cs
@@ -1,0 +1,462 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.Formats.Tar;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+using Microsoft.CmdPal.UI.ViewModels.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
+
+[TestClass]
+public class NpmCommandRunnerTests
+{
+    private const string ValidIntegrity = "sha512-abc123==";
+
+    [TestMethod]
+    public void BuildPackArguments_UsesExactSpec_DisablesScripts_AndWritesToDestination()
+    {
+        Assert.IsTrue(NpmArtifact.TryCreate("@contoso/sample", "1.2.3", ValidIntegrity, null, out var artifact, out _));
+
+        var args = NpmCommandRunner.BuildPackArguments(artifact!, "C:\\stage\\pack").ToArray();
+
+        Assert.AreEqual("pack", args[0]);
+        Assert.AreEqual("@contoso/sample@1.2.3", args[1]);
+        CollectionAssert.Contains(args, "--ignore-scripts");
+        CollectionAssert.Contains(args, "--no-audit");
+        CollectionAssert.Contains(args, "--no-fund");
+        CollectionAssert.Contains(args, "--loglevel=error");
+
+        var destinationIndex = args.ToList().IndexOf("--pack-destination");
+        Assert.IsTrue(destinationIndex >= 0);
+        Assert.AreEqual("C:\\stage\\pack", args[destinationIndex + 1]);
+
+        // With no registry configured, the registry flag is never emitted.
+        CollectionAssert.DoesNotContain(args, "--registry");
+    }
+
+    [TestMethod]
+    public void BuildPackArguments_NeverEmitsAFlagLikeSpec()
+    {
+        Assert.IsTrue(NpmArtifact.TryCreate("left-pad", "1.3.0", ValidIntegrity, null, out var artifact, out _));
+
+        var args = NpmCommandRunner.BuildPackArguments(artifact!, "C:\\stage\\pack").ToArray();
+
+        // The spec token (second argument) must never begin with '-', so npm cannot read it as a flag.
+        Assert.IsFalse(args[1].StartsWith('-'));
+    }
+
+    [TestMethod]
+    public void BuildPackArguments_PassesApprovedRegistry_ThroughItsOwnFlag()
+    {
+        Assert.IsTrue(NpmArtifact.TryCreate("left-pad", "1.3.0", ValidIntegrity, "https://registry.npmjs.org/", out var artifact, out _));
+
+        var args = NpmCommandRunner.BuildPackArguments(artifact!, "C:\\stage\\pack").ToArray();
+
+        var registryIndex = args.ToList().IndexOf("--registry");
+        Assert.IsTrue(registryIndex >= 0);
+        Assert.AreEqual("https://registry.npmjs.org/", args[registryIndex + 1]);
+    }
+
+    [TestMethod]
+    public void BuildCiArguments_RunsCi_WithoutAnyPackageSpec()
+    {
+        Assert.IsTrue(NpmArtifact.TryCreate("@contoso/sample", "1.2.3", ValidIntegrity, null, out var artifact, out _));
+
+        var args = NpmCommandRunner.BuildCiArguments(artifact!).ToArray();
+
+        Assert.AreEqual("ci", args[0]);
+        CollectionAssert.Contains(args, "--ignore-scripts");
+        CollectionAssert.Contains(args, "--no-audit");
+        CollectionAssert.Contains(args, "--no-fund");
+        CollectionAssert.Contains(args, "--loglevel=error");
+
+        // npm ci installs the frozen closure named in the shrinkwrap; it must never carry a package
+        // spec or version, because doing so would re-open range resolution at install time.
+        CollectionAssert.DoesNotContain(args, artifact!.InstallSpec);
+        CollectionAssert.DoesNotContain(args, "install");
+        CollectionAssert.DoesNotContain(args, "--save-exact");
+    }
+
+    [TestMethod]
+    public void BuildCiArguments_PassesApprovedRegistry_ThroughItsOwnFlag()
+    {
+        Assert.IsTrue(NpmArtifact.TryCreate("left-pad", "1.3.0", ValidIntegrity, "https://registry.npmjs.org/", out var artifact, out _));
+
+        var args = NpmCommandRunner.BuildCiArguments(artifact!).ToArray();
+
+        var registryIndex = args.ToList().IndexOf("--registry");
+        Assert.IsTrue(registryIndex >= 0);
+        Assert.AreEqual("https://registry.npmjs.org/", args[registryIndex + 1]);
+    }
+
+    [TestMethod]
+    public void RequirePublisherShrinkwrap_ReturnsNull_WhenShrinkwrapPresent()
+    {
+        var packageRoot = CreateTempDirectory();
+        File.WriteAllText(Path.Combine(packageRoot, "npm-shrinkwrap.json"), "{}");
+
+        Assert.IsNull(NpmCommandRunner.RequirePublisherShrinkwrap(packageRoot));
+    }
+
+    [TestMethod]
+    public void RequirePublisherShrinkwrap_ReturnsError_WhenShrinkwrapMissing()
+    {
+        // Fail closed: a package that only ships a package.json but no frozen closure is rejected.
+        var packageRoot = CreateTempDirectory();
+        File.WriteAllText(Path.Combine(packageRoot, "package.json"), "{\"name\":\"x\",\"version\":\"1.0.0\"}");
+        File.WriteAllText(Path.Combine(packageRoot, "package-lock.json"), "{}");
+
+        var error = NpmCommandRunner.RequirePublisherShrinkwrap(packageRoot);
+
+        Assert.IsNotNull(error);
+        Assert.AreEqual(Microsoft.CmdPal.UI.ViewModels.Properties.Resources.npm_runner_shrinkwrap_required, error);
+    }
+
+    [TestMethod]
+    public void ComputeTarballIntegrity_ReturnsSha512SubresourceIntegrity()
+    {
+        var dir = CreateTempDirectory();
+        var tarball = Path.Combine(dir, "sample.tgz");
+        var bytes = new byte[] { 1, 2, 3, 4, 5 };
+        File.WriteAllBytes(tarball, bytes);
+
+        var expected = "sha512-" + Convert.ToBase64String(System.Security.Cryptography.SHA512.HashData(bytes));
+
+        Assert.AreEqual(expected, NpmCommandRunner.ComputeTarballIntegrity(tarball));
+    }
+
+    [TestMethod]
+    public void FindPackedTarball_ReturnsTheSingleTgz()
+    {
+        var dir = CreateTempDirectory();
+        var tarball = Path.Combine(dir, "left-pad-1.3.0.tgz");
+        File.WriteAllText(tarball, "x");
+
+        Assert.AreEqual(tarball, NpmCommandRunner.FindPackedTarball(dir));
+    }
+
+    [TestMethod]
+    public void FindPackedTarball_ReturnsNull_WhenNoTarball()
+    {
+        var dir = CreateTempDirectory();
+
+        Assert.IsNull(NpmCommandRunner.FindPackedTarball(dir));
+    }
+
+    [TestMethod]
+    public void TryExtractPackage_ExtractsPublishedRoot_WithEmbeddedShrinkwrap()
+    {
+        // Build a real npm-style tarball (gzip tar rooted under "package/") that embeds a shrinkwrap,
+        // then prove the runner unpacks it so the published package becomes the root project and the
+        // shrinkwrap gate can see the frozen closure. No network is involved.
+        var dir = CreateTempDirectory();
+        var tarball = Path.Combine(dir, "sample.tgz");
+        WriteNpmTarball(tarball, new[]
+        {
+            ("package/package.json", "{\"name\":\"sample\",\"version\":\"1.0.0\"}"),
+            ("package/npm-shrinkwrap.json", "{\"lockfileVersion\":3,\"packages\":{\"\":{\"name\":\"sample\"}}}"),
+            ("package/index.js", "module.exports = {};"),
+        });
+
+        var packageRoot = Path.Combine(dir, "package");
+
+        var error = NpmCommandRunner.TryExtractPackage(tarball, packageRoot);
+
+        Assert.IsNull(error);
+        Assert.IsTrue(File.Exists(Path.Combine(packageRoot, "package.json")));
+        Assert.IsTrue(File.Exists(Path.Combine(packageRoot, "npm-shrinkwrap.json")));
+        Assert.IsNull(NpmCommandRunner.RequirePublisherShrinkwrap(packageRoot));
+    }
+
+    [TestMethod]
+    public void TryExtractPackage_ThenRequireShrinkwrap_RejectsTarballWithoutShrinkwrap()
+    {
+        var dir = CreateTempDirectory();
+        var tarball = Path.Combine(dir, "sample.tgz");
+        WriteNpmTarball(tarball, new[]
+        {
+            ("package/package.json", "{\"name\":\"sample\",\"version\":\"1.0.0\"}"),
+            ("package/index.js", "module.exports = {};"),
+        });
+
+        var packageRoot = Path.Combine(dir, "package");
+
+        Assert.IsNull(NpmCommandRunner.TryExtractPackage(tarball, packageRoot));
+        Assert.IsNotNull(NpmCommandRunner.RequirePublisherShrinkwrap(packageRoot));
+    }
+
+    [TestMethod]
+    public void VerifyLockfileIntegrity_ReadsPublisherShrinkwrap_WhenNoPackageLock()
+    {
+        // Only the shrinkwrap is present (as it would be after npm ci consumes it). The trusted
+        // URL + SRI gate must read it and accept a fully pinned, registry-sourced closure.
+        var dir = CreateTempDirectory();
+        var shrinkwrap = """
+        {
+          "lockfileVersion": 3,
+          "packages": {
+            "": { "name": "root" },
+            "node_modules/left-pad": {
+              "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+              "integrity": "sha512-abc123=="
+            }
+          }
+        }
+        """;
+        File.WriteAllText(Path.Combine(dir, "npm-shrinkwrap.json"), shrinkwrap);
+
+        Assert.IsNull(NpmCommandRunner.VerifyLockfileIntegrity(dir));
+    }
+
+    [TestMethod]
+    public void RemoveDirectory_DeletesAnOrdinaryDirectory()
+    {
+        var runner = new NpmCommandRunner();
+        var dir = CreateTempDirectory();
+        File.WriteAllText(Path.Combine(dir, "file.txt"), "x");
+
+        var removed = runner.RemoveDirectory(dir);
+
+        Assert.IsTrue(removed);
+        Assert.IsFalse(Directory.Exists(dir));
+    }
+
+    [TestMethod]
+    public void RemoveDirectory_ReturnsTrue_ForMissingDirectory()
+    {
+        var runner = new NpmCommandRunner();
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+
+        Assert.IsTrue(runner.RemoveDirectory(dir));
+    }
+
+    [TestMethod]
+    public void RemoveDirectory_RefusesToFollowAJunction_AndPreservesTheTarget()
+    {
+        var runner = new NpmCommandRunner();
+        var realTarget = CreateTempDirectory();
+        var sentinel = Path.Combine(realTarget, "keep.txt");
+        File.WriteAllText(sentinel, "precious");
+
+        var junctionParent = CreateTempDirectory();
+        var junction = Path.Combine(junctionParent, "link");
+
+        if (!TryCreateJunction(junction, realTarget))
+        {
+            Assert.Inconclusive("Could not create a junction on this machine.");
+            return;
+        }
+
+        try
+        {
+            var removed = runner.RemoveDirectory(junction);
+
+            // The runner must refuse to recurse through the reparse point, and the real target's
+            // contents must be untouched.
+            Assert.IsFalse(removed);
+            Assert.IsTrue(File.Exists(sentinel));
+        }
+        finally
+        {
+            // Remove the junction itself without following it, then the real target.
+            try
+            {
+                Directory.Delete(junction);
+            }
+            catch (IOException)
+            {
+            }
+        }
+    }
+
+    [TestMethod]
+    public void ResolveNpmInvocation_UsesNodeExeAndNpmCliJs_NotNpmCmd()
+    {
+        // Lay out a fake Node.js install: node.exe on PATH with npm-cli.js under its node_modules.
+        var nodeDir = CreateTempDirectory();
+        var nodeExe = Path.Combine(nodeDir, "node.exe");
+        File.WriteAllText(nodeExe, "binary");
+
+        // A sibling npm.cmd must be ignored in favor of the JavaScript entry point.
+        File.WriteAllText(Path.Combine(nodeDir, "npm.cmd"), "@echo off");
+
+        var npmCli = Path.Combine(nodeDir, "node_modules", "npm", "bin", "npm-cli.js");
+        Directory.CreateDirectory(Path.GetDirectoryName(npmCli)!);
+        File.WriteAllText(npmCli, "// npm");
+
+        var invocation = NpmCommandRunner.ResolveNpmInvocation(new[] { nodeDir });
+
+        Assert.IsNotNull(invocation);
+        Assert.AreEqual(nodeExe, invocation.Value.FileName);
+        Assert.AreEqual(1, invocation.Value.LauncherArguments.Count);
+        Assert.AreEqual(npmCli, invocation.Value.LauncherArguments[0]);
+        Assert.IsFalse(invocation.Value.FileName.EndsWith("npm.cmd", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [TestMethod]
+    public void ResolveNpmInvocation_ReturnsNull_WhenNpmCliMissing()
+    {
+        var nodeDir = CreateTempDirectory();
+        File.WriteAllText(Path.Combine(nodeDir, "node.exe"), "binary");
+
+        // No npm-cli.js anywhere reachable from this directory.
+        var invocation = NpmCommandRunner.ResolveNpmInvocation(new[] { nodeDir });
+
+        Assert.IsNull(invocation);
+    }
+
+    [TestMethod]
+    public void VerifyLockfileIntegrity_AcceptsRegistrySourcedTreeWithIntegrity()
+    {
+        var dir = CreateTempDirectory();
+        var lockfile = """
+        {
+          "lockfileVersion": 3,
+          "packages": {
+            "": { "name": "root" },
+            "node_modules/left-pad": {
+              "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+              "integrity": "sha512-abc123=="
+            }
+          }
+        }
+        """;
+        File.WriteAllText(Path.Combine(dir, "package-lock.json"), lockfile);
+
+        Assert.IsNull(NpmCommandRunner.VerifyLockfileIntegrity(dir));
+    }
+
+    [TestMethod]
+    public void VerifyLockfileIntegrity_RejectsNonRegistryResolution()
+    {
+        var dir = CreateTempDirectory();
+        var lockfile = """
+        {
+          "lockfileVersion": 3,
+          "packages": {
+            "": { "name": "root" },
+            "node_modules/evil": {
+              "resolved": "https://evil.example.com/evil/-/evil-1.0.0.tgz",
+              "integrity": "sha512-abc123=="
+            }
+          }
+        }
+        """;
+        File.WriteAllText(Path.Combine(dir, "package-lock.json"), lockfile);
+
+        Assert.IsNotNull(NpmCommandRunner.VerifyLockfileIntegrity(dir));
+    }
+
+    [TestMethod]
+    public void VerifyLockfileIntegrity_RejectsIntegrityLessResolution()
+    {
+        var dir = CreateTempDirectory();
+        var lockfile = """
+        {
+          "lockfileVersion": 3,
+          "packages": {
+            "": { "name": "root" },
+            "node_modules/left-pad": {
+              "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz"
+            }
+          }
+        }
+        """;
+        File.WriteAllText(Path.Combine(dir, "package-lock.json"), lockfile);
+
+        Assert.IsNotNull(NpmCommandRunner.VerifyLockfileIntegrity(dir));
+    }
+
+    [TestMethod]
+    public void VerifyLockfileIntegrity_FailsClosed_WhenLockfileMissing()
+    {
+        var dir = CreateTempDirectory();
+
+        Assert.IsNotNull(NpmCommandRunner.VerifyLockfileIntegrity(dir));
+    }
+
+    [TestMethod]
+    public void VerifyLockfileIntegrity_RejectsLegacyFileResolution()
+    {
+        var dir = CreateTempDirectory();
+        var lockfile = """
+        {
+          "lockfileVersion": 1,
+          "dependencies": {
+            "left-pad": {
+              "version": "file:../left-pad",
+              "resolved": "file:../left-pad"
+            }
+          }
+        }
+        """;
+        File.WriteAllText(Path.Combine(dir, "package-lock.json"), lockfile);
+
+        Assert.IsNotNull(NpmCommandRunner.VerifyLockfileIntegrity(dir));
+    }
+
+    private static string CreateTempDirectory()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "cmdpal-runner-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    /// <summary>
+    /// Writes a gzip-compressed tar archive (the format npm publishes) containing the given entries,
+    /// so extraction can be exercised without any network access.
+    /// </summary>
+    private static void WriteNpmTarball(string tarballPath, (string Name, string Content)[] entries)
+    {
+        using var fileStream = File.Create(tarballPath);
+        using var gzipStream = new GZipStream(fileStream, CompressionMode.Compress);
+        using var tarWriter = new TarWriter(gzipStream, TarEntryFormat.Pax);
+
+        foreach (var (name, content) in entries)
+        {
+            var entry = new PaxTarEntry(TarEntryType.RegularFile, name);
+            var bytes = Encoding.UTF8.GetBytes(content);
+            entry.DataStream = new MemoryStream(bytes);
+            tarWriter.WriteEntry(entry);
+        }
+    }
+
+    private static bool TryCreateJunction(string junctionPath, string targetPath)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo("cmd.exe")
+            {
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+            };
+            psi.ArgumentList.Add("/c");
+            psi.ArgumentList.Add("mklink");
+            psi.ArgumentList.Add("/J");
+            psi.ArgumentList.Add(junctionPath);
+            psi.ArgumentList.Add(targetPath);
+
+            using var process = Process.Start(psi);
+            if (process is null)
+            {
+                return false;
+            }
+
+            process.WaitForExit();
+            return process.ExitCode == 0 && Directory.Exists(junctionPath);
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/NpmCommandRunnerTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/NpmCommandRunnerTests.cs
@@ -3,12 +3,15 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Formats.Tar;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.CmdPal.UI.ViewModels.Services;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -148,6 +151,61 @@ public class NpmCommandRunnerTests
         var dir = CreateTempDirectory();
 
         Assert.IsNull(NpmCommandRunner.FindPackedTarball(dir));
+    }
+
+    [TestMethod]
+    public async Task TerminateAndWaitAsync_AggregateFailure_PreservesCallerCancellation()
+    {
+        var originalCancellation = new OperationCanceledException();
+
+        var thrown = await Assert.ThrowsExactlyAsync<OperationCanceledException>(async () =>
+        {
+            try
+            {
+                throw originalCancellation;
+            }
+            catch (OperationCanceledException)
+            {
+                await NpmCommandRunner.TerminateAndWaitAsync(
+                    () => false,
+                    () => throw new AggregateException(new Win32Exception("kill failed")),
+                    _ => Task.CompletedTask);
+                throw;
+            }
+        });
+
+        Assert.AreSame(originalCancellation, thrown);
+    }
+
+    [TestMethod]
+    public async Task TerminateAndWaitAsync_AggregateFailure_PreservesTimeoutHandling()
+    {
+        var timeoutHandled = false;
+
+        try
+        {
+            throw new OperationCanceledException();
+        }
+        catch (OperationCanceledException)
+        {
+            await NpmCommandRunner.TerminateAndWaitAsync(
+                () => false,
+                () => throw new AggregateException(new NotSupportedException("kill failed")),
+                _ => Task.CompletedTask);
+            timeoutHandled = true;
+        }
+
+        Assert.IsTrue(timeoutHandled);
+    }
+
+    [TestMethod]
+    public async Task TerminateAndWaitAsync_AggregateWithUnexpectedFailure_Propagates()
+    {
+        await Assert.ThrowsExactlyAsync<AggregateException>(() =>
+            NpmCommandRunner.TerminateAndWaitAsync(
+                () => false,
+                () => throw new AggregateException(new Win32Exception(), new InvalidDataException()),
+                _ => Task.CompletedTask));
     }
 
     [TestMethod]

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/NpmJsExtensionInstallerTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/NpmJsExtensionInstallerTests.cs
@@ -57,8 +57,8 @@ public class NpmJsExtensionInstallerTests
     [TestMethod]
     public async Task InstallAsync_FailsClosed_WhenPublisherShrinkwrapMissing()
     {
-        // r3-p5-01: a package whose publisher did not freeze the dependency closure with a published
-        // npm-shrinkwrap.json is rejected, and nothing is promoted into the watched root.
+        // r3-p5-01: reject a package that did not freeze its dependency closure with a published
+        // npm-shrinkwrap.json. Nothing should reach the watched root.
         var host = CreateHost();
         var runner = new FakeRunner { PublisherShipsShrinkwrap = false };
         var installer = new NpmJsExtensionInstaller(host, runner);
@@ -77,8 +77,8 @@ public class NpmJsExtensionInstallerTests
     [TestMethod]
     public async Task InstallAsync_PromotesPublisherFrozenClosure_WhenShrinkwrapPresent()
     {
-        // r3-p5-01: when the publisher shipped a shrinkwrap, the exact frozen tree the runner produced
-        // is what lands in the watched root, shrinkwrap and all, with no re-resolution by the installer.
+        // r3-p5-01: when the publisher ships a shrinkwrap, the frozen tree from the runner is what
+        // lands in the watched root. The installer does not resolve dependencies again.
         var host = CreateHost();
         var runner = new FakeRunner { HoistedDependencies = ["left-pad", "ms"] };
         var installer = new NpmJsExtensionInstaller(host, runner);
@@ -89,10 +89,10 @@ public class NpmJsExtensionInstallerTests
         var target = Path.Combine(host.ExtensionsRootPath, ExtensionName);
         Assert.IsTrue(File.Exists(Path.Combine(target, "package.json")));
 
-        // The publisher-frozen shrinkwrap travels with the promoted extension.
+        // The shrinkwrap travels with the promoted extension.
         Assert.IsTrue(File.Exists(Path.Combine(target, "npm-shrinkwrap.json")));
 
-        // The exact closure the publisher froze is installed under the package's own node_modules.
+        // The frozen dependency closure is installed under the package's own node_modules.
         Assert.IsTrue(Directory.Exists(Path.Combine(target, "node_modules", "left-pad")));
         Assert.IsTrue(Directory.Exists(Path.Combine(target, "node_modules", "ms")));
         AssertStagingEmpty(host);
@@ -111,7 +111,7 @@ public class NpmJsExtensionInstallerTests
         var target = Path.Combine(host.ExtensionsRootPath, ExtensionName);
         Assert.IsTrue(File.Exists(Path.Combine(target, "package.json")));
 
-        // The hoisted dependencies must sit under the promoted package's own node_modules.
+        // Hoisted dependencies must stay under the promoted package's own node_modules.
         Assert.IsTrue(Directory.Exists(Path.Combine(target, "node_modules", "left-pad")));
         Assert.IsTrue(Directory.Exists(Path.Combine(target, "node_modules", "ms")));
         AssertStagingEmpty(host);
@@ -141,7 +141,7 @@ public class NpmJsExtensionInstallerTests
         var runner = new FakeRunner();
         var installer = new NpmJsExtensionInstaller(host, runner);
 
-        // Missing version and integrity: never installable, npm is never invoked.
+        // Missing version and integrity means never installable, and npm is never invoked.
         var result = await installer.InstallAsync(ExtensionName, Package, null, null, null, CancellationToken.None);
 
         Assert.IsFalse(result.Succeeded);
@@ -370,9 +370,9 @@ public class NpmJsExtensionInstallerTests
         using var stopStarted = new ManualResetEventSlim(false);
         host.StopHook = token =>
         {
-            // Simulate the host blocking while it stops the provider, then observe the cancel that
-            // arrives after the operation has already begun. This mirrors the real host threading the
-            // uninstall token into its stop/delete steps.
+            // Simulate the host blocking while it stops the provider, then observe cancel after the
+            // operation has already begun. This matches the real host threading the uninstall token
+            // through stop and delete.
             stopStarted.Set();
             Assert.IsTrue(token.WaitHandle.WaitOne(TimeSpan.FromSeconds(5)), "Cancellation was not observed during stop.");
             token.ThrowIfCancellationRequested();
@@ -452,7 +452,7 @@ public class NpmJsExtensionInstallerTests
         var host = CreateHost();
         host.OrderLog = order;
 
-        // Hold registration open long enough to cancel while the extension is already promoted.
+        // Hold registration open long enough to cancel after the extension is promoted.
         host.RegistrationDelay = TimeSpan.FromSeconds(30);
         using var registrationStarted = new ManualResetEventSlim(false);
         host.RegistrationStarted = registrationStarted;
@@ -470,7 +470,7 @@ public class NpmJsExtensionInstallerTests
 
         Assert.IsFalse(result.Succeeded, "A canceled install must not report success.");
 
-        // Rollback must stop the host before removing the promoted directory so nothing is left both
+        // Rollback must stop the host before removing the promoted directory so nothing is left
         // installed and running.
         var log = order.ToArray();
         Assert.IsTrue(log.Length >= 2, "Rollback did not run stop and remove.");
@@ -486,10 +486,10 @@ public class NpmJsExtensionInstallerTests
     [TestMethod]
     public async Task InstallAsync_PreservesMixedScopedAndUnscopedDependencies()
     {
-        // The publisher-frozen closure npm ci installs under the package's own node_modules, including
-        // @scope directories, survives promotion so scoped, unscoped, and mixed dependencies all land
-        // in the promoted extension. The scoped-merge discard defect lives only in the phase-6
-        // JsExtensionPackageLayout, which is absent from phase-5.
+        // The closure npm ci installs under the package's own node_modules, including @scope
+        // directories, survives promotion. Scoped, unscoped, and mixed dependencies all land in the
+        // promoted extension. The scoped merge discard defect lives only in the phase 6
+        // JsExtensionPackageLayout, which is absent from phase 5.
         var host = CreateHost();
         var runner = new FakeRunner
         {
@@ -544,8 +544,8 @@ public class NpmJsExtensionInstallerTests
             }
         }
 
-        // Serialization plus the block-if-exists upgrade policy means exactly one install runs npm and
-        // succeeds while the other is refused, and npm is invoked only once.
+        // Serialization plus the block if exists upgrade policy means exactly one install runs npm and
+        // succeeds while the other is refused. npm is invoked only once.
         Assert.AreEqual(1, succeeded);
         Assert.AreEqual(1, blocked);
         Assert.AreEqual(1, runner.InstallCallCount);
@@ -565,7 +565,7 @@ public class NpmJsExtensionInstallerTests
                 bothEntered.Signal();
 
                 // Block until both installs have entered npm. If the installer serialized different
-                // directories this would deadlock and the wait below would time out.
+                // directories, this would deadlock and the wait below would time out.
                 Assert.IsTrue(release.Wait(TimeSpan.FromSeconds(5), hookToken), "Second install did not run in parallel.");
                 return Task.CompletedTask;
             },
@@ -794,9 +794,9 @@ public class NpmJsExtensionInstallerTests
                 return forced;
             }
 
-            // The real runner rejects a package whose publisher did not freeze the dependency closure
-            // with a published npm-shrinkwrap.json. Model that fail-closed decision before any package
-            // is materialized so nothing can be promoted.
+            // The real runner rejects packages that did not freeze their dependency closure with a
+            // published npm-shrinkwrap.json. Model that decision before any package is materialized so
+            // nothing can be promoted.
             if (!PublisherShipsShrinkwrap)
             {
                 return NpmCommandResult.Fail(Microsoft.CmdPal.UI.ViewModels.Properties.Resources.npm_runner_shrinkwrap_required);
@@ -839,7 +839,7 @@ public class NpmJsExtensionInstallerTests
         {
             // The runner extracts the tarball so the published package is the root project at
             // <staging>\package, runs npm ci there, and leaves the frozen closure under its own
-            // node_modules. Mirror that layout so the installer promotes it verbatim.
+            // node_modules. Mirror that layout so the installer promotes it as is.
             var packageDirectory = Path.Combine(stagingDirectory, NpmCommandRunner.PackageRootDirectoryName);
             Directory.CreateDirectory(packageDirectory);
 
@@ -854,7 +854,7 @@ public class NpmJsExtensionInstallerTests
                 version);
             File.WriteAllText(Path.Combine(packageDirectory, "package.json"), manifest);
 
-            // The publisher-frozen shrinkwrap travels inside the promoted tree.
+            // The shrinkwrap travels inside the promoted tree.
             File.WriteAllText(
                 Path.Combine(packageDirectory, "npm-shrinkwrap.json"),
                 "{\"lockfileVersion\":3,\"packages\":{\"\":{\"name\":\"root\"}}}");

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/NpmJsExtensionInstallerTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/NpmJsExtensionInstallerTests.cs
@@ -1,0 +1,870 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CmdPal.UI.ViewModels.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
+
+[TestClass]
+public class NpmJsExtensionInstallerTests
+{
+    private const string ValidIntegrity = "sha512-abc123==";
+    private const string Package = "@contoso/sample";
+    private const string Version = "1.2.3";
+    private const string ExtensionName = "sample-ext";
+
+    private static readonly string[] StopThenRemove = ["stop", "remove"];
+
+    private readonly List<string> _tempRoots = new();
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        foreach (var root in _tempRoots)
+        {
+            TryDeleteTree(root);
+        }
+    }
+
+    [TestMethod]
+    public async Task InstallAsync_PromotesUnscopedPackage_AndReportsInstalled()
+    {
+        var host = CreateHost();
+        var runner = new FakeRunner { ManifestName = "left-pad", ManifestVersion = "1.3.0" };
+        var installer = new NpmJsExtensionInstaller(host, runner);
+
+        var result = await installer.InstallAsync("left-pad-ext", "left-pad", "1.3.0", ValidIntegrity, null, CancellationToken.None);
+
+        Assert.IsTrue(result.Succeeded, result.ErrorMessage);
+        var target = Path.Combine(host.ExtensionsRootPath, "left-pad-ext");
+        Assert.IsTrue(Directory.Exists(target));
+        Assert.IsTrue(File.Exists(Path.Combine(target, "package.json")));
+        Assert.IsTrue(File.Exists(Path.Combine(target, "index.js")));
+        Assert.IsTrue(host.IsExtensionInstalled("left-pad-ext"));
+        AssertStagingEmpty(host);
+    }
+
+    [TestMethod]
+    public async Task InstallAsync_FailsClosed_WhenPublisherShrinkwrapMissing()
+    {
+        // r3-p5-01: a package whose publisher did not freeze the dependency closure with a published
+        // npm-shrinkwrap.json is rejected, and nothing is promoted into the watched root.
+        var host = CreateHost();
+        var runner = new FakeRunner { PublisherShipsShrinkwrap = false };
+        var installer = new NpmJsExtensionInstaller(host, runner);
+
+        var result = await installer.InstallAsync(ExtensionName, Package, Version, ValidIntegrity, null, CancellationToken.None);
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.AreEqual(
+            Microsoft.CmdPal.UI.ViewModels.Properties.Resources.npm_runner_shrinkwrap_required,
+            result.ErrorMessage);
+        Assert.IsFalse(Directory.Exists(Path.Combine(host.ExtensionsRootPath, ExtensionName)));
+        Assert.IsFalse(host.IsExtensionInstalled(ExtensionName));
+        AssertStagingEmpty(host);
+    }
+
+    [TestMethod]
+    public async Task InstallAsync_PromotesPublisherFrozenClosure_WhenShrinkwrapPresent()
+    {
+        // r3-p5-01: when the publisher shipped a shrinkwrap, the exact frozen tree the runner produced
+        // is what lands in the watched root, shrinkwrap and all, with no re-resolution by the installer.
+        var host = CreateHost();
+        var runner = new FakeRunner { HoistedDependencies = ["left-pad", "ms"] };
+        var installer = new NpmJsExtensionInstaller(host, runner);
+
+        var result = await installer.InstallAsync(ExtensionName, Package, Version, ValidIntegrity, null, CancellationToken.None);
+
+        Assert.IsTrue(result.Succeeded, result.ErrorMessage);
+        var target = Path.Combine(host.ExtensionsRootPath, ExtensionName);
+        Assert.IsTrue(File.Exists(Path.Combine(target, "package.json")));
+
+        // The publisher-frozen shrinkwrap travels with the promoted extension.
+        Assert.IsTrue(File.Exists(Path.Combine(target, "npm-shrinkwrap.json")));
+
+        // The exact closure the publisher froze is installed under the package's own node_modules.
+        Assert.IsTrue(Directory.Exists(Path.Combine(target, "node_modules", "left-pad")));
+        Assert.IsTrue(Directory.Exists(Path.Combine(target, "node_modules", "ms")));
+        AssertStagingEmpty(host);
+    }
+
+    [TestMethod]
+    public async Task InstallAsync_PromotesScopedPackage_WithHoistedDependencies()
+    {
+        var host = CreateHost();
+        var runner = new FakeRunner { HoistedDependencies = ["left-pad", "ms"] };
+        var installer = new NpmJsExtensionInstaller(host, runner);
+
+        var result = await installer.InstallAsync(ExtensionName, Package, Version, ValidIntegrity, null, CancellationToken.None);
+
+        Assert.IsTrue(result.Succeeded, result.ErrorMessage);
+        var target = Path.Combine(host.ExtensionsRootPath, ExtensionName);
+        Assert.IsTrue(File.Exists(Path.Combine(target, "package.json")));
+
+        // The hoisted dependencies must sit under the promoted package's own node_modules.
+        Assert.IsTrue(Directory.Exists(Path.Combine(target, "node_modules", "left-pad")));
+        Assert.IsTrue(Directory.Exists(Path.Combine(target, "node_modules", "ms")));
+        AssertStagingEmpty(host);
+    }
+
+    [TestMethod]
+    public async Task InstallAsync_StagesOutsideTheWatchedRoot()
+    {
+        var host = CreateHost();
+        var runner = new FakeRunner();
+        var installer = new NpmJsExtensionInstaller(host, runner);
+
+        await installer.InstallAsync(ExtensionName, Package, Version, ValidIntegrity, null, CancellationToken.None);
+
+        Assert.AreEqual(1, runner.StagingDirectories.Count);
+        var normalizedRoot = Path.TrimEndingDirectorySeparator(Path.GetFullPath(host.ExtensionsRootPath));
+        var staging = Path.GetFullPath(runner.StagingDirectories[0]);
+        Assert.IsFalse(
+            staging.StartsWith(normalizedRoot + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase),
+            $"Staging '{staging}' must not be under the watched root '{normalizedRoot}'.");
+    }
+
+    [TestMethod]
+    public async Task InstallAsync_FailsClosed_WhenArtifactIsIncomplete()
+    {
+        var host = CreateHost();
+        var runner = new FakeRunner();
+        var installer = new NpmJsExtensionInstaller(host, runner);
+
+        // Missing version and integrity: never installable, npm is never invoked.
+        var result = await installer.InstallAsync(ExtensionName, Package, null, null, null, CancellationToken.None);
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.IsNotNull(result.ErrorMessage);
+        Assert.AreEqual(0, runner.InstallCallCount);
+        Assert.IsFalse(Directory.Exists(Path.Combine(host.ExtensionsRootPath, ExtensionName)));
+    }
+
+    [TestMethod]
+    public async Task InstallAsync_Fails_WhenNpmNotAvailable()
+    {
+        var host = CreateHost();
+        var runner = new FakeRunner { NpmAvailable = false };
+        var installer = new NpmJsExtensionInstaller(host, runner);
+
+        var result = await installer.InstallAsync(ExtensionName, Package, Version, ValidIntegrity, null, CancellationToken.None);
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.AreEqual(0, runner.InstallCallCount);
+    }
+
+    [TestMethod]
+    public async Task InstallAsync_Fails_ForPathTraversalName()
+    {
+        var host = CreateHost();
+        var runner = new FakeRunner();
+        var installer = new NpmJsExtensionInstaller(host, runner);
+
+        var result = await installer.InstallAsync("..\\escape", Package, Version, ValidIntegrity, null, CancellationToken.None);
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.AreEqual(0, runner.InstallCallCount);
+    }
+
+    [TestMethod]
+    public async Task InstallAsync_Fails_AndDoesNotPromote_OnIntegrityMismatch()
+    {
+        var host = CreateHost();
+        var runner = new FakeRunner { ResolvedIntegrityOverride = "sha512-different==" };
+        var installer = new NpmJsExtensionInstaller(host, runner);
+
+        var result = await installer.InstallAsync(ExtensionName, Package, Version, ValidIntegrity, null, CancellationToken.None);
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.IsFalse(Directory.Exists(Path.Combine(host.ExtensionsRootPath, ExtensionName)));
+        AssertStagingEmpty(host);
+    }
+
+    [TestMethod]
+    public async Task InstallAsync_Fails_WhenResolvedIntegrityIsUnknown()
+    {
+        var host = CreateHost();
+        var runner = new FakeRunner { ReturnNullIntegrity = true };
+        var installer = new NpmJsExtensionInstaller(host, runner);
+
+        var result = await installer.InstallAsync(ExtensionName, Package, Version, ValidIntegrity, null, CancellationToken.None);
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.IsFalse(Directory.Exists(Path.Combine(host.ExtensionsRootPath, ExtensionName)));
+    }
+
+    [TestMethod]
+    public async Task InstallAsync_Fails_OnManifestIdentityMismatch()
+    {
+        var host = CreateHost();
+        var runner = new FakeRunner { ManifestName = "@contoso/other" };
+        var installer = new NpmJsExtensionInstaller(host, runner);
+
+        var result = await installer.InstallAsync(ExtensionName, Package, Version, ValidIntegrity, null, CancellationToken.None);
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.IsFalse(Directory.Exists(Path.Combine(host.ExtensionsRootPath, ExtensionName)));
+    }
+
+    [TestMethod]
+    public async Task InstallAsync_Fails_OnManifestVersionMismatch()
+    {
+        var host = CreateHost();
+        var runner = new FakeRunner { ManifestVersion = "9.9.9" };
+        var installer = new NpmJsExtensionInstaller(host, runner);
+
+        var result = await installer.InstallAsync(ExtensionName, Package, Version, ValidIntegrity, null, CancellationToken.None);
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.IsFalse(Directory.Exists(Path.Combine(host.ExtensionsRootPath, ExtensionName)));
+    }
+
+    [TestMethod]
+    public async Task InstallAsync_RollsBack_WhenRegistrationTimesOut()
+    {
+        var host = CreateHost();
+        host.RegistrationSucceeds = false;
+        var runner = new FakeRunner();
+        var installer = new NpmJsExtensionInstaller(host, runner);
+
+        var result = await installer.InstallAsync(ExtensionName, Package, Version, ValidIntegrity, null, CancellationToken.None);
+
+        Assert.IsFalse(result.Succeeded);
+
+        // A promoted directory that never registered must be rolled back, not left behind.
+        Assert.IsFalse(Directory.Exists(Path.Combine(host.ExtensionsRootPath, ExtensionName)));
+        AssertStagingEmpty(host);
+    }
+
+    [TestMethod]
+    public async Task InstallAsync_Fails_AndCleansStaging_OnNpmFailure()
+    {
+        var host = CreateHost();
+        var runner = new FakeRunner { NpmResult = NpmCommandResult.Fail("boom") };
+        var installer = new NpmJsExtensionInstaller(host, runner);
+
+        var result = await installer.InstallAsync(ExtensionName, Package, Version, ValidIntegrity, null, CancellationToken.None);
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.IsFalse(Directory.Exists(Path.Combine(host.ExtensionsRootPath, ExtensionName)));
+        AssertStagingEmpty(host);
+    }
+
+    [TestMethod]
+    public async Task InstallAsync_Cancelled_CleansStaging_AndLeavesNoTarget()
+    {
+        var host = CreateHost();
+        var runner = new FakeRunner { ThrowCancelled = true };
+        var installer = new NpmJsExtensionInstaller(host, runner);
+
+        using var cts = new CancellationTokenSource();
+        var result = await installer.InstallAsync(ExtensionName, Package, Version, ValidIntegrity, null, cts.Token);
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.IsFalse(Directory.Exists(Path.Combine(host.ExtensionsRootPath, ExtensionName)));
+        AssertStagingEmpty(host);
+    }
+
+    [TestMethod]
+    public async Task InstallAsync_Blocks_WhenTargetAlreadyExists_AndPreservesIt()
+    {
+        var host = CreateHost();
+        var target = Path.Combine(host.ExtensionsRootPath, ExtensionName);
+        Directory.CreateDirectory(target);
+        var sentinel = Path.Combine(target, "existing.txt");
+        File.WriteAllText(sentinel, "keep me");
+
+        var runner = new FakeRunner();
+        var installer = new NpmJsExtensionInstaller(host, runner);
+
+        var result = await installer.InstallAsync(ExtensionName, Package, Version, ValidIntegrity, null, CancellationToken.None);
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.AreEqual(0, runner.InstallCallCount);
+
+        // The pre-existing install must be untouched by a blocked reinstall.
+        Assert.IsTrue(File.Exists(sentinel));
+        Assert.AreEqual("keep me", File.ReadAllText(sentinel));
+    }
+
+    [TestMethod]
+    public async Task InstallAsync_Blocks_WhenHostReportsInstalled()
+    {
+        var host = CreateHost();
+        host.MarkInstalled(ExtensionName);
+        var runner = new FakeRunner();
+        var installer = new NpmJsExtensionInstaller(host, runner);
+
+        var result = await installer.InstallAsync(ExtensionName, Package, Version, ValidIntegrity, null, CancellationToken.None);
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.AreEqual(0, runner.InstallCallCount);
+    }
+
+    [TestMethod]
+    public async Task InstallAsync_AwaitsDelayedRegistration_ThenSucceeds()
+    {
+        var host = CreateHost();
+        host.RegistrationDelay = TimeSpan.FromMilliseconds(75);
+        var runner = new FakeRunner();
+        var installer = new NpmJsExtensionInstaller(host, runner);
+
+        var result = await installer.InstallAsync(ExtensionName, Package, Version, ValidIntegrity, null, CancellationToken.None);
+
+        Assert.IsTrue(result.Succeeded, result.ErrorMessage);
+        Assert.IsTrue(host.IsExtensionInstalled(ExtensionName));
+    }
+
+    [TestMethod]
+    public async Task UninstallAsync_StopsExtension_BeforeRemovingDirectory()
+    {
+        var order = new ConcurrentQueue<string>();
+        var host = CreateHost();
+        host.OrderLog = order;
+        var target = Path.Combine(host.ExtensionsRootPath, ExtensionName);
+        Directory.CreateDirectory(target);
+        File.WriteAllText(Path.Combine(target, "package.json"), "{}");
+
+        var runner = new FakeRunner { OrderLog = order };
+        var installer = new NpmJsExtensionInstaller(host, runner);
+
+        var result = await installer.UninstallAsync(ExtensionName, CancellationToken.None);
+
+        Assert.IsTrue(result.Succeeded, result.ErrorMessage);
+        CollectionAssert.AreEqual(StopThenRemove, order.ToArray());
+        Assert.IsFalse(Directory.Exists(target));
+    }
+
+    [TestMethod]
+    public async Task UninstallAsync_Fails_WhenRemoveFails()
+    {
+        var host = CreateHost();
+        var runner = new FakeRunner { RemoveSucceeds = false };
+        var installer = new NpmJsExtensionInstaller(host, runner);
+
+        var result = await installer.UninstallAsync(ExtensionName, CancellationToken.None);
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.IsNotNull(result.ErrorMessage);
+        Assert.AreEqual(1, host.StopCallCount);
+    }
+
+    [TestMethod]
+    public async Task UninstallAsync_CancelDuringStop_ReturnsCanceled_AndDoesNotRemove()
+    {
+        var host = CreateHost();
+        var target = Path.Combine(host.ExtensionsRootPath, ExtensionName);
+        Directory.CreateDirectory(target);
+        File.WriteAllText(Path.Combine(target, "package.json"), "{}");
+
+        using var stopStarted = new ManualResetEventSlim(false);
+        host.StopHook = token =>
+        {
+            // Simulate the host blocking while it stops the provider, then observe the cancel that
+            // arrives after the operation has already begun. This mirrors the real host threading the
+            // uninstall token into its stop/delete steps.
+            stopStarted.Set();
+            Assert.IsTrue(token.WaitHandle.WaitOne(TimeSpan.FromSeconds(5)), "Cancellation was not observed during stop.");
+            token.ThrowIfCancellationRequested();
+        };
+
+        var runner = new FakeRunner();
+        var installer = new NpmJsExtensionInstaller(host, runner);
+
+        using var cts = new CancellationTokenSource();
+        var task = Task.Run(() => installer.UninstallAsync(ExtensionName, cts.Token));
+
+        Assert.IsTrue(stopStarted.Wait(TimeSpan.FromSeconds(5)), "Uninstall did not reach the stop step.");
+        cts.Cancel();
+
+        var result = await task;
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.AreEqual(0, runner.RemoveCallCount, "Cancel during stop must not proceed to delete.");
+        Assert.IsTrue(Directory.Exists(target), "The extension directory must remain when uninstall is canceled.");
+    }
+
+    [TestMethod]
+    public async Task UninstallAsync_JunctionedRoot_IsRefused()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "cmdpal-installer-tests", Guid.NewGuid().ToString("N"));
+        _tempRoots.Add(root);
+        var realRoot = Path.Combine(root, "real");
+        var junctionRoot = Path.Combine(root, "JSExtensions");
+        Directory.CreateDirectory(realRoot);
+
+        if (!TryCreateJunction(junctionRoot, realRoot))
+        {
+            Assert.Inconclusive("Could not create a junction on this machine.");
+            return;
+        }
+
+        var host = new FakeHost(junctionRoot);
+        var runner = new FakeRunner();
+        var installer = new NpmJsExtensionInstaller(host, runner);
+
+        var result = await installer.UninstallAsync(ExtensionName, CancellationToken.None);
+
+        Assert.IsFalse(result.Succeeded, "A reparse-point extensions root must be refused.");
+        Assert.AreEqual(0, host.StopCallCount);
+        Assert.AreEqual(0, runner.RemoveCallCount);
+    }
+
+    [TestMethod]
+    public async Task InstallAsync_JunctionedRoot_IsRefused()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "cmdpal-installer-tests", Guid.NewGuid().ToString("N"));
+        _tempRoots.Add(root);
+        var realRoot = Path.Combine(root, "real");
+        var junctionRoot = Path.Combine(root, "JSExtensions");
+        Directory.CreateDirectory(realRoot);
+
+        if (!TryCreateJunction(junctionRoot, realRoot))
+        {
+            Assert.Inconclusive("Could not create a junction on this machine.");
+            return;
+        }
+
+        var host = new FakeHost(junctionRoot);
+        var runner = new FakeRunner();
+        var installer = new NpmJsExtensionInstaller(host, runner);
+
+        var result = await installer.InstallAsync(ExtensionName, Package, Version, ValidIntegrity, null, CancellationToken.None);
+
+        Assert.IsFalse(result.Succeeded, "A reparse-point extensions root must be refused.");
+        Assert.AreEqual(0, runner.InstallCallCount, "npm must not run when the root is refused.");
+    }
+
+    [TestMethod]
+    public async Task InstallAsync_CanceledDuringRegistration_RollsBack_StopThenRemove()
+    {
+        var order = new ConcurrentQueue<string>();
+        var host = CreateHost();
+        host.OrderLog = order;
+
+        // Hold registration open long enough to cancel while the extension is already promoted.
+        host.RegistrationDelay = TimeSpan.FromSeconds(30);
+        using var registrationStarted = new ManualResetEventSlim(false);
+        host.RegistrationStarted = registrationStarted;
+
+        var runner = new FakeRunner { OrderLog = order };
+        var installer = new NpmJsExtensionInstaller(host, runner);
+
+        using var cts = new CancellationTokenSource();
+        var task = Task.Run(() => installer.InstallAsync(ExtensionName, Package, Version, ValidIntegrity, null, cts.Token));
+
+        Assert.IsTrue(registrationStarted.Wait(TimeSpan.FromSeconds(5)), "Install did not reach provider registration.");
+        cts.Cancel();
+
+        var result = await task;
+
+        Assert.IsFalse(result.Succeeded, "A canceled install must not report success.");
+
+        // Rollback must stop the host before removing the promoted directory so nothing is left both
+        // installed and running.
+        var log = order.ToArray();
+        Assert.IsTrue(log.Length >= 2, "Rollback did not run stop and remove.");
+        Assert.AreEqual("stop", log[0]);
+        Assert.AreEqual("remove", log[1]);
+        Assert.AreEqual(1, host.StopCallCount);
+
+        var target = Path.Combine(host.ExtensionsRootPath, ExtensionName);
+        Assert.IsFalse(Directory.Exists(target), "The promoted directory must be removed on rollback.");
+        Assert.IsFalse(host.IsExtensionInstalled(ExtensionName), "Nothing must remain installed after a canceled install.");
+    }
+
+    [TestMethod]
+    public async Task InstallAsync_PreservesMixedScopedAndUnscopedDependencies()
+    {
+        // The publisher-frozen closure npm ci installs under the package's own node_modules, including
+        // @scope directories, survives promotion so scoped, unscoped, and mixed dependencies all land
+        // in the promoted extension. The scoped-merge discard defect lives only in the phase-6
+        // JsExtensionPackageLayout, which is absent from phase-5.
+        var host = CreateHost();
+        var runner = new FakeRunner
+        {
+            HoistedDependencies = ["left-pad", Path.Combine("@scope", "dep-a"), Path.Combine("@scope", "dep-b")],
+        };
+        var installer = new NpmJsExtensionInstaller(host, runner);
+
+        var result = await installer.InstallAsync(ExtensionName, Package, Version, ValidIntegrity, null, CancellationToken.None);
+
+        Assert.IsTrue(result.Succeeded, result.ErrorMessage);
+
+        var nodeModules = Path.Combine(host.ExtensionsRootPath, ExtensionName, "node_modules");
+        Assert.IsTrue(Directory.Exists(Path.Combine(nodeModules, "left-pad")), "Unscoped dependency was dropped.");
+        Assert.IsTrue(Directory.Exists(Path.Combine(nodeModules, "@scope", "dep-a")), "Scoped dependency dep-a was dropped.");
+        Assert.IsTrue(Directory.Exists(Path.Combine(nodeModules, "@scope", "dep-b")), "Scoped dependency dep-b was dropped.");
+    }
+
+    [TestMethod]
+    public void IsInstalled_DelegatesToHost()
+    {
+        var host = CreateHost();
+        host.MarkInstalled(ExtensionName);
+        var installer = new NpmJsExtensionInstaller(host, new FakeRunner());
+
+        Assert.IsTrue(installer.IsInstalled(ExtensionName));
+        Assert.IsFalse(installer.IsInstalled("not-installed"));
+    }
+
+    [TestMethod]
+    public async Task ConcurrentInstall_SameName_SerializesAndBlocksTheSecond()
+    {
+        var host = CreateHost();
+        var runner = new FakeRunner();
+        var installer = new NpmJsExtensionInstaller(host, runner);
+
+        var first = installer.InstallAsync(ExtensionName, Package, Version, ValidIntegrity, null, CancellationToken.None);
+        var second = installer.InstallAsync(ExtensionName, Package, Version, ValidIntegrity, null, CancellationToken.None);
+
+        var results = await Task.WhenAll(first, second);
+
+        var succeeded = 0;
+        var blocked = 0;
+        foreach (var result in results)
+        {
+            if (result.Succeeded)
+            {
+                succeeded++;
+            }
+            else
+            {
+                blocked++;
+            }
+        }
+
+        // Serialization plus the block-if-exists upgrade policy means exactly one install runs npm and
+        // succeeds while the other is refused, and npm is invoked only once.
+        Assert.AreEqual(1, succeeded);
+        Assert.AreEqual(1, blocked);
+        Assert.AreEqual(1, runner.InstallCallCount);
+    }
+
+    [TestMethod]
+    public async Task ConcurrentInstall_DifferentNames_RunInParallel()
+    {
+        var host = CreateHost();
+        using var bothEntered = new CountdownEvent(2);
+        using var release = new ManualResetEventSlim(false);
+
+        var runner = new FakeRunner
+        {
+            InstallHook = (_, _, hookToken) =>
+            {
+                bothEntered.Signal();
+
+                // Block until both installs have entered npm. If the installer serialized different
+                // directories this would deadlock and the wait below would time out.
+                Assert.IsTrue(release.Wait(TimeSpan.FromSeconds(5), hookToken), "Second install did not run in parallel.");
+                return Task.CompletedTask;
+            },
+        };
+
+        var installer = new NpmJsExtensionInstaller(host, runner);
+
+        var first = Task.Run(() => installer.InstallAsync("ext-one", Package, Version, ValidIntegrity, null, CancellationToken.None));
+        var second = Task.Run(() => installer.InstallAsync("ext-two", "left-pad", "1.3.0", ValidIntegrity, null, CancellationToken.None));
+
+        var parallel = bothEntered.Wait(TimeSpan.FromSeconds(5));
+        release.Set();
+
+        Assert.IsTrue(parallel, "Two installs of different extensions did not enter npm concurrently.");
+
+        var results = await Task.WhenAll(first, second);
+        Assert.IsTrue(results[0].Succeeded, results[0].ErrorMessage);
+        Assert.IsTrue(results[1].Succeeded, results[1].ErrorMessage);
+    }
+
+    private FakeHost CreateHost()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "cmdpal-installer-tests", Guid.NewGuid().ToString("N"));
+        var extensionsRoot = Path.Combine(root, "JSExtensions");
+        Directory.CreateDirectory(extensionsRoot);
+        _tempRoots.Add(root);
+        return new FakeHost(extensionsRoot);
+    }
+
+    private static void AssertStagingEmpty(FakeHost host)
+    {
+        var stagingRoot = Path.GetFullPath(host.ExtensionsRootPath) + ".staging";
+        if (Directory.Exists(stagingRoot))
+        {
+            var leftovers = Directory.GetFileSystemEntries(stagingRoot);
+            Assert.AreEqual(0, leftovers.Length, $"Staging root '{stagingRoot}' still holds {leftovers.Length} entries.");
+        }
+    }
+
+    private static void TryDeleteTree(string root)
+    {
+        try
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, recursive: true);
+            }
+
+            var staging = root + ".staging";
+            if (Directory.Exists(staging))
+            {
+                Directory.Delete(staging, recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+
+    private static bool TryCreateJunction(string junctionPath, string targetPath)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = "cmd.exe",
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+            };
+            psi.ArgumentList.Add("/c");
+            psi.ArgumentList.Add("mklink");
+            psi.ArgumentList.Add("/J");
+            psi.ArgumentList.Add(junctionPath);
+            psi.ArgumentList.Add(targetPath);
+
+            using var process = Process.Start(psi);
+            if (process is null)
+            {
+                return false;
+            }
+
+            process.WaitForExit();
+            return process.ExitCode == 0 && Directory.Exists(junctionPath);
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+    }
+
+    private sealed class FakeHost : IJsExtensionHost
+    {
+        private readonly HashSet<string> _installed = new(StringComparer.OrdinalIgnoreCase);
+        private readonly Lock _installedGate = new();
+
+        public FakeHost(string extensionsRootPath)
+        {
+            ExtensionsRootPath = extensionsRootPath;
+        }
+
+        public string ExtensionsRootPath { get; }
+
+        public bool RegistrationSucceeds { get; set; } = true;
+
+        public TimeSpan RegistrationDelay { get; set; } = TimeSpan.Zero;
+
+        public int StopCallCount { get; private set; }
+
+        public ConcurrentQueue<string>? OrderLog { get; set; }
+
+        public Action<CancellationToken>? StopHook { get; set; }
+
+        public ManualResetEventSlim? RegistrationStarted { get; set; }
+
+        public void MarkInstalled(string name)
+        {
+            lock (_installedGate)
+            {
+                _installed.Add(name);
+            }
+        }
+
+        public void StopExtension(string extensionDirectory, CancellationToken cancellationToken = default)
+        {
+            OrderLog?.Enqueue("stop");
+            StopCallCount++;
+            StopHook?.Invoke(cancellationToken);
+        }
+
+        public bool IsExtensionDiscoverable(string extensionDirectory) =>
+            File.Exists(Path.Combine(extensionDirectory, "package.json"));
+
+        public bool IsExtensionInstalled(string extensionName)
+        {
+            lock (_installedGate)
+            {
+                return _installed.Contains(extensionName);
+            }
+        }
+
+        public async Task<bool> RefreshAndAwaitProviderAsync(string extensionDirectory, TimeSpan timeout, CancellationToken cancellationToken)
+        {
+            RegistrationStarted?.Set();
+
+            if (RegistrationDelay > TimeSpan.Zero)
+            {
+                await Task.Delay(RegistrationDelay, cancellationToken).ConfigureAwait(false);
+            }
+
+            if (!RegistrationSucceeds)
+            {
+                return false;
+            }
+
+            var name = Path.GetFileName(Path.TrimEndingDirectorySeparator(extensionDirectory));
+            lock (_installedGate)
+            {
+                _installed.Add(name);
+            }
+
+            return true;
+        }
+    }
+
+    private sealed class FakeRunner : INpmCommandRunner
+    {
+        public bool NpmAvailable { get; set; } = true;
+
+        public bool RemoveSucceeds { get; set; } = true;
+
+        public bool CreatePackage { get; set; } = true;
+
+        public bool PublisherShipsShrinkwrap { get; set; } = true;
+
+        public bool ThrowCancelled { get; set; }
+
+        public bool ReturnNullIntegrity { get; set; }
+
+        public string? ResolvedIntegrityOverride { get; set; }
+
+        public string? ManifestName { get; set; }
+
+        public string? ManifestVersion { get; set; }
+
+        public string[] HoistedDependencies { get; set; } = [];
+
+        public NpmCommandResult? NpmResult { get; set; }
+
+        public Func<string, NpmArtifact, CancellationToken, Task>? InstallHook { get; set; }
+
+        public ConcurrentQueue<string>? OrderLog { get; set; }
+
+        public int InstallCallCount { get; private set; }
+
+        public int RemoveCallCount { get; private set; }
+
+        public List<string> StagingDirectories { get; } = new();
+
+        public bool IsNpmAvailable() => NpmAvailable;
+
+        public async Task<NpmCommandResult> InstallAsync(string stagingDirectory, NpmArtifact artifact, CancellationToken cancellationToken)
+        {
+            InstallCallCount++;
+            lock (StagingDirectories)
+            {
+                StagingDirectories.Add(stagingDirectory);
+            }
+
+            if (InstallHook is not null)
+            {
+                await InstallHook(stagingDirectory, artifact, cancellationToken).ConfigureAwait(false);
+            }
+
+            if (ThrowCancelled)
+            {
+                throw new OperationCanceledException();
+            }
+
+            if (NpmResult is { } forced)
+            {
+                return forced;
+            }
+
+            // The real runner rejects a package whose publisher did not freeze the dependency closure
+            // with a published npm-shrinkwrap.json. Model that fail-closed decision before any package
+            // is materialized so nothing can be promoted.
+            if (!PublisherShipsShrinkwrap)
+            {
+                return NpmCommandResult.Fail(Microsoft.CmdPal.UI.ViewModels.Properties.Resources.npm_runner_shrinkwrap_required);
+            }
+
+            if (CreatePackage)
+            {
+                MaterializePackage(stagingDirectory, artifact);
+            }
+
+            if (ReturnNullIntegrity)
+            {
+                return NpmCommandResult.Ok(null);
+            }
+
+            return NpmCommandResult.Ok(ResolvedIntegrityOverride ?? artifact.Integrity);
+        }
+
+        public bool RemoveDirectory(string targetDirectory, CancellationToken cancellationToken = default)
+        {
+            OrderLog?.Enqueue("remove");
+            RemoveCallCount++;
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!RemoveSucceeds)
+            {
+                return false;
+            }
+
+            if (Directory.Exists(targetDirectory))
+            {
+                Directory.Delete(targetDirectory, recursive: true);
+            }
+
+            return true;
+        }
+
+        private void MaterializePackage(string stagingDirectory, NpmArtifact artifact)
+        {
+            // The runner extracts the tarball so the published package is the root project at
+            // <staging>\package, runs npm ci there, and leaves the frozen closure under its own
+            // node_modules. Mirror that layout so the installer promotes it verbatim.
+            var packageDirectory = Path.Combine(stagingDirectory, NpmCommandRunner.PackageRootDirectoryName);
+            Directory.CreateDirectory(packageDirectory);
+
+            File.WriteAllText(Path.Combine(packageDirectory, "index.js"), "module.exports = {};");
+
+            var name = ManifestName ?? artifact.Package;
+            var version = ManifestVersion ?? artifact.Version;
+            var manifest = string.Format(
+                CultureInfo.InvariantCulture,
+                "{{\"name\":\"{0}\",\"version\":\"{1}\",\"main\":\"index.js\",\"cmdpal\":{{}}}}",
+                name,
+                version);
+            File.WriteAllText(Path.Combine(packageDirectory, "package.json"), manifest);
+
+            // The publisher-frozen shrinkwrap travels inside the promoted tree.
+            File.WriteAllText(
+                Path.Combine(packageDirectory, "npm-shrinkwrap.json"),
+                "{\"lockfileVersion\":3,\"packages\":{\"\":{\"name\":\"root\"}}}");
+
+            foreach (var dependency in HoistedDependencies)
+            {
+                var dependencyDirectory = Path.Combine(packageDirectory, "node_modules", dependency);
+                Directory.CreateDirectory(dependencyDirectory);
+                File.WriteAllText(Path.Combine(dependencyDirectory, "index.js"), "module.exports = {};");
+            }
+        }
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/NpmJsExtensionInstallerTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/NpmJsExtensionInstallerTests.cs
@@ -50,6 +50,7 @@ public class NpmJsExtensionInstallerTests
         Assert.IsTrue(Directory.Exists(target));
         Assert.IsTrue(File.Exists(Path.Combine(target, "package.json")));
         Assert.IsTrue(File.Exists(Path.Combine(target, "index.js")));
+        Assert.IsFalse(File.Exists(Path.Combine(target, JsonRpcExtensionService.GalleryInstallMarkerFileName)));
         Assert.IsTrue(host.IsExtensionInstalled("left-pad-ext"));
         AssertStagingEmpty(host);
     }
@@ -176,6 +177,44 @@ public class NpmJsExtensionInstallerTests
         Assert.AreEqual(0, runner.InstallCallCount);
     }
 
+    [DataTestMethod]
+    [DataRow("sample-ext.")]
+    [DataRow(" sample-ext")]
+    [DataRow("sample-ext ")]
+    [DataRow("CON")]
+    [DataRow("con.txt")]
+    [DataRow("CON.foo.txt")]
+    [DataRow("COM1.foo.bar")]
+    public async Task InstallAsync_Fails_ForWindowsAliasName(string extensionName)
+    {
+        var host = CreateHost();
+        var runner = new FakeRunner();
+        var installer = new NpmJsExtensionInstaller(host, runner);
+
+        var result = await installer.InstallAsync(extensionName, Package, Version, ValidIntegrity, null, CancellationToken.None);
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.AreEqual(0, runner.InstallCallCount);
+    }
+
+    [DataTestMethod]
+    [DataRow("sample-ext.")]
+    [DataRow("NUL")]
+    [DataRow("CON.foo.txt")]
+    [DataRow("COM1.foo.bar")]
+    public async Task UninstallAsync_Fails_ForWindowsAliasName(string extensionName)
+    {
+        var host = CreateHost();
+        var runner = new FakeRunner();
+        var installer = new NpmJsExtensionInstaller(host, runner);
+
+        var result = await installer.UninstallAsync(extensionName, CancellationToken.None);
+
+        Assert.IsFalse(result.Succeeded);
+        Assert.AreEqual(0, host.StopCallCount);
+        Assert.AreEqual(0, runner.RemoveCallCount);
+    }
+
     [TestMethod]
     public async Task InstallAsync_Fails_AndDoesNotPromote_OnIntegrityMismatch()
     {
@@ -244,6 +283,22 @@ public class NpmJsExtensionInstallerTests
         // A promoted directory that never registered must be rolled back, not left behind.
         Assert.IsFalse(Directory.Exists(Path.Combine(host.ExtensionsRootPath, ExtensionName)));
         AssertStagingEmpty(host);
+    }
+
+    [TestMethod]
+    public async Task InstallAsync_RemovesMarker_WhenRollbackDeleteFails()
+    {
+        var host = CreateHost();
+        host.RegistrationSucceeds = false;
+        var runner = new FakeRunner { RemoveSucceeds = false };
+        var installer = new NpmJsExtensionInstaller(host, runner);
+
+        var result = await installer.InstallAsync(ExtensionName, Package, Version, ValidIntegrity, null, CancellationToken.None);
+
+        var target = Path.Combine(host.ExtensionsRootPath, ExtensionName);
+        Assert.IsFalse(result.Succeeded);
+        Assert.IsTrue(Directory.Exists(target));
+        Assert.IsFalse(File.Exists(Path.Combine(target, JsonRpcExtensionService.GalleryInstallMarkerFileName)));
     }
 
     [TestMethod]
@@ -349,6 +404,10 @@ public class NpmJsExtensionInstallerTests
     public async Task UninstallAsync_Fails_WhenRemoveFails()
     {
         var host = CreateHost();
+        host.MarkInstalled(ExtensionName);
+        var target = Path.Combine(host.ExtensionsRootPath, ExtensionName);
+        Directory.CreateDirectory(target);
+        File.WriteAllText(Path.Combine(target, "package.json"), "{}");
         var runner = new FakeRunner { RemoveSucceeds = false };
         var installer = new NpmJsExtensionInstaller(host, runner);
 
@@ -357,6 +416,7 @@ public class NpmJsExtensionInstallerTests
         Assert.IsFalse(result.Succeeded);
         Assert.IsNotNull(result.ErrorMessage);
         Assert.AreEqual(1, host.StopCallCount);
+        Assert.IsTrue(host.IsExtensionInstalled(ExtensionName), "A failed delete must reload the surviving extension.");
     }
 
     [TestMethod]
@@ -368,21 +428,20 @@ public class NpmJsExtensionInstallerTests
         File.WriteAllText(Path.Combine(target, "package.json"), "{}");
 
         using var stopStarted = new ManualResetEventSlim(false);
-        host.StopHook = token =>
+        host.StopHook = async token =>
         {
             // Simulate the host blocking while it stops the provider, then observe cancel after the
             // operation has already begun. This matches the real host threading the uninstall token
             // through stop and delete.
             stopStarted.Set();
-            Assert.IsTrue(token.WaitHandle.WaitOne(TimeSpan.FromSeconds(5)), "Cancellation was not observed during stop.");
-            token.ThrowIfCancellationRequested();
+            await Task.Delay(Timeout.InfiniteTimeSpan, token).ConfigureAwait(false);
         };
 
         var runner = new FakeRunner();
         var installer = new NpmJsExtensionInstaller(host, runner);
 
         using var cts = new CancellationTokenSource();
-        var task = Task.Run(() => installer.UninstallAsync(ExtensionName, cts.Token));
+        var task = installer.UninstallAsync(ExtensionName, cts.Token);
 
         Assert.IsTrue(stopStarted.Wait(TimeSpan.FromSeconds(5)), "Uninstall did not reach the stop step.");
         cts.Cancel();
@@ -681,7 +740,7 @@ public class NpmJsExtensionInstallerTests
 
         public ConcurrentQueue<string>? OrderLog { get; set; }
 
-        public Action<CancellationToken>? StopHook { get; set; }
+        public Func<CancellationToken, Task>? StopHook { get; set; }
 
         public ManualResetEventSlim? RegistrationStarted { get; set; }
 
@@ -693,11 +752,20 @@ public class NpmJsExtensionInstallerTests
             }
         }
 
-        public void StopExtension(string extensionDirectory, CancellationToken cancellationToken = default)
+        public async Task StopExtensionAsync(string extensionDirectory, CancellationToken cancellationToken = default)
         {
             OrderLog?.Enqueue("stop");
             StopCallCount++;
-            StopHook?.Invoke(cancellationToken);
+            if (StopHook is not null)
+            {
+                await StopHook(cancellationToken).ConfigureAwait(false);
+            }
+
+            var name = Path.GetFileName(Path.TrimEndingDirectorySeparator(extensionDirectory));
+            lock (_installedGate)
+            {
+                _installed.Remove(name);
+            }
         }
 
         public bool IsExtensionDiscoverable(string extensionDirectory) =>

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/NpmJsExtensionInstallerTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/NpmJsExtensionInstallerTests.cs
@@ -574,7 +574,36 @@ public class NpmJsExtensionInstallerTests
         var installer = new NpmJsExtensionInstaller(host, new FakeRunner());
 
         Assert.IsTrue(installer.IsInstalled(ExtensionName));
+        Assert.IsTrue(installer.IsInstalled(ExtensionName.ToUpperInvariant()));
         Assert.IsFalse(installer.IsInstalled("not-installed"));
+    }
+
+    [DataTestMethod]
+    [DataRow("")]
+    [DataRow(" ")]
+    [DataRow(@"C:\Windows")]
+    [DataRow(@"\\server\share")]
+    [DataRow(@"..\escape")]
+    [DataRow(@"folder\extension")]
+    [DataRow("folder/extension")]
+    public void IsInstalled_RejectsUnsafeCatalogId(string extensionName)
+    {
+        var host = CreateHost();
+        var installer = new NpmJsExtensionInstaller(host, new FakeRunner());
+
+        Assert.IsFalse(installer.IsInstalled(extensionName));
+        Assert.AreEqual(0, host.IsInstalledCallCount);
+    }
+
+    [TestMethod]
+    public void IsInstalled_AcceptsValidPackageId()
+    {
+        var host = CreateHost();
+        host.MarkInstalled("contoso.sample-extension");
+        var installer = new NpmJsExtensionInstaller(host, new FakeRunner());
+
+        Assert.IsTrue(installer.IsInstalled("contoso.sample-extension"));
+        Assert.AreEqual(1, host.IsInstalledCallCount);
     }
 
     [TestMethod]
@@ -738,6 +767,8 @@ public class NpmJsExtensionInstallerTests
 
         public int StopCallCount { get; private set; }
 
+        public int IsInstalledCallCount { get; private set; }
+
         public ConcurrentQueue<string>? OrderLog { get; set; }
 
         public Func<CancellationToken, Task>? StopHook { get; set; }
@@ -773,6 +804,7 @@ public class NpmJsExtensionInstallerTests
 
         public bool IsExtensionInstalled(string extensionName)
         {
+            IsInstalledCallCount++;
             lock (_installedGate)
             {
                 return _installed.Contains(extensionName);


### PR DESCRIPTION
> [!WARNING]
> Part of a 7-PR stack adding JavaScript/TypeScript extension support to Command Palette (#49321 -> #49323 -> #49324 -> #49325 -> #49326 -> #49329 -> #49364). This one targets `dev/mjolley/phase-4-cmdpal-service`, not `main`, so don't merge it before #49325 lands.

> [!NOTE]
> Want to try the whole thing end to end? Run the branch from #49364.

## What's going on

Phase 5 makes JavaScript/TypeScript extensions installable from the gallery, the same place you already grab other CmdPal extensions.

