### PR TITLE
[Screen Ruler] Add DIP as an extra measurement unit

### DIFF
--- a/PowerToys.slnx
+++ b/PowerToys.slnx
@@ -795,6 +795,7 @@
     </Project>
   </Folder>
   <Folder Name="/modules/MeasureTool/Tests/">
+    <Project Path="src/modules/MeasureTool/Tests/MeasureToolCore.UnitTests/MeasureToolCore.UnitTests.vcxproj" Id="1b76e770-b56f-486f-89d9-9dfe7c5289e8" />
     <Project Path="src/modules/MeasureTool/Tests/ScreenRuler.UITests/ScreenRuler.UITests.csproj">
       <Platform Solution="*|ARM64" Project="ARM64" />
       <Platform Solution="*|x64" Project="x64" />

--- a/doc/devdocs/modules/screenruler.md
+++ b/doc/devdocs/modules/screenruler.md
@@ -10,7 +10,7 @@
 
 ## Overview
 
-Screen Ruler (project name: MeasureTool or Measure 2) is a PowerToys module that allows users to measure pixel distances and detect color boundaries on the screen. The tool renders an overlay UI using DirectX and provides several measurement utilities.
+Screen Ruler (project name: MeasureTool or Measure 2) is a PowerToys module that allows users to measure distances and detect color boundaries on the screen. Measurements can be displayed in physical pixels, display-independent pixels (DIP), inches, centimeters, or millimeters. The tool renders an overlay UI using DirectX and provides several measurement utilities.
 
 ## Features
 

--- a/doc/devdocs/modules/screenruler.md
+++ b/doc/devdocs/modules/screenruler.md
@@ -10,7 +10,7 @@
 
 ## Overview
 
-Screen Ruler (project name: MeasureTool or Measure 2) is a PowerToys module that allows users to measure distances and detect color boundaries on the screen. Measurements can be displayed in physical pixels, display-independent pixels (DIP), inches, centimeters, or millimeters. The tool renders an overlay UI using DirectX and provides several measurement utilities.
+Screen Ruler (project name: MeasureTool or Measure 2) is a PowerToys module that allows users to measure distances and detect color boundaries on the screen. Measurements are always displayed in physical pixels and can optionally include display-independent pixels (DIP), inches, centimeters, or millimeters. The tool renders an overlay UI using DirectX and provides several measurement utilities.
 
 ## Features
 

--- a/src/modules/MeasureTool/MeasureToolCore/BoundsToolOverlayUI.cpp
+++ b/src/modules/MeasureTool/MeasureToolCore/BoundsToolOverlayUI.cpp
@@ -9,7 +9,7 @@
 
 namespace
 {
-    Measurement GetMeasurement(const CursorDrag& currentBounds, POINT cursorPos, float px2mmRatio)
+    Measurement GetMeasurement(const CursorDrag& currentBounds, POINT cursorPos, float px2mmRatio, float monitorDpi)
     {
         D2D1_RECT_F rect;
         std::tie(rect.left, rect.right) =
@@ -17,7 +17,7 @@ namespace
         std::tie(rect.top, rect.bottom) =
             std::minmax(static_cast<float>(cursorPos.y), currentBounds.startPos.y);
 
-        return Measurement(rect, px2mmRatio);
+        return Measurement(rect, px2mmRatio, monitorDpi);
     }
 
     void CopyToClipboard(HWND window, const BoundsToolState& toolState, POINT cursorPos)
@@ -30,7 +30,8 @@ namespace
             if (handle == window && perScreen.currentBounds)
             {
                 auto px2mmRatio = toolState.commonState->GetPhysicalPx2MmRatio(window);
-                allMeasurements.push_back(GetMeasurement(*perScreen.currentBounds, cursorPos, px2mmRatio));
+                auto monitorDpi = toolState.commonState->GetScreenDpi(window);
+                allMeasurements.push_back(GetMeasurement(*perScreen.currentBounds, cursorPos, px2mmRatio, monitorDpi));
             }
         }
 
@@ -87,7 +88,8 @@ namespace
         if (const bool shiftPress = GetKeyState(VK_SHIFT) & 0x80000; shiftPress && perScreen.currentBounds)
         {
             auto px2mmRatio = toolState->commonState->GetPhysicalPx2MmRatio(window);
-            perScreen.measurements.push_back(GetMeasurement(*perScreen.currentBounds, cursorPos, px2mmRatio));
+            auto monitorDpi = toolState->commonState->GetScreenDpi(window);
+            perScreen.measurements.push_back(GetMeasurement(*perScreen.currentBounds, cursorPos, px2mmRatio, monitorDpi));
         }
 
         perScreen.currentBounds = std::nullopt;
@@ -276,7 +278,7 @@ namespace
                               text.buffer.size(),
                               true,
                               true,
-                              commonState.units | Measurement::Unit::Pixel); // Always show pixels.
+                              commonState.units);
 
         D2D_POINT_2F textBoxPos;
         if (textBoxCenter)
@@ -317,6 +319,7 @@ void DrawBoundsToolTick(const CommonState& commonState,
         std::tie(rect.left, rect.right) = std::minmax(perScreen.currentBounds->startPos.x, perScreen.currentBounds->currentPos.x);
         std::tie(rect.top, rect.bottom) = std::minmax(perScreen.currentBounds->startPos.y, perScreen.currentBounds->currentPos.y);
         auto px2mmRatio = toolState.commonState->GetPhysicalPx2MmRatio(window);
-        DrawMeasurement(Measurement{ rect, px2mmRatio }, commonState, window, d2dState, perScreen.currentBounds->currentPos);
+        auto monitorDpi = toolState.commonState->GetScreenDpi(window);
+        DrawMeasurement(Measurement{ rect, px2mmRatio, monitorDpi }, commonState, window, d2dState, perScreen.currentBounds->currentPos);
     }
 }

--- a/src/modules/MeasureTool/MeasureToolCore/BoundsToolOverlayUI.cpp
+++ b/src/modules/MeasureTool/MeasureToolCore/BoundsToolOverlayUI.cpp
@@ -278,7 +278,7 @@ namespace
                               text.buffer.size(),
                               true,
                               true,
-                              commonState.units);
+                              commonState.units | Measurement::Unit::Pixel); // Always show pixels.
 
         D2D_POINT_2F textBoxPos;
         if (textBoxCenter)

--- a/src/modules/MeasureTool/MeasureToolCore/MeasureToolOverlayUI.cpp
+++ b/src/modules/MeasureTool/MeasureToolCore/MeasureToolOverlayUI.cpp
@@ -147,7 +147,7 @@ namespace
                               text.buffer.size(),
                               drawHorizontalCrossLine,
                               drawVerticalCrossLine,
-                              commonState.units | Measurement::Unit::Pixel); // Always show pixels.
+                              commonState.units);
 
         d2dState.DrawTextBox(text.buffer.data(),
                              measureStringBufLen,

--- a/src/modules/MeasureTool/MeasureToolCore/MeasureToolOverlayUI.cpp
+++ b/src/modules/MeasureTool/MeasureToolCore/MeasureToolOverlayUI.cpp
@@ -147,7 +147,7 @@ namespace
                               text.buffer.size(),
                               drawHorizontalCrossLine,
                               drawVerticalCrossLine,
-                              commonState.units);
+                              commonState.units | Measurement::Unit::Pixel); // Always show pixels.
 
         d2dState.DrawTextBox(text.buffer.data(),
                              measureStringBufLen,

--- a/src/modules/MeasureTool/MeasureToolCore/Measurement.cpp
+++ b/src/modules/MeasureTool/MeasureToolCore/Measurement.cpp
@@ -2,7 +2,6 @@
 
 #include "Measurement.h"
 
-#include <array>
 #include <iostream>
 
 Measurement::Measurement(RECT winRect, float px2mmRatio, float monitorDpi) :
@@ -65,15 +64,98 @@ Measurement::PrintResult Measurement::Print(wchar_t* buf,
                                             const size_t bufSize,
                                             const bool printWidth,
                                             const bool printHeight,
-                                            const Unit units) const
+                                            const int units) const
 {
-    return MeasurementLogic::Format(buf,
-                                    bufSize,
-                                    printWidth,
-                                    printHeight,
-                                    Width(units),
-                                    Height(units),
-                                    GetUnitAbbreviation(units));
+    PrintResult result;
+
+    auto print = [=, &result](Measurement::Unit unit, const bool paren) {
+        if (paren)
+        {
+            result.strLen += swprintf_s(buf + result.strLen, bufSize - result.strLen, printWidth && printHeight ? L"\n(" : L" (");
+        }
+        if (printWidth)
+        {
+            result.strLen += swprintf_s(buf + result.strLen,
+                                        bufSize - result.strLen,
+                                        L"%.4g",
+                                        Width(unit));
+            if (printHeight)
+            {
+                result.crossSymbolPos[paren] = result.strLen + 1;
+                result.strLen += swprintf_s(buf + result.strLen,
+                                            bufSize - result.strLen,
+                                            L" \x00D7 ");
+            }
+        }
+        if (printHeight)
+        {
+            result.strLen += swprintf_s(buf + result.strLen,
+                                        bufSize - result.strLen,
+                                        L"%.4g",
+                                        Height(unit));
+        }
+        switch (unit)
+        {
+        case Measurement::Unit::Pixel:
+            result.strLen += swprintf_s(buf + result.strLen,
+                                        bufSize - result.strLen,
+                                        L" %s",
+                                        Measurement::GetUnitAbbreviation(unit));
+            break;
+        case Measurement::Unit::Inch:
+            result.strLen += swprintf_s(buf + result.strLen,
+                                        bufSize - result.strLen,
+                                        L" %s",
+                                        Measurement::GetUnitAbbreviation(unit));
+            break;
+        case Measurement::Unit::Centimetre:
+            result.strLen += swprintf_s(buf + result.strLen,
+                                        bufSize - result.strLen,
+                                        L" %s",
+                                        Measurement::GetUnitAbbreviation(unit));
+
+            break;
+        case Measurement::Unit::Millimetre:
+            result.strLen += swprintf_s(buf + result.strLen,
+                                        bufSize - result.strLen,
+                                        L" %s",
+                                        Measurement::GetUnitAbbreviation(unit));
+
+            break;
+        case Measurement::Unit::Dip:
+            result.strLen += swprintf_s(buf + result.strLen,
+                                        bufSize - result.strLen,
+                                        L" %s",
+                                        Measurement::GetUnitAbbreviation(unit));
+            break;
+        }
+        if (paren)
+        {
+            result.strLen += swprintf_s(buf + result.strLen, bufSize - result.strLen, L")");
+        }
+    };
+
+    int count = 0;
+    const Measurement::Unit allUnits[] = {
+        Measurement::Unit::Pixel,
+        Measurement::Unit::Dip,
+        Measurement::Unit::Millimetre,
+        Measurement::Unit::Inch,
+        Measurement::Unit::Centimetre,
+    };
+    // We only use two units at most, it would be to long otherwise.
+    for each (Measurement::Unit unit in allUnits)
+    {
+        if ((unit & units) == unit)
+        {
+            count += 1;
+            if (count > 2)
+                break;
+            print(unit, count != 1);
+        }
+    }
+
+    return result;
 }
 
 void Measurement::PrintToStream(std::wostream& stream,
@@ -87,7 +169,23 @@ void Measurement::PrintToStream(std::wostream& stream,
         stream << std::endl;
     }
 
-    std::array<wchar_t, 128> buffer{};
-    const auto result = Print(buffer.data(), buffer.size(), printWidth, printHeight, units);
-    stream.write(buffer.data(), result.strLen);
+    if (printWidth)
+    {
+        stream << Width(units);
+        if (printHeight)
+        {
+            stream << L" \x00D7 ";
+        }
+    }
+
+    if (printHeight)
+    {
+        stream << Height(units);
+    }
+
+    // If the unit is pixels, then the abbreviation will not be saved as it used to be.
+    if (units != Measurement::Unit::Pixel)
+    {
+        stream << L" " << Measurement::GetUnitAbbreviation(units);
+    }
 }

--- a/src/modules/MeasureTool/MeasureToolCore/Measurement.cpp
+++ b/src/modules/MeasureTool/MeasureToolCore/Measurement.cpp
@@ -2,10 +2,11 @@
 
 #include "Measurement.h"
 
+#include <array>
 #include <iostream>
 
-Measurement::Measurement(RECT winRect, float px2mmRatio) :
-    px2mmRatio{ px2mmRatio }
+Measurement::Measurement(RECT winRect, float px2mmRatio, float monitorDpi) :
+    px2mmRatio{ px2mmRatio }, monitorDpi{ monitorDpi }
 {
     rect.left = static_cast<float>(winRect.left);
     rect.right = static_cast<float>(winRect.right);
@@ -13,77 +14,21 @@ Measurement::Measurement(RECT winRect, float px2mmRatio) :
     rect.bottom = static_cast<float>(winRect.bottom);
 }
 
-Measurement::Measurement(D2D1_RECT_F d2dRect, float px2mmRatio) :
-    rect{ d2dRect }, px2mmRatio{ px2mmRatio }
+Measurement::Measurement(D2D1_RECT_F d2dRect, float px2mmRatio, float monitorDpi) :
+    rect{ d2dRect }, px2mmRatio{ px2mmRatio }, monitorDpi{ monitorDpi }
 {
 }
 
-namespace
-{
-    inline float Convert(const float pixels, const Measurement::Unit units, float px2mmRatio)
-    {
-        if (px2mmRatio > 0)
-        {
-            switch (units)
-            {
-            case Measurement::Unit::Pixel:
-                return pixels;
-            case Measurement::Unit::Inch:
-                return pixels * px2mmRatio / 10.0f / 2.54f;
-            case Measurement::Unit::Centimetre:
-                return pixels * px2mmRatio / 10.0f;
-            case Measurement::Unit::Millimetre:
-                return pixels * px2mmRatio;
-            default:
-                return pixels;
-            }
-        }
-        else
-        {
-            switch (units)
-            {
-            case Measurement::Unit::Pixel:
-                return pixels;
-            case Measurement::Unit::Inch:
-                return pixels / 96.0f;
-            case Measurement::Unit::Centimetre:
-                return pixels / 96.0f * 2.54f;
-            case Measurement::Unit::Millimetre:
-                return pixels / 96.0f / 10.0f * 2.54f;
-            default:
-                return pixels;
-            }
-        }
-    }
-}
-
-winrt::hstring Measurement::abbreviations[4]{};
+winrt::hstring Measurement::abbreviations[5]{};
 
 inline float Measurement::Width(const Unit units) const
 {
-    return Convert(rect.right - rect.left + 1.f, units, px2mmRatio);
+    return MeasurementLogic::Convert(rect.right - rect.left + 1.f, units, px2mmRatio, monitorDpi);
 }
 
 inline float Measurement::Height(const Unit units) const
 {
-    return Convert(rect.bottom - rect.top + 1.f, units, px2mmRatio);
-}
-
-Measurement::Unit Measurement::GetUnitFromIndex(int index)
-{
-    switch (index)
-    {
-    case 0:
-        return Measurement::Unit::Pixel;
-    case 1:
-        return Measurement::Unit::Inch;
-    case 2:
-        return Measurement::Unit::Centimetre;
-    case 3:
-        return Measurement::Unit::Millimetre;
-    default:
-        return Measurement::Unit::Pixel;
-    }
+    return MeasurementLogic::Convert(rect.bottom - rect.top + 1.f, units, px2mmRatio, monitorDpi);
 }
 
 void Measurement::InitResources()
@@ -94,6 +39,7 @@ void Measurement::InitResources()
     abbreviations[1] = mm.GetValue(L"Resources/MeasurementUnitAbbrInch").ValueAsString();
     abbreviations[2] = mm.GetValue(L"Resources/MeasurementUnitAbbrCentimetre").ValueAsString();
     abbreviations[3] = mm.GetValue(L"Resources/MeasurementUnitAbbrMillimetre").ValueAsString();
+    abbreviations[4] = mm.GetValue(L"Resources/MeasurementUnitAbbrDip").ValueAsString();
 }
 
 const wchar_t* Measurement::GetUnitAbbreviation(Measurement::Unit units)
@@ -108,6 +54,8 @@ const wchar_t* Measurement::GetUnitAbbreviation(Measurement::Unit units)
         return abbreviations[2].c_str();
     case Unit::Millimetre:
         return abbreviations[3].c_str();
+    case Unit::Dip:
+        return abbreviations[4].c_str();
     default:
         return L"??";
     }
@@ -117,91 +65,15 @@ Measurement::PrintResult Measurement::Print(wchar_t* buf,
                                             const size_t bufSize,
                                             const bool printWidth,
                                             const bool printHeight,
-                                            const int units) const
+                                            const Unit units) const
 {
-    PrintResult result;
-
-    auto print = [=, &result](Measurement::Unit unit, const bool paren) {
-        if (paren)
-        {
-            result.strLen += swprintf_s(buf + result.strLen, bufSize - result.strLen, printWidth && printHeight ? L"\n(" : L" (");
-        }
-        if (printWidth)
-        {
-            result.strLen += swprintf_s(buf + result.strLen,
-                                        bufSize - result.strLen,
-                                        L"%.4g",
-                                        Width(unit));
-            if (printHeight)
-            {
-                result.crossSymbolPos[paren] = result.strLen + 1;
-                result.strLen += swprintf_s(buf + result.strLen,
-                                            bufSize - result.strLen,
-                                            L" \x00D7 ");
-            }
-        }
-        if (printHeight)
-        {
-            result.strLen += swprintf_s(buf + result.strLen,
-                                        bufSize - result.strLen,
-                                        L"%.4g",
-                                        Height(unit));
-        }
-        switch (unit)
-        {
-        case Measurement::Unit::Pixel:
-            result.strLen += swprintf_s(buf + result.strLen,
-                                        bufSize - result.strLen,
-                                        L" %s",
-                                        Measurement::GetUnitAbbreviation(unit));
-            break;
-        case Measurement::Unit::Inch:
-            result.strLen += swprintf_s(buf + result.strLen,
-                                        bufSize - result.strLen,
-                                        L" %s",
-                                        Measurement::GetUnitAbbreviation(unit));
-            break;
-        case Measurement::Unit::Centimetre:
-            result.strLen += swprintf_s(buf + result.strLen,
-                                        bufSize - result.strLen,
-                                        L" %s",
-                                        Measurement::GetUnitAbbreviation(unit));
-
-            break;
-        case Measurement::Unit::Millimetre:
-            result.strLen += swprintf_s(buf + result.strLen,
-                                        bufSize - result.strLen,
-                                        L" %s",
-                                        Measurement::GetUnitAbbreviation(unit));
-
-            break;
-        }
-        if (paren)
-        {
-            result.strLen += swprintf_s(buf + result.strLen, bufSize - result.strLen, L")");
-        }
-    };
-
-    int count = 0;
-    const Measurement::Unit allUnits[] = {
-        Measurement::Unit::Pixel,
-        Measurement::Unit::Millimetre,
-        Measurement::Unit::Inch,
-        Measurement::Unit::Centimetre,
-    };
-    // We only use two units at most, it would be to long otherwise.
-    for each (Measurement::Unit unit in allUnits)
-    {
-        if ((unit & units) == unit)
-        {
-            count += 1;
-            if (count > 2)
-                break;
-            print(unit, count != 1);
-        }
-    }
-
-    return result;
+    return MeasurementLogic::Format(buf,
+                                    bufSize,
+                                    printWidth,
+                                    printHeight,
+                                    Width(units),
+                                    Height(units),
+                                    GetUnitAbbreviation(units));
 }
 
 void Measurement::PrintToStream(std::wostream& stream,
@@ -215,23 +87,7 @@ void Measurement::PrintToStream(std::wostream& stream,
         stream << std::endl;
     }
 
-    if (printWidth)
-    {
-        stream << Width(units);
-        if (printHeight)
-        {
-            stream << L" \x00D7 ";
-        }
-    }
-
-    if (printHeight)
-    {
-        stream << Height(units);
-    }
-
-    // If the unit is pixels, then the abbreviation will not be saved as it used to be.
-    if (units != Measurement::Unit::Pixel)
-    {
-        stream << L" " << Measurement::GetUnitAbbreviation(units);
-    }
+    std::array<wchar_t, 128> buffer{};
+    const auto result = Print(buffer.data(), buffer.size(), printWidth, printHeight, units);
+    stream.write(buffer.data(), result.strLen);
 }

--- a/src/modules/MeasureTool/MeasureToolCore/Measurement.h
+++ b/src/modules/MeasureTool/MeasureToolCore/Measurement.h
@@ -5,45 +5,42 @@
 #include <windef.h>
 #include <iosfwd>
 
+#include "MeasurementLogic.h"
+
 struct Measurement
 {
-    enum Unit
-    {
-        Pixel = 1,
-        Inch = 2,
-        Centimetre = 4,
-        Millimetre = 8,
-    };
+    using Unit = MeasurementLogic::Unit;
 
     D2D1_RECT_F rect = {}; // corners are inclusive
 
     float px2mmRatio = 0;
-    static winrt::hstring abbreviations[4]; // Abbreviations of units.
+    float monitorDpi = MeasurementLogic::DefaultDpi;
+    static winrt::hstring abbreviations[5]; // Abbreviations of units.
 
     Measurement(const Measurement&) = default;
     Measurement& operator=(const Measurement&) = default;
 
-    explicit Measurement(D2D1_RECT_F d2dRect, float px2mmRatio);
-    explicit Measurement(RECT winRect, float px2mmRatio);
+    explicit Measurement(D2D1_RECT_F d2dRect, float px2mmRatio, float monitorDpi);
+    explicit Measurement(RECT winRect, float px2mmRatio, float monitorDpi);
 
     float Width(const Unit units) const;
     float Height(const Unit units) const;
 
-    struct PrintResult
-    {
-        size_t crossSymbolPos[2] = {};
-        size_t strLen = {};
-    };
+    using PrintResult = MeasurementLogic::PrintResult;
 
     static void InitResources();
-    static Unit GetUnitFromIndex(int index);
+    static constexpr Unit GetUnitFromIndex(const int index) noexcept
+    {
+        return MeasurementLogic::GetUnitFromIndex(index);
+    }
+
     static const wchar_t* GetUnitAbbreviation(const Unit units);
 
     PrintResult Print(wchar_t* buf,
                       const size_t bufSize,
                       const bool printWidth,
                       const bool printHeight,
-                      const int units) const;
+                      const Unit units) const;
 
     void PrintToStream(std::wostream& stream,
                        const bool prependNewLine,

--- a/src/modules/MeasureTool/MeasureToolCore/Measurement.h
+++ b/src/modules/MeasureTool/MeasureToolCore/Measurement.h
@@ -26,7 +26,11 @@ struct Measurement
     float Width(const Unit units) const;
     float Height(const Unit units) const;
 
-    using PrintResult = MeasurementLogic::PrintResult;
+    struct PrintResult
+    {
+        size_t crossSymbolPos[2] = {};
+        size_t strLen = {};
+    };
 
     static void InitResources();
     static constexpr Unit GetUnitFromIndex(const int index) noexcept
@@ -40,7 +44,7 @@ struct Measurement
                       const size_t bufSize,
                       const bool printWidth,
                       const bool printHeight,
-                      const Unit units) const;
+                      const int units) const;
 
     void PrintToStream(std::wostream& stream,
                        const bool prependNewLine,

--- a/src/modules/MeasureTool/MeasureToolCore/MeasurementLogic.h
+++ b/src/modules/MeasureTool/MeasureToolCore/MeasurementLogic.h
@@ -1,0 +1,116 @@
+#pragma once
+
+#include <cstddef>
+#include <cwchar>
+
+namespace MeasurementLogic
+{
+    constexpr float DefaultDpi = 96.0f;
+
+    enum Unit
+    {
+        Pixel = 1,
+        Inch = 2,
+        Centimetre = 4,
+        Millimetre = 8,
+        Dip = 16,
+    };
+
+    constexpr Unit GetUnitFromIndex(const int index) noexcept
+    {
+        switch (index)
+        {
+        case 0:
+            return Unit::Pixel;
+        case 1:
+            return Unit::Inch;
+        case 2:
+            return Unit::Centimetre;
+        case 3:
+            return Unit::Millimetre;
+        case 4:
+            return Unit::Dip;
+        default:
+            return Unit::Pixel;
+        }
+    }
+
+    constexpr float Convert(const float pixels, const Unit units, const float px2mmRatio, const float monitorDpi) noexcept
+    {
+        if (units == Unit::Pixel)
+        {
+            return pixels;
+        }
+
+        if (units == Unit::Dip)
+        {
+            return monitorDpi > 0 ? pixels * DefaultDpi / monitorDpi : pixels;
+        }
+
+        if (px2mmRatio > 0)
+        {
+            switch (units)
+            {
+            case Unit::Inch:
+                return pixels * px2mmRatio / 25.4f;
+            case Unit::Centimetre:
+                return pixels * px2mmRatio / 10.0f;
+            case Unit::Millimetre:
+                return pixels * px2mmRatio;
+            default:
+                return pixels;
+            }
+        }
+
+        switch (units)
+        {
+        case Unit::Inch:
+            return pixels / DefaultDpi;
+        case Unit::Centimetre:
+            return pixels / DefaultDpi * 2.54f;
+        case Unit::Millimetre:
+            return pixels / DefaultDpi * 25.4f;
+        default:
+            return pixels;
+        }
+    }
+
+    struct PrintResult
+    {
+        size_t crossSymbolPos[2] = {};
+        size_t strLen = {};
+    };
+
+    inline PrintResult Format(wchar_t* buffer,
+                              const size_t bufferSize,
+                              const bool printWidth,
+                              const bool printHeight,
+                              const float width,
+                              const float height,
+                              const wchar_t* unitAbbreviation)
+    {
+        PrintResult result;
+
+        if (printWidth)
+        {
+            result.strLen += swprintf_s(buffer + result.strLen, bufferSize - result.strLen, L"%.4g", width);
+            if (printHeight)
+            {
+                result.crossSymbolPos[0] = result.strLen + 1;
+                result.strLen += swprintf_s(buffer + result.strLen, bufferSize - result.strLen, L" \x00D7 ");
+            }
+        }
+
+        if (printHeight)
+        {
+            result.strLen += swprintf_s(buffer + result.strLen, bufferSize - result.strLen, L"%.4g", height);
+        }
+
+        result.strLen += swprintf_s(buffer + result.strLen,
+                                    bufferSize - result.strLen,
+                                    L" %s",
+                                    unitAbbreviation);
+
+        return result;
+    }
+}

--- a/src/modules/MeasureTool/MeasureToolCore/MeasurementLogic.h
+++ b/src/modules/MeasureTool/MeasureToolCore/MeasurementLogic.h
@@ -1,8 +1,5 @@
 #pragma once
 
-#include <cstddef>
-#include <cwchar>
-
 namespace MeasurementLogic
 {
     constexpr float DefaultDpi = 96.0f;
@@ -73,44 +70,5 @@ namespace MeasurementLogic
         default:
             return pixels;
         }
-    }
-
-    struct PrintResult
-    {
-        size_t crossSymbolPos[2] = {};
-        size_t strLen = {};
-    };
-
-    inline PrintResult Format(wchar_t* buffer,
-                              const size_t bufferSize,
-                              const bool printWidth,
-                              const bool printHeight,
-                              const float width,
-                              const float height,
-                              const wchar_t* unitAbbreviation)
-    {
-        PrintResult result;
-
-        if (printWidth)
-        {
-            result.strLen += swprintf_s(buffer + result.strLen, bufferSize - result.strLen, L"%.4g", width);
-            if (printHeight)
-            {
-                result.crossSymbolPos[0] = result.strLen + 1;
-                result.strLen += swprintf_s(buffer + result.strLen, bufferSize - result.strLen, L" \x00D7 ");
-            }
-        }
-
-        if (printHeight)
-        {
-            result.strLen += swprintf_s(buffer + result.strLen, bufferSize - result.strLen, L"%.4g", height);
-        }
-
-        result.strLen += swprintf_s(buffer + result.strLen,
-                                    bufferSize - result.strLen,
-                                    L" %s",
-                                    unitAbbreviation);
-
-        return result;
     }
 }

--- a/src/modules/MeasureTool/MeasureToolCore/PowerToys.MeasureToolCore.vcxproj
+++ b/src/modules/MeasureTool/MeasureToolCore/PowerToys.MeasureToolCore.vcxproj
@@ -82,6 +82,7 @@
     <ClInclude Include="D2DState.h" />
     <ClInclude Include="DxgiAPI.h" />
     <ClInclude Include="Measurement.h" />
+    <ClInclude Include="MeasurementLogic.h" />
     <ClInclude Include="MeasureToolOverlayUI.h" />
     <ClInclude Include="PerGlyphOpacityTextRender.h" />
     <ClInclude Include="resource.h" />

--- a/src/modules/MeasureTool/MeasureToolCore/PowerToys.MeasureToolCore.vcxproj.filters
+++ b/src/modules/MeasureTool/MeasureToolCore/PowerToys.MeasureToolCore.vcxproj.filters
@@ -38,6 +38,7 @@
     <ClInclude Include="resource.h" />
     <ClInclude Include="CoordinateSystemConversion.h" />
     <ClInclude Include="Measurement.h" />
+    <ClInclude Include="MeasurementLogic.h" />
     <ClInclude Include="DxgiAPI.h" />
   </ItemGroup>
   <ItemGroup>

--- a/src/modules/MeasureTool/MeasureToolCore/ScreenCapturing.cpp
+++ b/src/modules/MeasureTool/MeasureToolCore/ScreenCapturing.cpp
@@ -295,6 +295,7 @@ void UpdateCaptureState(const CommonState& commonState,
                                     perColorChannelEdgeDetection,
                                     pixelTolerance);
     auto px2mmRatio = commonState.GetPhysicalPx2MmRatio(window);
+    auto monitorDpi = commonState.GetScreenDpi(window);
 
 #if defined(DEBUG_EDGES)
     char buffer[256];
@@ -312,7 +313,7 @@ void UpdateCaptureState(const CommonState& commonState,
     OutputDebugStringA(buffer);
 #endif
     state.Access([&](MeasureToolState& state) {
-        state.perScreen[window].measuredEdges = Measurement{ bounds, px2mmRatio };
+        state.perScreen[window].measuredEdges = Measurement{ bounds, px2mmRatio, monitorDpi };
     });
 }
 

--- a/src/modules/MeasureTool/MeasureToolCore/ToolState.h
+++ b/src/modules/MeasureTool/MeasureToolCore/ToolState.h
@@ -11,6 +11,7 @@
 #include <d2d1helper.h>
 #include <dCommon.h>
 
+#include <common/Display/dpi_aware.h>
 #include <common/Display/monitors.h>
 #include <common/utils/serialized.h>
 
@@ -47,6 +48,13 @@ struct CommonState
             ratio = size.width_mm / static_cast<float>(size.width_physical);
         }
         return ratio;
+    }
+
+    float GetScreenDpi(HWND window) const
+    {
+        unsigned int dpi = DPIAware::DEFAULT_DPI;
+        DPIAware::GetScreenDPIForWindow(window, dpi);
+        return static_cast<float>(dpi);
     }
 };
 

--- a/src/modules/MeasureTool/MeasureToolUI/Strings/en-us/Resources.resw
+++ b/src/modules/MeasureTool/MeasureToolUI/Strings/en-us/Resources.resw
@@ -69,6 +69,9 @@
     <data name="MeasurementUnitAbbrPixel" xml:space="preserve">
         <value>px</value>
     </data>
+    <data name="MeasurementUnitAbbrDip" xml:space="preserve">
+        <value>DIP</value>
+    </data>
     <data name="MeasurementUnitAbbrInch" xml:space="preserve">
         <value>in</value>
     </data>

--- a/src/modules/MeasureTool/Tests/MeasureToolCore.UnitTests/MeasureToolCore.UnitTests.vcxproj
+++ b/src/modules/MeasureTool/Tests/MeasureToolCore.UnitTests/MeasureToolCore.UnitTests.vcxproj
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <ProjectGuid>{1B76E770-B56F-486F-89D9-9DFE7C5289E8}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>MeasureToolCoreUnitTests</RootNamespace>
+    <ProjectSubType>NativeUnitTestProject</ProjectSubType>
+    <ProjectName>MeasureToolCore.UnitTests</ProjectName>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseOfMfc>false</UseOfMfc>
+    <UsePrecompiledHeaders>false</UsePrecompiledHeaders>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="Shared" />
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <OutDir>$(RepoRoot)$(Platform)\$(Configuration)\tests\MeasureToolCore\</OutDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\MeasureToolCore;$(RepoRoot)src\;$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NOMINMAX;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <UseFullPaths>true</UseFullPaths>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+    </ClCompile>
+    <Link>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="MeasurementLogicTests.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\MeasureToolCore\MeasurementLogic.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets" />
+</Project>

--- a/src/modules/MeasureTool/Tests/MeasureToolCore.UnitTests/MeasurementLogicTests.cpp
+++ b/src/modules/MeasureTool/Tests/MeasureToolCore.UnitTests/MeasurementLogicTests.cpp
@@ -5,9 +5,6 @@
 
 #include "MeasurementLogic.h"
 
-#include <array>
-#include <string>
-
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
 namespace MeasureToolCoreUnitTests
@@ -15,24 +12,6 @@ namespace MeasureToolCoreUnitTests
     namespace
     {
         constexpr float Tolerance = 0.0001f;
-
-        std::wstring Format(const float width,
-                            const float height,
-                            const bool printWidth,
-                            const bool printHeight,
-                            const wchar_t* abbreviation)
-        {
-            std::array<wchar_t, 128> buffer{};
-            const auto result = MeasurementLogic::Format(
-                buffer.data(),
-                buffer.size(),
-                printWidth,
-                printHeight,
-                width,
-                height,
-                abbreviation);
-            return std::wstring(buffer.data(), result.strLen);
-        }
     }
 
     TEST_CLASS (MeasurementLogicTests)
@@ -113,13 +92,5 @@ namespace MeasureToolCoreUnitTests
             Assert::IsTrue(MeasurementLogic::GetUnitFromIndex(5) == MeasurementLogic::Unit::Pixel);
         }
 
-        TEST_METHOD (FormattingProducesOneUnitAndSuffix)
-        {
-            Assert::AreEqual(std::wstring(L"150 \x00D7 100 px"), Format(150.0f, 100.0f, true, true, L"px"));
-            Assert::AreEqual(std::wstring(L"100 \x00D7 66.67 DIP"), Format(100.0f, 66.6667f, true, true, L"DIP"));
-            Assert::AreEqual(std::wstring(L"25.4 mm"), Format(25.4f, 0.0f, true, false, L"mm"));
-            Assert::AreEqual(std::wstring(L"2.54 cm"), Format(0.0f, 2.54f, false, true, L"cm"));
-            Assert::AreEqual(std::wstring(L"1 in"), Format(1.0f, 0.0f, true, false, L"in"));
-        }
     };
 }

--- a/src/modules/MeasureTool/Tests/MeasureToolCore.UnitTests/MeasurementLogicTests.cpp
+++ b/src/modules/MeasureTool/Tests/MeasureToolCore.UnitTests/MeasurementLogicTests.cpp
@@ -1,0 +1,125 @@
+#pragma warning(push)
+#pragma warning(disable : 26466)
+#include "CppUnitTest.h"
+#pragma warning(pop)
+
+#include "MeasurementLogic.h"
+
+#include <array>
+#include <string>
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace MeasureToolCoreUnitTests
+{
+    namespace
+    {
+        constexpr float Tolerance = 0.0001f;
+
+        std::wstring Format(const float width,
+                            const float height,
+                            const bool printWidth,
+                            const bool printHeight,
+                            const wchar_t* abbreviation)
+        {
+            std::array<wchar_t, 128> buffer{};
+            const auto result = MeasurementLogic::Format(
+                buffer.data(),
+                buffer.size(),
+                printWidth,
+                printHeight,
+                width,
+                height,
+                abbreviation);
+            return std::wstring(buffer.data(), result.strLen);
+        }
+    }
+
+    TEST_CLASS (MeasurementLogicTests)
+    {
+    public:
+        TEST_METHOD (PixelsAreUnchangedAtEveryScale)
+        {
+            for (const float dpi : { 96.0f, 120.0f, 144.0f, 192.0f })
+            {
+                Assert::AreEqual(
+                    150.0f,
+                    MeasurementLogic::Convert(150.0f, MeasurementLogic::Unit::Pixel, -1.0f, dpi),
+                    Tolerance);
+            }
+        }
+
+        TEST_METHOD (DipConversionUsesMonitorDpi)
+        {
+            const struct
+            {
+                float dpi;
+                float expected;
+            } testCases[] = {
+                { 96.0f, 150.0f },
+                { 120.0f, 120.0f },
+                { 144.0f, 100.0f },
+                { 192.0f, 75.0f },
+            };
+
+            for (const auto& testCase : testCases)
+            {
+                Assert::AreEqual(
+                    testCase.expected,
+                    MeasurementLogic::Convert(150.0f, MeasurementLogic::Unit::Dip, -1.0f, testCase.dpi),
+                    Tolerance);
+            }
+        }
+
+        TEST_METHOD (PhysicalUnitFallbackUses96Dpi)
+        {
+            Assert::AreEqual(
+                1.0f,
+                MeasurementLogic::Convert(96.0f, MeasurementLogic::Unit::Inch, -1.0f, 96.0f),
+                Tolerance);
+            Assert::AreEqual(
+                2.54f,
+                MeasurementLogic::Convert(96.0f, MeasurementLogic::Unit::Centimetre, -1.0f, 96.0f),
+                Tolerance);
+            Assert::AreEqual(
+                25.4f,
+                MeasurementLogic::Convert(96.0f, MeasurementLogic::Unit::Millimetre, -1.0f, 96.0f),
+                Tolerance);
+        }
+
+        TEST_METHOD (PhysicalMonitorRatioRemainsPreferred)
+        {
+            Assert::AreEqual(
+                1.0f,
+                MeasurementLogic::Convert(100.0f, MeasurementLogic::Unit::Inch, 0.254f, 192.0f),
+                Tolerance);
+            Assert::AreEqual(
+                2.54f,
+                MeasurementLogic::Convert(100.0f, MeasurementLogic::Unit::Centimetre, 0.254f, 192.0f),
+                Tolerance);
+            Assert::AreEqual(
+                25.4f,
+                MeasurementLogic::Convert(100.0f, MeasurementLogic::Unit::Millimetre, 0.254f, 192.0f),
+                Tolerance);
+        }
+
+        TEST_METHOD (UnitIndexesPreservePersistedMeanings)
+        {
+            Assert::IsTrue(MeasurementLogic::GetUnitFromIndex(0) == MeasurementLogic::Unit::Pixel);
+            Assert::IsTrue(MeasurementLogic::GetUnitFromIndex(1) == MeasurementLogic::Unit::Inch);
+            Assert::IsTrue(MeasurementLogic::GetUnitFromIndex(2) == MeasurementLogic::Unit::Centimetre);
+            Assert::IsTrue(MeasurementLogic::GetUnitFromIndex(3) == MeasurementLogic::Unit::Millimetre);
+            Assert::IsTrue(MeasurementLogic::GetUnitFromIndex(4) == MeasurementLogic::Unit::Dip);
+            Assert::IsTrue(MeasurementLogic::GetUnitFromIndex(5) == MeasurementLogic::Unit::Pixel);
+        }
+
+        TEST_METHOD (FormattingProducesOneUnitAndSuffix)
+        {
+            Assert::AreEqual(std::wstring(L"150 \x00D7 100 px"), Format(150.0f, 100.0f, true, true, L"px"));
+            Assert::AreEqual(std::wstring(L"100 \x00D7 66.67 DIP"), Format(100.0f, 66.6667f, true, true, L"DIP"));
+            Assert::AreEqual(std::wstring(L"25.4 mm"), Format(25.4f, 0.0f, true, false, L"mm"));
+            Assert::AreEqual(std::wstring(L"2.54 cm"), Format(0.0f, 2.54f, false, true, L"cm"));
+            Assert::AreEqual(std::wstring(L"1 in"), Format(1.0f, 0.0f, true, false, L"in"));
+        }
+    };
+}

--- a/src/modules/MeasureTool/Tests/ScreenRuler.UITests/TestBounds.cs
+++ b/src/modules/MeasureTool/Tests/ScreenRuler.UITests/TestBounds.cs
@@ -29,9 +29,9 @@ namespace ScreenRuler.UITests
         public void TestScreenRulerBoundsToolDipClipboard()
         {
             TestHelper.InitializeTest(this, "bounds DIP test");
-            TestHelper.SetMeasurementUnit(this, "Display-independent pixels (DIP)");
+            TestHelper.SetExtraMeasurementUnit(this, "Display-independent pixels (DIP)");
             TestHelper.PerformBoundsToolTest(this, "DIP");
-            TestHelper.SetMeasurementUnit(this, "Pixels");
+            TestHelper.SetExtraMeasurementUnit(this, "Show only pixels");
             TestHelper.CleanupTest(this);
         }
     }

--- a/src/modules/MeasureTool/Tests/ScreenRuler.UITests/TestBounds.cs
+++ b/src/modules/MeasureTool/Tests/ScreenRuler.UITests/TestBounds.cs
@@ -23,5 +23,16 @@ namespace ScreenRuler.UITests
             TestHelper.PerformBoundsToolTest(this);
             TestHelper.CleanupTest(this);
         }
+
+        [TestMethod("ScreenRuler.BoundsToolDipClipboard")]
+        [TestCategory("Spacing")]
+        public void TestScreenRulerBoundsToolDipClipboard()
+        {
+            TestHelper.InitializeTest(this, "bounds DIP test");
+            TestHelper.SetMeasurementUnit(this, "Display-independent pixels (DIP)");
+            TestHelper.PerformBoundsToolTest(this, "DIP");
+            TestHelper.SetMeasurementUnit(this, "Pixels");
+            TestHelper.CleanupTest(this);
+        }
     }
 }

--- a/src/modules/MeasureTool/Tests/ScreenRuler.UITests/TestHelper.cs
+++ b/src/modules/MeasureTool/Tests/ScreenRuler.UITests/TestHelper.cs
@@ -22,6 +22,7 @@ namespace ScreenRuler.UITests
         public const string HorizontalSpacingButtonName = "Button_SpacingHorizontal";
         public const string VerticalSpacingButtonName = "Button_SpacingVertical";
         public const string CloseButtonId = "Button_Close";
+        public const string MeasurementUnitComboBoxId = "ComboBox_ScreenRuler_MeasurementUnit";
 
         /// <summary>
         /// Performs common test initialization: navigate to settings, enable toggle, verify shortcut
@@ -37,6 +38,8 @@ namespace ScreenRuler.UITests
             Assert.IsTrue(
                 toggleSwitch.IsOn,
                 $"Screen Ruler toggle switch should be ON for {testName}");
+
+            SetMeasurementUnit(testBase, "Pixels");
 
             var activationKeys = ReadActivationShortcut(testBase);
             Assert.IsNotNull(activationKeys, "Should be able to read activation shortcut");
@@ -97,6 +100,23 @@ namespace ScreenRuler.UITests
             }
 
             return toggleSwitch;
+        }
+
+        /// <summary>
+        /// Select the Screen Ruler measurement unit.
+        /// </summary>
+        public static void SetMeasurementUnit(UITestBase testBase, string unitName)
+        {
+            var comboBox = testBase.Session.Find<ComboBox>(By.AccessibilityId(MeasurementUnitComboBoxId), 5000);
+            Assert.IsNotNull(comboBox, "Measurement unit combo box should be found");
+
+            if (!string.Equals(comboBox.Text, unitName, StringComparison.Ordinal))
+            {
+                comboBox.SelectTxt(unitName);
+                Task.Delay(500).Wait();
+            }
+
+            Assert.AreEqual(unitName, comboBox.Text, "Measurement unit selection should be updated");
         }
 
         /// <summary>
@@ -330,8 +350,8 @@ namespace ScreenRuler.UITests
 
             return spacingType switch
             {
-                "Spacing" => Regex.IsMatch(clipboardText, @"\d+\s*[�x×]\s*\d+"),
-                "Horizontal Spacing" or "Vertical Spacing" => Regex.IsMatch(clipboardText, @"^\d+$"),
+                "Spacing" => Regex.IsMatch(clipboardText, @"^\d+(?:\.\d+)?\s*[x×]\s*\d+(?:\.\d+)?\s+px$"),
+                "Horizontal Spacing" or "Vertical Spacing" => Regex.IsMatch(clipboardText, @"^\d+(?:\.\d+)?\s+px$"),
                 _ => false,
             };
         }
@@ -375,7 +395,7 @@ namespace ScreenRuler.UITests
         /// <summary>
         /// Perform a bounds tool test operation
         /// </summary>
-        public static void PerformBoundsToolTest(UITestBase testBase)
+        public static void PerformBoundsToolTest(UITestBase testBase, string expectedUnit = "px")
         {
             ClearClipboard();
 
@@ -419,9 +439,21 @@ namespace ScreenRuler.UITests
             // Validate results
             string clipboardText = GetClipboardText();
             Assert.IsFalse(string.IsNullOrEmpty(clipboardText), "Clipboard should contain measurement data");
-            Assert.IsTrue(
-                clipboardText.Contains("100 × 100") || clipboardText.Contains("100 x 100"),
-                $"Clipboard should contain '100 x 100', but contained: '{clipboardText}'");
+            if (expectedUnit == "px")
+            {
+                Assert.IsTrue(
+                    clipboardText.Contains("100 × 100 px") || clipboardText.Contains("100 x 100 px"),
+                    $"Clipboard should contain '100 x 100 px', but contained: '{clipboardText}'");
+            }
+            else
+            {
+                Assert.IsTrue(
+                    Regex.IsMatch(
+                        clipboardText,
+                        $@"^\d+(?:\.\d+)?\s*[x×]\s*\d+(?:\.\d+)?\s+{Regex.Escape(expectedUnit)}$"),
+                    $"Clipboard should contain one {expectedUnit} measurement, but contained: '{clipboardText}'");
+                Assert.IsFalse(clipboardText.Contains(" px", StringComparison.Ordinal), "Clipboard should not include an extra pixel measurement");
+            }
 
             // Cleanup - this will handle session attachment properly
             CloseScreenRulerUI(testBase);

--- a/src/modules/MeasureTool/Tests/ScreenRuler.UITests/TestHelper.cs
+++ b/src/modules/MeasureTool/Tests/ScreenRuler.UITests/TestHelper.cs
@@ -22,7 +22,7 @@ namespace ScreenRuler.UITests
         public const string HorizontalSpacingButtonName = "Button_SpacingHorizontal";
         public const string VerticalSpacingButtonName = "Button_SpacingVertical";
         public const string CloseButtonId = "Button_Close";
-        public const string MeasurementUnitComboBoxId = "ComboBox_ScreenRuler_MeasurementUnit";
+        public const string UnitsOfMeasureComboBoxId = "ComboBox_ScreenRuler_UnitsOfMeasure";
 
         /// <summary>
         /// Performs common test initialization: navigate to settings, enable toggle, verify shortcut
@@ -39,7 +39,7 @@ namespace ScreenRuler.UITests
                 toggleSwitch.IsOn,
                 $"Screen Ruler toggle switch should be ON for {testName}");
 
-            SetMeasurementUnit(testBase, "Pixels");
+            SetExtraMeasurementUnit(testBase, "Show only pixels");
 
             var activationKeys = ReadActivationShortcut(testBase);
             Assert.IsNotNull(activationKeys, "Should be able to read activation shortcut");
@@ -103,12 +103,12 @@ namespace ScreenRuler.UITests
         }
 
         /// <summary>
-        /// Select the Screen Ruler measurement unit.
+        /// Select the Screen Ruler extra measurement unit.
         /// </summary>
-        public static void SetMeasurementUnit(UITestBase testBase, string unitName)
+        public static void SetExtraMeasurementUnit(UITestBase testBase, string unitName)
         {
-            var comboBox = testBase.Session.Find<ComboBox>(By.AccessibilityId(MeasurementUnitComboBoxId), 5000);
-            Assert.IsNotNull(comboBox, "Measurement unit combo box should be found");
+            var comboBox = testBase.Session.Find<ComboBox>(By.AccessibilityId(UnitsOfMeasureComboBoxId), 5000);
+            Assert.IsNotNull(comboBox, "Extra measurement unit combo box should be found");
 
             if (!string.Equals(comboBox.Text, unitName, StringComparison.Ordinal))
             {
@@ -116,7 +116,7 @@ namespace ScreenRuler.UITests
                 Task.Delay(500).Wait();
             }
 
-            Assert.AreEqual(unitName, comboBox.Text, "Measurement unit selection should be updated");
+            Assert.AreEqual(unitName, comboBox.Text, "Extra measurement unit selection should be updated");
         }
 
         /// <summary>
@@ -350,8 +350,8 @@ namespace ScreenRuler.UITests
 
             return spacingType switch
             {
-                "Spacing" => Regex.IsMatch(clipboardText, @"^\d+(?:\.\d+)?\s*[x×]\s*\d+(?:\.\d+)?\s+px$"),
-                "Horizontal Spacing" or "Vertical Spacing" => Regex.IsMatch(clipboardText, @"^\d+(?:\.\d+)?\s+px$"),
+                "Spacing" => Regex.IsMatch(clipboardText, @"\d+\s*[�x×]\s*\d+"),
+                "Horizontal Spacing" or "Vertical Spacing" => Regex.IsMatch(clipboardText, @"^\d+$"),
                 _ => false,
             };
         }
@@ -442,8 +442,8 @@ namespace ScreenRuler.UITests
             if (expectedUnit == "px")
             {
                 Assert.IsTrue(
-                    clipboardText.Contains("100 × 100 px") || clipboardText.Contains("100 x 100 px"),
-                    $"Clipboard should contain '100 x 100 px', but contained: '{clipboardText}'");
+                    clipboardText.Contains("100 × 100") || clipboardText.Contains("100 x 100"),
+                    $"Clipboard should contain '100 x 100', but contained: '{clipboardText}'");
             }
             else
             {

--- a/src/settings-ui/Settings.UI.UnitTests/ModelsTests/MeasureToolSettingsTests.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ModelsTests/MeasureToolSettingsTests.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json;
+
+using Microsoft.PowerToys.Settings.UI.Library;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CommonLibTest
+{
+    [TestClass]
+    public class MeasureToolSettingsTests
+    {
+        [TestMethod]
+        public void DefaultMeasurementUnitIsPixels()
+        {
+            var settings = new MeasureToolSettings();
+
+            Assert.AreEqual(0, settings.Properties.UnitsOfMeasure.Value);
+        }
+
+        [TestMethod]
+        [DataRow(0, "Pixels")]
+        [DataRow(1, "Inches")]
+        [DataRow(2, "Centimeters")]
+        [DataRow(3, "Millimeters")]
+        [DataRow(4, "Display-independent pixels")]
+        public void MeasurementUnitRoundTripPreservesStableValue(int unitValue, string unitName)
+        {
+            var settings = new MeasureToolSettings();
+            settings.Properties.UnitsOfMeasure.Value = unitValue;
+
+            var deserialized = JsonSerializer.Deserialize<MeasureToolSettings>(settings.ToJsonString());
+
+            Assert.IsNotNull(deserialized, $"Failed to deserialize {unitName} settings.");
+            Assert.AreEqual(unitValue, deserialized.Properties.UnitsOfMeasure.Value, $"{unitName} value changed during serialization.");
+        }
+    }
+}

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/MeasureToolPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/MeasureToolPage.xaml
@@ -83,7 +83,7 @@
                         HeaderIcon="{ui:FontIcon Glyph=&#xECC6;}">
                         <ComboBox
                             MinWidth="{StaticResource SettingActionControlMinWidth}"
-                            AutomationProperties.AutomationId="ComboBox_ScreenRuler_MeasurementUnit"
+                            AutomationProperties.AutomationId="ComboBox_ScreenRuler_UnitsOfMeasure"
                             SelectedIndex="{x:Bind Path=ViewModel.UnitsOfMeasure, Mode=TwoWay}">
                             <ComboBoxItem x:Uid="MeasureTool_UnitsOfMeasure_Pixels" />
                             <ComboBoxItem x:Uid="MeasureTool_UnitsOfMeasure_Inches" />

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/MeasureToolPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/MeasureToolPage.xaml
@@ -81,11 +81,15 @@
                         Name="MeasureToolUnitsOfMeasure"
                         x:Uid="MeasureTool_UnitsOfMeasure"
                         HeaderIcon="{ui:FontIcon Glyph=&#xECC6;}">
-                        <ComboBox MinWidth="{StaticResource SettingActionControlMinWidth}" SelectedIndex="{x:Bind Path=ViewModel.UnitsOfMeasure, Mode=TwoWay}">
+                        <ComboBox
+                            MinWidth="{StaticResource SettingActionControlMinWidth}"
+                            AutomationProperties.AutomationId="ComboBox_ScreenRuler_MeasurementUnit"
+                            SelectedIndex="{x:Bind Path=ViewModel.UnitsOfMeasure, Mode=TwoWay}">
                             <ComboBoxItem x:Uid="MeasureTool_UnitsOfMeasure_Pixels" />
                             <ComboBoxItem x:Uid="MeasureTool_UnitsOfMeasure_Inches" />
                             <ComboBoxItem x:Uid="MeasureTool_UnitsOfMeasure_Centimeters" />
                             <ComboBoxItem x:Uid="MeasureTool_UnitsOfMeasure_Millimeters" />
+                            <ComboBoxItem x:Uid="MeasureTool_UnitsOfMeasure_DIP" />
                         </ComboBox>
                     </tkcontrols:SettingsCard>
 

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -181,10 +181,13 @@
     <value>Vertical spacing</value>
   </data>
   <data name="MeasureTool_UnitsOfMeasure.Header" xml:space="preserve">
-    <value>Extra units of measurement</value>
+    <value>Measurement unit</value>
+  </data>
+  <data name="MeasureTool_UnitsOfMeasure.Description" xml:space="preserve">
+    <value>Display-independent pixels adjust for Windows display scaling</value>
   </data>
   <data name="MeasureTool_UnitsOfMeasure_Pixels.Content" xml:space="preserve">
-    <value>Show only pixels</value>
+    <value>Pixels</value>
   </data>
   <data name="MeasureTool_UnitsOfMeasure_Inches.Content" xml:space="preserve">
     <value>Inches</value>
@@ -194,6 +197,9 @@
   </data>
   <data name="MeasureTool_UnitsOfMeasure_Millimeters.Content" xml:space="preserve">
     <value>Millimeters</value>
+  </data>
+  <data name="MeasureTool_UnitsOfMeasure_DIP.Content" xml:space="preserve">
+    <value>Display-independent pixels (DIP)</value>
   </data>
   <data name="MeasureTool_PixelTolerance.Header" xml:space="preserve">
     <value>Pixel tolerance for edge detection</value>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -181,13 +181,13 @@
     <value>Vertical spacing</value>
   </data>
   <data name="MeasureTool_UnitsOfMeasure.Header" xml:space="preserve">
-    <value>Measurement unit</value>
+    <value>Extra units of measurement</value>
   </data>
   <data name="MeasureTool_UnitsOfMeasure.Description" xml:space="preserve">
     <value>Display-independent pixels adjust for Windows display scaling</value>
   </data>
   <data name="MeasureTool_UnitsOfMeasure_Pixels.Content" xml:space="preserve">
-    <value>Pixels</value>
+    <value>Show only pixels</value>
   </data>
   <data name="MeasureTool_UnitsOfMeasure_Inches.Content" xml:space="preserve">
     <value>Inches</value>


### PR DESCRIPTION
## Summary of the Pull Request

Adds display-independent pixels (DIP) to Screen Ruler's existing **Extra units of measurement** setting. Physical pixels remain the primary overlay value; selecting DIP adds a second, parenthesized measurement that adjusts for Windows display scaling.

DIP values use the DPI of the monitor containing the measurement. This also corrects the millimeter fallback conversion when physical monitor dimensions are unavailable.


<img width="1079" height="81" alt="image" src="https://github.com/user-attachments/assets/a34fe0a8-1dc1-4f1d-97c6-1a0dc37bf2e3" />

Before vs after:

<img width="921" height="617" alt="image" src="https://github.com/user-attachments/assets/7b0ed0ce-7058-4f4f-b8ae-1fc3709e0ace" />


## PR Checklist

- [x] Closes #20304
- [x] Closes #46945
- [x] **Communication:** The scope was agreed before implementation
- [x] **Tests:** Added/updated and all focused tests pass
- [x] **Localization:** All end-user-facing strings can be localized
- [x] **Dev docs:** Added/updated
- [x] **New binaries:** Not applicable; no production binaries were added
- [ ] **Documentation updated:** A public documentation PR has not been filed

## Detailed Description of the Pull Request / Additional comments

- Preserves the existing persisted values for pixels, inches, centimeters, and millimeters; DIP is appended as value `4`.
- Preserves the existing overlay behavior: pixels are always displayed, with one optional extra unit on a second line.
- Preserves the existing clipboard behavior: pixel-only output has no suffix, while a selected extra unit is copied by itself.
- Converts physical pixels to DIP using each overlay window's monitor DPI.
- Corrects the 96-DPI millimeter fallback so 96 px equals 25.4 mm.
- Adds focused native conversion tests, settings compatibility tests, and DIP clipboard UI coverage.
- Keeps guides, calibration, browser-relative units, and other measurement modes out of scope.

## Validation Steps Performed

- Built `MeasureToolCore` for ARM64 Debug.
- Built `MeasureToolUI` for ARM64 Debug.
- Built PowerToys Settings for ARM64 Debug.
- Built and ran `MeasureToolCore.UnitTests`: 5 passed.
- Built and ran the Screen Ruler settings tests: 6 passed.
- Built `ScreenRuler.UITests`; local execution was not run because WinAppDriver is not installed.
- Ran XAML Styler on the changed Settings page.