### PR TITLE
[ZoomIt] Port recording/editing features from Mac ZoomIt (trim editor, snip-to-clipboard, recording border) and fix video trim reliability

### DIFF
--- a/src/modules/ZoomIt/ZoomIt/AudioSampleGenerator.cpp
+++ b/src/modules/ZoomIt/ZoomIt/AudioSampleGenerator.cpp
@@ -65,6 +65,8 @@ winrt::IAsyncAction AudioSampleGenerator::InitializeAsync()
     auto expected = false;
     if (m_initialized.compare_exchange_strong(expected, true))
     {
+      try
+      {
         // Reset state in case this instance is reused.
         m_endEvent.ResetEvent();
         m_startEvent.ResetEvent();
@@ -81,14 +83,27 @@ winrt::IAsyncAction AudioSampleGenerator::InitializeAsync()
         // Get AudioGraph encoding properties for resampling
         auto graphProps = m_audioGraph.EncodingProperties();
         m_graphSampleRate = graphProps.SampleRate();
-        m_graphChannels = graphProps.ChannelCount();
+
+        // Force the captured audio to stereo.  The default render device mix format
+        // is often multichannel (e.g. 7.1 / 8 channels), which produces a multichannel
+        // AAC track that plays back fine but cannot be re-encoded by the trim /
+        // MediaComposition transcode source reader (fails with 0xC00DA7FC /
+        // TranscodeFailureReason::Unknown).  Screen recordings only need stereo, so we
+        // build a stereo output-node format and let the graph downmix the multichannel
+        // mix automatically.  (Forcing the whole graph to stereo via
+        // AudioGraphSettings.EncodingProperties is rejected by many devices, so we only
+        // constrain the frame output node.)
+        auto outputProps = m_audioGraph.EncodingProperties();
+        outputProps.ChannelCount(2);
+        outputProps.Bitrate(outputProps.SampleRate() * 2 * outputProps.BitsPerSample());
+        m_graphChannels = 2;
 
         OutputDebugStringA(("AudioGraph initialized: " + std::to_string(m_graphSampleRate) +
             " Hz, " + std::to_string(m_graphChannels) + " ch\n").c_str());
 
         // Create submix node to mix microphone and loopback audio
         m_submixNode = m_audioGraph.CreateSubmixNode();
-        m_audioOutputNode = m_audioGraph.CreateFrameOutputNode();
+        m_audioOutputNode = m_audioGraph.CreateFrameOutputNode(outputProps);
         m_submixNode.AddOutgoingConnection(m_audioOutputNode);
 
         // Initialize WASAPI loopback capture for system audio (if enabled)
@@ -179,6 +194,20 @@ winrt::IAsyncAction AudioSampleGenerator::InitializeAsync()
         m_audioGraph.Start();
 
         m_asyncInitialized.SetEvent();
+      }
+      catch (...)
+      {
+          // Initialization failed partway through (common on headless /
+          // GPU-less VMs, cloud PCs, or machines without a usable audio
+          // capture device, where CreateDeviceInputNodeAsync throws).
+          // m_initialized was already set to true at the top, so unless we
+          // release these events here, Stop() would block forever on
+          // m_asyncInitialized.wait() and TryGetNextSample() would block
+          // forever on m_endEvent during teardown — deadlocking the recorder.
+          m_asyncInitialized.SetEvent();
+          m_endEvent.SetEvent();
+          throw;
+      }
     }
 }
 
@@ -326,8 +355,13 @@ void AudioSampleGenerator::Stop()
     // Flush any remaining samples from the loopback capture before stopping the audio graph
     FlushRemainingAudio();
 
-    // Stop the audio graph - no more quantum callbacks will run
-    m_audioGraph.Stop();
+    // Stop the audio graph - no more quantum callbacks will run.
+    // Guard against partial initialization: if InitializeAsync failed before
+    // the graph was created, m_audioGraph is null.
+    if (m_audioGraph)
+    {
+        m_audioGraph.Stop();
+    }
 
     // Close the microphone input node to release the device so Windows no longer
     // reports the microphone as in use by ZoomIt.
@@ -547,6 +581,7 @@ void AudioSampleGenerator::FlushRemainingAudio()
             }
 
             auto sample = winrt::MediaStreamSample::CreateFromBuffer(sampleBuffer, timestamp);
+            sample.Duration(duration);
             m_samples.push_back(sample);
             m_audioEvent.SetEvent();
 
@@ -620,6 +655,7 @@ void AudioSampleGenerator::CombineQueuedSamples()
     const uint32_t sampleCount = static_cast<uint32_t>(totalBytes) / sizeof(float);
     const uint32_t frames = (m_graphChannels > 0) ? (sampleCount / m_graphChannels) : 0;
     const int64_t durationTicks = (m_graphSampleRate > 0) ? (static_cast<int64_t>(frames) * 10000000LL / m_graphSampleRate) : 0;
+    combinedSample.Duration(winrt::Windows::Foundation::TimeSpan{ durationTicks });
     m_lastSampleTimestamp = firstTimestamp;
     m_lastSampleDuration = winrt::Windows::Foundation::TimeSpan{ durationTicks };
     m_hasLastSampleTimestamp = true;
@@ -790,6 +826,7 @@ void AudioSampleGenerator::OnAudioQuantumStarted(winrt::AudioGraph const& sender
             const uint32_t sampleCount = sampleBuffer.Length() / sizeof(float);
             const uint32_t frames = (m_graphChannels > 0) ? (sampleCount / m_graphChannels) : 0;
             const int64_t durationTicks = (m_graphSampleRate > 0) ? (static_cast<int64_t>(frames) * 10000000LL / m_graphSampleRate) : 0;
+            sample.Duration(winrt::TimeSpan{ durationTicks });
             m_lastSampleTimestamp = adjustedTs;
             m_lastSampleDuration = winrt::TimeSpan{ durationTicks };
             m_hasLastSampleTimestamp = true;

--- a/src/modules/ZoomIt/ZoomIt/GifRecordingSession.cpp
+++ b/src/modules/ZoomIt/ZoomIt/GifRecordingSession.cpp
@@ -12,6 +12,12 @@
 #include <shcore.h>
 
 extern DWORD g_RecordScaling;
+extern HWND g_hWndMain;
+
+// Must match the definition in ZoomIt.h.
+#ifndef WM_USER_RECORDING_NO_FRAMES
+#define WM_USER_RECORDING_NO_FRAMES (WM_USER + 112)
+#endif
 
 namespace winrt
 {
@@ -409,10 +415,28 @@ winrt::IAsyncAction GifRecordingSession::StartAsync()
             // Keep track of the last frame to duplicate when needed
             winrt::com_ptr<ID3D11Texture2D> lastCroppedTexture;
 
+            bool firstFrame = true;
             while (m_isRecording && !m_closed)
             {
                 captureAttempts++;
-                auto frame = m_frameWait->TryGetNextFrame();
+                // Bound the very first frame so a display that never delivers
+                // frames to Windows.Graphics.Capture (headless / GPU-less VM
+                // or some remote sessions) is detected and reported instead
+                // of blocking forever on an INFINITE wait.
+                constexpr DWORD c_firstFrameTimeoutMs = 3000;
+                auto frame = firstFrame
+                    ? m_frameWait->TryGetNextFrame( c_firstFrameTimeoutMs )
+                    : m_frameWait->TryGetNextFrame();
+                if (firstFrame && !frame && m_isRecording && !m_closed)
+                {
+                    // First frame never arrived — capture is not delivering
+                    // frames.  Notify the UI so it can tell the user instead
+                    // of silently producing an empty GIF.
+                    OutputDebugStringW(L"[GIF] first-frame timeout — capture delivered no frames; signaling capture-unavailable\n");
+                    PostMessage(g_hWndMain, WM_USER_RECORDING_NO_FRAMES, 0, 0);
+                    break;
+                }
+                firstFrame = false;
                 if (!frame && !m_isRecording)
                 {
                     // Recording was stopped while waiting for frame

--- a/src/modules/ZoomIt/ZoomIt/PanoramaCapture.cpp
+++ b/src/modules/ZoomIt/ZoomIt/PanoramaCapture.cpp
@@ -10344,7 +10344,9 @@ static bool RunPanoramaCaptureCommon( HWND hWnd, bool saveToFile )
 
     g_RecordCropping = TRUE;
     g_SelectRectangle.AspectRatio( 0.0 );
-    const bool started = g_SelectRectangle.Start( hWnd );
+    // Panorama uses a blue bounding rectangle to distinguish it from the yellow
+    // recording-region selection.
+    const bool started = g_SelectRectangle.Start( hWnd, false, RGB( 0, 120, 215 ) );
     g_RecordCropping = FALSE;
     if( !started )
     {

--- a/src/modules/ZoomIt/ZoomIt/SelectRectangle.cpp
+++ b/src/modules/ZoomIt/ZoomIt/SelectRectangle.cpp
@@ -33,10 +33,10 @@ static void SelectRectangleDebugLog( const wchar_t* format, ... )
 // SelectRectangle::Start
 //
 //----------------------------------------------------------------------------
-bool SelectRectangle::Start( HWND ownerWindow, bool fullMonitor )
+bool SelectRectangle::Start( HWND ownerWindow, bool fullMonitor, COLORREF borderColor )
 {
     m_stopping = false;
-    m_borderColor = RGB( 255, 222, 0 ); // Reset to yellow; turns orange once first frame is captured.
+    m_borderColor = borderColor; // Initial border color (yellow by default); turns orange once first frame is captured.
     m_recordingActive = false;           // Reset so SetRecordingActive fires on next recording.
     m_fullMonitor = fullMonitor;
 

--- a/src/modules/ZoomIt/ZoomIt/SelectRectangle.h
+++ b/src/modules/ZoomIt/ZoomIt/SelectRectangle.h
@@ -24,7 +24,9 @@ public:
     RECT SelectedRect() const { return m_selectedRect; }
     bool IsActive() const { return m_window != nullptr; }
 
-    bool Start( HWND ownerWindow = nullptr, bool fullMonitor = false );
+    // borderColor sets the initial selection border color (defaults to yellow to
+    // match the capture API). Panorama capture passes blue.
+    bool Start( HWND ownerWindow = nullptr, bool fullMonitor = false, COLORREF borderColor = RGB( 255, 222, 0 ) );
     void Stop();
     void UpdateOwner( HWND window );
     void Hide() { if( m_window ) ShowWindow( m_window.get(), SW_HIDE ); }

--- a/src/modules/ZoomIt/ZoomIt/VideoRecordingSession.cpp
+++ b/src/modules/ZoomIt/ZoomIt/VideoRecordingSession.cpp
@@ -93,7 +93,7 @@ int32_t EnsureEven(int32_t value)
 
 //----------------------------------------------------------------------------
 //
-// Recording startup diagnostics — active in ALL builds.
+// Recording startup diagnostics — opt-in via the registry (see RecDiagEnabled).
 // Logs QPC-based wall-clock timestamps so we can measure exactly where time
 // is spent during the recording startup pipeline.
 //
@@ -140,8 +140,40 @@ static void RecDiagCloseFile()
     }
 }
 
+//
+// Diagnostics are opt-in via the registry so they never fire for normal users.
+// Enable by setting the DWORD value:
+//   HKCU\Software\Sysinternals\ZoomIt\EnableDebugTrace = 1
+// The value is read once and cached, so toggling it requires a ZoomIt restart.
+//
+static bool RecDiagEnabled()
+{
+    static int s_enabled = -1; // -1 = not yet read, 0 = disabled, 1 = enabled
+    if( s_enabled == -1 )
+    {
+        s_enabled = 0;
+        HKEY hKey;
+        if( RegOpenKeyExW( HKEY_CURRENT_USER, L"Software\\Sysinternals\\ZoomIt", 0, KEY_QUERY_VALUE, &hKey ) == ERROR_SUCCESS )
+        {
+            DWORD val = 0;
+            DWORD type = 0;
+            DWORD size = sizeof( val );
+            if( RegQueryValueExW( hKey, L"EnableDebugTrace", nullptr, &type, reinterpret_cast<LPBYTE>( &val ), &size ) == ERROR_SUCCESS &&
+                type == REG_DWORD && val != 0 )
+            {
+                s_enabled = 1;
+            }
+            RegCloseKey( hKey );
+        }
+    }
+    return s_enabled == 1;
+}
+
 static void RecDiag( const wchar_t* fmt, ... )
 {
+    if( !RecDiagEnabled() )
+        return;
+
     wchar_t buf[512];
     int offset = swprintf_s( buf, L"[RecDiag +%.1fms] ", RecDiagElapsedMs() );
     va_list va;

--- a/src/modules/ZoomIt/ZoomIt/VideoRecordingSession.cpp
+++ b/src/modules/ZoomIt/ZoomIt/VideoRecordingSession.cpp
@@ -44,6 +44,9 @@ extern HWND g_hWndMain;
 #ifndef WM_USER_RECORDING_STARTED
 #define WM_USER_RECORDING_STARTED (WM_USER + 111)
 #endif
+#ifndef WM_USER_RECORDING_NO_FRAMES
+#define WM_USER_RECORDING_NO_FRAMES (WM_USER + 112)
+#endif
 
 HWND hDlgTrimDialog = nullptr;
 
@@ -1428,14 +1431,27 @@ void VideoRecordingSession::OnMediaStreamSourceSampleRequested(
         // so there is no timestamp gap at the start of the recording.
         auto cachedFrame = std::exchange( m_cachedStartingFrame, std::nullopt );
 
-        // When a webcam overlay is active, use a timeout so we keep
-        // producing video frames (with fresh webcam composites) even
-        // when the desktop is static.  Without this, TryGetNextFrame
-        // blocks forever on a static desktop and the webcam freezes.
-        const bool useTimeout = ( m_webcamCapture != nullptr ) && !cachedFrame;
-        const DWORD timeoutMs = useTimeout
-            ? static_cast<DWORD>( m_frameIntervalTicks / 10'000 )  // ticks → ms
-            : INFINITE;
+        // Decide how long to wait for a frame:
+        //  * The very first frame is bounded (c_firstFrameTimeoutMs) so a
+        //    display that never delivers frames to Windows.Graphics.Capture
+        //    (headless / GPU-less VMs, some remote sessions) is detected and
+        //    reported instead of hanging forever on an INFINITE wait.
+        //  * With a webcam overlay we time out each frame so a static desktop
+        //    still produces fresh webcam composites.
+        //  * Otherwise we block until the next desktop change.
+        constexpr DWORD c_firstFrameTimeoutMs = 3000;
+        const bool firstFrame = !m_hasVideoSample.load();
+        const bool webcamTimeout = ( m_webcamCapture != nullptr ) && !cachedFrame;
+
+        DWORD timeoutMs = INFINITE;
+        if( !cachedFrame )
+        {
+            if( firstFrame )
+                timeoutMs = c_firstFrameTimeoutMs;
+            else if( webcamTimeout )
+                timeoutMs = static_cast<DWORD>( m_frameIntervalTicks / 10'000 );  // ticks → ms
+        }
+        const bool useTimeout = !cachedFrame && ( timeoutMs != INFINITE );
 
         auto frame = cachedFrame
             ? cachedFrame
@@ -1445,11 +1461,20 @@ void VideoRecordingSession::OnMediaStreamSourceSampleRequested(
 
         // frame is nullopt either on timeout (static desktop) or end-of-capture.
         // On timeout with a cached desktop texture, produce a repeat frame.
-        const bool isRepeatFrame = !frame && useTimeout && m_cachedDesktopTex;
+        const bool isRepeatFrame = !frame && webcamTimeout && m_cachedDesktopTex;
 
         if( !frame && !isRepeatFrame )
         {
-            // True end-of-capture — no cached desktop to reuse.
+            // No frame available.  If we have never captured a single frame
+            // and the session was not closed by the user, the display is not
+            // delivering frames to Windows.Graphics.Capture (headless /
+            // GPU-less VM or some remote sessions).  Notify the UI so it can
+            // tell the user, instead of silently producing an empty file.
+            if( firstFrame && !m_closed.load() )
+            {
+                RecDiag( L"SampleReq VIDEO: first-frame timeout after %ums — capture delivered no frames; signaling capture-unavailable\n", c_firstFrameTimeoutMs );
+                PostMessage( g_hWndMain, WM_USER_RECORDING_NO_FRAMES, 0, 0 );
+            }
             request.Sample( nullptr );
             CloseInternal();
             return;
@@ -1490,13 +1515,17 @@ void VideoRecordingSession::OnMediaStreamSourceSampleRequested(
             else
             {
                 // New desktop frame — crop and copy to back buffer.
-                // If this is the cached starting frame, use the adjusted
-                // SRT (computed from QPC in OnStarting) instead of the
-                // stale SRT from the constructor.  The stale SRT is ~2-3s
-                // behind, creating a massive timestamp gap between frame
-                // #1 and #2 that causes the transcoder to starve video
-                // while filling the gap with audio.
-                if( cachedFrame.has_value() && m_adjustedStartSRT != 0 )
+                // The first emitted video sample must carry exactly the start SRT
+                // that OnStarting passed to SetActualStartPosition (and to the audio
+                // generator), so MediaStreamSource rebases the timeline to 0. In the
+                // normal path this is the cached starting frame. But when OnStarting's
+                // TryGetNextFrame timed out (QPC-fallback path) there is no cached
+                // frame, and the first real frame's SystemRelativeTime is slightly
+                // *earlier* than the fallback start SRT — emitting it verbatim yields a
+                // negative rebased timestamp that corrupts the MP4 timeline (its
+                // duration balloons to the absolute QPC value, breaking preview and
+                // trimming). Clamp the first sample to the start SRT in both paths.
+                if( !m_hasVideoSample.load() && m_adjustedStartSRT != 0 )
                     timeStamp = winrt::TimeSpan{ m_adjustedStartSRT };
                 else
                     timeStamp = frame->SystemRelativeTime;
@@ -1549,15 +1578,6 @@ void VideoRecordingSession::OnMediaStreamSourceSampleRequested(
                 m_hasQpcOrigin = true;
             }
             s_diagVideoCount++;
-            if( s_diagVideoCount <= 50 )
-            {
-                RecDiag( L"SampleReq VIDEO #%d: sysRelTime=%lld deltaFromStart=%.1fms repeat=%d cached=%d\n",
-                         s_diagVideoCount,
-                         timeStamp.count(),
-                         ( timeStamp.count() - s_diagStartTs ) / 10000.0,
-                         isRepeatFrame ? 1 : 0,
-                         ( s_diagVideoCount == 1 && cachedFrame.has_value() ) ? 1 : 0 );
-            }
 
 #if _DEBUG
             static int dbgFrameNum = 0;
@@ -1580,11 +1600,6 @@ void VideoRecordingSession::OnMediaStreamSourceSampleRequested(
             // Composite webcam overlay onto the back buffer.
             if( m_webcamCapture )
             {
-                if( s_diagVideoCount <= 3 )
-                {
-                    RecDiag( L"SampleReq VIDEO #%d: compositing LIVE webcam frame\n",
-                             s_diagVideoCount );
-                }
                 m_webcamCapture->CompositeOnto( backBuffer.get() );
             }
 
@@ -1651,32 +1666,13 @@ void VideoRecordingSession::OnMediaStreamSourceSampleRequested(
                 s_audioReqCount = 0;
             s_audioReqCount++;
 
-            if( s_audioReqCount <= 5 )
-            {
-                RecDiag( L"SampleReq AUDIO req #%d: calling TryGetNextSample (started=%d)...\n",
-                         s_audioReqCount, m_audioGenerator ? 1 : 0 );
-            }
-
             LARGE_INTEGER tBefore, tAfter, tFreq;
             QueryPerformanceFrequency( &tFreq );
             QueryPerformanceCounter( &tBefore );
 
             if (auto sample = m_audioGenerator ? m_audioGenerator->TryGetNextSample() : std::optional<winrt::MediaStreamSample>{}; sample.has_value())
             {
-                QueryPerformanceCounter( &tAfter );
-                double waitMs = static_cast<double>( tAfter.QuadPart - tBefore.QuadPart ) * 1000.0 / tFreq.QuadPart;
-
                 s_diagAudioCount++;
-                if( s_diagAudioCount <= 50 )
-                {
-                    auto ts = sample.value().Timestamp().count();
-                    auto dur = sample.value().Duration().count();
-                    RecDiag( L"SampleReq AUDIO #%d (req %d): timestamp=%lld (%.1fms) duration=%lld (%.1fms) waitMs=%.1f\n",
-                             s_diagAudioCount, s_audioReqCount,
-                             ts, ts / 10000.0,
-                             dur, dur / 10000.0,
-                             waitMs );
-                }
                 request.Sample(sample.value());
             }
             else
@@ -1814,13 +1810,26 @@ public:
                 // Use file dialog window as parent if found
                 HWND hParent = hFileDlg ? hFileDlg : m_hParent;
 
-                auto trimResult = VideoRecordingSession::ShowTrimDialog(hParent, m_videoPath, *m_pTrimStart, *m_pTrimEnd);
+                // The editor renders any edit (outer trim and/or interior deletes) to
+                // a temp file inside the dialog and returns it via m_pTrimmedPath. When
+                // it does, the outer save flow must use that file directly rather than
+                // re-trimming the raw recording (which loses deletes and can fail with
+                // 0xC00DA7FC).
+                std::wstring renderedPath;
+                auto trimResult = VideoRecordingSession::ShowTrimDialog(hParent, m_videoPath, *m_pTrimStart, *m_pTrimEnd, false, &renderedPath);
                 if (trimResult == IDOK)
                 {
-                    // Trim values are only written back when the user actually
-                    // changed the selection, so a non-zero trimEnd means a
-                    // real trim is requested.
-                    *m_pShouldTrim = (m_pTrimEnd->count() > 0);
+                    if (!renderedPath.empty())
+                    {
+                        // Editor already produced the final trimmed/composed file.
+                        *m_pTrimmedPath = renderedPath;
+                        *m_pShouldTrim = false;
+                    }
+                    else
+                    {
+                        // No edit was made; save the original recording as-is.
+                        *m_pShouldTrim = false;
+                    }
                 }
                 else if( trimResult == IDCANCEL )
                 {
@@ -1978,12 +1987,13 @@ INT_PTR VideoRecordingSession::ShowTrimDialog(
     const std::wstring& videoPath,
     winrt::TimeSpan& trimStart,
     winrt::TimeSpan& trimEnd,
-    bool standaloneMode)
+    bool standaloneMode,
+    std::wstring* pRenderedPath)
 {
     std::promise<INT_PTR> resultPromise;
     auto resultFuture = resultPromise.get_future();
 
-    std::thread staThread([hParent, videoPath, &trimStart, &trimEnd, standaloneMode, promise = std::move(resultPromise)]() mutable
+    std::thread staThread([hParent, videoPath, &trimStart, &trimEnd, standaloneMode, pRenderedPath, promise = std::move(resultPromise)]() mutable
     {
         bool coInitialized = false;
         try
@@ -2001,7 +2011,7 @@ INT_PTR VideoRecordingSession::ShowTrimDialog(
 
         try
         {
-            INT_PTR dlgResult = ShowTrimDialogInternal(hParent, videoPath, trimStart, trimEnd, standaloneMode);
+            INT_PTR dlgResult = ShowTrimDialogInternal(hParent, videoPath, trimStart, trimEnd, standaloneMode, pRenderedPath);
             promise.set_value(dlgResult);
         }
         catch (const winrt::hresult_error& e)
@@ -2061,7 +2071,8 @@ INT_PTR VideoRecordingSession::ShowTrimDialogInternal(
     const std::wstring& videoPath,
     winrt::TimeSpan& trimStart,
     winrt::TimeSpan& trimEnd,
-    bool standaloneMode)
+    bool standaloneMode,
+    std::wstring* pRenderedPath)
 {
     TrimDialogData data;
     data.videoPath = videoPath;
@@ -2274,6 +2285,15 @@ INT_PTR VideoRecordingSession::ShowTrimDialogInternal(
         {
             trimStart = data.trimStart;
             trimEnd = data.trimEnd;
+        }
+
+        // Non-standalone (post-recording) mode renders the edited composition to a
+        // temp file inside the dialog (see IDOK handler). Surface that path so the
+        // outer save flow moves it to the destination instead of re-trimming the
+        // raw recording.
+        if (pRenderedPath)
+        {
+            *pRenderedPath = data.renderedOutputPath;
         }
     }
 
@@ -2644,6 +2664,40 @@ static void DrawTimeline(HDC hdc, RECT rc, VideoRecordingSession::TrimDialogData
     FillRect(hdcMem, &rcActive, hActive);
     DeleteObject(hActive);
 
+    // Draw the pending "cut from the middle" delete region as a red overlay.
+    if (pData && pData->hasPendingDelete && pData->videoDuration.count() > 0)
+    {
+        int delStartX = std::clamp(TimelineTimeToClientX(pData, pData->pendingDeleteStart, width, dpi), trackLeft, trackRight);
+        int delEndX = std::clamp(TimelineTimeToClientX(pData, pData->pendingDeleteEnd, width, dpi), trackLeft, trackRight);
+        if (delEndX < delStartX)
+        {
+            std::swap(delStartX, delEndX);
+        }
+        RECT rcDelete{ delStartX, trackTop, delEndX, trackBottom };
+        HBRUSH hDelete = CreateSolidBrush(RGB(232, 17, 35)); // Windows red
+        FillRect(hdcMem, &rcDelete, hDelete);
+        DeleteObject(hDelete);
+    }
+
+    // Draw stitch markers where a deleted range was previously removed.
+    if (pData && !pData->deleteJoinMarkers.empty() && pData->videoDuration.count() > 0)
+    {
+        HPEN hStitchPen = CreatePen(PS_SOLID, (std::max)(1, ScaleForDpi(2, dpi)), RGB(232, 17, 35));
+        HPEN hOldStitchPen = static_cast<HPEN>(SelectObject(hdcMem, hStitchPen));
+        for (const auto& marker : pData->deleteJoinMarkers)
+        {
+            if (marker.count() <= 0 || marker.count() >= pData->videoDuration.count())
+            {
+                continue;
+            }
+            const int mx = std::clamp(TimelineTimeToClientX(pData, marker, width, dpi), trackLeft, trackRight);
+            MoveToEx(hdcMem, mx, trackTop, nullptr);
+            LineTo(hdcMem, mx, trackBottom);
+        }
+        SelectObject(hdcMem, hOldStitchPen);
+        DeleteObject(hStitchPen);
+    }
+
     HPEN hOutline = CreatePen(PS_SOLID, 1, darkMode ? RGB(80, 80, 85) : RGB(150, 150, 150));
     HPEN hOldPen = static_cast<HPEN>(SelectObject(hdcMem, hOutline));
     MoveToEx(hdcMem, trackLeft, trackTop, nullptr);
@@ -2791,6 +2845,47 @@ static void DrawTimeline(HDC hdc, RECT rc, VideoRecordingSession::TrimDialogData
 
     drawGripper(startX);
     drawGripper(endX);
+
+    // Draw red grips for the pending delete region so it can be re-dragged.
+    if (pData && pData->hasPendingDelete && pData->videoDuration.count() > 0)
+    {
+        auto drawDeleteGrip = [&](int x)
+        {
+            RECT handleRect{
+                x - timelineHandleHalfWidth,
+                trackTop - (timelineHandleHeight - timelineTrackHeight) / 2,
+                x + timelineHandleHalfWidth,
+                trackTop - (timelineHandleHeight - timelineTrackHeight) / 2 + timelineHandleHeight
+            };
+            const int cornerRadius = (std::max)(ScaleForDpi(6, dpi), timelineHandleHalfWidth);
+            const int lineInset = ScaleForDpi(6, dpi);
+            const int lineWidth = (std::max)(1, ScaleForDpi(2, dpi));
+
+            HBRUSH hFill = CreateSolidBrush(RGB(232, 17, 35));
+            HPEN hNullPen = static_cast<HPEN>(SelectObject(hdcMem, GetStockObject(NULL_PEN)));
+            HBRUSH hOldBrush2 = static_cast<HBRUSH>(SelectObject(hdcMem, hFill));
+            RoundRect(hdcMem, handleRect.left, handleRect.top, handleRect.right, handleRect.bottom, cornerRadius, cornerRadius);
+            SelectObject(hdcMem, hOldBrush2);
+            SelectObject(hdcMem, hNullPen);
+            DeleteObject(hFill);
+
+            HPEN hLinePen = CreatePen(PS_SOLID, lineWidth, RGB(255, 255, 255));
+            HPEN hOldLinePen = static_cast<HPEN>(SelectObject(hdcMem, hLinePen));
+            MoveToEx(hdcMem, x, handleRect.top + lineInset, nullptr);
+            LineTo(hdcMem, x, handleRect.bottom - lineInset);
+            SelectObject(hdcMem, hOldLinePen);
+            DeleteObject(hLinePen);
+        };
+
+        int delStartX = std::clamp(TimelineTimeToClientX(pData, pData->pendingDeleteStart, width, dpi), trackLeft, trackRight);
+        int delEndX = std::clamp(TimelineTimeToClientX(pData, pData->pendingDeleteEnd, width, dpi), trackLeft, trackRight);
+        if (delEndX < delStartX)
+        {
+            std::swap(delStartX, delEndX);
+        }
+        drawDeleteGrip(delStartX);
+        drawDeleteGrip(delEndX);
+    }
 
     const int posX = std::clamp(TimelineTimeToClientX(pData, pData->currentPosition, width, dpi), trackLeft, trackRight);
     const int posLineWidth = ScaleForDpi(2, dpi);
@@ -3295,7 +3390,7 @@ static winrt::fire_and_forget StartPlaybackAsync(HWND hDlg, VideoRecordingSessio
         // the MediaPlayer can play and seek across clip boundaries.
         // For a single-file session, use the faster file-based source.
         winrt::MediaSource mediaSource{ nullptr };
-        if (pData->composition && pData->composition.Clips().Size() > 1)
+        if (pData->composition && (pData->composition.Clips().Size() > 1 || pData->hasDeletes))
         {
             auto mss = pData->composition.GeneratePreviewMediaStreamSource(
                 static_cast<int>(pData->composition.Clips().GetAt(0).GetVideoEncodingProperties().Width()),
@@ -3643,6 +3738,200 @@ static winrt::fire_and_forget StartPlaybackAsync(HWND hDlg, VideoRecordingSessio
     RefreshPlaybackButtons(hDlg);
 }
 
+// Enable or disable the Delete Region button based on the current selection.
+static void UpdateDeleteButtonState(HWND hDlg, VideoRecordingSession::TrimDialogData* pData)
+{
+    HWND hDelete = GetDlgItem(hDlg, IDC_TRIM_DELETE);
+    if (!hDelete)
+    {
+        return;
+    }
+    bool enable = false;
+    if (pData && pData->hasPendingDelete && !pData->isGif)
+    {
+        const int64_t span = pData->pendingDeleteEnd.count() - pData->pendingDeleteStart.count();
+        enable = span >= 500000LL; // >= 0.05s
+    }
+    EnableWindow(hDelete, enable ? TRUE : FALSE);
+}
+
+// Rebuilds pData->composition so the interior range [deleteStart, deleteEnd]
+// (in composition time) is removed and the surrounding footage is stitched
+// together. Mirrors the macOS ZoomIt "Delete Region" edit.
+static void CommitDeleteRange(HWND hDlg, VideoRecordingSession::TrimDialogData* pData,
+    winrt::TimeSpan deleteStart, winrt::TimeSpan deleteEnd)
+{
+    using winrt::TimeSpan;
+    if (!pData || pData->isGif || !pData->composition)
+    {
+        return;
+    }
+
+    int64_t delStart = std::clamp<int64_t>(deleteStart.count(), 0, pData->videoDuration.count());
+    int64_t delEnd = std::clamp<int64_t>(deleteEnd.count(), 0, pData->videoDuration.count());
+    if (delEnd < delStart)
+    {
+        std::swap(delStart, delEnd);
+    }
+    const int64_t delDuration = delEnd - delStart;
+    constexpr int64_t kMinTicks = 500000LL; // 0.05s
+    if (delDuration < kMinTicks || (pData->videoDuration.count() - delDuration) < kMinTicks)
+    {
+        return;
+    }
+
+    // Snapshot for undo (clone so later edits don't mutate the saved state).
+    VideoRecordingSession::TrimDialogData::EditorUndoSnapshot snap;
+    snap.composition = pData->composition.Clone();
+    snap.videoDuration = pData->videoDuration;
+    snap.trimStart = pData->trimStart;
+    snap.trimEnd = pData->trimEnd;
+    snap.currentPosition = pData->currentPosition;
+    snap.clipBoundaries = pData->clipBoundaries;
+    snap.deleteJoinMarkers = pData->deleteJoinMarkers;
+    snap.hasDeletes = pData->hasDeletes;
+    pData->undoStack.push_back(std::move(snap));
+
+    // Build a new composition of the clips remaining after excising the range.
+    winrt::MediaComposition newComposition;
+    auto clips = pData->composition.Clips();
+    int64_t cursor = 0;
+    for (uint32_t i = 0; i < clips.Size(); ++i)
+    {
+        auto clip = clips.GetAt(i);
+        const int64_t effDur = clip.OriginalDuration().count()
+            - clip.TrimTimeFromStart().count()
+            - clip.TrimTimeFromEnd().count();
+        const int64_t effStart = cursor;
+        const int64_t effEnd = cursor + effDur;
+
+        // Left kept piece: [effStart, min(effEnd, delStart)]
+        const int64_t leftEnd = (std::min)(effEnd, delStart);
+        if (leftEnd > effStart)
+        {
+            auto leftPiece = clip.Clone();
+            const int64_t extraEndTrim = effEnd - leftEnd;
+            leftPiece.TrimTimeFromEnd(TimeSpan{ clip.TrimTimeFromEnd().count() + extraEndTrim });
+            newComposition.Clips().Append(leftPiece);
+        }
+
+        // Right kept piece: [max(effStart, delEnd), effEnd]
+        const int64_t rightStart = (std::max)(effStart, delEnd);
+        if (rightStart < effEnd)
+        {
+            auto rightPiece = clip.Clone();
+            const int64_t extraStartTrim = rightStart - effStart;
+            rightPiece.TrimTimeFromStart(TimeSpan{ clip.TrimTimeFromStart().count() + extraStartTrim });
+            newComposition.Clips().Append(rightPiece);
+        }
+
+        cursor = effEnd;
+    }
+
+    if (newComposition.Clips().Size() == 0)
+    {
+        pData->undoStack.pop_back();
+        return;
+    }
+
+    pData->composition = newComposition;
+    pData->hasDeletes = true;
+
+    // Remap a composition time through the deletion (times after the cut shift left).
+    auto mapTime = [&](int64_t t) -> int64_t
+    {
+        if (t <= delStart) return t;
+        if (t >= delEnd) return t - delDuration;
+        return delStart;
+    };
+
+    // Remap existing clip-boundary markers, dropping any inside the removed range.
+    std::vector<VideoRecordingSession::TrimDialogData::ClipBoundary> remappedBoundaries;
+    for (auto& b : pData->clipBoundaries)
+    {
+        if (b.time.count() > delStart && b.time.count() < delEnd)
+        {
+            continue;
+        }
+        VideoRecordingSession::TrimDialogData::ClipBoundary nb = b;
+        nb.time = TimeSpan{ mapTime(b.time.count()) };
+        remappedBoundaries.push_back(nb);
+    }
+    pData->clipBoundaries = std::move(remappedBoundaries);
+
+    // Remap prior stitch markers and add a new one at the cut point.
+    std::vector<TimeSpan> remappedStitches;
+    for (auto& m : pData->deleteJoinMarkers)
+    {
+        remappedStitches.push_back(TimeSpan{ mapTime(m.count()) });
+    }
+    remappedStitches.push_back(TimeSpan{ delStart });
+    pData->deleteJoinMarkers = std::move(remappedStitches);
+
+    // Update duration and remap trim/playhead into the new timeline.
+    pData->videoDuration = pData->composition.Duration();
+    int64_t newTrimStart = mapTime(pData->trimStart.count());
+    int64_t newTrimEnd = mapTime(pData->trimEnd.count());
+    if (newTrimEnd <= newTrimStart)
+    {
+        newTrimEnd = std::min<int64_t>(newTrimStart + kMinTicks, pData->videoDuration.count());
+    }
+    pData->trimStart = TimeSpan{ std::clamp<int64_t>(newTrimStart, 0, pData->videoDuration.count()) };
+    pData->trimEnd = TimeSpan{ std::clamp<int64_t>(newTrimEnd, 0, pData->videoDuration.count()) };
+    pData->originalTrimEnd = pData->videoDuration;
+    pData->currentPosition = TimeSpan{ std::clamp<int64_t>(delStart, pData->trimStart.count(), pData->trimEnd.count()) };
+
+    pData->hasPendingDelete = false;
+
+    // Force the MediaPlayer/preview to rebuild from the new composition.
+    CleanupMediaPlayer(pData);
+    pData->playbackFile = nullptr;
+
+    UpdateDurationDisplay(hDlg, pData);
+    UpdatePositionUI(hDlg, pData);
+    UpdateVideoPreview(hDlg, pData);
+    InvalidateRect(GetDlgItem(hDlg, IDC_TRIM_TIMELINE), nullptr, FALSE);
+    UpdateDeleteButtonState(hDlg, pData);
+
+    // Return keyboard focus to the timeline so Ctrl+Z (undo) is routed to its
+    // subclass handler. When the delete is committed via the Delete Region
+    // button, focus would otherwise stay on the button and Ctrl+Z would never
+    // reach the undo handler.
+    SetFocus(GetDlgItem(hDlg, IDC_TRIM_TIMELINE));
+}
+
+// Reverts the most recent committed delete edit.
+static void UndoLastDelete(HWND hDlg, VideoRecordingSession::TrimDialogData* pData)
+{
+    if (!pData || pData->undoStack.empty())
+    {
+        return;
+    }
+    auto snap = std::move(pData->undoStack.back());
+    pData->undoStack.pop_back();
+
+    pData->composition = snap.composition;
+    pData->videoDuration = snap.videoDuration;
+    pData->trimStart = snap.trimStart;
+    pData->trimEnd = snap.trimEnd;
+    pData->originalTrimEnd = snap.videoDuration;
+    pData->currentPosition = winrt::TimeSpan{ std::clamp<int64_t>(
+        snap.currentPosition.count(), 0, snap.videoDuration.count()) };
+    pData->clipBoundaries = snap.clipBoundaries;
+    pData->deleteJoinMarkers = snap.deleteJoinMarkers;
+    pData->hasDeletes = snap.hasDeletes;
+    pData->hasPendingDelete = false;
+
+    CleanupMediaPlayer(pData);
+    pData->playbackFile = nullptr;
+
+    UpdateDurationDisplay(hDlg, pData);
+    UpdatePositionUI(hDlg, pData);
+    UpdateVideoPreview(hDlg, pData);
+    InvalidateRect(GetDlgItem(hDlg, IDC_TRIM_TIMELINE), nullptr, FALSE);
+    UpdateDeleteButtonState(hDlg, pData);
+}
+
 static LRESULT CALLBACK TimelineSubclassProc(
     HWND hWnd,
     UINT message,
@@ -3702,6 +3991,9 @@ static LRESULT CALLBACK TimelineSubclassProc(
     {
         // Pause without recapturing position; we might be parked on a handle
         StopPlayback(pData->hDialog, pData, false);
+
+        // Take keyboard focus so Delete / Ctrl+Z reach this control.
+        SetFocus(hWnd);
 
         RECT rcClient{};
         GetClientRect(hWnd, &rcClient);
@@ -3764,8 +4056,31 @@ static LRESULT CALLBACK TimelineSubclassProc(
         const bool posHitKnob = inKnobBand && distToPos <= timelineHandleHitRadius;
         const bool posHitStem = inStemBand && distToPos <= ScaleForDpi(4, dpi); // tighter radius for stem
 
+        // Red delete-region grips take priority when a pending selection exists.
+        if (pData->hasPendingDelete && !pData->isGif && inGripperBand)
+        {
+            const int delStartX = TimelineTimeToClientX(pData, pData->pendingDeleteStart, width, dpi);
+            const int delEndX = TimelineTimeToClientX(pData, pData->pendingDeleteEnd, width, dpi);
+            const int distDelStart = abs(clampedX - delStartX);
+            const int distDelEnd = abs(clampedX - delEndX);
+            if (distDelStart <= timelineHandleHitRadius && distDelStart <= distDelEnd)
+            {
+                pData->dragMode = VideoRecordingSession::TrimDialogData::DeleteStart;
+                pData->pendingDeleteAnchor = pData->pendingDeleteEnd;
+            }
+            else if (distDelEnd <= timelineHandleHitRadius)
+            {
+                pData->dragMode = VideoRecordingSession::TrimDialogData::DeleteEnd;
+                pData->pendingDeleteAnchor = pData->pendingDeleteStart;
+            }
+        }
+
         // Prioritize playhead when clicking in the knob area (lollipop head below the track)
-        if (posHitKnob)
+        if (pData->dragMode != VideoRecordingSession::TrimDialogData::None)
+        {
+            // Already assigned to a delete grip above.
+        }
+        else if (posHitKnob)
         {
             pData->dragMode = VideoRecordingSession::TrimDialogData::Position;
         }
@@ -3798,6 +4113,11 @@ static LRESULT CALLBACK TimelineSubclassProc(
                 // Show resize cursor during grip drag
                 SetCursor(LoadCursor(nullptr, IDC_SIZEWE));
             }
+            else if (pData->dragMode == VideoRecordingSession::TrimDialogData::DeleteStart ||
+                     pData->dragMode == VideoRecordingSession::TrimDialogData::DeleteEnd)
+            {
+                SetCursor(LoadCursor(nullptr, IDC_SIZEWE));
+            }
             SetCapture(hWnd);
             return 0;
         }
@@ -3822,6 +4142,87 @@ static LRESULT CALLBACK TimelineSubclassProc(
             {
                 UpdateVideoPreview(pData->hDialog, pData, false);
             }
+            return 0;
+        }
+        break;
+    }
+
+    case WM_RBUTTONDOWN:
+    {
+        // Right-drag selects an interior region to delete ("cut from the middle").
+        if (pData->isGif)
+        {
+            break;
+        }
+        StopPlayback(pData->hDialog, pData, false);
+        SetFocus(hWnd);
+
+        RECT rcClient{};
+        GetClientRect(hWnd, &rcClient);
+        const int width = rcClient.right - rcClient.left;
+        if (width <= 0)
+        {
+            break;
+        }
+        const UINT dpi = GetDpiForWindowHelper(hWnd);
+        const int x = std::clamp(GET_X_LPARAM(lParam), 0, width);
+        const auto t = TimelinePixelToTime(pData, x, width, dpi);
+
+        pData->pendingDeleteAnchor = t;
+        pData->pendingDeleteStart = t;
+        pData->pendingDeleteEnd = t;
+        pData->hasPendingDelete = true;
+        pData->dragMode = VideoRecordingSession::TrimDialogData::DeleteEnd;
+        pData->isDragging = true;
+        pData->previewOverrideActive = false;
+        pData->restorePreviewOnRelease = false;
+        SetCapture(hWnd);
+        SetCursor(LoadCursor(nullptr, IDC_SIZEWE));
+        InvalidateRect(hWnd, nullptr, FALSE);
+        UpdateDeleteButtonState(pData->hDialog, pData);
+        return 0;
+    }
+
+    case WM_RBUTTONUP:
+    {
+        if (pData->isDragging &&
+            (pData->dragMode == VideoRecordingSession::TrimDialogData::DeleteStart ||
+             pData->dragMode == VideoRecordingSession::TrimDialogData::DeleteEnd))
+        {
+            pData->isDragging = false;
+            ReleaseCapture();
+            SetCursor(LoadCursor(nullptr, IDC_ARROW));
+            pData->dragMode = VideoRecordingSession::TrimDialogData::None;
+            // Discard a negligible (essentially zero-length) selection.
+            const int64_t span = pData->pendingDeleteEnd.count() - pData->pendingDeleteStart.count();
+            if (span < 500000LL)
+            {
+                pData->hasPendingDelete = false;
+            }
+            InvalidateRect(hWnd, nullptr, FALSE);
+            UpdateDeleteButtonState(pData->hDialog, pData);
+            return 0;
+        }
+        break;
+    }
+
+    case WM_KEYDOWN:
+    {
+        if (wParam == VK_DELETE && pData->hasPendingDelete && !pData->isGif)
+        {
+            CommitDeleteRange(pData->hDialog, pData, pData->pendingDeleteStart, pData->pendingDeleteEnd);
+            return 0;
+        }
+        if (wParam == 'Z' && (GetKeyState(VK_CONTROL) & 0x8000) && !pData->isGif)
+        {
+            UndoLastDelete(pData->hDialog, pData);
+            return 0;
+        }
+        if (wParam == VK_ESCAPE && pData->hasPendingDelete)
+        {
+            pData->hasPendingDelete = false;
+            InvalidateRect(hWnd, nullptr, FALSE);
+            UpdateDeleteButtonState(pData->hDialog, pData);
             return 0;
         }
         break;
@@ -3998,6 +4399,23 @@ static LRESULT CALLBACK TimelineSubclassProc(
                 requestPreviewUpdate = true;
             }
             break;
+
+        case VideoRecordingSession::TrimDialogData::DeleteStart:
+        case VideoRecordingSession::TrimDialogData::DeleteEnd:
+        {
+            // Both grip drags and right-drag creation use a fixed anchor; the
+            // selection spans [min(anchor, cursor), max(anchor, cursor)].
+            const int64_t anchor = pData->pendingDeleteAnchor.count();
+            const int64_t n = std::clamp<int64_t>(newTime.count(), 0LL, pData->videoDuration.count());
+            pData->pendingDeleteStart = winrt::TimeSpan{ (std::min)(anchor, n) };
+            pData->pendingDeleteEnd = winrt::TimeSpan{ (std::max)(anchor, n) };
+            pData->hasPendingDelete = true;
+            SetCursor(LoadCursor(nullptr, IDC_SIZEWE));
+            InvalidateRect(hWnd, nullptr, FALSE);
+            UpdateWindow(hWnd);
+            UpdateDeleteButtonState(pData->hDialog, pData);
+            break;
+        }
 
         default:
             break;
@@ -4768,6 +5186,17 @@ INT_PTR CALLBACK VideoRecordingSession::TrimDialogProc(HWND hDlg, UINT message, 
             }
         }
 
+        // The Delete Region button starts disabled; it enables once the user
+        // selects an interior region to cut. Interior delete is unavailable for GIFs.
+        if (HWND hDeleteBtn = GetDlgItem(hDlg, IDC_TRIM_DELETE))
+        {
+            EnableWindow(hDeleteBtn, FALSE);
+            if (pData->isGif)
+            {
+                ShowWindow(hDeleteBtn, SW_HIDE);
+            }
+        }
+
         // Ensure incoming times are sane and within bounds.
         if (pData->videoDuration.count() > 0)
         {
@@ -5150,6 +5579,19 @@ INT_PTR CALLBACK VideoRecordingSession::TrimDialogProc(HWND hDlg, UINT message, 
             int appendWidth;
             DluToPixels(55, 0, &appendWidth, nullptr);
             SetWindowPos(hAppend, nullptr, marginLeft, okCancelY, appendWidth, okCancelHeight,
+                SWP_NOZORDER | SWP_NOACTIVATE);
+        }
+
+        // Position Delete Region button (left-aligned, to the right of Append)
+        HWND hDelete = GetDlgItem(hDlg, IDC_TRIM_DELETE);
+        if (hDelete)
+        {
+            int appendWidth, deleteWidth, deleteSpacing;
+            DluToPixels(55, 0, &appendWidth, nullptr);
+            DluToPixels(70, 0, &deleteWidth, nullptr);
+            DluToPixels(4, 0, &deleteSpacing, nullptr);
+            const int deleteX = marginLeft + appendWidth + deleteSpacing;
+            SetWindowPos(hDelete, nullptr, deleteX, okCancelY, deleteWidth, okCancelHeight,
                 SWP_NOZORDER | SWP_NOACTIVATE);
         }
 
@@ -5857,6 +6299,22 @@ INT_PTR CALLBACK VideoRecordingSession::TrimDialogProc(HWND hDlg, UINT message, 
             break;
         }
 
+        case IDC_TRIM_DELETE:
+        {
+            if (HIWORD(wParam) == BN_CLICKED)
+            {
+                pData = reinterpret_cast<TrimDialogData*>(GetWindowLongPtr(hDlg, DWLP_USER));
+                if (!pData)
+                    return TRUE;
+                if (pData->hasPendingDelete && !pData->isGif)
+                {
+                    CommitDeleteRange(hDlg, pData, pData->pendingDeleteStart, pData->pendingDeleteEnd);
+                }
+                return TRUE;
+            }
+            break;
+        }
+
         case IDC_TRIM_APPEND:
         {
             if (HIWORD(wParam) == BN_CLICKED)
@@ -6188,9 +6646,20 @@ INT_PTR CALLBACK VideoRecordingSession::TrimDialogProc(HWND hDlg, UINT message, 
                 bool isGif = pData->isGif;
                 auto trimStart = pData->trimStart;
                 auto trimEnd = pData->trimEnd;
-                bool hasMultipleClips = !isGif && pData->composition && pData->composition.Clips().Size() > 1;
+                bool hasMultipleClips = !isGif && pData->composition &&
+                    (pData->composition.Clips().Size() > 1 || pData->hasDeletes);
                 auto composition = hasMultipleClips ? pData->composition : winrt::MediaComposition{ nullptr };
                 std::wstring savePathStr(savePath.get());
+
+                // Release the preview MediaPlayer and its source-file handles before
+                // rendering. StopPlayback() only pauses the player, so it keeps the
+                // source .mp4 open; RenderToFileAsync then fails with 0xC00DA7FC
+                // ("Stream is not in a state to handle the request"). The multi-clip
+                // composition (if any) is kept alive via the captured 'composition'
+                // local, so clearing pData->composition here is safe.
+                CleanupMediaPlayer(pData);
+                pData->playbackFile = nullptr;
+                pData->composition = nullptr;
 
                 // Close the trim dialog immediately
                 EndDialog(hDlg, IDOK);
@@ -6200,7 +6669,7 @@ INT_PTR CALLBACK VideoRecordingSession::TrimDialogProc(HWND hDlg, UINT message, 
                 {
                     winrt::IAsyncOperation<winrt::hstring> trimOp{ nullptr };
                     if (hasMultipleClips)
-                        trimOp = RenderCompositionAsync(composition, trimStart, trimEnd);
+                        trimOp = RenderCompositionAsync(composition, trimStart, trimEnd, videoPath);
                     else if (isGif)
                         trimOp = TrimGifAsync(videoPath, trimStart, trimEnd);
                     else
@@ -6225,10 +6694,29 @@ INT_PTR CALLBACK VideoRecordingSession::TrimDialogProc(HWND hDlg, UINT message, 
                         return TRUE;
                     }
 
-                    // Copy trimmed file to the user-chosen save location
-                    if (!CopyFile(trimmedPath.c_str(), savePathStr.c_str(), FALSE))
+                    // Copy trimmed file to the user-chosen save location. The media
+                    // pipeline can briefly retain the temp file handle after render, so
+                    // retry on sharing/access violations before giving up.
+                    BOOL copied = FALSE;
+                    DWORD copyError = 0;
+                    for (int attempt = 0; attempt < 5; ++attempt)
                     {
-                        MessageBox(nullptr, L"Failed to save the trimmed file.", L"Error", MB_OK | MB_ICONERROR);
+                        if (CopyFile(trimmedPath.c_str(), savePathStr.c_str(), FALSE))
+                        {
+                            copied = TRUE;
+                            break;
+                        }
+                        copyError = GetLastError();
+                        if (copyError != ERROR_SHARING_VIOLATION && copyError != ERROR_ACCESS_DENIED)
+                            break;
+                        Sleep(100);
+                    }
+
+                    if (!copied)
+                    {
+                        wchar_t msg[256]{};
+                        swprintf_s(msg, L"Failed to save the trimmed file (error %lu).", copyError);
+                        MessageBox(nullptr, msg, L"Error", MB_OK | MB_ICONERROR);
                         DeleteFile(trimmedPath.c_str());
                         return TRUE;
                     }
@@ -6244,9 +6732,100 @@ INT_PTR CALLBACK VideoRecordingSession::TrimDialogProc(HWND hDlg, UINT message, 
                 return TRUE;
             }
 
-            // Trim times are already set by mouse dragging
-            EndDialog(hDlg, IDOK);
-            return TRUE;
+            // Non-standalone (post-recording) mode: render the edited composition
+            // here on the dialog thread, honoring interior deletes/appends and any
+            // outer trim, then hand the temp path back to the caller. This reuses the
+            // preview clips that already work on this apartment and avoids re-trimming
+            // the raw fragmented recording on the main thread, which fails with
+            // 0xC00DA7FC and silently discards interior deletes.
+            {
+                bool isGif = pData->isGif;
+                auto trimStart = pData->trimStart;
+                auto trimEnd = pData->trimEnd;
+                std::wstring videoPath = pData->videoPath;
+                bool hasMultipleClips = !isGif && pData->composition &&
+                    (pData->composition.Clips().Size() > 1 || pData->hasDeletes);
+                const bool selectionChanged =
+                    (pData->trimStart.count() != pData->originalTrimStart.count()) ||
+                    (pData->trimEnd.count() != pData->originalTrimEnd.count());
+                const bool needsRender = hasMultipleClips || selectionChanged;
+                auto composition = hasMultipleClips ? pData->composition : winrt::MediaComposition{ nullptr };
+
+                RecDiag(L"TrimDlg IDOK: isGif=%d hasMultipleClips=%d hasDeletes=%d clips=%u selectionChanged=%d needsRender=%d trimStart=%lld trimEnd=%lld\n",
+                        isGif ? 1 : 0,
+                        hasMultipleClips ? 1 : 0,
+                        pData->hasDeletes ? 1 : 0,
+                        pData->composition ? pData->composition.Clips().Size() : 0u,
+                        selectionChanged ? 1 : 0,
+                        needsRender ? 1 : 0,
+                        trimStart.count(),
+                        trimEnd.count());
+
+                if (!needsRender)
+                {
+                    // No edits: nothing to render, let the outer flow save the original.
+                    EndDialog(hDlg, IDOK);
+                    return TRUE;
+                }
+
+                // Release the preview MediaPlayer and its source-file handle before
+                // rendering (StopPlayback only pauses it). The composition, if any, is
+                // kept alive via the captured 'composition' local.
+                CleanupMediaPlayer(pData);
+                pData->playbackFile = nullptr;
+                pData->composition = nullptr;
+
+                try
+                {
+                    winrt::IAsyncOperation<winrt::hstring> trimOp{ nullptr };
+                    if (hasMultipleClips)
+                        trimOp = RenderCompositionAsync(composition, trimStart, trimEnd, videoPath);
+                    else if (isGif)
+                        trimOp = TrimGifAsync(videoPath, trimStart, trimEnd);
+                    else
+                        trimOp = TrimVideoAsync(videoPath, trimStart, trimEnd);
+
+                    while (trimOp.Status() == winrt::AsyncStatus::Started)
+                    {
+                        MSG msg;
+                        while (PeekMessage(&msg, nullptr, 0, 0, PM_REMOVE))
+                        {
+                            TranslateMessage(&msg);
+                            DispatchMessage(&msg);
+                        }
+                        Sleep(10);
+                    }
+
+                    auto renderedPath = std::wstring(trimOp.GetResults());
+                    if (renderedPath.empty())
+                    {
+                        RecDiag(L"TrimDlg IDOK: render returned EMPTY path -> reporting failure\n");
+                        MessageBox(hDlg, L"Failed to trim video.", L"Error", MB_OK | MB_ICONERROR);
+                        EndDialog(hDlg, IDCANCEL);
+                        return TRUE;
+                    }
+
+                    RecDiag(L"TrimDlg IDOK: render succeeded -> %s\n", renderedPath.c_str());
+                    pData->renderedOutputPath = renderedPath;
+                }
+                catch (const winrt::hresult_error& e)
+                {
+                    RecDiag(L"TrimDlg IDOK: render threw hr=0x%08X\n", static_cast<uint32_t>(e.code()));
+                    MessageBox(hDlg, L"Failed to trim video.", L"Error", MB_OK | MB_ICONERROR);
+                    EndDialog(hDlg, IDCANCEL);
+                    return TRUE;
+                }
+                catch (...)
+                {
+                    RecDiag(L"TrimDlg IDOK: render threw unknown exception\n");
+                    MessageBox(hDlg, L"Failed to trim video.", L"Error", MB_OK | MB_ICONERROR);
+                    EndDialog(hDlg, IDCANCEL);
+                    return TRUE;
+                }
+
+                EndDialog(hDlg, IDOK);
+                return TRUE;
+            }
 
         case IDCANCEL:
             pData = reinterpret_cast<TrimDialogData*>(GetWindowLongPtr(hDlg, DWLP_USER));
@@ -6258,6 +6837,201 @@ INT_PTR CALLBACK VideoRecordingSession::TrimDialogProc(HWND hDlg, UINT message, 
     }
 
     return FALSE;
+}
+
+//----------------------------------------------------------------------------
+//
+// RenderCompositionToFileAsync
+//
+// Renders a MediaComposition to outputFile. It first tries the high-level
+// MediaComposition::RenderToFileAsync. That works for externally authored MP4s,
+// but throws 0xC00DA7FC ("Stream is not in a state to handle the request") on the
+// MP4s ZoomIt's live MediaTranscoder recording pipeline produces: those are
+// *fragmented* MP4s (moof/mdat) that MediaSource can play (so preview works) but
+// that MediaClip/MediaComposition cannot randomly seek for transcode/render.
+//
+// On failure it remuxes the recording into a standard (seekable) MP4 using a
+// MediaSource-based file transcode — PrepareFileTranscodeAsync uses the same
+// tolerant reader the preview does, so it can read the fragmented input — then
+// rebuilds the composition (preserving every clip's trim points, i.e. interior
+// deletes and the outer trim) against the clean file and renders that. Output
+// resolution is taken from the source file's video properties so arbitrary
+// crop-region dimensions are preserved.
+//
+//----------------------------------------------------------------------------
+static winrt::IAsyncOperation<winrt::hstring> RenderCompositionToFileAsync(
+    winrt::MediaComposition composition,
+    winrt::StorageFile outputFile,
+    std::wstring sourceVideoPath)
+{
+    // Attempt 1: high-level render (preferred, no forced re-encode profile).
+    RecDiag(L"RenderToFile: attempt1 high-level RenderToFileAsync (clips=%u)...\n",
+            composition ? composition.Clips().Size() : 0u);
+    try
+    {
+        auto renderResult = co_await composition.RenderToFileAsync(
+            outputFile, winrt::MediaTrimmingPreference::Precise);
+        RecDiag(L"RenderToFile: attempt1 result=%d\n", static_cast<int>(renderResult));
+        if (renderResult == winrt::TranscodeFailureReason::None)
+        {
+            co_return winrt::hstring(outputFile.Path());
+        }
+    }
+    catch (const winrt::hresult_error& e)
+    {
+        RecDiag(L"RenderToFile: attempt1 threw hr=0x%08X (expected on fragmented MP4)\n",
+                static_cast<uint32_t>(e.code()));
+    }
+
+    // Attempt 2: remux the fragmented recording into a standard MP4, then rebuild
+    // the composition against it and render.
+    //
+    // Every sub-step here can fail *transiently* in the moments right after
+    // recording, each previously aborting the trim with a spurious "Failed to trim
+    // video":
+    //   * Media Foundation releases the preview's source-file handle/decoder
+    //     asynchronously on a worker thread, so an immediate read can throw E_FAIL
+    //     (0x80004005) or leave PrepareFileTranscodeAsync briefly unable to transcode.
+    //   * The shell video-property handler may not have parsed the freshly written
+    //     fragmented MP4 yet, sporadically reporting 0x0 dimensions.
+    // These are all timing races, so retry the whole remux with a short backoff and
+    // only report failure once the pipeline has genuinely had time to settle.
+    constexpr int kRemuxMaxAttempts = 5;
+    for (int remuxAttempt = 0; remuxAttempt < kRemuxMaxAttempts; ++remuxAttempt)
+    {
+        // Back off before every retry (co_await is not permitted inside a catch).
+        if (remuxAttempt > 0)
+        {
+            co_await winrt::resume_after(std::chrono::milliseconds(250));
+        }
+
+        winrt::StorageFile remuxFile{ nullptr };
+        try
+        {
+            auto sourceFile = co_await winrt::StorageFile::GetFileFromPathAsync(sourceVideoPath);
+
+            // Resolution: prefer the composition clip's own encoding properties. They
+            // come straight from the capture pipeline and are reliable, whereas the
+            // fragmented recording MP4's shell metadata sometimes fails to parse right
+            // after capture and returns 0x0 (a sporadic cause of trim failures). Fall
+            // back to the shell video properties only if the clip exposes none.
+            uint32_t width = 0, height = 0;
+            try
+            {
+                if (composition.Clips().Size() > 0)
+                {
+                    auto clipProps = composition.Clips().GetAt(0).GetVideoEncodingProperties();
+                    if (clipProps)
+                    {
+                        width = clipProps.Width();
+                        height = clipProps.Height();
+                    }
+                }
+            }
+            catch (...)
+            {
+            }
+
+            if (width == 0 || height == 0)
+            {
+                try
+                {
+                    auto videoProps = co_await sourceFile.Properties().GetVideoPropertiesAsync();
+                    width = static_cast<uint32_t>(videoProps.Width());
+                    height = static_cast<uint32_t>(videoProps.Height());
+                }
+                catch (...)
+                {
+                }
+            }
+
+            if (width == 0 || height == 0)
+            {
+                RecDiag(L"RenderToFile: remux attempt %d — dimensions unresolved (0x0), retrying\n", remuxAttempt);
+                continue; // Dimensions not resolvable yet — back off and retry.
+            }
+
+            RecDiag(L"RenderToFile: remux attempt %d — dims=%ux%u, transcoding...\n", remuxAttempt, width, height);
+
+            auto profile = winrt::MediaEncodingProfile();
+            profile.Container().Subtype(L"MPEG4");
+            auto video = profile.Video();
+            video.Subtype(L"H264");
+            video.Width(width);
+            video.Height(height);
+            video.Bitrate(static_cast<uint32_t>(width * height * 30.0 * 2 * 0.07));
+            video.FrameRate().Numerator(30);
+            video.FrameRate().Denominator(1);
+            video.PixelAspectRatio().Numerator(1);
+            video.PixelAspectRatio().Denominator(1);
+            profile.Video(video);
+            profile.Audio(winrt::AudioEncodingProperties::CreateAac(44100, 2, 96000));
+
+            auto tempFolder = co_await winrt::StorageFolder::GetFolderFromPathAsync(
+                std::filesystem::temp_directory_path().wstring());
+            auto zoomitFolder = co_await tempFolder.CreateFolderAsync(
+                L"ZoomIt", winrt::CreationCollisionOption::OpenIfExists);
+            std::wstring remuxName = L"zoomit_remux_" + std::to_wstring(GetTickCount64()) + L".mp4";
+            remuxFile = co_await zoomitFolder.CreateFileAsync(
+                remuxName, winrt::CreationCollisionOption::ReplaceExisting);
+
+            // File-to-file transcode via a MediaSource reader (tolerates fragmented MP4),
+            // writing to a seekable StorageFile which yields a standard, indexed MP4.
+            winrt::MediaTranscoder remuxer;
+            remuxer.HardwareAccelerationEnabled(true);
+            auto remuxPrepare = co_await remuxer.PrepareFileTranscodeAsync(
+                sourceFile, remuxFile, profile);
+            if (!remuxPrepare.CanTranscode())
+            {
+                RecDiag(L"RenderToFile: remux attempt %d — CanTranscode()=false, retrying\n", remuxAttempt);
+                try { co_await remuxFile.DeleteAsync(); } catch (...) {}
+                continue; // Transcoder not ready yet — back off and retry.
+            }
+            co_await remuxPrepare.TranscodeAsync();
+
+            // Rebuild the composition against the clean file, copying every clip's trim
+            // points so interior deletes and the outer trim are preserved. All clips in
+            // the recording composition reference the same source, whose duration the
+            // remux preserves, so the trim offsets map 1:1 onto the clean file.
+            winrt::MediaComposition rebuilt;
+            for (auto&& origClip : composition.Clips())
+            {
+                auto newClip = co_await winrt::MediaClip::CreateFromFileAsync(remuxFile);
+                newClip.TrimTimeFromStart(origClip.TrimTimeFromStart());
+                newClip.TrimTimeFromEnd(origClip.TrimTimeFromEnd());
+                rebuilt.Clips().Append(newClip);
+            }
+
+            auto renderResult = co_await rebuilt.RenderToFileAsync(
+                outputFile, winrt::MediaTrimmingPreference::Precise);
+
+            try { co_await remuxFile.DeleteAsync(); } catch (...) {}
+
+            RecDiag(L"RenderToFile: remux attempt %d — final render result=%d\n",
+                    remuxAttempt, static_cast<int>(renderResult));
+            if (renderResult == winrt::TranscodeFailureReason::None)
+            {
+                co_return winrt::hstring(outputFile.Path());
+            }
+            continue; // Render reported a failure reason — back off and retry.
+        }
+        catch (const winrt::hresult_error& e)
+        {
+            RecDiag(L"RenderToFile: remux attempt %d threw hr=0x%08X\n",
+                    remuxAttempt, static_cast<uint32_t>(e.code()));
+            if (remuxFile) { DeleteFile(remuxFile.Path().c_str()); }
+            // Transient MF teardown race — fall through to the next attempt.
+        }
+        catch (...)
+        {
+            RecDiag(L"RenderToFile: remux attempt %d threw unknown exception\n", remuxAttempt);
+            if (remuxFile) { DeleteFile(remuxFile.Path().c_str()); }
+            // Fall through to the next attempt.
+        }
+    }
+
+    RecDiag(L"RenderToFile: all %d remux attempts exhausted -> returning empty\n", kRemuxMaxAttempts);
+    co_return winrt::hstring();
 }
 
 //----------------------------------------------------------------------------
@@ -6281,6 +7055,9 @@ winrt::IAsyncOperation<winrt::hstring> VideoRecordingSession::TrimVideoAsync(
         winrt::MediaComposition composition;
         auto clip = co_await winrt::MediaClip::CreateFromFileAsync(sourceFile);
 
+        RecDiag(L"TrimVideoAsync: clip created, originalDuration=%lld trimStart=%lld trimEnd=%lld\n",
+                clip.OriginalDuration().count(), trimTimeStart.count(), trimTimeEnd.count());
+
         // Set the trim times
         clip.TrimTimeFromStart(trimTimeStart);
         clip.TrimTimeFromEnd(clip.OriginalDuration() - trimTimeEnd);
@@ -6300,21 +7077,19 @@ winrt::IAsyncOperation<winrt::hstring> VideoRecordingSession::TrimVideoAsync(
         auto outputFile = co_await zoomitFolder.CreateFileAsync(
             filename, winrt::CreationCollisionOption::ReplaceExisting);
 
-        // Render the composition to the output file with fast trimming (no re-encode)
-        auto renderResult = co_await composition.RenderToFileAsync(
-            outputFile, winrt::MediaTrimmingPreference::Fast);
-
-        if (renderResult == winrt::TranscodeFailureReason::None)
-        {
-            co_return winrt::hstring(outputFile.Path());
-        }
-        else
-        {
-            co_return winrt::hstring();
-        }
+        // Render the trimmed clip. RenderToFileAsync throws 0xC00DA7FC on the MP4s
+        // produced by the live recording pipeline, so RenderCompositionToFileAsync
+        // falls back to transcoding the composition's own stream source.
+        co_return co_await RenderCompositionToFileAsync(composition, outputFile, sourceVideoPath);
+    }
+    catch (const winrt::hresult_error& e)
+    {
+        RecDiag(L"TrimVideoAsync: threw hr=0x%08X\n", static_cast<uint32_t>(e.code()));
+        co_return winrt::hstring();
     }
     catch (...)
     {
+        RecDiag(L"TrimVideoAsync: threw unknown exception\n");
         co_return winrt::hstring();
     }
 }
@@ -6329,7 +7104,8 @@ winrt::IAsyncOperation<winrt::hstring> VideoRecordingSession::TrimVideoAsync(
 winrt::IAsyncOperation<winrt::hstring> VideoRecordingSession::RenderCompositionAsync(
     winrt::MediaComposition composition,
     winrt::TimeSpan trimTimeStart,
-    winrt::TimeSpan trimTimeEnd)
+    winrt::TimeSpan trimTimeEnd,
+    const std::wstring& sourceVideoPath)
 {
     try
     {
@@ -6340,22 +7116,27 @@ winrt::IAsyncOperation<winrt::hstring> VideoRecordingSession::RenderCompositionA
             co_return winrt::hstring();
         }
 
-        // Apply trim start to the first clip
-        if (trimTimeStart.count() > 0)
-        {
-            auto firstClip = clips.GetAt(0);
-            auto currentTrimFromStart = firstClip.TrimTimeFromStart();
-            firstClip.TrimTimeFromStart(winrt::TimeSpan{ currentTrimFromStart.count() + trimTimeStart.count() });
-        }
-
-        // Apply trim end: trim from end of the last clip
+        // Capture the composition duration BEFORE applying any trim so that the
+        // start and end trims are both measured against the same (original)
+        // timeline. Applying the start trim first would shrink Duration() and
+        // cause the end trim to be computed against the wrong length.
         auto totalDuration = composition.Duration();
+
+        // Apply trim end first: trim from the end of the last clip.
         if (trimTimeEnd < totalDuration)
         {
             auto lastClip = clips.GetAt(clips.Size() - 1);
             auto trimFromEnd = winrt::TimeSpan{ totalDuration.count() - trimTimeEnd.count() };
             auto currentTrimFromEnd = lastClip.TrimTimeFromEnd();
             lastClip.TrimTimeFromEnd(winrt::TimeSpan{ currentTrimFromEnd.count() + trimFromEnd.count() });
+        }
+
+        // Apply trim start to the first clip.
+        if (trimTimeStart.count() > 0)
+        {
+            auto firstClip = clips.GetAt(0);
+            auto currentTrimFromStart = firstClip.TrimTimeFromStart();
+            firstClip.TrimTimeFromStart(winrt::TimeSpan{ currentTrimFromStart.count() + trimTimeStart.count() });
         }
 
         // Create output file in temp folder
@@ -6369,17 +7150,16 @@ winrt::IAsyncOperation<winrt::hstring> VideoRecordingSession::RenderCompositionA
         auto outputFile = co_await zoomitFolder.CreateFileAsync(
             filename, winrt::CreationCollisionOption::ReplaceExisting);
 
-        auto renderResult = co_await composition.RenderToFileAsync(
-            outputFile, winrt::MediaTrimmingPreference::Fast);
-
-        if (renderResult == winrt::TranscodeFailureReason::None)
-        {
-            co_return winrt::hstring(outputFile.Path());
-        }
-        else
-        {
-            co_return winrt::hstring();
-        }
+        // A composition with deletes/multiple clips joins non-contiguous source
+        // segments, which requires re-encoding. RenderToFileAsync throws 0xC00DA7FC
+        // on the recorded MP4, so RenderCompositionToFileAsync falls back to
+        // transcoding the composition's own stream source.
+        co_return co_await RenderCompositionToFileAsync(composition, outputFile, sourceVideoPath);
+    }
+    catch (const winrt::hresult_error& e)
+    {
+        RecDiag(L"RenderCompositionAsync: threw hr=0x%08X\n", static_cast<uint32_t>(e.code()));
+        co_return winrt::hstring();
     }
     catch (...)
     {

--- a/src/modules/ZoomIt/ZoomIt/VideoRecordingSession.h
+++ b/src/modules/ZoomIt/ZoomIt/VideoRecordingSession.h
@@ -149,12 +149,42 @@ public:
         HFONT hTimeLabelFont{ nullptr };
 
         // Mouse tracking for timeline
-        enum DragMode { None, TrimStart, Position, TrimEnd };
+        enum DragMode { None, TrimStart, Position, TrimEnd, DeleteStart, DeleteEnd };
         DragMode dragMode{ None };
         bool isDragging{ false };
+
+        // Interior "cut from the middle" editing. A pending delete region is
+        // selected on the timeline (right-drag or by dragging its red grips) and
+        // then committed with the Delete Region button or the Delete key, which
+        // removes that interval from the composition and stitches the halves.
+        bool hasPendingDelete{ false };
+        winrt::Windows::Foundation::TimeSpan pendingDeleteStart{ 0 };
+        winrt::Windows::Foundation::TimeSpan pendingDeleteEnd{ 0 };
+        winrt::Windows::Foundation::TimeSpan pendingDeleteAnchor{ 0 }; // Fixed endpoint during a delete-region drag
+        bool hasDeletes{ false };  // TRUE once any interior delete has been committed
+        std::vector<winrt::Windows::Foundation::TimeSpan> deleteJoinMarkers; // Stitch points
+
+        // Undo snapshots for committed delete edits (most recent last).
+        struct EditorUndoSnapshot
+        {
+            winrt::Windows::Media::Editing::MediaComposition composition{ nullptr };
+            winrt::Windows::Foundation::TimeSpan videoDuration{ 0 };
+            winrt::Windows::Foundation::TimeSpan trimStart{ 0 };
+            winrt::Windows::Foundation::TimeSpan trimEnd{ 0 };
+            winrt::Windows::Foundation::TimeSpan currentPosition{ 0 };
+            std::vector<ClipBoundary> clipBoundaries;
+            std::vector<winrt::Windows::Foundation::TimeSpan> deleteJoinMarkers;
+            bool hasDeletes{ false };
+        };
+        std::vector<EditorUndoSnapshot> undoStack;
+
         int lastPlayheadX{ -1 }; // Track last playhead pixel position for efficient invalidation
         MMRESULT mmTimerId{ 0 }; // Multimedia timer for smooth MP4 playback
         bool standaloneMode{ false }; // When true, OK becomes "Save As" and handles file saving directly
+        // Non-standalone (post-recording) mode: on OK the editor renders its edited
+        // composition (honoring interior deletes/appends and outer trim) to this temp
+        // file, which the outer save flow then moves to the user's chosen destination.
+        std::wstring renderedOutputPath;
 
         // Helper to convert time to pixel position
         int TimeToPixel(winrt::Windows::Foundation::TimeSpan time, int timelineWidth) const
@@ -186,7 +216,8 @@ public:
         const std::wstring& videoPath,
         winrt::Windows::Foundation::TimeSpan& trimStart,
         winrt::Windows::Foundation::TimeSpan& trimEnd,
-        bool standaloneMode = false);
+        bool standaloneMode = false,
+        std::wstring* pRenderedPath = nullptr);
 
 private:
     static INT_PTR CALLBACK TrimDialogProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam);
@@ -198,7 +229,8 @@ private:
     static winrt::Windows::Foundation::IAsyncOperation<winrt::hstring> RenderCompositionAsync(
         winrt::Windows::Media::Editing::MediaComposition composition,
         winrt::Windows::Foundation::TimeSpan trimTimeStart,
-        winrt::Windows::Foundation::TimeSpan trimTimeEnd);
+        winrt::Windows::Foundation::TimeSpan trimTimeEnd,
+        const std::wstring& sourceVideoPath);
     static winrt::Windows::Foundation::IAsyncOperation<winrt::hstring> TrimGifAsync(
         const std::wstring& sourceGifPath,
         winrt::Windows::Foundation::TimeSpan trimTimeStart,
@@ -208,7 +240,8 @@ private:
         const std::wstring& videoPath,
         winrt::Windows::Foundation::TimeSpan& trimStart,
         winrt::Windows::Foundation::TimeSpan& trimEnd,
-        bool standaloneMode = false);
+        bool standaloneMode = false,
+        std::wstring* pRenderedPath = nullptr);
 
 private:
     VideoRecordingSession(

--- a/src/modules/ZoomIt/ZoomIt/ZoomIt.h
+++ b/src/modules/ZoomIt/ZoomIt/ZoomIt.h
@@ -67,6 +67,7 @@ type_pEnableThemeDialogTexture    pEnableThemeDialogTexture;
 #define WM_USER_EXIT_MODE		WM_USER+109
 #define WM_USER_RELOAD_SETTINGS	WM_USER+110
 #define WM_USER_RECORDING_STARTED WM_USER+111
+#define WM_USER_RECORDING_NO_FRAMES WM_USER+112
 
 typedef struct _TYPED_KEY {
     RECT		rc;

--- a/src/modules/ZoomIt/ZoomIt/ZoomIt.rc
+++ b/src/modules/ZoomIt/ZoomIt/ZoomIt.rc
@@ -122,7 +122,7 @@ BEGIN
     DEFPUSHBUTTON   "OK",IDOK,184,308,50,14
     PUSHBUTTON      "Cancel",IDCANCEL,241,308,50,14
     LTEXT           "ZoomIt v12.11",IDC_VERSION,42,7,73,10
-    LTEXT           "Copyright © 2006-2026 Mark Russinovich",IDC_COPYRIGHT,42,17,251,8
+    LTEXT           "Copyright ï¿½ 2006-2026 Mark Russinovich",IDC_COPYRIGHT,42,17,251,8
     CONTROL         "<a HREF=""https://www.sysinternals.com"">Sysinternals - www.sysinternals.com</a>",IDC_LINK,
                     "SysLink",WS_TABSTOP,42,26,150,9
     ICON            "APPICON",IDC_STATIC,12,9,20,20
@@ -381,6 +381,7 @@ BEGIN
     CONTROL         "",IDC_TRIM_VOLUME_ICON,"Static",SS_OWNERDRAW | SS_NOTIFY,365,334,14,12
     CONTROL         "",IDC_TRIM_VOLUME,"msctls_trackbar32",TBS_NOTICKS | WS_TABSTOP,380,333,70,14
     PUSHBUTTON      "Append...",IDC_TRIM_APPEND,12,358,55,14
+    PUSHBUTTON      "Delete Region",IDC_TRIM_DELETE,71,358,70,14
     DEFPUSHBUTTON   "OK",IDOK,404,358,50,14
     PUSHBUTTON      "Cancel",IDCANCEL,458,358,50,14
 END

--- a/src/modules/ZoomIt/ZoomIt/ZoomItSettings.h
+++ b/src/modules/ZoomIt/ZoomIt/ZoomItSettings.h
@@ -71,6 +71,7 @@ DWORD   g_WebcamBrightness = 50;        // 0=dark, 50=neutral, 100=bright
 BOOLEAN g_RecordAspectRatio = FALSE; // Lock region selection to 16:9
 TCHAR	g_RecordingSaveLocationBuffer[MAX_PATH] = {0};
 TCHAR	g_ScreenshotSaveLocationBuffer[MAX_PATH] = {0};
+BOOLEAN g_SnipCopyToClipboard = FALSE; // When TRUE, saving a snip also copies it to the clipboard.
 DWORD	g_ThemeOverride = 2; // 0=light, 1=dark, 2=system default
 DWORD	g_TrimDialogWidth = 0;  // 0 means use default; stored in screen pixels
 DWORD	g_TrimDialogHeight = 0; // 0 means use default; stored in screen pixels
@@ -136,6 +137,7 @@ REG_SETTING RegSettings[] = {
     { L"RecordAspectRatio", SETTING_TYPE_BOOLEAN, 0, &g_RecordAspectRatio, static_cast<DOUBLE>(g_RecordAspectRatio) },
     { L"RecordingSaveLocation", SETTING_TYPE_STRING, sizeof(g_RecordingSaveLocationBuffer), g_RecordingSaveLocationBuffer, static_cast<DOUBLE>(0) },
     { L"ScreenshotSaveLocation", SETTING_TYPE_STRING, sizeof(g_ScreenshotSaveLocationBuffer), g_ScreenshotSaveLocationBuffer, static_cast<DOUBLE>(0) },
+    { L"SnipCopyToClipboard", SETTING_TYPE_BOOLEAN, 0, &g_SnipCopyToClipboard, static_cast<DOUBLE>(g_SnipCopyToClipboard) },
     { L"Theme", SETTING_TYPE_DWORD, 0, &g_ThemeOverride, static_cast<DOUBLE>(g_ThemeOverride) },
     { L"TrimDialogWidth", SETTING_TYPE_DWORD, 0, &g_TrimDialogWidth, static_cast<DOUBLE>(0) },
     { L"TrimDialogHeight", SETTING_TYPE_DWORD, 0, &g_TrimDialogHeight, static_cast<DOUBLE>(0) },

--- a/src/modules/ZoomIt/ZoomIt/Zoomit.cpp
+++ b/src/modules/ZoomIt/ZoomIt/Zoomit.cpp
@@ -6967,21 +6967,6 @@ auto GetUniqueScreenshotFilename()
 //----------------------------------------------------------------------------
 winrt::fire_and_forget StartRecordingAsync( HWND hWnd, LPRECT rcCrop, HWND hWndRecord ) try
 {
-    // ---- Recording startup timing diagnostics ----
-    LARGE_INTEGER _diagFreq, _diagT0, _diagT1;
-    QueryPerformanceFrequency( &_diagFreq );
-    QueryPerformanceCounter( &_diagT0 );
-    auto _diagMs = [&]() -> double {
-        QueryPerformanceCounter( &_diagT1 );
-        return static_cast<double>( _diagT1.QuadPart - _diagT0.QuadPart ) * 1000.0 / _diagFreq.QuadPart;
-    };
-    auto _diagLog = [&]( const wchar_t* label ) {
-        wchar_t buf[256];
-        swprintf_s( buf, L"[RecStartup +%.1fms] %s\n", _diagMs(), label );
-        OutputDebugStringW( buf );
-    };
-    _diagLog( L"entry" );
-
     // Capture the UI thread context so we can resume on it for the save dialog
     winrt::apartment_context uiThread;
 
@@ -6998,7 +6983,6 @@ winrt::fire_and_forget StartRecordingAsync( HWND hWnd, LPRECT rcCrop, HWND hWndR
         audioGenerator = std::make_unique<AudioSampleGenerator>(
             g_CaptureAudio, g_CaptureSystemAudio, g_MicMonoMix, g_NoiseCancellation );
         audioInitAction = audioGenerator->InitializeAsync();
-        _diagLog( L"audio InitializeAsync started (background)" );
     }
 
     auto tempFolderPath = std::filesystem::temp_directory_path().wstring();
@@ -7008,13 +6992,11 @@ winrt::fire_and_forget StartRecordingAsync( HWND hWnd, LPRECT rcCrop, HWND hWndR
     // Choose temp file extension based on format
     const wchar_t* tempFileName = (g_RecordingFormat == RecordingFormat::GIF) ? L"zoomit.gif" : L"zoomit.mp4";
     auto file = co_await appFolder.CreateFileAsync( tempFileName, winrt::CreationCollisionOption::ReplaceExisting );
-    _diagLog( L"temp file created" );
 
     // Get the device
     auto d3dDevice = util::CreateD3D11Device();
     auto dxgiDevice = d3dDevice.as<IDXGIDevice>();
     g_RecordDevice = CreateDirect3DDevice( dxgiDevice.get() );
-    _diagLog( L"D3D device created" );
 
     // Get the active MONITOR capture device
     HMONITOR hMon = NULL;
@@ -7030,10 +7012,8 @@ winrt::fire_and_forget StartRecordingAsync( HWND hWnd, LPRECT rcCrop, HWND hWndR
         item = util::CreateCaptureItemForWindow( hWndRecord );
     else
         item = util::CreateCaptureItemForMonitor( hMon );
-    _diagLog( L"capture item created" );
 
     auto stream = co_await file.OpenAsync( winrt::FileAccessMode::ReadWrite );
-    _diagLog( L"file stream opened" );
 
     // Create the appropriate recording session based on format
     OutputDebugStringW((L"Starting recording session. Framerate:  " + std::to_wstring(g_RecordFrameRate) + L" scaling: " + std::to_wstring(g_RecordScaling) + L" Format: " + (g_RecordingFormat == RecordingFormat::GIF ? L"GIF" : L"MP4") + L"\n").c_str());
@@ -7083,7 +7063,6 @@ winrt::fire_and_forget StartRecordingAsync( HWND hWnd, LPRECT rcCrop, HWND hWndR
     }
     else
     {
-        _diagLog( L"calling VideoRecordingSession::Create (constructor)" );
         g_RecordingSession = VideoRecordingSession::Create(
                                         g_RecordDevice,
                                         item,
@@ -7092,7 +7071,6 @@ winrt::fire_and_forget StartRecordingAsync( HWND hWnd, LPRECT rcCrop, HWND hWndR
                                         std::move(audioGenerator),
                                         audioInitAction,
                                         stream );
-        _diagLog( L"VideoRecordingSession::Create returned" );
 
         recordingStarted = (g_RecordingSession != nullptr);
 
@@ -7131,9 +7109,7 @@ winrt::fire_and_forget StartRecordingAsync( HWND hWnd, LPRECT rcCrop, HWND hWndR
         {
             try
             {
-                _diagLog( L"calling co_await StartAsync()" );
                 co_await g_RecordingSession->StartAsync();
-                _diagLog( L"StartAsync returned" );
             }
             catch (const winrt::hresult_error& error)
             {
@@ -10308,6 +10284,21 @@ LRESULT APIENTRY MainWndProc(
         g_SelectRectangle.SetRecordingActive();
         break;
 
+    case WM_USER_RECORDING_NO_FRAMES:
+        // The capture pipeline started but never delivered a single frame,
+        // so recording was aborted.  This is typical on headless / GPU-less
+        // virtual machines, cloud PCs, or remote sessions where
+        // Windows.Graphics.Capture cannot capture the display.  Tear down the
+        // recording border / state and tell the user why nothing was saved.
+        OutputDebugStringW( L"[RecBorder] WM_USER_RECORDING_NO_FRAMES received\n" );
+        StopRecording();
+        MessageBox( g_hWndMain,
+            L"ZoomIt could not capture any video from the display, so recording was cancelled.\n\n"
+            L"Screen recording uses Windows Graphics Capture, which needs a GPU-backed (WDDM) display. "
+            L"This is often unavailable on virtual machines, cloud PCs, or remote sessions that lack a virtual GPU.",
+            APPNAME, MB_OK | MB_ICONWARNING );
+        break;
+
     case WM_USER_SAVE_CURSOR:
         if( g_Zoomed == TRUE )
         {
@@ -10680,14 +10671,21 @@ LRESULT APIENTRY MainWndProc(
             saveDialog->SetFileName( suggestedName.c_str() );
             saveDialog->SetTitle( L"ZoomIt: Save Zoomed Screen..." );
 
-            // Set default folder to the last save location if available
+            // Set default folder to the configured/last save location if available.
+            // The stored value may be a directory (a user-configured default folder)
+            // or a full file path (the last saved screenshot); handle both.
             if( !g_ScreenshotSaveLocation.empty() )
             {
                 std::filesystem::path lastPath( g_ScreenshotSaveLocation );
-                if( lastPath.has_parent_path() )
+                std::error_code ec;
+                std::filesystem::path folderPath =
+                    std::filesystem::is_directory( lastPath, ec )
+                        ? lastPath
+                        : lastPath.parent_path();
+                if( !folderPath.empty() )
                 {
                     wil::com_ptr<IShellItem> folderItem;
-                    if( SUCCEEDED( SHCreateItemFromParsingName( lastPath.parent_path().c_str(),
+                    if( SUCCEEDED( SHCreateItemFromParsingName( folderPath.c_str(),
                         nullptr, IID_PPV_ARGS( &folderItem ) ) ) )
                     {
                         saveDialog->SetFolder( folderItem.get() );
@@ -10785,6 +10783,49 @@ LRESULT APIENTRY MainWndProc(
                 g_ScreenshotSaveLocation = targetFilePath;
                 wcsncpy_s(g_ScreenshotSaveLocationBuffer, g_ScreenshotSaveLocation.c_str(), _TRUNCATE);
                 reg.WriteRegSettings(RegSettings);
+
+                // When enabled, also place the captured (actual-size) image on the
+                // clipboard so the snip is immediately available to paste. CF_BITMAP
+                // takes ownership of the handle, so hand it a dedicated copy.
+                if( g_SnipCopyToClipboard )
+                {
+                    wil::unique_hdc hdcClipboard( CreateCompatibleDC( hdcScreen ) );
+                    HBITMAP hbmClipboard =
+                        CreateCompatibleBitmap( hdcScreen, saveWidth, saveHeight );
+                    if( hdcClipboard && hbmClipboard )
+                    {
+                        HGDIOBJ hOldClip = SelectObject( hdcClipboard.get(), hbmClipboard );
+                        BitBlt( hdcClipboard.get(),
+                                0, 0,
+                                saveWidth, saveHeight,
+                                hdcActualSize.get(),
+                                0, 0,
+                                SRCCOPY );
+                        SelectObject( hdcClipboard.get(), hOldClip );
+
+                        bool ownershipTransferred = false;
+                        if( OpenClipboard( hWnd ) )
+                        {
+                            EmptyClipboard();
+                            // SetClipboardData only transfers ownership on success;
+                            // on failure the handle is still ours and must be freed.
+                            if( SetClipboardData( CF_BITMAP, hbmClipboard ) != nullptr )
+                            {
+                                ownershipTransferred = true;
+                            }
+                            CloseClipboard();
+                        }
+
+                        if( !ownershipTransferred )
+                        {
+                            DeleteObject( hbmClipboard );
+                        }
+                    }
+                    else if( hbmClipboard )
+                    {
+                        DeleteObject( hbmClipboard );
+                    }
+                }
             }
             g_bSaveInProgress = false;
 

--- a/src/modules/ZoomIt/ZoomIt/pch.h
+++ b/src/modules/ZoomIt/ZoomIt/pch.h
@@ -107,3 +107,40 @@
 #include <robmikh.common/hwnd.interop.h>
 #include <robmikh.common/capture.desktop.interop.h>
 #include <robmikh.common/DesktopWindow.h>
+
+//----------------------------------------------------------------------------
+//
+// [ZoomIt] debug-output prefix.
+//
+// Route every OutputDebugString call in this module through a thin wrapper that
+// prepends "[ZoomIt] " so the traces can be filtered in DebugView. The wrapper
+// functions are defined BEFORE the macros, so their bodies call the real Win32
+// APIs (no self-recursion). The function-like macros only expand at call sites
+// (identifier immediately followed by '('), so plain references / declarations
+// of these names are unaffected. This mirrors the existing wrap-via-macro idiom
+// used above (e.g. D3D11CreateDevice -> WrapD3D11CreateDevice).
+//
+// Note: the suffixless OutputDebugString is already an object-like macro from
+// <windows.h> that expands to OutputDebugStringW/A, so it automatically chains
+// through these wrappers and must not be redefined here (would be C4005).
+//
+//----------------------------------------------------------------------------
+namespace zoomit_dbg
+{
+    inline void OutputW( const wchar_t* msg )
+    {
+        std::wstring s( L"[ZoomIt] " );
+        s += ( msg ? msg : L"" );
+        OutputDebugStringW( s.c_str() );
+    }
+
+    inline void OutputA( const char* msg )
+    {
+        std::string s( "[ZoomIt] " );
+        s += ( msg ? msg : "" );
+        OutputDebugStringA( s.c_str() );
+    }
+}
+
+#define OutputDebugStringW( s ) ::zoomit_dbg::OutputW( s )
+#define OutputDebugStringA( s ) ::zoomit_dbg::OutputA( s )

--- a/src/modules/ZoomIt/ZoomIt/resource.h
+++ b/src/modules/ZoomIt/ZoomIt/resource.h
@@ -128,6 +128,7 @@
 #define IDC_TRIM_APPEND                 1122
 #define IDC_RECORD_ASPECT_RATIO         1123
 #define IDC_WEBCAM_BACKGROUND_BLUR      1124
+#define IDC_TRIM_DELETE                 1136
 #define IDC_WEBCAM_BG_LABEL             1125
 #define IDC_WEBCAM_BG_MODE              1126
 #define IDC_WEBCAM_BG_IMAGE             1127
@@ -154,7 +155,7 @@
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        120
 #define _APS_NEXT_COMMAND_VALUE         40012
-#define _APS_NEXT_CONTROL_VALUE         1136
+#define _APS_NEXT_CONTROL_VALUE         1137
 #define _APS_NEXT_SYMED_VALUE           101
 #endif
 #endif

--- a/src/settings-ui/Settings.UI.Library/ZoomItProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/ZoomItProperties.cs
@@ -103,6 +103,8 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 
         public BoolProperty SmoothImage { get; set; }
 
+        public BoolProperty SnipCopyToClipboard { get; set; }
+
         public IntProperty ZoominSliderLevel { get; set; }
 
         public IntProperty RecordScaling { get; set; }

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/ZoomItPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/ZoomItPage.xaml
@@ -409,6 +409,9 @@
                     <tkcontrols:SettingsCard Name="ZoomItSnipSaveShortcut" x:Uid="ZoomIt_SnipSave_Shortcut">
                         <controls:ShortcutControl HotkeySettings="{x:Bind ViewModel.SnipSaveToggleKey, Mode=TwoWay}" />
                     </tkcontrols:SettingsCard>
+                    <tkcontrols:SettingsCard Name="ZoomItSnipCopyToClipboard" x:Uid="ZoomIt_SnipCopyToClipboard">
+                        <ToggleSwitch x:Uid="ToggleSwitch" IsOn="{x:Bind ViewModel.SnipCopyToClipboard, Mode=TwoWay}" />
+                    </tkcontrols:SettingsCard>
                     <tkcontrols:SettingsCard
                         Name="ZoomItSnipOcrShortcut"
                         x:Uid="ZoomIt_SnipOcr_Shortcut"

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -4971,6 +4971,12 @@ The break timer font matches the text font.</value>
   <data name="ZoomIt_SnipSave_Shortcut.Header" xml:space="preserve">
     <value>Save snip to file</value>
   </data>
+  <data name="ZoomIt_SnipCopyToClipboard.Header" xml:space="preserve">
+    <value>Copy to clipboard when saving</value>
+  </data>
+  <data name="ZoomIt_SnipCopyToClipboard.Description" xml:space="preserve">
+    <value>Also copy the snip to the clipboard whenever it is saved to a file</value>
+  </data>
   <data name="ZoomIt_PanoramaSave_Shortcut.Header" xml:space="preserve">
     <value>Save scrolling screenshot to file</value>
   </data>

--- a/src/settings-ui/Settings.UI/ViewModels/ZoomItViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/ZoomItViewModel.cs
@@ -276,6 +276,20 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             }
         }
 
+        public bool SnipCopyToClipboard
+        {
+            get => _zoomItSettings.Properties.SnipCopyToClipboard.Value;
+            set
+            {
+                if (_zoomItSettings.Properties.SnipCopyToClipboard.Value != value)
+                {
+                    _zoomItSettings.Properties.SnipCopyToClipboard.Value = value;
+                    OnPropertyChanged(nameof(SnipCopyToClipboard));
+                    NotifySettingsChanged();
+                }
+            }
+        }
+
         public int ZoominSliderLevel
         {
             get => _zoomItSettings.Properties.ZoominSliderLevel.Value;


### PR DESCRIPTION
## Summary of the Pull Request

Ports several recording and editing features from the Sysinternals **Mac ZoomIt** into the Windows PowerToys ZoomIt module, and hardens the video **trim/save** pipeline against a sporadic "Failed to trim the video" failure.

Highlights:
- **Video trim editor — interior "Delete Region" editing.** In the post-recording trim dialog you can now select and delete interior segments (not just trim the head/tail). Includes red timeline overlays with drag grips, right-drag to select, `Delete` to remove, `Ctrl+Z` to undo, and `Esc` to cancel a pending selection.
- **Reliable trim/render.** Fixed a sporadic *"Failed to trim the video"* error. The live capture pipeline produces **fragmented** MP4s (moof/mdat) that play in preview but fail `MediaComposition` render/seek with `0xC00DA7FC`. The render path now (a) sources resolution from the clip's encoding properties first, (b) retries transient failures (0×0 dimensions from a fragmented-MP4 metadata race, `!CanTranscode()`, post-remux render failure), and (c) remuxes fragmented MP4s to a standard seekable MP4 via `MediaTranscoder` before rendering.
- **Snip → Copy to clipboard.** New ZoomIt setting to copy a snip directly to the clipboard.
- **Recording border color.** The screen-recording selection border now uses a distinct color, and turns orange while recording is active.
- **GIF recording robustness.** First-frame timeout so GIF capture doesn't hang when no frames arrive.
- **Audio hardening.** Stereo downmix handling and defensive guards in the audio sample generator.
- **Opt-in diagnostics.** Recording diagnostics (`[RecDiag]`) are gated behind a registry DWORD `HKCU\Software\Sysinternals\ZoomIt\EnableDebugTrace` (off by default), and all module debug output is prefixed with `[ZoomIt]` for easy filtering in DebugView.
- **Fix:** GDI bitmap leak in the snip-to-clipboard path when `SetClipboardData` fails.

## PR Checklist

- [ ] **Tests:** ZoomIt is native Win32/WinRT with no unit-test harness; validated manually (see Validation Steps) 
- [ ] - [x] **Localization:** All end-user-facing strings can be localized <!-- new strings added to Settings.UI en-us Resources.resw -->
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** N/A: no new binaries/projects 
  - [ ] JSON for signing — N/A
  - [ ] WXS for installer — N/A
  - [ ] YML for CI pipeline — N/A
  - [ ] YML for signed pipeline — N/A
- [ ] **Documentation updated:** N/A

## Detailed Description of the Pull Request / Additional comments

Files changed (17):

**ZoomIt module (native)**
- `VideoRecordingSession.cpp/.h` — interior delete-region trim editor; render/trim reliability (resolution from clip encoding properties, retry loop, fragmented-MP4 → seekable remux); registry-gated `[RecDiag]` diagnostics.
- `GifRecordingSession.cpp` — first-frame timeout / no-frames handling.
- `AudioSampleGenerator.cpp` — stereo downmix + defensive guards.
- `SelectRectangle.cpp/.h`, `PanoramaCapture.cpp` — recording border color parameter.
- `Zoomit.cpp` — snip → clipboard workflow; GDI bitmap leak fix on `SetClipboardData` failure.
- `ZoomItSettings.h`, `ZoomIt.h`, `ZoomIt.rc`, `resource.h` — new setting + "Delete Region" button + message id.
- `pch.h` — `[ZoomIt]` debug-output prefix wrapper.

**Settings UI**
- `ZoomItProperties.cs`, `ZoomItViewModel.cs`, `ZoomItPage.xaml`, `Resources.resw` — "Copy snip to clipboard" setting and localized strings.

Note: ZoomIt is a Sysinternals port kept in its upstream code style, so it is intentionally exempt from the repo `.clang-format` (changed lines follow the surrounding Sysinternals convention).

## Validation Steps Performed

Manual validation (no automated ZoomIt harness):
- **Trim reliability:** Recorded multiple clips and used Trim → Save repeatedly (including 3-clip compositions produced by Delete Region); render now succeeds consistently (previously failed sporadically with "Failed to trim the video").
- **Delete Region editor:** Right-drag to select an interior segment, `Delete` to remove, `Ctrl+Z` to undo, `Esc` to cancel; saved output reflects the removed segments.
- **Snip → clipboard:** Enabled the new setting; snip is placed on the clipboard and pastes correctly. Verified no GDI handle leak when clipboard set fails.
- **Recording border:** Verified border color and the orange active-recording state (full-monitor and region).
- **GIF:** Confirmed capture no longer hangs when no frames arrive.
- **Diagnostics:** With `EnableDebugTrace` unset, no `%TEMP%\ZoomIt_RecDiag.log` and no `[RecDiag]` output; with it set to `1`, `[ZoomIt] [RecDiag ...]` traces appear.
- **Style checks:** XamlStyler (clean), StyleCop via building `Settings.UI.Library` and `PowerToys.Settings` (no `SA####` warnings), ZoomIt x64 Release builds with exit code 0.