### PR TITLE
[CmdPal] Respect the default browser profile

### DIFF
--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.WebSearch.UnitTests/BrowserInfoServiceExtensionsTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.WebSearch.UnitTests/BrowserInfoServiceExtensionsTests.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CmdPal.Ext.WebSearch.Helpers.Browser;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CmdPal.Ext.WebSearch.UnitTests;
+
+[TestClass]
+public class BrowserInfoServiceExtensionsTests
+{
+    [TestMethod]
+    public void OpenUsesDefaultBrowserCommandForWebUrl()
+    {
+        // Setup
+        var browser = new BrowserInfo
+        {
+            Name = "Microsoft Edge",
+            Path = @"C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe",
+            ArgumentsPattern = "--single-argument %1",
+        };
+        var browserInfoService = new StubBrowserInfoService(browser);
+        string? launchedPath = null;
+        string? launchedPattern = null;
+        string? launchedArguments = null;
+
+        // Act
+        var result = BrowserInfoServiceExtensions.Open(
+            browserInfoService,
+            "https://example.com/search?q=PowerToys",
+            (path, pattern, arguments) =>
+            {
+                launchedPath = path;
+                launchedPattern = pattern;
+                launchedArguments = arguments;
+                return true;
+            });
+
+        // Assert
+        Assert.IsTrue(result);
+        Assert.AreEqual(browser.Path, launchedPath);
+        Assert.AreEqual(browser.ArgumentsPattern, launchedPattern);
+        Assert.AreEqual("https://example.com/search?q=PowerToys", launchedArguments);
+    }
+
+    [TestMethod]
+    public void OpenDoesNotLaunchWhenDefaultBrowserIsUnknown()
+    {
+        // Setup
+        var browserInfoService = new StubBrowserInfoService(null);
+
+        // Act
+        var result = BrowserInfoServiceExtensions.Open(
+            browserInfoService,
+            "https://example.com",
+            (_, _, _) =>
+            {
+                Assert.Fail("The browser command must not run without a default browser.");
+                return false;
+            });
+
+        // Assert
+        Assert.IsFalse(result);
+    }
+
+    private sealed class StubBrowserInfoService(BrowserInfo? browser) : IBrowserInfoService
+    {
+        public BrowserInfo? GetDefaultBrowser() => browser;
+    }
+}

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/Helpers/Browser/BrowserInfoServiceExtensions.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.WebSearch/Helpers/Browser/BrowserInfoServiceExtensions.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using ManagedCommon;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 
 namespace Microsoft.CmdPal.Ext.WebSearch.Helpers.Browser;
@@ -28,23 +27,14 @@ internal static class BrowserInfoServiceExtensions
     /// </remarks>
     public static bool Open(this IBrowserInfoService browserInfoService, string url)
     {
-        // If the URL is a valid URI, attempt to open it with the default browser by invoking it through the shell.
-        if (Uri.TryCreate(url, UriKind.Absolute, out _))
-        {
-            try
-            {
-                ShellHelpers.OpenInShell(url);
-                return true;
-            }
-            catch (Exception ex)
-            {
-                Logger.LogDebug($"Failed to launch the URI {url}: {ex}");
-            }
-        }
-
-        // Use legacy method to open the URL if it's not a well-formed URI or if the shell launch fails.
-        // This may handle cases where the URL is a search query or a custom URI scheme.
-        var defaultBrowser = browserInfoService.GetDefaultBrowser();
-        return defaultBrowser != null && ShellHelpers.OpenCommandInShell(defaultBrowser.Path, defaultBrowser.ArgumentsPattern, url);
+        return Open(browserInfoService, url, OpenCommandInShell);
     }
+
+    internal static bool Open(this IBrowserInfoService browserInfoService, string url, Func<string?, string?, string?, bool> openCommand)
+    {
+        var defaultBrowser = browserInfoService.GetDefaultBrowser();
+        return defaultBrowser != null && openCommand(defaultBrowser.Path, defaultBrowser.ArgumentsPattern, url);
+    }
+
+    private static bool OpenCommandInShell(string? path, string? pattern, string? arguments) => ShellHelpers.OpenCommandInShell(path, pattern, arguments);
 }


### PR DESCRIPTION
## Summary
- open web URLs through the registered default browser command instead of the generic shell URL handler
- preserve the default Edge profile selected for external links
- add focused coverage for command arguments and the no-default-browser path

## Validation
- `git diff --check origin/main...HEAD` — passed
- focused test project restore — passed
- focused build/test — blocked locally because the installed Visual Studio Build Tools lack the PowerToys-required UWP v143 and Spectre-mitigated components; the added tests are expected to run in repository CI

Fixes #39866