### PR TITLE
[CmdPal] OAuth auth flow: SDK contract + Toolkit OAuthClient (Phase 1)

### DIFF
--- a/src/modules/cmdpal/Tests/Microsoft.CommandPalette.Extensions.Toolkit.UnitTests/Auth/ExtensionHostAuthTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CommandPalette.Extensions.Toolkit.UnitTests/Auth/ExtensionHostAuthTests.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.Foundation;
+
+namespace Microsoft.CommandPalette.Extensions.Toolkit.UnitTests.Auth;
+
+[TestClass]
+public class ExtensionHostAuthTests
+{
+    // A host that implements only IExtensionHost (no IExtensionHost2), i.e. an
+    // older Command Palette that predates the auth broker.
+    private sealed class LegacyHost : IExtensionHost
+    {
+        public IAsyncAction ShowStatus(IStatusMessage message, StatusContext context) => null!;
+
+        public IAsyncAction HideStatus(IStatusMessage message) => null!;
+
+        public IAsyncAction LogMessage(ILogMessage message) => null!;
+    }
+
+    [TestMethod]
+    public void SupportsAuthorization_FalseForLegacyHost()
+    {
+        ExtensionHost.Initialize(new LegacyHost());
+
+        Assert.IsFalse(ExtensionHost.SupportsAuthorization);
+    }
+
+    [TestMethod]
+    public async Task RequestAuthorizationAsync_LegacyHost_ThrowsNotSupported()
+    {
+        ExtensionHost.Initialize(new LegacyHost());
+
+        var request = new AuthorizationRequest
+        {
+            AuthorizationEndpoint = "https://example.test/authorize",
+        };
+
+        await Assert.ThrowsExceptionAsync<System.NotSupportedException>(
+            () => ExtensionHost.RequestAuthorizationAsync(request));
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CommandPalette.Extensions.Toolkit.UnitTests/Auth/MockHttpServer.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CommandPalette.Extensions.Toolkit.UnitTests/Auth/MockHttpServer.cs
@@ -1,0 +1,145 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.CommandPalette.Extensions.Toolkit.UnitTests.Auth;
+
+/// <summary>
+/// A minimal single-request loopback HTTP server built on <see cref="TcpListener"/>
+/// (so it needs no HTTP.SYS URL ACL / elevation). It accepts exactly one
+/// connection, captures the raw request, and replies with a caller-supplied
+/// status code and JSON body.
+/// </summary>
+internal sealed class MockHttpServer : IDisposable
+{
+    private readonly TcpListener _listener;
+    private readonly int _statusCode;
+    private readonly string _responseBody;
+    private readonly Task _serveTask;
+
+    public MockHttpServer(int statusCode, string responseBody)
+    {
+        _statusCode = statusCode;
+        _responseBody = responseBody;
+        _listener = new TcpListener(IPAddress.Loopback, 0);
+        _listener.Start();
+        Port = ((IPEndPoint)_listener.LocalEndpoint).Port;
+        _serveTask = Task.Run(ServeOneAsync);
+    }
+
+    public int Port { get; }
+
+    public string Url => $"http://127.0.0.1:{Port}/token";
+
+    /// <summary>The full raw HTTP request text captured from the client.</summary>
+    public string? CapturedRequest { get; private set; }
+
+    private async Task ServeOneAsync()
+    {
+        try
+        {
+            using var client = await _listener.AcceptTcpClientAsync();
+            using var stream = client.GetStream();
+
+            var buffer = new byte[8192];
+            var sb = new StringBuilder();
+            int headerEnd = -1;
+
+            // Read until we have the full header block.
+            while (headerEnd < 0)
+            {
+                var read = await stream.ReadAsync(buffer.AsMemory(0, buffer.Length));
+                if (read == 0)
+                {
+                    break;
+                }
+
+                sb.Append(Encoding.ASCII.GetString(buffer, 0, read));
+                headerEnd = sb.ToString().IndexOf("\r\n\r\n", StringComparison.Ordinal);
+            }
+
+            if (headerEnd < 0)
+            {
+                return;
+            }
+
+            var raw = sb.ToString();
+            var contentLength = ParseContentLength(raw);
+            var bodyStart = headerEnd + 4;
+            var bodyReceived = raw.Length - bodyStart;
+
+            // Drain the remaining request body so the client's write completes.
+            while (bodyReceived < contentLength)
+            {
+                var read = await stream.ReadAsync(buffer.AsMemory(0, buffer.Length));
+                if (read == 0)
+                {
+                    break;
+                }
+
+                sb.Append(Encoding.ASCII.GetString(buffer, 0, read));
+                bodyReceived += read;
+            }
+
+            CapturedRequest = sb.ToString();
+
+            var bodyBytes = Encoding.UTF8.GetBytes(_responseBody);
+            var header =
+                $"HTTP/1.1 {_statusCode} {ReasonPhrase(_statusCode)}\r\n" +
+                "Content-Type: application/json\r\n" +
+                $"Content-Length: {bodyBytes.Length}\r\n" +
+                "Connection: close\r\n\r\n";
+            var headerBytes = Encoding.ASCII.GetBytes(header);
+
+            await stream.WriteAsync(headerBytes);
+            await stream.WriteAsync(bodyBytes);
+            await stream.FlushAsync();
+        }
+        catch (Exception)
+        {
+            // Best-effort test server.
+        }
+    }
+
+    private static int ParseContentLength(string headers)
+    {
+        foreach (var line in headers.Split("\r\n"))
+        {
+            if (line.StartsWith("Content-Length:", StringComparison.OrdinalIgnoreCase))
+            {
+                if (int.TryParse(line["Content-Length:".Length..].Trim(), out var len))
+                {
+                    return len;
+                }
+            }
+        }
+
+        return 0;
+    }
+
+    private static string ReasonPhrase(int status) => status switch
+    {
+        200 => "OK",
+        400 => "Bad Request",
+        401 => "Unauthorized",
+        _ => "Status",
+    };
+
+    public void Dispose()
+    {
+        try
+        {
+            _listener.Stop();
+        }
+        catch (Exception)
+        {
+        }
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CommandPalette.Extensions.Toolkit.UnitTests/Auth/OAuthClientParametersTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CommandPalette.Extensions.Toolkit.UnitTests/Auth/OAuthClientParametersTests.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CommandPalette.Extensions.Toolkit.UnitTests.Auth;
+
+[TestClass]
+public class OAuthClientParametersTests
+{
+    [TestMethod]
+    public void BuildAuthorizationParameters_IncludesPkceAndCoreParams()
+    {
+        var client = new OAuthClient
+        {
+            ClientId = "my-client",
+            AuthorizationEndpoint = "https://example.test/authorize",
+            TokenEndpoint = "https://example.test/token",
+            Scopes = new[] { "openid", "profile" },
+        };
+
+        var parameters = client.BuildAuthorizationParameters("CHALLENGE");
+
+        Assert.AreEqual("code", parameters["response_type"]);
+        Assert.AreEqual("my-client", parameters["client_id"]);
+        Assert.AreEqual("CHALLENGE", parameters["code_challenge"]);
+        Assert.AreEqual("S256", parameters["code_challenge_method"]);
+        Assert.AreEqual("openid profile", parameters["scope"]);
+
+        // The host injects redirect_uri and state; the client must not set them.
+        Assert.IsFalse(parameters.ContainsKey("redirect_uri"));
+        Assert.IsFalse(parameters.ContainsKey("state"));
+    }
+
+    [TestMethod]
+    public void BuildAuthorizationParameters_OmitsScopeWhenEmpty()
+    {
+        var client = new OAuthClient
+        {
+            ClientId = "c",
+            AuthorizationEndpoint = "https://example.test/authorize",
+            TokenEndpoint = "https://example.test/token",
+        };
+
+        var parameters = client.BuildAuthorizationParameters("X");
+
+        Assert.IsFalse(parameters.ContainsKey("scope"));
+    }
+
+    [TestMethod]
+    public void BuildAuthorizationParameters_MergesAdditionalParameters()
+    {
+        var client = new OAuthClient
+        {
+            ClientId = "c",
+            AuthorizationEndpoint = "https://example.test/authorize",
+            TokenEndpoint = "https://example.test/token",
+            AdditionalAuthorizationParameters = new Dictionary<string, string>
+            {
+                ["prompt"] = "consent",
+                ["audience"] = "api://resource",
+            },
+        };
+
+        var parameters = client.BuildAuthorizationParameters("X");
+
+        Assert.AreEqual("consent", parameters["prompt"]);
+        Assert.AreEqual("api://resource", parameters["audience"]);
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CommandPalette.Extensions.Toolkit.UnitTests/Auth/OAuthClientRefreshTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CommandPalette.Extensions.Toolkit.UnitTests/Auth/OAuthClientRefreshTests.cs
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CommandPalette.Extensions.Toolkit.UnitTests.Auth;
+
+[TestClass]
+public class OAuthClientRefreshTests
+{
+    private static OAuthClient CreateClient(string tokenEndpoint) => new()
+    {
+        ClientId = "test-client",
+        AuthorizationEndpoint = "https://example.test/authorize",
+        TokenEndpoint = tokenEndpoint,
+        Scopes = new[] { "read", "write" },
+    };
+
+    [TestMethod]
+    public async Task RefreshAsync_ParsesSuccessResponse()
+    {
+        const string body = """
+        {"access_token":"new-access","refresh_token":"new-refresh","token_type":"Bearer","scope":"read write","expires_in":3600}
+        """;
+        using var server = new MockHttpServer(200, body);
+        var client = CreateClient(server.Url);
+
+        var token = await client.RefreshAsync("old-refresh");
+
+        Assert.AreEqual("new-access", token.AccessToken);
+        Assert.AreEqual("new-refresh", token.RefreshToken);
+        Assert.AreEqual("Bearer", token.TokenType);
+        Assert.AreEqual("read write", token.Scope);
+        Assert.IsNotNull(token.ExpiresAt);
+        Assert.IsFalse(token.IsExpired());
+
+        // The refresh_token grant must be posted with the caller's refresh token.
+        Assert.IsNotNull(server.CapturedRequest);
+        StringAssert.Contains(server.CapturedRequest!, "grant_type=refresh_token");
+        StringAssert.Contains(server.CapturedRequest!, "refresh_token=old-refresh");
+        StringAssert.Contains(server.CapturedRequest!, "client_id=test-client");
+    }
+
+    [TestMethod]
+    public async Task RefreshAsync_HandlesExpiresInAsString()
+    {
+        const string body = """
+        {"access_token":"a","token_type":"Bearer","expires_in":"1200"}
+        """;
+        using var server = new MockHttpServer(200, body);
+        var client = CreateClient(server.Url);
+
+        var token = await client.RefreshAsync("r");
+
+        Assert.IsNotNull(token.ExpiresAt);
+        Assert.IsFalse(token.IsExpired());
+    }
+
+    [TestMethod]
+    public async Task RefreshAsync_ProviderErrorBody_ThrowsOAuthException()
+    {
+        const string body = """
+        {"error":"invalid_grant","error_description":"The refresh token is expired."}
+        """;
+        using var server = new MockHttpServer(400, body);
+        var client = CreateClient(server.Url);
+
+        var ex = await Assert.ThrowsExceptionAsync<OAuthException>(() => client.RefreshAsync("r"));
+
+        StringAssert.Contains(ex.Message, "expired");
+    }
+
+    [TestMethod]
+    public async Task RefreshAsync_MissingAccessToken_ThrowsOAuthException()
+    {
+        const string body = """
+        {"token_type":"Bearer"}
+        """;
+        using var server = new MockHttpServer(200, body);
+        var client = CreateClient(server.Url);
+
+        await Assert.ThrowsExceptionAsync<OAuthException>(() => client.RefreshAsync("r"));
+    }
+
+    [TestMethod]
+    public async Task RefreshAsync_NonJsonResponse_ThrowsOAuthException()
+    {
+        using var server = new MockHttpServer(200, "this is not json");
+        var client = CreateClient(server.Url);
+
+        await Assert.ThrowsExceptionAsync<OAuthException>(() => client.RefreshAsync("r"));
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CommandPalette.Extensions.Toolkit.UnitTests/Auth/OAuthTokenSerializationTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CommandPalette.Extensions.Toolkit.UnitTests/Auth/OAuthTokenSerializationTests.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CommandPalette.Extensions.Toolkit.UnitTests.Auth;
+
+[TestClass]
+public class OAuthTokenSerializationTests
+{
+    [TestMethod]
+    public void RoundTrip_PreservesAllFields()
+    {
+        var expiresAt = DateTimeOffset.UtcNow.AddHours(1);
+        var original = new OAuthToken
+        {
+            AccessToken = "access-123",
+            RefreshToken = "refresh-456",
+            TokenType = "Bearer",
+            Scope = "read write",
+            IdToken = "id-789",
+            ExpiresAt = expiresAt,
+        };
+
+        var json = OAuthTokenSerialization.Serialize(original);
+        var restored = OAuthTokenSerialization.Deserialize(json);
+
+        Assert.IsNotNull(restored);
+        Assert.AreEqual(original.AccessToken, restored!.AccessToken);
+        Assert.AreEqual(original.RefreshToken, restored.RefreshToken);
+        Assert.AreEqual(original.TokenType, restored.TokenType);
+        Assert.AreEqual(original.Scope, restored.Scope);
+        Assert.AreEqual(original.IdToken, restored.IdToken);
+        Assert.IsNotNull(restored.ExpiresAt);
+        Assert.AreEqual(expiresAt.ToUnixTimeSeconds(), restored.ExpiresAt!.Value.ToUnixTimeSeconds());
+    }
+
+    [TestMethod]
+    public void RoundTrip_OmitsNullOptionalFields()
+    {
+        var original = new OAuthToken { AccessToken = "only-access" };
+
+        var json = OAuthTokenSerialization.Serialize(original);
+        var restored = OAuthTokenSerialization.Deserialize(json);
+
+        Assert.IsNotNull(restored);
+        Assert.AreEqual("only-access", restored!.AccessToken);
+        Assert.IsNull(restored.RefreshToken);
+        Assert.IsNull(restored.TokenType);
+        Assert.IsNull(restored.Scope);
+        Assert.IsNull(restored.IdToken);
+        Assert.IsNull(restored.ExpiresAt);
+    }
+
+    [TestMethod]
+    public void Deserialize_InvalidJson_ReturnsNull()
+    {
+        Assert.IsNull(OAuthTokenSerialization.Deserialize("not json"));
+        Assert.IsNull(OAuthTokenSerialization.Deserialize("[1,2,3]"));
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CommandPalette.Extensions.Toolkit.UnitTests/Auth/OAuthTokenTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CommandPalette.Extensions.Toolkit.UnitTests/Auth/OAuthTokenTests.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CommandPalette.Extensions.Toolkit.UnitTests.Auth;
+
+[TestClass]
+public class OAuthTokenTests
+{
+    [TestMethod]
+    public void IsExpired_NullExpiry_IsNeverExpired()
+    {
+        var token = new OAuthToken { AccessToken = "a" };
+
+        Assert.IsFalse(token.IsExpired());
+    }
+
+    [TestMethod]
+    public void IsExpired_FutureExpiryBeyondSkew_IsNotExpired()
+    {
+        var token = new OAuthToken
+        {
+            AccessToken = "a",
+            ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(10),
+        };
+
+        Assert.IsFalse(token.IsExpired());
+    }
+
+    [TestMethod]
+    public void IsExpired_PastExpiry_IsExpired()
+    {
+        var token = new OAuthToken
+        {
+            AccessToken = "a",
+            ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(-1),
+        };
+
+        Assert.IsTrue(token.IsExpired());
+    }
+
+    [TestMethod]
+    public void IsExpired_WithinDefaultSkew_IsExpired()
+    {
+        // 30 seconds out, default skew is 60 seconds -> considered expired.
+        var token = new OAuthToken
+        {
+            AccessToken = "a",
+            ExpiresAt = DateTimeOffset.UtcNow.AddSeconds(30),
+        };
+
+        Assert.IsTrue(token.IsExpired());
+    }
+
+    [TestMethod]
+    public void IsExpired_CustomSkew_IsRespected()
+    {
+        var token = new OAuthToken
+        {
+            AccessToken = "a",
+            ExpiresAt = DateTimeOffset.UtcNow.AddSeconds(30),
+        };
+
+        // With a tiny skew, 30s of remaining life is not yet expired.
+        Assert.IsFalse(token.IsExpired(TimeSpan.FromSeconds(5)));
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CommandPalette.Extensions.Toolkit.UnitTests/Auth/PkceTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CommandPalette.Extensions.Toolkit.UnitTests/Auth/PkceTests.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.RegularExpressions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CommandPalette.Extensions.Toolkit.UnitTests.Auth;
+
+[TestClass]
+public class PkceTests
+{
+    // RFC 7636 Appendix B known-answer vector.
+    private const string RfcVerifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+    private const string RfcChallenge = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM";
+
+    [TestMethod]
+    public void ComputeChallenge_MatchesRfc7636Vector()
+    {
+        Assert.AreEqual(RfcChallenge, Pkce.ComputeChallenge(RfcVerifier));
+    }
+
+    [TestMethod]
+    public void Generate_ProducesVerifierWithMatchingChallenge()
+    {
+        var (verifier, challenge) = Pkce.Generate();
+
+        Assert.AreEqual(Pkce.ComputeChallenge(verifier), challenge);
+    }
+
+    [TestMethod]
+    public void Generate_VerifierIsUrlSafeAndUnpadded()
+    {
+        var (verifier, challenge) = Pkce.Generate();
+
+        // Base64url alphabet only, no padding.
+        Assert.IsTrue(Regex.IsMatch(verifier, "^[A-Za-z0-9_-]+$"), verifier);
+        Assert.IsTrue(Regex.IsMatch(challenge, "^[A-Za-z0-9_-]+$"), challenge);
+
+        // 32 random bytes -> 43 base64url chars; SHA-256 -> 43 chars.
+        Assert.AreEqual(43, verifier.Length);
+        Assert.AreEqual(43, challenge.Length);
+    }
+
+    [TestMethod]
+    public void Generate_ProducesUniqueValues()
+    {
+        var (v1, _) = Pkce.Generate();
+        var (v2, _) = Pkce.Generate();
+
+        Assert.AreNotEqual(v1, v2);
+    }
+
+    [TestMethod]
+    public void Base64UrlEncode_StripsPaddingAndReplacesChars()
+    {
+        // 0xFB 0xFF -> base64 "+/8=" -> base64url "-_8".
+        var encoded = Pkce.Base64UrlEncode(new byte[] { 0xFB, 0xFF });
+
+        Assert.AreEqual("-_8", encoded);
+    }
+}

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/Auth/AuthorizationRequest.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/Auth/AuthorizationRequest.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.CommandPalette.Extensions.Toolkit;
+
+/// <summary>
+/// A ready-to-use <see cref="IAuthorizationRequest"/> implementation. The host
+/// injects <c>redirect_uri</c> and <c>state</c>, so do not put those in
+/// <see cref="Parameters"/>.
+/// </summary>
+public partial class AuthorizationRequest : IAuthorizationRequest
+{
+    public string DisplayName { get; set; } = string.Empty;
+
+    public string AuthorizationEndpoint { get; set; } = string.Empty;
+
+    public IReadOnlyDictionary<string, string> Parameters { get; set; } = new Dictionary<string, string>();
+
+    public AuthorizationRedirectKind RedirectKind { get; set; } = AuthorizationRedirectKind.Loopback;
+
+    public int TimeoutSeconds { get; set; }
+}

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/Auth/AuthorizationResult.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/Auth/AuthorizationResult.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.CommandPalette.Extensions.Toolkit;
+
+/// <summary>
+/// A ready-to-use <see cref="IAuthorizationResult"/> implementation. Command
+/// Palette produces this on the host side; the Toolkit type is provided for
+/// symmetry and testing.
+/// </summary>
+public partial class AuthorizationResult : IAuthorizationResult
+{
+    public bool IsSuccessful { get; set; }
+
+    public string RedirectUri { get; set; } = string.Empty;
+
+    public IReadOnlyDictionary<string, string> ResponseParameters { get; set; } = new Dictionary<string, string>();
+
+    public string Error { get; set; } = string.Empty;
+}

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/Auth/CredentialManagerTokenStore.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/Auth/CredentialManagerTokenStore.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Windows.Security.Credentials;
+
+namespace Microsoft.CommandPalette.Extensions.Toolkit;
+
+/// <summary>
+/// An <see cref="ITokenStore"/> backed by the Windows Credential Manager (via
+/// <see cref="PasswordVault"/>). Tokens are encrypted at rest per-user. Requires
+/// the extension to run as a packaged app (Command Palette extensions do).
+/// </summary>
+/// <remarks>
+/// The vault imposes a size limit on the stored secret (a few KB), which is fine
+/// for typical access/refresh tokens but may be exceeded by very large JWTs.
+/// </remarks>
+public sealed partial class CredentialManagerTokenStore : ITokenStore
+{
+    private const string ResourcePrefix = "Microsoft.CmdPal.OAuth:";
+
+    private readonly string _resource;
+
+    /// <summary>
+    /// Create a store. Use a distinct <paramref name="ns"/> per provider/account
+    /// namespace so keys don't collide across extensions.
+    /// </summary>
+    public CredentialManagerTokenStore(string ns = "default")
+    {
+        _resource = ResourcePrefix + ns;
+    }
+
+    public OAuthToken? Retrieve(string key)
+    {
+        try
+        {
+            var vault = new PasswordVault();
+            var credential = vault.Retrieve(_resource, key);
+            credential.RetrievePassword();
+            return OAuthTokenSerialization.Deserialize(credential.Password);
+        }
+        catch
+        {
+            // PasswordVault throws when the entry does not exist; treat as "no token".
+            return null;
+        }
+    }
+
+    public void Save(string key, OAuthToken token)
+    {
+        Remove(key);
+        var vault = new PasswordVault();
+        var json = OAuthTokenSerialization.Serialize(token);
+        vault.Add(new PasswordCredential(_resource, key, json));
+    }
+
+    public void Remove(string key)
+    {
+        try
+        {
+            var vault = new PasswordVault();
+            var credential = vault.Retrieve(_resource, key);
+            vault.Remove(credential);
+        }
+        catch
+        {
+            // Nothing stored under this key; nothing to remove.
+        }
+    }
+}

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/Auth/ITokenStore.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/Auth/ITokenStore.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CommandPalette.Extensions.Toolkit;
+
+/// <summary>
+/// A place to persist <see cref="OAuthToken"/>s between sessions. Implementations
+/// run inside the extension's process; Command Palette never sees stored tokens.
+/// </summary>
+public interface ITokenStore
+{
+    /// <summary>Retrieve a previously saved token, or null if none exists.</summary>
+    OAuthToken? Retrieve(string key);
+
+    /// <summary>Save (or overwrite) a token under <paramref name="key"/>.</summary>
+    void Save(string key, OAuthToken token);
+
+    /// <summary>Remove any token saved under <paramref name="key"/>.</summary>
+    void Remove(string key);
+}

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/Auth/OAuthClient.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/Auth/OAuthClient.cs
@@ -1,0 +1,271 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.CommandPalette.Extensions.Toolkit;
+
+/// <summary>
+/// A turnkey OAuth 2.0 Authorization Code + PKCE client for Command Palette
+/// extensions. It generates the PKCE verifier/challenge, asks the Command Palette
+/// host to run the interactive redirect (browser + capture), and then exchanges
+/// the authorization code for tokens at the provider's token endpoint. All
+/// secrets (PKCE verifier, tokens) stay inside the extension's process; Command
+/// Palette only brokers the browser redirect.
+/// </summary>
+public sealed partial class OAuthClient
+{
+    private static readonly HttpClient SharedHttpClient = new();
+
+    /// <summary>The OAuth client identifier (public client; no secret).</summary>
+    public required string ClientId { get; init; }
+
+    /// <summary>The provider's authorization endpoint URL.</summary>
+    public required string AuthorizationEndpoint { get; init; }
+
+    /// <summary>The provider's token endpoint URL.</summary>
+    public required string TokenEndpoint { get; init; }
+
+    /// <summary>Scopes to request. Joined with spaces into the <c>scope</c> parameter.</summary>
+    public IReadOnlyList<string> Scopes { get; init; } = Array.Empty<string>();
+
+    /// <summary>Which redirect mechanism Command Palette should host.</summary>
+    public AuthorizationRedirectKind RedirectKind { get; init; } = AuthorizationRedirectKind.Loopback;
+
+    /// <summary>Friendly name shown in the "waiting to sign in" status message.</summary>
+    public string DisplayName { get; init; } = string.Empty;
+
+    /// <summary>Redirect wait timeout in seconds. 0 uses the host default.</summary>
+    public int TimeoutSeconds { get; init; }
+
+    /// <summary>Extra provider-specific authorization parameters (e.g. <c>prompt</c>, <c>audience</c>).</summary>
+    public IReadOnlyDictionary<string, string>? AdditionalAuthorizationParameters { get; init; }
+
+    /// <summary>
+    /// Run the interactive Authorization Code + PKCE flow and return the tokens.
+    /// </summary>
+    /// <exception cref="NotSupportedException">The host does not support authentication.</exception>
+    /// <exception cref="OAuthException">The flow or token exchange failed.</exception>
+    public async Task<OAuthToken> AuthorizeAsync(CancellationToken cancellationToken = default)
+    {
+        var (verifier, challenge) = Pkce.Generate();
+
+        var parameters = BuildAuthorizationParameters(challenge);
+
+        var request = new AuthorizationRequest
+        {
+            DisplayName = DisplayName,
+            AuthorizationEndpoint = AuthorizationEndpoint,
+            Parameters = parameters,
+            RedirectKind = RedirectKind,
+            TimeoutSeconds = TimeoutSeconds,
+        };
+
+        var result = await ExtensionHost.RequestAuthorizationAsync(request, cancellationToken).ConfigureAwait(false);
+
+        if (!result.IsSuccessful)
+        {
+            throw new OAuthException(string.IsNullOrEmpty(result.Error) ? "Authorization failed." : result.Error);
+        }
+
+        var response = result.ResponseParameters;
+        if (response.TryGetValue("error", out var error) && !string.IsNullOrEmpty(error))
+        {
+            response.TryGetValue("error_description", out var description);
+            throw new OAuthException(string.IsNullOrEmpty(description) ? error : description, error);
+        }
+
+        if (!response.TryGetValue("code", out var code) || string.IsNullOrEmpty(code))
+        {
+            throw new OAuthException("The authorization response did not contain an authorization code.");
+        }
+
+        var body = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["grant_type"] = "authorization_code",
+            ["code"] = code,
+            ["redirect_uri"] = result.RedirectUri,
+            ["client_id"] = ClientId,
+            ["code_verifier"] = verifier,
+        };
+
+        return await ExchangeAsync(body, cancellationToken).ConfigureAwait(false);
+    }
+
+    internal Dictionary<string, string> BuildAuthorizationParameters(string challenge)
+    {
+        var parameters = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["response_type"] = "code",
+            ["client_id"] = ClientId,
+            ["code_challenge"] = challenge,
+            ["code_challenge_method"] = "S256",
+        };
+
+        if (Scopes is { Count: > 0 })
+        {
+            parameters["scope"] = string.Join(' ', Scopes);
+        }
+
+        if (AdditionalAuthorizationParameters is not null)
+        {
+            foreach (var pair in AdditionalAuthorizationParameters)
+            {
+                parameters[pair.Key] = pair.Value;
+            }
+        }
+
+        return parameters;
+    }
+
+    /// <summary>
+    /// Exchange a refresh token for a new token set.
+    /// </summary>
+    /// <exception cref="OAuthException">The refresh failed.</exception>
+    public async Task<OAuthToken> RefreshAsync(string refreshToken, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(refreshToken);
+
+        var body = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["grant_type"] = "refresh_token",
+            ["refresh_token"] = refreshToken,
+            ["client_id"] = ClientId,
+        };
+
+        if (Scopes is { Count: > 0 })
+        {
+            body["scope"] = string.Join(' ', Scopes);
+        }
+
+        return await ExchangeAsync(body, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<OAuthToken> ExchangeAsync(IDictionary<string, string> body, CancellationToken cancellationToken)
+    {
+        string json;
+        bool success;
+        try
+        {
+            using var content = new FormUrlEncodedContent(body);
+            using var httpRequest = new HttpRequestMessage(HttpMethod.Post, TokenEndpoint) { Content = content };
+
+            // Some providers (e.g. GitHub) default to form-encoded responses
+            // unless the client explicitly asks for JSON.
+            httpRequest.Headers.Accept.ParseAdd("application/json");
+
+            using var httpResponse = await SharedHttpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
+            success = httpResponse.IsSuccessStatusCode;
+            json = await httpResponse.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+            if (!success)
+            {
+                throw new OAuthException(
+                    TryParseError(json) ?? $"The token endpoint returned HTTP {(int)httpResponse.StatusCode}.");
+            }
+        }
+        catch (HttpRequestException ex)
+        {
+            throw new OAuthException("The token request could not be sent.", ex);
+        }
+
+        return ParseTokenResponse(json);
+    }
+
+    private static OAuthToken ParseTokenResponse(string json)
+    {
+        JsonDocument doc;
+        try
+        {
+            doc = JsonDocument.Parse(json);
+        }
+        catch (JsonException ex)
+        {
+            throw new OAuthException("The token response was not valid JSON.", ex);
+        }
+
+        using (doc)
+        {
+            var root = doc.RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+            {
+                throw new OAuthException("The token response was not a JSON object.");
+            }
+
+            if (root.TryGetProperty("error", out var errorEl) && errorEl.ValueKind == JsonValueKind.String)
+            {
+                var errorCode = errorEl.GetString();
+                var description = root.TryGetProperty("error_description", out var descEl) && descEl.ValueKind == JsonValueKind.String
+                    ? descEl.GetString()
+                    : null;
+                throw new OAuthException(string.IsNullOrEmpty(description) ? (errorCode ?? "Token request failed.") : description, errorCode);
+            }
+
+            var accessToken = GetString(root, "access_token");
+            if (string.IsNullOrEmpty(accessToken))
+            {
+                throw new OAuthException("The token response did not contain an access_token.");
+            }
+
+            DateTimeOffset? expiresAt = null;
+            if (root.TryGetProperty("expires_in", out var expiresEl))
+            {
+                long? seconds = expiresEl.ValueKind switch
+                {
+                    JsonValueKind.Number when expiresEl.TryGetInt64(out var n) => n,
+                    JsonValueKind.String when long.TryParse(expiresEl.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var s) => s,
+                    _ => null,
+                };
+                if (seconds is long secs)
+                {
+                    expiresAt = DateTimeOffset.UtcNow.AddSeconds(secs);
+                }
+            }
+
+            return new OAuthToken
+            {
+                AccessToken = accessToken,
+                RefreshToken = GetString(root, "refresh_token"),
+                TokenType = GetString(root, "token_type"),
+                Scope = GetString(root, "scope"),
+                IdToken = GetString(root, "id_token"),
+                ExpiresAt = expiresAt,
+            };
+        }
+    }
+
+    private static string? TryParseError(string json)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            if (root.ValueKind == JsonValueKind.Object &&
+                root.TryGetProperty("error", out var errorEl) &&
+                errorEl.ValueKind == JsonValueKind.String)
+            {
+                var description = root.TryGetProperty("error_description", out var descEl) && descEl.ValueKind == JsonValueKind.String
+                    ? descEl.GetString()
+                    : null;
+                return string.IsNullOrEmpty(description) ? errorEl.GetString() : description;
+            }
+        }
+        catch (JsonException)
+        {
+        }
+
+        return null;
+    }
+
+    private static string? GetString(JsonElement obj, string name) =>
+        obj.TryGetProperty(name, out var el) && el.ValueKind == JsonValueKind.String
+            ? el.GetString()
+            : null;
+}

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/Auth/OAuthException.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/Auth/OAuthException.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.CommandPalette.Extensions.Toolkit;
+
+/// <summary>
+/// Thrown when an OAuth flow fails: the provider returned an error, the redirect
+/// carried an <c>error</c> parameter, the flow was canceled or timed out, or the
+/// token exchange failed.
+/// </summary>
+public sealed class OAuthException : Exception
+{
+    /// <summary>
+    /// The OAuth <c>error</c> code when one was returned (e.g.
+    /// <c>access_denied</c>, <c>invalid_grant</c>), otherwise null.
+    /// </summary>
+    public string? ErrorCode { get; }
+
+    public OAuthException(string message)
+        : base(message)
+    {
+    }
+
+    public OAuthException(string message, string? errorCode)
+        : base(message)
+    {
+        ErrorCode = errorCode;
+    }
+
+    public OAuthException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/Auth/OAuthToken.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/Auth/OAuthToken.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.CommandPalette.Extensions.Toolkit;
+
+/// <summary>
+/// A token set returned from an OAuth 2.0 token endpoint.
+/// </summary>
+public sealed partial class OAuthToken
+{
+    public string AccessToken { get; init; } = string.Empty;
+
+    public string? RefreshToken { get; init; }
+
+    public string? TokenType { get; init; }
+
+    public string? Scope { get; init; }
+
+    public string? IdToken { get; init; }
+
+    /// <summary>
+    /// Absolute expiry, computed from the token endpoint's <c>expires_in</c>
+    /// (relative seconds) at the moment the response was received. Null when the
+    /// provider did not return an expiry.
+    /// </summary>
+    public DateTimeOffset? ExpiresAt { get; init; }
+
+    /// <summary>
+    /// True when the token has an expiry and it is within <paramref name="skew"/>
+    /// of now (default 60s of clock skew), so the caller should refresh.
+    /// </summary>
+    public bool IsExpired(TimeSpan? skew = null) =>
+        ExpiresAt is DateTimeOffset expiry &&
+        DateTimeOffset.UtcNow >= expiry - (skew ?? TimeSpan.FromSeconds(60));
+}

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/Auth/OAuthTokenSerialization.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/Auth/OAuthTokenSerialization.cs
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Globalization;
+using System.IO;
+using System.Text.Json;
+
+namespace Microsoft.CommandPalette.Extensions.Toolkit;
+
+/// <summary>
+/// Trim/AOT-safe (reflection-free) serialization of <see cref="OAuthToken"/> to a
+/// compact JSON blob, used by token stores. This is deliberately not the OAuth
+/// token-endpoint wire format; it is our own storage format.
+/// </summary>
+internal static class OAuthTokenSerialization
+{
+    public static string Serialize(OAuthToken token)
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            writer.WriteStartObject();
+            writer.WriteString("access_token", token.AccessToken);
+            if (token.RefreshToken is not null)
+            {
+                writer.WriteString("refresh_token", token.RefreshToken);
+            }
+
+            if (token.TokenType is not null)
+            {
+                writer.WriteString("token_type", token.TokenType);
+            }
+
+            if (token.Scope is not null)
+            {
+                writer.WriteString("scope", token.Scope);
+            }
+
+            if (token.IdToken is not null)
+            {
+                writer.WriteString("id_token", token.IdToken);
+            }
+
+            if (token.ExpiresAt is DateTimeOffset expiresAt)
+            {
+                writer.WriteString("expires_at", expiresAt.ToString("o", CultureInfo.InvariantCulture));
+            }
+
+            writer.WriteEndObject();
+        }
+
+        return System.Text.Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    public static OAuthToken? Deserialize(string json)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+            {
+                return null;
+            }
+
+            DateTimeOffset? expiresAt = null;
+            if (root.TryGetProperty("expires_at", out var expiresEl) &&
+                expiresEl.ValueKind == JsonValueKind.String &&
+                DateTimeOffset.TryParse(expiresEl.GetString(), CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var parsed))
+            {
+                expiresAt = parsed;
+            }
+
+            return new OAuthToken
+            {
+                AccessToken = GetString(root, "access_token") ?? string.Empty,
+                RefreshToken = GetString(root, "refresh_token"),
+                TokenType = GetString(root, "token_type"),
+                Scope = GetString(root, "scope"),
+                IdToken = GetString(root, "id_token"),
+                ExpiresAt = expiresAt,
+            };
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static string? GetString(JsonElement obj, string name) =>
+        obj.TryGetProperty(name, out var el) && el.ValueKind == JsonValueKind.String
+            ? el.GetString()
+            : null;
+}

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/Auth/Pkce.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/Auth/Pkce.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Microsoft.CommandPalette.Extensions.Toolkit;
+
+/// <summary>
+/// Helpers for the PKCE (Proof Key for Code Exchange, RFC 7636) extension to the
+/// OAuth 2.0 Authorization Code flow. The verifier is generated and kept inside
+/// the extension process; only the S256 challenge is ever sent to the browser.
+/// </summary>
+public static class Pkce
+{
+    /// <summary>
+    /// Generate a fresh PKCE verifier/challenge pair using the S256 method.
+    /// </summary>
+    /// <returns>
+    /// A tuple of (verifier, challenge). Send <c>challenge</c> as
+    /// <c>code_challenge</c> (with <c>code_challenge_method=S256</c>) on the
+    /// authorization request, and send <c>verifier</c> as <c>code_verifier</c>
+    /// when exchanging the authorization code for a token.
+    /// </returns>
+    public static (string Verifier, string Challenge) Generate()
+    {
+        // RFC 7636 allows a verifier of 43-128 chars. 32 random bytes -> 43
+        // base64url chars, which is the recommended length.
+        var bytes = RandomNumberGenerator.GetBytes(32);
+        var verifier = Base64UrlEncode(bytes);
+        var challenge = ComputeChallenge(verifier);
+        return (verifier, challenge);
+    }
+
+    /// <summary>
+    /// Compute the S256 code challenge for a given verifier:
+    /// <c>base64url(SHA256(ASCII(verifier)))</c>.
+    /// </summary>
+    public static string ComputeChallenge(string verifier)
+    {
+        ArgumentNullException.ThrowIfNull(verifier);
+        var hash = SHA256.HashData(Encoding.ASCII.GetBytes(verifier));
+        return Base64UrlEncode(hash);
+    }
+
+    /// <summary>
+    /// Base64url-encode without padding (RFC 4648 section 5), as required for
+    /// PKCE values and other OAuth parameters.
+    /// </summary>
+    public static string Base64UrlEncode(byte[] bytes)
+    {
+        ArgumentNullException.ThrowIfNull(bytes);
+        return Convert.ToBase64String(bytes)
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+    }
+}

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/ExtensionHost.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/ExtensionHost.cs
@@ -2,6 +2,10 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace Microsoft.CommandPalette.Extensions.Toolkit;
 
 public partial class ExtensionHost
@@ -71,6 +75,51 @@ public partial class ExtensionHost
                 {
                 }
             });
+        }
+    }
+
+    /// <summary>
+    /// True when the connected host supports interactive authorization
+    /// (i.e. it implements <see cref="IExtensionHost2"/>). Older Command Palette
+    /// versions return false.
+    /// </summary>
+    public static bool SupportsAuthorization => Host is IExtensionHost2;
+
+    /// <summary>
+    /// Ask the Command Palette host to run an interactive authorization flow. The
+    /// returned task completes when the redirect is captured (or the flow fails,
+    /// is canceled, or times out). Prefer <see cref="OAuthClient"/> for the common
+    /// Authorization Code + PKCE case.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="request"/> is null.</exception>
+    /// <exception cref="NotSupportedException">
+    /// The connected host does not implement <see cref="IExtensionHost2"/>.
+    /// </exception>
+    public static async Task<IAuthorizationResult> RequestAuthorizationAsync(
+        IAuthorizationRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (Host is not IExtensionHost2 host2)
+        {
+            throw new NotSupportedException(
+                "The Command Palette host does not support authentication. Update Command Palette to a newer version.");
+        }
+
+        var operation = host2.RequestAuthorizationAsync(request);
+        using (cancellationToken.Register(() =>
+        {
+            try
+            {
+                operation.Cancel();
+            }
+            catch (Exception)
+            {
+            }
+        }))
+        {
+            return await operation;
         }
     }
 }

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions/Microsoft.CommandPalette.Extensions.idl
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions/Microsoft.CommandPalette.Extensions.idl
@@ -248,6 +248,74 @@ namespace Microsoft.CommandPalette.Extensions
     
         Windows.Foundation.IAsyncAction LogMessage(ILogMessage message);
     };
+
+    // Where the identity provider should redirect the browser back to once the
+    // user has authorized (or denied) the request. Command Palette owns the
+    // redirect target: it allocates it, hosts it, and routes the captured
+    // redirect back to the extension that started the flow.
+    [contract(Microsoft.CommandPalette.Extensions.ExtensionsContract, 1)]
+    enum AuthorizationRedirectKind
+    {
+        // http://127.0.0.1:{ephemeral-port}/ . RFC 8252 loopback interface
+        // redirection. Broadest identity-provider support (Google, Entra, ...).
+        Loopback = 0,
+        // x-cmdpal://auth/callback . Uses Command Palette's registered protocol.
+        // Auto-foregrounds Command Palette, but only works with providers that
+        // allow custom-scheme redirect URIs.
+        CustomScheme = 1,
+    };
+
+    // The parameters an extension supplies to start an authorization flow. The
+    // host injects "redirect_uri" and a cryptographically-random "state" before
+    // opening the browser, so callers must NOT set those. Everything else the
+    // provider needs (client_id, scope, response_type, code_challenge,
+    // code_challenge_method, and any provider-specific extras) goes in
+    // Parameters. PKCE is owned entirely by the extension (the verifier never
+    // leaves the extension process).
+    [contract(Microsoft.CommandPalette.Extensions.ExtensionsContract, 1)]
+    interface IAuthorizationRequest
+    {
+        // Friendly name shown in the "waiting to sign in" status message.
+        String DisplayName { get; };
+        // The provider's authorization endpoint, e.g.
+        // "https://github.com/login/oauth/authorize".
+        String AuthorizationEndpoint { get; };
+        // Query parameters appended to the authorization endpoint. Do not
+        // include redirect_uri or state; the host supplies those.
+        Windows.Foundation.Collections.IMapView<String, String> Parameters { get; };
+        AuthorizationRedirectKind RedirectKind { get; };
+        // How long to wait for the redirect before failing. 0 means "use the
+        // host default" (60s). The host caps this (300s).
+        Int32 TimeoutSeconds { get; };
+    };
+
+    // The result of an authorization flow, handed back to the extension that
+    // started it. On success the extension completes the flow itself (exchanges
+    // the code at the token endpoint using its PKCE verifier and RedirectUri).
+    [contract(Microsoft.CommandPalette.Extensions.ExtensionsContract, 1)]
+    interface IAuthorizationResult
+    {
+        Boolean IsSuccessful { get; };
+        // The exact redirect_uri the host used. This MUST be sent to the token
+        // endpoint during code exchange (RFC 6749 requires it to match).
+        String RedirectUri { get; };
+        // The query parameters captured from the redirect (e.g. "code"). The
+        // host has already validated "state" and removed it.
+        Windows.Foundation.Collections.IMapView<String, String> ResponseParameters { get; };
+        // Populated when IsSuccessful is false (provider error, timeout, user
+        // cancellation, or a broker failure).
+        String Error { get; };
+    };
+
+    [contract(Microsoft.CommandPalette.Extensions.ExtensionsContract, 1)]
+    interface IExtensionHost2 requires IExtensionHost
+    {
+        // Run an interactive authorization flow. The host opens the browser to
+        // the authorization endpoint, captures the redirect, validates state,
+        // re-foregrounds Command Palette, and returns the captured parameters.
+        // The returned operation is cancelable.
+        Windows.Foundation.IAsyncOperation<IAuthorizationResult> RequestAuthorizationAsync(IAuthorizationRequest request);
+    };
     
     [contract(Microsoft.CommandPalette.Extensions.ExtensionsContract, 1)]
     interface IPage requires ICommand {


### PR DESCRIPTION
## Summary

Phase 1 of a built-in **OAuth authorization flow** for Command Palette extensions. This PR adds only the extension-facing SDK contract and the Toolkit `OAuthClient`; it does not yet wire up the host-side broker (that is Phase 2).

The design splits responsibility as a **hybrid**: Command Palette will be a thin, hardened redirect broker (browser open, `redirect_uri` allocation, `state` routing, redirect capture), while the Toolkit `OAuthClient` performs PKCE and token exchange **inside the extension's process**. Command Palette never stores third-party tokens.

This is the first of a stack of draft PRs:

| Phase | Scope | This PR |
|-------|-------|---------|
| 1 | SDK contract + Toolkit `OAuthClient` | this |
| 2 | Host broker (`AppExtensionHost` / loopback + custom scheme) | later |
| 3 | Host navigation (`IExtensionHost2.GoToPageAsync`) | later |
| 4 | Sample (SamplePagesExtension) + spec doc | later |

## What's in this PR

**SDK** (`Microsoft.CommandPalette.Extensions.idl`), all under contract v1 (no `contractversion` bump, mirroring how `ICommandProvider2/3/4` live under v1):
- `enum AuthorizationRedirectKind { Loopback, CustomScheme }`
- `interface IAuthorizationRequest` / `interface IAuthorizationResult`
- `interface IExtensionHost2 requires IExtensionHost` with `RequestAuthorizationAsync(IAuthorizationRequest) -> IAsyncOperation<IAuthorizationResult>`

Navigation (`GoToPageAsync`, Phase 3) will be added to this same `IExtensionHost2` rather than a new `IExtensionHost3`: the whole feature ships atomically as one stack, so there is no ABI reason to split.

**Toolkit** (`Microsoft.CommandPalette.Extensions.Toolkit/Auth/`):
- `Pkce` - S256 verifier/challenge + base64url helpers
- `AuthorizationRequest` / `AuthorizationResult` - ready-to-use contract impls
- `OAuthClient` - Authorization Code + PKCE: `AuthorizeAsync` / `RefreshAsync`, reflection-free JSON parsing (AOT/trim safe)
- `OAuthToken` (+ `IsExpired`), `OAuthException`, `ITokenStore`, `CredentialManagerTokenStore` (Windows Credential Manager via `PasswordVault`), `OAuthTokenSerialization`
- `ExtensionHost.RequestAuthorizationAsync` + `SupportsAuthorization` - QI-based capability detection against `IExtensionHost2` (cancelable; throws a clear `NotSupportedException` on older hosts)

## Capability detection

Older Command Palette builds don't implement `IExtensionHost2`. `ExtensionHost.SupportsAuthorization` returns `false` and `RequestAuthorizationAsync` throws a descriptive `NotSupportedException` so extensions can degrade gracefully.

## Tests

New `Toolkit.UnitTests/Auth` tests (all offline, no network):
- PKCE S256 against the RFC 7636 Appendix B known-answer vector; base64url shape/uniqueness
- `OAuthClient` token exchange + error handling via a self-contained loopback `TcpListener` mock endpoint (success, `expires_in` as number or string, provider `error` body, missing `access_token`, non-JSON)
- Authorization-parameter composition (PKCE + scope + extras; never sets `redirect_uri`/`state`)
- `OAuthTokenSerialization` round-trip; `OAuthToken.IsExpired` skew behavior
- Legacy-host `NotSupportedException` path

Full Toolkit suite: **668 passed / 1 skipped (pre-existing) / 0 failed**. Built x64 Debug (exit 0).

## Notes / limitations

- MVP grant support is **Authorization Code + PKCE** only; device-code / client-credentials are noted as future and don't require host changes.
- `CredentialManagerTokenStore` relies on `PasswordVault`, which caps secret size at a few KB - fine for typical tokens, may be exceeded by very large JWTs. Documented in the type's remarks.
- The host-side broker, loopback listener, and `x-cmdpal://auth/callback` routing arrive in Phase 2.