### PR TITLE
Dock: Remove our last 1px gap once and for all

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockWindow.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockWindow.xaml.cs
@@ -157,8 +157,6 @@ public sealed partial class DockWindow : WindowEx,
 
         InitializeComponent();
         Root.Children.Add(_dock);
-        ExtendsContentIntoTitleBar = true;
-        AppWindow.TitleBar.PreferredHeightOption = TitleBarHeightOption.Collapsed;
         _hiddenOwnerWindowBehavior.ShowInTaskbar(this, false);
         if (AppWindow.Presenter is OverlappedPresenter overlappedPresenter)
         {


### PR DESCRIPTION
I guess if you set ExtendsContentIntoTitleBar, well, WinUI will offset your island by x,y=0,1. That's what happens if you don't actually set any titlebar content.

* https://github.com/microsoft/microsoft-ui-xaml/blob/main/dxaml/xcp/components/WindowChrome/CWindowChrome.cpp#L202
* https://github.com/microsoft/microsoft-ui-xaml/blob/main/dxaml/xcp/components/WindowChrome/CWindowChrome.cpp#L171
* https://github.com/microsoft/microsoft-ui-xaml/blob/main/dxaml/xcp/components/WindowChrome/inc/CWindowChrome.h#L23

cause like, of course it does.

I'm sure there are previous threads to xlink this too
