### PR TITLE
[Keyboard Manager] Honor normal elevation when launching programs

### DIFF
--- a/src/common/utils/elevation.h
+++ b/src/common/utils/elevation.h
@@ -141,12 +141,23 @@ namespace
             return false;
         }
 
-        CComQIPtr<IShellDispatch2>(spdispShell)
-            ->ShellExecuteW(CComBSTR(pszFile),
-                            CComVariant(pszParameters ? pszParameters : L""),
-                            CComVariant(workingDir),
-                            CComVariant(L""),
-                            CComVariant(SW_SHOWNORMAL));
+        CComQIPtr<IShellDispatch2> shellDispatch(spdispShell);
+        if (shellDispatch == nullptr)
+        {
+            Logger::warn(L"Failed to query IShellDispatch2");
+            return false;
+        }
+
+        result = shellDispatch->ShellExecuteW(CComBSTR(pszFile),
+                                              CComVariant(pszParameters ? pszParameters : L""),
+                                              CComVariant(workingDir),
+                                              CComVariant(L""),
+                                              CComVariant(SW_SHOWNORMAL));
+        if (FAILED(result))
+        {
+            Logger::warn(L"ShellExecuteW() failed. {}", GetErrorString(result));
+            return false;
+        }
 
         return true;
     }

--- a/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardEventHandlers.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardEventHandlers.cpp
@@ -88,6 +88,26 @@ namespace
 
 namespace KeyboardEventHandlers
 {
+    namespace ProgramLauncher
+    {
+        std::wstring GetWorkingDirectory(const std::wstring& filePath, const std::wstring& configuredDirectory)
+        {
+            if (!configuredDirectory.empty())
+            {
+                return configuredDirectory;
+            }
+
+            const std::filesystem::path path{ filePath };
+            const auto extension = path.extension().wstring();
+            if (_wcsicmp(extension.c_str(), L".exe") != 0 && _wcsicmp(extension.c_str(), L".com") != 0)
+            {
+                return {};
+            }
+
+            return path.parent_path().wstring();
+        }
+    }
+
     // Function to handle a single key remap
     intptr_t HandleSingleKeyRemapEvent(KeyboardManagerInput::InputInterface& ii, LowlevelKeyboardEvent* data, State& state) noexcept
     {
@@ -1393,7 +1413,7 @@ namespace KeyboardEventHandlers
 
                 for (DWORD pid : processIds)
                 {
-                    ShowProgram(targetPid, fileNamePart, false, false, 0);
+                    ShowProgram(pid, fileNamePart, false, false, 0);
                 }
 
                 //if (!ShowProgram(targetPid, fileNamePart, false, false, 0))
@@ -1424,47 +1444,70 @@ namespace KeyboardEventHandlers
             expandedArgs.resize(dwSize);
             DWORD result = ExpandEnvironmentStrings(shortcut.runProgramArgs.c_str(), expandedArgs.data(), dwSize);
 
-            WCHAR currentDir[MAX_PATH];
-            WCHAR* currentDirPtr = currentDir;
-            result = ExpandEnvironmentStrings(shortcut.runProgramStartInDir.c_str(), currentDir, MAX_PATH);
-
-            if (shortcut.runProgramStartInDir == L"")
+            std::wstring currentDir;
+            if (shortcut.runProgramStartInDir.empty())
             {
-                currentDirPtr = nullptr;
+                currentDir = ProgramLauncher::GetWorkingDirectory(fullExpandedFilePath, {});
             }
             else
             {
-                DWORD dwAttrib = GetFileAttributesW(currentDir);
-
-                if (dwAttrib == INVALID_FILE_ATTRIBUTES)
+                WCHAR expandedCurrentDir[MAX_PATH];
+                result = ExpandEnvironmentStrings(shortcut.runProgramStartInDir.c_str(), expandedCurrentDir, MAX_PATH);
+                if (result == 0 || result > ARRAYSIZE(expandedCurrentDir))
                 {
                     std::wstring title = fmt::format(L"Error starting {}", fileNamePart);
-                    std::wstring message = fmt::format(L"The start in path was not valid. It could not be used.", currentDir);
-                    currentDirPtr = nullptr;
+                    std::wstring message = L"The start in path was not valid. It could not be used.";
+                    toast(title, message);
+                    return;
+                }
+
+                currentDir = ProgramLauncher::GetWorkingDirectory(fullExpandedFilePath, expandedCurrentDir);
+
+                DWORD dwAttrib = GetFileAttributesW(currentDir.c_str());
+
+                if (dwAttrib == INVALID_FILE_ATTRIBUTES || (dwAttrib & FILE_ATTRIBUTE_DIRECTORY) == 0)
+                {
+                    std::wstring title = fmt::format(L"Error starting {}", fileNamePart);
+                    std::wstring message = L"The start in path was not valid. It could not be used.";
                     toast(title, message);
                     return;
                 }
             }
 
             DWORD processId = 0;
-            HANDLE newProcessHandle;
+            HANDLE newProcessHandle = nullptr;
+            bool processStarted = false;
+            const auto currentDirPtr = currentDir.empty() ? nullptr : currentDir.c_str();
 
             if (shortcut.elevationLevel == Shortcut::ElevationLevel::Elevated)
             {
                 newProcessHandle = run_elevated(fullExpandedFilePath, expandedArgs, currentDirPtr, (shortcut.startWindowType == Shortcut::StartWindowType::Normal));
-                processId = GetProcessId(newProcessHandle);
+                processStarted = newProcessHandle != nullptr;
             }
             else if (shortcut.elevationLevel == Shortcut::ElevationLevel::NonElevated)
             {
-                run_non_elevated(fullExpandedFilePath, expandedArgs, &processId, currentDirPtr, (shortcut.startWindowType == Shortcut::StartWindowType::Normal));
+                if (ProgramLauncher::ShouldUseExplorerShell(shortcut.startWindowType))
+                {
+                    processStarted = RunNonElevatedEx(fullExpandedFilePath, expandedArgs, currentDir);
+                }
+                else
+                {
+                    processStarted = run_non_elevated(fullExpandedFilePath, expandedArgs, &processId, currentDirPtr, false);
+                }
             }
             else if (shortcut.elevationLevel == Shortcut::ElevationLevel::DifferentUser)
             {
                 newProcessHandle = run_as_different_user(fullExpandedFilePath, expandedArgs, currentDirPtr, (shortcut.startWindowType == Shortcut::StartWindowType::Normal));
-                processId = GetProcessId(newProcessHandle);
+                processStarted = newProcessHandle != nullptr;
             }
 
-            if (processId == 0)
+            if (newProcessHandle != nullptr)
+            {
+                processId = GetProcessId(newProcessHandle);
+                CloseHandle(newProcessHandle);
+            }
+
+            if (!processStarted)
             {
                 std::wstring title = fmt::format(L"Error starting {}", fileNamePart);
                 std::wstring message = fmt::format(L"The application might not have started.");
@@ -1472,7 +1515,7 @@ namespace KeyboardEventHandlers
                 return;
             }
 
-            if (shortcut.startWindowType == Shortcut::StartWindowType::Hidden)
+            if (processId != 0 && shortcut.startWindowType == Shortcut::StartWindowType::Hidden)
             {
                 HideProgram(processId, fileNamePart, 0);
             }
@@ -1900,7 +1943,7 @@ namespace KeyboardEventHandlers
         // reports it as up, so there is no reliable way to tell whether the user is
         // still physically holding the key or has released it. Re-pressing
         // unconditionally would risk leaving a modifier stuck down if the user let
-        // go during injection — the exact failure this change set prevents. Leaving
+        // go during injection - the exact failure this change set prevents. Leaving
         // the modifier released is always safe: the user taps it again to re-engage.
 
         return 1;

--- a/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardEventHandlers.h
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardEventHandlers.h
@@ -10,6 +10,15 @@ namespace KeyboardManagerInput
 
 namespace KeyboardEventHandlers
 {
+    namespace ProgramLauncher
+    {
+        constexpr bool ShouldUseExplorerShell(Shortcut::StartWindowType startWindowType) noexcept
+        {
+            return startWindowType == Shortcut::StartWindowType::Normal;
+        }
+
+        std::wstring GetWorkingDirectory(const std::wstring& filePath, const std::wstring& configuredDirectory);
+    }
 
     struct ResetChordsResults
     {

--- a/src/modules/keyboardmanager/KeyboardManagerEngineTest/KeyboardManagerEngineTest.vcxproj
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineTest/KeyboardManagerEngineTest.vcxproj
@@ -43,6 +43,7 @@
     <ClCompile Include="MockedInputSanityTests.cpp" />
     <ClCompile Include="SetKeyEventTests.cpp" />
     <ClCompile Include="OSLevelShortcutRemappingTests.cpp" />
+    <ClCompile Include="ProgramLauncherTests.cpp" />
     <ClCompile Include="MockedInput.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(UsePrecompiledHeaders)' != 'false'">Create</PrecompiledHeader>

--- a/src/modules/keyboardmanager/KeyboardManagerEngineTest/KeyboardManagerEngineTest.vcxproj.filters
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineTest/KeyboardManagerEngineTest.vcxproj.filters
@@ -39,6 +39,9 @@
     <ClCompile Include="AppSpecificShortcutRemappingTests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="ProgramLauncherTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h">

--- a/src/modules/keyboardmanager/KeyboardManagerEngineTest/ProgramLauncherTests.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineTest/ProgramLauncherTests.cpp
@@ -1,0 +1,64 @@
+#include "pch.h"
+
+// Suppressing 26466 - Don't use static_cast downcasts - in CppUnitTest.h
+#pragma warning(push)
+#pragma warning(disable : 26466)
+#include "CppUnitTest.h"
+#pragma warning(pop)
+
+#include <keyboardmanager/KeyboardManagerEngineLibrary/KeyboardEventHandlers.h>
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace RemappingLogicTests
+{
+    TEST_CLASS (ProgramLauncherTests)
+    {
+    public:
+        TEST_METHOD (NormalWindow_ShouldUseExplorerShell)
+        {
+            Assert::IsTrue(KeyboardEventHandlers::ProgramLauncher::ShouldUseExplorerShell(Shortcut::StartWindowType::Normal));
+        }
+
+        TEST_METHOD (HiddenWindow_ShouldUseCreateProcess)
+        {
+            Assert::IsFalse(KeyboardEventHandlers::ProgramLauncher::ShouldUseExplorerShell(Shortcut::StartWindowType::Hidden));
+        }
+
+        TEST_METHOD (EmptyWorkingDirectory_ShouldUseExecutableDirectory)
+        {
+            const auto workingDirectory = KeyboardEventHandlers::ProgramLauncher::GetWorkingDirectory(
+                L"C:\\Program Files\\Example\\Example.exe",
+                L"");
+
+            Assert::AreEqual(L"C:\\Program Files\\Example", workingDirectory.c_str());
+        }
+
+        TEST_METHOD (ExecutableExtensionCheck_ShouldBeCaseInsensitive)
+        {
+            const auto workingDirectory = KeyboardEventHandlers::ProgramLauncher::GetWorkingDirectory(
+                L"C:\\Tools\\Example.EXE",
+                L"");
+
+            Assert::AreEqual(L"C:\\Tools", workingDirectory.c_str());
+        }
+
+        TEST_METHOD (ConfiguredWorkingDirectory_ShouldTakePrecedence)
+        {
+            const auto workingDirectory = KeyboardEventHandlers::ProgramLauncher::GetWorkingDirectory(
+                L"C:\\Program Files\\Example\\Example.exe",
+                L"D:\\Application Data");
+
+            Assert::AreEqual(L"D:\\Application Data", workingDirectory.c_str());
+        }
+
+        TEST_METHOD (ShellTargetWithoutWorkingDirectory_ShouldRemainEmpty)
+        {
+            const auto workingDirectory = KeyboardEventHandlers::ProgramLauncher::GetWorkingDirectory(
+                L"C:\\Shortcuts\\Example.lnk",
+                L"");
+
+            Assert::IsTrue(workingDirectory.empty());
+        }
+    };
+}


### PR DESCRIPTION
## Summary of the Pull Request

Closes: #32206

Keyboard Manager's **Run program** action did not reliably honor `Elevation: Normal` when PowerToys was running as administrator. The existing path used `CreateProcessW` with Explorer as the parent process. That can create ordinary desktop executables with a non-elevated token, but it does not provide Explorer Shell activation semantics for packaged apps, app execution aliases, shortcuts, or file associations.

As a result, apps such as Windows Terminal, Firefox, VS Code, and other applications can start elevated, fail to connect to an existing non-elevated instance, use a different effective context, or fail to start at all. Users may then set mappings to `Elevated` merely to make them launch, unnecessarily granting administrator rights to the app and all child processes. This can affect profile/IPC behavior, drag and drop, updates, shell integration, and scripts launched by those applications.

This PR launches normal, visible program mappings through Explorer's `IShellDispatch2::ShellExecuteW` implementation. Explicit `Elevated` and `Different user` mappings retain their existing behavior. Hidden launches keep the `CreateProcessW` path because they need its window and process-ID control.

## PR Checklist

- [x] Closes: #32206
- [x] **Communication:** The issue discussion identifies this as unsafe/unexpected behavior and agrees it should be reworked
- [x] **Tests:** Added program-launch routing and working-directory tests; all Keyboard Manager Engine tests pass
- [x] **Localization:** No new user-facing strings
- [x] **Dev docs:** Not required for this behavioral bug fix
- [x] **New binaries:** None
- [x] **Documentation updated:** Not required

## Detailed Description of the Pull Request / Additional comments

- Routes normal, visible launches through the existing Explorer Shell automation helper so Shell targets receive the interactive user's non-elevated context.
- Keeps hidden launches on `CreateProcessW` to preserve hidden-window behavior and process tracking.
- Uses an executable's containing directory when `Start in` is empty, while leaving Shell targets such as `.lnk` files free to use their own metadata.
- Expands and validates an explicitly configured `Start in` directory before launching.
- Treats successful Shell dispatch as a successful launch even when no child PID is available.
- Checks `IShellDispatch2` and `ShellExecuteW` results instead of reporting success unconditionally.
- Closes process handles returned by elevated and different-user launches.
- Uses each matching PID when restoring an already-running application window.

No elevation checks, UAC behavior, code-signing checks, or Code Integrity policies are bypassed.

## Validation Steps Performed

- Built `KeyboardManagerEngineTest` with `tools\build\build.cmd -Platform x64 -Configuration Debug`: exit code 0, 0 warnings, 0 errors.
- Ran the native suite with Visual Studio `vstest.console.exe`: 109/109 tests passed.
- Built `KeyboardManagerEngine` and `PowerToys.KeyboardManager.dll`: exit code 0, 0 warnings, 0 errors.
- Ran `tools\build\build-essentials.cmd -Platform x64 -Configuration Debug`: exit code 0, 0 warnings, 0 errors.
- Manually ran PowerToys and Keyboard Manager Engine elevated, launched a mapping configured as `Normal`, and confirmed the target process was not elevated in Task Manager.
- Manually verified blank and explicit working directories, `.lnk` targets, file-association targets, and applications including Chrome, VS Code, Notion, and Steam.
- Confirmed mappings explicitly configured as `Elevated` still launch elevated.