### PR TITLE
[Shortcut Guide] Add Windows key hold activation options

### DIFF
--- a/doc/devdocs/modules/shortcut_guide.md
+++ b/doc/devdocs/modules/shortcut_guide.md
@@ -15,8 +15,17 @@ Shortcut Guide is a PowerToy that displays an overlay of available keyboard shor
 > The spec for the manifest files is in development and will be linked here once available.
 
 ## Usage
-- Press the user-defined hotkey to display the overlay
-- Press the hotkey again or press ESC to dismiss the overlay
+- Press the user-defined hotkey to display the full overlay.
+- Optionally, hold either Windows key to show taskbar indicators or the full overlay after a configurable delay.
+- Press the hotkey again or press ESC to dismiss the overlay. A full overlay opened by holding the Windows key can either close on key release or remain open, depending on the setting.
+
+The **Hold Windows key** setting is independent of the activation shortcut:
+
+- **Off** leaves the Windows key behavior unchanged.
+- **Show taskbar indicators** is the default and always hides the indicators when the Windows key is released.
+- **Open Shortcut Guide** can close on Windows-key release or remain open.
+
+The hold duration accepts values from 100 through 5,000 milliseconds and defaults to 900 milliseconds.
 
 ## Build and Debug Instructions
 
@@ -37,7 +46,7 @@ Shortcut Guide is a PowerToy that displays an overlay of available keyboard shor
 
 The Shortcut Guide module consists of the following 4 projects:
 
-### [`ShortcutGuide.Ui`](/src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuide.Ui.csproj
+### [`ShortcutGuide.Ui`](/src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuide.Ui.csproj)
 
 This is the main UI project for the Shortcut Guide module. Upon startup it does the following tasks:
 

--- a/doc/dsc/modules/ShortcutGuide.md
+++ b/doc/dsc/modules/ShortcutGuide.md
@@ -14,8 +14,8 @@ Manages configuration for the Shortcut Guide utility, which displays available k
 ## Description
 
 The `ShortcutGuide` module configures PowerToys Shortcut Guide, a utility that
-displays an overlay showing available Windows keyboard shortcuts when you hold
-the Windows key. It helps users discover and learn keyboard shortcuts.
+displays an overlay showing available Windows and application keyboard shortcuts.
+It can be opened with a configurable shortcut or by holding either Windows key.
 
 ## Properties
 
@@ -35,7 +35,15 @@ Sets the keyboard shortcut or method to open the shortcut guide.
 - `code` (integer) - Virtual key code
 - `key` (string) - Key name
 
-**Default:** Hold Windows key for 900ms
+**Default:** `Win+Shift+/`
+
+### WindowsKeyAction
+
+Sets the action performed after holding either Windows key.
+
+**Type:** integer  
+**Allowed values:** `0` (Off), `1` (Show taskbar indicators), `2` (Open Shortcut Guide)  
+**Default:** `1`
 
 ### OverlayOpacity
 
@@ -58,8 +66,17 @@ Sets the theme for the shortcut guide.
 Sets how long the Windows key must be held before showing the guide (in milliseconds).
 
 **Type:** integer  
-**Range:** `100` to `10000`  
+**Range:** `100` to `5000`  
 **Default:** `900`
+
+### CloseOnWindowsKeyRelease
+
+Controls whether the full Shortcut Guide closes when the Windows key is released.
+This setting applies when `WindowsKeyAction` is `2`; taskbar indicators always
+close on release.
+
+**Type:** boolean  
+**Default:** `true`
 
 ### ExcludedApps
 
@@ -71,13 +88,15 @@ List of applications where Shortcut Guide is disabled.
 
 ### Example 1 - Configure activation time with direct execution
 
-This example sets a faster activation time for the shortcut guide.
+This example opens the full Shortcut Guide after holding a Windows key for 600 milliseconds.
 
 ```powershell
 $config = @{
     settings = @{
         properties = @{
+            WindowsKeyAction = 2
             PressTime = 600
+            CloseOnWindowsKeyRelease = $true
         }
         name = "ShortcutGuide"
         version = "1.0"
@@ -146,7 +165,7 @@ resources:
 
 ### Example 4 - Quick activation
 
-This example configures for quick activation with a short press time.
+This example configures taskbar indicators with a short hold duration.
 
 ```bash
 dsc config set --file shortcutguide-quick.dsc.yaml
@@ -161,6 +180,7 @@ resources:
     properties:
       settings:
         properties:
+          WindowsKeyAction: 1
           PressTime: 400
         name: ShortcutGuide
         version: 1.0

--- a/src/common/interop/shared_constants.h
+++ b/src/common/interop/shared_constants.h
@@ -50,6 +50,8 @@ namespace CommonSharedConstants
 
     const wchar_t SHORTCUT_GUIDE_TRIGGER_EVENT[] = L"Local\\ShortcutGuide-TriggerEvent-d4275ad3-2531-4d19-9252-c0becbd9b496";
 
+    const wchar_t SHORTCUT_GUIDE_WINDOWS_KEY_TRIGGER_EVENT[] = L"Local\\ShortcutGuide-WindowsKeyTriggerEvent-0c134f7e-1cc9-4840-b482-4729020ecd0e";
+
     const wchar_t SHORTCUT_GUIDE_EXIT_EVENT[] = L"Local\\ShortcutGuide-ExitEvent-35697cdd-a3d2-47d6-a246-34efcc73eac0";
 
     const wchar_t FANCY_ZONES_EDITOR_TOGGLE_EVENT[] = L"Local\\FancyZones-ToggleEditorEvent-1e174338-06a3-472b-874d-073b21c62f14";

--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/Program.cs
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/Program.cs
@@ -23,6 +23,8 @@ namespace ShortcutGuide
 
         public static nint ForegroundWindowHandle { get; set; } = nint.Zero;
 
+        internal static string WindowsKeyTriggerEventName { get; private set; } = string.Empty;
+
         [STAThread]
         public static void Main(string[] args)
         {
@@ -30,12 +32,18 @@ namespace ShortcutGuide
             Logger.InitializeLogger("\\ShortcutGuide\\Logs");
             LogForegroundCapture(ForegroundWindowHandle);
 
-            // The module interface passes: <powertoys_pid> [telemetry]
+            // The module interface passes: <powertoys_pid> <windows_key_event_name>, or
+            // <powertoys_pid> telemetry for the short-lived telemetry process.
             if (args.Length >= 2 && args[1] == "telemetry")
             {
                 Logger.LogInfo("Telemetry mode requested. Sending settings telemetry.");
                 SendSettingsTelemetry();
                 return;
+            }
+
+            if (args.Length >= 2)
+            {
+                WindowsKeyTriggerEventName = args[1];
             }
 
             if (args.Length >= 1 && int.TryParse(args[0], out int runnerPID))
@@ -157,6 +165,9 @@ namespace ShortcutGuide
                     var props = settings.Properties;
                     PowerToysTelemetry.Log.WriteEvent(new ShortcutGuideSettingsEvent(
                         props.OpenShortcutGuide?.ToString() ?? string.Empty,
+                        props.WindowsKeyAction?.Value ?? (int)ShortcutGuideWindowsKeyAction.TaskbarIndicators,
+                        props.PressTime?.Value ?? ShortcutGuideProperties.DefaultPressTimeMs,
+                        props.CloseOnWindowsKeyRelease?.Value ?? true,
                         props.Theme?.Value ?? "system",
                         props.DisabledApps?.Value ?? string.Empty));
                 }

--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuideXAML/App.xaml.cs
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuideXAML/App.xaml.cs
@@ -43,9 +43,15 @@ namespace ShortcutGuide
 
         private EventWaitHandle? _launchedEvent;
 
+        private EventWaitHandle? _windowsKeyLaunchedEvent;
+
         private Thread? _listenForLaunchedEventThread;
 
         private static readonly UIntPtr _ignoreKeyEventFlag = 0x5557;
+
+        private volatile int _activeWindowsKey;
+
+        private volatile bool _closeOnWindowsKeyRelease = true;
 
         public App()
         {
@@ -92,6 +98,19 @@ namespace ShortcutGuide
                     Logger.LogError($"Failed to open existing event '{Constants.ShortcutGuideTriggerEvent()}': {ex.Message}");
                 }
 
+                if (!string.IsNullOrEmpty(Program.WindowsKeyTriggerEventName))
+                {
+                    try
+                    {
+                        _windowsKeyLaunchedEvent = EventWaitHandle.OpenExisting(Program.WindowsKeyTriggerEventName);
+                        Logger.LogInfo($"Opened Shortcut Guide Windows-key trigger event '{Program.WindowsKeyTriggerEventName}'.");
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.LogError($"Failed to open existing event '{Program.WindowsKeyTriggerEventName}': {ex.Message}");
+                    }
+                }
+
                 _listenForLaunchedEventThread = new Thread(ListenForLaunchedEvents)
                 {
                     IsBackground = true,
@@ -105,23 +124,24 @@ namespace ShortcutGuide
                 },
                 (int key) =>
                 {
-                    if (OverlayWindow.AppWindow.IsVisible)
+                    if (_activeWindowsKey != 0)
                     {
-                        OverlayWindow.DispatcherQueue.TryEnqueue(() =>
+                        if (_closeOnWindowsKeyRelease && OverlayWindow.AppWindow.IsVisible)
                         {
-                            OverlayWindow.CloseAnimated();
-                        });
+                            OverlayWindow.DispatcherQueue.TryEnqueue(() =>
+                            {
+                                OverlayWindow.CloseAnimated();
+                            });
+                        }
 
                         NativeMethods.SendInput(1, [new() { Type = 1, Data = new() { Keyboard = new NativeMethods.KEYBDINPUT { WVk = 0xFF, DwFlags = 0x2 } } }], Marshal.SizeOf<NativeMethods.INPUT>());
-                        SendSingleKeyboardInput((short)key, 0x2); // key up
+                        _activeWindowsKey = 0;
                     }
-                    else
-                    {
-                        SendSingleKeyboardInput((short)key, 0x2); // key up
-                    }
+
+                    SendSingleKeyboardInput((short)key, 0x2); // key up
                 },
-                () => true,
-                (int key, nuint specialFlags) => key == 91 && specialFlags != _ignoreKeyEventFlag);
+                () => _activeWindowsKey != 0,
+                (int key, nuint specialFlags) => key == _activeWindowsKey && specialFlags != _ignoreKeyEventFlag);
             }
             catch (Exception ex)
             {
@@ -138,6 +158,8 @@ namespace ShortcutGuide
             {
                 0xA5 => true, // VK_RMENU (Right Alt - AltGr)
                 0xA3 => true, // VK_RCONTROL
+                0x5B => true, // VK_LWIN
+                0x5C => true, // VK_RWIN
                 0x2D => true, // VK_INSERT
                 0x2E => true, // VK_DELETE
                 0x23 => true, // VK_END
@@ -177,58 +199,48 @@ namespace ShortcutGuide
 
         private void ListenForLaunchedEvents()
         {
-            if (_launchedEvent == null)
+            var handles = new List<WaitHandle>();
+            int shortcutEventIndex = -1;
+            int windowsKeyEventIndex = -1;
+
+            if (_launchedEvent != null)
+            {
+                shortcutEventIndex = handles.Count;
+                handles.Add(_launchedEvent);
+            }
+
+            if (_windowsKeyLaunchedEvent != null)
+            {
+                windowsKeyEventIndex = handles.Count;
+                handles.Add(_windowsKeyLaunchedEvent);
+            }
+
+            if (handles.Count == 0)
             {
                 return;
             }
 
-            var handles = new WaitHandle[] { _launchedEvent };
+            var waitHandles = handles.ToArray();
             try
             {
                 Logger.LogInfo("Shortcut Guide show-event listener started.");
                 while (true)
                 {
-                    var index = WaitHandle.WaitAny(handles);
-                    if (index == 0)
+                    var index = WaitHandle.WaitAny(waitHandles);
+                    if (index == shortcutEventIndex)
                     {
                         Logger.LogInfo("Shortcut Guide trigger event signaled.");
                         OverlayWindow.DispatcherQueue.TryEnqueue(async () =>
                         {
-                            // VK_LWIN long-press shows only the taskbar pane.
-                            // Use the Win32 key state directly: WPF's
-                            // System.Windows.Input.Keyboard is not initialized
-                            // on the WinUI UI thread.
-                            const int VK_LWIN = 0x5B;
-                            bool winKeyDown = (NativeMethods.GetAsyncKeyState(VK_LWIN) & 0x8000) != 0;
-
-                            if (winKeyDown)
-                            {
-                                if (OverlayWindow.AppWindow.IsVisible)
-                                {
-                                    return;
-                                }
-
-                                OverlayWindow.MainPaneControl.Visibility = Visibility.Collapsed;
-                                OverlayWindow.ShowOverlay();
-                                OverlayWindow.UpdateTaskbarPaneLayout();
-                                OverlayWindow.TaskbarPaneControl.Visibility = Visibility.Visible;
-                                return;
-                            }
-
-                            if (OverlayWindow.AppWindow.IsVisible)
-                            {
-                                OverlayWindow.CloseAnimated();
-                                OverlayWindow.MainPaneControl.Hide();
-                            }
-                            else
-                            {
-                                Program.ForegroundWindowHandle = NativeMethods.GetForegroundWindow();
-                                OverlayWindow.MainPaneControl.Visibility = Visibility.Collapsed;
-                                OverlayWindow.ShowOverlay();
-                                await OverlayWindow.MainPaneControl.Open();
-                                OverlayWindow.UpdateTaskbarPaneLayout();
-                                OverlayWindow.MainPaneControl.Visibility = Visibility.Visible;
-                            }
+                            await HandleShortcutTriggerAsync();
+                        });
+                    }
+                    else if (index == windowsKeyEventIndex)
+                    {
+                        Logger.LogInfo("Shortcut Guide Windows-key trigger event signaled.");
+                        OverlayWindow.DispatcherQueue.TryEnqueue(async () =>
+                        {
+                            await HandleWindowsKeyTriggerAsync();
                         });
                     }
                     else
@@ -243,6 +255,77 @@ namespace ShortcutGuide
             catch (ThreadInterruptedException)
             {
             }
+        }
+
+        private static async Task HandleShortcutTriggerAsync()
+        {
+            if (OverlayWindow.AppWindow.IsVisible)
+            {
+                OverlayWindow.CloseAnimated();
+                OverlayWindow.MainPaneControl.Hide();
+                return;
+            }
+
+            Program.ForegroundWindowHandle = NativeMethods.GetForegroundWindow();
+            OverlayWindow.MainPaneControl.Visibility = Visibility.Collapsed;
+            OverlayWindow.ShowOverlay();
+            await OverlayWindow.MainPaneControl.Open();
+            OverlayWindow.UpdateTaskbarPaneLayout();
+            OverlayWindow.MainPaneControl.Visibility = Visibility.Visible;
+        }
+
+        private async Task HandleWindowsKeyTriggerAsync()
+        {
+            const int VK_LWIN = 0x5B;
+            const int VK_RWIN = 0x5C;
+
+            var settings = SettingsUtils.Default.GetSettingsOrDefault<ShortcutGuideSettings>(
+                Microsoft.PowerToys.Settings.UI.Library.ShortcutGuideSettings.ModuleName);
+            var action = settings.Properties?.WindowsKeyAction?.Value switch
+            {
+                (int)ShortcutGuideWindowsKeyAction.Off => ShortcutGuideWindowsKeyAction.Off,
+                (int)ShortcutGuideWindowsKeyAction.OpenShortcutGuide => ShortcutGuideWindowsKeyAction.OpenShortcutGuide,
+                _ => ShortcutGuideWindowsKeyAction.TaskbarIndicators,
+            };
+
+            int pressedWindowsKey = (NativeMethods.GetAsyncKeyState(VK_LWIN) & 0x8000) != 0
+                ? VK_LWIN
+                : (NativeMethods.GetAsyncKeyState(VK_RWIN) & 0x8000) != 0
+                    ? VK_RWIN
+                    : 0;
+
+            if (action == ShortcutGuideWindowsKeyAction.Off || pressedWindowsKey == 0)
+            {
+                return;
+            }
+
+            _activeWindowsKey = pressedWindowsKey;
+            _closeOnWindowsKeyRelease = action == ShortcutGuideWindowsKeyAction.TaskbarIndicators ||
+                                        settings.Properties?.CloseOnWindowsKeyRelease?.Value != false;
+
+            if (OverlayWindow.AppWindow.IsVisible)
+            {
+                return;
+            }
+
+            if (action == ShortcutGuideWindowsKeyAction.OpenShortcutGuide)
+            {
+                Program.ForegroundWindowHandle = NativeMethods.GetForegroundWindow();
+            }
+
+            OverlayWindow.MainPaneControl.Visibility = Visibility.Collapsed;
+            OverlayWindow.ShowOverlay();
+
+            if (action == ShortcutGuideWindowsKeyAction.TaskbarIndicators)
+            {
+                OverlayWindow.UpdateTaskbarPaneLayout();
+                OverlayWindow.TaskbarPaneControl.Visibility = Visibility.Visible;
+                return;
+            }
+
+            await OverlayWindow.MainPaneControl.Open();
+            OverlayWindow.UpdateTaskbarPaneLayout();
+            OverlayWindow.MainPaneControl.Visibility = Visibility.Visible;
         }
 
         private void LoadData()
@@ -311,7 +394,9 @@ namespace ShortcutGuide
 
         public void Dispose()
         {
+            _winKeyUpKeyboardHook?.Dispose();
             _launchedEvent?.Dispose();
+            _windowsKeyLaunchedEvent?.Dispose();
 
             if (_listenForLaunchedEventThread == null)
             {

--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuideXAML/App.xaml.cs
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuideXAML/App.xaml.cs
@@ -299,14 +299,14 @@ namespace ShortcutGuide
                 return;
             }
 
-            _activeWindowsKey = pressedWindowsKey;
-            _closeOnWindowsKeyRelease = action == ShortcutGuideWindowsKeyAction.TaskbarIndicators ||
-                                        settings.Properties?.CloseOnWindowsKeyRelease?.Value != false;
-
             if (OverlayWindow.AppWindow.IsVisible)
             {
                 return;
             }
+
+            _activeWindowsKey = pressedWindowsKey;
+            _closeOnWindowsKeyRelease = action == ShortcutGuideWindowsKeyAction.TaskbarIndicators ||
+                                        settings.Properties?.CloseOnWindowsKeyRelease?.Value != false;
 
             if (action == ShortcutGuideWindowsKeyAction.OpenShortcutGuide)
             {

--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/Telemetry/ShortcutGuideSettingsEvent.cs
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/Telemetry/ShortcutGuideSettingsEvent.cs
@@ -15,15 +15,30 @@ public class ShortcutGuideSettingsEvent : EventBase, IEvent
 {
     public string Hotkey { get; }
 
+    public int WindowsKeyAction { get; }
+
+    public int WindowsKeyPressTime { get; }
+
+    public bool CloseOnWindowsKeyRelease { get; }
+
     public string Theme { get; }
 
     public string DisabledApps { get; }
 
     public PartA_PrivTags PartA_PrivTags => PartA_PrivTags.ProductAndServicePerformance;
 
-    public ShortcutGuideSettingsEvent(string hotkey, string theme, string disabledApps)
+    public ShortcutGuideSettingsEvent(
+        string hotkey,
+        int windowsKeyAction,
+        int windowsKeyPressTime,
+        bool closeOnWindowsKeyRelease,
+        string theme,
+        string disabledApps)
     {
         Hotkey = hotkey;
+        WindowsKeyAction = windowsKeyAction;
+        WindowsKeyPressTime = windowsKeyPressTime;
+        CloseOnWindowsKeyRelease = closeOnWindowsKeyRelease;
         Theme = theme;
         DisabledApps = disabledApps;
     }

--- a/src/modules/ShortcutGuide/ShortcutGuideModuleInterface/dllmain.cpp
+++ b/src/modules/ShortcutGuide/ShortcutGuideModuleInterface/dllmain.cpp
@@ -319,7 +319,16 @@ private:
         auto settingsObject = settings.get_raw_json();
         if (settingsObject.GetView().Size())
         {
-            auto propertiesObject = settingsObject.GetNamedObject(L"properties");
+            winrt::Windows::Data::Json::JsonObject propertiesObject;
+            try
+            {
+                propertiesObject = settingsObject.GetNamedObject(L"properties");
+            }
+            catch (...)
+            {
+                Logger::warn("Failed to initialize Shortcut Guide settings properties");
+            }
+
             try
             {
                 // Parse HotKey

--- a/src/modules/ShortcutGuide/ShortcutGuideModuleInterface/dllmain.cpp
+++ b/src/modules/ShortcutGuide/ShortcutGuideModuleInterface/dllmain.cpp
@@ -11,6 +11,20 @@
 #include "Generated Files/resource.h"
 #include <common/SettingsAPI/settings_objects.h>
 
+namespace
+{
+    enum class WindowsKeyAction
+    {
+        Off = 0,
+        TaskbarIndicators = 1,
+        OpenShortcutGuide = 2,
+    };
+
+    constexpr UINT defaultWindowsKeyPressTime = 900;
+    constexpr UINT minimumWindowsKeyPressTime = 100;
+    constexpr UINT maximumWindowsKeyPressTime = 5000;
+}
+
 BOOL APIENTRY DllMain(HMODULE /*hModule*/, DWORD /*ul_reason_for_call*/, LPVOID /*lpReserved*/)
 {
     return TRUE;
@@ -39,6 +53,12 @@ public:
         if (!triggerEvent)
         {
             Logger::warn(L"Failed to create {} event. {}", CommonSharedConstants::SHORTCUT_GUIDE_TRIGGER_EVENT, get_last_error_or_default(GetLastError()));
+        }
+
+        windowsKeyTriggerEvent = CreateEvent(nullptr, false, false, CommonSharedConstants::SHORTCUT_GUIDE_WINDOWS_KEY_TRIGGER_EVENT);
+        if (!windowsKeyTriggerEvent)
+        {
+            Logger::warn(L"Failed to create {} event. {}", CommonSharedConstants::SHORTCUT_GUIDE_WINDOWS_KEY_TRIGGER_EVENT, get_last_error_or_default(GetLastError()));
         }
 
         InitSettings();
@@ -132,6 +152,10 @@ public:
         {
             CloseHandle(triggerEvent);
         }
+        if (windowsKeyTriggerEvent)
+        {
+            CloseHandle(windowsKeyTriggerEvent);
+        }
 
         delete this;
     }
@@ -158,6 +182,22 @@ public:
         SetEvent(triggerEvent);
     }
 
+    virtual void on_win_key_long_press() override
+    {
+        Logger::trace("on_win_key_long_press()");
+        if (!_enabled || m_windowsKeyAction == WindowsKeyAction::Off)
+        {
+            return;
+        }
+
+        if (!IsProcessActive())
+        {
+            StartProcess();
+        }
+
+        SetEvent(windowsKeyTriggerEvent);
+    }
+
     virtual void send_settings_telemetry() override
     {
         Logger::trace("Send settings telemetry");
@@ -166,8 +206,8 @@ public:
             Logger::error("Failed to create a process to send settings telemetry");
         }
     }
-    virtual bool keep_track_of_pressed_win_key() override { return true; }
-    virtual UINT milliseconds_win_key_must_be_pressed() override { return 900; }
+    virtual bool keep_track_of_pressed_win_key() override { return m_windowsKeyAction != WindowsKeyAction::Off; }
+    virtual UINT milliseconds_win_key_must_be_pressed() override { return m_windowsKeyPressTime; }
 
 private:
     std::wstring app_name;
@@ -179,13 +219,11 @@ private:
     // Hotkey to invoke the module
     HotkeyEx m_hotkey;
 
-    // If the module should be activated through the legacy pressing windows key behavior.
-    const UINT DEFAULT_MILLISECONDS_WIN_KEY_PRESS_TIME_FOR_GLOBAL_WINDOWS_SHORTCUTS = 900;
-    const UINT DEFAULT_MILLISECONDS_WIN_KEY_PRESS_TIME_FOR_TASKBAR_ICON_SHORTCUTS = 900;
-    UINT m_millisecondsWinKeyPressTimeForGlobalWindowsShortcuts = DEFAULT_MILLISECONDS_WIN_KEY_PRESS_TIME_FOR_GLOBAL_WINDOWS_SHORTCUTS;
-    UINT m_millisecondsWinKeyPressTimeForTaskbarIconShortcuts = DEFAULT_MILLISECONDS_WIN_KEY_PRESS_TIME_FOR_TASKBAR_ICON_SHORTCUTS;
+    WindowsKeyAction m_windowsKeyAction = WindowsKeyAction::TaskbarIndicators;
+    UINT m_windowsKeyPressTime = defaultWindowsKeyPressTime;
 
     HANDLE triggerEvent;
+    HANDLE windowsKeyTriggerEvent;
     HANDLE exitEvent;
 
     bool StartProcess(std::wstring args = L"")
@@ -200,12 +238,21 @@ private:
             ResetEvent(triggerEvent);
         }
 
+        if (windowsKeyTriggerEvent)
+        {
+            ResetEvent(windowsKeyTriggerEvent);
+        }
+
         unsigned long powertoys_pid = GetCurrentProcessId();
         std::wstring executable_args = L"";
         executable_args.append(std::to_wstring(powertoys_pid));
-        if (!args.empty())
+        executable_args.append(L" ");
+        if (args.empty())
         {
-            executable_args.append(L" ");
+            executable_args.append(CommonSharedConstants::SHORTCUT_GUIDE_WINDOWS_KEY_TRIGGER_EVENT);
+        }
+        else
+        {
             executable_args.append(args);
         }
 
@@ -266,13 +313,17 @@ private:
 
     void ParseSettings(PowerToysSettings::PowerToyValues& settings)
     {
+        m_windowsKeyAction = WindowsKeyAction::TaskbarIndicators;
+        m_windowsKeyPressTime = defaultWindowsKeyPressTime;
+
         auto settingsObject = settings.get_raw_json();
         if (settingsObject.GetView().Size())
         {
+            auto propertiesObject = settingsObject.GetNamedObject(L"properties");
             try
             {
                 // Parse HotKey
-                auto jsonHotkeyObject = settingsObject.GetNamedObject(L"properties").GetNamedObject(L"open_shortcutguide");
+                auto jsonHotkeyObject = propertiesObject.GetNamedObject(L"open_shortcutguide");
                 auto hotkey = PowerToysSettings::HotkeyObject::from_json(jsonHotkeyObject);
                 m_hotkey = HotkeyEx();
                 if (hotkey.win_pressed())
@@ -301,6 +352,41 @@ private:
             {
                 Logger::warn("Failed to initialize Shortcut Guide start shortcut");
             }
+
+            try
+            {
+                if (propertiesObject.HasKey(L"win_key_action"))
+                {
+                    const auto propertyObject = propertiesObject.GetNamedObject(L"win_key_action");
+                    const auto action = static_cast<int>(propertyObject.GetNamedNumber(L"value"));
+                    if (action >= static_cast<int>(WindowsKeyAction::Off) &&
+                        action <= static_cast<int>(WindowsKeyAction::OpenShortcutGuide))
+                    {
+                        m_windowsKeyAction = static_cast<WindowsKeyAction>(action);
+                    }
+                }
+            }
+            catch (...)
+            {
+                Logger::warn("Failed to initialize Shortcut Guide Windows-key action");
+            }
+
+            try
+            {
+                if (propertiesObject.HasKey(L"press_time"))
+                {
+                    const auto propertyObject = propertiesObject.GetNamedObject(L"press_time");
+                    const auto pressTime = static_cast<int>(propertyObject.GetNamedNumber(L"value"));
+                    const auto clampedPressTime = (std::max)(
+                        static_cast<int>(minimumWindowsKeyPressTime),
+                        (std::min)(pressTime, static_cast<int>(maximumWindowsKeyPressTime)));
+                    m_windowsKeyPressTime = static_cast<UINT>(clampedPressTime);
+                }
+            }
+            catch (...)
+            {
+                Logger::warn("Failed to initialize Shortcut Guide Windows-key hold duration");
+            }
         }
         else
         {
@@ -312,14 +398,6 @@ private:
             Logger::info("Shortcut Guide is going to use default shortcut");
             m_hotkey.modifiersMask = MOD_SHIFT | MOD_WIN;
             m_hotkey.vkCode = VK_OEM_2;
-        }
-    }
-
-    void WindowsKeyPressBehavior()
-    {
-        if (IsProcessActive())
-        {
-            TerminateProcess(m_hProcess, 0);
         }
     }
 };

--- a/src/modules/interface/powertoy_module_interface.h
+++ b/src/modules/interface/powertoy_module_interface.h
@@ -135,7 +135,7 @@ public:
         return false;
     }
 
-    /* These are for enabling the legacy behavior of showing the shortcut guide after pressing the win key.
+    /* These are for enabling Shortcut Guide behavior after holding the Windows key.
      * keep_track_of_pressed_win_key returns true if the module wants to keep track of the win key being pressed.
      * milliseconds_win_key_must_be_pressed returns the number of milliseconds the win key should be pressed before triggering the module.
      * Don't use these for new modules.
@@ -153,6 +153,11 @@ public:
     virtual powertoys_gpo::gpo_rule_configured_t gpo_policy_enabled_configuration()
     {
         return powertoys_gpo::gpo_rule_configured_not_configured;
+    }
+
+    virtual void on_win_key_long_press()
+    {
+        OnHotkeyEx();
     }
 
     // Some actions like AdvancedPaste generate new inputs, which we don't want to catch again.

--- a/src/runner/centralized_kb_hook.cpp
+++ b/src/runner/centralized_kb_hook.cpp
@@ -212,6 +212,24 @@ namespace CentralizedKeyboardHook
         pressedKeyDescriptors.insert({ .virtualKey = vk, .moduleName = moduleName, .action = std::move(action), .idTimer = timerId, .millisecondsToPress = milliseconds });
     }
 
+    void ClearModulePressedKeyActions(const std::wstring& moduleName) noexcept
+    {
+        std::unique_lock lock{ pressedKeyMutex };
+        auto it = pressedKeyDescriptors.begin();
+        while (it != pressedKeyDescriptors.end())
+        {
+            if (it->moduleName == moduleName)
+            {
+                KillTimer(runnerWindow, it->idTimer);
+                it = pressedKeyDescriptors.erase(it);
+            }
+            else
+            {
+                ++it;
+            }
+        }
+    }
+
     void ClearModuleHotkeys(const std::wstring& moduleName) noexcept
     {
         Logger::trace(L"UnRegister hotkey action for {}", moduleName);
@@ -230,21 +248,7 @@ namespace CentralizedKeyboardHook
                 }
             }
         }
-        {
-            std::unique_lock lock{ pressedKeyMutex };
-            auto it = pressedKeyDescriptors.begin();
-            while (it != pressedKeyDescriptors.end())
-            {
-                if (it->moduleName == moduleName)
-                {
-                    it = pressedKeyDescriptors.erase(it);
-                }
-                else
-                {
-                    ++it;
-                }
-            }
-        }
+        ClearModulePressedKeyActions(moduleName);
     }
 
     void Start() noexcept

--- a/src/runner/centralized_kb_hook.h
+++ b/src/runner/centralized_kb_hook.h
@@ -10,6 +10,7 @@ namespace CentralizedKeyboardHook
     void Stop() noexcept;
     void SetHotkeyAction(const std::wstring& moduleName, const Hotkey& hotkey, std::function<bool()>&& action) noexcept;
     void AddPressedKeyAction(const std::wstring& moduleName, const DWORD vk, const UINT milliseconds, std::function<bool()>&& action) noexcept;
+    void ClearModulePressedKeyActions(const std::wstring& moduleName) noexcept;
     void ClearModuleHotkeys(const std::wstring& moduleName) noexcept;
     void RegisterWindow(HWND hwnd) noexcept;
 };

--- a/src/runner/powertoy_module.cpp
+++ b/src/runner/powertoy_module.cpp
@@ -79,6 +79,7 @@ void PowertoyModule::update_hotkeys()
 void PowertoyModule::UpdateHotkeyEx()
 {
     CentralizedHotkeys::UnregisterHotkeysForModule(pt_module->get_key());
+    CentralizedKeyboardHook::ClearModulePressedKeyActions(pt_module->get_key());
 
     auto container = pt_module->GetHotkeyEx();
     if (container.has_value() && pt_module->is_enabled())
@@ -99,14 +100,14 @@ void PowertoyModule::UpdateHotkeyEx()
     }
 
     // HACK:
-    // Just for enabling the shortcut guide legacy behavior of pressing the Windows Key.
+    // Just for enabling the Shortcut Guide behavior of holding the Windows key.
     // This is not the sort of behavior we'd like to have generalized on other modules.
     // But this was a way to bring back the long windows key behavior that the community wanted back while maintaining the separate process.
     if (pt_module->keep_track_of_pressed_win_key())
     {
         auto modulePtr = pt_module.get();
         auto action = [modulePtr] {
-            modulePtr->OnHotkeyEx();
+            modulePtr->on_win_key_long_press();
             return false;
         };
         CentralizedKeyboardHook::AddPressedKeyAction(pt_module->get_key(), VK_LWIN, pt_module->milliseconds_win_key_must_be_pressed(), action);

--- a/src/settings-ui/Settings.UI.Library/ShortcutGuideProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/ShortcutGuideProperties.cs
@@ -10,11 +10,18 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 {
     public class ShortcutGuideProperties
     {
+        public const int DefaultPressTimeMs = 900;
+        public const int MinimumPressTimeMs = 100;
+        public const int MaximumPressTimeMs = 5000;
+
         [CmdConfigureIgnore]
         public HotkeySettings DefaultOpenShortcutGuide => new HotkeySettings(true, false, false, true, 0xBF);
 
         public ShortcutGuideProperties()
         {
+            WindowsKeyAction = new IntProperty((int)ShortcutGuideWindowsKeyAction.TaskbarIndicators);
+            PressTime = new IntProperty(DefaultPressTimeMs);
+            CloseOnWindowsKeyRelease = new BoolProperty(true);
             Theme = new StringProperty("system");
             DisabledApps = new StringProperty();
             OpenShortcutGuide = DefaultOpenShortcutGuide;
@@ -24,6 +31,15 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 
         [JsonPropertyName("open_shortcutguide")]
         public HotkeySettings OpenShortcutGuide { get; set; }
+
+        [JsonPropertyName("win_key_action")]
+        public IntProperty WindowsKeyAction { get; set; }
+
+        [JsonPropertyName("press_time")]
+        public IntProperty PressTime { get; set; }
+
+        [JsonPropertyName("close_on_windows_key_release")]
+        public BoolProperty CloseOnWindowsKeyRelease { get; set; }
 
         [JsonPropertyName("theme")]
         public StringProperty Theme { get; set; }

--- a/src/settings-ui/Settings.UI.Library/ShortcutGuideWindowsKeyAction.cs
+++ b/src/settings-ui/Settings.UI.Library/ShortcutGuideWindowsKeyAction.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.PowerToys.Settings.UI.Library
+{
+    public enum ShortcutGuideWindowsKeyAction
+    {
+        Off = 0,
+        TaskbarIndicators = 1,
+        OpenShortcutGuide = 2,
+    }
+}

--- a/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/ShortcutGuide.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/ShortcutGuide.cs
@@ -7,6 +7,7 @@ using System.IO.Abstractions;
 using System.Text.Json;
 
 using Microsoft.PowerToys.Settings.UI.Library;
+using Microsoft.PowerToys.Settings.UI.Library.Interfaces;
 using Microsoft.PowerToys.Settings.UI.UnitTests.BackwardsCompatibility;
 using Microsoft.PowerToys.Settings.UI.UnitTests.Mocks;
 using Microsoft.PowerToys.Settings.UI.ViewModels;
@@ -24,12 +25,12 @@ namespace ViewModelTests
         /// Test if the original settings files were modified.
         /// </summary>
         [TestMethod]
-        [DataRow("v0.18.2", "settings.json")]
-        [DataRow("v0.19.2", "settings.json")]
-        [DataRow("v0.20.1", "settings.json")]
-        [DataRow("v0.21.1", "settings.json")]
-        [DataRow("v0.22.0", "settings.json")]
-        public void OriginalFilesModificationTest(string version, string fileName)
+        [DataRow("v0.18.2", "settings.json", 100)]
+        [DataRow("v0.19.2", "settings.json", 1150)]
+        [DataRow("v0.20.1", "settings.json", 650)]
+        [DataRow("v0.21.1", "settings.json", 1050)]
+        [DataRow("v0.22.0", "settings.json", 850)]
+        public void OriginalFilesModificationTest(string version, string fileName, int expectedPressTime)
         {
             var settingPathMock = new Mock<SettingPath>();
             var mockIOProvider = BackCompatTestProperties.GetModuleIOProvider(version, ShortcutGuideSettings.ModuleName, fileName);
@@ -48,6 +49,9 @@ namespace ViewModelTests
 
             // Verify that the old settings persisted
             Assert.AreEqual(originalGeneralSettings.Enabled.ShortcutGuide, viewModel.IsEnabled);
+            Assert.AreEqual(expectedPressTime, viewModel.PressTime);
+            Assert.AreEqual((int)ShortcutGuideWindowsKeyAction.TaskbarIndicators, viewModel.WindowsKeyActionIndex);
+            Assert.IsTrue(viewModel.CloseOnWindowsKeyRelease);
 
             // Verify that the stub file was used
             var expectedCallCount = 2;  // once via the view model, and once by the test (GetSettings<T>)
@@ -103,6 +107,122 @@ namespace ViewModelTests
             // Assert
             Func<string, bool> isDark = s => JsonSerializer.Deserialize<ShortcutGuideSettings>(s).Properties.Theme.Value == "dark";
             settingsUtilsMock.Verify(x => x.SaveSettings(It.Is<string>(y => isDark(y)), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+        }
+
+        [TestMethod]
+        public void WindowsKeySettingsShouldUseExpectedDefaults()
+        {
+            var properties = new ShortcutGuideProperties();
+
+            Assert.AreEqual((int)ShortcutGuideWindowsKeyAction.TaskbarIndicators, properties.WindowsKeyAction.Value);
+            Assert.AreEqual(ShortcutGuideProperties.DefaultPressTimeMs, properties.PressTime.Value);
+            Assert.IsTrue(properties.CloseOnWindowsKeyRelease.Value);
+        }
+
+        [TestMethod]
+        public void InvalidWindowsKeySettingsShouldBeNormalizedOnInitialization()
+        {
+            var settings = new ShortcutGuideSettings();
+            settings.Properties.WindowsKeyAction.Value = 42;
+            settings.Properties.PressTime.Value = ShortcutGuideProperties.MaximumPressTimeMs + 1;
+
+            var viewModel = CreateViewModel(settings, out _);
+
+            Assert.AreEqual((int)ShortcutGuideWindowsKeyAction.TaskbarIndicators, viewModel.WindowsKeyActionIndex);
+            Assert.AreEqual(ShortcutGuideProperties.MaximumPressTimeMs, viewModel.PressTime);
+            Assert.IsTrue(viewModel.IsWindowsKeyHoldEnabled);
+            Assert.IsFalse(viewModel.IsOpenShortcutGuideWindowsKeyAction);
+        }
+
+        [TestMethod]
+        public void WindowsKeyActionShouldUpdateConditionalStateAndPersist()
+        {
+            var settings = new ShortcutGuideSettings();
+            int ipcMessageCount = 0;
+            var viewModel = CreateViewModel(settings, out var settingsUtilsMock, _ => ipcMessageCount++);
+
+            viewModel.WindowsKeyActionIndex = (int)ShortcutGuideWindowsKeyAction.Off;
+
+            Assert.IsFalse(viewModel.IsWindowsKeyHoldEnabled);
+            Assert.IsFalse(viewModel.IsOpenShortcutGuideWindowsKeyAction);
+            Assert.AreEqual((int)ShortcutGuideWindowsKeyAction.Off, settings.Properties.WindowsKeyAction.Value);
+            Assert.AreEqual(1, ipcMessageCount);
+            settingsUtilsMock.Verify(
+                x => x.SaveSettings(
+                    It.Is<string>(json => JsonSerializer.Deserialize<ShortcutGuideSettings>(json).Properties.WindowsKeyAction.Value == (int)ShortcutGuideWindowsKeyAction.Off),
+                    ShortcutGuideSettings.ModuleName,
+                    It.IsAny<string>()),
+                Times.Once);
+
+            viewModel.WindowsKeyActionIndex = (int)ShortcutGuideWindowsKeyAction.OpenShortcutGuide;
+
+            Assert.IsTrue(viewModel.IsWindowsKeyHoldEnabled);
+            Assert.IsTrue(viewModel.IsOpenShortcutGuideWindowsKeyAction);
+        }
+
+        [TestMethod]
+        public void PressTimeShouldClampAtBothBoundariesAndPersist()
+        {
+            var settings = new ShortcutGuideSettings();
+            var viewModel = CreateViewModel(settings, out var settingsUtilsMock);
+
+            viewModel.PressTime = ShortcutGuideProperties.MinimumPressTimeMs - 1;
+
+            Assert.AreEqual(ShortcutGuideProperties.MinimumPressTimeMs, viewModel.PressTime);
+            Assert.AreEqual(ShortcutGuideProperties.MinimumPressTimeMs, settings.Properties.PressTime.Value);
+
+            viewModel.PressTime = ShortcutGuideProperties.MaximumPressTimeMs + 1;
+
+            Assert.AreEqual(ShortcutGuideProperties.MaximumPressTimeMs, viewModel.PressTime);
+            Assert.AreEqual(ShortcutGuideProperties.MaximumPressTimeMs, settings.Properties.PressTime.Value);
+            settingsUtilsMock.Verify(
+                x => x.SaveSettings(
+                    It.Is<string>(json => JsonSerializer.Deserialize<ShortcutGuideSettings>(json).Properties.PressTime.Value == ShortcutGuideProperties.MaximumPressTimeMs),
+                    ShortcutGuideSettings.ModuleName,
+                    It.IsAny<string>()),
+                Times.Once);
+        }
+
+        [TestMethod]
+        public void CloseOnWindowsKeyReleaseShouldPersist()
+        {
+            var settings = new ShortcutGuideSettings();
+            var viewModel = CreateViewModel(settings, out var settingsUtilsMock);
+
+            viewModel.CloseOnWindowsKeyRelease = false;
+
+            Assert.IsFalse(settings.Properties.CloseOnWindowsKeyRelease.Value);
+            settingsUtilsMock.Verify(
+                x => x.SaveSettings(
+                    It.Is<string>(json => JsonSerializer.Deserialize<ShortcutGuideSettings>(json).Properties.CloseOnWindowsKeyRelease.Value == false),
+                    ShortcutGuideSettings.ModuleName,
+                    It.IsAny<string>()),
+                Times.Once);
+        }
+
+        private static ShortcutGuideViewModel CreateViewModel(
+            ShortcutGuideSettings settings,
+            out Mock<SettingsUtils> settingsUtilsMock,
+            Action<string> ipcMessageReceived = null)
+        {
+            settingsUtilsMock = new Mock<SettingsUtils>(new FileSystem(), null);
+
+            var generalSettingsRepository = new Mock<ISettingsRepository<GeneralSettings>>();
+            generalSettingsRepository.SetupGet(x => x.SettingsConfig).Returns(new GeneralSettings());
+
+            var shortcutGuideSettingsRepository = new Mock<ISettingsRepository<ShortcutGuideSettings>>();
+            shortcutGuideSettingsRepository.SetupGet(x => x.SettingsConfig).Returns(settings);
+
+            return new ShortcutGuideViewModel(
+                settingsUtilsMock.Object,
+                generalSettingsRepository.Object,
+                shortcutGuideSettingsRepository.Object,
+                message =>
+                {
+                    ipcMessageReceived?.Invoke(message);
+                    return 0;
+                },
+                ShortCutGuideTestFolderName);
         }
     }
 }

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/ShortcutGuidePage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/ShortcutGuidePage.xaml
@@ -26,6 +26,44 @@
                     <tkcontrols:SettingsCard x:Uid="Activation_Shortcut" HeaderIcon="{ui:FontIcon Glyph=&#xEDA7;}">
                         <controls:ShortcutControl MinWidth="{StaticResource SettingActionControlMinWidth}" HotkeySettings="{x:Bind Path=ViewModel.OpenShortcutGuide, Mode=TwoWay}" />
                     </tkcontrols:SettingsCard>
+                    <tkcontrols:SettingsExpander
+                        Name="ShortcutGuideWindowsKeyAction"
+                        x:Uid="ShortcutGuide_WindowsKeyAction"
+                        HeaderIcon="{ui:FontIcon Glyph=&#xE765;}">
+                        <ComboBox
+                            MinWidth="{StaticResource SettingActionControlMinWidth}"
+                            AutomationProperties.AutomationId="ShortcutGuide_WindowsKeyAction"
+                            SelectedIndex="{x:Bind ViewModel.WindowsKeyActionIndex, Mode=TwoWay}">
+                            <ComboBoxItem x:Uid="ShortcutGuide_WindowsKeyAction_Off" />
+                            <ComboBoxItem x:Uid="ShortcutGuide_WindowsKeyAction_TaskbarIndicators" />
+                            <ComboBoxItem x:Uid="ShortcutGuide_WindowsKeyAction_OpenShortcutGuide" />
+                        </ComboBox>
+                        <tkcontrols:SettingsExpander.Items>
+                            <tkcontrols:SettingsCard
+                                Name="ShortcutGuidePressTime"
+                                x:Uid="ShortcutGuide_PressTime"
+                                IsEnabled="{x:Bind ViewModel.IsWindowsKeyHoldEnabled, Mode=OneWay}">
+                                <NumberBox
+                                    MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                    AutomationProperties.AutomationId="ShortcutGuide_PressTime"
+                                    LargeChange="100"
+                                    Maximum="5000"
+                                    Minimum="100"
+                                    SmallChange="50"
+                                    SpinButtonPlacementMode="Compact"
+                                    Value="{x:Bind ViewModel.PressTime, Mode=TwoWay}" />
+                            </tkcontrols:SettingsCard>
+                            <tkcontrols:SettingsCard
+                                Name="ShortcutGuideCloseOnWindowsKeyRelease"
+                                ContentAlignment="Left"
+                                Visibility="{x:Bind ViewModel.IsOpenShortcutGuideWindowsKeyAction, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
+                                <CheckBox
+                                    x:Uid="ShortcutGuide_CloseOnWindowsKeyRelease"
+                                    AutomationProperties.AutomationId="ShortcutGuide_CloseOnWindowsKeyRelease"
+                                    IsChecked="{x:Bind ViewModel.CloseOnWindowsKeyRelease, Mode=TwoWay}" />
+                            </tkcontrols:SettingsCard>
+                        </tkcontrols:SettingsExpander.Items>
+                    </tkcontrols:SettingsExpander>
                 </controls:SettingsGroup>
 
                 <controls:SettingsGroup x:Uid="Appearance_Behavior" IsEnabled="{x:Bind ViewModel.IsEnabled, Mode=OneWay}">

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -1171,6 +1171,28 @@ opera.exe</value>
     <value>Shortcut Guide</value>
     <comment>do not loc the Product name. Do you want this feature on / off</comment>
   </data>
+  <data name="ShortcutGuide_WindowsKeyAction.Header" xml:space="preserve">
+    <value>Hold Windows key</value>
+  </data>
+  <data name="ShortcutGuide_WindowsKeyAction.Description" xml:space="preserve">
+    <value>Choose what happens after holding the Windows key</value>
+  </data>
+  <data name="ShortcutGuide_WindowsKeyAction_Off.Content" xml:space="preserve">
+    <value>Off</value>
+  </data>
+  <data name="ShortcutGuide_WindowsKeyAction_TaskbarIndicators.Content" xml:space="preserve">
+    <value>Show taskbar indicators</value>
+  </data>
+  <data name="ShortcutGuide_WindowsKeyAction_OpenShortcutGuide.Content" xml:space="preserve">
+    <value>Open Shortcut Guide</value>
+  </data>
+  <data name="ShortcutGuide_PressTime.Header" xml:space="preserve">
+    <value>Hold duration (ms)</value>
+    <comment>ms = milliseconds</comment>
+  </data>
+  <data name="ShortcutGuide_CloseOnWindowsKeyRelease.Content" xml:space="preserve">
+    <value>Close Shortcut Guide when the Windows key is released</value>
+  </data>
   <data name="ShortcutGuide_WindowPosition.Header" xml:space="preserve">
     <value>Window position</value>
   </data>

--- a/src/settings-ui/Settings.UI/ViewModels/ShortcutGuideViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/ShortcutGuideViewModel.cs
@@ -54,6 +54,14 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
 
             InitializeEnabledValue();
 
+            _windowsKeyActionIndex = NormalizeWindowsKeyAction(Settings.Properties.WindowsKeyAction.Value);
+            Settings.Properties.WindowsKeyAction.Value = _windowsKeyActionIndex;
+            _pressTime = Math.Clamp(
+                Settings.Properties.PressTime.Value,
+                ShortcutGuideProperties.MinimumPressTimeMs,
+                ShortcutGuideProperties.MaximumPressTimeMs);
+            Settings.Properties.PressTime.Value = _pressTime;
+            _closeOnWindowsKeyRelease = Settings.Properties.CloseOnWindowsKeyRelease.Value;
             _disabledApps = Settings.Properties.DisabledApps.Value;
 
             switch (Settings.Properties.Theme.Value)
@@ -100,6 +108,9 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         private bool _isEnabled;
         private int _themeIndex;
         private int _positionIndex;
+        private int _windowsKeyActionIndex;
+        private int _pressTime;
+        private bool _closeOnWindowsKeyRelease;
 
         public bool IsEnabled
         {
@@ -147,6 +158,62 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                 if (Settings.Properties.OpenShortcutGuide != value)
                 {
                     Settings.Properties.OpenShortcutGuide = value ?? Settings.Properties.DefaultOpenShortcutGuide;
+                    NotifyPropertyChanged();
+                }
+            }
+        }
+
+        public int WindowsKeyActionIndex
+        {
+            get => _windowsKeyActionIndex;
+
+            set
+            {
+                int normalizedValue = NormalizeWindowsKeyAction(value);
+                if (_windowsKeyActionIndex != normalizedValue)
+                {
+                    _windowsKeyActionIndex = normalizedValue;
+                    Settings.Properties.WindowsKeyAction.Value = normalizedValue;
+                    OnPropertyChanged(nameof(IsWindowsKeyHoldEnabled));
+                    OnPropertyChanged(nameof(IsOpenShortcutGuideWindowsKeyAction));
+                    NotifyPropertyChanged();
+                }
+            }
+        }
+
+        public bool IsWindowsKeyHoldEnabled => _windowsKeyActionIndex != (int)ShortcutGuideWindowsKeyAction.Off;
+
+        public bool IsOpenShortcutGuideWindowsKeyAction => _windowsKeyActionIndex == (int)ShortcutGuideWindowsKeyAction.OpenShortcutGuide;
+
+        public int PressTime
+        {
+            get => _pressTime;
+
+            set
+            {
+                int clampedValue = Math.Clamp(
+                    value,
+                    ShortcutGuideProperties.MinimumPressTimeMs,
+                    ShortcutGuideProperties.MaximumPressTimeMs);
+                if (_pressTime != clampedValue)
+                {
+                    _pressTime = clampedValue;
+                    Settings.Properties.PressTime.Value = clampedValue;
+                    NotifyPropertyChanged();
+                }
+            }
+        }
+
+        public bool CloseOnWindowsKeyRelease
+        {
+            get => _closeOnWindowsKeyRelease;
+
+            set
+            {
+                if (_closeOnWindowsKeyRelease != value)
+                {
+                    _closeOnWindowsKeyRelease = value;
+                    Settings.Properties.CloseOnWindowsKeyRelease.Value = value;
                     NotifyPropertyChanged();
                 }
             }
@@ -236,6 +303,17 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         {
             InitializeEnabledValue();
             OnPropertyChanged(nameof(IsEnabled));
+        }
+
+        private static int NormalizeWindowsKeyAction(int value)
+        {
+            return value switch
+            {
+                (int)ShortcutGuideWindowsKeyAction.Off => value,
+                (int)ShortcutGuideWindowsKeyAction.TaskbarIndicators => value,
+                (int)ShortcutGuideWindowsKeyAction.OpenShortcutGuide => value,
+                _ => (int)ShortcutGuideWindowsKeyAction.TaskbarIndicators,
+            };
         }
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request

Adds configurable Windows-key hold activation to Shortcut Guide while keeping the regular activation shortcut independent.

Users can choose to disable Windows-key activation, show taskbar indicators, or open the full Shortcut Guide. Full-guide mode also supports a configurable hold duration and optional close-on-release behavior.

<img width="1099" height="611" alt="image" src="https://github.com/user-attachments/assets/e0fe4c0f-3bef-43f8-a526-d22caf9e484e" />


## PR Checklist

- [ ] Closes: N/A
- [x] **Communication:** The UX and behavior were discussed before implementation
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** All end-user-facing strings can be localized
- [x] **Dev docs:** Added/updated
- [ ] **New binaries:** Not applicable
- [ ] **Documentation updated:** Not applicable

## Detailed Description of the Pull Request / Additional comments

- Adds Off, taskbar-indicator, and full-guide Windows-key actions to Settings.
- Adds a 100–5,000 ms hold-duration setting and a full-guide close-on-release option.
- Handles left and right Windows keys and suppresses Start after an activated hold.
- Routes Windows-key holds through a dedicated event so custom activation shortcuts remain independent.
- Clears previous pressed-key registrations before refreshing them to prevent duplicate long-press callbacks.
- Preserves compatibility with the existing `press_time` setting and documents the new options.

## Validation Steps Performed

- Built the affected ARM64 Debug Settings, Runner, Shortcut Guide module-interface, and Shortcut Guide UI projects.
- `ShortcutGuide.UnitTests`: 7/7 passed.
- Targeted Settings tests: 12/12 passed.
- Manually verified Off, taskbar-indicator, full-guide close-on-release, and full-guide persistent modes.
- Verified configured hold thresholds, both Windows keys, Start suppression, and regular-shortcut independence.
- Validated the final Settings XAML layout in the running Settings app.