### PR TITLE
docs: fix incorrect registry hive name 'HKEY_LOCALE_MACHINE' to 'HKEY_LOCAL_MACHINE'

### DIFF
--- a/doc/devdocs/modules/launcher/plugins/registry.md
+++ b/doc/devdocs/modules/launcher/plugins/registry.md
@@ -4,7 +4,7 @@ The registry plugin allows users to search the Windows registry.
 
 ## Special functions (differ from the regular functions)
 
-* Support full base keys and short base keys (e.g. `HKLM` for `HKEY_LOCALE_MACHINE`).
+* Support full base keys and short base keys (e.g. `HKLM` for `HKEY_LOCAL_MACHINE`).
 * Show count of subkeys and count of values in the second result line.
 * Search for value names and value data inside a registry key (syntax: `[RegistryKey]\\[ValueName]` and `[RegistryKey]\\[ValueData]`)
 


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `doc/devdocs/modules/launcher/plugins/registry.md` (line 7).

## Problem

`HKEY_LOCALE_MACHINE` is incorrect; the correct Windows registry hive name is `HKEY_LOCAL_MACHINE`. `LOCALE` should be `LOCAL`.

The problematic text:

```markdown
Support full base keys and short base keys (e.g. `HKLM` for `HKEY_LOCALE_MACHINE`).
```

## Fix

Replaced with:

```markdown
Support full base keys and short base keys (e.g. `HKLM` for `HKEY_LOCAL_MACHINE`).
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text