### PR TITLE
CmdPal: Fix default alias mapping to commands

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.Common/BuiltInCommandIds.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Common/BuiltInCommandIds.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CmdPal.Common;
+
+/// <summary>
+/// Stable command identifiers shared by built-in providers and host features that persist command references.
+/// </summary>
+/// <remarks>
+/// These values are persisted by aliases, hotkeys, and pins. Changing a value requires migrating persisted references.
+/// </remarks>
+public static class BuiltInCommandIds
+{
+    private const string CmdPalPrefix = "com.microsoft.cmdpal.";
+
+    public static readonly string Registry = BuildCmdPalId("registry");
+
+    public static readonly string WindowsSettings = BuildCmdPalId("windowsSettings");
+
+    public static readonly string Calculator = BuildCmdPalId("calculator");
+
+    public static readonly string Run = BuildCmdPalId("run");
+
+    public static readonly string WindowWalker = BuildCmdPalId("windowwalker");
+
+    public static readonly string WebSearch = BuildCmdPalId("websearch");
+
+    public static readonly string FileSearch = "com.microsoft.indexer.fileSearch";
+
+    public static readonly string TimeDate = BuildCmdPalId("timedate");
+
+    private static string BuildCmdPalId(string suffix) => CmdPalPrefix + suffix;
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AliasManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AliasManager.cs
@@ -5,6 +5,7 @@
 using System.Collections.Immutable;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Messaging;
+using Microsoft.CmdPal.Common;
 using Microsoft.CmdPal.UI.ViewModels.Messages;
 using Microsoft.CmdPal.UI.ViewModels.Services;
 
@@ -13,21 +14,20 @@ namespace Microsoft.CmdPal.UI.ViewModels;
 public partial class AliasManager : ObservableObject
 {
     private const string DeprecatedShellCommandId = "com.microsoft.cmdpal.shell";
-    private const string RunCommandId = "com.microsoft.cmdpal.run";
 
     private readonly TopLevelCommandManager _topLevelCommandManager;
     private readonly ISettingsService _settingsService;
 
     private static readonly ImmutableList<CommandAlias> _defaultAliases = new List<CommandAlias>
     {
-        new CommandAlias(":", "com.microsoft.cmdpal.registry", true),
-        new CommandAlias("$", "com.microsoft.cmdpal.windowsSettings", true),
-        new CommandAlias("=", "com.microsoft.cmdpal.calculator", true),
-        new CommandAlias(">", RunCommandId, true),
-        new CommandAlias("<", "com.microsoft.cmdpal.windowwalker", true),
-        new CommandAlias("??", "com.microsoft.cmdpal.websearch", true),
-        new CommandAlias("file", "com.microsoft.indexer.fileSearch", false),
-        new CommandAlias(")", "com.microsoft.cmdpal.timedate", true),
+        new CommandAlias(":", BuiltInCommandIds.Registry, true),
+        new CommandAlias("$", BuiltInCommandIds.WindowsSettings, true),
+        new CommandAlias("=", BuiltInCommandIds.Calculator, true),
+        new CommandAlias(">", BuiltInCommandIds.Run, true),
+        new CommandAlias("<", BuiltInCommandIds.WindowWalker, true),
+        new CommandAlias("??", BuiltInCommandIds.WebSearch, true),
+        new CommandAlias("file", BuiltInCommandIds.FileSearch, false),
+        new CommandAlias(")", BuiltInCommandIds.TimeDate, true),
     }.ToImmutableList();
 
     public AliasManager(TopLevelCommandManager tlcManager, ISettingsService settingsService)
@@ -93,7 +93,7 @@ public partial class AliasManager : ObservableObject
 
     private static ImmutableDictionary<string, CommandAlias> MigrateRenamedRunAliases(ImmutableDictionary<string, CommandAlias> aliases)
     {
-        var runCommandHasAlias = aliases.Values.Any(alias => alias.CommandId == RunCommandId);
+        var runCommandHasAlias = aliases.Values.Any(alias => alias.CommandId == BuiltInCommandIds.Run);
         var migratedAliases = aliases;
         foreach (var alias in aliases)
         {
@@ -101,7 +101,7 @@ public partial class AliasManager : ObservableObject
             {
                 migratedAliases = runCommandHasAlias
                     ? migratedAliases.Remove(alias.Key)
-                    : migratedAliases.SetItem(alias.Key, alias.Value with { CommandId = RunCommandId });
+                    : migratedAliases.SetItem(alias.Key, alias.Value with { CommandId = BuiltInCommandIds.Run });
             }
         }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AliasManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AliasManager.cs
@@ -12,6 +12,9 @@ namespace Microsoft.CmdPal.UI.ViewModels;
 
 public partial class AliasManager : ObservableObject
 {
+    private const string DeprecatedShellCommandId = "com.microsoft.cmdpal.shell";
+    private const string RunCommandId = "com.microsoft.cmdpal.run";
+
     private readonly TopLevelCommandManager _topLevelCommandManager;
     private readonly ISettingsService _settingsService;
 
@@ -20,7 +23,7 @@ public partial class AliasManager : ObservableObject
         new CommandAlias(":", "com.microsoft.cmdpal.registry", true),
         new CommandAlias("$", "com.microsoft.cmdpal.windowsSettings", true),
         new CommandAlias("=", "com.microsoft.cmdpal.calculator", true),
-        new CommandAlias(">", "com.microsoft.cmdpal.shell", true),
+        new CommandAlias(">", RunCommandId, true),
         new CommandAlias("<", "com.microsoft.cmdpal.windowwalker", true),
         new CommandAlias("??", "com.microsoft.cmdpal.websearch", true),
         new CommandAlias("file", "com.microsoft.indexer.fileSearch", false),
@@ -31,6 +34,8 @@ public partial class AliasManager : ObservableObject
     {
         _topLevelCommandManager = tlcManager;
         _settingsService = settingsService;
+
+        MigrateRenamedRunAliases();
 
         if (_settingsService.Settings.Aliases.Count == 0)
         {
@@ -70,6 +75,37 @@ public partial class AliasManager : ObservableObject
                     .AddRange(_defaultAliases.ToDictionary(a => a.SearchPrefix, a => a)),
             },
             hotReload: false);
+    }
+
+    private void MigrateRenamedRunAliases()
+    {
+        var aliases = _settingsService.Settings.Aliases;
+        var migratedAliases = MigrateRenamedRunAliases(aliases);
+        if (ReferenceEquals(aliases, migratedAliases))
+        {
+            return;
+        }
+
+        _settingsService.UpdateSettings(
+            static s => s with { Aliases = MigrateRenamedRunAliases(s.Aliases) },
+            hotReload: false);
+    }
+
+    private static ImmutableDictionary<string, CommandAlias> MigrateRenamedRunAliases(ImmutableDictionary<string, CommandAlias> aliases)
+    {
+        var runCommandHasAlias = aliases.Values.Any(alias => alias.CommandId == RunCommandId);
+        var migratedAliases = aliases;
+        foreach (var alias in aliases)
+        {
+            if (alias.Value.CommandId == DeprecatedShellCommandId)
+            {
+                migratedAliases = runCommandHasAlias
+                    ? migratedAliases.Remove(alias.Key)
+                    : migratedAliases.SetItem(alias.Key, alias.Value with { CommandId = RunCommandId });
+            }
+        }
+
+        return migratedAliases;
     }
 
     public string? KeysFromId(string commandId)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Microsoft.CmdPal.UI.ViewModels.csproj
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Microsoft.CmdPal.UI.ViewModels.csproj
@@ -56,6 +56,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Microsoft.CmdPal.Common\Microsoft.CmdPal.Common.csproj" />
     <ProjectReference Include="..\extensionsdk\Microsoft.CommandPalette.Extensions.Toolkit\Microsoft.CommandPalette.Extensions.Toolkit.csproj" />
 
     <ProjectReference Include="..\ext\Microsoft.CmdPal.Ext.Apps\Microsoft.CmdPal.Ext.Apps.csproj" />

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/AliasManagerTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/AliasManagerTests.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CmdPal.UI.ViewModels.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
+
+[TestClass]
+public class AliasManagerTests
+{
+    [TestMethod]
+    public void Constructor_PopulatesRunDefaultAliasWithCurrentCommandId()
+    {
+        var (settingsService, getSettings) = CreateSettingsService(new SettingsModel());
+
+        _ = new AliasManager(null!, settingsService.Object);
+
+        var runAlias = getSettings().Aliases[">"];
+        Assert.AreEqual("com.microsoft.cmdpal.run", runAlias.CommandId);
+        Assert.IsTrue(runAlias.IsDirect);
+    }
+
+    [TestMethod]
+    public void Constructor_MigratesAliasesForRenamedRunCommand()
+    {
+        var aliases = ImmutableDictionary<string, CommandAlias>.Empty
+            .Add(">", new CommandAlias(">", "com.microsoft.cmdpal.shell", true))
+            .Add("run ", new CommandAlias("run", "com.microsoft.cmdpal.shell"))
+            .Add("=", new CommandAlias("=", "com.microsoft.cmdpal.calculator", true));
+        var (settingsService, getSettings) = CreateSettingsService(new SettingsModel { Aliases = aliases });
+
+        _ = new AliasManager(null!, settingsService.Object);
+
+        var migratedAliases = getSettings().Aliases;
+        Assert.AreEqual("com.microsoft.cmdpal.run", migratedAliases[">"].CommandId);
+        Assert.IsTrue(migratedAliases[">"].IsDirect);
+        Assert.AreEqual("com.microsoft.cmdpal.run", migratedAliases["run "].CommandId);
+        Assert.IsFalse(migratedAliases["run "].IsDirect);
+        Assert.AreEqual("com.microsoft.cmdpal.calculator", migratedAliases["="].CommandId);
+        Assert.IsFalse(migratedAliases.Values.Any(alias => alias.CommandId == "com.microsoft.cmdpal.shell"));
+    }
+
+    [TestMethod]
+    public void Constructor_RemovesDeprecatedAliasWhenRunAlreadyHasAlias()
+    {
+        var aliases = ImmutableDictionary<string, CommandAlias>.Empty
+            .Add(">", new CommandAlias(">", "com.microsoft.cmdpal.shell", true))
+            .Add("run ", new CommandAlias("run", "com.microsoft.cmdpal.run"));
+        var (settingsService, getSettings) = CreateSettingsService(new SettingsModel { Aliases = aliases });
+
+        _ = new AliasManager(null!, settingsService.Object);
+
+        var migratedAliases = getSettings().Aliases;
+        Assert.IsFalse(migratedAliases.ContainsKey(">"));
+        Assert.AreEqual("com.microsoft.cmdpal.run", migratedAliases["run "].CommandId);
+        Assert.IsFalse(migratedAliases["run "].IsDirect);
+        Assert.IsFalse(migratedAliases.Values.Any(alias => alias.CommandId == "com.microsoft.cmdpal.shell"));
+    }
+
+    private static (Mock<ISettingsService> Service, Func<SettingsModel> GetSettings) CreateSettingsService(SettingsModel initialSettings)
+    {
+        var settings = initialSettings;
+        var settingsService = new Mock<ISettingsService>();
+        settingsService.SetupGet(service => service.Settings).Returns(() => settings);
+        settingsService
+            .Setup(service => service.UpdateSettings(It.IsAny<Func<SettingsModel, SettingsModel>>(), It.IsAny<bool>()))
+            .Callback<Func<SettingsModel, SettingsModel>, bool>((transform, _) => settings = transform(settings));
+
+        return (settingsService, () => settings);
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/AliasManagerTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/AliasManagerTests.cs
@@ -3,8 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using Microsoft.CmdPal.Common;
 using Microsoft.CmdPal.UI.ViewModels.Services;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -15,15 +17,32 @@ namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
 public class AliasManagerTests
 {
     [TestMethod]
-    public void Constructor_PopulatesRunDefaultAliasWithCurrentCommandId()
+    public void Constructor_PopulatesDefaultAliasesWithBuiltInCommandIds()
     {
         var (settingsService, getSettings) = CreateSettingsService(new SettingsModel());
+        var expectedAliases = new Dictionary<string, (string CommandId, bool IsDirect)>
+        {
+            [":"] = (BuiltInCommandIds.Registry, true),
+            ["$"] = (BuiltInCommandIds.WindowsSettings, true),
+            ["="] = (BuiltInCommandIds.Calculator, true),
+            [">"] = (BuiltInCommandIds.Run, true),
+            ["<"] = (BuiltInCommandIds.WindowWalker, true),
+            ["??"] = (BuiltInCommandIds.WebSearch, true),
+            ["file "] = (BuiltInCommandIds.FileSearch, false),
+            [")"] = (BuiltInCommandIds.TimeDate, true),
+        };
 
         _ = new AliasManager(null!, settingsService.Object);
 
-        var runAlias = getSettings().Aliases[">"];
-        Assert.AreEqual("com.microsoft.cmdpal.run", runAlias.CommandId);
-        Assert.IsTrue(runAlias.IsDirect);
+        var aliases = getSettings().Aliases;
+        Assert.AreEqual(expectedAliases.Count, aliases.Count);
+        Assert.AreEqual(expectedAliases.Count, expectedAliases.Values.Select(alias => alias.CommandId).Distinct().Count());
+        foreach (var expectedAlias in expectedAliases)
+        {
+            Assert.IsTrue(aliases.TryGetValue(expectedAlias.Key, out var alias));
+            Assert.AreEqual(expectedAlias.Value.CommandId, alias.CommandId);
+            Assert.AreEqual(expectedAlias.Value.IsDirect, alias.IsDirect);
+        }
     }
 
     [TestMethod]
@@ -32,17 +51,17 @@ public class AliasManagerTests
         var aliases = ImmutableDictionary<string, CommandAlias>.Empty
             .Add(">", new CommandAlias(">", "com.microsoft.cmdpal.shell", true))
             .Add("run ", new CommandAlias("run", "com.microsoft.cmdpal.shell"))
-            .Add("=", new CommandAlias("=", "com.microsoft.cmdpal.calculator", true));
+            .Add("=", new CommandAlias("=", BuiltInCommandIds.Calculator, true));
         var (settingsService, getSettings) = CreateSettingsService(new SettingsModel { Aliases = aliases });
 
         _ = new AliasManager(null!, settingsService.Object);
 
         var migratedAliases = getSettings().Aliases;
-        Assert.AreEqual("com.microsoft.cmdpal.run", migratedAliases[">"].CommandId);
+        Assert.AreEqual(BuiltInCommandIds.Run, migratedAliases[">"].CommandId);
         Assert.IsTrue(migratedAliases[">"].IsDirect);
-        Assert.AreEqual("com.microsoft.cmdpal.run", migratedAliases["run "].CommandId);
+        Assert.AreEqual(BuiltInCommandIds.Run, migratedAliases["run "].CommandId);
         Assert.IsFalse(migratedAliases["run "].IsDirect);
-        Assert.AreEqual("com.microsoft.cmdpal.calculator", migratedAliases["="].CommandId);
+        Assert.AreEqual(BuiltInCommandIds.Calculator, migratedAliases["="].CommandId);
         Assert.IsFalse(migratedAliases.Values.Any(alias => alias.CommandId == "com.microsoft.cmdpal.shell"));
     }
 
@@ -51,14 +70,14 @@ public class AliasManagerTests
     {
         var aliases = ImmutableDictionary<string, CommandAlias>.Empty
             .Add(">", new CommandAlias(">", "com.microsoft.cmdpal.shell", true))
-            .Add("run ", new CommandAlias("run", "com.microsoft.cmdpal.run"));
+            .Add("run ", new CommandAlias("run", BuiltInCommandIds.Run));
         var (settingsService, getSettings) = CreateSettingsService(new SettingsModel { Aliases = aliases });
 
         _ = new AliasManager(null!, settingsService.Object);
 
         var migratedAliases = getSettings().Aliases;
         Assert.IsFalse(migratedAliases.ContainsKey(">"));
-        Assert.AreEqual("com.microsoft.cmdpal.run", migratedAliases["run "].CommandId);
+        Assert.AreEqual(BuiltInCommandIds.Run, migratedAliases["run "].CommandId);
         Assert.IsFalse(migratedAliases["run "].IsDirect);
         Assert.IsFalse(migratedAliases.Values.Any(alias => alias.CommandId == "com.microsoft.cmdpal.shell"));
     }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Pages/CalculatorListPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Calc/Pages/CalculatorListPage.cs
@@ -1,10 +1,11 @@
-﻿// Copyright (c) Microsoft Corporation
+// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using Microsoft.CmdPal.Common;
 using Microsoft.CmdPal.Common.Commands;
 using Microsoft.CmdPal.Ext.Calc.Helper;
 using Microsoft.CmdPal.Ext.Calc.Properties;
@@ -41,7 +42,7 @@ public sealed partial class CalculatorListPage : DynamicListPage
         Icon = Icons.CalculatorIcon;
         Name = Resources.calculator_title;
         PlaceholderText = Resources.calculator_placeholder_text;
-        Id = "com.microsoft.cmdpal.calculator";
+        Id = BuiltInCommandIds.Calculator;
 
         _emptyItem = new ListItem(new NoOpCommand())
         {

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Indexer/Pages/IndexerPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Indexer/Pages/IndexerPage.cs
@@ -10,6 +10,7 @@ using System.Globalization;
 using System.Text.Encodings.Web;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CmdPal.Common;
 using Microsoft.CmdPal.Ext.Indexer.Indexer;
 using Microsoft.CmdPal.Ext.Indexer.Properties;
 using Microsoft.CommandPalette.Extensions;
@@ -44,7 +45,7 @@ internal sealed partial class IndexerPage : DynamicListPage, IDisposable
 
     public IndexerPage()
     {
-        Id = "com.microsoft.indexer.fileSearch";
+        Id = BuiltInCommandIds.FileSearch;
         Icon = Icons.FileExplorerIcon;
         Name = Resources.Indexer_Title;
         PlaceholderText = Resources.Indexer_PlaceholderText;

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Registry/Microsoft.CmdPal.Ext.Registry.csproj
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Registry/Microsoft.CmdPal.Ext.Registry.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="System.ServiceProcess.ServiceController" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\Microsoft.CmdPal.Common\Microsoft.CmdPal.Common.csproj" />
     <ProjectReference Include="..\..\..\..\common\ManagedCommon\ManagedCommon.csproj" />
     <!-- CmdPal Toolkit reference now included via Common.ExtDependencies.props -->
   </ItemGroup>

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Registry/Pages/RegistryListPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Registry/Pages/RegistryListPage.cs
@@ -1,10 +1,11 @@
-﻿// Copyright (c) Microsoft Corporation
+// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.CmdPal.Common;
 using Microsoft.CmdPal.Ext.Registry.Classes;
 using Microsoft.CmdPal.Ext.Registry.Helpers;
 using Microsoft.CmdPal.Ext.Registry.Properties;
@@ -24,7 +25,7 @@ internal sealed partial class RegistryListPage : DynamicListPage
     {
         Icon = Icons.RegistryIcon;
         Name = Title = Resources.Registry_Page_Title;
-        Id = "com.microsoft.cmdpal.registry";
+        Id = BuiltInCommandIds.Registry;
         _settingsManager = settingsManager;
         _emptyMessage = new CommandItem()
         {

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Shell/Run/RunListPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Shell/Run/RunListPage.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using Microsoft.CmdPal.Common;
 using Microsoft.CmdPal.Common.Services;
 using Microsoft.CmdPal.Ext.Shell;
 using Microsoft.CommandPalette.Extensions;
@@ -69,7 +70,7 @@ public sealed partial class RunListPage : AsyncDynamicListPage
         bool suppressUriFallback = false)
     {
         Icon = Icons.RunV2Icon;
-        Id = "com.microsoft.cmdpal.run";
+        Id = BuiltInCommandIds.Run;
 
         Name = ResourceLoaderInstance.GetString("Run_plugin_name");
         Title = ResourceLoaderInstance.GetString("Run_generic_run_command");

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Pages/TimeDateExtensionPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.TimeDate/Pages/TimeDateExtensionPage.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using Microsoft.CmdPal.Common;
 using Microsoft.CmdPal.Ext.TimeDate.Helpers;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
@@ -19,7 +20,7 @@ internal sealed partial class TimeDateExtensionPage : DynamicListPage
         Title = Resources.Microsoft_plugin_timedate_main_page_title;
         Name = Resources.Microsoft_plugin_timedate_main_page_name;
         PlaceholderText = Resources.Microsoft_plugin_timedate_placeholder_text;
-        Id = "com.microsoft.cmdpal.timedate";
+        Id = BuiltInCommandIds.TimeDate;
         _settingsManager = settingsManager;
         ShowDetails = true;
     }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/Microsoft.CmdPal.Ext.WebSearch.csproj
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/Microsoft.CmdPal.Ext.WebSearch.csproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Microsoft.CmdPal.Common\Microsoft.CmdPal.Common.csproj" />
     <ProjectReference Include="..\..\..\..\common\ManagedCommon\ManagedCommon.csproj" />
   </ItemGroup>
 

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/Pages/WebSearchListPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/Pages/WebSearchListPage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation
+// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
 using System.Threading;
+using Microsoft.CmdPal.Common;
 using Microsoft.CmdPal.Ext.WebSearch.Commands;
 using Microsoft.CmdPal.Ext.WebSearch.Helpers;
 using Microsoft.CmdPal.Ext.WebSearch.Helpers.Browser;
@@ -33,7 +34,7 @@ internal sealed partial class WebSearchListPage : DynamicListPage, IDisposable
         Name = Resources.command_item_title;
         Title = Resources.command_item_title;
         Icon = Icons.WebSearch;
-        Id = "com.microsoft.cmdpal.websearch";
+        Id = BuiltInCommandIds.WebSearch;
 
         _settingsManager = settingsManager;
         _browserInfoService = browserInfoService;

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowWalker/Microsoft.CmdPal.Ext.WindowWalker.csproj
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowWalker/Microsoft.CmdPal.Ext.WindowWalker.csproj
@@ -14,6 +14,7 @@
     <None Remove="Assets\WindowWalker.svg" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\Microsoft.CmdPal.Common\Microsoft.CmdPal.Common.csproj" />
     <ProjectReference Include="..\..\..\..\common\ManagedCommon\ManagedCommon.csproj" />
     <ProjectReference Include="..\..\..\..\common\ManagedCsWin32\ManagedCsWin32.csproj" />
     <!-- WASDK, WebView2, CmdPal Toolkit references now included via Common.ExtDependencies.props -->

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowWalker/Pages/WindowWalkerListPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowWalker/Pages/WindowWalkerListPage.cs
@@ -1,10 +1,11 @@
-﻿// Copyright (c) Microsoft Corporation
+// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.Messaging;
+using Microsoft.CmdPal.Common;
 using Microsoft.CmdPal.Ext.WindowWalker.Components;
 using Microsoft.CmdPal.Ext.WindowWalker.Helpers;
 using Microsoft.CmdPal.Ext.WindowWalker.Messages;
@@ -23,7 +24,7 @@ internal sealed partial class WindowWalkerListPage : DynamicListPage, IDisposabl
     {
         Icon = Icons.WindowWalkerIcon;
         Name = Resources.windowwalker_name;
-        Id = "com.microsoft.cmdpal.windowwalker";
+        Id = BuiltInCommandIds.WindowWalker;
         PlaceholderText = Resources.windowwalker_PlaceholderText;
 
         EmptyContent = new CommandItem(new NoOpCommand())

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/Microsoft.CmdPal.Ext.WindowsSettings.csproj
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/Microsoft.CmdPal.Ext.WindowsSettings.csproj
@@ -22,6 +22,7 @@
     <!-- WASDK, WebView2, CmdPal Toolkit references now included via Common.ExtDependencies.props -->
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\Microsoft.CmdPal.Common\Microsoft.CmdPal.Common.csproj" />
     <ProjectReference Include="..\..\..\..\common\ManagedCommon\ManagedCommon.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/Pages/WindowsSettingsListPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsSettings/Pages/WindowsSettingsListPage.cs
@@ -1,10 +1,11 @@
-﻿// Copyright (c) Microsoft Corporation
+// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.CmdPal.Common;
 using Microsoft.CmdPal.Ext.WindowsSettings.Classes;
 using Microsoft.CmdPal.Ext.WindowsSettings.Helpers;
 using Microsoft.CmdPal.Ext.WindowsSettings.Properties;
@@ -21,7 +22,7 @@ internal sealed partial class WindowsSettingsListPage : DynamicListPage
     {
         Icon = Icons.WindowsSettingsIcon;
         Name = Resources.settings_title;
-        Id = "com.microsoft.cmdpal.windowsSettings";
+        Id = BuiltInCommandIds.WindowsSettings;
         _windowsSettings = windowsSettings;
 
         EmptyContent = new CommandItem(new NoOpCommand())


### PR DESCRIPTION
## Summary of the Pull Request

This PR fixes an invalid command ID for the **Run** page in the default alias map.

- Updates the map to use the new command ID.
- Adds a migration from the old command ID to the new one.
- Introduces shared constants for command IDs to help prevent future regressions.
- Adds unit tests for the migration and to guard against future regressions.

 
<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #49371
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

