### PR TITLE
[QuickAccent] Clarify, expand and correct currency symbol mappings

### DIFF
--- a/src/modules/poweraccent/PowerAccent.Common/CharacterMappings.cs
+++ b/src/modules/poweraccent/PowerAccent.Common/CharacterMappings.cs
@@ -143,15 +143,15 @@ public static class CharacterMappings
         // language, but rather a set of symbols used across languages.
         new(Language.CUR, "Currency", LanguageGroup.Special, new Dictionary<LetterKey, string[]>
         {
-            [LetterKey.VK_B] = ["฿", "в"],
-            [LetterKey.VK_C] = ["¢", "₡", "č"],
+            [LetterKey.VK_B] = ["฿", "в"], // Bulgarian Lev (лв)
+            [LetterKey.VK_C] = ["¢", "₡", "č"], // Czech Koruna (Kč)
             [LetterKey.VK_D] = ["₫"],
             [LetterKey.VK_E] = ["€"],
             [LetterKey.VK_F] = ["ƒ"],
             [LetterKey.VK_H] = ["₴"],
             [LetterKey.VK_K] = ["₭"],
-            [LetterKey.VK_L] = ["ł"],
-            [LetterKey.VK_N] = ["л"],
+            [LetterKey.VK_L] = ["ł"], // Polish Złoty (zł)
+            [LetterKey.VK_N] = ["л"], // Bulgarian Lev (лв)
             [LetterKey.VK_M] = ["₼"],
             [LetterKey.VK_P] = ["£", "₽", "₱"],
             [LetterKey.VK_R] = ["₹", "៛", "﷼"],
@@ -159,7 +159,6 @@ public static class CharacterMappings
             [LetterKey.VK_T] = ["₮", "₺", "₸"],
             [LetterKey.VK_W] = ["₩"],
             [LetterKey.VK_Y] = ["¥"],
-            [LetterKey.VK_Z] = ["z"],
         }),
 
         new(Language.CY, "Welsh", LanguageGroup.Language, new Dictionary<LetterKey, string[]>
@@ -240,7 +239,7 @@ public static class CharacterMappings
             [LetterKey.VK_B] = ["β"],
             [LetterKey.VK_C] = ["χ"],
             [LetterKey.VK_D] = ["δ"],
-            [LetterKey.VK_E] = ["ε", "έ", "η", "ή"],
+            [LetterKey.VK_E] = ["ε", "έ", "η", "ή", "€"],
             [LetterKey.VK_F] = ["φ"],
             [LetterKey.VK_G] = ["γ"],
             [LetterKey.VK_I] = ["ι", "ί"],
@@ -350,6 +349,7 @@ public static class CharacterMappings
             [LetterKey.VK_G] = ["ױ"],
             [LetterKey.VK_H] = ["ײ", "ײַ", "ׯ", "\u05b4"],
             [LetterKey.VK_M] = ["\u05b5"],
+            [LetterKey.VK_N] = ["₪"],
             [LetterKey.VK_P] = ["\u05b7", "\u05b2"],
             [LetterKey.VK_S] = ["\u05bc"],
             [LetterKey.VK_T] = ["ﭏ"],
@@ -699,7 +699,7 @@ public static class CharacterMappings
         new(Language.VI, "Vietnamese", LanguageGroup.Language, new Dictionary<LetterKey, string[]>
         {
             [LetterKey.VK_A] = ["à", "ả", "ã", "á", "ạ", "ă", "ằ", "ẳ", "ẵ", "ắ", "ặ", "â", "ầ", "ẩ", "ẫ", "ấ", "ậ"],
-            [LetterKey.VK_D] = ["đ"],
+            [LetterKey.VK_D] = ["đ", "₫"],
             [LetterKey.VK_E] = ["è", "ẻ", "ẽ", "é", "ẹ", "ê", "ề", "ể", "ễ", "ế", "ệ"],
             [LetterKey.VK_I] = ["ì", "ỉ", "ĩ", "í", "ị"],
             [LetterKey.VK_O] = ["ò", "ỏ", "õ", "ó", "ọ", "ô", "ồ", "ổ", "ỗ", "ố", "ộ", "ơ", "ờ", "ở", "ỡ", "ớ", "ợ"],


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
After a review of the current currency-related mappings, this PR makes a few corrections, adds explanatory comments where certain mappings may be confusing, and adds a small number of new mappings to fill gaps and to complete euro area country coverage for `€`.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] Closes: #xxx
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
Changes:

1. Removed `z` from the Currency set. I think this was mistakenly added alongside `ł` for the Polish Złoty (`zł`), but it's just a plain `z` character so does not need to be present.
2. Added comments for all the characters in the currency set which do not independently represent a currency. For example, c with caron `č` is required for Czech Koruna (`Kč`), but `K` is a standard letter.
3. Added the Euro `€` character to the **E** key for the Greece set. It has been the currency in Greece since 2001, so this was a real gap. Now all the eurozone countries represented in Quick Accent have the same mapping.
4. Added the Shekel (or NIS/ILS) `₪` to the Hebrew set.
5. Added the Dong `₫` to the Vietnamese set.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
Compiled and ran locally to confirm new additions were present:

<img width="750" height="108" alt="image" src="https://github.com/user-attachments/assets/ce30e425-446f-4288-bb52-72e29768ef76" />


Confirmed all Quick Accent unit tests still ran successfully:

<img width="348" height="78" alt="image" src="https://github.com/user-attachments/assets/b275a966-65d9-406e-838e-675b9dcd2c50" />

