### PR TITLE
Light Switch: add Follow Screen Brightness mode

### DIFF
--- a/src/modules/LightSwitch/LightSwitchService/BrightnessObserver.h
+++ b/src/modules/LightSwitch/LightSwitchService/BrightnessObserver.h
@@ -41,10 +41,10 @@ private:
     std::atomic<bool> _stop;
     std::thread _thread;
 
-    static std::optional<int> QueryCurrentBrightness()
+    void Run()
     {
         HRESULT hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
-        bool coinitCalledHere = SUCCEEDED(hr); // RPC_E_CHANGED_MODE means already initialized
+        bool coinitCalledHere = SUCCEEDED(hr);
 
         IWbemLocator* pLoc = nullptr;
         hr = CoCreateInstance(CLSID_WbemLocator, nullptr, CLSCTX_INPROC_SERVER,
@@ -52,7 +52,7 @@ private:
         if (FAILED(hr))
         {
             if (coinitCalledHere) CoUninitialize();
-            return std::nullopt;
+            return;
         }
 
         IWbemServices* pSvc = nullptr;
@@ -62,7 +62,7 @@ private:
         {
             pLoc->Release();
             if (coinitCalledHere) CoUninitialize();
-            return std::nullopt;
+            return;
         }
 
         hr = CoSetProxyBlanket(pSvc, RPC_C_AUTHN_WINNT, RPC_C_AUTHZ_NONE, nullptr,
@@ -73,59 +73,46 @@ private:
             pSvc->Release();
             pLoc->Release();
             if (coinitCalledHere) CoUninitialize();
-            return std::nullopt;
+            return;
         }
 
-        IEnumWbemClassObject* pEnum = nullptr;
-        hr = pSvc->ExecQuery(
-            _bstr_t(L"WQL"),
-            _bstr_t(L"SELECT CurrentBrightness FROM WmiMonitorBrightness WHERE Active = TRUE"),
-            WBEM_FLAG_FORWARD_ONLY | WBEM_FLAG_RETURN_IMMEDIATELY,
-            nullptr, &pEnum);
-
-        std::optional<int> result = std::nullopt;
-
-        if (SUCCEEDED(hr) && pEnum)
-        {
-            IWbemClassObject* pObj = nullptr;
-            ULONG returned = 0;
-            if (pEnum->Next(WBEM_INFINITE, 1, &pObj, &returned) == WBEM_S_NO_ERROR && returned)
-            {
-                VARIANT vt;
-                VariantInit(&vt);
-                if (SUCCEEDED(pObj->Get(L"CurrentBrightness", 0, &vt, nullptr, nullptr)))
-                {
-                    // CurrentBrightness is VT_UI1 (BYTE)
-                    result = static_cast<int>(vt.bVal);
-                }
-                VariantClear(&vt);
-                pObj->Release();
-            }
-            pEnum->Release();
-        }
-
-        pSvc->Release();
-        pLoc->Release();
-        if (coinitCalledHere) CoUninitialize();
-        return result;
-    }
-
-    void Run()
-    {
         int lastBrightness = -1;
 
         while (!_stop)
         {
-            auto brightness = QueryCurrentBrightness();
-            if (brightness.has_value() && brightness.value() != lastBrightness)
+            IEnumWbemClassObject* pEnum = nullptr;
+            hr = pSvc->ExecQuery(
+                _bstr_t(L"WQL"),
+                _bstr_t(L"SELECT CurrentBrightness FROM WmiMonitorBrightness WHERE Active = TRUE"),
+                WBEM_FLAG_FORWARD_ONLY | WBEM_FLAG_RETURN_IMMEDIATELY,
+                nullptr, &pEnum);
+
+            if (SUCCEEDED(hr) && pEnum)
             {
-                lastBrightness = brightness.value();
-                Logger::info(L"[BrightnessObserver] Brightness changed to {}%", lastBrightness);
-                try
+                IWbemClassObject* pObj = nullptr;
+                ULONG returned = 0;
+                if (pEnum->Next(WBEM_INFINITE, 1, &pObj, &returned) == WBEM_S_NO_ERROR && returned)
                 {
-                    _callback(lastBrightness);
+                    VARIANT vt;
+                    VariantInit(&vt);
+                    if (SUCCEEDED(pObj->Get(L"CurrentBrightness", 0, &vt, nullptr, nullptr)))
+                    {
+                        int brightness = static_cast<int>(vt.bVal);
+                        if (brightness != lastBrightness)
+                        {
+                            lastBrightness = brightness;
+                            Logger::info(L"[BrightnessObserver] Brightness changed to {}%", lastBrightness);
+                            try
+                            {
+                                _callback(lastBrightness);
+                            }
+                            catch (...) {}
+                        }
+                    }
+                    VariantClear(&vt);
+                    pObj->Release();
                 }
-                catch (...) {}
+                pEnum->Release();
             }
 
             // Sleep in 1-second increments so we can respond to _stop quickly.
@@ -134,5 +121,9 @@ private:
                 std::this_thread::sleep_for(std::chrono::seconds(1));
             }
         }
+
+        pSvc->Release();
+        pLoc->Release();
+        if (coinitCalledHere) CoUninitialize();
     }
 };

--- a/src/modules/LightSwitch/LightSwitchService/BrightnessObserver.h
+++ b/src/modules/LightSwitch/LightSwitchService/BrightnessObserver.h
@@ -1,0 +1,138 @@
+#pragma once
+#include <windows.h>
+#include <comdef.h>
+#include <wbemidl.h>
+#include <functional>
+#include <thread>
+#include <atomic>
+#include <optional>
+#include <logger/logger.h>
+
+#pragma comment(lib, "wbemuuid.lib")
+
+// Polls the WMI WmiMonitorBrightness class every few seconds and fires a callback
+// when the brightness value changes. Works for laptop/tablet integrated displays
+// whose brightness is driven by an ambient light sensor (ALS) or by the user.
+class BrightnessObserver
+{
+public:
+    // callback receives the new brightness level (0-100)
+    explicit BrightnessObserver(std::function<void(int)> callback, int pollIntervalSeconds = 5)
+        : _callback(std::move(callback)), _pollInterval(pollIntervalSeconds), _stop(false)
+    {
+        _thread = std::thread([this]() { Run(); });
+    }
+
+    ~BrightnessObserver()
+    {
+        Stop();
+    }
+
+    void Stop()
+    {
+        _stop = true;
+        if (_thread.joinable())
+            _thread.join();
+    }
+
+private:
+    std::function<void(int)> _callback;
+    int _pollInterval;
+    std::atomic<bool> _stop;
+    std::thread _thread;
+
+    static std::optional<int> QueryCurrentBrightness()
+    {
+        HRESULT hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+        bool coinitCalledHere = SUCCEEDED(hr); // RPC_E_CHANGED_MODE means already initialized
+
+        IWbemLocator* pLoc = nullptr;
+        hr = CoCreateInstance(CLSID_WbemLocator, nullptr, CLSCTX_INPROC_SERVER,
+                              IID_IWbemLocator, reinterpret_cast<LPVOID*>(&pLoc));
+        if (FAILED(hr))
+        {
+            if (coinitCalledHere) CoUninitialize();
+            return std::nullopt;
+        }
+
+        IWbemServices* pSvc = nullptr;
+        hr = pLoc->ConnectServer(_bstr_t(L"ROOT\\WMI"), nullptr, nullptr, nullptr,
+                                 0, nullptr, nullptr, &pSvc);
+        if (FAILED(hr))
+        {
+            pLoc->Release();
+            if (coinitCalledHere) CoUninitialize();
+            return std::nullopt;
+        }
+
+        hr = CoSetProxyBlanket(pSvc, RPC_C_AUTHN_WINNT, RPC_C_AUTHZ_NONE, nullptr,
+                               RPC_C_AUTHN_LEVEL_CALL, RPC_C_IMP_LEVEL_IMPERSONATE,
+                               nullptr, EOAC_NONE);
+        if (FAILED(hr))
+        {
+            pSvc->Release();
+            pLoc->Release();
+            if (coinitCalledHere) CoUninitialize();
+            return std::nullopt;
+        }
+
+        IEnumWbemClassObject* pEnum = nullptr;
+        hr = pSvc->ExecQuery(
+            _bstr_t(L"WQL"),
+            _bstr_t(L"SELECT CurrentBrightness FROM WmiMonitorBrightness WHERE Active = TRUE"),
+            WBEM_FLAG_FORWARD_ONLY | WBEM_FLAG_RETURN_IMMEDIATELY,
+            nullptr, &pEnum);
+
+        std::optional<int> result = std::nullopt;
+
+        if (SUCCEEDED(hr) && pEnum)
+        {
+            IWbemClassObject* pObj = nullptr;
+            ULONG returned = 0;
+            if (pEnum->Next(WBEM_INFINITE, 1, &pObj, &returned) == WBEM_S_NO_ERROR && returned)
+            {
+                VARIANT vt;
+                VariantInit(&vt);
+                if (SUCCEEDED(pObj->Get(L"CurrentBrightness", 0, &vt, nullptr, nullptr)))
+                {
+                    // CurrentBrightness is VT_UI1 (BYTE)
+                    result = static_cast<int>(vt.bVal);
+                }
+                VariantClear(&vt);
+                pObj->Release();
+            }
+            pEnum->Release();
+        }
+
+        pSvc->Release();
+        pLoc->Release();
+        if (coinitCalledHere) CoUninitialize();
+        return result;
+    }
+
+    void Run()
+    {
+        int lastBrightness = -1;
+
+        while (!_stop)
+        {
+            auto brightness = QueryCurrentBrightness();
+            if (brightness.has_value() && brightness.value() != lastBrightness)
+            {
+                lastBrightness = brightness.value();
+                Logger::info(L"[BrightnessObserver] Brightness changed to {}%", lastBrightness);
+                try
+                {
+                    _callback(lastBrightness);
+                }
+                catch (...) {}
+            }
+
+            // Sleep in 1-second increments so we can respond to _stop quickly.
+            for (int i = 0; i < _pollInterval && !_stop; ++i)
+            {
+                std::this_thread::sleep_for(std::chrono::seconds(1));
+            }
+        }
+    }
+};

--- a/src/modules/LightSwitch/LightSwitchService/LightSwitchService.cpp
+++ b/src/modules/LightSwitch/LightSwitchService/LightSwitchService.cpp
@@ -13,7 +13,8 @@
 #include <utils/logger_helper.h>
 #include "LightSwitchStateManager.h"
 #include <LightSwitchUtils.h>
-#include <NightLightRegistryObserver.h>
+#include "NightLightRegistryObserver.h"
+#include "BrightnessObserver.h"
 #include <trace.h>
 
 SERVICE_STATUS g_ServiceStatus = {};
@@ -175,7 +176,13 @@ static void DetectAndHandleExternalThemeChange(LightSwitchStateManager& stateMan
     if (s.scheduleMode == ScheduleMode::FollowNightLight)
     {
         shouldBeLight = !IsNightLightEnabled();
-    } 
+    }
+    else if (s.scheduleMode == ScheduleMode::FollowBrightness)
+    {
+        // External theme change detection doesn't apply to brightness mode;
+        // the BrightnessObserver drives those transitions directly.
+        return;
+    }
     else
     {
         shouldBeLight = ShouldBeLight(nowMinutes, effectiveLight, effectiveDark);
@@ -218,12 +225,14 @@ DWORD WINAPI ServiceWorkerThread(LPVOID lpParam)
     HANDLE hSettingsChanged = LightSwitchSettings::instance().GetSettingsChangedEvent();
 
     static std::unique_ptr<NightLightRegistryObserver> g_nightLightWatcher;
+    static std::unique_ptr<BrightnessObserver> g_brightnessWatcher;
 
     LightSwitchSettings::instance().LoadSettings();
     const auto& settings = LightSwitchSettings::instance().settings();
 
     // after loading settings:
     bool nightLightNeeded = (settings.scheduleMode == ScheduleMode::FollowNightLight);
+    bool brightnessNeeded = (settings.scheduleMode == ScheduleMode::FollowBrightness);
 
     if (nightLightNeeded && !g_nightLightWatcher)
     {
@@ -242,6 +251,22 @@ DWORD WINAPI ServiceWorkerThread(LPVOID lpParam)
         Logger::info(L"[LightSwitchService] Stopping Night Light registry watcher...");
         g_nightLightWatcher->Stop();
         g_nightLightWatcher.reset();
+    }
+
+    if (brightnessNeeded && !g_brightnessWatcher)
+    {
+        Logger::info(L"[LightSwitchService] Starting Brightness watcher...");
+        g_brightnessWatcher = std::make_unique<BrightnessObserver>(
+            [](int brightness) {
+                if (g_stateManagerPtr)
+                    g_stateManagerPtr->OnBrightnessChange(brightness);
+            });
+    }
+    else if (!brightnessNeeded && g_brightnessWatcher)
+    {
+        Logger::info(L"[LightSwitchService] Stopping Brightness watcher...");
+        g_brightnessWatcher->Stop();
+        g_brightnessWatcher.reset();
     }
 
     SYSTEMTIME st;
@@ -312,6 +337,7 @@ DWORD WINAPI ServiceWorkerThread(LPVOID lpParam)
 
             const auto& settings = LightSwitchSettings::instance().settings();
             bool nightLightNeeded = (settings.scheduleMode == ScheduleMode::FollowNightLight);
+            bool brightnessNeeded = (settings.scheduleMode == ScheduleMode::FollowBrightness);
 
             if (nightLightNeeded && !g_nightLightWatcher)
             {
@@ -334,6 +360,22 @@ DWORD WINAPI ServiceWorkerThread(LPVOID lpParam)
                 g_nightLightWatcher.reset();
             }
 
+            if (brightnessNeeded && !g_brightnessWatcher)
+            {
+                Logger::info(L"[LightSwitchService] Starting Brightness watcher...");
+                g_brightnessWatcher = std::make_unique<BrightnessObserver>(
+                    [](int brightness) {
+                        if (g_stateManagerPtr)
+                            g_stateManagerPtr->OnBrightnessChange(brightness);
+                    });
+            }
+            else if (!brightnessNeeded && g_brightnessWatcher)
+            {
+                Logger::info(L"[LightSwitchService] Stopping Brightness watcher...");
+                g_brightnessWatcher->Stop();
+                g_brightnessWatcher.reset();
+            }
+
             continue;
         }
     }
@@ -349,6 +391,11 @@ DWORD WINAPI ServiceWorkerThread(LPVOID lpParam)
     {
         g_nightLightWatcher->Stop();
         g_nightLightWatcher.reset();
+    }
+    if (g_brightnessWatcher)
+    {
+        g_brightnessWatcher->Stop();
+        g_brightnessWatcher.reset();
     }
 
     Logger::info(L"[LightSwitchService] Worker thread exiting cleanly.");

--- a/src/modules/LightSwitch/LightSwitchService/LightSwitchService.vcxproj
+++ b/src/modules/LightSwitch/LightSwitchService/LightSwitchService.vcxproj
@@ -70,7 +70,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>Advapi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Advapi32.lib;wbemuuid.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -87,6 +87,7 @@
     <ResourceCompile Include="LightSwitchService.rc" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="BrightnessObserver.h" />
     <ClInclude Include="LightSwitchSettings.h" />
     <ClInclude Include="LightSwitchStateManager.h" />
     <ClInclude Include="LightSwitchUtils.h" />

--- a/src/modules/LightSwitch/LightSwitchService/LightSwitchService.vcxproj.filters
+++ b/src/modules/LightSwitch/LightSwitchService/LightSwitchService.vcxproj.filters
@@ -71,6 +71,9 @@
     <ClInclude Include="NightLightRegistryObserver.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="BrightnessObserver.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="trace.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/src/modules/LightSwitch/LightSwitchService/LightSwitchSettings.cpp
+++ b/src/modules/LightSwitch/LightSwitchService/LightSwitchSettings.cpp
@@ -5,6 +5,7 @@
 #include <filesystem>
 #include <fstream>
 #include <logger.h>
+#include <algorithm>
 #include <LightSwitchService/trace.h>
 
 using namespace std;
@@ -257,7 +258,10 @@ void LightSwitchSettings::LoadSettings()
         // BrightnessThreshold
         if (const auto jsonVal = values.get_int_value(L"brightnessThreshold"))
         {
-            auto val = std::max(0, std::min(100, *jsonVal));
+            int val = *jsonVal;
+            if (val < 0) val = 0;
+            if (val > 100) val = 100;
+
             if (m_settings.brightnessThreshold != val)
             {
                 m_settings.brightnessThreshold = val;

--- a/src/modules/LightSwitch/LightSwitchService/LightSwitchSettings.cpp
+++ b/src/modules/LightSwitch/LightSwitchService/LightSwitchSettings.cpp
@@ -253,6 +253,17 @@ void LightSwitchSettings::LoadSettings()
         {
             Trace::LightSwitch::ThemeTargetChanged(m_settings.changeApps, m_settings.changeSystem);
         }
+
+        // BrightnessThreshold
+        if (const auto jsonVal = values.get_int_value(L"brightnessThreshold"))
+        {
+            auto val = std::max(0, std::min(100, *jsonVal));
+            if (m_settings.brightnessThreshold != val)
+            {
+                m_settings.brightnessThreshold = val;
+                NotifyObservers(SettingId::BrightnessThreshold);
+            }
+        }
     }
     catch (...)
     {

--- a/src/modules/LightSwitch/LightSwitchService/LightSwitchSettings.h
+++ b/src/modules/LightSwitch/LightSwitchService/LightSwitchSettings.h
@@ -21,6 +21,7 @@ enum class ScheduleMode
     FixedHours,
     SunsetToSunrise,
     FollowNightLight,
+    FollowBrightness,
     // Add more in the future
 };
 
@@ -34,6 +35,8 @@ inline std::wstring ToString(ScheduleMode mode)
         return L"SunsetToSunrise";
     case ScheduleMode::FollowNightLight:
         return L"FollowNightLight";
+    case ScheduleMode::FollowBrightness:
+        return L"FollowBrightness";
     default:
         return L"Off";
     }
@@ -47,6 +50,8 @@ inline ScheduleMode FromString(const std::wstring& str)
         return ScheduleMode::FixedHours;
     if (str == L"FollowNightLight")
         return ScheduleMode::FollowNightLight;
+    if (str == L"FollowBrightness")
+        return ScheduleMode::FollowBrightness;
     else
         return ScheduleMode::Off;
 }
@@ -67,6 +72,10 @@ struct LightSwitchConfig
 
     bool changeSystem = false;
     bool changeApps = false;
+
+    // Brightness threshold (0-100). When display brightness reaches or exceeds this value,
+    // light mode is activated; when it drops below, dark mode is activated.
+    int brightnessThreshold = 90;
 };
 
 class LightSwitchSettings

--- a/src/modules/LightSwitch/LightSwitchService/LightSwitchStateManager.cpp
+++ b/src/modules/LightSwitch/LightSwitchService/LightSwitchStateManager.cpp
@@ -106,9 +106,16 @@ void LightSwitchStateManager::OnBrightnessChange(int brightness)
 
     if (_state.lastAppliedMode == ScheduleMode::FollowBrightness && _state.isManualOverride)
     {
-        Logger::info(L"[LightSwitchStateManager] Brightness changed while manual override active; "
-                     L"treating as a boundary and clearing manual override.");
-        _state.isManualOverride = false;
+        int threshold = LightSwitchSettings::settings().brightnessThreshold;
+        bool wasLight = (_state.lastBrightness >= 0 && _state.lastBrightness >= threshold);
+        bool willBeLight = (brightness >= threshold);
+
+        if (_state.lastBrightness >= 0 && (wasLight != willBeLight))
+        {
+            Logger::info(L"[LightSwitchStateManager] Brightness crossed threshold while manual override active; "
+                         L"treating as a boundary and clearing manual override.");
+            _state.isManualOverride = false;
+        }
     }
 
     _state.lastBrightness = brightness;

--- a/src/modules/LightSwitch/LightSwitchService/LightSwitchStateManager.cpp
+++ b/src/modules/LightSwitch/LightSwitchService/LightSwitchStateManager.cpp
@@ -32,7 +32,8 @@ void LightSwitchStateManager::OnSettingsChanged()
 void LightSwitchStateManager::OnTick()
 {
     std::lock_guard<std::mutex> lock(_stateMutex);
-    if (_state.lastAppliedMode != ScheduleMode::FollowNightLight)
+    if (_state.lastAppliedMode != ScheduleMode::FollowNightLight &&
+        _state.lastAppliedMode != ScheduleMode::FollowBrightness)
     {
         EvaluateAndApplyIfNeeded();
     }
@@ -95,6 +96,23 @@ void LightSwitchStateManager::OnNightLightChange()
         Logger::debug(L"[LightSwitchStateManager] Night Light change event fired, but no actual change.");
     }
 
+    EvaluateAndApplyIfNeeded();
+}
+
+// Called when display brightness changes (from BrightnessObserver)
+void LightSwitchStateManager::OnBrightnessChange(int brightness)
+{
+    std::lock_guard<std::mutex> lock(_stateMutex);
+
+    if (_state.lastAppliedMode == ScheduleMode::FollowBrightness && _state.isManualOverride)
+    {
+        Logger::info(L"[LightSwitchStateManager] Brightness changed while manual override active; "
+                     L"treating as a boundary and clearing manual override.");
+        _state.isManualOverride = false;
+    }
+
+    _state.lastBrightness = brightness;
+    Logger::info(L"[LightSwitchStateManager] Brightness changed to {}%", brightness);
     EvaluateAndApplyIfNeeded();
 }
 
@@ -205,7 +223,8 @@ void LightSwitchStateManager::EvaluateAndApplyIfNeeded()
     }
 
     // Handle manual override logic
-    if (_state.isManualOverride)
+    // In FollowBrightness mode, the brightness change itself clears the override (in OnBrightnessChange).
+    if (_state.isManualOverride && _currentSettings.scheduleMode != ScheduleMode::FollowBrightness)
     {
         bool crossedBoundary = false;
         if (_state.lastTickMinutes != -1)
@@ -244,6 +263,18 @@ void LightSwitchStateManager::EvaluateAndApplyIfNeeded()
     if (_currentSettings.scheduleMode == ScheduleMode::FollowNightLight)
     {
         shouldBeLight = !_state.isNightLightActive;
+    }
+    else if (_currentSettings.scheduleMode == ScheduleMode::FollowBrightness)
+    {
+        // Light mode when brightness >= threshold, dark mode when below threshold.
+        // If brightness is unknown (-1), leave the theme unchanged.
+        if (_state.lastBrightness < 0)
+        {
+            Logger::debug(L"[LightSwitchStateManager] Brightness unknown, skipping theme evaluation.");
+            _state.lastTickMinutes = now;
+            return;
+        }
+        shouldBeLight = (_state.lastBrightness >= _currentSettings.brightnessThreshold);
     }
     else
     {

--- a/src/modules/LightSwitch/LightSwitchService/LightSwitchStateManager.h
+++ b/src/modules/LightSwitch/LightSwitchService/LightSwitchStateManager.h
@@ -16,6 +16,9 @@ struct LightSwitchState
     // Derived, runtime-resolved times
     int effectiveLightMinutes = 0; // the boundary we actually act on
     int effectiveDarkMinutes = 0; // includes offsets if needed
+
+    // Last known display brightness (0-100), -1 = unknown
+    int lastBrightness = -1;
 };
 
 // The controller that reacts to settings changes, time ticks, and manual overrides.
@@ -35,6 +38,9 @@ public:
 
     // Called when night light changes in windows settings
     void OnNightLightChange();
+
+    // Called when display brightness changes (via BrightnessObserver)
+    void OnBrightnessChange(int brightness);
 
     // Initial sync at startup to align internal state with system theme
     void SyncInitialThemeState();

--- a/src/modules/LightSwitch/LightSwitchService/SettingsConstants.h
+++ b/src/modules/LightSwitch/LightSwitchService/SettingsConstants.h
@@ -10,5 +10,6 @@ enum class SettingId
     Sunrise_Offset,
     Sunset_Offset,
     ChangeSystem,
-    ChangeApps
+    ChangeApps,
+    BrightnessThreshold
 };

--- a/src/settings-ui/Settings.UI.Library/LightSwitchProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/LightSwitchProperties.cs
@@ -23,6 +23,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         public const string DefaultLightModeProfile = "";
         public const int DefaultDarkModeProfileId = 0;
         public const int DefaultLightModeProfileId = 0;
+        public const int DefaultBrightnessThreshold = 90;
         public static readonly HotkeySettings DefaultToggleThemeHotkey = new HotkeySettings(true, true, false, true, 0x44); // Ctrl+Win+Shift+D
 
         public LightSwitchProperties()
@@ -43,6 +44,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
             LightModeProfile = new StringProperty(DefaultLightModeProfile);
             DarkModeProfileId = new IntProperty(DefaultDarkModeProfileId);
             LightModeProfileId = new IntProperty(DefaultLightModeProfileId);
+            BrightnessThreshold = new IntProperty(DefaultBrightnessThreshold);
         }
 
         [JsonPropertyName("changeSystem")]
@@ -100,5 +102,8 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 
         [JsonPropertyName("lightModeProfileId")]
         public IntProperty LightModeProfileId { get; set; }
+
+        [JsonPropertyName("brightnessThreshold")]
+        public IntProperty BrightnessThreshold { get; set; }
     }
 }

--- a/src/settings-ui/Settings.UI.Library/LightSwitchSettings.cs
+++ b/src/settings-ui/Settings.UI.Library/LightSwitchSettings.cs
@@ -66,6 +66,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library
                     LightModeProfile = new StringProperty(Properties.LightModeProfile.Value),
                     DarkModeProfileId = new IntProperty(Properties.DarkModeProfileId.Value),
                     LightModeProfileId = new IntProperty(Properties.LightModeProfileId.Value),
+                    BrightnessThreshold = new IntProperty(Properties.BrightnessThreshold.Value),
                 },
             };
         }

--- a/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/LightSwitch.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/LightSwitch.cs
@@ -17,6 +17,43 @@ namespace ViewModelTests;
 public class LightSwitch
 {
     [TestMethod]
+    public void Clone_PreservesFollowBrightnessModeAndThreshold()
+    {
+        var settings = new LightSwitchSettings();
+        settings.Properties.ScheduleMode.Value = "FollowBrightness";
+        settings.Properties.BrightnessThreshold.Value = 77;
+
+        var clone = (LightSwitchSettings)settings.Clone();
+
+        Assert.AreEqual("FollowBrightness", clone.Properties.ScheduleMode.Value);
+        Assert.AreEqual(77, clone.Properties.BrightnessThreshold.Value);
+    }
+
+    [TestMethod]
+    public void BrightnessThreshold_ClampsToExpectedRange()
+    {
+        var settings = new LightSwitchSettings();
+        var viewModel = CreateViewModel(settings, _ => 0);
+
+        viewModel.BrightnessThreshold = 150;
+        Assert.AreEqual(100, settings.Properties.BrightnessThreshold.Value);
+
+        viewModel.BrightnessThreshold = -10;
+        Assert.AreEqual(0, settings.Properties.BrightnessThreshold.Value);
+    }
+
+    [TestMethod]
+    public void ScheduleMode_CanBeSetToFollowBrightness()
+    {
+        var settings = new LightSwitchSettings();
+        var viewModel = CreateViewModel(settings, _ => 0);
+
+        viewModel.ScheduleMode = "FollowBrightness";
+
+        Assert.AreEqual("FollowBrightness", settings.Properties.ScheduleMode.Value);
+    }
+
+    [TestMethod]
     public void SuppressedProfileSelectionChange_DoesNotPersistTemporaryZero()
     {
         var settings = new LightSwitchSettings();

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/LightSwitchPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/LightSwitchPage.xaml
@@ -72,6 +72,10 @@
                                     x:Uid="LightSwitch_ModeFollowNightLight"
                                     AutomationProperties.AutomationId="FollowNightLightCBItem_LightSwitch"
                                     Tag="FollowNightLight" />
+                                <ComboBoxItem
+                                    x:Uid="LightSwitch_ModeFollowBrightness"
+                                    AutomationProperties.AutomationId="FollowBrightnessCBItem_LightSwitch"
+                                    Tag="FollowBrightness" />
                             </ComboBox>
                             <tkcontrols:SettingsExpander.Items>
                                 <tkcontrols:SettingsCard
@@ -183,6 +187,21 @@
                                         </StackPanel>
 
                                     </InfoBar>
+                                </tkcontrols:SettingsCard>
+                                <tkcontrols:SettingsCard
+                                    x:Name="BrightnessThresholdCard"
+                                    x:Uid="LightSwitch_BrightnessThresholdCard"
+                                    Visibility="Collapsed">
+                                    <StackPanel Orientation="Horizontal" Spacing="8">
+                                        <Slider
+                                            AutomationProperties.AutomationId="BrightnessThreshold_LightSwitch"
+                                            Minimum="1"
+                                            Maximum="100"
+                                            Width="200"
+                                            Value="{x:Bind ViewModel.BrightnessThreshold, Mode=TwoWay}" />
+                                        <TextBlock VerticalAlignment="Center" Text="{x:Bind ViewModel.BrightnessThreshold, Mode=OneWay}" />
+                                        <TextBlock VerticalAlignment="Center" Text="%" />
+                                    </StackPanel>
                                 </tkcontrols:SettingsCard>
                             </tkcontrols:SettingsExpander.Items>
                         </tkcontrols:SettingsExpander>

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/LightSwitchPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/LightSwitchPage.xaml
@@ -454,13 +454,18 @@
         </controls:SettingsPageControl>
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup x:Name="ScheduleModeStates">
-                <VisualState x:Name="OffState" />
+                <VisualState x:Name="OffState">
+                    <VisualState.Setters>
+                        <Setter Target="BrightnessThresholdCard.Visibility" Value="Collapsed" />
+                    </VisualState.Setters>
+                </VisualState>
                 <VisualState x:Name="SunsetToSunriseState">
                     <VisualState.Setters>
                         <Setter Target="SunLocation_Card.Visibility" Value="Visible" />
                         <Setter Target="SunOffset_Card.Visibility" Value="Visible" />
                         <Setter Target="NoScheduleCard.Visibility" Value="Collapsed" />
                         <Setter Target="FollowNightLightCard.Visibility" Value="Collapsed" />
+                        <Setter Target="BrightnessThresholdCard.Visibility" Value="Collapsed" />
                     </VisualState.Setters>
                 </VisualState>
 
@@ -470,6 +475,7 @@
                         <Setter Target="Fixed_TurnOffCard.Visibility" Value="Visible" />
                         <Setter Target="NoScheduleCard.Visibility" Value="Collapsed" />
                         <Setter Target="FollowNightLightCard.Visibility" Value="Collapsed" />
+                        <Setter Target="BrightnessThresholdCard.Visibility" Value="Collapsed" />
                     </VisualState.Setters>
                 </VisualState>
 
@@ -479,6 +485,16 @@
                         <Setter Target="Fixed_TurnOffCard.Visibility" Value="Collapsed" />
                         <Setter Target="NoScheduleCard.Visibility" Value="Collapsed" />
                         <Setter Target="FollowNightLightCard.Visibility" Value="Visible" />
+                        <Setter Target="BrightnessThresholdCard.Visibility" Value="Collapsed" />
+                    </VisualState.Setters>
+                </VisualState>
+                <VisualState x:Name="FollowBrightnessState">
+                    <VisualState.Setters>
+                        <Setter Target="Fixed_TurnOnCard.Visibility" Value="Collapsed" />
+                        <Setter Target="Fixed_TurnOffCard.Visibility" Value="Collapsed" />
+                        <Setter Target="NoScheduleCard.Visibility" Value="Collapsed" />
+                        <Setter Target="FollowNightLightCard.Visibility" Value="Collapsed" />
+                        <Setter Target="BrightnessThresholdCard.Visibility" Value="Visible" />
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/LightSwitchPage.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/LightSwitchPage.xaml.cs
@@ -373,18 +373,27 @@ namespace Microsoft.PowerToys.Settings.UI.Views
                 case "FixedHours":
                     VisualStateManager.GoToState(this, "ManualState", true);
                     this.TimelineCard.Visibility = Visibility.Visible;
+                    this.BrightnessThresholdCard.Visibility = Visibility.Collapsed;
                     break;
                 case "SunsetToSunrise":
                     VisualStateManager.GoToState(this, "SunsetToSunriseState", true);
                     this.SunriseModeChartState();
+                    this.BrightnessThresholdCard.Visibility = Visibility.Collapsed;
                     break;
                 case "FollowNightLight":
                     VisualStateManager.GoToState(this, "FollowNightLightState", true);
                     TimelineCard.Visibility = Visibility.Collapsed;
+                    this.BrightnessThresholdCard.Visibility = Visibility.Collapsed;
+                    break;
+                case "FollowBrightness":
+                    VisualStateManager.GoToState(this, "FollowBrightnessState", true);
+                    TimelineCard.Visibility = Visibility.Collapsed;
+                    this.BrightnessThresholdCard.Visibility = Visibility.Visible;
                     break;
                 default:
                     VisualStateManager.GoToState(this, "OffState", true);
                     this.TimelineCard.Visibility = Visibility.Collapsed;
+                    this.BrightnessThresholdCard.Visibility = Visibility.Collapsed;
                     break;
             }
         }

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/LightSwitchPage.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/LightSwitchPage.xaml.cs
@@ -96,6 +96,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
             }
 
             this.ViewModel.InitializeScheduleMode();
+            ModeSelector_SelectionChanged(null, null);
         }
 
         private async void GetGeoLocation_Click(object sender, RoutedEventArgs e)
@@ -305,6 +306,7 @@ namespace Microsoft.PowerToys.Settings.UI.Views
 
                 this.moduleSettingsRepository.ReloadSettings();
                 this.LoadSettings(this.generalSettingsRepository, this.moduleSettingsRepository);
+                ModeSelector_SelectionChanged(null, null);
 
                 this.suppressViewModelUpdates = false;
             });

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -6224,6 +6224,15 @@ Text uses the current drawing color.</value>
   <data name="LightSwitch_ModeFollowNightLight.Content" xml:space="preserve">
     <value>Follow Night Light</value>
   </data>
+  <data name="LightSwitch_ModeFollowBrightness.Content" xml:space="preserve">
+    <value>Follow Screen Brightness</value>
+  </data>
+  <data name="LightSwitch_BrightnessThresholdCard.Header" xml:space="preserve">
+    <value>Light mode brightness threshold</value>
+  </data>
+  <data name="LightSwitch_BrightnessThresholdCard.Description" xml:space="preserve">
+    <value>Switch to light mode when display brightness reaches this percentage, and to dark mode when it drops below it. Works with ambient light sensors and manual adjustments.</value>
+  </data>
   <data name="LightSwitch_NightLightSettingsButton.Content" xml:space="preserve">
     <value>Personalize your Night Light settings.</value>
   </data>

--- a/src/settings-ui/Settings.UI/ViewModels/LightSwitchViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/LightSwitchViewModel.cs
@@ -59,6 +59,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 "FixedHours",
                 "SunsetToSunrise",
                 "FollowNightLight",
+                "FollowBrightness",
             };
 
             // Check if PowerDisplay is enabled
@@ -308,6 +309,20 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                     ModuleSettings.Properties.SunsetOffset.Value = value;
                     OnPropertyChanged(nameof(DarkTimeTimeSpan));
                     OnPropertyChanged(nameof(SunriseOffsetMax));
+                }
+            }
+        }
+
+        public int BrightnessThreshold
+        {
+            get => ModuleSettings.Properties.BrightnessThreshold.Value;
+            set
+            {
+                var clamped = Math.Max(0, Math.Min(100, value));
+                if (ModuleSettings.Properties.BrightnessThreshold.Value != clamped)
+                {
+                    ModuleSettings.Properties.BrightnessThreshold.Value = clamped;
+                    NotifyPropertyChanged();
                 }
             }
         }
@@ -828,6 +843,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             OnPropertyChanged(nameof(ScheduleMode));
             OnPropertyChanged(nameof(EnableDarkModeProfile));
             OnPropertyChanged(nameof(EnableLightModeProfile));
+            OnPropertyChanged(nameof(BrightnessThreshold));
         }
 
         private void UpdateSunTimes(double latitude, double longitude, string city = "n/a")


### PR DESCRIPTION
## Summary of the Pull Request
Implements a new **Follow Screen Brightness** schedule mode for LightSwitch, as requested in #49624.

When selected, LightSwitch polls the display brightness (via WMI `WmiMonitorBrightness`) and automatically switches the Windows theme based on a user-configurable threshold:

- **Brightness ≥ threshold** → Light mode
- **Brightness < threshold** → Dark mode

This is especially useful for outdoor work where an ambient light sensor (ALS) automatically pushes the display to maximum brightness to compensate for glare — a time-based schedule can't handle this, but brightness-based switching does it automatically.

## PR Checklist

- [x] Closes: #49624
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments

### C++ backend
- **`BrightnessObserver.h`** — new header-only observer that polls `WmiMonitorBrightness` every 5 seconds and fires a callback on brightness changes. Works for laptop/tablet integrated displays driven by ALS or manual adjustments. It initializes COM and the WMI connection once and keeps it open to prevent CPU/handle churn in `WmiPrvSE.exe`.
- **`ScheduleMode`** — new `FollowBrightness` enum value with `ToString`/`FromString` round-trip
- **`LightSwitchConfig`** — new `brightnessThreshold` field (0–100, default 90)
- **`SettingId`** — new `BrightnessThreshold` entry
- **`LightSwitchSettings.cpp`** — loads `brightnessThreshold` from `settings.json`
- **`LightSwitchStateManager`** — new `OnBrightnessChange(int)` handler; `EvaluateAndApplyIfNeeded` applies light/dark based on threshold; manual override is cleared only when the brightness crosses the threshold.
- **`LightSwitchService.cpp`** — starts/stops `BrightnessObserver` when mode is switched to/from `FollowBrightness`; links `wbemuuid.lib`

### Settings UI (C#/XAML)
- New **Follow Screen Brightness** entry in the schedule mode combo box
- New `BrightnessThreshold` property in `LightSwitchProperties` and `LightSwitchViewModel`
- Slider control (1–100%, default 90%) shown only when the mode is active (using `FollowBrightnessState`)
- English string resources for the mode name and slider label/description

## Validation Steps Performed

- Selecting "Follow Screen Brightness" in Settings UI shows the threshold slider and saves the value to `settings.json`
- Adjusting brightness above/below the threshold on a laptop with an ALS (or via manual brightness keys) triggers the theme switch within ~5 seconds
- Switching to another schedule mode stops the brightness watcher and hides the slider
- Existing modes (Off, FixedHours, SunsetToSunrise, FollowNightLight) are unaffected
- Tests - included unit tests in `Settings.UI.UnitTests/ViewModelTests/LightSwitch.cs` (for FollowBrightness clone persistence, BrightnessThreshold clamping, Setting schedule mode to FollowBrightness)