### PR TITLE
BUILD: Fix the version.vcxproj FastUpToDate check

### DIFF
--- a/src/common/version/version.vcxproj
+++ b/src/common/version/version.vcxproj
@@ -1,7 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   
-  <Target Name="GenerateVersionData" BeforeTargets="PrepareForBuild">
+  <!-- Make sure Inputs/Outputs are set correctly, so that we only regenerate
+  the version header when the version actually changes. Otherwise this will
+  dirty FastUpToDate checks for almost everything -->
+  <Target Name="GenerateVersionData"
+    BeforeTargets="PrepareForBuild"
+    Inputs="$(RepoRoot)src\Version.props"
+    Outputs="$(MSBuildProjectDirectory)\Generated Files\version_gen.h">
     <ItemGroup>
       <HeaderLines Include="#pragma once" />
       <HeaderLines Include="#define VERSION_MAJOR $(Version.Split('.')[0])" />

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/Microsoft.CmdPal.Ext.PerformanceMonitor.csproj
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/Microsoft.CmdPal.Ext.PerformanceMonitor.csproj
@@ -60,8 +60,15 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+  
   <ItemGroup>
-    <Content Update="Assets\**\*.*">
+    <None Remove="Assets\PerformanceMonitorExtension.svg" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Update="Assets\PerformanceMonitorExtension.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Update="Assets\PerformanceMonitorExtension.svg">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsTerminal/Microsoft.CmdPal.Ext.WindowsTerminal.csproj
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WindowsTerminal/Microsoft.CmdPal.Ext.WindowsTerminal.csproj
@@ -2,19 +2,15 @@
   <Import Project="$(RepoRoot)src\Common.Dotnet.CsWinRT.props" />
   <Import Project="$(RepoRoot)src\Common.Dotnet.AotCompatibility.props" />
   <Import Project="..\Common.ExtDependencies.props" />
-  <Import Project="..\..\Microsoft.CmdPal.UI\CmdPal.pre.props" />
 
   <PropertyGroup>
     <RootNamespace>Microsoft.CmdPal.Ext.WindowsTerminal</RootNamespace>
-    <!-- <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\WinUI3Apps\CmdPal</OutputPath> -->
+    <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\WinUI3Apps\CmdPal</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <!-- MRT from windows app sdk will search for a pri file with the same name of the module before defaulting to resources.pri -->
     <ProjectPriFileName>Microsoft.CmdPal.Ext.WindowsTerminal.pri</ProjectPriFileName>
   </PropertyGroup>
-  <ItemGroup>
-    <None Remove="Assets\WindowsTerminal.svg" />
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\common\ManagedCommon\ManagedCommon.csproj" />
     <!-- CmdPal Toolkit reference now included via Common.ExtDependencies.props -->
@@ -33,6 +29,9 @@
     <Content Remove="Assets\WindowsTerminal.dark.png" />
     <Content Remove="Assets\WindowsTerminal.light.png" />
     <Content Remove="Assets\WindowsTerminal.light.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Remove="Assets\WindowsTerminal.svg" />
   </ItemGroup>
   <ItemGroup>
     <Content Update="Assets\WindowsTerminal.png">


### PR DESCRIPTION
This has been my personal enemy for a year now.

VS will skip doing work for your build if it thinks everything is up-to-
date. But this version project has been treated as dirty for a long time
now. What that means is that incremental builds (READ: dev inner loop
builds) end up building the world CONSTANTLY. Because VS thinks FOR SOME
REASON that this project needs to rebuild.

By setting the `Inputs`/`Outputs` for this `Target`, VS is smart enough
to only re-run the task if the inputs actually changed since the last
build.

Tested by building the code, then building again, and observing that
all the projects were successfully noted as up-to-date

drive-by: fix some of the other `csproj` files for cmdpal. 


Closes #45296