### PR TITLE
[Quick Accent] New character reference guide to show language set contents

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -131,7 +131,6 @@
     <PackageVersion Include="System.Text.Json" Version="10.0.9" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageVersion Include="ToolGood.Words.Pinyin" Version="3.1.0.3" />
-    <PackageVersion Include="UnicodeInformation" Version="2.6.0" />
     <PackageVersion Include="UnitsNet" Version="5.56.0" />
     <PackageVersion Include="UTF.Unknown" Version="2.6.0" />
     <PackageVersion Include="WinUIEx" Version="2.8.0" />

--- a/doc/devdocs/modules/quickaccent.md
+++ b/doc/devdocs/modules/quickaccent.md
@@ -97,6 +97,7 @@ The module includes multiple language-specific character sets and special charac
 - Various language sets for different alphabets and writing systems
 - Special character sets (currency symbols, mathematical notations, etc.)
 - These sets are defined in the core component and can be extended
+- The Settings UI includes a character reference guide for browsing and searching the same character data by language set. Standalone combining marks are displayed with a dotted circle placeholder while preserving the original character when copied.
 
 ### Known Behaviors
 

--- a/src/modules/poweraccent/PowerAccent.Common/UnicodeHelper.cs
+++ b/src/modules/poweraccent/PowerAccent.Common/UnicodeHelper.cs
@@ -1,0 +1,111 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace PowerAccent.Common;
+
+/// <summary>
+/// Provides Unicode character metadata by calling the ICU library that ships with
+/// Windows 10 version 1903 and later.
+/// </summary>
+public static class UnicodeHelper
+{
+    // u_charName name choice: 0 = U_UNICODE_CHAR_NAME (official Unicode name).
+    private const int UnicodeCharName = 0;
+    private const int BufferSize = 128;
+    private static bool _icuUnavailable;
+
+    /// <summary>
+    /// Returns the Unicode name(s) for all code points in <paramref name="character"/>.
+    /// For multi-code-point strings (e.g. combining sequences or surrogate pairs) the
+    /// individual names are joined with " + ". Returns <see langword="null"/> if no
+    /// names can be determined (e.g. control characters, private-use area, or ICU
+    /// unavailable).
+    /// </summary>
+    /// <remarks>
+    /// Requires <c>icu.dll</c>, which ships with Windows 10 version 1903 (May 2019)
+    /// and later.
+    /// </remarks>
+    public static string GetCharacterName(string character)
+    {
+        if (string.IsNullOrEmpty(character) || _icuUnavailable)
+        {
+            return null;
+        }
+
+        try
+        {
+            var names = new List<string>();
+
+            // Enumerate every code point in the string — handles surrogate pairs and
+            // combining sequences such as "°C" (U+00B0 + U+0043) correctly.
+            for (int i = 0; i < character.Length;)
+            {
+                int codePoint = char.ConvertToUtf32(character, i);
+                i += char.IsHighSurrogate(character[i]) ? 2 : 1;
+
+                // The native function writes a null-terminated ASCII string.
+                // We pass a raw byte[] so the P/Invoke marshaller never touches the
+                // encoding — then decode as Latin-1 ourselves.
+                string name = GetCodePointName(codePoint);
+                if (!string.IsNullOrEmpty(name))
+                {
+                    names.Add(name);
+                }
+            }
+
+            return names.Count > 0 ? string.Join(" + ", names) : null;
+        }
+        catch (DllNotFoundException)
+        {
+            _icuUnavailable = true;
+        }
+        catch (EntryPointNotFoundException)
+        {
+            _icuUnavailable = true;
+        }
+
+        return null;
+    }
+
+    private static string GetCodePointName(int codePoint)
+    {
+        byte[] buffer = new byte[BufferSize];
+
+        while (true)
+        {
+            int errorCode = 0;
+            int length = NativeIcu.UCharName(codePoint, UnicodeCharName, buffer, buffer.Length, ref errorCode);
+            if (length <= 0)
+            {
+                return null;
+            }
+
+            if (length < buffer.Length)
+            {
+                return Encoding.Latin1.GetString(buffer, 0, length);
+            }
+
+            // ICU returns the required length excluding the null terminator.
+            buffer = new byte[length + 1];
+        }
+    }
+
+    private static class NativeIcu
+    {
+        // We use the unified Windows system ICU library available on Windows 10
+        // version 1903 (May 2019) and later.
+        // CharSet.None keeps the marshaller out of encoding decisions - the function
+        // writes a null-terminated ASCII string which we decode manually.
+        [DllImport("icu.dll", EntryPoint = "u_charName", CharSet = CharSet.None, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int UCharName(
+            int codePoint,
+            int nameChoice,
+            [Out] byte[] buffer,
+            int bufferLength,
+            ref int errorCode);
+    }
+}

--- a/src/modules/poweraccent/PowerAccent.Core/PowerAccent.Core.csproj
+++ b/src/modules/poweraccent/PowerAccent.Core/PowerAccent.Core.csproj
@@ -21,7 +21,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="UnicodeInformation" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/modules/poweraccent/PowerAccent.Core/PowerAccent.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/PowerAccent.cs
@@ -188,8 +188,7 @@ public partial class PowerAccent : IDisposable
         if (codePointInfo.Count == 1)
         {
             return string.Format(
-                CultureInfo.InvariantCulture,
-                "(U+{0:X4}) {1}", codePointInfo[0].CodePoint, codePointInfo[0].Name);
+                CultureInfo.InvariantCulture, "(U+{0:X4}) {1}", codePointInfo[0].CodePoint, codePointInfo[0].Name);
         }
 
         // Multiple code points. Build the description string with each code point's information.

--- a/src/modules/poweraccent/PowerAccent.Core/PowerAccent.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/PowerAccent.cs
@@ -3,14 +3,14 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Globalization;
-using System.Text;
-using System.Unicode;
 
 using ManagedCommon;
+using PowerAccent.Common;
 using PowerAccent.Core.Services;
 using PowerAccent.Core.Tools;
 using PowerToys.PowerAccentKeyboardService;
 
+using LetterKey = PowerToys.PowerAccentKeyboardService.LetterKey;
 using PowerAccentActivationKey = Microsoft.PowerToys.Settings.UI.Library.Enumerations.PowerAccentActivationKey;
 
 namespace PowerAccent.Core;
@@ -53,19 +53,12 @@ public partial class PowerAccent : IDisposable
 
         Logger.InitializeLogger("\\QuickAccent\\Logs");
 
-        LoadUnicodeInfoCache();
-
         _keyboardListener = new KeyboardListener();
         _keyboardListener.InitHook();
         _settingService = new SettingsService(_keyboardListener);
         _usageInfo = new CharactersUsageInfo();
 
         SetEvents();
-    }
-
-    private void LoadUnicodeInfoCache()
-    {
-        UnicodeInfo.GetCharInfo(0);
     }
 
     private void SetEvents()
@@ -169,64 +162,47 @@ public partial class PowerAccent : IDisposable
 
     private string GetCharacterDescription(string character)
     {
-        List<UnicodeCharInfo> unicodeList = new List<UnicodeCharInfo>();
-        foreach (var codePoint in character.AsCodePointEnumerable())
-        {
-            unicodeList.Add(UnicodeInfo.GetCharInfo(codePoint));
-        }
-
-        if (unicodeList.Count == 0)
+        // TODO: Zero-width joiners (U+200D) and variation selectors (U+FE0F, etc.) currently show
+        // up as their own entries in the description (e.g. for complex emoji sequences). In the
+        // future, when we support arbitrary user-defined sequences, we will want to filter these
+        // out for display purposes, since they're not meaningful to users even though they're
+        // technically part of the code point sequence.
+        if (string.IsNullOrEmpty(character))
         {
             return string.Empty;
         }
 
-        var description = new StringBuilder();
-        if (unicodeList.Count == 1)
+        // Enumerate code points manually to handle surrogate pairs and combining sequences
+        // correctly. For example, "°C" is a two-code-point string (U+00B0 + U+0043) but should
+        // be treated as a single character for description purposes.
+        var codePointInfo = new List<(int CodePoint, string Str, string Name)>();
+        for (int i = 0; i < character.Length;)
         {
-            var unicode = unicodeList.First();
-            var charUnicodeNumber = unicode.CodePoint.ToString("X4", CultureInfo.InvariantCulture);
-            description.AppendFormat(CultureInfo.InvariantCulture, "(U+{0}) {1}", charUnicodeNumber, unicode.Name);
-
-            return description.ToString();
+            int codePoint = char.ConvertToUtf32(character, i);
+            string codePointString = char.ConvertFromUtf32(codePoint);
+            string name = UnicodeHelper.GetCharacterName(codePointString) ?? string.Empty;
+            codePointInfo.Add((codePoint, codePointString, name));
+            i += char.IsHighSurrogate(character[i]) ? 2 : 1;
         }
 
-        var displayTextAndCodes = new StringBuilder();
-        var names = new StringBuilder();
-        foreach (var unicode in unicodeList)
+        if (codePointInfo.Count == 1)
         {
-            var charUnicodeNumber = unicode.CodePoint.ToString("X4", CultureInfo.InvariantCulture);
-            if (displayTextAndCodes.Length > 0)
-            {
-                displayTextAndCodes.Append(" - ");
-            }
-
-            displayTextAndCodes.AppendFormat(CultureInfo.InvariantCulture, "{0}: (U+{1})", unicode.GetDisplayText(), charUnicodeNumber);
-
-            if (names.Length > 0)
-            {
-                names.Append(", ");
-            }
-
-            names.Append(unicode.Name);
+            return string.Format(
+                CultureInfo.InvariantCulture,
+                "(U+{0:X4}) {1}", codePointInfo[0].CodePoint, codePointInfo[0].Name);
         }
 
-        description.Append(displayTextAndCodes);
-        description.Append(": ");
-        description.Append(names);
+        // Multiple code points. Build the description string with each code point's information.
+        string displayTextAndCodes = string.Join(" - ", codePointInfo.Select(info =>
+            string.Format(CultureInfo.InvariantCulture, "{0}: (U+{1:X4})", info.Str, info.CodePoint)));
 
-        return description.ToString();
+        string names = string.Join(", ", codePointInfo.Select(info => info.Name));
+
+        return string.Format(CultureInfo.InvariantCulture, "{0}: {1}", displayTextAndCodes, names);
     }
 
-    private string[] GetCharacterDescriptions(string[] characters)
-    {
-        string[] charInfoCollection = Array.Empty<string>();
-        foreach (string character in characters)
-        {
-            charInfoCollection = charInfoCollection.Append<string>(GetCharacterDescription(character)).ToArray<string>();
-        }
-
-        return charInfoCollection;
-    }
+    private string[] GetCharacterDescriptions(string[] characters) =>
+        Array.ConvertAll(characters, GetCharacterDescription);
 
     private void SendInputAndHideToolbar(InputType inputType)
     {

--- a/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/PowerAccentReferenceGuideViewModelTests.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/PowerAccentReferenceGuideViewModelTests.cs
@@ -1,0 +1,128 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using Microsoft.PowerToys.Settings.UI.ViewModels;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ViewModelTests
+{
+    [TestClass]
+    public sealed class PowerAccentReferenceGuideViewModelTests
+    {
+        [TestMethod]
+        public void Constructor_SelectedLanguages_AppearInSelectedSetsGroup()
+        {
+            var viewModel = CreateViewModel(["FR"]);
+
+            var selectedGroup = viewModel.FilteredGroups.First();
+
+            Assert.AreEqual("Selected sets", selectedGroup.GroupHeader);
+            Assert.IsTrue(selectedGroup.Languages.Any(language => language.DisplayName == "French" && language.IsSelected));
+        }
+
+        [TestMethod]
+        public void Constructor_UnselectedLanguages_RemainInLanguageGroups()
+        {
+            var viewModel = CreateViewModel(["FR"]);
+
+            var languageGroup = viewModel.FilteredGroups.First(group => group.GroupHeader == "Language sets");
+
+            Assert.IsTrue(languageGroup.Languages.Any(language => language.DisplayName == "German" && !language.IsSelected));
+        }
+
+        [TestMethod]
+        public void Constructor_NoSelectedLanguages_OmitsSelectedSetsGroup()
+        {
+            var viewModel = CreateViewModel([]);
+
+            Assert.IsFalse(viewModel.FilteredGroups.Any(group => group.GroupHeader == "Selected sets"));
+        }
+
+        [TestMethod]
+        public void Constructor_UnknownSelectedLanguageCode_IsIgnored()
+        {
+            var viewModel = CreateViewModel(["NotALanguage"]);
+
+            Assert.IsFalse(viewModel.FilteredGroups.Any(group => group.GroupHeader == "Selected sets"));
+        }
+
+        [TestMethod]
+        public void SearchQuery_FiltersGroupsToMatchingCharacters()
+        {
+            var viewModel = CreateViewModel([]);
+
+            viewModel.SearchQuery = "ß";
+
+            Assert.IsFalse(viewModel.IsEmpty);
+            Assert.IsTrue(viewModel.FilteredGroups.SelectMany(group => group.Languages).Any(language => language.DisplayName == "German"));
+            Assert.IsTrue(viewModel.FilteredGroups
+                .SelectMany(group => group.Languages)
+                .SelectMany(language => language.KeyMappings)
+                .SelectMany(mapping => mapping.Characters)
+                .Any(character => character.Value.Contains('ß')));
+        }
+
+        [TestMethod]
+        public void SearchQuery_NoMatches_SetsIsEmpty()
+        {
+            var viewModel = CreateViewModel([]);
+
+            viewModel.SearchQuery = "No matching character";
+
+            Assert.IsTrue(viewModel.IsEmpty);
+            Assert.AreEqual(0, viewModel.FilteredGroups.Count);
+        }
+
+        [TestMethod]
+        public void SearchQuery_Cleared_RestoresAllGroups()
+        {
+            var viewModel = CreateViewModel([]);
+            var originalCount = viewModel.FilteredGroups.Count;
+
+            viewModel.SearchQuery = "ß";
+            viewModel.SearchQuery = string.Empty;
+
+            Assert.AreEqual(originalCount, viewModel.FilteredGroups.Count);
+        }
+
+        [TestMethod]
+        public void CharacterModel_CombiningMark_UsesDottedCircleDisplayValue()
+        {
+            var model = new CharacterModel("\u0301");
+
+            Assert.AreEqual("\u0301", model.Value);
+            Assert.AreEqual("◌\u0301", model.DisplayValue);
+        }
+
+        [TestMethod]
+        public void CharacterModel_BaseCharacterWithCombiningMark_UsesOriginalDisplayValue()
+        {
+            var model = new CharacterModel("y\u0300");
+
+            Assert.AreEqual("y\u0300", model.Value);
+            Assert.AreEqual("y\u0300", model.DisplayValue);
+        }
+
+        private static PowerAccentReferenceGuideViewModel CreateViewModel(string[] selectedLanguageCodes)
+        {
+            return new PowerAccentReferenceGuideViewModel(selectedLanguageCodes, GetLocalizedString);
+        }
+
+        private static string GetLocalizedString(string resourceId)
+        {
+            return resourceId switch
+            {
+                "QuickAccent_ReferenceGuide_SelectedSets" => "Selected sets",
+                "QuickAccent_Group_Language" => "Language sets",
+                "QuickAccent_Group_Special" => "Special sets",
+                "QuickAccent_Group_UserDefined" => "User-defined sets",
+                "QuickAccent_SelectedLanguage_French" => "French",
+                "QuickAccent_SelectedLanguage_German" => "German",
+                _ when resourceId.StartsWith("QuickAccent_SelectedLanguage_", System.StringComparison.Ordinal) => resourceId["QuickAccent_SelectedLanguage_".Length..],
+                _ => resourceId,
+            };
+        }
+    }
+}

--- a/src/settings-ui/Settings.UI/PowerToys.Settings.csproj
+++ b/src/settings-ui/Settings.UI/PowerToys.Settings.csproj
@@ -175,6 +175,9 @@
 		<None Update="Assets\Settings\Scripts\DisableModule.ps1">
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>
+		<Page Update="SettingsXAML\Views\PowerAccentReferenceGuidePage.xaml">
+			<Generator>MSBuild:Compile</Generator>
+		</Page>
 		<Page Update="SettingsXAML\Controls\TitleBar\TitleBar.xaml">
 			<Generator>MSBuild:Compile</Generator>
 		</Page>

--- a/src/settings-ui/Settings.UI/SettingsXAML/App.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/App.xaml
@@ -18,6 +18,7 @@
                 <ResourceDictionary Source="/SettingsXAML/Styles/TextBlock.xaml" />
                 <ResourceDictionary Source="/SettingsXAML/Styles/Button.xaml" />
                 <ResourceDictionary Source="/SettingsXAML/Styles/InfoBadge.xaml" />
+                <ResourceDictionary Source="/SettingsXAML/Styles/ListView.xaml" />
                 <ResourceDictionary Source="/SettingsXAML/Themes/Colors.xaml" />
                 <ResourceDictionary Source="/SettingsXAML/Themes/Generic.xaml" />
                 <ResourceDictionary Source="/SettingsXAML/Controls/Timeline/TimelineStyles.xaml" />

--- a/src/settings-ui/Settings.UI/SettingsXAML/Styles/ListView.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Styles/ListView.xaml
@@ -1,0 +1,22 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!--  Strips hover, pressed and selection visuals from ListView items in read-only lists.  -->
+    <Style x:Key="NonInteractiveListViewItemStyle" TargetType="ListViewItem">
+        <Setter Property="IsTabStop" Value="False" />
+        <Setter Property="Padding" Value="0" />
+        <Setter Property="Margin" Value="0" />
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ListViewItem">
+                    <ContentPresenter
+                        HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                        Content="{TemplateBinding Content}"
+                        ContentTemplate="{TemplateBinding ContentTemplate}" />
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+</ResourceDictionary>

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerAccentPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerAccentPage.xaml
@@ -164,6 +164,17 @@
                     </tkcontrols:SettingsExpander>
                 </controls:SettingsGroup>
 
+                <controls:SettingsGroup x:Uid="QuickAccent_ReferenceGuide" IsEnabled="{x:Bind ViewModel.IsEnabled, Mode=OneWay}">
+                    <tkcontrols:SettingsCard
+                        x:Uid="QuickAccent_ReferenceGuide_Card"
+                        HeaderIcon="{ui:FontIcon Glyph=&#xE736;}">
+                        <Button
+                            x:Uid="QuickAccent_ReferenceGuide_Button"
+                            Click="ReferenceGuideButton_Click"
+                            MinWidth="{StaticResource SettingActionControlMinWidth}" />
+                    </tkcontrols:SettingsCard>
+                </controls:SettingsGroup>
+
                 <controls:SettingsGroup x:Uid="QuickAccent_Toolbar" IsEnabled="{x:Bind ViewModel.IsEnabled, Mode=OneWay}">
                     <tkcontrols:SettingsCard
                         Name="QuickAccentToolbarPosition"

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerAccentPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerAccentPage.xaml
@@ -165,13 +165,11 @@
                 </controls:SettingsGroup>
 
                 <controls:SettingsGroup x:Uid="QuickAccent_ReferenceGuide" IsEnabled="{x:Bind ViewModel.IsEnabled, Mode=OneWay}">
-                    <tkcontrols:SettingsCard
-                        x:Uid="QuickAccent_ReferenceGuide_Card"
-                        HeaderIcon="{ui:FontIcon Glyph=&#xE736;}">
+                    <tkcontrols:SettingsCard x:Uid="QuickAccent_ReferenceGuide_Card" HeaderIcon="{ui:FontIcon Glyph=&#xE736;}">
                         <Button
                             x:Uid="QuickAccent_ReferenceGuide_Button"
-                            Click="ReferenceGuideButton_Click"
-                            MinWidth="{StaticResource SettingActionControlMinWidth}" />
+                            MinWidth="{StaticResource SettingActionControlMinWidth}"
+                            Click="ReferenceGuideButton_Click" />
                     </tkcontrols:SettingsCard>
                 </controls:SettingsGroup>
 

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerAccentPage.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerAccentPage.xaml.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using CommunityToolkit.WinUI;
 using Microsoft.PowerToys.Settings.UI.Helpers;
 using Microsoft.PowerToys.Settings.UI.Library;
+using Microsoft.PowerToys.Settings.UI.Services;
 using Microsoft.PowerToys.Settings.UI.ViewModels;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -35,33 +36,75 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             SetCheckBoxStatus();
         }
 
+        private bool updatingSelectAllCheckBox;
+
         private void SetCheckBoxStatus()
         {
-            if (ViewModel.SelectedLanguageOptions.Length == 0)
+            updatingSelectAllCheckBox = true;
+            try
             {
-                this.QuickAccent_SelectedLanguage_All.IsChecked = false;
-                this.QuickAccent_SelectedLanguage_All.IsThreeState = false;
+                if (ViewModel.SelectedLanguageOptions.Length == 0)
+                {
+                    this.QuickAccent_SelectedLanguage_All.IsChecked = false;
+                    this.QuickAccent_SelectedLanguage_All.IsThreeState = false;
+                }
+                else if (ViewModel.AllSelected)
+                {
+                    this.QuickAccent_SelectedLanguage_All.IsChecked = true;
+                    this.QuickAccent_SelectedLanguage_All.IsThreeState = false;
+                }
+                else
+                {
+                    this.QuickAccent_SelectedLanguage_All.IsThreeState = true;
+                    this.QuickAccent_SelectedLanguage_All.IsChecked = null;
+                }
             }
-            else if (ViewModel.AllSelected)
+            finally
             {
-                this.QuickAccent_SelectedLanguage_All.IsChecked = true;
-                this.QuickAccent_SelectedLanguage_All.IsThreeState = false;
-            }
-            else
-            {
-                this.QuickAccent_SelectedLanguage_All.IsThreeState = true;
-                this.QuickAccent_SelectedLanguage_All.IsChecked = null;
+                updatingSelectAllCheckBox = false;
             }
         }
 
         private void QuickAccent_SelectedLanguage_SelectAll(object sender, RoutedEventArgs e)
         {
-            this.QuickAccent_Language_Select.SelectAllSafe();
+            if (updatingSelectAllCheckBox)
+            {
+                return;
+            }
+
+            loadingLanguageListDontTriggerSelectionChanged = true;
+            try
+            {
+                this.QuickAccent_Language_Select.SelectAllSafe();
+                ViewModel.SelectedLanguageOptions = ViewModel.Languages.ToArray();
+            }
+            finally
+            {
+                loadingLanguageListDontTriggerSelectionChanged = false;
+            }
+
+            SetCheckBoxStatus();
         }
 
         private void QuickAccent_SelectedLanguage_UnselectAll(object sender, RoutedEventArgs e)
         {
-            this.QuickAccent_Language_Select.DeselectAll();
+            if (updatingSelectAllCheckBox)
+            {
+                return;
+            }
+
+            loadingLanguageListDontTriggerSelectionChanged = true;
+            try
+            {
+                this.QuickAccent_Language_Select.DeselectAll();
+                ViewModel.SelectedLanguageOptions = [];
+            }
+            finally
+            {
+                loadingLanguageListDontTriggerSelectionChanged = false;
+            }
+
+            SetCheckBoxStatus();
         }
 
         private bool loadingLanguageListDontTriggerSelectionChanged;
@@ -121,6 +164,17 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             QuickAccent_Language_Select.MaxWidth = Math.Max(
                 QuickAccent_Language_Select.MinWidth,
                 availableWidth);
+        }
+
+        private void ReferenceGuideButton_Click(object sender, RoutedEventArgs e)
+        {
+            // Pass the currently selected language codes so the reference guide can
+            // surface them at the top and mark them as selected.
+            var selectedCodes = ViewModel.SelectedLanguageOptions
+                .Select(l => l.LanguageCode)
+                .ToArray();
+
+            NavigationService.Navigate<PowerAccentReferenceGuidePage>(selectedCodes);
         }
     }
 }

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerAccentReferenceGuidePage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerAccentReferenceGuidePage.xaml
@@ -1,0 +1,166 @@
+<local:NavigablePage
+    x:Class="Microsoft.PowerToys.Settings.UI.Views.PowerAccentReferenceGuidePage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:Microsoft.PowerToys.Settings.UI.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:Microsoft.PowerToys.Settings.UI.Helpers"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:tkcontrols="using:CommunityToolkit.WinUI.Controls"
+    xmlns:vm="using:Microsoft.PowerToys.Settings.UI.ViewModels"
+    AutomationProperties.LandmarkType="Main"
+    mc:Ignorable="d">
+
+    <local:NavigablePage.Resources>
+        <!--  Groups the flat FilteredGroups collection for the ListView with GroupStyle.  -->
+        <CollectionViewSource
+            x:Name="LanguagesViewSource"
+            IsSourceGrouped="True"
+            ItemsPath="Languages" />
+
+        <!--  Compact borderless style for individual character copy buttons.  -->
+        <Style x:Key="CharacterButtonStyle" TargetType="Button">
+            <Setter Property="Padding" Value="4,2" />
+            <Setter Property="MinWidth" Value="0" />
+            <Setter Property="MinHeight" Value="0" />
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="FontSize" Value="18" />
+        </Style>
+    </local:NavigablePage.Resources>
+
+    <Grid RowDefinitions="Auto,Auto,*">
+
+        <!--  Page header with back button  -->
+        <Grid
+            Grid.Row="0"
+            Padding="24,12"
+            BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}"
+            BorderThickness="0,0,0,1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <Button
+                Grid.Column="0"
+                Margin="0,0,12,0"
+                Click="BackButton_Click"
+                Style="{ThemeResource NavigationBackButtonSmallStyle}" />
+            <TextBlock
+                x:Uid="QuickAccent_ReferenceGuide_Title"
+                Grid.Column="1"
+                VerticalAlignment="Center"
+                Style="{ThemeResource SubtitleTextBlockStyle}"
+                TextTrimming="CharacterEllipsis" />
+            <AutoSuggestBox
+                x:Uid="QuickAccent_ReferenceGuide_Search"
+                Grid.Column="2"
+                Width="220"
+                Margin="16,0,0,0"
+                HorizontalAlignment="Right"
+                QueryIcon="Find"
+                Text="{x:Bind ViewModel.SearchQuery, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+        </Grid>
+
+        <!--  Usage hint  -->
+        <InfoBar
+            x:Uid="QuickAccent_ReferenceGuide_Hint"
+            Grid.Row="1"
+            Margin="24,8"
+            IsClosable="False"
+            IsOpen="True"
+            IsTabStop="False"
+            Severity="Informational" />
+
+        <!--  Empty state  -->
+        <TextBlock
+            x:Uid="QuickAccent_ReferenceGuide_NoResults"
+            Grid.Row="2"
+            Margin="24,24"
+            Visibility="{x:Bind ViewModel.IsEmpty, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}" />
+
+        <!--  Main scrollable content - single virtualising ListView with GroupStyle  -->
+        <ListView
+            Grid.Row="2"
+            Padding="24,0,24,24"
+            IsItemClickEnabled="False"
+            ItemContainerStyle="{StaticResource NonInteractiveListViewItemStyle}"
+            ItemsSource="{x:Bind LanguagesViewSource.View, Mode=OneWay}"
+            SelectionMode="None">
+
+            <!--  Language card template  -->
+            <ListView.ItemTemplate>
+                <DataTemplate x:DataType="vm:ReferenceLanguageModel">
+                    <controls:Card
+                        Title="{x:Bind DisplayName}"
+                        Margin="0,4"
+                        Padding="12,4,12,12">
+                        <controls:Card.Content>
+                            <!--  Key mappings - one row per key  -->
+                            <ItemsControl ItemsSource="{x:Bind KeyMappings}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate x:DataType="vm:KeyMappingModel">
+                                        <!--  Left-aligned with the Card's 16px title indent.  -->
+                                        <Grid
+                                            Margin="4,2"
+                                            VerticalAlignment="Center"
+                                            ColumnDefinitions="96,*">
+
+                                            <!--  Key label (Margin vertically aligns the key label with the characters)  -->
+                                            <TextBlock
+                                                Grid.Column="0"
+                                                Margin="0,2,0,0"
+                                                VerticalAlignment="Center"
+                                                FontSize="13"
+                                                FontWeight="SemiBold"
+                                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                Text="{x:Bind KeyLabel}" />
+
+                                            <!--  Characters for this key - each is a button that copies to clipboard  -->
+                                            <ItemsControl
+                                                Grid.Column="1"
+                                                VerticalAlignment="Center"
+                                                ItemsSource="{x:Bind Characters}">
+                                                <ItemsControl.ItemsPanel>
+                                                    <ItemsPanelTemplate>
+                                                        <tkcontrols:WrapPanel HorizontalSpacing="4" Orientation="Horizontal" />
+                                                    </ItemsPanelTemplate>
+                                                </ItemsControl.ItemsPanel>
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate x:DataType="vm:CharacterModel">
+                                                        <Button
+                                                            Click="CharacterButton_Click"
+                                                            Content="{x:Bind DisplayValue}"
+                                                            Style="{StaticResource CharacterButtonStyle}"
+                                                            ToolTipService.ToolTip="{x:Bind Tooltip}" />
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+                                        </Grid>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </controls:Card.Content>
+                    </controls:Card>
+                </DataTemplate>
+            </ListView.ItemTemplate>
+
+            <!--  Group header template  -->
+            <ListView.GroupStyle>
+                <GroupStyle>
+                    <GroupStyle.HeaderTemplate>
+                        <DataTemplate x:DataType="vm:ReferenceGroupModel">
+                            <TextBlock
+                                Margin="0,16,0,0"
+                                Style="{ThemeResource BodyStrongTextBlockStyle}"
+                                Text="{x:Bind GroupHeader}" />
+                        </DataTemplate>
+                    </GroupStyle.HeaderTemplate>
+                </GroupStyle>
+            </ListView.GroupStyle>
+
+        </ListView>
+
+    </Grid>
+</local:NavigablePage>

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerAccentReferenceGuidePage.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerAccentReferenceGuidePage.xaml.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.PowerToys.Settings.UI.Helpers;
+using Microsoft.PowerToys.Settings.UI.Services;
+using Microsoft.PowerToys.Settings.UI.ViewModels;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Windows.ApplicationModel.DataTransfer;
+
+namespace Microsoft.PowerToys.Settings.UI.Views
+{
+    public sealed partial class PowerAccentReferenceGuidePage : NavigablePage
+    {
+        public PowerAccentReferenceGuideViewModel ViewModel { get; private set; }
+
+        public PowerAccentReferenceGuidePage()
+        {
+            InitializeComponent();
+        }
+
+        /// <summary>
+        /// Reinitialises the ViewModel each time the page is navigated to, so that any
+        /// change to the user's language selection since the last visit is reflected.
+        /// The navigation parameter should be the set of selected language code strings
+        /// passed from <see cref="PowerAccentPage"/>.
+        /// </summary>
+        protected override void OnNavigatedTo(Microsoft.UI.Xaml.Navigation.NavigationEventArgs e)
+        {
+            base.OnNavigatedTo(e);
+
+            var selectedCodes = e.Parameter as string[] ?? [];
+
+            ViewModel = new PowerAccentReferenceGuideViewModel(
+                selectedCodes,
+                ResourceLoaderInstance.ResourceLoader.GetString);
+
+            // CollectionViewSource is a resource and cannot track ViewModel changes via
+            // x:Bind, so set its Source manually after the ViewModel is ready.
+            LanguagesViewSource.Source = ViewModel.FilteredGroups;
+            ViewModel.FilteredGroupsReplaced += (_, _) =>
+            {
+                // Swap to an empty collection first then back to the real one — WinUI 3's
+                // CollectionViewSource does not observe grouped ObservableCollection mutations
+                // directly, so we must reassign. Using an empty collection rather than null
+                // avoids the crash that occurs when the ListView holds a live view reference.
+                var groups = ViewModel.FilteredGroups;
+                LanguagesViewSource.Source = new System.Collections.ObjectModel.ObservableCollection<ReferenceGroupModel>();
+                LanguagesViewSource.Source = groups;
+
+                Bindings.Update();
+            };
+
+            // ViewModel was null during InitializeComponent, so push all x:Bind values now.
+            Bindings.Update();
+        }
+
+        private void BackButton_Click(object sender, RoutedEventArgs e)
+        {
+            NavigationService.GoBack();
+        }
+
+        private void CharacterButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is Button { DataContext: CharacterModel characterModel })
+            {
+                var dataPackage = new DataPackage();
+                dataPackage.SetText(characterModel.Value);
+                Clipboard.SetContent(dataPackage);
+            }
+        }
+    }
+}

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -3588,6 +3588,30 @@ Activate by holding the key for the character you want to add an accent to, then
   <data name="QuickAccent_Group_Language" xml:space="preserve">
     <value>Language sets</value>
   </data>
+  <data name="QuickAccent_ReferenceGuide.Header" xml:space="preserve">
+    <value>Character reference guide</value>
+  </data>
+  <data name="QuickAccent_ReferenceGuide_Card.Header" xml:space="preserve">
+    <value>View characters organised by language, with search</value>
+  </data>
+  <data name="QuickAccent_ReferenceGuide_Button.Content" xml:space="preserve">
+    <value>Open reference guide</value>
+  </data>
+  <data name="QuickAccent_ReferenceGuide_Title.Text" xml:space="preserve">
+    <value>Character reference guide</value>
+  </data>
+  <data name="QuickAccent_ReferenceGuide_Search.PlaceholderText" xml:space="preserve">
+    <value>Search for a character…</value>
+  </data>
+  <data name="QuickAccent_ReferenceGuide_Hint.Message" xml:space="preserve">
+    <value>Hover over a character to see its Unicode name. Click to copy it to the clipboard.</value>
+  </data>
+  <data name="QuickAccent_ReferenceGuide_NoResults.Text" xml:space="preserve">
+    <value>No characters found matching your search.</value>
+  </data>
+  <data name="QuickAccent_ReferenceGuide_SelectedSets" xml:space="preserve">
+    <value>Selected sets</value>
+  </data>
   <data name="QuickAccent_SelectedLanguage_Special" xml:space="preserve">
     <value>Special Characters</value>
   </data>

--- a/src/settings-ui/Settings.UI/ViewModels/CharacterModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/CharacterModel.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+
+using PowerAccent.Common;
+
+namespace Microsoft.PowerToys.Settings.UI.ViewModels
+{
+    /// <summary>
+    /// Pairs a displayable character with its Unicode name for use in the Quick Accent
+    /// reference guide. The name is resolved once at construction time via
+    /// <see cref="UnicodeHelper.GetCharacterName"/> and falls back to the character
+    /// itself when unavailable.
+    /// </summary>
+    public sealed record CharacterModel
+    {
+        /// <summary>Gets the character string (may be a surrogate pair for characters above U+FFFF).</summary>
+        public string Value { get; init; }
+
+        /// <summary>Gets the value to display in the reference guide.</summary>
+        public string DisplayValue { get; init; }
+
+        /// <summary>
+        /// Gets the tooltip text to display. This is the Unicode character name when
+        /// available (e.g. "Latin Small Letter E With Acute"), otherwise the character
+        /// itself.
+        /// </summary>
+        public string Tooltip { get; init; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CharacterModel"/> class. The
+        /// Unicode name is resolved automatically.
+        /// </summary>
+        public CharacterModel(string value)
+        {
+            Value = value;
+            DisplayValue = ContainsOnlyCombiningMarks(value) ? $"◌{value}" : value;
+            Tooltip = UnicodeHelper.GetCharacterName(value) ?? value;
+        }
+
+        private static bool ContainsOnlyCombiningMarks(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return false;
+            }
+
+            for (var index = 0; index < value.Length;)
+            {
+                var category = CharUnicodeInfo.GetUnicodeCategory(value, index);
+
+                if (category is not UnicodeCategory.NonSpacingMark
+                    and not UnicodeCategory.SpacingCombiningMark
+                    and not UnicodeCategory.EnclosingMark)
+                {
+                    return false;
+                }
+
+                index += char.IsHighSurrogate(value[index]) ? 2 : 1;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/settings-ui/Settings.UI/ViewModels/KeyMappingModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/KeyMappingModel.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.PowerToys.Settings.UI.ViewModels
+{
+    /// <summary>
+    /// Represents a single key-to-characters mapping row within a language entry in the
+    /// Quick Accent reference guide.
+    /// </summary>
+    public sealed record KeyMappingModel(string KeyLabel, IReadOnlyList<CharacterModel> Characters);
+}

--- a/src/settings-ui/Settings.UI/ViewModels/PowerAccentReferenceGuideViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/PowerAccentReferenceGuideViewModel.cs
@@ -1,0 +1,223 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Microsoft.PowerToys.Settings.UI.Library.Helpers;
+using PowerAccent.Common;
+
+namespace Microsoft.PowerToys.Settings.UI.ViewModels
+{
+    public partial class PowerAccentReferenceGuideViewModel : Observable
+    {
+        private string _searchQuery = string.Empty;
+
+        /// <summary>
+        /// Raised once after <see cref="FilteredGroups"/> has been fully mutated by a
+        /// filter change. The view subscribes to this instead of <see cref="ObservableCollection{T}.CollectionChanged"/>
+        /// so that the <c>CollectionViewSource</c> source-swap happens exactly once per
+        /// filter operation rather than once per item mutation.
+        /// </summary>
+        public event EventHandler FilteredGroupsReplaced;
+
+        /// <summary>
+        /// Gets or sets the current search query. Setting this filters
+        /// <see cref="FilteredGroups"/> in real time.
+        /// </summary>
+        public string SearchQuery
+        {
+            get => _searchQuery;
+            set
+            {
+                if (_searchQuery != value)
+                {
+                    _searchQuery = value;
+                    UpdateFilteredGroups(value);
+                    OnPropertyChanged(nameof(SearchQuery));
+                    OnPropertyChanged(nameof(IsEmpty));
+                    FilteredGroupsReplaced?.Invoke(this, EventArgs.Empty);
+                }
+            }
+        }
+
+        /// <summary>
+        /// The full unfiltered reference data, built once at construction time from
+        /// <see cref="CharacterMappings.All"/> using the provided selected language codes.
+        /// </summary>
+        private readonly IReadOnlyList<ReferenceGroupModel> _allGroups;
+
+        /// <summary>
+        /// Gets the reference data filtered by <see cref="SearchQuery"/>. When the query
+        /// is empty the full list is returned. When non-empty, only languages that contain
+        /// the query string as a substring of any mapped character are included.
+        /// Matching is case-insensitive. No Unicode normalisation is performed.
+        /// </summary>
+        /// <remarks>
+        /// This is an <see cref="ObservableCollection{T}"/> that is mutated in place on
+        /// each filter change so that the bound <c>ListView</c> only updates changed
+        /// items rather than rebuilding from scratch.
+        /// </remarks>
+        public ObservableCollection<ReferenceGroupModel> FilteredGroups { get; } = new();
+
+        /// <summary>
+        /// Gets a value indicating whether <see cref="FilteredGroups"/> is empty, i.e.
+        /// the search query produced no matches. Used to show an empty-state message in
+        /// the UI.
+        /// </summary>
+        public bool IsEmpty => FilteredGroups.Count == 0;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PowerAccentReferenceGuideViewModel"/> class.
+        /// </summary>
+        /// <param name="selectedLanguageCodes">
+        /// The set of language codes (i.e. <see cref="Language"/> enum names) currently
+        /// selected by the user. Selected languages are surfaced at the top of each
+        /// group and visually distinguished from unselected ones.
+        /// </param>
+        /// <param name="getLocalizedString">
+        /// Delegate used to resolve localised strings from resource IDs. Injected to
+        /// keep the ViewModel testable without a live resource loader.
+        /// </param>
+        public PowerAccentReferenceGuideViewModel(
+            IReadOnlyCollection<string> selectedLanguageCodes,
+            Func<string, string> getLocalizedString)
+        {
+            _allGroups = BuildGroups(selectedLanguageCodes, getLocalizedString);
+            foreach (var group in _allGroups)
+            {
+                FilteredGroups.Add(group);
+            }
+        }
+
+        private void UpdateFilteredGroups(string query)
+        {
+            var matching = string.IsNullOrEmpty(query)
+                ? _allGroups
+                : _allGroups
+                    .Select(group =>
+                    {
+                        var langs = group.Languages
+                            .Where(lang => lang.KeyMappings
+                                .Any(mapping => mapping.Characters
+                                    .Any(ch => ch.Value.Contains(query, StringComparison.OrdinalIgnoreCase))))
+                            .ToList();
+                        return langs.Count > 0
+                            ? new ReferenceGroupModel { GroupHeader = group.GroupHeader, Languages = langs }
+                            : null;
+                    })
+                    .Where(g => g != null)
+                    .OfType<ReferenceGroupModel>()
+                    .ToList();
+
+            // Mutate the existing collection in place: remove groups no longer present,
+            // add new ones. This preserves the ListView's item containers and avoids a
+            // full re-render of the visible list.
+            for (int i = FilteredGroups.Count - 1; i >= 0; i--)
+            {
+                if (!matching.Any(g => g.GroupHeader == FilteredGroups[i].GroupHeader))
+                {
+                    FilteredGroups.RemoveAt(i);
+                }
+            }
+
+            for (int i = 0; i < matching.Count; i++)
+            {
+                if (i >= FilteredGroups.Count || FilteredGroups[i].GroupHeader != matching[i].GroupHeader)
+                {
+                    FilteredGroups.Insert(i, matching[i]);
+                }
+                else
+                {
+                    // Group is present - replace it so language membership updates.
+                    FilteredGroups[i] = matching[i];
+                }
+            }
+        }
+
+        private static IReadOnlyList<ReferenceGroupModel> BuildGroups(
+            IReadOnlyCollection<string> selectedLanguageCodes,
+            Func<string, string> getLocalizedString)
+        {
+            // Build the flat list of reference models from CharacterMappings.All,
+            // resolving display names via the resource loader.
+            var allModels = CharacterMappings.All
+                .Select(lang =>
+                {
+                    bool isSelected = selectedLanguageCodes.Contains(lang.Id.ToString(), StringComparer.OrdinalIgnoreCase);
+                    string displayName = getLocalizedString($"QuickAccent_SelectedLanguage_{lang.Identifier}");
+
+                    var keyMappings = lang.Characters
+                        .OrderBy(kvp => kvp.Key)
+                        .Select(kvp => new KeyMappingModel(
+                            kvp.Key.ToString()
+                                .Replace("VK_", string.Empty, StringComparison.Ordinal)
+                                .TrimEnd('_'),
+                            kvp.Value.Select(ch => new CharacterModel(ch)).ToList()))
+                        .ToList();
+
+                    return (lang.Group, isSelected, displayName, keyMappings);
+                })
+                .ToList();
+
+            var groups = new List<ReferenceGroupModel>();
+
+            // "Selected sets" synthetic group - selected character sets surfaced first.
+            var selectedModels = allModels
+                .Where(m => m.isSelected)
+                .OrderBy(m => m.displayName, StringComparer.CurrentCulture)
+                .Select(m => new ReferenceLanguageModel
+                {
+                    DisplayName = m.displayName,
+                    IsSelected = true,
+                    KeyMappings = m.keyMappings,
+                })
+                .ToList();
+
+            if (selectedModels.Count > 0)
+            {
+                groups.Add(new ReferenceGroupModel
+                {
+                    GroupHeader = getLocalizedString("QuickAccent_ReferenceGuide_SelectedSets"),
+                    Languages = selectedModels,
+                });
+            }
+
+            // Remaining groups in GroupDisplayOrder order, unselected languages only.
+            foreach (var group in CharacterMappings.GroupDisplayOrder)
+            {
+                var groupModels = allModels
+                    .Where(m => m.Group == group && !m.isSelected)
+                    .OrderBy(m => m.displayName, StringComparer.CurrentCulture)
+                    .Select(m => new ReferenceLanguageModel
+                    {
+                        DisplayName = m.displayName,
+                        IsSelected = false,
+                        KeyMappings = m.keyMappings,
+                    })
+                    .ToList();
+
+                if (groupModels.Count > 0)
+                {
+                    string groupResourceKey = group switch
+                    {
+                        LanguageGroup.Language => "QuickAccent_Group_Language",
+                        LanguageGroup.Special => "QuickAccent_Group_Special",
+                        LanguageGroup.UserDefined => "QuickAccent_Group_UserDefined",
+                        _ => group.ToString(),
+                    };
+
+                    groups.Add(new ReferenceGroupModel
+                    {
+                        GroupHeader = getLocalizedString(groupResourceKey),
+                        Languages = groupModels,
+                    });
+                }
+            }
+
+            return groups;
+        }
+    }
+}

--- a/src/settings-ui/Settings.UI/ViewModels/ReferenceGroupModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/ReferenceGroupModel.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Microsoft.PowerToys.Settings.UI.ViewModels
+{
+    /// <summary>
+    /// Represents a group of language entries in the Quick Accent reference guide,
+    /// with a localised group header.
+    /// </summary>
+    /// <remarks>
+    /// Implements <see cref="IEnumerable{T}"/> so that a WinUI 3
+    /// <c>CollectionViewSource</c> with <c>IsSourceGrouped="True"</c> can use this
+    /// type directly as a group - the view source enumerates the group to get its
+    /// items and uses the group object itself as the group header.
+    /// </remarks>
+    public sealed class ReferenceGroupModel : IEnumerable<ReferenceLanguageModel>
+    {
+        /// <summary>Gets the localised display name for this group.</summary>
+        public string GroupHeader { get; init; }
+
+        /// <summary>Gets the language entries belonging to this group.</summary>
+        public IReadOnlyList<ReferenceLanguageModel> Languages { get; init; }
+
+        /// <inheritdoc/>
+        public IEnumerator<ReferenceLanguageModel> GetEnumerator() => Languages.GetEnumerator();
+
+        /// <inheritdoc/>
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/src/settings-ui/Settings.UI/ViewModels/ReferenceLanguageModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/ReferenceLanguageModel.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.PowerToys.Settings.UI.ViewModels
+{
+    /// <summary>
+    /// Represents a language entry in the Quick Accent reference guide, including its
+    /// display name, key mappings, and whether the user has currently selected it.
+    /// </summary>
+    public sealed class ReferenceLanguageModel
+    {
+        /// <summary>Gets the localised display name for this language.</summary>
+        public string DisplayName { get; init; }
+
+        /// <summary>Gets a value indicating whether this language is currently selected by the user.</summary>
+        public bool IsSelected { get; init; }
+
+        /// <summary>Gets the key-to-characters mappings declared for this language.</summary>
+        public IReadOnlyList<KeyMappingModel> KeyMappings { get; init; }
+    }
+}


### PR DESCRIPTION
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #47438
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
This PR includes a new reference guide feature for Quick Accent's Settings page to show the character mappings for each language. Previously, a language's mappings were unavailable to view unless the user inspected the source code or tested each key in turn after enabling a language.

## Interface

Accessed via the new **Open reference guide** button on the Quick Accent settings page:

<img width="983" height="437" alt="image" src="https://github.com/user-attachments/assets/5c05a90b-9bf2-471d-99fb-6ab592235d95" />

The user's selected language(s) are listed first, with the others beneath in alphabetical order:

<img width="956" height="806" alt="image" src="https://github.com/user-attachments/assets/ac68be40-7bb1-49e1-a20a-883f67b2a359" />

Hover over any character to see its Unicode description. These often have great descriptions:

<img width="432" height="176" alt="image" src="https://github.com/user-attachments/assets/caf95e9a-20f6-49eb-87a8-c17e72cf1d45" />

Click on any character to copy it to the clipboard:

https://github.com/user-attachments/assets/67bfc14f-7ab3-492c-a345-d7fa5462b164

Search for any character to filter the list to only the language(s) where it is included:

<img width="942" height="657" alt="image" src="https://github.com/user-attachments/assets/88a4a0c6-1732-4bf1-a120-af7b08139742" />

<img width="942" height="245" alt="image" src="https://github.com/user-attachments/assets/0a17d012-8307-411a-b12b-2d5bf88f7773" />

(Unfortunately, we don't have a language containing this emoji just yet.)

## Additional features
### Combining marks
Some Unicode code points are combining marks like diacritics, which can be very small and difficult to discern. A standard way of illustrating the effect of a combining mark is to use the dotted circle (https://en.wikipedia.org/wiki/Dotted_circle). The reference guide uses this method to better show diacritics, as illustrated here for Hebrew:

<img width="260" height="572" alt="image" src="https://github.com/user-attachments/assets/44d849f7-014a-4285-a43b-c17a5bcd1c44" />

We may wish to add this feature as an option for Quick Accent's main selection interface in the future.

### UnicodeInformation replacement
Previously, Quick Accent relied upon the UnicodeInformation nuget package for Unicode character description information. This is a 1.5 MB DLL (with the package near 7.5 MB) and outdated, with the last release from more than 3 years ago. As such it doesn't include the latest changes and additions to the Unicode standard, which will be important when we move to support user-defined languages in the future. It would have needed to have been referenced by the Settings UI project as part of this update.

Instead, this PR introduces a small UnicodeHelper class which retrieves the Unicode descriptions directly from the Windows ICU library, which is serviced as a standard Windows component, and is automatically updated when a new version of the Unicode standard releases. This also removes the previous need to load and prepare the cache for the Unicode information. The information retrieved is in the exact same format as before. (The ICU library has been a standard component since Windows 10 version 1903.)

### Miscellaneous
This adds a re-entrancy guard to the All languages tri-state checkbox on the settings page. No functionality change, just a robustness improvement.

A minor refactoring to `GetCharacterDescription()` (beyond now calling `UnicodeHelper` to get the underlying character information) simplifies the flow and hopefully makes this more readable. I added a note about removing Zero-Width Joiner descriptions in the future, as description length may become an issue in the future with fully custom mappings.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- 9 new unit tests under **Settings.UI.UnitTests/ViewModelTests/PowerAccentReferenceGuideViewModelTests**
- Confirmed that all unit tests pass, including all **Settings.UI.UnitTests** and **PowerAccent*** tests.
- Manual testing to confirm that:
    - Navigation to the guide and back (using the standard back arrow button) work
    - Ordering is correct and the groupings follow the user's currently selected sets
    - Filtering works as expected for simple characters and more complex instances like `°C`
    - Formatting and descriptions are the same as before for single- and multi-codepoint Unicode characters
    - The UnicodeInformation package is not referenced in any other project

### Unit tests
<img width="260" height="52" alt="image" src="https://github.com/user-attachments/assets/e3d67cb4-4008-4911-bcdf-3d0299caf48f" />

<img width="317" height="71" alt="image" src="https://github.com/user-attachments/assets/5313fa5c-cfcf-4396-91f9-9074b57ba193" />

## Screen recording

This screen recording shows how the reference guide is opened via the main Quick Accent page, demonstrates the filtering and hover functionality, and finally shows using the back button to return to the originating Quick Accent settings page:

https://github.com/user-attachments/assets/ebc1bb59-014e-423c-99b7-4cd3c7c58caf
