### PR TITLE
[Deps] Update Microsoft.Data.Sqlite 10.0.9 -> 10.0.10

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -41,7 +41,7 @@
     <PackageVersion Include="MessagePack" Version="3.1.7" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.102" />
     <PackageVersion Include="Microsoft.CommandPalette.Extensions" Version="0.9.260303001" />
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.10" />
     <!-- Including Microsoft.Bcl.AsyncInterfaces to force version, since it's used by Microsoft.SemanticKernel. -->
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Graphics.Win2D" Version="1.3.2" />


### PR DESCRIPTION
## Summary

Update `Microsoft.Data.Sqlite` from **10.0.9 → 10.0.10** (latest stable on the .NET 10 line) in central package management (`Directory.Packages.props`). Consumed by PowerLauncher (PowerToys Run).

## Details

- Patch update to the managed ADO.NET provider.
- **Dependency graph unchanged** — 10.0.10 still references `SQLitePCLRaw.bundle_e_sqlite3` / `SQLitePCLRaw.core` **2.1.11** (verified by diffing the 10.0.9 vs 10.0.10 nuspecs), so there are no new/changed transitive dependencies to conflict with the repo's pinned versions.
- `11.0.0-preview.x` exists but targets .NET 11 — not appropriate for this net10 app, so this stays on the supported 10.0.x line.

## Note on the native engine

This bumps the **managed provider**, not the native SQLite engine. The engine is bundled by `SQLitePCLRaw` (`e_sqlite3`), which stays at **2.1.11** here. If a native-engine refresh is also wanted, that's a separate change — an explicit `SQLitePCLRaw` override (2.1.12 on the stable line, or the 3.0.x major).

## Validation

Local restore can't complete in this environment: PowerToys restores from the curated `PowerToysPublicDependencies` feed, which hasn't ingested 10.0.10 yet, and the sandbox lacks the feed auth to trigger the upstream pull (401). CI (with feed auth) will ingest it from the upstream nuget.org source. Compatibility was verified out-of-band by diffing the 10.0.9 vs 10.0.10 dependency manifests — identical apart from the `Microsoft.Data.Sqlite.Core` patch. CI restore/build is the gating validation.

## Risk

Very low — single-patch bump within the same minor line, no transitive changes.
