### PR TITLE
[Quick Accent] Correction and additions to Bulgarian key mappings

### DIFF
--- a/src/modules/poweraccent/PowerAccent.Common/CharacterMappings.cs
+++ b/src/modules/poweraccent/PowerAccent.Common/CharacterMappings.cs
@@ -106,7 +106,9 @@ public static class CharacterMappings
 
         new(Language.BG, "Bulgarian", LanguageGroup.Language, new Dictionary<LetterKey, string[]>
         {
-            [LetterKey.VK_I] = ["й"],
+            [LetterKey.VK_E] = ["€"],
+            [LetterKey.VK_I] = ["ѝ"],
+            [LetterKey.VK_COMMA] = ["„", "“", "«", "»"],
         }),
 
         new(Language.CA, "Catalan", LanguageGroup.Language, new Dictionary<LetterKey, string[]>


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This corrects the short I being present on the **I** key, and adds the euro and common punctuation characters for the Bulgarian set.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] Closes: #xxx
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
`й` was present in the Bulgarian set, which made no sense because every Bulgarian keyboard layout includes the short I. This must have been a mis-type for `ѝ`, which is present on most layouts, but absent on the traditional non-BDS layout. This update replaces the short I with `ѝ`.

Bulgaria adopted the euro currency in January 2026, replacing the lev, so including it on **E** makes sense, as it will become more and more common in written communication and is not present on one of the keyboard layouts.

Finally, Bulgarian typographic quotes (the `„` low-9 and `“` high-6) are added, along with the double angle quotes for compatibility with other Belarusian sets.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Compiled locally and checked that the new characters were available:
<img width="750" height="110" alt="image" src="https://github.com/user-attachments/assets/d5ac0ac1-5814-492e-b2ba-e7747204e668" />

Confirmed that all unit tests still pass:

<img width="336" height="75" alt="image" src="https://github.com/user-attachments/assets/eb4360c1-ac7e-4e5c-9cfb-a51a95c41c2a" />

