### PR TITLE
[Mouse Without Borders] Fix German ampersand localization

### DIFF
--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -2063,6 +2063,7 @@ Made with 💗 by Microsoft and the PowerToys community.</value>
   </data>
   <data name="Oobe_MouseWithoutBorders.Description" xml:space="preserve">
     <value>Mouse Without Borders enables using the mouse pointer, keyboard, clipboard and drag and drop between machines in the same local network.</value>
+    <comment>For German, use "Drag &amp; Drop" with a literal ampersand character, not the text "&amp;amp;".</comment>
   </data>
   <data name="Oobe_PowerRename.Description" xml:space="preserve">
     <value>PowerRename enables you to perform simple bulk renaming, searching and replacing file names.</value>


### PR DESCRIPTION
## Summary of the Pull Request

Adds translator guidance for the Mouse Without Borders OOBE description so the German translation uses a literal ampersand in "Drag & Drop" instead of displaying the HTML entity text.

## PR Checklist

- [x] Closes: #42943
- [x] **Communication:** Requested by a core contributor
- [x] ~~**Tests:** Added/updated and all pass~~ Not applicable; localization comment only
- [x] **Localization:** All end-user-facing strings can be localized
- [x] ~~**Dev docs:** Added/updated~~ Not applicable
- [x] ~~**New binaries:** Added on the required places~~ Not applicable
- [x] ~~**Documentation updated:**~~ Not applicable

## Detailed Description of the Pull Request / Additional comments

The German translation of `Oobe_MouseWithoutBorders.Description` currently renders `Drag &amp; Drop`. The resource comment now gives translators the exact expected `Drag & Drop` text and clarifies that the ampersand must be entered as a literal character rather than as an HTML entity.

## Validation Steps Performed

- Parsed `Resources.resw` as XML and confirmed the comment resolves to the intended literal ampersand and erroneous entity text.
- Confirmed the patch passes `git diff --check`.