### PR TITLE
[PowerAccent] Forward key-up after false activation

### DIFF
--- a/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.cpp
+++ b/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.cpp
@@ -345,10 +345,10 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
                     }
                     m_toolbarVisible = false;
 
-                    // In press-and-hold the base letter already typed on key-down and no trigger
-                    // key was consumed, so let this key-up pass through to avoid a stuck-key
-                    // perception. Trigger modes keep swallowing it as before.
-                    return m_settings.activationKey != PowerAccentActivationKey::PressAndHold;
+                    // The matching letter key-down was passed to the rest of the hook chain.
+                    // Pass its key-up through as well so downstream hooks and applications do not
+                    // retain a stale pressed-key state after a false start.
+                    return false;
                 }
                 Logger::debug(L"Hide toolbar event and input char");
 


### PR DESCRIPTION
## Summary of the Pull Request

Quick Accent passes the owner letter's key-down to the rest of the low-level keyboard hook chain. When activation is canceled before the configured threshold, trigger-key modes currently swallow the matching key-up. This leaves downstream keyboard state reporting the letter as held and causes Keyboard Manager's shortcut-to-shortcut safety check to reject later remaps.

This change forwards the owner letter's key-up on that false-start path, balancing the event pair for downstream hooks and applications. Successful Quick Accent activation behavior is unchanged.

Partial fix: #38089

## PR Checklist

- [ ] Closes 
- [ ] **Communication:** Root cause, deterministic reproduction, and validation were posted on #38089; awaiting core-contributor review
- [ ] **Tests:** No automated low-level keyboard-hook test seam is available; extensive manual validation is documented below
- [x] **Localization:** No end-user-facing strings changed
- [x] **Dev docs:** No developer documentation changes are required for this targeted bug fix
- [x] **New binaries:** No new binaries were added
- [ ] **Documentation updated:** No user-facing documentation change is required

## Detailed Description of the Pull Request / Additional comments

The false-start path runs when the owner letter is released before Quick Accent's activation threshold. Its key-down was already allowed through by `OnKeyDown`, but `OnKeyUp` returned `true` for the Space/arrow activation modes. Returning `true` from the low-level hook prevents later hooks and the target application from receiving the release.

Keyboard Manager intentionally checks that no unrelated key is held before applying a shortcut-to-shortcut remap. The missing release therefore makes several remaps stop together while both PowerToys processes remain responsive. It also explains why locking and unlocking the Windows session restores them: the stale keyboard state is reset.

The fix is intentionally in Quick Accent rather than relaxing Keyboard Manager's safety check, which must continue to reject remaps when unrelated keys are genuinely held.

Full captured evidence and source analysis: https://github.com/microsoft/PowerToys/issues/38089#issuecomment-5171089872

## Validation Steps Performed

- Built `PowerAccentKeyboardService` from current `main` in Release x64: 0 warnings, 0 errors. Spectre mitigation was disabled for the local build because the corresponding Visual Studio libraries were not installed.
- Built and installed the same change against PowerToys 0.100.2 so the test DLL matched the installed release ABI.
- Repeated dozens of false activations with E/N/O/Y by pressing Space and releasing the owner letter before the 500 ms threshold.
- Interleaved successful Quick Accent selections to verify normal activation still worked.
- Captured `GetAsyncKeyState` transitions and confirmed both the letter and Space changed from down to up; all sampled keys remained up after testing.
- Continuously tested a Left Shift+O -> Left Alt+Tab Keyboard Manager remap; it remained functional throughout.
- Completed an additional user soak test without recurrence; locking/unlocking was no longer required.
