### PR TITLE
FileLocksmith: Fix the context menu resource name

### DIFF
--- a/src/modules/FileLocksmith/FileLocksmithContextMenu/Resources.resx
+++ b/src/modules/FileLocksmith/FileLocksmithContextMenu/Resources.resx
@@ -120,7 +120,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="File_Locksmith_Context_Menu_Entry" xml:space="preserve">
+  <data name="FileLocksmith_Context_Menu_Entry" xml:space="preserve">
     <value>Unlock with File Locksmith</value>
     <comment>This text will be shown when the user opens the context menu (right clicks) a file. File Locksmith is the product name, do not loc.</comment>
   </data>

--- a/src/modules/FileLocksmith/FileLocksmithContextMenu/dllmain.cpp
+++ b/src/modules/FileLocksmith/FileLocksmithContextMenu/dllmain.cpp
@@ -181,7 +181,7 @@ protected:
     ComPtr<IUnknown> m_site;
 
 private:
-    std::wstring context_menu_caption = GET_RESOURCE_STRING_FALLBACK(IDS_FILE_LOCKSMITH_CONTEXT_MENU_ENTRY, L"Unlock with File Locksmith");
+    std::wstring context_menu_caption = GET_RESOURCE_STRING_FALLBACK(IDS_FILELOCKSMITH_CONTEXT_MENU_ENTRY, L"Unlock with File Locksmith");
 };
 
 CoCreatableClass(FileLocksmithContextMenuCommand)


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Rename the context menu resource key to match code usage and ensure successful lookup.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: 37271
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [x] **New binaries:** None added
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
- Resources.resx: changed key from `File_Locksmith_Context_Menu_Entry` to `FileLocksmith_Context_Menu_Entry`.
- dllmain.cpp: updated the `GET_RESOURCE_STRING_FALLBACK` identifier to `IDS_FILELOCKSMITH_CONTEXT_MENU_ENTRY` so the context menu caption is loaded correctly.

The classic context menu is localized, so I matched the key to the `FileLocksmithExt` project.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

