### PR TITLE
docs: add Quick Shell to third-party Run plugins

### DIFF
--- a/doc/thirdPartyRunPlugins.md
+++ b/doc/thirdPartyRunPlugins.md
@@ -44,6 +44,7 @@ Contact the developers of a plugin directly for assistance with a specific plugi
 | [HttpStatusCodes](https://github.com/grzhan/HttpStatusCodePowerToys) | [grzhan](https://github.com/grzhan) | Search for http status codes |
 | [SVGL](https://github.com/Sameerjs6/powertoys-svgl) | [SameerJS6](https://github.com/SameerJS6) | Search, Browse and copy SVG logos from SVGL. |
 | [QuickNotes](https://github.com/ruslanlap/CommunityPowerToysRunPlugin-QuickNotes) | [ruslanlap](https://github.com/ruslanlap) | Create, manage, and search notes directly from PowerToys Run. |
+| [Quick Shell](https://github.com/tonythethompson/QuickShell) | [tonythethompson](https://github.com/tonythethompson) | Open saved project folders in any terminal; shared shortcuts with the Quick Shell extension |
 | [Weather](https://github.com/ruslanlap/PowerToysRun-Weather) | [ruslanlap](https://github.com/ruslanlap) | Get real-time weather information directly from PowerToys Run. |
 | [Pomodoro](https://github.com/ruslanlap/PowerToysRun-Pomodoro) | [ruslanlap](https://github.com/ruslanlap) | Manage Pomodoro productivity sessions directly from PowerToys Run. |
 | [Definition](https://github.com/ruslanlap/PowerToysRun-Definition) | [ruslanlap](https://github.com/ruslanlap) | Lookup word definitions, phonetics, and synonyms directly in PowerToys Run. |


### PR DESCRIPTION
## Summary

Adds [Quick Shell](https://github.com/tonythethompson/QuickShell) to the community PowerToys Run plugins list.

- **Plugin:** Quick Shell (`qs` keyword)
- **Author:** [tonythethompson](https://github.com/tonythethompson)
- **Description:** Open saved project folders in any terminal; shared shortcuts with the Quick Shell Command Palette extension

## Install

- WinGet (bundled CmdPal + Run): `winget install tonythethompson.QuickShell`
- Run-only ZIP: [`QuickShell.Run-x64.zip`](https://github.com/tonythethompson/QuickShell/releases/latest) / [`QuickShell.Run-ARM64.zip`](https://github.com/tonythethompson/QuickShell/releases/latest)
- Run-only EXE: `QuickShellforRun-Setup-*-x64.exe` / `*-arm64.exe` from the same release

Docs: https://github.com/tonythethompson/QuickShell/blob/master/docs/powertoys-run-plugin.md

## Validation

- [x] Listed under General plugins
- [x] Links to GitHub repo and author profile
- [x] Release assets include Run plugin ZIP and installer


Made with [Cursor](https://cursor.com)