### PR TITLE
[MouseWithoutBorders] Increase PBKDF2 key derivation iterations to 100,000

### DIFF
--- a/src/modules/MouseWithoutBorders/App/Core/Encryption.cs
+++ b/src/modules/MouseWithoutBorders/App/Core/Encryption.cs
@@ -38,7 +38,8 @@ internal static class Encryption
     private const int SaltSize = 16;
 
     // Number of PBKDF2 iterations used to derive the symmetric key from the shared secret.
-    private const int KeyDerivationIterations = 50000;
+    // Use at least 100,000 iterations to strengthen the derived key against brute-force attempts.
+    private const int KeyDerivationIterations = 100000;
 
     // Length (in bytes) of the derived AES-256 key.
     private const int DerivedKeyLength = 32;


### PR DESCRIPTION
## Summary
Increases the PBKDF2 iteration count used to derive the Mouse Without Borders AES-256 session key from 50,000 to 100,000, strengthening the derived key against brute-force attempts.

## Changes
- `Encryption.cs`: `KeyDerivationIterations` 50,000 -> 100,000 (used by `GenLegalKey` via `Rfc2898DeriveBytes.Pbkdf2`).

The unrelated SHA-512 stretch loop in `Get24BitHash` is deliberately left unchanged - it is not a `Rfc2898DeriveBytes` key derivation and drives the connection framing/identity value.

## Compatibility
This changes the derived key, so all paired machines must run this version. Mouse Without Borders already requires the same version on every machine (it surfaces *"make sure you run the same version in all machines"* on a key/handshake mismatch), consistent with the per-connection salt/IV change in #48742. The existing key and settings are preserved and the key is derived fresh per connection, so **no re-pairing is needed once every machine is updated** - only a transient, self-healing failure during a mixed-version window.

## Validation
- Built `MouseWithoutBorders` (Release | x64) - clean, exit 0.
