### PR TITLE
[Quick Accent] Fix window width when descriptions are disabled

### DIFF
--- a/src/modules/poweraccent/PowerAccent.UI/PowerAccentXAML/MainWindow.xaml.cs
+++ b/src/modules/poweraccent/PowerAccent.UI/PowerAccentXAML/MainWindow.xaml.cs
@@ -14,9 +14,10 @@ namespace PowerAccent.UI;
 
 public sealed partial class MainWindow : TransparentWindow, IDisposable
 {
-    // Accent-bar geometry (DIP). Width is derived from the item count (count * ItemWidthDip) plus the
-    // surface margin, not measured from the ListView: its DesiredSize (wrapped in a ScrollViewer) is
-    // racy while item containers realize and intermittently reports 0, yielding a blank/clipped bar.
+    // Accent-bar geometry (DIP). Width is derived from the item count (count * ItemWidthDip) plus
+    // HorizontalSurfaceOverheadDip (Surface outer margin + its 1px border on each side), not
+    // measured from the ListView: its DesiredSize (wrapped in a ScrollViewer) is racy while item
+    // containers realize and intermittently reports 0, yielding a blank/clipped bar.
     // The one-row bar hugs its content like the WPF original, capped at the monitor width; beyond
     // that it scrolls and ScrollIntoView reveals the selected glyph.
     private const double RowHeightDip = 92;          // one row of accent pills (item Height=48 + card border)

--- a/src/modules/poweraccent/PowerAccent.UI/PowerAccentXAML/MainWindow.xaml.cs
+++ b/src/modules/poweraccent/PowerAccent.UI/PowerAccentXAML/MainWindow.xaml.cs
@@ -25,6 +25,9 @@ public sealed partial class MainWindow : TransparentWindow, IDisposable
     private const double ItemWidthDip = 48;            // one accent cell (ListViewItem Grid MinWidth=48)
     private const double DescriptionMinWidthDip = 648; // min bar width while the description row shows (WPF parity)
 
+    // Handles the fractional pixels that may occur with scaled displays from truncating the character list.
+    private const double LayoutRoundingDip = 1;
+
     private readonly Core.PowerAccent _powerAccent;
     private int _selectedIndex = -1;
     private bool _active;
@@ -138,7 +141,7 @@ public sealed partial class MainWindow : TransparentWindow, IDisposable
         // the class-level note on why the ListView is not measured), capped at the monitor's max
         // usable width so long lists scroll.
         double maxWidthDip = _powerAccent.GetDisplayMaxWidth();
-        double contentWidthDip = (ViewModel.Characters.Count * ItemWidthDip) + Selector.HorizontalSurfaceOverheadDip;
+        double contentWidthDip = (ViewModel.Characters.Count * ItemWidthDip) + Selector.HorizontalSurfaceOverheadDip + LayoutRoundingDip;
 
         // The Unicode description row needs room for a readable line; the WPF original gave it a
         // 600px MinWidth. Widen a short accent bar to match when the row is shown (the accent bar

--- a/src/modules/poweraccent/PowerAccent.UI/PowerAccentXAML/MainWindow.xaml.cs
+++ b/src/modules/poweraccent/PowerAccent.UI/PowerAccentXAML/MainWindow.xaml.cs
@@ -25,7 +25,7 @@ public sealed partial class MainWindow : TransparentWindow, IDisposable
     private const double ItemWidthDip = 48;            // one accent cell (ListViewItem Grid MinWidth=48)
     private const double DescriptionMinWidthDip = 648; // min bar width while the description row shows (WPF parity)
 
-    // Handles the fractional pixels that may occur with scaled displays from truncating the character list.
+    // Prevents the fractional pixels that may occur with scaled displays from truncating the character list.
     private const double LayoutRoundingDip = 1;
 
     private readonly Core.PowerAccent _powerAccent;

--- a/src/modules/poweraccent/PowerAccent.UI/PowerAccentXAML/MainWindow.xaml.cs
+++ b/src/modules/poweraccent/PowerAccent.UI/PowerAccentXAML/MainWindow.xaml.cs
@@ -137,7 +137,7 @@ public sealed partial class MainWindow : TransparentWindow, IDisposable
         // the class-level note on why the ListView is not measured), capped at the monitor's max
         // usable width so long lists scroll.
         double maxWidthDip = _powerAccent.GetDisplayMaxWidth();
-        double contentWidthDip = (ViewModel.Characters.Count * ItemWidthDip) + Selector.HorizontalSurfaceMarginDip;
+        double contentWidthDip = (ViewModel.Characters.Count * ItemWidthDip) + Selector.HorizontalSurfaceOverheadDip;
 
         // The Unicode description row needs room for a readable line; the WPF original gave it a
         // 600px MinWidth. Widen a short accent bar to match when the row is shown (the accent bar

--- a/src/modules/poweraccent/PowerAccent.UI/PowerAccentXAML/MainWindow.xaml.cs
+++ b/src/modules/poweraccent/PowerAccent.UI/PowerAccentXAML/MainWindow.xaml.cs
@@ -14,11 +14,11 @@ namespace PowerAccent.UI;
 
 public sealed partial class MainWindow : TransparentWindow, IDisposable
 {
-    // Accent-bar geometry (DIP). Width is derived from the item count (count * ItemWidthDip), not
-    // measured from the ListView: its DesiredSize (wrapped in a ScrollViewer) is racy while item
-    // containers realize and intermittently reports 0, yielding a blank/clipped bar. The one-row bar
-    // hugs its content like the WPF original, capped at the monitor width; beyond that it scrolls
-    // and ScrollIntoView reveals the selected glyph.
+    // Accent-bar geometry (DIP). Width is derived from the item count (count * ItemWidthDip) plus the
+    // surface margin, not measured from the ListView: its DesiredSize (wrapped in a ScrollViewer) is
+    // racy while item containers realize and intermittently reports 0, yielding a blank/clipped bar.
+    // The one-row bar hugs its content like the WPF original, capped at the monitor width; beyond
+    // that it scrolls and ScrollIntoView reveals the selected glyph.
     private const double RowHeightDip = 92;          // one row of accent pills (item Height=48 + card border)
     private const double DescriptionHeightDip = 36;  // extra row shown when the Unicode description is on
     private const double ItemWidthDip = 48;            // one accent cell (ListViewItem Grid MinWidth=48)
@@ -133,10 +133,11 @@ public sealed partial class MainWindow : TransparentWindow, IDisposable
 
     private void SizeAndPosition()
     {
-        // Width hugs the content: item count * ItemWidthDip (see the class-level note on why the
-        // ListView is not measured), capped at the monitor's max usable width so long lists scroll.
+        // Width hugs the content: item count * ItemWidthDip plus the space outside the ListView (see
+        // the class-level note on why the ListView is not measured), capped at the monitor's max
+        // usable width so long lists scroll.
         double maxWidthDip = _powerAccent.GetDisplayMaxWidth();
-        double contentWidthDip = ViewModel.Characters.Count * ItemWidthDip;
+        double contentWidthDip = (ViewModel.Characters.Count * ItemWidthDip) + Selector.HorizontalSurfaceMarginDip;
 
         // The Unicode description row needs room for a readable line; the WPF original gave it a
         // 600px MinWidth. Widen a short accent bar to match when the row is shown (the accent bar

--- a/src/modules/poweraccent/PowerAccent.UI/PowerAccentXAML/SelectorControl.xaml.cs
+++ b/src/modules/poweraccent/PowerAccent.UI/PowerAccentXAML/SelectorControl.xaml.cs
@@ -25,6 +25,10 @@ public sealed partial class SelectorControl : UserControl
     // Number of items currently in the accent bar (mirrors the bound ObservableCollection).
     public int ItemCount => CharactersList.Items.Count;
 
+    // The window sizing calculation must reserve the space outside the accent list as well as the
+    // items themselves. Read it from the surface so the calculation stays in sync with the XAML.
+    internal double HorizontalSurfaceMarginDip => Surface.Margin.Left + Surface.Margin.Right;
+
     // Wire the inner TransientSurface to the hosting window's Show/Hide so it animates in/out.
     // TransientSurface.SubscribeTo explicitly supports being "placed within" the window content.
     public void SubscribeSurfaceTo(TransparentWindow host) => Surface.SubscribeTo(host);

--- a/src/modules/poweraccent/PowerAccent.UI/PowerAccentXAML/SelectorControl.xaml.cs
+++ b/src/modules/poweraccent/PowerAccent.UI/PowerAccentXAML/SelectorControl.xaml.cs
@@ -25,9 +25,12 @@ public sealed partial class SelectorControl : UserControl
     // Number of items currently in the accent bar (mirrors the bound ObservableCollection).
     public int ItemCount => CharactersList.Items.Count;
 
-    // The window sizing calculation must reserve the space outside the accent list as well as the
-    // items themselves. Read it from the surface so the calculation stays in sync with the XAML.
-    internal double HorizontalSurfaceMarginDip => Surface.Margin.Left + Surface.Margin.Right;
+    // The window sizing calculation must reserve all horizontal space outside the ListView: the
+    // Surface's outer margin plus its border (1px each side from DefaultTransientSurfaceStyle).
+    // Reading both from the live element means the formula stays correct if either value changes.
+    internal double HorizontalSurfaceOverheadDip =>
+        Surface.Margin.Left + Surface.Margin.Right +
+        Surface.BorderThickness.Left + Surface.BorderThickness.Right;
 
     // Wire the inner TransientSurface to the hosting window's Show/Hide so it animates in/out.
     // TransientSurface.SubscribeTo explicitly supports being "placed within" the window content.


### PR DESCRIPTION
## Summary of the Pull Request

Fixes Quick Accent clipping or horizontally shifting the last character when Unicode descriptions are disabled and the character list is short.

The WinUI window width was calculated as `item count × 48 DIPs`, but the selector surface also has 24-DIP left and right margins and a 1-DIP border on each side. Those values reduced the usable list width. Fractional layout rounding at scaled display settings could then leave the viewport one physical pixel too narrow even after accounting for the nominal XAML dimensions.

The sizing calculation now reads the surface's live horizontal margin and border thickness and includes them in the requested window width. It also adds a 1-DIP layout-rounding allowance so the character list is not truncated at fractional display scales.

## PR Checklist

- [x] Closes: #49346
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
  - The proposed root cause and approach were posted in the [contribution thread](https://github.com/microsoft/PowerToys/issues/28769#issuecomment-5013633279); maintainer confirmation is still pending.
- [ ] **Tests:** Added/updated and all pass
  - No automated test was added because this fix connects runtime WinUI layout values and display scaling to the window-size calculation; a unit test that duplicated the XAML dimensions would not catch the integration regression.
- [x] **Localization:** All end-user-facing strings can be localized
  - No strings changed.
- [x] **Dev docs:** Added/updated
  - No developer documentation changes are needed for this focused layout correction.
- [x] **New binaries:** Added on the required places
  - No binaries or projects were added.
  - [x] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries — not applicable
  - [x] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder — not applicable
  - [x] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects — not applicable
  - [x] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml) — not applicable
- [ ] **Documentation updated:** Not applicable; there is no user-facing behavior or documentation change.

## Detailed Description of the Pull Request / Additional comments

`SelectorControl.xaml` gives the `TransientSurface` a `Margin=24,24,24,16`, and `DefaultTransientSurfaceStyle` supplies a 1-DIP border on each side. For the four-character reproduction in #49346, the previous calculation requested a 192-DIP window (`4 × 48`). After the 48 DIPs of horizontal surface margin, only 144 DIPs remained for the list, which is exactly three character cells.

`SelectorControl` now exposes the computed left-plus-right surface margin and border thickness internally. `MainWindow.SizeAndPosition()` adds that live overhead to the character-driven width before applying the existing description minimum and monitor-width clamp. A further 1-DIP allowance covers fractional physical-pixel rounding at scaled display settings.

With four characters, the calculation reserves the complete 192-DIP list width, the 50-DIP surface overhead, and the 1-DIP layout-rounding allowance. This leaves long-list scrolling, selected-character scrolling, description sizing, monitor clamping, DPI conversion, and window positioning unchanged.

## Validation Steps Performed

- `git diff --check` passes.
- Built `PowerAccent.UI` locally with Visual Studio 2026 in `Debug|x64`; the build completed successfully with 0 warnings and 0 errors.
- Runtime-tested with Unicode descriptions disabled and only `SPECIAL` enabled. Holding `X` and pressing `Space` displayed all four mapped characters (`ẋ`, `×`, `ˣ`, `ₓ`) without clipping or scrolling.
- Reproduced the one-pixel horizontal shift with all character sets enabled at 150% and 175% display scaling.
- Retested the 1-DIP layout-rounding allowance at both 150% and 175%; all seven `F` characters remained stationary while cycling through the selection.
- Verified the description minimum and maximum monitor-width clamp remain in the same order after the corrected content width is calculated.