### PR TITLE
PowerDisplay: Publish monitor state through one locked, rename-based write

### DIFF
--- a/src/modules/powerdisplay/PowerDisplay.Lib.UnitTests/MonitorStateSaveTests.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Lib.UnitTests/MonitorStateSaveTests.cs
@@ -1,0 +1,163 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PowerDisplay.Common.Services;
+
+namespace PowerDisplay.UnitTests;
+
+/// <summary>
+/// Covers the single write path <see cref="MonitorStateManager"/> funnels both saves through — the
+/// debounced save and the flush <c>Dispose</c> performs — and the publish-by-rename that keeps an
+/// interrupted write from damaging what is already on disk. These assert the current design; the
+/// original two-writer collision stopped being expressible once there was one write method.
+/// </summary>
+[TestClass]
+public sealed class MonitorStateSaveTests
+{
+    private const string MonitorA = @"\\?\DISPLAY#AOCB326#5&ABC&0&UID1";
+
+    private string _directory = null!;
+    private string _statePath = null!;
+
+    [TestInitialize]
+    public void Initialize()
+    {
+        _directory = Path.Combine(Path.GetTempPath(), $"PowerDisplaySave-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_directory);
+        _statePath = Path.Combine(_directory, "monitor_state.json");
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        try
+        {
+            if (Directory.Exists(_directory))
+            {
+                Directory.Delete(_directory, recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+            // Leaving a temp directory behind is not worth failing an otherwise green test over.
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+
+    [TestMethod]
+    public void ConcurrentWrites_DoNotCollideOnTheStateFile()
+    {
+        // Drives what `_writeLock` exists for. Every write goes through one temp path opened for
+        // exclusive write, so without the lock two threads landing together fail at CreateFile with
+        // "The process cannot access the file because it is being used by another process".
+        using var manager = new MonitorStateManager(_statePath);
+        manager.UpdateMonitorParameter(MonitorA, "Brightness", 42);
+
+        const int Writers = 4;
+        const int WritesPerThread = 40;
+
+        var failures = new List<Exception>();
+        using var start = new Barrier(Writers);
+        var threads = new List<Thread>();
+
+        for (var i = 0; i < Writers; i++)
+        {
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    // Inside the try: a throw here would otherwise be unhandled on a background
+                    // thread and take down the test host instead of failing the test.
+                    start.SignalAndWait();
+
+                    for (var write = 0; write < WritesPerThread; write++)
+                    {
+                        manager.WriteStateFile();
+                    }
+                }
+                catch (Exception ex)
+                {
+                    lock (failures)
+                    {
+                        failures.Add(ex);
+                    }
+                }
+            })
+            {
+                IsBackground = true,
+            };
+
+            threads.Add(thread);
+            thread.Start();
+        }
+
+        foreach (var thread in threads)
+        {
+            Assert.IsTrue(thread.Join(TimeSpan.FromSeconds(30)), "A writer thread did not finish.");
+        }
+
+        Assert.AreEqual(
+            0,
+            failures.Count,
+            $"Concurrent writes collided on the state file: {(failures.Count > 0 ? failures[0].ToString() : string.Empty)}");
+    }
+
+    [TestMethod]
+    public void Dispose_FlushesPendingChanges()
+    {
+        // The debounce window is 2 s and this test does not wait it out, so the value on disk can
+        // only have come from the flush in Dispose.
+        using (var manager = new MonitorStateManager(_statePath))
+        {
+            manager.UpdateMonitorParameter(MonitorA, "Brightness", 37);
+            Assert.IsFalse(File.Exists(_statePath), "The debounced save must not have run yet.");
+        }
+
+        using var reloaded = new MonitorStateManager(_statePath);
+        Assert.AreEqual(37, reloaded.GetMonitorParameters(MonitorA)?.Brightness);
+    }
+
+    [TestMethod]
+    public void Dispose_WithoutChanges_WritesNothing()
+    {
+        using (var manager = new MonitorStateManager(_statePath))
+        {
+            manager.GetMonitorParameters(MonitorA);
+        }
+
+        Assert.IsFalse(File.Exists(_statePath), "A manager that observed no change must not write.");
+    }
+
+    [TestMethod]
+    public void FailedWrite_LeavesTheExistingStateFileIntact()
+    {
+        using (var seed = new MonitorStateManager(_statePath))
+        {
+            seed.UpdateMonitorParameter(MonitorA, "Brightness", 42);
+        }
+
+        var published = File.ReadAllText(_statePath);
+
+        // Occupying the temp path with a directory fails the write at exactly the point where an
+        // in-place File.WriteAllText would already have truncated the published file.
+        Directory.CreateDirectory(_statePath + ".tmp");
+
+        using (var manager = new MonitorStateManager(_statePath))
+        {
+            manager.UpdateMonitorParameter(MonitorA, "Brightness", 99);
+        }
+
+        Assert.AreEqual(
+            published,
+            File.ReadAllText(_statePath),
+            "A write that could not complete must leave the published file untouched.");
+    }
+}

--- a/src/modules/powerdisplay/PowerDisplay.Lib/Services/MonitorStateManager.cs
+++ b/src/modules/powerdisplay/PowerDisplay.Lib/Services/MonitorStateManager.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
-using System.Threading.Tasks;
 using ManagedCommon;
 using PowerDisplay.Common.Models;
 using PowerDisplay.Common.Serialization;
@@ -28,6 +27,7 @@ namespace PowerDisplay.Common.Services
         private readonly string _stateFilePath;
         private readonly ConcurrentDictionary<string, MonitorState> _states = new(MonitorIdComparer.Instance);
         private readonly SimpleDebouncer _saveDebouncer;
+        private readonly object _writeLock = new();
 
         private volatile bool _disposed;
         private volatile bool _isDirty; // Track pending changes for flush on dispose
@@ -54,15 +54,24 @@ namespace PowerDisplay.Common.Services
         /// Uses PathConstants for consistent path management.
         /// </summary>
         public MonitorStateManager()
+            : this(PathConstants.MonitorStateFilePath, ensureDefaultDirectory: true)
         {
-            // Use PathConstants for consistent path management
-            PathConstants.EnsurePowerDisplayFolderExists();
-            _stateFilePath = PathConstants.MonitorStateFilePath;
+        }
 
-            // Initialize debouncer for batching rapid updates (e.g., slider drag)
+        internal MonitorStateManager(string stateFilePath)
+            : this(stateFilePath, ensureDefaultDirectory: false)
+        {
+        }
+
+        private MonitorStateManager(string stateFilePath, bool ensureDefaultDirectory)
+        {
+            if (ensureDefaultDirectory)
+            {
+                PathConstants.EnsurePowerDisplayFolderExists();
+            }
+
+            _stateFilePath = stateFilePath;
             _saveDebouncer = new SimpleDebouncer(SaveDebounceMs);
-
-            // Load existing state if available
             LoadStateFromDisk();
         }
 
@@ -117,7 +126,7 @@ namespace PowerDisplay.Common.Services
                 // Schedule debounced save (SimpleDebouncer handles cancellation of previous calls)
                 if (shouldSave)
                 {
-                    _saveDebouncer.Debounce(SaveStateToDiskAsync);
+                    _saveDebouncer.Debounce(SaveStateToDisk);
                 }
             }
             catch (Exception ex)
@@ -203,7 +212,7 @@ namespace PowerDisplay.Common.Services
                 }
 
                 _isDirty = true;
-                _saveDebouncer.Debounce(SaveStateToDiskAsync);
+                _saveDebouncer.Debounce(SaveStateToDisk);
 
                 Logger.LogInfo(
                     $"[MonitorStateManager] Legacy migration finished: {migrated} migrated, {dropped} dropped (no match).");
@@ -263,10 +272,41 @@ namespace PowerDisplay.Common.Services
         }
 
         /// <summary>
-        /// Save current state to disk immediately (async).
-        /// Called by timer after debounce period.
+        /// Serializes the current state and publishes the whole file. Both save paths go through here.
         /// </summary>
-        private async Task SaveStateToDiskAsync()
+        /// <remarks>
+        /// <c>_writeLock</c> serializes the two callers — the debounced save and the flush in
+        /// <see cref="Dispose"/> — because cancelling the debouncer cannot reach a save already past
+        /// its delay, and the write opens with <c>FileShare.Read</c>, so a colliding write loses at
+        /// <c>CreateFile</c> and is dropped whole. <see cref="BuildStateJson"/> runs inside the lock,
+        /// so the last snapshot built is the one that lands. Both paths write synchronously:
+        /// <see cref="Dispose"/> has to flush without awaiting, the file is a few hundred bytes, and
+        /// the async API was the only reason there were two write paths to collide in the first place.
+        /// <para>
+        /// The bytes go to a temp file and are renamed in, as <c>CrashDetectionScope</c> and
+        /// <c>ProfileStore</c> do, because an in-place write truncates before it writes and not every
+        /// exit path runs <see cref="Dispose"/> — the runner's Terminate event and its exit watchdog
+        /// both call <c>Environment.Exit</c> outright. The rename keeps an interrupted write from
+        /// emptying the file and dropping every monitor's state instead of just the last change.
+        /// Deliberately no <c>Flush(flushToDisk: true)</c>: the threat here is process death, which
+        /// the page cache survives, not power loss — and this flush runs on the UI thread at shutdown,
+        /// where a FlushFileBuffers on a busy disk would be felt.
+        /// </para>
+        /// </remarks>
+        internal void WriteStateFile()
+        {
+            lock (_writeLock)
+            {
+                var tempPath = _stateFilePath + ".tmp";
+                File.WriteAllText(tempPath, BuildStateJson());
+                File.Move(tempPath, _stateFilePath, overwrite: true);
+            }
+        }
+
+        /// <summary>
+        /// Writes the current state to disk. Called by the debouncer after the quiet period.
+        /// </summary>
+        private void SaveStateToDisk()
         {
             try
             {
@@ -275,42 +315,22 @@ namespace PowerDisplay.Common.Services
                     return;
                 }
 
-                var json = BuildStateJson();
-
-                // Write to disk asynchronously
-                await File.WriteAllTextAsync(_stateFilePath, json);
-
-                // Clear dirty flag after successful save
+                // Cleared before the snapshot, not after it: a change landing mid-write re-marks
+                // dirty and is saved by the debounce that change schedules. Clearing afterwards
+                // swallows that bit and Dispose then skips the flush entirely.
                 _isDirty = false;
+                WriteStateFile();
             }
             catch (Exception ex)
             {
+                _isDirty = true;
                 Logger.LogError($"Failed to save monitor state: {ex.Message}");
             }
         }
 
         /// <summary>
-        /// Save current state to disk synchronously.
-        /// Called during Dispose to flush pending changes without risk of deadlock.
-        /// </summary>
-        private void SaveStateToDiskSync()
-        {
-            try
-            {
-                var json = BuildStateJson();
-
-                // Write to disk synchronously - safe for Dispose
-                File.WriteAllText(_stateFilePath, json);
-            }
-            catch (Exception ex)
-            {
-                Logger.LogError($"Failed to save monitor state (sync): {ex.Message}");
-            }
-        }
-
-        /// <summary>
         /// Build the JSON string for state file.
-        /// Shared logic between async and sync save methods.
+        /// Called by <see cref="WriteStateFile"/> under the write lock.
         /// </summary>
         /// <returns>JSON string for state file</returns>
         private string BuildStateJson()
@@ -354,13 +374,20 @@ namespace PowerDisplay.Common.Services
             _disposed = true;
             _isDirty = false;
 
-            // Dispose debouncer first to cancel any pending saves
+            // Dispose the debouncer first so no further save is scheduled. A save already past its
+            // delay is beyond its reach, which is what _writeLock covers.
             _saveDebouncer?.Dispose();
 
-            // Flush any pending changes before disposing using sync method to avoid deadlock
             if (wasDirty)
             {
-                SaveStateToDiskSync();
+                try
+                {
+                    WriteStateFile();
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogError($"Failed to flush monitor state on dispose: {ex.Message}");
+                }
             }
 
             GC.SuppressFinalize(this);


### PR DESCRIPTION
## Summary of the Pull Request

`MonitorStateManager` wrote `monitor_state.json` from two independent paths: the debounced save used `File.WriteAllTextAsync`, `Dispose` used `File.WriteAllText`. Disposing while a debounced save had already passed its delay left both holding the same path, and the loser threw an `IOException` into a catch that only logged — so the flush `Dispose` exists to perform was silently dropped and the user's last change did not survive the exit.

Both paths now go through one method that serializes and publishes under a single lock, writing a temp file and renaming it in.

## PR Checklist

- [ ] Closes: #xxx
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** All end-user-facing strings can be localized — this PR adds none
- [ ] **Dev docs:** Added/updated
- [x] **New binaries:** Added on the required places — none added, so no signing JSON, installer WXS or CI YML change is required
- [ ] **Documentation updated**

## Detailed Description of the Pull Request / Additional comments

### The collision

`Dispose` disposes the debouncer before flushing, which cancels a pending `Task.Delay` but cannot reach a save that has already passed it and stopped observing the token. That save is inside `File.WriteAllTextAsync` when `Dispose` reaches its own `File.WriteAllText`, and neither opens the file with a `FileShare` that tolerates the other.

The window is narrow, but the loser is usually the one that matters: `Dispose` runs from `App.Shutdown`, and the change it is flushing is whatever the user did in the last two seconds before quitting.

### One locked write path

Both callers now go through `WriteStateFile`, which takes `_writeLock` and does the serialize-and-write inside it. `BuildStateJson` runs under the lock too, so the last snapshot built is the one that lands.

The write is synchronous on both paths. `File.WriteAllTextAsync` bought nothing here — without `FileOptions.Asynchronous` it is synchronous I/O behind a `Task`, and this file is a few hundred bytes — and it was the only reason there were two write paths to collide in the first place. `Dispose` has to flush without awaiting anyway.

This is also why the fix is a `lock` rather than a `SemaphoreSlim`: a semaphore would need `WaitAsync` on one side and `Wait(timeout)` on the other, plus a decision about what to do when the timeout expires. The "risk of deadlock" the old comment on the sync path referred to applies to blocking on an async method, not to a plain monitor.

### Publish by rename

The bytes go to `monitor_state.json.tmp` and are renamed in, the same shape `CrashDetectionScope` and `ProfileStore` already use.

An in-place `File.WriteAllText` truncates before it writes, and **not every exit path runs `Dispose`** — the runner's Terminate event and its exit watchdog both call `Environment.Exit` outright. Dying inside that window leaves a zero-length file, which costs every monitor's saved brightness, contrast, volume and color temperature rather than just the last change. The rename makes publication atomic: readers see either the old file or the new one.

Deliberately no `Flush(flushToDisk: true)`. The threat being defended against is process death, which the page cache survives; power loss is not in scope. And this flush runs on the UI thread at shutdown, where a `FlushFileBuffers` on a busy disk would be felt.

### Dirty flag ordering

`SaveStateToDisk` clears `_isDirty` **before** taking the snapshot rather than after. A change landing mid-write then re-marks the state dirty and is picked up by the debounce that change schedules. Clearing afterwards swallows that bit, and `Dispose` skips the flush entirely. A failed write re-marks dirty so the flush still gets its chance.

### Testability

`MonitorStateManager` gains an internal constructor taking a state file path, so tests can drive it against a temp directory instead of the real LocalAppData location.

## Validation Steps Performed

- `PowerDisplay.Lib` and `PowerDisplay.Lib.UnitTests` built for x64 Debug with VS MSBuild — 0 errors, 0 warnings; `PowerDisplay.Lib.UnitTests.dll` under `vstest.console.exe`: **273 passed, 0 failed**
- Each guard was verified by removing it and confirming exactly one test turns red:

| removed | test that turns red |
| --- | --- |
| `lock (_writeLock)` | `ConcurrentWrites_DoNotCollideOnTheStateFile` |
| the temp-file-and-rename, writing in place instead | `FailedWrite_LeavesTheExistingStateFileIntact` |

- Note on what the concurrency test pins: once there is a single write method, the original two-writer collision is no longer expressible, so the test asserts the current design — four threads calling `WriteStateFile` concurrently. Without the lock they collide at `CreateFile` on the shared temp path, which is the same failure mode by a different route.
- No end-to-end manual check was performed. The window is a few milliseconds wide and only opens when a debounced save is mid-write at the exact moment `Dispose` runs, so reproducing it by hand is unreliable — the tests drive the same contention deterministically instead.
