### PR TITLE
[CmdPal] Host-side OAuth redirect broker (Phase 2)

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AppExtensionHost.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AppExtensionHost.cs
@@ -5,13 +5,14 @@
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using Microsoft.CmdPal.Common;
+using Microsoft.CmdPal.UI.ViewModels.Auth;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 using Windows.Foundation;
 
 namespace Microsoft.CmdPal.UI.ViewModels;
 
-public abstract partial class AppExtensionHost : IExtensionHost
+public abstract partial class AppExtensionHost : IExtensionHost, IExtensionHost2
 {
     private static readonly GlobalLogPageContext _globalLogPageContext = new();
 
@@ -168,6 +169,14 @@ public abstract partial class AppExtensionHost : IExtensionHost
 
         return Task.CompletedTask.AsAsyncAction();
     }
+
+    /// <summary>
+    /// <see cref="IExtensionHost2"/>. Delegate the interactive authorization flow
+    /// to the process-wide <see cref="AuthBrokerService"/>, passing this host so
+    /// it can surface a cancelable, non-blocking status while the browser is open.
+    /// </summary>
+    public IAsyncOperation<IAuthorizationResult> RequestAuthorizationAsync(IAuthorizationRequest request)
+        => AuthBrokerService.Instance.RequestAuthorizationAsync(request, this);
 
     public abstract string? GetExtensionDisplayName();
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Auth/AuthBrokerService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Auth/AuthBrokerService.cs
@@ -1,0 +1,445 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Runtime.InteropServices.WindowsRuntime;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+using Windows.Foundation;
+
+namespace Microsoft.CmdPal.UI.ViewModels.Auth;
+
+/// <summary>
+/// The Command Palette side of the built-in authorization flow. Command Palette
+/// acts as a thin, hardened redirect broker: it allocates the redirect target,
+/// injects a cryptographically-random <c>state</c>, opens the browser, captures
+/// the single redirect, validates <c>state</c>, and hands the raw response
+/// parameters back to the extension. Command Palette never sees the PKCE
+/// verifier and never stores third-party tokens; the Toolkit's OAuthClient does
+/// the code exchange inside the extension's process.
+/// </summary>
+public sealed partial class AuthBrokerService : IDisposable
+{
+    /// <summary>The custom-scheme redirect target reused from the existing protocol wiring.</summary>
+    public const string CustomSchemeRedirectUri = "x-cmdpal://auth/callback";
+
+    private static readonly TimeSpan DefaultTimeoutValue = TimeSpan.FromSeconds(60);
+    private static readonly TimeSpan MaxTimeoutValue = TimeSpan.FromSeconds(300);
+
+    private static readonly Lazy<AuthBrokerService> LazyInstance = new(() =>
+        new AuthBrokerService(new DefaultAuthBrokerPlatform(), new TcpLoopbackRedirectListenerFactory()));
+
+    // Pending custom-scheme flows, keyed by their single-use state. A flow is
+    // completed when a protocol activation carrying the matching state arrives.
+    private readonly ConcurrentDictionary<string, TaskCompletionSource<IReadOnlyDictionary<string, string>>> _pendingCustomScheme = new(StringComparer.Ordinal);
+
+    private readonly ILoopbackRedirectListenerFactory _loopbackFactory;
+    private readonly TimeSpan _defaultTimeout;
+    private readonly TimeSpan _maxTimeout;
+
+    private IAuthBrokerPlatform _platform;
+
+    // Canceled (and replaced) when the broker is torn down, cancelling every
+    // in-flight flow. Nothing sensitive is stranded: the PKCE verifier lives in
+    // the extension, not here.
+    private CancellationTokenSource _shutdownCts = new();
+
+    public AuthBrokerService(IAuthBrokerPlatform platform, ILoopbackRedirectListenerFactory loopbackFactory)
+        : this(platform, loopbackFactory, DefaultTimeoutValue, MaxTimeoutValue)
+    {
+    }
+
+    internal AuthBrokerService(
+        IAuthBrokerPlatform platform,
+        ILoopbackRedirectListenerFactory loopbackFactory,
+        TimeSpan defaultTimeout,
+        TimeSpan maxTimeout)
+    {
+        _platform = platform ?? throw new ArgumentNullException(nameof(platform));
+        _loopbackFactory = loopbackFactory ?? throw new ArgumentNullException(nameof(loopbackFactory));
+        _defaultTimeout = defaultTimeout;
+        _maxTimeout = maxTimeout;
+    }
+
+    /// <summary>The process-wide broker used by the running app.</summary>
+    public static AuthBrokerService Instance => LazyInstance.Value;
+
+    /// <summary>
+    /// Replace the platform hooks (browser launch + re-foreground). Called once
+    /// during host startup so the broker can drive the real window.
+    /// </summary>
+    public void SetPlatform(IAuthBrokerPlatform platform)
+    {
+        _platform = platform ?? throw new ArgumentNullException(nameof(platform));
+    }
+
+    /// <summary>
+    /// Run an interactive authorization flow. The returned operation is
+    /// cancelable; cancelling it abandons the wait and fails the flow.
+    /// </summary>
+    public IAsyncOperation<IAuthorizationResult> RequestAuthorizationAsync(IAuthorizationRequest request, AppExtensionHost? statusHost)
+    {
+        return AsyncInfo.Run(token => RunFlowAsync(request, statusHost, token));
+    }
+
+    /// <summary>
+    /// Route a captured <c>x-cmdpal://auth/callback</c> protocol activation to
+    /// the pending flow whose single-use <c>state</c> matches. Unknown state is
+    /// ignored (returns false) so stray activations cannot complete a flow.
+    /// </summary>
+    public bool TryCompleteCustomSchemeRedirect(string uri)
+    {
+        if (string.IsNullOrEmpty(uri) || !Uri.TryCreate(uri, UriKind.Absolute, out var parsed))
+        {
+            return false;
+        }
+
+        return TryCompleteCustomSchemeRedirect(parsed);
+    }
+
+    public bool TryCompleteCustomSchemeRedirect(Uri uri)
+    {
+        ArgumentNullException.ThrowIfNull(uri);
+
+        var query = uri.Query.StartsWith('?') ? uri.Query[1..] : uri.Query;
+        var parameters = QueryStringParser.Parse(query);
+        if (!parameters.TryGetValue("state", out var state) || string.IsNullOrEmpty(state))
+        {
+            return false;
+        }
+
+        // TryRemove enforces single-use: a second activation for the same state
+        // finds nothing and is ignored.
+        if (_pendingCustomScheme.TryRemove(state, out var tcs))
+        {
+            return tcs.TrySetResult(parameters);
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Cancel every in-flight flow (e.g. on broker teardown) and reset so future
+    /// flows can run.
+    /// </summary>
+    public void CancelAllFlows()
+    {
+        var old = Interlocked.Exchange(ref _shutdownCts, new CancellationTokenSource());
+        try
+        {
+            old.Cancel();
+        }
+        catch (Exception)
+        {
+        }
+        finally
+        {
+            old.Dispose();
+        }
+
+        foreach (var key in _pendingCustomScheme.Keys)
+        {
+            if (_pendingCustomScheme.TryRemove(key, out var tcs))
+            {
+                tcs.TrySetCanceled();
+            }
+        }
+    }
+
+    /// <summary>Cancel any in-flight flows and release the shutdown token source.</summary>
+    public void Dispose()
+    {
+        CancelAllFlows();
+        _shutdownCts.Dispose();
+    }
+
+    internal async Task<IAuthorizationResult> RunFlowAsync(IAuthorizationRequest request, AppExtensionHost? statusHost, CancellationToken cancellationToken)
+    {
+        if (request is null)
+        {
+            return Failure("The authorization request was null.");
+        }
+
+        var endpoint = request.AuthorizationEndpoint;
+        if (string.IsNullOrWhiteSpace(endpoint) || !Uri.TryCreate(endpoint, UriKind.Absolute, out _))
+        {
+            return Failure("The authorization endpoint is missing or invalid.");
+        }
+
+        var state = GenerateState();
+        var timeout = ResolveTimeout(request.TimeoutSeconds);
+
+        var shutdownCts = _shutdownCts;
+        using var timeoutCts = new CancellationTokenSource(timeout);
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token, shutdownCts.Token);
+
+        IStatusMessage? status = null;
+        try
+        {
+            status = ShowStatus(statusHost, request.DisplayName);
+
+            IReadOnlyDictionary<string, string> captured;
+            string redirectUri;
+
+            if (request.RedirectKind == AuthorizationRedirectKind.CustomScheme)
+            {
+                (captured, redirectUri) = await RunCustomSchemeFlowAsync(request, endpoint, state, linked.Token).ConfigureAwait(false);
+            }
+            else
+            {
+                (captured, redirectUri) = await RunLoopbackFlowAsync(request, endpoint, state, linked.Token).ConfigureAwait(false);
+            }
+
+            if (!captured.TryGetValue("state", out var returnedState) || !FixedTimeEquals(returnedState, state))
+            {
+                return Failure("The authorization response state did not match the request.");
+            }
+
+            var response = StripState(captured);
+
+            if (response.TryGetValue("error", out var providerError) && !string.IsNullOrEmpty(providerError))
+            {
+                return Failure(FormatProviderError(response));
+            }
+
+            // The redirect landed; bring Command Palette back to the foreground.
+            _platform.BringToForeground();
+
+            return Success(redirectUri, response);
+        }
+        catch (OperationCanceledException)
+        {
+            if (shutdownCts.IsCancellationRequested)
+            {
+                return Failure("The authorization flow was canceled because Command Palette is shutting down.");
+            }
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return Failure("The authorization flow was canceled.");
+            }
+
+            return Failure("The authorization flow timed out before the browser returned.");
+        }
+        catch (Exception ex)
+        {
+            return Failure($"The authorization flow failed: {ex.Message}");
+        }
+        finally
+        {
+            HideStatus(statusHost, status);
+        }
+    }
+
+    private async Task<(IReadOnlyDictionary<string, string> Captured, string RedirectUri)> RunLoopbackFlowAsync(
+        IAuthorizationRequest request, string endpoint, string state, CancellationToken cancellationToken)
+    {
+        using var listener = _loopbackFactory.Create();
+        var redirectUri = listener.RedirectUri;
+        var parameters = ComposeParameters(request, redirectUri, state);
+        _platform.LaunchBrowser(new Uri(BuildAuthorizationUrl(endpoint, parameters)));
+        var captured = await listener.WaitForRedirectAsync(cancellationToken).ConfigureAwait(false);
+        return (captured, redirectUri);
+    }
+
+    private async Task<(IReadOnlyDictionary<string, string> Captured, string RedirectUri)> RunCustomSchemeFlowAsync(
+        IAuthorizationRequest request, string endpoint, string state, CancellationToken cancellationToken)
+    {
+        var redirectUri = CustomSchemeRedirectUri;
+        var tcs = new TaskCompletionSource<IReadOnlyDictionary<string, string>>(TaskCreationOptions.RunContinuationsAsynchronously);
+        if (!_pendingCustomScheme.TryAdd(state, tcs))
+        {
+            throw new InvalidOperationException("A duplicate authorization state was generated.");
+        }
+
+        try
+        {
+            var parameters = ComposeParameters(request, redirectUri, state);
+            _platform.LaunchBrowser(new Uri(BuildAuthorizationUrl(endpoint, parameters)));
+
+            using (cancellationToken.Register(() => tcs.TrySetCanceled(cancellationToken)))
+            {
+                var captured = await tcs.Task.ConfigureAwait(false);
+                return (captured, redirectUri);
+            }
+        }
+        finally
+        {
+            _pendingCustomScheme.TryRemove(state, out _);
+        }
+    }
+
+    private TimeSpan ResolveTimeout(int timeoutSeconds)
+    {
+        if (timeoutSeconds <= 0)
+        {
+            return _defaultTimeout;
+        }
+
+        var requested = TimeSpan.FromSeconds(timeoutSeconds);
+        return requested > _maxTimeout ? _maxTimeout : requested;
+    }
+
+    private IStatusMessage? ShowStatus(AppExtensionHost? statusHost, string? displayName)
+    {
+        if (statusHost is null)
+        {
+            return null;
+        }
+
+        var name = string.IsNullOrWhiteSpace(displayName) ? "the extension" : displayName;
+        var message = new StatusMessage
+        {
+            Message = $"Waiting for you to finish signing in to {name} in your browser...",
+            State = MessageState.Info,
+        };
+
+        try
+        {
+            _ = statusHost.ShowStatus(message, StatusContext.Extension);
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+
+        return message;
+    }
+
+    private static void HideStatus(AppExtensionHost? statusHost, IStatusMessage? status)
+    {
+        if (statusHost is null || status is null)
+        {
+            return;
+        }
+
+        try
+        {
+            _ = statusHost.HideStatus(status);
+        }
+        catch (Exception)
+        {
+        }
+    }
+
+    /// <summary>Generate a 256-bit, URL-safe, single-use state token.</summary>
+    internal static string GenerateState()
+    {
+        var bytes = RandomNumberGenerator.GetBytes(32);
+        return Base64UrlEncode(bytes);
+    }
+
+    /// <summary>
+    /// Copy the extension-supplied parameters and inject the host-owned
+    /// <c>redirect_uri</c> and <c>state</c>. Any caller-supplied redirect_uri or
+    /// state is overwritten; the host owns those.
+    /// </summary>
+    internal static Dictionary<string, string> ComposeParameters(IAuthorizationRequest request, string redirectUri, string state)
+    {
+        var parameters = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        if (request.Parameters is not null)
+        {
+            foreach (var pair in request.Parameters)
+            {
+                parameters[pair.Key] = pair.Value;
+            }
+        }
+
+        parameters["redirect_uri"] = redirectUri;
+        parameters["state"] = state;
+        return parameters;
+    }
+
+    internal static string BuildAuthorizationUrl(string endpoint, IReadOnlyDictionary<string, string> parameters)
+    {
+        var builder = new StringBuilder(endpoint);
+        builder.Append(endpoint.Contains('?', StringComparison.Ordinal) ? '&' : '?');
+
+        var first = true;
+        foreach (var pair in parameters)
+        {
+            if (!first)
+            {
+                builder.Append('&');
+            }
+
+            first = false;
+            builder.Append(Uri.EscapeDataString(pair.Key));
+            builder.Append('=');
+            builder.Append(Uri.EscapeDataString(pair.Value));
+        }
+
+        return builder.ToString();
+    }
+
+    private static Dictionary<string, string> StripState(IReadOnlyDictionary<string, string> captured)
+    {
+        var response = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var pair in captured)
+        {
+            if (!string.Equals(pair.Key, "state", StringComparison.Ordinal))
+            {
+                response[pair.Key] = pair.Value;
+            }
+        }
+
+        return response;
+    }
+
+    private static string FormatProviderError(IReadOnlyDictionary<string, string> response)
+    {
+        var error = response.TryGetValue("error", out var e) ? e : "unknown_error";
+        if (response.TryGetValue("error_description", out var description) && !string.IsNullOrEmpty(description))
+        {
+            return $"The identity provider returned an error: {error} ({description}).";
+        }
+
+        return $"The identity provider returned an error: {error}.";
+    }
+
+    private static bool FixedTimeEquals(string? a, string b)
+    {
+        if (a is null)
+        {
+            return false;
+        }
+
+        var aBytes = Encoding.UTF8.GetBytes(a);
+        var bBytes = Encoding.UTF8.GetBytes(b);
+        if (aBytes.Length != bBytes.Length)
+        {
+            return false;
+        }
+
+        return CryptographicOperations.FixedTimeEquals(aBytes, bBytes);
+    }
+
+    private static string Base64UrlEncode(byte[] bytes) =>
+        Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+
+    private static IAuthorizationResult Success(string redirectUri, IReadOnlyDictionary<string, string> response) =>
+        new AuthorizationResult
+        {
+            IsSuccessful = true,
+            RedirectUri = redirectUri,
+            ResponseParameters = response,
+            Error = string.Empty,
+        };
+
+    private static IAuthorizationResult Failure(string error) =>
+        new AuthorizationResult
+        {
+            IsSuccessful = false,
+            RedirectUri = string.Empty,
+            ResponseParameters = new Dictionary<string, string>(),
+            Error = error,
+        };
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Auth/DefaultAuthBrokerPlatform.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Auth/DefaultAuthBrokerPlatform.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.CmdPal.UI.ViewModels.Auth;
+
+/// <summary>
+/// Fallback platform used until the UI layer registers a window-aware one (and
+/// in unit-test-free code paths). It can open the browser but cannot re-foreground
+/// the window, so <see cref="BringToForeground"/> is a no-op here.
+/// </summary>
+public sealed partial class DefaultAuthBrokerPlatform : IAuthBrokerPlatform
+{
+    public void LaunchBrowser(Uri authorizationUri)
+    {
+        ArgumentNullException.ThrowIfNull(authorizationUri);
+        _ = global::Windows.System.Launcher.LaunchUriAsync(authorizationUri);
+    }
+
+    public void BringToForeground()
+    {
+        // The UI layer registers a platform that can foreground the window; the
+        // fallback intentionally does nothing.
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Auth/IAuthBrokerPlatform.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Auth/IAuthBrokerPlatform.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Microsoft.CmdPal.UI.ViewModels.Auth;
+
+/// <summary>
+/// The UI-thread coupled pieces of the authorization broker: launching the
+/// system browser and re-foregrounding Command Palette once the redirect is
+/// captured. Kept behind an interface so the broker's state and lifecycle logic
+/// can be unit tested without a real browser or window.
+/// </summary>
+public interface IAuthBrokerPlatform
+{
+    /// <summary>Open the default browser to the authorization URL.</summary>
+    void LaunchBrowser(Uri authorizationUri);
+
+    /// <summary>Bring the Command Palette window back to the foreground.</summary>
+    void BringToForeground();
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Auth/ILoopbackRedirectListener.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Auth/ILoopbackRedirectListener.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.CmdPal.UI.ViewModels.Auth;
+
+/// <summary>
+/// A single-use loopback redirect target for an authorization flow. The broker
+/// allocates one of these per <see cref="AuthorizationRedirectKind.Loopback"/>
+/// request, hands the extension the resulting <see cref="RedirectUri"/>, and
+/// awaits the single browser redirect that carries the provider's response.
+/// </summary>
+public interface ILoopbackRedirectListener : IDisposable
+{
+    /// <summary>
+    /// The <c>redirect_uri</c> to advertise to the identity provider, e.g.
+    /// <c>http://127.0.0.1:{port}/</c>. Bound to the loopback interface only.
+    /// </summary>
+    string RedirectUri { get; }
+
+    /// <summary>
+    /// Wait for exactly one browser redirect to <see cref="RedirectUri"/> and
+    /// return its query parameters. Requests to any other path are answered and
+    /// ignored so the listener keeps waiting for the real callback.
+    /// </summary>
+    Task<IReadOnlyDictionary<string, string>> WaitForRedirectAsync(CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Creates <see cref="ILoopbackRedirectListener"/> instances. Abstracted so unit
+/// tests can substitute a listener that resolves a canned redirect without
+/// binding a socket.
+/// </summary>
+public interface ILoopbackRedirectListenerFactory
+{
+    ILoopbackRedirectListener Create();
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Auth/QueryStringParser.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Auth/QueryStringParser.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.CmdPal.UI.ViewModels.Auth;
+
+/// <summary>
+/// Parses an <c>application/x-www-form-urlencoded</c> query string (without the
+/// leading '?') into a case-sensitive dictionary. Later duplicate keys win.
+/// </summary>
+internal static class QueryStringParser
+{
+    public static Dictionary<string, string> Parse(string? query)
+    {
+        var result = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (string.IsNullOrEmpty(query))
+        {
+            return result;
+        }
+
+        foreach (var pair in query.Split('&', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var eq = pair.IndexOf('=');
+            string key;
+            string value;
+            if (eq < 0)
+            {
+                key = Decode(pair);
+                value = string.Empty;
+            }
+            else
+            {
+                key = Decode(pair[..eq]);
+                value = Decode(pair[(eq + 1)..]);
+            }
+
+            if (key.Length > 0)
+            {
+                result[key] = value;
+            }
+        }
+
+        return result;
+    }
+
+    private static string Decode(string value) =>
+        Uri.UnescapeDataString(value.Replace('+', ' '));
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Auth/TcpLoopbackRedirectListener.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Auth/TcpLoopbackRedirectListener.cs
@@ -1,0 +1,145 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.CmdPal.UI.ViewModels.Auth;
+
+/// <summary>
+/// A minimal single-request loopback HTTP server for capturing an OAuth
+/// redirect. It binds to <see cref="IPAddress.Loopback"/> (127.0.0.1) only,
+/// never to any external interface, on an ephemeral high port. It accepts
+/// connections until the browser hits the callback path, captures the query
+/// parameters, serves a small "you can return to Command Palette" page, and
+/// stops. Requests to any other path get a 404 so the listener keeps waiting.
+/// </summary>
+public sealed partial class TcpLoopbackRedirectListener : ILoopbackRedirectListener
+{
+    private const string LandingPageHtml =
+        "<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"utf-8\">" +
+        "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">" +
+        "<title>Command Palette</title></head>" +
+        "<body style=\"font-family:Segoe UI,system-ui,sans-serif;text-align:center;padding-top:64px\">" +
+        "<h2>Sign-in complete</h2>" +
+        "<p>You can close this tab and return to Command Palette.</p></body></html>";
+
+    private readonly TcpListener _listener;
+    private bool _disposed;
+
+    public TcpLoopbackRedirectListener()
+    {
+        // Bind to the loopback interface only. Never 0.0.0.0 / ::.
+        _listener = new TcpListener(IPAddress.Loopback, 0);
+        _listener.Start();
+        var port = ((IPEndPoint)_listener.LocalEndpoint).Port;
+        RedirectUri = $"http://127.0.0.1:{port}/";
+    }
+
+    public string RedirectUri { get; }
+
+    public async Task<IReadOnlyDictionary<string, string>> WaitForRedirectAsync(CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            using var client = await _listener.AcceptTcpClientAsync(cancellationToken).ConfigureAwait(false);
+            using var stream = client.GetStream();
+
+            var requestLine = await ReadRequestLineAsync(stream, cancellationToken).ConfigureAwait(false);
+            var (path, query) = ParseRequestTarget(requestLine);
+
+            // The advertised redirect_uri path is "/". Anything else (favicon,
+            // etc.) is not the callback, so answer 404 and keep listening.
+            if (!string.Equals(path, "/", StringComparison.Ordinal) || query.Count == 0)
+            {
+                await WriteResponseAsync(stream, 404, "text/plain", "Not found", cancellationToken).ConfigureAwait(false);
+                continue;
+            }
+
+            await WriteResponseAsync(stream, 200, "text/html; charset=utf-8", LandingPageHtml, cancellationToken).ConfigureAwait(false);
+            return query;
+        }
+    }
+
+    private static async Task<string> ReadRequestLineAsync(NetworkStream stream, CancellationToken cancellationToken)
+    {
+        var buffer = new byte[8192];
+        var sb = new StringBuilder();
+
+        while (sb.Length < buffer.Length)
+        {
+            var read = await stream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+            if (read == 0)
+            {
+                break;
+            }
+
+            sb.Append(Encoding.ASCII.GetString(buffer, 0, read));
+            var newline = sb.ToString().IndexOf('\n');
+            if (newline >= 0)
+            {
+                return sb.ToString(0, newline).TrimEnd('\r');
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private static (string Path, IReadOnlyDictionary<string, string> Query) ParseRequestTarget(string requestLine)
+    {
+        // "GET /?code=...&state=... HTTP/1.1"
+        var parts = requestLine.Split(' ');
+        var target = parts.Length >= 2 ? parts[1] : "/";
+
+        var queryIndex = target.IndexOf('?');
+        if (queryIndex < 0)
+        {
+            return (target, new Dictionary<string, string>());
+        }
+
+        var path = target[..queryIndex];
+        var query = QueryStringParser.Parse(target[(queryIndex + 1)..]);
+        return (path, query);
+    }
+
+    private static async Task WriteResponseAsync(NetworkStream stream, int statusCode, string contentType, string body, CancellationToken cancellationToken)
+    {
+        var bodyBytes = Encoding.UTF8.GetBytes(body);
+        var reason = statusCode == 200 ? "OK" : "Not Found";
+        var header =
+            $"HTTP/1.1 {statusCode} {reason}\r\n" +
+            $"Content-Type: {contentType}\r\n" +
+            $"Content-Length: {bodyBytes.Length}\r\n" +
+            "Connection: close\r\n\r\n";
+        var headerBytes = Encoding.ASCII.GetBytes(header);
+
+        await stream.WriteAsync(headerBytes, cancellationToken).ConfigureAwait(false);
+        await stream.WriteAsync(bodyBytes, cancellationToken).ConfigureAwait(false);
+        await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        try
+        {
+            _listener.Stop();
+        }
+        catch (Exception)
+        {
+        }
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Auth/TcpLoopbackRedirectListenerFactory.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Auth/TcpLoopbackRedirectListenerFactory.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Net.Sockets;
+
+namespace Microsoft.CmdPal.UI.ViewModels.Auth;
+
+/// <summary>
+/// Default <see cref="ILoopbackRedirectListenerFactory"/>. Produces listeners
+/// backed by a raw <see cref="TcpListener"/> so no HTTP.SYS URL ACL (and thus no
+/// elevation) is required inside the packaged Command Palette process.
+/// </summary>
+public sealed partial class TcpLoopbackRedirectListenerFactory : ILoopbackRedirectListenerFactory
+{
+    public ILoopbackRedirectListener Create() => new TcpLoopbackRedirectListener();
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/WindowAuthBrokerPlatform.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/WindowAuthBrokerPlatform.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using CommunityToolkit.Mvvm.Messaging;
+using Microsoft.CmdPal.UI.Messages;
+using Microsoft.CmdPal.UI.ViewModels.Auth;
+
+namespace Microsoft.CmdPal.UI.Helpers;
+
+/// <summary>
+/// Window-aware <see cref="IAuthBrokerPlatform"/>. Opens the system browser and
+/// re-foregrounds the Command Palette window (via the existing summon message)
+/// once the authorization redirect is captured.
+/// </summary>
+public sealed partial class WindowAuthBrokerPlatform : IAuthBrokerPlatform
+{
+    public void LaunchBrowser(Uri authorizationUri)
+    {
+        ArgumentNullException.ThrowIfNull(authorizationUri);
+        _ = global::Windows.System.Launcher.LaunchUriAsync(authorizationUri);
+    }
+
+    public void BringToForeground()
+    {
+        // Reuse the same summon path the tray icon and settings use to bring the
+        // window forward without navigating anywhere.
+        WeakReferenceMessenger.Default.Send<HotkeySummonMessage>(new(string.Empty, IntPtr.Zero));
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml.cs
@@ -140,6 +140,10 @@ public sealed partial class MainWindow : WindowEx,
             CommandPaletteHost.SetHostHwnd((ulong)_hwnd.Value);
         }
 
+        // Give the authorization broker a window-aware platform so it can open
+        // the browser and re-foreground Command Palette when a redirect lands.
+        ViewModels.Auth.AuthBrokerService.Instance.SetPlatform(new WindowAuthBrokerPlatform());
+
         // The HWND itself is borderless / transparent — the visible card lives inside
         // RootElement (CmdPalMainControl) and draws its own corners, border, shadow, and
         // backdrop via the SystemBackdropElement. The frame can be re-enabled via an
@@ -1416,6 +1420,20 @@ public sealed partial class MainWindow : WindowEx,
                         else if (uri.StartsWith("x-cmdpal://settings", StringComparison.OrdinalIgnoreCase))
                         {
                             WeakReferenceMessenger.Default.Send<OpenSettingsMessage>(new());
+                            return;
+                        }
+                        else if (uri.StartsWith("x-cmdpal://auth/callback", StringComparison.OrdinalIgnoreCase))
+                        {
+                            // OAuth redirect for a CustomScheme authorization flow.
+                            // Route it to the pending broker request by its state;
+                            // an unknown state is ignored. Never log the URI: it
+                            // can carry an authorization code.
+                            var handled = ViewModels.Auth.AuthBrokerService.Instance.TryCompleteCustomSchemeRedirect(uri);
+                            if (!handled)
+                            {
+                                Logger.LogWarning("Received an auth callback that did not match a pending request.");
+                            }
+
                             return;
                         }
                         else if (uri.StartsWith("x-cmdpal://reload", StringComparison.OrdinalIgnoreCase))

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/Auth/AuthBrokerServiceTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/Auth/AuthBrokerServiceTests.cs
@@ -1,0 +1,326 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CmdPal.UI.ViewModels.Auth;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CmdPal.UI.ViewModels.UnitTests.Auth;
+
+[TestClass]
+public sealed class AuthBrokerServiceTests
+{
+    private static readonly TimeSpan LongTimeout = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan MaxTimeout = TimeSpan.FromSeconds(300);
+
+    [TestMethod]
+    public void GenerateState_IsUrlSafeAndUnique()
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        for (var i = 0; i < 200; i++)
+        {
+            var state = AuthBrokerService.GenerateState();
+
+            // 32 bytes -> 43 base64url chars, comfortably above the 128-bit floor.
+            Assert.IsTrue(state.Length >= 22, $"state too short: {state.Length}");
+            foreach (var c in state)
+            {
+                var ok = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-' || c == '_';
+                Assert.IsTrue(ok, $"non-url-safe char '{c}' in state");
+            }
+
+            Assert.IsTrue(seen.Add(state), "state was not unique");
+        }
+    }
+
+    [TestMethod]
+    public void ComposeParameters_InjectsRedirectAndState_AndOverridesCallerValues()
+    {
+        var request = new AuthorizationRequest
+        {
+            Parameters = new Dictionary<string, string>
+            {
+                ["client_id"] = "abc",
+                ["scope"] = "openid profile",
+
+                // These must be overwritten; the host owns them.
+                ["redirect_uri"] = "http://evil.example/",
+                ["state"] = "caller-supplied",
+            },
+        };
+
+        var composed = AuthBrokerService.ComposeParameters(request, "http://127.0.0.1:5000/", "host-state");
+
+        Assert.AreEqual("abc", composed["client_id"]);
+        Assert.AreEqual("openid profile", composed["scope"]);
+        Assert.AreEqual("http://127.0.0.1:5000/", composed["redirect_uri"]);
+        Assert.AreEqual("host-state", composed["state"]);
+    }
+
+    [TestMethod]
+    public void BuildAuthorizationUrl_AppendsQueryAndEscapes()
+    {
+        var noQuery = AuthBrokerService.BuildAuthorizationUrl(
+            "https://idp.example/authorize",
+            new Dictionary<string, string> { ["scope"] = "a b", ["state"] = "x/y" });
+        Assert.IsTrue(noQuery.StartsWith("https://idp.example/authorize?", StringComparison.Ordinal));
+        Assert.IsTrue(noQuery.Contains("scope=a%20b", StringComparison.Ordinal));
+        Assert.IsTrue(noQuery.Contains("state=x%2Fy", StringComparison.Ordinal));
+
+        var withQuery = AuthBrokerService.BuildAuthorizationUrl(
+            "https://idp.example/authorize?foo=bar",
+            new Dictionary<string, string> { ["state"] = "z" });
+        Assert.IsTrue(withQuery.Contains("?foo=bar&state=z", StringComparison.Ordinal));
+    }
+
+    [TestMethod]
+    public async Task Loopback_HappyPath_ReturnsCode_StripsState_Foregrounds()
+    {
+        var platform = new RecordingPlatform();
+        var listener = new FakeListener
+        {
+            OnWait = _ =>
+            {
+                var state = QueryValue(platform.LaunchedUri!, "state");
+                return Task.FromResult<IReadOnlyDictionary<string, string>>(
+                    new Dictionary<string, string> { ["code"] = "abc123", ["state"] = state });
+            },
+        };
+        var broker = new AuthBrokerService(platform, new FakeFactory(listener), LongTimeout, MaxTimeout);
+
+        var result = await broker.RunFlowAsync(LoopbackRequest(), null, CancellationToken.None);
+
+        Assert.IsTrue(result.IsSuccessful, result.Error);
+        Assert.AreEqual(listener.RedirectUri, result.RedirectUri);
+        Assert.AreEqual("abc123", result.ResponseParameters["code"]);
+        Assert.IsFalse(result.ResponseParameters.ContainsKey("state"), "state should be stripped");
+        Assert.AreEqual(1, platform.ForegroundCount);
+        Assert.IsTrue(listener.Disposed, "listener should be disposed");
+
+        // The launched URL carries the host-injected redirect_uri.
+        Assert.AreEqual(listener.RedirectUri, QueryValue(platform.LaunchedUri!, "redirect_uri"));
+    }
+
+    [TestMethod]
+    public async Task Loopback_StateMismatch_Fails()
+    {
+        var platform = new RecordingPlatform();
+        var listener = new FakeListener
+        {
+            OnWait = _ => Task.FromResult<IReadOnlyDictionary<string, string>>(
+                new Dictionary<string, string> { ["code"] = "abc", ["state"] = "not-the-right-state" }),
+        };
+        var broker = new AuthBrokerService(platform, new FakeFactory(listener), LongTimeout, MaxTimeout);
+
+        var result = await broker.RunFlowAsync(LoopbackRequest(), null, CancellationToken.None);
+
+        Assert.IsFalse(result.IsSuccessful);
+        Assert.IsTrue(result.Error.Contains("state", StringComparison.OrdinalIgnoreCase));
+        Assert.AreEqual(0, platform.ForegroundCount);
+    }
+
+    [TestMethod]
+    public async Task Loopback_ProviderError_Fails()
+    {
+        var platform = new RecordingPlatform();
+        var listener = new FakeListener
+        {
+            OnWait = _ =>
+            {
+                var state = QueryValue(platform.LaunchedUri!, "state");
+                return Task.FromResult<IReadOnlyDictionary<string, string>>(
+                    new Dictionary<string, string> { ["error"] = "access_denied", ["state"] = state });
+            },
+        };
+        var broker = new AuthBrokerService(platform, new FakeFactory(listener), LongTimeout, MaxTimeout);
+
+        var result = await broker.RunFlowAsync(LoopbackRequest(), null, CancellationToken.None);
+
+        Assert.IsFalse(result.IsSuccessful);
+        Assert.IsTrue(result.Error.Contains("access_denied", StringComparison.Ordinal));
+    }
+
+    [TestMethod]
+    public async Task Loopback_Timeout_Fails()
+    {
+        var platform = new RecordingPlatform();
+        var listener = new FakeListener
+        {
+            OnWait = async ct =>
+            {
+                await Task.Delay(Timeout.Infinite, ct);
+                return new Dictionary<string, string>();
+            },
+        };
+        var broker = new AuthBrokerService(platform, new FakeFactory(listener), TimeSpan.FromMilliseconds(150), MaxTimeout);
+
+        var result = await broker.RunFlowAsync(LoopbackRequest(), null, CancellationToken.None);
+
+        Assert.IsFalse(result.IsSuccessful);
+        Assert.IsTrue(result.Error.Contains("timed out", StringComparison.OrdinalIgnoreCase), result.Error);
+    }
+
+    [TestMethod]
+    public async Task Loopback_Cancel_Fails()
+    {
+        var platform = new RecordingPlatform();
+        var listener = new FakeListener
+        {
+            OnWait = async ct =>
+            {
+                await Task.Delay(Timeout.Infinite, ct);
+                return new Dictionary<string, string>();
+            },
+        };
+        var broker = new AuthBrokerService(platform, new FakeFactory(listener), LongTimeout, MaxTimeout);
+
+        using var cts = new CancellationTokenSource();
+        var task = broker.RunFlowAsync(LoopbackRequest(), null, cts.Token);
+        Assert.IsTrue(platform.LaunchedSignal.Wait(TimeSpan.FromSeconds(5)));
+        cts.Cancel();
+
+        var result = await task;
+
+        Assert.IsFalse(result.IsSuccessful);
+        Assert.IsTrue(result.Error.Contains("canceled", StringComparison.OrdinalIgnoreCase), result.Error);
+    }
+
+    [TestMethod]
+    public async Task CancelAllFlows_CancelsInFlightLoopback()
+    {
+        var platform = new RecordingPlatform();
+        var listener = new FakeListener
+        {
+            OnWait = async ct =>
+            {
+                await Task.Delay(Timeout.Infinite, ct);
+                return new Dictionary<string, string>();
+            },
+        };
+        var broker = new AuthBrokerService(platform, new FakeFactory(listener), LongTimeout, MaxTimeout);
+
+        var task = broker.RunFlowAsync(LoopbackRequest(), null, CancellationToken.None);
+        Assert.IsTrue(platform.LaunchedSignal.Wait(TimeSpan.FromSeconds(5)));
+        broker.CancelAllFlows();
+
+        var result = await task;
+
+        Assert.IsFalse(result.IsSuccessful);
+        Assert.IsTrue(result.Error.Contains("shutting down", StringComparison.OrdinalIgnoreCase), result.Error);
+    }
+
+    [TestMethod]
+    public void CustomScheme_UnknownState_IsIgnored()
+    {
+        var broker = new AuthBrokerService(new RecordingPlatform(), new FakeFactory(new FakeListener()), LongTimeout, MaxTimeout);
+
+        var handled = broker.TryCompleteCustomSchemeRedirect("x-cmdpal://auth/callback?code=x&state=does-not-exist");
+
+        Assert.IsFalse(handled);
+    }
+
+    [TestMethod]
+    public async Task CustomScheme_HappyPath_RoutesByState_AndIsSingleUse()
+    {
+        var platform = new RecordingPlatform();
+        var broker = new AuthBrokerService(platform, new FakeFactory(new FakeListener()), LongTimeout, MaxTimeout);
+
+        var task = broker.RunFlowAsync(CustomSchemeRequest(), null, CancellationToken.None);
+        Assert.IsTrue(platform.LaunchedSignal.Wait(TimeSpan.FromSeconds(5)));
+
+        var state = QueryValue(platform.LaunchedUri!, "state");
+        Assert.AreEqual(AuthBrokerService.CustomSchemeRedirectUri, QueryValue(platform.LaunchedUri!, "redirect_uri"));
+
+        var handled = broker.TryCompleteCustomSchemeRedirect($"x-cmdpal://auth/callback?code=xyz&state={state}");
+        Assert.IsTrue(handled);
+
+        var result = await task;
+        Assert.IsTrue(result.IsSuccessful, result.Error);
+        Assert.AreEqual("xyz", result.ResponseParameters["code"]);
+        Assert.AreEqual(AuthBrokerService.CustomSchemeRedirectUri, result.RedirectUri);
+
+        // Single-use: a second activation for the same state is ignored.
+        var second = broker.TryCompleteCustomSchemeRedirect($"x-cmdpal://auth/callback?code=xyz&state={state}");
+        Assert.IsFalse(second);
+    }
+
+    private static AuthorizationRequest LoopbackRequest() => new()
+    {
+        DisplayName = "Test Provider",
+        AuthorizationEndpoint = "https://idp.example/authorize",
+        RedirectKind = AuthorizationRedirectKind.Loopback,
+        Parameters = new Dictionary<string, string> { ["client_id"] = "abc" },
+    };
+
+    private static AuthorizationRequest CustomSchemeRequest() => new()
+    {
+        DisplayName = "Test Provider",
+        AuthorizationEndpoint = "https://idp.example/authorize",
+        RedirectKind = AuthorizationRedirectKind.CustomScheme,
+        Parameters = new Dictionary<string, string> { ["client_id"] = "abc" },
+    };
+
+    private static string QueryValue(Uri uri, string key)
+    {
+        var query = uri.Query.StartsWith('?') ? uri.Query[1..] : uri.Query;
+        foreach (var pair in query.Split('&', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var eq = pair.IndexOf('=');
+            var k = eq < 0 ? pair : pair[..eq];
+            if (string.Equals(Uri.UnescapeDataString(k), key, StringComparison.Ordinal))
+            {
+                return eq < 0 ? string.Empty : Uri.UnescapeDataString(pair[(eq + 1)..]);
+            }
+        }
+
+        return string.Empty;
+    }
+
+    private sealed class RecordingPlatform : IAuthBrokerPlatform
+    {
+        public Uri? LaunchedUri { get; private set; }
+
+        public int ForegroundCount { get; private set; }
+
+        public ManualResetEventSlim LaunchedSignal { get; } = new(false);
+
+        public void LaunchBrowser(Uri authorizationUri)
+        {
+            LaunchedUri = authorizationUri;
+            LaunchedSignal.Set();
+        }
+
+        public void BringToForeground() => ForegroundCount++;
+    }
+
+    private sealed class FakeListener : ILoopbackRedirectListener
+    {
+        public string RedirectUri { get; set; } = "http://127.0.0.1:5000/";
+
+        public bool Disposed { get; private set; }
+
+        public Func<CancellationToken, Task<IReadOnlyDictionary<string, string>>>? OnWait { get; set; }
+
+        public Task<IReadOnlyDictionary<string, string>> WaitForRedirectAsync(CancellationToken cancellationToken)
+            => OnWait is null
+                ? Task.FromResult<IReadOnlyDictionary<string, string>>(new Dictionary<string, string>())
+                : OnWait(cancellationToken);
+
+        public void Dispose() => Disposed = true;
+    }
+
+    private sealed class FakeFactory : ILoopbackRedirectListenerFactory
+    {
+        private readonly ILoopbackRedirectListener _listener;
+
+        public FakeFactory(ILoopbackRedirectListener listener) => _listener = listener;
+
+        public ILoopbackRedirectListener Create() => _listener;
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/Auth/TcpLoopbackRedirectListenerTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/Auth/TcpLoopbackRedirectListenerTests.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CmdPal.UI.ViewModels.Auth;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CmdPal.UI.ViewModels.UnitTests.Auth;
+
+[TestClass]
+public sealed class TcpLoopbackRedirectListenerTests
+{
+    [TestMethod]
+    public void RedirectUri_BindsLoopbackOnly()
+    {
+        using var listener = new TcpLoopbackRedirectListener();
+        StringAssert.StartsWith(listener.RedirectUri, "http://127.0.0.1:");
+        StringAssert.EndsWith(listener.RedirectUri, "/");
+    }
+
+    [TestMethod]
+    public async Task WaitForRedirect_CapturesCallbackQuery_AndIgnoresOtherPaths()
+    {
+        using var listener = new TcpLoopbackRedirectListener();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+
+        var waitTask = listener.WaitForRedirectAsync(cts.Token);
+
+        using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+
+        // A non-callback path (e.g. favicon) must be answered and ignored so the
+        // listener keeps waiting for the real redirect.
+        try
+        {
+            await client.GetAsync(listener.RedirectUri + "favicon.ico", cts.Token);
+        }
+        catch (HttpRequestException)
+        {
+        }
+
+        Assert.IsFalse(waitTask.IsCompleted, "listener should still be waiting after a non-callback request");
+
+        // The real redirect on the callback path ("/").
+        var response = await client.GetAsync(listener.RedirectUri + "?code=abc123&state=xyz789", cts.Token);
+        Assert.IsTrue(response.IsSuccessStatusCode);
+
+        IReadOnlyDictionary<string, string> captured = await waitTask;
+        Assert.AreEqual("abc123", captured["code"]);
+        Assert.AreEqual("xyz789", captured["state"]);
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 of the Command Palette built-in OAuth authorization flow: the host-side redirect broker. This is the second of a stack of 4 draft PRs and targets the Phase 1 branch (`dev/mjolley/cmdpal-auth-flow`, #49440).

Command Palette acts as a thin, hardened redirect broker. It allocates the redirect target, injects a cryptographically random `state`, opens the browser, captures the single redirect, validates `state`, and hands the raw response parameters back to the extension. Command Palette never sees the PKCE verifier and never stores third-party tokens; the Toolkit's `OAuthClient` performs the code exchange inside the extension's process.

## What this adds

- `AuthBrokerService` (`Microsoft.CmdPal.UI.ViewModels/Auth`): 256-bit `state` generation with single-use, fixed-time validation; parameter composition (appends `redirect_uri` and `state`); loopback and custom-scheme flows; timeout (default 60s, cap 300s), cancellation, concurrency, and teardown handling; non-blocking status via the host. Auth codes and tokens are never logged.
- Loopback capture bound to `127.0.0.1` only via a raw `TcpListener`, so no HTTP.SYS URL ACL and no elevation are required inside the packaged process.
- Custom scheme `x-cmdpal://auth/callback` routed by `state` from `MainWindow.HandleLaunchNonUI`, reusing the existing single-instance protocol activation wiring.
- `AppExtensionHost` implements `IExtensionHost2.RequestAuthorizationAsync`, delegating to the broker.
- Testability seams (`IAuthBrokerPlatform`, `ILoopbackRedirectListenerFactory`) with a default platform and a UI platform that re-foregrounds the window on capture.

## Testing

- Build: `build.ps1 -Path src\modules\cmdpal -Platform x64 -Configuration Debug`, exit code 0.
- 14 new Auth unit tests (state generation, parameter composition and override, URL building, loopback happy path and state-mismatch and provider-error and timeout and cancel, cancel-all-flows, custom-scheme unknown-state and happy path and single-use), plus a real loopback TCP integration test.
- All CmdPal `*.UnitTests` projects pass with zero failures.

## Scope

Changes are limited to `src/modules/cmdpal` (CommandPalette.slnf). No XAML changed. Draft while the rest of the stack lands.
