### PR TITLE
CmdPal: when expanding compact mode, don't be too tall

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml.cs
@@ -1919,11 +1919,10 @@ public sealed partial class MainWindow : WindowEx,
             // In compact mode the card sizes itself to its content and anchors to the top.
             RootElement.SetCardStretch(false);
 
-            // Only the compact + centered configuration needs a screen-fit clamp. There the card
-            // is anchored near the vertical center of the display, so an expanded list could run
-            // off the bottom edge; cap its height so it always fits. In every other case the card
-            // is free to fill the (fixed-size) HWND as before.
-            var cardMaxHeight = expanded && IsCenteringSummon(settings)
+            // The HWND can extend below the current display after moving from a taller monitor.
+            // Always clamp an expanded compact card to the visible work area; the transparent
+            // portion of the HWND may remain off-screen, but the card and its content must not.
+            var cardMaxHeight = expanded
                 ? ComputeExpandedCardMaxHeightDip()
                 : double.PositiveInfinity;
             RootElement.SetCardMaxHeight(cardMaxHeight);
@@ -1937,18 +1936,19 @@ public sealed partial class MainWindow : WindowEx,
         var dpi = (int)this.GetDpiForWindow();
         var scale = dpi / 96.0;
 
-        var displayArea = DisplayArea.GetFromWindowId(AppWindow.Id, DisplayAreaFallback.Nearest);
-        var workArea = displayArea.WorkArea;
-
         var padding = RootElement.ShadowPadding;
         var cardTopPhysical = AppWindow.Position.Y + (padding.Top * scale);
+
+        // Select the display from the visible card rather than from the HWND. An oversized HWND
+        // can overlap another display (or have its center below the intended display), causing
+        // GetFromWindowId to choose a work area unrelated to the card the user is looking at.
+        var cardCenterXPhysical = AppWindow.Position.X + (AppWindow.Size.Width / 2);
+        var displayArea = DisplayArea.GetFromPoint(
+            new PointInt32(cardCenterXPhysical, (int)Math.Round(cardTopPhysical)),
+            DisplayAreaFallback.Nearest);
+        var workArea = displayArea.WorkArea;
         var availablePhysical = (workArea.Y + workArea.Height) - cardTopPhysical - (padding.Bottom * scale);
 
-        if (availablePhysical <= 0)
-        {
-            return double.PositiveInfinity;
-        }
-
-        return availablePhysical / scale;
+        return Math.Max(0, availablePhysical / scale);
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
@@ -1042,6 +1042,14 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
 
     public void Receive(ExpandCompactModeMessage message)
     {
+        // Down/Tab expands the shell synchronously before broadcasting this message so the
+        // host can resize the card. In that case the requested state is already applied;
+        // re-evaluating from the empty query would immediately collapse it again.
+        if (ExpandedMode == message.Expanded)
+        {
+            return;
+        }
+
         // Re-evaluate from the current authoritative page state rather than applying the
         // message's snapshot directly. The message can race with navigation: following a
         // 1-character alias clears the home search (sending a "collapse") right as we
@@ -1099,6 +1107,7 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
         }
 
         HandleExpandCompactOnUiThread(true);
+        WeakReferenceMessenger.Default.Send<ExpandCompactModeMessage>(new(true));
         return true;
     }
 


### PR DESCRIPTION
If you open command palette on one display and resize its expanded size to be very tall, then you move command palette to a monitor that is not that tall and expand it, we will still expand our control to fit the full size of our HWND, which is taller than this new monitor. This PR fixes that by making sure to measure the size that's available on the current monitor and limit the max height of our control when we're expanding it, so that the bottom of the control always fits on the current monitor.

Closes: not filed I don't think
