### PR TITLE
CmdPal: Add file and list settings controls

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AdaptiveCardParserRegistrations.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AdaptiveCardParserRegistrations.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using AdaptiveCards.ObjectModel.WinUI3;
+
+namespace Microsoft.CmdPal.UI.ViewModels;
+
+public static class AdaptiveCardParserRegistrations
+{
+    public static AdaptiveElementParserRegistration ElementParsers { get; } = new();
+
+    public static AdaptiveActionParserRegistration ActionParsers { get; } = new();
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AdaptiveCards/AdaptiveListValueCodec.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AdaptiveCards/AdaptiveListValueCodec.cs
@@ -1,0 +1,172 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+#pragma warning disable SA1402 // File may only contain a single type
+
+namespace Microsoft.CmdPal.UI.ViewModels.AdaptiveCards;
+
+/// <summary>
+/// Reads and writes the <c>value</c> of Command Palette's custom list inputs.
+/// </summary>
+/// <remarks>
+/// This is the host's half of a wire contract shared with
+/// <c>Microsoft.CommandPalette.Extensions.Toolkit</c>: a JSON array of objects, so per-item
+/// properties can be added later without changing the shape. An array of bare strings is also
+/// accepted. Properties that are not recognized are preserved rather than dropped, so an extension
+/// built against a newer SDK does not lose per-item state when the form is saved here.
+/// </remarks>
+public static class AdaptiveListValueCodec
+{
+    public const string KeyPropertyName = "key";
+    public const string ValuePropertyName = "value";
+
+    /// <summary>
+    /// Reads list entries. Returns <see langword="false"/> when the value is present but is not a
+    /// well-formed array, so the caller can avoid replacing a value it could not read.
+    /// </summary>
+    public static bool TryParseItems(string? value, out List<AdaptiveListItemValue> items)
+    {
+        items = [];
+        if (!TryParseArray(value, out var array))
+        {
+            return false;
+        }
+
+        foreach (var entry in array)
+        {
+            var source = entry as JsonObject;
+            var text = source is null ? AsString(entry) : AsString(source[ValuePropertyName]);
+            if (!string.IsNullOrEmpty(text))
+            {
+                items.Add(new AdaptiveListItemValue(text, source));
+            }
+        }
+
+        return true;
+    }
+
+    public static string ToItemsValue(IEnumerable<AdaptiveListItemValue> items) =>
+        new JsonArray(items
+            .Select(static item => (JsonNode)item.ToJson((ValuePropertyName, item.Value)))
+            .ToArray())
+            .ToJsonString();
+
+    /// <summary>
+    /// Reads key/value entries. Returns <see langword="false"/> when the value is present but is
+    /// not a well-formed array.
+    /// </summary>
+    public static bool TryParsePairs(string? value, out List<AdaptiveKeyValuePairValue> pairs)
+    {
+        pairs = [];
+        if (!TryParseArray(value, out var array))
+        {
+            return false;
+        }
+
+        foreach (var entry in array)
+        {
+            if (entry is not JsonObject source)
+            {
+                continue;
+            }
+
+            pairs.Add(new AdaptiveKeyValuePairValue(
+                AsString(source[KeyPropertyName]) ?? string.Empty,
+                AsString(source[ValuePropertyName]) ?? string.Empty,
+                source));
+        }
+
+        return true;
+    }
+
+    public static string ToPairsValue(IEnumerable<AdaptiveKeyValuePairValue> pairs) =>
+        new JsonArray(pairs
+            .Select(static pair => (JsonNode)pair.ToJson(
+                (KeyPropertyName, pair.Key),
+                (ValuePropertyName, pair.Value)))
+            .ToArray())
+            .ToJsonString();
+
+    private static bool TryParseArray(string? value, out JsonArray array)
+    {
+        array = [];
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return true;
+        }
+
+        JsonNode? node;
+        try
+        {
+            node = JsonNode.Parse(value);
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+
+        if (node is not JsonArray parsed)
+        {
+            return false;
+        }
+
+        array = parsed;
+        return true;
+    }
+
+    private static string? AsString(JsonNode? node) =>
+        node is JsonValue value && value.TryGetValue<string>(out var text) ? text : null;
+}
+
+/// <summary>
+/// One entry of a custom list input, along with the JSON object it was parsed from.
+/// </summary>
+public abstract class AdaptiveListEntryValue(JsonObject? source)
+{
+    /// <summary>
+    /// Gets the object this entry was parsed from, or <see langword="null"/> for an entry the user
+    /// just added.
+    /// </summary>
+    protected JsonObject? Source { get; } = source;
+
+    /// <summary>
+    /// Returns the source object with the supplied properties applied, so properties this version
+    /// does not recognize are carried through unchanged.
+    /// </summary>
+    internal JsonObject ToJson(params (string Name, string Value)[] properties)
+    {
+        var json = Source?.DeepClone().AsObject() ?? [];
+        foreach (var (name, value) in properties)
+        {
+            json[name] = value;
+        }
+
+        return json;
+    }
+}
+
+/// <summary>
+/// One entry of a string or path list.
+/// </summary>
+public sealed class AdaptiveListItemValue(string value, JsonObject? source = null)
+    : AdaptiveListEntryValue(source)
+{
+    public string Value { get; } = value;
+}
+
+/// <summary>
+/// One entry of a key/value list.
+/// </summary>
+public sealed class AdaptiveKeyValuePairValue(string key, string value, JsonObject? source = null)
+    : AdaptiveListEntryValue(source)
+{
+    public string Key { get; } = key;
+
+    public string Value { get; } = value;
+}
+
+#pragma warning restore SA1402 // File may only contain a single type

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentFormViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ContentFormViewModel.cs
@@ -47,7 +47,16 @@ public partial class ContentFormViewModel(IFormContent _form, WeakReference<IPag
         {
             var template = new AdaptiveCardTemplate(templateJson);
             var cardJson = template.Expand(dataJson);
-            card = AdaptiveCard.FromJsonString(cardJson);
+            card = AdaptiveCard.FromJsonString(
+                cardJson,
+                AdaptiveCardParserRegistrations.ElementParsers,
+                AdaptiveCardParserRegistrations.ActionParsers);
+
+            foreach (var warning in card.Warnings)
+            {
+                Logger.LogWarning($"Adaptive Card parse warning ({warning.StatusCode}): {warning.Message}");
+            }
+
             return true;
         }
         catch (Exception ex)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/App.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/App.xaml.cs
@@ -27,6 +27,7 @@ using Microsoft.CmdPal.Ext.WindowsSettings;
 using Microsoft.CmdPal.Ext.WindowsTerminal;
 using Microsoft.CmdPal.Ext.WindowWalker;
 using Microsoft.CmdPal.Ext.WinGet;
+using Microsoft.CmdPal.UI.Controls;
 using Microsoft.CmdPal.UI.Helpers;
 using Microsoft.CmdPal.UI.Services;
 using Microsoft.CmdPal.UI.ViewModels;
@@ -83,6 +84,8 @@ public partial class App : Application, IDisposable
         IconProvider.Initialize(Services);
 
         this.InitializeComponent();
+
+        ContentFormControl.RegisterCustomElements();
 
         // Ensure types used in XAML are preserved for AOT compilation
         TypePreservation.PreserveTypes();

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/AdaptiveCards/AdaptiveCustomElementJson.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/AdaptiveCards/AdaptiveCustomElementJson.cs
@@ -1,0 +1,236 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using AdaptiveCards.ObjectModel.WinUI3;
+using Windows.Data.Json;
+
+namespace Microsoft.CmdPal.UI.Controls.AdaptiveCards;
+
+internal static class AdaptiveCustomElementJson
+{
+    public static void ParseCommonProperties(
+        IAdaptiveCardElement element,
+        JsonObject inputJson,
+        AdaptiveElementParserRegistration elementParsers,
+        AdaptiveActionParserRegistration actionParsers,
+        IList<AdaptiveWarning> warnings)
+    {
+        element.AdditionalProperties = JsonObject.Parse(inputJson.Stringify());
+
+        element.Id = inputJson.GetNamedString("id", string.Empty);
+        if (string.IsNullOrEmpty(element.Id))
+        {
+            warnings.Add(new AdaptiveWarning(
+                WarningStatusCode.RequiredPropertyMissing,
+                $"{element.ElementTypeString}.id is required."));
+        }
+
+        element.IsVisible = inputJson.GetNamedBoolean("isVisible", true);
+        element.Separator = inputJson.GetNamedBoolean("separator", false);
+        element.Spacing = ParseEnum(
+            inputJson,
+            "spacing",
+            Spacing.Default,
+            element.ElementTypeString,
+            warnings);
+        element.Height = ParseEnum(
+            inputJson,
+            "height",
+            HeightType.Auto,
+            element.ElementTypeString,
+            warnings);
+
+        ParseRequirements(element, inputJson, warnings);
+        ParseFallback(element, inputJson, elementParsers, actionParsers, warnings);
+    }
+
+    public static JsonObject Create(IAdaptiveCardElement element)
+    {
+        var json = element.AdditionalProperties is null
+            ? new JsonObject()
+            : JsonObject.Parse(element.AdditionalProperties.Stringify());
+
+        SetString(json, "type", element.ElementTypeString);
+        SetString(json, "id", element.Id);
+        SetBoolean(json, "isVisible", element.IsVisible);
+        SetBoolean(json, "separator", element.Separator);
+        SetString(json, "spacing", ToJsonName(element.Spacing));
+        SetString(json, "height", ToJsonName(element.Height));
+
+        if (element.FallbackType == FallbackType.Drop)
+        {
+            SetString(json, "fallback", "drop");
+        }
+        else if (element.FallbackType == FallbackType.Content && element.FallbackContent is not null)
+        {
+            try
+            {
+                json.SetNamedValue("fallback", element.FallbackContent.ToJson());
+            }
+            catch
+            {
+                // Keep the original fallback from AdditionalProperties when a nested element cannot serialize.
+            }
+        }
+        else
+        {
+            json.Remove("fallback");
+        }
+
+        return json;
+    }
+
+    public static void SetString(JsonObject json, string propertyName, string? value) =>
+        json.SetNamedValue(propertyName, JsonValue.CreateStringValue(value ?? string.Empty));
+
+    public static void SetBoolean(JsonObject json, string propertyName, bool value) =>
+        json.SetNamedValue(propertyName, JsonValue.CreateBooleanValue(value));
+
+    public static void SetStringArray(JsonObject json, string propertyName, IEnumerable<string> values)
+    {
+        var array = new JsonArray();
+        foreach (var value in values)
+        {
+            array.Add(JsonValue.CreateStringValue(value));
+        }
+
+        json.SetNamedValue(propertyName, array);
+    }
+
+    private static TEnum ParseEnum<TEnum>(
+        JsonObject inputJson,
+        string propertyName,
+        TEnum defaultValue,
+        string elementType,
+        IList<AdaptiveWarning> warnings)
+        where TEnum : struct, Enum
+    {
+        var value = inputJson.GetNamedString(propertyName, string.Empty);
+        if (string.IsNullOrEmpty(value))
+        {
+            return defaultValue;
+        }
+
+        if (Enum.TryParse<TEnum>(value, ignoreCase: true, out var parsedValue))
+        {
+            return parsedValue;
+        }
+
+        warnings.Add(new AdaptiveWarning(
+            WarningStatusCode.UnknownEnumValue,
+            $"{elementType}.{propertyName} has unknown value '{value}'."));
+        return defaultValue;
+    }
+
+    /// <summary>
+    /// Reads the <c>requires</c> map so the renderer can fall back when the host does not provide
+    /// a feature the card asks for.
+    /// </summary>
+    private static void ParseRequirements(
+        IAdaptiveCardElement element,
+        JsonObject inputJson,
+        IList<AdaptiveWarning> warnings)
+    {
+        if (!inputJson.TryGetValue("requires", out var requires))
+        {
+            return;
+        }
+
+        if (requires.ValueType != JsonValueType.Object)
+        {
+            warnings.Add(new AdaptiveWarning(
+                WarningStatusCode.InvalidValue,
+                $"{element.ElementTypeString}.requires must be an object."));
+            return;
+        }
+
+        foreach (var requirement in requires.GetObject())
+        {
+            if (requirement.Value.ValueType != JsonValueType.String)
+            {
+                warnings.Add(new AdaptiveWarning(
+                    WarningStatusCode.InvalidValue,
+                    $"{element.ElementTypeString}.requires.{requirement.Key} must be a version string."));
+                continue;
+            }
+
+            element.Requirements.Add(new AdaptiveRequirement(requirement.Key, requirement.Value.GetString()));
+        }
+    }
+
+    private static void ParseFallback(
+        IAdaptiveCardElement element,
+        JsonObject inputJson,
+        AdaptiveElementParserRegistration elementParsers,
+        AdaptiveActionParserRegistration actionParsers,
+        IList<AdaptiveWarning> warnings)
+    {
+        if (!inputJson.TryGetValue("fallback", out var fallback))
+        {
+            return;
+        }
+
+        if (fallback.ValueType == JsonValueType.String)
+        {
+            if (string.Equals(fallback.GetString(), "drop", StringComparison.OrdinalIgnoreCase))
+            {
+                element.FallbackType = FallbackType.Drop;
+            }
+            else
+            {
+                warnings.Add(new AdaptiveWarning(
+                    WarningStatusCode.InvalidValue,
+                    $"{element.ElementTypeString}.fallback must be 'drop' or an Adaptive Card element."));
+            }
+
+            return;
+        }
+
+        if (fallback.ValueType != JsonValueType.Object)
+        {
+            warnings.Add(new AdaptiveWarning(
+                WarningStatusCode.InvalidValue,
+                $"{element.ElementTypeString}.fallback must be 'drop' or an Adaptive Card element."));
+            return;
+        }
+
+        var fallbackJson = fallback.GetObject();
+        var fallbackType = fallbackJson.GetNamedString("type", string.Empty);
+        if (string.IsNullOrEmpty(fallbackType))
+        {
+            warnings.Add(new AdaptiveWarning(
+                WarningStatusCode.RequiredPropertyMissing,
+                $"{element.ElementTypeString}.fallback.type is required."));
+            return;
+        }
+
+        IAdaptiveElementParser? parser;
+        try
+        {
+            parser = elementParsers.Get(fallbackType);
+        }
+        catch
+        {
+            parser = null;
+        }
+
+        if (parser is null)
+        {
+            warnings.Add(new AdaptiveWarning(
+                WarningStatusCode.UnknownElementType,
+                $"{element.ElementTypeString}.fallback has unknown element type '{fallbackType}'."));
+            return;
+        }
+
+        element.FallbackContent = parser.FromJson(fallbackJson, elementParsers, actionParsers, warnings);
+        element.FallbackType = FallbackType.Content;
+    }
+
+    private static string ToJsonName<TEnum>(TEnum value)
+        where TEnum : struct, Enum
+    {
+        var name = value.ToString();
+        return name.Length == 0 ? string.Empty : char.ToLowerInvariant(name[0]) + name[1..];
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/AdaptiveCards/AdaptiveCustomInputControlBase.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/AdaptiveCards/AdaptiveCustomInputControlBase.cs
@@ -1,0 +1,185 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using System.Text;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Controls;
+using RS_ = Microsoft.CmdPal.UI.Helpers.ResourceLoaderInstance;
+
+#pragma warning disable SA1402 // File may only contain a single type
+
+namespace Microsoft.CmdPal.UI.Controls.AdaptiveCards;
+
+internal abstract partial class AdaptiveCustomInputControlBase : Grid, IAdaptiveCustomInputControl
+{
+    protected AdaptiveCustomInputControlBase(
+        string? header,
+        string? description,
+        bool isRequired)
+    {
+        HorizontalAlignment = HorizontalAlignment.Stretch;
+
+        RootPanel = new StackPanel
+        {
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            Spacing = 8,
+        };
+
+        if (!string.IsNullOrEmpty(header))
+        {
+            RootPanel.Children.Add(new TextBlock
+            {
+                Text = isRequired ? $"{header} *" : header,
+                FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
+                TextWrapping = TextWrapping.Wrap,
+            });
+        }
+
+        if (!string.IsNullOrEmpty(description) &&
+            !string.Equals(description, header, StringComparison.OrdinalIgnoreCase))
+        {
+            RootPanel.Children.Add(new TextBlock
+            {
+                Text = description,
+                FontSize = 12,
+                TextWrapping = TextWrapping.Wrap,
+            });
+        }
+
+        ValidationError = new TextBlock
+        {
+            FontSize = 12,
+            TextWrapping = TextWrapping.Wrap,
+            Visibility = Visibility.Collapsed,
+        };
+        ApplyCriticalForeground(ValidationError);
+    }
+
+    protected StackPanel RootPanel { get; }
+
+    protected TextBlock ValidationError { get; }
+
+    protected bool ValidationWasRequested { get; private set; }
+
+    public abstract string CurrentValue { get; }
+
+    public UIElement ValidationErrorElement => ValidationError;
+
+    public bool ValidateInput()
+    {
+        ValidationWasRequested = true;
+        return UpdateValidation();
+    }
+
+    public abstract void FocusInput();
+
+    protected abstract bool UpdateValidation();
+
+    protected void CompleteLayout()
+    {
+        RootPanel.Children.Add(ValidationError);
+        Children.Add(RootPanel);
+    }
+
+    protected void UpdateValidationIfRequested()
+    {
+        if (ValidationWasRequested)
+        {
+            UpdateValidation();
+        }
+    }
+
+    protected void ShowValidationError(string message)
+    {
+        ValidationWasRequested = true;
+        ValidationError.Text = message;
+        ValidationError.Visibility = Visibility.Visible;
+    }
+
+    protected static Button CreateTextButton(string text, string glyph)
+    {
+        var content = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            Spacing = 6,
+        };
+        content.Children.Add(new FontIcon { Glyph = glyph, FontSize = 14 });
+        content.Children.Add(new TextBlock { Text = text, VerticalAlignment = VerticalAlignment.Center });
+        return new Button { Content = content };
+    }
+
+    protected static void ApplyCriticalForeground(TextBlock textBlock)
+    {
+        if (Application.Current.Resources.TryGetValue("SystemFillColorCriticalBrush", out var resource) &&
+            resource is Microsoft.UI.Xaml.Media.Brush brush)
+        {
+            textBlock.Foreground = brush;
+        }
+    }
+}
+
+internal abstract partial class AdaptiveListInputControlBase : AdaptiveCustomInputControlBase
+{
+    protected const string AddGlyph = "\uE710";
+    protected const string DeleteGlyph = "\uE74D";
+    protected const double ListItemMinHeight = 34;
+
+    private const double ListMaxHeight = 240;
+    private const int AlwaysVisibleScrollBarItemCount = 7;
+
+    private static readonly CompositeFormat _removeItemLabelFormat =
+        CompositeFormat.Parse(RS_.GetString("AdaptiveListInput_RemoveItem"));
+
+    protected AdaptiveListInputControlBase(AdaptiveListInputElement element)
+        : base(element.Header, element.Description, element.IsRequired)
+    {
+        ItemsList = new ListBox
+        {
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            HorizontalContentAlignment = HorizontalAlignment.Stretch,
+            MaxHeight = ListMaxHeight,
+            MinHeight = ListItemMinHeight,
+            SelectionMode = SelectionMode.Single,
+        };
+
+        if (!string.IsNullOrEmpty(element.Header))
+        {
+            AutomationProperties.SetName(ItemsList, element.Header);
+        }
+
+        ScrollViewer.SetHorizontalScrollBarVisibility(ItemsList, ScrollBarVisibility.Disabled);
+        ScrollViewer.SetVerticalScrollMode(ItemsList, ScrollMode.Enabled);
+        ScrollViewer.SetIsVerticalRailEnabled(ItemsList, true);
+        RootPanel.Children.Add(ItemsList);
+    }
+
+    protected ListBox ItemsList { get; }
+
+    protected string GetRemoveItemLabel(string item) =>
+        string.Format(CultureInfo.CurrentCulture, _removeItemLabelFormat, item);
+
+    protected void RefreshListItems<T>(IReadOnlyCollection<T> items, Func<T, UIElement> createItemRow)
+    {
+        ItemsList.Items.Clear();
+        foreach (var item in items)
+        {
+            ItemsList.Items.Add(new ListBoxItem
+            {
+                Content = createItemRow(item),
+                HorizontalContentAlignment = HorizontalAlignment.Stretch,
+                MinHeight = ListItemMinHeight,
+                Padding = new Thickness(8, 2, 16, 2),
+            });
+        }
+
+        var scrollBarVisibility = items.Count >= AlwaysVisibleScrollBarItemCount
+            ? ScrollBarVisibility.Visible
+            : ScrollBarVisibility.Auto;
+        ScrollViewer.SetVerticalScrollBarVisibility(ItemsList, scrollBarVisibility);
+    }
+}
+
+#pragma warning restore SA1402 // File may only contain a single type

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/AdaptiveCards/AdaptiveCustomInputValue.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/AdaptiveCards/AdaptiveCustomInputValue.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using AdaptiveCards.ObjectModel.WinUI3;
+using AdaptiveCards.Rendering.WinUI3;
+using Microsoft.UI.Xaml;
+
+#pragma warning disable SA1402 // File may only contain a single type
+
+namespace Microsoft.CmdPal.UI.Controls.AdaptiveCards;
+
+internal sealed partial class AdaptiveCustomInputValue : IAdaptiveInputValue
+{
+    private readonly IAdaptiveCustomInputControl _control;
+
+    public AdaptiveCustomInputValue(IAdaptiveInputElement element, IAdaptiveCustomInputControl control)
+    {
+        InputElement = element;
+        _control = control;
+        ErrorMessage = control.ValidationErrorElement;
+    }
+
+    public bool Validate() => _control.ValidateInput();
+
+    public void SetFocus() => _control.FocusInput();
+
+    public UIElement? ErrorMessage { get; set; }
+
+    public IAdaptiveInputElement InputElement { get; set; }
+
+    public string CurrentValue => _control.CurrentValue;
+}
+
+internal interface IAdaptiveCustomInputControl
+{
+    string CurrentValue { get; }
+
+    UIElement ValidationErrorElement { get; }
+
+    bool ValidateInput();
+
+    void FocusInput();
+}
+
+#pragma warning restore SA1402 // File may only contain a single type

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/AdaptiveCards/AdaptiveFilePathInputElement.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/AdaptiveCards/AdaptiveFilePathInputElement.cs
@@ -1,0 +1,277 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
+using AdaptiveCards.ObjectModel.WinUI3;
+using AdaptiveCards.Rendering.WinUI3;
+using ManagedCommon;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Controls;
+using Windows.Data.Json;
+using RS_ = Microsoft.CmdPal.UI.Helpers.ResourceLoaderInstance;
+
+#pragma warning disable SA1402 // File may only contain a single type
+
+namespace Microsoft.CmdPal.UI.Controls.AdaptiveCards;
+
+internal enum AdaptiveFilePathSelectionMode
+{
+    File,
+    Folder,
+}
+
+internal sealed partial class AdaptiveFilePathInputElement : IAdaptiveInputElement, IAdaptiveCardElement, ICustomAdaptiveCardElement
+{
+    public static string CustomInputType => "Input.CommandPalette.FilePath";
+
+    public string? Header { get; set; }
+
+    public string? Description { get; set; }
+
+    public string? Value { get; set; }
+
+    public string? Placeholder { get; set; }
+
+    public string? ErrorMessage { get; set; }
+
+    public string? ValidationPattern { get; set; }
+
+    public string? ValidationErrorMessage { get; set; }
+
+    public AdaptiveFilePathSelectionMode SelectionMode { get; set; }
+
+    public List<string> FileTypeFilter { get; } = [];
+
+    public bool IsRequired { get; set; }
+
+    // Adaptive Cards renders this label outside custom inputs. The custom renderer uses Header instead.
+    public string? Label { get; set; }
+
+    public JsonObject ToJson()
+    {
+        var json = AdaptiveCustomElementJson.Create(this);
+        AdaptiveCustomElementJson.SetString(json, "header", Header);
+        AdaptiveCustomElementJson.SetString(json, "description", Description);
+        AdaptiveCustomElementJson.SetString(json, "value", Value);
+        AdaptiveCustomElementJson.SetString(json, "placeholder", Placeholder);
+        AdaptiveCustomElementJson.SetBoolean(json, "isRequired", IsRequired);
+        AdaptiveCustomElementJson.SetString(json, "errorMessage", ErrorMessage);
+        AdaptiveCustomElementJson.SetString(
+            json,
+            "selectionMode",
+            SelectionMode == AdaptiveFilePathSelectionMode.File ? "file" : "folder");
+        AdaptiveCustomElementJson.SetStringArray(json, "fileTypeFilter", FileTypeFilter);
+        AdaptiveCustomElementJson.SetString(json, "validationPattern", ValidationPattern);
+        AdaptiveCustomElementJson.SetString(json, "validationErrorMessage", ValidationErrorMessage);
+        return json;
+    }
+
+    public JsonObject? AdditionalProperties { get; set; }
+
+    public ElementType ElementType { get; } = ElementType.Custom;
+
+    public string ElementTypeString => CustomInputType;
+
+    public IAdaptiveCardElement? FallbackContent { get; set; }
+
+    public FallbackType FallbackType { get; set; }
+
+    public HeightType Height { get; set; }
+
+    public string? Id { get; set; }
+
+    public bool IsVisible { get; set; } = true;
+
+    public IList<AdaptiveRequirement> Requirements { get; } = [];
+
+    public bool Separator { get; set; }
+
+    public Spacing Spacing { get; set; }
+}
+
+internal sealed partial class AdaptiveFilePathInputElementParser : IAdaptiveElementParser
+{
+    public IAdaptiveCardElement FromJson(
+        JsonObject inputJson,
+        AdaptiveElementParserRegistration elementParsers,
+        AdaptiveActionParserRegistration actionParsers,
+        IList<AdaptiveWarning> warnings)
+    {
+        var selectionModeValue = inputJson.GetNamedString("selectionMode", "file");
+        var selectionMode = AdaptiveFilePathSelectionMode.File;
+        if (string.Equals(selectionModeValue, "folder", StringComparison.OrdinalIgnoreCase))
+        {
+            selectionMode = AdaptiveFilePathSelectionMode.Folder;
+        }
+        else if (!string.Equals(selectionModeValue, "file", StringComparison.OrdinalIgnoreCase))
+        {
+            warnings.Add(new AdaptiveWarning(
+                WarningStatusCode.InvalidValue,
+                $"{AdaptiveFilePathInputElement.CustomInputType}.selectionMode must be file or folder."));
+        }
+
+        var adaptiveLabel = inputJson.GetNamedString("label", string.Empty);
+        var element = new AdaptiveFilePathInputElement
+        {
+            Label = string.Empty,
+            Header = inputJson.GetNamedString("header", adaptiveLabel),
+            Description = inputJson.GetNamedString("description", string.Empty),
+            Value = inputJson.GetNamedString("value", string.Empty),
+            Placeholder = inputJson.GetNamedString("placeholder", string.Empty),
+            IsRequired = inputJson.GetNamedBoolean("isRequired", false),
+            ErrorMessage = inputJson.GetNamedString("errorMessage", string.Empty),
+            ValidationPattern = AdaptiveInputValidation.ParsePattern(
+                inputJson,
+                "validationPattern",
+                AdaptiveFilePathInputElement.CustomInputType,
+                warnings),
+            ValidationErrorMessage = inputJson.GetNamedString("validationErrorMessage", string.Empty),
+            SelectionMode = selectionMode,
+        };
+
+        AdaptiveCustomElementJson.ParseCommonProperties(
+            element,
+            inputJson,
+            elementParsers,
+            actionParsers,
+            warnings);
+
+        if (inputJson.TryGetValue("fileTypeFilter", out var filterValue) &&
+            filterValue.ValueType == JsonValueType.Array)
+        {
+            foreach (var value in filterValue.GetArray())
+            {
+                if (value.ValueType == JsonValueType.String)
+                {
+                    element.FileTypeFilter.Add(value.GetString());
+                }
+            }
+        }
+
+        return element;
+    }
+}
+
+internal sealed partial class AdaptiveFilePathInputElementRenderer : IAdaptiveElementRenderer
+{
+    public UIElement Render(IAdaptiveCardElement element, AdaptiveRenderContext context, AdaptiveRenderArgs renderArgs)
+    {
+        var input = (AdaptiveFilePathInputElement)element;
+        var control = new AdaptiveFilePathInputControl(input);
+        context.AddInputValue(new AdaptiveCustomInputValue(input, control), renderArgs);
+        return control;
+    }
+}
+
+internal sealed partial class AdaptiveFilePathInputControl : AdaptiveCustomInputControlBase
+{
+    private static readonly CompositeFormat _browseForFormat =
+        CompositeFormat.Parse(RS_.GetString("AdaptiveFilePathInput_BrowseFor"));
+
+    private readonly AdaptiveFilePathInputElement _element;
+    private readonly Regex? _validationRegex;
+    private readonly TextBox _pathTextBox;
+    private readonly Button _browseButton;
+
+    public AdaptiveFilePathInputControl(AdaptiveFilePathInputElement element)
+        : base(element.Header, element.Description, element.IsRequired)
+    {
+        _element = element;
+        _validationRegex = AdaptiveInputValidation.CreateRegex(element.ValidationPattern);
+
+        var fieldName = string.IsNullOrEmpty(element.Header)
+            ? RS_.GetString(element.SelectionMode == AdaptiveFilePathSelectionMode.File
+                ? "AdaptiveFilePathInput_FilePath"
+                : "AdaptiveFilePathInput_FolderPath")
+            : element.Header;
+
+        var inputRow = new Grid { ColumnSpacing = 8 };
+        inputRow.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        inputRow.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+        _pathTextBox = new TextBox
+        {
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            PlaceholderText = string.IsNullOrEmpty(element.Placeholder)
+                ? RS_.GetString(element.SelectionMode == AdaptiveFilePathSelectionMode.File
+                    ? "AdaptiveFilePathInput_FilePlaceholder"
+                    : "AdaptiveFilePathInput_FolderPlaceholder")
+                : element.Placeholder,
+            Text = element.Value ?? string.Empty,
+        };
+        AutomationProperties.SetName(_pathTextBox, fieldName);
+        _pathTextBox.TextChanged += (_, _) => UpdateValidationIfRequested();
+        inputRow.Children.Add(_pathTextBox);
+
+        _browseButton = new Button
+        {
+            Content = RS_.GetString("AdaptiveFilePathInput_Browse"),
+            VerticalAlignment = VerticalAlignment.Stretch,
+        };
+        var browseLabel = string.Format(CultureInfo.CurrentCulture, _browseForFormat, fieldName);
+        AutomationProperties.SetName(_browseButton, browseLabel);
+        _browseButton.Click += BrowseButton_Click;
+        Grid.SetColumn(_browseButton, 1);
+        inputRow.Children.Add(_browseButton);
+        RootPanel.Children.Add(inputRow);
+        CompleteLayout();
+    }
+
+    public override string CurrentValue => _pathTextBox.Text;
+
+    public override void FocusInput() => _pathTextBox.Focus(FocusState.Programmatic);
+
+    private async void BrowseButton_Click(object sender, RoutedEventArgs e)
+    {
+        try
+        {
+            var path = _element.SelectionMode == AdaptiveFilePathSelectionMode.File
+                ? await AdaptiveFilePicker.PickFileAsync(
+                    this,
+                    _element.FileTypeFilter,
+                    RS_.GetString("AdaptiveFilePathInput_SelectFile"))
+                : await AdaptiveFilePicker.PickFolderAsync(
+                    this,
+                    RS_.GetString("AdaptiveFilePathInput_SelectFolder"));
+
+            if (!string.IsNullOrEmpty(path))
+            {
+                _pathTextBox.Text = path;
+                _pathTextBox.Focus(FocusState.Programmatic);
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError("Failed to pick a path for an adaptive-card input", ex);
+        }
+    }
+
+    protected override bool UpdateValidation()
+    {
+        var value = _pathTextBox.Text;
+        if (_element.IsRequired && string.IsNullOrWhiteSpace(value))
+        {
+            ShowValidationError(string.IsNullOrEmpty(_element.ErrorMessage)
+                ? RS_.GetString("AdaptiveFilePathInput_RequiredError")
+                : _element.ErrorMessage);
+            return false;
+        }
+
+        if (!string.IsNullOrEmpty(value) && !AdaptiveInputValidation.IsMatch(_validationRegex, value))
+        {
+            ShowValidationError(string.IsNullOrEmpty(_element.ValidationErrorMessage)
+                ? RS_.GetString("AdaptiveFilePathInput_ValidationError")
+                : _element.ValidationErrorMessage);
+            return false;
+        }
+
+        ValidationError.Visibility = Visibility.Collapsed;
+        return true;
+    }
+}
+
+#pragma warning restore SA1402 // File may only contain a single type

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/AdaptiveCards/AdaptiveFilePicker.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/AdaptiveCards/AdaptiveFilePicker.cs
@@ -2,9 +2,13 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using CommunityToolkit.Mvvm.Messaging;
+using Microsoft.CmdPal.Common.Messages;
 using Microsoft.UI;
 using Microsoft.UI.Xaml;
 using Microsoft.Windows.Storage.Pickers;
+using Windows.Win32;
+using Windows.Win32.UI.WindowsAndMessaging;
 
 namespace Microsoft.CmdPal.UI.Controls.AdaptiveCards;
 
@@ -44,15 +48,35 @@ internal static class AdaptiveFilePicker
         return (await picker.PickSingleFolderAsync())?.Path;
     }
 
+    /// <summary>
+    /// Resolves the window that should own the picker dialog. Command Palette has more than one
+    /// window — the palette and the settings window — and a settings form renders in either, so
+    /// the owner has to be resolved per invocation rather than assumed to be the palette.
+    /// </summary>
     private static WindowId GetOwnerWindowId(FrameworkElement owner)
     {
-        var contentIslandEnvironment = owner.XamlRoot?.ContentIslandEnvironment;
-        if (contentIslandEnvironment is null)
+        // Preferred, but null in Command Palette's windows today.
+        var appWindowId = owner.XamlRoot?.ContentIslandEnvironment?.AppWindowId;
+        if (appWindowId is not null && appWindowId.Value.Value != 0)
         {
-            throw new InvalidOperationException("The adaptive-card input is not attached to a window.");
+            return appWindowId.Value;
         }
 
-        return contentIslandEnvironment.AppWindowId;
+        // Both windows live on this thread, so the active one is the window the user just clicked
+        // in. GA_ROOTOWNER maps a menu flyout's popup window back to the window that owns it.
+        var activeWindow = PInvoke.GetActiveWindow();
+        if (activeWindow != IntPtr.Zero)
+        {
+            var ownerWindow = PInvoke.GetAncestor(activeWindow, GET_ANCESTOR_FLAGS.GA_ROOTOWNER);
+            return Win32Interop.GetWindowIdFromWindow(ownerWindow != IntPtr.Zero ? ownerWindow : activeWindow);
+        }
+
+        // Last resort: the palette window answers this, which is right when it is the only window.
+        var message = new GetHwndMessage();
+        WeakReferenceMessenger.Default.Send(message);
+        return message.Hwnd != 0
+            ? Win32Interop.GetWindowIdFromWindow((nint)message.Hwnd)
+            : throw new InvalidOperationException("Could not resolve a window to own the picker.");
     }
 
     private static string? NormalizeFileTypeFilter(string filter)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/AdaptiveCards/AdaptiveFilePicker.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/AdaptiveCards/AdaptiveFilePicker.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.UI;
+using Microsoft.UI.Xaml;
+using Microsoft.Windows.Storage.Pickers;
+
+namespace Microsoft.CmdPal.UI.Controls.AdaptiveCards;
+
+internal static class AdaptiveFilePicker
+{
+    public static async Task<string?> PickFileAsync(
+        FrameworkElement owner,
+        IEnumerable<string> fileTypeFilter,
+        string commitButtonText)
+    {
+        var picker = new FileOpenPicker(GetOwnerWindowId(owner))
+        {
+            CommitButtonText = commitButtonText,
+        };
+
+        var filterWasAdded = false;
+        foreach (var filter in fileTypeFilter.Select(NormalizeFileTypeFilter).Where(static filter => filter is not null))
+        {
+            picker.FileTypeFilter.Add(filter!);
+            filterWasAdded = true;
+        }
+
+        if (!filterWasAdded)
+        {
+            picker.FileTypeFilter.Add("*");
+        }
+
+        return (await picker.PickSingleFileAsync())?.Path;
+    }
+
+    public static async Task<string?> PickFolderAsync(FrameworkElement owner, string commitButtonText)
+    {
+        var picker = new FolderPicker(GetOwnerWindowId(owner))
+        {
+            CommitButtonText = commitButtonText,
+        };
+        return (await picker.PickSingleFolderAsync())?.Path;
+    }
+
+    private static WindowId GetOwnerWindowId(FrameworkElement owner)
+    {
+        var contentIslandEnvironment = owner.XamlRoot?.ContentIslandEnvironment;
+        if (contentIslandEnvironment is null)
+        {
+            throw new InvalidOperationException("The adaptive-card input is not attached to a window.");
+        }
+
+        return contentIslandEnvironment.AppWindowId;
+    }
+
+    private static string? NormalizeFileTypeFilter(string filter)
+    {
+        var normalized = filter.Trim();
+        if (string.IsNullOrEmpty(normalized))
+        {
+            return null;
+        }
+
+        if (normalized is "*" or "*.*")
+        {
+            return "*";
+        }
+
+        if (normalized.StartsWith("*.", StringComparison.Ordinal))
+        {
+            normalized = normalized[1..];
+        }
+
+        return normalized.StartsWith('.')
+            ? normalized
+            : $".{normalized}";
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/AdaptiveCards/AdaptiveInputValidation.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/AdaptiveCards/AdaptiveInputValidation.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.RegularExpressions;
+using AdaptiveCards.ObjectModel.WinUI3;
+using ManagedCommon;
+using Windows.Data.Json;
+
+namespace Microsoft.CmdPal.UI.Controls.AdaptiveCards;
+
+internal static class AdaptiveInputValidation
+{
+    private static readonly TimeSpan _matchTimeout = TimeSpan.FromMilliseconds(250);
+
+    public static string ParsePattern(
+        JsonObject inputJson,
+        string propertyName,
+        string inputType,
+        IList<AdaptiveWarning> warnings)
+    {
+        var pattern = inputJson.GetNamedString(propertyName, string.Empty);
+        if (string.IsNullOrEmpty(pattern))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            _ = CreateRegex(pattern);
+            return pattern;
+        }
+        catch (ArgumentException ex)
+        {
+            warnings.Add(new AdaptiveWarning(
+                WarningStatusCode.InvalidValue,
+                $"{inputType}.{propertyName} is not a valid regular expression: {ex.Message}"));
+            return string.Empty;
+        }
+    }
+
+    public static Regex? CreateRegex(string? pattern) =>
+        string.IsNullOrEmpty(pattern)
+            ? null
+            : new Regex(pattern, RegexOptions.CultureInvariant, _matchTimeout);
+
+    public static bool IsMatch(Regex? regex, string value)
+    {
+        if (regex is null)
+        {
+            return true;
+        }
+
+        try
+        {
+            return regex.IsMatch(value);
+        }
+        catch (RegexMatchTimeoutException ex)
+        {
+            Logger.LogWarning($"Adaptive-card list input validation timed out: {ex.Message}");
+            return false;
+        }
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/AdaptiveCards/AdaptiveKeyValueListInputElement.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/AdaptiveCards/AdaptiveKeyValueListInputElement.cs
@@ -1,0 +1,389 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.RegularExpressions;
+using AdaptiveCards.ObjectModel.WinUI3;
+using AdaptiveCards.Rendering.WinUI3;
+using ManagedCommon;
+using Microsoft.CmdPal.UI.ViewModels.AdaptiveCards;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using Windows.Data.Json;
+using Windows.System;
+using RS_ = Microsoft.CmdPal.UI.Helpers.ResourceLoaderInstance;
+
+#pragma warning disable SA1402 // File may only contain a single type
+
+namespace Microsoft.CmdPal.UI.Controls.AdaptiveCards;
+
+internal sealed partial class AdaptiveKeyValueListInputElement : AdaptiveListInputElement, ICustomAdaptiveCardElement
+{
+    public static string CustomInputType => "Input.CommandPalette.KeyValueList";
+
+    public override string ElementTypeString => CustomInputType;
+
+    public string? KeyPlaceholder { get; set; }
+
+    public string? ValuePlaceholder { get; set; }
+
+    public string? MissingKeyErrorMessage { get; set; }
+
+    public string? KeyValidationPattern { get; set; }
+
+    public string? KeyValidationErrorMessage { get; set; }
+
+    public string? ValueValidationPattern { get; set; }
+
+    public string? ValueValidationErrorMessage { get; set; }
+
+    public bool PreventDuplicateKeys { get; set; }
+
+    public string? DuplicateKeyErrorMessage { get; set; }
+
+    public override JsonObject ToJson()
+    {
+        var json = base.ToJson();
+        json.Remove("placeholder");
+        json.Remove("itemValidationPattern");
+        json.Remove("itemValidationErrorMessage");
+        json.Remove("preventDuplicates");
+        json.Remove("duplicateItemErrorMessage");
+        AdaptiveCustomElementJson.SetString(json, "keyPlaceholder", KeyPlaceholder);
+        AdaptiveCustomElementJson.SetString(json, "valuePlaceholder", ValuePlaceholder);
+        AdaptiveCustomElementJson.SetString(json, "missingKeyErrorMessage", MissingKeyErrorMessage);
+        AdaptiveCustomElementJson.SetString(json, "keyValidationPattern", KeyValidationPattern);
+        AdaptiveCustomElementJson.SetString(json, "keyValidationErrorMessage", KeyValidationErrorMessage);
+        AdaptiveCustomElementJson.SetString(json, "valueValidationPattern", ValueValidationPattern);
+        AdaptiveCustomElementJson.SetString(json, "valueValidationErrorMessage", ValueValidationErrorMessage);
+        AdaptiveCustomElementJson.SetBoolean(json, "preventDuplicateKeys", PreventDuplicateKeys);
+        AdaptiveCustomElementJson.SetString(json, "duplicateKeyErrorMessage", DuplicateKeyErrorMessage);
+        return json;
+    }
+}
+
+internal sealed partial class AdaptiveKeyValueListInputElementParser : IAdaptiveElementParser
+{
+    public IAdaptiveCardElement FromJson(
+        JsonObject inputJson,
+        AdaptiveElementParserRegistration elementParsers,
+        AdaptiveActionParserRegistration actionParsers,
+        IList<AdaptiveWarning> warnings)
+    {
+        var element = AdaptiveListInputElementParser.Parse<AdaptiveKeyValueListInputElement>(
+            inputJson,
+            elementParsers,
+            actionParsers,
+            warnings);
+        element.KeyPlaceholder = inputJson.GetNamedString("keyPlaceholder", string.Empty);
+        element.ValuePlaceholder = inputJson.GetNamedString("valuePlaceholder", string.Empty);
+        element.MissingKeyErrorMessage = inputJson.GetNamedString("missingKeyErrorMessage", string.Empty);
+        element.KeyValidationPattern = AdaptiveInputValidation.ParsePattern(
+            inputJson,
+            "keyValidationPattern",
+            AdaptiveKeyValueListInputElement.CustomInputType,
+            warnings);
+        element.KeyValidationErrorMessage = inputJson.GetNamedString("keyValidationErrorMessage", string.Empty);
+        element.ValueValidationPattern = AdaptiveInputValidation.ParsePattern(
+            inputJson,
+            "valueValidationPattern",
+            AdaptiveKeyValueListInputElement.CustomInputType,
+            warnings);
+        element.ValueValidationErrorMessage = inputJson.GetNamedString("valueValidationErrorMessage", string.Empty);
+        element.PreventDuplicateKeys = inputJson.GetNamedBoolean("preventDuplicateKeys", false);
+        element.DuplicateKeyErrorMessage = inputJson.GetNamedString("duplicateKeyErrorMessage", string.Empty);
+        return element;
+    }
+}
+
+internal sealed partial class AdaptiveKeyValueListInputElementRenderer : IAdaptiveElementRenderer
+{
+    public UIElement Render(IAdaptiveCardElement element, AdaptiveRenderContext context, AdaptiveRenderArgs renderArgs)
+    {
+        var input = (AdaptiveKeyValueListInputElement)element;
+        var control = new AdaptiveKeyValueListInputControl(input);
+        context.AddInputValue(new AdaptiveCustomInputValue(input, control), renderArgs);
+        return control;
+    }
+}
+
+internal sealed partial class AdaptiveKeyValueListInputControl : AdaptiveListInputControlBase
+{
+    private readonly AdaptiveKeyValueListInputElement _element;
+    private readonly List<AdaptiveKeyValuePairValue> _items;
+    private readonly string? _unreadableValue;
+    private readonly Regex? _keyValidationRegex;
+    private readonly Regex? _valueValidationRegex;
+
+    private readonly TextBox _keyTextBox;
+    private readonly TextBox _valueTextBox;
+    private readonly Button _addButton;
+
+    private bool _wasEdited;
+
+    public AdaptiveKeyValueListInputControl(AdaptiveKeyValueListInputElement element)
+        : base(element)
+    {
+        _element = element;
+        if (AdaptiveListValueCodec.TryParsePairs(element.Value, out var parsedPairs))
+        {
+            _items = parsedPairs;
+        }
+        else
+        {
+            // Keep the value we could not read so that saving the form does not discard it.
+            _items = [];
+            _unreadableValue = element.Value;
+            Logger.LogWarning($"Could not read the value of {element.ElementTypeString} '{element.Id}'.");
+        }
+
+        _keyValidationRegex = AdaptiveInputValidation.CreateRegex(element.KeyValidationPattern);
+        _valueValidationRegex = AdaptiveInputValidation.CreateRegex(element.ValueValidationPattern);
+
+        var addControls = new Grid { ColumnSpacing = 8 };
+        addControls.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        addControls.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        addControls.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+        _keyTextBox = new TextBox
+        {
+            Header = RS_.GetString("AdaptiveKeyValueListInput_Key"),
+            PlaceholderText = string.IsNullOrEmpty(element.KeyPlaceholder)
+                ? RS_.GetString("AdaptiveKeyValueListInput_KeyPlaceholder")
+                : element.KeyPlaceholder,
+        };
+        _keyTextBox.KeyDown += AddTextBox_KeyDown;
+
+        _valueTextBox = new TextBox
+        {
+            Header = RS_.GetString("AdaptiveKeyValueListInput_Value"),
+            PlaceholderText = string.IsNullOrEmpty(element.ValuePlaceholder)
+                ? RS_.GetString("AdaptiveKeyValueListInput_ValuePlaceholder")
+                : element.ValuePlaceholder,
+        };
+        _valueTextBox.KeyDown += AddTextBox_KeyDown;
+        Grid.SetColumn(_valueTextBox, 1);
+
+        _addButton = CreateTextButton(RS_.GetString("AdaptiveListInput_Add"), AddGlyph);
+        _addButton.IsEnabled = false;
+        _addButton.VerticalAlignment = VerticalAlignment.Bottom;
+        _addButton.Click += (_, _) => AddItem();
+        Grid.SetColumn(_addButton, 2);
+
+        _keyTextBox.TextChanged += (_, _) =>
+            _addButton.IsEnabled = !string.IsNullOrWhiteSpace(_keyTextBox.Text);
+
+        addControls.Children.Add(_keyTextBox);
+        addControls.Children.Add(_valueTextBox);
+        addControls.Children.Add(_addButton);
+        RootPanel.Children.Add(addControls);
+        CompleteLayout();
+        RefreshItems();
+    }
+
+    public override string CurrentValue =>
+        _unreadableValue is not null && !_wasEdited
+            ? _unreadableValue
+            : AdaptiveListValueCodec.ToPairsValue(_items);
+
+    public override void FocusInput() => _keyTextBox.Focus(FocusState.Programmatic);
+
+    private void AddTextBox_KeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        if (e.Key == VirtualKey.Enter)
+        {
+            e.Handled = true;
+            AddItem();
+        }
+    }
+
+    private void AddItem()
+    {
+        var key = _keyTextBox.Text;
+        var value = _valueTextBox.Text;
+
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            ShowValidationError(GetMissingKeyErrorMessage());
+            _keyTextBox.Focus(FocusState.Programmatic);
+            return;
+        }
+
+        if (!AdaptiveInputValidation.IsMatch(_keyValidationRegex, key))
+        {
+            ShowValidationError(GetKeyValidationErrorMessage());
+            _keyTextBox.Focus(FocusState.Programmatic);
+            return;
+        }
+
+        if (!AdaptiveInputValidation.IsMatch(_valueValidationRegex, value))
+        {
+            ShowValidationError(GetValueValidationErrorMessage());
+            _valueTextBox.Focus(FocusState.Programmatic);
+            return;
+        }
+
+        if (_element.PreventDuplicateKeys &&
+            _items.Any(item => string.Equals(item.Key, key, StringComparison.Ordinal)))
+        {
+            ShowValidationError(GetDuplicateKeyErrorMessage());
+            _keyTextBox.Focus(FocusState.Programmatic);
+            return;
+        }
+
+        _items.Add(new AdaptiveKeyValuePairValue(key, value));
+        _wasEdited = true;
+        _keyTextBox.Text = string.Empty;
+        _valueTextBox.Text = string.Empty;
+        RefreshItems();
+        UpdateValidationIfRequested();
+        _keyTextBox.Focus(FocusState.Programmatic);
+    }
+
+    private void RefreshItems()
+    {
+        RefreshListItems(_items, CreateItemRow);
+    }
+
+    private UIElement CreateItemRow(AdaptiveKeyValuePairValue item)
+    {
+        var row = new Grid
+        {
+            ColumnSpacing = 8,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+            MinHeight = ListItemMinHeight,
+        };
+        row.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        row.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+        row.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        row.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+        var keyText = new TextBlock
+        {
+            Text = string.IsNullOrWhiteSpace(item.Key)
+                ? RS_.GetString("AdaptiveKeyValueListInput_MissingKeyDisplay")
+                : item.Key,
+            TextTrimming = TextTrimming.CharacterEllipsis,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        if (string.IsNullOrWhiteSpace(item.Key))
+        {
+            ApplyCriticalForeground(keyText);
+        }
+
+        ToolTipService.SetToolTip(keyText, item.Key);
+        row.Children.Add(keyText);
+
+        var separator = new TextBlock
+        {
+            Text = "=",
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        AutomationProperties.SetAccessibilityView(separator, AccessibilityView.Raw);
+        Grid.SetColumn(separator, 1);
+        row.Children.Add(separator);
+
+        var valueText = new TextBlock
+        {
+            Text = item.Value,
+            TextTrimming = TextTrimming.CharacterEllipsis,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        ToolTipService.SetToolTip(valueText, item.Value);
+        Grid.SetColumn(valueText, 2);
+        row.Children.Add(valueText);
+
+        var removeLabel = GetRemoveItemLabel($"{item.Key} = {item.Value}");
+        var removeButton = new Button
+        {
+            Style = (Style)Application.Current.Resources["SubtleButtonStyle"],
+            Content = new FontIcon { Glyph = DeleteGlyph, FontSize = 14 },
+            MinHeight = 30,
+            MinWidth = 30,
+            Padding = new Thickness(6),
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        AutomationProperties.SetName(removeButton, removeLabel);
+        ToolTipService.SetToolTip(removeButton, removeLabel);
+        removeButton.Click += (_, _) =>
+        {
+            _items.Remove(item);
+            _wasEdited = true;
+            RefreshItems();
+            UpdateValidationIfRequested();
+        };
+        Grid.SetColumn(removeButton, 3);
+        row.Children.Add(removeButton);
+
+        return row;
+    }
+
+    protected override bool UpdateValidation()
+    {
+        if (_element.IsRequired && _items.Count == 0)
+        {
+            ShowValidationError(string.IsNullOrEmpty(_element.ErrorMessage)
+                ? RS_.GetString("AdaptiveListInput_RequiredError")
+                : _element.ErrorMessage);
+            return false;
+        }
+
+        if (_items.Any(static item => string.IsNullOrWhiteSpace(item.Key)))
+        {
+            ShowValidationError(GetMissingKeyErrorMessage());
+            return false;
+        }
+
+        if (_items.Any(item => !AdaptiveInputValidation.IsMatch(_keyValidationRegex, item.Key)))
+        {
+            ShowValidationError(GetKeyValidationErrorMessage());
+            return false;
+        }
+
+        if (_items.Any(item => !AdaptiveInputValidation.IsMatch(_valueValidationRegex, item.Value)))
+        {
+            ShowValidationError(GetValueValidationErrorMessage());
+            return false;
+        }
+
+        if (_element.PreventDuplicateKeys && HasDuplicateKeys())
+        {
+            ShowValidationError(GetDuplicateKeyErrorMessage());
+            return false;
+        }
+
+        ValidationError.Visibility = Visibility.Collapsed;
+        return true;
+    }
+
+    private string GetMissingKeyErrorMessage() =>
+        string.IsNullOrEmpty(_element.MissingKeyErrorMessage)
+            ? RS_.GetString("AdaptiveKeyValueListInput_MissingKeyError")
+            : _element.MissingKeyErrorMessage;
+
+    private string GetKeyValidationErrorMessage() =>
+        string.IsNullOrEmpty(_element.KeyValidationErrorMessage)
+            ? RS_.GetString("AdaptiveKeyValueListInput_KeyValidationError")
+            : _element.KeyValidationErrorMessage;
+
+    private string GetValueValidationErrorMessage() =>
+        string.IsNullOrEmpty(_element.ValueValidationErrorMessage)
+            ? RS_.GetString("AdaptiveKeyValueListInput_ValueValidationError")
+            : _element.ValueValidationErrorMessage;
+
+    private string GetDuplicateKeyErrorMessage() =>
+        string.IsNullOrEmpty(_element.DuplicateKeyErrorMessage)
+            ? RS_.GetString("AdaptiveKeyValueListInput_DuplicateKeyError")
+            : _element.DuplicateKeyErrorMessage;
+
+    private bool HasDuplicateKeys()
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        return _items.Any(item => !seen.Add(item.Key));
+    }
+}
+
+#pragma warning restore SA1402 // File may only contain a single type

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/AdaptiveCards/AdaptiveListInputControl.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/AdaptiveCards/AdaptiveListInputControl.cs
@@ -1,0 +1,396 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.RegularExpressions;
+using ManagedCommon;
+using Microsoft.CmdPal.UI.ViewModels.AdaptiveCards;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using Windows.System;
+using RS_ = Microsoft.CmdPal.UI.Helpers.ResourceLoaderInstance;
+
+namespace Microsoft.CmdPal.UI.Controls.AdaptiveCards;
+
+internal sealed partial class AdaptiveListInputControl : AdaptiveListInputControlBase
+{
+    private const string FileGlyph = "\uE8A5";
+    private const string FolderGlyph = "\uE8B7";
+
+    private readonly AdaptiveListInputElement _element;
+    private readonly AdaptiveFilePathListInputElement? _pathElement;
+    private readonly List<AdaptiveListItem> _items;
+    private readonly Regex? _itemValidationRegex;
+
+    private readonly string? _unreadableValue;
+
+    private TextBox? _newItemTextBox;
+    private Button? _addButton;
+    private bool _wasEdited;
+
+    public AdaptiveListInputControl(AdaptiveListInputElement element)
+        : base(element)
+    {
+        _element = element;
+        _pathElement = element as AdaptiveFilePathListInputElement;
+        if (AdaptiveListValueCodec.TryParseItems(element.Value, out var parsedItems))
+        {
+            _items = parsedItems.Select(static item => new AdaptiveListItem(item)).ToList();
+        }
+        else
+        {
+            // Keep the value we could not read so that saving the form does not discard it.
+            _items = [];
+            _unreadableValue = element.Value;
+            Logger.LogWarning($"Could not read the value of {element.ElementTypeString} '{element.Id}'.");
+        }
+
+        _itemValidationRegex = AdaptiveInputValidation.CreateRegex(element.ItemValidationPattern);
+
+        RootPanel.Children.Add(_pathElement is null ? CreateStringAddControl() : CreatePathAddControl());
+        CompleteLayout();
+        RefreshItems();
+    }
+
+    public override string CurrentValue =>
+        _unreadableValue is not null && !_wasEdited
+            ? _unreadableValue
+            : AdaptiveListValueCodec.ToItemsValue(_items.Select(static item => item.Source));
+
+    public override void FocusInput()
+    {
+        (_newItemTextBox as Control ?? _addButton)?.Focus(FocusState.Programmatic);
+    }
+
+    private UIElement CreateStringAddControl()
+    {
+        var panel = new Grid { ColumnSpacing = 8 };
+        panel.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        panel.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+        _newItemTextBox = new TextBox
+        {
+            PlaceholderText = string.IsNullOrEmpty(_element.Placeholder)
+                ? RS_.GetString("AdaptiveStringListInput_Placeholder")
+                : _element.Placeholder,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        };
+        _newItemTextBox.KeyDown += NewItemTextBox_KeyDown;
+
+        _addButton = CreateTextButton(RS_.GetString("AdaptiveListInput_Add"), AddGlyph);
+        _addButton.Click += (_, _) => AddTextItem();
+
+        panel.Children.Add(_newItemTextBox);
+        Grid.SetColumn(_addButton, 1);
+        panel.Children.Add(_addButton);
+        return panel;
+    }
+
+    private UIElement CreatePathAddControl()
+    {
+        var allowFiles = _pathElement!.AllowFiles;
+        var allowFolders = _pathElement.AllowFolders;
+
+        _addButton = CreateTextButton(
+            allowFiles && allowFolders
+                ? RS_.GetString("AdaptiveListInput_Add")
+                : allowFiles
+                    ? RS_.GetString("AdaptiveFilePathListInput_AddFile")
+                    : RS_.GetString("AdaptiveFilePathListInput_AddFolder"),
+            AddGlyph);
+        _addButton.HorizontalAlignment = HorizontalAlignment.Left;
+
+        if (allowFiles && allowFolders)
+        {
+            var flyout = new MenuFlyout();
+            var addFile = new MenuFlyoutItem
+            {
+                Text = RS_.GetString("AdaptiveFilePathListInput_AddFile"),
+                Icon = new FontIcon { Glyph = FileGlyph },
+            };
+            addFile.Click += async (_, _) => await PickFileAsync();
+            flyout.Items.Add(addFile);
+
+            var addFolder = new MenuFlyoutItem
+            {
+                Text = RS_.GetString("AdaptiveFilePathListInput_AddFolder"),
+                Icon = new FontIcon { Glyph = FolderGlyph },
+            };
+            addFolder.Click += async (_, _) => await PickFolderAsync();
+            flyout.Items.Add(addFolder);
+            _addButton.Flyout = flyout;
+        }
+        else if (allowFiles)
+        {
+            _addButton.Click += async (_, _) => await PickFileAsync();
+        }
+        else
+        {
+            _addButton.Click += async (_, _) => await PickFolderAsync();
+        }
+
+        return _addButton;
+    }
+
+    private void NewItemTextBox_KeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        if (e.Key == VirtualKey.Enter)
+        {
+            e.Handled = true;
+            AddTextItem();
+        }
+    }
+
+    private void AddTextItem()
+    {
+        if (_newItemTextBox is null || string.IsNullOrWhiteSpace(_newItemTextBox.Text))
+        {
+            return;
+        }
+
+        if (!IsItemValid(_newItemTextBox.Text))
+        {
+            ShowValidationError(GetItemValidationErrorMessage());
+            _newItemTextBox.Focus(FocusState.Programmatic);
+            return;
+        }
+
+        if (_element.PreventDuplicates &&
+            _items.Any(item => DuplicateComparer.Equals(item.Value, _newItemTextBox.Text)))
+        {
+            ShowValidationError(GetDuplicateItemErrorMessage());
+            _newItemTextBox.Focus(FocusState.Programmatic);
+            return;
+        }
+
+        _items.Add(new AdaptiveListItem(_newItemTextBox.Text));
+        _wasEdited = true;
+        _newItemTextBox.Text = string.Empty;
+        RefreshItems();
+        UpdateValidationIfRequested();
+        _newItemTextBox.Focus(FocusState.Programmatic);
+    }
+
+    private void AddPath(string? path, AdaptivePathItemKind kind)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return;
+        }
+
+        if (_element.PreventDuplicates &&
+            _items.Any(item => StringComparer.OrdinalIgnoreCase.Equals(item.Value, path)))
+        {
+            ShowValidationError(GetDuplicateItemErrorMessage());
+            _addButton?.Focus(FocusState.Programmatic);
+            return;
+        }
+
+        if (!IsItemValid(path))
+        {
+            ShowValidationError(GetItemValidationErrorMessage());
+            return;
+        }
+
+        _items.Add(new AdaptiveListItem(path, kind: kind));
+        _wasEdited = true;
+        RefreshItems();
+        UpdateValidationIfRequested();
+    }
+
+    private async Task PickFileAsync()
+    {
+        try
+        {
+            var path = await AdaptiveFilePicker.PickFileAsync(
+                this,
+                _pathElement!.FileTypeFilter,
+                RS_.GetString("AdaptiveFilePathListInput_AddFile"));
+            AddPath(path, AdaptivePathItemKind.File);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError("Failed to pick a file for an adaptive-card path list", ex);
+        }
+    }
+
+    private async Task PickFolderAsync()
+    {
+        try
+        {
+            var path = await AdaptiveFilePicker.PickFolderAsync(
+                this,
+                RS_.GetString("AdaptiveFilePathListInput_AddFolder"));
+            AddPath(path, AdaptivePathItemKind.Folder);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError("Failed to pick a folder for an adaptive-card path list", ex);
+        }
+    }
+
+    private void RefreshItems()
+    {
+        RefreshListItems(_items, CreateItemRow);
+    }
+
+    private UIElement CreateItemRow(AdaptiveListItem item)
+    {
+        var row = new Grid
+        {
+            ColumnSpacing = 8,
+            MinHeight = ListItemMinHeight,
+            HorizontalAlignment = HorizontalAlignment.Stretch,
+        };
+
+        var textColumn = 0;
+        if (_pathElement is not null)
+        {
+            row.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(24) });
+            var icon = new FontIcon
+            {
+                Glyph = IsFolderPath(item) ? FolderGlyph : FileGlyph,
+                FontSize = 16,
+                VerticalAlignment = VerticalAlignment.Center,
+            };
+            AutomationProperties.SetAccessibilityView(icon, AccessibilityView.Raw);
+            row.Children.Add(icon);
+            textColumn = 1;
+        }
+
+        row.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+        row.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
+
+        var text = new TextBlock
+        {
+            Text = item.Value,
+            TextTrimming = TextTrimming.CharacterEllipsis,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        ToolTipService.SetToolTip(text, item.Value);
+        Grid.SetColumn(text, textColumn);
+        row.Children.Add(text);
+
+        var removeButton = new Button
+        {
+            Style = (Style)Application.Current.Resources["SubtleButtonStyle"],
+            Content = new FontIcon { Glyph = DeleteGlyph, FontSize = 14 },
+            MinWidth = 30,
+            MinHeight = 30,
+            Padding = new Thickness(6),
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        var removeLabel = GetRemoveItemLabel(item.Value);
+        AutomationProperties.SetName(removeButton, removeLabel);
+        ToolTipService.SetToolTip(removeButton, removeLabel);
+        removeButton.Click += (_, _) =>
+        {
+            _items.Remove(item);
+            _wasEdited = true;
+            RefreshItems();
+            UpdateValidationIfRequested();
+        };
+
+        Grid.SetColumn(removeButton, textColumn + 1);
+        row.Children.Add(removeButton);
+        return row;
+    }
+
+    private bool IsFolderPath(AdaptiveListItem item)
+    {
+        if (_pathElement?.AllowFolders == true && _pathElement.AllowFiles == false)
+        {
+            return true;
+        }
+
+        if (_pathElement?.AllowFiles == true && _pathElement.AllowFolders == false)
+        {
+            return false;
+        }
+
+        if (item.PathKind is AdaptivePathItemKind.Folder)
+        {
+            return true;
+        }
+
+        if (item.PathKind is AdaptivePathItemKind.File)
+        {
+            return false;
+        }
+
+        return item.Value.EndsWith(Path.DirectorySeparatorChar) ||
+            item.Value.EndsWith(Path.AltDirectorySeparatorChar) ||
+            !Path.HasExtension(item.Value);
+    }
+
+    protected override bool UpdateValidation()
+    {
+        if (_element.IsRequired && _items.Count == 0)
+        {
+            ShowValidationError(string.IsNullOrEmpty(_element.ErrorMessage)
+                ? RS_.GetString("AdaptiveListInput_RequiredError")
+                : _element.ErrorMessage);
+            return false;
+        }
+
+        if (_items.Any(item => !IsItemValid(item.Value)))
+        {
+            ShowValidationError(GetItemValidationErrorMessage());
+            return false;
+        }
+
+        if (_element.PreventDuplicates && HasDuplicateItems())
+        {
+            ShowValidationError(GetDuplicateItemErrorMessage());
+            return false;
+        }
+
+        ValidationError.Visibility = Visibility.Collapsed;
+        return true;
+    }
+
+    private string GetItemValidationErrorMessage() =>
+        string.IsNullOrEmpty(_element.ItemValidationErrorMessage)
+            ? RS_.GetString("AdaptiveListInput_ItemValidationError")
+            : _element.ItemValidationErrorMessage;
+
+    private string GetDuplicateItemErrorMessage() =>
+        string.IsNullOrEmpty(_element.DuplicateItemErrorMessage)
+            ? RS_.GetString("AdaptiveListInput_DuplicateItemError")
+            : _element.DuplicateItemErrorMessage;
+
+    private StringComparer DuplicateComparer =>
+        _pathElement is null ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
+
+    private bool HasDuplicateItems()
+    {
+        var seen = new HashSet<string>(DuplicateComparer);
+        return _items.Any(item => !seen.Add(item.Value));
+    }
+
+    private bool IsItemValid(string item) =>
+        AdaptiveInputValidation.IsMatch(_itemValidationRegex, item);
+
+    private sealed class AdaptiveListItem(AdaptiveListItemValue source, AdaptivePathItemKind? kind = null)
+    {
+        public AdaptiveListItem(string value, AdaptivePathItemKind? kind = null)
+            : this(new AdaptiveListItemValue(value), kind)
+        {
+        }
+
+        public AdaptiveListItemValue Source { get; } = source;
+
+        public string Value => Source.Value;
+
+        public AdaptivePathItemKind? PathKind { get; } = kind;
+    }
+
+    private enum AdaptivePathItemKind
+    {
+        File,
+        Folder,
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/AdaptiveCards/AdaptiveListInputElements.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/AdaptiveCards/AdaptiveListInputElements.cs
@@ -1,0 +1,223 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using AdaptiveCards.ObjectModel.WinUI3;
+using AdaptiveCards.Rendering.WinUI3;
+using Microsoft.UI.Xaml;
+using Windows.Data.Json;
+
+#pragma warning disable SA1402 // File may only contain a single type
+
+namespace Microsoft.CmdPal.UI.Controls.AdaptiveCards;
+
+internal abstract partial class AdaptiveListInputElement : IAdaptiveInputElement, IAdaptiveCardElement
+{
+    public string? Header { get; set; }
+
+    public string? Description { get; set; }
+
+    public string? Value { get; set; }
+
+    public string? Placeholder { get; set; }
+
+    public string? ErrorMessage { get; set; }
+
+    public string? ItemValidationPattern { get; set; }
+
+    public string? ItemValidationErrorMessage { get; set; }
+
+    public bool PreventDuplicates { get; set; }
+
+    public string? DuplicateItemErrorMessage { get; set; }
+
+    public bool IsRequired { get; set; }
+
+    // Adaptive Cards renders this label outside custom inputs. The custom renderer uses Header instead.
+    public string? Label { get; set; }
+
+    public virtual JsonObject ToJson()
+    {
+        var json = AdaptiveCustomElementJson.Create(this);
+        AdaptiveCustomElementJson.SetString(json, "header", Header);
+        AdaptiveCustomElementJson.SetString(json, "description", Description);
+        AdaptiveCustomElementJson.SetString(json, "value", Value);
+        AdaptiveCustomElementJson.SetString(json, "placeholder", Placeholder);
+        AdaptiveCustomElementJson.SetBoolean(json, "isRequired", IsRequired);
+        AdaptiveCustomElementJson.SetString(json, "errorMessage", ErrorMessage);
+        AdaptiveCustomElementJson.SetString(json, "itemValidationPattern", ItemValidationPattern);
+        AdaptiveCustomElementJson.SetString(json, "itemValidationErrorMessage", ItemValidationErrorMessage);
+        AdaptiveCustomElementJson.SetBoolean(json, "preventDuplicates", PreventDuplicates);
+        AdaptiveCustomElementJson.SetString(json, "duplicateItemErrorMessage", DuplicateItemErrorMessage);
+        return json;
+    }
+
+    public JsonObject? AdditionalProperties { get; set; }
+
+    public ElementType ElementType { get; } = ElementType.Custom;
+
+    public abstract string ElementTypeString { get; }
+
+    public IAdaptiveCardElement? FallbackContent { get; set; }
+
+    public FallbackType FallbackType { get; set; }
+
+    public HeightType Height { get; set; }
+
+    public string? Id { get; set; }
+
+    public bool IsVisible { get; set; } = true;
+
+    public IList<AdaptiveRequirement> Requirements { get; } = [];
+
+    public bool Separator { get; set; }
+
+    public Spacing Spacing { get; set; }
+}
+
+internal sealed partial class AdaptiveStringListInputElement : AdaptiveListInputElement, ICustomAdaptiveCardElement
+{
+    public static string CustomInputType => "Input.CommandPalette.StringList";
+
+    public override string ElementTypeString => CustomInputType;
+}
+
+internal sealed partial class AdaptiveFilePathListInputElement : AdaptiveListInputElement, ICustomAdaptiveCardElement
+{
+    public static string CustomInputType => "Input.CommandPalette.FilePathList";
+
+    public override string ElementTypeString => CustomInputType;
+
+    public bool AllowFiles { get; set; } = true;
+
+    public bool AllowFolders { get; set; } = true;
+
+    public List<string> FileTypeFilter { get; } = [];
+
+    public override JsonObject ToJson()
+    {
+        var json = base.ToJson();
+        json.Remove("placeholder");
+        AdaptiveCustomElementJson.SetBoolean(json, "allowFiles", AllowFiles);
+        AdaptiveCustomElementJson.SetBoolean(json, "allowFolders", AllowFolders);
+        AdaptiveCustomElementJson.SetStringArray(json, "fileTypeFilter", FileTypeFilter);
+        return json;
+    }
+}
+
+internal static class AdaptiveListInputElementParser
+{
+    public static T Parse<T>(
+        JsonObject inputJson,
+        AdaptiveElementParserRegistration elementParsers,
+        AdaptiveActionParserRegistration actionParsers,
+        IList<AdaptiveWarning> warnings)
+        where T : AdaptiveListInputElement, new()
+    {
+        var adaptiveLabel = inputJson.GetNamedString("label", string.Empty);
+        var element = new T
+        {
+            Label = string.Empty,
+            Header = inputJson.GetNamedString("header", adaptiveLabel),
+            Description = inputJson.GetNamedString("description", string.Empty),
+            Value = inputJson.GetNamedString("value", string.Empty),
+            Placeholder = inputJson.GetNamedString("placeholder", string.Empty),
+            IsRequired = inputJson.GetNamedBoolean("isRequired", false),
+            ErrorMessage = inputJson.GetNamedString("errorMessage", string.Empty),
+            ItemValidationPattern = AdaptiveInputValidation.ParsePattern(
+                inputJson,
+                "itemValidationPattern",
+                typeof(T).Name,
+                warnings),
+            ItemValidationErrorMessage = inputJson.GetNamedString("itemValidationErrorMessage", string.Empty),
+            PreventDuplicates = inputJson.GetNamedBoolean("preventDuplicates", false),
+            DuplicateItemErrorMessage = inputJson.GetNamedString("duplicateItemErrorMessage", string.Empty),
+        };
+
+        AdaptiveCustomElementJson.ParseCommonProperties(
+            element,
+            inputJson,
+            elementParsers,
+            actionParsers,
+            warnings);
+        return element;
+    }
+}
+
+internal sealed partial class AdaptiveStringListInputElementParser : IAdaptiveElementParser
+{
+    public IAdaptiveCardElement FromJson(
+        JsonObject inputJson,
+        AdaptiveElementParserRegistration elementParsers,
+        AdaptiveActionParserRegistration actionParsers,
+        IList<AdaptiveWarning> warnings) =>
+        AdaptiveListInputElementParser.Parse<AdaptiveStringListInputElement>(
+            inputJson,
+            elementParsers,
+            actionParsers,
+            warnings);
+}
+
+internal sealed partial class AdaptiveFilePathListInputElementParser : IAdaptiveElementParser
+{
+    public IAdaptiveCardElement FromJson(
+        JsonObject inputJson,
+        AdaptiveElementParserRegistration elementParsers,
+        AdaptiveActionParserRegistration actionParsers,
+        IList<AdaptiveWarning> warnings)
+    {
+        var element = AdaptiveListInputElementParser.Parse<AdaptiveFilePathListInputElement>(
+            inputJson,
+            elementParsers,
+            actionParsers,
+            warnings);
+        element.AllowFiles = inputJson.GetNamedBoolean("allowFiles", true);
+        element.AllowFolders = inputJson.GetNamedBoolean("allowFolders", true);
+
+        if (!element.AllowFiles && !element.AllowFolders)
+        {
+            warnings.Add(new AdaptiveWarning(
+                WarningStatusCode.InvalidValue,
+                $"{AdaptiveFilePathListInputElement.CustomInputType} must allow files, folders, or both."));
+            element.AllowFolders = true;
+        }
+
+        if (inputJson.TryGetValue("fileTypeFilter", out var filterValue) &&
+            filterValue.ValueType == JsonValueType.Array)
+        {
+            foreach (var value in filterValue.GetArray())
+            {
+                if (value.ValueType == JsonValueType.String)
+                {
+                    element.FileTypeFilter.Add(value.GetString());
+                }
+            }
+        }
+
+        return element;
+    }
+}
+
+internal sealed partial class AdaptiveStringListInputElementRenderer : IAdaptiveElementRenderer
+{
+    public UIElement Render(IAdaptiveCardElement element, AdaptiveRenderContext context, AdaptiveRenderArgs renderArgs)
+    {
+        var input = (AdaptiveStringListInputElement)element;
+        var control = new AdaptiveListInputControl(input);
+        context.AddInputValue(new AdaptiveCustomInputValue(input, control), renderArgs);
+        return control;
+    }
+}
+
+internal sealed partial class AdaptiveFilePathListInputElementRenderer : IAdaptiveElementRenderer
+{
+    public UIElement Render(IAdaptiveCardElement element, AdaptiveRenderContext context, AdaptiveRenderArgs renderArgs)
+    {
+        var input = (AdaptiveFilePathListInputElement)element;
+        var control = new AdaptiveListInputControl(input);
+        context.AddInputValue(new AdaptiveCustomInputValue(input, control), renderArgs);
+        return control;
+    }
+}
+
+#pragma warning restore SA1402 // File may only contain a single type

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/AdaptiveCards/ICustomAdaptiveCardElement.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/AdaptiveCards/ICustomAdaptiveCardElement.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CmdPal.UI.Controls.AdaptiveCards;
+
+internal interface ICustomAdaptiveCardElement
+{
+    static abstract string CustomInputType { get; }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContentFormControl.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContentFormControl.xaml.cs
@@ -4,6 +4,7 @@
 
 using AdaptiveCards.ObjectModel.WinUI3;
 using AdaptiveCards.Rendering.WinUI3;
+using Microsoft.CmdPal.UI.Controls.AdaptiveCards;
 using Microsoft.CmdPal.UI.ViewModels;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation;
@@ -17,6 +18,7 @@ namespace Microsoft.CmdPal.UI.Controls;
 public sealed partial class ContentFormControl : UserControl
 {
     private static readonly AdaptiveCardRenderer _renderer;
+    private static bool _customElementsRegistered;
     private ContentFormViewModel? _viewModel;
 
     // LOAD-BEARING: if you don't hang onto a reference to the RenderedAdaptiveCard
@@ -37,6 +39,32 @@ public sealed partial class ContentFormControl : UserControl
         {
             OverrideStyles = null,
         };
+    }
+
+    internal static void RegisterCustomElements()
+    {
+        if (_customElementsRegistered)
+        {
+            return;
+        }
+
+        Register<AdaptiveStringListInputElement, AdaptiveStringListInputElementParser, AdaptiveStringListInputElementRenderer>();
+        Register<AdaptiveFilePathListInputElement, AdaptiveFilePathListInputElementParser, AdaptiveFilePathListInputElementRenderer>();
+        Register<AdaptiveKeyValueListInputElement, AdaptiveKeyValueListInputElementParser, AdaptiveKeyValueListInputElementRenderer>();
+        Register<AdaptiveFilePathInputElement, AdaptiveFilePathInputElementParser, AdaptiveFilePathInputElementRenderer>();
+
+        _customElementsRegistered = true;
+
+        return;
+
+        static void Register<TElement, TParser, TRenderer>()
+            where TElement : IAdaptiveCardElement, ICustomAdaptiveCardElement
+            where TParser : IAdaptiveElementParser, new()
+            where TRenderer : IAdaptiveElementRenderer, new()
+        {
+            AdaptiveCardParserRegistrations.ElementParsers.Set(TElement.CustomInputType, new TParser());
+            _renderer.ElementRenderers.Set(TElement.CustomInputType, new TRenderer());
+        }
     }
 
     public ContentFormControl()

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/NativeMethods.txt
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/NativeMethods.txt
@@ -1,6 +1,7 @@
 GetPhysicallyInstalledSystemMemory
 GlobalMemoryStatusEx
 GetSystemInfo
+GetActiveWindow
 GetForegroundWindow
 SetForegroundWindow
 GetWindowRect

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Strings/en-us/Resources.resw
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Strings/en-us/Resources.resw
@@ -1406,4 +1406,112 @@ Right-click to remove the key combination, thereby deactivating the shortcut.</v
     <value>Dock position</value>
     <comment>Per-monitor dock position settings card header</comment>
   </data>
+  <data name="AdaptiveListInput_Add" xml:space="preserve">
+    <value>Add</value>
+    <comment>Button that adds an entry to a list in an adaptive-card form.</comment>
+  </data>
+  <data name="AdaptiveListInput_RemoveItem" xml:space="preserve">
+    <value>Remove {0}</value>
+    <comment>Accessible label for a button that removes an entry from a list. {0} is the entry text or path.</comment>
+  </data>
+  <data name="AdaptiveListInput_RequiredError" xml:space="preserve">
+    <value>Add at least one item.</value>
+    <comment>Validation error shown when a required list has no entries.</comment>
+  </data>
+  <data name="AdaptiveListInput_ItemValidationError" xml:space="preserve">
+    <value>One or more items have an invalid format.</value>
+    <comment>Validation error shown when a string-list entry does not match its configured regular expression.</comment>
+  </data>
+  <data name="AdaptiveListInput_DuplicateItemError" xml:space="preserve">
+    <value>Each item must be unique.</value>
+    <comment>Validation error shown when duplicate string-list entries are not allowed.</comment>
+  </data>
+  <data name="AdaptiveStringListInput_Placeholder" xml:space="preserve">
+    <value>New item</value>
+    <comment>Placeholder in the text box used to add an entry to a string list.</comment>
+  </data>
+  <data name="AdaptiveFilePathListInput_AddFile" xml:space="preserve">
+    <value>Add file</value>
+    <comment>Button or menu item that opens a file picker to add a path.</comment>
+  </data>
+  <data name="AdaptiveFilePathListInput_AddFolder" xml:space="preserve">
+    <value>Add folder</value>
+    <comment>Button or menu item that opens a folder picker to add a path.</comment>
+  </data>
+  <data name="AdaptiveKeyValueListInput_Key" xml:space="preserve">
+    <value>Key</value>
+    <comment>Label for the key field of a key/value list entry.</comment>
+  </data>
+  <data name="AdaptiveKeyValueListInput_Value" xml:space="preserve">
+    <value>Value</value>
+    <comment>Label for the value field of a key/value list entry.</comment>
+  </data>
+  <data name="AdaptiveKeyValueListInput_KeyPlaceholder" xml:space="preserve">
+    <value>New key</value>
+    <comment>Placeholder in the key field used to add a key/value list entry.</comment>
+  </data>
+  <data name="AdaptiveKeyValueListInput_ValuePlaceholder" xml:space="preserve">
+    <value>New value</value>
+    <comment>Placeholder in the value field used to add a key/value list entry.</comment>
+  </data>
+  <data name="AdaptiveKeyValueListInput_MissingKeyDisplay" xml:space="preserve">
+    <value>(missing key)</value>
+    <comment>Text displayed for a persisted key/value list entry that does not contain a key.</comment>
+  </data>
+  <data name="AdaptiveKeyValueListInput_MissingKeyError" xml:space="preserve">
+    <value>Each value must have a key.</value>
+    <comment>Validation error shown when a key/value list entry has no key.</comment>
+  </data>
+  <data name="AdaptiveKeyValueListInput_KeyValidationError" xml:space="preserve">
+    <value>One or more keys have an invalid format.</value>
+    <comment>Validation error shown when a key does not match its configured regular expression.</comment>
+  </data>
+  <data name="AdaptiveKeyValueListInput_ValueValidationError" xml:space="preserve">
+    <value>One or more values have an invalid format.</value>
+    <comment>Validation error shown when a value does not match its configured regular expression.</comment>
+  </data>
+  <data name="AdaptiveKeyValueListInput_DuplicateKeyError" xml:space="preserve">
+    <value>Each key must be unique.</value>
+    <comment>Validation error shown when duplicate keys are not allowed in a key/value list.</comment>
+  </data>
+  <data name="AdaptiveFilePathInput_Browse" xml:space="preserve">
+    <value>Browse...</value>
+    <comment>Button that opens a picker for a single file or folder path.</comment>
+  </data>
+  <data name="AdaptiveFilePathInput_BrowseFor" xml:space="preserve">
+    <value>Browse for {0}</value>
+    <comment>Accessible label for the browse button. {0} is the name of the path field.</comment>
+  </data>
+  <data name="AdaptiveFilePathInput_FilePath" xml:space="preserve">
+    <value>File path</value>
+    <comment>Accessible name for a single-file path field without a developer-provided header.</comment>
+  </data>
+  <data name="AdaptiveFilePathInput_FolderPath" xml:space="preserve">
+    <value>Folder path</value>
+    <comment>Accessible name for a single-folder path field without a developer-provided header.</comment>
+  </data>
+  <data name="AdaptiveFilePathInput_FilePlaceholder" xml:space="preserve">
+    <value>Enter or select a file</value>
+    <comment>Default placeholder for a single-file path field.</comment>
+  </data>
+  <data name="AdaptiveFilePathInput_FolderPlaceholder" xml:space="preserve">
+    <value>Enter or select a folder</value>
+    <comment>Default placeholder for a single-folder path field.</comment>
+  </data>
+  <data name="AdaptiveFilePathInput_SelectFile" xml:space="preserve">
+    <value>Select file</value>
+    <comment>Commit button text in the single-file picker.</comment>
+  </data>
+  <data name="AdaptiveFilePathInput_SelectFolder" xml:space="preserve">
+    <value>Select folder</value>
+    <comment>Commit button text in the single-folder picker.</comment>
+  </data>
+  <data name="AdaptiveFilePathInput_RequiredError" xml:space="preserve">
+    <value>Select or enter a path.</value>
+    <comment>Validation error shown when a required single-path input is empty.</comment>
+  </data>
+  <data name="AdaptiveFilePathInput_ValidationError" xml:space="preserve">
+    <value>The path has an invalid format.</value>
+    <comment>Validation error shown when a single path does not match its configured regular expression.</comment>
+  </data>
 </root>

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/AdaptiveListValueCodecTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/AdaptiveListValueCodecTests.cs
@@ -1,0 +1,139 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CmdPal.UI.ViewModels.AdaptiveCards;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
+
+/// <summary>
+/// Covers the host's half of the wire contract for Command Palette's custom list inputs. The
+/// literals here must match what Microsoft.CommandPalette.Extensions.Toolkit emits and accepts —
+/// see ListSettingTests in the toolkit's own test project.
+/// </summary>
+[TestClass]
+public class AdaptiveListValueCodecTests
+{
+    private static readonly string[] _items = ["alpha", "beta"];
+    private static readonly string[] _pairKeys = ["alpha", "beta"];
+    private static readonly string[] _pairValues = ["one", "two=three"];
+
+    [TestMethod]
+    public void Items_RoundTripThroughTheWireShape()
+    {
+        Assert.IsTrue(AdaptiveListValueCodec.TryParseItems("""[{"value":"alpha"},{"value":"beta"}]""", out var parsed));
+
+        CollectionAssert.AreEqual(_items, parsed.Select(static item => item.Value).ToArray());
+        Assert.AreEqual(
+            """[{"value":"alpha"},{"value":"beta"}]""",
+            AdaptiveListValueCodec.ToItemsValue(parsed));
+    }
+
+    [TestMethod]
+    public void Items_AcceptBareStrings()
+    {
+        Assert.IsTrue(AdaptiveListValueCodec.TryParseItems("""["alpha","beta"]""", out var parsed));
+
+        CollectionAssert.AreEqual(_items, parsed.Select(static item => item.Value).ToArray());
+    }
+
+    [TestMethod]
+    public void Items_EmptyValueIsAnEmptyList()
+    {
+        Assert.IsTrue(AdaptiveListValueCodec.TryParseItems(string.Empty, out var parsed));
+
+        Assert.AreEqual(0, parsed.Count);
+        Assert.AreEqual("[]", AdaptiveListValueCodec.ToItemsValue(parsed));
+    }
+
+    [TestMethod]
+    public void Items_PreserveUnrecognizedPerItemProperties()
+    {
+        Assert.IsTrue(AdaptiveListValueCodec.TryParseItems(
+            """[{"value":"alpha","enabled":false},{"value":"beta"}]""",
+            out var parsed));
+
+        Assert.AreEqual(
+            """[{"value":"alpha","enabled":false},{"value":"beta"}]""",
+            AdaptiveListValueCodec.ToItemsValue(parsed));
+    }
+
+    [TestMethod]
+    public void Items_PreserveUnrecognizedPropertiesWhenTheEntryIsEdited()
+    {
+        Assert.IsTrue(AdaptiveListValueCodec.TryParseItems("""[{"value":"alpha","enabled":false}]""", out var parsed));
+
+        // A new entry alongside one the user did not touch.
+        var edited = parsed.Concat([new AdaptiveListItemValue("gamma")]).ToList();
+
+        Assert.AreEqual(
+            """[{"value":"alpha","enabled":false},{"value":"gamma"}]""",
+            AdaptiveListValueCodec.ToItemsValue(edited));
+    }
+
+    [TestMethod]
+    public void Items_MalformedValueIsRejected()
+    {
+        Assert.IsFalse(AdaptiveListValueCodec.TryParseItems("not an array", out var parsed));
+        Assert.AreEqual(0, parsed.Count);
+
+        Assert.IsFalse(AdaptiveListValueCodec.TryParseItems("""{"value":"alpha"}""", out _));
+    }
+
+    [TestMethod]
+    public void Pairs_RoundTripThroughTheWireShape()
+    {
+        Assert.IsTrue(AdaptiveListValueCodec.TryParsePairs(
+            """[{"key":"alpha","value":"one"},{"key":"beta","value":"two=three"}]""",
+            out var parsed));
+
+        CollectionAssert.AreEqual(_pairKeys, parsed.Select(static pair => pair.Key).ToArray());
+        CollectionAssert.AreEqual(_pairValues, parsed.Select(static pair => pair.Value).ToArray());
+        Assert.AreEqual(
+            """[{"key":"alpha","value":"one"},{"key":"beta","value":"two=three"}]""",
+            AdaptiveListValueCodec.ToPairsValue(parsed));
+    }
+
+    [TestMethod]
+    public void Pairs_PreserveUnrecognizedPerItemProperties()
+    {
+        Assert.IsTrue(AdaptiveListValueCodec.TryParsePairs(
+            """[{"key":"alpha","value":"one","enabled":false}]""",
+            out var parsed));
+
+        Assert.AreEqual(
+            """[{"key":"alpha","value":"one","enabled":false}]""",
+            AdaptiveListValueCodec.ToPairsValue(parsed));
+    }
+
+    [TestMethod]
+    public void Pairs_PreserveDuplicateKeysAndEmptyValues()
+    {
+        Assert.IsTrue(AdaptiveListValueCodec.TryParsePairs(
+            """[{"key":"same","value":"one"},{"key":"same","value":""}]""",
+            out var parsed));
+
+        Assert.AreEqual(2, parsed.Count);
+        Assert.AreEqual(
+            """[{"key":"same","value":"one"},{"key":"same","value":""}]""",
+            AdaptiveListValueCodec.ToPairsValue(parsed));
+    }
+
+    [TestMethod]
+    public void Pairs_MalformedValueIsRejected()
+    {
+        Assert.IsFalse(AdaptiveListValueCodec.TryParsePairs("{not an array}", out var parsed));
+        Assert.AreEqual(0, parsed.Count);
+    }
+
+    [TestMethod]
+    public void Pairs_NewEntriesSerializeWithoutASourceObject()
+    {
+        var pairs = new List<AdaptiveKeyValuePairValue> { new("alpha", "one") };
+
+        Assert.AreEqual("""[{"key":"alpha","value":"one"}]""", AdaptiveListValueCodec.ToPairsValue(pairs));
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CommandPalette.Extensions.Toolkit.UnitTests/FilePathSettingTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CommandPalette.Extensions.Toolkit.UnitTests/FilePathSettingTests.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Nodes;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CommandPalette.Extensions.Toolkit.UnitTests;
+
+[TestClass]
+public class FilePathSettingTests
+{
+    private static readonly string[] _fileTypeFilters = [".exe", "*.cmd"];
+
+    [TestMethod]
+    public void FilePathSetting_FileMode_EmitsPickerAndValidationOptions()
+    {
+        var setting = new FilePathSetting(
+            "executable",
+            "Executable",
+            "Choose an executable",
+            @"C:\Tools\app.exe",
+            FilePathSelectionMode.File)
+        {
+            FileTypeFilter = [".exe", "*.cmd"],
+            Placeholder = "Executable path",
+            ValidationPattern = @"(?i)^.+\.(exe|cmd)$",
+            ValidationErrorMessage = "Choose an executable.",
+        };
+
+        var dictionary = setting.ToDictionary();
+
+        Assert.AreEqual("Input.CommandPalette.FilePath", dictionary["type"]);
+        Assert.AreEqual("file", dictionary["selectionMode"]);
+        Assert.AreEqual("Executable path", dictionary["placeholder"]);
+        Assert.AreEqual(@"(?i)^.+\.(exe|cmd)$", dictionary["validationPattern"]);
+        Assert.AreEqual("Choose an executable.", dictionary["validationErrorMessage"]);
+        CollectionAssert.AreEqual(
+            _fileTypeFilters,
+            ((List<string>)dictionary["fileTypeFilter"]).ToArray());
+    }
+
+    [TestMethod]
+    public void FilePathSetting_FolderMode_EmitsFolderSelectionMode()
+    {
+        var setting = new FilePathSetting(
+            "folder",
+            @"C:\Tools",
+            FilePathSelectionMode.Folder);
+
+        Assert.AreEqual("folder", setting.ToDictionary()["selectionMode"]);
+    }
+
+    [TestMethod]
+    public void FilePathSetting_DefaultsToFileMode()
+    {
+        var setting = new FilePathSetting("path", string.Empty);
+
+        Assert.AreEqual(FilePathSelectionMode.File, setting.SelectionMode);
+        Assert.AreEqual("file", setting.ToDictionary()["selectionMode"]);
+    }
+
+    [TestMethod]
+    public void FilePathSetting_ToForm_UsesCustomElementType()
+    {
+        var setting = new FilePathSetting("path", string.Empty);
+
+        var form = JsonNode.Parse(setting.ToForm())!.AsObject();
+        var input = form["body"]!.AsArray()[0]!.AsObject();
+
+        Assert.AreEqual("Input.CommandPalette.FilePath", input["type"]!.GetValue<string>());
+        Assert.AreEqual("file", input["selectionMode"]!.GetValue<string>());
+    }
+
+    [TestMethod]
+    public void FilePathSetting_FallsBackToTextInputUnderTheSameId()
+    {
+        var setting = new FilePathSetting("path", "Executable", "Choose one", @"C:\Tools\app.exe");
+
+        var form = JsonNode.Parse(setting.ToForm())!.AsObject();
+        var fallback = form["body"]!.AsArray()[0]!["fallback"]!.AsObject();
+
+        Assert.AreEqual("Input.Text", fallback["type"]!.GetValue<string>());
+        Assert.AreEqual("path", fallback["id"]!.GetValue<string>());
+        Assert.AreEqual(@"C:\Tools\app.exe", fallback["value"]!.GetValue<string>());
+    }
+
+    [TestMethod]
+    public void FilePathSetting_UpdateStoresSubmittedPath()
+    {
+        var setting = new FilePathSetting("path", string.Empty);
+
+        setting.Update(new JsonObject { ["path"] = @"C:\Tools\app.exe" });
+
+        Assert.AreEqual(@"C:\Tools\app.exe", setting.Value);
+    }
+
+    [TestMethod]
+    public void FilePathSetting_InvalidOptions_Throw()
+    {
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() =>
+            new FilePathSetting("path", string.Empty, (FilePathSelectionMode)42));
+
+        var setting = new FilePathSetting("path", string.Empty);
+        Assert.ThrowsException<ArgumentException>(() => setting.ValidationPattern = "[");
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CommandPalette.Extensions.Toolkit.UnitTests/ListSettingTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CommandPalette.Extensions.Toolkit.UnitTests/ListSettingTests.cs
@@ -1,0 +1,383 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Nodes;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CommandPalette.Extensions.Toolkit.UnitTests;
+
+[TestClass]
+public class ListSettingTests
+{
+    private static readonly string[] _submittedItems = ["gamma", "delta"];
+    private static readonly string[] _loadedItems = ["alpha", "beta"];
+    private static readonly string[] _pathItems = ["C:\\Tools", "C:\\Program Files"];
+    private static readonly string[] _fileTypeFilters = [".exe", "*.cmd"];
+    private static readonly string[] _listInputTypes = ["Input.CommandPalette.StringList", "Input.CommandPalette.FilePathList", "Input.CommandPalette.KeyValueList"];
+    private static readonly KeyValuePair<string, string>[] _keyValueItems =
+    [
+        new("key=part", "C:\\Tools=value\nnext"),
+        new("plain", string.Empty),
+    ];
+
+    private static readonly KeyValuePair<string, string>[] _loadedKeyValueItems =
+    [
+        new("alpha", "one"),
+        new("beta", "two=three"),
+    ];
+
+    [TestMethod]
+    public void StringListSetting_PersistsItemsAsJsonArray()
+    {
+        var setting = new StringListSetting("items", ["alpha", "beta"]);
+
+        // The settings file and the card carry the same shape.
+        Assert.AreEqual("""[{"value":"alpha"},{"value":"beta"}]""", setting.ToDictionary()["value"]);
+        var state = JsonNode.Parse($"{{{setting.ToState()}}}")!.AsObject();
+        Assert.AreEqual(
+            """[{"value":"alpha"},{"value":"beta"}]""",
+            state["items"]!.ToJsonString());
+    }
+
+    [TestMethod]
+    public void StringListSetting_SettingsUpdate_ReadsPersistedArray()
+    {
+        var setting = new StringListSetting("items", []);
+        var settings = new Settings();
+        settings.Add(setting);
+
+        settings.Update("""{"items":["alpha","beta"]}""");
+
+        CollectionAssert.AreEqual(_loadedItems, setting.Value!.ToArray());
+    }
+
+    [TestMethod]
+    public void StringListSetting_UpdateFromForm_ReadsAdaptiveCardValue()
+    {
+        var setting = new StringListSetting("items", []);
+        var settings = new Settings();
+        settings.Add(setting);
+
+        settings.UpdateFromForm(new JsonObject { ["items"] = CardValue("items", _submittedItems, static (k, v) => new StringListSetting(k, v)) }.ToJsonString());
+
+        CollectionAssert.AreEqual(_submittedItems, setting.Value!.ToArray());
+    }
+
+    [TestMethod]
+    public void StringListSetting_UnknownPerItemPropertiesAreIgnoredOnRead()
+    {
+        var setting = new StringListSetting("items", []);
+        var settings = new Settings();
+        settings.Add(setting);
+
+        settings.UpdateFromForm(new JsonObject
+        {
+            ["items"] = """[{"value":"alpha","enabled":false},{"value":"beta"}]""",
+        }.ToJsonString());
+
+        CollectionAssert.AreEqual(_loadedItems, setting.Value!.ToArray());
+    }
+
+    [TestMethod]
+    public void StringListSetting_MalformedCardValueKeepsTheCurrentValue()
+    {
+        var setting = new StringListSetting("items", ["alpha", "beta"]);
+        var settings = new Settings();
+        settings.Add(setting);
+
+        settings.UpdateFromForm(new JsonObject { ["items"] = "not an array" }.ToJsonString());
+
+        CollectionAssert.AreEqual(_loadedItems, setting.Value!.ToArray());
+    }
+
+    [TestMethod]
+    public void KeyValueListSetting_MalformedCardValueKeepsTheCurrentValue()
+    {
+        var setting = new KeyValueListSetting("pairs", _loadedKeyValueItems);
+        var settings = new Settings();
+        settings.Add(setting);
+
+        settings.UpdateFromForm(new JsonObject { ["pairs"] = "{not an array}" }.ToJsonString());
+
+        CollectionAssert.AreEqual(_loadedKeyValueItems, setting.Value!.ToArray());
+    }
+
+    [TestMethod]
+    public void StringListSetting_RoundTripsThroughPersistedState()
+    {
+        var setting = new StringListSetting("items", ["alpha", "beta"]);
+        var reloaded = new StringListSetting("items", []);
+        var settings = new Settings();
+        settings.Add(reloaded);
+
+        settings.Update($"{{{setting.ToState()}}}");
+
+        CollectionAssert.AreEqual(setting.Value!.ToArray(), reloaded.Value!.ToArray());
+    }
+
+    [TestMethod]
+    public void StringListSetting_EmitsValidationPattern()
+    {
+        var setting = new StringListSetting("items", ["alpha"])
+        {
+            ItemValidationPattern = "^[a-z]+$",
+            ItemValidationErrorMessage = "Use lowercase letters.",
+            PreventDuplicates = true,
+            DuplicateItemErrorMessage = "Use unique items.",
+        };
+
+        var dictionary = setting.ToDictionary();
+
+        Assert.AreEqual("^[a-z]+$", dictionary["itemValidationPattern"]);
+        Assert.AreEqual("Use lowercase letters.", dictionary["itemValidationErrorMessage"]);
+        Assert.AreEqual(true, dictionary["preventDuplicates"]);
+        Assert.AreEqual("Use unique items.", dictionary["duplicateItemErrorMessage"]);
+    }
+
+    [TestMethod]
+    public void StringListSetting_PreventDuplicates_DefaultsToFalse()
+    {
+        var setting = new StringListSetting("items", ["alpha", "alpha"]);
+
+        Assert.AreEqual(false, setting.PreventDuplicates);
+        Assert.AreEqual(false, setting.ToDictionary()["preventDuplicates"]);
+    }
+
+    [TestMethod]
+    public void StringListSetting_InvalidValidationPattern_Throws()
+    {
+        var setting = new StringListSetting("items", []);
+
+        Assert.ThrowsException<ArgumentException>(() => setting.ItemValidationPattern = "[");
+    }
+
+    [TestMethod]
+    public void FilePathListSetting_EmitsPickerOptions()
+    {
+        var setting = new FilePathListSetting(
+            "searchPaths",
+            "Search paths",
+            "Additional folders to search",
+            ["C:\\Tools"],
+            FilePathListItemType.Folders)
+        {
+            FileTypeFilter = [".exe", "*.cmd"],
+        };
+
+        var dictionary = setting.ToDictionary();
+
+        Assert.AreEqual("Input.CommandPalette.FilePathList", dictionary["type"]);
+        Assert.AreEqual(false, dictionary["allowFiles"]);
+        Assert.AreEqual(true, dictionary["allowFolders"]);
+        CollectionAssert.AreEqual(
+            _fileTypeFilters,
+            ((List<string>)dictionary["fileTypeFilter"]).ToArray());
+    }
+
+    [TestMethod]
+    public void FilePathListSetting_NoAllowedItemTypes_Throws()
+    {
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() =>
+            new FilePathListSetting("paths", [], (FilePathListItemType)0));
+    }
+
+    [TestMethod]
+    public void FilePathListSetting_ToForm_UsesRegisteredCustomElementType()
+    {
+        var setting = new FilePathListSetting("paths", [])
+        {
+            FileTypeFilter = [".exe"],
+        };
+
+        var form = JsonNode.Parse(setting.ToForm())!.AsObject();
+        var input = form["body"]!.AsArray()[0]!.AsObject();
+
+        Assert.AreEqual("Input.CommandPalette.FilePathList", input["type"]!.GetValue<string>());
+        Assert.AreEqual(".exe", input["fileTypeFilter"]!.AsArray()[0]!.GetValue<string>());
+    }
+
+    [TestMethod]
+    public void ListSettings_EmitFallbackNoticeNamingTheSetting()
+    {
+        var setting = new StringListSetting("items", "Search paths", "Where to look", ["alpha"]);
+
+        var form = JsonNode.Parse(setting.ToForm())!.AsObject();
+        var fallback = form["body"]!.AsArray()[0]!["fallback"]!.AsObject();
+
+        Assert.AreEqual("TextBlock", fallback["type"]!.GetValue<string>());
+        Assert.AreEqual(true, fallback["wrap"]!.GetValue<bool>());
+        StringAssert.Contains(fallback["text"]!.GetValue<string>(), "Search paths");
+    }
+
+    [TestMethod]
+    public void FilePathListSetting_RoundTripsThroughPersistedState()
+    {
+        var setting = new FilePathListSetting("paths", ["C:\\Tools", "C:\\Program Files"]);
+        var reloaded = new FilePathListSetting("paths", []);
+        var settings = new Settings();
+        settings.Add(reloaded);
+
+        settings.Update($"{{{setting.ToState()}}}");
+
+        CollectionAssert.AreEqual(setting.Value!.ToArray(), reloaded.Value!.ToArray());
+    }
+
+    [TestMethod]
+    public void CustomInputSettings_EnteredValuesRoundTripThroughPersistedState()
+    {
+        var stringList = new StringListSetting("strings", []);
+        var pathList = new FilePathListSetting("paths", []);
+        var keyValueList = new KeyValueListSetting("pairs", []);
+        var singlePath = new FilePathSetting("singlePath", string.Empty);
+        var settings = new Settings();
+        settings.Add(stringList);
+        settings.Add(pathList);
+        settings.Add(keyValueList);
+        settings.Add(singlePath);
+
+        settings.UpdateFromForm(new JsonObject
+        {
+            ["strings"] = CardValue("items", _submittedItems, static (k, v) => new StringListSetting(k, v)),
+            ["paths"] = CardValue("paths", _pathItems, static (k, v) => new FilePathListSetting(k, v)),
+            ["pairs"] = CardValue("pairs", _keyValueItems, static (k, v) => new KeyValueListSetting(k, v)),
+            ["singlePath"] = @"C:\Tools\app.exe",
+        }.ToJsonString());
+
+        var reloadedStringList = new StringListSetting("strings", []);
+        var reloadedPathList = new FilePathListSetting("paths", []);
+        var reloadedKeyValueList = new KeyValueListSetting("pairs", []);
+        var reloadedSinglePath = new FilePathSetting("singlePath", string.Empty);
+        var reloadedSettings = new Settings();
+        reloadedSettings.Add(reloadedStringList);
+        reloadedSettings.Add(reloadedPathList);
+        reloadedSettings.Add(reloadedKeyValueList);
+        reloadedSettings.Add(reloadedSinglePath);
+
+        reloadedSettings.Update(settings.ToJson());
+
+        CollectionAssert.AreEqual(_submittedItems, reloadedStringList.Value!.ToArray());
+        CollectionAssert.AreEqual(_pathItems, reloadedPathList.Value!.ToArray());
+        CollectionAssert.AreEqual(_keyValueItems, reloadedKeyValueList.Value!.ToArray());
+        Assert.AreEqual(@"C:\Tools\app.exe", reloadedSinglePath.Value);
+    }
+
+    [TestMethod]
+    public void KeyValueListSetting_PersistsPairsAsJsonArray()
+    {
+        var setting = new KeyValueListSetting("pairs", [new("name", "value=with equals")]);
+
+        var state = JsonNode.Parse($"{{{setting.ToState()}}}")!.AsObject();
+        var entry = state["pairs"]!.AsArray()[0]!.AsObject();
+
+        Assert.AreEqual("name", entry["key"]!.GetValue<string>());
+        Assert.AreEqual("value=with equals", entry["value"]!.GetValue<string>());
+        Assert.AreEqual(
+            """[{"key":"name","value":"value=with equals"}]""",
+            setting.ToDictionary()["value"]);
+    }
+
+    [TestMethod]
+    public void KeyValueListSetting_SettingsUpdate_ReadsPersistedArray()
+    {
+        var setting = new KeyValueListSetting("pairs", []);
+        var settings = new Settings();
+        settings.Add(setting);
+
+        settings.Update("""{"pairs":[{"key":"alpha","value":"one"},{"key":"beta","value":"two=three"}]}""");
+
+        CollectionAssert.AreEqual(_loadedKeyValueItems, setting.Value!.ToArray());
+    }
+
+    [TestMethod]
+    public void KeyValueListSetting_UpdateFromForm_ReadsAdaptiveCardValue()
+    {
+        var setting = new KeyValueListSetting("pairs", []);
+        var settings = new Settings();
+        settings.Add(setting);
+
+        settings.UpdateFromForm(
+            new JsonObject { ["pairs"] = CardValue("pairs", _loadedKeyValueItems, static (k, v) => new KeyValueListSetting(k, v)) }.ToJsonString());
+
+        CollectionAssert.AreEqual(_loadedKeyValueItems, setting.Value!.ToArray());
+    }
+
+    [TestMethod]
+    public void KeyValueListSetting_RoundTripsDuplicateKeysAndEscapedCharacters()
+    {
+        var setting = new KeyValueListSetting("pairs", _keyValueItems);
+        var reloaded = new KeyValueListSetting("pairs", []);
+        var settings = new Settings();
+        settings.Add(reloaded);
+
+        settings.Update($"{{{setting.ToState()}}}");
+
+        CollectionAssert.AreEqual(_keyValueItems, reloaded.Value!.ToArray());
+    }
+
+    [TestMethod]
+    public void KeyValueListSetting_EmitsValidationPatterns()
+    {
+        var setting = new KeyValueListSetting("pairs", [new("name", "value")])
+        {
+            KeyValidationPattern = "^[a-z]+$",
+            KeyValidationErrorMessage = "Invalid key.",
+            ValueValidationPattern = "^.+$",
+            ValueValidationErrorMessage = "Invalid value.",
+            PreventDuplicateKeys = true,
+            DuplicateKeyErrorMessage = "Use unique keys.",
+        };
+
+        var dictionary = setting.ToDictionary();
+
+        Assert.AreEqual("Input.CommandPalette.KeyValueList", dictionary["type"]);
+        Assert.AreEqual("^[a-z]+$", dictionary["keyValidationPattern"]);
+        Assert.AreEqual("^.+$", dictionary["valueValidationPattern"]);
+        Assert.AreEqual(true, dictionary["preventDuplicateKeys"]);
+        Assert.AreEqual("Use unique keys.", dictionary["duplicateKeyErrorMessage"]);
+    }
+
+    [TestMethod]
+    public void KeyValueListSetting_PreventDuplicateKeys_DefaultsToFalse()
+    {
+        var setting = new KeyValueListSetting("pairs", [new("key", "one"), new("key", "two")]);
+
+        Assert.AreEqual(false, setting.PreventDuplicateKeys);
+        Assert.AreEqual(false, setting.ToDictionary()["preventDuplicateKeys"]);
+    }
+
+    [TestMethod]
+    public void KeyValueListSetting_InvalidValidationPattern_Throws()
+    {
+        var setting = new KeyValueListSetting("pairs", []);
+
+        Assert.ThrowsException<ArgumentException>(() => setting.KeyValidationPattern = "[");
+        Assert.ThrowsException<ArgumentException>(() => setting.ValueValidationPattern = "(");
+    }
+
+    // Builds a submission the way the setting itself renders one, so the tests never carry a
+    // second encoder that could drift from the SDK. The exact wire shape is pinned by the
+    // *_EmitsCardValue tests below; the host's copy of it lives in AdaptiveListValueCodec.
+    private static string CardValue<T>(string key, IReadOnlyList<T> items, Func<string, IReadOnlyList<T>, Setting<IReadOnlyList<T>>> create) =>
+        (string)create(key, items).ToDictionary()["value"];
+
+    [TestMethod]
+    public void SettingsForm_ContainsEveryListInputType()
+    {
+        var settings = new Settings();
+        settings.Add(new StringListSetting("strings", ["alpha"]));
+        settings.Add(new FilePathListSetting("paths", [@"C:\Tools"]));
+        settings.Add(new KeyValueListSetting("pairs", [new("key", "value")]));
+
+        var form = JsonNode.Parse(settings.ToFormJson())!.AsObject();
+        var inputTypes = form["body"]!
+            .AsArray()
+            .Select(input => input!["type"]!.GetValue<string>())
+            .ToArray();
+
+        CollectionAssert.AreEqual(_listInputTypes, inputTypes);
+    }
+}

--- a/src/modules/cmdpal/ext/SamplePagesExtension/Pages/SampleListSettingsPage.cs
+++ b/src/modules/cmdpal/ext/SamplePagesExtension/Pages/SampleListSettingsPage.cs
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+
+namespace SamplePagesExtension;
+
+internal sealed partial class SampleListSettingsPage : ContentPage
+{
+    private readonly Settings _settings = new();
+
+    public SampleListSettingsPage()
+    {
+        Name = "Path and list settings controls";
+        Icon = new IconInfo("\uE8FD");
+
+        _settings.Add(new FilePathSetting(
+            "singleExecutable",
+            "Single file",
+            "Enter an executable path or choose one with the file picker.",
+            @"C:\Windows\System32\cmd.exe",
+            FilePathSelectionMode.File)
+        {
+            FileTypeFilter = [".exe", ".cmd", ".bat"],
+            Placeholder = "Executable path",
+            ValidationPattern = @"(?i)^.+\.(exe|cmd|bat)$",
+            ValidationErrorMessage = "Choose an .exe, .cmd, or .bat file.",
+        });
+
+        _settings.Add(new FilePathSetting(
+            "singleFolder",
+            "Single folder",
+            "Enter a folder path or choose one with the folder picker.",
+            @"C:\Windows\System32",
+            FilePathSelectionMode.Folder)
+        {
+            Placeholder = "Folder path",
+        });
+
+        _settings.Add(new StringListSetting(
+            "identifiers",
+            "Plain strings",
+            "Add identifiers containing letters, numbers, underscores, or hyphens.",
+            ["alpha", "beta-item"])
+        {
+            Placeholder = "New identifier",
+            ItemValidationPattern = "^[A-Za-z][A-Za-z0-9_-]*$",
+            ItemValidationErrorMessage = "Identifiers must start with a letter and contain only letters, numbers, underscores, or hyphens.",
+            PreventDuplicates = true,
+            DuplicateItemErrorMessage = "Identifiers must be unique.",
+        });
+
+        _settings.Add(new FilePathListSetting(
+            "searchPaths",
+            "Custom search paths",
+            "Add files or folders to search. The file picker is limited to executables and command files.",
+            [@"C:\Windows\System32"],
+            FilePathListItemType.FilesAndFolders)
+        {
+            FileTypeFilter = [".exe", ".cmd", ".bat"],
+        });
+
+        _settings.Add(new KeyValueListSetting(
+            "variables",
+            "Key/value pairs",
+            "Pairs are stored as structured entries, so keys and values may contain equals signs.",
+            [
+                new("environment", "development"),
+                new("connectionString", "Server=localhost;Database=sample"),
+            ])
+        {
+            IsRequired = true,
+            KeyPlaceholder = "Variable name",
+            ValuePlaceholder = "Variable value",
+            MissingKeyErrorMessage = "Every value must have a variable name.",
+            KeyValidationPattern = "^[A-Za-z_][A-Za-z0-9_.-]*$",
+            KeyValidationErrorMessage = "Keys must start with a letter or underscore and use only letters, numbers, dots, underscores, or hyphens.",
+            ValueValidationPattern = "^.+$",
+            ValueValidationErrorMessage = "Values cannot be empty.",
+            PreventDuplicateKeys = true,
+            DuplicateKeyErrorMessage = "Variable names must be unique.",
+        });
+    }
+
+    public override IContent[] GetContent() => _settings.ToContent();
+}

--- a/src/modules/cmdpal/ext/SamplePagesExtension/SamplesListPage.cs
+++ b/src/modules/cmdpal/ext/SamplePagesExtension/SamplesListPage.cs
@@ -130,6 +130,11 @@ public partial class SamplesListPage : ListPage
             Title = "Sample settings page",
             Subtitle = "A demo of the settings helpers",
         },
+        new ListItem(new SampleListSettingsPage())
+        {
+            Title = "Path and list settings controls",
+            Subtitle = "Manage strings, file paths, and escaped key/value pairs",
+        },
 
         // Data package samples
         new ListItem(new SampleDataTransferPage())

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/FilePathListSetting.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/FilePathListSetting.cs
@@ -1,0 +1,157 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json.Nodes;
+
+namespace Microsoft.CommandPalette.Extensions.Toolkit;
+
+/// <summary>
+/// Specifies which kinds of paths a <see cref="FilePathListSetting"/> can add.
+/// </summary>
+[Flags]
+public enum FilePathListItemType
+{
+    Files = 1,
+    Folders = 2,
+    FilesAndFolders = Files | Folders,
+}
+
+/// <summary>
+/// A setting that manages a list of paths using the Windows file and folder pickers.
+/// </summary>
+/// <remarks>
+/// The value is stored in the settings file and carried on the adaptive card as the same JSON
+/// array of objects, <c>[{ "value": "…" }]</c>, so per-item properties can be added later without
+/// changing the shape. Readers accept an array of bare strings and ignore properties they do not
+/// recognize.
+/// </remarks>
+public sealed class FilePathListSetting : Setting<IReadOnlyList<string>>
+{
+    private FilePathListItemType _allowedItemTypes = FilePathListItemType.FilesAndFolders;
+    private string _itemValidationPattern = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the kinds of paths the user can add.
+    /// </summary>
+    public FilePathListItemType AllowedItemTypes
+    {
+        get => _allowedItemTypes;
+        set => _allowedItemTypes = ValidateAllowedItemTypes(value);
+    }
+
+    /// <summary>
+    /// Gets or sets the file extensions shown by the file picker.
+    /// Values may use forms such as <c>.txt</c>, <c>*.txt</c>, or <c>*</c>.
+    /// </summary>
+    public List<string> FileTypeFilter { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets an optional regular expression that every path must match.
+    /// The pattern is not anchored, so use <c>^</c> and <c>$</c> to match a whole path.
+    /// </summary>
+    public string ItemValidationPattern
+    {
+        get => _itemValidationPattern;
+        set => _itemValidationPattern = RegularExpressionPattern.Validate(value, nameof(ItemValidationPattern));
+    }
+
+    /// <summary>
+    /// Gets or sets the error shown when a path does not match <see cref="ItemValidationPattern"/>.
+    /// </summary>
+    public string ItemValidationErrorMessage { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether duplicate paths are rejected.
+    /// Path comparisons in the host are ordinal and case-insensitive. The default is <see langword="false"/>.
+    /// </summary>
+    public bool PreventDuplicates { get; set; }
+
+    /// <summary>
+    /// Gets or sets the error shown when <see cref="PreventDuplicates"/> is enabled and duplicate paths exist.
+    /// </summary>
+    public string DuplicateItemErrorMessage { get; set; } = string.Empty;
+
+    private FilePathListSetting()
+        : base()
+    {
+        Value = [];
+    }
+
+    public FilePathListSetting(
+        string key,
+        IReadOnlyList<string> defaultValue,
+        FilePathListItemType allowedItemTypes = FilePathListItemType.FilesAndFolders)
+        : base(key, defaultValue)
+    {
+        AllowedItemTypes = allowedItemTypes;
+    }
+
+    public FilePathListSetting(
+        string key,
+        string label,
+        string description,
+        IReadOnlyList<string> defaultValue,
+        FilePathListItemType allowedItemTypes = FilePathListItemType.FilesAndFolders)
+        : base(key, label, description, defaultValue)
+    {
+        AllowedItemTypes = allowedItemTypes;
+    }
+
+    public override Dictionary<string, object> ToDictionary()
+    {
+        return new Dictionary<string, object>
+        {
+            { "type", "Input.CommandPalette.FilePathList" },
+            { "id", Key },
+            { "label", string.Empty },
+            { "header", Label },
+            { "description", Description },
+            { "value", StringListSettingUtilities.ToJsonArray(Value) },
+            { "isRequired", IsRequired },
+            { "errorMessage", ErrorMessage },
+            { "itemValidationPattern", ItemValidationPattern },
+            { "itemValidationErrorMessage", ItemValidationErrorMessage },
+            { "preventDuplicates", PreventDuplicates },
+            { "duplicateItemErrorMessage", DuplicateItemErrorMessage },
+            { "fallback", SettingFallback.Notice(Label) },
+            { "allowFiles", AllowedItemTypes.HasFlag(FilePathListItemType.Files) },
+            { "allowFolders", AllowedItemTypes.HasFlag(FilePathListItemType.Folders) },
+            { "fileTypeFilter", FileTypeFilter },
+        };
+    }
+
+    public override void Update(JsonObject payload)
+    {
+        if (payload[Key] is JsonArray array)
+        {
+            Value = StringListSettingUtilities.ParseArray(array);
+        }
+    }
+
+    public override void UpdateFromForm(JsonObject payload)
+    {
+        if (payload[Key] is JsonValue value &&
+            value.TryGetValue<string>(out var submittedValue) &&
+            StringListSettingUtilities.TryParseJsonArray(submittedValue, out var items))
+        {
+            Value = items;
+        }
+    }
+
+    public override string ToState() => StringListSettingUtilities.ToPersistedValue(Key, Value);
+
+    private static FilePathListItemType ValidateAllowedItemTypes(FilePathListItemType allowedItemTypes)
+    {
+        const FilePathListItemType all = FilePathListItemType.FilesAndFolders;
+        if ((allowedItemTypes & all) == 0 || (allowedItemTypes & ~all) != 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(allowedItemTypes),
+                allowedItemTypes,
+                "At least one supported path type must be allowed.");
+        }
+
+        return allowedItemTypes;
+    }
+}

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/FilePathSetting.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/FilePathSetting.cs
@@ -1,0 +1,147 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Microsoft.CommandPalette.Extensions.Toolkit;
+
+/// <summary>
+/// Specifies whether a <see cref="FilePathSetting"/> selects a file or a folder.
+/// </summary>
+public enum FilePathSelectionMode
+{
+    File,
+    Folder,
+}
+
+/// <summary>
+/// A setting that lets the user enter or browse for one file or folder path.
+/// </summary>
+public sealed class FilePathSetting : Setting<string>
+{
+    private FilePathSelectionMode _selectionMode;
+    private string _validationPattern = string.Empty;
+
+    /// <summary>
+    /// Gets or sets whether the picker selects a file or folder.
+    /// </summary>
+    public FilePathSelectionMode SelectionMode
+    {
+        get => _selectionMode;
+        set => _selectionMode = ValidateSelectionMode(value);
+    }
+
+    /// <summary>
+    /// Gets or sets the file extensions shown by the file picker.
+    /// Values may use forms such as <c>.txt</c>, <c>*.txt</c>, or <c>*</c>.
+    /// This property is ignored when <see cref="SelectionMode"/> is <see cref="FilePathSelectionMode.Folder"/>.
+    /// </summary>
+    public List<string> FileTypeFilter { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets the placeholder shown by the path text box.
+    /// </summary>
+    public string Placeholder { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets an optional regular expression that the path must match.
+    /// </summary>
+    public string ValidationPattern
+    {
+        get => _validationPattern;
+        set => _validationPattern = RegularExpressionPattern.Validate(value, nameof(ValidationPattern));
+    }
+
+    /// <summary>
+    /// Gets or sets the error shown when the path does not match <see cref="ValidationPattern"/>.
+    /// </summary>
+    public string ValidationErrorMessage { get; set; } = string.Empty;
+
+    private FilePathSetting()
+        : base()
+    {
+        Value = string.Empty;
+    }
+
+    public FilePathSetting(
+        string key,
+        string defaultValue,
+        FilePathSelectionMode selectionMode = FilePathSelectionMode.File)
+        : base(key, defaultValue)
+    {
+        SelectionMode = selectionMode;
+    }
+
+    public FilePathSetting(
+        string key,
+        string label,
+        string description,
+        string defaultValue,
+        FilePathSelectionMode selectionMode = FilePathSelectionMode.File)
+        : base(key, label, description, defaultValue)
+    {
+        SelectionMode = selectionMode;
+    }
+
+    public override Dictionary<string, object> ToDictionary()
+    {
+        return new Dictionary<string, object>
+        {
+            { "type", "Input.CommandPalette.FilePath" },
+            { "id", Key },
+            { "label", string.Empty },
+            { "header", Label },
+            { "description", Description },
+            { "value", Value ?? string.Empty },
+            { "isRequired", IsRequired },
+            { "errorMessage", ErrorMessage },
+            { "selectionMode", SelectionMode == FilePathSelectionMode.File ? "file" : "folder" },
+            { "fileTypeFilter", FileTypeFilter },
+            { "placeholder", Placeholder },
+            { "validationPattern", ValidationPattern },
+            { "validationErrorMessage", ValidationErrorMessage },
+
+            // A path is an ordinary string, so a host that does not know this element type can
+            // fall back to a plain text box under the same id and still round-trip the value.
+            {
+                "fallback", new Dictionary<string, object>
+                {
+                    { "type", "Input.Text" },
+                    { "id", Key },
+                    { "title", Label },
+                    { "label", Description },
+                    { "value", Value ?? string.Empty },
+                    { "isRequired", IsRequired },
+                    { "errorMessage", ErrorMessage },
+                    { "placeholder", Placeholder },
+                }
+            },
+        };
+    }
+
+    public override void Update(JsonObject payload)
+    {
+        if (payload[Key] is JsonValue value && value.TryGetValue<string>(out var submittedValue))
+        {
+            Value = submittedValue;
+        }
+    }
+
+    public override string ToState() =>
+        $"\"{Key}\": {JsonSerializer.Serialize(Value, JsonSerializationContext.Default.String)}";
+
+    private static FilePathSelectionMode ValidateSelectionMode(FilePathSelectionMode selectionMode)
+    {
+        if (selectionMode is not FilePathSelectionMode.File and not FilePathSelectionMode.Folder)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(selectionMode),
+                selectionMode,
+                "The selection mode must be File or Folder.");
+        }
+
+        return selectionMode;
+    }
+}

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/ISettingsForm.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/ISettingsForm.cs
@@ -12,6 +12,8 @@ internal interface ISettingsForm
 
     public void Update(JsonObject payload);
 
+    public void UpdateFromForm(JsonObject payload);
+
     public Dictionary<string, object> ToDictionary();
 
     public string ToDataIdentifier();

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/JsonSerializationContext.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/JsonSerializationContext.cs
@@ -13,6 +13,7 @@ namespace Microsoft.CommandPalette.Extensions.Toolkit;
 [JsonSerializable(typeof(bool))]
 [JsonSerializable(typeof(Choice))]
 [JsonSerializable(typeof(List<Choice>))]
+[JsonSerializable(typeof(List<string>))]
 [JsonSerializable(typeof(List<ChoiceSetSetting>))]
 [JsonSerializable(typeof(Dictionary<string, object>), TypeInfoPropertyName = "Dictionary")]
 [JsonSerializable(typeof(List<Dictionary<string, object>>))]

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/KeyValueListSetting.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/KeyValueListSetting.cs
@@ -1,0 +1,206 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Microsoft.CommandPalette.Extensions.Toolkit;
+
+/// <summary>
+/// A setting that lets the user add and remove key/value pairs.
+/// </summary>
+/// <remarks>
+/// The value is stored in the settings file as a JSON array of <c>{ "key": …, "value": … }</c>
+/// objects, and the adaptive card carries the same array. Duplicate keys are preserved, so the
+/// entries are an array rather than an object, and per-item properties can be added later without
+/// changing the shape.
+/// </remarks>
+public sealed class KeyValueListSetting : Setting<IReadOnlyList<KeyValuePair<string, string>>>
+{
+    private const string KeyPropertyName = "key";
+    private const string ValuePropertyName = "value";
+
+    private string _keyValidationPattern = string.Empty;
+    private string _valueValidationPattern = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the placeholder shown by the key text box.
+    /// </summary>
+    public string KeyPlaceholder { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the placeholder shown by the value text box.
+    /// </summary>
+    public string ValuePlaceholder { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the validation error shown when a pair has no key.
+    /// </summary>
+    public string MissingKeyErrorMessage { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets an optional regular expression that every key must match.
+    /// The pattern is not anchored, so use <c>^</c> and <c>$</c> to match a whole key.
+    /// </summary>
+    public string KeyValidationPattern
+    {
+        get => _keyValidationPattern;
+        set => _keyValidationPattern = RegularExpressionPattern.Validate(value, nameof(KeyValidationPattern));
+    }
+
+    /// <summary>
+    /// Gets or sets the error shown when a key does not match <see cref="KeyValidationPattern"/>.
+    /// </summary>
+    public string KeyValidationErrorMessage { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets an optional regular expression that every value must match.
+    /// The pattern is not anchored, so use <c>^</c> and <c>$</c> to match a whole value.
+    /// </summary>
+    public string ValueValidationPattern
+    {
+        get => _valueValidationPattern;
+        set => _valueValidationPattern = RegularExpressionPattern.Validate(value, nameof(ValueValidationPattern));
+    }
+
+    /// <summary>
+    /// Gets or sets the error shown when a value does not match <see cref="ValueValidationPattern"/>.
+    /// </summary>
+    public string ValueValidationErrorMessage { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether pairs with duplicate keys are rejected.
+    /// Comparisons are ordinal and case-sensitive. The default is <see langword="false"/>.
+    /// </summary>
+    public bool PreventDuplicateKeys { get; set; }
+
+    /// <summary>
+    /// Gets or sets the error shown when <see cref="PreventDuplicateKeys"/> is enabled and duplicate keys exist.
+    /// </summary>
+    public string DuplicateKeyErrorMessage { get; set; } = string.Empty;
+
+    private KeyValueListSetting()
+        : base()
+    {
+        Value = [];
+    }
+
+    public KeyValueListSetting(string key, IReadOnlyList<KeyValuePair<string, string>> defaultValue)
+        : base(key, defaultValue)
+    {
+    }
+
+    public KeyValueListSetting(
+        string key,
+        string label,
+        string description,
+        IReadOnlyList<KeyValuePair<string, string>> defaultValue)
+        : base(key, label, description, defaultValue)
+    {
+    }
+
+    public override Dictionary<string, object> ToDictionary()
+    {
+        return new Dictionary<string, object>
+        {
+            { "type", "Input.CommandPalette.KeyValueList" },
+            { "id", Key },
+            { "label", string.Empty },
+            { "header", Label },
+            { "description", Description },
+            { "value", ToJsonArray(Value) },
+            { "isRequired", IsRequired },
+            { "errorMessage", ErrorMessage },
+            { "keyPlaceholder", KeyPlaceholder },
+            { "valuePlaceholder", ValuePlaceholder },
+            { "missingKeyErrorMessage", MissingKeyErrorMessage },
+            { "keyValidationPattern", KeyValidationPattern },
+            { "keyValidationErrorMessage", KeyValidationErrorMessage },
+            { "valueValidationPattern", ValueValidationPattern },
+            { "valueValidationErrorMessage", ValueValidationErrorMessage },
+            { "preventDuplicateKeys", PreventDuplicateKeys },
+            { "duplicateKeyErrorMessage", DuplicateKeyErrorMessage },
+            { "fallback", SettingFallback.Notice(Label) },
+        };
+    }
+
+    public override void Update(JsonObject payload)
+    {
+        if (payload[Key] is not JsonArray array)
+        {
+            return;
+        }
+
+        Value = ParseArray(array);
+    }
+
+    public override void UpdateFromForm(JsonObject payload)
+    {
+        if (payload[Key] is JsonValue value &&
+            value.TryGetValue<string>(out var submittedValue) &&
+            TryParseJsonArray(submittedValue, out var items))
+        {
+            Value = items;
+        }
+    }
+
+    public override string ToState() => $"\"{Key}\": {ToJsonArray(Value)}";
+
+    private static IReadOnlyList<KeyValuePair<string, string>> Normalize(
+        IEnumerable<KeyValuePair<string, string>>? items) =>
+        items?.Select(static item => new KeyValuePair<string, string>(
+            item.Key ?? string.Empty,
+            item.Value ?? string.Empty)).ToArray() ?? [];
+
+    private static string ToJsonArray(IEnumerable<KeyValuePair<string, string>>? items) =>
+        new JsonArray(Normalize(items)
+            .Select(static item => (JsonNode)new JsonObject
+            {
+                [KeyPropertyName] = item.Key,
+                [ValuePropertyName] = item.Value,
+            })
+            .ToArray())
+            .ToJsonString();
+
+    private static bool TryParseJsonArray(
+        string? value,
+        out IReadOnlyList<KeyValuePair<string, string>> items)
+    {
+        items = [];
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return true;
+        }
+
+        JsonNode? node;
+        try
+        {
+            node = JsonNode.Parse(value);
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+
+        if (node is not JsonArray array)
+        {
+            return false;
+        }
+
+        items = ParseArray(array);
+        return true;
+    }
+
+    private static IReadOnlyList<KeyValuePair<string, string>> ParseArray(JsonArray array) =>
+        array
+            .OfType<JsonObject>()
+            .Select(static entry => new KeyValuePair<string, string>(
+                AsString(entry[KeyPropertyName]),
+                AsString(entry[ValuePropertyName])))
+            .ToArray();
+
+    private static string AsString(JsonNode? node) =>
+        node is JsonValue value && value.TryGetValue<string>(out var text) ? text : string.Empty;
+}

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/Properties/Resources.Designer.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/Properties/Resources.Designer.cs
@@ -169,6 +169,24 @@ namespace Microsoft.CommandPalette.Extensions.Toolkit.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &quot;{0}&quot; needs a newer version of Command Palette to be edited here..
+        /// </summary>
+        internal static string Setting_UnsupportedByHost {
+            get {
+                return ResourceManager.GetString("Setting_UnsupportedByHost", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This setting needs a newer version of Command Palette to be edited here..
+        /// </summary>
+        internal static string Setting_UnsupportedByHostNoLabel {
+            get {
+                return ResourceManager.GetString("Setting_UnsupportedByHostNoLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Settings.
         /// </summary>
         internal static string Settings {

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/Properties/Resources.resx
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/Properties/Resources.resx
@@ -160,4 +160,12 @@
   <data name="FilePickerParameterRun_PlaceholderText" xml:space="preserve">
     <value>Select a file</value>
   </data>
+  <data name="Setting_UnsupportedByHost" xml:space="preserve">
+    <value>"{0}" needs a newer version of Command Palette to be edited here.</value>
+    <comment>Shown in place of a setting whose input control the installed Command Palette does not support. {0} is the setting label.</comment>
+  </data>
+  <data name="Setting_UnsupportedByHostNoLabel" xml:space="preserve">
+    <value>This setting needs a newer version of Command Palette to be edited here.</value>
+    <comment>Shown in place of a setting that has no label and whose input control the installed Command Palette does not support.</comment>
+  </data>
 </root>

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/RegularExpressionPattern.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/RegularExpressionPattern.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.RegularExpressions;
+
+namespace Microsoft.CommandPalette.Extensions.Toolkit;
+
+internal static class RegularExpressionPattern
+{
+    private static readonly TimeSpan _matchTimeout = TimeSpan.FromMilliseconds(250);
+
+    public static string Validate(string? pattern, string propertyName)
+    {
+        if (string.IsNullOrEmpty(pattern))
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            _ = new Regex(pattern, RegexOptions.CultureInvariant, _matchTimeout);
+            return pattern;
+        }
+        catch (ArgumentException ex)
+        {
+            throw new ArgumentException("The validation pattern must be a valid regular expression.", propertyName, ex);
+        }
+    }
+}

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/SettingFallback.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/SettingFallback.cs
@@ -8,10 +8,17 @@ using System.Text;
 namespace Microsoft.CommandPalette.Extensions.Toolkit;
 
 /// <summary>
-/// Builds the <c>fallback</c> content emitted alongside Command Palette's custom card inputs.
-/// A host that does not recognize those element types renders the fallback instead of dropping
-/// the setting silently.
+/// Builds the <c>fallback</c> content emitted alongside Command Palette's custom card inputs, so
+/// a host that does not recognize those element types can render something instead of dropping the
+/// setting silently.
 /// </summary>
+/// <remarks>
+/// AdaptiveCards.Rendering.WinUI3 2.2.4-beta does not act on this: XamlBuilder::RenderFallback
+/// resolves the substitute control and then returns a default-constructed result, so the caller
+/// drops it. The content is emitted anyway because it is correct per the Adaptive Cards schema and
+/// costs nothing until the renderer is fixed, at which point already-published cards start
+/// degrading properly with no change on either side.
+/// </remarks>
 internal static class SettingFallback
 {
     private static readonly CompositeFormat _unsupportedFormat =
@@ -24,12 +31,12 @@ internal static class SettingFallback
     public static Dictionary<string, object> Notice(string label) => new()
     {
         { "type", "TextBlock" },
-        {
-            "text",
-            string.IsNullOrEmpty(label)
-                ? Properties.Resources.Setting_UnsupportedByHostNoLabel
-                : string.Format(CultureInfo.CurrentCulture, _unsupportedFormat, label)
-        },
+        { "text", NoticeText(label) },
         { "wrap", true },
     };
+
+    private static string NoticeText(string label) =>
+        string.IsNullOrEmpty(label)
+            ? Properties.Resources.Setting_UnsupportedByHostNoLabel
+            : string.Format(CultureInfo.CurrentCulture, _unsupportedFormat, label);
 }

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/SettingFallback.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/SettingFallback.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using System.Text;
+
+namespace Microsoft.CommandPalette.Extensions.Toolkit;
+
+/// <summary>
+/// Builds the <c>fallback</c> content emitted alongside Command Palette's custom card inputs.
+/// A host that does not recognize those element types renders the fallback instead of dropping
+/// the setting silently.
+/// </summary>
+internal static class SettingFallback
+{
+    private static readonly CompositeFormat _unsupportedFormat =
+        CompositeFormat.Parse(Properties.Resources.Setting_UnsupportedByHost);
+
+    /// <summary>
+    /// A read-only notice naming the setting. It is a <c>TextBlock</c> rather than an input, so a
+    /// host that renders it submits nothing for this key and cannot overwrite the stored value.
+    /// </summary>
+    public static Dictionary<string, object> Notice(string label) => new()
+    {
+        { "type", "TextBlock" },
+        {
+            "text",
+            string.IsNullOrEmpty(label)
+                ? Properties.Resources.Setting_UnsupportedByHostNoLabel
+                : string.Format(CultureInfo.CurrentCulture, _unsupportedFormat, label)
+        },
+        { "wrap", true },
+    };
+}

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/Setting`1.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/Setting`1.cs
@@ -74,7 +74,23 @@ public abstract class Setting<T> : ISettingsForm
         return json;
     }
 
+    /// <summary>
+    /// Applies a value for this setting. <paramref name="payload"/>[<see cref="Key"/>] holds the
+    /// value previously written by <see cref="ToState"/> when the settings file is loaded, and the
+    /// value produced by the input control when the settings card is submitted. Those two
+    /// representations are the same for every setting that does not override
+    /// <see cref="UpdateFromForm"/>.
+    /// </summary>
     public abstract void Update(JsonObject payload);
+
+    /// <summary>
+    /// Applies a value submitted from the rendered adaptive card.
+    /// <paramref name="payload"/>[<see cref="Key"/>] holds the value produced by the input control,
+    /// which uses the representation emitted by <see cref="ToDictionary"/>. The default is correct
+    /// for settings whose card representation and persisted representation are the same; override
+    /// it when they differ.
+    /// </summary>
+    public virtual void UpdateFromForm(JsonObject payload) => Update(payload);
 
     public abstract string ToState();
 }

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/Settings.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/Settings.cs
@@ -83,7 +83,23 @@ public sealed partial class Settings : ICommandSettings
         return $"{{\n{content}\n}}";
     }
 
+    /// <summary>
+    /// Applies persisted values, as read from the settings file.
+    /// </summary>
     public void Update(string data)
+    {
+        Apply(data, static (setting, payload) => setting.Update(payload));
+    }
+
+    /// <summary>
+    /// Applies values submitted from the rendered settings card.
+    /// </summary>
+    internal void UpdateFromForm(string data)
+    {
+        Apply(data, static (setting, payload) => setting.UpdateFromForm(payload));
+    }
+
+    private void Apply(string data, Action<ISettingsForm, JsonObject> apply)
     {
         var formInput = JsonNode.Parse(data)?.AsObject();
         if (formInput is null)
@@ -93,10 +109,9 @@ public sealed partial class Settings : ICommandSettings
 
         foreach (var key in _settings.Keys)
         {
-            var value = _settings[key];
-            if (value is ISettingsForm f)
+            if (_settings[key] is ISettingsForm f)
             {
-                f.Update(formInput);
+                apply(f, formInput);
             }
         }
     }

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/SettingsForm.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/SettingsForm.cs
@@ -30,7 +30,7 @@ public partial class SettingsForm : FormContent
         // current settings value.
         TemplateJson = _settings.ToFormJson();
 
-        _settings.Update(inputs);
+        _settings.UpdateFromForm(inputs);
         _settings.RaiseSettingsChanged();
 
         return CommandResult.GoHome();

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/StringListSetting.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/StringListSetting.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json.Nodes;
+
+namespace Microsoft.CommandPalette.Extensions.Toolkit;
+
+/// <summary>
+/// A setting that lets the user add and remove strings from a list.
+/// </summary>
+/// <remarks>
+/// The value is stored in the settings file and carried on the adaptive card as the same JSON
+/// array of objects, <c>[{ "value": "…" }]</c>, so per-item properties can be added later without
+/// changing the shape. Readers accept an array of bare strings and ignore properties they do not
+/// recognize.
+/// </remarks>
+public sealed class StringListSetting : Setting<IReadOnlyList<string>>
+{
+    private string _itemValidationPattern = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the placeholder shown by the add-item text box.
+    /// </summary>
+    public string Placeholder { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets an optional regular expression that every item must match.
+    /// The pattern is not anchored, so use <c>^</c> and <c>$</c> to match a whole item.
+    /// </summary>
+    public string ItemValidationPattern
+    {
+        get => _itemValidationPattern;
+        set => _itemValidationPattern = RegularExpressionPattern.Validate(value, nameof(ItemValidationPattern));
+    }
+
+    /// <summary>
+    /// Gets or sets the error shown when an item does not match <see cref="ItemValidationPattern"/>.
+    /// </summary>
+    public string ItemValidationErrorMessage { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether duplicate items are rejected.
+    /// Comparisons are ordinal and case-sensitive. The default is <see langword="false"/>.
+    /// </summary>
+    public bool PreventDuplicates { get; set; }
+
+    /// <summary>
+    /// Gets or sets the error shown when <see cref="PreventDuplicates"/> is enabled and duplicate items exist.
+    /// </summary>
+    public string DuplicateItemErrorMessage { get; set; } = string.Empty;
+
+    private StringListSetting()
+        : base()
+    {
+        Value = [];
+    }
+
+    public StringListSetting(string key, IReadOnlyList<string> defaultValue)
+        : base(key, defaultValue)
+    {
+    }
+
+    public StringListSetting(string key, string label, string description, IReadOnlyList<string> defaultValue)
+        : base(key, label, description, defaultValue)
+    {
+    }
+
+    public override Dictionary<string, object> ToDictionary()
+    {
+        return new Dictionary<string, object>
+        {
+            { "type", "Input.CommandPalette.StringList" },
+            { "id", Key },
+            { "label", string.Empty },
+            { "header", Label },
+            { "description", Description },
+            { "value", StringListSettingUtilities.ToJsonArray(Value) },
+            { "isRequired", IsRequired },
+            { "errorMessage", ErrorMessage },
+            { "placeholder", Placeholder },
+            { "itemValidationPattern", ItemValidationPattern },
+            { "itemValidationErrorMessage", ItemValidationErrorMessage },
+            { "preventDuplicates", PreventDuplicates },
+            { "duplicateItemErrorMessage", DuplicateItemErrorMessage },
+            { "fallback", SettingFallback.Notice(Label) },
+        };
+    }
+
+    public override void Update(JsonObject payload)
+    {
+        if (payload[Key] is JsonArray array)
+        {
+            Value = StringListSettingUtilities.ParseArray(array);
+        }
+    }
+
+    public override void UpdateFromForm(JsonObject payload)
+    {
+        if (payload[Key] is JsonValue value &&
+            value.TryGetValue<string>(out var submittedValue) &&
+            StringListSettingUtilities.TryParseJsonArray(submittedValue, out var items))
+        {
+            Value = items;
+        }
+    }
+
+    public override string ToState() => StringListSettingUtilities.ToPersistedValue(Key, Value);
+}

--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/StringListSettingUtilities.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/StringListSettingUtilities.cs
@@ -1,0 +1,99 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Microsoft.CommandPalette.Extensions.Toolkit;
+
+/// <summary>
+/// Conversions between a string list and the JSON array used by both the settings file and the
+/// adaptive card.
+/// </summary>
+/// <remarks>
+/// Entries are objects — <c>[{ "value": "…" }]</c> — so per-item properties can be added later
+/// without changing the shape. Readers also accept an array of bare strings, and ignore
+/// properties they do not recognize.
+/// </remarks>
+internal static class StringListSettingUtilities
+{
+    private const string ValuePropertyName = "value";
+
+    /// <summary>
+    /// Writes the entries, for either the settings file or a custom list input.
+    /// </summary>
+    public static string ToJsonArray(IEnumerable<string>? items) =>
+        BuildArray(items).ToJsonString();
+
+    /// <summary>
+    /// Writes the entries as this setting's line in the settings file.
+    /// </summary>
+    public static string ToPersistedValue(string key, IEnumerable<string>? items) =>
+        $"\"{key}\": {ToJsonArray(items)}";
+
+    /// <summary>
+    /// Reads entries from a parsed array, ignoring anything that is not a string or an object
+    /// carrying a string <c>value</c>.
+    /// </summary>
+    public static IReadOnlyList<string> ParseArray(JsonArray array)
+    {
+        var items = new List<string>(array.Count);
+        foreach (var entry in array)
+        {
+            var text = entry is JsonObject entryObject ? AsString(entryObject[ValuePropertyName]) : AsString(entry);
+            if (!string.IsNullOrEmpty(text))
+            {
+                items.Add(text);
+            }
+        }
+
+        return items;
+    }
+
+    /// <summary>
+    /// Reads entries from unparsed text. Returns <see langword="false"/> when the text is not a
+    /// well-formed array, so the caller can keep the value it already has.
+    /// </summary>
+    public static bool TryParseJsonArray(string? value, out IReadOnlyList<string> items)
+    {
+        items = [];
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return true;
+        }
+
+        JsonNode? node;
+        try
+        {
+            node = JsonNode.Parse(value);
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+
+        if (node is not JsonArray array)
+        {
+            return false;
+        }
+
+        items = ParseArray(array);
+        return true;
+    }
+
+    public static IReadOnlyList<string> Normalize(IEnumerable<string?>? items) =>
+        items?
+            .Where(static item => !string.IsNullOrEmpty(item))
+            .Select(static item => item!)
+            .ToArray() ?? [];
+
+    private static JsonArray BuildArray(IEnumerable<string>? items) =>
+        new(Normalize(items)
+            .Select(static item => (JsonNode)new JsonObject { [ValuePropertyName] = item })
+            .ToArray());
+
+    private static string? AsString(JsonNode? node) =>
+        node is JsonValue value && value.TryGetValue<string>(out var text) ? text : null;
+}


### PR DESCRIPTION
## Summary of the Pull Request

This PR adds reusable Command Palette extension settings controls for selecting files and folders and managing lists.

The new controls include:

- `FilePathSetting` for selecting a single file or folder.
- `FilePathListSetting` for managing multiple file and/or folder paths.
- `StringListSetting` for managing plain string values.
- `KeyValueListSetting` for managing key-value pairs.
- Optional regex validation for strings, keys, and values.
- Optional duplicate prevention for strings and key-value keys.
- Configurable file picker filters.
- Custom persisted-string conversion.
- Fallback content when the Command Palette host does not support a control. But this has no direct impact now, because there's a bug in WinUI3 AC renderer that throws it away (sad panda).

## Pictures? Picture!

<img width="856" height="974" alt="image" src="https://github.com/user-attachments/assets/2e5d9ee1-9eca-48a7-803a-76a96859722e" />



<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
- [x] Closes: #49622 
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

This PR extends `Microsoft.CommandPalette.Extensions.Toolkit` with file-path, file-path-list, string-list, and key-value-list settings.

The Command Palette host registers custom Adaptive Card input elements during application startup. The controls use native file and folder pickers parented to the window containing the form, so they work correctly in both the Settings window and palette-hosted forms.

List controls render as constrained, scrollable lists with add and remove actions. They support developer-configurable validation, duplicate handling, picker modes, and error messages.

List values crossing the extension/host boundary use a structured codec that preserves unknown properties and remains compatible with the previously accepted bare-string representation. Persisted values can use the default newline representation or developer-provided conversion callbacks.

The SDK emits Adaptive Card `requires` and fallback information so extensions built with the new controls can provide actionable content when loaded by an older Command Palette host.

A Sample Pages extension page demonstrates all new setting types and their validation options.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

