### PR TITLE
[PowerDisplay] Drop redundant hardcoded PlatformToolset (inherit Cpp.Build.props)

### DIFF
--- a/src/common/UnitTests-CommonUtils/UnitTests-CommonUtils.vcxproj
+++ b/src/common/UnitTests-CommonUtils/UnitTests-CommonUtils.vcxproj
@@ -13,7 +13,6 @@
   <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
-    <PlatformToolset>v143</PlatformToolset>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\tests\UnitTestsCommonUtils\</OutDir>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/src/modules/powerdisplay/PowerDisplayModuleInterface/PowerDisplayModuleInterface.vcxproj
+++ b/src/modules/powerdisplay/PowerDisplayModuleInterface/PowerDisplayModuleInterface.vcxproj
@@ -29,13 +29,11 @@
   <PropertyGroup Condition="'$(Configuration)'=='Debug'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>


### PR DESCRIPTION
## Summary

Remove the redundant hardcoded `<PlatformToolset>v143</PlatformToolset>` from two C++ projects so they inherit the toolset from the shared `Cpp.Build.props` like every other project.

## Why

`Cpp.Build.props` is force-imported into **every** C++ project via `Directory.Build.props`:

```xml
<ForceImportBeforeCppProps>$(RepoRoot)Cpp.Build.props</ForceImportBeforeCppProps>
```

MSBuild imports it during `Microsoft.Cpp.props` — i.e. *after* each project's own PropertyGroups — and it sets the toolset for the whole repo:

```xml
<PlatformToolset>v143</PlatformToolset>
<PlatformToolset Condition="'$(VisualStudioVersion)' == '18.0'">v145</PlatformToolset>
```

Two projects set `<PlatformToolset>v143</PlatformToolset>` directly in their Configuration PropertyGroups:

- `src/modules/powerdisplay/PowerDisplayModuleInterface/PowerDisplayModuleInterface.vcxproj` (Debug + Release)
- `src/common/UnitTests-CommonUtils/UnitTests-CommonUtils.vcxproj`

That value was dead config — the force-imported prop already overrode it to `v145` on VS2026 (v18). The other module interfaces (Awake, FancyZones, …) don't set `PlatformToolset` at all; these two were just over-specified VS-template projects.

## Change

Delete the redundant `PlatformToolset` lines so both projects inherit from `Cpp.Build.props`.

## Validation

Built both projects locally with VS2026 (v18), Release x64, with no `PlatformToolset` in the vcxproj:
- Both resolve to the `v145` toolset (MSVC `14.51`, `VC\v180`) via the force-imported prop.
- Both produce their DLLs with no errors (`PowerToys.PowerDisplayModuleInterface.dll`, `Common.Utils.UnitTests.dll`).

## Risk

Very low — no change to the produced binaries (effective toolset is unchanged); this just removes dead config and makes these two projects consistent with the rest of the repo.
