### PR TITLE
CmdPal: Prevent scaling empty icon size

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoaderService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconLoaderService.cs
@@ -155,7 +155,9 @@ internal sealed partial class IconLoaderService : IIconLoaderService
         Size iconSize,
         double scale)
     {
-        var scaledSize = new Size(iconSize.Width * scale, iconSize.Height * scale);
+        var scaledSize = iconSize.IsEmpty
+            ? iconSize
+            : new Size(iconSize.Width * scale, iconSize.Height * scale);
 
         if (!string.IsNullOrEmpty(iconString))
         {
@@ -215,7 +217,9 @@ internal sealed partial class IconLoaderService : IIconLoaderService
 
     private static IconSource? GetStringIconSource(string iconString, string? fontFamily, Size size)
     {
-        var iconSize = (int)Math.Max(size.Width, size.Height);
+        var iconSize = size.IsEmpty
+            ? DefaultIconSize
+            : (int)Math.Max(size.Width, size.Height);
         return IconPathConverter.IconSourceMUX(iconString, fontFamily, iconSize);
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconProvider.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/Icons/IconProvider.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using ManagedCommon;
 using Microsoft.CmdPal.UI.Controls;
 using Microsoft.CmdPal.UI.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
@@ -60,6 +61,11 @@ public static partial class IconProvider
                     args.Scale),
                 _ => null,
             };
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError("Failed to provide icon source", ex);
+            args.Value = null;
         }
         finally
         {


### PR DESCRIPTION
## Summary of the Pull Request

This PR prevents a crash caused by attempting to apply DPI scaling to an empty icon. Size.Empty has width and height values of negative infinity. Scaling those values still produces negative infinity, which is not valid for a Size.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #49360
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

