### PR TITLE
[Keyboard Manager] Recover shortcut remaps stranded in the invoked state

### DIFF
--- a/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardEventHandlers.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardEventHandlers.cpp
@@ -307,6 +307,60 @@ namespace KeyboardEventHandlers
     }
     */
 
+    // Function to clear shortcut remaps that can no longer leave the invoked state.
+    //
+    // While a shortcut-to-shortcut remap is invoked, the target shortcut's modifiers are held
+    // down by injection, and every path that clears isShortcutInvoked for it sits behind a
+    // check that those modifiers are still reported as held. If they go up without Keyboard
+    // Manager observing the events - the release reached an elevated window while PowerToys
+    // is not elevated, another low-level hook swallowed it, or the session was switched -
+    // none of those paths can run again. The remap then stays invoked, and the invoked check
+    // below makes that single entry skip every other shortcut remap, so all of them appear to
+    // stop working at once.
+    void RecoverStrandedShortcutRemaps(KeyboardManagerInput::InputInterface& ii, State& state, const std::optional<std::wstring>& activatedApp)
+    {
+        ShortcutRemapTable& reMap = state.GetShortcutRemapTable(activatedApp);
+        bool recoveredAny = false;
+
+        for (auto& it : reMap)
+        {
+            if (!it.second.isShortcutInvoked || it.second.targetShortcut.index() != 1)
+            {
+                continue;
+            }
+
+            const Shortcut& targetShortcut = std::get<Shortcut>(it.second.targetShortcut);
+
+            // A target without modifiers is never gated on their state, so it can still be
+            // cleared normally and must not be touched here.
+            if (targetShortcut.CheckModifiersKeyboardState(ii))
+            {
+                continue;
+            }
+
+            // The injected action key can still be down even though its modifiers are gone,
+            // so release it instead of leaving the user with a stuck key.
+            if (ii.GetVirtualKeyState(targetShortcut.GetActionKey()))
+            {
+                std::vector<INPUT> keyEventList;
+                Helpers::SetKeyEvent(keyEventList, INPUT_KEYBOARD, static_cast<WORD>(targetShortcut.GetActionKey()), KEYEVENTF_KEYUP, KeyboardManagerConstants::KEYBOARDMANAGER_SHORTCUT_FLAG);
+                ii.SendVirtualInput(keyEventList);
+            }
+
+            it.second.isShortcutInvoked = false;
+            it.second.modifierKeysInvoked.Reset();
+            it.second.isOriginalActionKeyPressed = false;
+            recoveredAny = true;
+        }
+
+        // The activated app stays pinned for as long as an app-specific remap is invoked, so
+        // release it too once nothing is invoked any more.
+        if (recoveredAny && activatedApp)
+        {
+            state.SetActivatedApp(KeyboardManagerConstants::NoActivatedApp);
+        }
+    }
+
     // Function to handle a shortcut remap
     intptr_t HandleShortcutRemapEvent(KeyboardManagerInput::InputInterface& ii, LowlevelKeyboardEvent* data, State& state, const std::optional<std::wstring>& activatedApp) noexcept
     {
@@ -314,6 +368,14 @@ namespace KeyboardEventHandlers
 
         // Check if any shortcut is currently in the invoked state
         bool isShortcutInvoked = state.CheckShortcutRemapInvoked(activatedApp);
+
+        // Nothing is invoked in the overwhelming majority of events, so only pay for the
+        // stranded-state scan when there is something that could be stranded.
+        if (isShortcutInvoked)
+        {
+            RecoverStrandedShortcutRemaps(ii, state, activatedApp);
+            isShortcutInvoked = state.CheckShortcutRemapInvoked(activatedApp);
+        }
 
         // Get shortcut table for given activatedApp
         ShortcutRemapTable& reMap = state.GetShortcutRemapTable(activatedApp);

--- a/src/modules/keyboardmanager/KeyboardManagerEngineTest/OSLevelShortcutRemappingTests.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineTest/OSLevelShortcutRemappingTests.cpp
@@ -2510,5 +2510,53 @@ namespace RemappingLogicTests
             Assert::AreEqual(false, mockedInputHandler.GetVirtualKeyState(VK_LCONTROL));
             Assert::AreEqual(false, mockedInputHandler.GetVirtualKeyState(VK_BACK));
         }
+
+        // Test that a remap left invoked because its target modifiers went up unseen does not block other remaps
+        TEST_METHOD (InvokedShortcutWithReleasedTargetModifiers_ShouldNotBlockOtherShortcuts_OnNextInvocation)
+        {
+            // Remap Ctrl+A to Alt+V
+            Shortcut firstSrc;
+            firstSrc.SetKey(VK_CONTROL);
+            firstSrc.SetKey(0x41);
+            Shortcut firstDest;
+            firstDest.SetKey(VK_MENU);
+            firstDest.SetKey(0x56);
+            testState.AddOSLevelShortcut(firstSrc, firstDest);
+
+            // Remap Ctrl+B to Alt+X
+            Shortcut secondSrc;
+            secondSrc.SetKey(VK_CONTROL);
+            secondSrc.SetKey(0x42);
+            Shortcut secondDest;
+            secondDest.SetKey(VK_MENU);
+            secondDest.SetKey(0x58);
+            testState.AddOSLevelShortcut(secondSrc, secondDest);
+
+            std::vector<INPUT> firstShortcutDown{
+                { .type = INPUT_KEYBOARD, .ki = { .wVk = VK_CONTROL } },
+                { .type = INPUT_KEYBOARD, .ki = { .wVk = 'A' } },
+            };
+            mockedInputHandler.SendVirtualInput(firstShortcutDown);
+
+            Assert::AreEqual(true, testState.osLevelShortcutReMap[firstSrc].isShortcutInvoked);
+
+            // The user lets go of every key but the engine never observes those events, for
+            // example because the release reached an elevated window. Only the keyboard state
+            // changes, so the remap stays invoked while its target modifiers are already up
+            // and none of the paths that clear the invoked state can run again.
+            mockedInputHandler.ResetKeyboardState();
+
+            std::vector<INPUT> secondShortcutDown{
+                { .type = INPUT_KEYBOARD, .ki = { .wVk = VK_CONTROL } },
+                { .type = INPUT_KEYBOARD, .ki = { .wVk = 'B' } },
+            };
+            mockedInputHandler.SendVirtualInput(secondShortcutDown);
+
+            // The stranded remap must be cleared and the second remap must still be applied
+            Assert::AreEqual(false, testState.osLevelShortcutReMap[firstSrc].isShortcutInvoked);
+            Assert::AreEqual(true, testState.osLevelShortcutReMap[secondSrc].isShortcutInvoked);
+            Assert::AreEqual(true, mockedInputHandler.GetVirtualKeyState(VK_MENU));
+            Assert::AreEqual(true, mockedInputHandler.GetVirtualKeyState(0x58));
+        }
     };
 }


### PR DESCRIPTION
## Summary of the Pull Request

While a shortcut-to-shortcut remap is invoked, Keyboard Manager holds the **target** shortcut's modifiers down by injection. Every path that clears `isShortcutInvoked` for such a remap sits behind a check that those modifiers are still reported as held (`KeyboardEventHandlers.cpp`, the `CheckModifiersKeyboardState` gate above cases 2–5). If they go up without the engine observing the events, none of those paths can run again and the remap stays invoked.

`CheckShortcutRemapInvoked` then keeps reporting that entry as invoked, and `HandleShortcutRemapEvent` skips **every other** shortcut remap while anything is invoked — so all shortcut remaps appear to stop working at once.

## PR Checklist

- [ ] **Related issue:** #38089 — one of several contributing causes; this PR does not close it
- [ ] **Communication:** opened as a draft for maintainer input on the approach
- [x] **Tests:** added `InvokedShortcutWithReleasedTargetModifiers_ShouldNotBlockOtherShortcuts_OnNextInvocation`; verified it fails without the production change and passes with it
- [x] **Localization:** no end-user-facing strings changed
- [x] **Dev docs:** no developer documentation changes required
- [x] **New binaries:** no new binaries were added
- [x] **Documentation updated:** no user-facing documentation change required

## Detailed Description of the Pull Request / Additional comments

### How an entry gets stranded

Cases 2–5 in the invoked branch are all guarded by:

```cpp
if (!remapToShortcut || (remapToShortcut && std::get<Shortcut>(it->second.targetShortcut).CheckModifiersKeyboardState(ii)))
```

`CheckModifiersKeyboardState` reads `GetAsyncKeyState`. So if the target modifiers are released without the engine seeing the key events, that whole block is skipped permanently:

- the release reached an elevated window while PowerToys is not elevated, so the hook never ran;
- another low-level hook earlier in the chain swallowed it;
- the session was switched or locked, which resets keyboard state wholesale.

Only Case 1 remains reachable, and it needs a key-up of one of the **source** shortcut's modifiers. Those were already released when the remap was invoked, so nothing clears the state until the user happens to press and release one of them again. For a `Ctrl+…` remap that can be seconds; for a `Win+Ctrl+Alt+…` remap it can be a very long time. **Every** shortcut remap is dead for that whole window.

Note this only affects **shortcut-to-shortcut** remaps — for remap-to-key and remap-to-text the `!remapToShortcut` arm short-circuits the gate. That matches the reports where some remaps keep working while shortcut remaps stop together.

### The change

`RecoverStrandedShortcutRemaps` runs before the invoked check and clears any entry that can no longer leave the invoked state: invoked, remapping to a shortcut, and its target modifiers no longer held. A target with no modifiers is never gated on their state, so it is skipped and left to the normal paths.

It also releases the injected target action key if it is still down, so the recovery cannot strand a key itself.

The scan only runs when something is already invoked, so the common path is unchanged.

### What this does not do

This is deliberately a recovery, not a redesign. It does not attempt to make the gate itself robust, and it does not touch the release machinery in cases 1–5. If maintainers prefer a different trigger — a session-change notification, or a timeout — I am happy to rework it; the detection condition here was chosen because it is exact rather than heuristic.

## Validation Steps Performed

- `KeyboardManagerEngine` and `KeyboardManagerEngineTest` build clean in Debug x64 (0 warnings, 0 errors).
- `KeyboardManager.Engine.UnitTests`: 104 / 104 passing with the change.
- Reverted only the production file and rebuilt: the new test fails with `Assert failed. Expected:<0> Actual:<1>`, confirming it exercises the stranding rather than passing vacuously.
