### PR TITLE
[Settings] Make attribution links localizable

### DIFF
--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/ColorPickerPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/ColorPickerPage.xaml
@@ -216,8 +216,8 @@
             <controls:PageLink x:Uid="LearnMore_ColorPicker" Link="https://aka.ms/PowerToysOverview_ColorPicker" />
         </controls:SettingsPageControl.PrimaryLinks>
         <controls:SettingsPageControl.SecondaryLinks>
-            <controls:PageLink Link="https://github.com/martinchrzan/ColorPicker/" Text="Martin Chrzan's Color Picker" />
-            <controls:PageLink Link="https://medium.com/@Niels9001/a-fluent-color-meter-for-powertoys-20407ededf0c" Text="Niels Laute's UX concept" />
+            <controls:PageLink x:Uid="Attribution_ColorPicker" Link="https://github.com/martinchrzan/ColorPicker/" />
+            <controls:PageLink x:Uid="Attribution_ColorPicker_UXConcept" Link="https://medium.com/@Niels9001/a-fluent-color-meter-for-powertoys-20407ededf0c" />
         </controls:SettingsPageControl.SecondaryLinks>
     </controls:SettingsPageControl>
 </local:NavigablePage>

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/ImageResizerPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/ImageResizerPage.xaml
@@ -290,7 +290,7 @@
             <controls:PageLink x:Uid="LearnMore_ImageResizer" Link="https://aka.ms/PowerToysOverview_ImageResizer" />
         </controls:SettingsPageControl.PrimaryLinks>
         <controls:SettingsPageControl.SecondaryLinks>
-            <controls:PageLink Link="https://github.com/bricelam/ImageResizer/" Text="Brice Lambson's ImageResizer" />
+            <controls:PageLink x:Uid="Attribution_ImageResizer" Link="https://github.com/bricelam/ImageResizer/" />
         </controls:SettingsPageControl.SecondaryLinks>
     </controls:SettingsPageControl>
 </local:NavigablePage>

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/MouseUtilsPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/MouseUtilsPage.xaml
@@ -504,8 +504,8 @@
             <controls:PageLink x:Uid="LearnMore_MouseUtils" Link="https://aka.ms/PowerToysOverview_MouseUtilities" />
         </controls:SettingsPageControl.PrimaryLinks>
         <controls:SettingsPageControl.SecondaryLinks>
-            <controls:PageLink Link="https://devblogs.microsoft.com/oldnewthing/author/oldnewthing" Text="Raymond Chen's Find My Mouse" />
-            <controls:PageLink Link="https://michael-clayton.com/projects/fancymouse" Text="Michael Clayton's Mouse Jump (FancyMouse)" />
+            <controls:PageLink x:Uid="Attribution_MouseUtils_FindMyMouse" Link="https://devblogs.microsoft.com/oldnewthing/author/oldnewthing" />
+            <controls:PageLink x:Uid="Attribution_MouseUtils_MouseJump" Link="https://michael-clayton.com/projects/fancymouse" />
         </controls:SettingsPageControl.SecondaryLinks>
     </controls:SettingsPageControl>
 </local:NavigablePage>

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/MouseWithoutBordersPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/MouseWithoutBordersPage.xaml
@@ -502,7 +502,7 @@
         </controls:SettingsPageControl.PrimaryLinks>
         <controls:SettingsPageControl.SecondaryLinks>
             <controls:PageLink Link="http://aka.ms/mm" Text="Mouse without Borders" />
-            <controls:PageLink Link="https://github.com/microsoft/PowerToys/blob/main/COMMUNITY.md#mouse-without-borders-original-contributors" Text="Truong Do (Đỗ Đức Trường) and other original contributors" />
+            <controls:PageLink x:Uid="Attribution_MouseWithoutBorders_OriginalContributors" Link="https://github.com/microsoft/PowerToys/blob/main/COMMUNITY.md#mouse-without-borders-original-contributors" />
         </controls:SettingsPageControl.SecondaryLinks>
     </controls:SettingsPageControl>
 </local:NavigablePage>

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/NewPlusPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/NewPlusPage.xaml
@@ -207,7 +207,7 @@
             <controls:PageLink x:Uid="NewPlus_Learn_More" Link="https://aka.ms/PowerToysOverview_NewPlus" />
         </controls:SettingsPageControl.PrimaryLinks>
         <controls:SettingsPageControl.SecondaryLinks>
-            <controls:PageLink Link="https://www.onegreatworld.com/products/productivity-plus-pack/?ref=settings_pt" Text="Based on Christian Gaardmark's New++ from the Productivity Plus Pack" />
+            <controls:PageLink x:Uid="Attribution_NewPlus" Link="https://www.onegreatworld.com/products/productivity-plus-pack/?ref=settings_pt" />
         </controls:SettingsPageControl.SecondaryLinks>
     </controls:SettingsPageControl>
 

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerAccentPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerAccentPage.xaml
@@ -243,7 +243,7 @@
             <controls:PageLink x:Uid="LearnMore_QuickAccent" Link="https://aka.ms/PowerToysOverview_QuickAccent" />
         </controls:SettingsPageControl.PrimaryLinks>
         <controls:SettingsPageControl.SecondaryLinks>
-            <controls:PageLink Link="https://github.com/damienleroy/PowerAccent" Text="Damien Leroy's PowerAccent" />
+            <controls:PageLink x:Uid="Attribution_PowerAccent" Link="https://github.com/damienleroy/PowerAccent" />
         </controls:SettingsPageControl.SecondaryLinks>
     </controls:SettingsPageControl>
 </local:NavigablePage>

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerLauncherPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerLauncherPage.xaml
@@ -806,7 +806,7 @@
         </controls:SettingsPageControl.PrimaryLinks>
         <controls:SettingsPageControl.SecondaryLinks>
             <controls:PageLink Link="https://github.com/Wox-launcher/Wox/" Text="Wox" />
-            <controls:PageLink Link="https://github.com/betsegaw/windowwalker/" Text="Beta Tadele's Window Walker" />
+            <controls:PageLink x:Uid="Attribution_PowerLauncher_WindowWalker" Link="https://github.com/betsegaw/windowwalker/" />
         </controls:SettingsPageControl.SecondaryLinks>
     </controls:SettingsPageControl>
 </local:NavigablePage>

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerOcrPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerOcrPage.xaml
@@ -74,7 +74,7 @@
             <controls:PageLink x:Uid="LearnMore_TextExtractor" Link="https://aka.ms/PowerToysOverview_TextExtractor" />
         </controls:SettingsPageControl.PrimaryLinks>
         <controls:SettingsPageControl.SecondaryLinks>
-            <controls:PageLink Link="https://github.com/TheJoeFin/Text-Grab" Text="Based upon Joseph Finney's Text Grab" />
+            <controls:PageLink x:Uid="Attribution_TextExtractor" Link="https://github.com/TheJoeFin/Text-Grab" />
         </controls:SettingsPageControl.SecondaryLinks>
     </controls:SettingsPageControl>
 </local:NavigablePage>

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerPreviewPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerPreviewPage.xaml
@@ -286,8 +286,8 @@
             <controls:PageLink x:Uid="LearnMore_PowerPreview" Link="https://aka.ms/PowerToysOverview_FileExplorerAddOns" />
         </controls:SettingsPageControl.PrimaryLinks>
         <controls:SettingsPageControl.SecondaryLinks>
-            <controls:PageLink Link="https://noraajunker.ch" Text="Noraa Junker's work on developer file preview" />
-            <controls:PageLink Link="https://www.pedrolamas.com" Text="Pedro Lamas's work on G-Code, Binary G-Code, STL, and QOI" />
+            <controls:PageLink x:Uid="Attribution_PowerPreview_DeveloperFilePreview" Link="https://noraajunker.ch" />
+            <controls:PageLink x:Uid="Attribution_PowerPreview_FileFormats" Link="https://www.pedrolamas.com" />
         </controls:SettingsPageControl.SecondaryLinks>
     </controls:SettingsPageControl>
 </local:NavigablePage>

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerRenamePage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/PowerRenamePage.xaml
@@ -154,7 +154,7 @@
             <controls:PageLink x:Uid="LearnMore_PowerRename" Link="https://aka.ms/PowerToysOverview_PowerRename" />
         </controls:SettingsPageControl.PrimaryLinks>
         <controls:SettingsPageControl.SecondaryLinks>
-            <controls:PageLink Link="https://github.com/chrdavis/SmartRename" Text="Chris Davis's SmartRenamer" />
+            <controls:PageLink x:Uid="Attribution_PowerRename" Link="https://github.com/chrdavis/SmartRename" />
         </controls:SettingsPageControl.SecondaryLinks>
     </controls:SettingsPageControl>
 </local:NavigablePage>

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/ShortcutGuidePage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/ShortcutGuidePage.xaml
@@ -75,7 +75,7 @@
             <controls:PageLink x:Uid="LearnMore_ShortcutGuide" Link="https://aka.ms/PowerToysOverview_ShortcutGuide" />
         </controls:SettingsPageControl.PrimaryLinks>
         <controls:SettingsPageControl.SecondaryLinks>
-            <controls:PageLink Link="https://noraajunker.ch" Text="Noraa Junker's work on Shortcut Guide V2" />
+            <controls:PageLink x:Uid="Attribution_ShortcutGuide" Link="https://noraajunker.ch" />
         </controls:SettingsPageControl.SecondaryLinks>
     </controls:SettingsPageControl>
 </local:NavigablePage>

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/ZoomItPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/ZoomItPage.xaml
@@ -457,7 +457,7 @@
             <controls:PageLink x:Uid="LearnMore_ZoomIt" Link="https://aka.ms/PowerToysOverview_ZoomIt" />
         </controls:SettingsPageControl.PrimaryLinks>
         <controls:SettingsPageControl.SecondaryLinks>
-            <controls:PageLink Link="https://learn.microsoft.com/sysinternals/downloads/zoomit" Text="Sysinternals ZoomIt by Mark Russinovich, Alex Mihaiuc, John Stephens" />
+            <controls:PageLink x:Uid="Attribution_ZoomIt" Link="https://learn.microsoft.com/sysinternals/downloads/zoomit" />
         </controls:SettingsPageControl.SecondaryLinks>
     </controls:SettingsPageControl>
 </local:NavigablePage>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -121,6 +121,66 @@
     <value>Inspired by Rooler</value>
     <comment>Rooler is a name of the tool.</comment>
   </data>
+  <data name="Attribution_ColorPicker.Text" xml:space="preserve">
+    <value>Martin Chrzan's Color Picker</value>
+    <comment>Martin Chrzan is a person's name and Color Picker is a product name. Do not localize either name; localize the attribution wording.</comment>
+  </data>
+  <data name="Attribution_ColorPicker_UXConcept.Text" xml:space="preserve">
+    <value>Niels Laute's UX concept</value>
+    <comment>Niels Laute is a person's name and UX is an acronym. Do not localize the name or acronym; localize the attribution wording.</comment>
+  </data>
+  <data name="Attribution_ImageResizer.Text" xml:space="preserve">
+    <value>Brice Lambson's ImageResizer</value>
+    <comment>Brice Lambson is a person's name and ImageResizer is a product name. Do not localize either name; localize the attribution wording.</comment>
+  </data>
+  <data name="Attribution_MouseUtils_FindMyMouse.Text" xml:space="preserve">
+    <value>Raymond Chen's Find My Mouse</value>
+    <comment>Raymond Chen is a person's name and Find My Mouse is a product name. Do not localize either name; localize the attribution wording.</comment>
+  </data>
+  <data name="Attribution_MouseUtils_MouseJump.Text" xml:space="preserve">
+    <value>Michael Clayton's Mouse Jump (FancyMouse)</value>
+    <comment>Michael Clayton is a person's name. Mouse Jump and FancyMouse are product names. Do not localize these names; localize the attribution wording.</comment>
+  </data>
+  <data name="Attribution_MouseWithoutBorders_OriginalContributors.Text" xml:space="preserve">
+    <value>Truong Do (Đỗ Đức Trường) and other original contributors</value>
+    <comment>Truong Do and Đỗ Đức Trường are forms of the same person's name. Do not localize either form; localize "and other original contributors".</comment>
+  </data>
+  <data name="Attribution_NewPlus.Text" xml:space="preserve">
+    <value>Based on Christian Gaardmark's New++ from the Productivity Plus Pack</value>
+    <comment>Christian Gaardmark is a person's name. New++ and Productivity Plus Pack are product names. Do not localize these names; localize the attribution wording.</comment>
+  </data>
+  <data name="Attribution_PowerAccent.Text" xml:space="preserve">
+    <value>Damien Leroy's PowerAccent</value>
+    <comment>Damien Leroy is a person's name and PowerAccent is a product name. Do not localize either name; localize the attribution wording.</comment>
+  </data>
+  <data name="Attribution_PowerLauncher_WindowWalker.Text" xml:space="preserve">
+    <value>Beta Tadele's Window Walker</value>
+    <comment>Beta Tadele is a person's name and Window Walker is a product name. Do not localize either name; localize the attribution wording.</comment>
+  </data>
+  <data name="Attribution_PowerPreview_DeveloperFilePreview.Text" xml:space="preserve">
+    <value>Noraa Junker's work on developer file preview</value>
+    <comment>Noraa Junker is a person's name. Do not localize the name; localize the attribution wording.</comment>
+  </data>
+  <data name="Attribution_PowerPreview_FileFormats.Text" xml:space="preserve">
+    <value>Pedro Lamas's work on G-Code, Binary G-Code, STL, and QOI</value>
+    <comment>Pedro Lamas is a person's name. G-Code, Binary G-Code, STL, and QOI are file format names. Do not localize these names; localize the attribution wording, including "and".</comment>
+  </data>
+  <data name="Attribution_PowerRename.Text" xml:space="preserve">
+    <value>Chris Davis's SmartRenamer</value>
+    <comment>Chris Davis is a person's name and SmartRenamer is a product name. Do not localize either name; localize the attribution wording.</comment>
+  </data>
+  <data name="Attribution_ShortcutGuide.Text" xml:space="preserve">
+    <value>Noraa Junker's work on Shortcut Guide V2</value>
+    <comment>Noraa Junker is a person's name and Shortcut Guide V2 is a product name. Do not localize either name; localize the attribution wording.</comment>
+  </data>
+  <data name="Attribution_TextExtractor.Text" xml:space="preserve">
+    <value>Based upon Joseph Finney's Text Grab</value>
+    <comment>Joseph Finney is a person's name and Text Grab is a product name. Do not localize either name; localize the attribution wording.</comment>
+  </data>
+  <data name="Attribution_ZoomIt.Text" xml:space="preserve">
+    <value>Sysinternals ZoomIt by Mark Russinovich, Alex Mihaiuc, John Stephens</value>
+    <comment>Sysinternals ZoomIt is a product name. Mark Russinovich, Alex Mihaiuc, and John Stephens are people's names. Do not localize these names; localize the attribution wording.</comment>
+  </data>
   <data name="Shell_MeasureTool.Content" xml:space="preserve">
     <value>Screen Ruler</value>
     <comment>Product name: Navigation view item name for Screen Ruler</comment>
@@ -1077,7 +1137,7 @@ opera.exe</value>
   </data>
   <data name="FileExplorerPreview_ToggleSwitch_Thumbnail_STL.Header" xml:space="preserve">
     <value>Stereolithography</value>
-    <comment>{Locked}</comment>
+    <comment>Technical term for the full name of the STL file format.</comment>
   </data>
   <data name="FileExplorerPreview_ToggleSwitch_Thumbnail_STL.Description" xml:space="preserve">
     <value>.stl</value>


### PR DESCRIPTION
## Summary of the Pull Request

Moves Settings attribution link text into localized resources so Turkish and other locales can translate grammatical wording while preserving contributor and product names. Also makes the technical term "Stereolithography" translatable.

## PR Checklist

- [x] Closes: #35272
- [x] **Communication:** Requested in #35272
- [x] **Tests:** Resource/XAML-only change; the ARM64 Debug Settings UI build passes
- [x] **Localization:** All end-user-facing strings can be localized
- [x] **Dev docs:** Not applicable
- [x] **New binaries:** Not applicable
- [x] **Documentation updated:** Not applicable

## Detailed Description of the Pull Request / Additional comments

The affected attribution labels were hard-coded in XAML, preventing the localization pipeline from translating text such as "and other original contributors." Each label now uses an `x:Uid` resource, with translator comments that explicitly identify contributor, product, and file-format names that must remain unchanged. Links containing only a person or product name remain hard-coded.

The locked `Stereolithography` resource is also unlocked because it is a translatable technical term rather than a name.

## Validation Steps Performed

- Restored and built PowerToys build essentials for ARM64 Debug
- Built `src/settings-ui/PowerToys.Settings.slnf` for ARM64 Debug
- Validated all attribution `x:Uid` values resolve to unique `.Text` resources