### PR TITLE
[PowerDisplay] Run the tray Exit through Shutdown so teardown is not skipped

### DIFF
--- a/src/modules/powerdisplay/PowerDisplay/PowerDisplayXAML/App.xaml.cs
+++ b/src/modules/powerdisplay/PowerDisplay/PowerDisplayXAML/App.xaml.cs
@@ -176,7 +176,7 @@ namespace PowerDisplay
                 _trayIconService = new TrayIconService(
                     _settingsUtils,
                     ToggleMainWindow,
-                    () => Environment.Exit(0),
+                    Shutdown,
                     OpenSettings);
                 _trayIconService.SetupTrayIcon();
                 Logger.LogTrace("OnLaunched: TrayIconService initialized");


### PR DESCRIPTION
## Summary of the Pull Request

PowerDisplay's tray context menu **Exit** ended the process with
`Environment.Exit(0)`, skipping the teardown that `App.Shutdown()` already
performs. Point it at `Shutdown()` instead — a one-line change.

What Exit was skipping:

- `TrayIconService.Destroy()` — `Shell_NotifyIcon(NIM_DELETE)`, the icon and
  popup-menu handles, and restoring the subclassed window procedure. Without the
  `NIM_DELETE`, the notification area can keep showing a stale PowerDisplay icon
  until the Shell next validates it, which in practice is when the pointer passes
  over it.
- `MainWindow.Dispose()` — which cancels the CLI named-pipe server's
  `CancellationTokenSource` and disposes the hotkey service, the message hook and
  `MainViewModel` (monitor manager, display-change watcher, per-monitor view
  models).

`Environment.Exit` does not run finalizers, so none of that happened by another
route.

The named-pipe terminate message (`PowerDisplayTerminateAppMessage`) has always
gone through `Shutdown()`, so this only makes the tray menu agree with a path
that is already shipping. The tray menu command is dispatched from the
subclassed main-window procedure, so it already runs on the UI thread that owns
these objects, and `Shutdown()` still ends with `Environment.Exit(0)` — the
process exits unconditionally either way.

## PR Checklist

- [ ] Closes: #xxx — no filed issue. Found while working on #49410; split out so
      it can be reviewed on its own.
- [ ] **Communication:** I've discussed this with core contributors already. If
      the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass — none added. The change is
      process-exit wiring inside `App.OnLaunched`, which has no test harness;
      validated manually.
- [x] **Localization:** All end-user-facing strings can be localized — no new or
      changed strings.
- [ ] **Dev docs:** Added/updated — no doc change warranted for a one-line
      teardown fix.
- [ ] **New binaries:** Added on the required places — none.
- [ ] **Documentation updated:** no user-facing behaviour change.

## Detailed Description of the Pull Request / Additional comments

### Deliberately not in scope

Two other paths still call `Environment.Exit(0)` directly, and both are
pre-existing and unchanged here:

- The runner **Terminate** event (`Constants.TerminatePowerDisplayEvent()`) —
  the module-disable and PowerToys-exit path. Its callback is already marshalled
  to the UI thread by `NativeEventWaiter`, so it *could* be routed the same way,
  but adding teardown work to the runner's shutdown path should be validated
  against the runner's shutdown timeout on its own rather than riding along with
  a tray-menu fix.
- The `RunnerHelper.WaitForPowerToysRunner` watchdog, whose callback runs on a
  background thread and would need marshalling to the UI thread first.

Happy to follow up on either if reviewers would rather see them fixed together.

## Validation Steps Performed

- Tray icon → right-click → **Exit**: PowerDisplay exits, the notification icon
  disappears immediately rather than lingering until hover.
- Re-launch from PowerToys Settings after a tray Exit: the tray icon comes back
  once, not twice.
- `powerdisplay` CLI still works after a launch/tray-Exit/launch cycle,
  confirming the named pipe was released rather than left to process teardown.
- Existing terminate paths unchanged: disabling PowerDisplay in Settings and
  quitting PowerToys both still exit the process.
