### PR TITLE
Add OpenAI-compatible provider to Advanced Paste

### DIFF
--- a/src/modules/AdvancedPaste/AdvancedPaste.UnitTests/Mocks/IntegrationTestUserSettings.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste.UnitTests/Mocks/IntegrationTestUserSettings.cs
@@ -22,15 +22,21 @@ internal sealed class IntegrationTestUserSettings : IUserSettings
     private readonly IReadOnlyList<AdvancedPasteCustomAction> _customActions;
     private readonly IReadOnlyList<PasteFormats> _additionalActions;
 
-    public IntegrationTestUserSettings()
+    public IntegrationTestUserSettings(
+        AIServiceType serviceType = AIServiceType.OpenAI,
+        string modelName = "gpt-4o",
+        string endpointUrl = "",
+        bool moderationEnabled = true,
+        string providerId = "integration-openai")
     {
         var provider = new PasteAIProviderDefinition
         {
-            Id = "integration-openai",
+            Id = providerId,
             EnableAdvancedAI = true,
-            ServiceTypeKind = AIServiceType.OpenAI,
-            ModelName = "gpt-4o",
-            ModerationEnabled = true,
+            ServiceTypeKind = serviceType,
+            ModelName = modelName,
+            EndpointUrl = endpointUrl,
+            ModerationEnabled = moderationEnabled,
         };
 
         _configuration = new PasteAIConfiguration

--- a/src/modules/AdvancedPaste/AdvancedPaste.UnitTests/ServicesTests/OpenAICompatibleGatewayIntegrationTests.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste.UnitTests/ServicesTests/OpenAICompatibleGatewayIntegrationTests.cs
@@ -1,0 +1,135 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+using AdvancedPaste.Helpers;
+using AdvancedPaste.Models;
+using AdvancedPaste.Models.KernelQueryCache;
+using AdvancedPaste.Services;
+using AdvancedPaste.Services.CustomActions;
+using AdvancedPaste.Services.OpenAI;
+using AdvancedPaste.UnitTests.Mocks;
+using AdvancedPaste.UnitTests.Utils;
+using Microsoft.PowerToys.Settings.UI.Library;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AdvancedPaste.UnitTests.ServicesTests;
+
+[TestClass]
+public sealed class OpenAICompatibleGatewayIntegrationTests
+{
+    private const string ProviderId = "integration-openaicompatible";
+
+    private EnhancedVaultCredentialsProvider _credentialsProvider;
+    private ICustomActionTransformService _customActionTransformService;
+    private IKernelService _kernelService;
+    private RecordingKernelQueryCacheService _queryCacheService;
+
+    [TestInitialize]
+    public void TestInitialize()
+    {
+        string endpoint = Environment.GetEnvironmentVariable("POWERTOYS_OPENAI_COMPATIBLE_ENDPOINT");
+        string model = Environment.GetEnvironmentVariable("POWERTOYS_OPENAI_COMPATIBLE_MODEL");
+
+        if (!PasteAIProviderValidation.TryGetOpenAICompatibleEndpoint(endpoint, out _) ||
+            !PasteAIProviderValidation.IsValidOpenAICompatibleModelName(model))
+        {
+            Assert.Inconclusive("Set POWERTOYS_OPENAI_COMPATIBLE_ENDPOINT and POWERTOYS_OPENAI_COMPATIBLE_MODEL to run live Gateway tests.");
+        }
+
+        IntegrationTestUserSettings userSettings = new(
+            AIServiceType.OpenAICompatible,
+            model,
+            endpoint,
+            moderationEnabled: false,
+            providerId: ProviderId);
+        _credentialsProvider = new EnhancedVaultCredentialsProvider(userSettings);
+
+        if (!_credentialsProvider.IsConfigured())
+        {
+            Assert.Inconclusive("Live Gateway credential is not configured in Windows Password Vault.");
+        }
+
+        PromptModerationService moderationService = new(_credentialsProvider);
+        PasteAIProviderFactory providerFactory = new();
+        _customActionTransformService = new CustomActionTransformService(moderationService, providerFactory, _credentialsProvider, userSettings);
+        _queryCacheService = new RecordingKernelQueryCacheService();
+        _kernelService = new AdvancedAIKernelService(_credentialsProvider, _queryCacheService, moderationService, userSettings, _customActionTransformService);
+    }
+
+    [TestMethod]
+    [TestCategory("LiveGateway")]
+    [DataRow("Translate to German", "What is that?", "Was ist das\\?")]
+    [DataRow("Summarize in one short sentence", "PowerToys is a set of utilities for Windows power users. It helps users customize workflows and improve productivity.", "PowerToys")]
+    [DataRow("Convert to a JSON object with lowercase keys. Output only JSON.", "Name: Alice\nDepartment: Engineering", "\\\"name\\\"\\s*:\\s*\\\"Alice\\\"")]
+    public async Task CustomAction_TransformsText(string prompt, string input, string expectedPattern)
+    {
+        var result = await _customActionTransformService.TransformAsync(
+            prompt,
+            input,
+            null,
+            CancellationToken.None,
+            new NoOpProgress());
+
+        Assert.IsTrue(Regex.IsMatch(result.Content, expectedPattern, RegexOptions.IgnoreCase));
+        Assert.IsTrue(result.Usage.HasUsage);
+    }
+
+    [TestMethod]
+    [TestCategory("LiveGateway")]
+    public async Task CustomAction_TransformsImage()
+    {
+        var input = await ResourceUtils.GetImageAssetAsDataPackageAsync("image_with_text_example.png");
+        var imageBytes = await input.GetView().GetImageAsPngBytesAsync();
+
+        var result = await _customActionTransformService.TransformAsync(
+            "Extract the text from this image",
+            null,
+            imageBytes,
+            CancellationToken.None,
+            new NoOpProgress());
+
+        StringAssert.Contains(result.Content, "This is an image with text");
+        Assert.IsTrue(result.Usage.HasUsage);
+    }
+
+    [TestMethod]
+    [TestCategory("LiveGateway")]
+    public async Task AdvancedAI_InvokesTools()
+    {
+        var input = DataPackageHelpers.CreateFromText("What is that?");
+
+        var output = await _kernelService.TransformClipboardAsync(
+            "Translate to German and format as JSON",
+            input.GetView(),
+            isSavedQuery: false,
+            CancellationToken.None,
+            new NoOpProgress());
+        var outputText = await output.GetView().GetTextOrEmptyAsync();
+
+        Assert.IsTrue(Regex.IsMatch(outputText, "Was ist das\\?", RegexOptions.IgnoreCase));
+        Assert.IsNotNull(_queryCacheService.WrittenValue);
+        CollectionAssert.Contains(
+            _queryCacheService.WrittenValue.ActionChain.Select(item => item.Format).ToArray(),
+            PasteFormats.CustomTextTransformation);
+    }
+
+    private sealed class RecordingKernelQueryCacheService : IKernelQueryCacheService
+    {
+        public CacheValue WrittenValue { get; private set; }
+
+        public CacheValue ReadOrNull(CacheKey cacheKey) => null;
+
+        public Task WriteAsync(CacheKey cacheKey, CacheValue value)
+        {
+            WrittenValue = value;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/modules/AdvancedPaste/AdvancedPaste.UnitTests/ServicesTests/OpenAICompatibleGatewayIntegrationTests.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste.UnitTests/ServicesTests/OpenAICompatibleGatewayIntegrationTests.cs
@@ -51,11 +51,6 @@ public sealed class OpenAICompatibleGatewayIntegrationTests
             providerId: ProviderId);
         _credentialsProvider = new EnhancedVaultCredentialsProvider(userSettings);
 
-        if (!_credentialsProvider.IsConfigured())
-        {
-            Assert.Inconclusive("Live Gateway credential is not configured in Windows Password Vault.");
-        }
-
         PromptModerationService moderationService = new(_credentialsProvider);
         PasteAIProviderFactory providerFactory = new();
         _customActionTransformService = new CustomActionTransformService(moderationService, providerFactory, _credentialsProvider, userSettings);

--- a/src/modules/AdvancedPaste/AdvancedPaste.UnitTests/ServicesTests/OpenAICompatibleProviderTests.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste.UnitTests/ServicesTests/OpenAICompatibleProviderTests.cs
@@ -13,6 +13,7 @@ using AdvancedPaste.Helpers;
 using AdvancedPaste.Services;
 using AdvancedPaste.Services.CustomActions;
 using AdvancedPaste.UnitTests.Mocks;
+using AdvancedPaste.ViewModels;
 using Microsoft.PowerToys.Settings.UI.Library;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -45,10 +46,13 @@ public sealed class OpenAICompatibleProviderTests
     [TestMethod]
     [DataRow("https://api.example.com/v1", true)]
     [DataRow("http://localhost:8080/v1", true)]
+    [DataRow("  http://localhost:8080/v1  ", true)]
+    [DataRow("http://user:password@localhost:8080/v1", false)]
+    [DataRow("http://localhost:8080/v1#fragment", false)]
     [DataRow("ftp://example.com/v1", false)]
     [DataRow("example.com/v1", false)]
     [DataRow("", false)]
-    public void EndpointValidation_AcceptsOnlyAbsoluteHttpEndpoints(string endpoint, bool expected)
+    public void EndpointValidation_AcceptsOnlySafeAbsoluteHttpEndpoints(string endpoint, bool expected)
     {
         Assert.AreEqual(expected, PasteAIProviderValidation.TryGetOpenAICompatibleEndpoint(endpoint, out _));
     }
@@ -121,6 +125,14 @@ public sealed class OpenAICompatibleProviderTests
     }
 
     [TestMethod]
+    public void AdvancedAIAvailability_DoesNotRequireCredentialForCompatibleProvider()
+    {
+        Assert.IsFalse(OptionsViewModel.RequiresConfiguredCredentialForAdvancedAI(AIServiceType.OpenAICompatible));
+        Assert.IsTrue(OptionsViewModel.RequiresConfiguredCredentialForAdvancedAI(AIServiceType.OpenAI));
+        Assert.IsTrue(OptionsViewModel.RequiresConfiguredCredentialForAdvancedAI(AIServiceType.AzureOpenAI));
+    }
+
+    [TestMethod]
     public void Provider_DoesNotUseClientModeration()
     {
         Assert.IsFalse(CustomActionTransformService.ShouldModerate(new PasteAIConfig
@@ -146,17 +158,22 @@ public sealed class OpenAICompatibleProviderTests
             new System.InvalidOperationException("A model name is required for OpenAICompatible."),
             -1);
         var rejectedRequest = ErrorHelpers.TranslateOpenAICompatibleError(new HttpRequestException(), (int)HttpStatusCode.BadRequest);
+        var authenticationFailed = ErrorHelpers.TranslateOpenAICompatibleError(new HttpRequestException(), (int)HttpStatusCode.Unauthorized);
+        var rateLimited = ErrorHelpers.TranslateOpenAICompatibleError(new HttpRequestException(), (int)HttpStatusCode.TooManyRequests);
         var unavailableModel = ErrorHelpers.TranslateOpenAICompatibleError(new HttpRequestException(), (int)HttpStatusCode.ServiceUnavailable);
         var networkError = ErrorHelpers.TranslateOpenAICompatibleError(new HttpRequestException(), -1);
+        const int GenericStatusCode = 418;
+        var genericError = ErrorHelpers.TranslateOpenAICompatibleError(new HttpRequestException(), GenericStatusCode);
+        var resourceLoader = ResourceLoaderInstance.ResourceLoader;
 
-        Assert.IsFalse(string.IsNullOrWhiteSpace(invalidEndpoint));
-        Assert.IsFalse(string.IsNullOrWhiteSpace(invalidModel));
-        Assert.IsFalse(string.IsNullOrWhiteSpace(rejectedRequest));
-        Assert.IsFalse(string.IsNullOrWhiteSpace(unavailableModel));
-        Assert.IsFalse(string.IsNullOrWhiteSpace(networkError));
-        Assert.AreNotEqual(invalidEndpoint, invalidModel);
-        Assert.AreNotEqual(rejectedRequest, networkError);
-        Assert.AreNotEqual(unavailableModel, networkError);
+        Assert.AreEqual(resourceLoader.GetString("OpenAICompatibleEndpointInvalid"), invalidEndpoint);
+        Assert.AreEqual(resourceLoader.GetString("OpenAICompatibleModelRequired"), invalidModel);
+        Assert.AreEqual(resourceLoader.GetString("OpenAICompatibleRequestRejected"), rejectedRequest);
+        Assert.AreEqual(resourceLoader.GetString("OpenAICompatibleAuthenticationFailed"), authenticationFailed);
+        Assert.AreEqual(resourceLoader.GetString("OpenAICompatibleRateLimited"), rateLimited);
+        Assert.AreEqual(resourceLoader.GetString("OpenAICompatibleServiceUnavailable"), unavailableModel);
+        Assert.AreEqual(resourceLoader.GetString("OpenAICompatibleNetworkError"), networkError);
+        StringAssert.Contains(genericError, GenericStatusCode.ToString(System.Globalization.CultureInfo.InvariantCulture));
     }
 
     [TestMethod]

--- a/src/modules/AdvancedPaste/AdvancedPaste.UnitTests/ServicesTests/OpenAICompatibleProviderTests.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste.UnitTests/ServicesTests/OpenAICompatibleProviderTests.cs
@@ -6,13 +6,16 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Reflection;
 using System.Text.Json;
 
 using AdvancedPaste.Helpers;
 using AdvancedPaste.Services;
 using AdvancedPaste.Services.CustomActions;
+using AdvancedPaste.UnitTests.Mocks;
 using Microsoft.PowerToys.Settings.UI.Library;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
 
 namespace AdvancedPaste.UnitTests.ServicesTests;
 
@@ -75,6 +78,46 @@ public sealed class OpenAICompatibleProviderTests
         var semanticKernelProvider = (SemanticKernelPasteProvider)provider;
         CollectionAssert.Contains(semanticKernelProvider.SupportedServiceTypes.ToArray(), AIServiceType.OpenAICompatible);
         Assert.IsTrue(AdvancedAIKernelService.IsServiceTypeSupported(AIServiceType.OpenAICompatible));
+    }
+
+    [TestMethod]
+    public void SemanticKernelProvider_AllowsMissingCredential()
+    {
+        var provider = new SemanticKernelPasteProvider(new PasteAIConfig
+        {
+            ProviderType = AIServiceType.OpenAICompatible,
+            Model = "test-model",
+            Endpoint = "http://localhost:8080/v1",
+            ApiKey = string.Empty,
+        });
+        var createKernel = typeof(SemanticKernelPasteProvider).GetMethod("CreateKernel", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        Assert.IsNotNull(createKernel);
+        Assert.IsNotNull(createKernel.Invoke(provider, null));
+    }
+
+    [TestMethod]
+    public void AdvancedAIKernelService_AllowsMissingCredential()
+    {
+        var credentialsProvider = new Mock<IAICredentialsProvider>();
+        credentialsProvider.Setup(provider => provider.GetKey()).Returns(string.Empty);
+        var userSettings = new IntegrationTestUserSettings(
+            AIServiceType.OpenAICompatible,
+            "test-model",
+            "http://localhost:8080/v1",
+            moderationEnabled: false,
+            providerId: "no-auth-provider");
+        var service = new AdvancedAIKernelService(
+            credentialsProvider.Object,
+            new NoOpKernelQueryCacheService(),
+            new Mock<IPromptModerationService>().Object,
+            userSettings,
+            new Mock<ICustomActionTransformService>().Object);
+        var createKernel = typeof(KernelServiceBase).GetMethod("CreateKernel", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        Assert.IsNotNull(createKernel);
+        Assert.IsNotNull(createKernel.Invoke(service, null));
+        credentialsProvider.Verify(provider => provider.Refresh(), Times.Once);
     }
 
     [TestMethod]

--- a/src/modules/AdvancedPaste/AdvancedPaste.UnitTests/ServicesTests/OpenAICompatibleProviderTests.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste.UnitTests/ServicesTests/OpenAICompatibleProviderTests.cs
@@ -1,0 +1,160 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+
+using AdvancedPaste.Helpers;
+using AdvancedPaste.Services;
+using AdvancedPaste.Services.CustomActions;
+using Microsoft.PowerToys.Settings.UI.Library;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AdvancedPaste.UnitTests.ServicesTests;
+
+[TestClass]
+public sealed class OpenAICompatibleProviderTests
+{
+    [TestMethod]
+    public void ServiceType_RoundTripsThroughPersistedValues()
+    {
+        Assert.AreEqual(AIServiceType.OpenAICompatible, "OpenAICompatible".ToAIServiceType());
+        Assert.AreEqual(AIServiceType.OpenAICompatible, "openai-compatible".ToAIServiceType());
+        Assert.AreEqual("OpenAICompatible", AIServiceType.OpenAICompatible.ToConfigurationString());
+        Assert.AreEqual("openaicompatible", AIServiceType.OpenAICompatible.ToNormalizedKey());
+    }
+
+    [TestMethod]
+    public void ProviderDefaults_RequireExplicitConfiguration()
+    {
+        Assert.AreEqual(string.Empty, PasteAIProviderDefaults.GetDefaultModelName(AIServiceType.OpenAICompatible));
+
+        var metadata = AIServiceTypeRegistry.GetMetadata(AIServiceType.OpenAICompatible);
+        Assert.AreEqual("OpenAI Compatible", metadata.DisplayName);
+        Assert.IsTrue(metadata.IsOnlineService);
+        Assert.IsTrue(metadata.IsAvailableInUI);
+    }
+
+    [TestMethod]
+    [DataRow("https://api.example.com/v1", true)]
+    [DataRow("http://localhost:8080/v1", true)]
+    [DataRow("ftp://example.com/v1", false)]
+    [DataRow("example.com/v1", false)]
+    [DataRow("", false)]
+    public void EndpointValidation_AcceptsOnlyAbsoluteHttpEndpoints(string endpoint, bool expected)
+    {
+        Assert.AreEqual(expected, PasteAIProviderValidation.TryGetOpenAICompatibleEndpoint(endpoint, out _));
+    }
+
+    [TestMethod]
+    [DataRow("test-model", true)]
+    [DataRow("  test-model  ", true)]
+    [DataRow("", false)]
+    [DataRow("   ", false)]
+    public void ModelValidation_RejectsEmptyNames(string modelName, bool expected)
+    {
+        Assert.AreEqual(expected, PasteAIProviderValidation.IsValidOpenAICompatibleModelName(modelName));
+    }
+
+    [TestMethod]
+    public void ProviderFactory_UsesSemanticKernelProvider()
+    {
+        var provider = new PasteAIProviderFactory().CreateProvider(new PasteAIConfig
+        {
+            ProviderType = AIServiceType.OpenAICompatible,
+            Model = "test-model",
+            Endpoint = "https://api.example.com/v1",
+            ApiKey = "test-key",
+        });
+
+        Assert.IsInstanceOfType(provider, typeof(SemanticKernelPasteProvider));
+        var semanticKernelProvider = (SemanticKernelPasteProvider)provider;
+        CollectionAssert.Contains(semanticKernelProvider.SupportedServiceTypes.ToArray(), AIServiceType.OpenAICompatible);
+        Assert.IsTrue(AdvancedAIKernelService.IsServiceTypeSupported(AIServiceType.OpenAICompatible));
+    }
+
+    [TestMethod]
+    public void Provider_DoesNotUseClientModeration()
+    {
+        Assert.IsFalse(CustomActionTransformService.ShouldModerate(new PasteAIConfig
+        {
+            ProviderType = AIServiceType.OpenAICompatible,
+            ModerationEnabled = true,
+        }));
+
+        Assert.IsTrue(CustomActionTransformService.ShouldModerate(new PasteAIConfig
+        {
+            ProviderType = AIServiceType.OpenAI,
+            ModerationEnabled = true,
+        }));
+    }
+
+    [TestMethod]
+    public void ErrorTranslation_ProvidesSpecificCompatibleProviderMessages()
+    {
+        var invalidEndpoint = ErrorHelpers.TranslateOpenAICompatibleError(
+            new System.InvalidOperationException("A valid HTTP or HTTPS endpoint is required for OpenAICompatible."),
+            -1);
+        var invalidModel = ErrorHelpers.TranslateOpenAICompatibleError(
+            new System.InvalidOperationException("A model name is required for OpenAICompatible."),
+            -1);
+        var rejectedRequest = ErrorHelpers.TranslateOpenAICompatibleError(new HttpRequestException(), (int)HttpStatusCode.BadRequest);
+        var unavailableModel = ErrorHelpers.TranslateOpenAICompatibleError(new HttpRequestException(), (int)HttpStatusCode.ServiceUnavailable);
+        var networkError = ErrorHelpers.TranslateOpenAICompatibleError(new HttpRequestException(), -1);
+
+        Assert.IsFalse(string.IsNullOrWhiteSpace(invalidEndpoint));
+        Assert.IsFalse(string.IsNullOrWhiteSpace(invalidModel));
+        Assert.IsFalse(string.IsNullOrWhiteSpace(rejectedRequest));
+        Assert.IsFalse(string.IsNullOrWhiteSpace(unavailableModel));
+        Assert.IsFalse(string.IsNullOrWhiteSpace(networkError));
+        Assert.AreNotEqual(invalidEndpoint, invalidModel);
+        Assert.AreNotEqual(rejectedRequest, networkError);
+        Assert.AreNotEqual(unavailableModel, networkError);
+    }
+
+    [TestMethod]
+    public void VaultEntries_AreIsolatedByProviderId()
+    {
+        var first = EnhancedVaultCredentialsProvider.BuildCredentialEntry(AIServiceType.OpenAICompatible, "provider-one");
+        var second = EnhancedVaultCredentialsProvider.BuildCredentialEntry(AIServiceType.OpenAICompatible, "provider-two");
+
+        Assert.IsTrue(first.HasValue);
+        Assert.IsTrue(second.HasValue);
+        Assert.AreEqual("PowerToys_AdvancedPaste_OpenAICompatible", first.Value.Resource);
+        Assert.AreEqual(first.Value.Resource, second.Value.Resource);
+        Assert.AreNotEqual(first.Value.Username, second.Value.Username);
+        StringAssert.Contains(first.Value.Username, "openaicompatible");
+    }
+
+    [TestMethod]
+    public void Configuration_SerializesWithoutCredential()
+    {
+        var provider = new PasteAIProviderDefinition
+        {
+            Id = "compatible-provider",
+            ServiceTypeKind = AIServiceType.OpenAICompatible,
+            ModelName = "test-model",
+            EndpointUrl = "https://api.example.com/v1",
+            ModerationEnabled = false,
+            EnableAdvancedAI = true,
+        };
+        var configuration = new PasteAIConfiguration
+        {
+            ActiveProviderId = provider.Id,
+            Providers = new ObservableCollection<PasteAIProviderDefinition> { provider },
+        };
+
+        var json = configuration.ToString();
+        var roundTripped = JsonSerializer.Deserialize(json, SettingsSerializationContext.Default.PasteAIConfiguration);
+
+        Assert.IsNotNull(roundTripped);
+        Assert.AreEqual(AIServiceType.OpenAICompatible, roundTripped.ActiveProvider.ServiceTypeKind);
+        Assert.AreEqual(provider.EndpointUrl, roundTripped.ActiveProvider.EndpointUrl);
+        Assert.AreEqual(provider.ModelName, roundTripped.ActiveProvider.ModelName);
+        Assert.IsFalse(json.Contains("api-key", System.StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/src/modules/AdvancedPaste/AdvancedPaste/Helpers/ErrorHelpers.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/Helpers/ErrorHelpers.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Globalization;
 using System.Net;
 
@@ -16,4 +17,36 @@ public static class ErrorHelpers
         HttpStatusCode.OK => string.Empty,
         _ => ResourceLoaderInstance.ResourceLoader.GetString("OpenAIApiKeyError") + apiRequestStatus.ToString(CultureInfo.InvariantCulture),
     };
+
+    public static string TranslateOpenAICompatibleError(Exception exception, int apiRequestStatus)
+    {
+        var resourceLoader = ResourceLoaderInstance.ResourceLoader;
+        if (exception is InvalidOperationException)
+        {
+            if (exception.Message.Contains("endpoint", StringComparison.OrdinalIgnoreCase))
+            {
+                return resourceLoader.GetString("OpenAICompatibleEndpointInvalid");
+            }
+
+            if (exception.Message.Contains("model name", StringComparison.OrdinalIgnoreCase))
+            {
+                return resourceLoader.GetString("OpenAICompatibleModelRequired");
+            }
+
+            if (exception.Message.Contains("API key", StringComparison.OrdinalIgnoreCase))
+            {
+                return resourceLoader.GetString("OpenAICompatibleTokenRequired");
+            }
+        }
+
+        return (HttpStatusCode)apiRequestStatus switch
+        {
+            HttpStatusCode.BadRequest => resourceLoader.GetString("OpenAICompatibleRequestRejected"),
+            HttpStatusCode.NotFound => resourceLoader.GetString("OpenAICompatibleEndpointOrModelNotFound"),
+            HttpStatusCode.ServiceUnavailable => resourceLoader.GetString("OpenAICompatibleServiceUnavailable"),
+            0 => resourceLoader.GetString("OpenAICompatibleNetworkError"),
+            _ when apiRequestStatus < 0 => resourceLoader.GetString("OpenAICompatibleNetworkError"),
+            _ => TranslateErrorText(apiRequestStatus),
+        };
+    }
 }

--- a/src/modules/AdvancedPaste/AdvancedPaste/Helpers/ErrorHelpers.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/Helpers/ErrorHelpers.cs
@@ -37,11 +37,17 @@ public static class ErrorHelpers
         return (HttpStatusCode)apiRequestStatus switch
         {
             HttpStatusCode.BadRequest => resourceLoader.GetString("OpenAICompatibleRequestRejected"),
+            HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden => resourceLoader.GetString("OpenAICompatibleAuthenticationFailed"),
             HttpStatusCode.NotFound => resourceLoader.GetString("OpenAICompatibleEndpointOrModelNotFound"),
-            HttpStatusCode.ServiceUnavailable => resourceLoader.GetString("OpenAICompatibleServiceUnavailable"),
+            HttpStatusCode.TooManyRequests => resourceLoader.GetString("OpenAICompatibleRateLimited"),
+            HttpStatusCode.RequestTimeout or HttpStatusCode.BadGateway or HttpStatusCode.ServiceUnavailable or HttpStatusCode.GatewayTimeout
+                => resourceLoader.GetString("OpenAICompatibleServiceUnavailable"),
             0 => resourceLoader.GetString("OpenAICompatibleNetworkError"),
             _ when apiRequestStatus < 0 => resourceLoader.GetString("OpenAICompatibleNetworkError"),
-            _ => TranslateErrorText(apiRequestStatus),
+            _ => string.Format(
+                CultureInfo.InvariantCulture,
+                resourceLoader.GetString("OpenAICompatibleRequestFailed"),
+                apiRequestStatus),
         };
     }
 }

--- a/src/modules/AdvancedPaste/AdvancedPaste/Helpers/ErrorHelpers.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/Helpers/ErrorHelpers.cs
@@ -32,11 +32,6 @@ public static class ErrorHelpers
             {
                 return resourceLoader.GetString("OpenAICompatibleModelRequired");
             }
-
-            if (exception.Message.Contains("API key", StringComparison.OrdinalIgnoreCase))
-            {
-                return resourceLoader.GetString("OpenAICompatibleTokenRequired");
-            }
         }
 
         return (HttpStatusCode)apiRequestStatus switch

--- a/src/modules/AdvancedPaste/AdvancedPaste/Services/AdvancedAIKernelService.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/Services/AdvancedAIKernelService.cs
@@ -52,16 +52,11 @@ public sealed class AdvancedAIKernelService : KernelServiceBase
         var runtimeConfig = GetRuntimeConfiguration();
         var serviceType = runtimeConfig.ServiceType;
         var modelName = runtimeConfig.ModelName;
-        var requiresApiKey = RequiresApiKey(serviceType);
-        var apiKey = string.Empty;
-        if (requiresApiKey)
+        this.credentialsProvider.Refresh();
+        var apiKey = (this.credentialsProvider.GetKey() ?? string.Empty).Trim();
+        if (RequiresApiKey(serviceType) && string.IsNullOrWhiteSpace(apiKey))
         {
-            this.credentialsProvider.Refresh();
-            apiKey = (this.credentialsProvider.GetKey() ?? string.Empty).Trim();
-            if (string.IsNullOrWhiteSpace(apiKey))
-            {
-                throw new InvalidOperationException($"An API key is required for {serviceType} but none was found in the credential vault.");
-            }
+            throw new InvalidOperationException($"An API key is required for {serviceType} but none was found in the credential vault.");
         }
 
         var endpoint = string.IsNullOrWhiteSpace(runtimeConfig.Endpoint) ? null : runtimeConfig.Endpoint.Trim();
@@ -74,8 +69,9 @@ public sealed class AdvancedAIKernelService : KernelServiceBase
                 break;
             case AIServiceType.OpenAICompatible:
                 var compatibleModelName = RequireOpenAICompatibleModelName(modelName);
+                var compatibleApiKey = string.IsNullOrWhiteSpace(apiKey) ? null : apiKey;
 #pragma warning disable SKEXP0010 // OpenAI-compatible custom endpoints are experimental in Semantic Kernel.
-                kernelBuilder.AddOpenAIChatCompletion(compatibleModelName, RequireOpenAICompatibleEndpoint(endpoint), apiKey, serviceId: compatibleModelName);
+                kernelBuilder.AddOpenAIChatCompletion(compatibleModelName, RequireOpenAICompatibleEndpoint(endpoint), compatibleApiKey, serviceId: compatibleModelName);
 #pragma warning restore SKEXP0010
                 break;
             case AIServiceType.AzureOpenAI:
@@ -202,7 +198,7 @@ public sealed class AdvancedAIKernelService : KernelServiceBase
 
     private static bool RequiresApiKey(AIServiceType serviceType)
     {
-        return true;
+        return serviceType != AIServiceType.OpenAICompatible;
     }
 
     private static string RequireEndpoint(string endpoint, AIServiceType serviceType)

--- a/src/modules/AdvancedPaste/AdvancedPaste/Services/AdvancedAIKernelService.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/Services/AdvancedAIKernelService.cs
@@ -72,6 +72,12 @@ public sealed class AdvancedAIKernelService : KernelServiceBase
             case AIServiceType.OpenAI:
                 kernelBuilder.AddOpenAIChatCompletion(modelName, apiKey, serviceId: modelName);
                 break;
+            case AIServiceType.OpenAICompatible:
+                var compatibleModelName = RequireOpenAICompatibleModelName(modelName);
+#pragma warning disable SKEXP0010 // OpenAI-compatible custom endpoints are experimental in Semantic Kernel.
+                kernelBuilder.AddOpenAIChatCompletion(compatibleModelName, RequireOpenAICompatibleEndpoint(endpoint), apiKey, serviceId: compatibleModelName);
+#pragma warning restore SKEXP0010
+                break;
             case AIServiceType.AzureOpenAI:
                 kernelBuilder.AddAzureOpenAIChatCompletion(deployment, RequireEndpoint(endpoint, serviceType), apiKey, serviceId: modelName);
                 break;
@@ -99,10 +105,10 @@ public sealed class AdvancedAIKernelService : KernelServiceBase
     {
         if (!string.IsNullOrWhiteSpace(config?.ModelName))
         {
-            return config.ModelName;
+            return config.ServiceTypeKind == AIServiceType.OpenAICompatible ? config.ModelName.Trim() : config.ModelName;
         }
 
-        return "gpt-4o";
+        return config?.ServiceTypeKind == AIServiceType.OpenAICompatible ? string.Empty : "gpt-4o";
     }
 
     protected override IKernelRuntimeConfiguration GetRuntimeConfiguration()
@@ -184,9 +190,9 @@ public sealed class AdvancedAIKernelService : KernelServiceBase
         return IsServiceTypeSupported(serviceType);
     }
 
-    private static bool IsServiceTypeSupported(AIServiceType serviceType)
+    internal static bool IsServiceTypeSupported(AIServiceType serviceType)
     {
-        return serviceType is AIServiceType.OpenAI or AIServiceType.AzureOpenAI;
+        return serviceType is AIServiceType.OpenAI or AIServiceType.AzureOpenAI or AIServiceType.OpenAICompatible;
     }
 
     private static AIServiceType NormalizeServiceType(AIServiceType serviceType)
@@ -207,6 +213,26 @@ public sealed class AdvancedAIKernelService : KernelServiceBase
         }
 
         throw new InvalidOperationException($"Endpoint is required for {serviceType} configuration but was not provided.");
+    }
+
+    private static Uri RequireOpenAICompatibleEndpoint(string endpoint)
+    {
+        if (PasteAIProviderValidation.TryGetOpenAICompatibleEndpoint(endpoint, out var endpointUri))
+        {
+            return endpointUri;
+        }
+
+        throw new InvalidOperationException("A valid HTTP or HTTPS endpoint is required for OpenAICompatible.");
+    }
+
+    private static string RequireOpenAICompatibleModelName(string modelName)
+    {
+        if (PasteAIProviderValidation.IsValidOpenAICompatibleModelName(modelName))
+        {
+            return modelName.Trim();
+        }
+
+        throw new InvalidOperationException("A model name is required for OpenAICompatible.");
     }
 
     private PromptExecutionSettings CreatePromptExecutionSettings()

--- a/src/modules/AdvancedPaste/AdvancedPaste/Services/CustomActions/CustomActionTransformService.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/Services/CustomActions/CustomActionTransformService.cs
@@ -110,7 +110,10 @@ namespace AdvancedPaste.Services.CustomActions
                 Logger.LogError($"{nameof(CustomActionTransformService)}.{nameof(TransformAsync)} failed", ex);
                 var statusCode = ExtractStatusCode(ex);
                 var modelName = providerConfig.Model ?? string.Empty;
-                AdvancedPasteCustomActionErrorEvent errorEvent = new(providerConfig.ProviderType, modelName, statusCode, ex is PasteActionModeratedException ? PasteActionModeratedException.ErrorDescription : ex.Message);
+                var telemetryError = providerConfig.ProviderType == AIServiceType.OpenAICompatible
+                    ? "OpenAICompatibleRequestFailed"
+                    : ex is PasteActionModeratedException ? PasteActionModeratedException.ErrorDescription : ex.Message;
+                AdvancedPasteCustomActionErrorEvent errorEvent = new(providerConfig.ProviderType, modelName, statusCode, telemetryError);
                 PowerToysTelemetry.Log.WriteEvent(errorEvent);
 
                 if (ex is PasteActionException or OperationCanceledException)
@@ -120,6 +123,7 @@ namespace AdvancedPaste.Services.CustomActions
 
                 var failureMessage = providerConfig.ProviderType switch
                 {
+                    AIServiceType.OpenAICompatible => ErrorHelpers.TranslateOpenAICompatibleError(ex, statusCode),
                     AIServiceType.OpenAI or AIServiceType.AzureOpenAI => ErrorHelpers.TranslateErrorText(statusCode),
                     _ => ResourceLoaderInstance.ResourceLoader.GetString("PasteError"),
                 };
@@ -194,7 +198,7 @@ namespace AdvancedPaste.Services.CustomActions
             };
         }
 
-        private static bool ShouldModerate(PasteAIConfig providerConfig)
+        internal static bool ShouldModerate(PasteAIConfig providerConfig)
         {
             if (providerConfig is null || !providerConfig.ModerationEnabled)
             {

--- a/src/modules/AdvancedPaste/AdvancedPaste/Services/CustomActions/SemanticKernelPasteProvider.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/Services/CustomActions/SemanticKernelPasteProvider.cs
@@ -147,8 +147,9 @@ namespace AdvancedPaste.Services.CustomActions
                     break;
                 case AIServiceType.OpenAICompatible:
                     var compatibleModelName = RequireOpenAICompatibleModelName(_config.Model);
+                    var compatibleApiKey = string.IsNullOrWhiteSpace(apiKey) ? null : apiKey;
 #pragma warning disable SKEXP0010 // OpenAI-compatible custom endpoints are experimental in Semantic Kernel.
-                    kernelBuilder.AddOpenAIChatCompletion(compatibleModelName, RequireOpenAICompatibleEndpoint(endpoint), apiKey, serviceId: compatibleModelName);
+                    kernelBuilder.AddOpenAIChatCompletion(compatibleModelName, RequireOpenAICompatibleEndpoint(endpoint), compatibleApiKey, serviceId: compatibleModelName);
 #pragma warning restore SKEXP0010
                     break;
                 case AIServiceType.AzureOpenAI:
@@ -191,7 +192,7 @@ namespace AdvancedPaste.Services.CustomActions
         {
             return serviceType switch
             {
-                AIServiceType.Ollama => false,
+                AIServiceType.Ollama or AIServiceType.OpenAICompatible => false,
                 _ => true,
             };
         }

--- a/src/modules/AdvancedPaste/AdvancedPaste/Services/CustomActions/SemanticKernelPasteProvider.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/Services/CustomActions/SemanticKernelPasteProvider.cs
@@ -29,6 +29,7 @@ namespace AdvancedPaste.Services.CustomActions
             AIServiceType.Google,
             AIServiceType.AzureAIInference,
             AIServiceType.Ollama,
+            AIServiceType.OpenAICompatible,
         };
 
         public static PasteAIProviderRegistration Registration { get; } = new(SupportedTypes, config => new SemanticKernelPasteProvider(config));
@@ -144,6 +145,12 @@ namespace AdvancedPaste.Services.CustomActions
                 case AIServiceType.OpenAI:
                     kernelBuilder.AddOpenAIChatCompletion(_config.Model, apiKey, serviceId: _config.Model);
                     break;
+                case AIServiceType.OpenAICompatible:
+                    var compatibleModelName = RequireOpenAICompatibleModelName(_config.Model);
+#pragma warning disable SKEXP0010 // OpenAI-compatible custom endpoints are experimental in Semantic Kernel.
+                    kernelBuilder.AddOpenAIChatCompletion(compatibleModelName, RequireOpenAICompatibleEndpoint(endpoint), apiKey, serviceId: compatibleModelName);
+#pragma warning restore SKEXP0010
+                    break;
                 case AIServiceType.AzureOpenAI:
                     var deploymentName = string.IsNullOrWhiteSpace(_config.DeploymentName) ? _config.Model : _config.DeploymentName;
                     kernelBuilder.AddAzureOpenAIChatCompletion(deploymentName, RequireEndpoint(endpoint, _serviceType), apiKey, serviceId: _config.Model);
@@ -172,7 +179,7 @@ namespace AdvancedPaste.Services.CustomActions
         {
             return _serviceType switch
             {
-                AIServiceType.OpenAI or AIServiceType.AzureOpenAI => new OpenAIPromptExecutionSettings
+                AIServiceType.OpenAI or AIServiceType.AzureOpenAI or AIServiceType.OpenAICompatible => new OpenAIPromptExecutionSettings
                 {
                     FunctionChoiceBehavior = null,
                 },
@@ -197,6 +204,26 @@ namespace AdvancedPaste.Services.CustomActions
             }
 
             throw new InvalidOperationException($"Endpoint is required for {serviceType} but was not provided.");
+        }
+
+        private static Uri RequireOpenAICompatibleEndpoint(string endpoint)
+        {
+            if (PasteAIProviderValidation.TryGetOpenAICompatibleEndpoint(endpoint, out var endpointUri))
+            {
+                return endpointUri;
+            }
+
+            throw new InvalidOperationException("A valid HTTP or HTTPS endpoint is required for OpenAICompatible.");
+        }
+
+        private static string RequireOpenAICompatibleModelName(string modelName)
+        {
+            if (PasteAIProviderValidation.IsValidOpenAICompatibleModelName(modelName))
+            {
+                return modelName.Trim();
+            }
+
+            throw new InvalidOperationException("A model name is required for OpenAICompatible.");
         }
     }
 }

--- a/src/modules/AdvancedPaste/AdvancedPaste/Services/EnhancedVaultCredentialsProvider.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/Services/EnhancedVaultCredentialsProvider.cs
@@ -129,7 +129,7 @@ public sealed class EnhancedVaultCredentialsProvider : IAICredentialsProvider
         }
     }
 
-    private static (string Resource, string Username)? BuildCredentialEntry(AIServiceType serviceType, string providerId)
+    internal static (string Resource, string Username)? BuildCredentialEntry(AIServiceType serviceType, string providerId)
     {
         string resource;
         string serviceKey;
@@ -139,6 +139,10 @@ public sealed class EnhancedVaultCredentialsProvider : IAICredentialsProvider
             case AIServiceType.OpenAI:
                 resource = "https://platform.openai.com/api-keys";
                 serviceKey = "openai";
+                break;
+            case AIServiceType.OpenAICompatible:
+                resource = "PowerToys_AdvancedPaste_OpenAICompatible";
+                serviceKey = "openaicompatible";
                 break;
             case AIServiceType.AzureOpenAI:
                 resource = "https://azure.microsoft.com/products/ai-services/openai-service";

--- a/src/modules/AdvancedPaste/AdvancedPaste/Services/KernelServiceBase.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/Services/KernelServiceBase.cs
@@ -117,7 +117,11 @@ public abstract class KernelServiceBase(
             Logger.LogError($"Error executing kernel operation", ex);
             Logger.LogError($"Kernel operation Error: \n{FormatChatHistory(chatHistory)}");
 
-            AdvancedPasteSemanticKernelErrorEvent errorEvent = new(ex is PasteActionModeratedException ? PasteActionModeratedException.ErrorDescription : ex.Message);
+            var isOpenAICompatible = GetRuntimeConfiguration().ServiceType == AIServiceType.OpenAICompatible;
+            var telemetryError = isOpenAICompatible
+                ? "OpenAICompatibleRequestFailed"
+                : ex is PasteActionModeratedException ? PasteActionModeratedException.ErrorDescription : ex.Message;
+            AdvancedPasteSemanticKernelErrorEvent errorEvent = new(telemetryError);
             PowerToysTelemetry.Log.WriteEvent(errorEvent);
 
             if (ex is PasteActionException or OperationCanceledException)
@@ -126,9 +130,12 @@ public abstract class KernelServiceBase(
             }
             else
             {
-                var message = ex is HttpOperationException httpOperationEx
-                    ? ErrorHelpers.TranslateErrorText((int?)httpOperationEx.StatusCode ?? -1)
-                    : ResourceLoaderInstance.ResourceLoader.GetString("PasteError");
+                var statusCode = ex is HttpOperationException httpOperationEx ? (int?)httpOperationEx.StatusCode ?? -1 : -1;
+                var message = isOpenAICompatible
+                    ? ErrorHelpers.TranslateOpenAICompatibleError(ex, statusCode)
+                    : ex is HttpOperationException
+                        ? ErrorHelpers.TranslateErrorText(statusCode)
+                        : ResourceLoaderInstance.ResourceLoader.GetString("PasteError");
 
                 var lastAssistantMessage = chatHistory.LastOrDefault(chatMessage => chatMessage.Role == AuthorRole.Assistant)?.ToString();
                 throw new PasteActionException(message, innerException: ex, aiServiceMessage: lastAssistantMessage);

--- a/src/modules/AdvancedPaste/AdvancedPaste/Strings/en-us/Resources.resw
+++ b/src/modules/AdvancedPaste/AdvancedPaste/Strings/en-us/Resources.resw
@@ -141,9 +141,6 @@
   <data name="OpenAICompatibleModelRequired" xml:space="preserve">
     <value>A model name is required for the configured AI endpoint.</value>
   </data>
-  <data name="OpenAICompatibleTokenRequired" xml:space="preserve">
-    <value>An API token is required for the configured AI endpoint.</value>
-  </data>
   <data name="OpenAICompatibleRequestRejected" xml:space="preserve">
     <value>The configured AI endpoint rejected the request. Check the model name and whether the model supports this input.</value>
   </data>

--- a/src/modules/AdvancedPaste/AdvancedPaste/Strings/en-us/Resources.resw
+++ b/src/modules/AdvancedPaste/AdvancedPaste/Strings/en-us/Resources.resw
@@ -153,6 +153,16 @@
   <data name="OpenAICompatibleNetworkError" xml:space="preserve">
     <value>Could not reach the configured AI endpoint. Check the endpoint and network connection.</value>
   </data>
+  <data name="OpenAICompatibleAuthenticationFailed" xml:space="preserve">
+    <value>The configured AI endpoint rejected the credentials. Check the API token and authentication settings.</value>
+  </data>
+  <data name="OpenAICompatibleRateLimited" xml:space="preserve">
+    <value>The configured AI endpoint is rate limiting requests. Try again later.</value>
+  </data>
+  <data name="OpenAICompatibleRequestFailed" xml:space="preserve">
+    <value>The configured AI endpoint returned status code: {0}</value>
+    <comment>{0} is the HTTP status code. Do not translate {0}.</comment>
+  </data>
   <data name="PasteActionCanceled" xml:space="preserve">
     <value>The paste operation was canceled</value>
   </data>

--- a/src/modules/AdvancedPaste/AdvancedPaste/Strings/en-us/Resources.resw
+++ b/src/modules/AdvancedPaste/AdvancedPaste/Strings/en-us/Resources.resw
@@ -135,6 +135,27 @@
   <data name="OpenAIApiKeyError" xml:space="preserve">
     <value>OpenAI request failed with status code: </value>
   </data>
+  <data name="OpenAICompatibleEndpointInvalid" xml:space="preserve">
+    <value>The configured AI endpoint must be an absolute HTTP or HTTPS URL.</value>
+  </data>
+  <data name="OpenAICompatibleModelRequired" xml:space="preserve">
+    <value>A model name is required for the configured AI endpoint.</value>
+  </data>
+  <data name="OpenAICompatibleTokenRequired" xml:space="preserve">
+    <value>An API token is required for the configured AI endpoint.</value>
+  </data>
+  <data name="OpenAICompatibleRequestRejected" xml:space="preserve">
+    <value>The configured AI endpoint rejected the request. Check the model name and whether the model supports this input.</value>
+  </data>
+  <data name="OpenAICompatibleEndpointOrModelNotFound" xml:space="preserve">
+    <value>The configured AI endpoint or model was not found.</value>
+  </data>
+  <data name="OpenAICompatibleServiceUnavailable" xml:space="preserve">
+    <value>The configured AI endpoint or model is temporarily unavailable.</value>
+  </data>
+  <data name="OpenAICompatibleNetworkError" xml:space="preserve">
+    <value>Could not reach the configured AI endpoint. Check the endpoint and network connection.</value>
+  </data>
   <data name="PasteActionCanceled" xml:space="preserve">
     <value>The paste operation was canceled</value>
   </data>

--- a/src/modules/AdvancedPaste/AdvancedPaste/ViewModels/OptionsViewModel.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/ViewModels/OptionsViewModel.cs
@@ -866,7 +866,8 @@ namespace AdvancedPaste.ViewModels
         private static bool SupportsAdvancedAI(AIServiceType serviceType)
         {
             return serviceType is AIServiceType.OpenAI
-                or AIServiceType.AzureOpenAI;
+                or AIServiceType.AzureOpenAI
+                or AIServiceType.OpenAICompatible;
         }
 
         private bool UpdateOpenAIKey()

--- a/src/modules/AdvancedPaste/AdvancedPaste/ViewModels/OptionsViewModel.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste/ViewModels/OptionsViewModel.cs
@@ -132,12 +132,13 @@ namespace AdvancedPaste.ViewModels
                     return false;
                 }
 
-                if (!TryResolveAdvancedAIProvider(out _))
+                if (!TryResolveAdvancedAIProvider(out var provider))
                 {
                     return false;
                 }
 
-                return _credentialsProvider.IsConfigured();
+                return !RequiresConfiguredCredentialForAdvancedAI(provider.ServiceTypeKind)
+                    || _credentialsProvider.IsConfigured();
             }
         }
 
@@ -868,6 +869,11 @@ namespace AdvancedPaste.ViewModels
             return serviceType is AIServiceType.OpenAI
                 or AIServiceType.AzureOpenAI
                 or AIServiceType.OpenAICompatible;
+        }
+
+        internal static bool RequiresConfiguredCredentialForAdvancedAI(AIServiceType serviceType)
+        {
+            return serviceType != AIServiceType.OpenAICompatible;
         }
 
         private bool UpdateOpenAIKey()

--- a/src/settings-ui/Settings.UI.Library/AIServiceType.cs
+++ b/src/settings-ui/Settings.UI.Library/AIServiceType.cs
@@ -19,5 +19,6 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         Google,
         AzureAIInference,
         Ollama,
+        OpenAICompatible,
     }
 }

--- a/src/settings-ui/Settings.UI.Library/AIServiceTypeExtensions.cs
+++ b/src/settings-ui/Settings.UI.Library/AIServiceTypeExtensions.cs
@@ -31,6 +31,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
                 "google" or "googleai" or "googlegemini" => AIServiceType.Google,
                 "azureaiinference" or "azureinference" => AIServiceType.AzureAIInference,
                 "ollama" => AIServiceType.Ollama,
+                "openaicompatible" or "openai-compatible" => AIServiceType.OpenAICompatible,
                 _ => AIServiceType.Unknown,
             };
         }
@@ -51,6 +52,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
                 AIServiceType.Google => "Google",
                 AIServiceType.AzureAIInference => "AzureAIInference",
                 AIServiceType.Ollama => "Ollama",
+                AIServiceType.OpenAICompatible => "OpenAICompatible",
                 AIServiceType.Unknown => string.Empty,
                 _ => throw new ArgumentOutOfRangeException(nameof(serviceType), serviceType, "Unsupported AI service type."),
             };
@@ -72,6 +74,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
                 AIServiceType.Google => "google",
                 AIServiceType.AzureAIInference => "azureaiinference",
                 AIServiceType.Ollama => "ollama",
+                AIServiceType.OpenAICompatible => "openaicompatible",
                 _ => string.Empty,
             };
         }

--- a/src/settings-ui/Settings.UI.Library/AIServiceTypeRegistry.cs
+++ b/src/settings-ui/Settings.UI.Library/AIServiceTypeRegistry.cs
@@ -118,6 +118,14 @@ public static class AIServiceTypeRegistry
             PrivacyLabel = "AdvancedPaste_OpenAI_PrivacyLabel",
             PrivacyUri = new Uri("https://openai.com/privacy"),
         },
+        [AIServiceType.OpenAICompatible] = new AIServiceTypeMetadata
+        {
+            ServiceType = AIServiceType.OpenAICompatible,
+            DisplayName = "OpenAI Compatible",
+            IconPath = "ms-appx:///Assets/Settings/Icons/Models/OpenAI.light.svg",
+            IsOnlineService = true,
+            LegalDescription = "AdvancedPaste_OpenAICompatible_LegalDescription",
+        },
         [AIServiceType.Unknown] = new AIServiceTypeMetadata
         {
             ServiceType = AIServiceType.Unknown,

--- a/src/settings-ui/Settings.UI.Library/PasteAIProviderValidation.cs
+++ b/src/settings-ui/Settings.UI.Library/PasteAIProviderValidation.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.PowerToys.Settings.UI.Library;
+
+/// <summary>
+/// Validation helpers for Paste AI provider settings.
+/// </summary>
+public static class PasteAIProviderValidation
+{
+    /// <summary>
+    /// Validates an OpenAI-compatible model name.
+    /// </summary>
+    public static bool IsValidOpenAICompatibleModelName(string modelName)
+    {
+        return !string.IsNullOrWhiteSpace(modelName);
+    }
+
+    /// <summary>
+    /// Validates and parses an OpenAI-compatible HTTP or HTTPS endpoint.
+    /// </summary>
+    public static bool TryGetOpenAICompatibleEndpoint(string endpoint, out Uri endpointUri)
+    {
+        return Uri.TryCreate(endpoint?.Trim(), UriKind.Absolute, out endpointUri)
+            && (endpointUri.Scheme == Uri.UriSchemeHttp || endpointUri.Scheme == Uri.UriSchemeHttps);
+    }
+}

--- a/src/settings-ui/Settings.UI.Library/PasteAIProviderValidation.cs
+++ b/src/settings-ui/Settings.UI.Library/PasteAIProviderValidation.cs
@@ -25,6 +25,8 @@ public static class PasteAIProviderValidation
     public static bool TryGetOpenAICompatibleEndpoint(string endpoint, out Uri endpointUri)
     {
         return Uri.TryCreate(endpoint?.Trim(), UriKind.Absolute, out endpointUri)
-            && (endpointUri.Scheme == Uri.UriSchemeHttp || endpointUri.Scheme == Uri.UriSchemeHttps);
+            && (endpointUri.Scheme == Uri.UriSchemeHttp || endpointUri.Scheme == Uri.UriSchemeHttps)
+            && string.IsNullOrEmpty(endpointUri.UserInfo)
+            && string.IsNullOrEmpty(endpointUri.Fragment);
     }
 }

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/AdvancedPastePage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/AdvancedPastePage.xaml
@@ -514,6 +514,11 @@
                             x:Name="PasteAIApiKeyPasswordBox"
                             x:Uid="AdvancedPaste_APIKey"
                             MinWidth="200" />
+                        <TextBlock
+                            x:Name="PasteAIValidationErrorTextBlock"
+                            Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+                            TextWrapping="Wrap"
+                            Visibility="Collapsed" />
                         <TextBox
                             x:Name="PasteAIApiVersionTextBox"
                             x:Uid="AdvancedPaste_APIVersion"

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/AdvancedPastePage.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/AdvancedPastePage.xaml.cs
@@ -824,7 +824,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             }
 
             // For endpoint-based services, keep empty if the user didn't provide a value.
-            if (RequiresApiKeyForService(serviceType) && string.IsNullOrWhiteSpace(trimmedApiKey))
+            if (RequiresApiKeyForService(serviceType) && serviceKind != AIServiceType.OpenAICompatible && string.IsNullOrWhiteSpace(trimmedApiKey))
             {
                 args.Cancel = true;
                 ShowPasteAIValidationError("AdvancedPaste_OpenAICompatible_TokenRequired", PasteAIApiKeyPasswordBox);

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/AdvancedPastePage.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/AdvancedPastePage.xaml.cs
@@ -888,6 +888,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
                 AIServiceType.AzureAIInference => "https://{resource-name}.cognitiveservices.azure.com/",
                 AIServiceType.Mistral => "https://api.mistral.ai/v1/",
                 AIServiceType.Ollama => "http://localhost:11434/",
+                AIServiceType.OpenAICompatible => "http://localhost:1234/v1/",
                 _ => string.Empty,
             };
         }

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/AdvancedPastePage.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/AdvancedPastePage.xaml.cs
@@ -321,7 +321,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             bool isFoundryLocal = serviceKind == AIServiceType.FoundryLocal;
             bool requiresApiKey = RequiresApiKeyForService(selectedType);
             bool showModerationToggle = serviceKind == AIServiceType.OpenAI;
-            bool showAdvancedAI = serviceKind == AIServiceType.OpenAI || serviceKind == AIServiceType.AzureOpenAI;
+            bool showAdvancedAI = serviceKind is AIServiceType.OpenAI or AIServiceType.AzureOpenAI or AIServiceType.OpenAICompatible;
 
             if (string.IsNullOrWhiteSpace(draft.EndpointUrl))
             {
@@ -345,6 +345,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             PasteAIEnableAdvancedAICheckBox.Visibility = showAdvancedAI ? Visibility.Visible : Visibility.Collapsed;
             PasteAIApiKeyPasswordBox.Visibility = requiresApiKey ? Visibility.Visible : Visibility.Collapsed;
             PasteAIModelNameTextBox.Visibility = isFoundryLocal ? Visibility.Collapsed : Visibility.Visible;
+            PasteAIValidationErrorTextBlock.Visibility = Visibility.Collapsed;
 
             if (requiresApiKey)
             {
@@ -774,6 +775,8 @@ namespace Microsoft.PowerToys.Settings.UI.Views
 
         private void PasteAIProviderConfigurationDialog_PrimaryButtonClick(ContentDialog sender, ContentDialogButtonClickEventArgs args)
         {
+            PasteAIValidationErrorTextBlock.Visibility = Visibility.Collapsed;
+
             var draft = ViewModel?.PasteAIProviderDraft;
             if (draft is null)
             {
@@ -788,6 +791,26 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             var serviceKind = draft.ServiceTypeKind;
             bool requiresEndpoint = RequiresEndpointForService(serviceKind);
             string endpoint = (draft.EndpointUrl ?? string.Empty).Trim();
+
+            if (serviceKind == AIServiceType.OpenAICompatible)
+            {
+                string modelName = (draft.ModelName ?? string.Empty).Trim();
+                if (!PasteAIProviderValidation.IsValidOpenAICompatibleModelName(modelName))
+                {
+                    args.Cancel = true;
+                    ShowPasteAIValidationError("AdvancedPaste_OpenAICompatible_ModelRequired", PasteAIModelNameTextBox);
+                    return;
+                }
+
+                if (!PasteAIProviderValidation.TryGetOpenAICompatibleEndpoint(endpoint, out _))
+                {
+                    args.Cancel = true;
+                    ShowPasteAIValidationError("AdvancedPaste_OpenAICompatible_EndpointInvalid", PasteAIEndpointUrlTextBox);
+                    return;
+                }
+
+                draft.ModelName = modelName;
+            }
 
             // Never persist placeholder text or stale values for services that don't use an endpoint.
             if (!requiresEndpoint)
@@ -804,6 +827,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             if (RequiresApiKeyForService(serviceType) && string.IsNullOrWhiteSpace(trimmedApiKey))
             {
                 args.Cancel = true;
+                ShowPasteAIValidationError("AdvancedPaste_OpenAICompatible_TokenRequired", PasteAIApiKeyPasswordBox);
                 return;
             }
 
@@ -812,6 +836,13 @@ namespace Microsoft.PowerToys.Settings.UI.Views
 
             // Show success message
             ShowApiKeySavedMessage("Paste AI");
+        }
+
+        private void ShowPasteAIValidationError(string resourceKey, Control control)
+        {
+            PasteAIValidationErrorTextBlock.Text = ResourceLoaderInstance.ResourceLoader.GetString(resourceKey);
+            PasteAIValidationErrorTextBlock.Visibility = Visibility.Visible;
+            control?.Focus(FocusState.Programmatic);
         }
 
         private void PasteAIEnableAdvancedAICheckBox_Toggled(object sender, RoutedEventArgs e)
@@ -845,7 +876,8 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             return serviceKind is AIServiceType.AzureOpenAI
                 or AIServiceType.AzureAIInference
                 or AIServiceType.Mistral
-                or AIServiceType.Ollama;
+                or AIServiceType.Ollama
+                or AIServiceType.OpenAICompatible;
         }
 
         private static string GetEndpointPlaceholder(AIServiceType serviceKind)

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -643,6 +643,9 @@ opera.exe</value>
   <data name="AdvancedPaste_OpenAI_LegalDescription" xml:space="preserve">
     <value>Your API key connects directly to OpenAI services. By setting up this provider, you agree to comply with OpenAI's usage policies and data handling practices.</value>
   </data>
+  <data name="AdvancedPaste_OpenAICompatible_LegalDescription" xml:space="preserve">
+    <value>Clipboard content is sent to the configured OpenAI-compatible endpoint. Review that service's data handling practices before using this provider.</value>
+  </data>
   <data name="AdvancedPaste_OpenAI_TermsLabel" xml:space="preserve">
     <value>Terms of Use</value>
   </data>
@@ -6037,6 +6040,15 @@ The break timer font matches the text font.</value>
   </data>
   <data name="AdvancedPaste_APIKey.PlaceholderText" xml:space="preserve">
     <value>Enter API key</value>
+  </data>
+  <data name="AdvancedPaste_OpenAICompatible_ModelRequired" xml:space="preserve">
+    <value>Enter a model name.</value>
+  </data>
+  <data name="AdvancedPaste_OpenAICompatible_EndpointInvalid" xml:space="preserve">
+    <value>Enter an absolute HTTP or HTTPS endpoint.</value>
+  </data>
+  <data name="AdvancedPaste_OpenAICompatible_TokenRequired" xml:space="preserve">
+    <value>Enter an API token.</value>
   </data>
   <data name="AdvancedPaste_APIVersion.Header" xml:space="preserve">
     <value>API version</value>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -644,7 +644,7 @@ opera.exe</value>
     <value>Your API key connects directly to OpenAI services. By setting up this provider, you agree to comply with OpenAI's usage policies and data handling practices.</value>
   </data>
   <data name="AdvancedPaste_OpenAICompatible_LegalDescription" xml:space="preserve">
-    <value>Clipboard content is sent to the configured OpenAI-compatible endpoint. Review that service's data handling practices before using this provider.</value>
+    <value>Clipboard content is sent to the configured OpenAI-compatible endpoint. Review that service's data handling practices before using this provider, and use HTTPS unless you trust the local network connection.</value>
   </data>
   <data name="AdvancedPaste_OpenAI_TermsLabel" xml:space="preserve">
     <value>Terms of Use</value>

--- a/src/settings-ui/Settings.UI/ViewModels/AdvancedPasteViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/AdvancedPasteViewModel.cs
@@ -952,6 +952,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 "mistral" => "https://console.mistral.ai/account/api-keys",
                 "google" => "https://ai.google.dev/",
                 "ollama" => "https://ollama.com/",
+                "openaicompatible" => "PowerToys_AdvancedPaste_OpenAICompatible",
                 _ => "https://platform.openai.com/api-keys",
             };
         }


### PR DESCRIPTION
## Summary of the Pull Request

Adds a generic OpenAI-compatible provider to Advanced Paste. Users explicitly enter the endpoint and model, and can optionally provide an API token; no provider endpoint, model, or credential is preconfigured.

Tracking proposal: #46741. This PR remains a draft pending agreement from the PowerToys team.

## PR Checklist

- [x] Closes: #46741
- [ ] **Communication:** Discussion started in #46741 and contribution registered in #28769; awaiting core contributor agreement
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [x] **New binaries:** Not applicable; this change adds no binaries or test projects
- [ ] **Documentation updated:** Not applicable

## Detailed Description of the Pull Request / Additional comments

- Adds `AIServiceType.OpenAICompatible` and registers it as an online Advanced Paste provider.
- Adds settings UI for endpoint, model, optional API token, and Advanced AI opt-in.
- Validates the endpoint as an absolute HTTP(S) URI and requires a non-empty model; the token is optional for unauthenticated self-hosted endpoints.
- Stores credentials in Windows Password Vault, isolated by provider ID, and removes them when the provider is deleted.
- Uses the configured OpenAI-compatible Chat Completions endpoint for regular transformations and Advanced AI tool calls.
- Keeps client-side OpenAI moderation disabled for this provider; moderation remains the configured endpoint's responsibility.
- Extends factory, error handling, usage, telemetry, settings serialization, and tests without adding third-party dependencies.

## Validation

- Release x64 build succeeded for Settings UI, Advanced Paste, and AdvancedPaste.UnitTests.
- AdvancedPaste.UnitTests: 65 total, 46 passed, 19 skipped, 0 failed.
- Repository scan confirmed no endpoint, model, API token, or credential is preconfigured by this change.

