### PR TITLE
[Mouse Utilities] Clarify Gliding Cursor description

### DIFF
--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -2907,7 +2907,7 @@ Right-click to remove the key combination, thereby deactivating the shortcut.</v
     <value>Gliding cursor</value>
   </data>
   <data name="MouseUtils_GlidingCursor.Description" xml:space="preserve">
-    <value>An accessibility feature that lets you control the mouse with a single button using guided horizontal and vertical lines</value>
+    <value>Position the cursor and click anywhere on the screen using only a keyboard shortcut</value>
   </data>
   <data name="MouseUtils_GlidingCursor_InitialSpeed.Header" xml:space="preserve">
     <value>Initial line speed</value>


### PR DESCRIPTION
## Summary
- replace the misleading Gliding Cursor description in PowerToys Settings
- clarify that the feature positions the cursor and clicks using only a keyboard shortcut

## Validation
- parsed `Resources.resw` as XML
- `git diff --check`
- Settings UI dependency restore completed; the build could not finish because the D: drive ran out of space

Addresses #45598.