### PR TITLE
[UI] Fix abnormal blinking when keep pressing a non-modifier key or windows key when setting a new hotkey shortcut

### DIFF
--- a/src/settings-ui/Settings.UI/SettingsXAML/Controls/ShortcutControl/ShortcutControl.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Controls/ShortcutControl/ShortcutControl.xaml.cs
@@ -504,8 +504,12 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
         private void Hotkey_KeyDown(int key)
         {
             KeyEventHandler(key, true, key);
+            List<object> newKeys = internalSettings.GetKeysList();
+            if (c.Keys == null || !c.JudgeIfKeyValueSame(newKeys))
+            {
+                c.Keys = newKeys;
+            }
 
-            c.Keys = internalSettings.GetKeysList();
             c.ConflictMessage = string.Empty;
             c.HasConflict = false;
 
@@ -682,8 +686,13 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
             _isDialogOpen = true;
             try
             {
-                c.Keys = null;
-                c.Keys = HotkeySettings?.GetKeysList() ?? new List<object>();
+                List<object> newKeys = HotkeySettings?.GetKeysList() ?? new List<object>();
+
+                if (c.Keys == null || !c.JudgeIfKeyValueSame(newKeys))
+                {
+                    c.Keys = null;
+                    c.Keys = newKeys ?? new List<object>();
+                }
 
                 c.IgnoreConflict = IgnoreConflict;
                 c.HasConflict = hotkeySettings?.HasConflict ?? false;

--- a/src/settings-ui/Settings.UI/SettingsXAML/Controls/ShortcutControl/ShortcutDialogContentControl.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Controls/ShortcutControl/ShortcutDialogContentControl.xaml.cs
@@ -65,8 +65,15 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
 
         public List<object> Keys
         {
-            get { return (List<object>)GetValue(KeysProperty); }
-            set { SetValue(KeysProperty, value); }
+            get => (List<object>)GetValue(KeysProperty);
+
+            set
+            {
+                if (Keys != null || !JudgeIfKeyValueSame(value))
+                {
+                    SetValue(KeysProperty, value);
+                }
+            }
         }
 
         public bool IsError
@@ -128,6 +135,29 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
         private void LearnMoreBtn_Click(object sender, RoutedEventArgs e)
         {
             LearnMoreClick?.Invoke(this, new RoutedEventArgs());
+        }
+
+        public bool JudgeIfKeyValueSame(List<object> newValue)
+        {
+            List<object> currentValue = (List<object>)GetValue(KeysProperty);
+
+            if (currentValue == null && newValue == null)
+            {
+                return true;
+            }
+
+            if (currentValue == null || newValue == null)
+            {
+                return false;
+            }
+
+            if (currentValue.Count != newValue.Count)
+            {
+                return false;
+            }
+
+            var set = new HashSet<object>(currentValue);
+            return set.SetEquals(newValue);
         }
     }
 }

--- a/src/settings-ui/Settings.UI/SettingsXAML/Controls/ShortcutControl/ShortcutDialogContentControl.xaml.cs
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Controls/ShortcutControl/ShortcutDialogContentControl.xaml.cs
@@ -69,7 +69,7 @@ namespace Microsoft.PowerToys.Settings.UI.Controls
 
             set
             {
-                if (Keys != null || !JudgeIfKeyValueSame(value))
+if (!JudgeIfKeyValueSame(value))
                 {
                     SetValue(KeysProperty, value);
                 }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] Closes: #xxx
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** No change required
- [x] **Dev docs:** No change required
- [ ] **New binaries:** No binary added
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments


The latest release of PowerToys still blinks abnormally when keep pressing non-modifier keys or windows key. I've fixed this problem in this PR.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

Just try to make a shortcut, and don't release the last key for seconds.
