### PR TITLE
ZoomIt: Add DemoMirror to mirror a monitor, region, or window to a second display

### DIFF
--- a/src/modules/ZoomIt/ZoomIt/CaptureFrameWait.cpp
+++ b/src/modules/ZoomIt/ZoomIt/CaptureFrameWait.cpp
@@ -33,7 +33,8 @@ namespace util
 CaptureFrameWait::CaptureFrameWait(
     winrt::IDirect3DDevice const& device,
     winrt::GraphicsCaptureItem const& item,
-    winrt::SizeInt32 const& size)
+    winrt::SizeInt32 const& size,
+    bool borderRequired)
 {
     m_device = device;
     m_item = item;
@@ -48,6 +49,11 @@ CaptureFrameWait::CaptureFrameWait(
         1,
         size);
     m_session = m_framePool.CreateCaptureSession(m_item);
+
+    if( !borderRequired )
+    {
+        ShowCaptureBorder( false );
+    }
 
     m_framePool.FrameArrived({ this, &CaptureFrameWait::OnFrameArrived });
     m_session.StartCapture();

--- a/src/modules/ZoomIt/ZoomIt/CaptureFrameWait.h
+++ b/src/modules/ZoomIt/ZoomIt/CaptureFrameWait.h
@@ -100,10 +100,14 @@ struct CaptureFrame
 class CaptureFrameWait
 {
 public:
+    // borderRequired false suppresses the system capture border before the
+    // session starts; the process must already hold borderless capture
+    // access for it to take effect.
     CaptureFrameWait(
         winrt::Direct3D11::IDirect3DDevice const& device,
         winrt::GraphicsCaptureItem const& item,
-        winrt::SizeInt32 const& size );
+        winrt::SizeInt32 const& size,
+        bool borderRequired = true );
     ~CaptureFrameWait();
 
     std::optional<CaptureFrame> TryGetNextFrame();

--- a/src/modules/ZoomIt/ZoomIt/CaptureFrameWait.h
+++ b/src/modules/ZoomIt/ZoomIt/CaptureFrameWait.h
@@ -124,6 +124,11 @@ public:
             m_session.IsBorderRequired( show );
         }
     }
+    void RecreateFramePool( winrt::SizeInt32 const& size )
+    {
+        auto lock = m_lock.lock_exclusive();
+        m_framePool.Recreate( m_device, winrt::DirectXPixelFormat::B8G8R8A8UIntNormalized, 1, size );
+    }
 
 private:
     void OnFrameArrived(

--- a/src/modules/ZoomIt/ZoomIt/MirrorWindow.cpp
+++ b/src/modules/ZoomIt/ZoomIt/MirrorWindow.cpp
@@ -16,6 +16,11 @@
 #include "pch.h"
 #include "MirrorWindow.h"
 
+namespace util
+{
+    using namespace robmikh::common::desktop;
+}
+
 const float MIRROR_ZOOM_MAX = 8.0f;
 const float MIRROR_ZOOM_ANIMATION_STEP = 0.3f;
 const float MIRROR_PAN_ANIMATION_STEP = 0.25f;
@@ -44,7 +49,8 @@ static RECT GetMonitorRect( HMONITOR monitor )
 //----------------------------------------------------------------------------
 bool MirrorWindow::Start( winrt::GraphicsCaptureItem const& item, RECT sourceRect,
                           HWND sourceWindow, HMONITOR sourceMonitor,
-                          HMONITOR targetMonitor, HWND notifyWindow )
+                          HMONITOR targetMonitor, HWND notifyWindow,
+                          std::function<AnnotationState()> annotationQuery )
 {
     if( IsActive() )
     {
@@ -54,6 +60,9 @@ bool MirrorWindow::Start( winrt::GraphicsCaptureItem const& item, RECT sourceRec
     m_sourceRect = sourceRect;
     m_sourceWindow = sourceWindow;
     m_notifyWindow = notifyWindow;
+    m_annotationQuery = annotationQuery;
+    m_annotationState = AnnotationState::None;
+    m_monitorOverride = false;
     m_zoom = 1.0f;
     m_zoomTarget = 1.0f;
     m_sourceTexture = nullptr;
@@ -247,6 +256,112 @@ void MirrorWindow::Stop()
     m_winrtDevice = nullptr;
     m_sourceWindow = nullptr;
     m_notifyWindow = nullptr;
+    m_annotationQuery = nullptr;
+    m_annotationState = AnnotationState::None;
+    m_monitorOverride = false;
+}
+
+//----------------------------------------------------------------------------
+//
+// MirrorWindow::SwitchCapture
+//
+// Replaces the capture source mid-mirror, resizing the swapchain to the new
+// content size and re-fitting the mirror window.
+//
+//----------------------------------------------------------------------------
+bool MirrorWindow::SwitchCapture( winrt::GraphicsCaptureItem const& item, bool enableCursor )
+{
+    try
+    {
+        auto frameWait = std::make_unique<CaptureFrameWait>( m_winrtDevice, item, item.Size() );
+        frameWait->EnableCursorCapture( enableCursor );
+        frameWait->ShowCaptureBorder( false );
+        m_frameWait->StopCapture();
+        m_frameWait = std::move( frameWait );
+    }
+    catch( ... )
+    {
+        return false;
+    }
+
+    m_poolSize = item.Size();
+    m_bufferWidth = m_poolSize.Width;
+    m_bufferHeight = m_poolSize.Height;
+    m_contentSize = m_poolSize;
+    m_sourceTexture = nullptr;
+    if( FAILED( m_swapChain->ResizeBuffers( 2, m_bufferWidth, m_bufferHeight,
+                                            DXGI_FORMAT_B8G8R8A8_UNORM, 0 ) ) )
+    {
+        return false;
+    }
+    PostMessage( m_window, WM_MIRROR_RELAYOUT, 0, 0 );
+    return true;
+}
+
+//----------------------------------------------------------------------------
+//
+// MirrorWindow::UpdateAnnotationState
+//
+// While mirroring a window, ZoomIt's zoom/draw/live-zoom overlays aren't
+// part of the window's surface, so they wouldn't show in the mirror. When
+// one of those modes activates, temporarily mirror the monitor under the
+// cursor (where the annotation UI appears) instead, and switch back to the
+// window when the mode exits. Returns true when the capture was switched so
+// the caller can discard the frame from the previous capture.
+//
+//----------------------------------------------------------------------------
+bool MirrorWindow::UpdateAnnotationState()
+{
+    const AnnotationState state = m_annotationQuery();
+    if( state == m_annotationState )
+    {
+        return false;
+    }
+    bool switched = false;
+
+    if( state == AnnotationState::None )
+    {
+        if( IsWindow( m_sourceWindow ) )
+        {
+            try
+            {
+                auto item = util::CreateCaptureItemForWindow( m_sourceWindow );
+                if( SwitchCapture( item, true ) )
+                {
+                    m_monitorOverride = false;
+                    switched = true;
+                }
+            }
+            catch( ... ) {}
+        }
+    }
+    else if( !m_monitorOverride )
+    {
+        POINT cursorPos;
+        GetCursorPos( &cursorPos );
+        HMONITOR monitor = MonitorFromPoint( cursorPos, MONITOR_DEFAULTTONEAREST );
+        try
+        {
+            auto item = util::CreateCaptureItemForMonitor( monitor );
+
+            // Live zoom already renders a magnified cursor into the frame;
+            // capturing the cursor too would double it.
+            if( SwitchCapture( item, state != AnnotationState::AnnotatingLiveZoom ) )
+            {
+                m_overrideRect = GetMonitorRect( monitor );
+                m_monitorOverride = true;
+                switched = true;
+            }
+        }
+        catch( ... ) {}
+    }
+    else
+    {
+        // Already mirroring the monitor; just track the cursor-capture state.
+        m_frameWait->EnableCursorCapture( state != AnnotationState::AnnotatingLiveZoom );
+    }
+    m_annotationState = state;
+    return switched;
 }
 
 //----------------------------------------------------------------------------
@@ -356,12 +471,27 @@ void MirrorWindow::RenderLoop()
             break;
         }
 
+        // Stop if the mirrored window went away.
+        if( m_sourceWindow != nullptr && !IsWindow( m_sourceWindow ) )
+        {
+            PostMessage( m_notifyWindow, WM_USER_MIRROR_STOP, 0, 0 );
+            break;
+        }
+
+        // Switch between window and monitor capture as ZoomIt annotation
+        // modes come and go. On a switch, discard any frame from the
+        // previous capture.
+        if( m_sourceWindow != nullptr && m_annotationQuery && UpdateAnnotationState() )
+        {
+            continue;
+        }
+
         if( frame )
         {
             // A mirrored window can resize; recreate the frame pool, cache
             // texture, and swapchain at the new content size and re-fit the
             // mirror window to the new aspect ratio.
-            if( m_sourceWindow != nullptr &&
+            if( m_sourceWindow != nullptr && !m_monitorOverride &&
                 frame->ContentSize.Width > 0 && frame->ContentSize.Height > 0 &&
                 ( frame->ContentSize.Width != m_poolSize.Width ||
                   frame->ContentSize.Height != m_poolSize.Height ))
@@ -383,10 +513,20 @@ void MirrorWindow::RenderLoop()
             }
 
             auto frameTexture = GetDXGIInterfaceFromObject<ID3D11Texture2D>( frame->FrameTexture );
+            D3D11_TEXTURE2D_DESC textureDesc;
+            frameTexture->GetDesc( &textureDesc );
+            if( m_sourceTexture != nullptr )
+            {
+                // The cached copy must match the frame exactly for CopyResource.
+                D3D11_TEXTURE2D_DESC cachedDesc;
+                m_sourceTexture->GetDesc( &cachedDesc );
+                if( cachedDesc.Width != textureDesc.Width || cachedDesc.Height != textureDesc.Height )
+                {
+                    m_sourceTexture = nullptr;
+                }
+            }
             if( m_sourceTexture == nullptr )
             {
-                D3D11_TEXTURE2D_DESC textureDesc;
-                frameTexture->GetDesc( &textureDesc );
                 textureDesc.Usage = D3D11_USAGE_DEFAULT;
                 textureDesc.BindFlags = 0;
                 textureDesc.CPUAccessFlags = 0;
@@ -398,13 +538,6 @@ void MirrorWindow::RenderLoop()
             }
             m_context->CopyResource( m_sourceTexture.get(), frameTexture.get() );
             m_contentSize = frame->ContentSize;
-        }
-        else if( m_sourceWindow != nullptr && !IsWindow( m_sourceWindow ) )
-        {
-            // The mirrored window closed; have the main window stop
-            // mirroring, since this window belongs to its thread.
-            PostMessage( m_notifyWindow, WM_USER_MIRROR_STOP, 0, 0 );
-            break;
         }
 
         if( m_sourceTexture != nullptr )
@@ -439,9 +572,10 @@ void MirrorWindow::RenderFrame()
     m_sourceTexture->GetDesc( &sourceDesc );
 
     // The mirrored region in texture coordinates, clamped to the captured
-    // content, which changes when a mirrored window resizes.
+    // content, which changes when a mirrored window resizes. Window and
+    // monitor-override captures mirror the full captured content.
     RECT crop = m_textureCrop;
-    if( m_sourceWindow != nullptr )
+    if( m_monitorOverride || m_sourceWindow != nullptr )
     {
         SetRect( &crop, 0, 0, m_contentSize.Width, m_contentSize.Height );
     }
@@ -467,7 +601,12 @@ void MirrorWindow::RenderFrame()
         POINT cursorPos;
         if( GetCursorPos( &cursorPos ) )
         {
-            if( m_sourceWindow != nullptr )
+            if( m_monitorOverride )
+            {
+                desiredX = static_cast<float>( cursorPos.x - m_overrideRect.left );
+                desiredY = static_cast<float>( cursorPos.y - m_overrideRect.top );
+            }
+            else if( m_sourceWindow != nullptr )
             {
                 RECT windowRect;
                 if( GetWindowRect( m_sourceWindow, &windowRect ) &&

--- a/src/modules/ZoomIt/ZoomIt/MirrorWindow.cpp
+++ b/src/modules/ZoomIt/ZoomIt/MirrorWindow.cpp
@@ -134,6 +134,18 @@ bool MirrorWindow::Start( winrt::GraphicsCaptureItem const& item, RECT sourceRec
             THROW_LAST_ERROR_IF( GetLastError() != ERROR_CLASS_ALREADY_EXISTS );
         }
 
+        // Full-monitor black backdrop behind the mirror so letterbox areas
+        // don't show the presentation. Created first so the mirror window,
+        // created after it, starts out above it.
+        m_backdropWindow = CreateWindowExW( WS_EX_TOPMOST | WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE | WS_EX_TRANSPARENT,
+                                            m_className, L"ZoomIt DemoMirror Backdrop", WS_POPUP,
+                                            m_targetRect.left, m_targetRect.top,
+                                            m_targetRect.right - m_targetRect.left,
+                                            m_targetRect.bottom - m_targetRect.top,
+                                            nullptr, nullptr, GetModuleHandle( nullptr ), nullptr );
+        THROW_LAST_ERROR_IF_NULL( m_backdropWindow );
+        SetWindowDisplayAffinity( m_backdropWindow, WDA_EXCLUDEFROMCAPTURE );
+
         // No activation and click-through: the mirror is display-only and
         // must never steal focus from the demo app.
         m_window = CreateWindowExW( WS_EX_TOPMOST | WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE | WS_EX_TRANSPARENT,
@@ -176,6 +188,7 @@ bool MirrorWindow::Start( winrt::GraphicsCaptureItem const& item, RECT sourceRec
         return false;
     }
 
+    ShowWindow( m_backdropWindow, SW_SHOWNA );
     ShowWindow( m_window, SW_SHOWNA );
 
     // Ctrl+Up/Ctrl+Down zoom the mirror, matching LiveZoom. Registration
@@ -219,6 +232,11 @@ void MirrorWindow::Stop()
         UnregisterHotKey( m_window, ZOOM_OUT_HOTKEY_ID );
         DestroyWindow( m_window );
         m_window = nullptr;
+    }
+    if( m_backdropWindow != nullptr )
+    {
+        DestroyWindow( m_backdropWindow );
+        m_backdropWindow = nullptr;
     }
 
     m_frameWait = nullptr;
@@ -291,6 +309,12 @@ LRESULT MirrorWindow::WindowProc( HWND window, UINT message, WPARAM wordParam, L
         {
             SetWindowPos( window, HWND_TOPMOST, 0, 0, 0, 0,
                           SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE );
+            if( m_backdropWindow != nullptr )
+            {
+                // Keep the backdrop directly below the mirror.
+                SetWindowPos( m_backdropWindow, window, 0, 0, 0, 0,
+                              SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE );
+            }
             return 0;
         }
         break;

--- a/src/modules/ZoomIt/ZoomIt/MirrorWindow.cpp
+++ b/src/modules/ZoomIt/ZoomIt/MirrorWindow.cpp
@@ -1,0 +1,438 @@
+//==============================================================================
+//
+// Zoomit
+// Sysinternals - www.sysinternals.com
+//
+// DemoMirror: mirrors a screen region or window, including the mouse cursor,
+// onto a second monitor so an audience can follow a demo app on the
+// presentation monitor without the presenter leaving the presentation.
+//
+// Frames come from Windows.Graphics.Capture (CaptureFrameWait) with cursor
+// capture enabled, get cached in a texture, and the visible sub-rectangle is
+// copied into a flip-model swapchain whose source size drives the zoom: DXGI
+// stretches the sub-rectangle to the window with linear filtering.
+//
+//==============================================================================
+#include "pch.h"
+#include "MirrorWindow.h"
+
+const float MIRROR_ZOOM_MAX = 8.0f;
+const float MIRROR_ZOOM_ANIMATION_STEP = 0.3f;
+const float MIRROR_PAN_ANIMATION_STEP = 0.25f;
+const DWORD MIRROR_FRAME_TIMEOUT_MS = 33;
+const UINT MIRROR_TOPMOST_TIMER_MS = 250;
+
+//----------------------------------------------------------------------------
+//
+// GetMonitorRect
+//
+//----------------------------------------------------------------------------
+static RECT GetMonitorRect( HMONITOR monitor )
+{
+    MONITORINFO monitorInfo = { sizeof( monitorInfo ) };
+    GetMonitorInfo( monitor, &monitorInfo );
+    return monitorInfo.rcMonitor;
+}
+
+//----------------------------------------------------------------------------
+//
+// MirrorWindow::Start
+//
+// Creates the mirror window on the target monitor and starts capturing and
+// presenting the source.
+//
+//----------------------------------------------------------------------------
+bool MirrorWindow::Start( winrt::GraphicsCaptureItem const& item, RECT sourceRect,
+                          HWND sourceWindow, HMONITOR sourceMonitor,
+                          HMONITOR targetMonitor, HWND notifyWindow )
+{
+    if( IsActive() )
+    {
+        return false;
+    }
+
+    m_sourceRect = sourceRect;
+    m_sourceWindow = sourceWindow;
+    m_notifyWindow = notifyWindow;
+    m_zoom = 1.0f;
+    m_zoomTarget = 1.0f;
+    m_sourceTexture = nullptr;
+    m_contentSize = item.Size();
+
+    // The mirrored region in capture-texture coordinates: monitor captures
+    // are relative to the monitor origin, window captures use the full
+    // captured content.
+    if( m_sourceWindow != nullptr )
+    {
+        SetRect( &m_textureCrop, 0, 0, m_contentSize.Width, m_contentSize.Height );
+    }
+    else
+    {
+        RECT monitorRect = GetMonitorRect( sourceMonitor );
+        SetRect( &m_textureCrop,
+                 sourceRect.left - monitorRect.left,
+                 sourceRect.top - monitorRect.top,
+                 sourceRect.right - monitorRect.left,
+                 sourceRect.bottom - monitorRect.top );
+    }
+    m_bufferWidth = m_textureCrop.right - m_textureCrop.left;
+    m_bufferHeight = m_textureCrop.bottom - m_textureCrop.top;
+    if( m_bufferWidth <= 0 || m_bufferHeight <= 0 )
+    {
+        return false;
+    }
+
+    m_centerX = m_bufferWidth / 2.0f;
+    m_centerY = m_bufferHeight / 2.0f;
+
+    // Size the mirror to the largest rectangle with the source's aspect
+    // ratio that fits on the target monitor, centered.
+    RECT targetRect = GetMonitorRect( targetMonitor );
+    const int monitorWidth = targetRect.right - targetRect.left;
+    const int monitorHeight = targetRect.bottom - targetRect.top;
+    const double scale = min( static_cast<double>( monitorWidth ) / m_bufferWidth,
+                              static_cast<double>( monitorHeight ) / m_bufferHeight );
+    const int windowWidth = max( 1, static_cast<int>( m_bufferWidth * scale ) );
+    const int windowHeight = max( 1, static_cast<int>( m_bufferHeight * scale ) );
+    const int windowLeft = targetRect.left + ( monitorWidth - windowWidth ) / 2;
+    const int windowTop = targetRect.top + ( monitorHeight - windowHeight ) / 2;
+
+    try
+    {
+        // A dedicated D3D device keeps mirroring independent of any
+        // simultaneous recording session.
+        m_device = util::CreateD3D11Device();
+        m_device->GetImmediateContext( m_context.put() );
+        auto multithread = m_context.try_as<ID3D11Multithread>();
+        if( multithread )
+        {
+            multithread->SetMultithreadProtected( TRUE );
+        }
+
+        auto dxgiDevice = m_device.as<IDXGIDevice>();
+        m_winrtDevice = CreateDirect3DDevice( dxgiDevice.get() );
+
+        m_frameWait = std::make_unique<CaptureFrameWait>( m_winrtDevice, item, item.Size() );
+        m_frameWait->EnableCursorCapture( true );
+        m_frameWait->ShowCaptureBorder( false );
+
+        WNDCLASSW windowClass{};
+        windowClass.lpfnWndProc = []( HWND window, UINT message, WPARAM wordParam, LPARAM longParam ) -> LRESULT
+        {
+            if( message == WM_NCCREATE )
+            {
+                auto createStruct = reinterpret_cast<LPCREATESTRUCT>( longParam );
+                SetWindowLongPtrW( window, GWLP_USERDATA, reinterpret_cast<LONG_PTR>( createStruct->lpCreateParams ) );
+                return TRUE;
+            }
+
+            auto self = reinterpret_cast<MirrorWindow*>( GetWindowLongPtrW( window, GWLP_USERDATA ) );
+            if( self == nullptr )
+            {
+                return DefWindowProcW( window, message, wordParam, longParam );
+            }
+            return self->WindowProc( window, message, wordParam, longParam );
+        };
+        windowClass.hInstance = GetModuleHandle( nullptr );
+        windowClass.hCursor = LoadCursorW( nullptr, IDC_ARROW );
+        windowClass.hbrBackground = static_cast<HBRUSH>( GetStockObject( BLACK_BRUSH ) );
+        windowClass.lpszClassName = m_className;
+        if( RegisterClassW( &windowClass ) == 0 )
+        {
+            THROW_LAST_ERROR_IF( GetLastError() != ERROR_CLASS_ALREADY_EXISTS );
+        }
+
+        // No activation and click-through: the mirror is display-only and
+        // must never steal focus from the demo app.
+        m_window = CreateWindowExW( WS_EX_TOPMOST | WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE | WS_EX_TRANSPARENT,
+                                    m_className, L"ZoomIt DemoMirror", WS_POPUP,
+                                    windowLeft, windowTop, windowWidth, windowHeight,
+                                    nullptr, nullptr, GetModuleHandle( nullptr ), this );
+        THROW_LAST_ERROR_IF_NULL( m_window );
+
+        // Never let the mirror feed back into a capture.
+        SetWindowDisplayAffinity( m_window, WDA_EXCLUDEFROMCAPTURE );
+
+        DXGI_SWAP_CHAIN_DESC1 swapChainDesc{};
+        swapChainDesc.Width = m_bufferWidth;
+        swapChainDesc.Height = m_bufferHeight;
+        swapChainDesc.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+        swapChainDesc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+        swapChainDesc.SampleDesc.Count = 1;
+        swapChainDesc.BufferCount = 2;
+        swapChainDesc.Scaling = DXGI_SCALING_STRETCH;
+        swapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL;
+        swapChainDesc.AlphaMode = DXGI_ALPHA_MODE_IGNORE;
+
+        auto dxgiDevice2 = m_device.as<IDXGIDevice2>();
+        winrt::com_ptr<IDXGIAdapter> adapter;
+        winrt::check_hresult( dxgiDevice2->GetParent( winrt::guid_of<IDXGIAdapter>(), adapter.put_void() ) );
+        winrt::com_ptr<IDXGIFactory2> factory;
+        winrt::check_hresult( adapter->GetParent( winrt::guid_of<IDXGIFactory2>(), factory.put_void() ) );
+
+        winrt::com_ptr<IDXGISwapChain1> swapChain;
+        winrt::check_hresult( factory->CreateSwapChainForHwnd( m_device.get(), m_window, &swapChainDesc,
+                                                               nullptr, nullptr, swapChain.put() ) );
+        m_swapChain = swapChain.as<IDXGISwapChain2>();
+        factory->MakeWindowAssociation( m_window, DXGI_MWA_NO_ALT_ENTER | DXGI_MWA_NO_WINDOW_CHANGES );
+    }
+    catch( ... )
+    {
+        Stop();
+        return false;
+    }
+
+    ShowWindow( m_window, SW_SHOWNA );
+
+    // Ctrl+Up/Ctrl+Down zoom the mirror, matching LiveZoom. Registration
+    // fails benignly when LiveZoom is active and owns the keys.
+    RegisterHotKey( m_window, ZOOM_IN_HOTKEY_ID, MOD_CONTROL, VK_UP );
+    RegisterHotKey( m_window, ZOOM_OUT_HOTKEY_ID, MOD_CONTROL, VK_DOWN );
+
+    // The presentation reasserts topmost when a slide show starts, so
+    // periodically reclaim it like live zoom does.
+    SetTimer( m_window, TOPMOST_TIMER_ID, MIRROR_TOPMOST_TIMER_MS, nullptr );
+
+    m_stopEvent.ResetEvent();
+    m_renderThread = std::thread( &MirrorWindow::RenderLoop, this );
+    return true;
+}
+
+//----------------------------------------------------------------------------
+//
+// MirrorWindow::Stop
+//
+// Stops the capture and render thread and tears down the window. Also
+// handles partially-initialized state when Start fails.
+//
+//----------------------------------------------------------------------------
+void MirrorWindow::Stop()
+{
+    m_stopEvent.SetEvent();
+    if( m_frameWait )
+    {
+        m_frameWait->StopCapture();
+    }
+    if( m_renderThread.joinable() )
+    {
+        m_renderThread.join();
+    }
+
+    if( m_window != nullptr )
+    {
+        KillTimer( m_window, TOPMOST_TIMER_ID );
+        UnregisterHotKey( m_window, ZOOM_IN_HOTKEY_ID );
+        UnregisterHotKey( m_window, ZOOM_OUT_HOTKEY_ID );
+        DestroyWindow( m_window );
+        m_window = nullptr;
+    }
+
+    m_frameWait = nullptr;
+    m_sourceTexture = nullptr;
+    m_swapChain = nullptr;
+    m_context = nullptr;
+    m_device = nullptr;
+    m_winrtDevice = nullptr;
+    m_sourceWindow = nullptr;
+    m_notifyWindow = nullptr;
+}
+
+//----------------------------------------------------------------------------
+//
+// MirrorWindow::WindowProc
+//
+//----------------------------------------------------------------------------
+LRESULT MirrorWindow::WindowProc( HWND window, UINT message, WPARAM wordParam, LPARAM longParam )
+{
+    switch( message )
+    {
+    case WM_HOTKEY:
+        if( wordParam == ZOOM_IN_HOTKEY_ID )
+        {
+            float zoomTarget = m_zoomTarget;
+            if( zoomTarget < MIRROR_ZOOM_MAX )
+            {
+                m_zoomTarget = zoomTarget * 2;
+            }
+            return 0;
+        }
+        else if( wordParam == ZOOM_OUT_HOTKEY_ID )
+        {
+            float zoomTarget = m_zoomTarget;
+            if( zoomTarget > 1.0f )
+            {
+                m_zoomTarget = max( zoomTarget / 2, 1.0f );
+            }
+            return 0;
+        }
+        break;
+
+    case WM_TIMER:
+        if( wordParam == TOPMOST_TIMER_ID )
+        {
+            SetWindowPos( window, HWND_TOPMOST, 0, 0, 0, 0,
+                          SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE );
+            return 0;
+        }
+        break;
+
+    case WM_MOUSEACTIVATE:
+        return MA_NOACTIVATE;
+    }
+    return DefWindowProcW( window, message, wordParam, longParam );
+}
+
+//----------------------------------------------------------------------------
+//
+// MirrorWindow::RenderLoop
+//
+// Render thread: caches arriving capture frames and presents them. The
+// timeout keeps zoom/pan animating when the source is static, since
+// Windows.Graphics.Capture only delivers frames on change.
+//
+//----------------------------------------------------------------------------
+void MirrorWindow::RenderLoop()
+{
+    winrt::init_apartment( winrt::apartment_type::multi_threaded );
+
+    while( !m_stopEvent.is_signaled() )
+    {
+        auto frame = m_frameWait->TryGetNextFrame( MIRROR_FRAME_TIMEOUT_MS );
+        if( m_stopEvent.is_signaled() )
+        {
+            break;
+        }
+
+        if( frame )
+        {
+            auto frameTexture = GetDXGIInterfaceFromObject<ID3D11Texture2D>( frame->FrameTexture );
+            if( m_sourceTexture == nullptr )
+            {
+                D3D11_TEXTURE2D_DESC textureDesc;
+                frameTexture->GetDesc( &textureDesc );
+                textureDesc.Usage = D3D11_USAGE_DEFAULT;
+                textureDesc.BindFlags = 0;
+                textureDesc.CPUAccessFlags = 0;
+                textureDesc.MiscFlags = 0;
+                if( FAILED( m_device->CreateTexture2D( &textureDesc, nullptr, m_sourceTexture.put() ) ) )
+                {
+                    break;
+                }
+            }
+            m_context->CopyResource( m_sourceTexture.get(), frameTexture.get() );
+            m_contentSize = frame->ContentSize;
+        }
+        else if( m_sourceWindow != nullptr && !IsWindow( m_sourceWindow ) )
+        {
+            // The mirrored window closed; have the main window stop
+            // mirroring, since this window belongs to its thread.
+            PostMessage( m_notifyWindow, WM_USER_MIRROR_STOP, 0, 0 );
+            break;
+        }
+
+        if( m_sourceTexture != nullptr )
+        {
+            RenderFrame();
+        }
+    }
+
+    winrt::uninit_apartment();
+}
+
+//----------------------------------------------------------------------------
+//
+// MirrorWindow::RenderFrame
+//
+// Copies the visible sub-rectangle of the cached source frame into the
+// swapchain and presents it. The sub-rectangle shrinks with the zoom level
+// and pans to follow the mouse.
+//
+//----------------------------------------------------------------------------
+void MirrorWindow::RenderFrame()
+{
+    // Animate toward the target zoom level.
+    const float zoomTarget = m_zoomTarget;
+    m_zoom += ( zoomTarget - m_zoom ) * MIRROR_ZOOM_ANIMATION_STEP;
+    if( fabsf( zoomTarget - m_zoom ) < 0.01f )
+    {
+        m_zoom = zoomTarget;
+    }
+
+    D3D11_TEXTURE2D_DESC sourceDesc;
+    m_sourceTexture->GetDesc( &sourceDesc );
+
+    // The mirrored region in texture coordinates, clamped to the captured
+    // content, which changes when a mirrored window resizes.
+    RECT crop = m_textureCrop;
+    if( m_sourceWindow != nullptr )
+    {
+        SetRect( &crop, 0, 0, m_contentSize.Width, m_contentSize.Height );
+    }
+    crop.left = max( crop.left, 0L );
+    crop.top = max( crop.top, 0L );
+    crop.right = min( crop.right, static_cast<LONG>( sourceDesc.Width ) );
+    crop.bottom = min( crop.bottom, static_cast<LONG>( sourceDesc.Height ) );
+    const int cropWidth = crop.right - crop.left;
+    const int cropHeight = crop.bottom - crop.top;
+    if( cropWidth <= 0 || cropHeight <= 0 )
+    {
+        return;
+    }
+
+    const int subWidth = max( 1, min( static_cast<int>( cropWidth / m_zoom ), m_bufferWidth ) );
+    const int subHeight = max( 1, min( static_cast<int>( cropHeight / m_zoom ), m_bufferHeight ) );
+
+    // Pan to follow the mouse when zoomed.
+    float desiredX = cropWidth / 2.0f;
+    float desiredY = cropHeight / 2.0f;
+    if( m_zoom > 1.0f )
+    {
+        POINT cursorPos;
+        if( GetCursorPos( &cursorPos ) )
+        {
+            if( m_sourceWindow != nullptr )
+            {
+                RECT windowRect;
+                if( GetWindowRect( m_sourceWindow, &windowRect ) &&
+                    windowRect.right > windowRect.left && windowRect.bottom > windowRect.top )
+                {
+                    desiredX = ( cursorPos.x - windowRect.left ) * static_cast<float>( cropWidth ) /
+                                    ( windowRect.right - windowRect.left );
+                    desiredY = ( cursorPos.y - windowRect.top ) * static_cast<float>( cropHeight ) /
+                                    ( windowRect.bottom - windowRect.top );
+                }
+            }
+            else
+            {
+                desiredX = static_cast<float>( cursorPos.x - m_sourceRect.left );
+                desiredY = static_cast<float>( cursorPos.y - m_sourceRect.top );
+            }
+        }
+    }
+    desiredX = max( subWidth / 2.0f, min( desiredX, cropWidth - subWidth / 2.0f ) );
+    desiredY = max( subHeight / 2.0f, min( desiredY, cropHeight - subHeight / 2.0f ) );
+    m_centerX += ( desiredX - m_centerX ) * MIRROR_PAN_ANIMATION_STEP;
+    m_centerY += ( desiredY - m_centerY ) * MIRROR_PAN_ANIMATION_STEP;
+
+    int boxLeft = crop.left + static_cast<int>( m_centerX - subWidth / 2.0f );
+    int boxTop = crop.top + static_cast<int>( m_centerY - subHeight / 2.0f );
+    boxLeft = max( static_cast<int>( crop.left ), min( boxLeft, static_cast<int>( crop.right ) - subWidth ) );
+    boxTop = max( static_cast<int>( crop.top ), min( boxTop, static_cast<int>( crop.bottom ) - subHeight ) );
+
+    D3D11_BOX box;
+    box.left = boxLeft;
+    box.top = boxTop;
+    box.right = boxLeft + subWidth;
+    box.bottom = boxTop + subHeight;
+    box.front = 0;
+    box.back = 1;
+
+    winrt::com_ptr<ID3D11Texture2D> backBuffer;
+    if( FAILED( m_swapChain->GetBuffer( 0, winrt::guid_of<ID3D11Texture2D>(), backBuffer.put_void() ) ) )
+    {
+        return;
+    }
+    m_context->CopySubresourceRegion( backBuffer.get(), 0, 0, 0, 0, m_sourceTexture.get(), 0, &box );
+    m_swapChain->SetSourceSize( subWidth, subHeight );
+    m_swapChain->Present( 1, 0 );
+}

--- a/src/modules/ZoomIt/ZoomIt/MirrorWindow.cpp
+++ b/src/modules/ZoomIt/ZoomIt/MirrorWindow.cpp
@@ -23,9 +23,6 @@ namespace util
     using namespace robmikh::common::desktop;
 }
 
-const float MIRROR_ZOOM_MAX = 8.0f;
-const float MIRROR_ZOOM_ANIMATION_STEP = 0.3f;
-const float MIRROR_PAN_ANIMATION_STEP = 0.25f;
 const DWORD MIRROR_FRAME_TIMEOUT_MS = 33;
 const UINT MIRROR_TOPMOST_TIMER_MS = 250;
 
@@ -139,8 +136,6 @@ bool MirrorWindow::Start( winrt::GraphicsCaptureItem const& item, RECT sourceRec
     m_annotationQuery = annotationQuery;
     m_annotationState = AnnotationState::None;
     m_monitorOverride = false;
-    m_zoom = 1.0f;
-    m_zoomTarget = 1.0f;
     m_sourceTexture = nullptr;
     m_contentSize = item.Size();
     m_poolSize = item.Size();
@@ -174,9 +169,6 @@ bool MirrorWindow::Start( winrt::GraphicsCaptureItem const& item, RECT sourceRec
     {
         return false;
     }
-
-    m_centerX = m_imageWidth / 2.0f;
-    m_centerY = m_imageHeight / 2.0f;
 
     RECT windowRect = ComputeWindowRect();
 
@@ -312,11 +304,6 @@ bool MirrorWindow::Start( winrt::GraphicsCaptureItem const& item, RECT sourceRec
         ShowWindow( m_borderWindow, SW_SHOWNA );
     }
 
-    // Ctrl+Up/Ctrl+Down zoom the mirror, matching LiveZoom. Registration
-    // fails benignly when LiveZoom is active and owns the keys.
-    RegisterHotKey( m_window, ZOOM_IN_HOTKEY_ID, MOD_CONTROL, VK_UP );
-    RegisterHotKey( m_window, ZOOM_OUT_HOTKEY_ID, MOD_CONTROL, VK_DOWN );
-
     // The presentation reasserts topmost when a slide show starts, so
     // periodically reclaim it like live zoom does.
     SetTimer( m_window, TOPMOST_TIMER_ID, MIRROR_TOPMOST_TIMER_MS, nullptr );
@@ -349,8 +336,6 @@ void MirrorWindow::Stop()
     if( m_window != nullptr )
     {
         KillTimer( m_window, TOPMOST_TIMER_ID );
-        UnregisterHotKey( m_window, ZOOM_IN_HOTKEY_ID );
-        UnregisterHotKey( m_window, ZOOM_OUT_HOTKEY_ID );
         DestroyWindow( m_window );
         m_window = nullptr;
     }
@@ -438,11 +423,11 @@ bool MirrorWindow::UpdateAnnotationState()
     }
     bool switched = false;
 
-    if( m_trackWindow )
+    if( m_trackWindow || m_sourceWindow == nullptr )
     {
-        // Window tracking already captures the monitor, so annotations show
-        // in place; just avoid a doubled cursor while live zoom renders a
-        // magnified one.
+        // Monitor captures (screen, region, and window tracking) show
+        // annotations in place; just avoid a doubled cursor while live zoom
+        // renders a magnified one.
         m_frameWait->EnableCursorCapture( state != AnnotationState::AnnotatingLiveZoom );
         m_annotationState = state;
         return false;
@@ -477,7 +462,6 @@ bool MirrorWindow::UpdateAnnotationState()
             // capturing the cursor too would double it.
             if( SwitchCapture( item, state != AnnotationState::AnnotatingLiveZoom ) )
             {
-                m_overrideRect = GetMonitorRect( monitor );
                 m_monitorOverride = true;
                 switched = true;
             }
@@ -584,27 +568,6 @@ LRESULT MirrorWindow::WindowProc( HWND window, UINT message, WPARAM wordParam, L
         UpdateBorderWindow();
         return 0;
 
-    case WM_HOTKEY:
-        if( wordParam == ZOOM_IN_HOTKEY_ID )
-        {
-            float zoomTarget = m_zoomTarget;
-            if( zoomTarget < MIRROR_ZOOM_MAX )
-            {
-                m_zoomTarget = zoomTarget * 2;
-            }
-            return 0;
-        }
-        else if( wordParam == ZOOM_OUT_HOTKEY_ID )
-        {
-            float zoomTarget = m_zoomTarget;
-            if( zoomTarget > 1.0f )
-            {
-                m_zoomTarget = max( zoomTarget / 2, 1.0f );
-            }
-            return 0;
-        }
-        break;
-
     case WM_TIMER:
         if( wordParam == TOPMOST_TIMER_ID )
         {
@@ -678,7 +641,7 @@ void MirrorWindow::RenderLoop()
         // Switch between window and monitor capture as ZoomIt annotation
         // modes come and go. On a switch, discard any frame from the
         // previous capture.
-        if( m_sourceWindow != nullptr && m_annotationQuery && UpdateAnnotationState() )
+        if( m_annotationQuery && UpdateAnnotationState() )
         {
             continue;
         }
@@ -752,21 +715,12 @@ void MirrorWindow::RenderLoop()
 //
 // MirrorWindow::RenderFrame
 //
-// Copies the visible sub-rectangle of the cached source frame into the
-// swapchain and presents it. The sub-rectangle shrinks with the zoom level
-// and pans to follow the mouse.
+// Copies the mirrored region of the cached source frame into the swapchain
+// and presents it.
 //
 //----------------------------------------------------------------------------
 void MirrorWindow::RenderFrame()
 {
-    // Animate toward the target zoom level.
-    const float zoomTarget = m_zoomTarget;
-    m_zoom += ( zoomTarget - m_zoom ) * MIRROR_ZOOM_ANIMATION_STEP;
-    if( fabsf( zoomTarget - m_zoom ) < 0.01f )
-    {
-        m_zoom = zoomTarget;
-    }
-
     D3D11_TEXTURE2D_DESC sourceDesc;
     m_sourceTexture->GetDesc( &sourceDesc );
 
@@ -782,7 +736,6 @@ void MirrorWindow::RenderFrame()
         {
             return;
         }
-        m_sourceRect = windowRect;
         SetRect( &crop,
                  windowRect.left - m_sourceMonitorRect.left,
                  windowRect.top - m_sourceMonitorRect.top,
@@ -812,55 +765,14 @@ void MirrorWindow::RenderFrame()
         PostMessage( m_window, WM_MIRROR_RELAYOUT, 0, 0 );
     }
 
-    const int subWidth = max( 1, min( static_cast<int>( cropWidth / m_zoom ), m_bufferWidth ) );
-    const int subHeight = max( 1, min( static_cast<int>( cropHeight / m_zoom ), m_bufferHeight ) );
-
-    // Pan to follow the mouse when zoomed.
-    float desiredX = cropWidth / 2.0f;
-    float desiredY = cropHeight / 2.0f;
-    if( m_zoom > 1.0f )
-    {
-        POINT cursorPos;
-        if( GetCursorPos( &cursorPos ) )
-        {
-            if( m_monitorOverride )
-            {
-                desiredX = static_cast<float>( cursorPos.x - m_overrideRect.left );
-                desiredY = static_cast<float>( cursorPos.y - m_overrideRect.top );
-            }
-            else if( m_sourceWindow != nullptr && !m_trackWindow )
-            {
-                RECT windowRect = GetWindowFrameRect( m_sourceWindow );
-                if( windowRect.right > windowRect.left && windowRect.bottom > windowRect.top )
-                {
-                    desiredX = ( cursorPos.x - windowRect.left ) * static_cast<float>( cropWidth ) /
-                                    ( windowRect.right - windowRect.left );
-                    desiredY = ( cursorPos.y - windowRect.top ) * static_cast<float>( cropHeight ) /
-                                    ( windowRect.bottom - windowRect.top );
-                }
-            }
-            else
-            {
-                desiredX = static_cast<float>( cursorPos.x - m_sourceRect.left );
-                desiredY = static_cast<float>( cursorPos.y - m_sourceRect.top );
-            }
-        }
-    }
-    desiredX = max( subWidth / 2.0f, min( desiredX, cropWidth - subWidth / 2.0f ) );
-    desiredY = max( subHeight / 2.0f, min( desiredY, cropHeight - subHeight / 2.0f ) );
-    m_centerX += ( desiredX - m_centerX ) * MIRROR_PAN_ANIMATION_STEP;
-    m_centerY += ( desiredY - m_centerY ) * MIRROR_PAN_ANIMATION_STEP;
-
-    int boxLeft = crop.left + static_cast<int>( m_centerX - subWidth / 2.0f );
-    int boxTop = crop.top + static_cast<int>( m_centerY - subHeight / 2.0f );
-    boxLeft = max( static_cast<int>( crop.left ), min( boxLeft, static_cast<int>( crop.right ) - subWidth ) );
-    boxTop = max( static_cast<int>( crop.top ), min( boxTop, static_cast<int>( crop.bottom ) - subHeight ) );
+    const int width = min( cropWidth, m_bufferWidth );
+    const int height = min( cropHeight, m_bufferHeight );
 
     D3D11_BOX box;
-    box.left = boxLeft;
-    box.top = boxTop;
-    box.right = boxLeft + subWidth;
-    box.bottom = boxTop + subHeight;
+    box.left = crop.left;
+    box.top = crop.top;
+    box.right = crop.left + width;
+    box.bottom = crop.top + height;
     box.front = 0;
     box.back = 1;
 
@@ -870,6 +782,6 @@ void MirrorWindow::RenderFrame()
         return;
     }
     m_context->CopySubresourceRegion( backBuffer.get(), 0, 0, 0, 0, m_sourceTexture.get(), 0, &box );
-    m_swapChain->SetSourceSize( subWidth, subHeight );
+    m_swapChain->SetSourceSize( width, height );
     m_swapChain->Present( 1, 0 );
 }

--- a/src/modules/ZoomIt/ZoomIt/MirrorWindow.cpp
+++ b/src/modules/ZoomIt/ZoomIt/MirrorWindow.cpp
@@ -30,6 +30,36 @@ const UINT MIRROR_TOPMOST_TIMER_MS = 250;
 
 //----------------------------------------------------------------------------
 //
+// RequestBorderlessCapture
+//
+// Windows 11 draws a yellow system border around captured windows and
+// monitors unless the process requests borderless capture access, which is
+// granted without a prompt for desktop apps. Until the request completes,
+// IsBorderRequired(false) has no effect. Must be called from an MTA thread
+// because it blocks on the request.
+//
+//----------------------------------------------------------------------------
+static void RequestBorderlessCapture()
+{
+    static bool requested = false;
+    if( requested )
+    {
+        return;
+    }
+    requested = true;
+
+    try
+    {
+        if( winrt::ApiInformation::IsTypePresent( L"Windows.Graphics.Capture.GraphicsCaptureAccess" ) )
+        {
+            winrt::GraphicsCaptureAccess::RequestAccessAsync( winrt::GraphicsCaptureAccessKind::Borderless ).get();
+        }
+    }
+    catch( ... ) {}
+}
+
+//----------------------------------------------------------------------------
+//
 // GetMonitorRect
 //
 //----------------------------------------------------------------------------
@@ -204,14 +234,14 @@ bool MirrorWindow::Start( winrt::GraphicsCaptureItem const& item, RECT sourceRec
         {
             // Bright green border around the mirrored window so the
             // presenter can see what's being mirrored, matching the record
-            // border's width and translucency but distinct in color. It
+            // border's width but fully opaque and distinct in color. It
             // follows the window as it moves and resizes.
             m_borderWindow = CreateWindowExW( WS_EX_TOPMOST | WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE | WS_EX_TRANSPARENT | WS_EX_LAYERED,
                                               m_className, L"ZoomIt DemoMirror Border", WS_POPUP,
                                               0, 0, 0, 0,
                                               nullptr, nullptr, GetModuleHandle( nullptr ), this );
             THROW_LAST_ERROR_IF_NULL( m_borderWindow );
-            SetLayeredWindowAttributes( m_borderWindow, 0, 191, LWA_ALPHA );
+            SetLayeredWindowAttributes( m_borderWindow, 0, 255, LWA_ALPHA );
             EnableWindow( m_borderWindow, FALSE );
             SetWindowDisplayAffinity( m_borderWindow, WDA_EXCLUDEFROMCAPTURE );
             m_borderTarget = m_sourceRect;
@@ -568,6 +598,11 @@ LRESULT MirrorWindow::WindowProc( HWND window, UINT message, WPARAM wordParam, L
 void MirrorWindow::RenderLoop()
 {
     winrt::init_apartment( winrt::apartment_type::multi_threaded );
+
+    // The borderless-capture grant must exist before IsBorderRequired(false)
+    // works, so acquire it and re-apply the setting to the live session.
+    RequestBorderlessCapture();
+    m_frameWait->ShowCaptureBorder( false );
 
     while( !m_stopEvent.is_signaled() )
     {

--- a/src/modules/ZoomIt/ZoomIt/MirrorWindow.cpp
+++ b/src/modules/ZoomIt/ZoomIt/MirrorWindow.cpp
@@ -15,6 +15,7 @@
 //==============================================================================
 #include "pch.h"
 #include "MirrorWindow.h"
+#include "Utility.h"
 
 namespace util
 {
@@ -198,6 +199,24 @@ bool MirrorWindow::Start( winrt::GraphicsCaptureItem const& item, RECT sourceRec
                                                                nullptr, nullptr, swapChain.put() ) );
         m_swapChain = swapChain.as<IDXGISwapChain2>();
         factory->MakeWindowAssociation( m_window, DXGI_MWA_NO_ALT_ENTER | DXGI_MWA_NO_WINDOW_CHANGES );
+
+        if( m_sourceWindow != nullptr )
+        {
+            // Bright green border around the mirrored window so the
+            // presenter can see what's being mirrored, matching the record
+            // border's width and translucency but distinct in color. It
+            // follows the window as it moves and resizes.
+            m_borderWindow = CreateWindowExW( WS_EX_TOPMOST | WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE | WS_EX_TRANSPARENT | WS_EX_LAYERED,
+                                              m_className, L"ZoomIt DemoMirror Border", WS_POPUP,
+                                              0, 0, 0, 0,
+                                              nullptr, nullptr, GetModuleHandle( nullptr ), this );
+            THROW_LAST_ERROR_IF_NULL( m_borderWindow );
+            SetLayeredWindowAttributes( m_borderWindow, 0, 191, LWA_ALPHA );
+            EnableWindow( m_borderWindow, FALSE );
+            SetWindowDisplayAffinity( m_borderWindow, WDA_EXCLUDEFROMCAPTURE );
+            m_borderTarget = m_sourceRect;
+            UpdateBorderWindow();
+        }
     }
     catch( ... )
     {
@@ -207,6 +226,10 @@ bool MirrorWindow::Start( winrt::GraphicsCaptureItem const& item, RECT sourceRec
 
     ShowWindow( m_backdropWindow, SW_SHOWNA );
     ShowWindow( m_window, SW_SHOWNA );
+    if( m_borderWindow != nullptr )
+    {
+        ShowWindow( m_borderWindow, SW_SHOWNA );
+    }
 
     // Ctrl+Up/Ctrl+Down zoom the mirror, matching LiveZoom. Registration
     // fails benignly when LiveZoom is active and owns the keys.
@@ -254,6 +277,11 @@ void MirrorWindow::Stop()
     {
         DestroyWindow( m_backdropWindow );
         m_backdropWindow = nullptr;
+    }
+    if( m_borderWindow != nullptr )
+    {
+        DestroyWindow( m_borderWindow );
+        m_borderWindow = nullptr;
     }
 
     m_frameWait = nullptr;
@@ -421,6 +449,38 @@ RECT MirrorWindow::ComputeWindowRect() const
 
 //----------------------------------------------------------------------------
 //
+// MirrorWindow::UpdateBorderWindow
+//
+// Positions the border frame just outside the source window rectangle,
+// using a window region so only the frame is visible.
+//
+//----------------------------------------------------------------------------
+void MirrorWindow::UpdateBorderWindow()
+{
+    if( m_borderWindow == nullptr )
+    {
+        return;
+    }
+
+    const RECT target = m_borderTarget;
+    const int width = ScaleForDpi( 2, GetDpiForWindowHelper( m_borderWindow ) );
+    RECT outer = target;
+    InflateRect( &outer, width, width );
+
+    wil::unique_hrgn region{ CreateRectRgn( 0, 0, outer.right - outer.left, outer.bottom - outer.top ) };
+    wil::unique_hrgn inside{ CreateRectRgn( width, width,
+                                            width + ( target.right - target.left ),
+                                            width + ( target.bottom - target.top ) ) };
+    CombineRgn( region.get(), region.get(), inside.get(), RGN_XOR );
+
+    SetWindowPos( m_borderWindow, HWND_TOPMOST, outer.left, outer.top,
+                  outer.right - outer.left, outer.bottom - outer.top, SWP_NOACTIVATE );
+    SetWindowRgn( m_borderWindow, region.release(), TRUE );
+    RedrawWindow( m_borderWindow, nullptr, nullptr, RDW_INVALIDATE | RDW_UPDATENOW | RDW_FRAME );
+}
+
+//----------------------------------------------------------------------------
+//
 // MirrorWindow::WindowProc
 //
 //----------------------------------------------------------------------------
@@ -428,6 +488,22 @@ LRESULT MirrorWindow::WindowProc( HWND window, UINT message, WPARAM wordParam, L
 {
     switch( message )
     {
+    case WM_ERASEBKGND:
+        if( window == m_borderWindow )
+        {
+            RECT clientRect;
+            GetClientRect( window, &clientRect );
+            HBRUSH brush = CreateSolidBrush( MIRROR_BORDER_COLOR );
+            FillRect( reinterpret_cast<HDC>( wordParam ), &clientRect, brush );
+            DeleteObject( brush );
+            return 1;
+        }
+        break;
+
+    case WM_MIRROR_BORDER:
+        UpdateBorderWindow();
+        return 0;
+
     case WM_HOTKEY:
         if( wordParam == ZOOM_IN_HOTKEY_ID )
         {
@@ -506,6 +582,18 @@ void MirrorWindow::RenderLoop()
         {
             PostMessage( m_notifyWindow, WM_USER_MIRROR_STOP, 0, 0 );
             break;
+        }
+
+        // Track the source window with the border.
+        if( m_sourceWindow != nullptr && m_borderWindow != nullptr )
+        {
+            RECT windowRect;
+            if( GetWindowRect( m_sourceWindow, &windowRect ) &&
+                !EqualRect( &windowRect, &m_borderTarget ))
+            {
+                m_borderTarget = windowRect;
+                PostMessage( m_window, WM_MIRROR_BORDER, 0, 0 );
+            }
         }
 
         // Switch between window and monitor capture as ZoomIt annotation

--- a/src/modules/ZoomIt/ZoomIt/MirrorWindow.cpp
+++ b/src/modules/ZoomIt/ZoomIt/MirrorWindow.cpp
@@ -58,6 +58,8 @@ bool MirrorWindow::Start( winrt::GraphicsCaptureItem const& item, RECT sourceRec
     m_zoomTarget = 1.0f;
     m_sourceTexture = nullptr;
     m_contentSize = item.Size();
+    m_poolSize = item.Size();
+    m_targetRect = GetMonitorRect( targetMonitor );
 
     // The mirrored region in capture-texture coordinates: monitor captures
     // are relative to the monitor origin, window captures use the full
@@ -85,17 +87,7 @@ bool MirrorWindow::Start( winrt::GraphicsCaptureItem const& item, RECT sourceRec
     m_centerX = m_bufferWidth / 2.0f;
     m_centerY = m_bufferHeight / 2.0f;
 
-    // Size the mirror to the largest rectangle with the source's aspect
-    // ratio that fits on the target monitor, centered.
-    RECT targetRect = GetMonitorRect( targetMonitor );
-    const int monitorWidth = targetRect.right - targetRect.left;
-    const int monitorHeight = targetRect.bottom - targetRect.top;
-    const double scale = min( static_cast<double>( monitorWidth ) / m_bufferWidth,
-                              static_cast<double>( monitorHeight ) / m_bufferHeight );
-    const int windowWidth = max( 1, static_cast<int>( m_bufferWidth * scale ) );
-    const int windowHeight = max( 1, static_cast<int>( m_bufferHeight * scale ) );
-    const int windowLeft = targetRect.left + ( monitorWidth - windowWidth ) / 2;
-    const int windowTop = targetRect.top + ( monitorHeight - windowHeight ) / 2;
+    RECT windowRect = ComputeWindowRect();
 
     try
     {
@@ -146,7 +138,9 @@ bool MirrorWindow::Start( winrt::GraphicsCaptureItem const& item, RECT sourceRec
         // must never steal focus from the demo app.
         m_window = CreateWindowExW( WS_EX_TOPMOST | WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE | WS_EX_TRANSPARENT,
                                     m_className, L"ZoomIt DemoMirror", WS_POPUP,
-                                    windowLeft, windowTop, windowWidth, windowHeight,
+                                    windowRect.left, windowRect.top,
+                                    windowRect.right - windowRect.left,
+                                    windowRect.bottom - windowRect.top,
                                     nullptr, nullptr, GetModuleHandle( nullptr ), this );
         THROW_LAST_ERROR_IF_NULL( m_window );
 
@@ -239,6 +233,31 @@ void MirrorWindow::Stop()
 
 //----------------------------------------------------------------------------
 //
+// MirrorWindow::ComputeWindowRect
+//
+// The largest rectangle with the source's aspect ratio that fits on the
+// target monitor, centered.
+//
+//----------------------------------------------------------------------------
+RECT MirrorWindow::ComputeWindowRect() const
+{
+    const int monitorWidth = m_targetRect.right - m_targetRect.left;
+    const int monitorHeight = m_targetRect.bottom - m_targetRect.top;
+    const double scale = min( static_cast<double>( monitorWidth ) / m_bufferWidth,
+                              static_cast<double>( monitorHeight ) / m_bufferHeight );
+    const int windowWidth = max( 1, static_cast<int>( m_bufferWidth * scale ) );
+    const int windowHeight = max( 1, static_cast<int>( m_bufferHeight * scale ) );
+
+    RECT windowRect;
+    windowRect.left = m_targetRect.left + ( monitorWidth - windowWidth ) / 2;
+    windowRect.top = m_targetRect.top + ( monitorHeight - windowHeight ) / 2;
+    windowRect.right = windowRect.left + windowWidth;
+    windowRect.bottom = windowRect.top + windowHeight;
+    return windowRect;
+}
+
+//----------------------------------------------------------------------------
+//
 // MirrorWindow::WindowProc
 //
 //----------------------------------------------------------------------------
@@ -276,6 +295,16 @@ LRESULT MirrorWindow::WindowProc( HWND window, UINT message, WPARAM wordParam, L
         }
         break;
 
+    case WM_MIRROR_RELAYOUT:
+    {
+        // The mirrored window resized; re-fit to its new aspect ratio.
+        RECT windowRect = ComputeWindowRect();
+        SetWindowPos( window, HWND_TOPMOST, windowRect.left, windowRect.top,
+                      windowRect.right - windowRect.left,
+                      windowRect.bottom - windowRect.top, SWP_NOACTIVATE );
+        return 0;
+    }
+
     case WM_MOUSEACTIVATE:
         return MA_NOACTIVATE;
     }
@@ -305,6 +334,30 @@ void MirrorWindow::RenderLoop()
 
         if( frame )
         {
+            // A mirrored window can resize; recreate the frame pool, cache
+            // texture, and swapchain at the new content size and re-fit the
+            // mirror window to the new aspect ratio.
+            if( m_sourceWindow != nullptr &&
+                frame->ContentSize.Width > 0 && frame->ContentSize.Height > 0 &&
+                ( frame->ContentSize.Width != m_poolSize.Width ||
+                  frame->ContentSize.Height != m_poolSize.Height ))
+            {
+                m_poolSize = frame->ContentSize;
+                m_bufferWidth = m_poolSize.Width;
+                m_bufferHeight = m_poolSize.Height;
+                m_sourceTexture = nullptr;
+                m_frameWait->RecreateFramePool( m_poolSize );
+                if( FAILED( m_swapChain->ResizeBuffers( 2, m_bufferWidth, m_bufferHeight,
+                                                        DXGI_FORMAT_B8G8R8A8_UNORM, 0 ) ) )
+                {
+                    break;
+                }
+                PostMessage( m_window, WM_MIRROR_RELAYOUT, 0, 0 );
+
+                // Wait for a frame at the new size.
+                continue;
+            }
+
             auto frameTexture = GetDXGIInterfaceFromObject<ID3D11Texture2D>( frame->FrameTexture );
             if( m_sourceTexture == nullptr )
             {

--- a/src/modules/ZoomIt/ZoomIt/MirrorWindow.cpp
+++ b/src/modules/ZoomIt/ZoomIt/MirrorWindow.cpp
@@ -122,7 +122,7 @@ bool MirrorWindow::Start( winrt::GraphicsCaptureItem const& item, RECT sourceRec
                           HWND sourceWindow, HMONITOR sourceMonitor,
                           HMONITOR targetMonitor, HWND notifyWindow,
                           std::function<AnnotationState()> annotationQuery,
-                          bool trackWindow )
+                          bool trackWindow, HWND sourceBorderWindow )
 {
     if( IsActive() )
     {
@@ -131,6 +131,7 @@ bool MirrorWindow::Start( winrt::GraphicsCaptureItem const& item, RECT sourceRec
 
     m_sourceRect = sourceRect;
     m_sourceWindow = sourceWindow;
+    m_sourceBorderWindow = sourceBorderWindow;
     m_trackWindow = trackWindow;
     m_notifyWindow = notifyWindow;
     m_annotationQuery = annotationQuery;
@@ -139,6 +140,8 @@ bool MirrorWindow::Start( winrt::GraphicsCaptureItem const& item, RECT sourceRec
     m_sourceTexture = nullptr;
     m_contentSize = item.Size();
     m_poolSize = item.Size();
+    m_sourceMonitor = sourceMonitor;
+    m_targetMonitor = targetMonitor;
     m_targetRect = GetMonitorRect( targetMonitor );
     m_sourceMonitorRect = GetMonitorRect( sourceMonitor );
 
@@ -235,7 +238,6 @@ bool MirrorWindow::Start( winrt::GraphicsCaptureItem const& item, RECT sourceRec
                                             m_targetRect.bottom - m_targetRect.top,
                                             nullptr, nullptr, GetModuleHandle( nullptr ), nullptr );
         THROW_LAST_ERROR_IF_NULL( m_backdropWindow );
-        SetWindowDisplayAffinity( m_backdropWindow, WDA_EXCLUDEFROMCAPTURE );
 
         // No activation and click-through: the mirror is display-only and
         // must never steal focus from the demo app.
@@ -247,8 +249,11 @@ bool MirrorWindow::Start( winrt::GraphicsCaptureItem const& item, RECT sourceRec
                                     nullptr, nullptr, GetModuleHandle( nullptr ), this );
         THROW_LAST_ERROR_IF_NULL( m_window );
 
-        // Never let the mirror feed back into a capture.
-        SetWindowDisplayAffinity( m_window, WDA_EXCLUDEFROMCAPTURE );
+        // The mirror and backdrop stay visible to captures so screen
+        // sharing (e.g. Teams) of the target monitor shows the mirrored
+        // content. Self-capture can't happen: the target monitor is never
+        // the source, and the annotation override below pins monitor
+        // capture to the source monitor.
 
         DXGI_SWAP_CHAIN_DESC1 swapChainDesc{};
         swapChainDesc.Width = m_bufferWidth;
@@ -357,6 +362,9 @@ void MirrorWindow::Stop()
     m_device = nullptr;
     m_winrtDevice = nullptr;
     m_sourceWindow = nullptr;
+    m_sourceBorderWindow = nullptr;
+    m_sourceMonitor = nullptr;
+    m_targetMonitor = nullptr;
     m_notifyWindow = nullptr;
     m_annotationQuery = nullptr;
     m_annotationState = AnnotationState::None;
@@ -410,8 +418,11 @@ bool MirrorWindow::SwitchCapture( winrt::GraphicsCaptureItem const& item, bool e
 // part of the window's surface, so they wouldn't show in the mirror. When
 // one of those modes activates, temporarily mirror the monitor under the
 // cursor (where the annotation UI appears) instead, and switch back to the
-// window when the mode exits. Returns true when the capture was switched so
-// the caller can discard the frame from the previous capture.
+// window when the mode exits. The target monitor is never captured — the
+// mirror is capture-visible and would feed back into itself — so the
+// source monitor stands in when the cursor is there. Returns true when the
+// capture was switched so the caller can discard the frame from the
+// previous capture.
 //
 //----------------------------------------------------------------------------
 bool MirrorWindow::UpdateAnnotationState()
@@ -454,6 +465,14 @@ bool MirrorWindow::UpdateAnnotationState()
         POINT cursorPos;
         GetCursorPos( &cursorPos );
         HMONITOR monitor = MonitorFromPoint( cursorPos, MONITOR_DEFAULTTONEAREST );
+
+        // The mirror is visible to captures, so capturing the target
+        // monitor would feed the mirror back into itself; the annotation
+        // UI is on the source monitor anyway.
+        if( monitor == m_targetMonitor )
+        {
+            monitor = m_sourceMonitor;
+        }
         try
         {
             auto item = util::CreateCaptureItemForMonitor( monitor );
@@ -578,6 +597,22 @@ LRESULT MirrorWindow::WindowProc( HWND window, UINT message, WPARAM wordParam, L
                 // Keep the backdrop directly below the mirror.
                 SetWindowPos( m_backdropWindow, window, 0, 0, 0, 0,
                               SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE );
+            }
+
+            // Static zoom and draw cover the source monitor with a
+            // full-screen topmost window, hiding the green border; reclaim
+            // it like live zoom does for the webcam preview. Skip during
+            // live zoom, whose own reclaim timer would fight this one and
+            // flicker the border.
+            if( m_annotationQuery == nullptr ||
+                m_annotationQuery() != AnnotationState::AnnotatingLiveZoom )
+            {
+                HWND border = m_borderWindow != nullptr ? m_borderWindow : m_sourceBorderWindow;
+                if( border != nullptr && IsWindow( border ))
+                {
+                    SetWindowPos( border, HWND_TOPMOST, 0, 0, 0, 0,
+                                  SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOSIZE );
+                }
             }
             return 0;
         }

--- a/src/modules/ZoomIt/ZoomIt/MirrorWindow.cpp
+++ b/src/modules/ZoomIt/ZoomIt/MirrorWindow.cpp
@@ -53,10 +53,27 @@ static void RequestBorderlessCapture()
     {
         if( winrt::ApiInformation::IsTypePresent( L"Windows.Graphics.Capture.GraphicsCaptureAccess" ) )
         {
-            winrt::GraphicsCaptureAccess::RequestAccessAsync( winrt::GraphicsCaptureAccessKind::Borderless ).get();
+            auto status = winrt::GraphicsCaptureAccess::RequestAccessAsync( winrt::GraphicsCaptureAccessKind::Borderless ).get();
+            wchar_t message[128];
+            swprintf_s( message, L"[Mirror] Borderless capture access status=%d\n", static_cast<int>( status ) );
+            OutputDebugStringW( message );
+        }
+        else
+        {
+            OutputDebugStringW( L"[Mirror] GraphicsCaptureAccess type not present\n" );
         }
     }
-    catch( ... ) {}
+    catch( const winrt::hresult_error& error )
+    {
+        wchar_t message[256];
+        swprintf_s( message, L"[Mirror] Borderless capture access request failed: 0x%08X\n",
+                    static_cast<unsigned>( error.code().value ) );
+        OutputDebugStringW( message );
+    }
+    catch( ... )
+    {
+        OutputDebugStringW( L"[Mirror] Borderless capture access request failed\n" );
+    }
 }
 
 //----------------------------------------------------------------------------

--- a/src/modules/ZoomIt/ZoomIt/MirrorWindow.cpp
+++ b/src/modules/ZoomIt/ZoomIt/MirrorWindow.cpp
@@ -16,6 +16,7 @@
 #include "pch.h"
 #include "MirrorWindow.h"
 #include "Utility.h"
+#include <dwmapi.h>
 
 namespace util
 {
@@ -68,6 +69,31 @@ static RECT GetMonitorRect( HMONITOR monitor )
     MONITORINFO monitorInfo = { sizeof( monitorInfo ) };
     GetMonitorInfo( monitor, &monitorInfo );
     return monitorInfo.rcMonitor;
+}
+
+//----------------------------------------------------------------------------
+//
+// MirrorWindow::GetWindowFrameRect
+//
+// GetWindowRect includes the invisible resize borders around modern
+// windows, which would mirror as a margin of desktop; the DWM extended
+// frame bounds are the visible edges.
+//
+//----------------------------------------------------------------------------
+RECT MirrorWindow::GetWindowFrameRect( HWND window )
+{
+    typedef HRESULT ( WINAPI *type_pDwmGetWindowAttribute )( HWND, DWORD, PVOID, DWORD );
+    static type_pDwmGetWindowAttribute pDwmGetWindowAttributeDynamic =
+        reinterpret_cast<type_pDwmGetWindowAttribute>(
+            GetProcAddress( LoadLibraryW( L"dwmapi.dll" ), "DwmGetWindowAttribute" ) );
+
+    RECT rect{};
+    if( pDwmGetWindowAttributeDynamic == nullptr ||
+        FAILED( pDwmGetWindowAttributeDynamic( window, DWMWA_EXTENDED_FRAME_BOUNDS, &rect, sizeof( rect ) ) ) )
+    {
+        GetWindowRect( window, &rect );
+    }
+    return rect;
 }
 
 //----------------------------------------------------------------------------
@@ -139,6 +165,15 @@ bool MirrorWindow::Start( winrt::GraphicsCaptureItem const& item, RECT sourceRec
 
     try
     {
+        // Acquire the borderless-capture grant before creating the session
+        // so the yellow system capture border never appears. The request
+        // blocks, and needs an MTA thread.
+        std::thread( []() {
+            winrt::init_apartment( winrt::apartment_type::multi_threaded );
+            RequestBorderlessCapture();
+            winrt::uninit_apartment();
+        } ).join();
+
         // A dedicated D3D device keeps mirroring independent of any
         // simultaneous recording session.
         m_device = util::CreateD3D11Device();
@@ -152,9 +187,8 @@ bool MirrorWindow::Start( winrt::GraphicsCaptureItem const& item, RECT sourceRec
         auto dxgiDevice = m_device.as<IDXGIDevice>();
         m_winrtDevice = CreateDirect3DDevice( dxgiDevice.get() );
 
-        m_frameWait = std::make_unique<CaptureFrameWait>( m_winrtDevice, item, item.Size() );
+        m_frameWait = std::make_unique<CaptureFrameWait>( m_winrtDevice, item, item.Size(), false );
         m_frameWait->EnableCursorCapture( true );
-        m_frameWait->ShowCaptureBorder( false );
 
         WNDCLASSW windowClass{};
         windowClass.lpfnWndProc = []( HWND window, UINT message, WPARAM wordParam, LPARAM longParam ) -> LRESULT
@@ -340,9 +374,8 @@ bool MirrorWindow::SwitchCapture( winrt::GraphicsCaptureItem const& item, bool e
 {
     try
     {
-        auto frameWait = std::make_unique<CaptureFrameWait>( m_winrtDevice, item, item.Size() );
+        auto frameWait = std::make_unique<CaptureFrameWait>( m_winrtDevice, item, item.Size(), false );
         frameWait->EnableCursorCapture( enableCursor );
-        frameWait->ShowCaptureBorder( false );
         m_frameWait->StopCapture();
         m_frameWait = std::move( frameWait );
     }
@@ -599,11 +632,6 @@ void MirrorWindow::RenderLoop()
 {
     winrt::init_apartment( winrt::apartment_type::multi_threaded );
 
-    // The borderless-capture grant must exist before IsBorderRequired(false)
-    // works, so acquire it and re-apply the setting to the live session.
-    RequestBorderlessCapture();
-    m_frameWait->ShowCaptureBorder( false );
-
     while( !m_stopEvent.is_signaled() )
     {
         auto frame = m_frameWait->TryGetNextFrame( MIRROR_FRAME_TIMEOUT_MS );
@@ -622,9 +650,8 @@ void MirrorWindow::RenderLoop()
         // Track the source window with the border.
         if( m_sourceWindow != nullptr && m_borderWindow != nullptr )
         {
-            RECT windowRect;
-            if( GetWindowRect( m_sourceWindow, &windowRect ) &&
-                !EqualRect( &windowRect, &m_borderTarget ))
+            RECT windowRect = GetWindowFrameRect( m_sourceWindow );
+            if( !IsRectEmpty( &windowRect ) && !EqualRect( &windowRect, &m_borderTarget ))
             {
                 m_borderTarget = windowRect;
                 PostMessage( m_window, WM_MIRROR_BORDER, 0, 0 );
@@ -733,8 +760,8 @@ void MirrorWindow::RenderFrame()
     RECT crop = m_textureCrop;
     if( m_trackWindow )
     {
-        RECT windowRect;
-        if( !GetWindowRect( m_sourceWindow, &windowRect ) )
+        RECT windowRect = GetWindowFrameRect( m_sourceWindow );
+        if( IsRectEmpty( &windowRect ) )
         {
             return;
         }
@@ -786,9 +813,8 @@ void MirrorWindow::RenderFrame()
             }
             else if( m_sourceWindow != nullptr && !m_trackWindow )
             {
-                RECT windowRect;
-                if( GetWindowRect( m_sourceWindow, &windowRect ) &&
-                    windowRect.right > windowRect.left && windowRect.bottom > windowRect.top )
+                RECT windowRect = GetWindowFrameRect( m_sourceWindow );
+                if( windowRect.right > windowRect.left && windowRect.bottom > windowRect.top )
                 {
                     desiredX = ( cursorPos.x - windowRect.left ) * static_cast<float>( cropWidth ) /
                                     ( windowRect.right - windowRect.left );

--- a/src/modules/ZoomIt/ZoomIt/MirrorWindow.cpp
+++ b/src/modules/ZoomIt/ZoomIt/MirrorWindow.cpp
@@ -50,7 +50,8 @@ static RECT GetMonitorRect( HMONITOR monitor )
 bool MirrorWindow::Start( winrt::GraphicsCaptureItem const& item, RECT sourceRect,
                           HWND sourceWindow, HMONITOR sourceMonitor,
                           HMONITOR targetMonitor, HWND notifyWindow,
-                          std::function<AnnotationState()> annotationQuery )
+                          std::function<AnnotationState()> annotationQuery,
+                          bool trackWindow )
 {
     if( IsActive() )
     {
@@ -59,6 +60,7 @@ bool MirrorWindow::Start( winrt::GraphicsCaptureItem const& item, RECT sourceRec
 
     m_sourceRect = sourceRect;
     m_sourceWindow = sourceWindow;
+    m_trackWindow = trackWindow;
     m_notifyWindow = notifyWindow;
     m_annotationQuery = annotationQuery;
     m_annotationState = AnnotationState::None;
@@ -69,32 +71,38 @@ bool MirrorWindow::Start( winrt::GraphicsCaptureItem const& item, RECT sourceRec
     m_contentSize = item.Size();
     m_poolSize = item.Size();
     m_targetRect = GetMonitorRect( targetMonitor );
+    m_sourceMonitorRect = GetMonitorRect( sourceMonitor );
 
     // The mirrored region in capture-texture coordinates: monitor captures
     // are relative to the monitor origin, window captures use the full
-    // captured content.
-    if( m_sourceWindow != nullptr )
+    // captured content. Window tracking captures the monitor and recomputes
+    // the crop from the window rect every frame.
+    if( m_trackWindow || m_sourceWindow == nullptr )
     {
-        SetRect( &m_textureCrop, 0, 0, m_contentSize.Width, m_contentSize.Height );
+        SetRect( &m_textureCrop,
+                 sourceRect.left - m_sourceMonitorRect.left,
+                 sourceRect.top - m_sourceMonitorRect.top,
+                 sourceRect.right - m_sourceMonitorRect.left,
+                 sourceRect.bottom - m_sourceMonitorRect.top );
     }
     else
     {
-        RECT monitorRect = GetMonitorRect( sourceMonitor );
-        SetRect( &m_textureCrop,
-                 sourceRect.left - monitorRect.left,
-                 sourceRect.top - monitorRect.top,
-                 sourceRect.right - monitorRect.left,
-                 sourceRect.bottom - monitorRect.top );
+        SetRect( &m_textureCrop, 0, 0, m_contentSize.Width, m_contentSize.Height );
     }
-    m_bufferWidth = m_textureCrop.right - m_textureCrop.left;
-    m_bufferHeight = m_textureCrop.bottom - m_textureCrop.top;
-    if( m_bufferWidth <= 0 || m_bufferHeight <= 0 )
+
+    // The swapchain covers the full capture; the displayed image is the
+    // crop, which drives the mirror window's aspect ratio.
+    m_bufferWidth = m_trackWindow ? m_contentSize.Width : ( m_textureCrop.right - m_textureCrop.left );
+    m_bufferHeight = m_trackWindow ? m_contentSize.Height : ( m_textureCrop.bottom - m_textureCrop.top );
+    m_imageWidth = m_textureCrop.right - m_textureCrop.left;
+    m_imageHeight = m_textureCrop.bottom - m_textureCrop.top;
+    if( m_bufferWidth <= 0 || m_bufferHeight <= 0 || m_imageWidth <= 0 || m_imageHeight <= 0 )
     {
         return false;
     }
 
-    m_centerX = m_bufferWidth / 2.0f;
-    m_centerY = m_bufferHeight / 2.0f;
+    m_centerX = m_imageWidth / 2.0f;
+    m_centerY = m_imageHeight / 2.0f;
 
     RECT windowRect = ComputeWindowRect();
 
@@ -259,6 +267,7 @@ void MirrorWindow::Stop()
     m_annotationQuery = nullptr;
     m_annotationState = AnnotationState::None;
     m_monitorOverride = false;
+    m_trackWindow = false;
 }
 
 //----------------------------------------------------------------------------
@@ -287,6 +296,8 @@ bool MirrorWindow::SwitchCapture( winrt::GraphicsCaptureItem const& item, bool e
     m_poolSize = item.Size();
     m_bufferWidth = m_poolSize.Width;
     m_bufferHeight = m_poolSize.Height;
+    m_imageWidth = m_bufferWidth;
+    m_imageHeight = m_bufferHeight;
     m_contentSize = m_poolSize;
     m_sourceTexture = nullptr;
     if( FAILED( m_swapChain->ResizeBuffers( 2, m_bufferWidth, m_bufferHeight,
@@ -318,6 +329,16 @@ bool MirrorWindow::UpdateAnnotationState()
         return false;
     }
     bool switched = false;
+
+    if( m_trackWindow )
+    {
+        // Window tracking already captures the monitor, so annotations show
+        // in place; just avoid a doubled cursor while live zoom renders a
+        // magnified one.
+        m_frameWait->EnableCursorCapture( state != AnnotationState::AnnotatingLiveZoom );
+        m_annotationState = state;
+        return false;
+    }
 
     if( state == AnnotationState::None )
     {
@@ -376,10 +397,10 @@ RECT MirrorWindow::ComputeWindowRect() const
 {
     const int monitorWidth = m_targetRect.right - m_targetRect.left;
     const int monitorHeight = m_targetRect.bottom - m_targetRect.top;
-    const double scale = min( static_cast<double>( monitorWidth ) / m_bufferWidth,
-                              static_cast<double>( monitorHeight ) / m_bufferHeight );
-    const int windowWidth = max( 1, static_cast<int>( m_bufferWidth * scale ) );
-    const int windowHeight = max( 1, static_cast<int>( m_bufferHeight * scale ) );
+    const double scale = min( static_cast<double>( monitorWidth ) / m_imageWidth,
+                              static_cast<double>( monitorHeight ) / m_imageHeight );
+    const int windowWidth = max( 1, static_cast<int>( m_imageWidth * scale ) );
+    const int windowHeight = max( 1, static_cast<int>( m_imageHeight * scale ) );
 
     RECT windowRect;
     windowRect.left = m_targetRect.left + ( monitorWidth - windowWidth ) / 2;
@@ -491,7 +512,7 @@ void MirrorWindow::RenderLoop()
             // A mirrored window can resize; recreate the frame pool, cache
             // texture, and swapchain at the new content size and re-fit the
             // mirror window to the new aspect ratio.
-            if( m_sourceWindow != nullptr && !m_monitorOverride &&
+            if( m_sourceWindow != nullptr && !m_monitorOverride && !m_trackWindow &&
                 frame->ContentSize.Width > 0 && frame->ContentSize.Height > 0 &&
                 ( frame->ContentSize.Width != m_poolSize.Width ||
                   frame->ContentSize.Height != m_poolSize.Height ))
@@ -499,6 +520,8 @@ void MirrorWindow::RenderLoop()
                 m_poolSize = frame->ContentSize;
                 m_bufferWidth = m_poolSize.Width;
                 m_bufferHeight = m_poolSize.Height;
+                m_imageWidth = m_bufferWidth;
+                m_imageHeight = m_bufferHeight;
                 m_sourceTexture = nullptr;
                 m_frameWait->RecreateFramePool( m_poolSize );
                 if( FAILED( m_swapChain->ResizeBuffers( 2, m_bufferWidth, m_bufferHeight,
@@ -573,9 +596,24 @@ void MirrorWindow::RenderFrame()
 
     // The mirrored region in texture coordinates, clamped to the captured
     // content, which changes when a mirrored window resizes. Window and
-    // monitor-override captures mirror the full captured content.
+    // monitor-override captures mirror the full captured content; window
+    // tracking follows the window rect within the monitor capture.
     RECT crop = m_textureCrop;
-    if( m_monitorOverride || m_sourceWindow != nullptr )
+    if( m_trackWindow )
+    {
+        RECT windowRect;
+        if( !GetWindowRect( m_sourceWindow, &windowRect ) )
+        {
+            return;
+        }
+        m_sourceRect = windowRect;
+        SetRect( &crop,
+                 windowRect.left - m_sourceMonitorRect.left,
+                 windowRect.top - m_sourceMonitorRect.top,
+                 windowRect.right - m_sourceMonitorRect.left,
+                 windowRect.bottom - m_sourceMonitorRect.top );
+    }
+    else if( m_monitorOverride || m_sourceWindow != nullptr )
     {
         SetRect( &crop, 0, 0, m_contentSize.Width, m_contentSize.Height );
     }
@@ -588,6 +626,14 @@ void MirrorWindow::RenderFrame()
     if( cropWidth <= 0 || cropHeight <= 0 )
     {
         return;
+    }
+
+    // A tracked window's crop changes as it resizes; re-fit the mirror.
+    if( m_trackWindow && ( cropWidth != m_imageWidth || cropHeight != m_imageHeight ))
+    {
+        m_imageWidth = cropWidth;
+        m_imageHeight = cropHeight;
+        PostMessage( m_window, WM_MIRROR_RELAYOUT, 0, 0 );
     }
 
     const int subWidth = max( 1, min( static_cast<int>( cropWidth / m_zoom ), m_bufferWidth ) );
@@ -606,7 +652,7 @@ void MirrorWindow::RenderFrame()
                 desiredX = static_cast<float>( cursorPos.x - m_overrideRect.left );
                 desiredY = static_cast<float>( cursorPos.y - m_overrideRect.top );
             }
-            else if( m_sourceWindow != nullptr )
+            else if( m_sourceWindow != nullptr && !m_trackWindow )
             {
                 RECT windowRect;
                 if( GetWindowRect( m_sourceWindow, &windowRect ) &&

--- a/src/modules/ZoomIt/ZoomIt/MirrorWindow.cpp
+++ b/src/modules/ZoomIt/ZoomIt/MirrorWindow.cpp
@@ -397,8 +397,17 @@ RECT MirrorWindow::ComputeWindowRect() const
 {
     const int monitorWidth = m_targetRect.right - m_targetRect.left;
     const int monitorHeight = m_targetRect.bottom - m_targetRect.top;
-    const double scale = min( static_cast<double>( monitorWidth ) / m_imageWidth,
-                              static_cast<double>( monitorHeight ) / m_imageHeight );
+    double scale = min( static_cast<double>( monitorWidth ) / m_imageWidth,
+                        static_cast<double>( monitorHeight ) / m_imageHeight );
+
+    // Mirror windows at native size, scaling only when they don't fit on
+    // the target monitor, so the image stays stable as the window resizes.
+    // Regions always fill the monitor.
+    if( m_sourceWindow != nullptr )
+    {
+        scale = min( scale, 1.0 );
+    }
+
     const int windowWidth = max( 1, static_cast<int>( m_imageWidth * scale ) );
     const int windowHeight = max( 1, static_cast<int>( m_imageHeight * scale ) );
 

--- a/src/modules/ZoomIt/ZoomIt/MirrorWindow.h
+++ b/src/modules/ZoomIt/ZoomIt/MirrorWindow.h
@@ -44,6 +44,9 @@ public:
     // the region under the tracked window instead of the window's own
     // surface, so ZoomIt annotations show in place, at the cost of
     // occluding windows becoming visible.
+    // sourceBorderWindow is the caller-owned green border (the region/
+    // monitor SelectRectangle); the topmost timer keeps it above the
+    // full-screen static zoom/draw window.
     bool Start( winrt::GraphicsCaptureItem const& item,
                 RECT sourceRect,
                 HWND sourceWindow,
@@ -51,7 +54,8 @@ public:
                 HMONITOR targetMonitor,
                 HWND notifyWindow,
                 std::function<AnnotationState()> annotationQuery = nullptr,
-                bool trackWindow = false );
+                bool trackWindow = false,
+                HWND sourceBorderWindow = nullptr );
     void Stop();
 
 private:
@@ -75,11 +79,14 @@ private:
     HWND	m_borderWindow = nullptr;
     HWND	m_notifyWindow = nullptr;
     HWND	m_sourceWindow = nullptr;
+    HWND	m_sourceBorderWindow = nullptr;	// caller-owned region/monitor border
     RECT	m_borderTarget{};	// source window rect the border follows
     RECT	m_sourceRect{};		// mirrored region in screen coordinates
     RECT	m_textureCrop{};	// mirrored region in capture-texture coordinates
     RECT	m_targetRect{};		// target monitor rectangle
     RECT	m_sourceMonitorRect{};	// source monitor rectangle (window tracking)
+    HMONITOR	m_sourceMonitor = nullptr;
+    HMONITOR	m_targetMonitor = nullptr;
     bool	m_trackWindow = false;	// monitor capture cropped to the window rect
     int		m_bufferWidth = 0;	// swapchain dimensions
     int		m_bufferHeight = 0;

--- a/src/modules/ZoomIt/ZoomIt/MirrorWindow.h
+++ b/src/modules/ZoomIt/ZoomIt/MirrorWindow.h
@@ -33,6 +33,10 @@ public:
 
     bool IsActive() const { return m_window != nullptr; }
 
+    // Visible window bounds, excluding the invisible resize/shadow frame
+    // that GetWindowRect includes.
+    static RECT GetWindowFrameRect( HWND window );
+
     // For window mirroring, sourceWindow is the mirrored window and
     // sourceRect is its window rect; for region mirroring, sourceWindow is
     // null and sourceRect is the mirrored region in screen coordinates.

--- a/src/modules/ZoomIt/ZoomIt/MirrorWindow.h
+++ b/src/modules/ZoomIt/ZoomIt/MirrorWindow.h
@@ -20,6 +20,11 @@
 class MirrorWindow
 {
 public:
+    // ZoomIt annotation modes (zoom/draw/live zoom) render in overlay
+    // windows a window capture can't see; while one is active a window
+    // mirror temporarily switches to capturing the monitor.
+    enum class AnnotationState { None, Annotating, AnnotatingLiveZoom };
+
     ~MirrorWindow() { Stop(); }
 
     bool IsActive() const { return m_window != nullptr; }
@@ -32,7 +37,8 @@ public:
                 HWND sourceWindow,
                 HMONITOR sourceMonitor,
                 HMONITOR targetMonitor,
-                HWND notifyWindow );
+                HWND notifyWindow,
+                std::function<AnnotationState()> annotationQuery = nullptr );
     void Stop();
 
 private:
@@ -44,6 +50,8 @@ private:
 
     void RenderLoop();
     void RenderFrame();
+    bool UpdateAnnotationState();
+    bool SwitchCapture( winrt::GraphicsCaptureItem const& item, bool enableCursor );
     RECT ComputeWindowRect() const;
     LRESULT WindowProc( HWND window, UINT message, WPARAM wordParam, LPARAM longParam );
 
@@ -66,6 +74,11 @@ private:
     winrt::com_ptr<ID3D11Texture2D>		m_sourceTexture;
     winrt::Direct3D11::IDirect3DDevice	m_winrtDevice{ nullptr };
     std::unique_ptr<CaptureFrameWait>	m_frameWait;
+
+    std::function<AnnotationState()>	m_annotationQuery;
+    AnnotationState	m_annotationState = AnnotationState::None;
+    bool	m_monitorOverride = false;	// capturing the monitor while annotating
+    RECT	m_overrideRect{};			// override monitor rectangle
 
     std::thread			m_renderThread;
     wil::unique_event	m_stopEvent{ wil::EventOptions::ManualReset };

--- a/src/modules/ZoomIt/ZoomIt/MirrorWindow.h
+++ b/src/modules/ZoomIt/ZoomIt/MirrorWindow.h
@@ -17,6 +17,10 @@
 // window closed. Keep distinct from the WM_USER messages in zoomit.h.
 #define WM_USER_MIRROR_STOP		WM_USER+112
 
+// Bright green, distinguishing the mirror border from the yellow
+// record/panorama borders and the orange recording-active border.
+#define MIRROR_BORDER_COLOR		RGB( 0, 255, 0 )
+
 class MirrorWindow
 {
 public:
@@ -52,19 +56,24 @@ private:
     static const UINT_PTR TOPMOST_TIMER_ID = 1;
     // Private to the mirror window: re-fit it to the source's aspect ratio.
     static const UINT WM_MIRROR_RELAYOUT = WM_USER + 1;
+    // Private to the mirror window: move the border to the source window.
+    static const UINT WM_MIRROR_BORDER = WM_USER + 2;
 
     void RenderLoop();
     void RenderFrame();
     bool UpdateAnnotationState();
     bool SwitchCapture( winrt::GraphicsCaptureItem const& item, bool enableCursor );
     RECT ComputeWindowRect() const;
+    void UpdateBorderWindow();
     LRESULT WindowProc( HWND window, UINT message, WPARAM wordParam, LPARAM longParam );
 
     const wchar_t* m_className = L"ZoomitMirrorWindow";
     HWND	m_window = nullptr;
     HWND	m_backdropWindow = nullptr;
+    HWND	m_borderWindow = nullptr;
     HWND	m_notifyWindow = nullptr;
     HWND	m_sourceWindow = nullptr;
+    RECT	m_borderTarget{};	// source window rect the border follows
     RECT	m_sourceRect{};		// mirrored region in screen coordinates
     RECT	m_textureCrop{};	// mirrored region in capture-texture coordinates
     RECT	m_targetRect{};		// target monitor rectangle

--- a/src/modules/ZoomIt/ZoomIt/MirrorWindow.h
+++ b/src/modules/ZoomIt/ZoomIt/MirrorWindow.h
@@ -55,8 +55,6 @@ public:
     void Stop();
 
 private:
-    static const int ZOOM_IN_HOTKEY_ID = 1;
-    static const int ZOOM_OUT_HOTKEY_ID = 2;
     static const UINT_PTR TOPMOST_TIMER_ID = 1;
     // Private to the mirror window: re-fit it to the source's aspect ratio.
     static const UINT WM_MIRROR_RELAYOUT = WM_USER + 1;
@@ -100,12 +98,7 @@ private:
     std::function<AnnotationState()>	m_annotationQuery;
     AnnotationState	m_annotationState = AnnotationState::None;
     bool	m_monitorOverride = false;	// capturing the monitor while annotating
-    RECT	m_overrideRect{};			// override monitor rectangle
 
     std::thread			m_renderThread;
     wil::unique_event	m_stopEvent{ wil::EventOptions::ManualReset };
-    std::atomic<float>	m_zoomTarget{ 1.0f };
-    float	m_zoom = 1.0f;
-    float	m_centerX = 0;
-    float	m_centerY = 0;
 };

--- a/src/modules/ZoomIt/ZoomIt/MirrorWindow.h
+++ b/src/modules/ZoomIt/ZoomIt/MirrorWindow.h
@@ -1,0 +1,70 @@
+//==============================================================================
+//
+// Zoomit
+// Sysinternals - www.sysinternals.com
+//
+// DemoMirror: mirrors a screen region or window, including the mouse cursor,
+// onto a second monitor so an audience can follow a demo app on the
+// presentation monitor without the presenter leaving the presentation.
+//
+//==============================================================================
+#pragma once
+
+#include "pch.h"
+#include "CaptureFrameWait.h"
+
+// Posted to the notify window when mirroring must stop because the mirrored
+// window closed. Keep distinct from the WM_USER messages in zoomit.h.
+#define WM_USER_MIRROR_STOP		WM_USER+112
+
+class MirrorWindow
+{
+public:
+    ~MirrorWindow() { Stop(); }
+
+    bool IsActive() const { return m_window != nullptr; }
+
+    // For window mirroring, sourceWindow is the mirrored window and
+    // sourceRect is its window rect; for region mirroring, sourceWindow is
+    // null and sourceRect is the mirrored region in screen coordinates.
+    bool Start( winrt::GraphicsCaptureItem const& item,
+                RECT sourceRect,
+                HWND sourceWindow,
+                HMONITOR sourceMonitor,
+                HMONITOR targetMonitor,
+                HWND notifyWindow );
+    void Stop();
+
+private:
+    static const int ZOOM_IN_HOTKEY_ID = 1;
+    static const int ZOOM_OUT_HOTKEY_ID = 2;
+    static const UINT_PTR TOPMOST_TIMER_ID = 1;
+
+    void RenderLoop();
+    void RenderFrame();
+    LRESULT WindowProc( HWND window, UINT message, WPARAM wordParam, LPARAM longParam );
+
+    const wchar_t* m_className = L"ZoomitMirrorWindow";
+    HWND	m_window = nullptr;
+    HWND	m_notifyWindow = nullptr;
+    HWND	m_sourceWindow = nullptr;
+    RECT	m_sourceRect{};		// mirrored region in screen coordinates
+    RECT	m_textureCrop{};	// mirrored region in capture-texture coordinates
+    int		m_bufferWidth = 0;
+    int		m_bufferHeight = 0;
+    winrt::SizeInt32	m_contentSize{};
+
+    winrt::com_ptr<ID3D11Device>		m_device;
+    winrt::com_ptr<ID3D11DeviceContext>	m_context;
+    winrt::com_ptr<IDXGISwapChain2>		m_swapChain;
+    winrt::com_ptr<ID3D11Texture2D>		m_sourceTexture;
+    winrt::Direct3D11::IDirect3DDevice	m_winrtDevice{ nullptr };
+    std::unique_ptr<CaptureFrameWait>	m_frameWait;
+
+    std::thread			m_renderThread;
+    wil::unique_event	m_stopEvent{ wil::EventOptions::ManualReset };
+    std::atomic<float>	m_zoomTarget{ 1.0f };
+    float	m_zoom = 1.0f;
+    float	m_centerX = 0;
+    float	m_centerY = 0;
+};

--- a/src/modules/ZoomIt/ZoomIt/MirrorWindow.h
+++ b/src/modules/ZoomIt/ZoomIt/MirrorWindow.h
@@ -49,6 +49,7 @@ private:
 
     const wchar_t* m_className = L"ZoomitMirrorWindow";
     HWND	m_window = nullptr;
+    HWND	m_backdropWindow = nullptr;
     HWND	m_notifyWindow = nullptr;
     HWND	m_sourceWindow = nullptr;
     RECT	m_sourceRect{};		// mirrored region in screen coordinates

--- a/src/modules/ZoomIt/ZoomIt/MirrorWindow.h
+++ b/src/modules/ZoomIt/ZoomIt/MirrorWindow.h
@@ -39,9 +39,12 @@ private:
     static const int ZOOM_IN_HOTKEY_ID = 1;
     static const int ZOOM_OUT_HOTKEY_ID = 2;
     static const UINT_PTR TOPMOST_TIMER_ID = 1;
+    // Private to the mirror window: re-fit it to the source's aspect ratio.
+    static const UINT WM_MIRROR_RELAYOUT = WM_USER + 1;
 
     void RenderLoop();
     void RenderFrame();
+    RECT ComputeWindowRect() const;
     LRESULT WindowProc( HWND window, UINT message, WPARAM wordParam, LPARAM longParam );
 
     const wchar_t* m_className = L"ZoomitMirrorWindow";
@@ -50,9 +53,11 @@ private:
     HWND	m_sourceWindow = nullptr;
     RECT	m_sourceRect{};		// mirrored region in screen coordinates
     RECT	m_textureCrop{};	// mirrored region in capture-texture coordinates
+    RECT	m_targetRect{};		// target monitor rectangle
     int		m_bufferWidth = 0;
     int		m_bufferHeight = 0;
     winrt::SizeInt32	m_contentSize{};
+    winrt::SizeInt32	m_poolSize{};
 
     winrt::com_ptr<ID3D11Device>		m_device;
     winrt::com_ptr<ID3D11DeviceContext>	m_context;

--- a/src/modules/ZoomIt/ZoomIt/MirrorWindow.h
+++ b/src/modules/ZoomIt/ZoomIt/MirrorWindow.h
@@ -32,13 +32,18 @@ public:
     // For window mirroring, sourceWindow is the mirrored window and
     // sourceRect is its window rect; for region mirroring, sourceWindow is
     // null and sourceRect is the mirrored region in screen coordinates.
+    // With trackWindow, item must be a monitor capture: the mirror shows
+    // the region under the tracked window instead of the window's own
+    // surface, so ZoomIt annotations show in place, at the cost of
+    // occluding windows becoming visible.
     bool Start( winrt::GraphicsCaptureItem const& item,
                 RECT sourceRect,
                 HWND sourceWindow,
                 HMONITOR sourceMonitor,
                 HMONITOR targetMonitor,
                 HWND notifyWindow,
-                std::function<AnnotationState()> annotationQuery = nullptr );
+                std::function<AnnotationState()> annotationQuery = nullptr,
+                bool trackWindow = false );
     void Stop();
 
 private:
@@ -63,8 +68,12 @@ private:
     RECT	m_sourceRect{};		// mirrored region in screen coordinates
     RECT	m_textureCrop{};	// mirrored region in capture-texture coordinates
     RECT	m_targetRect{};		// target monitor rectangle
-    int		m_bufferWidth = 0;
+    RECT	m_sourceMonitorRect{};	// source monitor rectangle (window tracking)
+    bool	m_trackWindow = false;	// monitor capture cropped to the window rect
+    int		m_bufferWidth = 0;	// swapchain dimensions
     int		m_bufferHeight = 0;
+    int		m_imageWidth = 0;	// displayed image dimensions, for layout
+    int		m_imageHeight = 0;
     winrt::SizeInt32	m_contentSize{};
     winrt::SizeInt32	m_poolSize{};
 

--- a/src/modules/ZoomIt/ZoomIt/SelectRectangle.cpp
+++ b/src/modules/ZoomIt/ZoomIt/SelectRectangle.cpp
@@ -36,7 +36,7 @@ static void SelectRectangleDebugLog( const wchar_t* format, ... )
 bool SelectRectangle::Start( HWND ownerWindow, bool fullMonitor )
 {
     m_stopping = false;
-    m_borderColor = RGB( 255, 222, 0 ); // Reset to yellow; turns orange once first frame is captured.
+    m_borderColor = m_configuredBorderColor; // Reset from the recording-active orange.
     m_recordingActive = false;           // Reset so SetRecordingActive fires on next recording.
     m_fullMonitor = fullMonitor;
 

--- a/src/modules/ZoomIt/ZoomIt/SelectRectangle.h
+++ b/src/modules/ZoomIt/ZoomIt/SelectRectangle.h
@@ -21,6 +21,7 @@ public:
     int MinSize() const { return m_minSize; }
     void AspectRatio( double ratio ) { m_aspectRatio = ratio; }
     double AspectRatio() const { return m_aspectRatio; }
+    void BorderColor( COLORREF color ) { m_borderColor = color; }
     RECT SelectedRect() const { return m_selectedRect; }
     bool IsActive() const { return m_window != nullptr; }
 

--- a/src/modules/ZoomIt/ZoomIt/SelectRectangle.h
+++ b/src/modules/ZoomIt/ZoomIt/SelectRectangle.h
@@ -21,7 +21,8 @@ public:
     int MinSize() const { return m_minSize; }
     void AspectRatio( double ratio ) { m_aspectRatio = ratio; }
     double AspectRatio() const { return m_aspectRatio; }
-    void BorderColor( COLORREF color ) { m_borderColor = color; }
+    // Sets the border color Start resets to (default: capture-API yellow).
+    void BorderColor( COLORREF color ) { m_configuredBorderColor = color; m_borderColor = color; }
     RECT SelectedRect() const { return m_selectedRect; }
     bool IsActive() const { return m_window != nullptr; }
 
@@ -47,6 +48,7 @@ private:
     double m_aspectRatio = 0.0; // 0 = no constraint, e.g. 16.0/9.0
     RECT m_selectedRect{};
     COLORREF m_borderColor = RGB( 255, 222, 0 ); // default: yellow (matches capture API)
+    COLORREF m_configuredBorderColor = RGB( 255, 222, 0 ); // color Start resets to
     bool m_recordingActive = false; // true once first frame is captured
     bool m_fullMonitor = false;       // true when recording full screen
 

--- a/src/modules/ZoomIt/ZoomIt/ZoomIt.rc
+++ b/src/modules/ZoomIt/ZoomIt/ZoomIt.rc
@@ -269,8 +269,8 @@ BEGIN
     LTEXT           "Enter the hotkey to mirror the entire screen, enter it with the Shift key to select a region to mirror, or with the Alt key to mirror the window under the cursor. Enter the hotkey again to stop mirroring.",IDC_STATIC,7,39,272,27
     LTEXT           "Mirror Toggle:",IDC_STATIC,7,73,62,8
     CONTROL         "",IDC_MIRROR_HOTKEY,"msctls_hotkey32",WS_BORDER | WS_TABSTOP,73,71,80,12
-    CONTROL         "Mirror windows by tracking their screen region, so zoom and draw show in place (uncheck to mirror the window's own surface, unaffected by overlapping windows):",IDC_MIRROR_TRACK_WINDOW,
-                    "Button",BS_AUTOCHECKBOX | BS_TOP | BS_MULTILINE | WS_TABSTOP,7,91,272,26
+    LTEXT           "When mirroring a window, DemoMirror can track the window's screen region so ZoomIt zoom and draw show in place. Uncheck to mirror the window's surface directly, unaffected by overlapping windows.",IDC_STATIC,7,91,272,27
+    CONTROL         "Track window region:",IDC_MIRROR_TRACK_WINDOW,"Button",BS_AUTOCHECKBOX | BS_LEFTTEXT | BS_RIGHT | WS_TABSTOP,7,121,90,10
 END
 
 RECORD DIALOGEX 0, 0, 276, 228

--- a/src/modules/ZoomIt/ZoomIt/ZoomIt.rc
+++ b/src/modules/ZoomIt/ZoomIt/ZoomIt.rc
@@ -265,13 +265,12 @@ DEMOMIRROR DIALOGEX 0, 0, 317, 136
 STYLE DS_SETFONT | DS_FIXEDSYS | DS_CONTROL | WS_CHILD | WS_SYSMENU
 FONT 8, "MS Shell Dlg", 400, 0, 0x1
 BEGIN
-    LTEXT           "DemoMirror mirrors a region of the screen or a window, including the mouse pointer, onto a second monitor. Use it to show a demo app on the presentation monitor, on top of the slide show, without leaving the presentation.",IDC_STATIC,7,7,272,27
-    LTEXT           "Enter the hotkey to select a region to mirror and enter it again to stop mirroring. To mirror the window under the cursor instead, enter the hotkey with the Alt key in the opposite mode.",IDC_STATIC,7,39,272,19
-    LTEXT           "Use Ctrl+Up and Ctrl+Down to zoom the mirrored image around the mouse pointer.",IDC_STATIC,7,63,272,13
-    LTEXT           "Mirror Toggle:",IDC_STATIC,7,87,62,8
-    CONTROL         "",IDC_MIRROR_HOTKEY,"msctls_hotkey32",WS_BORDER | WS_TABSTOP,73,85,80,12
+    LTEXT           "DemoMirror mirrors the screen, a region of the screen, or a window, including the mouse pointer, onto a second monitor. Use it to show a demo app on the presentation monitor, on top of the slide show, without leaving the presentation.",IDC_STATIC,7,7,272,27
+    LTEXT           "Enter the hotkey to mirror the entire screen, enter it with the Shift key to select a region to mirror, or with the Alt key to mirror the window under the cursor. Enter the hotkey again to stop mirroring.",IDC_STATIC,7,39,272,27
+    LTEXT           "Mirror Toggle:",IDC_STATIC,7,73,62,8
+    CONTROL         "",IDC_MIRROR_HOTKEY,"msctls_hotkey32",WS_BORDER | WS_TABSTOP,73,71,80,12
     CONTROL         "Mirror windows by tracking their screen region, so zoom and draw show in place (uncheck to mirror the window's own surface, unaffected by overlapping windows):",IDC_MIRROR_TRACK_WINDOW,
-                    "Button",BS_AUTOCHECKBOX | BS_TOP | BS_MULTILINE | WS_TABSTOP,7,105,272,26
+                    "Button",BS_AUTOCHECKBOX | BS_TOP | BS_MULTILINE | WS_TABSTOP,7,91,272,26
 END
 
 RECORD DIALOGEX 0, 0, 276, 228

--- a/src/modules/ZoomIt/ZoomIt/ZoomIt.rc
+++ b/src/modules/ZoomIt/ZoomIt/ZoomIt.rc
@@ -122,7 +122,7 @@ BEGIN
     DEFPUSHBUTTON   "OK",IDOK,184,308,50,14
     PUSHBUTTON      "Cancel",IDCANCEL,241,308,50,14
     LTEXT           "ZoomIt v12.11",IDC_VERSION,42,7,73,10
-    LTEXT           "Copyright © 2006-2026 Mark Russinovich",IDC_COPYRIGHT,42,17,251,8
+    LTEXT           "Copyright ï¿½ 2006-2026 Mark Russinovich",IDC_COPYRIGHT,42,17,251,8
     CONTROL         "<a HREF=""https://www.sysinternals.com"">Sysinternals - www.sysinternals.com</a>",IDC_LINK,
                     "SysLink",WS_TABSTOP,42,26,150,9
     ICON            "APPICON",IDC_STATIC,12,9,20,20
@@ -259,6 +259,17 @@ BEGIN
     LTEXT           "To enter and exit LiveZoom, enter the hotkey specified below.",IDC_STATIC,7,71,230,13
     LTEXT           "LiveZoom Toggle:",IDC_STATIC,7,87,62,8
     CONTROL         "",IDC_LIVE_HOTKEY,"msctls_hotkey32",WS_BORDER | WS_TABSTOP,73,85,80,12
+END
+
+DEMOMIRROR DIALOGEX 0, 0, 317, 136
+STYLE DS_SETFONT | DS_FIXEDSYS | DS_CONTROL | WS_CHILD | WS_SYSMENU
+FONT 8, "MS Shell Dlg", 400, 0, 0x1
+BEGIN
+    LTEXT           "DemoMirror mirrors a region of the screen or a window, including the mouse pointer, onto a second monitor. Use it to show a demo app on the presentation monitor, on top of the slide show, without leaving the presentation.",IDC_STATIC,7,7,272,27
+    LTEXT           "Enter the hotkey to select a region to mirror and enter it again to stop mirroring. To mirror the window under the cursor instead, enter the hotkey with the Alt key in the opposite mode.",IDC_STATIC,7,39,272,19
+    LTEXT           "Use Ctrl+Up and Ctrl+Down to zoom the mirrored image around the mouse pointer.",IDC_STATIC,7,63,272,13
+    LTEXT           "Mirror Toggle:",IDC_STATIC,7,87,62,8
+    CONTROL         "",IDC_MIRROR_HOTKEY,"msctls_hotkey32",WS_BORDER | WS_TABSTOP,73,85,80,12
 END
 
 RECORD DIALOGEX 0, 0, 276, 228
@@ -450,6 +461,14 @@ BEGIN
         BOTTOMMARGIN, 89
     END
 
+    "DEMOMIRROR", DIALOG
+    BEGIN
+        LEFTMARGIN, 7
+        RIGHTMARGIN, 279
+        TOPMARGIN, 7
+        BOTTOMMARGIN, 97
+    END
+
     "RECORD", DIALOG
     BEGIN
         LEFTMARGIN, 7
@@ -517,6 +536,11 @@ BEGIN
 END
 
 LIVEZOOM AFX_DIALOG_LAYOUT
+BEGIN
+    0
+END
+
+DEMOMIRROR AFX_DIALOG_LAYOUT
 BEGIN
     0
 END

--- a/src/modules/ZoomIt/ZoomIt/ZoomIt.rc
+++ b/src/modules/ZoomIt/ZoomIt/ZoomIt.rc
@@ -270,6 +270,8 @@ BEGIN
     LTEXT           "Use Ctrl+Up and Ctrl+Down to zoom the mirrored image around the mouse pointer.",IDC_STATIC,7,63,272,13
     LTEXT           "Mirror Toggle:",IDC_STATIC,7,87,62,8
     CONTROL         "",IDC_MIRROR_HOTKEY,"msctls_hotkey32",WS_BORDER | WS_TABSTOP,73,85,80,12
+    CONTROL         "Mirror windows by tracking their screen region, so zoom and draw show in place (uncheck to mirror the window's own surface, unaffected by overlapping windows):",IDC_MIRROR_TRACK_WINDOW,
+                    "Button",BS_AUTOCHECKBOX | BS_TOP | BS_MULTILINE | WS_TABSTOP,7,105,272,26
 END
 
 RECORD DIALOGEX 0, 0, 276, 228

--- a/src/modules/ZoomIt/ZoomIt/ZoomIt.vcxproj
+++ b/src/modules/ZoomIt/ZoomIt/ZoomIt.vcxproj
@@ -257,6 +257,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="GifRecordingSession.cpp" />
+    <ClCompile Include="MirrorWindow.cpp" />
     <ClCompile Include="NoiseSuppressor.cpp" />
     <ClCompile Include="PanoramaCapture.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Use</PrecompiledHeader>
@@ -478,6 +479,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\ZoomItModuleInterface\Trace.h" />
     <ClInclude Include="GifRecordingSession.h" />
     <ClInclude Include="ImageEncoder.h" />
+    <ClInclude Include="MirrorWindow.h" />
     <ClInclude Include="NoiseSuppressor.h" />
     <ClInclude Include="PanoramaCapture.h" />
     <ClInclude Include="pch.h" />

--- a/src/modules/ZoomIt/ZoomIt/ZoomIt.vcxproj.filters
+++ b/src/modules/ZoomIt/ZoomIt/ZoomIt.vcxproj.filters
@@ -30,6 +30,9 @@
     <ClCompile Include="pch.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="MirrorWindow.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="SelectRectangle.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -129,6 +132,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="pch.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="MirrorWindow.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="SelectRectangle.h">

--- a/src/modules/ZoomIt/ZoomIt/ZoomItSettings.h
+++ b/src/modules/ZoomIt/ZoomIt/ZoomItSettings.h
@@ -21,6 +21,7 @@ DWORD   g_SnipSaveToggleKey = ((HOTKEYF_CONTROL | HOTKEYF_SHIFT) << 8) | '6';
 DWORD   g_SnipPanoramaToggleKey = ((HOTKEYF_CONTROL) << 8) | '8';
 DWORD   g_SnipPanoramaSaveToggleKey = ((HOTKEYF_CONTROL | HOTKEYF_SHIFT) << 8) | '8';
 DWORD   g_SnipOcrToggleKey = ((HOTKEYF_CONTROL | HOTKEYF_ALT) << 8) | '6';
+DWORD   g_MirrorToggleKey = ((HOTKEYF_CONTROL) << 8) | '9';
 
 DWORD	g_ShowExpiredTime = 1;
 DWORD	g_SliderZoomLevel = 3;
@@ -86,6 +87,7 @@ REG_SETTING RegSettings[] = {
     { L"SnipPanoramaToggleKey", SETTING_TYPE_DWORD, 0, &g_SnipPanoramaToggleKey, static_cast<DOUBLE>(g_SnipPanoramaToggleKey) },
     { L"SnipPanoramaSaveToggleKey", SETTING_TYPE_DWORD, 0, &g_SnipPanoramaSaveToggleKey, static_cast<DOUBLE>(g_SnipPanoramaSaveToggleKey) },
     { L"SnipOcrToggleKey", SETTING_TYPE_DWORD, 0, &g_SnipOcrToggleKey, static_cast<DOUBLE>(g_SnipOcrToggleKey) },
+    { L"MirrorToggleKey", SETTING_TYPE_DWORD, 0, &g_MirrorToggleKey, static_cast<DOUBLE>(g_MirrorToggleKey) },
     { L"PenColor", SETTING_TYPE_DWORD, 0, &g_PenColor, static_cast<DOUBLE>(g_PenColor) },
     { L"PenWidth", SETTING_TYPE_DWORD, 0, &g_RootPenWidth, static_cast<DOUBLE>(g_RootPenWidth) },
     { L"OptionsShown", SETTING_TYPE_BOOLEAN, 0, &g_OptionsShown, static_cast<DOUBLE>(g_OptionsShown) },

--- a/src/modules/ZoomIt/ZoomIt/ZoomItSettings.h
+++ b/src/modules/ZoomIt/ZoomIt/ZoomItSettings.h
@@ -22,6 +22,7 @@ DWORD   g_SnipPanoramaToggleKey = ((HOTKEYF_CONTROL) << 8) | '8';
 DWORD   g_SnipPanoramaSaveToggleKey = ((HOTKEYF_CONTROL | HOTKEYF_SHIFT) << 8) | '8';
 DWORD   g_SnipOcrToggleKey = ((HOTKEYF_CONTROL | HOTKEYF_ALT) << 8) | '6';
 DWORD   g_MirrorToggleKey = ((HOTKEYF_CONTROL) << 8) | '9';
+BOOLEAN g_MirrorTrackWindow = TRUE;
 
 DWORD	g_ShowExpiredTime = 1;
 DWORD	g_SliderZoomLevel = 3;
@@ -88,6 +89,7 @@ REG_SETTING RegSettings[] = {
     { L"SnipPanoramaSaveToggleKey", SETTING_TYPE_DWORD, 0, &g_SnipPanoramaSaveToggleKey, static_cast<DOUBLE>(g_SnipPanoramaSaveToggleKey) },
     { L"SnipOcrToggleKey", SETTING_TYPE_DWORD, 0, &g_SnipOcrToggleKey, static_cast<DOUBLE>(g_SnipOcrToggleKey) },
     { L"MirrorToggleKey", SETTING_TYPE_DWORD, 0, &g_MirrorToggleKey, static_cast<DOUBLE>(g_MirrorToggleKey) },
+    { L"MirrorTrackWindow", SETTING_TYPE_BOOLEAN, 0, &g_MirrorTrackWindow, static_cast<DOUBLE>(g_MirrorTrackWindow) },
     { L"PenColor", SETTING_TYPE_DWORD, 0, &g_PenColor, static_cast<DOUBLE>(g_PenColor) },
     { L"PenWidth", SETTING_TYPE_DWORD, 0, &g_RootPenWidth, static_cast<DOUBLE>(g_RootPenWidth) },
     { L"OptionsShown", SETTING_TYPE_BOOLEAN, 0, &g_OptionsShown, static_cast<DOUBLE>(g_OptionsShown) },

--- a/src/modules/ZoomIt/ZoomIt/Zoomit.cpp
+++ b/src/modules/ZoomIt/ZoomIt/Zoomit.cpp
@@ -17,6 +17,7 @@
 #include "ZoomItSettings.h"
 #include "GifRecordingSession.h"
 #include "WebcamPreviewWindow.h"
+#include "MirrorWindow.h"
 #include "BreakTimer.h"
 #include "PanoramaCapture.h"
 #include "ImageEncoder.h"
@@ -102,6 +103,8 @@ COLORREF	g_CustomColors[16];
 #define SNIP_PANORAMA_HOTKEY     19
 #define SNIP_PANORAMA_SAVE_HOTKEY 20
 #define WEBCAM_TOGGLE_HOTKEY     21
+#define MIRROR_HOTKEY            22
+#define MIRROR_WINDOW_HOTKEY     23
 
 #define ZOOM_PAGE	  0
 #define LIVE_PAGE	  1
@@ -117,6 +120,7 @@ COLORREF	g_CustomColors[16];
 #define RECORD_PAGE	  6
 #define SNIP_PAGE	  7
 #define PANORAMA_PAGE 8
+#define MIRROR_PAGE	  9
 
 OPTION_TABS g_OptionsTabs[] = {
     { _T("Zoom"), NULL },
@@ -127,7 +131,8 @@ OPTION_TABS g_OptionsTabs[] = {
     { _T("Break"), NULL },
     { _T("Record"), NULL },
     { _T("Snip"), NULL },
-    { _T("Panorama"), NULL }
+    { _T("Panorama"), NULL },
+    { _T("DemoMirror"), NULL }
 };
 
 static const TCHAR* g_RecordingFormats[] = {
@@ -176,6 +181,7 @@ DWORD   g_SnipPanoramaToggleMod;
 DWORD   g_SnipOcrToggleMod;
 DWORD   g_SnipSaveToggleMod;
 DWORD   g_SnipPanoramaSaveToggleMod;
+DWORD   g_MirrorToggleMod;
 
 BOOLEAN	g_ZoomOnLiveZoom = FALSE;
 DWORD	g_PenWidth = PEN_WIDTH;
@@ -214,6 +220,8 @@ BOOL	g_RecordToggle = FALSE;
 BOOL	g_RecordCropping = FALSE;
 SelectRectangle g_SelectRectangle;
 WebcamPreviewWindow g_WebcamPreview;
+SelectRectangle g_MirrorSelectRectangle;
+MirrorWindow g_MirrorWindow;
 // The full path of the last saved recording file.
 std::wstring	g_RecordingSaveLocation;
 // The last user-chosen recording filename. Used to construct unique recording filenames.
@@ -418,6 +426,8 @@ const wchar_t* HotkeyIdToString( WPARAM hotkeyId )
     case SNIP_OCR_HOTKEY: return L"SNIP_OCR_HOTKEY";
     case SNIP_PANORAMA_HOTKEY: return L"SNIP_PANORAMA_HOTKEY";
     case SNIP_PANORAMA_SAVE_HOTKEY: return L"SNIP_PANORAMA_SAVE_HOTKEY";
+    case MIRROR_HOTKEY: return L"MIRROR_HOTKEY";
+    case MIRROR_WINDOW_HOTKEY: return L"MIRROR_WINDOW_HOTKEY";
     default: return L"UNKNOWN_HOTKEY";
     }
 }
@@ -3559,6 +3569,8 @@ void UnregisterAllHotkeys( HWND hWnd )
     unregisterHotkey( SAVE_CROP_HOTKEY );
     unregisterHotkey( COPY_IMAGE_HOTKEY );
     unregisterHotkey( COPY_CROP_HOTKEY );
+    unregisterHotkey( MIRROR_HOTKEY );
+    unregisterHotkey( MIRROR_WINDOW_HOTKEY );
 }
 
 //----------------------------------------------------------------------------
@@ -3610,6 +3622,13 @@ void RegisterAllHotkeys(HWND hWnd)
         }
         if ( windowMod != 0 ) {
             registerHotkey( RECORD_WINDOW_HOTKEY, windowMod | MOD_NOREPEAT, g_RecordToggleKey & 0xFF );
+        }
+    }
+    if (g_MirrorToggleKey) {
+        registerHotkey( MIRROR_HOTKEY, g_MirrorToggleMod | MOD_NOREPEAT, g_MirrorToggleKey & 0xFF );
+        UINT mirrorWindowMod = g_MirrorToggleMod ^ MOD_ALT;
+        if ( mirrorWindowMod != 0 ) {
+            registerHotkey( MIRROR_WINDOW_HOTKEY, mirrorWindowMod | MOD_NOREPEAT, g_MirrorToggleKey & 0xFF );
         }
     }
 
@@ -4828,6 +4847,7 @@ INT_PTR CALLBACK OptionsProc( HWND hDlg, UINT message,
     DWORD			newSnipSaveToggleKey, newSnipSaveToggleMod;
     DWORD			newSnipPanoramaSaveToggleKey, newSnipPanoramaSaveToggleMod;
     DWORD			newLiveZoomToggleKey, newLiveZoomToggleMod;
+    DWORD			newMirrorToggleKey, newMirrorToggleMod;
     static std::vector<std::pair<std::wstring, std::wstring>>	microphones;
 
     auto CleanupFonts = [&]()
@@ -5065,6 +5085,7 @@ INT_PTR CALLBACK OptionsProc( HWND hDlg, UINT message,
         if( g_SnipPanoramaToggleKey) SendMessage( GetDlgItem( g_OptionsTabs[PANORAMA_PAGE].hPage, IDC_SNIP_PANORAMA_HOTKEY), HKM_SETHOTKEY, g_SnipPanoramaToggleKey, 0 );
         if( g_SnipPanoramaSaveToggleKey) SendMessage( GetDlgItem( g_OptionsTabs[PANORAMA_PAGE].hPage, IDC_SNIP_PANORAMA_SAVE_HOTKEY), HKM_SETHOTKEY, g_SnipPanoramaSaveToggleKey, 0 );
         if( g_SnipOcrToggleKey) SendMessage( GetDlgItem( g_OptionsTabs[SNIP_PAGE].hPage, IDC_SNIP_OCR_HOTKEY), HKM_SETHOTKEY, g_SnipOcrToggleKey, 0 );
+        if( g_MirrorToggleKey) SendMessage( GetDlgItem( g_OptionsTabs[MIRROR_PAGE].hPage, IDC_MIRROR_HOTKEY), HKM_SETHOTKEY, g_MirrorToggleKey, 0 );
         CheckDlgButton( hDlg, IDC_SHOW_TRAY_ICON,
             g_ShowTrayIcon ? BST_CHECKED: BST_UNCHECKED );
         CheckDlgButton( hDlg, IDC_AUTOSTART,
@@ -5529,6 +5550,7 @@ INT_PTR CALLBACK OptionsProc( HWND hDlg, UINT message,
             newSnipPanoramaToggleKey = static_cast<DWORD>(SendMessage( GetDlgItem( g_OptionsTabs[PANORAMA_PAGE].hPage, IDC_SNIP_PANORAMA_HOTKEY), HKM_GETHOTKEY, 0, 0 ));
             newSnipPanoramaSaveToggleKey = static_cast<DWORD>(SendMessage( GetDlgItem( g_OptionsTabs[PANORAMA_PAGE].hPage, IDC_SNIP_PANORAMA_SAVE_HOTKEY), HKM_GETHOTKEY, 0, 0 ));
             newSnipOcrToggleKey = static_cast<DWORD>(SendMessage( GetDlgItem( g_OptionsTabs[SNIP_PAGE].hPage, IDC_SNIP_OCR_HOTKEY), HKM_GETHOTKEY, 0, 0 ));
+            newMirrorToggleKey = static_cast<DWORD>(SendMessage( GetDlgItem( g_OptionsTabs[MIRROR_PAGE].hPage, IDC_MIRROR_HOTKEY), HKM_GETHOTKEY, 0, 0 ));
 
             newToggleMod = GetKeyMod( newToggleKey );
             newLiveZoomToggleMod = GetKeyMod( newLiveZoomToggleKey );
@@ -5541,6 +5563,7 @@ INT_PTR CALLBACK OptionsProc( HWND hDlg, UINT message,
             newSnipPanoramaToggleMod = GetKeyMod( newSnipPanoramaToggleKey );
             newSnipPanoramaSaveToggleMod = GetKeyMod( newSnipPanoramaSaveToggleKey );
             newSnipOcrToggleMod = GetKeyMod( newSnipOcrToggleKey );
+            newMirrorToggleMod = GetKeyMod( newMirrorToggleKey );
 
             g_SliderZoomLevel = static_cast<int>(SendMessage( GetDlgItem(g_OptionsTabs[ZOOM_PAGE].hPage, IDC_ZOOM_SLIDER), TBM_GETPOS, 0, 0 ));
             g_DemoTypeSpeedSlider = static_cast<int>(SendMessage( GetDlgItem( g_OptionsTabs[DEMOTYPE_PAGE].hPage, IDC_DEMOTYPE_SPEED_SLIDER ), TBM_GETPOS, 0, 0 ));
@@ -5662,6 +5685,15 @@ INT_PTR CALLBACK OptionsProc( HWND hDlg, UINT message,
                     APPNAME, MB_ICONERROR);
                 UnregisterAllHotkeys(GetParent(hDlg));
                 break;
+            }
+            else if( UINT mirrorWindowMod = newMirrorToggleMod ^ MOD_ALT; newMirrorToggleKey &&
+                (!RegisterHotKey(GetParent(hDlg), MIRROR_HOTKEY, newMirrorToggleMod | MOD_NOREPEAT, newMirrorToggleKey & 0xFF) ||
+                (mirrorWindowMod != 0 && !RegisterHotKey(GetParent(hDlg), MIRROR_WINDOW_HOTKEY, mirrorWindowMod | MOD_NOREPEAT, newMirrorToggleKey & 0xFF)))) {
+
+                MessageBox(hDlg, L"The specified mirror hotkey is already in use.\nSelect a different mirror hotkey.",
+                    APPNAME, MB_ICONERROR);
+                UnregisterAllHotkeys(GetParent(hDlg));
+                break;
             } else {
 
                 g_BreakTimeout = newTimeout;
@@ -5686,6 +5718,8 @@ INT_PTR CALLBACK OptionsProc( HWND hDlg, UINT message,
                 g_SnipPanoramaSaveToggleMod = newSnipPanoramaSaveToggleMod;
                 g_SnipOcrToggleKey = newSnipOcrToggleKey;
                 g_SnipOcrToggleMod = newSnipOcrToggleMod;
+                g_MirrorToggleKey = newMirrorToggleKey;
+                g_MirrorToggleMod = newMirrorToggleMod;
                 reg.WriteRegSettings( RegSettings );
                 EnableDisableTrayIcon( GetParent( hDlg ), g_ShowTrayIcon );
 
@@ -6960,6 +6994,45 @@ auto GetUniqueScreenshotFilename()
 
 //----------------------------------------------------------------------------
 //
+// FindMirrorTargetMonitor
+//
+// Picks the monitor to mirror onto: the one showing a PowerPoint slide show
+// if there is one, otherwise the first monitor that isn't the source.
+//
+//----------------------------------------------------------------------------
+HMONITOR FindMirrorTargetMonitor( HMONITOR sourceMonitor )
+{
+    HWND hWndSlideShow = FindWindow( L"screenClass", NULL );
+    if( hWndSlideShow != NULL && IsWindowVisible( hWndSlideShow ) ) {
+
+        HMONITOR hMonitor = MonitorFromWindow( hWndSlideShow, MONITOR_DEFAULTTONEAREST );
+        if( hMonitor != sourceMonitor ) {
+
+            return hMonitor;
+        }
+    }
+
+    struct MONITOR_SEARCH {
+        HMONITOR	sourceMonitor;
+        HMONITOR	targetMonitor;
+    } search = { sourceMonitor, NULL };
+
+    EnumDisplayMonitors( NULL, NULL, []( HMONITOR hMonitor, HDC, LPRECT, LPARAM lParam ) -> BOOL {
+
+        auto search = reinterpret_cast<MONITOR_SEARCH *>( lParam );
+        if( hMonitor != search->sourceMonitor && search->targetMonitor == NULL ) {
+
+            search->targetMonitor = hMonitor;
+            return FALSE;
+        }
+        return TRUE;
+    }, reinterpret_cast<LPARAM>( &search ));
+
+    return search.targetMonitor;
+}
+
+//----------------------------------------------------------------------------
+//
 // StartRecordingAsync
 //
 // Initiates screen recording and handles the save dialog workflow.
@@ -7754,6 +7827,7 @@ LRESULT APIENTRY MainWndProc(
         g_SnipPanoramaSaveToggleMod = GetKeyMod( g_SnipPanoramaSaveToggleKey );
         g_SnipOcrToggleMod = GetKeyMod( g_SnipOcrToggleKey );
         g_RecordToggleMod = GetKeyMod( g_RecordToggleKey );
+        g_MirrorToggleMod = GetKeyMod( g_MirrorToggleKey );
 
         if( !g_OptionsShown && !g_StartedByPowerToys ) {
             // First run should show options when running as standalone. If not running as standalone,
@@ -7850,6 +7924,16 @@ LRESULT APIENTRY MainWndProc(
                     (windowMod != 0 && !RegisterHotKey(hWnd, RECORD_WINDOW_HOTKEY, windowMod | MOD_NOREPEAT, g_RecordToggleKey & 0xFF))) {
 
                     MessageBox(hWnd, L"The specified record hotkey is already in use.\nSelect a different record hotkey.",
+                        APPNAME, MB_ICONERROR);
+                    showOptions = TRUE;
+                }
+            }
+            if (showOptions == FALSE && g_MirrorToggleKey) {
+                UINT mirrorWindowMod = g_MirrorToggleMod ^ MOD_ALT;
+                if (!RegisterHotKey(hWnd, MIRROR_HOTKEY, g_MirrorToggleMod | MOD_NOREPEAT, g_MirrorToggleKey & 0xFF) ||
+                    (mirrorWindowMod != 0 && !RegisterHotKey(hWnd, MIRROR_WINDOW_HOTKEY, mirrorWindowMod | MOD_NOREPEAT, g_MirrorToggleKey & 0xFF))) {
+
+                    MessageBox(hWnd, L"The specified mirror hotkey is already in use.\nSelect a different mirror hotkey.",
                         APPNAME, MB_ICONERROR);
                     showOptions = TRUE;
                 }
@@ -8611,6 +8695,106 @@ LRESULT APIENTRY MainWndProc(
                 StopRecording();
             }
             break;
+
+        case MIRROR_HOTKEY:
+        case MIRROR_WINDOW_HOTKEY: {
+
+            //
+            // DemoMirror: mirror a region or window, including the mouse
+            // cursor, onto a second monitor on top of a slide show so the
+            // audience can follow a demo without the presenter leaving the
+            // presentation. Entered once to start mirroring and again to
+            // stop.
+            //
+            if( g_MirrorWindow.IsActive() ) {
+
+                g_MirrorWindow.Stop();
+                g_MirrorSelectRectangle.Stop();
+                break;
+            }
+
+            if( g_RecordCropping == TRUE || g_bSaveInProgress ) {
+
+                break;
+            }
+
+            bool mirrorCaptureSupported = false;
+            try {
+
+                mirrorCaptureSupported = winrt::GraphicsCaptureSession::IsSupported();
+            }
+            catch( const winrt::hresult_error& ) {}
+            if( !mirrorCaptureSupported ) {
+
+                MessageBox( hWnd, L"Screen mirroring requires Windows 10, May 2019 Update or higher.", APPNAME, MB_OK );
+                break;
+            }
+
+            HWND		hWndMirrorSource = NULL;
+            HMONITOR	mirrorSourceMonitor = NULL;
+            RECT		mirrorSourceRect = {};
+
+            if( wParam == MIRROR_WINDOW_HOTKEY ) {
+
+                // Mirror the top-level window under the cursor.
+                POINT mirrorPoint;
+                GetCursorPos( &mirrorPoint );
+                hWndMirrorSource = WindowFromPoint( mirrorPoint );
+                while( hWndMirrorSource != NULL && GetParent( hWndMirrorSource ) != NULL ) {
+
+                    hWndMirrorSource = GetParent( hWndMirrorSource );
+                }
+                if( hWndMirrorSource == NULL || hWndMirrorSource == GetDesktopWindow() ||
+                    hWndMirrorSource == hWnd ) {
+
+                    break;
+                }
+                mirrorSourceMonitor = MonitorFromWindow( hWndMirrorSource, MONITOR_DEFAULTTONEAREST );
+                GetWindowRect( hWndMirrorSource, &mirrorSourceRect );
+
+            } else {
+
+                // Select the region to mirror. The selection border stays up
+                // to show what's being mirrored; it is excluded from capture.
+                g_RecordCropping = TRUE;
+                g_MirrorSelectRectangle.AspectRatio( 0.0 );
+                bool mirrorCanceled = !g_MirrorSelectRectangle.Start( nullptr );
+                g_RecordCropping = FALSE;
+                if( mirrorCanceled ) {
+
+                    break;
+                }
+                mirrorSourceRect = g_MirrorSelectRectangle.SelectedRect();
+                mirrorSourceMonitor = MonitorFromRect( &mirrorSourceRect, MONITOR_DEFAULTTONEAREST );
+            }
+
+            HMONITOR mirrorTargetMonitor = FindMirrorTargetMonitor( mirrorSourceMonitor );
+            if( mirrorTargetMonitor == NULL ) {
+
+                g_MirrorSelectRectangle.Stop();
+                MessageBox( hWnd, L"Screen mirroring requires a second monitor.", APPNAME, MB_OK );
+                break;
+            }
+
+            winrt::Windows::Graphics::Capture::GraphicsCaptureItem mirrorItem{ nullptr };
+            try {
+
+                if( hWndMirrorSource != NULL )
+                    mirrorItem = util::CreateCaptureItemForWindow( hWndMirrorSource );
+                else
+                    mirrorItem = util::CreateCaptureItemForMonitor( mirrorSourceMonitor );
+            }
+            catch( const winrt::hresult_error& ) {}
+
+            if( mirrorItem == nullptr ||
+                !g_MirrorWindow.Start( mirrorItem, mirrorSourceRect, hWndMirrorSource,
+                                       mirrorSourceMonitor, mirrorTargetMonitor, hWnd )) {
+
+                g_MirrorSelectRectangle.Stop();
+                MessageBox( hWnd, L"Unable to start screen mirroring.", APPNAME, MB_OK );
+            }
+            break;
+        }
 
         case ZOOM_HOTKEY:
             //
@@ -10295,6 +10479,12 @@ LRESULT APIENTRY MainWndProc(
         StopRecording();
         break;
 
+    case WM_USER_MIRROR_STOP:
+        // The mirrored window closed.
+        g_MirrorWindow.Stop();
+        g_MirrorSelectRectangle.Stop();
+        break;
+
     case WM_USER_RECORDING_STARTED:
         // The first video frame has been captured.  Change the selection
         // border from yellow to orange so the user knows recording is live.
@@ -10424,6 +10614,7 @@ LRESULT APIENTRY MainWndProc(
         g_SnipPanoramaSaveToggleMod = GetKeyMod(g_SnipPanoramaSaveToggleKey);
         g_SnipOcrToggleMod = GetKeyMod(g_SnipOcrToggleKey);
         g_RecordToggleMod = GetKeyMod(g_RecordToggleKey);
+        g_MirrorToggleMod = GetKeyMod(g_MirrorToggleKey);
         BOOL showOptions = FALSE;
         if (g_ToggleKey)
         {
@@ -10549,6 +10740,19 @@ LRESULT APIENTRY MainWndProc(
                 if(!g_StartedByPowerToys)
                 {
                     MessageBox(hWnd, L"The specified record hotkey is already in use.\nSelect a different record hotkey.", APPNAME, MB_ICONERROR);
+                }
+                showOptions = TRUE;
+            }
+        }
+        if (g_MirrorToggleKey)
+        {
+            UINT mirrorWindowMod = g_MirrorToggleMod ^ MOD_ALT;
+            if (!RegisterHotKey(hWnd, MIRROR_HOTKEY, g_MirrorToggleMod | MOD_NOREPEAT, g_MirrorToggleKey & 0xFF) ||
+                (mirrorWindowMod != 0 && !RegisterHotKey(hWnd, MIRROR_WINDOW_HOTKEY, mirrorWindowMod | MOD_NOREPEAT, g_MirrorToggleKey & 0xFF)))
+            {
+                if(!g_StartedByPowerToys)
+                {
+                    MessageBox(hWnd, L"The specified mirror hotkey is already in use.\nSelect a different mirror hotkey.", APPNAME, MB_ICONERROR);
                 }
                 showOptions = TRUE;
             }

--- a/src/modules/ZoomIt/ZoomIt/Zoomit.cpp
+++ b/src/modules/ZoomIt/ZoomIt/Zoomit.cpp
@@ -105,6 +105,7 @@ COLORREF	g_CustomColors[16];
 #define WEBCAM_TOGGLE_HOTKEY     21
 #define MIRROR_HOTKEY            22
 #define MIRROR_WINDOW_HOTKEY     23
+#define MIRROR_CROP_HOTKEY       24
 
 #define ZOOM_PAGE	  0
 #define LIVE_PAGE	  1
@@ -428,6 +429,7 @@ const wchar_t* HotkeyIdToString( WPARAM hotkeyId )
     case SNIP_PANORAMA_SAVE_HOTKEY: return L"SNIP_PANORAMA_SAVE_HOTKEY";
     case MIRROR_HOTKEY: return L"MIRROR_HOTKEY";
     case MIRROR_WINDOW_HOTKEY: return L"MIRROR_WINDOW_HOTKEY";
+    case MIRROR_CROP_HOTKEY: return L"MIRROR_CROP_HOTKEY";
     default: return L"UNKNOWN_HOTKEY";
     }
 }
@@ -3571,6 +3573,7 @@ void UnregisterAllHotkeys( HWND hWnd )
     unregisterHotkey( COPY_CROP_HOTKEY );
     unregisterHotkey( MIRROR_HOTKEY );
     unregisterHotkey( MIRROR_WINDOW_HOTKEY );
+    unregisterHotkey( MIRROR_CROP_HOTKEY );
 }
 
 //----------------------------------------------------------------------------
@@ -3626,7 +3629,11 @@ void RegisterAllHotkeys(HWND hWnd)
     }
     if (g_MirrorToggleKey) {
         registerHotkey( MIRROR_HOTKEY, g_MirrorToggleMod | MOD_NOREPEAT, g_MirrorToggleKey & 0xFF );
+        UINT mirrorCropMod = g_MirrorToggleMod ^ MOD_SHIFT;
         UINT mirrorWindowMod = g_MirrorToggleMod ^ MOD_ALT;
+        if ( mirrorCropMod != 0 ) {
+            registerHotkey( MIRROR_CROP_HOTKEY, mirrorCropMod | MOD_NOREPEAT, g_MirrorToggleKey & 0xFF );
+        }
         if ( mirrorWindowMod != 0 ) {
             registerHotkey( MIRROR_WINDOW_HOTKEY, mirrorWindowMod | MOD_NOREPEAT, g_MirrorToggleKey & 0xFF );
         }
@@ -5689,8 +5696,9 @@ INT_PTR CALLBACK OptionsProc( HWND hDlg, UINT message,
                 UnregisterAllHotkeys(GetParent(hDlg));
                 break;
             }
-            else if( UINT mirrorWindowMod = newMirrorToggleMod ^ MOD_ALT; newMirrorToggleKey &&
+            else if( UINT mirrorCropMod = newMirrorToggleMod ^ MOD_SHIFT, mirrorWindowMod = newMirrorToggleMod ^ MOD_ALT; newMirrorToggleKey &&
                 (!RegisterHotKey(GetParent(hDlg), MIRROR_HOTKEY, newMirrorToggleMod | MOD_NOREPEAT, newMirrorToggleKey & 0xFF) ||
+                (mirrorCropMod != 0 && !RegisterHotKey(GetParent(hDlg), MIRROR_CROP_HOTKEY, mirrorCropMod | MOD_NOREPEAT, newMirrorToggleKey & 0xFF)) ||
                 (mirrorWindowMod != 0 && !RegisterHotKey(GetParent(hDlg), MIRROR_WINDOW_HOTKEY, mirrorWindowMod | MOD_NOREPEAT, newMirrorToggleKey & 0xFF)))) {
 
                 MessageBox(hDlg, L"The specified mirror hotkey is already in use.\nSelect a different mirror hotkey.",
@@ -7932,8 +7940,10 @@ LRESULT APIENTRY MainWndProc(
                 }
             }
             if (showOptions == FALSE && g_MirrorToggleKey) {
+                UINT mirrorCropMod = g_MirrorToggleMod ^ MOD_SHIFT;
                 UINT mirrorWindowMod = g_MirrorToggleMod ^ MOD_ALT;
                 if (!RegisterHotKey(hWnd, MIRROR_HOTKEY, g_MirrorToggleMod | MOD_NOREPEAT, g_MirrorToggleKey & 0xFF) ||
+                    (mirrorCropMod != 0 && !RegisterHotKey(hWnd, MIRROR_CROP_HOTKEY, mirrorCropMod | MOD_NOREPEAT, g_MirrorToggleKey & 0xFF)) ||
                     (mirrorWindowMod != 0 && !RegisterHotKey(hWnd, MIRROR_WINDOW_HOTKEY, mirrorWindowMod | MOD_NOREPEAT, g_MirrorToggleKey & 0xFF))) {
 
                     MessageBox(hWnd, L"The specified mirror hotkey is already in use.\nSelect a different mirror hotkey.",
@@ -8700,14 +8710,15 @@ LRESULT APIENTRY MainWndProc(
             break;
 
         case MIRROR_HOTKEY:
+        case MIRROR_CROP_HOTKEY:
         case MIRROR_WINDOW_HOTKEY: {
 
             //
-            // DemoMirror: mirror a region or window, including the mouse
-            // cursor, onto a second monitor on top of a slide show so the
-            // audience can follow a demo without the presenter leaving the
-            // presentation. Entered once to start mirroring and again to
-            // stop.
+            // DemoMirror: mirror the screen, a region (Shift), or a window
+            // (Alt), including the mouse cursor, onto a second monitor on
+            // top of a slide show so the audience can follow a demo without
+            // the presenter leaving the presentation. Entered once to start
+            // mirroring and again to stop.
             //
             if( g_MirrorWindow.IsActive() ) {
 
@@ -8755,7 +8766,7 @@ LRESULT APIENTRY MainWndProc(
                 mirrorSourceMonitor = MonitorFromWindow( hWndMirrorSource, MONITOR_DEFAULTTONEAREST );
                 mirrorSourceRect = MirrorWindow::GetWindowFrameRect( hWndMirrorSource );
 
-            } else {
+            } else if( wParam == MIRROR_CROP_HOTKEY ) {
 
                 // Select the region to mirror. The selection border stays up
                 // to show what's being mirrored; it is excluded from capture.
@@ -8773,6 +8784,22 @@ LRESULT APIENTRY MainWndProc(
 
                 // The selection border defaults to translucent; make the
                 // mirror border fully opaque so it reads bright green.
+                SetLayeredWindowAttributes( g_MirrorSelectRectangle.Window(), 0, 255, LWA_ALPHA );
+
+            } else {
+
+                // Mirror the entire monitor under the cursor, with a
+                // full-monitor border showing that mirroring is active.
+                POINT mirrorPoint;
+                GetCursorPos( &mirrorPoint );
+                mirrorSourceMonitor = MonitorFromPoint( mirrorPoint, MONITOR_DEFAULTTONEAREST );
+                MONITORINFO mirrorMonitorInfo = { sizeof( mirrorMonitorInfo ) };
+                GetMonitorInfo( mirrorSourceMonitor, &mirrorMonitorInfo );
+                mirrorSourceRect = mirrorMonitorInfo.rcMonitor;
+
+                g_MirrorSelectRectangle.BorderColor( MIRROR_BORDER_COLOR );
+                g_MirrorSelectRectangle.AspectRatio( 0.0 );
+                g_MirrorSelectRectangle.Start( nullptr, true );
                 SetLayeredWindowAttributes( g_MirrorSelectRectangle.Window(), 0, 255, LWA_ALPHA );
             }
 
@@ -10771,8 +10798,10 @@ LRESULT APIENTRY MainWndProc(
         }
         if (g_MirrorToggleKey)
         {
+            UINT mirrorCropMod = g_MirrorToggleMod ^ MOD_SHIFT;
             UINT mirrorWindowMod = g_MirrorToggleMod ^ MOD_ALT;
             if (!RegisterHotKey(hWnd, MIRROR_HOTKEY, g_MirrorToggleMod | MOD_NOREPEAT, g_MirrorToggleKey & 0xFF) ||
+                (mirrorCropMod != 0 && !RegisterHotKey(hWnd, MIRROR_CROP_HOTKEY, mirrorCropMod | MOD_NOREPEAT, g_MirrorToggleKey & 0xFF)) ||
                 (mirrorWindowMod != 0 && !RegisterHotKey(hWnd, MIRROR_WINDOW_HOTKEY, mirrorWindowMod | MOD_NOREPEAT, g_MirrorToggleKey & 0xFF)))
             {
                 if(!g_StartedByPowerToys)

--- a/src/modules/ZoomIt/ZoomIt/Zoomit.cpp
+++ b/src/modules/ZoomIt/ZoomIt/Zoomit.cpp
@@ -8837,10 +8837,12 @@ LRESULT APIENTRY MainWndProc(
                 return MirrorWindow::AnnotationState::None;
             };
 
+            HWND mirrorBorderWindow = hWndMirrorSource == NULL ? g_MirrorSelectRectangle.Window() : NULL;
             if( mirrorItem == nullptr ||
                 !g_MirrorWindow.Start( mirrorItem, mirrorSourceRect, hWndMirrorSource,
                                        mirrorSourceMonitor, mirrorTargetMonitor, hWnd,
-                                       mirrorAnnotationQuery, mirrorTrackWindow )) {
+                                       mirrorAnnotationQuery, mirrorTrackWindow,
+                                       mirrorBorderWindow )) {
 
                 g_MirrorSelectRectangle.Stop();
                 MessageBox( hWnd, L"Unable to start screen mirroring.", APPNAME, MB_OK );

--- a/src/modules/ZoomIt/ZoomIt/Zoomit.cpp
+++ b/src/modules/ZoomIt/ZoomIt/Zoomit.cpp
@@ -8753,7 +8753,7 @@ LRESULT APIENTRY MainWndProc(
                     break;
                 }
                 mirrorSourceMonitor = MonitorFromWindow( hWndMirrorSource, MONITOR_DEFAULTTONEAREST );
-                GetWindowRect( hWndMirrorSource, &mirrorSourceRect );
+                mirrorSourceRect = MirrorWindow::GetWindowFrameRect( hWndMirrorSource );
 
             } else {
 

--- a/src/modules/ZoomIt/ZoomIt/Zoomit.cpp
+++ b/src/modules/ZoomIt/ZoomIt/Zoomit.cpp
@@ -5086,6 +5086,8 @@ INT_PTR CALLBACK OptionsProc( HWND hDlg, UINT message,
         if( g_SnipPanoramaSaveToggleKey) SendMessage( GetDlgItem( g_OptionsTabs[PANORAMA_PAGE].hPage, IDC_SNIP_PANORAMA_SAVE_HOTKEY), HKM_SETHOTKEY, g_SnipPanoramaSaveToggleKey, 0 );
         if( g_SnipOcrToggleKey) SendMessage( GetDlgItem( g_OptionsTabs[SNIP_PAGE].hPage, IDC_SNIP_OCR_HOTKEY), HKM_SETHOTKEY, g_SnipOcrToggleKey, 0 );
         if( g_MirrorToggleKey) SendMessage( GetDlgItem( g_OptionsTabs[MIRROR_PAGE].hPage, IDC_MIRROR_HOTKEY), HKM_SETHOTKEY, g_MirrorToggleKey, 0 );
+        CheckDlgButton( g_OptionsTabs[MIRROR_PAGE].hPage, IDC_MIRROR_TRACK_WINDOW,
+            g_MirrorTrackWindow ? BST_CHECKED: BST_UNCHECKED );
         CheckDlgButton( hDlg, IDC_SHOW_TRAY_ICON,
             g_ShowTrayIcon ? BST_CHECKED: BST_UNCHECKED );
         CheckDlgButton( hDlg, IDC_AUTOSTART,
@@ -5575,6 +5577,7 @@ INT_PTR CALLBACK OptionsProc( HWND hDlg, UINT message,
             g_MicMonoMix = IsDlgButtonChecked(g_OptionsTabs[RECORD_PAGE].hPage, IDC_MIC_MONO_MIX) == BST_CHECKED;
             g_NoiseCancellation = IsDlgButtonChecked(g_OptionsTabs[RECORD_PAGE].hPage, IDC_NOISE_CANCELLATION) == BST_CHECKED;
             g_RecordAspectRatio = IsDlgButtonChecked(g_OptionsTabs[RECORD_PAGE].hPage, IDC_RECORD_ASPECT_RATIO) == BST_CHECKED;
+            g_MirrorTrackWindow = IsDlgButtonChecked(g_OptionsTabs[MIRROR_PAGE].hPage, IDC_MIRROR_TRACK_WINDOW) == BST_CHECKED;
             GetDlgItemText( g_OptionsTabs[BREAK_PAGE].hPage, IDC_TIMER, text, 3 );
             text[2] = 0;
             newTimeout = _tstoi( text );
@@ -8776,10 +8779,15 @@ LRESULT APIENTRY MainWndProc(
                 break;
             }
 
+            // With window tracking, mirror the monitor region under the
+            // window instead of the window's own surface so ZoomIt zoom and
+            // draw annotations show in place.
+            bool mirrorTrackWindow = ( hWndMirrorSource != NULL && g_MirrorTrackWindow );
+
             winrt::Windows::Graphics::Capture::GraphicsCaptureItem mirrorItem{ nullptr };
             try {
 
-                if( hWndMirrorSource != NULL )
+                if( hWndMirrorSource != NULL && !mirrorTrackWindow )
                     mirrorItem = util::CreateCaptureItemForWindow( hWndMirrorSource );
                 else
                     mirrorItem = util::CreateCaptureItemForMonitor( mirrorSourceMonitor );
@@ -8800,7 +8808,7 @@ LRESULT APIENTRY MainWndProc(
             if( mirrorItem == nullptr ||
                 !g_MirrorWindow.Start( mirrorItem, mirrorSourceRect, hWndMirrorSource,
                                        mirrorSourceMonitor, mirrorTargetMonitor, hWnd,
-                                       mirrorAnnotationQuery )) {
+                                       mirrorAnnotationQuery, mirrorTrackWindow )) {
 
                 g_MirrorSelectRectangle.Stop();
                 MessageBox( hWnd, L"Unable to start screen mirroring.", APPNAME, MB_OK );

--- a/src/modules/ZoomIt/ZoomIt/Zoomit.cpp
+++ b/src/modules/ZoomIt/ZoomIt/Zoomit.cpp
@@ -8786,9 +8786,21 @@ LRESULT APIENTRY MainWndProc(
             }
             catch( const winrt::hresult_error& ) {}
 
+            // Reports when a zoom/draw/live-zoom mode is active so a window
+            // mirror can temporarily capture the monitor instead - those
+            // modes render in overlay windows a window capture can't see.
+            auto mirrorAnnotationQuery = []() {
+                if( g_hWndLiveZoom != NULL && IsWindowVisible( g_hWndLiveZoom ))
+                    return MirrorWindow::AnnotationState::AnnotatingLiveZoom;
+                if( g_Zoomed )
+                    return MirrorWindow::AnnotationState::Annotating;
+                return MirrorWindow::AnnotationState::None;
+            };
+
             if( mirrorItem == nullptr ||
                 !g_MirrorWindow.Start( mirrorItem, mirrorSourceRect, hWndMirrorSource,
-                                       mirrorSourceMonitor, mirrorTargetMonitor, hWnd )) {
+                                       mirrorSourceMonitor, mirrorTargetMonitor, hWnd,
+                                       mirrorAnnotationQuery )) {
 
                 g_MirrorSelectRectangle.Stop();
                 MessageBox( hWnd, L"Unable to start screen mirroring.", APPNAME, MB_OK );

--- a/src/modules/ZoomIt/ZoomIt/Zoomit.cpp
+++ b/src/modules/ZoomIt/ZoomIt/Zoomit.cpp
@@ -8770,6 +8770,10 @@ LRESULT APIENTRY MainWndProc(
                 }
                 mirrorSourceRect = g_MirrorSelectRectangle.SelectedRect();
                 mirrorSourceMonitor = MonitorFromRect( &mirrorSourceRect, MONITOR_DEFAULTTONEAREST );
+
+                // The selection border defaults to translucent; make the
+                // mirror border fully opaque so it reads bright green.
+                SetLayeredWindowAttributes( g_MirrorSelectRectangle.Window(), 0, 255, LWA_ALPHA );
             }
 
             HMONITOR mirrorTargetMonitor = FindMirrorTargetMonitor( mirrorSourceMonitor );

--- a/src/modules/ZoomIt/ZoomIt/Zoomit.cpp
+++ b/src/modules/ZoomIt/ZoomIt/Zoomit.cpp
@@ -8760,6 +8760,7 @@ LRESULT APIENTRY MainWndProc(
                 // Select the region to mirror. The selection border stays up
                 // to show what's being mirrored; it is excluded from capture.
                 g_RecordCropping = TRUE;
+                g_MirrorSelectRectangle.BorderColor( MIRROR_BORDER_COLOR );
                 g_MirrorSelectRectangle.AspectRatio( 0.0 );
                 bool mirrorCanceled = !g_MirrorSelectRectangle.Start( nullptr );
                 g_RecordCropping = FALSE;

--- a/src/modules/ZoomIt/ZoomIt/resource.h
+++ b/src/modules/ZoomIt/ZoomIt/resource.h
@@ -140,6 +140,7 @@
 #define IDC_SNIP_SAVE_HOTKEY            1134
 #define IDC_SNIP_PANORAMA_SAVE_HOTKEY   1135
 #define IDC_MIRROR_HOTKEY               1136
+#define IDC_MIRROR_TRACK_WINDOW         1137
 #define IDC_SAVE                        40002
 #define IDC_COPY                        40004
 #define IDC_RECORD                      40006
@@ -155,7 +156,7 @@
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        120
 #define _APS_NEXT_COMMAND_VALUE         40012
-#define _APS_NEXT_CONTROL_VALUE         1137
+#define _APS_NEXT_CONTROL_VALUE         1138
 #define _APS_NEXT_SYMED_VALUE           101
 #endif
 #endif

--- a/src/modules/ZoomIt/ZoomIt/resource.h
+++ b/src/modules/ZoomIt/ZoomIt/resource.h
@@ -139,6 +139,7 @@
 #define IDC_NOISE_CANCELLATION          1133
 #define IDC_SNIP_SAVE_HOTKEY            1134
 #define IDC_SNIP_PANORAMA_SAVE_HOTKEY   1135
+#define IDC_MIRROR_HOTKEY               1136
 #define IDC_SAVE                        40002
 #define IDC_COPY                        40004
 #define IDC_RECORD                      40006
@@ -154,7 +155,7 @@
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        120
 #define _APS_NEXT_COMMAND_VALUE         40012
-#define _APS_NEXT_CONTROL_VALUE         1136
+#define _APS_NEXT_CONTROL_VALUE         1137
 #define _APS_NEXT_SYMED_VALUE           101
 #endif
 #endif

--- a/src/modules/ZoomIt/ZoomItSettingsInterop/ZoomItSettings.cpp
+++ b/src/modules/ZoomIt/ZoomItSettingsInterop/ZoomItSettings.cpp
@@ -76,6 +76,7 @@ namespace winrt::PowerToys::ZoomItSettingsInterop::implementation
         { L"SnipPanoramaSaveToggleKey", SPECIAL_SEMANTICS_SHORTCUT },
         { L"BreakTimerKey", SPECIAL_SEMANTICS_SHORTCUT },
         { L"DemoTypeToggleKey", SPECIAL_SEMANTICS_SHORTCUT },
+        { L"MirrorToggleKey", SPECIAL_SEMANTICS_SHORTCUT },
         { L"PenColor", SPECIAL_SEMANTICS_COLOR },
         { L"BreakPenColor", SPECIAL_SEMANTICS_COLOR },
         { L"Font", SPECIAL_SEMANTICS_LOG_FONT },

--- a/src/settings-ui/Settings.UI.Library/ZoomItProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/ZoomItProperties.cs
@@ -46,6 +46,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         [CmdConfigureIgnore]
         public static HotkeySettings DefaultDemoTypeToggleKey => new HotkeySettings(false, true, false, false, '7'); // Ctrl+7
 
+        [CmdConfigureIgnore]
+        public static HotkeySettings DefaultMirrorToggleKey => new HotkeySettings(false, true, false, false, '9'); // Ctrl+9
+
         public KeyboardKeysProperty ToggleKey { get; set; }
 
         public KeyboardKeysProperty LiveZoomToggleKey { get; set; }
@@ -138,5 +141,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         public BoolProperty RecordAspectRatio { get; set; }
 
         public BoolProperty BreakLockWorkstation { get; set; }
+
+        public KeyboardKeysProperty MirrorToggleKey { get; set; }
+
+        public BoolProperty MirrorTrackWindow { get; set; }
     }
 }

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/ZoomItPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/ZoomItPage.xaml
@@ -399,6 +399,29 @@
                         </tkcontrols:SettingsExpander.Items>
                     </tkcontrols:SettingsExpander>
                 </controls:SettingsGroup>
+                <controls:SettingsGroup x:Uid="ZoomIt_MirrorGroup" IsEnabled="{x:Bind ViewModel.IsEnabled, Mode=OneWay}">
+                    <tkcontrols:SettingsExpander
+                        Name="ZoomItMirrorShortcut"
+                        x:Uid="ZoomIt_Mirror_Shortcut"
+                        HeaderIcon="{ui:FontIcon Glyph=&#xE7F4;}"
+                        IsExpanded="True">
+                        <controls:ShortcutControl HotkeySettings="{x:Bind ViewModel.MirrorToggleKey, Mode=TwoWay}" />
+                        <tkcontrols:SettingsExpander.Items>
+                            <tkcontrols:SettingsCard Name="ZoomItMirrorTrackWindow" ContentAlignment="Left">
+                                <CheckBox x:Uid="ZoomIt_Mirror_TrackWindow" IsChecked="{x:Bind ViewModel.MirrorTrackWindow, Mode=TwoWay}" />
+                            </tkcontrols:SettingsCard>
+                            <tkcontrols:SettingsCard>
+                                <tkcontrols:SettingsCard.Description>
+                                    <StackPanel Orientation="Vertical" Spacing="4">
+                                        <tkcontrols:MarkdownTextBlock Config="{StaticResource DescriptionTextMarkdownConfig}" Text="{x:Bind ViewModel.MirrorToggleKey, Mode=OneWay, Converter={StaticResource HotkeySettingsToLocalizedStringConverter}, ConverterParameter=ZoomIt_Mirror_Shortcut_FullScreen}" />
+                                        <tkcontrols:MarkdownTextBlock Config="{StaticResource DescriptionTextMarkdownConfig}" Text="{x:Bind ViewModel.MirrorToggleKeyCrop, Mode=OneWay, Converter={StaticResource HotkeySettingsToLocalizedStringConverter}, ConverterParameter=ZoomIt_Mirror_Shortcut_Crop}" />
+                                        <tkcontrols:MarkdownTextBlock Config="{StaticResource DescriptionTextMarkdownConfig}" Text="{x:Bind ViewModel.MirrorToggleKeyWindow, Mode=OneWay, Converter={StaticResource HotkeySettingsToLocalizedStringConverter}, ConverterParameter=ZoomIt_Mirror_Shortcut_Window}" />
+                                    </StackPanel>
+                                </tkcontrols:SettingsCard.Description>
+                            </tkcontrols:SettingsCard>
+                        </tkcontrols:SettingsExpander.Items>
+                    </tkcontrols:SettingsExpander>
+                </controls:SettingsGroup>
                 <controls:SettingsGroup x:Uid="ZoomIt_SnipGroup" IsEnabled="{x:Bind ViewModel.IsEnabled, Mode=OneWay}">
                     <tkcontrols:SettingsCard
                         Name="ZoomItSnipShortcut"

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -4848,6 +4848,27 @@ The break timer font matches the text font.</value>
   <data name="ZoomIt_Record_Shortcut_Window" xml:space="preserve">
     <value>Press **{0}** to record a specific window</value>
   </data>
+  <data name="ZoomIt_MirrorGroup.Header" xml:space="preserve">
+    <value>DemoMirror</value>
+  </data>
+  <data name="ZoomIt_MirrorGroup.Description" xml:space="preserve">
+    <value>Mirror the screen, a region of the screen, or a window, including the mouse pointer, onto a second monitor, on top of a slide show. Use ZoomIt zoom and draw to annotate the mirrored image.</value>
+  </data>
+  <data name="ZoomIt_Mirror_Shortcut.Header" xml:space="preserve">
+    <value>Mirror activation</value>
+  </data>
+  <data name="ZoomIt_Mirror_Shortcut_FullScreen" xml:space="preserve">
+    <value>Press **{0}** to start or stop mirroring the screen</value>
+  </data>
+  <data name="ZoomIt_Mirror_Shortcut_Crop" xml:space="preserve">
+    <value>Press **{0}** to mirror a portion of the screen</value>
+  </data>
+  <data name="ZoomIt_Mirror_Shortcut_Window" xml:space="preserve">
+    <value>Press **{0}** to mirror a specific window</value>
+  </data>
+  <data name="ZoomIt_Mirror_TrackWindow.Content" xml:space="preserve">
+    <value>Mirror windows by tracking their screen region, so zoom and draw show in place</value>
+  </data>
   <data name="ZoomIt_Record_Scaling.Header" xml:space="preserve">
     <value>Scaling</value>
   </data>

--- a/src/settings-ui/Settings.UI/ViewModels/ZoomItViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/ZoomItViewModel.cs
@@ -407,6 +407,74 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             }
         }
 
+        public HotkeySettings MirrorToggleKey
+        {
+            get => _zoomItSettings.Properties.MirrorToggleKey.Value;
+            set
+            {
+                if (_zoomItSettings.Properties.MirrorToggleKey.Value != value)
+                {
+                    _zoomItSettings.Properties.MirrorToggleKey.Value = value ?? ZoomItProperties.DefaultMirrorToggleKey;
+                    OnPropertyChanged(nameof(MirrorToggleKey));
+                    OnPropertyChanged(nameof(MirrorToggleKeyCrop));
+                    OnPropertyChanged(nameof(MirrorToggleKeyWindow));
+                    NotifySettingsChanged();
+                }
+            }
+        }
+
+        public HotkeySettings MirrorToggleKeyCrop
+        {
+            get
+            {
+                var baseKey = _zoomItSettings.Properties.MirrorToggleKey.Value;
+                if (baseKey == null)
+                {
+                    return null;
+                }
+
+                // XOR with Shift: if Shift is present, remove it; if absent, add it.
+                // If the result would have no modifier keys, return null to avoid displaying a bare-key shortcut label.
+                if (baseKey.Shift && !baseKey.Win && !baseKey.Ctrl && !baseKey.Alt)
+                {
+                    return null;
+                }
+
+                return new HotkeySettings(
+                    baseKey.Win,
+                    baseKey.Ctrl,
+                    baseKey.Alt,
+                    !baseKey.Shift,  // XOR with Shift
+                    baseKey.Code);
+            }
+        }
+
+        public HotkeySettings MirrorToggleKeyWindow
+        {
+            get
+            {
+                var baseKey = _zoomItSettings.Properties.MirrorToggleKey.Value;
+                if (baseKey == null)
+                {
+                    return null;
+                }
+
+                // XOR with Alt: if Alt is present, remove it; if absent, add it.
+                // If the result would have no modifier keys, return null to avoid displaying a bare-key shortcut label.
+                if (baseKey.Alt && !baseKey.Win && !baseKey.Ctrl && !baseKey.Shift)
+                {
+                    return null;
+                }
+
+                return new HotkeySettings(
+                    baseKey.Win,
+                    baseKey.Ctrl,
+                    !baseKey.Alt,    // XOR with Alt
+                    baseKey.Shift,
+                    baseKey.Code);
+            }
+        }
+
         public HotkeySettings SnipToggleKey
         {
             get => _zoomItSettings.Properties.SnipToggleKey.Value;
@@ -1184,6 +1252,20 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 {
                     _zoomItSettings.Properties.RecordAspectRatio.Value = value;
                     OnPropertyChanged(nameof(RecordAspectRatio));
+                    NotifySettingsChanged();
+                }
+            }
+        }
+
+        public bool MirrorTrackWindow
+        {
+            get => _zoomItSettings.Properties.MirrorTrackWindow.Value;
+            set
+            {
+                if (_zoomItSettings.Properties.MirrorTrackWindow.Value != value)
+                {
+                    _zoomItSettings.Properties.MirrorTrackWindow.Value = value;
+                    OnPropertyChanged(nameof(MirrorTrackWindow));
                     NotifySettingsChanged();
                 }
             }


### PR DESCRIPTION
## Summary of the Pull Request

Adds **DemoMirror** to ZoomIt: a new hotkey family (default Ctrl+9) that live-mirrors content onto a second monitor — designed for presenters who want to demo an app on their laptop screen while the audience sees it on the presentation display (e.g., on top of a PowerPoint slideshow), without leaving Presenter View.

- **Ctrl+9** — mirror the entire monitor under the cursor
- **Ctrl+Shift+9** — mirror a selected region
- **Ctrl+Alt+9** — mirror the window under the cursor (with optional window tracking)

The mirror includes the mouse cursor, targets the monitor running a PowerPoint slideshow when one is found (otherwise the first non-source monitor), letterboxes on a black backdrop, shows a bright green border around the mirrored source, and works with ZoomIt's existing zoom and draw/annotation modes. The mirrored content is visible in Teams/meeting screen shares.

## PR Checklist

- [ ] Closes: #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [x] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [x] **New binaries:** None added
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments

**Capture & rendering:** Uses Windows.Graphics.Capture through the existing `CaptureFrameWait` helper (cursor capture enabled, system capture border suppressed). A new `MirrorWindow` class hosts a topmost, no-activate, click-through window on the target monitor with an HWND-bound flip-model swapchain; a render thread caches frames so static content keeps rendering. A black backdrop window letterboxes the mirrored content.

**Window mode:** Windows mirror at native size (scaled down only if larger than the target monitor), crop to the DWM extended frame bounds (`DWMWA_EXTENDED_FRAME_BOUNDS`) to exclude invisible resize borders, adapt to source-window resizes by recreating the frame pool and swapchain, and auto-stop when the mirrored window closes. A new **Track window** setting (default on) captures the monitor cropped to the tracked window each frame so annotations show in place and the crop follows moves/resizes; when off, window-surface capture is used instead.

**Annotations:** Window capture can't see ZoomIt's own overlay windows, so while zoom/draw/LiveZoom is active the render thread switches capture to the monitor under the cursor and back on exit, letting annotations appear in the mirror.

**Screen-share compatibility:** The mirror and backdrop windows are visible to display capture so remote meeting attendees see the mirrored content; self-capture feedback loops are avoided by substituting the source monitor when the annotation-override capture would resolve to the target monitor. The green border stays above ZoomIt's own fullscreen-topmost windows via the mirror's topmost-reassert timer.

**Win11 capture border:** `IsBorderRequired(false)` is silently ignored until the process calls `GraphicsCaptureAccess::RequestAccessAsync(Borderless)`; this is now requested (auto-granted for desktop apps) before session creation.

**Settings:** New DemoMirror tab in ZoomIt's options dialog (hotkey + track-window checkbox), persisted in registry settings, and exposed in the PowerToys Settings UI (`ZoomItProperties`, `ZoomItViewModel`, `ZoomItPage.xaml`) with localizable strings in `Resources.resw`.

## Validation Steps Performed

Manually tested on a two-monitor setup (including a Surface ARM device with an external monitor):

- Monitor, region, and window mirroring via all three hotkeys, with the mouse cursor visible in the mirror
- Native-size and scaled-down window mirroring; letterboxing on the backdrop
- Window move/resize while mirrored (both tracking and non-tracking modes); auto-stop on window close
- Zoom and draw annotations appearing in the mirror in all modes
- Mirrored content visible to remote attendees in a real Microsoft Teams display share
- Green border correctly colored and staying above static zoom; no lingering Windows 11 capture border
- Settings round-trip through both the ZoomIt options dialog and the PowerToys Settings UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)