### PR TITLE
Redesign the CmdPal Dock performance monitor

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.Common/NativeFormContentTypes.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Common/NativeFormContentTypes.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CmdPal.Common;
+
+/// <summary>
+/// Identifies in-box form payloads that have a native Command Palette renderer.
+/// Unrecognized values continue through the normal Adaptive Cards pipeline.
+/// </summary>
+public static class NativeFormContentTypes
+{
+    public const string PerformanceOverview = "cmdpal://native/performance-overview/v1";
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.Common/NativePerformanceOverviewCommandIds.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.Common/NativePerformanceOverviewCommandIds.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CmdPal.Common;
+
+/// <summary>
+/// Stable command identifiers consumed by the native performance overview.
+/// </summary>
+public static class NativePerformanceOverviewCommandIds
+{
+    public const string PreviousGpu = "com.microsoft.cmdpal.gpu_widget.prev";
+    public const string NextGpu = "com.microsoft.cmdpal.gpu_widget.next";
+    public const string PreviousNetwork = "com.microsoft.cmdpal.network_widget.prev";
+    public const string NextNetwork = "com.microsoft.cmdpal.network_widget.next";
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandPaletteContentPageViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandPaletteContentPageViewModel.cs
@@ -17,6 +17,7 @@ public partial class CommandPaletteContentPageViewModel : ContentPageViewModel
     {
         ContentViewModel? viewModel = content switch
         {
+            IFormContent form when ContentPerformanceOverviewViewModel.IsPerformanceOverview(form) => new ContentPerformanceOverviewViewModel(form, context),
             IFormContent form => new ContentFormViewModel(form, context),
             IMarkdownContent markdown => new ContentMarkdownViewModel(markdown, context),
             ITreeContent tree => new ContentTreeViewModel(tree, context),

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandPaletteContentPageViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandPaletteContentPageViewModel.cs
@@ -17,7 +17,7 @@ public partial class CommandPaletteContentPageViewModel : ContentPageViewModel
     {
         ContentViewModel? viewModel = content switch
         {
-            IFormContent form when ContentPerformanceOverviewViewModel.IsPerformanceOverview(form) => new ContentPerformanceOverviewViewModel(form, context),
+            IFormContent form when ContentPerformanceOverviewViewModel.IsPerformanceOverview(form) => new ContentPerformanceOverviewViewModel(form, context, InvokeCommandById),
             IFormContent form => new ContentFormViewModel(form, context),
             IMarkdownContent markdown => new ContentMarkdownViewModel(markdown, context),
             ITreeContent tree => new ContentTreeViewModel(tree, context),

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentPageViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentPageViewModel.cs
@@ -20,12 +20,14 @@ public partial class ContentPageViewModel : PageViewModel, ICommandBarContext
     private readonly Lock _commandsLock = new();
     private volatile CommandSnapshot _snapshot = CommandSnapshot.Empty;
 
+    public bool HasInlineCommandSurface { get; private set; }
+
     [ObservableProperty]
     public partial ObservableCollection<ContentViewModel> Content { get; set; } = [];
 
     private List<IContextItemViewModel> Commands { get; } = [];
 
-    public bool HasCommands => _snapshot.PrimaryCommand is not null;
+    public bool HasCommands => PrimaryCommand is not null;
 
     public DetailsViewModel? Details { get; private set; }
 
@@ -33,17 +35,22 @@ public partial class ContentPageViewModel : PageViewModel, ICommandBarContext
     public bool HasDetails => Details is not null;
 
     /////// ICommandBarContext ///////
-    public IReadOnlyList<IContextItemViewModel> MoreCommands => _snapshot.MoreCommands;
+    public IReadOnlyList<IContextItemViewModel> MoreCommands =>
+        HasInlineCommandSurface ? CommandSnapshot.Empty.MoreCommands : _snapshot.MoreCommands;
 
-    public bool HasMoreCommands => _snapshot.SecondaryCommand is not null;
+    public bool HasMoreCommands => SecondaryCommand is not null;
 
-    public bool CanOpenContextMenu => _snapshot.AllCommands.Any(item => item is CommandItemViewModel command && command.ShouldBeVisible);
+    public bool CanOpenContextMenu =>
+        !HasInlineCommandSurface
+        && _snapshot.AllCommands.Any(item => item is CommandItemViewModel command && command.ShouldBeVisible);
 
-    public string SecondaryCommandName => _snapshot.SecondaryCommand?.Name ?? string.Empty;
+    public string SecondaryCommandName => SecondaryCommand?.Name ?? string.Empty;
 
-    public CommandItemViewModel? PrimaryCommand => _snapshot.PrimaryCommand;
+    public CommandItemViewModel? PrimaryCommand =>
+        HasInlineCommandSurface ? null : _snapshot.PrimaryCommand;
 
-    public CommandItemViewModel? SecondaryCommand => _snapshot.SecondaryCommand;
+    public CommandItemViewModel? SecondaryCommand =>
+        HasInlineCommandSurface ? null : _snapshot.SecondaryCommand;
 
     public IReadOnlyList<IContextItemViewModel> AllCommands => _snapshot.AllCommands;
 
@@ -84,6 +91,20 @@ public partial class ContentPageViewModel : PageViewModel, ICommandBarContext
 
         var oneContent = newContent.Count == 1;
         newContent.ForEach(c => c.OnlyControlOnPage = oneContent);
+        var hasInlineCommandSurface = newContent.Any(static content => content is ContentPerformanceOverviewViewModel);
+        if (HasInlineCommandSurface != hasInlineCommandSurface)
+        {
+            HasInlineCommandSurface = hasInlineCommandSurface;
+            UpdateProperty(
+                nameof(HasInlineCommandSurface),
+                nameof(HasCommands),
+                nameof(MoreCommands),
+                nameof(HasMoreCommands),
+                nameof(CanOpenContextMenu),
+                nameof(SecondaryCommandName),
+                nameof(PrimaryCommand),
+                nameof(SecondaryCommand));
+        }
 
         // Now, back to a UI thread to update the observable collection
         DoOnUiThread(
@@ -259,6 +280,20 @@ public partial class ContentPageViewModel : PageViewModel, ICommandBarContext
         {
             contextItem.SafeCleanup();
         }
+    }
+
+    protected void InvokeCommandById(string commandId)
+    {
+        var command = _snapshot.AllCommands
+            .OfType<CommandContextItemViewModel>()
+            .FirstOrDefault(item => string.Equals(item.Command.Id, commandId, StringComparison.Ordinal));
+        if (command is null)
+        {
+            ShowException(new InvalidOperationException($"Page command '{commandId}' is not available."));
+            return;
+        }
+
+        WeakReferenceMessenger.Default.Send<PerformCommandMessage>(new(command.Command.Model, command.Model));
     }
 
     private void RefreshCommandSnapshotsUnsafe()

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentPerformanceOverviewViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentPerformanceOverviewViewModel.cs
@@ -56,12 +56,12 @@ public sealed partial class ContentPerformanceOverviewViewModel(
     private bool _canSwitchNetwork;
     private string _networkDetailText = string.Empty;
     private int _networkPercent;
-    private string _networkInLabelText = string.Empty;
-    private string _networkOutLabelText = string.Empty;
-    private string _networkInText = string.Empty;
-    private string _networkOutText = string.Empty;
-    private int _networkInPercent;
-    private int _networkOutPercent;
+    private string _networkSendLabelText = string.Empty;
+    private string _networkReceiveLabelText = string.Empty;
+    private string _networkSendText = string.Empty;
+    private string _networkReceiveText = string.Empty;
+    private int _networkSendPercent;
+    private int _networkReceivePercent;
     private string _previousGpuCommandText = string.Empty;
     private string _nextGpuCommandText = string.Empty;
     private string _previousNetworkCommandText = string.Empty;
@@ -127,17 +127,17 @@ public sealed partial class ContentPerformanceOverviewViewModel(
 
     public int NetworkPercent => _networkPercent;
 
-    public string NetworkInLabelText => _networkInLabelText;
+    public string NetworkSendLabelText => _networkSendLabelText;
 
-    public string NetworkOutLabelText => _networkOutLabelText;
+    public string NetworkReceiveLabelText => _networkReceiveLabelText;
 
-    public string NetworkInText => _networkInText;
+    public string NetworkSendText => _networkSendText;
 
-    public string NetworkOutText => _networkOutText;
+    public string NetworkReceiveText => _networkReceiveText;
 
-    public int NetworkInPercent => _networkInPercent;
+    public int NetworkSendPercent => _networkSendPercent;
 
-    public int NetworkOutPercent => _networkOutPercent;
+    public int NetworkReceivePercent => _networkReceivePercent;
 
     public string PreviousGpuCommandText => _previousGpuCommandText;
 
@@ -238,12 +238,12 @@ public sealed partial class ContentPerformanceOverviewViewModel(
         var canSwitchNetwork = GetOptionalBool(data, "canSwitchNetwork");
         var networkDetailText = GetRequiredString(data, "networkDetailText");
         var networkPercent = GetPercent(data, "networkPercent");
-        var networkInLabelText = GetOptionalString(data, "networkInLabelText");
-        var networkOutLabelText = GetOptionalString(data, "networkOutLabelText");
-        var networkInText = GetOptionalString(data, "networkInText");
-        var networkOutText = GetOptionalString(data, "networkOutText");
-        var networkInPercent = GetOptionalPercent(data, "networkInPercent", networkPercent);
-        var networkOutPercent = GetOptionalPercent(data, "networkOutPercent", 0);
+        var networkSendLabelText = GetOptionalString(data, "networkSendLabelText");
+        var networkReceiveLabelText = GetOptionalString(data, "networkReceiveLabelText");
+        var networkSendText = GetOptionalString(data, "networkSendText");
+        var networkReceiveText = GetOptionalString(data, "networkReceiveText");
+        var networkSendPercent = GetOptionalPercent(data, "networkSendPercent", networkPercent);
+        var networkReceivePercent = GetOptionalPercent(data, "networkReceivePercent", 0);
         var previousGpuCommandText = GetOptionalString(data, "previousGpuCommandText");
         var nextGpuCommandText = GetOptionalString(data, "nextGpuCommandText");
         var previousNetworkCommandText = GetOptionalString(data, "previousNetworkCommandText");
@@ -286,12 +286,12 @@ public sealed partial class ContentPerformanceOverviewViewModel(
         SetValue(ref _canSwitchNetwork, canSwitchNetwork, nameof(CanSwitchNetwork), changedProperties);
         SetValue(ref _networkDetailText, networkDetailText, nameof(NetworkDetailText), changedProperties);
         SetValue(ref _networkPercent, networkPercent, nameof(NetworkPercent), changedProperties);
-        SetValue(ref _networkInLabelText, string.IsNullOrEmpty(networkInLabelText) ? networkLabelText : networkInLabelText, nameof(NetworkInLabelText), changedProperties);
-        SetValue(ref _networkOutLabelText, string.IsNullOrEmpty(networkOutLabelText) ? networkLabelText : networkOutLabelText, nameof(NetworkOutLabelText), changedProperties);
-        SetValue(ref _networkInText, string.IsNullOrEmpty(networkInText) ? networkDetailText : networkInText, nameof(NetworkInText), changedProperties);
-        SetValue(ref _networkOutText, networkOutText, nameof(NetworkOutText), changedProperties);
-        SetValue(ref _networkInPercent, networkInPercent, nameof(NetworkInPercent), changedProperties);
-        SetValue(ref _networkOutPercent, networkOutPercent, nameof(NetworkOutPercent), changedProperties);
+        SetValue(ref _networkSendLabelText, string.IsNullOrEmpty(networkSendLabelText) ? networkLabelText : networkSendLabelText, nameof(NetworkSendLabelText), changedProperties);
+        SetValue(ref _networkReceiveLabelText, string.IsNullOrEmpty(networkReceiveLabelText) ? networkLabelText : networkReceiveLabelText, nameof(NetworkReceiveLabelText), changedProperties);
+        SetValue(ref _networkSendText, string.IsNullOrEmpty(networkSendText) ? networkDetailText : networkSendText, nameof(NetworkSendText), changedProperties);
+        SetValue(ref _networkReceiveText, networkReceiveText, nameof(NetworkReceiveText), changedProperties);
+        SetValue(ref _networkSendPercent, networkSendPercent, nameof(NetworkSendPercent), changedProperties);
+        SetValue(ref _networkReceivePercent, networkReceivePercent, nameof(NetworkReceivePercent), changedProperties);
         SetValue(ref _previousGpuCommandText, previousGpuCommandText, nameof(PreviousGpuCommandText), changedProperties);
         SetValue(ref _nextGpuCommandText, nextGpuCommandText, nameof(NextGpuCommandText), changedProperties);
         SetValue(ref _previousNetworkCommandText, previousNetworkCommandText, nameof(PreviousNetworkCommandText), changedProperties);

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentPerformanceOverviewViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentPerformanceOverviewViewModel.cs
@@ -45,11 +45,23 @@ public sealed partial class ContentPerformanceOverviewViewModel(
     private string _diskLabelText = string.Empty;
     private string _diskDetailText = string.Empty;
     private int _diskPercent;
+    private string _diskReadLabelText = string.Empty;
+    private string _diskWriteLabelText = string.Empty;
+    private string _diskReadText = string.Empty;
+    private string _diskWriteText = string.Empty;
+    private int _diskReadPercent;
+    private int _diskWritePercent;
     private string _networkLabelText = string.Empty;
     private string _networkAdapterName = string.Empty;
     private bool _canSwitchNetwork;
     private string _networkDetailText = string.Empty;
     private int _networkPercent;
+    private string _networkInLabelText = string.Empty;
+    private string _networkOutLabelText = string.Empty;
+    private string _networkInText = string.Empty;
+    private string _networkOutText = string.Empty;
+    private int _networkInPercent;
+    private int _networkOutPercent;
     private string _previousGpuCommandText = string.Empty;
     private string _nextGpuCommandText = string.Empty;
     private string _previousNetworkCommandText = string.Empty;
@@ -93,6 +105,18 @@ public sealed partial class ContentPerformanceOverviewViewModel(
 
     public int DiskPercent => _diskPercent;
 
+    public string DiskReadLabelText => _diskReadLabelText;
+
+    public string DiskWriteLabelText => _diskWriteLabelText;
+
+    public string DiskReadText => _diskReadText;
+
+    public string DiskWriteText => _diskWriteText;
+
+    public int DiskReadPercent => _diskReadPercent;
+
+    public int DiskWritePercent => _diskWritePercent;
+
     public string NetworkLabelText => _networkLabelText;
 
     public string NetworkAdapterName => _networkAdapterName;
@@ -102,6 +126,18 @@ public sealed partial class ContentPerformanceOverviewViewModel(
     public string NetworkDetailText => _networkDetailText;
 
     public int NetworkPercent => _networkPercent;
+
+    public string NetworkInLabelText => _networkInLabelText;
+
+    public string NetworkOutLabelText => _networkOutLabelText;
+
+    public string NetworkInText => _networkInText;
+
+    public string NetworkOutText => _networkOutText;
+
+    public int NetworkInPercent => _networkInPercent;
+
+    public int NetworkOutPercent => _networkOutPercent;
 
     public string PreviousGpuCommandText => _previousGpuCommandText;
 
@@ -191,17 +227,29 @@ public sealed partial class ContentPerformanceOverviewViewModel(
         var diskLabelText = GetRequiredString(data, "diskLabelText");
         var diskDetailText = GetRequiredString(data, "diskDetailText");
         var diskPercent = GetPercent(data, "diskPercent");
+        var diskReadLabelText = GetOptionalString(data, "diskReadLabelText");
+        var diskWriteLabelText = GetOptionalString(data, "diskWriteLabelText");
+        var diskReadText = GetOptionalString(data, "diskReadText");
+        var diskWriteText = GetOptionalString(data, "diskWriteText");
+        var diskReadPercent = GetOptionalPercent(data, "diskReadPercent", diskPercent);
+        var diskWritePercent = GetOptionalPercent(data, "diskWritePercent", 0);
         var networkLabelText = GetRequiredString(data, "networkLabelText");
         var networkAdapterName = GetOptionalString(data, "networkAdapterName");
         var canSwitchNetwork = GetOptionalBool(data, "canSwitchNetwork");
         var networkDetailText = GetRequiredString(data, "networkDetailText");
         var networkPercent = GetPercent(data, "networkPercent");
+        var networkInLabelText = GetOptionalString(data, "networkInLabelText");
+        var networkOutLabelText = GetOptionalString(data, "networkOutLabelText");
+        var networkInText = GetOptionalString(data, "networkInText");
+        var networkOutText = GetOptionalString(data, "networkOutText");
+        var networkInPercent = GetOptionalPercent(data, "networkInPercent", networkPercent);
+        var networkOutPercent = GetOptionalPercent(data, "networkOutPercent", 0);
         var previousGpuCommandText = GetOptionalString(data, "previousGpuCommandText");
         var nextGpuCommandText = GetOptionalString(data, "nextGpuCommandText");
         var previousNetworkCommandText = GetOptionalString(data, "previousNetworkCommandText");
         var nextNetworkCommandText = GetOptionalString(data, "nextNetworkCommandText");
 
-        List<string> changedProperties = new(30);
+        List<string> changedProperties = new(42);
 
         SetValue(ref _titleText, titleText, nameof(TitleText), changedProperties);
         SetValue(ref _statusText, statusText, nameof(StatusText), changedProperties);
@@ -226,12 +274,24 @@ public sealed partial class ContentPerformanceOverviewViewModel(
         SetValue(ref _diskLabelText, diskLabelText, nameof(DiskLabelText), changedProperties);
         SetValue(ref _diskDetailText, diskDetailText, nameof(DiskDetailText), changedProperties);
         SetValue(ref _diskPercent, diskPercent, nameof(DiskPercent), changedProperties);
+        SetValue(ref _diskReadLabelText, string.IsNullOrEmpty(diskReadLabelText) ? diskLabelText : diskReadLabelText, nameof(DiskReadLabelText), changedProperties);
+        SetValue(ref _diskWriteLabelText, string.IsNullOrEmpty(diskWriteLabelText) ? diskLabelText : diskWriteLabelText, nameof(DiskWriteLabelText), changedProperties);
+        SetValue(ref _diskReadText, string.IsNullOrEmpty(diskReadText) ? diskDetailText : diskReadText, nameof(DiskReadText), changedProperties);
+        SetValue(ref _diskWriteText, diskWriteText, nameof(DiskWriteText), changedProperties);
+        SetValue(ref _diskReadPercent, diskReadPercent, nameof(DiskReadPercent), changedProperties);
+        SetValue(ref _diskWritePercent, diskWritePercent, nameof(DiskWritePercent), changedProperties);
 
         SetValue(ref _networkLabelText, networkLabelText, nameof(NetworkLabelText), changedProperties);
         SetValue(ref _networkAdapterName, networkAdapterName, nameof(NetworkAdapterName), changedProperties);
         SetValue(ref _canSwitchNetwork, canSwitchNetwork, nameof(CanSwitchNetwork), changedProperties);
         SetValue(ref _networkDetailText, networkDetailText, nameof(NetworkDetailText), changedProperties);
         SetValue(ref _networkPercent, networkPercent, nameof(NetworkPercent), changedProperties);
+        SetValue(ref _networkInLabelText, string.IsNullOrEmpty(networkInLabelText) ? networkLabelText : networkInLabelText, nameof(NetworkInLabelText), changedProperties);
+        SetValue(ref _networkOutLabelText, string.IsNullOrEmpty(networkOutLabelText) ? networkLabelText : networkOutLabelText, nameof(NetworkOutLabelText), changedProperties);
+        SetValue(ref _networkInText, string.IsNullOrEmpty(networkInText) ? networkDetailText : networkInText, nameof(NetworkInText), changedProperties);
+        SetValue(ref _networkOutText, networkOutText, nameof(NetworkOutText), changedProperties);
+        SetValue(ref _networkInPercent, networkInPercent, nameof(NetworkInPercent), changedProperties);
+        SetValue(ref _networkOutPercent, networkOutPercent, nameof(NetworkOutPercent), changedProperties);
         SetValue(ref _previousGpuCommandText, previousGpuCommandText, nameof(PreviousGpuCommandText), changedProperties);
         SetValue(ref _nextGpuCommandText, nextGpuCommandText, nameof(NextGpuCommandText), changedProperties);
         SetValue(ref _previousNetworkCommandText, previousNetworkCommandText, nameof(PreviousNetworkCommandText), changedProperties);
@@ -259,6 +319,11 @@ public sealed partial class ContentPerformanceOverviewViewModel(
 
     private static int GetPercent(JsonObject data, string propertyName) =>
         Math.Clamp(GetRequiredInt(data, propertyName), 0, 100);
+
+    private static int GetOptionalPercent(JsonObject data, string propertyName, int fallback) =>
+        data[propertyName] is null
+            ? fallback
+            : Math.Clamp(data[propertyName]!.GetValue<int>(), 0, 100);
 
     [RelayCommand]
     private void PreviousGpu() => _commandInvoker?.Invoke(NativePerformanceOverviewCommandIds.PreviousGpu);

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentPerformanceOverviewViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentPerformanceOverviewViewModel.cs
@@ -4,6 +4,7 @@
 
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using CommunityToolkit.Mvvm.Input;
 using Microsoft.CmdPal.Common;
 using Microsoft.CmdPal.UI.ViewModels.Models;
 using Microsoft.CommandPalette.Extensions;
@@ -17,11 +18,13 @@ namespace Microsoft.CmdPal.UI.ViewModels;
 /// </summary>
 public sealed partial class ContentPerformanceOverviewViewModel(
     IFormContent form,
-    WeakReference<IPageContext> context) : ContentViewModel(context)
+    WeakReference<IPageContext> context,
+    Action<string>? commandInvoker = null) : ContentViewModel(context)
 {
     private const int SupportedSchemaVersion = 1;
 
     private readonly ExtensionObject<IFormContent> _formModel = new(form);
+    private readonly Action<string>? _commandInvoker = commandInvoker;
 
     private string _titleText = string.Empty;
     private string _statusText = string.Empty;
@@ -32,6 +35,8 @@ public sealed partial class ContentPerformanceOverviewViewModel(
     private string _cpuDetailText = string.Empty;
     private int _cpuPercent;
     private string _gpuLabelText = string.Empty;
+    private string _gpuAdapterName = string.Empty;
+    private bool _canSwitchGpu;
     private string _gpuDetailText = string.Empty;
     private int _gpuPercent;
     private string _memoryLabelText = string.Empty;
@@ -41,8 +46,14 @@ public sealed partial class ContentPerformanceOverviewViewModel(
     private string _diskDetailText = string.Empty;
     private int _diskPercent;
     private string _networkLabelText = string.Empty;
+    private string _networkAdapterName = string.Empty;
+    private bool _canSwitchNetwork;
     private string _networkDetailText = string.Empty;
     private int _networkPercent;
+    private string _previousGpuCommandText = string.Empty;
+    private string _nextGpuCommandText = string.Empty;
+    private string _previousNetworkCommandText = string.Empty;
+    private string _nextNetworkCommandText = string.Empty;
 
     public string TitleText => _titleText;
 
@@ -62,6 +73,10 @@ public sealed partial class ContentPerformanceOverviewViewModel(
 
     public string GpuLabelText => _gpuLabelText;
 
+    public string GpuAdapterName => _gpuAdapterName;
+
+    public bool CanSwitchGpu => _canSwitchGpu;
+
     public string GpuDetailText => _gpuDetailText;
 
     public int GpuPercent => _gpuPercent;
@@ -80,9 +95,21 @@ public sealed partial class ContentPerformanceOverviewViewModel(
 
     public string NetworkLabelText => _networkLabelText;
 
+    public string NetworkAdapterName => _networkAdapterName;
+
+    public bool CanSwitchNetwork => _canSwitchNetwork;
+
     public string NetworkDetailText => _networkDetailText;
 
     public int NetworkPercent => _networkPercent;
+
+    public string PreviousGpuCommandText => _previousGpuCommandText;
+
+    public string NextGpuCommandText => _nextGpuCommandText;
+
+    public string PreviousNetworkCommandText => _previousNetworkCommandText;
+
+    public string NextNetworkCommandText => _nextNetworkCommandText;
 
     public static bool IsPerformanceOverview(IFormContent content) =>
         string.Equals(
@@ -154,6 +181,8 @@ public sealed partial class ContentPerformanceOverviewViewModel(
         var cpuDetailText = GetRequiredString(data, "cpuDetailText");
         var cpuPercent = GetPercent(data, "cpuPercent");
         var gpuLabelText = GetRequiredString(data, "gpuLabelText");
+        var gpuAdapterName = GetOptionalString(data, "gpuAdapterName");
+        var canSwitchGpu = GetOptionalBool(data, "canSwitchGpu");
         var gpuDetailText = GetRequiredString(data, "gpuDetailText");
         var gpuPercent = GetPercent(data, "gpuPercent");
         var memoryLabelText = GetRequiredString(data, "memoryLabelText");
@@ -163,10 +192,16 @@ public sealed partial class ContentPerformanceOverviewViewModel(
         var diskDetailText = GetRequiredString(data, "diskDetailText");
         var diskPercent = GetPercent(data, "diskPercent");
         var networkLabelText = GetRequiredString(data, "networkLabelText");
+        var networkAdapterName = GetOptionalString(data, "networkAdapterName");
+        var canSwitchNetwork = GetOptionalBool(data, "canSwitchNetwork");
         var networkDetailText = GetRequiredString(data, "networkDetailText");
         var networkPercent = GetPercent(data, "networkPercent");
+        var previousGpuCommandText = GetOptionalString(data, "previousGpuCommandText");
+        var nextGpuCommandText = GetOptionalString(data, "nextGpuCommandText");
+        var previousNetworkCommandText = GetOptionalString(data, "previousNetworkCommandText");
+        var nextNetworkCommandText = GetOptionalString(data, "nextNetworkCommandText");
 
-        List<string> changedProperties = new(20);
+        List<string> changedProperties = new(30);
 
         SetValue(ref _titleText, titleText, nameof(TitleText), changedProperties);
         SetValue(ref _statusText, statusText, nameof(StatusText), changedProperties);
@@ -179,6 +214,8 @@ public sealed partial class ContentPerformanceOverviewViewModel(
         SetValue(ref _cpuPercent, cpuPercent, nameof(CpuPercent), changedProperties);
 
         SetValue(ref _gpuLabelText, gpuLabelText, nameof(GpuLabelText), changedProperties);
+        SetValue(ref _gpuAdapterName, gpuAdapterName, nameof(GpuAdapterName), changedProperties);
+        SetValue(ref _canSwitchGpu, canSwitchGpu, nameof(CanSwitchGpu), changedProperties);
         SetValue(ref _gpuDetailText, gpuDetailText, nameof(GpuDetailText), changedProperties);
         SetValue(ref _gpuPercent, gpuPercent, nameof(GpuPercent), changedProperties);
 
@@ -191,8 +228,14 @@ public sealed partial class ContentPerformanceOverviewViewModel(
         SetValue(ref _diskPercent, diskPercent, nameof(DiskPercent), changedProperties);
 
         SetValue(ref _networkLabelText, networkLabelText, nameof(NetworkLabelText), changedProperties);
+        SetValue(ref _networkAdapterName, networkAdapterName, nameof(NetworkAdapterName), changedProperties);
+        SetValue(ref _canSwitchNetwork, canSwitchNetwork, nameof(CanSwitchNetwork), changedProperties);
         SetValue(ref _networkDetailText, networkDetailText, nameof(NetworkDetailText), changedProperties);
         SetValue(ref _networkPercent, networkPercent, nameof(NetworkPercent), changedProperties);
+        SetValue(ref _previousGpuCommandText, previousGpuCommandText, nameof(PreviousGpuCommandText), changedProperties);
+        SetValue(ref _nextGpuCommandText, nextGpuCommandText, nameof(NextGpuCommandText), changedProperties);
+        SetValue(ref _previousNetworkCommandText, previousNetworkCommandText, nameof(PreviousNetworkCommandText), changedProperties);
+        SetValue(ref _nextNetworkCommandText, nextNetworkCommandText, nameof(NextNetworkCommandText), changedProperties);
 
         if (changedProperties.Count > 0)
         {
@@ -208,8 +251,26 @@ public sealed partial class ContentPerformanceOverviewViewModel(
         data[propertyName]?.GetValue<int>()
         ?? throw new JsonException($"Missing native performance overview property: {propertyName}.");
 
+    private static string GetOptionalString(JsonObject data, string propertyName) =>
+        data[propertyName]?.GetValue<string>() ?? string.Empty;
+
+    private static bool GetOptionalBool(JsonObject data, string propertyName) =>
+        data[propertyName]?.GetValue<bool>() ?? false;
+
     private static int GetPercent(JsonObject data, string propertyName) =>
         Math.Clamp(GetRequiredInt(data, propertyName), 0, 100);
+
+    [RelayCommand]
+    private void PreviousGpu() => _commandInvoker?.Invoke(NativePerformanceOverviewCommandIds.PreviousGpu);
+
+    [RelayCommand]
+    private void NextGpu() => _commandInvoker?.Invoke(NativePerformanceOverviewCommandIds.NextGpu);
+
+    [RelayCommand]
+    private void PreviousNetwork() => _commandInvoker?.Invoke(NativePerformanceOverviewCommandIds.PreviousNetwork);
+
+    [RelayCommand]
+    private void NextNetwork() => _commandInvoker?.Invoke(NativePerformanceOverviewCommandIds.NextNetwork);
 
     private static void SetValue<T>(
         ref T target,

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentPerformanceOverviewViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentPerformanceOverviewViewModel.cs
@@ -1,0 +1,237 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.CmdPal.Common;
+using Microsoft.CmdPal.UI.ViewModels.Models;
+using Microsoft.CommandPalette.Extensions;
+
+namespace Microsoft.CmdPal.UI.ViewModels;
+
+/// <summary>
+/// Observable host-side projection for the in-box performance overview.
+/// The instance and its bound native visual tree stay alive while DataJson
+/// updates mutate these properties in place.
+/// </summary>
+public sealed partial class ContentPerformanceOverviewViewModel(
+    IFormContent form,
+    WeakReference<IPageContext> context) : ContentViewModel(context)
+{
+    private const int SupportedSchemaVersion = 1;
+
+    private readonly ExtensionObject<IFormContent> _formModel = new(form);
+
+    private string _titleText = string.Empty;
+    private string _statusText = string.Empty;
+    private string _heroMetric = string.Empty;
+    private string _heroLabelText = string.Empty;
+    private string _heroValueText = string.Empty;
+    private string _cpuLabelText = string.Empty;
+    private string _cpuDetailText = string.Empty;
+    private int _cpuPercent;
+    private string _gpuLabelText = string.Empty;
+    private string _gpuDetailText = string.Empty;
+    private int _gpuPercent;
+    private string _memoryLabelText = string.Empty;
+    private string _memoryDetailText = string.Empty;
+    private int _memoryPercent;
+    private string _diskLabelText = string.Empty;
+    private string _diskDetailText = string.Empty;
+    private int _diskPercent;
+    private string _networkLabelText = string.Empty;
+    private string _networkDetailText = string.Empty;
+    private int _networkPercent;
+
+    public string TitleText => _titleText;
+
+    public string StatusText => _statusText;
+
+    public string HeroMetric => _heroMetric;
+
+    public string HeroLabelText => _heroLabelText;
+
+    public string HeroValueText => _heroValueText;
+
+    public string CpuLabelText => _cpuLabelText;
+
+    public string CpuDetailText => _cpuDetailText;
+
+    public int CpuPercent => _cpuPercent;
+
+    public string GpuLabelText => _gpuLabelText;
+
+    public string GpuDetailText => _gpuDetailText;
+
+    public int GpuPercent => _gpuPercent;
+
+    public string MemoryLabelText => _memoryLabelText;
+
+    public string MemoryDetailText => _memoryDetailText;
+
+    public int MemoryPercent => _memoryPercent;
+
+    public string DiskLabelText => _diskLabelText;
+
+    public string DiskDetailText => _diskDetailText;
+
+    public int DiskPercent => _diskPercent;
+
+    public string NetworkLabelText => _networkLabelText;
+
+    public string NetworkDetailText => _networkDetailText;
+
+    public int NetworkPercent => _networkPercent;
+
+    public static bool IsPerformanceOverview(IFormContent content) =>
+        string.Equals(
+            content.TemplateJson,
+            NativeFormContentTypes.PerformanceOverview,
+            StringComparison.Ordinal);
+
+    public override void InitializeProperties()
+    {
+        var model = _formModel.Unsafe;
+        if (model is null)
+        {
+            return;
+        }
+
+        model.PropChanged += Model_PropChanged;
+        ApplyDataJsonIfPresent(model.DataJson);
+    }
+
+    private void Model_PropChanged(object sender, IPropChangedEventArgs args)
+    {
+        if (!string.Equals(args.PropertyName, nameof(IFormContent.DataJson), StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        try
+        {
+            var model = _formModel.Unsafe;
+            if (model is not null)
+            {
+                ApplyDataJsonIfPresent(model.DataJson);
+            }
+        }
+        catch (Exception ex)
+        {
+            ShowException(ex);
+        }
+    }
+
+    private void ApplyDataJsonIfPresent(string dataJson)
+    {
+        if (!string.IsNullOrWhiteSpace(dataJson))
+        {
+            ApplyDataJson(dataJson);
+        }
+    }
+
+    private void ApplyDataJson(string dataJson)
+    {
+        var data = JsonNode.Parse(dataJson) as JsonObject
+            ?? throw new JsonException("The native performance overview payload must be a JSON object.");
+
+        var schemaVersion = GetRequiredInt(data, "schemaVersion");
+        if (schemaVersion != SupportedSchemaVersion)
+        {
+            throw new JsonException($"Unsupported native performance overview schema version: {schemaVersion}.");
+        }
+
+        // Read and validate the complete sample before mutating any backing
+        // fields so a malformed update cannot leave the observable state
+        // partially advanced.
+        var titleText = GetRequiredString(data, "titleText");
+        var statusText = GetRequiredString(data, "statusText");
+        var heroMetric = GetRequiredString(data, "heroMetric");
+        var heroLabelText = GetRequiredString(data, "heroLabelText");
+        var heroValueText = GetRequiredString(data, "heroValueText");
+        var cpuLabelText = GetRequiredString(data, "cpuLabelText");
+        var cpuDetailText = GetRequiredString(data, "cpuDetailText");
+        var cpuPercent = GetPercent(data, "cpuPercent");
+        var gpuLabelText = GetRequiredString(data, "gpuLabelText");
+        var gpuDetailText = GetRequiredString(data, "gpuDetailText");
+        var gpuPercent = GetPercent(data, "gpuPercent");
+        var memoryLabelText = GetRequiredString(data, "memoryLabelText");
+        var memoryDetailText = GetRequiredString(data, "memoryDetailText");
+        var memoryPercent = GetPercent(data, "memoryPercent");
+        var diskLabelText = GetRequiredString(data, "diskLabelText");
+        var diskDetailText = GetRequiredString(data, "diskDetailText");
+        var diskPercent = GetPercent(data, "diskPercent");
+        var networkLabelText = GetRequiredString(data, "networkLabelText");
+        var networkDetailText = GetRequiredString(data, "networkDetailText");
+        var networkPercent = GetPercent(data, "networkPercent");
+
+        List<string> changedProperties = new(20);
+
+        SetValue(ref _titleText, titleText, nameof(TitleText), changedProperties);
+        SetValue(ref _statusText, statusText, nameof(StatusText), changedProperties);
+        SetValue(ref _heroMetric, heroMetric, nameof(HeroMetric), changedProperties);
+        SetValue(ref _heroLabelText, heroLabelText, nameof(HeroLabelText), changedProperties);
+        SetValue(ref _heroValueText, heroValueText, nameof(HeroValueText), changedProperties);
+
+        SetValue(ref _cpuLabelText, cpuLabelText, nameof(CpuLabelText), changedProperties);
+        SetValue(ref _cpuDetailText, cpuDetailText, nameof(CpuDetailText), changedProperties);
+        SetValue(ref _cpuPercent, cpuPercent, nameof(CpuPercent), changedProperties);
+
+        SetValue(ref _gpuLabelText, gpuLabelText, nameof(GpuLabelText), changedProperties);
+        SetValue(ref _gpuDetailText, gpuDetailText, nameof(GpuDetailText), changedProperties);
+        SetValue(ref _gpuPercent, gpuPercent, nameof(GpuPercent), changedProperties);
+
+        SetValue(ref _memoryLabelText, memoryLabelText, nameof(MemoryLabelText), changedProperties);
+        SetValue(ref _memoryDetailText, memoryDetailText, nameof(MemoryDetailText), changedProperties);
+        SetValue(ref _memoryPercent, memoryPercent, nameof(MemoryPercent), changedProperties);
+
+        SetValue(ref _diskLabelText, diskLabelText, nameof(DiskLabelText), changedProperties);
+        SetValue(ref _diskDetailText, diskDetailText, nameof(DiskDetailText), changedProperties);
+        SetValue(ref _diskPercent, diskPercent, nameof(DiskPercent), changedProperties);
+
+        SetValue(ref _networkLabelText, networkLabelText, nameof(NetworkLabelText), changedProperties);
+        SetValue(ref _networkDetailText, networkDetailText, nameof(NetworkDetailText), changedProperties);
+        SetValue(ref _networkPercent, networkPercent, nameof(NetworkPercent), changedProperties);
+
+        if (changedProperties.Count > 0)
+        {
+            UpdateProperty(changedProperties.ToArray());
+        }
+    }
+
+    private static string GetRequiredString(JsonObject data, string propertyName) =>
+        data[propertyName]?.GetValue<string>()
+        ?? throw new JsonException($"Missing native performance overview property: {propertyName}.");
+
+    private static int GetRequiredInt(JsonObject data, string propertyName) =>
+        data[propertyName]?.GetValue<int>()
+        ?? throw new JsonException($"Missing native performance overview property: {propertyName}.");
+
+    private static int GetPercent(JsonObject data, string propertyName) =>
+        Math.Clamp(GetRequiredInt(data, propertyName), 0, 100);
+
+    private static void SetValue<T>(
+        ref T target,
+        T value,
+        string propertyName,
+        ICollection<string> changedProperties)
+    {
+        if (!EqualityComparer<T>.Default.Equals(target, value))
+        {
+            target = value;
+            changedProperties.Add(propertyName);
+        }
+    }
+
+    protected override void UnsafeCleanup()
+    {
+        base.UnsafeCleanup();
+
+        var model = _formModel.Unsafe;
+        if (model is not null)
+        {
+            model.PropChanged -= Model_PropChanged;
+        }
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Dock/DockBandViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Dock/DockBandViewModel.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Immutable;
 using System.Collections.ObjectModel;
+using Microsoft.CmdPal.Common;
 using Microsoft.CmdPal.UI.ViewModels.Models;
 using Microsoft.CmdPal.UI.ViewModels.Services;
 using Microsoft.CmdPal.UI.ViewModels.Settings;
@@ -21,6 +22,10 @@ public sealed partial class DockBandViewModel : ExtensionObjectViewModel
     private readonly IContextMenuFactory _contextMenuFactory;
 
     private DockBandSettings _bandSettings;
+    private Dictionary<IListItem, DockItemViewModel> _viewModelCache = new(ReferenceEqualityComparer.Instance);
+    private int _refreshInFlight;
+    private int _refreshRequested;
+    private int _cleanupStarted;
 
     public ObservableCollection<DockItemViewModel> Items { get; } = new();
 
@@ -232,24 +237,168 @@ public sealed partial class DockBandViewModel : ExtensionObjectViewModel
 
     private void InitializeFromList(IListPage list)
     {
-        var items = list.GetItems();
-        var newViewModels = new List<DockItemViewModel>();
-        foreach (var item in items)
+        if (Volatile.Read(ref _cleanupStarted) != 0)
         {
-            var newItemVm = new DockItemViewModel(new(item), this.PageContext, _showTitles, _showSubtitles, _contextMenuFactory);
-            newItemVm.SlowInitializeProperties();
-            newViewModels.Add(newItemVm);
+            return;
         }
 
-        List<DockItemViewModel> removed = new();
-        DoOnUiThread(() =>
+        Interlocked.Exchange(ref _refreshRequested, 1);
+        if (Interlocked.CompareExchange(ref _refreshInFlight, 1, 0) != 0)
         {
-            ListHelpers.InPlaceUpdateList(Items, newViewModels, out removed);
-        });
+            return;
+        }
 
-        foreach (var removedItem in removed)
+        BuildRefresh(list);
+    }
+
+    private void BuildRefresh(IListPage list)
+    {
+        List<DockItemViewModel> createdViewModels = [];
+        try
         {
-            removedItem.SafeCleanup();
+            Interlocked.Exchange(ref _refreshRequested, 0);
+            if (Volatile.Read(ref _cleanupStarted) != 0)
+            {
+                CompleteRefresh(list);
+                return;
+            }
+
+            var items = list.GetItems();
+            var currentCache = Volatile.Read(ref _viewModelCache);
+            var itemModels = new List<IListItem>(items.Length);
+            var newViewModels = new List<DockItemViewModel>(items.Length);
+
+            foreach (var item in items)
+            {
+                if (item is null)
+                {
+                    continue;
+                }
+
+                if (!currentCache.TryGetValue(item, out var itemViewModel))
+                {
+                    itemViewModel = new DockItemViewModel(new(item), PageContext, _showTitles, _showSubtitles, _contextMenuFactory);
+                    createdViewModels.Add(itemViewModel);
+                    itemViewModel.SlowInitializeProperties();
+                }
+
+                itemModels.Add(item);
+                newViewModels.Add(itemViewModel);
+            }
+
+            if (!TryDoOnUiThread(() => ApplyRefresh(list, itemModels, newViewModels, createdViewModels)))
+            {
+                QueueCleanup(createdViewModels);
+                CompleteRefresh(list);
+            }
+        }
+        catch
+        {
+            QueueCleanup(createdViewModels);
+            Interlocked.Exchange(ref _refreshInFlight, 0);
+            throw;
+        }
+    }
+
+    private void ApplyRefresh(
+        IListPage list,
+        IReadOnlyList<IListItem> itemModels,
+        IReadOnlyList<DockItemViewModel> newViewModels,
+        IReadOnlyList<DockItemViewModel> createdViewModels)
+    {
+        List<DockItemViewModel> removedItems = [];
+        try
+        {
+            if (Volatile.Read(ref _cleanupStarted) != 0)
+            {
+                return;
+            }
+
+            foreach (var viewModel in newViewModels)
+            {
+                viewModel.ShowTitle = _showTitles;
+                viewModel.ShowSubtitle = _showSubtitles;
+            }
+
+            ListHelpers.InPlaceUpdateList(Items, newViewModels, out removedItems);
+
+            var nextCache = new Dictionary<IListItem, DockItemViewModel>(itemModels.Count, ReferenceEqualityComparer.Instance);
+            for (var i = 0; i < itemModels.Count; i++)
+            {
+                nextCache[itemModels[i]] = Items[i];
+            }
+
+            Volatile.Write(ref _viewModelCache, nextCache);
+        }
+        finally
+        {
+            CleanupDiscardedViewModels(removedItems, createdViewModels);
+            CompleteRefresh(list);
+        }
+    }
+
+    private void CompleteRefresh(IListPage list)
+    {
+        Interlocked.Exchange(ref _refreshInFlight, 0);
+        if (Volatile.Read(ref _cleanupStarted) != 0 ||
+            Volatile.Read(ref _refreshRequested) == 0)
+        {
+            return;
+        }
+
+        _ = Task.Run(
+            () =>
+            {
+                try
+                {
+                    InitializeFromList(list);
+                }
+                catch (Exception ex)
+                {
+                    CoreLogger.LogError("Failed to refresh a Dock band.", ex);
+                }
+            });
+    }
+
+    private void CleanupDiscardedViewModels(
+        IEnumerable<DockItemViewModel> removedItems,
+        IEnumerable<DockItemViewModel> createdViewModels)
+    {
+        var retained = new HashSet<DockItemViewModel>(Items, ReferenceEqualityComparer.Instance);
+        var discarded = new HashSet<DockItemViewModel>(ReferenceEqualityComparer.Instance);
+
+        foreach (var item in removedItems)
+        {
+            if (!retained.Contains(item))
+            {
+                discarded.Add(item);
+            }
+        }
+
+        foreach (var item in createdViewModels)
+        {
+            if (!retained.Contains(item))
+            {
+                discarded.Add(item);
+            }
+        }
+
+        QueueCleanup(discarded);
+    }
+
+    private static void QueueCleanup(IEnumerable<DockItemViewModel> viewModels)
+    {
+        var pendingCleanup = viewModels.ToArray();
+        if (pendingCleanup.Length != 0)
+        {
+            _ = Task.Run(
+                () =>
+                {
+                    foreach (var viewModel in pendingCleanup)
+                    {
+                        viewModel.SafeCleanup();
+                    }
+                });
         }
     }
 
@@ -259,17 +408,33 @@ public sealed partial class DockBandViewModel : ExtensionObjectViewModel
         var list = command.Model.Unsafe as IListPage;
         if (list is not null)
         {
-            InitializeFromList(list);
             list.ItemsChanged += HandleItemsChanged;
+            if (Volatile.Read(ref _cleanupStarted) != 0)
+            {
+                list.ItemsChanged -= HandleItemsChanged;
+                return;
+            }
+
+            InitializeFromList(list);
         }
         else
         {
             var dockItem = new DockItemViewModel(_rootItem, _showTitles, _showSubtitles, _contextMenuFactory);
             dockItem.SlowInitializeProperties();
-            DoOnUiThread(() =>
+            if (!TryDoOnUiThread(() =>
             {
-                Items.Add(dockItem);
-            });
+                if (Volatile.Read(ref _cleanupStarted) == 0)
+                {
+                    Items.Add(dockItem);
+                }
+                else
+                {
+                    QueueCleanup([dockItem]);
+                }
+            }))
+            {
+                QueueCleanup([dockItem]);
+            }
         }
     }
 
@@ -283,6 +448,7 @@ public sealed partial class DockBandViewModel : ExtensionObjectViewModel
 
     protected override void UnsafeCleanup()
     {
+        Interlocked.Exchange(ref _cleanupStarted, 1);
         base.UnsafeCleanup();
 
         var command = _rootItem.Command;
@@ -291,10 +457,21 @@ public sealed partial class DockBandViewModel : ExtensionObjectViewModel
             list.ItemsChanged -= HandleItemsChanged;
         }
 
-        foreach (var item in Items)
+        Volatile.Write(
+            ref _viewModelCache,
+            new Dictionary<IListItem, DockItemViewModel>(ReferenceEqualityComparer.Instance));
+
+        if (!TryDoOnUiThread(DrainItems))
         {
-            item.SafeCleanup();
+            QueueCleanup(Items.ToArray());
         }
+    }
+
+    private void DrainItems()
+    {
+        var items = Items.ToArray();
+        Items.Clear();
+        QueueCleanup(items);
     }
 }
 
@@ -401,6 +578,10 @@ public partial class DockItemViewModel : CommandItemViewModel
             }
         };
     }
+
+    public override bool Equals(object? obj) => obj is DockItemViewModel viewModel && viewModel.Model.Equals(Model);
+
+    public override int GetHashCode() => Model.GetHashCode();
 }
 
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Dock/DockBandViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Dock/DockBandViewModel.cs
@@ -31,6 +31,8 @@ public sealed partial class DockBandViewModel : ExtensionObjectViewModel
 
     public string Id => _rootItem.Command.Id;
 
+    public string ProviderId => _bandSettings.ProviderId;
+
     /// <summary>
     /// Gets or sets a value indicating whether titles are shown for items in this band.
     /// This is a preview value - call <see cref="SaveLabelSettings"/> to persist or
@@ -298,6 +300,9 @@ public sealed partial class DockBandViewModel : ExtensionObjectViewModel
 
 public partial class DockItemViewModel : CommandItemViewModel
 {
+    private const double DefaultTitleMinWidth = 24;
+    private const double TransferRateTitleMinWidth = 64;
+
     private bool _showTitle = true;
     private bool _showSubtitle = true;
 
@@ -348,6 +353,14 @@ public partial class DockItemViewModel : CommandItemViewModel
 
     public override string Title => _showTitle ? ItemTitle : string.Empty;
 
+    public double TitleMinWidth => GetTitleMinWidth(Title);
+
+    internal static double GetTitleMinWidth(string title) =>
+        title.EndsWith("bps", StringComparison.OrdinalIgnoreCase) ||
+        title.EndsWith("/s", StringComparison.OrdinalIgnoreCase)
+            ? TransferRateTitleMinWidth
+            : DefaultTitleMinWidth;
+
     public override string Subtitle => _showSubtitle ? base.Subtitle : string.Empty;
 
     public override bool HasText => (_showTitle && !string.IsNullOrEmpty(ItemTitle)) || (_showSubtitle && !string.IsNullOrEmpty(base.Subtitle));
@@ -380,6 +393,11 @@ public partial class DockItemViewModel : CommandItemViewModel
             if (e.PropertyName is nameof(Title) or nameof(Subtitle))
             {
                 UpdateProperty(nameof(Tooltip));
+            }
+
+            if (e.PropertyName == nameof(Title))
+            {
+                UpdateProperty(nameof(TitleMinWidth));
             }
         };
     }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ExtensionObjectViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ExtensionObjectViewModel.cs
@@ -255,6 +255,9 @@ public abstract partial class ExtensionObjectViewModel : ObservableObject, IBatc
     private static PropertyChangedEventArgs Args(string name) => new(name);
 
     protected void DoOnUiThread(Action action)
+        => _ = TryDoOnUiThread(action);
+
+    protected bool TryDoOnUiThread(Action action)
     {
         if (PageContext.TryGetTarget(out var pageContext))
         {
@@ -263,7 +266,10 @@ public abstract partial class ExtensionObjectViewModel : ObservableObject, IBatc
                 CancellationToken.None,
                 TaskCreationOptions.None,
                 pageContext.Scheduler);
+            return true;
         }
+
+        return false;
     }
 
     protected virtual void UnsafeCleanup()

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Messages/PerformCommandMessage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Messages/PerformCommandMessage.cs
@@ -20,6 +20,8 @@ public record PerformCommandMessage
 
     public bool TransientPage { get; set; }
 
+    public bool UseCompactDockPresentation { get; set; }
+
     /// <summary>
     /// Optional callback raised by <see cref="ShellViewModel"/> just before a
     /// <see cref="ShowConfirmationMessage"/> is dispatched for this command's

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/PageViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/PageViewModel.cs
@@ -16,6 +16,10 @@ public partial class PageViewModel : ExtensionObjectViewModel, IPageContext
     public TaskScheduler Scheduler { get; private set; }
 
     private readonly ExtensionObject<IPage> _pageModel;
+    private readonly Lock _lifecycleLock = new();
+    private bool _initializationInProgress;
+    private bool _cleanupRequested;
+    private bool _cleanupCompleted;
 
     public bool IsLoading => ModelIsLoading || (!IsInitialized);
 
@@ -45,6 +49,18 @@ public partial class PageViewModel : ExtensionObjectViewModel, IPageContext
     /// </summary>
     [ObservableProperty]
     public partial bool HasBackButton { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this page is the temporary root
+    /// of a transient Dock window.
+    /// </summary>
+    public bool IsTransientPage { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this page uses the compact,
+    /// chrome-free Performance Monitor Dock presentation.
+    /// </summary>
+    public bool UseCompactDockPresentation { get; set; }
 
     // This is set from the SearchBar
     [ObservableProperty]
@@ -132,13 +148,33 @@ public partial class PageViewModel : ExtensionObjectViewModel, IPageContext
 
         // TODO: We may want to investigate using some sort of AsyncEnumerable or populating these as they come into the UI layer
         //       Though we have to think about threading here and circling back to the UI thread with a TaskScheduler.
+        lock (_lifecycleLock)
+        {
+            if (_cleanupRequested)
+            {
+                return Task.FromResult(false);
+            }
+
+            _initializationInProgress = true;
+        }
+
+        var initialized = false;
         try
         {
             InitializeProperties();
+            initialized = true;
         }
         catch (Exception ex)
         {
             ShowException(ex, _pageModel?.Unsafe?.Name);
+        }
+        finally
+        {
+            CompleteInitialization();
+        }
+
+        if (!initialized)
+        {
             return Task.FromResult(false);
         }
 
@@ -146,7 +182,16 @@ public partial class PageViewModel : ExtensionObjectViewModel, IPageContext
         Task.Factory.StartNew(
             () =>
             {
-                IsInitialized = true;
+                var publishInitialized = false;
+                lock (_lifecycleLock)
+                {
+                    publishInitialized = !_cleanupRequested;
+                }
+
+                if (publishInitialized)
+                {
+                    IsInitialized = true;
+                }
 
                 // TODO: Do we want an event/signal here that the Page Views can listen to? (i.e. ListPage setting the selected index to 0, however, in async world the user may have already started navigating around page...)
             },
@@ -275,6 +320,57 @@ public partial class PageViewModel : ExtensionObjectViewModel, IPageContext
         if (model is not null)
         {
             model.PropChanged -= Model_PropChanged;
+        }
+    }
+
+    public override void SafeCleanup()
+    {
+        var cleanupNow = false;
+        lock (_lifecycleLock)
+        {
+            if (_cleanupCompleted)
+            {
+                return;
+            }
+
+            _cleanupRequested = true;
+            if (!_initializationInProgress)
+            {
+                _cleanupCompleted = true;
+                cleanupNow = true;
+            }
+        }
+
+        if (cleanupNow)
+        {
+            base.SafeCleanup();
+        }
+    }
+
+    private void CompleteInitialization()
+    {
+        var cleanupNow = false;
+        lock (_lifecycleLock)
+        {
+            _initializationInProgress = false;
+            if (_cleanupRequested && !_cleanupCompleted)
+            {
+                _cleanupCompleted = true;
+                cleanupNow = true;
+            }
+        }
+
+        if (cleanupNow)
+        {
+            base.SafeCleanup();
+        }
+    }
+
+    public void SafeCleanupIfTransient()
+    {
+        if (IsTransientPage)
+        {
+            SafeCleanup();
         }
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ShellViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ShellViewModel.cs
@@ -113,7 +113,7 @@ public partial class ShellViewModel : ObservableObject,
     public bool ShouldShowCommandBar =>
         !CurrentPage.UseCompactDockPresentation
         || CurrentPage is not ContentPageViewModel contentPage
-        || contentPage.CanOpenContextMenu;
+        || (contentPage.CanOpenContextMenu && !contentPage.HasInlineCommandSurface);
 
     public PageViewModel NullPage { get; private set; }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ShellViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ShellViewModel.cs
@@ -67,6 +67,8 @@ public partial class ShellViewModel : ObservableObject,
                     IsSearchBoxVisible = true;
                 }
 
+                UpdateTransientChromeProperties();
+
                 if (oldValue is IDisposable disposable)
                 {
                     try
@@ -88,6 +90,13 @@ public partial class ShellViewModel : ObservableObject,
         {
             IsSearchBoxVisible = CurrentPage.HasSearchBox;
         }
+
+        if (e.PropertyName is nameof(PageViewModel.HasSearchBox)
+            or nameof(PageViewModel.HasBackButton)
+            or nameof(ContentPageViewModel.CanOpenContextMenu))
+        {
+            UpdateTransientChromeProperties();
+        }
     }
 
     private IPage? _rootPage;
@@ -98,6 +107,13 @@ public partial class ShellViewModel : ObservableObject,
     public bool IsNested => _isNested && !_currentlyTransient;
 
     public bool IsTransient => _currentlyTransient;
+
+    public bool ShouldShowTopBar => !CurrentPage.UseCompactDockPresentation || CurrentPage.HasSearchBox || CurrentPage.HasBackButton;
+
+    public bool ShouldShowCommandBar =>
+        !CurrentPage.UseCompactDockPresentation
+        || CurrentPage is not ContentPageViewModel contentPage
+        || contentPage.CanOpenContextMenu;
 
     public PageViewModel NullPage { get; private set; }
 
@@ -191,18 +207,7 @@ public partial class ShellViewModel : ObservableObject,
                             {
                                 if (cancellationToken.IsCancellationRequested)
                                 {
-                                    if (viewModel is IDisposable disposable)
-                                    {
-                                        try
-                                        {
-                                            disposable.Dispose();
-                                        }
-                                        catch (Exception ex)
-                                        {
-                                            CoreLogger.LogError(ex.ToString());
-                                        }
-                                    }
-
+                                    viewModel.SafeCleanup();
                                     return;
                                 }
 
@@ -221,18 +226,7 @@ public partial class ShellViewModel : ObservableObject,
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                if (viewModel is IDisposable disposable)
-                {
-                    try
-                    {
-                        disposable.Dispose();
-                    }
-                    catch (Exception ex)
-                    {
-                        CoreLogger.LogError(ex.ToString());
-                    }
-                }
-
+                viewModel.SafeCleanup();
                 return;
             }
 
@@ -304,7 +298,7 @@ public partial class ShellViewModel : ObservableObject,
                 }
 
                 _isNested = !isMainPage;
-                _currentlyTransient = message.TransientPage;
+                SetTransientState(message.TransientPage);
 
                 // Telemetry: Track extension page navigation for session metrics
                 if (host is not null)
@@ -326,6 +320,8 @@ public partial class ShellViewModel : ObservableObject,
 
                 pageViewModel.IsRootPage = isMainPage;
                 pageViewModel.HasBackButton = IsNested;
+                pageViewModel.IsTransientPage = message.TransientPage;
+                pageViewModel.UseCompactDockPresentation = message.UseCompactDockPresentation;
 
                 // Clear command bar, ViewModel initialization can already set new commands if it wants to
                 OnUIThread(() => WeakReferenceMessenger.Default.Send<UpdateCommandBarMessage>(new(null)));
@@ -546,7 +542,7 @@ public partial class ShellViewModel : ObservableObject,
     /// </summary>
     public void ResetToHome()
     {
-        _currentlyTransient = false;
+        SetTransientState(false);
         _rootPageService.GoHome();
         WeakReferenceMessenger.Default.Send<PerformCommandMessage>(new(new ExtensionObject<ICommand>(_rootPage)));
     }
@@ -566,12 +562,31 @@ public partial class ShellViewModel : ObservableObject,
         // If the window was hidden while we had a transient page, we need to reset that state.
         if (_currentlyTransient)
         {
-            _currentlyTransient = false;
+            SetTransientState(false);
 
             // navigate back to the main page without animation
             GoHome(withAnimation: false, focusSearch: false);
             WeakReferenceMessenger.Default.Send<PerformCommandMessage>(new(new ExtensionObject<ICommand>(_rootPage)));
         }
+    }
+
+    private void SetTransientState(bool value)
+    {
+        if (_currentlyTransient == value)
+        {
+            return;
+        }
+
+        _currentlyTransient = value;
+        OnPropertyChanged(nameof(IsNested));
+        OnPropertyChanged(nameof(IsTransient));
+        UpdateTransientChromeProperties();
+    }
+
+    private void UpdateTransientChromeProperties()
+    {
+        OnPropertyChanged(nameof(ShouldShowTopBar));
+        OnPropertyChanged(nameof(ShouldShowCommandBar));
     }
 
     private void OnUIThread(Action action)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/PerformanceOverviewControl.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/PerformanceOverviewControl.xaml
@@ -1,0 +1,323 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<UserControl
+    x:Class="Microsoft.CmdPal.UI.Controls.PerformanceOverviewControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Background="Transparent"
+    mc:Ignorable="d">
+
+    <UserControl.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.ThemeDictionaries>
+                <ResourceDictionary x:Key="Light">
+                    <SolidColorBrush x:Key="PerformanceAccentBrush" Color="#FF0063B1" />
+                    <SolidColorBrush x:Key="PerformanceAccentTextBrush" Color="#FF005A9E" />
+                    <SolidColorBrush x:Key="PerformanceAttentionBrush" Color="#FFD13438" />
+                    <SolidColorBrush x:Key="PerformanceAttentionTextBrush" Color="#FFB10E1E" />
+                    <SolidColorBrush x:Key="PerformanceGoodBrush" Color="#FF54A254" />
+                    <SolidColorBrush x:Key="PerformanceGoodTextBrush" Color="#FF0B6A0B" />
+                    <SolidColorBrush x:Key="PerformanceTrackBrush" Color="#73808080" />
+                    <SolidColorBrush x:Key="PerformanceWarningBrush" Color="#FFC3AB23" />
+                    <SolidColorBrush x:Key="PerformanceWarningTextBrush" Color="#FF6D5700" />
+                </ResourceDictionary>
+                <ResourceDictionary x:Key="Dark">
+                    <SolidColorBrush x:Key="PerformanceAccentBrush" Color="#FF0063B1" />
+                    <SolidColorBrush x:Key="PerformanceAccentTextBrush" Color="#FF75B9FF" />
+                    <SolidColorBrush x:Key="PerformanceAttentionBrush" Color="#FFD13438" />
+                    <SolidColorBrush x:Key="PerformanceAttentionTextBrush" Color="#FFFF6B6B" />
+                    <SolidColorBrush x:Key="PerformanceGoodBrush" Color="#FF54A254" />
+                    <SolidColorBrush x:Key="PerformanceGoodTextBrush" Color="#FF6CCB5F" />
+                    <SolidColorBrush x:Key="PerformanceTrackBrush" Color="#73808080" />
+                    <SolidColorBrush x:Key="PerformanceWarningBrush" Color="#FFC3AB23" />
+                    <SolidColorBrush x:Key="PerformanceWarningTextBrush" Color="#FFF4C430" />
+                </ResourceDictionary>
+                <ResourceDictionary x:Key="HighContrast">
+                    <StaticResource x:Key="PerformanceAccentBrush" ResourceKey="SystemColorHighlightBrush" />
+                    <StaticResource x:Key="PerformanceAccentTextBrush" ResourceKey="SystemColorWindowTextBrush" />
+                    <StaticResource x:Key="PerformanceAttentionBrush" ResourceKey="SystemColorHighlightBrush" />
+                    <StaticResource x:Key="PerformanceAttentionTextBrush" ResourceKey="SystemColorWindowTextBrush" />
+                    <StaticResource x:Key="PerformanceGoodBrush" ResourceKey="SystemColorHighlightBrush" />
+                    <StaticResource x:Key="PerformanceGoodTextBrush" ResourceKey="SystemColorWindowTextBrush" />
+                    <StaticResource x:Key="PerformanceTrackBrush" ResourceKey="SystemColorButtonFaceBrush" />
+                    <StaticResource x:Key="PerformanceWarningBrush" ResourceKey="SystemColorHighlightBrush" />
+                    <StaticResource x:Key="PerformanceWarningTextBrush" ResourceKey="SystemColorWindowTextBrush" />
+                </ResourceDictionary>
+            </ResourceDictionary.ThemeDictionaries>
+            <Style x:Key="PerformanceOverviewProgressBarStyle" TargetType="ProgressBar">
+                <Setter Property="Background" Value="Transparent" />
+                <Setter Property="BorderThickness" Value="0" />
+                <Setter Property="CornerRadius" Value="2" />
+                <Setter Property="HorizontalAlignment" Value="Stretch" />
+                <Setter Property="IsHitTestVisible" Value="False" />
+                <Setter Property="Maximum" Value="100" />
+                <Setter Property="MinHeight" Value="4" />
+                <Setter Property="Minimum" Value="0" />
+                <Setter Property="VerticalAlignment" Value="Stretch" />
+            </Style>
+        </ResourceDictionary>
+    </UserControl.Resources>
+
+    <Grid
+        AutomationProperties.AutomationId="PerformanceOverviewDashboard"
+        AutomationProperties.Name="{x:Bind ViewModel.TitleText, Mode=OneWay}">
+        <StackPanel Spacing="8">
+            <Grid ColumnSpacing="8">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+
+                <TextBlock
+                    AutomationProperties.AutomationId="PerformanceOverviewTitle"
+                    FontSize="12"
+                    FontWeight="SemiBold"
+                    Text="{x:Bind ViewModel.TitleText, Mode=OneWay}"
+                    TextTrimming="CharacterEllipsis" />
+                <TextBlock
+                    Grid.Column="1"
+                    AutomationProperties.AutomationId="PerformanceOverviewStatus"
+                    FontSize="12"
+                    Foreground="{ThemeResource PerformanceGoodTextBrush}"
+                    Text="{x:Bind ViewModel.StatusText, Mode=OneWay}" />
+            </Grid>
+
+            <Border
+                Padding="12,8"
+                Background="{ThemeResource ControlFillColorSecondaryBrush}"
+                CornerRadius="{ThemeResource ControlCornerRadius}">
+                <StackPanel Spacing="1">
+                    <TextBlock
+                        AutomationProperties.AutomationId="PerformanceOverviewHeroLabel"
+                        FontSize="12"
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        Text="{x:Bind ViewModel.HeroLabelText, Mode=OneWay}"
+                        TextTrimming="CharacterEllipsis" />
+                    <TextBlock
+                        AutomationProperties.AutomationId="PerformanceOverviewHeroValue"
+                        AutomationProperties.HelpText="{x:Bind ViewModel.HeroMetric, Mode=OneWay}"
+                        FontSize="20"
+                        FontWeight="SemiBold"
+                        Text="{x:Bind ViewModel.HeroValueText, Mode=OneWay}"
+                        TextTrimming="CharacterEllipsis" />
+                </StackPanel>
+            </Border>
+
+            <Grid RowSpacing="4">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="4" />
+                </Grid.RowDefinitions>
+                <Grid ColumnSpacing="8">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="64" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock
+                        AutomationProperties.AutomationId="PerformanceOverviewCpuLabel"
+                        FontSize="12"
+                        FontWeight="SemiBold"
+                        Foreground="{ThemeResource PerformanceAccentTextBrush}"
+                        Text="{x:Bind ViewModel.CpuLabelText, Mode=OneWay}"
+                        TextTrimming="CharacterEllipsis" />
+                    <TextBlock
+                        Grid.Column="1"
+                        AutomationProperties.AutomationId="PerformanceOverviewCpuDetail"
+                        FontSize="12"
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        HorizontalAlignment="Stretch"
+                        Text="{x:Bind ViewModel.CpuDetailText, Mode=OneWay}"
+                        TextAlignment="Right"
+                        TextTrimming="CharacterEllipsis" />
+                </Grid>
+                <Grid Grid.Row="1">
+                    <Border
+                        Height="1"
+                        Background="{ThemeResource PerformanceTrackBrush}"
+                        CornerRadius="0.5"
+                        VerticalAlignment="Center" />
+                    <ProgressBar
+                        AutomationProperties.AutomationId="PerformanceOverviewCpuBar"
+                        AutomationProperties.HelpText="{x:Bind ViewModel.CpuDetailText, Mode=OneWay}"
+                        AutomationProperties.Name="{x:Bind ViewModel.CpuLabelText, Mode=OneWay}"
+                        Foreground="{ThemeResource PerformanceAccentBrush}"
+                        Style="{StaticResource PerformanceOverviewProgressBarStyle}"
+                        Value="{x:Bind ViewModel.CpuPercent, Mode=OneWay}" />
+                </Grid>
+            </Grid>
+
+            <Grid RowSpacing="4">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="4" />
+                </Grid.RowDefinitions>
+                <Grid ColumnSpacing="8">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="64" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock
+                        AutomationProperties.AutomationId="PerformanceOverviewGpuLabel"
+                        FontSize="12"
+                        FontWeight="SemiBold"
+                        Foreground="{ThemeResource PerformanceAccentTextBrush}"
+                        Text="{x:Bind ViewModel.GpuLabelText, Mode=OneWay}"
+                        TextTrimming="CharacterEllipsis" />
+                    <TextBlock
+                        Grid.Column="1"
+                        AutomationProperties.AutomationId="PerformanceOverviewGpuDetail"
+                        FontSize="12"
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        HorizontalAlignment="Stretch"
+                        Text="{x:Bind ViewModel.GpuDetailText, Mode=OneWay}"
+                        TextAlignment="Right"
+                        TextTrimming="CharacterEllipsis" />
+                </Grid>
+                <Grid Grid.Row="1">
+                    <Border
+                        Height="1"
+                        Background="{ThemeResource PerformanceTrackBrush}"
+                        CornerRadius="0.5"
+                        VerticalAlignment="Center" />
+                    <ProgressBar
+                        AutomationProperties.AutomationId="PerformanceOverviewGpuBar"
+                        AutomationProperties.HelpText="{x:Bind ViewModel.GpuDetailText, Mode=OneWay}"
+                        AutomationProperties.Name="{x:Bind ViewModel.GpuLabelText, Mode=OneWay}"
+                        Foreground="{ThemeResource PerformanceAccentBrush}"
+                        Style="{StaticResource PerformanceOverviewProgressBarStyle}"
+                        Value="{x:Bind ViewModel.GpuPercent, Mode=OneWay}" />
+                </Grid>
+            </Grid>
+
+            <Grid RowSpacing="4">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="4" />
+                </Grid.RowDefinitions>
+                <Grid ColumnSpacing="8">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="64" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock
+                        AutomationProperties.AutomationId="PerformanceOverviewMemoryLabel"
+                        FontSize="12"
+                        FontWeight="SemiBold"
+                        Foreground="{ThemeResource PerformanceWarningTextBrush}"
+                        Text="{x:Bind ViewModel.MemoryLabelText, Mode=OneWay}"
+                        TextTrimming="CharacterEllipsis" />
+                    <TextBlock
+                        Grid.Column="1"
+                        AutomationProperties.AutomationId="PerformanceOverviewMemoryDetail"
+                        FontSize="12"
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        HorizontalAlignment="Stretch"
+                        Text="{x:Bind ViewModel.MemoryDetailText, Mode=OneWay}"
+                        TextAlignment="Right"
+                        TextTrimming="CharacterEllipsis" />
+                </Grid>
+                <Grid Grid.Row="1">
+                    <Border
+                        Height="1"
+                        Background="{ThemeResource PerformanceTrackBrush}"
+                        CornerRadius="0.5"
+                        VerticalAlignment="Center" />
+                    <ProgressBar
+                        AutomationProperties.AutomationId="PerformanceOverviewMemoryBar"
+                        AutomationProperties.HelpText="{x:Bind ViewModel.MemoryDetailText, Mode=OneWay}"
+                        AutomationProperties.Name="{x:Bind ViewModel.MemoryLabelText, Mode=OneWay}"
+                        Foreground="{ThemeResource PerformanceWarningBrush}"
+                        Style="{StaticResource PerformanceOverviewProgressBarStyle}"
+                        Value="{x:Bind ViewModel.MemoryPercent, Mode=OneWay}" />
+                </Grid>
+            </Grid>
+
+            <Grid RowSpacing="4">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="4" />
+                </Grid.RowDefinitions>
+                <Grid ColumnSpacing="8">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="64" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock
+                        AutomationProperties.AutomationId="PerformanceOverviewDiskLabel"
+                        FontSize="12"
+                        FontWeight="SemiBold"
+                        Foreground="{ThemeResource PerformanceGoodTextBrush}"
+                        Text="{x:Bind ViewModel.DiskLabelText, Mode=OneWay}"
+                        TextTrimming="CharacterEllipsis" />
+                    <TextBlock
+                        Grid.Column="1"
+                        AutomationProperties.AutomationId="PerformanceOverviewDiskDetail"
+                        FontSize="12"
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        HorizontalAlignment="Stretch"
+                        Text="{x:Bind ViewModel.DiskDetailText, Mode=OneWay}"
+                        TextAlignment="Right"
+                        TextTrimming="CharacterEllipsis" />
+                </Grid>
+                <Grid Grid.Row="1">
+                    <Border
+                        Height="1"
+                        Background="{ThemeResource PerformanceTrackBrush}"
+                        CornerRadius="0.5"
+                        VerticalAlignment="Center" />
+                    <ProgressBar
+                        AutomationProperties.AutomationId="PerformanceOverviewDiskBar"
+                        AutomationProperties.HelpText="{x:Bind ViewModel.DiskDetailText, Mode=OneWay}"
+                        AutomationProperties.Name="{x:Bind ViewModel.DiskLabelText, Mode=OneWay}"
+                        Foreground="{ThemeResource PerformanceGoodBrush}"
+                        Style="{StaticResource PerformanceOverviewProgressBarStyle}"
+                        Value="{x:Bind ViewModel.DiskPercent, Mode=OneWay}" />
+                </Grid>
+            </Grid>
+
+            <Grid RowSpacing="4">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="4" />
+                </Grid.RowDefinitions>
+                <Grid ColumnSpacing="8">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="64" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock
+                        AutomationProperties.AutomationId="PerformanceOverviewNetworkLabel"
+                        FontSize="12"
+                        FontWeight="SemiBold"
+                        Foreground="{ThemeResource PerformanceAttentionTextBrush}"
+                        Text="{x:Bind ViewModel.NetworkLabelText, Mode=OneWay}"
+                        TextTrimming="CharacterEllipsis" />
+                    <TextBlock
+                        Grid.Column="1"
+                        AutomationProperties.AutomationId="PerformanceOverviewNetworkDetail"
+                        FontSize="12"
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        HorizontalAlignment="Stretch"
+                        Text="{x:Bind ViewModel.NetworkDetailText, Mode=OneWay}"
+                        TextAlignment="Right"
+                        TextTrimming="CharacterEllipsis" />
+                </Grid>
+                <Grid Grid.Row="1">
+                    <Border
+                        Height="1"
+                        Background="{ThemeResource PerformanceTrackBrush}"
+                        CornerRadius="0.5"
+                        VerticalAlignment="Center" />
+                    <ProgressBar
+                        AutomationProperties.AutomationId="PerformanceOverviewNetworkBar"
+                        AutomationProperties.HelpText="{x:Bind ViewModel.NetworkDetailText, Mode=OneWay}"
+                        AutomationProperties.Name="{x:Bind ViewModel.NetworkLabelText, Mode=OneWay}"
+                        Foreground="{ThemeResource PerformanceAttentionBrush}"
+                        Style="{StaticResource PerformanceOverviewProgressBarStyle}"
+                        Value="{x:Bind ViewModel.NetworkPercent, Mode=OneWay}" />
+                </Grid>
+            </Grid>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/PerformanceOverviewControl.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/PerformanceOverviewControl.xaml
@@ -56,6 +56,18 @@
                 <Setter Property="Minimum" Value="0" />
                 <Setter Property="VerticalAlignment" Value="Stretch" />
             </Style>
+            <Style
+                x:Key="PerformanceOverviewAdapterButtonStyle"
+                BasedOn="{StaticResource SubtleButtonStyle}"
+                TargetType="Button">
+                <Setter Property="CornerRadius" Value="3" />
+                <Setter Property="Height" Value="24" />
+                <Setter Property="MinHeight" Value="0" />
+                <Setter Property="MinWidth" Value="0" />
+                <Setter Property="Padding" Value="0" />
+                <Setter Property="VerticalAlignment" Value="Center" />
+                <Setter Property="Width" Value="24" />
+            </Style>
         </ResourceDictionary>
     </UserControl.Resources>
 
@@ -156,6 +168,9 @@
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="64" />
                         <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
                     <TextBlock
                         AutomationProperties.AutomationId="PerformanceOverviewGpuLabel"
@@ -166,6 +181,14 @@
                         TextTrimming="CharacterEllipsis" />
                     <TextBlock
                         Grid.Column="1"
+                        AutomationProperties.AutomationId="PerformanceOverviewGpuAdapter"
+                        FontSize="11"
+                        Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                        Text="{x:Bind ViewModel.GpuAdapterName, Mode=OneWay}"
+                        TextTrimming="CharacterEllipsis"
+                        ToolTipService.ToolTip="{x:Bind ViewModel.GpuAdapterName, Mode=OneWay}" />
+                    <TextBlock
+                        Grid.Column="2"
                         AutomationProperties.AutomationId="PerformanceOverviewGpuDetail"
                         FontSize="12"
                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
@@ -173,6 +196,26 @@
                         Text="{x:Bind ViewModel.GpuDetailText, Mode=OneWay}"
                         TextAlignment="Right"
                         TextTrimming="CharacterEllipsis" />
+                    <Button
+                        Grid.Column="3"
+                        AutomationProperties.AutomationId="PerformanceOverviewPreviousGpu"
+                        AutomationProperties.Name="{x:Bind ViewModel.PreviousGpuCommandText, Mode=OneWay}"
+                        Command="{x:Bind ViewModel.PreviousGpuCommand}"
+                        Style="{StaticResource PerformanceOverviewAdapterButtonStyle}"
+                        ToolTipService.ToolTip="{x:Bind ViewModel.PreviousGpuCommandText, Mode=OneWay}"
+                        Visibility="{x:Bind ViewModel.CanSwitchGpu, Mode=OneWay}">
+                        <FontIcon FontSize="10" Glyph="&#xE76B;" />
+                    </Button>
+                    <Button
+                        Grid.Column="4"
+                        AutomationProperties.AutomationId="PerformanceOverviewNextGpu"
+                        AutomationProperties.Name="{x:Bind ViewModel.NextGpuCommandText, Mode=OneWay}"
+                        Command="{x:Bind ViewModel.NextGpuCommand}"
+                        Style="{StaticResource PerformanceOverviewAdapterButtonStyle}"
+                        ToolTipService.ToolTip="{x:Bind ViewModel.NextGpuCommandText, Mode=OneWay}"
+                        Visibility="{x:Bind ViewModel.CanSwitchGpu, Mode=OneWay}">
+                        <FontIcon FontSize="10" Glyph="&#xE76C;" />
+                    </Button>
                 </Grid>
                 <Grid Grid.Row="1">
                     <Border
@@ -285,23 +328,64 @@
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="64" />
                         <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
                     <TextBlock
+                        Grid.RowSpan="2"
                         AutomationProperties.AutomationId="PerformanceOverviewNetworkLabel"
                         FontSize="12"
                         FontWeight="SemiBold"
                         Foreground="{ThemeResource PerformanceAttentionTextBrush}"
                         Text="{x:Bind ViewModel.NetworkLabelText, Mode=OneWay}"
-                        TextTrimming="CharacterEllipsis" />
+                        TextTrimming="CharacterEllipsis"
+                        VerticalAlignment="Center" />
                     <TextBlock
                         Grid.Column="1"
+                        Grid.ColumnSpan="3"
                         AutomationProperties.AutomationId="PerformanceOverviewNetworkDetail"
                         FontSize="12"
                         Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                        HorizontalAlignment="Stretch"
                         Text="{x:Bind ViewModel.NetworkDetailText, Mode=OneWay}"
                         TextAlignment="Right"
                         TextTrimming="CharacterEllipsis" />
+                    <TextBlock
+                        Grid.Row="1"
+                        Grid.Column="1"
+                        AutomationProperties.AutomationId="PerformanceOverviewNetworkAdapter"
+                        FontSize="11"
+                        Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                        Text="{x:Bind ViewModel.NetworkAdapterName, Mode=OneWay}"
+                        TextAlignment="Right"
+                        TextTrimming="CharacterEllipsis"
+                        ToolTipService.ToolTip="{x:Bind ViewModel.NetworkAdapterName, Mode=OneWay}"
+                        VerticalAlignment="Center" />
+                    <Button
+                        Grid.Row="1"
+                        Grid.Column="2"
+                        AutomationProperties.AutomationId="PerformanceOverviewPreviousNetwork"
+                        AutomationProperties.Name="{x:Bind ViewModel.PreviousNetworkCommandText, Mode=OneWay}"
+                        Command="{x:Bind ViewModel.PreviousNetworkCommand}"
+                        Style="{StaticResource PerformanceOverviewAdapterButtonStyle}"
+                        ToolTipService.ToolTip="{x:Bind ViewModel.PreviousNetworkCommandText, Mode=OneWay}"
+                        Visibility="{x:Bind ViewModel.CanSwitchNetwork, Mode=OneWay}">
+                        <FontIcon FontSize="10" Glyph="&#xE76B;" />
+                    </Button>
+                    <Button
+                        Grid.Row="1"
+                        Grid.Column="3"
+                        AutomationProperties.AutomationId="PerformanceOverviewNextNetwork"
+                        AutomationProperties.Name="{x:Bind ViewModel.NextNetworkCommandText, Mode=OneWay}"
+                        Command="{x:Bind ViewModel.NextNetworkCommand}"
+                        Style="{StaticResource PerformanceOverviewAdapterButtonStyle}"
+                        ToolTipService.ToolTip="{x:Bind ViewModel.NextNetworkCommandText, Mode=OneWay}"
+                        Visibility="{x:Bind ViewModel.CanSwitchNetwork, Mode=OneWay}">
+                        <FontIcon FontSize="10" Glyph="&#xE76C;" />
+                    </Button>
                 </Grid>
                 <Grid Grid.Row="1">
                     <Border

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/PerformanceOverviewControl.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/PerformanceOverviewControl.xaml
@@ -276,48 +276,49 @@
                 </Grid>
             </Grid>
 
-            <Grid RowSpacing="4">
+            <Grid
+                ColumnSpacing="8"
+                RowSpacing="4">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="64" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="4" />
                 </Grid.RowDefinitions>
-                <Grid ColumnSpacing="8">
+                <TextBlock
+                    AutomationProperties.AutomationId="PerformanceOverviewDiskLabel"
+                    FontSize="12"
+                    FontWeight="SemiBold"
+                    Foreground="{ThemeResource PerformanceGoodTextBrush}"
+                    Text="{x:Bind ViewModel.DiskLabelText, Mode=OneWay}"
+                    TextTrimming="CharacterEllipsis" />
+                <Grid
+                    Grid.Column="1"
+                    ColumnSpacing="8">
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="64" />
+                        <ColumnDefinition Width="*" />
                         <ColumnDefinition Width="*" />
                     </Grid.ColumnDefinitions>
                     <TextBlock
-                        AutomationProperties.AutomationId="PerformanceOverviewDiskLabel"
+                        AutomationProperties.AutomationId="PerformanceOverviewDiskReadText"
                         FontSize="12"
-                        FontWeight="SemiBold"
-                        Foreground="{ThemeResource PerformanceGoodTextBrush}"
-                        Text="{x:Bind ViewModel.DiskLabelText, Mode=OneWay}"
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        Text="{x:Bind ViewModel.DiskReadText, Mode=OneWay}"
                         TextTrimming="CharacterEllipsis" />
-                    <Grid
+                    <TextBlock
                         Grid.Column="1"
-                        ColumnSpacing="8">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="*" />
-                        </Grid.ColumnDefinitions>
-                        <TextBlock
-                            AutomationProperties.AutomationId="PerformanceOverviewDiskReadText"
-                            FontSize="12"
-                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                            Text="{x:Bind ViewModel.DiskReadText, Mode=OneWay}"
-                            TextTrimming="CharacterEllipsis" />
-                        <TextBlock
-                            Grid.Column="1"
-                            AutomationProperties.AutomationId="PerformanceOverviewDiskWriteText"
-                            FontSize="12"
-                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                            Text="{x:Bind ViewModel.DiskWriteText, Mode=OneWay}"
-                            TextAlignment="Right"
-                            TextTrimming="CharacterEllipsis" />
-                    </Grid>
+                        AutomationProperties.AutomationId="PerformanceOverviewDiskWriteText"
+                        FontSize="12"
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        Text="{x:Bind ViewModel.DiskWriteText, Mode=OneWay}"
+                        TextAlignment="Right"
+                        TextTrimming="CharacterEllipsis" />
                 </Grid>
                 <Grid
                     Grid.Row="1"
+                    Grid.Column="1"
                     ColumnSpacing="8">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*" />
@@ -354,90 +355,92 @@
                 </Grid>
             </Grid>
 
-            <Grid RowSpacing="4">
+            <Grid
+                ColumnSpacing="8"
+                RowSpacing="4">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="64" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="4" />
                 </Grid.RowDefinitions>
-                <Grid ColumnSpacing="8">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="64" />
-                        <ColumnDefinition Width="*" />
-                        <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="Auto" />
-                    </Grid.ColumnDefinitions>
+                <TextBlock
+                    AutomationProperties.AutomationId="PerformanceOverviewNetworkLabel"
+                    FontSize="12"
+                    FontWeight="SemiBold"
+                    Foreground="{ThemeResource PerformanceAttentionTextBrush}"
+                    Text="{x:Bind ViewModel.NetworkLabelText, Mode=OneWay}"
+                    TextTrimming="CharacterEllipsis"
+                    VerticalAlignment="Center" />
+                <Grid Grid.Column="1">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
-                    <TextBlock
-                        Grid.RowSpan="2"
-                        AutomationProperties.AutomationId="PerformanceOverviewNetworkLabel"
-                        FontSize="12"
-                        FontWeight="SemiBold"
-                        Foreground="{ThemeResource PerformanceAttentionTextBrush}"
-                        Text="{x:Bind ViewModel.NetworkLabelText, Mode=OneWay}"
-                        TextTrimming="CharacterEllipsis"
-                        VerticalAlignment="Center" />
-                    <Grid
-                        Grid.Column="1"
-                        Grid.ColumnSpan="3"
-                        ColumnSpacing="8">
+                    <Grid ColumnSpacing="8">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
                         <TextBlock
-                            AutomationProperties.AutomationId="PerformanceOverviewNetworkInText"
+                            AutomationProperties.AutomationId="PerformanceOverviewNetworkSendText"
                             FontSize="12"
                             Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                            Text="{x:Bind ViewModel.NetworkInText, Mode=OneWay}"
+                            Text="{x:Bind ViewModel.NetworkSendText, Mode=OneWay}"
                             TextTrimming="CharacterEllipsis" />
                         <TextBlock
                             Grid.Column="1"
-                            AutomationProperties.AutomationId="PerformanceOverviewNetworkOutText"
+                            AutomationProperties.AutomationId="PerformanceOverviewNetworkReceiveText"
                             FontSize="12"
                             Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                            Text="{x:Bind ViewModel.NetworkOutText, Mode=OneWay}"
+                            Text="{x:Bind ViewModel.NetworkReceiveText, Mode=OneWay}"
                             TextAlignment="Right"
                             TextTrimming="CharacterEllipsis" />
                     </Grid>
-                    <TextBlock
+                    <Grid
                         Grid.Row="1"
-                        Grid.Column="1"
-                        AutomationProperties.AutomationId="PerformanceOverviewNetworkAdapter"
-                        FontSize="11"
-                        Foreground="{ThemeResource TextFillColorTertiaryBrush}"
-                        Text="{x:Bind ViewModel.NetworkAdapterName, Mode=OneWay}"
-                        TextAlignment="Right"
-                        TextTrimming="CharacterEllipsis"
-                        ToolTipService.ToolTip="{x:Bind ViewModel.NetworkAdapterName, Mode=OneWay}"
-                        VerticalAlignment="Center" />
-                    <Button
-                        Grid.Row="1"
-                        Grid.Column="2"
-                        AutomationProperties.AutomationId="PerformanceOverviewPreviousNetwork"
-                        AutomationProperties.Name="{x:Bind ViewModel.PreviousNetworkCommandText, Mode=OneWay}"
-                        Command="{x:Bind ViewModel.PreviousNetworkCommand}"
-                        Style="{StaticResource PerformanceOverviewAdapterButtonStyle}"
-                        ToolTipService.ToolTip="{x:Bind ViewModel.PreviousNetworkCommandText, Mode=OneWay}"
-                        Visibility="{x:Bind ViewModel.CanSwitchNetwork, Mode=OneWay}">
-                        <FontIcon FontSize="10" Glyph="&#xE76B;" />
-                    </Button>
-                    <Button
-                        Grid.Row="1"
-                        Grid.Column="3"
-                        AutomationProperties.AutomationId="PerformanceOverviewNextNetwork"
-                        AutomationProperties.Name="{x:Bind ViewModel.NextNetworkCommandText, Mode=OneWay}"
-                        Command="{x:Bind ViewModel.NextNetworkCommand}"
-                        Style="{StaticResource PerformanceOverviewAdapterButtonStyle}"
-                        ToolTipService.ToolTip="{x:Bind ViewModel.NextNetworkCommandText, Mode=OneWay}"
-                        Visibility="{x:Bind ViewModel.CanSwitchNetwork, Mode=OneWay}">
-                        <FontIcon FontSize="10" Glyph="&#xE76C;" />
-                    </Button>
+                        ColumnSpacing="8">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock
+                            AutomationProperties.AutomationId="PerformanceOverviewNetworkAdapter"
+                            FontSize="11"
+                            Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                            Text="{x:Bind ViewModel.NetworkAdapterName, Mode=OneWay}"
+                            TextAlignment="Right"
+                            TextTrimming="CharacterEllipsis"
+                            ToolTipService.ToolTip="{x:Bind ViewModel.NetworkAdapterName, Mode=OneWay}"
+                            VerticalAlignment="Center" />
+                        <Button
+                            Grid.Column="1"
+                            AutomationProperties.AutomationId="PerformanceOverviewPreviousNetwork"
+                            AutomationProperties.Name="{x:Bind ViewModel.PreviousNetworkCommandText, Mode=OneWay}"
+                            Command="{x:Bind ViewModel.PreviousNetworkCommand}"
+                            Style="{StaticResource PerformanceOverviewAdapterButtonStyle}"
+                            ToolTipService.ToolTip="{x:Bind ViewModel.PreviousNetworkCommandText, Mode=OneWay}"
+                            Visibility="{x:Bind ViewModel.CanSwitchNetwork, Mode=OneWay}">
+                            <FontIcon FontSize="10" Glyph="&#xE76B;" />
+                        </Button>
+                        <Button
+                            Grid.Column="2"
+                            AutomationProperties.AutomationId="PerformanceOverviewNextNetwork"
+                            AutomationProperties.Name="{x:Bind ViewModel.NextNetworkCommandText, Mode=OneWay}"
+                            Command="{x:Bind ViewModel.NextNetworkCommand}"
+                            Style="{StaticResource PerformanceOverviewAdapterButtonStyle}"
+                            ToolTipService.ToolTip="{x:Bind ViewModel.NextNetworkCommandText, Mode=OneWay}"
+                            Visibility="{x:Bind ViewModel.CanSwitchNetwork, Mode=OneWay}">
+                            <FontIcon FontSize="10" Glyph="&#xE76C;" />
+                        </Button>
+                    </Grid>
                 </Grid>
                 <Grid
                     Grid.Row="1"
+                    Grid.Column="1"
                     ColumnSpacing="8">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*" />
@@ -450,12 +453,12 @@
                             CornerRadius="0.5"
                             VerticalAlignment="Center" />
                         <ProgressBar
-                            AutomationProperties.AutomationId="PerformanceOverviewNetworkInBar"
-                            AutomationProperties.HelpText="{x:Bind ViewModel.NetworkInText, Mode=OneWay}"
-                            AutomationProperties.Name="{x:Bind ViewModel.NetworkInLabelText, Mode=OneWay}"
+                            AutomationProperties.AutomationId="PerformanceOverviewNetworkSendBar"
+                            AutomationProperties.HelpText="{x:Bind ViewModel.NetworkSendText, Mode=OneWay}"
+                            AutomationProperties.Name="{x:Bind ViewModel.NetworkSendLabelText, Mode=OneWay}"
                             Foreground="{ThemeResource PerformanceAttentionBrush}"
                             Style="{StaticResource PerformanceOverviewProgressBarStyle}"
-                            Value="{x:Bind ViewModel.NetworkInPercent, Mode=OneWay}" />
+                            Value="{x:Bind ViewModel.NetworkSendPercent, Mode=OneWay}" />
                     </Grid>
                     <Grid Grid.Column="1">
                         <Border
@@ -464,12 +467,12 @@
                             CornerRadius="0.5"
                             VerticalAlignment="Center" />
                         <ProgressBar
-                            AutomationProperties.AutomationId="PerformanceOverviewNetworkOutBar"
-                            AutomationProperties.HelpText="{x:Bind ViewModel.NetworkOutText, Mode=OneWay}"
-                            AutomationProperties.Name="{x:Bind ViewModel.NetworkOutLabelText, Mode=OneWay}"
+                            AutomationProperties.AutomationId="PerformanceOverviewNetworkReceiveBar"
+                            AutomationProperties.HelpText="{x:Bind ViewModel.NetworkReceiveText, Mode=OneWay}"
+                            AutomationProperties.Name="{x:Bind ViewModel.NetworkReceiveLabelText, Mode=OneWay}"
                             Foreground="{ThemeResource PerformanceAttentionBrush}"
                             Style="{StaticResource PerformanceOverviewProgressBarStyle}"
-                            Value="{x:Bind ViewModel.NetworkOutPercent, Mode=OneWay}" />
+                            Value="{x:Bind ViewModel.NetworkReceivePercent, Mode=OneWay}" />
                     </Grid>
                 </Grid>
             </Grid>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/PerformanceOverviewControl.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/PerformanceOverviewControl.xaml
@@ -293,29 +293,64 @@
                         Foreground="{ThemeResource PerformanceGoodTextBrush}"
                         Text="{x:Bind ViewModel.DiskLabelText, Mode=OneWay}"
                         TextTrimming="CharacterEllipsis" />
-                    <TextBlock
+                    <Grid
                         Grid.Column="1"
-                        AutomationProperties.AutomationId="PerformanceOverviewDiskDetail"
-                        FontSize="12"
-                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                        HorizontalAlignment="Stretch"
-                        Text="{x:Bind ViewModel.DiskDetailText, Mode=OneWay}"
-                        TextAlignment="Right"
-                        TextTrimming="CharacterEllipsis" />
+                        ColumnSpacing="8">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock
+                            AutomationProperties.AutomationId="PerformanceOverviewDiskReadText"
+                            FontSize="12"
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            Text="{x:Bind ViewModel.DiskReadText, Mode=OneWay}"
+                            TextTrimming="CharacterEllipsis" />
+                        <TextBlock
+                            Grid.Column="1"
+                            AutomationProperties.AutomationId="PerformanceOverviewDiskWriteText"
+                            FontSize="12"
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            Text="{x:Bind ViewModel.DiskWriteText, Mode=OneWay}"
+                            TextAlignment="Right"
+                            TextTrimming="CharacterEllipsis" />
+                    </Grid>
                 </Grid>
-                <Grid Grid.Row="1">
-                    <Border
-                        Height="1"
-                        Background="{ThemeResource PerformanceTrackBrush}"
-                        CornerRadius="0.5"
-                        VerticalAlignment="Center" />
-                    <ProgressBar
-                        AutomationProperties.AutomationId="PerformanceOverviewDiskBar"
-                        AutomationProperties.HelpText="{x:Bind ViewModel.DiskDetailText, Mode=OneWay}"
-                        AutomationProperties.Name="{x:Bind ViewModel.DiskLabelText, Mode=OneWay}"
-                        Foreground="{ThemeResource PerformanceGoodBrush}"
-                        Style="{StaticResource PerformanceOverviewProgressBarStyle}"
-                        Value="{x:Bind ViewModel.DiskPercent, Mode=OneWay}" />
+                <Grid
+                    Grid.Row="1"
+                    ColumnSpacing="8">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Grid>
+                        <Border
+                            Height="1"
+                            Background="{ThemeResource PerformanceTrackBrush}"
+                            CornerRadius="0.5"
+                            VerticalAlignment="Center" />
+                        <ProgressBar
+                            AutomationProperties.AutomationId="PerformanceOverviewDiskReadBar"
+                            AutomationProperties.HelpText="{x:Bind ViewModel.DiskReadText, Mode=OneWay}"
+                            AutomationProperties.Name="{x:Bind ViewModel.DiskReadLabelText, Mode=OneWay}"
+                            Foreground="{ThemeResource PerformanceGoodBrush}"
+                            Style="{StaticResource PerformanceOverviewProgressBarStyle}"
+                            Value="{x:Bind ViewModel.DiskReadPercent, Mode=OneWay}" />
+                    </Grid>
+                    <Grid Grid.Column="1">
+                        <Border
+                            Height="1"
+                            Background="{ThemeResource PerformanceTrackBrush}"
+                            CornerRadius="0.5"
+                            VerticalAlignment="Center" />
+                        <ProgressBar
+                            AutomationProperties.AutomationId="PerformanceOverviewDiskWriteBar"
+                            AutomationProperties.HelpText="{x:Bind ViewModel.DiskWriteText, Mode=OneWay}"
+                            AutomationProperties.Name="{x:Bind ViewModel.DiskWriteLabelText, Mode=OneWay}"
+                            Foreground="{ThemeResource PerformanceGoodBrush}"
+                            Style="{StaticResource PerformanceOverviewProgressBarStyle}"
+                            Value="{x:Bind ViewModel.DiskWritePercent, Mode=OneWay}" />
+                    </Grid>
                 </Grid>
             </Grid>
 
@@ -344,15 +379,29 @@
                         Text="{x:Bind ViewModel.NetworkLabelText, Mode=OneWay}"
                         TextTrimming="CharacterEllipsis"
                         VerticalAlignment="Center" />
-                    <TextBlock
+                    <Grid
                         Grid.Column="1"
                         Grid.ColumnSpan="3"
-                        AutomationProperties.AutomationId="PerformanceOverviewNetworkDetail"
-                        FontSize="12"
-                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                        Text="{x:Bind ViewModel.NetworkDetailText, Mode=OneWay}"
-                        TextAlignment="Right"
-                        TextTrimming="CharacterEllipsis" />
+                        ColumnSpacing="8">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock
+                            AutomationProperties.AutomationId="PerformanceOverviewNetworkInText"
+                            FontSize="12"
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            Text="{x:Bind ViewModel.NetworkInText, Mode=OneWay}"
+                            TextTrimming="CharacterEllipsis" />
+                        <TextBlock
+                            Grid.Column="1"
+                            AutomationProperties.AutomationId="PerformanceOverviewNetworkOutText"
+                            FontSize="12"
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            Text="{x:Bind ViewModel.NetworkOutText, Mode=OneWay}"
+                            TextAlignment="Right"
+                            TextTrimming="CharacterEllipsis" />
+                    </Grid>
                     <TextBlock
                         Grid.Row="1"
                         Grid.Column="1"
@@ -387,19 +436,41 @@
                         <FontIcon FontSize="10" Glyph="&#xE76C;" />
                     </Button>
                 </Grid>
-                <Grid Grid.Row="1">
-                    <Border
-                        Height="1"
-                        Background="{ThemeResource PerformanceTrackBrush}"
-                        CornerRadius="0.5"
-                        VerticalAlignment="Center" />
-                    <ProgressBar
-                        AutomationProperties.AutomationId="PerformanceOverviewNetworkBar"
-                        AutomationProperties.HelpText="{x:Bind ViewModel.NetworkDetailText, Mode=OneWay}"
-                        AutomationProperties.Name="{x:Bind ViewModel.NetworkLabelText, Mode=OneWay}"
-                        Foreground="{ThemeResource PerformanceAttentionBrush}"
-                        Style="{StaticResource PerformanceOverviewProgressBarStyle}"
-                        Value="{x:Bind ViewModel.NetworkPercent, Mode=OneWay}" />
+                <Grid
+                    Grid.Row="1"
+                    ColumnSpacing="8">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Grid>
+                        <Border
+                            Height="1"
+                            Background="{ThemeResource PerformanceTrackBrush}"
+                            CornerRadius="0.5"
+                            VerticalAlignment="Center" />
+                        <ProgressBar
+                            AutomationProperties.AutomationId="PerformanceOverviewNetworkInBar"
+                            AutomationProperties.HelpText="{x:Bind ViewModel.NetworkInText, Mode=OneWay}"
+                            AutomationProperties.Name="{x:Bind ViewModel.NetworkInLabelText, Mode=OneWay}"
+                            Foreground="{ThemeResource PerformanceAttentionBrush}"
+                            Style="{StaticResource PerformanceOverviewProgressBarStyle}"
+                            Value="{x:Bind ViewModel.NetworkInPercent, Mode=OneWay}" />
+                    </Grid>
+                    <Grid Grid.Column="1">
+                        <Border
+                            Height="1"
+                            Background="{ThemeResource PerformanceTrackBrush}"
+                            CornerRadius="0.5"
+                            VerticalAlignment="Center" />
+                        <ProgressBar
+                            AutomationProperties.AutomationId="PerformanceOverviewNetworkOutBar"
+                            AutomationProperties.HelpText="{x:Bind ViewModel.NetworkOutText, Mode=OneWay}"
+                            AutomationProperties.Name="{x:Bind ViewModel.NetworkOutLabelText, Mode=OneWay}"
+                            Foreground="{ThemeResource PerformanceAttentionBrush}"
+                            Style="{StaticResource PerformanceOverviewProgressBarStyle}"
+                            Value="{x:Bind ViewModel.NetworkOutPercent, Mode=OneWay}" />
+                    </Grid>
                 </Grid>
             </Grid>
         </StackPanel>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/PerformanceOverviewControl.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/PerformanceOverviewControl.xaml.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CmdPal.UI.ViewModels;
+using Microsoft.UI.Xaml.Controls;
+
+namespace Microsoft.CmdPal.UI.Controls;
+
+public sealed partial class PerformanceOverviewControl : UserControl
+{
+    private ContentPerformanceOverviewViewModel _viewModel = null!;
+
+    public ContentPerformanceOverviewViewModel ViewModel
+    {
+        get => _viewModel;
+        set
+        {
+            if (ReferenceEquals(_viewModel, value))
+            {
+                return;
+            }
+
+            _viewModel = value;
+            Bindings.Update();
+        }
+    }
+
+    public PerformanceOverviewControl()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Converters/ContentTemplateSelector.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Converters/ContentTemplateSelector.cs
@@ -14,6 +14,8 @@ public partial class ContentTemplateSelector : DataTemplateSelector
     // These will be "filled-in" in the XAML code.
     public DataTemplate? FormTemplate { get; set; }
 
+    public DataTemplate? PerformanceOverviewTemplate { get; set; }
+
     public DataTemplate? MarkdownTemplate { get; set; }
 
     public DataTemplate? TreeTemplate { get; set; }
@@ -27,6 +29,7 @@ public partial class ContentTemplateSelector : DataTemplateSelector
         return item is ContentViewModel element
             ? element switch
             {
+                ContentPerformanceOverviewViewModel => PerformanceOverviewTemplate,
                 ContentFormViewModel => FormTemplate,
                 ContentMarkdownViewModel => MarkdownTemplate,
                 ContentTreeViewModel => TreeTemplate,

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockControl.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockControl.xaml
@@ -37,6 +37,7 @@
                         <DataTemplate x:DataType="dockVm:DockItemViewModel">
                             <local:DockItemControl
                                 Title="{x:Bind Title, Mode=OneWay}"
+                                TitleMinWidth="{x:Bind TitleMinWidth, Mode=OneWay}"
                                 RightTapped="BandItem_RightTapped"
                                 Subtitle="{x:Bind Subtitle, Mode=OneWay}"
                                 Tag="{x:Bind}"

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockControl.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockControl.xaml.cs
@@ -29,6 +29,13 @@ namespace Microsoft.CmdPal.UI.Dock;
 
 public sealed partial class DockControl : UserControl, IRecipient<CloseContextMenuMessage>, IRecipient<EnterDockEditModeMessage>, IRecipient<ExitDockEditModeMessage>, IRecipient<CrossMonitorBandDropMessage>
 {
+    private const string PerformanceMonitorProviderId = "PerformanceMonitor";
+    private const string CpuOverviewPageId = "com.microsoft.cmdpal.performanceWidget.cpu.dockOverview";
+    private const string MemoryOverviewPageId = "com.microsoft.cmdpal.performanceWidget.memory.dockOverview";
+    private const string NetworkOverviewPageId = "com.microsoft.cmdpal.performanceWidget.network.dockOverview";
+    private const string DiskOverviewPageId = "com.microsoft.cmdpal.performanceWidget.disk.dockOverview";
+    private const string GpuOverviewPageId = "com.microsoft.cmdpal.performanceWidget.gpu.dockOverview";
+
     private DockViewModel _viewModel;
 
     internal DockViewModel ViewModel => _viewModel;
@@ -313,7 +320,7 @@ public sealed partial class DockControl : UserControl, IRecipient<CloseContextMe
             // Use the center of the border as the point to open at
             var borderCenter = GetDockItemCenter(dockItem);
 
-            InvokeItem(item, borderCenter);
+            InvokeItem(item, band.ProviderId, borderCenter);
             e.Handled = true;
         }
     }
@@ -415,28 +422,30 @@ public sealed partial class DockControl : UserControl, IRecipient<CloseContextMe
         }
     }
 
-    private void InvokeItem(DockItemViewModel item, Point pos)
+    private void InvokeItem(DockItemViewModel item, string providerId, Point pos)
     {
         var command = item.Command;
         var hwnd = OwnerHwnd;
+        var useCompactSize = UsesCompactDockPresentation(providerId, command.Id);
         try
         {
             PerformCommandMessage m = new(command.Model)
             {
                 WithAnimation = false,
                 TransientPage = true,
+                UseCompactDockPresentation = useCompactSize,
 
                 // If the command is invokable and its result asks for a
                 // confirmation dialog, surface the cmdpal window anchored at
                 // this dock item before the dialog appears.
                 OnBeforeShowConfirmation = () =>
-                    WeakReferenceMessenger.Default.Send<RequestShowPaletteAtMessage>(new(pos, hwnd)),
+                    WeakReferenceMessenger.Default.Send<RequestShowPaletteAtMessage>(new(pos, hwnd, useCompactSize)),
             };
             WeakReferenceMessenger.Default.Send(m);
 
             if (IsPageCommand(command.Model.Unsafe))
             {
-                WeakReferenceMessenger.Default.Send<RequestShowPaletteAtMessage>(new(pos, hwnd));
+                WeakReferenceMessenger.Default.Send<RequestShowPaletteAtMessage>(new(pos, hwnd, useCompactSize));
             }
         }
         catch (COMException e)
@@ -451,6 +460,14 @@ public sealed partial class DockControl : UserControl, IRecipient<CloseContextMe
         // navigates into a page rather than performing an action in place.
         return command is not null and not IInvokableCommand;
     }
+
+    private static bool UsesCompactDockPresentation(string? providerId, string commandId) =>
+        string.Equals(providerId, PerformanceMonitorProviderId, StringComparison.Ordinal)
+        && commandId is CpuOverviewPageId
+            or MemoryOverviewPageId
+            or NetworkOverviewPageId
+            or DiskOverviewPageId
+            or GpuOverviewPageId;
 
     private static Point GetDockItemCenter(FrameworkElement dockItem)
     {
@@ -474,9 +491,16 @@ public sealed partial class DockControl : UserControl, IRecipient<CloseContextMe
             return;
         }
 
-        if (IsPageCommand(command.Command.Model.Unsafe))
+        try
         {
-            WeakReferenceMessenger.Default.Send<RequestShowPaletteAtMessage>(new(pos.Value, OwnerHwnd));
+            if (IsPageCommand(command.Command.Model.Unsafe))
+            {
+                WeakReferenceMessenger.Default.Send<RequestShowPaletteAtMessage>(new(pos.Value, OwnerHwnd, false));
+            }
+        }
+        catch (COMException e)
+        {
+            Logger.LogError("Error reading dock context command", e);
         }
     }
 
@@ -495,7 +519,7 @@ public sealed partial class DockControl : UserControl, IRecipient<CloseContextMe
         var hwnd = OwnerHwnd;
         var capturedPos = pos.Value;
         message.OnBeforeShowConfirmation = () =>
-            WeakReferenceMessenger.Default.Send<RequestShowPaletteAtMessage>(new(capturedPos, hwnd));
+            WeakReferenceMessenger.Default.Send<RequestShowPaletteAtMessage>(new(capturedPos, hwnd, false));
     }
 
     private void ContextMenuFlyout_Opened(object sender, object e)
@@ -512,6 +536,8 @@ public sealed partial class DockControl : UserControl, IRecipient<CloseContextMe
         {
             ContextMenuFlyout.Hide();
         }
+
+        _bandContextMenuPalettePos = null;
     }
 
     private void RootGrid_RightTapped(object sender, Microsoft.UI.Xaml.Input.RightTappedRoutedEventArgs e)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockItemControl.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockItemControl.xaml
@@ -99,7 +99,7 @@
                                         Visibility="{TemplateBinding TextVisibility}">
                                         <TextBlock
                                             x:Name="TitleText"
-                                            MinWidth="24"
+                                            MinWidth="{TemplateBinding TitleMinWidth}"
                                             MaxWidth="100"
                                             HorizontalAlignment="Stretch"
                                             VerticalAlignment="Center"

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockItemControl.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockItemControl.xaml.cs
@@ -17,6 +17,8 @@ namespace Microsoft.CmdPal.UI.Dock;
 [ContentProperty(Name = nameof(Icon))]
 public sealed partial class DockItemControl : Control
 {
+    private const double DefaultTitleMinWidth = 24;
+
     public DockItemControl()
     {
         DefaultStyleKey = typeof(DockItemControl);
@@ -46,6 +48,15 @@ public sealed partial class DockItemControl : Control
     {
         get => (string)GetValue(TitleProperty);
         set => SetValue(TitleProperty, value);
+    }
+
+    public static readonly DependencyProperty TitleMinWidthProperty =
+        DependencyProperty.Register(nameof(TitleMinWidth), typeof(double), typeof(DockItemControl), new PropertyMetadata(DefaultTitleMinWidth));
+
+    public double TitleMinWidth
+    {
+        get => (double)GetValue(TitleMinWidthProperty);
+        set => SetValue(TitleMinWidthProperty, value);
     }
 
     public static readonly DependencyProperty SubtitleProperty =

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockWindow.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockWindow.xaml.cs
@@ -1522,7 +1522,7 @@ public sealed partial class DockWindow : WindowEx,
         {
             _paletteOpenedFromDock = true;
             RevealAutoHideDock(immediate: true);
-            RequestShowPaletteOnUiThread(message.PosDips);
+            RequestShowPaletteOnUiThread(message.PosDips, message.UseCompactSize);
         });
     }
 
@@ -1575,7 +1575,7 @@ public sealed partial class DockWindow : WindowEx,
         MonitorLabelTeachingTip.IsOpen = false;
     }
 
-    private void RequestShowPaletteOnUiThread(Point posDips)
+    private void RequestShowPaletteOnUiThread(Point posDips, bool useCompactSize)
     {
         // pos is relative to our root. We need to convert to absolute
         // virtual-screen coords.
@@ -1673,7 +1673,7 @@ public sealed partial class DockWindow : WindowEx,
 
         // Now that we know the anchor corner, and where to attempt to place it, we can
         // ask the palette to show itself there.
-        WeakReferenceMessenger.Default.Send<ShowPaletteAtMessage>(new(screenPosPixels, anchorPoint));
+        WeakReferenceMessenger.Default.Send<ShowPaletteAtMessage>(new(screenPosPixels, anchorPoint, dpi, useCompactSize));
     }
 
     public DockWindowViewModel WindowViewModel => _windowViewModel;
@@ -1798,11 +1798,11 @@ internal static class ShowDesktop
 
 internal sealed record BringToTopMessage(bool BringToFront);
 
-internal sealed record RequestShowPaletteAtMessage(Point PosDips, IntPtr OwnerHwnd);
+internal sealed record RequestShowPaletteAtMessage(Point PosDips, IntPtr OwnerHwnd, bool UseCompactSize);
 
 internal sealed record ShowDockMonitorLabelsMessage(bool Show);
 
-internal sealed record ShowPaletteAtMessage(Point PosPixels, AnchorPoint Anchor);
+internal sealed record ShowPaletteAtMessage(Point PosPixels, AnchorPoint Anchor, uint Dpi, bool UseCompactSize);
 
 internal enum AnchorPoint
 {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ContentPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ContentPage.xaml
@@ -47,6 +47,7 @@
                 FormTemplate="{StaticResource FormContentTemplate}"
                 ImageTemplate="{StaticResource ImageContentTemplate}"
                 MarkdownTemplate="{StaticResource MarkdownContentTemplate}"
+                PerformanceOverviewTemplate="{StaticResource PerformanceOverviewContentTemplate}"
                 PlainTextTemplate="{StaticResource PlainTextContentTemplate}"
                 TreeTemplate="{StaticResource TreeContentTemplate}" />
 
@@ -55,12 +56,19 @@
                 FormTemplate="{StaticResource NestedFormContentTemplate}"
                 ImageTemplate="{StaticResource ImageContentTemplate}"
                 MarkdownTemplate="{StaticResource NestedMarkdownContentTemplate}"
+                PerformanceOverviewTemplate="{StaticResource PerformanceOverviewContentTemplate}"
                 PlainTextTemplate="{StaticResource PlainTextContentTemplate}"
                 TreeTemplate="{StaticResource TreeContentTemplate}" />
 
             <DataTemplate x:Key="FormContentTemplate" x:DataType="viewModels:ContentFormViewModel">
                 <Grid Margin="0,4,4,4" Padding="12,8,8,8">
                     <cmdPalControls:ContentFormControl ViewModel="{x:Bind}" />
+                </Grid>
+            </DataTemplate>
+
+            <DataTemplate x:Key="PerformanceOverviewContentTemplate" x:DataType="viewModels:ContentPerformanceOverviewViewModel">
+                <Grid Margin="0,4,4,4" Padding="12,8,8,8">
+                    <cmdPalControls:PerformanceOverviewControl ViewModel="{x:Bind}" />
                 </Grid>
             </DataTemplate>
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/BindTransformers.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/BindTransformers.cs
@@ -28,6 +28,9 @@ internal static class BindTransformers
     public static Visibility VisibleWhenAny(bool value1, bool value2)
         => (value1 || value2) ? Visibility.Visible : Visibility.Collapsed;
 
+    public static Visibility VisibleWhenAll(bool value1, bool value2)
+        => (value1 && value2) ? Visibility.Visible : Visibility.Collapsed;
+
     public static Thickness BottomBorderThicknessWhenAll(bool value1, bool value2)
         => value1 && value2 ? new Thickness(0, 0, 0, 1) : new Thickness(0);
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml.cs
@@ -107,10 +107,18 @@ public sealed partial class MainWindow : WindowEx,
     // over the same band). These MUST match or the two disagree about where resizing is.
     private const int ResizeBorderThicknessDip = 8;
 
+    private const int DockPaletteWidthDip = 360;
+    private const int DockPaletteHeightDip = 400;
+
+    private readonly double _standardMinWidth;
+    private readonly double _standardMinHeight;
+
     private WindowPosition _currentWindowPosition = new();
 
     private bool _preventHideWhenDeactivated;
     private bool _isLoadedFromDock;
+    private bool _useCompactDockPresentation;
+    private double _compactDockCardMaxHeightDip = DockPaletteHeightDip;
 
     private DevRibbon? _devRibbon;
 
@@ -123,6 +131,8 @@ public sealed partial class MainWindow : WindowEx,
     public MainWindow()
     {
         InitializeComponent();
+        _standardMinWidth = MinWidth;
+        _standardMinHeight = MinHeight;
 
         ViewModel = App.Current.Services.GetService<MainWindowViewModel>()!;
 
@@ -776,6 +786,9 @@ public sealed partial class MainWindow : WindowEx,
         ShowHwnd(hwndValue, positionWindowForAnchor);
     }
 
+    private void ShowHwnd(IntPtr hwndValue, RectInt32 bounds) =>
+        ShowHwnd(hwndValue, _ => MoveAndResizeDpiAware(bounds));
+
     private void ShowHwnd(IntPtr hwndValue, Action<HWND>? positionWindow)
     {
         StopAutoGoHome();
@@ -904,8 +917,13 @@ public sealed partial class MainWindow : WindowEx,
     public void Receive(ShowWindowMessage message)
     {
         _isLoadedFromDock = false;
+        _useCompactDockPresentation = false;
+        MinWidth = _standardMinWidth;
+        MinHeight = _standardMinHeight;
 
         var settings = App.Current.Services.GetRequiredService<ISettingsService>().Settings;
+        RootElement.SetCardStretch(!settings.CompactMode);
+        RootElement.SetCardMaxHeight(double.PositiveInfinity);
 
         // Start session tracking
         _sessionStopwatch = Stopwatch.StartNew();
@@ -917,14 +935,64 @@ public sealed partial class MainWindow : WindowEx,
 
     internal void Receive(ShowPaletteAtMessage message)
     {
+        // A Dock item can be invoked while another transient page is still visible.
+        // Cloak before changing layout or bounds so DWM never presents the intermediate
+        // normal palette size.
+        if (!Cloak() && IsVisibleToUser)
+        {
+            PInvoke.ShowWindow(_hwnd, SHOW_WINDOW_CMD.SW_HIDE);
+        }
+
         _isLoadedFromDock = true;
+        _useCompactDockPresentation = message.UseCompactSize;
+        MinWidth = message.UseCompactSize ? 0 : _standardMinWidth;
+        MinHeight = message.UseCompactSize ? 0 : _standardMinHeight;
 
-        // Reset the size in case users have resized a dock window.
-        // Ideally in the future, we'll have defined sizes that opening
-        // a dock window will adhere to, but alas, that's the future.
-        RestoreWindowPositionFromMemory();
+        if (message.UseCompactSize)
+        {
+            var bounds = GetCompactDockBounds(message, out var availableHeightDip);
+            RootElement.SetCardStretch(false);
+            _compactDockCardMaxHeightDip = Math.Max(
+                1,
+                availableHeightDip - RootElement.ShadowPadding.Top - RootElement.ShadowPadding.Bottom);
+            RootElement.SetCardMaxHeight(_compactDockCardMaxHeightDip);
+            ShowHwnd(HWND.Null, bounds);
+        }
+        else
+        {
+            // Restore the pre-Dock size while cloaked. The anchor move below also
+            // runs before ShowWindow, so the first visible frame is final.
+            RestoreWindowPositionFromMemory();
+            var settings = App.Current.Services.GetRequiredService<ISettingsService>().Settings;
+            RootElement.SetCardStretch(!settings.CompactMode);
+            RootElement.SetCardMaxHeight(double.PositiveInfinity);
+            ShowHwnd(HWND.Null, message.PosPixels, message.Anchor);
+        }
+    }
 
-        ShowHwnd(HWND.Null, message.PosPixels, message.Anchor);
+    private RectInt32 GetCompactDockBounds(ShowPaletteAtMessage message, out double availableHeightDip)
+    {
+        var effectiveDpi = message.Dpi == 0 ? this.GetDpiForWindow() : message.Dpi;
+        var scale = effectiveDpi / 96.0;
+        var anchorPoint = new PointInt32((int)message.PosPixels.X, (int)message.PosPixels.Y);
+        var workArea = DisplayArea.GetFromPoint(anchorPoint, DisplayAreaFallback.Nearest).WorkArea;
+        var workAreaRight = workArea.X + workArea.Width;
+        var workAreaBottom = workArea.Y + workArea.Height;
+        var anchorX = Math.Clamp(anchorPoint.X, workArea.X, workAreaRight);
+        var anchorY = Math.Clamp(anchorPoint.Y, workArea.Y, workAreaBottom);
+        var anchorsRight = message.Anchor is AnchorPoint.TopRight or AnchorPoint.BottomRight;
+        var anchorsBottom = message.Anchor is AnchorPoint.BottomLeft or AnchorPoint.BottomRight;
+
+        var availableWidth = anchorsRight ? anchorX - workArea.X : workAreaRight - anchorX;
+        var availableHeight = anchorsBottom ? anchorY - workArea.Y : workAreaBottom - anchorY;
+        var width = Math.Min((int)Math.Round(DockPaletteWidthDip * scale), Math.Max(1, availableWidth));
+        var height = Math.Min((int)Math.Round(DockPaletteHeightDip * scale), Math.Max(1, availableHeight));
+        var x = anchorsRight ? anchorX - width : anchorX;
+        var y = anchorsBottom ? anchorY - height : anchorY;
+
+        availableHeightDip = height / scale;
+
+        return new RectInt32(x, y, width, height);
     }
 
     public void Receive(HideWindowMessage message)
@@ -1905,6 +1973,13 @@ public sealed partial class MainWindow : WindowEx,
     // instead of resizing the window we simply shrink or grow the visible card inside it.
     private void HandleExpandCompactOnUiThread(bool expanded)
     {
+        if (_isLoadedFromDock && _useCompactDockPresentation)
+        {
+            RootElement.SetCardStretch(false);
+            RootElement.SetCardMaxHeight(_compactDockCardMaxHeightDip);
+            return;
+        }
+
         var settings = App.Current.Services.GetRequiredService<ISettingsService>().Settings;
 
         if (!settings.CompactMode)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml
@@ -194,7 +194,10 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <Grid Grid.Row="0" Background="{ThemeResource LayerOnAcrylicPrimaryBackgroundBrush}">
+        <Grid
+            Grid.Row="0"
+            Background="{ThemeResource LayerOnAcrylicPrimaryBackgroundBrush}"
+            Visibility="{x:Bind h:BindTransformers.BoolToVisibility(ViewModel.ShouldShowTopBar), Mode=OneWay}">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
@@ -563,7 +566,7 @@
             Background="{ThemeResource LayerOnAcrylicSecondaryBackgroundBrush}"
             BorderBrush="{ThemeResource CmdPal.DividerStrokeColorDefaultBrush}"
             BorderThickness="0,1,0,0"
-            Visibility="{x:Bind ExpandedMode, Mode=OneWay}">
+            Visibility="{x:Bind h:BindTransformers.VisibleWhenAll(ExpandedMode, ViewModel.ShouldShowCommandBar), Mode=OneWay}">
             <cpcontrols:CommandBar CurrentPageViewModel="{x:Bind ViewModel.CurrentPage, Mode=OneWay}" />
         </Grid>
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
@@ -241,6 +241,14 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
             if (!ViewModel.IsNested)
             {
                 // todo BODGY
+                foreach (var entry in RootFrame.BackStack)
+                {
+                    if (entry.Parameter is AsyncNavigationRequest { TargetViewModel: PageViewModel pageViewModel })
+                    {
+                        pageViewModel.SafeCleanupIfTransient();
+                    }
+                }
+
                 RootFrame.BackStack.Clear();
             }
         });

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.PerformanceMonitor.UnitTests/NetworkAdapterSelectionTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.PerformanceMonitor.UnitTests/NetworkAdapterSelectionTests.cs
@@ -1,0 +1,152 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using CoreWidgetProvider.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CmdPal.Ext.PerformanceMonitor.UnitTests;
+
+[TestClass]
+public sealed class NetworkAdapterSelectionTests
+{
+    [TestMethod]
+    public void SelectBusiestNetworkIndex_PrefersCurrentTraffic()
+    {
+        NetworkStats.Data[] samples =
+        [
+            new() { Bandwidth = 10_000_000_000 },
+            new() { Bandwidth = 1_000_000_000, Sent = 100, Received = 200 },
+        ];
+
+        Assert.AreEqual(1, NetworkStats.SelectBusiestNetworkIndex(samples, 0));
+    }
+
+    [TestMethod]
+    public void SelectBusiestNetworkIndex_SelectsConnectedAdapterWhenFallbackIsDisconnected()
+    {
+        NetworkStats.Data[] samples =
+        [
+            new(),
+            new() { Bandwidth = 500_000_000 },
+            new() { Bandwidth = 1_000_000_000 },
+        ];
+
+        Assert.AreEqual(1, NetworkStats.SelectBusiestNetworkIndex(samples, 0));
+    }
+
+    [TestMethod]
+    public void SelectBusiestNetworkIndex_PreservesConnectedFallbackWhenIdle()
+    {
+        NetworkStats.Data[] samples =
+        [
+            new() { Bandwidth = 10_000_000_000 },
+            new() { Bandwidth = 1_000_000_000 },
+        ];
+
+        Assert.AreEqual(1, NetworkStats.SelectBusiestNetworkIndex(samples, 1));
+    }
+
+    [TestMethod]
+    public void SelectBusiestNetworkIndex_RequiresMeaningfulThroughputLead()
+    {
+        NetworkStats.Data[] samples =
+        [
+            new() { Bandwidth = 1_000_000_000, Sent = 500, Received = 500 },
+            new() { Bandwidth = 1_000_000_000, Sent = 550, Received = 550 },
+        ];
+
+        Assert.AreEqual(0, NetworkStats.SelectBusiestNetworkIndex(samples, 0));
+
+        samples[1].Received = 1_450;
+        Assert.AreEqual(1, NetworkStats.SelectBusiestNetworkIndex(samples, 0));
+    }
+
+    [TestMethod]
+    public void SelectBusiestNetworkIndex_PreservesFallbackWhenSamplesAreEqual()
+    {
+        NetworkStats.Data[] samples = [new(), new(), new()];
+
+        Assert.AreEqual(2, NetworkStats.SelectBusiestNetworkIndex(samples, 2));
+    }
+
+    [TestMethod]
+    public void SelectAdjacentNetworkIndex_SkipsDisconnectedAdaptersAndWraps()
+    {
+        NetworkStats.Data[] samples =
+        [
+            new() { Bandwidth = 1_000_000_000 },
+            new(),
+            new() { Bandwidth = 500_000_000 },
+            new(),
+        ];
+
+        Assert.AreEqual(2, NetworkStats.CountSelectableNetworks(samples));
+        Assert.AreEqual(2, NetworkStats.SelectNextNetworkIndex(samples, 0));
+        Assert.AreEqual(0, NetworkStats.SelectNextNetworkIndex(samples, 2));
+        Assert.AreEqual(2, NetworkStats.SelectPreviousNetworkIndex(samples, 0));
+        Assert.AreEqual(0, NetworkStats.SelectPreviousNetworkIndex(samples, 2));
+    }
+
+    [TestMethod]
+    public void SelectAdjacentNetworkIndex_PreservesSelectionWhenAllAdaptersAreDisconnected()
+    {
+        NetworkStats.Data[] samples = [new(), new()];
+
+        Assert.AreEqual(0, NetworkStats.CountSelectableNetworks(samples));
+        Assert.AreEqual(1, NetworkStats.SelectPreviousNetworkIndex(samples, 1));
+        Assert.AreEqual(1, NetworkStats.SelectNextNetworkIndex(samples, 1));
+    }
+
+    [TestMethod]
+    public void ManualSelection_PreventsAutomaticSelectionFromOverwritingIndex()
+    {
+        var selection = new PerformanceMetricSelectionState();
+
+        Assert.AreEqual(2, selection.UpdateAutomaticNetworkIndex(2));
+        Assert.IsTrue(selection.SelectNetworkManually(1));
+
+        Assert.IsFalse(selection.IsNetworkSelectionAutomatic);
+        Assert.AreEqual(1, selection.UpdateAutomaticNetworkIndex(0));
+        Assert.AreEqual(1, selection.NetworkIndex);
+    }
+
+    [TestMethod]
+    public void NoOpManualSelection_PreservesAutomaticSelection()
+    {
+        var selection = new PerformanceMetricSelectionState();
+
+        Assert.AreEqual(1, selection.UpdateAutomaticNetworkIndex(1));
+        Assert.IsFalse(selection.SelectNetworkManually(1));
+
+        Assert.IsTrue(selection.IsNetworkSelectionAutomatic);
+        Assert.AreEqual(0, selection.UpdateAutomaticNetworkIndex(0));
+    }
+
+    [TestMethod]
+    public void DisconnectedManualSelection_RecoversAndRestoresAutomaticSelection()
+    {
+        var selection = new PerformanceMetricSelectionState();
+
+        Assert.AreEqual(1, selection.UpdateAutomaticNetworkIndex(1));
+        Assert.IsTrue(selection.SelectNetworkManually(2));
+        Assert.AreEqual(1, selection.RecoverNetworkSelection(2, 1));
+
+        Assert.IsTrue(selection.IsNetworkSelectionAutomatic);
+        Assert.AreEqual(0, selection.UpdateAutomaticNetworkIndex(0));
+    }
+
+    [TestMethod]
+    public void Recovery_DoesNotOverwriteNewerManualSelection()
+    {
+        var selection = new PerformanceMetricSelectionState();
+
+        Assert.AreEqual(0, selection.UpdateAutomaticNetworkIndex(0));
+        Assert.IsTrue(selection.SelectNetworkManually(1));
+        Assert.IsTrue(selection.SelectNetworkManually(2));
+        Assert.AreEqual(2, selection.RecoverNetworkSelection(1, 0));
+
+        Assert.IsFalse(selection.IsNetworkSelectionAutomatic);
+        Assert.AreEqual(2, selection.NetworkIndex);
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.PerformanceMonitor.UnitTests/OnLoadStaticPageTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.PerformanceMonitor.UnitTests/OnLoadStaticPageTests.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.Foundation;
+
+namespace Microsoft.CmdPal.Ext.PerformanceMonitor.UnitTests;
+
+[TestClass]
+public sealed partial class OnLoadStaticPageTests
+{
+    private sealed partial class TestPage : OnLoadStaticListPage
+    {
+        public int LoadedCount { get; private set; }
+
+        public int UnloadedCount { get; private set; }
+
+        public override IListItem[] GetItems() => [];
+
+        protected override void Loaded() => LoadedCount++;
+
+        protected override void Unloaded() => UnloadedCount++;
+    }
+
+    [TestMethod]
+    public void RemovingBeforeAdding_DoesNotSuppressLaterLoad()
+    {
+        var page = new TestPage();
+        TypedEventHandler<object, IItemsChangedEventArgs> handler = (_, _) => { };
+
+        page.ItemsChanged -= handler;
+        page.ItemsChanged += handler;
+
+        Assert.AreEqual(1, page.LoadedCount);
+        Assert.AreEqual(0, page.UnloadedCount);
+
+        page.ItemsChanged -= handler;
+
+        Assert.AreEqual(1, page.UnloadedCount);
+    }
+
+    [TestMethod]
+    public void RemovingUnknownSubscriber_DoesNotUnloadActivePage()
+    {
+        var page = new TestPage();
+        TypedEventHandler<object, IItemsChangedEventArgs> activeHandler = (_, _) => { };
+        TypedEventHandler<object, IItemsChangedEventArgs> unknownHandler = (_, _) => { };
+
+        page.ItemsChanged += activeHandler;
+        page.ItemsChanged -= unknownHandler;
+
+        Assert.AreEqual(1, page.LoadedCount);
+        Assert.AreEqual(0, page.UnloadedCount);
+
+        page.ItemsChanged -= activeHandler;
+
+        Assert.AreEqual(1, page.UnloadedCount);
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.PerformanceMonitor.UnitTests/PerformanceOverviewFormatterTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.PerformanceMonitor.UnitTests/PerformanceOverviewFormatterTests.cs
@@ -1,0 +1,133 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CmdPal.Ext.PerformanceMonitor.UnitTests;
+
+[TestClass]
+public class PerformanceOverviewFormatterTests
+{
+    [DataTestMethod]
+    [DataRow(null, 0)]
+    [DataRow("", 0)]
+    [DataRow("   ", 0)]
+    [DataRow("0%", 0)]
+    [DataRow("42%", 42)]
+    [DataRow("100%", 100)]
+    [DataRow(" 42% ", 42)]
+    [DataRow("42 %", 42)]
+    [DataRow("150%", 100)]
+    [DataRow("-5%", 0)]
+    [DataRow("--", 0)]
+    [DataRow("???", 0)]
+    [DataRow("not a percent", 0)]
+    public void ParsePercentText_ParsesAndClampsExpectedValues(string percentText, int expected)
+    {
+        Assert.AreEqual(expected, PerformanceOverviewFormatter.ParsePercentText(percentText));
+    }
+
+    [DataTestMethod]
+    [DataRow(-100, 0)]
+    [DataRow(-1, 0)]
+    [DataRow(0, 0)]
+    [DataRow(42, 42)]
+    [DataRow(100, 100)]
+    [DataRow(101, 100)]
+    [DataRow(1000, 100)]
+    public void ClampPercent_ClampsToZeroToHundredRange(int percent, int expected)
+    {
+        Assert.AreEqual(expected, PerformanceOverviewFormatter.ClampPercent(percent));
+    }
+
+    [DataTestMethod]
+    [DataRow((int)PerformanceMetricKind.Cpu, "cpu")]
+    [DataRow((int)PerformanceMetricKind.Memory, "memory")]
+    [DataRow((int)PerformanceMetricKind.Network, "network")]
+    [DataRow((int)PerformanceMetricKind.Disk, "disk")]
+    [DataRow((int)PerformanceMetricKind.Gpu, "gpu")]
+    public void GetMetricKey_ReturnsStableKey(int metricValue, string expectedKey)
+    {
+        Assert.AreEqual(expectedKey, PerformanceOverviewFormatter.GetMetricKey((PerformanceMetricKind)metricValue));
+    }
+
+    [TestMethod]
+    public void GetMetricKey_RejectsMetricsNotShownInOverview()
+    {
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() =>
+            PerformanceOverviewFormatter.GetMetricKey(PerformanceMetricKind.Battery));
+    }
+
+    [DataTestMethod]
+    [DataRow((int)PerformanceMetricKind.Cpu, "cpu")]
+    [DataRow((int)PerformanceMetricKind.Memory, "memory")]
+    [DataRow((int)PerformanceMetricKind.Network, "network")]
+    [DataRow((int)PerformanceMetricKind.Disk, "disk")]
+    [DataRow((int)PerformanceMetricKind.Gpu, "gpu")]
+    public void SelectMetricValue_ReturnsValueForSelectedMetric(int metricValue, string expected)
+    {
+        var actual = PerformanceOverviewFormatter.SelectMetricValue(
+            (PerformanceMetricKind)metricValue,
+            "cpu",
+            "memory",
+            "network",
+            "disk",
+            "gpu");
+
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void SelectMetricValue_RejectsMetricsNotShownInOverview()
+    {
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() =>
+            PerformanceOverviewFormatter.SelectMetricValue(
+                PerformanceMetricKind.Battery,
+                "cpu",
+                "memory",
+                "network",
+                "disk",
+                "gpu"));
+    }
+
+    [TestMethod]
+    public void RollingNetworkThroughputNormalizer_AddsHeadroomAbovePeak()
+    {
+        var normalizer = new RollingNetworkThroughputNormalizer();
+        var timestamp = DateTimeOffset.UtcNow;
+
+        Assert.AreEqual(83, normalizer.AddSample(10_000_000, timestamp));
+    }
+
+    [TestMethod]
+    public void RollingNetworkThroughputNormalizer_UsesMinimumScaleForIdleTraffic()
+    {
+        var normalizer = new RollingNetworkThroughputNormalizer();
+        var timestamp = DateTimeOffset.UtcNow;
+
+        Assert.AreEqual(10, normalizer.AddSample(12_500, timestamp));
+    }
+
+    [TestMethod]
+    public void RollingNetworkThroughputNormalizer_RetainsPeakForSixtySeconds()
+    {
+        var normalizer = new RollingNetworkThroughputNormalizer();
+        var timestamp = DateTimeOffset.UtcNow;
+
+        normalizer.AddSample(10_000_000, timestamp);
+
+        Assert.AreEqual(8, normalizer.AddSample(1_000_000, timestamp.AddSeconds(59)));
+        Assert.AreEqual(83, normalizer.AddSample(1_000_000, timestamp.AddSeconds(61)));
+    }
+
+    [TestMethod]
+    public void RollingNetworkThroughputNormalizer_ClampsInvalidSamplesToZero()
+    {
+        var normalizer = new RollingNetworkThroughputNormalizer();
+
+        Assert.AreEqual(0, normalizer.AddSample(double.NaN, DateTimeOffset.UtcNow));
+        Assert.AreEqual(0, normalizer.AddSample(-1, DateTimeOffset.UtcNow));
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.PerformanceMonitor.UnitTests/PerformanceOverviewFormatterTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.PerformanceMonitor.UnitTests/PerformanceOverviewFormatterTests.cs
@@ -93,27 +93,27 @@ public class PerformanceOverviewFormatterTests
     }
 
     [TestMethod]
-    public void RollingNetworkThroughputNormalizer_AddsHeadroomAbovePeak()
+    public void RollingThroughputNormalizer_AddsHeadroomAbovePeak()
     {
-        var normalizer = new RollingNetworkThroughputNormalizer();
+        var normalizer = new RollingThroughputNormalizer();
         var timestamp = DateTimeOffset.UtcNow;
 
         Assert.AreEqual(83, normalizer.AddSample(10_000_000, timestamp));
     }
 
     [TestMethod]
-    public void RollingNetworkThroughputNormalizer_UsesMinimumScaleForIdleTraffic()
+    public void RollingThroughputNormalizer_UsesMinimumScaleForIdleTraffic()
     {
-        var normalizer = new RollingNetworkThroughputNormalizer();
+        var normalizer = new RollingThroughputNormalizer();
         var timestamp = DateTimeOffset.UtcNow;
 
         Assert.AreEqual(10, normalizer.AddSample(12_500, timestamp));
     }
 
     [TestMethod]
-    public void RollingNetworkThroughputNormalizer_RetainsPeakForSixtySeconds()
+    public void RollingThroughputNormalizer_RetainsPeakForSixtySeconds()
     {
-        var normalizer = new RollingNetworkThroughputNormalizer();
+        var normalizer = new RollingThroughputNormalizer();
         var timestamp = DateTimeOffset.UtcNow;
 
         normalizer.AddSample(10_000_000, timestamp);
@@ -123,11 +123,21 @@ public class PerformanceOverviewFormatterTests
     }
 
     [TestMethod]
-    public void RollingNetworkThroughputNormalizer_ClampsInvalidSamplesToZero()
+    public void RollingThroughputNormalizer_ClampsInvalidSamplesToZero()
     {
-        var normalizer = new RollingNetworkThroughputNormalizer();
+        var normalizer = new RollingThroughputNormalizer();
 
         Assert.AreEqual(0, normalizer.AddSample(double.NaN, DateTimeOffset.UtcNow));
         Assert.AreEqual(0, normalizer.AddSample(-1, DateTimeOffset.UtcNow));
+    }
+
+    [TestMethod]
+    public void RollingThroughputNormalizer_UsesSharedScaleForPair()
+    {
+        var normalizer = new RollingThroughputNormalizer();
+        var percentages = normalizer.AddPairSample(10_000_000, 5_000_000, DateTimeOffset.UtcNow);
+
+        Assert.AreEqual(83, percentages.FirstPercent);
+        Assert.AreEqual(42, percentages.SecondPercent);
     }
 }

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/ContentPerformanceOverviewViewModelTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/ContentPerformanceOverviewViewModelTests.cs
@@ -137,7 +137,19 @@ public sealed partial class ContentPerformanceOverviewViewModelTests
         Assert.AreEqual(34, viewModel.MemoryPercent);
         Assert.AreEqual(45, viewModel.DiskPercent);
         Assert.AreEqual(66, viewModel.NetworkPercent);
-        Assert.AreEqual("Send 1.0 MB/s · Receive 2.0 MB/s", viewModel.NetworkDetailText);
+        Assert.AreEqual("Disk Read", viewModel.DiskReadLabelText);
+        Assert.AreEqual("Disk Write", viewModel.DiskWriteLabelText);
+        Assert.AreEqual("Read 1.0 MB/s", viewModel.DiskReadText);
+        Assert.AreEqual("Write 2.0 MB/s", viewModel.DiskWriteText);
+        Assert.AreEqual(45, viewModel.DiskReadPercent);
+        Assert.AreEqual(55, viewModel.DiskWritePercent);
+        Assert.AreEqual("In 2.0 MB/s · Out 1.0 MB/s", viewModel.NetworkDetailText);
+        Assert.AreEqual("Network In", viewModel.NetworkInLabelText);
+        Assert.AreEqual("Network Out", viewModel.NetworkOutLabelText);
+        Assert.AreEqual("In 2.0 MB/s", viewModel.NetworkInText);
+        Assert.AreEqual("Out 1.0 MB/s", viewModel.NetworkOutText);
+        Assert.AreEqual(66, viewModel.NetworkInPercent);
+        Assert.AreEqual(56, viewModel.NetworkOutPercent);
         Assert.AreEqual("NVIDIA Test GPU", viewModel.GpuAdapterName);
         Assert.AreEqual("Test Ethernet", viewModel.NetworkAdapterName);
         Assert.IsTrue(viewModel.CanSwitchGpu);
@@ -164,6 +176,10 @@ public sealed partial class ContentPerformanceOverviewViewModelTests
         Assert.AreEqual(50, viewModel.MemoryPercent);
         Assert.AreEqual(0, viewModel.DiskPercent);
         Assert.AreEqual(100, viewModel.NetworkPercent);
+        Assert.AreEqual(0, viewModel.DiskReadPercent);
+        Assert.AreEqual(10, viewModel.DiskWritePercent);
+        Assert.AreEqual(100, viewModel.NetworkInPercent);
+        Assert.AreEqual(100, viewModel.NetworkOutPercent);
     }
 
     [TestMethod]
@@ -185,6 +201,54 @@ public sealed partial class ContentPerformanceOverviewViewModelTests
         Assert.AreEqual("cpu", viewModel.HeroMetric);
         Assert.AreEqual("37%", viewModel.HeroValueText);
         Assert.AreEqual(37, viewModel.CpuPercent);
+    }
+
+    [TestMethod]
+    public void LegacyPayloadWithoutDirectionalFields_UsesAggregateFallbacks()
+    {
+        var data = JsonNode.Parse(BuildPayload("disk", "44%", 11, 22, 33, 44, 55))!.AsObject();
+        foreach (var propertyName in new[]
+        {
+            "diskReadText",
+            "diskWriteText",
+            "diskReadLabelText",
+            "diskWriteLabelText",
+            "diskReadPercent",
+            "diskWritePercent",
+            "networkInText",
+            "networkOutText",
+            "networkInLabelText",
+            "networkOutLabelText",
+            "networkInPercent",
+            "networkOutPercent",
+        })
+        {
+            data.Remove(propertyName);
+        }
+
+        var form = new FormContent
+        {
+            TemplateJson = NativeFormContentTypes.PerformanceOverview,
+            DataJson = data.ToJsonString(),
+        };
+        var viewModel = new ContentPerformanceOverviewViewModel(
+            form,
+            new WeakReference<IPageContext>(new TestPageContext()));
+
+        viewModel.InitializeProperties();
+
+        Assert.AreEqual(viewModel.DiskLabelText, viewModel.DiskReadLabelText);
+        Assert.AreEqual(viewModel.DiskLabelText, viewModel.DiskWriteLabelText);
+        Assert.AreEqual(viewModel.DiskDetailText, viewModel.DiskReadText);
+        Assert.AreEqual(string.Empty, viewModel.DiskWriteText);
+        Assert.AreEqual(viewModel.DiskPercent, viewModel.DiskReadPercent);
+        Assert.AreEqual(0, viewModel.DiskWritePercent);
+        Assert.AreEqual(viewModel.NetworkLabelText, viewModel.NetworkInLabelText);
+        Assert.AreEqual(viewModel.NetworkLabelText, viewModel.NetworkOutLabelText);
+        Assert.AreEqual(viewModel.NetworkDetailText, viewModel.NetworkInText);
+        Assert.AreEqual(string.Empty, viewModel.NetworkOutText);
+        Assert.AreEqual(viewModel.NetworkPercent, viewModel.NetworkInPercent);
+        Assert.AreEqual(0, viewModel.NetworkOutPercent);
     }
 
     [TestMethod]
@@ -284,11 +348,23 @@ public sealed partial class ContentPerformanceOverviewViewModelTests
             ["diskLabelText"] = "Disk",
             ["diskDetailText"] = "Read 1.0 MB/s · Write 2.0 MB/s",
             ["diskPercent"] = diskPercent,
+            ["diskReadLabelText"] = "Disk Read",
+            ["diskWriteLabelText"] = "Disk Write",
+            ["diskReadText"] = "Read 1.0 MB/s",
+            ["diskWriteText"] = "Write 2.0 MB/s",
+            ["diskReadPercent"] = diskPercent,
+            ["diskWritePercent"] = diskPercent + 10,
             ["networkLabelText"] = "Network",
             ["networkAdapterName"] = "Test Ethernet",
             ["canSwitchNetwork"] = true,
-            ["networkDetailText"] = "Send 1.0 MB/s · Receive 2.0 MB/s",
+            ["networkDetailText"] = "In 2.0 MB/s · Out 1.0 MB/s",
             ["networkPercent"] = networkPercent,
+            ["networkInLabelText"] = "Network In",
+            ["networkOutLabelText"] = "Network Out",
+            ["networkInText"] = "In 2.0 MB/s",
+            ["networkOutText"] = "Out 1.0 MB/s",
+            ["networkInPercent"] = networkPercent,
+            ["networkOutPercent"] = networkPercent - 10,
             ["previousGpuCommandText"] = "Previous GPU",
             ["nextGpuCommandText"] = "Next GPU",
             ["previousNetworkCommandText"] = "Previous network",

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/ContentPerformanceOverviewViewModelTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/ContentPerformanceOverviewViewModelTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using Microsoft.CmdPal.Common;
@@ -42,7 +43,9 @@ public sealed partial class ContentPerformanceOverviewViewModelTests
 
     private sealed partial class TestContentPage : Microsoft.CommandPalette.Extensions.Toolkit.ContentPage
     {
-        public override IContent[] GetContent() => [];
+        public IContent[] Content { get; init; } = [];
+
+        public override IContent[] GetContent() => Content;
     }
 
     [TestMethod]
@@ -74,6 +77,40 @@ public sealed partial class ContentPerformanceOverviewViewModelTests
     }
 
     [TestMethod]
+    public void InlineAdapterCommands_AreNotPromotedToPageKeyboardActions()
+    {
+        var form = new FormContent
+        {
+            TemplateJson = NativeFormContentTypes.PerformanceOverview,
+            DataJson = BuildPayload("cpu", "11%", 11, 22, 33, 44, 55),
+        };
+        var page = new TestContentPage
+        {
+            Content = [form],
+            Commands =
+            [
+                new CommandContextItem(new NoOpCommand { Name = "Previous GPU" }),
+                new CommandContextItem(new NoOpCommand { Name = "Next GPU" }),
+            ],
+        };
+        var pageViewModel = new CommandPaletteContentPageViewModel(
+            page,
+            TaskScheduler.Default,
+            new TestAppExtensionHost(),
+            CommandProviderContext.Empty);
+
+        pageViewModel.InitializeProperties();
+
+        Assert.IsTrue(pageViewModel.HasInlineCommandSurface);
+        Assert.IsFalse(pageViewModel.HasCommands);
+        Assert.IsFalse(pageViewModel.HasMoreCommands);
+        Assert.IsFalse(pageViewModel.CanOpenContextMenu);
+        Assert.IsNull(pageViewModel.PrimaryCommand);
+        Assert.IsNull(pageViewModel.SecondaryCommand);
+        Assert.AreEqual(2, pageViewModel.AllCommands.Count);
+    }
+
+    [TestMethod]
     public void DataJsonUpdate_MutatesExistingObservableViewModel()
     {
         var context = new TestPageContext();
@@ -101,6 +138,10 @@ public sealed partial class ContentPerformanceOverviewViewModelTests
         Assert.AreEqual(45, viewModel.DiskPercent);
         Assert.AreEqual(66, viewModel.NetworkPercent);
         Assert.AreEqual("Send 1.0 MB/s · Receive 2.0 MB/s", viewModel.NetworkDetailText);
+        Assert.AreEqual("NVIDIA Test GPU", viewModel.GpuAdapterName);
+        Assert.AreEqual("Test Ethernet", viewModel.NetworkAdapterName);
+        Assert.IsTrue(viewModel.CanSwitchGpu);
+        Assert.IsTrue(viewModel.CanSwitchNetwork);
     }
 
     [TestMethod]
@@ -172,6 +213,36 @@ public sealed partial class ContentPerformanceOverviewViewModelTests
         Assert.AreEqual(11, viewModel.CpuPercent);
     }
 
+    [TestMethod]
+    public void AdapterCommands_RouteStableCommandIds()
+    {
+        var invokedCommandIds = new List<string>();
+        var form = new FormContent
+        {
+            TemplateJson = NativeFormContentTypes.PerformanceOverview,
+            DataJson = BuildPayload("cpu", "11%", 11, 22, 33, 44, 55),
+        };
+        var viewModel = new ContentPerformanceOverviewViewModel(
+            form,
+            new WeakReference<IPageContext>(new TestPageContext()),
+            invokedCommandIds.Add);
+
+        viewModel.PreviousGpuCommand.Execute(null);
+        viewModel.NextGpuCommand.Execute(null);
+        viewModel.PreviousNetworkCommand.Execute(null);
+        viewModel.NextNetworkCommand.Execute(null);
+
+        CollectionAssert.AreEqual(
+            new[]
+            {
+                NativePerformanceOverviewCommandIds.PreviousGpu,
+                NativePerformanceOverviewCommandIds.NextGpu,
+                NativePerformanceOverviewCommandIds.PreviousNetwork,
+                NativePerformanceOverviewCommandIds.NextNetwork,
+            },
+            invokedCommandIds);
+    }
+
     private static string BuildPayload(
         string heroMetric,
         string heroValue,
@@ -203,6 +274,8 @@ public sealed partial class ContentPerformanceOverviewViewModelTests
             ["cpuDetailText"] = $"{cpuPercent}% · 4.0 GHz",
             ["cpuPercent"] = cpuPercent,
             ["gpuLabelText"] = "GPU",
+            ["gpuAdapterName"] = "NVIDIA Test GPU",
+            ["canSwitchGpu"] = true,
             ["gpuDetailText"] = $"{gpuPercent}% · 40 °C",
             ["gpuPercent"] = gpuPercent,
             ["memoryLabelText"] = "RAM",
@@ -212,8 +285,14 @@ public sealed partial class ContentPerformanceOverviewViewModelTests
             ["diskDetailText"] = "Read 1.0 MB/s · Write 2.0 MB/s",
             ["diskPercent"] = diskPercent,
             ["networkLabelText"] = "Network",
+            ["networkAdapterName"] = "Test Ethernet",
+            ["canSwitchNetwork"] = true,
             ["networkDetailText"] = "Send 1.0 MB/s · Receive 2.0 MB/s",
             ["networkPercent"] = networkPercent,
+            ["previousGpuCommandText"] = "Previous GPU",
+            ["nextGpuCommandText"] = "Next GPU",
+            ["previousNetworkCommandText"] = "Previous network",
+            ["nextNetworkCommandText"] = "Next network",
         }.ToJsonString();
     }
 }

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/ContentPerformanceOverviewViewModelTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/ContentPerformanceOverviewViewModelTests.cs
@@ -143,13 +143,13 @@ public sealed partial class ContentPerformanceOverviewViewModelTests
         Assert.AreEqual("Write 2.0 MB/s", viewModel.DiskWriteText);
         Assert.AreEqual(45, viewModel.DiskReadPercent);
         Assert.AreEqual(55, viewModel.DiskWritePercent);
-        Assert.AreEqual("In 2.0 MB/s · Out 1.0 MB/s", viewModel.NetworkDetailText);
-        Assert.AreEqual("Network In", viewModel.NetworkInLabelText);
-        Assert.AreEqual("Network Out", viewModel.NetworkOutLabelText);
-        Assert.AreEqual("In 2.0 MB/s", viewModel.NetworkInText);
-        Assert.AreEqual("Out 1.0 MB/s", viewModel.NetworkOutText);
-        Assert.AreEqual(66, viewModel.NetworkInPercent);
-        Assert.AreEqual(56, viewModel.NetworkOutPercent);
+        Assert.AreEqual("Send 1.0 MB/s · Receive 2.0 MB/s", viewModel.NetworkDetailText);
+        Assert.AreEqual("Network Send", viewModel.NetworkSendLabelText);
+        Assert.AreEqual("Network Receive", viewModel.NetworkReceiveLabelText);
+        Assert.AreEqual("Send 1.0 MB/s", viewModel.NetworkSendText);
+        Assert.AreEqual("Receive 2.0 MB/s", viewModel.NetworkReceiveText);
+        Assert.AreEqual(56, viewModel.NetworkSendPercent);
+        Assert.AreEqual(66, viewModel.NetworkReceivePercent);
         Assert.AreEqual("NVIDIA Test GPU", viewModel.GpuAdapterName);
         Assert.AreEqual("Test Ethernet", viewModel.NetworkAdapterName);
         Assert.IsTrue(viewModel.CanSwitchGpu);
@@ -178,8 +178,8 @@ public sealed partial class ContentPerformanceOverviewViewModelTests
         Assert.AreEqual(100, viewModel.NetworkPercent);
         Assert.AreEqual(0, viewModel.DiskReadPercent);
         Assert.AreEqual(10, viewModel.DiskWritePercent);
-        Assert.AreEqual(100, viewModel.NetworkInPercent);
-        Assert.AreEqual(100, viewModel.NetworkOutPercent);
+        Assert.AreEqual(100, viewModel.NetworkSendPercent);
+        Assert.AreEqual(100, viewModel.NetworkReceivePercent);
     }
 
     [TestMethod]
@@ -215,12 +215,12 @@ public sealed partial class ContentPerformanceOverviewViewModelTests
             "diskWriteLabelText",
             "diskReadPercent",
             "diskWritePercent",
-            "networkInText",
-            "networkOutText",
-            "networkInLabelText",
-            "networkOutLabelText",
-            "networkInPercent",
-            "networkOutPercent",
+            "networkSendText",
+            "networkReceiveText",
+            "networkSendLabelText",
+            "networkReceiveLabelText",
+            "networkSendPercent",
+            "networkReceivePercent",
         })
         {
             data.Remove(propertyName);
@@ -243,12 +243,12 @@ public sealed partial class ContentPerformanceOverviewViewModelTests
         Assert.AreEqual(string.Empty, viewModel.DiskWriteText);
         Assert.AreEqual(viewModel.DiskPercent, viewModel.DiskReadPercent);
         Assert.AreEqual(0, viewModel.DiskWritePercent);
-        Assert.AreEqual(viewModel.NetworkLabelText, viewModel.NetworkInLabelText);
-        Assert.AreEqual(viewModel.NetworkLabelText, viewModel.NetworkOutLabelText);
-        Assert.AreEqual(viewModel.NetworkDetailText, viewModel.NetworkInText);
-        Assert.AreEqual(string.Empty, viewModel.NetworkOutText);
-        Assert.AreEqual(viewModel.NetworkPercent, viewModel.NetworkInPercent);
-        Assert.AreEqual(0, viewModel.NetworkOutPercent);
+        Assert.AreEqual(viewModel.NetworkLabelText, viewModel.NetworkSendLabelText);
+        Assert.AreEqual(viewModel.NetworkLabelText, viewModel.NetworkReceiveLabelText);
+        Assert.AreEqual(viewModel.NetworkDetailText, viewModel.NetworkSendText);
+        Assert.AreEqual(string.Empty, viewModel.NetworkReceiveText);
+        Assert.AreEqual(viewModel.NetworkPercent, viewModel.NetworkSendPercent);
+        Assert.AreEqual(0, viewModel.NetworkReceivePercent);
     }
 
     [TestMethod]
@@ -357,14 +357,14 @@ public sealed partial class ContentPerformanceOverviewViewModelTests
             ["networkLabelText"] = "Network",
             ["networkAdapterName"] = "Test Ethernet",
             ["canSwitchNetwork"] = true,
-            ["networkDetailText"] = "In 2.0 MB/s · Out 1.0 MB/s",
+            ["networkDetailText"] = "Send 1.0 MB/s · Receive 2.0 MB/s",
             ["networkPercent"] = networkPercent,
-            ["networkInLabelText"] = "Network In",
-            ["networkOutLabelText"] = "Network Out",
-            ["networkInText"] = "In 2.0 MB/s",
-            ["networkOutText"] = "Out 1.0 MB/s",
-            ["networkInPercent"] = networkPercent,
-            ["networkOutPercent"] = networkPercent - 10,
+            ["networkSendLabelText"] = "Network Send",
+            ["networkReceiveLabelText"] = "Network Receive",
+            ["networkSendText"] = "Send 1.0 MB/s",
+            ["networkReceiveText"] = "Receive 2.0 MB/s",
+            ["networkSendPercent"] = networkPercent - 10,
+            ["networkReceivePercent"] = networkPercent,
             ["previousGpuCommandText"] = "Previous GPU",
             ["nextGpuCommandText"] = "Next GPU",
             ["previousNetworkCommandText"] = "Previous network",

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/ContentPerformanceOverviewViewModelTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/ContentPerformanceOverviewViewModelTests.cs
@@ -1,0 +1,219 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using Microsoft.CmdPal.Common;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
+
+[TestClass]
+public sealed partial class ContentPerformanceOverviewViewModelTests
+{
+    private sealed class TestPageContext : IPageContext
+    {
+        public TaskScheduler Scheduler => TaskScheduler.Default;
+
+        public ICommandProviderContext ProviderContext => CommandProviderContext.Empty;
+
+        public void ShowException(Exception ex, string? extensionHint = null) => Assert.Fail(ex.ToString());
+    }
+
+    private sealed class RecordingPageContext : IPageContext
+    {
+        public TaskScheduler Scheduler => TaskScheduler.Default;
+
+        public ICommandProviderContext ProviderContext => CommandProviderContext.Empty;
+
+        public Exception? LastException { get; private set; }
+
+        public void ShowException(Exception ex, string? extensionHint = null) => LastException = ex;
+    }
+
+    private sealed partial class TestAppExtensionHost : AppExtensionHost
+    {
+        public override string? GetExtensionDisplayName() => "Test Host";
+    }
+
+    private sealed partial class TestContentPage : Microsoft.CommandPalette.Extensions.Toolkit.ContentPage
+    {
+        public override IContent[] GetContent() => [];
+    }
+
+    [TestMethod]
+    public void ViewModelFromContent_UsesNativeRendererOnlyForPerformanceMarker()
+    {
+        var context = new TestPageContext();
+        var contextReference = new WeakReference<IPageContext>(context);
+        var pageViewModel = new CommandPaletteContentPageViewModel(
+            new TestContentPage(),
+            TaskScheduler.Default,
+            new TestAppExtensionHost(),
+            CommandProviderContext.Empty);
+
+        var nativeForm = new FormContent
+        {
+            TemplateJson = NativeFormContentTypes.PerformanceOverview,
+            DataJson = BuildPayload("cpu", "11%", 11, 22, 33, 44, 55),
+        };
+        var adaptiveForm = new FormContent
+        {
+            TemplateJson = "{}",
+            DataJson = "{}",
+        };
+
+        Assert.IsInstanceOfType<ContentPerformanceOverviewViewModel>(
+            pageViewModel.ViewModelFromContent(nativeForm, contextReference));
+        Assert.IsInstanceOfType<ContentFormViewModel>(
+            pageViewModel.ViewModelFromContent(adaptiveForm, contextReference));
+    }
+
+    [TestMethod]
+    public void DataJsonUpdate_MutatesExistingObservableViewModel()
+    {
+        var context = new TestPageContext();
+        var form = new FormContent
+        {
+            TemplateJson = NativeFormContentTypes.PerformanceOverview,
+            DataJson = BuildPayload("cpu", "11%", 11, 22, 33, 44, 55),
+        };
+        var viewModel = new ContentPerformanceOverviewViewModel(
+            form,
+            new WeakReference<IPageContext>(context));
+
+        viewModel.InitializeProperties();
+        var originalViewModel = viewModel;
+
+        form.DataJson = BuildPayload("network", "66%", 12, 23, 34, 45, 66);
+
+        Assert.AreSame(originalViewModel, viewModel);
+        Assert.AreEqual("network", viewModel.HeroMetric);
+        Assert.AreEqual("Network", viewModel.HeroLabelText);
+        Assert.AreEqual("66%", viewModel.HeroValueText);
+        Assert.AreEqual(12, viewModel.CpuPercent);
+        Assert.AreEqual(23, viewModel.GpuPercent);
+        Assert.AreEqual(34, viewModel.MemoryPercent);
+        Assert.AreEqual(45, viewModel.DiskPercent);
+        Assert.AreEqual(66, viewModel.NetworkPercent);
+        Assert.AreEqual("Send 1.0 MB/s · Receive 2.0 MB/s", viewModel.NetworkDetailText);
+    }
+
+    [TestMethod]
+    public void DataJsonUpdate_ClampsPercentValues()
+    {
+        var context = new TestPageContext();
+        var form = new FormContent
+        {
+            TemplateJson = NativeFormContentTypes.PerformanceOverview,
+            DataJson = BuildPayload("memory", "100%", -1, 101, 50, 0, 500),
+        };
+        var viewModel = new ContentPerformanceOverviewViewModel(
+            form,
+            new WeakReference<IPageContext>(context));
+
+        viewModel.InitializeProperties();
+
+        Assert.AreEqual(0, viewModel.CpuPercent);
+        Assert.AreEqual(100, viewModel.GpuPercent);
+        Assert.AreEqual(50, viewModel.MemoryPercent);
+        Assert.AreEqual(0, viewModel.DiskPercent);
+        Assert.AreEqual(100, viewModel.NetworkPercent);
+    }
+
+    [TestMethod]
+    public void EmptyInitialData_AcceptsFirstLiveSampleWithoutRecreatingViewModel()
+    {
+        var context = new TestPageContext();
+        var form = new FormContent
+        {
+            TemplateJson = NativeFormContentTypes.PerformanceOverview,
+            DataJson = string.Empty,
+        };
+        var viewModel = new ContentPerformanceOverviewViewModel(
+            form,
+            new WeakReference<IPageContext>(context));
+
+        viewModel.InitializeProperties();
+        form.DataJson = BuildPayload("cpu", "37%", 37, 10, 20, 30, 40);
+
+        Assert.AreEqual("cpu", viewModel.HeroMetric);
+        Assert.AreEqual("37%", viewModel.HeroValueText);
+        Assert.AreEqual(37, viewModel.CpuPercent);
+    }
+
+    [TestMethod]
+    public void MalformedUpdate_DoesNotPartiallyMutateExistingSample()
+    {
+        var context = new RecordingPageContext();
+        var form = new FormContent
+        {
+            TemplateJson = NativeFormContentTypes.PerformanceOverview,
+            DataJson = BuildPayload("cpu", "11%", 11, 22, 33, 44, 55),
+        };
+        var viewModel = new ContentPerformanceOverviewViewModel(
+            form,
+            new WeakReference<IPageContext>(context));
+
+        viewModel.InitializeProperties();
+        form.DataJson = new JsonObject
+        {
+            ["schemaVersion"] = 1,
+            ["titleText"] = "Incomplete update",
+        }.ToJsonString();
+
+        Assert.IsNotNull(context.LastException);
+        Assert.AreEqual("Performance monitor", viewModel.TitleText);
+        Assert.AreEqual("11%", viewModel.HeroValueText);
+        Assert.AreEqual(11, viewModel.CpuPercent);
+    }
+
+    private static string BuildPayload(
+        string heroMetric,
+        string heroValue,
+        int cpuPercent,
+        int gpuPercent,
+        int memoryPercent,
+        int diskPercent,
+        int networkPercent)
+    {
+        var heroLabel = heroMetric switch
+        {
+            "cpu" => "CPU",
+            "gpu" => "GPU",
+            "memory" => "RAM",
+            "disk" => "Disk",
+            "network" => "Network",
+            _ => throw new ArgumentOutOfRangeException(nameof(heroMetric)),
+        };
+
+        return new JsonObject
+        {
+            ["schemaVersion"] = 1,
+            ["titleText"] = "Performance monitor",
+            ["statusText"] = "Live",
+            ["heroMetric"] = heroMetric,
+            ["heroLabelText"] = heroLabel,
+            ["heroValueText"] = heroValue,
+            ["cpuLabelText"] = "CPU",
+            ["cpuDetailText"] = $"{cpuPercent}% · 4.0 GHz",
+            ["cpuPercent"] = cpuPercent,
+            ["gpuLabelText"] = "GPU",
+            ["gpuDetailText"] = $"{gpuPercent}% · 40 °C",
+            ["gpuPercent"] = gpuPercent,
+            ["memoryLabelText"] = "RAM",
+            ["memoryDetailText"] = "8.0 GB of 16.0 GB",
+            ["memoryPercent"] = memoryPercent,
+            ["diskLabelText"] = "Disk",
+            ["diskDetailText"] = "Read 1.0 MB/s · Write 2.0 MB/s",
+            ["diskPercent"] = diskPercent,
+            ["networkLabelText"] = "Network",
+            ["networkDetailText"] = "Send 1.0 MB/s · Receive 2.0 MB/s",
+            ["networkPercent"] = networkPercent,
+        }.ToJsonString();
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/DockItemViewModelTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/DockItemViewModelTests.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CmdPal.UI.ViewModels.Dock;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
+
+[TestClass]
+public class DockItemViewModelTests
+{
+    [DataTestMethod]
+    [DataRow("0.0 Kbps")]
+    [DataRow("100 Mbps")]
+    [DataRow("1.0 GB/s")]
+    [DataRow("50.0 MiB/s")]
+    public void GetTitleMinWidth_ReservesTransferRateWidth(string title)
+    {
+        Assert.AreEqual(64, DockItemViewModel.GetTitleMinWidth(title));
+    }
+
+    [DataTestMethod]
+    [DataRow("")]
+    [DataRow("42%")]
+    [DataRow("1:57 PM")]
+    public void GetTitleMinWidth_KeepsDefaultWidthForOtherTitles(string title)
+    {
+        Assert.AreEqual(24, DockItemViewModel.GetTitleMinWidth(title));
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/DockItemViewModelTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/DockItemViewModelTests.cs
@@ -2,14 +2,114 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.CmdPal.UI.ViewModels.Dock;
+using Microsoft.CmdPal.UI.ViewModels.Models;
+using Microsoft.CmdPal.UI.ViewModels.Services;
+using Microsoft.CmdPal.UI.ViewModels.Settings;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
 
 namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
 
 [TestClass]
-public class DockItemViewModelTests
+public partial class DockItemViewModelTests
 {
+    private sealed class TestPageContext(TaskScheduler scheduler) : IPageContext
+    {
+        public TaskScheduler Scheduler { get; } = scheduler;
+
+        public ICommandProviderContext ProviderContext => CommandProviderContext.Empty;
+
+        public void ShowException(Exception ex, string? extensionHint = null)
+        {
+            throw new AssertFailedException($"Unexpected exception from view model: {ex}");
+        }
+    }
+
+    private sealed class QueuedTaskScheduler : TaskScheduler
+    {
+        private readonly ConcurrentQueue<Task> _tasks = [];
+
+        protected override IEnumerable<Task> GetScheduledTasks() => _tasks.ToArray();
+
+        protected override void QueueTask(Task task) => _tasks.Enqueue(task);
+
+        protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued) => false;
+
+        public void ExecuteAllAvailable()
+        {
+            while (_tasks.TryDequeue(out var task))
+            {
+                TryExecuteTask(task);
+            }
+        }
+
+        public void ExecuteUntil(Func<bool> condition)
+        {
+            var timeout = Stopwatch.StartNew();
+            while (!condition())
+            {
+                ExecuteAllAvailable();
+                if (timeout.Elapsed > TimeSpan.FromSeconds(2))
+                {
+                    Assert.Fail("Timed out waiting for scheduled Dock work.");
+                }
+
+                Thread.Sleep(5);
+            }
+        }
+    }
+
+    private sealed partial class TestDockPage : ListPage
+    {
+        private IListItem[] _items;
+        private int _getItemsCallCount;
+        private Action? _getItemsCallback;
+
+        public TestDockPage(IListItem item)
+        {
+            _items = [item];
+        }
+
+        public int GetItemsCallCount => Volatile.Read(ref _getItemsCallCount);
+
+        public override IListItem[] GetItems()
+        {
+            Interlocked.Increment(ref _getItemsCallCount);
+            Interlocked.Exchange(ref _getItemsCallback, null)?.Invoke();
+            return Volatile.Read(ref _items);
+        }
+
+        public int ItemsChangedSubscriberCount =>
+            ((Delegate?)typeof(ListPage)
+                .GetField(nameof(ItemsChanged), BindingFlags.Instance | BindingFlags.NonPublic)!
+                .GetValue(this))?
+                .GetInvocationList()
+                .Length ?? 0;
+
+        public void SetItem(IListItem item) => Volatile.Write(ref _items, [item]);
+
+        public void OnNextGetItems(Action callback) => Volatile.Write(ref _getItemsCallback, callback);
+
+        public void TriggerItemsChanged() => RaiseItemsChanged(_items.Length);
+    }
+
+    private sealed record BandFixture(
+        DockBandViewModel Band,
+        CommandItemViewModel Root,
+        TestDockPage Page,
+        TestPageContext Context,
+        QueuedTaskScheduler Scheduler);
+
     [DataTestMethod]
     [DataRow("0.0 Kbps")]
     [DataRow("100 Mbps")]
@@ -27,5 +127,177 @@ public class DockItemViewModelTests
     public void GetTitleMinWidth_KeepsDefaultWidthForOtherTitles(string title)
     {
         Assert.AreEqual(24, DockItemViewModel.GetTitleMinWidth(title));
+    }
+
+    [TestMethod]
+    public void ItemsChanged_CleansReplacedViewModelAfterUiUpdate()
+    {
+        var fixture = CreateBandFixture();
+        try
+        {
+            var original = fixture.Band.Items[0];
+            fixture.Page.SetItem(CreateItem("Replacement"));
+
+            fixture.Page.TriggerItemsChanged();
+            fixture.Scheduler.ExecuteUntil(() => !ReferenceEquals(original, fixture.Band.Items[0]));
+
+            Assert.IsTrue(
+                SpinWait.SpinUntil(
+                    () => original.Initialized.HasFlag(InitializedState.CleanedUp),
+                    TimeSpan.FromSeconds(2)),
+                "The replaced Dock item was not cleaned.");
+        }
+        finally
+        {
+            CleanupFixture(fixture);
+        }
+    }
+
+    [TestMethod]
+    public void RepeatedItemsChanged_ReusesStableViewModel()
+    {
+        var fixture = CreateBandFixture();
+        try
+        {
+            var original = fixture.Band.Items[0];
+
+            for (var i = 0; i < 100; i++)
+            {
+                fixture.Page.TriggerItemsChanged();
+                fixture.Scheduler.ExecuteAllAvailable();
+            }
+
+            Assert.AreSame(original, fixture.Band.Items[0]);
+            Assert.IsFalse(original.Initialized.HasFlag(InitializedState.CleanedUp));
+        }
+        finally
+        {
+            CleanupFixture(fixture);
+        }
+    }
+
+    [TestMethod]
+    public void BurstyItemsChanged_CoalescesRefreshWork()
+    {
+        var fixture = CreateBandFixture();
+        try
+        {
+            var initialCalls = fixture.Page.GetItemsCallCount;
+
+            for (var i = 0; i < 1000; i++)
+            {
+                fixture.Page.TriggerItemsChanged();
+            }
+
+            Assert.AreEqual(initialCalls + 1, fixture.Page.GetItemsCallCount);
+
+            fixture.Scheduler.ExecuteAllAvailable();
+            Assert.IsTrue(
+                SpinWait.SpinUntil(
+                    () => fixture.Page.GetItemsCallCount == initialCalls + 2,
+                    TimeSpan.FromSeconds(2)),
+                "The coalesced follow-up refresh did not run.");
+            fixture.Scheduler.ExecuteAllAvailable();
+
+            Assert.AreEqual(initialCalls + 2, fixture.Page.GetItemsCallCount);
+            Assert.AreEqual(1, fixture.Band.Items.Count);
+        }
+        finally
+        {
+            CleanupFixture(fixture);
+        }
+    }
+
+    [TestMethod]
+    public void CleanupWithQueuedRefresh_DoesNotRepopulateItems()
+    {
+        var fixture = CreateBandFixture();
+        try
+        {
+            var original = fixture.Band.Items[0];
+            fixture.Page.SetItem(CreateItem("Replacement"));
+            fixture.Page.TriggerItemsChanged();
+
+            fixture.Band.SafeCleanup();
+            fixture.Scheduler.ExecuteAllAvailable();
+
+            Assert.AreEqual(0, fixture.Band.Items.Count);
+            Assert.IsTrue(
+                SpinWait.SpinUntil(
+                    () => original.Initialized.HasFlag(InitializedState.CleanedUp),
+                    TimeSpan.FromSeconds(2)),
+                "The disposed Dock item was not cleaned.");
+        }
+        finally
+        {
+            CleanupFixture(fixture);
+        }
+    }
+
+    [TestMethod]
+    public void CleanupDuringInitialization_DoesNotLeaveItemsChangedSubscription()
+    {
+        var fixture = CreateBandFixture(cleanupDuringInitialization: true);
+        try
+        {
+            Assert.AreEqual(0, fixture.Page.ItemsChangedSubscriberCount);
+        }
+        finally
+        {
+            CleanupFixture(fixture);
+        }
+    }
+
+    private static BandFixture CreateBandFixture(bool cleanupDuringInitialization = false)
+    {
+        var scheduler = new QueuedTaskScheduler();
+        var context = new TestPageContext(scheduler);
+        var page = new TestDockPage(CreateItem("Initial"))
+        {
+            Id = "test.dock.page",
+            Name = "Test Dock Page",
+            Title = "Test Dock Page",
+        };
+        var root = new CommandItemViewModel(
+            new(new CommandItem(page) { Title = page.Title }),
+            new(context),
+            DefaultContextMenuFactory.Instance);
+        root.SlowInitializeProperties();
+
+        var settingsService = new Mock<ISettingsService>();
+        settingsService.SetupGet(service => service.Settings).Returns(new SettingsModel());
+
+        var band = new DockBandViewModel(
+            root,
+            new(context),
+            new DockBandSettings { ProviderId = "test", CommandId = page.Id },
+            settingsService.Object,
+            DefaultContextMenuFactory.Instance);
+        if (cleanupDuringInitialization)
+        {
+            page.OnNextGetItems(band.SafeCleanup);
+        }
+
+        band.InitializeProperties();
+        if (cleanupDuringInitialization)
+        {
+            scheduler.ExecuteAllAvailable();
+        }
+        else
+        {
+            scheduler.ExecuteUntil(() => band.Items.Count == 1);
+        }
+
+        return new(band, root, page, context, scheduler);
+    }
+
+    private static ListItem CreateItem(string title) =>
+        new(new NoOpCommand { Name = title }) { Title = title };
+
+    private static void CleanupFixture(BandFixture fixture)
+    {
+        fixture.Band.SafeCleanup();
+        fixture.Root.SafeCleanup();
+        fixture.Scheduler.ExecuteAllAvailable();
     }
 }

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/PageViewModelLifecycleTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/PageViewModelLifecycleTests.cs
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
+
+[TestClass]
+public sealed partial class PageViewModelLifecycleTests
+{
+    private sealed partial class TestAppExtensionHost : AppExtensionHost
+    {
+        public override string? GetExtensionDisplayName() => "Test Host";
+    }
+
+    private class TrackingPageViewModel : PageViewModel
+    {
+        public int CleanupCount { get; private set; }
+
+        public TrackingPageViewModel()
+            : base(null, TaskScheduler.Default, new TestAppExtensionHost(), CommandProviderContext.Empty)
+        {
+        }
+
+        protected override void UnsafeCleanup()
+        {
+            CleanupCount++;
+            base.UnsafeCleanup();
+        }
+    }
+
+    private sealed class BlockingPageViewModel : TrackingPageViewModel
+    {
+        public ManualResetEventSlim InitializationStarted { get; } = new();
+
+        public ManualResetEventSlim ContinueInitialization { get; } = new();
+
+        public override void InitializeProperties()
+        {
+            InitializationStarted.Set();
+            Assert.IsTrue(ContinueInitialization.Wait(TimeSpan.FromSeconds(5)));
+        }
+    }
+
+    [TestMethod]
+    public void CleanupIfTransient_OnlyCleansDiscardedTransientPages()
+    {
+        var rootPage = new TrackingPageViewModel();
+        var transientPage = new TrackingPageViewModel { IsTransientPage = true };
+        var nestedPage = new TrackingPageViewModel();
+
+        rootPage.SafeCleanupIfTransient();
+        transientPage.SafeCleanupIfTransient();
+        nestedPage.SafeCleanupIfTransient();
+        transientPage.SafeCleanupIfTransient();
+
+        Assert.AreEqual(0, rootPage.CleanupCount);
+        Assert.AreEqual(1, transientPage.CleanupCount);
+        Assert.AreEqual(0, nestedPage.CleanupCount);
+
+        rootPage.SafeCleanup();
+        nestedPage.SafeCleanup();
+    }
+
+    [TestMethod]
+    public async Task CleanupDuringInitialization_IsDeferredUntilInitializationCompletes()
+    {
+        var page = new BlockingPageViewModel();
+        var initialization = Task.Run(page.InitializeAsync);
+
+        Assert.IsTrue(page.InitializationStarted.Wait(TimeSpan.FromSeconds(5)));
+
+        page.SafeCleanup();
+        Assert.AreEqual(0, page.CleanupCount);
+
+        page.ContinueInitialization.Set();
+        await initialization;
+
+        Assert.AreEqual(1, page.CleanupCount);
+        page.SafeCleanup();
+        Assert.AreEqual(1, page.CleanupCount);
+    }
+}

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/DevHome/Helpers/GPUStats.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/DevHome/Helpers/GPUStats.cs
@@ -357,6 +357,14 @@ internal sealed partial class GPUStats : PerformanceCounterSourceBase, IDisposab
         }
     }
 
+    internal int GetGPUCount()
+    {
+        lock (_statsLock)
+        {
+            return _stats.Count;
+        }
+    }
+
     internal int GetPrevGPUIndex(int gpuActiveIndex)
     {
         lock (_statsLock)

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/DevHome/Helpers/NetworkStats.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/DevHome/Helpers/NetworkStats.cs
@@ -5,14 +5,19 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using Microsoft.CmdPal.Common;
 
 namespace CoreWidgetProvider.Helpers;
 
 internal sealed partial class NetworkStats : PerformanceCounterSourceBase, IDisposable
 {
+    private const float MinimumSwitchDeltaBytesPerSecond = 128;
+    private const float SwitchHysteresisRatio = 0.25f;
+
     private readonly Dictionary<string, List<PerformanceCounter>> _networkCounters = new();
+    private readonly List<string> _networkNames = [];
+    private readonly List<Data> _networkUsagesByIndex = [];
+    private readonly object _statsLock = new();
     private bool _networkCounterReadFailureLogged;
 
     private Dictionary<string, Data> NetworkUsages { get; set; } = new();
@@ -32,6 +37,11 @@ internal sealed partial class NetworkStats : PerformanceCounterSourceBase, IDisp
         }
 
         public float Received
+        {
+            get; set;
+        }
+
+        public float Bandwidth
         {
             get; set;
         }
@@ -69,9 +79,12 @@ internal sealed partial class NetworkStats : PerformanceCounterSourceBase, IDisp
                     }
 
                     var instanceCounters = new List<PerformanceCounter> { bytesSent, bytesReceived, currentBandwidth };
+                    var usage = new Data();
                     _networkCounters.Add(instanceName, instanceCounters);
+                    _networkNames.Add(instanceName);
+                    _networkUsagesByIndex.Add(usage);
                     NetChartValues.Add(instanceName, new List<float>());
-                    NetworkUsages.Add(instanceName, new Data());
+                    NetworkUsages.Add(instanceName, usage);
                 }
                 catch (Exception)
                 {
@@ -87,7 +100,6 @@ internal sealed partial class NetworkStats : PerformanceCounterSourceBase, IDisp
 
     public void GetData()
     {
-        float maxUsage = 0;
         foreach (var networkCounterWithName in _networkCounters)
         {
             try
@@ -95,26 +107,21 @@ internal sealed partial class NetworkStats : PerformanceCounterSourceBase, IDisp
                 var sent = networkCounterWithName.Value[0].NextValue();
                 var received = networkCounterWithName.Value[1].NextValue();
                 var bandWidth = networkCounterWithName.Value[2].NextValue();
-                if (bandWidth == 0)
-                {
-                    continue;
-                }
-
-                var usage = 8 * (sent + received) / bandWidth;
+                var usage = bandWidth > 0 ? 8 * (sent + received) / bandWidth : 0;
                 var name = networkCounterWithName.Key;
-                NetworkUsages[name].Sent = sent;
-                NetworkUsages[name].Received = received;
-                NetworkUsages[name].Usage = usage;
+                lock (_statsLock)
+                {
+                    var data = NetworkUsages[name];
+                    data.Sent = bandWidth > 0 ? sent : 0;
+                    data.Received = bandWidth > 0 ? received : 0;
+                    data.Usage = usage;
+                    data.Bandwidth = Math.Max(0, bandWidth);
+                }
 
                 var chartValues = NetChartValues[name];
                 lock (chartValues)
                 {
                     ChartHelper.AddNextChartValue(usage * 100, chartValues);
-                }
-
-                if (usage > maxUsage)
-                {
-                    maxUsage = usage;
                 }
             }
             catch (Exception ex)
@@ -126,64 +133,171 @@ internal sealed partial class NetworkStats : PerformanceCounterSourceBase, IDisp
 
     public string CreateNetImageUrl(int netChartIndex)
     {
-        return ChartHelper.CreateImageUrl(NetChartValues.ElementAt(netChartIndex).Value, ChartHelper.ChartType.Net);
-    }
-
-    public string GetNetworkName(int networkIndex)
-    {
-        if (NetChartValues.Count <= networkIndex)
+        if (netChartIndex < 0 || netChartIndex >= _networkNames.Count)
         {
             return string.Empty;
         }
 
-        return NetChartValues.ElementAt(networkIndex).Key;
+        return ChartHelper.CreateImageUrl(NetChartValues[_networkNames[netChartIndex]], ChartHelper.ChartType.Net);
+    }
+
+    public string GetNetworkName(int networkIndex)
+    {
+        if (networkIndex < 0 || networkIndex >= _networkNames.Count)
+        {
+            return string.Empty;
+        }
+
+        return _networkNames[networkIndex];
     }
 
     public Data GetNetworkUsage(int networkIndex)
     {
-        if (NetChartValues.Count <= networkIndex)
+        lock (_statsLock)
         {
-            return new Data();
+            if (networkIndex < 0 || networkIndex >= _networkUsagesByIndex.Count)
+            {
+                return new Data();
+            }
+
+            var value = _networkUsagesByIndex[networkIndex];
+            return new Data
+            {
+                Usage = value.Usage,
+                Sent = value.Sent,
+                Received = value.Received,
+                Bandwidth = value.Bandwidth,
+            };
+        }
+    }
+
+    public int GetSelectableNetworkCount()
+    {
+        lock (_statsLock)
+        {
+            return CountSelectableNetworks(_networkUsagesByIndex);
+        }
+    }
+
+    internal static int CountSelectableNetworks(IReadOnlyList<Data> networkUsages)
+    {
+        var count = 0;
+        foreach (var networkUsage in networkUsages)
+        {
+            if (IsSelectableNetwork(networkUsage))
+            {
+                count++;
+            }
         }
 
-        var currNetworkName = NetChartValues.ElementAt(networkIndex).Key;
-        if (!NetworkUsages.TryGetValue(currNetworkName, out var value))
+        return count;
+    }
+
+    public int GetBusiestNetworkIndex(int fallbackIndex)
+    {
+        lock (_statsLock)
         {
-            return new Data();
+            return SelectBusiestNetworkIndex(_networkUsagesByIndex, fallbackIndex);
+        }
+    }
+
+    internal static int SelectBusiestNetworkIndex(IReadOnlyList<Data> networkUsages, int fallbackIndex)
+    {
+        if (networkUsages.Count == 0)
+        {
+            return 0;
         }
 
-        return value;
+        var selectedIndex = Math.Clamp(fallbackIndex, 0, networkUsages.Count - 1);
+        var fallbackIsSelectable = IsSelectableNetwork(networkUsages[selectedIndex]);
+        if (!fallbackIsSelectable)
+        {
+            for (var index = 0; index < networkUsages.Count; index++)
+            {
+                if (IsSelectableNetwork(networkUsages[index]))
+                {
+                    selectedIndex = index;
+                    break;
+                }
+            }
+        }
+
+        var selectedThroughput = GetThroughput(networkUsages[selectedIndex]);
+        var busiestIndex = selectedIndex;
+        var busiestThroughput = selectedThroughput;
+        for (var index = 0; index < networkUsages.Count; index++)
+        {
+            var candidate = networkUsages[index];
+            if (!IsSelectableNetwork(candidate))
+            {
+                continue;
+            }
+
+            var candidateThroughput = GetThroughput(candidate);
+            if (candidateThroughput > busiestThroughput)
+            {
+                busiestIndex = index;
+                busiestThroughput = candidateThroughput;
+            }
+        }
+
+        if (!fallbackIsSelectable)
+        {
+            return busiestIndex;
+        }
+
+        var switchDelta = Math.Max(MinimumSwitchDeltaBytesPerSecond, selectedThroughput * SwitchHysteresisRatio);
+        return busiestThroughput > selectedThroughput + switchDelta
+            ? busiestIndex
+            : selectedIndex;
     }
 
     public int GetPrevNetworkIndex(int networkIndex)
     {
-        if (NetChartValues.Count == 0)
+        lock (_statsLock)
         {
-            return 0;
+            return SelectPreviousNetworkIndex(_networkUsagesByIndex, networkIndex);
         }
-
-        if (networkIndex == 0)
-        {
-            return NetChartValues.Count - 1;
-        }
-
-        return networkIndex - 1;
     }
 
     public int GetNextNetworkIndex(int networkIndex)
     {
-        if (NetChartValues.Count == 0)
+        lock (_statsLock)
         {
-            return 0;
+            return SelectNextNetworkIndex(_networkUsagesByIndex, networkIndex);
         }
-
-        if (networkIndex == NetChartValues.Count - 1)
-        {
-            return 0;
-        }
-
-        return networkIndex + 1;
     }
+
+    internal static int SelectPreviousNetworkIndex(IReadOnlyList<Data> networkUsages, int currentIndex) =>
+        SelectAdjacentNetworkIndex(networkUsages, currentIndex, -1);
+
+    internal static int SelectNextNetworkIndex(IReadOnlyList<Data> networkUsages, int currentIndex) =>
+        SelectAdjacentNetworkIndex(networkUsages, currentIndex, 1);
+
+    private static int SelectAdjacentNetworkIndex(IReadOnlyList<Data> networkUsages, int currentIndex, int direction)
+    {
+        if (networkUsages.Count == 0)
+        {
+            return 0;
+        }
+
+        var selectedIndex = Math.Clamp(currentIndex, 0, networkUsages.Count - 1);
+        for (var offset = 1; offset <= networkUsages.Count; offset++)
+        {
+            var candidateIndex = (selectedIndex + (direction * offset) + networkUsages.Count) % networkUsages.Count;
+            if (IsSelectableNetwork(networkUsages[candidateIndex]))
+            {
+                return candidateIndex;
+            }
+        }
+
+        return selectedIndex;
+    }
+
+    private static float GetThroughput(Data networkUsage) =>
+        Math.Max(0, networkUsage.Sent) + Math.Max(0, networkUsage.Received);
+
+    private static bool IsSelectableNetwork(Data networkUsage) => Math.Max(0, networkUsage.Bandwidth) > 0;
 
     public void Dispose()
     {

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/OnLoadStaticPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/OnLoadStaticPage.cs
@@ -83,25 +83,37 @@ internal abstract partial class OnLoadBasePage : Page
     {
         add
         {
-            InternalItemsChanged += value;
             lock (_loadLock)
             {
-                if (_loadCount == 0)
+                InternalItemsChanged += value;
+                try
                 {
-                    Loaded();
-                }
+                    if (_loadCount == 0)
+                    {
+                        Loaded();
+                    }
 
-                _loadCount++;
+                    _loadCount++;
+                }
+                catch
+                {
+                    InternalItemsChanged -= value;
+                    throw;
+                }
             }
         }
 
         remove
         {
-            InternalItemsChanged -= value;
             lock (_loadLock)
             {
+                if (InternalItemsChanged?.GetInvocationList().Contains(value) != true)
+                {
+                    return;
+                }
+
+                InternalItemsChanged -= value;
                 _loadCount--;
-                _loadCount = Math.Max(0, _loadCount);
                 if (_loadCount == 0)
                 {
                     Unloaded();

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceMetricSelectionState.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceMetricSelectionState.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+
+namespace Microsoft.CmdPal.Ext.PerformanceMonitor;
+
+internal sealed class PerformanceMetricSelectionState
+{
+    private int _diskIndex;
+    private int _networkIndex;
+    private int _gpuIndex;
+
+    public int DiskIndex
+    {
+        get => Volatile.Read(ref _diskIndex);
+        set => Volatile.Write(ref _diskIndex, value);
+    }
+
+    public int NetworkIndex
+    {
+        get => Volatile.Read(ref _networkIndex);
+        set => Volatile.Write(ref _networkIndex, value);
+    }
+
+    public int GpuIndex
+    {
+        get => Volatile.Read(ref _gpuIndex);
+        set => Volatile.Write(ref _gpuIndex, value);
+    }
+}

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceMetricSelectionState.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceMetricSelectionState.cs
@@ -8,9 +8,11 @@ namespace Microsoft.CmdPal.Ext.PerformanceMonitor;
 
 internal sealed class PerformanceMetricSelectionState
 {
+    private readonly object _networkSelectionLock = new();
     private int _diskIndex;
     private int _networkIndex;
     private int _gpuIndex;
+    private bool _automaticallySelectNetwork = true;
 
     public int DiskIndex
     {
@@ -20,8 +22,66 @@ internal sealed class PerformanceMetricSelectionState
 
     public int NetworkIndex
     {
-        get => Volatile.Read(ref _networkIndex);
-        set => Volatile.Write(ref _networkIndex, value);
+        get
+        {
+            lock (_networkSelectionLock)
+            {
+                return _networkIndex;
+            }
+        }
+    }
+
+    public bool IsNetworkSelectionAutomatic
+    {
+        get
+        {
+            lock (_networkSelectionLock)
+            {
+                return _automaticallySelectNetwork;
+            }
+        }
+    }
+
+    public int UpdateAutomaticNetworkIndex(int value)
+    {
+        lock (_networkSelectionLock)
+        {
+            if (_automaticallySelectNetwork)
+            {
+                _networkIndex = value;
+            }
+
+            return _networkIndex;
+        }
+    }
+
+    public bool SelectNetworkManually(int value)
+    {
+        lock (_networkSelectionLock)
+        {
+            if (_networkIndex == value)
+            {
+                return false;
+            }
+
+            _automaticallySelectNetwork = false;
+            _networkIndex = value;
+            return true;
+        }
+    }
+
+    public int RecoverNetworkSelection(int expectedIndex, int replacementIndex)
+    {
+        lock (_networkSelectionLock)
+        {
+            if (_networkIndex == expectedIndex && replacementIndex != expectedIndex)
+            {
+                _automaticallySelectNetwork = true;
+                _networkIndex = replacementIndex;
+            }
+
+            return _networkIndex;
+        }
     }
 
     public int GpuIndex

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceMonitorCommandsProvider.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceMonitorCommandsProvider.cs
@@ -207,11 +207,20 @@ public partial class PerformanceMonitorCommandsProvider : CommandProvider
         var selectionState = new PerformanceMetricSelectionState();
         var mainPage = new PerformanceWidgetsPage(_settingsManager, selectionState: selectionState);
         _mainPage = mainPage;
-        var networkThroughputNormalizer = new RollingNetworkThroughputNormalizer();
+        var networkThroughputNormalizer = new RollingThroughputNormalizer();
+        var networkDirectionNormalizer = new RollingThroughputNormalizer();
+        var diskDirectionNormalizer = new RollingThroughputNormalizer();
         var dockOverviewPages = new Dictionary<PerformanceMetricKind, PerformanceOverviewPage>();
         foreach (var metric in OverviewMetrics)
         {
-            dockOverviewPages.Add(metric, new PerformanceOverviewPage(mainPage, metric, networkThroughputNormalizer));
+            dockOverviewPages.Add(
+                metric,
+                new PerformanceOverviewPage(
+                    mainPage,
+                    metric,
+                    networkThroughputNormalizer,
+                    networkDirectionNormalizer,
+                    diskDirectionNormalizer));
         }
 
         _dockOverviewPages = [.. dockOverviewPages.Values];

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceMonitorCommandsProvider.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceMonitorCommandsProvider.cs
@@ -29,10 +29,20 @@ public partial class PerformanceMonitorCommandsProvider : CommandProvider
         PerformanceMetricKind.Battery,
     ];
 
+    private static readonly PerformanceMetricKind[] OverviewMetrics =
+    [
+        PerformanceMetricKind.Cpu,
+        PerformanceMetricKind.Memory,
+        PerformanceMetricKind.Network,
+        PerformanceMetricKind.Disk,
+        PerformanceMetricKind.Gpu,
+    ];
+
     internal static ProviderCrashSentinel CrashSentinel { get; } = new(ProviderIdValue);
 
     private readonly Lock _stateLock = new();
     private readonly SettingsManager _settingsManager = new();
+    private PerformanceOverviewPage[] _dockOverviewPages = [];
     private ICommandItem[] _commands = [];
     private ICommandItem[] _bands = [];
     private PerformanceWidgetsPage? _mainPage;
@@ -194,14 +204,27 @@ public partial class PerformanceMonitorCommandsProvider : CommandProvider
     {
         DisposeActivePages();
 
-        _mainPage = new PerformanceWidgetsPage(_settingsManager, false);
-        _bandPage = new PerformanceWidgetsPage(_settingsManager, true);
-        _cpuBandPage = new PerformanceWidgetsPage(_settingsManager, true, PerformanceMetricKind.Cpu);
-        _memoryBandPage = new PerformanceWidgetsPage(_settingsManager, true, PerformanceMetricKind.Memory);
-        _networkBandPage = new PerformanceWidgetsPage(_settingsManager, true, PerformanceMetricKind.Network);
-        _diskBandPage = new PerformanceWidgetsPage(_settingsManager, true, PerformanceMetricKind.Disk);
-        _gpuBandPage = new PerformanceWidgetsPage(_settingsManager, true, PerformanceMetricKind.Gpu);
-        _batteryBandPage = new PerformanceWidgetsPage(_settingsManager, true, PerformanceMetricKind.Battery);
+        var selectionState = new PerformanceMetricSelectionState();
+        var mainPage = new PerformanceWidgetsPage(_settingsManager, selectionState: selectionState);
+        _mainPage = mainPage;
+        var networkThroughputNormalizer = new RollingNetworkThroughputNormalizer();
+        var dockOverviewPages = new Dictionary<PerformanceMetricKind, PerformanceOverviewPage>();
+        foreach (var metric in OverviewMetrics)
+        {
+            dockOverviewPages.Add(metric, new PerformanceOverviewPage(mainPage, metric, networkThroughputNormalizer));
+        }
+
+        _dockOverviewPages = [.. dockOverviewPages.Values];
+        ICommand? GetDockOverviewPage(PerformanceMetricKind metric) =>
+            dockOverviewPages.TryGetValue(metric, out var page) ? page : null;
+
+        _bandPage = new PerformanceWidgetsPage(_settingsManager, true, itemCommandFactory: GetDockOverviewPage, selectionState: selectionState);
+        _cpuBandPage = new PerformanceWidgetsPage(_settingsManager, true, PerformanceMetricKind.Cpu, GetDockOverviewPage, selectionState);
+        _memoryBandPage = new PerformanceWidgetsPage(_settingsManager, true, PerformanceMetricKind.Memory, GetDockOverviewPage, selectionState);
+        _networkBandPage = new PerformanceWidgetsPage(_settingsManager, true, PerformanceMetricKind.Network, GetDockOverviewPage, selectionState);
+        _diskBandPage = new PerformanceWidgetsPage(_settingsManager, true, PerformanceMetricKind.Disk, GetDockOverviewPage, selectionState);
+        _gpuBandPage = new PerformanceWidgetsPage(_settingsManager, true, PerformanceMetricKind.Gpu, GetDockOverviewPage, selectionState);
+        _batteryBandPage = new PerformanceWidgetsPage(_settingsManager, true, PerformanceMetricKind.Battery, selectionState: selectionState);
 
         List<ICommandItem> bands = [
             new CommandItem(_bandPage) { Title = DisplayName },
@@ -233,6 +256,13 @@ public partial class PerformanceMonitorCommandsProvider : CommandProvider
 
     private void DisposeActivePages()
     {
+        foreach (var page in _dockOverviewPages)
+        {
+            page.Dispose();
+        }
+
+        _dockOverviewPages = [];
+
         _mainPage?.Dispose();
         _mainPage = null;
 

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceOverviewFormatter.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceOverviewFormatter.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Globalization;
+
+namespace Microsoft.CmdPal.Ext.PerformanceMonitor;
+
+/// <summary>
+/// Pure formatting and metric-selection helpers used by the compact
+/// <see cref="PerformanceOverviewPage"/> dashboard. These are intentionally
+/// free of I/O, WinRT, and UI state so they can be unit tested directly.
+/// </summary>
+internal static class PerformanceOverviewFormatter
+{
+    /// <summary>
+    /// Parses a formatted percentage string (e.g. "42%", as produced by
+    /// <see cref="WidgetPage.FloatToPercentString(float)"/>) back into a
+    /// clamped 0-100 integer. Returns 0 for null, empty, or unparsable input
+    /// so a missing or errored metric renders as an empty bar instead of
+    /// throwing.
+    /// </summary>
+    internal static int ParsePercentText(string? percentText)
+    {
+        if (string.IsNullOrWhiteSpace(percentText))
+        {
+            return 0;
+        }
+
+        var trimmed = percentText.Trim().TrimEnd('%').Trim();
+
+        return int.TryParse(trimmed, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)
+            ? ClampPercent(value)
+            : 0;
+    }
+
+    /// <summary>Clamps a percentage to the valid 0-100 range.</summary>
+    internal static int ClampPercent(int percent) => Math.Clamp(percent, 0, 100);
+
+    internal static string GetMetricKey(PerformanceMetricKind metric) => metric switch
+    {
+        PerformanceMetricKind.Cpu => "cpu",
+        PerformanceMetricKind.Memory => "memory",
+        PerformanceMetricKind.Network => "network",
+        PerformanceMetricKind.Disk => "disk",
+        PerformanceMetricKind.Gpu => "gpu",
+        _ => throw new ArgumentOutOfRangeException(nameof(metric), metric, "The metric is not available in the performance overview."),
+    };
+
+    internal static string SelectMetricValue(
+        PerformanceMetricKind metric,
+        string cpuValue,
+        string memoryValue,
+        string networkValue,
+        string diskValue,
+        string gpuValue)
+    {
+        return metric switch
+        {
+            PerformanceMetricKind.Cpu => cpuValue,
+            PerformanceMetricKind.Memory => memoryValue,
+            PerformanceMetricKind.Network => networkValue,
+            PerformanceMetricKind.Disk => diskValue,
+            PerformanceMetricKind.Gpu => gpuValue,
+            _ => throw new ArgumentOutOfRangeException(nameof(metric), metric, "The metric is not available in the performance overview."),
+        };
+    }
+}

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceOverviewPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceOverviewPage.cs
@@ -294,14 +294,14 @@ internal sealed partial class PerformanceOverviewPage : OnLoadContentPage, IDisp
             throughput.Sent + throughput.Received,
             timestamp);
         var directionPercentages = _networkDirectionNormalizer.AddPairSample(
-            throughput.Received,
             throughput.Sent,
+            throughput.Received,
             timestamp);
         var percentText = networkPercent.ToString(CultureInfo.InvariantCulture) + "%";
-        var inLabel = Resources.GetResource("Network_In_Subtitle");
-        var outLabel = Resources.GetResource("Network_Out_Subtitle");
-        var inText = _networkPage.GetContentValue("netReceived");
-        var outText = _networkPage.GetContentValue("netSent");
+        var sendLabel = Resources.GetResource("Network_Send_Subtitle");
+        var receiveLabel = Resources.GetResource("Network_Receive_Subtitle");
+        var sendText = _networkPage.GetContentValue("netSent");
+        var receiveText = _networkPage.GetContentValue("netReceived");
         var networkLabel = Resources.GetResource("Network_Usage_Subtitle");
 
         json["networkLabelText"] = networkLabel;
@@ -310,16 +310,16 @@ internal sealed partial class PerformanceOverviewPage : OnLoadContentPage, IDisp
         json["networkDetailText"] = string.Format(
             CultureInfo.CurrentCulture,
             Resources.GetResource("Overview_Network_Detail_Format"),
-            inLabel,
-            inText,
-            outLabel,
-            outText);
-        json["networkInLabelText"] = FormatDirectionalLabel(networkLabel, inLabel);
-        json["networkOutLabelText"] = FormatDirectionalLabel(networkLabel, outLabel);
-        json["networkInText"] = FormatDirectionalValue(inLabel, inText);
-        json["networkOutText"] = FormatDirectionalValue(outLabel, outText);
-        json["networkInPercent"] = directionPercentages.FirstPercent;
-        json["networkOutPercent"] = directionPercentages.SecondPercent;
+            sendLabel,
+            sendText,
+            receiveLabel,
+            receiveText);
+        json["networkSendLabelText"] = FormatDirectionalLabel(networkLabel, sendLabel);
+        json["networkReceiveLabelText"] = FormatDirectionalLabel(networkLabel, receiveLabel);
+        json["networkSendText"] = FormatDirectionalValue(sendLabel, sendText);
+        json["networkReceiveText"] = FormatDirectionalValue(receiveLabel, receiveText);
+        json["networkSendPercent"] = directionPercentages.FirstPercent;
+        json["networkReceivePercent"] = directionPercentages.SecondPercent;
         json["networkPercent"] = networkPercent;
         return percentText;
     }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceOverviewPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceOverviewPage.cs
@@ -37,7 +37,9 @@ internal sealed partial class PerformanceOverviewPage : OnLoadContentPage, IDisp
     private readonly Timer _refreshTimer;
     private readonly PerformanceMetricKind _heroMetric;
     private readonly string _heroLabel;
-    private readonly RollingNetworkThroughputNormalizer _networkThroughputNormalizer;
+    private readonly RollingThroughputNormalizer _networkThroughputNormalizer;
+    private readonly RollingThroughputNormalizer _networkDirectionNormalizer;
+    private readonly RollingThroughputNormalizer _diskDirectionNormalizer;
 
     private readonly SystemCPUUsageWidgetPage _cpuPage;
     private readonly SystemMemoryUsageWidgetPage _memoryPage;
@@ -51,10 +53,14 @@ internal sealed partial class PerformanceOverviewPage : OnLoadContentPage, IDisp
     public PerformanceOverviewPage(
         PerformanceWidgetsPage metricsPage,
         PerformanceMetricKind heroMetric,
-        RollingNetworkThroughputNormalizer networkThroughputNormalizer)
+        RollingThroughputNormalizer networkThroughputNormalizer,
+        RollingThroughputNormalizer networkDirectionNormalizer,
+        RollingThroughputNormalizer diskDirectionNormalizer)
     {
         _heroMetric = heroMetric;
         _networkThroughputNormalizer = networkThroughputNormalizer;
+        _networkDirectionNormalizer = networkDirectionNormalizer;
+        _diskDirectionNormalizer = diskDirectionNormalizer;
         _heroLabel = PerformanceOverviewFormatter.SelectMetricValue(
             heroMetric,
             Resources.GetResource("CPU_Usage_Subtitle"),
@@ -178,12 +184,13 @@ internal sealed partial class PerformanceOverviewPage : OnLoadContentPage, IDisp
     private JsonObject BuildDataJson()
     {
         var json = new JsonObject();
+        var timestamp = DateTimeOffset.UtcNow;
 
         var cpuPercentText = AddCpuData(json);
         var memoryPercentText = AddMemoryData(json);
         var gpuPercentText = AddGpuData(json);
-        var diskPercentText = AddDiskData(json);
-        var networkPercentText = AddNetworkData(json);
+        var diskPercentText = AddDiskData(json, timestamp);
+        var networkPercentText = AddNetworkData(json, timestamp);
 
         json["schemaVersion"] = 1;
         json["titleText"] = Resources.GetResource("Performance_Monitor_Title");
@@ -247,45 +254,91 @@ internal sealed partial class PerformanceOverviewPage : OnLoadContentPage, IDisp
         return percentText;
     }
 
-    private string AddDiskData(JsonObject json)
+    private string AddDiskData(JsonObject json, DateTimeOffset timestamp)
     {
         var rawPercentText = _diskPage.GetContentValue("diskUsage");
         var percentText = FirstNonEmpty(rawPercentText, Resources.GetResource("Disk_Usage_Unknown"));
+        var readLabel = Resources.GetResource("Disk_Read_Subtitle");
+        var writeLabel = Resources.GetResource("Disk_Write_Subtitle");
+        var readText = _diskPage.GetContentValue("diskRead");
+        var writeText = _diskPage.GetContentValue("diskWrite");
+        var throughput = _diskPage.GetThroughputBytesPerSecond();
+        var directionPercentages = _diskDirectionNormalizer.AddPairSample(
+            throughput.Read,
+            throughput.Write,
+            timestamp);
+        var diskLabel = Resources.GetResource("Disk_Usage_Subtitle");
 
-        json["diskLabelText"] = Resources.GetResource("Disk_Usage_Subtitle");
+        json["diskLabelText"] = diskLabel;
         json["diskDetailText"] = string.Format(
             CultureInfo.CurrentCulture,
             Resources.GetResource("Overview_Disk_Detail_Format"),
-            Resources.GetResource("Disk_Read_Subtitle"),
-            _diskPage.GetContentValue("diskRead"),
-            Resources.GetResource("Disk_Write_Subtitle"),
-            _diskPage.GetContentValue("diskWrite"));
+            readLabel,
+            readText,
+            writeLabel,
+            writeText);
+        json["diskReadLabelText"] = FormatDirectionalLabel(diskLabel, readLabel);
+        json["diskWriteLabelText"] = FormatDirectionalLabel(diskLabel, writeLabel);
+        json["diskReadText"] = FormatDirectionalValue(readLabel, readText);
+        json["diskWriteText"] = FormatDirectionalValue(writeLabel, writeText);
+        json["diskReadPercent"] = directionPercentages.FirstPercent;
+        json["diskWritePercent"] = directionPercentages.SecondPercent;
         json["diskPercent"] = PerformanceOverviewFormatter.ParsePercentText(rawPercentText);
         return percentText;
     }
 
-    private string AddNetworkData(JsonObject json)
+    private string AddNetworkData(JsonObject json, DateTimeOffset timestamp)
     {
+        var throughput = _networkPage.GetThroughputBytesPerSecond();
         var networkPercent = _networkThroughputNormalizer.AddSample(
-            _networkPage.GetTotalThroughputBytesPerSecond(),
-            DateTimeOffset.UtcNow);
+            throughput.Sent + throughput.Received,
+            timestamp);
+        var directionPercentages = _networkDirectionNormalizer.AddPairSample(
+            throughput.Received,
+            throughput.Sent,
+            timestamp);
         var percentText = networkPercent.ToString(CultureInfo.InvariantCulture) + "%";
+        var inLabel = Resources.GetResource("Network_In_Subtitle");
+        var outLabel = Resources.GetResource("Network_Out_Subtitle");
+        var inText = _networkPage.GetContentValue("netReceived");
+        var outText = _networkPage.GetContentValue("netSent");
+        var networkLabel = Resources.GetResource("Network_Usage_Subtitle");
 
-        json["networkLabelText"] = Resources.GetResource("Network_Usage_Subtitle");
+        json["networkLabelText"] = networkLabel;
         json["networkAdapterName"] = _networkPage.GetContentValue("networkName");
         json["canSwitchNetwork"] = _networkPage.GetAdapterCount() > 1;
         json["networkDetailText"] = string.Format(
             CultureInfo.CurrentCulture,
             Resources.GetResource("Overview_Network_Detail_Format"),
-            Resources.GetResource("Network_Send_Subtitle"),
-            _networkPage.GetContentValue("netSent"),
-            Resources.GetResource("Network_Receive_Subtitle"),
-            _networkPage.GetContentValue("netReceived"));
+            inLabel,
+            inText,
+            outLabel,
+            outText);
+        json["networkInLabelText"] = FormatDirectionalLabel(networkLabel, inLabel);
+        json["networkOutLabelText"] = FormatDirectionalLabel(networkLabel, outLabel);
+        json["networkInText"] = FormatDirectionalValue(inLabel, inText);
+        json["networkOutText"] = FormatDirectionalValue(outLabel, outText);
+        json["networkInPercent"] = directionPercentages.FirstPercent;
+        json["networkOutPercent"] = directionPercentages.SecondPercent;
         json["networkPercent"] = networkPercent;
         return percentText;
     }
 
     private static string FirstNonEmpty(string value, string fallback) => string.IsNullOrEmpty(value) ? fallback : value;
+
+    private static string FormatDirectionalLabel(string metricLabel, string directionLabel) =>
+        string.Format(
+            CultureInfo.CurrentCulture,
+            Resources.GetResource("Overview_Directional_Label_Format"),
+            metricLabel,
+            directionLabel);
+
+    private static string FormatDirectionalValue(string label, string value) =>
+        string.Format(
+            CultureInfo.CurrentCulture,
+            Resources.GetResource("Overview_Directional_Value_Format"),
+            label,
+            value);
 
     private static string FormatPercentDetail(string percentText, string detailText) =>
         string.IsNullOrEmpty(detailText)

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceOverviewPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceOverviewPage.cs
@@ -1,0 +1,299 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Globalization;
+using System.Text.Json.Nodes;
+using System.Threading;
+using CoreWidgetProvider.Helpers;
+using Microsoft.CmdPal.Common;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+
+namespace Microsoft.CmdPal.Ext.PerformanceMonitor;
+
+/// <summary>
+/// Compact, single-glance dashboard opened from the Performance Monitor dock
+/// band. It follows the Dock design with a contextual headline and thin,
+/// full-width CPU/GPU/RAM/Disk/Network utilization rows.
+/// </summary>
+internal sealed partial class PerformanceOverviewPage : OnLoadContentPage, IDisposable
+{
+    private static readonly TimeSpan RefreshDelay = TimeSpan.FromMilliseconds(150);
+
+    public override string Id => $"com.microsoft.cmdpal.performanceWidget.{PerformanceWidgetsPage.GetMetricSuffix(_heroMetric)}.dockOverview";
+
+    public override string Title => Resources.GetResource("Performance_Monitor_Title");
+
+    public override IconInfo Icon => Icons.PerformanceMonitorIcon;
+
+    private readonly Lock _refreshLock = new();
+    private readonly FormContent _formContent = new()
+    {
+        TemplateJson = NativeFormContentTypes.PerformanceOverview,
+    };
+
+    private readonly Timer _refreshTimer;
+    private readonly PerformanceMetricKind _heroMetric;
+    private readonly string _heroLabel;
+    private readonly RollingNetworkThroughputNormalizer _networkThroughputNormalizer;
+
+    private readonly SystemCPUUsageWidgetPage _cpuPage;
+    private readonly SystemMemoryUsageWidgetPage _memoryPage;
+    private readonly SystemDiskUsageWidgetPage _diskPage;
+    private readonly SystemNetworkUsageWidgetPage _networkPage;
+    private readonly SystemGPUUsageWidgetPage _gpuPage;
+
+    private bool _isLoaded;
+    private bool _disposed;
+
+    public PerformanceOverviewPage(
+        PerformanceWidgetsPage metricsPage,
+        PerformanceMetricKind heroMetric,
+        RollingNetworkThroughputNormalizer networkThroughputNormalizer)
+    {
+        _heroMetric = heroMetric;
+        _networkThroughputNormalizer = networkThroughputNormalizer;
+        _heroLabel = PerformanceOverviewFormatter.SelectMetricValue(
+            heroMetric,
+            Resources.GetResource("CPU_Usage_Subtitle"),
+            Resources.GetResource("Overview_RAM_Label"),
+            Resources.GetResource("Network_Usage_Subtitle"),
+            Resources.GetResource("Disk_Usage_Subtitle"),
+            Resources.GetResource("GPU_Usage_Subtitle"));
+
+        _cpuPage = metricsPage.CpuPage;
+        _memoryPage = metricsPage.MemoryPage;
+        _diskPage = metricsPage.DiskPage;
+        _networkPage = metricsPage.NetworkPage;
+        _gpuPage = metricsPage.GpuPage;
+
+        _refreshTimer = new Timer(
+            _ => RefreshIfLoaded(),
+            null,
+            Timeout.InfiniteTimeSpan,
+            Timeout.InfiniteTimeSpan);
+
+        _cpuPage.Updated += OnMetricUpdated;
+        _memoryPage.Updated += OnMetricUpdated;
+        _diskPage.Updated += OnMetricUpdated;
+        _networkPage.Updated += OnMetricUpdated;
+        _gpuPage.Updated += OnMetricUpdated;
+    }
+
+    protected override void Loaded()
+    {
+        lock (_refreshLock)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _isLoaded = true;
+        }
+
+        _cpuPage.PushActivate();
+        _memoryPage.PushActivate();
+        _diskPage.PushActivate();
+        _networkPage.PushActivate();
+        _gpuPage.PushActivate();
+
+        Refresh();
+    }
+
+    protected override void Unloaded()
+    {
+        lock (_refreshLock)
+        {
+            _isLoaded = false;
+            if (!_disposed)
+            {
+                _refreshTimer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+            }
+        }
+
+        _cpuPage.PopActivate();
+        _memoryPage.PopActivate();
+        _diskPage.PopActivate();
+        _networkPage.PopActivate();
+        _gpuPage.PopActivate();
+    }
+
+    public override IContent[] GetContent()
+    {
+        if (string.IsNullOrEmpty(_formContent.DataJson))
+        {
+            Refresh();
+        }
+
+        return [_formContent];
+    }
+
+    private void OnMetricUpdated(object? sender, EventArgs e)
+    {
+        lock (_refreshLock)
+        {
+            if (_isLoaded && !_disposed)
+            {
+                // All metric timers fire in the same burst. Debounce that burst
+                // so the native dashboard receives one coherent sample.
+                _refreshTimer.Change(RefreshDelay, Timeout.InfiniteTimeSpan);
+            }
+        }
+    }
+
+    private void Refresh()
+    {
+        lock (_refreshLock)
+        {
+            if (!_disposed)
+            {
+                RefreshCore();
+            }
+        }
+    }
+
+    private void RefreshIfLoaded()
+    {
+        lock (_refreshLock)
+        {
+            if (_isLoaded && !_disposed)
+            {
+                RefreshCore();
+            }
+        }
+    }
+
+    private void RefreshCore() => _formContent.DataJson = BuildDataJson().ToJsonString();
+
+    private JsonObject BuildDataJson()
+    {
+        var json = new JsonObject();
+
+        var cpuPercentText = AddCpuData(json);
+        var memoryPercentText = AddMemoryData(json);
+        var gpuPercentText = AddGpuData(json);
+        var diskPercentText = AddDiskData(json);
+        var networkPercentText = AddNetworkData(json);
+
+        json["schemaVersion"] = 1;
+        json["titleText"] = Resources.GetResource("Performance_Monitor_Title");
+        json["statusText"] = Resources.GetResource("Overview_Live_Status");
+        json["heroMetric"] = PerformanceOverviewFormatter.GetMetricKey(_heroMetric);
+        json["heroLabelText"] = _heroLabel;
+        json["heroValueText"] = PerformanceOverviewFormatter.SelectMetricValue(
+            _heroMetric,
+            cpuPercentText,
+            memoryPercentText,
+            networkPercentText,
+            diskPercentText,
+            gpuPercentText);
+
+        return json;
+    }
+
+    private string AddCpuData(JsonObject json)
+    {
+        var rawPercentText = _cpuPage.GetContentValue("cpuUsage");
+        var percentText = FirstNonEmpty(rawPercentText, Resources.GetResource("CPU_Usage_Unknown"));
+
+        json["cpuLabelText"] = Resources.GetResource("CPU_Usage_Subtitle");
+        json["cpuDetailText"] = FormatPercentDetail(percentText, _cpuPage.GetContentValue("cpuSpeed"));
+        json["cpuPercent"] = PerformanceOverviewFormatter.ParsePercentText(rawPercentText);
+        return percentText;
+    }
+
+    private string AddMemoryData(JsonObject json)
+    {
+        var rawPercentText = _memoryPage.GetContentValue("memUsage");
+        var percentText = FirstNonEmpty(rawPercentText, Resources.GetResource("Memory_Usage_Unknown"));
+
+        json["memoryLabelText"] = Resources.GetResource("Overview_RAM_Label");
+        json["memoryDetailText"] = string.Format(
+            CultureInfo.CurrentCulture,
+            Resources.GetResource("Overview_Memory_Detail_Format"),
+            _memoryPage.GetContentValue("usedMem"),
+            _memoryPage.GetContentValue("allMem"));
+        json["memoryPercent"] = PerformanceOverviewFormatter.ParsePercentText(rawPercentText);
+        return percentText;
+    }
+
+    private string AddGpuData(JsonObject json)
+    {
+        var rawPercentText = _gpuPage.GetContentValue("gpuUsage");
+        var percentText = FirstNonEmpty(rawPercentText, Resources.GetResource("GPU_Usage_Unknown"));
+        var temperatureText = _gpuPage.GetContentValue("gpuTemp");
+
+        json["gpuLabelText"] = Resources.GetResource("GPU_Usage_Subtitle");
+        json["gpuDetailText"] = temperatureText == "--"
+            ? percentText
+            : FormatPercentDetail(percentText, temperatureText);
+        json["gpuPercent"] = PerformanceOverviewFormatter.ParsePercentText(rawPercentText);
+        return percentText;
+    }
+
+    private string AddDiskData(JsonObject json)
+    {
+        var rawPercentText = _diskPage.GetContentValue("diskUsage");
+        var percentText = FirstNonEmpty(rawPercentText, Resources.GetResource("Disk_Usage_Unknown"));
+
+        json["diskLabelText"] = Resources.GetResource("Disk_Usage_Subtitle");
+        json["diskDetailText"] = string.Format(
+            CultureInfo.CurrentCulture,
+            Resources.GetResource("Overview_Disk_Detail_Format"),
+            Resources.GetResource("Disk_Read_Subtitle"),
+            _diskPage.GetContentValue("diskRead"),
+            Resources.GetResource("Disk_Write_Subtitle"),
+            _diskPage.GetContentValue("diskWrite"));
+        json["diskPercent"] = PerformanceOverviewFormatter.ParsePercentText(rawPercentText);
+        return percentText;
+    }
+
+    private string AddNetworkData(JsonObject json)
+    {
+        var networkPercent = _networkThroughputNormalizer.AddSample(
+            _networkPage.GetTotalThroughputBytesPerSecond(),
+            DateTimeOffset.UtcNow);
+        var percentText = networkPercent.ToString(CultureInfo.InvariantCulture) + "%";
+
+        json["networkLabelText"] = Resources.GetResource("Network_Usage_Subtitle");
+        json["networkDetailText"] = string.Format(
+            CultureInfo.CurrentCulture,
+            Resources.GetResource("Overview_Network_Detail_Format"),
+            Resources.GetResource("Network_Send_Subtitle"),
+            _networkPage.GetContentValue("netSent"),
+            Resources.GetResource("Network_Receive_Subtitle"),
+            _networkPage.GetContentValue("netReceived"));
+        json["networkPercent"] = networkPercent;
+        return percentText;
+    }
+
+    private static string FirstNonEmpty(string value, string fallback) => string.IsNullOrEmpty(value) ? fallback : value;
+
+    private static string FormatPercentDetail(string percentText, string detailText) =>
+        string.IsNullOrEmpty(detailText)
+            ? percentText
+            : string.Format(
+                CultureInfo.CurrentCulture,
+                Resources.GetResource("Overview_Percent_Detail_Format"),
+                percentText,
+                detailText);
+
+    public void Dispose()
+    {
+        _cpuPage.Updated -= OnMetricUpdated;
+        _memoryPage.Updated -= OnMetricUpdated;
+        _diskPage.Updated -= OnMetricUpdated;
+        _networkPage.Updated -= OnMetricUpdated;
+        _gpuPage.Updated -= OnMetricUpdated;
+
+        lock (_refreshLock)
+        {
+            _isLoaded = false;
+            _disposed = true;
+            _refreshTimer.Dispose();
+        }
+    }
+}

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceOverviewPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceOverviewPage.cs
@@ -69,6 +69,13 @@ internal sealed partial class PerformanceOverviewPage : OnLoadContentPage, IDisp
         _networkPage = metricsPage.NetworkPage;
         _gpuPage = metricsPage.GpuPage;
 
+        Commands = [
+            _gpuPage.PreviousAdapterCommand,
+            _gpuPage.NextAdapterCommand,
+            _networkPage.PreviousAdapterCommand,
+            _networkPage.NextAdapterCommand,
+        ];
+
         _refreshTimer = new Timer(
             _ => RefreshIfLoaded(),
             null,
@@ -190,6 +197,10 @@ internal sealed partial class PerformanceOverviewPage : OnLoadContentPage, IDisp
             networkPercentText,
             diskPercentText,
             gpuPercentText);
+        json["previousGpuCommandText"] = Resources.GetResource("Previous_GPU_Title");
+        json["nextGpuCommandText"] = Resources.GetResource("Next_GPU_Title");
+        json["previousNetworkCommandText"] = Resources.GetResource("Previous_Network_Title");
+        json["nextNetworkCommandText"] = Resources.GetResource("Next_Network_Title");
 
         return json;
     }
@@ -227,6 +238,8 @@ internal sealed partial class PerformanceOverviewPage : OnLoadContentPage, IDisp
         var temperatureText = _gpuPage.GetContentValue("gpuTemp");
 
         json["gpuLabelText"] = Resources.GetResource("GPU_Usage_Subtitle");
+        json["gpuAdapterName"] = _gpuPage.GetContentValue("gpuName");
+        json["canSwitchGpu"] = _gpuPage.GetAdapterCount() > 1;
         json["gpuDetailText"] = temperatureText == "--"
             ? percentText
             : FormatPercentDetail(percentText, temperatureText);
@@ -259,6 +272,8 @@ internal sealed partial class PerformanceOverviewPage : OnLoadContentPage, IDisp
         var percentText = networkPercent.ToString(CultureInfo.InvariantCulture) + "%";
 
         json["networkLabelText"] = Resources.GetResource("Network_Usage_Subtitle");
+        json["networkAdapterName"] = _networkPage.GetContentValue("networkName");
+        json["canSwitchNetwork"] = _networkPage.GetAdapterCount() > 1;
         json["networkDetailText"] = string.Format(
             CultureInfo.CurrentCulture,
             Resources.GetResource("Overview_Network_Detail_Format"),

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceWidgetsPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceWidgetsPage.cs
@@ -69,6 +69,7 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
     private readonly string _id;
     private readonly bool _isBandPage;
     private readonly PerformanceMetricKind? _singleMetric;
+    private readonly Func<PerformanceMetricKind, ICommand?>? _itemCommandFactory;
 
     private readonly SystemCPUUsageWidgetPage? _cpuPage;
     private readonly ListItem? _cpuItem;
@@ -85,6 +86,16 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
     private readonly SystemGPUUsageWidgetPage? _gpuPage;
     private readonly ListItem? _gpuItem;
 
+    internal SystemCPUUsageWidgetPage CpuPage => _cpuPage ?? throw new InvalidOperationException("CPU metrics are not available on this page.");
+
+    internal SystemMemoryUsageWidgetPage MemoryPage => _memoryPage ?? throw new InvalidOperationException("Memory metrics are not available on this page.");
+
+    internal SystemDiskUsageWidgetPage DiskPage => _diskPage ?? throw new InvalidOperationException("Disk metrics are not available on this page.");
+
+    internal SystemNetworkUsageWidgetPage NetworkPage => _networkPage ?? throw new InvalidOperationException("Network metrics are not available on this page.");
+
+    internal SystemGPUUsageWidgetPage GpuPage => _gpuPage ?? throw new InvalidOperationException("GPU metrics are not available on this page.");
+
     private readonly SystemBatteryUsageWidgetPage? _batteryPage;
     private readonly ListItem? _batteryItem;
 
@@ -100,18 +111,26 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
     private string _diskReadSpeed = string.Empty;
     private string _diskWriteSpeed = string.Empty;
 
-    public PerformanceWidgetsPage(SettingsManager settingsManager, bool isBandPage = false, PerformanceMetricKind? singleMetric = null)
+    public PerformanceWidgetsPage(
+        SettingsManager settingsManager,
+        bool isBandPage = false,
+        PerformanceMetricKind? singleMetric = null,
+        Func<PerformanceMetricKind, ICommand?>? itemCommandFactory = null,
+        PerformanceMetricSelectionState? selectionState = null)
     {
+        selectionState ??= new PerformanceMetricSelectionState();
         _isBandPage = isBandPage;
         _singleMetric = singleMetric;
+        _itemCommandFactory = isBandPage ? itemCommandFactory : null;
         _id = GetBandId(singleMetric);
 
         if (IncludesMetric(PerformanceMetricKind.Cpu))
         {
             _cpuPage = new SystemCPUUsageWidgetPage();
-            _cpuItem = new ListItem(_cpuPage)
+            _cpuItem = new ListItem(GetItemCommand(PerformanceMetricKind.Cpu, _cpuPage))
             {
                 Title = _cpuPage.GetItemTitle(isBandPage),
+                Icon = Icons.CpuIcon,
                 MoreCommands = _cpuPage.Commands,
             };
 
@@ -124,9 +143,10 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
         if (IncludesMetric(PerformanceMetricKind.Memory))
         {
             _memoryPage = new SystemMemoryUsageWidgetPage();
-            _memoryItem = new ListItem(_memoryPage)
+            _memoryItem = new ListItem(GetItemCommand(PerformanceMetricKind.Memory, _memoryPage))
             {
                 Title = _memoryPage.GetItemTitle(isBandPage),
+                Icon = Icons.MemoryIcon,
                 MoreCommands = _memoryPage.Commands,
             };
 
@@ -138,16 +158,17 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
 
         if (IncludesMetric(PerformanceMetricKind.Network))
         {
-            _networkPage = new SystemNetworkUsageWidgetPage(settingsManager);
-            _networkItem = new ListItem(_networkPage)
+            _networkPage = new SystemNetworkUsageWidgetPage(settingsManager, selectionState);
+            _networkItem = new ListItem(GetItemCommand(PerformanceMetricKind.Network, _networkPage))
             {
                 Title = _networkPage.GetItemTitle(isBandPage),
+                Icon = Icons.NetworkIcon,
                 MoreCommands = _networkPage.Commands,
             };
 
             if (isBandPage)
             {
-                _networkUpItem = new ListItem(_networkPage)
+                _networkUpItem = new ListItem(GetItemCommand(PerformanceMetricKind.Network, _networkPage))
                 {
                     Title = $"{_networkUpSpeed}",
                     Subtitle = Resources.GetResource("Network_Send_Subtitle"),
@@ -155,7 +176,7 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
                     MoreCommands = _networkPage.Commands,
                 };
 
-                _networkDownItem = new ListItem(_networkPage)
+                _networkDownItem = new ListItem(GetItemCommand(PerformanceMetricKind.Network, _networkPage))
                 {
                     Title = $"{_networkDownSpeed}",
                     Subtitle = Resources.GetResource("Network_Receive_Subtitle"),
@@ -176,10 +197,11 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
 
         if (IncludesMetric(PerformanceMetricKind.Disk))
         {
-            _diskPage = new SystemDiskUsageWidgetPage(settingsManager);
-            _diskItem = new ListItem(_diskPage)
+            _diskPage = new SystemDiskUsageWidgetPage(settingsManager, selectionState);
+            _diskItem = new ListItem(GetItemCommand(PerformanceMetricKind.Disk, _diskPage))
             {
                 Title = _diskPage.GetItemTitle(isBandPage),
+                Icon = Icons.HardDriveIcon,
                 MoreCommands = _diskPage.Commands,
             };
 
@@ -196,10 +218,11 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
 
         if (IncludesMetric(PerformanceMetricKind.Gpu))
         {
-            _gpuPage = new SystemGPUUsageWidgetPage();
-            _gpuItem = new ListItem(_gpuPage)
+            _gpuPage = new SystemGPUUsageWidgetPage(selectionState);
+            _gpuItem = new ListItem(GetItemCommand(PerformanceMetricKind.Gpu, _gpuPage))
             {
                 Title = _gpuPage.GetItemTitle(isBandPage),
+                Icon = Icons.GpuIcon,
                 MoreCommands = _gpuPage.Commands,
             };
 
@@ -224,7 +247,7 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
             if (batteryStats.HasBattery)
             {
                 _batteryPage = new SystemBatteryUsageWidgetPage();
-                _batteryItem = new ListItem(_batteryPage)
+                _batteryItem = new ListItem(GetItemCommand(PerformanceMetricKind.Battery, _batteryPage))
                 {
                     Title = _batteryPage.GetItemTitle(isBandPage),
                     Icon = _batteryPage.CurrentIcon,
@@ -327,7 +350,7 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
         {
             if (_networkUpItem is null)
             {
-                _networkUpItem = new ListItem(_networkPage!)
+                _networkUpItem = new ListItem(GetItemCommand(PerformanceMetricKind.Network, _networkPage!))
                 {
                     Title = $"{_networkUpSpeed}",
                     Subtitle = Resources.GetResource("Network_Send_Subtitle"),
@@ -340,7 +363,7 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
 
             if (_networkDownItem is null)
             {
-                _networkDownItem = new ListItem(_networkPage!)
+                _networkDownItem = new ListItem(GetItemCommand(PerformanceMetricKind.Network, _networkPage!))
                 {
                     Title = $"{_networkDownSpeed}",
                     Subtitle = Resources.GetResource("Network_Receive_Subtitle"),
@@ -360,7 +383,7 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
 
     private IListItem[] CreateDiskBandItems()
     {
-        _diskReadItem ??= new ListItem(_diskPage!)
+        _diskReadItem ??= new ListItem(GetItemCommand(PerformanceMetricKind.Disk, _diskPage!))
         {
             Subtitle = Resources.GetResource("Disk_Read_Subtitle"),
             Icon = Icons.FileReadIcon,
@@ -368,7 +391,7 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
         };
         _diskReadItem.Title = _diskReadSpeed;
 
-        _diskWriteItem ??= new ListItem(_diskPage!)
+        _diskWriteItem ??= new ListItem(GetItemCommand(PerformanceMetricKind.Disk, _diskPage!))
         {
             Subtitle = Resources.GetResource("Disk_Write_Subtitle"),
             Icon = Icons.FileWriteIcon,
@@ -399,7 +422,10 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
         return _singleMetric is null || _singleMetric == metric;
     }
 
-    private static string GetMetricSuffix(PerformanceMetricKind metric)
+    private ICommand GetItemCommand(PerformanceMetricKind metric, ICommand metricPage) =>
+        _itemCommandFactory?.Invoke(metric) ?? metricPage;
+
+    internal static string GetMetricSuffix(PerformanceMetricKind metric)
     {
         return metric switch
         {
@@ -461,6 +487,20 @@ internal abstract partial class WidgetPage : OnLoadContentPage
         _formContent.DataJson = ContentDataJson.ToJsonString();
 
         Updated?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Thread-safe lookup of a single already-formatted content value. Lets a
+    /// sibling page (e.g. the compact <see cref="PerformanceOverviewPage"/>
+    /// dashboard) reuse this page's latest data without duplicating its data
+    /// collection or reaching into <see cref="ContentData"/> directly.
+    /// </summary>
+    internal string GetContentValue(string key)
+    {
+        lock (ContentData)
+        {
+            return ContentData.TryGetValue(key, out var value) ? value : string.Empty;
+        }
     }
 
     protected abstract void LoadContentData();
@@ -779,11 +819,14 @@ internal sealed partial class SystemDiskUsageWidgetPage : WidgetPage, IDisposabl
 
     private readonly DataManager _dataManager;
     private readonly SettingsManager _settingsManager;
-    private int _diskIndex;
+    private readonly PerformanceMetricSelectionState _selectionState;
 
-    public SystemDiskUsageWidgetPage(SettingsManager settingsManager)
+    public SystemDiskUsageWidgetPage(
+        SettingsManager settingsManager,
+        PerformanceMetricSelectionState? selectionState = null)
     {
         _settingsManager = settingsManager;
+        _selectionState = selectionState ?? new PerformanceMetricSelectionState();
         _dataManager = new(DataType.Disk, () => UpdateWidget());
         Commands = [
             new CommandContextItem(new PrevDiskCommand(this) { Name = Resources.GetResource("Previous_Disk_Title") }),
@@ -805,14 +848,15 @@ internal sealed partial class SystemDiskUsageWidgetPage : WidgetPage, IDisposabl
 
             var dataDuration = timer.ElapsedMilliseconds;
 
-            var diskName = currentData.GetDiskName(_diskIndex);
-            var diskStats = currentData.GetDiskUsage(_diskIndex);
+            var diskIndex = _selectionState.DiskIndex;
+            var diskName = currentData.GetDiskName(diskIndex);
+            var diskStats = currentData.GetDiskUsage(diskIndex);
 
             ContentData["diskUsage"] = FloatToPercentString(diskStats.Usage);
             ContentData["diskRead"] = SpeedToString(diskStats.Read);
             ContentData["diskWrite"] = SpeedToString(diskStats.Written);
             ContentData["diskName"] = diskName;
-            ContentData["diskGraphUrl"] = currentData.CreateDiskImageUrl(_diskIndex);
+            ContentData["diskGraphUrl"] = currentData.CreateDiskImageUrl(diskIndex);
             ContentData["chartHeight"] = ChartHelper.ChartHeight + "px";
             ContentData["chartWidth"] = ChartHelper.ChartWidth + "px";
 
@@ -905,13 +949,13 @@ internal sealed partial class SystemDiskUsageWidgetPage : WidgetPage, IDisposabl
 
     private void HandlePrevDisk()
     {
-        _diskIndex = _dataManager.GetDiskStats().GetPrevDiskIndex(_diskIndex);
+        _selectionState.DiskIndex = _dataManager.GetDiskStats().GetPrevDiskIndex(_selectionState.DiskIndex);
         UpdateWidget();
     }
 
     private void HandleNextDisk()
     {
-        _diskIndex = _dataManager.GetDiskStats().GetNextDiskIndex(_diskIndex);
+        _selectionState.DiskIndex = _dataManager.GetDiskStats().GetNextDiskIndex(_selectionState.DiskIndex);
         UpdateWidget();
     }
 
@@ -971,11 +1015,15 @@ internal sealed partial class SystemNetworkUsageWidgetPage : WidgetPage, IDispos
 
     private readonly DataManager _dataManager;
     private readonly SettingsManager _settingsManager;
-    private int _networkIndex;
+    private readonly PerformanceMetricSelectionState _selectionState;
+    private float _totalThroughputBytesPerSecond;
 
-    public SystemNetworkUsageWidgetPage(SettingsManager settingsManager)
+    public SystemNetworkUsageWidgetPage(
+        SettingsManager settingsManager,
+        PerformanceMetricSelectionState? selectionState = null)
     {
         _settingsManager = settingsManager;
+        _selectionState = selectionState ?? new PerformanceMetricSelectionState();
         _dataManager = new(DataType.Network, () => UpdateWidget());
         Commands = [
             new CommandContextItem(new PrevNetworkCommand(this) { Name = Resources.GetResource("Previous_Network_Title") }),
@@ -997,14 +1045,16 @@ internal sealed partial class SystemNetworkUsageWidgetPage : WidgetPage, IDispos
 
             var dataDuration = timer.ElapsedMilliseconds;
 
-            var netName = currentData.GetNetworkName(_networkIndex);
-            var networkStats = currentData.GetNetworkUsage(_networkIndex);
+            var networkIndex = _selectionState.NetworkIndex;
+            var netName = currentData.GetNetworkName(networkIndex);
+            var networkStats = currentData.GetNetworkUsage(networkIndex);
+            _totalThroughputBytesPerSecond = Math.Max(0, networkStats.Sent + networkStats.Received);
 
             ContentData["networkUsage"] = FloatToPercentString(networkStats.Usage);
             ContentData["netSent"] = SpeedToString(networkStats.Sent);
             ContentData["netReceived"] = SpeedToString(networkStats.Received);
             ContentData["networkName"] = netName;
-            ContentData["netGraphUrl"] = currentData.CreateNetImageUrl(_networkIndex);
+            ContentData["netGraphUrl"] = currentData.CreateNetImageUrl(networkIndex);
             ContentData["chartHeight"] = ChartHelper.ChartHeight + "px";
             ContentData["chartWidth"] = ChartHelper.ChartWidth + "px";
 
@@ -1014,6 +1064,7 @@ internal sealed partial class SystemNetworkUsageWidgetPage : WidgetPage, IDispos
         }
         catch (Exception e)
         {
+            _totalThroughputBytesPerSecond = 0;
             ContentData.Clear();
             ContentData["errorMessage"] = e.Message;
             return;
@@ -1067,6 +1118,14 @@ internal sealed partial class SystemNetworkUsageWidgetPage : WidgetPage, IDispos
         }
     }
 
+    internal float GetTotalThroughputBytesPerSecond()
+    {
+        lock (ContentData)
+        {
+            return _totalThroughputBytesPerSecond;
+        }
+    }
+
     private string SpeedToString(float bytesPerSec)
     {
         return _settingsManager.NetworkSpeedUnit switch
@@ -1097,13 +1156,13 @@ internal sealed partial class SystemNetworkUsageWidgetPage : WidgetPage, IDispos
 
     private void HandlePrevNetwork()
     {
-        _networkIndex = _dataManager.GetNetworkStats().GetPrevNetworkIndex(_networkIndex);
+        _selectionState.NetworkIndex = _dataManager.GetNetworkStats().GetPrevNetworkIndex(_selectionState.NetworkIndex);
         UpdateWidget();
     }
 
     private void HandleNextNetwork()
     {
-        _networkIndex = _dataManager.GetNetworkStats().GetNextNetworkIndex(_networkIndex);
+        _selectionState.NetworkIndex = _dataManager.GetNetworkStats().GetNextNetworkIndex(_selectionState.NetworkIndex);
         UpdateWidget();
     }
 
@@ -1163,10 +1222,11 @@ internal sealed partial class SystemGPUUsageWidgetPage : WidgetPage, IDisposable
 
     private readonly DataManager _dataManager;
     private readonly string _gpuActiveEngType = "3D";
-    private int _gpuActiveIndex;
+    private readonly PerformanceMetricSelectionState _selectionState;
 
-    public SystemGPUUsageWidgetPage()
+    public SystemGPUUsageWidgetPage(PerformanceMetricSelectionState? selectionState = null)
     {
+        _selectionState = selectionState ?? new PerformanceMetricSelectionState();
         _dataManager = new(DataType.GPU, () => UpdateWidget());
 
         Commands = [
@@ -1189,12 +1249,13 @@ internal sealed partial class SystemGPUUsageWidgetPage : WidgetPage, IDisposable
 
             var dataDuration = timer.ElapsedMilliseconds;
 
-            var gpuName = stats.GetGPUName(_gpuActiveIndex);
+            var gpuIndex = _selectionState.GpuIndex;
+            var gpuName = stats.GetGPUName(gpuIndex);
 
-            ContentData["gpuUsage"] = FloatToPercentString(stats.GetGPUUsage(_gpuActiveIndex, _gpuActiveEngType));
+            ContentData["gpuUsage"] = FloatToPercentString(stats.GetGPUUsage(gpuIndex, _gpuActiveEngType));
             ContentData["gpuName"] = gpuName;
-            ContentData["gpuTemp"] = stats.GetGPUTemperature(_gpuActiveIndex);
-            ContentData["gpuGraphUrl"] = stats.CreateGPUImageUrl(_gpuActiveIndex);
+            ContentData["gpuTemp"] = stats.GetGPUTemperature(gpuIndex);
+            ContentData["gpuGraphUrl"] = stats.CreateGPUImageUrl(gpuIndex);
             ContentData["chartHeight"] = ChartHelper.ChartHeight + "px";
             ContentData["chartWidth"] = ChartHelper.ChartWidth + "px";
 
@@ -1262,13 +1323,13 @@ internal sealed partial class SystemGPUUsageWidgetPage : WidgetPage, IDisposable
 
     private void HandlePrevGPU()
     {
-        _gpuActiveIndex = _dataManager.GetGPUStats().GetPrevGPUIndex(_gpuActiveIndex);
+        _selectionState.GpuIndex = _dataManager.GetGPUStats().GetPrevGPUIndex(_selectionState.GpuIndex);
         UpdateWidget();
     }
 
     private void HandleNextGPU()
     {
-        _gpuActiveIndex = _dataManager.GetGPUStats().GetNextGPUIndex(_gpuActiveIndex);
+        _selectionState.GpuIndex = _dataManager.GetGPUStats().GetNextGPUIndex(_selectionState.GpuIndex);
         UpdateWidget();
     }
 

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceWidgetsPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceWidgetsPage.cs
@@ -1032,6 +1032,10 @@ internal sealed partial class SystemNetworkUsageWidgetPage : WidgetPage, IDispos
         ];
     }
 
+    internal IContextItem PreviousAdapterCommand => Commands[0];
+
+    internal IContextItem NextAdapterCommand => Commands[1];
+
     protected override void LoadContentData()
     {
         // CoreLogger.LogDebug("Getting Network stats");
@@ -1046,6 +1050,18 @@ internal sealed partial class SystemNetworkUsageWidgetPage : WidgetPage, IDispos
             var dataDuration = timer.ElapsedMilliseconds;
 
             var networkIndex = _selectionState.NetworkIndex;
+            if (_selectionState.IsNetworkSelectionAutomatic)
+            {
+                networkIndex = _selectionState.UpdateAutomaticNetworkIndex(
+                    currentData.GetBusiestNetworkIndex(networkIndex));
+            }
+            else if (currentData.GetNetworkUsage(networkIndex).Bandwidth <= 0)
+            {
+                networkIndex = _selectionState.RecoverNetworkSelection(
+                    networkIndex,
+                    currentData.GetBusiestNetworkIndex(networkIndex));
+            }
+
             var netName = currentData.GetNetworkName(networkIndex);
             var networkStats = currentData.GetNetworkUsage(networkIndex);
             _totalThroughputBytesPerSecond = Math.Max(0, networkStats.Sent + networkStats.Received);
@@ -1126,6 +1142,8 @@ internal sealed partial class SystemNetworkUsageWidgetPage : WidgetPage, IDispos
         }
     }
 
+    internal int GetAdapterCount() => _dataManager.GetNetworkStats().GetSelectableNetworkCount();
+
     private string SpeedToString(float bytesPerSec)
     {
         return _settingsManager.NetworkSpeedUnit switch
@@ -1156,14 +1174,20 @@ internal sealed partial class SystemNetworkUsageWidgetPage : WidgetPage, IDispos
 
     private void HandlePrevNetwork()
     {
-        _selectionState.NetworkIndex = _dataManager.GetNetworkStats().GetPrevNetworkIndex(_selectionState.NetworkIndex);
-        UpdateWidget();
+        if (_selectionState.SelectNetworkManually(
+            _dataManager.GetNetworkStats().GetPrevNetworkIndex(_selectionState.NetworkIndex)))
+        {
+            UpdateWidget();
+        }
     }
 
     private void HandleNextNetwork()
     {
-        _selectionState.NetworkIndex = _dataManager.GetNetworkStats().GetNextNetworkIndex(_selectionState.NetworkIndex);
-        UpdateWidget();
+        if (_selectionState.SelectNetworkManually(
+            _dataManager.GetNetworkStats().GetNextNetworkIndex(_selectionState.NetworkIndex)))
+        {
+            UpdateWidget();
+        }
     }
 
     public void Dispose()
@@ -1180,7 +1204,7 @@ internal sealed partial class SystemNetworkUsageWidgetPage : WidgetPage, IDispos
             _page = page;
         }
 
-        public override string Id => "com.microsoft.cmdpal.network_widget.prev";
+        public override string Id => NativePerformanceOverviewCommandIds.PreviousNetwork;
 
         public override IconInfo Icon => Icons.NavigateBackwardIcon;
 
@@ -1200,7 +1224,7 @@ internal sealed partial class SystemNetworkUsageWidgetPage : WidgetPage, IDispos
             _page = page;
         }
 
-        public override string Id => "com.microsoft.cmdpal.network_widget.next";
+        public override string Id => NativePerformanceOverviewCommandIds.NextNetwork;
 
         public override IconInfo Icon => Icons.NavigateForwardIcon;
 
@@ -1235,6 +1259,10 @@ internal sealed partial class SystemGPUUsageWidgetPage : WidgetPage, IDisposable
             new CommandContextItem(OpenTaskManagerCommand.Instance),
         ];
     }
+
+    internal IContextItem PreviousAdapterCommand => Commands[0];
+
+    internal IContextItem NextAdapterCommand => Commands[1];
 
     protected override void LoadContentData()
     {
@@ -1303,6 +1331,8 @@ internal sealed partial class SystemGPUUsageWidgetPage : WidgetPage, IDisposable
         return Resources.GetResource("GPU_Usage_Subtitle");
     }
 
+    internal int GetAdapterCount() => _dataManager.GetGPUStats().GetGPUCount();
+
     internal override void PushActivate()
     {
         base.PushActivate();
@@ -1347,7 +1377,7 @@ internal sealed partial class SystemGPUUsageWidgetPage : WidgetPage, IDisposable
             _page = page;
         }
 
-        public override string Id => "com.microsoft.cmdpal.gpu_widget.prev";
+        public override string Id => NativePerformanceOverviewCommandIds.PreviousGpu;
 
         public override IconInfo Icon => Icons.NavigateBackwardIcon;
 
@@ -1367,7 +1397,7 @@ internal sealed partial class SystemGPUUsageWidgetPage : WidgetPage, IDisposable
             _page = page;
         }
 
-        public override string Id => "com.microsoft.cmdpal.gpu_widget.next";
+        public override string Id => NativePerformanceOverviewCommandIds.NextGpu;
 
         public override IconInfo Icon => Icons.NavigateForwardIcon;
 

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceWidgetsPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceWidgetsPage.cs
@@ -820,6 +820,8 @@ internal sealed partial class SystemDiskUsageWidgetPage : WidgetPage, IDisposabl
     private readonly DataManager _dataManager;
     private readonly SettingsManager _settingsManager;
     private readonly PerformanceMetricSelectionState _selectionState;
+    private float _readThroughputBytesPerSecond;
+    private float _writeThroughputBytesPerSecond;
 
     public SystemDiskUsageWidgetPage(
         SettingsManager settingsManager,
@@ -851,6 +853,8 @@ internal sealed partial class SystemDiskUsageWidgetPage : WidgetPage, IDisposabl
             var diskIndex = _selectionState.DiskIndex;
             var diskName = currentData.GetDiskName(diskIndex);
             var diskStats = currentData.GetDiskUsage(diskIndex);
+            _readThroughputBytesPerSecond = Math.Max(0, diskStats.Read);
+            _writeThroughputBytesPerSecond = Math.Max(0, diskStats.Written);
 
             ContentData["diskUsage"] = FloatToPercentString(diskStats.Usage);
             ContentData["diskRead"] = SpeedToString(diskStats.Read);
@@ -866,6 +870,8 @@ internal sealed partial class SystemDiskUsageWidgetPage : WidgetPage, IDisposabl
         }
         catch (Exception e)
         {
+            _readThroughputBytesPerSecond = 0;
+            _writeThroughputBytesPerSecond = 0;
             ContentData.Clear();
             ContentData["errorMessage"] = e.Message;
             return;
@@ -916,6 +922,14 @@ internal sealed partial class SystemDiskUsageWidgetPage : WidgetPage, IDisposabl
         else
         {
             return "???";
+        }
+    }
+
+    internal (float Read, float Write) GetThroughputBytesPerSecond()
+    {
+        lock (ContentData)
+        {
+            return (_readThroughputBytesPerSecond, _writeThroughputBytesPerSecond);
         }
     }
 
@@ -1016,7 +1030,8 @@ internal sealed partial class SystemNetworkUsageWidgetPage : WidgetPage, IDispos
     private readonly DataManager _dataManager;
     private readonly SettingsManager _settingsManager;
     private readonly PerformanceMetricSelectionState _selectionState;
-    private float _totalThroughputBytesPerSecond;
+    private float _sentThroughputBytesPerSecond;
+    private float _receivedThroughputBytesPerSecond;
 
     public SystemNetworkUsageWidgetPage(
         SettingsManager settingsManager,
@@ -1064,7 +1079,8 @@ internal sealed partial class SystemNetworkUsageWidgetPage : WidgetPage, IDispos
 
             var netName = currentData.GetNetworkName(networkIndex);
             var networkStats = currentData.GetNetworkUsage(networkIndex);
-            _totalThroughputBytesPerSecond = Math.Max(0, networkStats.Sent + networkStats.Received);
+            _sentThroughputBytesPerSecond = Math.Max(0, networkStats.Sent);
+            _receivedThroughputBytesPerSecond = Math.Max(0, networkStats.Received);
 
             ContentData["networkUsage"] = FloatToPercentString(networkStats.Usage);
             ContentData["netSent"] = SpeedToString(networkStats.Sent);
@@ -1080,7 +1096,8 @@ internal sealed partial class SystemNetworkUsageWidgetPage : WidgetPage, IDispos
         }
         catch (Exception e)
         {
-            _totalThroughputBytesPerSecond = 0;
+            _sentThroughputBytesPerSecond = 0;
+            _receivedThroughputBytesPerSecond = 0;
             ContentData.Clear();
             ContentData["errorMessage"] = e.Message;
             return;
@@ -1134,11 +1151,11 @@ internal sealed partial class SystemNetworkUsageWidgetPage : WidgetPage, IDispos
         }
     }
 
-    internal float GetTotalThroughputBytesPerSecond()
+    internal (float Sent, float Received) GetThroughputBytesPerSecond()
     {
         lock (ContentData)
         {
-            return _totalThroughputBytesPerSecond;
+            return (_sentThroughputBytesPerSecond, _receivedThroughputBytesPerSecond);
         }
     }
 

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/RollingNetworkThroughputNormalizer.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/RollingNetworkThroughputNormalizer.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Microsoft.CmdPal.Ext.PerformanceMonitor;
+
+internal sealed class RollingNetworkThroughputNormalizer
+{
+    internal static readonly TimeSpan Window = TimeSpan.FromSeconds(60);
+
+    internal const double HeadroomMultiplier = 1.2;
+    internal const double MinimumScaleBytesPerSecond = 125_000;
+
+    private readonly Queue<Sample> _samples = new();
+    private readonly Lock _samplesLock = new();
+
+    internal int AddSample(double bytesPerSecond, DateTimeOffset timestamp)
+    {
+        var currentThroughput = double.IsFinite(bytesPerSecond)
+            ? Math.Max(0, bytesPerSecond)
+            : 0;
+
+        lock (_samplesLock)
+        {
+            var cutoff = timestamp - Window;
+            while (_samples.Count > 0 && _samples.Peek().Timestamp <= cutoff)
+            {
+                _samples.Dequeue();
+            }
+
+            _samples.Enqueue(new(timestamp, currentThroughput));
+
+            var rollingPeak = 0.0;
+            foreach (var sample in _samples)
+            {
+                rollingPeak = Math.Max(rollingPeak, sample.BytesPerSecond);
+            }
+
+            var scale = Math.Max(MinimumScaleBytesPerSecond, rollingPeak * HeadroomMultiplier);
+            return Math.Clamp(
+                (int)Math.Round(currentThroughput * 100 / scale, MidpointRounding.AwayFromZero),
+                0,
+                100);
+        }
+    }
+
+    private readonly record struct Sample(DateTimeOffset Timestamp, double BytesPerSecond);
+}

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/RollingThroughputNormalizer.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/RollingThroughputNormalizer.cs
@@ -8,7 +8,7 @@ using System.Threading;
 
 namespace Microsoft.CmdPal.Ext.PerformanceMonitor;
 
-internal sealed class RollingNetworkThroughputNormalizer
+internal sealed class RollingThroughputNormalizer
 {
     internal static readonly TimeSpan Window = TimeSpan.FromSeconds(60);
 
@@ -18,11 +18,17 @@ internal sealed class RollingNetworkThroughputNormalizer
     private readonly Queue<Sample> _samples = new();
     private readonly Lock _samplesLock = new();
 
-    internal int AddSample(double bytesPerSecond, DateTimeOffset timestamp)
+    internal int AddSample(double bytesPerSecond, DateTimeOffset timestamp) =>
+        AddPairSample(bytesPerSecond, 0, timestamp).FirstPercent;
+
+    internal ThroughputPairPercentages AddPairSample(
+        double firstBytesPerSecond,
+        double secondBytesPerSecond,
+        DateTimeOffset timestamp)
     {
-        var currentThroughput = double.IsFinite(bytesPerSecond)
-            ? Math.Max(0, bytesPerSecond)
-            : 0;
+        var firstThroughput = NormalizeThroughput(firstBytesPerSecond);
+        var secondThroughput = NormalizeThroughput(secondBytesPerSecond);
+        var currentPeak = Math.Max(firstThroughput, secondThroughput);
 
         lock (_samplesLock)
         {
@@ -32,7 +38,7 @@ internal sealed class RollingNetworkThroughputNormalizer
                 _samples.Dequeue();
             }
 
-            _samples.Enqueue(new(timestamp, currentThroughput));
+            _samples.Enqueue(new(timestamp, currentPeak));
 
             var rollingPeak = 0.0;
             foreach (var sample in _samples)
@@ -41,12 +47,22 @@ internal sealed class RollingNetworkThroughputNormalizer
             }
 
             var scale = Math.Max(MinimumScaleBytesPerSecond, rollingPeak * HeadroomMultiplier);
-            return Math.Clamp(
-                (int)Math.Round(currentThroughput * 100 / scale, MidpointRounding.AwayFromZero),
-                0,
-                100);
+            return new(
+                ToPercent(firstThroughput, scale),
+                ToPercent(secondThroughput, scale));
         }
     }
 
+    private static double NormalizeThroughput(double bytesPerSecond) =>
+        double.IsFinite(bytesPerSecond) ? Math.Max(0, bytesPerSecond) : 0;
+
+    private static int ToPercent(double bytesPerSecond, double scale) =>
+        Math.Clamp(
+            (int)Math.Round(bytesPerSecond * 100 / scale, MidpointRounding.AwayFromZero),
+            0,
+            100);
+
     private readonly record struct Sample(DateTimeOffset Timestamp, double BytesPerSecond);
+
+    internal readonly record struct ThroughputPairPercentages(int FirstPercent, int SecondPercent);
 }

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/Strings/en-US/Resources.resw
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/Strings/en-US/Resources.resw
@@ -424,6 +424,12 @@
   <data name="Network_Receive_Subtitle" xml:space="preserve">
     <value>Receive</value>
   </data>
+  <data name="Network_In_Subtitle" xml:space="preserve">
+    <value>In</value>
+  </data>
+  <data name="Network_Out_Subtitle" xml:space="preserve">
+    <value>Out</value>
+  </data>
   <data name="Disk_Read_Subtitle" xml:space="preserve">
     <value>Read</value>
   </data>
@@ -479,12 +485,20 @@
     <value>{0} · {1}</value>
     <comment>Compact metric detail. {0} is utilization percentage and {1} is a secondary measurement such as speed or temperature.</comment>
   </data>
+  <data name="Overview_Directional_Value_Format" xml:space="preserve">
+    <value>{0} {1}</value>
+    <comment>Compact directional throughput value. {0} is a localized direction such as "Read" or "In", and {1} is its speed.</comment>
+  </data>
+  <data name="Overview_Directional_Label_Format" xml:space="preserve">
+    <value>{0} {1}</value>
+    <comment>Accessible label for a directional throughput bar. {0} is the metric such as "Disk" or "Network", and {1} is the direction such as "Read" or "In".</comment>
+  </data>
   <data name="Overview_Disk_Detail_Format" xml:space="preserve">
     <value>{0} {1} · {2} {3}</value>
     <comment>Compact disk detail shown in the performance overview dashboard. {0}/{2} are the localized "Read"/"Write" words, {1}/{3} are their speeds.</comment>
   </data>
   <data name="Overview_Network_Detail_Format" xml:space="preserve">
     <value>{0} {1} · {2} {3}</value>
-    <comment>Compact network detail shown in the performance overview dashboard. {0}/{2} are the localized "Send"/"Receive" words, {1}/{3} are their speeds.</comment>
+    <comment>Compact network detail shown in the performance overview dashboard. {0}/{2} are the localized "In"/"Out" words, {1}/{3} are their speeds.</comment>
   </data>
 </root>

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/Strings/en-US/Resources.resw
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/Strings/en-US/Resources.resw
@@ -463,4 +463,28 @@
   <data name="Disk_Speed_Unit_BinaryBytesPerSec" xml:space="preserve">
     <value>Binary bytes per second (KiB/s, MiB/s, GiB/s)</value>
   </data>
+  <data name="Overview_Memory_Detail_Format" xml:space="preserve">
+    <value>{0} / {1}</value>
+    <comment>Compact memory detail shown in the performance overview dashboard. {0} is memory in use, {1} is total memory.</comment>
+  </data>
+  <data name="Overview_Live_Status" xml:space="preserve">
+    <value>Live</value>
+    <comment>Status shown in the performance overview header while metrics update.</comment>
+  </data>
+  <data name="Overview_RAM_Label" xml:space="preserve">
+    <value>RAM</value>
+    <comment>Short memory label used in the compact performance overview.</comment>
+  </data>
+  <data name="Overview_Percent_Detail_Format" xml:space="preserve">
+    <value>{0} · {1}</value>
+    <comment>Compact metric detail. {0} is utilization percentage and {1} is a secondary measurement such as speed or temperature.</comment>
+  </data>
+  <data name="Overview_Disk_Detail_Format" xml:space="preserve">
+    <value>{0} {1} · {2} {3}</value>
+    <comment>Compact disk detail shown in the performance overview dashboard. {0}/{2} are the localized "Read"/"Write" words, {1}/{3} are their speeds.</comment>
+  </data>
+  <data name="Overview_Network_Detail_Format" xml:space="preserve">
+    <value>{0} {1} · {2} {3}</value>
+    <comment>Compact network detail shown in the performance overview dashboard. {0}/{2} are the localized "Send"/"Receive" words, {1}/{3} are their speeds.</comment>
+  </data>
 </root>

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/Strings/en-US/Resources.resw
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/Strings/en-US/Resources.resw
@@ -424,12 +424,6 @@
   <data name="Network_Receive_Subtitle" xml:space="preserve">
     <value>Receive</value>
   </data>
-  <data name="Network_In_Subtitle" xml:space="preserve">
-    <value>In</value>
-  </data>
-  <data name="Network_Out_Subtitle" xml:space="preserve">
-    <value>Out</value>
-  </data>
   <data name="Disk_Read_Subtitle" xml:space="preserve">
     <value>Read</value>
   </data>
@@ -487,11 +481,11 @@
   </data>
   <data name="Overview_Directional_Value_Format" xml:space="preserve">
     <value>{0} {1}</value>
-    <comment>Compact directional throughput value. {0} is a localized direction such as "Read" or "In", and {1} is its speed.</comment>
+    <comment>Compact directional throughput value. {0} is a localized direction such as "Read" or "Send", and {1} is its speed.</comment>
   </data>
   <data name="Overview_Directional_Label_Format" xml:space="preserve">
     <value>{0} {1}</value>
-    <comment>Accessible label for a directional throughput bar. {0} is the metric such as "Disk" or "Network", and {1} is the direction such as "Read" or "In".</comment>
+    <comment>Accessible label for a directional throughput bar. {0} is the metric such as "Disk" or "Network", and {1} is the direction such as "Read" or "Send".</comment>
   </data>
   <data name="Overview_Disk_Detail_Format" xml:space="preserve">
     <value>{0} {1} · {2} {3}</value>
@@ -499,6 +493,6 @@
   </data>
   <data name="Overview_Network_Detail_Format" xml:space="preserve">
     <value>{0} {1} · {2} {3}</value>
-    <comment>Compact network detail shown in the performance overview dashboard. {0}/{2} are the localized "In"/"Out" words, {1}/{3} are their speeds.</comment>
+    <comment>Compact network detail shown in the performance overview dashboard. {0}/{2} are the localized "Send"/"Receive" words, {1}/{3} are their speeds.</comment>
   </data>
 </root>


### PR DESCRIPTION
## Summary of the Pull Request

CmdPal's Dock performance monitor was underutilized and its Adaptive Card refresh path visibly pulsed while updating. This PR replaces that surface with a persistent native WinUI overview, strengthens its refresh lifecycle, restores reliable GPU/network adapter selection, and presents disk and network throughput as meaningful directional pairs.

## PR Checklist

- [ ] Closes: N/A
- [x] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated - N/A; no developer workflow or API documentation changed
- [ ] **New binaries:** Added on the required places - N/A; no new binaries or test projects
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries - N/A
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder - N/A
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects - N/A
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml) - N/A
- [ ] **Documentation updated:** N/A; no public documentation changes are required

## Detailed Description of the Pull Request / Additional comments

- Adds a native performance-overview content type, view model, and WinUI control so the dashboard visual tree remains alive while bound values update in place. Existing Adaptive Card content remains unchanged.
- Shows CPU, GPU, RAM, Disk, and Network in the compact Cal-inspired layout, preserving the thin track and thicker colored fill treatment.
- Hardens Dock page ownership, subscription cleanup, view-model reuse, and refresh coalescing to prevent retained pages and unbounded queued updates.
- Selects the active connected network interface automatically, preserves manual adapter choices, recovers after disconnects, and exposes compact GPU/network adapter controls.
- Displays Disk Read/Write and Network Send/Receive as paired bars. Each pair shares a 60-second rolling peak with 20% headroom and a minimum throughput scale, while aggregate values remain available for hero display and schema-v1 compatibility.
- Keeps the paired tracks aligned beneath their directional values rather than spanning under the metric-label column.

## Validation Steps Performed

- Built the affected CmdPal UI and both focused test projects for x64 Release.
- Ran the Performance Monitor and CmdPal UI ViewModel suites together: 253 passed, 0 failed, 0 skipped.
- Verified loose-package restart behavior, Dock/main icons, live metric refresh, active-network selection, adapter cycling, disconnect recovery, and independent Send/Receive and Read/Write updates.
- Confirmed the native dashboard updates without the Adaptive Card refresh pulse.
- Completed a 10-minute resource soak after the lifecycle fix and a final 30-second sample; memory remained stable and handle/thread counts did not grow.
- Completed final Opus 5 max reviews of the lifecycle, adapter, paired-meter, accessibility, mapping, and layout changes with no remaining high-confidence findings.