### PR TITLE
[Keyboard Manager] Resume remapping when the editor dies without resetting the suspend event

### DIFF
--- a/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardManager.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardManager.cpp
@@ -69,7 +69,6 @@ KeyboardManager::KeyboardManager()
             StopLowlevelKeyboardHook();
     };
 
-    editorIsRunningEvent = CreateEvent(nullptr, true, false, KeyboardManagerConstants::EditorWindowEventName.c_str());
     settingsEventWaiter.start(KeyboardManagerConstants::SettingsEventName, changeSettingsCallback);
 }
 
@@ -184,6 +183,27 @@ bool KeyboardManager::HasRegisteredRemappingsUnchecked() const
     return !(state.appSpecificShortcutReMap.empty() && state.appSpecificShortcutReMapSortedKeys.empty() && state.osLevelShortcutReMap.empty() && state.osLevelShortcutReMapSortedKeys.empty() && state.singleKeyReMap.empty() && state.singleKeyToTextReMap.empty());
 }
 
+bool KeyboardManager::IsEditorSuspendingRemappings() noexcept
+{
+    // The editor signals this event for as long as one of its windows is open, which
+    // suspends every remap. Open the event for each check instead of holding a handle for
+    // the engine's lifetime: a named event only exists while some process holds a handle to
+    // it, so an editor that crashed or was killed before resetting the event takes the whole
+    // object down with it and remapping resumes on its own. Holding a handle here kept the
+    // object alive with its signaled state, which silently disabled Keyboard Manager until
+    // the module was restarted.
+    HANDLE editorIsRunningEvent = OpenEventW(SYNCHRONIZE, FALSE, KeyboardManagerConstants::EditorWindowEventName.c_str());
+    if (editorIsRunningEvent == nullptr)
+    {
+        return false;
+    }
+
+    const bool suspended = WaitForSingleObject(editorIsRunningEvent, 0) == WAIT_OBJECT_0;
+    CloseHandle(editorIsRunningEvent);
+
+    return suspended;
+}
+
 intptr_t KeyboardManager::HandleKeyboardHookEvent(LowlevelKeyboardEvent* data) noexcept
 {
     if (loadingSettings)
@@ -192,7 +212,7 @@ intptr_t KeyboardManager::HandleKeyboardHookEvent(LowlevelKeyboardEvent* data) n
     }
 
     // Suspend remapping if remap key/shortcut window is opened
-    if (editorIsRunningEvent != nullptr && WaitForSingleObject(editorIsRunningEvent, 0) == WAIT_OBJECT_0)
+    if (IsEditorSuspendingRemappings())
     {
         return 0;
     }

--- a/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardManager.h
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardManager.h
@@ -12,14 +12,6 @@ public:
     // Constructor
     KeyboardManager();
 
-    ~KeyboardManager()
-    {
-        if (editorIsRunningEvent)
-        {
-            CloseHandle(editorIsRunningEvent);
-        }
-    }
-
     void StartLowlevelKeyboardHook();
     void StopLowlevelKeyboardHook();
 
@@ -53,13 +45,14 @@ private:
 
     std::atomic_bool loadingSettings = false;
 
-    HANDLE editorIsRunningEvent = nullptr;
-
     // Hook procedure definition
     static LRESULT CALLBACK HookProc(int nCode, WPARAM wParam, LPARAM lParam);
 
     // Load settings from the file.
     void LoadSettings();
+
+    // Returns true while an editor window is open and remapping must stay suspended
+    static bool IsEditorSuspendingRemappings() noexcept;
 
     // Function called by the hook procedure to handle the events. This is the starting point function for remapping
     intptr_t HandleKeyboardHookEvent(LowlevelKeyboardEvent* data) noexcept;


### PR DESCRIPTION
## Summary of the Pull Request

The Keyboard Manager editor signals `PowerToys_KeyboardManager_Event_EditorWindow` for as long as an editor window is open, and `HandleKeyboardHookEvent` returns early for **every** key event while it is signaled. Resetting it is done by an RAII guard inside the editor process, so an editor that crashes or is killed never gets to reset it — and Keyboard Manager silently stops applying every remap until the module is toggled off and on or PowerToys is restarted.

## PR Checklist

- [ ] **Related issue:** #38089 — one of several contributing causes; this PR does not close it
- [ ] **Communication:** opened as a draft for maintainer input on the approach
- [ ] **Tests:** no test seam exists for the cross-process event lifetime; validation was done by hand (see below)
- [x] **Localization:** no end-user-facing strings changed
- [x] **Dev docs:** no developer documentation changes required
- [x] **New binaries:** no new binaries were added
- [x] **Documentation updated:** no user-facing documentation change required

## Detailed Description of the Pull Request / Additional comments

The suspend handshake today:

| Side | Code | Behaviour |
|---|---|---|
| Editor | `EditKeyboardWindow.cpp` / `EditShortcutsWindow.cpp` → `EventLocker` | `SetEvent` on construction, `ResetEvent` **in the destructor** |
| Engine | `KeyboardManager` constructor | `CreateEvent(...)` and holds that handle for the whole process lifetime |

If the editor process dies before its destructor runs, `ResetEvent` never happens. The event object would normally disappear with its last handle — but the engine holds one, so the object survives **with its signaled state**, and `HandleKeyboardHookEvent` keeps bailing out on every key event forever.

The fix relies on that same lifetime rule instead of fighting it: a named event only exists while some process holds a handle to it. The engine now opens the event per check rather than holding one, so a dead editor takes the whole object down with it, `OpenEvent` simply fails, and remapping resumes on its own.

This requires no editor-side change and adds no new kernel object.

### Cost

The check becomes `OpenEventW` + `CloseHandle` per key event instead of `WaitForSingleObject` on a cached handle — roughly two extra kernel calls per keystroke. I chose exact semantics over throttling because the editor must suspend remapping *immediately* when it opens, otherwise the user's first keypress inside the editor can get remapped. If you would prefer a throttled check, that is a small follow-up.

### Related observation, not fixed here

Two things noticed while working on this, both pre-existing and out of scope:

1. If two editor windows are open at once, the first one to close calls `ResetEvent` and un-suspends the engine while the second is still open.
2. The newer `KeyboardManagerEditorUI` (C#) does not appear to signal this event at all.

Happy to file those separately if they are news.

## Validation Steps Performed

- `KeyboardManagerEngine` builds clean in Debug x64 (0 warnings, 0 errors).
- `KeyboardManager.Engine.UnitTests`: 104 / 104 passing.
- Behaviour reasoning verified against the named-object lifetime rules; a maintainer repro is: open the KBM editor, kill `PowerToys.KeyboardManagerEditor.exe` from Task Manager, then try any remap. Before this change remaps stay dead until the module is toggled; after it they work immediately.
