### PR TITLE
docs: fix missing space after inline code in new-powertoy.md

### DIFF
--- a/doc/devdocs/development/new-powertoy.md
+++ b/doc/devdocs/development/new-powertoy.md
@@ -181,7 +181,7 @@ PowerToys settings are stored per-module as JSON under:
 
 - In `src\settings-ui\Settings.UI.Library\` create `<module>Properties.cs` and `<module>Settings.cs`
 - `<module>Properties.cs` is where you will define your defaults. Every setting needs to be represented here. This should match what was set in the Module Interface.
-- `<module>Settings.cs`is where your settings.json will be built from. The structure should match the following
+- `<module>Settings.cs` is where your settings.json will be built from. The structure should match the following
 ```cs
 public ModuleSettings()
 {


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `doc/devdocs/development/new-powertoy.md` (line 184).

## Problem

Missing space between the inline code and "is". The text reads `` `<module>Settings.cs`is `` which should be `` `<module>Settings.cs` is ``.

The problematic text:

```markdown
`<module>Settings.cs`is where your settings.json will be built from.
```

## Fix

Replaced with:

```markdown
`<module>Settings.cs` is where your settings.json will be built from.
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text