### PR TITLE
[PowerDisplay] Add HDR SDR brightness controls and shortcuts

### DIFF
--- a/src/modules/powerdisplay/PowerDisplay.Lib.UnitTests/PowerDisplayHotkeySettingsTests.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Lib.UnitTests/PowerDisplayHotkeySettingsTests.cs
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using System.Text.Json;
+using Microsoft.PowerToys.Settings.UI.Library;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace PowerDisplay.UnitTests;
+
+[TestClass]
+public class PowerDisplayHotkeySettingsTests
+{
+    [TestMethod]
+    public void Defaults_LeaveAdjustmentShortcutsUnbound()
+    {
+        var properties = new PowerDisplayProperties();
+
+        Assert.IsTrue(properties.ActivationShortcut.IsValid());
+        Assert.IsFalse(properties.IncreaseBrightnessShortcut.IsValid());
+        Assert.IsFalse(properties.DecreaseBrightnessShortcut.IsValid());
+        Assert.IsFalse(properties.IncreaseContrastShortcut.IsValid());
+        Assert.IsFalse(properties.DecreaseContrastShortcut.IsValid());
+        Assert.IsFalse(properties.IncreaseVolumeShortcut.IsValid());
+        Assert.IsFalse(properties.DecreaseVolumeShortcut.IsValid());
+        Assert.IsFalse(properties.IncreaseSdrContentBrightnessShortcut.IsValid());
+        Assert.IsFalse(properties.DecreaseSdrContentBrightnessShortcut.IsValid());
+        Assert.IsFalse(properties.SdrContentBrightnessReplacesPrimarySlider);
+    }
+
+    [TestMethod]
+    public void Deserialize_LegacyJsonMissingShortcuts_UsesUnboundDefaults()
+    {
+        const string legacyJson = """
+        {
+            "monitor_refresh_delay": 5,
+            "show_system_tray_icon": true
+        }
+        """;
+
+        var properties = JsonSerializer.Deserialize<PowerDisplayProperties>(legacyJson);
+
+        Assert.IsNotNull(properties);
+        Assert.IsFalse(properties.IncreaseBrightnessShortcut.IsValid());
+        Assert.IsFalse(properties.DecreaseSdrContentBrightnessShortcut.IsValid());
+        Assert.IsFalse(properties.SdrContentBrightnessReplacesPrimarySlider);
+    }
+
+    [TestMethod]
+    public void RoundTrip_PreservesAdjustmentShortcut()
+    {
+        var original = new PowerDisplayProperties
+        {
+            IncreaseContrastShortcut = new HotkeySettings(true, true, false, false, 0xBB),
+        };
+
+        var json = JsonSerializer.Serialize(original);
+        var restored = JsonSerializer.Deserialize<PowerDisplayProperties>(json);
+
+        Assert.IsNotNull(restored);
+        Assert.AreEqual(original.IncreaseContrastShortcut, restored.IncreaseContrastShortcut);
+        StringAssert.Contains(json, "\"increase_contrast_shortcut\"");
+    }
+
+    [TestMethod]
+    public void RoundTrip_PreservesSdrPrimarySliderPreference()
+    {
+        var original = new PowerDisplayProperties
+        {
+            SdrContentBrightnessReplacesPrimarySlider = true,
+        };
+
+        var json = JsonSerializer.Serialize(original);
+        var restored = JsonSerializer.Deserialize<PowerDisplayProperties>(json);
+
+        Assert.IsNotNull(restored);
+        Assert.IsTrue(restored.SdrContentBrightnessReplacesPrimarySlider);
+        StringAssert.Contains(json, "\"sdr_content_brightness_replaces_primary_slider\"");
+    }
+
+    [TestMethod]
+    public void HotkeyAccessors_ExposeActivationAndAllAdjustmentActions()
+    {
+        var accessors = new PowerDisplaySettings().GetAllHotkeyAccessors();
+
+        Assert.AreEqual(9, accessors.Length);
+        Assert.IsTrue(accessors.All(accessor => accessor.Value != null));
+    }
+}

--- a/src/modules/powerdisplay/PowerDisplay.Lib.UnitTests/SdrContentBrightnessLevelTests.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Lib.UnitTests/SdrContentBrightnessLevelTests.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PowerDisplay.Common.Utils;
+
+namespace PowerDisplay.UnitTests;
+
+[TestClass]
+public class SdrContentBrightnessLevelTests
+{
+    [DataTestMethod]
+    [DataRow(0, 1000u)]
+    [DataRow(1, 1050u)]
+    [DataRow(50, 3500u)]
+    [DataRow(100, 6000u)]
+    public void ToRaw_MapsSystemSliderRange(int percentage, uint expected)
+    {
+        Assert.AreEqual(expected, SdrContentBrightnessLevel.ToRaw(percentage));
+    }
+
+    [DataTestMethod]
+    [DataRow(1000u, 0)]
+    [DataRow(1050u, 1)]
+    [DataRow(3500u, 50)]
+    [DataRow(6000u, 100)]
+    public void FromRaw_MapsSystemSliderRange(uint rawValue, int expected)
+    {
+        Assert.AreEqual(expected, SdrContentBrightnessLevel.FromRaw(rawValue));
+    }
+
+    [TestMethod]
+    public void Conversion_ClampsOutOfRangeValues()
+    {
+        Assert.AreEqual(1000u, SdrContentBrightnessLevel.ToRaw(-10));
+        Assert.AreEqual(6000u, SdrContentBrightnessLevel.ToRaw(110));
+        Assert.AreEqual(0, SdrContentBrightnessLevel.FromRaw(0));
+        Assert.AreEqual(100, SdrContentBrightnessLevel.FromRaw(7000));
+    }
+}

--- a/src/modules/powerdisplay/PowerDisplay.Lib/Drivers/DDC/MonitorDiscoveryHelper.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Lib/Drivers/DDC/MonitorDiscoveryHelper.cs
@@ -131,11 +131,17 @@ namespace PowerDisplay.Common.Drivers.DDC
                     Id = monitorId,
                     Name = name.Trim(),
                     CurrentBrightness = 50, // Initial placeholder; overwritten if the VCP read succeeds
+                    CurrentSdrContentBrightness = monitorInfo.SdrContentBrightness ?? 0,
                     Handle = physicalMonitor.HPhysicalMonitor,
-                    Capabilities = MonitorCapabilities.DdcCi,
+                    Capabilities = MonitorCapabilities.DdcCi
+                        | (monitorInfo.IsHdrSupported ? MonitorCapabilities.Hdr : MonitorCapabilities.None)
+                        | (monitorInfo.IsHdrEnabled && monitorInfo.SdrContentBrightness.HasValue
+                            ? MonitorCapabilities.SdrContentBrightness
+                            : MonitorCapabilities.None),
                     CommunicationMethod = "DDC/CI",
                     MonitorNumber = monitorInfo.MonitorNumber,
                     GdiDeviceName = monitorInfo.GdiDeviceName ?? string.Empty,
+                    IsHdrEnabled = monitorInfo.IsHdrEnabled,
                     Orientation = DmdoDefault, // Orientation will be set separately if needed
                 };
 

--- a/src/modules/powerdisplay/PowerDisplay.Lib/Drivers/DisplayConfigInventory.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Lib/Drivers/DisplayConfigInventory.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using ManagedCommon;
+using PowerDisplay.Common.Utils;
 using Windows.Win32.Foundation;
 using static PowerDisplay.Common.Drivers.NativeConstants;
 using static PowerDisplay.Common.Drivers.PInvoke;
@@ -76,12 +77,22 @@ namespace PowerDisplay.Common.Drivers
                         continue;
                     }
 
+                    var (isHdrSupported, isHdrEnabled) = GetHdrState(path.TargetInfo.AdapterId, path.TargetInfo.Id);
+                    var sdrContentBrightness = isHdrEnabled
+                        ? GetSdrContentBrightness(path.TargetInfo.AdapterId, path.TargetInfo.Id)
+                        : null;
+
                     monitorInfo[devicePath] = new MonitorDisplayInfo
                     {
                         DevicePath = devicePath,
                         GdiDeviceName = gdiDeviceName,
                         FriendlyName = friendlyName ?? string.Empty,
                         MonitorNumber = i + 1, // 1-based, matches Windows Display Settings
+                        AdapterId = path.TargetInfo.AdapterId,
+                        TargetId = path.TargetInfo.Id,
+                        IsHdrSupported = isHdrSupported,
+                        IsHdrEnabled = isHdrEnabled,
+                        SdrContentBrightness = sdrContentBrightness,
                     };
                 }
             }
@@ -91,6 +102,62 @@ namespace PowerDisplay.Common.Drivers
             }
 
             return monitorInfo;
+        }
+
+        private static unsafe (bool Supported, bool Enabled) GetHdrState(LUID adapterId, uint targetId)
+        {
+            // Windows 11 exposes an explicit active color mode, which lets us distinguish HDR
+            // from WCG. Fall back to the Windows 10 flags when the v2 query is unavailable.
+            var advancedColorInfo2 = new DisplayConfigAdvancedColorInfo2
+            {
+                Header = new DisplayConfigDeviceInfoHeader
+                {
+                    Type = DisplayconfigDeviceInfoGetAdvancedColorInfo2,
+                    Size = (uint)sizeof(DisplayConfigAdvancedColorInfo2),
+                    AdapterId = adapterId,
+                    Id = targetId,
+                },
+            };
+
+            if (DisplayConfigGetDeviceInfo(&advancedColorInfo2) == 0)
+            {
+                return (
+                    advancedColorInfo2.HighDynamicRangeSupported,
+                    advancedColorInfo2.HighDynamicRangeUserEnabled && advancedColorInfo2.IsHdrActive);
+            }
+
+            var advancedColorInfo = new DisplayConfigAdvancedColorInfo
+            {
+                Header = new DisplayConfigDeviceInfoHeader
+                {
+                    Type = DisplayconfigDeviceInfoGetAdvancedColorInfo,
+                    Size = (uint)sizeof(DisplayConfigAdvancedColorInfo),
+                    AdapterId = adapterId,
+                    Id = targetId,
+                },
+            };
+
+            return DisplayConfigGetDeviceInfo(&advancedColorInfo) == 0
+                ? (advancedColorInfo.AdvancedColorSupported, advancedColorInfo.AdvancedColorEnabled)
+                : (false, false);
+        }
+
+        private static unsafe int? GetSdrContentBrightness(LUID adapterId, uint targetId)
+        {
+            var whiteLevel = new DisplayConfigSdrWhiteLevel
+            {
+                Header = new DisplayConfigDeviceInfoHeader
+                {
+                    Type = DisplayconfigDeviceInfoGetSdrWhiteLevel,
+                    Size = (uint)sizeof(DisplayConfigSdrWhiteLevel),
+                    AdapterId = adapterId,
+                    Id = targetId,
+                },
+            };
+
+            return DisplayConfigGetDeviceInfo(&whiteLevel) == 0
+                ? SdrContentBrightnessLevel.FromRaw(whiteLevel.SdrWhiteLevel)
+                : null;
         }
 
         /// <summary>

--- a/src/modules/powerdisplay/PowerDisplay.Lib/Drivers/HdrSdrBrightnessController.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Lib/Drivers/HdrSdrBrightnessController.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using ManagedCommon;
+using PowerDisplay.Common.Models;
+using PowerDisplay.Common.Utils;
+using PowerDisplay.Models;
+using Windows.Win32.Foundation;
+using static PowerDisplay.Common.Drivers.NativeConstants;
+using static PowerDisplay.Common.Drivers.PInvoke;
+
+namespace PowerDisplay.Common.Drivers
+{
+    /// <summary>
+    /// Writes the Windows HDR SDR-reference-white setting for active display targets.
+    /// </summary>
+    internal sealed class HdrSdrBrightnessController
+    {
+        private readonly Dictionary<string, DisplayTarget> _targets = new(MonitorIdComparer.Instance);
+
+        public void UpdateTargets(IEnumerable<MonitorDisplayInfo> targets)
+        {
+            _targets.Clear();
+
+            foreach (var target in targets)
+            {
+                if (!target.IsHdrEnabled || !target.SdrContentBrightness.HasValue)
+                {
+                    continue;
+                }
+
+                var monitorId = MonitorIdentity.FromDevicePath(target.DevicePath);
+                if (!string.IsNullOrEmpty(monitorId))
+                {
+                    _targets[monitorId] = new DisplayTarget(target.AdapterId, target.TargetId);
+                }
+            }
+        }
+
+        public unsafe MonitorOperationResult SetSdrContentBrightness(string monitorId, int percentage)
+        {
+            if (!_targets.TryGetValue(monitorId, out var target))
+            {
+                return MonitorOperationResult.Failure(
+                    "HDR is not active or SDR content brightness is unavailable for this display.");
+            }
+
+            var request = new DisplayConfigSetSdrWhiteLevel
+            {
+                Header = new DisplayConfigDeviceInfoHeader
+                {
+                    Type = DisplayconfigDeviceInfoSetSdrWhiteLevel,
+                    Size = (uint)sizeof(DisplayConfigSetSdrWhiteLevel),
+                    AdapterId = target.AdapterId,
+                    Id = target.TargetId,
+                },
+                SdrWhiteLevel = SdrContentBrightnessLevel.ToRaw(percentage),
+                FinalValue = 1,
+            };
+
+            var result = DisplayConfigSetDeviceInfo(&request);
+            if (result == 0)
+            {
+                return MonitorOperationResult.Success();
+            }
+
+            Logger.LogWarning(
+                $"[HDR] DisplayConfigSetDeviceInfo failed for '{monitorId}' with Win32 error {result}");
+            return MonitorOperationResult.Failure("Failed to set SDR content brightness.", result);
+        }
+
+        private readonly record struct DisplayTarget(LUID AdapterId, uint TargetId);
+    }
+}

--- a/src/modules/powerdisplay/PowerDisplay.Lib/Drivers/MonitorDisplayInfo.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Lib/Drivers/MonitorDisplayInfo.cs
@@ -2,6 +2,8 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Windows.Win32.Foundation;
+
 namespace PowerDisplay.Common.Drivers
 {
     /// <summary>
@@ -35,5 +37,31 @@ namespace PowerDisplay.Common.Drivers
         /// 1-based index (paths[0] = 1, paths[1] = 2, etc.)
         /// </summary>
         public int MonitorNumber { get; init; }
+
+        /// <summary>
+        /// Gets the display adapter identifier used by DisplayConfig device-info calls.
+        /// </summary>
+        public LUID AdapterId { get; init; }
+
+        /// <summary>
+        /// Gets the DisplayConfig target identifier on <see cref="AdapterId"/>.
+        /// </summary>
+        public uint TargetId { get; init; }
+
+        /// <summary>
+        /// Gets a value indicating whether the active path reports HDR support.
+        /// </summary>
+        public bool IsHdrSupported { get; init; }
+
+        /// <summary>
+        /// Gets a value indicating whether HDR is currently active on this path.
+        /// </summary>
+        public bool IsHdrEnabled { get; init; }
+
+        /// <summary>
+        /// Gets the current Windows SDR content brightness percentage when HDR is active
+        /// and the SDR white level could be read; otherwise, <see langword="null"/>.
+        /// </summary>
+        public int? SdrContentBrightness { get; init; }
     }
 }

--- a/src/modules/powerdisplay/PowerDisplay.Lib/Drivers/NativeConstants.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Lib/Drivers/NativeConstants.cs
@@ -68,6 +68,27 @@ namespace PowerDisplay.Common.Drivers
         public const uint DisplayconfigDeviceInfoGetTargetName = 2;
 
         /// <summary>
+        /// Get the legacy Advanced Color capability and enabled-state flags.
+        /// </summary>
+        public const uint DisplayconfigDeviceInfoGetAdvancedColorInfo = 9;
+
+        /// <summary>
+        /// Get the SDR reference-white level for an Advanced Color display.
+        /// </summary>
+        public const uint DisplayconfigDeviceInfoGetSdrWhiteLevel = 11;
+
+        /// <summary>
+        /// Get the Windows 11 Advanced Color v2 state, including the active HDR/WCG mode.
+        /// </summary>
+        public const uint DisplayconfigDeviceInfoGetAdvancedColorInfo2 = 15;
+
+        /// <summary>
+        /// Private device-info request used by the Windows HDR settings page to commit the
+        /// SDR content brightness value. This is deliberately isolated behind capability checks.
+        /// </summary>
+        public const uint DisplayconfigDeviceInfoSetSdrWhiteLevel = 0xFFFFFFEE;
+
+        /// <summary>
         /// Retrieve the current settings for the display device.
         /// </summary>
         public const int EnumCurrentSettings = -1;

--- a/src/modules/powerdisplay/PowerDisplay.Lib/Drivers/NativeStructures/DisplayConfigAdvancedColorInfo.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Lib/Drivers/NativeStructures/DisplayConfigAdvancedColorInfo.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+namespace PowerDisplay.Common.Drivers
+{
+    /// <summary>
+    /// Managed layout for DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct DisplayConfigAdvancedColorInfo
+    {
+        public DisplayConfigDeviceInfoHeader Header;
+        public uint Value;
+        public uint ColorEncoding;
+        public uint BitsPerColorChannel;
+
+        public readonly bool AdvancedColorSupported => (Value & 0x1) != 0;
+
+        public readonly bool AdvancedColorEnabled => (Value & 0x2) != 0;
+    }
+}

--- a/src/modules/powerdisplay/PowerDisplay.Lib/Drivers/NativeStructures/DisplayConfigAdvancedColorInfo2.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Lib/Drivers/NativeStructures/DisplayConfigAdvancedColorInfo2.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+namespace PowerDisplay.Common.Drivers
+{
+    /// <summary>
+    /// Managed layout for DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO_2 (Windows 11).
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct DisplayConfigAdvancedColorInfo2
+    {
+        public DisplayConfigDeviceInfoHeader Header;
+        public uint Value;
+        public uint ColorEncoding;
+        public uint BitsPerColorChannel;
+        public uint ActiveColorMode;
+
+        public readonly bool HighDynamicRangeSupported => (Value & 0x10) != 0;
+
+        public readonly bool HighDynamicRangeUserEnabled => (Value & 0x20) != 0;
+
+        public readonly bool IsHdrActive => ActiveColorMode == 2;
+    }
+}

--- a/src/modules/powerdisplay/PowerDisplay.Lib/Drivers/NativeStructures/DisplayConfigSdrWhiteLevel.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Lib/Drivers/NativeStructures/DisplayConfigSdrWhiteLevel.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+namespace PowerDisplay.Common.Drivers
+{
+    /// <summary>
+    /// Managed layout for DISPLAYCONFIG_SDR_WHITE_LEVEL.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct DisplayConfigSdrWhiteLevel
+    {
+        public DisplayConfigDeviceInfoHeader Header;
+        public uint SdrWhiteLevel;
+    }
+}

--- a/src/modules/powerdisplay/PowerDisplay.Lib/Drivers/NativeStructures/DisplayConfigSetSdrWhiteLevel.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Lib/Drivers/NativeStructures/DisplayConfigSetSdrWhiteLevel.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+namespace PowerDisplay.Common.Drivers
+{
+    /// <summary>
+    /// Request layout used by Windows Settings to commit the HDR SDR-white-level slider.
+    /// The associated device-info type is private, so callers must capability-gate failures.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct DisplayConfigSetSdrWhiteLevel
+    {
+        public DisplayConfigDeviceInfoHeader Header;
+        public uint SdrWhiteLevel;
+        public byte FinalValue;
+        public byte Reserved1;
+        public byte Reserved2;
+        public byte Reserved3;
+    }
+}

--- a/src/modules/powerdisplay/PowerDisplay.Lib/Drivers/PInvoke.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Lib/Drivers/PInvoke.cs
@@ -37,6 +37,22 @@ namespace PowerDisplay.Common.Drivers
         internal static unsafe partial int DisplayConfigGetDeviceInfo(
             DisplayConfigSourceDeviceName* sourceName);
 
+        [LibraryImport("user32.dll")]
+        internal static unsafe partial int DisplayConfigGetDeviceInfo(
+            DisplayConfigAdvancedColorInfo* advancedColorInfo);
+
+        [LibraryImport("user32.dll")]
+        internal static unsafe partial int DisplayConfigGetDeviceInfo(
+            DisplayConfigAdvancedColorInfo2* advancedColorInfo);
+
+        [LibraryImport("user32.dll")]
+        internal static unsafe partial int DisplayConfigGetDeviceInfo(
+            DisplayConfigSdrWhiteLevel* sdrWhiteLevel);
+
+        [LibraryImport("user32.dll")]
+        internal static unsafe partial int DisplayConfigSetDeviceInfo(
+            DisplayConfigSetSdrWhiteLevel* sdrWhiteLevel);
+
         // ==================== User32.dll - Monitor Enumeration ====================
         [LibraryImport("user32.dll")]
         [return: MarshalAs(UnmanagedType.Bool)]

--- a/src/modules/powerdisplay/PowerDisplay.Lib/Drivers/WMI/WmiController.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Lib/Drivers/WMI/WmiController.cs
@@ -271,12 +271,19 @@ namespace PowerDisplay.Common.Drivers.WMI
                                 Id = MonitorIdentity.FromDevicePath(displayInfo.DevicePath),
                                 Name = string.Empty,
                                 CurrentBrightness = currentBrightness,
+                                CurrentSdrContentBrightness = displayInfo.SdrContentBrightness ?? 0,
                                 InstanceName = instanceName,
-                                Capabilities = MonitorCapabilities.Brightness | MonitorCapabilities.Wmi,
+                                Capabilities = MonitorCapabilities.Brightness
+                                    | MonitorCapabilities.Wmi
+                                    | (displayInfo.IsHdrSupported ? MonitorCapabilities.Hdr : MonitorCapabilities.None)
+                                    | (displayInfo.IsHdrEnabled && displayInfo.SdrContentBrightness.HasValue
+                                        ? MonitorCapabilities.SdrContentBrightness
+                                        : MonitorCapabilities.None),
                                 CommunicationMethod = "WMI",
                                 SupportsColorTemperature = false,
                                 MonitorNumber = displayInfo.MonitorNumber,
                                 GdiDeviceName = displayInfo.GdiDeviceName ?? string.Empty,
+                                IsHdrEnabled = displayInfo.IsHdrEnabled,
                             };
 
                             monitor.ReadValues |= MonitorReadFlags.Brightness;

--- a/src/modules/powerdisplay/PowerDisplay.Lib/Models/Monitor.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Lib/Models/Monitor.cs
@@ -26,6 +26,7 @@ namespace PowerDisplay.Common.Models
     public partial class Monitor : INotifyPropertyChanged, IMonitorData
     {
         private int _currentBrightness;
+        private int _currentSdrContentBrightness;
         private int _currentColorTemperature = 0x05; // Default to 6500K preset (VCP 0x14 value)
         private int _currentInputSource; // VCP 0x60 value
         private int _currentPowerState = 0x01; // Default to On (VCP 0xD6 value)
@@ -58,6 +59,24 @@ namespace PowerDisplay.Common.Models
                 if (_currentBrightness != clamped)
                 {
                     _currentBrightness = clamped;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the Windows HDR SDR-content-brightness balance as a percentage (0-100).
+        /// This controls the SDR reference white level and does not change the monitor backlight.
+        /// </summary>
+        public int CurrentSdrContentBrightness
+        {
+            get => _currentSdrContentBrightness;
+            set
+            {
+                var clamped = Math.Clamp(value, 0, 100);
+                if (_currentSdrContentBrightness != clamped)
+                {
+                    _currentSdrContentBrightness = clamped;
                     OnPropertyChanged();
                 }
             }
@@ -184,6 +203,18 @@ namespace PowerDisplay.Common.Models
         /// Gets a value indicating whether the monitor supports volume adjustment (for audio-capable monitors)
         /// </summary>
         public bool SupportsVolume => Capabilities.HasFlag(MonitorCapabilities.Volume);
+
+        /// <summary>
+        /// Gets a value indicating whether HDR is currently active and Windows exposed an
+        /// SDR reference-white level for this display.
+        /// </summary>
+        public bool SupportsSdrContentBrightness =>
+            Capabilities.HasFlag(MonitorCapabilities.SdrContentBrightness);
+
+        /// <summary>
+        /// Gets or sets a value indicating whether HDR is currently active on this display path.
+        /// </summary>
+        public bool IsHdrEnabled { get; set; }
 
         private int _currentContrast = 50;
         private int _currentVolume = 50;

--- a/src/modules/powerdisplay/PowerDisplay.Lib/Models/MonitorCapabilities.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Lib/Models/MonitorCapabilities.cs
@@ -48,5 +48,10 @@ namespace PowerDisplay.Common.Models
         /// Supports volume control
         /// </summary>
         Volume = 1 << 6,
+
+        /// <summary>
+        /// Supports changing the Windows SDR content brightness while HDR is active.
+        /// </summary>
+        SdrContentBrightness = 1 << 7,
     }
 }

--- a/src/modules/powerdisplay/PowerDisplay.Lib/Services/MonitorManager.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Lib/Services/MonitorManager.cs
@@ -31,6 +31,7 @@ namespace PowerDisplay.Common.Services
         private readonly Dictionary<string, Monitor> _monitorLookup = new(MonitorIdComparer.Instance);
         private readonly SemaphoreSlim _discoveryLock = new(1, 1);
         private readonly DisplayRotationService _rotationService = new();
+        private readonly HdrSdrBrightnessController _hdrSdrBrightnessController = new();
 
         // Built-in entries are loaded automatically by the service constructor.
         private readonly MonitorBlacklistService _blacklistService = new();
@@ -166,6 +167,7 @@ namespace PowerDisplay.Common.Services
             }
 
             inventory = filteredInventory;
+            _hdrSdrBrightnessController.UpdateTargets(inventory.Values);
 
             if (inventory.Count == 0)
             {
@@ -266,6 +268,38 @@ namespace PowerDisplay.Common.Services
                     mon.ReadValues |= MonitorReadFlags.Brightness;
                 },
                 cancellationToken);
+
+        /// <summary>
+        /// Sets the Windows SDR content brightness for an HDR-active display.
+        /// This changes the SDR reference white level, not the physical monitor backlight.
+        /// </summary>
+        public Task<MonitorOperationResult> SetSdrContentBrightnessAsync(
+            string monitorId,
+            int brightness,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            brightness = Math.Clamp(brightness, 0, 100);
+
+            if (!_monitorLookup.TryGetValue(monitorId, out var monitor))
+            {
+                return Task.FromResult(MonitorOperationResult.Failure($"Monitor not found: {monitorId}"));
+            }
+
+            if (!monitor.SupportsSdrContentBrightness)
+            {
+                return Task.FromResult(MonitorOperationResult.Failure(
+                    "HDR is not active or SDR content brightness is unavailable for this display."));
+            }
+
+            var result = _hdrSdrBrightnessController.SetSdrContentBrightness(monitorId, brightness);
+            if (result.IsSuccess)
+            {
+                monitor.CurrentSdrContentBrightness = brightness;
+            }
+
+            return Task.FromResult(result);
+        }
 
         /// <summary>
         /// Set contrast of the specified monitor (DDC/CI controllers only; returns Failure on others).

--- a/src/modules/powerdisplay/PowerDisplay.Lib/Utils/SdrContentBrightnessLevel.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Lib/Utils/SdrContentBrightnessLevel.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace PowerDisplay.Common.Utils
+{
+    /// <summary>
+    /// Converts between the Windows HDR SDR-white-level fixed-point value and the
+    /// 0-100 value shown by the system SDR content brightness slider.
+    /// </summary>
+    public static class SdrContentBrightnessLevel
+    {
+        public const uint MinimumRawValue = 1000;
+        public const uint MaximumRawValue = 6000;
+        private const uint RawUnitsPerPercent = 50;
+
+        public static int FromRaw(uint rawValue)
+        {
+            var clamped = Math.Clamp(rawValue, MinimumRawValue, MaximumRawValue);
+            return (int)((clamped - MinimumRawValue + (RawUnitsPerPercent / 2)) / RawUnitsPerPercent);
+        }
+
+        public static uint ToRaw(int percentage)
+        {
+            var clamped = Math.Clamp(percentage, 0, 100);
+            return MinimumRawValue + ((uint)clamped * RawUnitsPerPercent);
+        }
+    }
+}

--- a/src/modules/powerdisplay/PowerDisplay/Helpers/HotkeyService.cs
+++ b/src/modules/powerdisplay/PowerDisplay/Helpers/HotkeyService.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using ManagedCommon;
 using Microsoft.PowerToys.Settings.UI.Library;
@@ -16,19 +17,41 @@ namespace PowerDisplay.Helpers
     /// </summary>
     internal sealed partial class HotkeyService : IDisposable
     {
-        private const int HotkeyId = 9001;
+        private const int ToggleWindowHotkeyId = 9001;
+        private const int IncreaseBrightnessHotkeyId = 9002;
+        private const int DecreaseBrightnessHotkeyId = 9003;
+        private const int IncreaseContrastHotkeyId = 9004;
+        private const int DecreaseContrastHotkeyId = 9005;
+        private const int IncreaseVolumeHotkeyId = 9006;
+        private const int DecreaseVolumeHotkeyId = 9007;
+        private const int IncreaseSdrContentBrightnessHotkeyId = 9008;
+        private const int DecreaseSdrContentBrightnessHotkeyId = 9009;
 
         private readonly SettingsUtils _settingsUtils;
-        private readonly Action _hotkeyAction;
+        private readonly Dictionary<int, Action> _hotkeyActions;
+        private readonly HashSet<int> _registeredHotkeyIds = new();
 
         private nint _hwnd;
-        private bool _isRegistered;
         private bool _disposed;
 
-        public HotkeyService(SettingsUtils settingsUtils, Action hotkeyAction)
+        public HotkeyService(
+            SettingsUtils settingsUtils,
+            Action toggleWindowAction,
+            Action<PowerDisplayHotkeyAction> adjustmentAction)
         {
             _settingsUtils = settingsUtils;
-            _hotkeyAction = hotkeyAction;
+            _hotkeyActions = new Dictionary<int, Action>
+            {
+                [ToggleWindowHotkeyId] = toggleWindowAction,
+                [IncreaseBrightnessHotkeyId] = () => adjustmentAction(PowerDisplayHotkeyAction.IncreaseBrightness),
+                [DecreaseBrightnessHotkeyId] = () => adjustmentAction(PowerDisplayHotkeyAction.DecreaseBrightness),
+                [IncreaseContrastHotkeyId] = () => adjustmentAction(PowerDisplayHotkeyAction.IncreaseContrast),
+                [DecreaseContrastHotkeyId] = () => adjustmentAction(PowerDisplayHotkeyAction.DecreaseContrast),
+                [IncreaseVolumeHotkeyId] = () => adjustmentAction(PowerDisplayHotkeyAction.IncreaseVolume),
+                [DecreaseVolumeHotkeyId] = () => adjustmentAction(PowerDisplayHotkeyAction.DecreaseVolume),
+                [IncreaseSdrContentBrightnessHotkeyId] = () => adjustmentAction(PowerDisplayHotkeyAction.IncreaseSdrContentBrightness),
+                [DecreaseSdrContentBrightnessHotkeyId] = () => adjustmentAction(PowerDisplayHotkeyAction.DecreaseSdrContentBrightness),
+            };
         }
 
         /// <summary>
@@ -47,47 +70,55 @@ namespace PowerDisplay.Helpers
         /// <returns>True if the message was handled.</returns>
         public bool HandleMessage(uint uMsg, nuint wParam)
         {
-            if (uMsg == WmHotkey && (int)wParam == HotkeyId)
+            var hotkeyId = (int)wParam;
+            if (uMsg != WmHotkey ||
+                !_registeredHotkeyIds.Contains(hotkeyId) ||
+                !_hotkeyActions.TryGetValue(hotkeyId, out var action))
             {
-                try
-                {
-                    _hotkeyAction?.Invoke();
-                }
-                catch (Exception ex)
-                {
-                    Logger.LogError($"[HotkeyService] Hotkey action failed: {ex.Message}");
-                }
-
-                return true;
+                return false;
             }
 
-            return false;
+            try
+            {
+                action();
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError($"[HotkeyService] Hotkey action failed: {ex.Message}");
+            }
+
+            return true;
         }
 
         /// <summary>
-        /// Reload settings and re-register hotkey.
+        /// Reload settings and re-register all configured hotkeys.
         /// Call this when settings change.
         /// </summary>
         public void ReloadSettings()
         {
-            UnregisterHotkey();
+            UnregisterHotkeys();
 
             var settings = _settingsUtils.GetSettingsOrDefault<PowerDisplaySettings>(PowerDisplaySettings.ModuleName);
-            var hotkey = settings?.Properties?.ActivationShortcut;
-
-            if (hotkey == null || !hotkey.IsValid())
+            if (settings?.Properties == null)
             {
                 return;
             }
 
-            RegisterHotkey(hotkey);
+            RegisterHotkey(ToggleWindowHotkeyId, settings.Properties.ActivationShortcut);
+            RegisterHotkey(IncreaseBrightnessHotkeyId, settings.Properties.IncreaseBrightnessShortcut);
+            RegisterHotkey(DecreaseBrightnessHotkeyId, settings.Properties.DecreaseBrightnessShortcut);
+            RegisterHotkey(IncreaseContrastHotkeyId, settings.Properties.IncreaseContrastShortcut);
+            RegisterHotkey(DecreaseContrastHotkeyId, settings.Properties.DecreaseContrastShortcut);
+            RegisterHotkey(IncreaseVolumeHotkeyId, settings.Properties.IncreaseVolumeShortcut);
+            RegisterHotkey(DecreaseVolumeHotkeyId, settings.Properties.DecreaseVolumeShortcut);
+            RegisterHotkey(IncreaseSdrContentBrightnessHotkeyId, settings.Properties.IncreaseSdrContentBrightnessShortcut);
+            RegisterHotkey(DecreaseSdrContentBrightnessHotkeyId, settings.Properties.DecreaseSdrContentBrightnessShortcut);
         }
 
-        private void RegisterHotkey(HotkeySettings hotkey)
+        private void RegisterHotkey(int hotkeyId, HotkeySettings? hotkey)
         {
-            if (_hwnd == 0)
+            if (_hwnd == 0 || hotkey == null || !hotkey.IsValid())
             {
-                Logger.LogWarning("[HotkeyService] Cannot register hotkey: window handle not set");
                 return;
             }
 
@@ -98,32 +129,35 @@ namespace PowerDisplay.Helpers
                 | (hotkey.Alt ? ModAlt : 0)
                 | (hotkey.Shift ? ModShift : 0);
 
-            if (RegisterHotKeyNative(_hwnd, HotkeyId, modifiers, (uint)hotkey.Code))
+            if (RegisterHotKeyNative(_hwnd, hotkeyId, modifiers, (uint)hotkey.Code))
             {
-                _isRegistered = true;
+                _registeredHotkeyIds.Add(hotkeyId);
             }
             else
             {
-                Logger.LogError($"[HotkeyService] Failed to register hotkey: {hotkey}, error={Marshal.GetLastWin32Error()}");
+                Logger.LogError(
+                    $"[HotkeyService] Failed to register hotkey id={hotkeyId}: {hotkey}, error={Marshal.GetLastWin32Error()}");
             }
         }
 
-        private void UnregisterHotkey()
+        private void UnregisterHotkeys()
         {
-            if (!_isRegistered || _hwnd == 0)
+            if (_hwnd == 0)
             {
                 return;
             }
 
-            bool success = UnregisterHotKeyNative(_hwnd, HotkeyId);
-
-            if (!success)
+            foreach (var hotkeyId in _registeredHotkeyIds)
             {
-                var error = Marshal.GetLastWin32Error();
-                Logger.LogWarning($"[HotkeyService] Failed to unregister hotkey, error={error}");
+                if (!UnregisterHotKeyNative(_hwnd, hotkeyId))
+                {
+                    var error = Marshal.GetLastWin32Error();
+                    Logger.LogWarning(
+                        $"[HotkeyService] Failed to unregister hotkey id={hotkeyId}, error={error}");
+                }
             }
 
-            _isRegistered = false;
+            _registeredHotkeyIds.Clear();
         }
 
         public void Dispose()
@@ -133,7 +167,7 @@ namespace PowerDisplay.Helpers
                 return;
             }
 
-            UnregisterHotkey();
+            UnregisterHotkeys();
             _disposed = true;
         }
 

--- a/src/modules/powerdisplay/PowerDisplay/Helpers/PowerDisplayHotkeyAction.cs
+++ b/src/modules/powerdisplay/PowerDisplay/Helpers/PowerDisplayHotkeyAction.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace PowerDisplay.Helpers
+{
+    internal enum PowerDisplayHotkeyAction
+    {
+        IncreaseBrightness,
+        DecreaseBrightness,
+        IncreaseContrast,
+        DecreaseContrast,
+        IncreaseVolume,
+        DecreaseVolume,
+        IncreaseSdrContentBrightness,
+        DecreaseSdrContentBrightness,
+    }
+}

--- a/src/modules/powerdisplay/PowerDisplay/PowerDisplayXAML/MainWindow.xaml
+++ b/src/modules/powerdisplay/PowerDisplay/PowerDisplayXAML/MainWindow.xaml
@@ -508,7 +508,7 @@
                                                     Height="{StaticResource FlyoutSliderRowHeight}"
                                                     Margin="{StaticResource FlyoutSectionTopMargin}"
                                                     ColumnSpacing="{StaticResource FlyoutStandardSpacing}"
-                                                    Visibility="{x:Bind helpers:VisibilityConverter.BoolToVisibility(ShowBrightnessSlider), Mode=OneWay}">
+                                                    Visibility="{x:Bind helpers:VisibilityConverter.BoolToVisibility(ShowPhysicalBrightnessSlider), Mode=OneWay}">
                                                     <Grid.ColumnDefinitions>
                                                         <ColumnDefinition Width="{StaticResource FlyoutSliderIconColumnWidth}" />
                                                         <ColumnDefinition Width="*" />
@@ -531,6 +531,42 @@
                                                         Maximum="100"
                                                         Minimum="0"
                                                         Value="{x:Bind Brightness, Mode=TwoWay}" />
+                                                </Grid>
+
+                                                <!--  SDR Content Brightness (HDR mode)  -->
+                                                <Grid
+                                                    Height="{StaticResource FlyoutSliderRowHeight}"
+                                                    Margin="{StaticResource FlyoutSectionTopMargin}"
+                                                    ColumnSpacing="{StaticResource FlyoutStandardSpacing}"
+                                                    Visibility="{x:Bind helpers:VisibilityConverter.BoolToVisibility(ShowSdrContentBrightnessSlider), Mode=OneWay}">
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="{StaticResource FlyoutSliderIconColumnWidth}" />
+                                                        <ColumnDefinition Width="*" />
+                                                    </Grid.ColumnDefinitions>
+                                                    <Viewbox
+                                                        Width="20"
+                                                        Height="{StaticResource FlyoutActionGlyphFontSize}"
+                                                        HorizontalAlignment="Center"
+                                                        VerticalAlignment="Center"
+                                                        StretchDirection="DownOnly">
+                                                        <TextBlock
+                                                            x:Uid="SdrContentBrightnessTooltip"
+                                                            AutomationProperties.AccessibilityView="Raw"
+                                                            FontSize="{StaticResource FlyoutSecondaryTextFontSize}"
+                                                            FontWeight="SemiBold"
+                                                            TextAlignment="Center" />
+                                                    </Viewbox>
+                                                    <Slider
+                                                        x:Uid="SdrContentBrightnessAutomation"
+                                                        Grid.Column="1"
+                                                        VerticalAlignment="Center"
+                                                        helpers:SliderExtensions.IsMouseWheelEnabled="True"
+                                                        helpers:SliderExtensions.MouseWheelChange="{x:Bind MouseWheelIncrement, Mode=OneWay}"
+                                                        IsEnabled="{x:Bind IsInteractionEnabled, Mode=OneWay}"
+                                                        IsTabStop="True"
+                                                        Maximum="100"
+                                                        Minimum="0"
+                                                        Value="{x:Bind SdrContentBrightness, Mode=TwoWay}" />
                                                 </Grid>
 
                                                 <!--  Contrast Control  -->

--- a/src/modules/powerdisplay/PowerDisplay/PowerDisplayXAML/MainWindow.xaml.cs
+++ b/src/modules/powerdisplay/PowerDisplay/PowerDisplayXAML/MainWindow.xaml.cs
@@ -69,7 +69,10 @@ namespace PowerDisplay
                 // 5. Initialize HotkeyService for in-process hotkey handling (CmdPal pattern)
                 Logger.LogTrace("MainWindow constructor: Initializing HotkeyService");
                 var hwnd = this.GetWindowHandle();
-                _hotkeyService = new HotkeyService(_settingsUtils, ToggleWindow);
+                _hotkeyService = new HotkeyService(
+                    _settingsUtils,
+                    ToggleWindow,
+                    action => _ = ViewModel.HandleAdjustmentHotkeyAsync(action));
                 _hotkeyService.Initialize(hwnd);
 
                 // 6. Subclass WndProc to route WM_HOTKEY messages into HotkeyService.

--- a/src/modules/powerdisplay/PowerDisplay/Strings/en-us/Resources.resw
+++ b/src/modules/powerdisplay/PowerDisplay/Strings/en-us/Resources.resw
@@ -142,6 +142,13 @@
   <data name="BrightnessTooltip.ToolTipService.ToolTip" xml:space="preserve">
     <value>Brightness</value>
   </data>
+  <data name="SdrContentBrightnessTooltip.ToolTipService.ToolTip" xml:space="preserve">
+    <value>SDR content brightness (HDR mode)</value>
+  </data>
+  <data name="SdrContentBrightnessTooltip.Text" xml:space="preserve">
+    <value>SDR</value>
+    <comment>Short label for the SDR content brightness control. SDR is an industry-standard acronym.</comment>
+  </data>
   <data name="ContrastTooltip.ToolTipService.ToolTip" xml:space="preserve">
     <value>Contrast</value>
   </data>
@@ -183,6 +190,9 @@
   </data>
   <data name="BrightnessAutomation.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Brightness</value>
+  </data>
+  <data name="SdrContentBrightnessAutomation.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>SDR content brightness in HDR mode</value>
   </data>
   <data name="AppName" xml:space="preserve">
     <value>Power Display</value>

--- a/src/modules/powerdisplay/PowerDisplay/ViewModels/MainViewModel.Hotkeys.cs
+++ b/src/modules/powerdisplay/PowerDisplay/ViewModels/MainViewModel.Hotkeys.cs
@@ -1,0 +1,104 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using ManagedCommon;
+using PowerDisplay.Helpers;
+
+namespace PowerDisplay.ViewModels;
+
+public partial class MainViewModel
+{
+    private readonly SemaphoreSlim _hotkeyAdjustmentGate = new(1, 1);
+
+    /// <summary>
+    /// Applies a user-bound adjustment shortcut to every currently visible display that supports
+    /// the requested setting. The shared mouse-wheel increment is also the shortcut step.
+    /// </summary>
+    internal async Task HandleAdjustmentHotkeyAsync(PowerDisplayHotkeyAction action)
+    {
+        if (!IsInteractionEnabled)
+        {
+            return;
+        }
+
+        await _hotkeyAdjustmentGate.WaitAsync();
+        try
+        {
+            var step = Math.Clamp(MouseWheelIncrement, 1, 100);
+            var delta = IsDecreaseAction(action) ? -step : step;
+            var monitors = Monitors.ToList();
+            List<Task> writes = action switch
+            {
+                PowerDisplayHotkeyAction.IncreaseBrightness or
+                PowerDisplayHotkeyAction.DecreaseBrightness => BuildBrightnessWrites(monitors, delta),
+
+                PowerDisplayHotkeyAction.IncreaseContrast or
+                PowerDisplayHotkeyAction.DecreaseContrast => monitors
+                    .Where(m => m.SupportsContrast)
+                    .Select(m => m.SetContrastAsync(Adjust(m.Contrast, delta)))
+                    .ToList(),
+
+                PowerDisplayHotkeyAction.IncreaseVolume or
+                PowerDisplayHotkeyAction.DecreaseVolume => monitors
+                    .Where(m => m.SupportsVolume)
+                    .Select(m => m.SetVolumeAsync(Adjust(m.Volume, delta)))
+                    .ToList(),
+
+                PowerDisplayHotkeyAction.IncreaseSdrContentBrightness or
+                PowerDisplayHotkeyAction.DecreaseSdrContentBrightness => monitors
+                    .Where(m => m.SupportsSdrContentBrightness)
+                    .Select(m => m.SetSdrContentBrightnessAsync(Adjust(m.SdrContentBrightness, delta)))
+                    .ToList(),
+
+                _ => new List<Task>(),
+            };
+
+            if (writes.Count > 0)
+            {
+                await Task.WhenAll(writes);
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError($"[Hotkey] Failed to apply {action}: {ex.Message}");
+        }
+        finally
+        {
+            _hotkeyAdjustmentGate.Release();
+        }
+    }
+
+    private List<Task> BuildBrightnessWrites(IReadOnlyList<MonitorViewModel> monitors, int delta)
+    {
+        if (!LinkedLevelsActive)
+        {
+            return monitors
+                .Where(m => m.SupportsPrimaryBrightness)
+                .Select(m => m.SetPrimaryBrightnessAsync(Adjust(m.PrimaryBrightness, delta)))
+                .ToList();
+        }
+
+        var linkedValue = Adjust(LinkedBrightness, delta);
+        SetLinkedBrightnessSilently(linkedValue);
+
+        return monitors
+            .Where(m => m.SupportsPrimaryBrightness)
+            .Select(m => m.SetPrimaryBrightnessAsync(
+                IsLinkedTarget(m) ? linkedValue : Adjust(m.PrimaryBrightness, delta)))
+            .ToList();
+    }
+
+    private static int Adjust(int value, int delta) => Math.Clamp(value + delta, 0, 100);
+
+    private static bool IsDecreaseAction(PowerDisplayHotkeyAction action) =>
+        action is PowerDisplayHotkeyAction.DecreaseBrightness
+            or PowerDisplayHotkeyAction.DecreaseContrast
+            or PowerDisplayHotkeyAction.DecreaseVolume
+            or PowerDisplayHotkeyAction.DecreaseSdrContentBrightness;
+}

--- a/src/modules/powerdisplay/PowerDisplay/ViewModels/MainViewModel.LinkedBrightness.cs
+++ b/src/modules/powerdisplay/PowerDisplay/ViewModels/MainViewModel.LinkedBrightness.cs
@@ -34,12 +34,12 @@ public partial class MainViewModel
     private DispatcherQueueTimer? _linkedBrightnessCommitTimer;
 
     /// <summary>
-    /// Returns true when the monitor is currently driven by linked brightness — it supports
-    /// brightness and the user has not excluded it. This mirrors the planner's linked-target rule
-    /// for live ViewModels on the broadcast and optimistic-update hot paths.
+    /// Returns true when the monitor is currently driven by linked brightness — it supports its
+    /// current primary brightness target and the user has not excluded it. In SDR replacement
+    /// mode, an HDR-active monitor's primary target is SDR content brightness.
     /// </summary>
     private bool IsLinkedTarget(MonitorViewModel monitor) =>
-        monitor.SupportsBrightness && !_excludedMonitorIds.Contains(monitor.Id);
+        monitor.SupportsPrimaryBrightness && !_excludedMonitorIds.Contains(monitor.Id);
 
     /// <summary>
     /// Snapshot the currently included brightness-capable monitors as
@@ -50,7 +50,7 @@ public partial class MainViewModel
             .Select(m => new LinkedBrightnessPlanner.LinkTarget(
             m.Id,
             m.MonitorNumber,
-            m.Brightness))
+            m.PrimaryBrightness))
             .ToList();
 
     /// <summary>
@@ -147,6 +147,17 @@ public partial class MainViewModel
     }
 
     /// <summary>
+    /// Rebuilds linked-brightness state when HDR monitors switch between physical brightness and
+    /// SDR content brightness as their primary control.
+    /// </summary>
+    partial void OnSdrContentBrightnessReplacesPrimarySliderChanged(bool value)
+    {
+        CancelPendingLinkedBrightnessCommit();
+        RecomputeLinkedBrightnessAvailability();
+        OnPropertyChanged(nameof(ShowLinkLevelsToggle));
+    }
+
+    /// <summary>
     /// Partial change hook fired by the source-generator for <see cref="LinkedBrightness"/>.
     /// Optimistically updates every linked monitor's brightness value to match the master value
     /// that will be broadcast to hardware, so it is correct if the monitor is later excluded or
@@ -172,7 +183,7 @@ public partial class MainViewModel
         {
             if (IsLinkedTarget(vm))
             {
-                vm.UpdateBrightnessDisplay(value);
+                vm.UpdatePrimaryBrightnessDisplay(value);
             }
         }
 
@@ -252,7 +263,7 @@ public partial class MainViewModel
 
     /// <summary>
     /// Broadcast the linked brightness value to every linked target via
-    /// <see cref="MonitorViewModel.SetBrightnessAsync"/>. Each per-VM call already wraps hardware
+    /// <see cref="MonitorViewModel.SetPrimaryBrightnessAsync"/>. Each per-VM call already wraps hardware
     /// errors in its own try/catch, so a single failing monitor does not break the others.
     /// </summary>
     private async Task BroadcastLinkedBrightnessAsync(int value)
@@ -266,7 +277,7 @@ public partial class MainViewModel
         {
             var writes = Monitors
                 .Where(IsLinkedTarget)
-                .Select(m => m.SetBrightnessAsync(value))
+                .Select(m => m.SetPrimaryBrightnessAsync(value))
                 .ToList();
 
             if (writes.Count > 0)

--- a/src/modules/powerdisplay/PowerDisplay/ViewModels/MainViewModel.cs
+++ b/src/modules/powerdisplay/PowerDisplay/ViewModels/MainViewModel.cs
@@ -132,11 +132,18 @@ public partial class MainViewModel : ObservableObject, IDisposable
     public partial bool ShowIdentifyMonitorsButton { get; set; }
 
     /// <summary>
-    /// Gets or sets the per-mouse-wheel-notch step applied to every flyout slider. Loaded from
-    /// PowerDisplaySettings; defaults to 5 (the historical hardcoded step).
+    /// Gets or sets the step applied to every flyout slider mouse-wheel action and adjustment
+    /// shortcut. Loaded from PowerDisplaySettings; defaults to 5.
     /// </summary>
     [ObservableProperty]
     public partial int MouseWheelIncrement { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether HDR-active monitors use Windows SDR content
+    /// brightness as their primary brightness control instead of the physical backlight.
+    /// </summary>
+    [ObservableProperty]
+    public partial bool SdrContentBrightnessReplacesPrimarySlider { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether brightness slider changes are broadcast to all
@@ -153,7 +160,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
     /// <summary>
     /// Gets or sets the brightness value driving the linked "All Displays" slider. Setter is
     /// debounced and broadcasts on commit to every linked target: a
-    /// <see cref="MonitorViewModel.SupportsBrightness"/> monitor not excluded from sync (see
+    /// <see cref="MonitorViewModel.SupportsPrimaryBrightness"/> monitor not excluded from sync (see
     /// <c>OnLinkedBrightnessChanged</c>). Synchronously updates each linked monitor's brightness
     /// value so it is correct if the monitor is later excluded or link mode is disabled — the
     /// linked broadcast is the single source of hardware writes while link mode is active.
@@ -180,12 +187,12 @@ public partial class MainViewModel : ObservableObject, IDisposable
     /// "All Displays" card subtitle ("N linked"). Counts brightness-capable monitors the user
     /// has not excluded (see <see cref="MonitorViewModel.IsExcludedFromSync"/>).
     /// </summary>
-    public int LinkedMonitorsCount => Monitors.Count(m => m.SupportsBrightness && !IsMonitorExcludedFromSync(m.Id));
+    public int LinkedMonitorsCount => Monitors.Count(m => m.SupportsPrimaryBrightness && !IsMonitorExcludedFromSync(m.Id));
 
     /// <summary>
     /// Gets the count of brightness-capable monitors excluded from linked brightness.
     /// </summary>
-    public int ExcludedMonitorsCount => Monitors.Count(m => m.SupportsBrightness && IsMonitorExcludedFromSync(m.Id));
+    public int ExcludedMonitorsCount => Monitors.Count(m => m.SupportsPrimaryBrightness && IsMonitorExcludedFromSync(m.Id));
 
     /// <summary>
     /// Gets a value indicating whether the "N excluded" subtitle fragment should be visible on
@@ -234,14 +241,14 @@ public partial class MainViewModel : ObservableObject, IDisposable
 
     /// <summary>
     /// Gets a value indicating whether the link-levels toggle should be visible. Shown when at
-    /// least two monitors report <see cref="MonitorViewModel.SupportsBrightness"/> (the entry-point
+    /// least two monitors report <see cref="MonitorViewModel.SupportsPrimaryBrightness"/> (the entry-point
     /// gate — counting raw entries would show the toggle even when only one display can actually be
     /// driven), OR whenever link mode is already active. The second clause guarantees the user can
     /// always turn link mode back off, even if monitors were unplugged down to one controllable
     /// display while linked — otherwise the "All displays" card would strand them with no way out.
     /// Recomputed by <see cref="UpdateMonitorList"/> and on <see cref="LinkedLevelsActive"/> change.
     /// </summary>
-    public bool ShowLinkLevelsToggle => LinkedLevelsActive || Monitors.Count(m => m.SupportsBrightness) >= 2;
+    public bool ShowLinkLevelsToggle => LinkedLevelsActive || Monitors.Count(m => m.SupportsPrimaryBrightness) >= 2;
 
     public bool ShowLinkLevelsInactiveIcon => !LinkedLevelsActive;
 
@@ -529,6 +536,8 @@ public partial class MainViewModel : ObservableObject, IDisposable
             ShowProfileSwitcher = settings.Properties.ShowProfileSwitcher;
             ShowIdentifyMonitorsButton = settings.Properties.ShowIdentifyMonitorsButton;
             MouseWheelIncrement = settings.Properties.MouseWheelIncrement;
+            SdrContentBrightnessReplacesPrimarySlider =
+                settings.Properties.SdrContentBrightnessReplacesPrimarySlider;
 
             // Load the linked-brightness exclusion set before applying LinkedLevelsActive. If this
             // method runs after monitors are already discovered, the toggle hook can seed the master

--- a/src/modules/powerdisplay/PowerDisplay/ViewModels/MonitorViewModel.cs
+++ b/src/modules/powerdisplay/PowerDisplay/ViewModels/MonitorViewModel.cs
@@ -38,6 +38,7 @@ public partial class MonitorViewModel : ObservableObject, IDisposable
     private readonly MainViewModel? _mainViewModel;
 
     private int _brightness;
+    private int _sdrContentBrightness;
     private int _contrast;
     private int _volume;
 
@@ -46,12 +47,13 @@ public partial class MonitorViewModel : ObservableObject, IDisposable
     // External / programmatic apply paths (SetBrightnessAsync etc.) bypass the setters
     // and therefore never schedule a debounced commit.
     private DispatcherQueueTimer? _brightnessCommitTimer;
+    private DispatcherQueueTimer? _sdrContentBrightnessCommitTimer;
     private DispatcherQueueTimer? _contrastCommitTimer;
     private DispatcherQueueTimer? _volumeCommitTimer;
 
     // Visibility settings (controlled by Settings UI)
     [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(ShowBrightnessSlider))]
+    [NotifyPropertyChangedFor(nameof(ShowPhysicalBrightnessSlider))]
     public partial bool ShowBrightness { get; set; }
 
     [ObservableProperty]
@@ -85,9 +87,44 @@ public partial class MonitorViewModel : ObservableObject, IDisposable
         {
             _brightness = brightness;
             OnPropertyChanged(nameof(Brightness));
+            if (!UsesSdrContentBrightnessAsPrimary)
+            {
+                OnPropertyChanged(nameof(PrimaryBrightness));
+            }
         }
 
         await ApplyPropertyToHardwareAsync(nameof(Brightness), brightness, _monitorManager.SetBrightnessAsync);
+    }
+
+    /// <summary>
+    /// Applies the Windows SDR content brightness while HDR is active.
+    /// </summary>
+    public async Task SetSdrContentBrightnessAsync(int brightness)
+    {
+        brightness = Math.Clamp(brightness, 0, 100);
+
+        if (_sdrContentBrightness != brightness)
+        {
+            _sdrContentBrightness = brightness;
+            OnPropertyChanged(nameof(SdrContentBrightness));
+            if (UsesSdrContentBrightnessAsPrimary)
+            {
+                OnPropertyChanged(nameof(PrimaryBrightness));
+            }
+        }
+
+        try
+        {
+            var result = await _monitorManager.SetSdrContentBrightnessAsync(Id, brightness);
+            if (!result.IsSuccess)
+            {
+                Logger.LogWarning($"[{Id}] Failed to set SDR content brightness: {result.ErrorMessage}");
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError($"[{Id}] Exception setting SDR content brightness: {ex.Message}");
+        }
     }
 
     /// <summary>
@@ -248,6 +285,7 @@ public partial class MonitorViewModel : ObservableObject, IDisposable
 
         // Initialize basic properties from monitor
         _brightness = monitor.CurrentBrightness;
+        _sdrContentBrightness = monitor.CurrentSdrContentBrightness;
         _contrast = monitor.CurrentContrast;
         _volume = monitor.CurrentVolume;
     }
@@ -310,13 +348,49 @@ public partial class MonitorViewModel : ObservableObject, IDisposable
     public bool SupportsBrightness => _monitor.SupportsBrightness;
 
     /// <summary>
+    /// Gets a value indicating whether HDR is active and Windows exposes the SDR content
+    /// brightness balance for this display.
+    /// </summary>
+    public bool SupportsSdrContentBrightness => _monitor.SupportsSdrContentBrightness;
+
+    /// <summary>
+    /// Gets a value indicating whether this HDR-active monitor uses SDR content brightness as
+    /// its primary brightness control.
+    /// </summary>
+    public bool UsesSdrContentBrightnessAsPrimary =>
+        SupportsSdrContentBrightness &&
+        (_mainViewModel?.SdrContentBrightnessReplacesPrimarySlider ?? false);
+
+    /// <summary>
+    /// Gets a value indicating whether this monitor has a brightness value that can participate
+    /// in the primary and linked brightness controls.
+    /// </summary>
+    public bool SupportsPrimaryBrightness => UsesSdrContentBrightnessAsPrimary || SupportsBrightness;
+
+    /// <summary>
+    /// Gets the value represented by the primary brightness control for this monitor.
+    /// </summary>
+    public int PrimaryBrightness =>
+        UsesSdrContentBrightnessAsPrimary ? SdrContentBrightness : Brightness;
+
+    /// <summary>
+    /// Applies the value represented by the primary brightness control for this monitor.
+    /// </summary>
+    public Task SetPrimaryBrightnessAsync(int brightness) =>
+        UsesSdrContentBrightnessAsPrimary
+            ? SetSdrContentBrightnessAsync(brightness)
+            : SetBrightnessAsync(brightness);
+
+    /// <summary>
     /// Gets a value indicating whether this monitor's brightness is currently driven by linked
     /// mode rather than its own slider. True when the parent has link mode on, this monitor
-    /// supports brightness, and the user has not excluded it. When true the per-card brightness
-    /// row shows a disabled linked-mode hint — the "All Displays" master slider broadcasts the
-    /// value instead.
+    /// supports its current primary brightness target, and the user has not excluded it. When true
+    /// the per-card primary row is hidden — the "All Displays" master slider broadcasts the value.
     /// </summary>
-    public bool IsBrightnessLinked => (_mainViewModel?.LinkedLevelsActive ?? false) && SupportsBrightness && !IsExcludedFromSync;
+    public bool IsBrightnessLinked =>
+        (_mainViewModel?.LinkedLevelsActive ?? false) &&
+        SupportsPrimaryBrightness &&
+        !IsExcludedFromSync;
 
     /// <summary>
     /// Gets a value indicating whether the per-card brightness slider accepts input. Disabled both
@@ -326,7 +400,20 @@ public partial class MonitorViewModel : ObservableObject, IDisposable
     /// </summary>
     public bool IsBrightnessSliderEnabled => IsInteractionEnabled && !IsBrightnessLinked;
 
-    public bool ShowBrightnessSlider => ShowBrightness && !IsBrightnessLinked;
+    public bool ShowPhysicalBrightnessSlider =>
+        ShowBrightness &&
+        SupportsBrightness &&
+        !UsesSdrContentBrightnessAsPrimary &&
+        !IsBrightnessLinked;
+
+    /// <summary>
+    /// Gets a value indicating whether the SDR content brightness row should be shown. It remains
+    /// a separate row by default; replacement mode makes it the primary row and linked mode then
+    /// hides it in favor of the "All displays" slider.
+    /// </summary>
+    public bool ShowSdrContentBrightnessSlider =>
+        SupportsSdrContentBrightness &&
+        (!UsesSdrContentBrightnessAsPrimary || !IsBrightnessLinked);
 
     public bool ShowIncludedInSyncIcon => !IsExcludedFromSync;
 
@@ -347,7 +434,8 @@ public partial class MonitorViewModel : ObservableObject, IDisposable
                 OnPropertyChanged();
                 OnPropertyChanged(nameof(IsBrightnessLinked));
                 OnPropertyChanged(nameof(IsBrightnessSliderEnabled));
-                OnPropertyChanged(nameof(ShowBrightnessSlider));
+                OnPropertyChanged(nameof(ShowPhysicalBrightnessSlider));
+                OnPropertyChanged(nameof(ShowSdrContentBrightnessSlider));
                 OnPropertyChanged(nameof(ShowIncludedInSyncIcon));
                 OnPropertyChanged(nameof(SyncToggleToolTip));
             }
@@ -356,9 +444,11 @@ public partial class MonitorViewModel : ObservableObject, IDisposable
 
     /// <summary>
     /// Gets a value indicating whether the per-card exclude toggle is shown. Only relevant while
-    /// link mode is on and the monitor supports brightness — otherwise exclusion has no effect.
+    /// link mode is on and the monitor supports its current primary brightness target.
     /// </summary>
-    public bool ShowExcludeButton => (_mainViewModel?.LinkedLevelsActive ?? false) && SupportsBrightness;
+    public bool ShowExcludeButton =>
+        (_mainViewModel?.LinkedLevelsActive ?? false) &&
+        SupportsPrimaryBrightness;
 
     /// <summary>
     /// Gets the tooltip for the per-card linked-brightness toggle. The action reverses with the
@@ -489,7 +579,33 @@ public partial class MonitorViewModel : ObservableObject, IDisposable
             {
                 _brightness = value;
                 OnPropertyChanged();
+                if (!UsesSdrContentBrightnessAsPrimary)
+                {
+                    OnPropertyChanged(nameof(PrimaryBrightness));
+                }
+
                 ScheduleCommit(ref _brightnessCommitTimer, () => SetBrightnessAsync(_brightness));
+            }
+        }
+    }
+
+    public int SdrContentBrightness
+    {
+        get => _sdrContentBrightness;
+        set
+        {
+            if (_sdrContentBrightness != value)
+            {
+                _sdrContentBrightness = value;
+                OnPropertyChanged();
+                if (UsesSdrContentBrightnessAsPrimary)
+                {
+                    OnPropertyChanged(nameof(PrimaryBrightness));
+                }
+
+                ScheduleCommit(
+                    ref _sdrContentBrightnessCommitTimer,
+                    () => SetSdrContentBrightnessAsync(_sdrContentBrightness));
             }
         }
     }
@@ -509,7 +625,48 @@ public partial class MonitorViewModel : ObservableObject, IDisposable
         {
             _brightness = value;
             OnPropertyChanged(nameof(Brightness));
+            if (!UsesSdrContentBrightnessAsPrimary)
+            {
+                OnPropertyChanged(nameof(PrimaryBrightness));
+            }
         }
+    }
+
+    /// <summary>
+    /// Updates whichever value is represented by the primary brightness control without
+    /// scheduling a hardware write.
+    /// </summary>
+    public void UpdatePrimaryBrightnessDisplay(int value)
+    {
+        value = Math.Clamp(value, 0, 100);
+        if (UsesSdrContentBrightnessAsPrimary)
+        {
+            if (_sdrContentBrightness != value)
+            {
+                _sdrContentBrightness = value;
+                OnPropertyChanged(nameof(SdrContentBrightness));
+                OnPropertyChanged(nameof(PrimaryBrightness));
+            }
+        }
+        else
+        {
+            UpdateBrightnessDisplay(value);
+        }
+    }
+
+    /// <summary>
+    /// Refreshes primary-slider bindings after the SDR replacement preference changes.
+    /// </summary>
+    public void RefreshPrimaryBrightnessMode()
+    {
+        OnPropertyChanged(nameof(UsesSdrContentBrightnessAsPrimary));
+        OnPropertyChanged(nameof(SupportsPrimaryBrightness));
+        OnPropertyChanged(nameof(PrimaryBrightness));
+        OnPropertyChanged(nameof(IsBrightnessLinked));
+        OnPropertyChanged(nameof(IsBrightnessSliderEnabled));
+        OnPropertyChanged(nameof(ShowPhysicalBrightnessSlider));
+        OnPropertyChanged(nameof(ShowSdrContentBrightnessSlider));
+        OnPropertyChanged(nameof(ShowExcludeButton));
     }
 
     /// <summary>
@@ -880,8 +1037,13 @@ public partial class MonitorViewModel : ObservableObject, IDisposable
             // Link mode toggled — refresh the linked hint, exclude button, and slider state.
             OnPropertyChanged(nameof(IsBrightnessLinked));
             OnPropertyChanged(nameof(IsBrightnessSliderEnabled));
-            OnPropertyChanged(nameof(ShowBrightnessSlider));
+            OnPropertyChanged(nameof(ShowPhysicalBrightnessSlider));
+            OnPropertyChanged(nameof(ShowSdrContentBrightnessSlider));
             OnPropertyChanged(nameof(ShowExcludeButton));
+        }
+        else if (e.PropertyName == nameof(MainViewModel.SdrContentBrightnessReplacesPrimarySlider))
+        {
+            RefreshPrimaryBrightnessMode();
         }
     }
 
@@ -976,6 +1138,7 @@ public partial class MonitorViewModel : ObservableObject, IDisposable
         // gone (unplug/refresh) or the app is shutting down, so a hardware write would
         // race a half-torn-down MonitorManager.
         _brightnessCommitTimer?.Stop();
+        _sdrContentBrightnessCommitTimer?.Stop();
         _contrastCommitTimer?.Stop();
         _volumeCommitTimer?.Stop();
 

--- a/src/modules/powerdisplay/PowerDisplayModuleInterface/dllmain.cpp
+++ b/src/modules/powerdisplay/PowerDisplayModuleInterface/dllmain.cpp
@@ -391,8 +391,8 @@ public:
     virtual void set_config(const wchar_t* /*config*/) override
     {
         // Settings changes are handled via dedicated Windows Events:
-        // - HotkeyUpdatedPowerDisplayEvent: triggered by Settings UI when activation shortcut changes
-        // - SettingsUpdatedPowerDisplayEvent: triggered for tray icon visibility changes
+        // - HotkeyUpdatedPowerDisplayEvent: triggered when an activation or adjustment shortcut changes
+        // - SettingsUpdatedPowerDisplayEvent: triggered for other module settings changes
         // PowerDisplay.exe reads settings directly from file when these events are signaled.
     }
 

--- a/src/settings-ui/Settings.UI.Library/PowerDisplayProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/PowerDisplayProperties.cs
@@ -17,8 +17,17 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         public PowerDisplayProperties()
         {
             ActivationShortcut = DefaultActivationShortcut;
+            IncreaseBrightnessShortcut = new HotkeySettings();
+            DecreaseBrightnessShortcut = new HotkeySettings();
+            IncreaseContrastShortcut = new HotkeySettings();
+            DecreaseContrastShortcut = new HotkeySettings();
+            IncreaseVolumeShortcut = new HotkeySettings();
+            DecreaseVolumeShortcut = new HotkeySettings();
+            IncreaseSdrContentBrightnessShortcut = new HotkeySettings();
+            DecreaseSdrContentBrightnessShortcut = new HotkeySettings();
             MonitorRefreshDelay = 5;
             MouseWheelIncrement = 5;
+            SdrContentBrightnessReplacesPrimarySlider = false;
             Monitors = new List<MonitorInfo>();
             RestoreSettingsOnStartup = false;
             ShowSystemTrayIcon = true;
@@ -42,6 +51,30 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             set => _activationShortcut = value;
         }
 
+        [JsonPropertyName("increase_brightness_shortcut")]
+        public HotkeySettings IncreaseBrightnessShortcut { get; set; }
+
+        [JsonPropertyName("decrease_brightness_shortcut")]
+        public HotkeySettings DecreaseBrightnessShortcut { get; set; }
+
+        [JsonPropertyName("increase_contrast_shortcut")]
+        public HotkeySettings IncreaseContrastShortcut { get; set; }
+
+        [JsonPropertyName("decrease_contrast_shortcut")]
+        public HotkeySettings DecreaseContrastShortcut { get; set; }
+
+        [JsonPropertyName("increase_volume_shortcut")]
+        public HotkeySettings IncreaseVolumeShortcut { get; set; }
+
+        [JsonPropertyName("decrease_volume_shortcut")]
+        public HotkeySettings DecreaseVolumeShortcut { get; set; }
+
+        [JsonPropertyName("increase_sdr_content_brightness_shortcut")]
+        public HotkeySettings IncreaseSdrContentBrightnessShortcut { get; set; }
+
+        [JsonPropertyName("decrease_sdr_content_brightness_shortcut")]
+        public HotkeySettings DecreaseSdrContentBrightnessShortcut { get; set; }
+
         /// <summary>
         /// Gets or sets delay in seconds before refreshing monitors after display changes (hot-plug).
         /// This allows hardware to stabilize before querying DDC/CI.
@@ -50,11 +83,18 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         public int MonitorRefreshDelay { get; set; }
 
         /// <summary>
-        /// Gets or sets the amount each PowerDisplay flyout slider (brightness, contrast, volume)
-        /// changes per mouse-wheel notch. Defaults to 5, the historical hardcoded step.
+        /// Gets or sets the amount each PowerDisplay flyout slider and adjustment shortcut
+        /// changes per step. Defaults to 5, the historical hardcoded mouse-wheel step.
         /// </summary>
         [JsonPropertyName("mouse_wheel_increment")]
         public int MouseWheelIncrement { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether an HDR-active display's primary brightness
+        /// control adjusts Windows SDR content brightness instead of the physical backlight.
+        /// </summary>
+        [JsonPropertyName("sdr_content_brightness_replaces_primary_slider")]
+        public bool SdrContentBrightnessReplacesPrimarySlider { get; set; }
 
         [JsonPropertyName("monitors")]
         public List<MonitorInfo> Monitors { get; set; }

--- a/src/settings-ui/Settings.UI.Library/PowerDisplaySettings.cs
+++ b/src/settings-ui/Settings.UI.Library/PowerDisplaySettings.cs
@@ -49,6 +49,38 @@ namespace Microsoft.PowerToys.Settings.UI.Library
                     () => Properties.ActivationShortcut,
                     value => Properties.ActivationShortcut = value ?? Properties.DefaultActivationShortcut,
                     "Activation_Shortcut"),
+                new HotkeyAccessor(
+                    () => Properties.IncreaseBrightnessShortcut,
+                    value => Properties.IncreaseBrightnessShortcut = value ?? new HotkeySettings(),
+                    "PowerDisplay_IncreaseBrightnessShortcut"),
+                new HotkeyAccessor(
+                    () => Properties.DecreaseBrightnessShortcut,
+                    value => Properties.DecreaseBrightnessShortcut = value ?? new HotkeySettings(),
+                    "PowerDisplay_DecreaseBrightnessShortcut"),
+                new HotkeyAccessor(
+                    () => Properties.IncreaseContrastShortcut,
+                    value => Properties.IncreaseContrastShortcut = value ?? new HotkeySettings(),
+                    "PowerDisplay_IncreaseContrastShortcut"),
+                new HotkeyAccessor(
+                    () => Properties.DecreaseContrastShortcut,
+                    value => Properties.DecreaseContrastShortcut = value ?? new HotkeySettings(),
+                    "PowerDisplay_DecreaseContrastShortcut"),
+                new HotkeyAccessor(
+                    () => Properties.IncreaseVolumeShortcut,
+                    value => Properties.IncreaseVolumeShortcut = value ?? new HotkeySettings(),
+                    "PowerDisplay_IncreaseVolumeShortcut"),
+                new HotkeyAccessor(
+                    () => Properties.DecreaseVolumeShortcut,
+                    value => Properties.DecreaseVolumeShortcut = value ?? new HotkeySettings(),
+                    "PowerDisplay_DecreaseVolumeShortcut"),
+                new HotkeyAccessor(
+                    () => Properties.IncreaseSdrContentBrightnessShortcut,
+                    value => Properties.IncreaseSdrContentBrightnessShortcut = value ?? new HotkeySettings(),
+                    "PowerDisplay_IncreaseSdrContentBrightnessShortcut"),
+                new HotkeyAccessor(
+                    () => Properties.DecreaseSdrContentBrightnessShortcut,
+                    value => Properties.DecreaseSdrContentBrightnessShortcut = value ?? new HotkeySettings(),
+                    "PowerDisplay_DecreaseSdrContentBrightnessShortcut"),
             };
 
             return hotkeyAccessors.ToArray();

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerDisplayPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerDisplayPage.xaml
@@ -77,6 +77,30 @@
                                     <tkcontrols:SettingsCard x:Uid="PowerDisplay_ActivationShortcut">
                                         <controls:ShortcutControl HotkeySettings="{x:Bind Path=ViewModel.ActivationShortcut, Mode=TwoWay}" />
                                     </tkcontrols:SettingsCard>
+                                    <tkcontrols:SettingsCard x:Uid="PowerDisplay_IncreaseBrightnessShortcut">
+                                        <controls:ShortcutControl HotkeySettings="{x:Bind Path=ViewModel.IncreaseBrightnessShortcut, Mode=TwoWay}" />
+                                    </tkcontrols:SettingsCard>
+                                    <tkcontrols:SettingsCard x:Uid="PowerDisplay_DecreaseBrightnessShortcut">
+                                        <controls:ShortcutControl HotkeySettings="{x:Bind Path=ViewModel.DecreaseBrightnessShortcut, Mode=TwoWay}" />
+                                    </tkcontrols:SettingsCard>
+                                    <tkcontrols:SettingsCard x:Uid="PowerDisplay_IncreaseContrastShortcut">
+                                        <controls:ShortcutControl HotkeySettings="{x:Bind Path=ViewModel.IncreaseContrastShortcut, Mode=TwoWay}" />
+                                    </tkcontrols:SettingsCard>
+                                    <tkcontrols:SettingsCard x:Uid="PowerDisplay_DecreaseContrastShortcut">
+                                        <controls:ShortcutControl HotkeySettings="{x:Bind Path=ViewModel.DecreaseContrastShortcut, Mode=TwoWay}" />
+                                    </tkcontrols:SettingsCard>
+                                    <tkcontrols:SettingsCard x:Uid="PowerDisplay_IncreaseVolumeShortcut">
+                                        <controls:ShortcutControl HotkeySettings="{x:Bind Path=ViewModel.IncreaseVolumeShortcut, Mode=TwoWay}" />
+                                    </tkcontrols:SettingsCard>
+                                    <tkcontrols:SettingsCard x:Uid="PowerDisplay_DecreaseVolumeShortcut">
+                                        <controls:ShortcutControl HotkeySettings="{x:Bind Path=ViewModel.DecreaseVolumeShortcut, Mode=TwoWay}" />
+                                    </tkcontrols:SettingsCard>
+                                    <tkcontrols:SettingsCard x:Uid="PowerDisplay_IncreaseSdrContentBrightnessShortcut">
+                                        <controls:ShortcutControl HotkeySettings="{x:Bind Path=ViewModel.IncreaseSdrContentBrightnessShortcut, Mode=TwoWay}" />
+                                    </tkcontrols:SettingsCard>
+                                    <tkcontrols:SettingsCard x:Uid="PowerDisplay_DecreaseSdrContentBrightnessShortcut">
+                                        <controls:ShortcutControl HotkeySettings="{x:Bind Path=ViewModel.DecreaseSdrContentBrightnessShortcut, Mode=TwoWay}" />
+                                    </tkcontrols:SettingsCard>
 
                                     <tkcontrols:SettingsCard x:Uid="PowerDisplay_MonitorRefreshDelay">
                                         <ComboBox
@@ -89,6 +113,9 @@
                                             MinWidth="{StaticResource PowerDisplayCompactActionControlMinWidth}"
                                             ItemsSource="{x:Bind ViewModel.MouseWheelIncrementOptions}"
                                             SelectedItem="{x:Bind ViewModel.MouseWheelIncrement, Mode=TwoWay}" />
+                                    </tkcontrols:SettingsCard>
+                                    <tkcontrols:SettingsCard x:Uid="PowerDisplay_SdrContentBrightnessReplacesPrimarySlider">
+                                        <ToggleSwitch IsOn="{x:Bind ViewModel.SdrContentBrightnessReplacesPrimarySlider, Mode=TwoWay}" />
                                     </tkcontrols:SettingsCard>
                                     <tkcontrols:SettingsCard ContentAlignment="Left">
                                         <CheckBox x:Uid="PowerDisplay_RestoreSettingsOnStartup" IsChecked="{x:Bind ViewModel.RestoreSettingsOnStartup, Mode=TwoWay}" />

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -5562,6 +5562,54 @@ The break timer font matches the text font.</value>
     <value>Activation shortcut</value>
     <comment>Header for the PowerDisplay activation shortcut setting</comment>
   </data>
+  <data name="PowerDisplay_IncreaseBrightnessShortcut.Header" xml:space="preserve">
+    <value>Increase display brightness</value>
+  </data>
+  <data name="PowerDisplay_IncreaseBrightnessShortcut.Description" xml:space="preserve">
+    <value>Increase brightness on all supported displays.</value>
+  </data>
+  <data name="PowerDisplay_DecreaseBrightnessShortcut.Header" xml:space="preserve">
+    <value>Decrease display brightness</value>
+  </data>
+  <data name="PowerDisplay_DecreaseBrightnessShortcut.Description" xml:space="preserve">
+    <value>Decrease brightness on all supported displays.</value>
+  </data>
+  <data name="PowerDisplay_IncreaseContrastShortcut.Header" xml:space="preserve">
+    <value>Increase display contrast</value>
+  </data>
+  <data name="PowerDisplay_IncreaseContrastShortcut.Description" xml:space="preserve">
+    <value>Increase contrast on all supported displays.</value>
+  </data>
+  <data name="PowerDisplay_DecreaseContrastShortcut.Header" xml:space="preserve">
+    <value>Decrease display contrast</value>
+  </data>
+  <data name="PowerDisplay_DecreaseContrastShortcut.Description" xml:space="preserve">
+    <value>Decrease contrast on all supported displays.</value>
+  </data>
+  <data name="PowerDisplay_IncreaseVolumeShortcut.Header" xml:space="preserve">
+    <value>Increase display volume</value>
+  </data>
+  <data name="PowerDisplay_IncreaseVolumeShortcut.Description" xml:space="preserve">
+    <value>Increase volume on all supported displays.</value>
+  </data>
+  <data name="PowerDisplay_DecreaseVolumeShortcut.Header" xml:space="preserve">
+    <value>Decrease display volume</value>
+  </data>
+  <data name="PowerDisplay_DecreaseVolumeShortcut.Description" xml:space="preserve">
+    <value>Decrease volume on all supported displays.</value>
+  </data>
+  <data name="PowerDisplay_IncreaseSdrContentBrightnessShortcut.Header" xml:space="preserve">
+    <value>Increase SDR content brightness</value>
+  </data>
+  <data name="PowerDisplay_IncreaseSdrContentBrightnessShortcut.Description" xml:space="preserve">
+    <value>Increase SDR content brightness on all displays currently using HDR.</value>
+  </data>
+  <data name="PowerDisplay_DecreaseSdrContentBrightnessShortcut.Header" xml:space="preserve">
+    <value>Decrease SDR content brightness</value>
+  </data>
+  <data name="PowerDisplay_DecreaseSdrContentBrightnessShortcut.Description" xml:space="preserve">
+    <value>Decrease SDR content brightness on all displays currently using HDR.</value>
+  </data>
   <data name="PowerDisplay_LaunchButtonControl.Header" xml:space="preserve">
     <value>Open Power Display</value>
     <comment>{Locked="Power Display"}</comment>
@@ -5588,10 +5636,16 @@ The break timer font matches the text font.</value>
     <value>Number of seconds to wait after display changes before refreshing monitors. Increase if monitors are not detected after hot-plug.</value>
   </data>
   <data name="PowerDisplay_MouseWheelIncrement.Header" xml:space="preserve">
-    <value>Mouse wheel increment</value>
+    <value>Adjustment increment</value>
   </data>
   <data name="PowerDisplay_MouseWheelIncrement.Description" xml:space="preserve">
-    <value>How much brightness, contrast, and volume sliders change per mouse wheel notch.</value>
+    <value>How much brightness, contrast, and volume change per mouse wheel notch or adjustment shortcut.</value>
+  </data>
+  <data name="PowerDisplay_SdrContentBrightnessReplacesPrimarySlider.Header" xml:space="preserve">
+    <value>SDR Replaces Primary Slider</value>
+  </data>
+  <data name="PowerDisplay_SdrContentBrightnessReplacesPrimarySlider.Description" xml:space="preserve">
+    <value>Control SDR brightness from main brightness slider while HDR is active.</value>
   </data>
   <data name="PowerDisplay_AdvancedSettings.Header" xml:space="preserve">
     <value>Advanced</value>

--- a/src/settings-ui/Settings.UI/ViewModels/DashboardViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/DashboardViewModel.cs
@@ -823,7 +823,31 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 new DashboardModuleShortcutItem() { Label = resourceLoader.GetString("PowerDisplay_ToggleWindow"), Shortcut = settings.Properties.ActivationShortcut.GetKeysList() },
                 new DashboardModuleButtonItem() { ButtonTitle = resourceLoader.GetString("PowerDisplay_LaunchButtonControl/Header"), IsButtonDescriptionVisible = true, ButtonDescription = resourceLoader.GetString("PowerDisplay_LaunchButtonControl/Description"), ButtonGlyph = "ms-appx:///Assets/Settings/Icons/PowerDisplay.png", ButtonClickHandler = PowerDisplayLaunchClicked },
             };
+
+            AddShortcutIfBound("PowerDisplay_IncreaseBrightnessShortcut/Header", settings.Properties.IncreaseBrightnessShortcut);
+            AddShortcutIfBound("PowerDisplay_DecreaseBrightnessShortcut/Header", settings.Properties.DecreaseBrightnessShortcut);
+            AddShortcutIfBound("PowerDisplay_IncreaseContrastShortcut/Header", settings.Properties.IncreaseContrastShortcut);
+            AddShortcutIfBound("PowerDisplay_DecreaseContrastShortcut/Header", settings.Properties.DecreaseContrastShortcut);
+            AddShortcutIfBound("PowerDisplay_IncreaseVolumeShortcut/Header", settings.Properties.IncreaseVolumeShortcut);
+            AddShortcutIfBound("PowerDisplay_DecreaseVolumeShortcut/Header", settings.Properties.DecreaseVolumeShortcut);
+            AddShortcutIfBound("PowerDisplay_IncreaseSdrContentBrightnessShortcut/Header", settings.Properties.IncreaseSdrContentBrightnessShortcut);
+            AddShortcutIfBound("PowerDisplay_DecreaseSdrContentBrightnessShortcut/Header", settings.Properties.DecreaseSdrContentBrightnessShortcut);
+
             return new ObservableCollection<DashboardModuleItem>(list);
+
+            void AddShortcutIfBound(string resourceKey, HotkeySettings shortcut)
+            {
+                if (shortcut?.IsValid() == true)
+                {
+                    list.Insert(
+                        list.Count - 1,
+                        new DashboardModuleShortcutItem()
+                        {
+                            Label = resourceLoader.GetString(resourceKey),
+                            Shortcut = shortcut.GetKeysList(),
+                        });
+                }
+            }
         }
 
         internal void SWVersionButtonClicked()

--- a/src/settings-ui/Settings.UI/ViewModels/PowerDisplayViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/PowerDisplayViewModel.cs
@@ -367,11 +367,108 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             }
         }
 
+        public HotkeySettings IncreaseBrightnessShortcut
+        {
+            get => _settings.Properties.IncreaseBrightnessShortcut;
+            set => SetPowerDisplayHotkey(
+                _settings.Properties.IncreaseBrightnessShortcut,
+                value,
+                v => _settings.Properties.IncreaseBrightnessShortcut = v);
+        }
+
+        public HotkeySettings DecreaseBrightnessShortcut
+        {
+            get => _settings.Properties.DecreaseBrightnessShortcut;
+            set => SetPowerDisplayHotkey(
+                _settings.Properties.DecreaseBrightnessShortcut,
+                value,
+                v => _settings.Properties.DecreaseBrightnessShortcut = v);
+        }
+
+        public HotkeySettings IncreaseContrastShortcut
+        {
+            get => _settings.Properties.IncreaseContrastShortcut;
+            set => SetPowerDisplayHotkey(
+                _settings.Properties.IncreaseContrastShortcut,
+                value,
+                v => _settings.Properties.IncreaseContrastShortcut = v);
+        }
+
+        public HotkeySettings DecreaseContrastShortcut
+        {
+            get => _settings.Properties.DecreaseContrastShortcut;
+            set => SetPowerDisplayHotkey(
+                _settings.Properties.DecreaseContrastShortcut,
+                value,
+                v => _settings.Properties.DecreaseContrastShortcut = v);
+        }
+
+        public HotkeySettings IncreaseVolumeShortcut
+        {
+            get => _settings.Properties.IncreaseVolumeShortcut;
+            set => SetPowerDisplayHotkey(
+                _settings.Properties.IncreaseVolumeShortcut,
+                value,
+                v => _settings.Properties.IncreaseVolumeShortcut = v);
+        }
+
+        public HotkeySettings DecreaseVolumeShortcut
+        {
+            get => _settings.Properties.DecreaseVolumeShortcut;
+            set => SetPowerDisplayHotkey(
+                _settings.Properties.DecreaseVolumeShortcut,
+                value,
+                v => _settings.Properties.DecreaseVolumeShortcut = v);
+        }
+
+        public HotkeySettings IncreaseSdrContentBrightnessShortcut
+        {
+            get => _settings.Properties.IncreaseSdrContentBrightnessShortcut;
+            set => SetPowerDisplayHotkey(
+                _settings.Properties.IncreaseSdrContentBrightnessShortcut,
+                value,
+                v => _settings.Properties.IncreaseSdrContentBrightnessShortcut = v);
+        }
+
+        public HotkeySettings DecreaseSdrContentBrightnessShortcut
+        {
+            get => _settings.Properties.DecreaseSdrContentBrightnessShortcut;
+            set => SetPowerDisplayHotkey(
+                _settings.Properties.DecreaseSdrContentBrightnessShortcut,
+                value,
+                v => _settings.Properties.DecreaseSdrContentBrightnessShortcut = v);
+        }
+
+        private void SetPowerDisplayHotkey(
+            HotkeySettings currentValue,
+            HotkeySettings newValue,
+            Action<HotkeySettings> setter,
+            [CallerMemberName] string propertyName = null)
+        {
+            newValue ??= new HotkeySettings();
+            if (SetSettingsProperty(currentValue, newValue, setter, propertyName))
+            {
+                SignalNamedEvent(Constants.HotkeyUpdatedPowerDisplayEvent());
+                Logger.LogInfo($"{propertyName} changed, signaled HotkeyUpdatedPowerDisplayEvent");
+            }
+        }
+
         public override Dictionary<string, HotkeySettings[]> GetAllHotkeySettings()
         {
             var hotkeysDict = new Dictionary<string, HotkeySettings[]>
             {
-                [ModuleName] = [ActivationShortcut],
+                [ModuleName] =
+                [
+                    ActivationShortcut,
+                    IncreaseBrightnessShortcut,
+                    DecreaseBrightnessShortcut,
+                    IncreaseContrastShortcut,
+                    DecreaseContrastShortcut,
+                    IncreaseVolumeShortcut,
+                    DecreaseVolumeShortcut,
+                    IncreaseSdrContentBrightnessShortcut,
+                    DecreaseSdrContentBrightnessShortcut,
+                ],
             };
 
             return hotkeysDict;
@@ -391,7 +488,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         public List<int> MonitorRefreshDelayOptions => _monitorRefreshDelayOptions;
 
         /// <summary>
-        /// Gets or sets the per-mouse-wheel-notch step shared by all PowerDisplay flyout sliders.
+        /// Gets or sets the step shared by PowerDisplay flyout sliders and adjustment shortcuts.
         /// </summary>
         public int MouseWheelIncrement
         {
@@ -409,6 +506,25 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         private readonly List<int> _mouseWheelIncrementOptions = new List<int> { 1, 2, 5, 10, 15, 20, 25 };
 
         public List<int> MouseWheelIncrementOptions => _mouseWheelIncrementOptions;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the primary brightness control targets SDR
+        /// content brightness while HDR is active.
+        /// </summary>
+        public bool SdrContentBrightnessReplacesPrimarySlider
+        {
+            get => _settings.Properties.SdrContentBrightnessReplacesPrimarySlider;
+            set
+            {
+                if (SetSettingsProperty(
+                    _settings.Properties.SdrContentBrightnessReplacesPrimarySlider,
+                    value,
+                    v => _settings.Properties.SdrContentBrightnessReplacesPrimarySlider = v))
+                {
+                    SignalSettingsUpdated();
+                }
+            }
+        }
 
         public ObservableCollection<MonitorInfo> Monitors
         {


### PR DESCRIPTION
## Summary of the Pull Request

Adds HDR-aware SDR content brightness controls and configurable adjustment shortcuts to Power Display.

- Detects active HDR per display and exposes the Windows SDR content brightness level separately from the physical monitor backlight.
- Adds an optional **SDR Replaces Primary Slider** setting so the main and linked brightness controls target SDR content brightness while HDR is active.
- Adds user-bindable increase/decrease shortcuts for brightness, contrast, display volume, and SDR content brightness.
- Uses the existing adjustment increment for both mouse-wheel and shortcut changes.
- Keeps new shortcut fields unbound and the SDR primary-slider preference disabled by default for settings compatibility.

## PR Checklist

- [x] Closes: #49478
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all relevant tests pass
- [x] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [x] **New binaries:** Not applicable; this PR adds no executables, DLL projects, or external dependencies
- [ ] **Documentation updated:** No public documentation change is included

## Detailed Description of the Pull Request / Additional comments

Power Display currently controls monitor hardware brightness through WMI or DDC/CI. On an HDR desktop, Windows has a separate SDR reference-white control that changes how ordinary SDR content is presented without changing the physical backlight or HDR highlights.

This change:

1. Extends the DisplayConfig inventory with Advanced Color state and SDR white-level queries.
   - Windows 11 Advanced Color v2 state distinguishes active HDR from WCG.
   - The legacy Advanced Color query remains as a fallback.
   - The SDR control is only surfaced when HDR is active and the current white level can be read.
2. Maps the Windows SDR white-level range (`1000`–`6000`) to the flyout's `0`–`100` slider.
3. Adds an `SDR`-labeled flyout row and an optional setting that replaces each HDR display's primary brightness target with SDR content brightness.
4. Routes linked brightness and ordinary brightness shortcuts through the same primary-target selection, including mixed HDR/SDR multi-monitor setups.
5. Registers eight optional in-process adjustment hotkeys and includes them in Settings conflict discovery and the dashboard when bound.

### Compatibility boundary

The Windows SDK publicly exposes the SDR white-level getter but not a corresponding setter. The write path uses the private `DisplayConfigSetDeviceInfo` request type used by Windows Settings (`0xFFFFFFEE`). It is isolated in `HdrSdrBrightnessController`, capability-gated by successful public state/read queries, and returns a normal failed monitor operation if Windows or a display driver rejects it.

The new settings fields are optional and constructor-defaulted, so existing `settings.json` files deserialize without migration.

No new third-party dependencies, binaries, GPO behavior, elevation behavior, installer changes, or Runner/Settings IPC contracts are introduced.

## Validation Steps Performed

- Ran the repository XamlStyler against both modified XAML files.
- Built `PowerDisplay.csproj`, x64 Debug, with the repository build script.
- Built `PowerToys.Settings.csproj`, x64 Debug, with the repository build script.
- Built `PowerDisplay.Lib.UnitTests.csproj`, x64 Debug.
- Ran 14 focused SDR conversion and settings/shortcut serialization tests: **14 passed**.
- Ran the complete Power Display library test assembly: **196 passed / 199 total**. The three failures are existing crash-recovery tests that require the `PowerToys.Interop.Constants` COM class to be registered in standalone VSTest (`REGDB_E_CLASSNOTREG`).
- Manually validated on an HDR display:
  - SDR content brightness changes affect SDR content.
  - The `SDR` label renders without clipping.
  - HDR-off capability gating hides the control.
  - **SDR Replaces Primary Slider** routes the main slider as expected.
  - Adjustment shortcuts work while the flyout is hidden.
  - Power Display starts successfully after the XAML layout change.

Local builds used `/p:SpectreMitigation=false` because the local Visual Studio installation does not include the Spectre-mitigated libraries, and suppressed an existing unrelated C4819 warning from the ZoomIt header.
