### PR TITLE
[Deps] Pin System.Security.Cryptography.Xml to 10.0.10

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -126,6 +126,8 @@
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
     <PackageVersion Include="System.Reactive" Version="6.0.1" />
     <PackageVersion Include="System.Runtime.Caching" Version="10.0.10" />
+    <!-- Explicitly pinned so the transitive dependency stays aligned with the 10.0.10 .NET package set. Relies on CentralPackageTransitivePinningEnabled. -->
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.10" />
     <PackageVersion Include="System.ServiceProcess.ServiceController" Version="10.0.10" />
     <PackageVersion Include="System.Text.Encoding.CodePages" Version="10.0.10" />
     <PackageVersion Include="System.Text.Json" Version="10.0.10" />


### PR DESCRIPTION
## Summary of the Pull Request

Adds an explicit Central Package Management pin for `System.Security.Cryptography.Xml` at `10.0.10` in `Directory.Packages.props`, aligning it with the rest of the .NET 10 package set updated in #49419.

## PR Checklist

- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
- [ ] **Documentation updated**

## Detailed Description of the Pull Request / Additional comments

`System.Security.Cryptography.Xml` is not referenced directly by any project; it is a **transitive** dependency. Two requesters exist in the resolved graph:

| Requester | Requested `System.Security.Cryptography.Xml` |
|-----------|----------------------------------------------|
| `Microsoft.Windows.Compatibility` 10.0.10 | 10.0.10 |
| `System.ServiceModel.Primitives` 8.1.2 | 8.0.2 |

Because the package was never explicitly pinned, it could resolve to the older `8.0.2` in any project that pulls the `System.ServiceModel.*` subtree without `Microsoft.Windows.Compatibility`. This PR adds an explicit by-name pin so it consistently resolves to `10.0.10`, matching the other .NET 10 packages that #49419 aligned.

The repo has `CentralPackageTransitivePinningEnabled=true`, so a single `<PackageVersion>` entry is sufficient — no per-project `<PackageReference>` is needed. Its dependency `System.Security.Cryptography.Pkcs` (and sibling `ProtectedData`) already resolve to `10.0.10`, so no further pins are required.

## Validation Steps Performed

`dotnet restore` of `AdvancedPaste.csproj` (x64) completes with exit code 0 and resolves `System.Security.Cryptography.Xml/10.0.10` in `project.assets.json`, with no `NU1109` version conflict. Full build validation is covered by CI.
