### PR TITLE
FancyZones: apply edited custom layout spacing/sensitivity/zone count to active work areas immediately

### DIFF
--- a/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
@@ -739,6 +739,7 @@ LRESULT FancyZones::WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lpa
         else if (message == WM_PRIV_CUSTOM_LAYOUTS_FILE_UPDATE)
         {
             CustomLayouts::instance().LoadData();
+            RefreshLayouts();
         }
         else if (message == WM_PRIV_APPLIED_LAYOUTS_FILE_UPDATE)
         {

--- a/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/WorkArea.cpp
@@ -5,6 +5,7 @@
 
 #include "FancyZonesData/AppliedLayouts.h"
 #include "FancyZonesData/AppZoneHistory.h"
+#include "FancyZonesData/CustomLayouts.h"
 #include "ZonesOverlay.h"
 #include "Settings.h"
 #include <FancyZonesLib/FancyZonesWindowProperties.h>
@@ -303,11 +304,26 @@ void WorkArea::InitSnappedWindows()
 
 void WorkArea::CalculateZoneSet()
 {
-    const auto appliedLayout = AppliedLayouts::instance().GetDeviceLayout(m_uniqueId);
+    auto appliedLayout = AppliedLayouts::instance().GetDeviceLayout(m_uniqueId);
     if (!appliedLayout.has_value())
     {
         Logger::error(L"Layout wasn't applied. Can't init layout on work area {}x{}", m_workAreaRect.width(), m_workAreaRect.height());
         return;
+    }
+
+    // For custom layouts the spacing, sensitivity radius and zone count live in the custom
+    // layout definition (custom-layouts.json), while the applied-layouts.json snapshot keeps a
+    // copy taken at apply time. Editing those properties only rewrites custom-layouts.json, so
+    // without this sync the snapshot stays stale and the edits don't take effect until the layout
+    // is re-applied (see GH #44058). Re-derive the scalar properties from the current custom
+    // layout using the same logic the apply path uses (CustomLayouts::GetLayout also derives the
+    // canvas zone count from the zone list, keeping it consistent with Layout::Init validation).
+    if (appliedLayout->type == FancyZonesDataTypes::ZoneSetLayoutType::Custom)
+    {
+        if (const auto refreshed = CustomLayouts::instance().GetLayout(appliedLayout->uuid))
+        {
+            appliedLayout = refreshed;
+        }
     }
 
     m_layout = std::make_unique<Layout>(appliedLayout.value());

--- a/src/modules/fancyzones/FancyZonesTests/UnitTests/WorkArea.Spec.cpp
+++ b/src/modules/fancyzones/FancyZonesTests/UnitTests/WorkArea.Spec.cpp
@@ -1,10 +1,13 @@
 #include "pch.h"
 
+#include <algorithm>
 #include <filesystem>
+#include <vector>
 
 #include <FancyZonesLib/WorkArea.h>
 #include <FancyZonesLib/FancyZonesData/AppliedLayouts.h>
 #include <FancyZonesLib/FancyZonesData/AppZoneHistory.h>
+#include <FancyZonesLib/FancyZonesData/CustomLayouts.h>
 #include <FancyZonesLib/FancyZonesData/DefaultLayouts.h>
 #include <FancyZonesLib/FancyZonesWindowProperties.h>
 #include <FancyZonesLib/LayoutAssignedWindows.h>
@@ -37,6 +40,7 @@ namespace FancyZonesUnitTests
 
             AppZoneHistory::instance().LoadData();
             AppliedLayouts::instance().LoadData();
+            CustomLayouts::instance().LoadData();
             DefaultLayouts::instance().LoadData();
         }
 
@@ -44,6 +48,7 @@ namespace FancyZonesUnitTests
         {
             std::filesystem::remove(AppliedLayouts::AppliedLayoutsFileName());
             std::filesystem::remove(AppZoneHistory::AppZoneHistoryFileName());
+            std::filesystem::remove(CustomLayouts::CustomLayoutsFileName());
             std::filesystem::remove(DefaultLayouts::DefaultLayoutsFileName());
         }
 
@@ -172,6 +177,99 @@ namespace FancyZonesUnitTests
             Assert::AreEqual(static_cast<int>(FancyZonesDataTypes::ZoneSetLayoutType::Grid), static_cast<int>(actualLayout->Type()));
             Assert::AreEqual(static_cast<size_t>(4), actualLayout->Zones().size());
             Assert::IsTrue(GUID_NULL == actualLayout->Id());
+        }
+
+        // Saves a 1x2 custom grid layout to custom-layouts.json so it can be resolved by uuid.
+        void SaveCustomGridLayout(const GUID& uuid, bool showSpacing, int spacing, int sensitivityRadius)
+        {
+            json::JsonObject root{};
+            json::JsonArray layoutsArray{};
+
+            json::JsonObject gridLayoutJson{};
+            gridLayoutJson.SetNamedValue(NonLocalizable::CustomLayoutsIds::UuidID, json::value(FancyZonesUtils::GuidToString(uuid).value()));
+            gridLayoutJson.SetNamedValue(NonLocalizable::CustomLayoutsIds::NameID, json::value(L"Custom grid layout"));
+            gridLayoutJson.SetNamedValue(NonLocalizable::CustomLayoutsIds::TypeID, json::value(NonLocalizable::CustomLayoutsIds::GridID));
+
+            json::JsonArray rowsPercentage{};
+            rowsPercentage.Append(json::value(10000));
+
+            json::JsonArray columnsPercentage{};
+            columnsPercentage.Append(json::value(5000));
+            columnsPercentage.Append(json::value(5000));
+
+            json::JsonArray cells{};
+            {
+                json::JsonArray cellsRow{};
+                cellsRow.Append(json::value(0));
+                cellsRow.Append(json::value(1));
+                cells.Append(cellsRow);
+            }
+
+            json::JsonObject info{};
+            info.SetNamedValue(NonLocalizable::CustomLayoutsIds::RowsID, json::value(1));
+            info.SetNamedValue(NonLocalizable::CustomLayoutsIds::ColumnsID, json::value(2));
+            info.SetNamedValue(NonLocalizable::CustomLayoutsIds::RowsPercentageID, rowsPercentage);
+            info.SetNamedValue(NonLocalizable::CustomLayoutsIds::ColumnsPercentageID, columnsPercentage);
+            info.SetNamedValue(NonLocalizable::CustomLayoutsIds::CellChildMapID, cells);
+            info.SetNamedValue(NonLocalizable::CustomLayoutsIds::ShowSpacingID, json::value(showSpacing));
+            info.SetNamedValue(NonLocalizable::CustomLayoutsIds::SpacingID, json::value(spacing));
+            info.SetNamedValue(NonLocalizable::CustomLayoutsIds::SensitivityRadiusID, json::value(sensitivityRadius));
+
+            gridLayoutJson.SetNamedValue(NonLocalizable::CustomLayoutsIds::InfoID, info);
+            layoutsArray.Append(gridLayoutJson);
+            root.SetNamedValue(NonLocalizable::CustomLayoutsIds::CustomLayoutsArrayID, layoutsArray);
+
+            json::to_file(CustomLayouts::CustomLayoutsFileName(), root);
+            CustomLayouts::instance().LoadData();
+        }
+
+        // Regression test for GH #44058: editing a custom layout's spacing only rewrites
+        // custom-layouts.json, while applied-layouts.json keeps a snapshot taken at apply time.
+        // An already-created WorkArea must pick up the edited spacing when it is refreshed
+        // (WorkArea::InitLayout, which is what the custom-layouts file-update handler calls via
+        // RefreshLayouts). Without re-deriving the scalar properties from the current custom
+        // layout the stale snapshot is used and the edit has no effect until re-apply.
+        TEST_METHOD (EditedCustomLayoutSpacingRefreshesExistingWorkArea)
+        {
+            const auto uuid = FancyZonesUtils::GuidFromString(L"{5A9D6A0F-4C6E-4C0C-8B1B-9F3E7C2D1A11}").value();
+
+            auto zoneGap = [](const auto& zones) -> LONG {
+                std::vector<RECT> rects;
+                for (const auto& [id, zone] : zones)
+                {
+                    rects.push_back(zone.GetZoneRect());
+                }
+                std::sort(rects.begin(), rects.end(), [](const RECT& a, const RECT& b) { return a.left < b.left; });
+                return rects[1].left - rects[0].right;
+            };
+
+            // The layout and its applied snapshot initially have no spacing.
+            SaveCustomGridLayout(uuid, /*showSpacing*/ false, /*spacing*/ 0, /*sensitivityRadius*/ 5);
+            LayoutData snapshot{
+                .uuid = uuid,
+                .type = FancyZonesDataTypes::ZoneSetLayoutType::Custom,
+                .showSpacing = false,
+                .spacing = 0,
+                .zoneCount = 2,
+                .sensitivityRadius = 5,
+            };
+            AppliedLayouts::instance().ApplyLayout(m_workAreaId, snapshot);
+
+            auto workArea = WorkArea::Create({}, m_workAreaId, m_emptyUniqueId, m_workAreaRect);
+            Assert::IsFalse(workArea == nullptr);
+            Assert::IsNotNull(workArea->GetLayout().get());
+            Assert::AreEqual(static_cast<size_t>(2), workArea->GetLayout()->Zones().size());
+            Assert::AreEqual(0L, zoneGap(workArea->GetLayout()->Zones()), L"Zones should be adjacent before the edit");
+
+            // User edits the layout to add spacing; only custom-layouts.json is rewritten, the
+            // applied-layouts snapshot stays stale.
+            SaveCustomGridLayout(uuid, /*showSpacing*/ true, /*spacing*/ 100, /*sensitivityRadius*/ 30);
+
+            // The custom-layouts file-update handler refreshes active work areas via InitLayout.
+            workArea->InitLayout();
+
+            Assert::AreEqual(static_cast<size_t>(2), workArea->GetLayout()->Zones().size());
+            Assert::IsTrue(zoneGap(workArea->GetLayout()->Zones()) > 20, L"Edited spacing was not applied to the existing work area");
         }
     };
 


### PR DESCRIPTION
## Summary of the Pull Request

When a **custom layout** is edited in the FancyZones editor while windows are already snapped to it, changes to the layout's *scalar* properties — **spacing between zones**, **highlight/activation sensitivity radius**, and **zone count** (for canvas layouts) — were **not applied to already-active work areas** until PowerToys (or FancyZones) was restarted. Only the grid **shape/edges** refreshed live.

This PR makes those scalar edits take effect immediately on existing work areas, resolving the remaining gap in issue 44058.

## PR Checklist

- [x] Closes: #44058
- [x] **Communication:** This addresses the behavior tracked in the linked issue.
- [x] **Tests:** Added `EditedCustomLayoutSpacingRefreshesExistingWorkArea` regression test; existing FancyZones unit tests pass.
- [x] **Localization:** No new end-user-facing strings.
- [x] **Dev docs:** N/A (no public API or doc surface change).
- [x] **New binaries:** None added.

## Detailed Description of the Pull Request / Additional comments

### Root cause

For a **Custom**-type layout, `WorkArea::CalculateZoneSet` builds its `Layout` from `AppliedLayouts::GetDeviceLayout()`, which returns a snapshot from `applied-layouts.json`. The zone **shape** is read live from the `CustomLayouts` store, but the scalar properties (`spacing`, `sensitivityRadius`, and `zoneCount`) were taken from that **stale applied-layouts snapshot**. So when the editor updated the custom layout and fired `WM_PRIV_CUSTOM_LAYOUTS_FILE_UPDATE`, the existing work areas re-laid-out their grid geometry but kept the *old* spacing/sensitivity/zone count.

### The fix

In `WorkArea::CalculateZoneSet`, for Custom-type layouts, re-derive the scalar properties from the **live** `CustomLayouts` store instead of the stale snapshot:

```cpp
if (const auto refreshed = CustomLayouts::instance().GetLayout(appliedLayout->uuid))
{
    appliedLayout = refreshed;
}
```

`CustomLayouts::GetLayout` returns the canonical `LayoutData` used by the apply path (it derives grid zone count from `zoneCount()` and canvas zone count from `zones.size()`), so the refreshed values exactly match what a fresh apply would produce.

**Why this is low-risk:**
- Scoped strictly to **Custom** layouts; templated layouts (Grid/Columns/etc.) are untouched.
- At initial apply-time, the live store and the applied-layouts snapshot are equal, so behavior is unchanged for the common case — only a genuine *edit* of an already-applied custom layout changes the outcome (which is the intended fix).

This complements the editor-side `RefreshLayouts()` call (which refreshes zone shape) so that **all** properties of an edited custom layout now apply live.

## Validation Steps Performed

**Automated:** Added `EditedCustomLayoutSpacingRefreshesExistingWorkArea` in `FancyZonesTests/UnitTests/WorkArea.Spec.cpp`. It creates a work area on a grid custom layout, asserts adjacent zones are flush, then edits the custom layout's spacing, re-initializes the layout via `InitLayout()`, and asserts the new spacing gap is present on the existing zones. Built the FancyZones unit tests and ran the `WorkArea` suite — all pass.

**Manual (end-to-end):**
1. Create a **grid custom layout** in the FancyZones editor and apply it.
2. Snap a window into one of its zones.
3. Re-open the editor, edit the layout: change the **edge position** *and* the **space between zones** (and optionally sensitivity), then **Save**.
4. **Before this fix:** the zone edges move, but the spacing between snapped windows keeps the *old* gap until PowerToys is restarted.
5. **After this fix:** the new spacing (and sensitivity) are applied to the already-snapped/active work area immediately, with no restart.
