### PR TITLE
PowerDisplay: Always write the saved value when restoring monitor settings

### DIFF
--- a/src/modules/powerdisplay/PowerDisplay/ViewModels/MainViewModel.Settings.cs
+++ b/src/modules/powerdisplay/PowerDisplay/ViewModels/MainViewModel.Settings.cs
@@ -77,14 +77,24 @@ public partial class MainViewModel
         }
     }
 
+    /// <summary>
+    /// Queues an absolute write of <paramref name="savedValue"/> onto the monitor.
+    /// </summary>
+    /// <remarks>
+    /// The write is unconditional. A restore used to be skipped when the saved value already equalled
+    /// the value the UI was showing, but that value is only an observation when the discovery-time VCP
+    /// read succeeded. Otherwise it is a placeholder — 50 brightness from
+    /// <c>MonitorDiscoveryHelper</c>, or <c>Monitor</c>'s never-read backing-field defaults of 50
+    /// contrast, 50 volume and <c>0x05</c> color temperature — and a saved value that happened to match
+    /// one of those silently dropped the restore.
+    /// </remarks>
     private static void TryRestore(
         List<Task> tasks,
         int? savedValue,
         bool isVisible,
-        int currentValue,
         Func<int, Task> setter)
     {
-        if (savedValue.HasValue && isVisible && savedValue.Value != currentValue)
+        if (savedValue.HasValue && isVisible)
         {
             tasks.Add(setter(savedValue.Value));
         }
@@ -341,16 +351,16 @@ public partial class MainViewModel
             }
 
             // Apply brightness if included in profile
-            TryRestore(updateTasks, setting.Brightness, monitorVm.ShowBrightness, monitorVm.Brightness, monitorVm.SetBrightnessAsync);
+            TryRestore(updateTasks, setting.Brightness, monitorVm.ShowBrightness, monitorVm.SetBrightnessAsync);
 
             // Apply contrast if supported and value provided
-            TryRestore(updateTasks, setting.Contrast, monitorVm.ShowContrast, monitorVm.Contrast, monitorVm.SetContrastAsync);
+            TryRestore(updateTasks, setting.Contrast, monitorVm.ShowContrast, monitorVm.SetContrastAsync);
 
             // Apply volume if supported and value provided
-            TryRestore(updateTasks, setting.Volume, monitorVm.ShowVolume, monitorVm.Volume, monitorVm.SetVolumeAsync);
+            TryRestore(updateTasks, setting.Volume, monitorVm.ShowVolume, monitorVm.SetVolumeAsync);
 
             // Apply color temperature if included in profile
-            TryRestore(updateTasks, setting.ColorTemperatureVcp, monitorVm.ShowColorTemperature, monitorVm.ColorTemperature, monitorVm.SetColorTemperatureAsync);
+            TryRestore(updateTasks, setting.ColorTemperatureVcp, monitorVm.ShowColorTemperature, monitorVm.SetColorTemperatureAsync);
         }
 
         // Wait for all updates to complete
@@ -362,7 +372,7 @@ public partial class MainViewModel
 
     /// <summary>
     /// Restore monitor settings from state file - ONLY called at startup when RestoreSettingsOnStartup is enabled.
-    /// Compares saved values with current hardware values and only writes when different.
+    /// Writes every saved value the monitor exposes a control for.
     /// </summary>
     public async Task RestoreMonitorSettingsAsync()
     {
@@ -381,10 +391,10 @@ public partial class MainViewModel
 
                 var (brightness, colorTemp, contrast, volume) = savedState.Value;
 
-                TryRestore(updateTasks, brightness, monitorVm.ShowBrightness, monitorVm.Brightness, monitorVm.SetBrightnessAsync);
-                TryRestore(updateTasks, colorTemp, monitorVm.ShowColorTemperature, monitorVm.ColorTemperature, monitorVm.SetColorTemperatureAsync);
-                TryRestore(updateTasks, contrast, monitorVm.ShowContrast, monitorVm.Contrast, monitorVm.SetContrastAsync);
-                TryRestore(updateTasks, volume, monitorVm.ShowVolume, monitorVm.Volume, monitorVm.SetVolumeAsync);
+                TryRestore(updateTasks, brightness, monitorVm.ShowBrightness, monitorVm.SetBrightnessAsync);
+                TryRestore(updateTasks, colorTemp, monitorVm.ShowColorTemperature, monitorVm.SetColorTemperatureAsync);
+                TryRestore(updateTasks, contrast, monitorVm.ShowContrast, monitorVm.SetContrastAsync);
+                TryRestore(updateTasks, volume, monitorVm.ShowVolume, monitorVm.SetVolumeAsync);
             }
 
             if (updateTasks.Count > 0)


### PR DESCRIPTION
## Summary of the Pull Request

`TryRestore` skipped writing a saved monitor value when it already equalled the value `MonitorViewModel` was showing. That displayed value is only an observation when the discovery-time VCP read succeeded. When the read failed it is a placeholder:

| setting | value when the read failed | source |
| --- | --- | --- |
| brightness | `50` | `MonitorDiscoveryHelper` stamps it — *"Initial placeholder; overwritten if the VCP read succeeds"* |
| contrast | `50` | `Monitor` backing-field default |
| volume | `50` | `Monitor` backing-field default |
| color temperature | `0x05` (6500K) | `Monitor` backing-field default |

A saved value that happened to equal one of those silently suppressed the restore, and the monitor kept whatever it powered on with. `50` is the mid-slider value and `0x05` is the most common preset, so the coincidence is not rare.

This drops the comparison: a restore now always writes.

## PR Checklist

- [ ] Closes: #xxx — no issue; found while splitting up #49445
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass — none added; `TryRestore` is a private helper in the `PowerDisplay` app project, which has no test project
- [x] **Localization:** All end-user-facing strings can be localized — this PR adds none
- [ ] **Dev docs:** Added/updated
- [x] **New binaries:** Added on the required places — none added; no new project, so no signing JSON, installer WXS or CI YML change is required
- [ ] **Documentation updated**

## Detailed Description of the Pull Request / Additional comments

### Why remove the check rather than refine it

The skip-if-equal check dates from PowerDisplay's first commit (#42642, where it read `// Restore brightness if different from current`); #47051 only refactored it into the shared `TryRestore` helper. It is day-one "obviously we shouldn't write twice" code, not a response to a reported problem.

Removing it is correct by construction: with no skip branch there is no state in which a restore silently does nothing. Any narrower fix has to decide *when* the displayed value can be trusted, and gets that decision wrong in exactly the cases that are hardest to reproduce.

### Cost

Two, both bounded:

- **A redundant VCP write when the monitor already sits at the saved value.** Some panels surface a write on their OSD. Both paths that reach here are user-initiated: startup restore only runs when `RestoreSettingsOnStartup` is enabled, and a profile apply happens because the user invoked that profile.
- **Time.** At most four writes per monitor, serialised on that monitor's I2C bus (~100 ms each). Monitors still run in parallel through the existing `Task.WhenAll`.

The `isVisible` guard is untouched, so a monitor still never receives a write for a feature it does not expose — an unsupported VCP `0x14` is not written just because a profile carries a color temperature. Input source and power state are not restored here at all.

### If the redundant write turns out to matter

The narrower fix is to keep the comparison and add one clause: also write when `(monitor.ReadValues & flag) != flag`, i.e. when the compared value was never read off the hardware. `MonitorReadFlags` already carries exactly that information, and `Monitor.ReadValues` is already maintained by the discovery-time `Initialize*` methods, so it is a small change on top of this one. I went with the simpler version first — happy to switch if a maintainer would rather keep the optimisation.

## Validation Steps Performed

- built `PowerDisplay` and `PowerDisplay.Lib.UnitTests` for x64 Debug with VS MSBuild — 0 errors, 0 warnings
- ran `PowerDisplay.Lib.UnitTests.dll` with `vstest.console.exe`: **186 passed, 0 failed** — unchanged from `main`; this PR touches only the app project and adds no tests
- no hardware validation performed: the placeholder path this PR fixes is reachable only on a monitor whose VCP read fails during discovery
