### PR TITLE
fix(keyboardmanager): handle title bar setup failure

### DIFF
--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/KeyboardManagerEditorXAML/MainWindow.xaml.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/KeyboardManagerEditorXAML/MainWindow.xaml.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.WindowsRuntime;
 using KeyboardManagerEditorUI.Helpers;
+using ManagedCommon;
 using Microsoft.UI;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
@@ -27,6 +28,8 @@ namespace KeyboardManagerEditorUI
 {
     public sealed partial class MainWindow : WindowEx
     {
+        private const int ErrorAlreadyInitialized = unchecked((int)0x800704DF);
+
         public MainWindow()
         {
             this.InitializeComponent();
@@ -37,10 +40,22 @@ namespace KeyboardManagerEditorUI
 
         private void SetTitleBar()
         {
-            ExtendsContentIntoTitleBar = true;
             this.SetIcon(@"Assets\KeyboardManagerEditor\Keyboard.ico");
-            this.SetTitleBar(titleBar);
             Title = "Keyboard Manager";
+
+            try
+            {
+                if (AppWindowTitleBar.IsCustomizationSupported())
+                {
+                    ExtendsContentIntoTitleBar = true;
+                    this.SetTitleBar(titleBar);
+                }
+            }
+            catch (Exception ex) when (ex.HResult == ErrorAlreadyInitialized)
+            {
+                // Windows App SDK can report this error while initializing a custom title bar on Windows 10.
+                Logger.LogError("Failed to customize the title bar; falling back to the default system title bar.", ex);
+            }
         }
 
         private void MainWindow_Activated(object sender, WindowActivatedEventArgs args)


### PR DESCRIPTION
Fixes #49399.

On some Windows 10 systems, the new Keyboard Manager editor closes before its window opens. This happens when custom title bar setup fails with `ERROR_ALREADY_INITIALIZED`.

This change checks whether custom title bars are supported. It handles only this known error, writes it to the log, and lets the editor continue with the normal Windows title bar. Other errors are not hidden.

## PR Checklist

- [x] Closes: #49399
- [ ] **Communication:** This change has not been discussed with core contributors yet.
- [ ] **Tests:** No automated test was added. This error comes from Windows App SDK while creating the window and depends on the affected Windows 10 setup.
- [x] **Localization:** No user-facing text was changed.
- [x] **Dev docs:** No developer documentation changes are needed.
- [x] **New binaries:** No binaries or projects were added.
- [ ] **Documentation updated:** Not needed because this does not change documented user behavior.

## Detailed Description of the Pull Request / Additional comments

`MainWindow.xaml.cs` now checks `AppWindowTitleBar.IsCustomizationSupported()` before setting a custom title bar.

It also handles HRESULT `0x800704DF` (`ERROR_ALREADY_INITIALIZED`). This is the error shown in the crash report. The check is kept narrow so other title bar errors are still reported normally.

If this error occurs, the editor uses the normal Windows title bar instead of closing during startup.

Testing was not possible because i dont have a windows 10 setup right now.