### PR TITLE
[CmdPal] Add host-driven navigation (GoToPageAsync on IExtensionHost2)

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AppExtensionHost.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AppExtensionHost.cs
@@ -4,8 +4,11 @@
 
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using CommunityToolkit.Mvvm.Messaging;
 using Microsoft.CmdPal.Common;
 using Microsoft.CmdPal.UI.ViewModels.Auth;
+using Microsoft.CmdPal.UI.ViewModels.Messages;
+using Microsoft.CmdPal.UI.ViewModels.Models;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 using Windows.Foundation;
@@ -177,6 +180,41 @@ public abstract partial class AppExtensionHost : IExtensionHost, IExtensionHost2
     /// </summary>
     public IAsyncOperation<IAuthorizationResult> RequestAuthorizationAsync(IAuthorizationRequest request)
         => AuthBrokerService.Instance.RequestAuthorizationAsync(request, this);
+
+    /// <summary>
+    /// <see cref="IExtensionHost2"/>. Navigate Command Palette to a page owned by
+    /// the extension. Reuses the existing navigation pipeline: a
+    /// <see cref="PerformCommandMessage"/> with <see cref="PerformCommandMessage.ShowWindowIfPage"/>
+    /// set foregrounds the window and navigates when the command is a page. When
+    /// the mode is GoHome or GoBack, the stack is reset first via the matching
+    /// message. A null page is treated as a graceful no-op.
+    /// </summary>
+    public IAsyncAction GoToPageAsync(ICommand? page, NavigationMode navigationMode)
+    {
+        if (page is null)
+        {
+            return Task.CompletedTask.AsAsyncAction();
+        }
+
+        return Task.Run(() =>
+        {
+            switch (navigationMode)
+            {
+                case NavigationMode.GoHome:
+                    WeakReferenceMessenger.Default.Send<GoHomeMessage>(new(WithAnimation: false, FocusSearch: false));
+                    break;
+                case NavigationMode.GoBack:
+                    WeakReferenceMessenger.Default.Send<GoBackMessage>(new(WithAnimation: false, FocusSearch: false));
+                    break;
+                case NavigationMode.Push:
+                default:
+                    break;
+            }
+
+            WeakReferenceMessenger.Default.Send<PerformCommandMessage>(
+                new(new ExtensionObject<ICommand>(page)) { ShowWindowIfPage = true });
+        }).AsAsyncAction();
+    }
 
     public abstract string? GetExtensionDisplayName();
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AppExtensionHost.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AppExtensionHost.cs
@@ -12,6 +12,7 @@ using Microsoft.CmdPal.UI.ViewModels.Models;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 using Windows.Foundation;
+using DispatcherQueue = Microsoft.UI.Dispatching.DispatcherQueue;
 
 namespace Microsoft.CmdPal.UI.ViewModels;
 
@@ -30,6 +31,8 @@ public abstract partial class AppExtensionHost : IExtensionHost, IExtensionHost2
     public ObservableCollection<StatusMessageViewModel> StatusMessages { get; } = [];
 
     public static void SetHostHwnd(ulong hostHwnd) => _hostingHwnd = hostHwnd;
+
+    public static void SetUiDispatcherQueue(DispatcherQueue queue) => UiDispatcher.Queue = queue;
 
     public void DebugLog(string message)
     {
@@ -196,7 +199,7 @@ public abstract partial class AppExtensionHost : IExtensionHost, IExtensionHost2
             return Task.CompletedTask.AsAsyncAction();
         }
 
-        return Task.Run(() =>
+        void SendNavigation()
         {
             switch (navigationMode)
             {
@@ -213,10 +216,56 @@ public abstract partial class AppExtensionHost : IExtensionHost, IExtensionHost2
 
             WeakReferenceMessenger.Default.Send<PerformCommandMessage>(
                 new(new ExtensionObject<ICommand>(page)) { ShowWindowIfPage = true });
-        }).AsAsyncAction();
+        }
+
+        // PerformCommand (the receiver of PerformCommandMessage) is UI-thread affine:
+        // it creates page view models and drives frame navigation. Extensions call
+        // this method from their own (non-UI) thread, so marshal the sends onto the
+        // UI thread. When there is no registered dispatcher (unit tests) or we are
+        // already on the UI thread, run inline so behavior and the returned action
+        // complete synchronously.
+        var dispatcher = UiDispatcher.Queue;
+        if (dispatcher is null || dispatcher.HasThreadAccess)
+        {
+            SendNavigation();
+            return Task.CompletedTask.AsAsyncAction();
+        }
+
+        var tcs = new TaskCompletionSource();
+        if (!dispatcher.TryEnqueue(() =>
+            {
+                try
+                {
+                    SendNavigation();
+                    tcs.TrySetResult();
+                }
+                catch (Exception ex)
+                {
+                    tcs.TrySetException(ex);
+                }
+            }))
+        {
+            // Enqueue failed (e.g. dispatcher shutting down); fall back to inline so
+            // the caller's await is never left hanging.
+            SendNavigation();
+            tcs.TrySetResult();
+        }
+
+        return tcs.Task.AsAsyncAction();
     }
 
     public abstract string? GetExtensionDisplayName();
+
+    // Holds the UI DispatcherQueue in a dedicated nested type so that reading it
+    // from GoToPageAsync does not force AppExtensionHost's static initializer to
+    // run. That initializer builds a GlobalLogPageContext, which captures the
+    // current SynchronizationContext, so forcing it on a non-UI thread (as in the
+    // headless unit tests) would throw. Keeping the queue here lets the inline
+    // navigation path run without touching that initializer.
+    private static class UiDispatcher
+    {
+        public static DispatcherQueue? Queue { get; set; }
+    }
 }
 
 public interface IAppHostService

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml.cs
@@ -140,6 +140,10 @@ public sealed partial class MainWindow : WindowEx,
             CommandPaletteHost.SetHostHwnd((ulong)_hwnd.Value);
         }
 
+        // Give host-driven navigation (GoToPageAsync) the UI dispatcher so it can
+        // marshal onto the UI thread when an extension calls it from a background thread.
+        CommandPaletteHost.SetUiDispatcherQueue(this.DispatcherQueue);
+
         // Give the authorization broker a window-aware platform so it can open
         // the browser and re-foreground Command Palette when a redirect lands.
         ViewModels.Auth.AuthBrokerService.Instance.SetPlatform(new WindowAuthBrokerPlatform());

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/Auth/AppExtensionHostNavigationTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/Auth/AppExtensionHostNavigationTests.cs
@@ -1,0 +1,136 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.Messaging;
+using Microsoft.CmdPal.UI.ViewModels.Messages;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CmdPal.UI.ViewModels.UnitTests.Auth;
+
+[TestClass]
+public sealed partial class AppExtensionHostNavigationTests
+{
+    private sealed partial class TestAppExtensionHost : AppExtensionHost
+    {
+        public override string? GetExtensionDisplayName() => "Test Host";
+    }
+
+    // A minimal page so the recipient can confirm the exact command was wrapped.
+    private sealed partial class TestPage : Command
+    {
+    }
+
+    [TestMethod]
+    public async Task GoToPageAsync_Push_SendsPerformCommandWithShowWindow()
+    {
+        var recipient = new object();
+        PerformCommandMessage? received = null;
+        var homeOrBackSent = false;
+
+        WeakReferenceMessenger.Default.Register<PerformCommandMessage>(recipient, (_, m) => received = m);
+        WeakReferenceMessenger.Default.Register<GoHomeMessage>(recipient, (_, _) => homeOrBackSent = true);
+        WeakReferenceMessenger.Default.Register<GoBackMessage>(recipient, (_, _) => homeOrBackSent = true);
+
+        try
+        {
+            var host = new TestAppExtensionHost();
+            var page = new TestPage();
+
+            await host.GoToPageAsync(page, NavigationMode.Push);
+
+            Assert.IsNotNull(received, "PerformCommandMessage was not sent");
+            Assert.IsTrue(received!.ShowWindowIfPage, "ShowWindowIfPage should be set");
+            Assert.AreSame(page, received.Command.Unsafe, "the wrapped command should be the supplied page");
+            Assert.IsFalse(homeOrBackSent, "Push must not reset the navigation stack");
+        }
+        finally
+        {
+            WeakReferenceMessenger.Default.UnregisterAll(recipient);
+        }
+    }
+
+    [TestMethod]
+    public async Task GoToPageAsync_GoHome_SendsGoHomeThenPerformCommand()
+    {
+        var recipient = new object();
+        var goHomeSent = false;
+        var goBackSent = false;
+        var performSent = false;
+
+        WeakReferenceMessenger.Default.Register<GoHomeMessage>(recipient, (_, _) => goHomeSent = true);
+        WeakReferenceMessenger.Default.Register<GoBackMessage>(recipient, (_, _) => goBackSent = true);
+        WeakReferenceMessenger.Default.Register<PerformCommandMessage>(recipient, (_, _) => performSent = true);
+
+        try
+        {
+            var host = new TestAppExtensionHost();
+
+            await host.GoToPageAsync(new TestPage(), NavigationMode.GoHome);
+
+            Assert.IsTrue(goHomeSent, "GoHomeMessage should be sent for GoHome mode");
+            Assert.IsFalse(goBackSent, "GoBackMessage should not be sent for GoHome mode");
+            Assert.IsTrue(performSent, "PerformCommandMessage should still be sent");
+        }
+        finally
+        {
+            WeakReferenceMessenger.Default.UnregisterAll(recipient);
+        }
+    }
+
+    [TestMethod]
+    public async Task GoToPageAsync_GoBack_SendsGoBackThenPerformCommand()
+    {
+        var recipient = new object();
+        var goHomeSent = false;
+        var goBackSent = false;
+        var performSent = false;
+
+        WeakReferenceMessenger.Default.Register<GoHomeMessage>(recipient, (_, _) => goHomeSent = true);
+        WeakReferenceMessenger.Default.Register<GoBackMessage>(recipient, (_, _) => goBackSent = true);
+        WeakReferenceMessenger.Default.Register<PerformCommandMessage>(recipient, (_, _) => performSent = true);
+
+        try
+        {
+            var host = new TestAppExtensionHost();
+
+            await host.GoToPageAsync(new TestPage(), NavigationMode.GoBack);
+
+            Assert.IsTrue(goBackSent, "GoBackMessage should be sent for GoBack mode");
+            Assert.IsFalse(goHomeSent, "GoHomeMessage should not be sent for GoBack mode");
+            Assert.IsTrue(performSent, "PerformCommandMessage should still be sent");
+        }
+        finally
+        {
+            WeakReferenceMessenger.Default.UnregisterAll(recipient);
+        }
+    }
+
+    [TestMethod]
+    public async Task GoToPageAsync_NullPage_IsGracefulNoOp()
+    {
+        var recipient = new object();
+        var anySent = false;
+
+        WeakReferenceMessenger.Default.Register<PerformCommandMessage>(recipient, (_, _) => anySent = true);
+        WeakReferenceMessenger.Default.Register<GoHomeMessage>(recipient, (_, _) => anySent = true);
+        WeakReferenceMessenger.Default.Register<GoBackMessage>(recipient, (_, _) => anySent = true);
+
+        try
+        {
+            var host = new TestAppExtensionHost();
+
+            await host.GoToPageAsync(null, NavigationMode.Push);
+
+            Assert.IsFalse(anySent, "a null page should not send any navigation message");
+        }
+        finally
+        {
+            WeakReferenceMessenger.Default.UnregisterAll(recipient);
+        }
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CommandPalette.Extensions.Toolkit.UnitTests/Auth/ExtensionHostNavigationTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CommandPalette.Extensions.Toolkit.UnitTests/Auth/ExtensionHostNavigationTests.cs
@@ -1,0 +1,111 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.Foundation;
+
+namespace Microsoft.CommandPalette.Extensions.Toolkit.UnitTests.Auth;
+
+[TestClass]
+public class ExtensionHostNavigationTests
+{
+    // A host that implements only IExtensionHost (no IExtensionHost2), i.e. an
+    // older Command Palette that predates host-driven navigation.
+    private sealed class LegacyHost : IExtensionHost
+    {
+        public IAsyncAction ShowStatus(IStatusMessage message, StatusContext context) => null!;
+
+        public IAsyncAction HideStatus(IStatusMessage message) => null!;
+
+        public IAsyncAction LogMessage(ILogMessage message) => null!;
+    }
+
+    // A host that supports navigation and records what it was asked to do.
+    private sealed class NavigatingHost : IExtensionHost2
+    {
+        public ICommand? LastPage { get; private set; }
+
+        public NavigationMode LastMode { get; private set; }
+
+        public int GoToPageCallCount { get; private set; }
+
+        public IAsyncAction ShowStatus(IStatusMessage message, StatusContext context) => null!;
+
+        public IAsyncAction HideStatus(IStatusMessage message) => null!;
+
+        public IAsyncAction LogMessage(ILogMessage message) => null!;
+
+        public IAsyncOperation<IAuthorizationResult> RequestAuthorizationAsync(IAuthorizationRequest request) => null!;
+
+        public IAsyncAction GoToPageAsync(ICommand page, NavigationMode navigationMode)
+        {
+            LastPage = page;
+            LastMode = navigationMode;
+            GoToPageCallCount++;
+            return Task.CompletedTask.AsAsyncAction();
+        }
+    }
+
+    [TestMethod]
+    public void SupportsNavigation_FalseForLegacyHost()
+    {
+        ExtensionHost.Initialize(new LegacyHost());
+
+        Assert.IsFalse(ExtensionHost.SupportsNavigation);
+    }
+
+    [TestMethod]
+    public void SupportsNavigation_TrueForHost2()
+    {
+        ExtensionHost.Initialize(new NavigatingHost());
+
+        Assert.IsTrue(ExtensionHost.SupportsNavigation);
+    }
+
+    [TestMethod]
+    public async Task GoToPageAsync_LegacyHost_ThrowsNotSupported()
+    {
+        ExtensionHost.Initialize(new LegacyHost());
+
+        await Assert.ThrowsExceptionAsync<System.NotSupportedException>(
+            () => ExtensionHost.GoToPageAsync(new Command()));
+    }
+
+    [TestMethod]
+    public async Task GoToPageAsync_NullPage_ThrowsArgumentNull()
+    {
+        ExtensionHost.Initialize(new NavigatingHost());
+
+        await Assert.ThrowsExceptionAsync<System.ArgumentNullException>(
+            () => ExtensionHost.GoToPageAsync(null!));
+    }
+
+    [TestMethod]
+    public async Task GoToPageAsync_ForwardsPageAndMode()
+    {
+        var host = new NavigatingHost();
+        ExtensionHost.Initialize(host);
+
+        var page = new Command();
+
+        await ExtensionHost.GoToPageAsync(page, NavigationMode.GoHome);
+
+        Assert.AreEqual(1, host.GoToPageCallCount);
+        Assert.AreSame(page, host.LastPage);
+        Assert.AreEqual(NavigationMode.GoHome, host.LastMode);
+    }
+
+    [TestMethod]
+    public async Task GoToPageAsync_DefaultsToPush()
+    {
+        var host = new NavigatingHost();
+        ExtensionHost.Initialize(host);
+
+        await ExtensionHost.GoToPageAsync(new Command());
+
+        Assert.AreEqual(NavigationMode.Push, host.LastMode);
+    }
+}

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/ExtensionHost.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/ExtensionHost.cs
@@ -122,4 +122,36 @@ public partial class ExtensionHost
             return await operation;
         }
     }
+
+    /// <summary>
+    /// True when the connected host supports host-driven navigation
+    /// (i.e. it implements <see cref="IExtensionHost2"/>). This is the same
+    /// capability that gates authorization. Older Command Palette versions
+    /// return false.
+    /// </summary>
+    public static bool SupportsNavigation => Host is IExtensionHost2;
+
+    /// <summary>
+    /// Ask Command Palette to navigate to one of this extension's pages (for
+    /// example, right after a successful sign-in). The host summons its window
+    /// and navigates to the supplied page.
+    /// </summary>
+    /// <param name="page">The page to navigate to. Typically an <c>IPage</c>.</param>
+    /// <param name="navigationMode">Controls navigation stack behavior.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="page"/> is null.</exception>
+    /// <exception cref="NotSupportedException">
+    /// The connected host does not implement <see cref="IExtensionHost2"/>.
+    /// </exception>
+    public static async Task GoToPageAsync(ICommand page, NavigationMode navigationMode = NavigationMode.Push)
+    {
+        ArgumentNullException.ThrowIfNull(page);
+
+        if (Host is not IExtensionHost2 host2)
+        {
+            throw new NotSupportedException(
+                "The Command Palette host does not support navigation. Update Command Palette to a newer version.");
+        }
+
+        await host2.GoToPageAsync(page, navigationMode);
+    }
 }

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions/Microsoft.CommandPalette.Extensions.idl
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions/Microsoft.CommandPalette.Extensions.idl
@@ -315,6 +315,12 @@ namespace Microsoft.CommandPalette.Extensions
         // re-foregrounds Command Palette, and returns the captured parameters.
         // The returned operation is cancelable.
         Windows.Foundation.IAsyncOperation<IAuthorizationResult> RequestAuthorizationAsync(IAuthorizationRequest request);
+
+        // Navigate Command Palette to a page provided by this extension. `page`
+        // is a live page object owned by the extension (typically an IPage). The
+        // host summons its window and navigates to that page. navigationMode
+        // controls stack behavior (Push / GoBack then Push / GoHome then Push).
+        Windows.Foundation.IAsyncAction GoToPageAsync(ICommand page, NavigationMode navigationMode);
     };
     
     [contract(Microsoft.CommandPalette.Extensions.ExtensionsContract, 1)]


### PR DESCRIPTION
## Summary
Phase 3 of the built-in Command Palette auth feature: host-driven navigation. An extension can ask Command Palette to navigate to one of its own pages (typically right after a successful sign-in) via a new `GoToPageAsync` member on the existing `IExtensionHost2` interface. There is no `IExtensionHost3`; the whole feature ships as one atomic stack, so the method lives on the same `IExtensionHost2` that carries `RequestAuthorizationAsync`.

## Changes
- **SDK IDL**: add `Windows.Foundation.IAsyncAction GoToPageAsync(ICommand page, NavigationMode navigationMode)` to `IExtensionHost2` (contract v1, no version bump; `NavigationMode` enum already existed).
- **Host** (`AppExtensionHost.GoToPageAsync`): reuse the existing navigation pipeline. Send a `PerformCommandMessage` with `ShowWindowIfPage = true` (which foregrounds the window and navigates when the command is a page), preceded by `GoHomeMessage` / `GoBackMessage` for the GoHome / GoBack modes. A null page is a graceful no-op.
- **Toolkit** (`ExtensionHost`): add `GoToPageAsync(ICommand page, NavigationMode navigationMode = NavigationMode.Push)` and `SupportsNavigation => Host is IExtensionHost2`, mirroring the existing `RequestAuthorizationAsync` / `SupportsAuthorization` helper (`NotSupportedException` on legacy host, `ArgumentNullException` on null; AOT/trim safe).
- **Tests**: Toolkit fake-host tests (capability true/false, `NotSupportedException`, `ArgumentNullException`, arg forwarding) plus host ViewModels tests asserting the correct messages are sent for Push / GoHome / GoBack and that a null page sends nothing.

## Validation
- Build: `build.ps1 -Path src\modules\cmdpal -Platform x64 -Configuration Debug` exit code 0.
- All CmdPal `*.UnitTests` run with zero failures (WindowWalker is an empty placeholder project with no tests).

Stacked on `dev/mjolley/cmdpal-auth-broker` (Phase 2). Draft.
