### PR TITLE
[Keyboard Manager] Reinstall the keyboard hook if Windows drops it

### DIFF
--- a/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardManager.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardManager.cpp
@@ -110,6 +110,17 @@ LRESULT CALLBACK KeyboardManager::HookProc(int nCode, const WPARAM wParam, const
     {
         event.lParam = reinterpret_cast<KBDLLHOOKSTRUCT*>(lParam);
         event.wParam = wParam;
+
+        keyboardManagerObjectPtr->lastHookEventTick = GetTickCount();
+
+        // Answer the watchdog probe and swallow it so it never reaches anything else.
+        if (event.lParam->dwExtraInfo == KeyboardManagerConstants::KEYBOARDMANAGER_HOOK_PROBE_FLAG)
+        {
+            keyboardManagerObjectPtr->hookProbePending = false;
+            keyboardManagerObjectPtr->missedHookProbes = 0;
+            return 1;
+        }
+
         event.lParam->vkCode = Helpers::EncodeKeyNumpadOrigin(event.lParam->vkCode, event.lParam->flags & LLKHF_EXTENDED);
 
         if (keyboardManagerObjectPtr->HandleKeyboardHookEvent(&event) == 1)
@@ -124,6 +135,105 @@ LRESULT CALLBACK KeyboardManager::HookProc(int nCode, const WPARAM wParam, const
     }
 
     return CallNextHookEx(hookHandleCopy, nCode, wParam, lParam);
+}
+
+// Windows silently unregisters a low level hook whose callback exceeds
+// LowLevelHooksTimeout (300 ms by default), and there is no notification and no API to ask
+// whether a HHOOK is still installed. Until now nothing reinstalled it, so a single slow
+// callback could leave every remap dead until PowerToys was restarted.
+//
+// Inject a tagged key event and check on the next tick whether the hook saw it. The probe
+// uses an unassigned virtual key and the hook swallows it, so applications never see it.
+//
+// The probe is only sent when the system reports user input that the hook did not observe.
+// Injecting on an idle machine would refresh the system idle timer and keep the display
+// awake, and a hook dropped while nobody is typing does no harm until typing resumes, at
+// which point the comparison below notices it.
+void KeyboardManager::VerifyHookIsStillInstalled()
+{
+    if (!hookHandle)
+    {
+        hookProbePending = false;
+        missedHookProbes = 0;
+        return;
+    }
+
+    if (hookProbePending)
+    {
+        ++missedHookProbes;
+        if (missedHookProbes >= KeyboardManagerConstants::HookWatchdogMissesBeforeReinstall)
+        {
+            Logger::warn(L"Low level keyboard hook stopped receiving events. Reinstalling it.");
+            Trace::Error(0, L"Low level keyboard hook was dropped", L"KeyboardManager::VerifyHookIsStillInstalled");
+
+            // Both calls reset the watchdog state through StopHookWatchdog.
+            StopLowlevelKeyboardHook();
+            StartLowlevelKeyboardHook();
+            return;
+        }
+    }
+
+    LASTINPUTINFO lastInput{};
+    lastInput.cbSize = sizeof(lastInput);
+    if (!GetLastInputInfo(&lastInput))
+    {
+        return;
+    }
+
+    // Wrap safe comparison. A positive result means the system registered input after the
+    // last event the hook saw, which is the only situation worth probing.
+    if (static_cast<int>(lastInput.dwTime - lastHookEventTick) <= 0)
+    {
+        hookProbePending = false;
+        missedHookProbes = 0;
+        return;
+    }
+
+    INPUT probe{};
+    probe.type = INPUT_KEYBOARD;
+    probe.ki.wVk = static_cast<WORD>(KeyboardManagerConstants::DUMMY_KEY);
+    probe.ki.dwFlags = KEYEVENTF_KEYUP;
+    probe.ki.dwExtraInfo = KeyboardManagerConstants::KEYBOARDMANAGER_HOOK_PROBE_FLAG;
+
+    hookProbePending = true;
+    if (!inputHandler.SendVirtualInput({ probe }))
+    {
+        // The probe never entered the input stream, so its absence says nothing about the
+        // hook. Do not count it as a miss.
+        hookProbePending = false;
+    }
+}
+
+void CALLBACK KeyboardManager::HookWatchdogTimerProc(HWND, UINT, UINT_PTR, DWORD)
+{
+    if (keyboardManagerObjectPtr != nullptr)
+    {
+        keyboardManagerObjectPtr->VerifyHookIsStillInstalled();
+    }
+}
+
+void KeyboardManager::StartHookWatchdog()
+{
+    if (!hookWatchdogTimerId)
+    {
+        hookWatchdogTimerId = SetTimer(nullptr, 0, KeyboardManagerConstants::HookWatchdogIntervalMs, HookWatchdogTimerProc);
+        if (!hookWatchdogTimerId)
+        {
+            Logger::error(L"Failed to start the keyboard hook watchdog. {}", get_last_error_or_default(GetLastError()));
+        }
+    }
+}
+
+void KeyboardManager::StopHookWatchdog()
+{
+    if (hookWatchdogTimerId)
+    {
+        KillTimer(nullptr, hookWatchdogTimerId);
+        hookWatchdogTimerId = 0;
+    }
+
+    hookProbePending = false;
+    missedHookProbes = 0;
 }
 
 void KeyboardManager::StartLowlevelKeyboardHook()
@@ -145,12 +255,17 @@ void KeyboardManager::StartLowlevelKeyboardHook()
             show_last_error_message(L"SetWindowsHookEx", errorCode, L"PowerToys - Keyboard Manager");
             auto errorMessage = get_last_error_message(errorCode);
             Trace::Error(errorCode, errorMessage.has_value() ? errorMessage.value() : L"", L"StartLowlevelKeyboardHook::SetWindowsHookEx");
+            return;
         }
     }
+
+    StartHookWatchdog();
 }
 
 void KeyboardManager::StopLowlevelKeyboardHook()
 {
+    StopHookWatchdog();
+
     if (hookHandle)
     {
         UnhookWindowsHookEx(hookHandle);

--- a/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardManager.h
+++ b/src/modules/keyboardmanager/KeyboardManagerEngineLibrary/KeyboardManager.h
@@ -55,8 +55,24 @@ private:
 
     HANDLE editorIsRunningEvent = nullptr;
 
+    // Watchdog state used to detect a low level hook that Windows dropped, see
+    // KeyboardManager.cpp. Only touched from the engine's message loop thread, which is also
+    // the thread the hook procedure runs on. lastHookEventTick is in GetTickCount units so it
+    // can be compared against LASTINPUTINFO::dwTime.
+    UINT_PTR hookWatchdogTimerId = 0;
+    DWORD lastHookEventTick = 0;
+    bool hookProbePending = false;
+    int missedHookProbes = 0;
+
     // Hook procedure definition
     static LRESULT CALLBACK HookProc(int nCode, WPARAM wParam, LPARAM lParam);
+
+    // Timer procedure which verifies that the low level hook is still installed
+    static void CALLBACK HookWatchdogTimerProc(HWND window, UINT message, UINT_PTR timerId, DWORD elapsed);
+
+    void StartHookWatchdog();
+    void StopHookWatchdog();
+    void VerifyHookIsStillInstalled();
 
     // Load settings from the file.
     void LoadSettings();

--- a/src/modules/keyboardmanager/common/KeyboardManagerConstants.h
+++ b/src/modules/keyboardmanager/common/KeyboardManagerConstants.h
@@ -87,6 +87,14 @@ namespace KeyboardManagerConstants
     inline const ULONG_PTR KEYBOARDMANAGER_SINGLEKEY_FLAG = 0x11; // Single key remaps
     inline const ULONG_PTR KEYBOARDMANAGER_SHORTCUT_FLAG = 0x101; // Shortcut remaps
     inline const ULONG_PTR KEYBOARDMANAGER_SUPPRESS_FLAG = 0x111; // Key events which must be suppressed
+    inline const ULONG_PTR KEYBOARDMANAGER_HOOK_PROBE_FLAG = 0x1001; // Probe used to verify the low level hook is still installed
+
+    // How often the engine verifies that its low level keyboard hook is still installed
+    inline const UINT HookWatchdogIntervalMs = 5000;
+
+    // How many probes in a row have to go unseen before the hook is treated as dropped. A
+    // single miss can also mean the probe simply has not been dispatched yet.
+    inline const int HookWatchdogMissesBeforeReinstall = 2;
 
     // Dummy key event used in between key up and down events to prevent certain global events from happening
     inline const DWORD DUMMY_KEY = 0xFF;


### PR DESCRIPTION
## Summary of the Pull Request

Windows silently unregisters a low-level hook whose callback exceeds `LowLevelHooksTimeout` (300 ms by default). There is no notification and no API to ask whether an `HHOOK` is still installed, and the Keyboard Manager engine only ever installed its hook on enable — nothing ever reinstalled it. One slow callback could therefore leave every remap dead until PowerToys was restarted, which matches the reports of shortcuts working for a while and then stopping until PowerToys is exited and reopened.

This adds a watchdog that detects the dropped hook and reinstalls it.

## PR Checklist

- [ ] **Related issue:** #38089 — one of several contributing causes; this PR does not close it
- [ ] **Communication:** opened as a draft; this is the most design-heavy of the set and I expect discussion
- [ ] **Tests:** no test seam exists for hook installation; validation was done by build and by reasoning through the state machine
- [x] **Localization:** no end-user-facing strings changed
- [x] **Dev docs:** no developer documentation changes required
- [x] **New binaries:** no new binaries were added
- [x] **Documentation updated:** no user-facing documentation change required

## Detailed Description of the Pull Request / Additional comments

The repo already acknowledges the mechanism in `AltWindowCycle.cpp`:

> The runner calls enable()/disable()/on_hotkey() on the same thread that services the centralized `WH_KEYBOARD_LL` hook, and **Windows silently drops hooks that exceed `LowLevelHooksTimeout` (300 ms by default)**.

But neither `KeyboardManager.cpp` nor `centralized_kb_hook.cpp` has any liveness check or re-arm. This PR covers the Keyboard Manager engine; the runner's centralized hook has the same gap and is left for a separate change.

### How detection works

1. `HookProc` records the tick of the last event it saw.
2. A 5 s thread timer on the engine's message loop compares that against `LASTINPUTINFO::dwTime`.
3. If the system registered input that the hook did **not** see, a key event tagged with a new `KEYBOARDMANAGER_HOOK_PROBE_FLAG` is injected. The hook answers and swallows it, so applications never see it.
4. Two consecutive unanswered probes mean the hook is gone, and it is reinstalled.

### Why the probe is not sent unconditionally

`SendInput` refreshes the system idle timer. A watchdog that injected a key every 5 s would silently turn PowerToys into a keep-awake and stop the screensaver and display sleep from ever engaging. So the probe is only sent when there is genuine recent user input that the hook missed. A hook dropped while nobody is typing does no harm until typing resumes, and the comparison notices it at that point.

Mouse-only activity can trigger a probe (the hook does not see mouse input), but the user is demonstrably active then, so the idle-timer refresh is moot.

### Design points I would like input on

- **Two misses before re-arming.** A single miss can also mean the probe simply has not been dispatched yet. Two at a 5 s interval means up to ~10 s of dead remaps in the worst case. Faster detection is possible at a higher false-positive rate.
- **Re-arming changes hook chain position.** `SetWindowsHookEx` puts the hook at the front of the chain, so a reinstall moves Keyboard Manager ahead of hooks installed after it. That is arguably desirable for KBM but it is a behaviour change worth naming.
- **`DUMMY_KEY` (`0xFF`) is reused as the probe key.** It is already this codebase's "harmless key" and the runner's centralized hook injects the same value. If the hook is dead the probe does reach the rest of the chain; other hooks see an unassigned `0xFF` key-up.
- **Whether the same watchdog belongs in `centralized_kb_hook.cpp`.** The activation-shortcut gap there is real and produces a very similar user report.

## Validation Steps Performed

- `KeyboardManagerEngine` builds clean in Debug x64 (0 warnings, 0 errors).
- `KeyboardManager.Engine.UnitTests`: 104 / 104 passing.
- Verified that the watchdog timer id cannot collide with `run_message_loop`'s own stop timer (that one is `0` when no timeout is passed, which is the case for the engine).
