### PR TITLE
PowerDisplay: Release physical-monitor handles that discovery abandons

### DIFF
--- a/src/modules/powerdisplay/PowerDisplay.Lib/Drivers/DDC/DdcCiController.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Lib/Drivers/DDC/DdcCiController.cs
@@ -352,6 +352,35 @@ namespace PowerDisplay.Common.Drivers.DDC
         }
 
         /// <summary>
+        /// Releases a physical-monitor handle that discovery abandoned.
+        /// </summary>
+        /// <remarks>
+        /// Handles only reach <see cref="PhysicalMonitorHandleManager"/> through monitors that were
+        /// successfully built: the map is rebuilt from the returned monitor list, and its cleanup pass
+        /// only destroys handles that were in the previous map. A handle dropped on an abandon path
+        /// therefore never gets destroyed, and every discovery over a monitor that keeps failing leaks
+        /// one more — and a discovery runs on every display-topology change, so a docking-station
+        /// user accumulates them for the process lifetime.
+        /// </remarks>
+        private static void ReleaseAbandonedPhysical(PHYSICAL_MONITOR physical)
+        {
+            if (physical.HPhysicalMonitor == IntPtr.Zero)
+            {
+                return;
+            }
+
+            try
+            {
+                DestroyPhysicalMonitor(physical.HPhysicalMonitor);
+            }
+            catch (Exception ex) when (ex is not OutOfMemoryException)
+            {
+                Logger.LogWarning(
+                    $"DDC: failed to destroy abandoned physical monitor handle 0x{physical.HPhysicalMonitor:X}: {ex.Message}");
+            }
+        }
+
+        /// <summary>
         /// Fetches DDC/CI capabilities with retry, falling back to direct VCP probing
         /// when <see cref="MaxCompatibilityMode"/> is on and the cap string is missing
         /// or unparsable. Cancellation is honored both during the cap-string fetch
@@ -705,6 +734,12 @@ namespace PowerDisplay.Common.Drivers.DDC
                         Logger.LogWarning(
                             $"DDC: Physical monitor index {i} exceeds available QueryDisplayConfig entries " +
                             $"({matchingInfos.Count}) for {gdiName}");
+
+                        for (int unmatched = i; unmatched < physicals.Length; unmatched++)
+                        {
+                            ReleaseAbandonedPhysical(physicals[unmatched]);
+                        }
+
                         break;
                     }
 
@@ -743,6 +778,7 @@ namespace PowerDisplay.Common.Drivers.DDC
                     {
                         Logger.LogWarning(
                             $"DDC: [DevicePath={info.DevicePath}] monitor ignored — capabilities unavailable");
+                        ReleaseAbandonedPhysical(physical);
                         continue;
                     }
 
@@ -756,6 +792,12 @@ namespace PowerDisplay.Common.Drivers.DDC
                     if (monitor != null)
                     {
                         monitors.Add(monitor);
+                    }
+                    else
+                    {
+                        // Construction failed or threw. Either way this physical never becomes a
+                        // Monitor, so it never reaches the handle manager.
+                        ReleaseAbandonedPhysical(physical);
                     }
                 }
 


### PR DESCRIPTION
## Summary of the Pull Request

`DdcCiController.DiscoverFromHandleAsync` abandons a physical monitor on three paths without destroying its handle.

Handles only reach `PhysicalMonitorHandleManager` through monitors that were successfully built: the map is rebuilt from the returned monitor list, and its cleanup pass only destroys handles that were in the *previous* map. A handle dropped on an abandon path therefore never gets destroyed. A discovery runs on every display-topology change, so a monitor that keeps failing leaks one more handle per discovery for the process lifetime — a docking-station user accumulates them.

Extracted from #49445, where the same fix is bundled with maximum-compatibility-mode work it does not depend on.

## PR Checklist

- [ ] Closes: #xxx — no issue; extracted from #49445
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass — none added; rationale below
- [x] **Localization:** All end-user-facing strings can be localized — this PR adds none
- [ ] **Dev docs:** Added/updated
- [x] **New binaries:** Added on the required places — none added; no new project, so no signing JSON, installer WXS or CI YML change is required
- [ ] **Documentation updated**

## Detailed Description of the Pull Request / Additional comments

### The three leaking paths

| path | before this PR |
| --- | --- |
| more physical monitors than `QueryDisplayConfig` entries for the GDI name | `break` leaves `physicals[i..]` unreleased — the whole tail, not just the current one |
| capabilities unavailable | `continue` |
| `BuildMonitorFromPhysical` returned null (construction failed, or it threw and was caught) | no `else` branch at all |

`ReleaseAbandonedPhysical` is null-handle safe and swallows a failing `DestroyPhysicalMonitor` at warn level: one handle that cannot be destroyed must not take down the rest of the discovery pass.

### Why there are no tests

Reaching these call sites means faking the whole native enumeration surface — `EnumDisplayMonitors`, `GetMonitorInfo`, `GetPhysicalMonitorsFromHMONITOR` — which is a larger seam than a one-file leak fix should introduce. The paths were verified by reading instead. Happy to add the seam if a maintainer would rather have it covered.

### Known remaining leaks, deliberately out of scope

- `GetPhysicalMonitorsWithRetryAsync`'s retry loop discards a whole array of live handles when it retries after seeing NULL handles.
- Cancellation unwinds `DiscoverMonitorsAsync` before `UpdateHandleMap` runs, so that pass's handles never enter the map and are never destroyed.

Both predate this change and are better addressed separately.

## Validation Steps Performed

- built `PowerDisplay.Lib` and `PowerDisplay.Lib.UnitTests` for x64 Debug with VS MSBuild — 0 errors, 0 warnings
- ran `PowerDisplay.Lib.UnitTests.dll` with `vstest.console.exe`: **186 passed, 0 failed** — no new tests; this only confirms nothing regressed
- no hardware validation performed: reaching an abandon path needs a monitor whose capabilities fetch fails or whose construction throws
