### PR TITLE
[Settings] Align File Explorer navigation title

### DIFF
--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -511,8 +511,8 @@ opera.exe</value>
     <comment>Product name: Navigation view item name for Shortcut Guide</comment>
   </data>
   <data name="Shell_PowerPreview.Content" xml:space="preserve">
-    <value>File Explorer Add-ons</value>
-    <comment>Product name: Navigation view item name for File Explorer.  Please use File Explorer as in the context of File Explorer in Windows</comment>
+    <value>File Explorer</value>
+    <comment>Navigation view item name for File Explorer. Keep this translation consistent with FileExplorerPreview.ModuleTitle and use the localized Windows product name.</comment>
   </data>
   <data name="Shell_FancyZones.Content" xml:space="preserve">
     <value>FancyZones</value>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -511,8 +511,8 @@ opera.exe</value>
     <comment>Product name: Navigation view item name for Shortcut Guide</comment>
   </data>
   <data name="Shell_PowerPreview.Content" xml:space="preserve">
-    <value>File Explorer</value>
-    <comment>Navigation view item name for File Explorer. Keep this translation consistent with FileExplorerPreview.ModuleTitle and use the localized Windows product name.</comment>
+    <value>File Explorer Add-ons</value>
+    <comment>Product name: Navigation view item name for File Explorer.  Please use File Explorer as in the context of File Explorer in Windows</comment>
   </data>
   <data name="Shell_FancyZones.Content" xml:space="preserve">
     <value>FancyZones</value>
@@ -1382,7 +1382,8 @@ opera.exe</value>
     <comment>{Locked}</comment>
   </data>
   <data name="FileExplorerPreview.ModuleTitle" xml:space="preserve">
-    <value>File Explorer</value>
+    <value>File Explorer Add-ons</value>
+    <comment>Product name: Settings page title for File Explorer Add-ons. Keep this translation consistent with Shell_PowerPreview.Content.</comment>
   </data>
   <data name="ImageResizer.ModuleTitle" xml:space="preserve">
     <value>Image Resizer</value>


### PR DESCRIPTION
## Summary
- keep the `File Explorer Add-ons` source string in the navigation view
- use the same title on the File Explorer Add-ons settings page through `FileExplorerPreview.ModuleTitle`
- add translator guidance to keep the navigation and page-title values consistent

## Validation
- parsed `Resources.resw` as XML
- ran `git diff --check`
- verified both resource values resolve to `File Explorer Add-ons`

Fixes #24414.