### PR TITLE
[CmdPal] Add number separators to calculator results

### DIFF
--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Calc.UnitTests/PrimaryActionTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Calc.UnitTests/PrimaryActionTests.cs
@@ -84,6 +84,41 @@ public class PrimaryActionTests
         Assert.IsInstanceOfType(GetFallbackSecondaryCommand(item), typeof(CalculatorCopyCommand));
     }
 
+    [DataTestMethod]
+    [DataRow("en-US", "1,234,567.89", "1234567.89")]
+    [DataRow("de-DE", "1.234.567,89", "1234567,89")]
+    public void ResultTitlesUseCultureGroupingWithoutChangingOperationalValues(string cultureName, string expectedTitle, string expectedRawResult)
+    {
+        var culture = new CultureInfo(cultureName);
+        var settings = new Settings();
+        TypedEventHandler<object, object> handleReplace = (_, _) => { };
+
+        var pageItem = ResultHelper.CreateResultForPage(
+            1234567.89m,
+            culture,
+            culture,
+            "1234567.89",
+            settings,
+            handleReplace);
+
+        Assert.IsNotNull(pageItem);
+        Assert.AreEqual(expectedTitle, pageItem.Title);
+        Assert.IsInstanceOfType(pageItem.Command, typeof(CalculatorCopyCommand));
+        Assert.AreEqual(expectedRawResult, ((CalculatorCopyCommand)pageItem.Command).Text);
+
+        var fallbackItem = ResultHelper.CreateResultForFallback(
+            1234567.89m,
+            culture,
+            culture,
+            "1234567.89");
+
+        Assert.IsNotNull(fallbackItem);
+        Assert.AreEqual(expectedTitle, fallbackItem.Title);
+        Assert.AreEqual(expectedRawResult, fallbackItem.TextToSuggest);
+        Assert.IsInstanceOfType(fallbackItem.Command, typeof(CopyTextCommand));
+        Assert.AreEqual(expectedRawResult, ((CopyTextCommand)fallbackItem.Command).Text);
+    }
+
     private static ICommand GetFallbackSecondaryCommand(FallbackCalculatorItem item)
     {
         var secondaryCommand = item.MoreCommands

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Calc.UnitTests/QueryTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Calc.UnitTests/QueryTests.cs
@@ -158,6 +158,41 @@ public class QueryTests : CommandPaletteUnitTestBase
     }
 
     [DataTestMethod]
+    [DataRow(false, PrimaryAction.Copy)]
+    [DataRow(false, PrimaryAction.Paste)]
+    [DataRow(true, PrimaryAction.Copy)]
+    [DataRow(true, PrimaryAction.Paste)]
+    public void GroupedResultContinuationUsesRawValue(bool useEquals, PrimaryAction primaryAction)
+    {
+        CultureInfo.CurrentCulture = new CultureInfo("hi-IN", false);
+        var settings = new Settings(primaryAction: primaryAction);
+        var page = new CalculatorListPage(settings);
+
+        if (useEquals)
+        {
+            page.UpdateSearchText(string.Empty, "12345678=");
+        }
+        else
+        {
+            page.UpdateSearchText(string.Empty, "12345678");
+            var result = page.GetItems().Single();
+            var replaceCommand = result.MoreCommands
+                .OfType<CommandItem>()
+                .Select(item => item.Command)
+                .OfType<ReplaceQueryCommand>()
+                .Single();
+
+            replaceCommand.Invoke();
+        }
+
+        Assert.AreEqual("12345678", page.SearchText);
+
+        page.UpdateSearchText(page.SearchText, page.SearchText + "+1");
+
+        Assert.AreEqual("1,23,45,679", page.GetItems().Single().Title);
+    }
+
+    [DataTestMethod]
     [DataRow("2^64", "18,446,744,073,709,551,616", "0x10000000000000000")]
     [DataRow("0-(2^64)", "-18,446,744,073,709,551,616", "-0x10000000000000000")]
     public void TopLevelPageQuery_ReturnsResult_WhenIntegerExceedsInt64Bounds(string input, string expectedTitle, string expectedHexContext)

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Calc.UnitTests/QueryTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Calc.UnitTests/QueryTests.cs
@@ -49,11 +49,11 @@ public class QueryTests : CommandPaletteUnitTestBase
     [DataRow("max(123,456)", "456")]
     [DataRow("max(123,min(12,pow(2,6)))", "123")]
     [DataRow("max    (    12, 34  )", "34")]
-    [DataRow("ceil(123,456.23)", "123457")]
-    [DataRow("max(ceil(123,456.23),2)", "123457")]
-    [DataRow("pow(round(1,234.5),2)", "1525225")]
-    [DataRow("max(1e3,2e3)", "2000")]
-    [DataRow("pow(1.5e2,2)", "22500")]
+    [DataRow("ceil(123,456.23)", "123,457")]
+    [DataRow("max(ceil(123,456.23),2)", "123,457")]
+    [DataRow("pow(round(1,234.5),2)", "1,525,225")]
+    [DataRow("max(1e3,2e3)", "2,000")]
+    [DataRow("pow(1.5e2,2)", "22,500")]
     [DataRow("max(0b1010,0o12)", "10")]
     public void TopLevelPageQueryTest(string input, string expectedResult)
     {
@@ -158,8 +158,8 @@ public class QueryTests : CommandPaletteUnitTestBase
     }
 
     [DataTestMethod]
-    [DataRow("2^64", "18446744073709551616", "0x10000000000000000")]
-    [DataRow("0-(2^64)", "-18446744073709551616", "-0x10000000000000000")]
+    [DataRow("2^64", "18,446,744,073,709,551,616", "0x10000000000000000")]
+    [DataRow("0-(2^64)", "-18,446,744,073,709,551,616", "-0x10000000000000000")]
     public void TopLevelPageQuery_ReturnsResult_WhenIntegerExceedsInt64Bounds(string input, string expectedTitle, string expectedHexContext)
     {
         var settings = new Settings(outputUseEnglishFormat: true);

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Commands/CalculatorPasteCommand.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Commands/CalculatorPasteCommand.cs
@@ -22,6 +22,8 @@ public sealed partial class CalculatorPasteCommand : InvokableCommand
     private string _query;
     private string _text;
 
+    internal string Text => _text;
+
     public CalculatorPasteCommand(string result, string query, ISettingsInterface settings, bool canStoreHistory = true)
         : this(result, query, settings, () => canStoreHistory)
     {

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Helper/ResultHelper.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Helper/ResultHelper.cs
@@ -39,6 +39,7 @@ public static class ResultHelper
         }
 
         var result = roundedResult?.ToString(outputCulture);
+        var displayResult = FormatForDisplay(roundedResult.Value, outputCulture);
 
         var replaceCommand = new ReplaceQueryCommand();
         replaceCommand.ReplaceRequested += handleReplace;
@@ -59,7 +60,7 @@ public static class ResultHelper
         return new ListItem(primaryCommand)
         {
             Icon = Icons.ResultIcon,
-            Title = result,
+            Title = displayResult,
             Subtitle = query,
             MoreCommands = [
                 new CommandContextItem(secondaryCommand),
@@ -93,6 +94,7 @@ public static class ResultHelper
     private static ListItem CreateResultItem(decimal? roundedResult, CultureInfo inputCulture, CultureInfo outputCulture, string query, ICommand copyCommand, bool hideOnCopy)
     {
         var decimalResult = roundedResult?.ToString(outputCulture);
+        var displayResult = FormatForDisplay(roundedResult.Value, outputCulture);
         var decimalValue = (decimal)roundedResult;
 
         List<IContextItem> context = [];
@@ -155,12 +157,21 @@ public static class ResultHelper
 
         return new ListItem(copyCommand)
         {
-            // Using CurrentCulture since this is user facing
-            Title = decimalResult,
+            Title = displayResult,
             Subtitle = query,
             TextToSuggest = decimalResult,
             MoreCommands = context.ToArray(),
         };
+    }
+
+    private static string FormatForDisplay(decimal value, CultureInfo culture)
+    {
+        var rawValue = value.ToString(culture);
+        var decimalSeparator = culture.NumberFormat.NumberDecimalSeparator;
+        var decimalSeparatorIndex = rawValue.IndexOf(decimalSeparator, StringComparison.Ordinal);
+        var decimalPlaces = decimalSeparatorIndex >= 0 ? rawValue.Length - decimalSeparatorIndex - decimalSeparator.Length : 0;
+
+        return value.ToString($"N{decimalPlaces}", culture);
     }
 
     private static CopyTextCommand CreateCopyCommand(string text, string name, bool hideOnCopy)

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Pages/CalculatorListPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Pages/CalculatorListPage.cs
@@ -77,7 +77,7 @@ public sealed partial class CalculatorListPage : DynamicListPage
 
     private void HandleReplaceQuery(object sender, object args)
     {
-        var lastResult = _items[0].Title;
+        var lastResult = GetOperationalResult(_items[0]);
         if (!string.IsNullOrEmpty(lastResult))
         {
             _skipQuerySearchText = lastResult;
@@ -117,8 +117,9 @@ public sealed partial class CalculatorListPage : DynamicListPage
 
         if (copyResultToSearchText && result is not null)
         {
-            _skipQuerySearchText = result.Title;
-            SearchText = result.Title;
+            var operationalResult = GetOperationalResult(result);
+            _skipQuerySearchText = operationalResult;
+            SearchText = operationalResult;
 
             // LOAD BEARING: The SearchText setter does not raise a PropertyChanged notification,
             // so we must raise it explicitly to ensure the UI updates correctly.
@@ -241,6 +242,16 @@ public sealed partial class CalculatorListPage : DynamicListPage
     }
 
     public override IListItem[] GetItems() => _items.ToArray();
+
+    private static string GetOperationalResult(ListItem result)
+    {
+        return result.Command switch
+        {
+            CalculatorCopyCommand copyCommand => copyCommand.Text,
+            CalculatorPasteCommand pasteCommand => pasteCommand.Text,
+            _ => result.Title,
+        };
+    }
 
     private static ListItem CreateSectionHeader(string title)
     {


### PR DESCRIPTION
## Summary of the Pull Request

Adds culture-aware digit grouping to visible Command Palette calculator result titles. Values used for copy, paste, suggestions, history, and reparsing remain raw.

## PR Checklist

- [x] Closes: #40203
- [x] **Communication:** Discussed in [the PowerToys contribution thread](https://github.com/microsoft/PowerToys/issues/28769#issuecomment-4997103654) and acknowledged by a core contributor
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** No new end-user-facing strings
- [x] **Dev docs:** Not applicable; no developer workflow or API changed
- [x] **New binaries:** None
- [ ] **Documentation updated:** Not applicable; no user documentation change required

## Detailed Description of the Pull Request / Additional comments

Calculator results previously used the same ungrouped string for both the visible title and operational values. This change derives a culture-aware, display-only string while preserving the existing decimal precision. Page and fallback result titles use the grouped string; command text and `TextToSuggest` remain unformatted.

Tests cover `en-US` and `de-DE` grouping and verify that copy and suggestion values remain raw.

## Validation Steps Performed

- Built `Microsoft.CmdPal.Ext.Calc.UnitTests` for x64 Debug with the repository build script
- Verified the new regression test failed against the pre-change implementation, then passed after the change: 2/2 culture cases
- Ran the full calculator test assembly: 375/375 passed
- Built and launched the packaged x64 Windows UI; a raw `500000` query displayed `500,000` while retaining raw `500000` operational text

### Windows UI evidence

The raw query `500000` displays the grouped result title `500,000` while retaining raw operational text `500000`.

<img width="800" height="480" alt="Command Palette calculator showing grouped result title 500,000 for raw query 500000" src="https://github.com/user-attachments/assets/2412e43f-f5e9-4cda-a3d4-2840b9d55953" />
