### PR TITLE
CmdPal: Remove [ComImport] from Bookmarks extension

### DIFF
--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Bookmark/Helpers/CommandLauncher.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Bookmark/Helpers/CommandLauncher.cs
@@ -2,9 +2,9 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.ComponentModel;
-using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
 using ManagedCommon;
+using ManagedCsWin32;
 using Microsoft.CmdPal.Common.Helpers;
 
 namespace Microsoft.CmdPal.Ext.Bookmarks.Helpers;
@@ -71,29 +71,10 @@ internal static class CommandLauncher
     {
         public static void ActivateApplication(string aumid, string? args, int options, out uint pid)
         {
-            var mgr = (IApplicationActivationManager)new _ApplicationActivationManager();
-            var hr = mgr.ActivateApplication(aumid, args ?? string.Empty, options, out pid);
-            if (hr < 0)
-            {
-                throw new Win32Exception(hr);
-            }
-        }
-
-        [ComImport]
-        [Guid("45BA127D-10A8-46EA-8AB7-56EA9078943C")]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "Private class")]
-        private class _ApplicationActivationManager;
-
-        [ComImport]
-        [Guid("2E941141-7F97-4756-BA1D-9DECDE894A3D")]
-        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-        private interface IApplicationActivationManager
-        {
-            int ActivateApplication(
-                [MarshalAs(UnmanagedType.LPWStr)] string appUserModelId,
-                [MarshalAs(UnmanagedType.LPWStr)] string arguments,
-                int options,
-                out uint processId);
+            var mgr = ComHelper.CreateComInstance<IApplicationActivationManager>(
+                ref Unsafe.AsRef(in CLSID.ApplicationActivationManager),
+                CLSCTX.InProcServer);
+            mgr.ActivateApplication(aumid, args ?? string.Empty, options, out pid);
         }
     }
 }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Bookmark/Helpers/IApplicationActivationManager.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Bookmark/Helpers/IApplicationActivationManager.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+
+namespace Microsoft.CmdPal.Ext.Bookmarks.Helpers;
+
+[GeneratedComInterface(StringMarshalling = StringMarshalling.Utf16)]
+[Guid("2E941141-7F97-4756-BA1D-9DECDE894A3D")]
+internal partial interface IApplicationActivationManager
+{
+    void ActivateApplication(string appUserModelId, string arguments, int options, out uint processId);
+}

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Bookmark/Microsoft.CmdPal.Ext.Bookmarks.csproj
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Bookmark/Microsoft.CmdPal.Ext.Bookmarks.csproj
@@ -11,6 +11,7 @@
     <ProjectPriFileName>Microsoft.CmdPal.Ext.Bookmarks.pri</ProjectPriFileName>
   </PropertyGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\..\..\common\ManagedCsWin32\ManagedCsWin32.csproj" />
     <ProjectReference Include="..\..\Microsoft.CmdPal.Common\Microsoft.CmdPal.Common.csproj" />
     <ProjectReference Include="..\..\extensionsdk\Microsoft.CommandPalette.Extensions.Toolkit\Microsoft.CommandPalette.Extensions.Toolkit.csproj" />
     <ProjectReference Include="..\..\ext\Microsoft.CmdPal.Ext.Indexer\Microsoft.CmdPal.Ext.Indexer.csproj" />


### PR DESCRIPTION
## Summary of the Pull Request

This PR fixes invalid Native AOT code generation issue in Bookmarks built-in extension.

CommandLauncher+ApplicationActivationManager was marked with [ComImport], not compatible with AOT.

```
29>  ILC: Method '[Microsoft.CmdPal.Ext.Bookmarks]Microsoft.CmdPal.Ext.Bookmarks.Helpers.CommandLauncher+ApplicationActivationManager+_ApplicationActivationManager..ctor()' will always throw because: Invalid IL or CLR metadata in 'Void _ApplicationActivationManager..ctor()'
```

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #49355 
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

