### PR TITLE
[CmdPal] Add setting to use English system command names

### DIFF
--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.System.UnitTests/QueryTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.System.UnitTests/QueryTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Globalization;
 using System.Linq;
 using Microsoft.CmdPal.Ext.System.Helpers;
 using Microsoft.CmdPal.Ext.System.Pages;
@@ -144,5 +145,45 @@ public class QueryTests : CommandPaletteUnitTestBase
         var firstItem = result.FirstOrDefault();
         var firstItemIsUefiCommand = firstItem?.Title.Contains("UEFI", StringComparison.OrdinalIgnoreCase) ?? false;
         Assert.AreEqual(hasCommand, firstItemIsUefiCommand, $"Expected to match (or not match) 'UEFI firmware settings' but got '{firstItem?.Title}'");
+    }
+
+    [DataTestMethod]
+    [DataRow("shutdown", "Shutdown computer")]
+    [DataRow("restart", "Restart computer")]
+    [DataRow("sign out", "Sign out of computer")]
+    [DataRow("uefi", "UEFI firmware settings")]
+    public void EnglishCommandsWhenLocalizationDisabledTest(string input, string matchedTitle)
+    {
+        // With the "localize system commands" setting disabled the titles must be the
+        // English (en-US) strings regardless of the current UI culture.
+        var settings = new Settings(localizeSystemCommands: false);
+        var pages = new SystemCommandPage(settings);
+        var allCommands = pages.GetItems();
+
+        var result = Query(input, allCommands);
+
+        Assert.IsNotNull(result);
+        var firstItem = result.FirstOrDefault();
+        Assert.IsNotNull(firstItem, "No items matched the query.");
+        Assert.AreEqual(matchedTitle, firstItem.Title, $"Expected the English title for '{input}' but got '{firstItem.Title}'");
+    }
+
+    [TestMethod]
+    public void EnglishCultureLookupProducesEnglishTitlesTest()
+    {
+        // Calling the command builder with an explicit en-US culture must produce English
+        // titles independent of the machine's UI language.
+        var commands = Commands.GetSystemCommands(
+            isUefi: true,
+            hideEmptyRecycleBin: false,
+            confirmCommands: false,
+            emptyRBSuccessMessage: false,
+            culture: new CultureInfo("en-US"));
+
+        var titles = commands.Select(c => c.Title).ToList();
+
+        CollectionAssert.Contains(titles, "Shutdown computer");
+        CollectionAssert.Contains(titles, "Restart computer");
+        CollectionAssert.Contains(titles, "UEFI firmware settings");
     }
 }

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.System.UnitTests/Settings.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.System.UnitTests/Settings.cs
@@ -18,14 +18,16 @@ public class Settings : ISettingsInterface
     private bool showDialogToConfirmCommand;
     private bool showSuccessMessageAfterEmptyingRecycleBin;
     private FirmwareType firmwareType;
+    private bool localizeSystemCommands;
 
-    public Settings(bool hideDisconnectedNetworkInfo = false, bool hideEmptyRecycleBin = false, bool showDialogToConfirmCommand = false, bool showSuccessMessageAfterEmptyingRecycleBin = false, FirmwareType firmwareType = FirmwareType.Uefi)
+    public Settings(bool hideDisconnectedNetworkInfo = false, bool hideEmptyRecycleBin = false, bool showDialogToConfirmCommand = false, bool showSuccessMessageAfterEmptyingRecycleBin = false, FirmwareType firmwareType = FirmwareType.Uefi, bool localizeSystemCommands = true)
     {
         this.hideDisconnectedNetworkInfo = hideDisconnectedNetworkInfo;
         this.hideEmptyRecycleBin = hideEmptyRecycleBin;
         this.showDialogToConfirmCommand = showDialogToConfirmCommand;
         this.showSuccessMessageAfterEmptyingRecycleBin = showSuccessMessageAfterEmptyingRecycleBin;
         this.firmwareType = firmwareType;
+        this.localizeSystemCommands = localizeSystemCommands;
     }
 
     public bool HideDisconnectedNetworkInfo() => hideDisconnectedNetworkInfo;
@@ -35,6 +37,8 @@ public class Settings : ISettingsInterface
     public bool ShowDialogToConfirmCommand() => showDialogToConfirmCommand;
 
     public bool ShowSuccessMessageAfterEmptyingRecycleBin() => showSuccessMessageAfterEmptyingRecycleBin;
+
+    public bool LocalizeSystemCommands() => localizeSystemCommands;
 
     public FirmwareType GetSystemFirmwareType() => firmwareType;
 }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.System/FallbackSystemCommandItem.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.System/FallbackSystemCommandItem.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using Microsoft.CmdPal.Ext.System.Helpers;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
@@ -21,12 +22,13 @@ internal sealed partial class FallbackSystemCommandItem : FallbackCommandItem
         Subtitle = string.Empty;
         Icon = Icons.LockIcon;
 
+        var culture = settings.LocalizeSystemCommands() ? CultureInfo.CurrentUICulture : new CultureInfo("en-US");
         var isBootedInUefiMode = settings.GetSystemFirmwareType() == FirmwareType.Uefi;
         var hideEmptyRB = settings.HideEmptyRecycleBin();
         var confirmSystemCommands = settings.ShowDialogToConfirmCommand();
         var showSuccessOnEmptyRB = settings.ShowSuccessMessageAfterEmptyingRecycleBin();
 
-        systemCommands = Commands.GetSystemCommands(isBootedInUefiMode, hideEmptyRB, confirmSystemCommands, showSuccessOnEmptyRB);
+        systemCommands = Commands.GetSystemCommands(isBootedInUefiMode, hideEmptyRB, confirmSystemCommands, showSuccessOnEmptyRB, culture);
     }
 
     private readonly List<IListItem> systemCommands;

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.System/Helpers/Commands.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.System/Helpers/Commands.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation
+﻿// Copyright (c) Microsoft Corporation
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -30,14 +30,24 @@ internal static class Commands
     private static DateTime timeOfLastNetworkQuery;
 
     /// <summary>
+    /// Gets a resource string in the requested culture. Used so that the command names can
+    /// be shown/matched in English instead of the system language if the user disabled the
+    /// "localize system commands" setting. (Confirmation dialogs always follow the UI
+    /// language, matching the behavior of the PowerToys Run System plugin.)
+    /// </summary>
+    private static string GetString(string resourceName, CultureInfo culture)
+        => Resources.ResourceManager.GetString(resourceName, culture) ?? string.Empty;
+
+    /// <summary>
     /// Returns a list with all system command results
     /// </summary>
     /// <param name="isUefi">Value indicating if the system is booted in uefi mode</param>
     /// <param name="hideEmptyRecycleBin">Value indicating if we should hide the Empty Recycle Bin command.</param>
     /// <param name="confirmCommands">A value indicating if the user should confirm the system commands</param>
     /// <param name="emptyRBSuccessMessage">Show a success message after empty Recycle Bin.</param>
+    /// <param name="culture">The culture to use for the result's title and subtitle</param>
     /// <returns>A list of all results</returns>
-    public static List<IListItem> GetSystemCommands(bool isUefi, bool hideEmptyRecycleBin, bool confirmCommands, bool emptyRBSuccessMessage)
+    public static List<IListItem> GetSystemCommands(bool isUefi, bool hideEmptyRecycleBin, bool confirmCommands, bool emptyRBSuccessMessage, CultureInfo culture)
     {
         var results = new List<IListItem>();
         results.AddRange(new[]
@@ -48,7 +58,7 @@ internal static class Commands
                     Id = "com.microsoft.cmdpal.builtin.system.shutdown",
                 })
             {
-                Title = Resources.Microsoft_plugin_sys_shutdown_computer,
+                Title = GetString(nameof(Resources.Microsoft_plugin_sys_shutdown_computer), culture),
                 Icon = Icons.ShutdownIcon,
             },
             new ListItem(
@@ -57,7 +67,7 @@ internal static class Commands
                     Id = "com.microsoft.cmdpal.builtin.system.restart",
                 })
             {
-                Title = Resources.Microsoft_plugin_sys_restart_computer,
+                Title = GetString(nameof(Resources.Microsoft_plugin_sys_restart_computer), culture),
                 Icon = Icons.RestartIcon,
             },
             new ListItem(
@@ -66,7 +76,7 @@ internal static class Commands
                     Id = "com.microsoft.cmdpal.builtin.system.signout",
                 })
             {
-                Title = Resources.Microsoft_plugin_sys_sign_out,
+                Title = GetString(nameof(Resources.Microsoft_plugin_sys_sign_out), culture),
                 Icon = Icons.LogoffIcon,
             },
             new ListItem(
@@ -75,7 +85,7 @@ internal static class Commands
                     Id = "com.microsoft.cmdpal.builtin.system.lock",
                 })
             {
-                Title = Resources.Microsoft_plugin_sys_lock,
+                Title = GetString(nameof(Resources.Microsoft_plugin_sys_lock), culture),
                 Icon = Icons.LockIcon,
             },
             new ListItem(
@@ -84,7 +94,7 @@ internal static class Commands
                     Id = "com.microsoft.cmdpal.builtin.system.sleep",
                 })
             {
-                Title = Resources.Microsoft_plugin_sys_sleep,
+                Title = GetString(nameof(Resources.Microsoft_plugin_sys_sleep), culture),
                 Icon = Icons.SleepIcon,
             },
             new ListItem(
@@ -93,7 +103,7 @@ internal static class Commands
                     Id = "com.microsoft.cmdpal.builtin.system.hibernate",
                 })
             {
-                Title = Resources.Microsoft_plugin_sys_hibernate,
+                Title = GetString(nameof(Resources.Microsoft_plugin_sys_hibernate), culture),
                 Icon = Icons.HibernateIcon,
             },
         });
@@ -108,7 +118,7 @@ internal static class Commands
                     Id = "com.microsoft.cmdpal.builtin.system.recycle_bin",
                 })
                 {
-                    Title = Resources.Microsoft_plugin_sys_RecycleBinOpen,
+                    Title = GetString(nameof(Resources.Microsoft_plugin_sys_RecycleBinOpen), culture),
                     Icon = Icons.RecycleBinIcon,
                 },
                 new ListItem(new EmptyRecycleBinConfirmation(emptyRBSuccessMessage)
@@ -116,7 +126,7 @@ internal static class Commands
                     Id = "com.microsoft.cmdpal.builtin.system.empty_recycle_bin",
                 })
                 {
-                    Title = Resources.Microsoft_plugin_sys_RecycleBinEmptyResult,
+                    Title = GetString(nameof(Resources.Microsoft_plugin_sys_RecycleBinEmptyResult), culture),
                     Icon = Icons.RecycleBinIcon,
                 },
             });
@@ -129,7 +139,7 @@ internal static class Commands
                     Id = "com.microsoft.cmdpal.builtin.system.recycle_bin",
                 })
                 {
-                    Title = Resources.Microsoft_plugin_sys_RecycleBin,
+                    Title = GetString(nameof(Resources.Microsoft_plugin_sys_RecycleBin), culture),
                     Icon = Icons.RecycleBinIcon,
                 });
         }
@@ -144,8 +154,8 @@ internal static class Commands
                 Id = "com.microsoft.cmdpal.builtin.system.restart_shell",
             })
         {
-            Title = Resources.Microsoft_plugin_sys_RestartShell!,
-            Subtitle = Resources.Microsoft_plugin_sys_RestartShell_description!,
+            Title = GetString(nameof(Resources.Microsoft_plugin_sys_RestartShell), culture),
+            Subtitle = GetString(nameof(Resources.Microsoft_plugin_sys_RestartShell_description), culture),
             Icon = Icons.RestartShellIcon,
         });
 
@@ -154,8 +164,8 @@ internal static class Commands
         {
             results.Add(new ListItem(new ExecuteCommandConfirmation(Resources.Microsoft_plugin_command_name_reboot, confirmCommands, Resources.Microsoft_plugin_sys_uefi_confirmation, () => OpenInShellHelper.OpenInShell("shutdown", "/r /fw /t 0", null, OpenInShellHelper.ShellRunAsType.Administrator)))
             {
-                Title = Resources.Microsoft_plugin_sys_uefi,
-                Subtitle = Resources.Microsoft_plugin_sys_uefi_description,
+                Title = GetString(nameof(Resources.Microsoft_plugin_sys_uefi), culture),
+                Subtitle = GetString(nameof(Resources.Microsoft_plugin_sys_uefi_description), culture),
                 Icon = Icons.FirmwareSettingsIcon,
             });
         }
@@ -168,7 +178,7 @@ internal static class Commands
     /// </summary>
     /// <param name="manager">The tSettingsManager instance</param>
     /// <returns>The list of available results</returns>
-    public static List<IListItem> GetNetworkConnectionResults(ISettingsInterface manager)
+    public static List<IListItem> GetNetworkConnectionResults(ISettingsInterface manager, CultureInfo culture)
     {
         var results = new List<IListItem>();
 
@@ -180,9 +190,9 @@ internal static class Commands
             networkPropertiesCache = NetworkConnectionProperties.GetList();
         }
 
-        var sysIpv4DescriptionCompositeFormate = CompositeFormat.Parse(Resources.Microsoft_plugin_sys_ip4_description);
-        var sysIpv6DescriptionCompositeFormate = CompositeFormat.Parse(Resources.Microsoft_plugin_sys_ip6_description);
-        var sysMacDescriptionCompositeFormate = CompositeFormat.Parse(Resources.Microsoft_plugin_sys_mac_description);
+        var sysIpv4DescriptionCompositeFormate = CompositeFormat.Parse(GetString(nameof(Resources.Microsoft_plugin_sys_ip4_description), culture));
+        var sysIpv6DescriptionCompositeFormate = CompositeFormat.Parse(GetString(nameof(Resources.Microsoft_plugin_sys_ip6_description), culture));
+        var sysMacDescriptionCompositeFormate = CompositeFormat.Parse(GetString(nameof(Resources.Microsoft_plugin_sys_mac_description), culture));
         var hideDisconnectedNetworkInfo = manager.HideDisconnectedNetworkInfo();
 
         foreach (var intInfo in networkPropertiesCache)
@@ -237,9 +247,11 @@ internal static class Commands
         var list = new List<IListItem>();
         var listLock = new object();
 
+        var culture = manager.LocalizeSystemCommands() ? CultureInfo.CurrentUICulture : new CultureInfo("en-US");
+
         // Network (ip and mac) results are slow with many network cards and returned delayed.
         // On global queries the first word/part has to be 'ip', 'mac' or 'address' for network results
-        var networkConnectionResults = Commands.GetNetworkConnectionResults(manager);
+        var networkConnectionResults = Commands.GetNetworkConnectionResults(manager, culture);
 
         var isBootedInUefiMode = manager.GetSystemFirmwareType() == FirmwareType.Uefi;
 
@@ -248,7 +260,7 @@ internal static class Commands
         var showSuccessOnEmptyRB = manager.ShowSuccessMessageAfterEmptyingRecycleBin();
 
         // normal system commands are fast and can be returned immediately
-        var systemCommands = Commands.GetSystemCommands(isBootedInUefiMode, hideEmptyRB, confirmSystemCommands, showSuccessOnEmptyRB);
+        var systemCommands = Commands.GetSystemCommands(isBootedInUefiMode, hideEmptyRB, confirmSystemCommands, showSuccessOnEmptyRB, culture);
         list.AddRange(systemCommands);
         list.AddRange(networkConnectionResults);
 

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.System/Helpers/ISettingsInterface.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.System/Helpers/ISettingsInterface.cs
@@ -20,5 +20,7 @@ public interface ISettingsInterface
 
     public bool HideDisconnectedNetworkInfo();
 
+    public bool LocalizeSystemCommands();
+
     public FirmwareType GetSystemFirmwareType();
 }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.System/Helpers/SettingsManager.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.System/Helpers/SettingsManager.cs
@@ -37,6 +37,12 @@ public class SettingsManager : JsonSettingsManager, ISettingsInterface
         Resources.Microsoft_plugin_ext_settings_hideDisconnectedNetworkInfo,
         false);
 
+    private readonly ToggleSetting _localizeSystemCommands = new(
+        Namespaced(nameof(LocalizeSystemCommands)),
+        Resources.Microsoft_plugin_ext_settings_localizeSystemCommands,
+        Resources.Microsoft_plugin_ext_settings_localizeSystemCommands,
+        true);
+
     internal static string SettingsJsonPath()
     {
         var directory = Utilities.BaseSettingsPath("Microsoft.CmdPal");
@@ -53,6 +59,8 @@ public class SettingsManager : JsonSettingsManager, ISettingsInterface
 
     public bool HideDisconnectedNetworkInfo() => _hideDisconnectedNetworkInfo.Value;
 
+    public bool LocalizeSystemCommands() => _localizeSystemCommands.Value;
+
     public FirmwareType GetSystemFirmwareType() => Win32Helpers.GetSystemFirmwareType();
 
     public SettingsManager()
@@ -63,6 +71,7 @@ public class SettingsManager : JsonSettingsManager, ISettingsInterface
         Settings.Add(_showSuccessMessageAfterEmptyingRecycleBin);
         Settings.Add(_hideEmptyRecycleBin);
         Settings.Add(_hideDisconnectedNetworkInfo);
+        Settings.Add(_localizeSystemCommands);
 
         LoadSettings();
 

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.System/Properties/Resources.Designer.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.System/Properties/Resources.Designer.cs
@@ -203,6 +203,15 @@ namespace Microsoft.CmdPal.Ext.System {
                 return ResourceManager.GetString("Microsoft_plugin_ext_settings_hideDisconnectedNetworkInfo", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Use localized system commands instead of English ones.
+        /// </summary>
+        public static string Microsoft_plugin_ext_settings_localizeSystemCommands {
+            get {
+                return ResourceManager.GetString("Microsoft_plugin_ext_settings_localizeSystemCommands", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to System commands.

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.System/Properties/Resources.resx
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.System/Properties/Resources.resx
@@ -161,6 +161,10 @@
   <data name="Microsoft_plugin_ext_settings_hideDisconnectedNetworkInfo" xml:space="preserve">
     <value>Hide disconnected network info</value>
   </data>
+  <data name="Microsoft_plugin_ext_settings_localizeSystemCommands" xml:space="preserve">
+    <value>Use localized system commands instead of English ones</value>
+    <comment>Label of a toggle setting. When disabled, command names like "Shutdown computer" are shown in English regardless of the system language.</comment>
+  </data>
   <data name="Microsoft_plugin_ext_system_page_title" xml:space="preserve">
     <value>Windows system commands</value>
   </data>


### PR DESCRIPTION
## Summary of the Pull Request

Adds a **"Use localized system commands instead of English ones"** setting to the Windows System Commands extension, restoring the option PowerToys Run offers (`LocalizeSystemCommands`). The default is **on** (localized), so nothing changes unless a user opts out. When disabled, system command titles and network result descriptions resolve from the en-US resources regardless of the OS display language, so users on non-English systems can find commands by typing `shutdown`, `restart`, etc.

Confirmation dialogs keep following the UI language â^@^T same behavior as the PowerToys Run System plugin.

## PR Checklist

- [x] Closes: #38593
- [x] **Communication:** The issue is labeled `Help Wanted`; I commented on the issue before opening this PR
- [x] **Tests:** Added/updated and all pass
- [ ] **Localization:** One new resx string (the setting label), with a translator comment
- [ ] **Dev docs:** n/a
- [ ] **New binaries:** n/a

## Detailed Description of the Pull Request / Additional comments

This is a direct port of the PowerToys Run behavior (see `Microsoft.PowerToys.Run.Plugin.System` â^@^T `Main.cs` `LocalizeSystemCommands` option and `Components/Commands.cs` culture-aware lookups):

- `SettingsManager` / `ISettingsInterface`: new `ToggleSetting` (`LocalizeSystemCommands`, default `true`).
- `Commands.cs`: a `CultureInfo` is threaded through `GetAllCommands` â^F^R `GetSystemCommands` / `GetNetworkConnectionResults`. Titles and network description strings resolve via `Resources.ResourceManager.GetString(nameof(...), culture)` (a small helper handles the null fallback; `nameof` keeps the keys compile-checked). Culture is `CurrentUICulture` when the setting is on, `en-US` when off.
- `FallbackSystemCommandItem` (top-level search fallback) selects the culture the same way.
- Confirmation messages and command button names intentionally keep using the static (UI-culture) properties, matching PowerToys Run, where only the searchable titles/subtitles switch language.

## Validation Steps Performed

- Unit tests: all pass, including 5 new ones:
  - `EnglishCommandsWhenLocalizationDisabledTest` (4 rows) â^@^T with the setting off, queries like `shutdown` resolve to the English titles through the full `SystemCommandPage` path.
  - `EnglishCultureLookupProducesEnglishTitlesTest` â^@^T calling the command builder with an explicit `en-US` culture yields English titles regardless of machine language.
  - All existing tests unchanged and green (default setting preserves current behavior).
- Built and ran CmdPal locally (Debug x64): the setting shows up under Extensions â^F^R System commands, and commands keep working with it toggled off (screenshots below).

**A note on demo evidence:** I run an en-US display language, so both modes render identically on my machine and I can't produce a meaningful before/after screenshot myself. I previously wrote here that shipping builds don't localize these titles at all — that was wrong, and I've removed it; it came from a bad reading of my local package inspection. What the unit tests cover is the part that's verifiable without a localized build: that an explicit en-US lookup returns the English titles, that the fallback is safe, and that the default path is byte-for-byte the current behavior.


### Screenshots


<img width="1266" height="715" alt="Screenshot 2026-07-18 181918" src="https://github.com/user-attachments/assets/e1832f37-e6b3-4392-96fb-0655a27ae8d7" />
<img width="775" height="446" alt="Screenshot 2026-07-18 181951" src="https://github.com/user-attachments/assets/a630d7ca-ecca-4129-893f-72e3a8ab5bf4" />


