### PR TITLE
[Mouse Utilities] Fix Chinese Ctrl translation

### DIFF
--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -2719,7 +2719,7 @@ Right-click to remove the key combination, thereby deactivating the shortcut.</v
   </data>
   <data name="MouseUtils_FindMyMouse_ActivationDoubleControlPress.Content" xml:space="preserve">
     <value>Press Left Control twice</value>
-    <comment>Left control is the physical key on the keyboard. In Traditional Chinese, keep the key label as "Ctrl" instead of translating it as "控制鍵".</comment>
+    <comment>Left control is the physical key on the keyboard. In Chinese, keep the key label as "Ctrl" instead of translating it as "控制键" (Simplified) or "控制鍵" (Traditional).</comment>
   </data>
   <data name="MouseUtils_FindMyMouse_ActivationShakeMouse.Content" xml:space="preserve">
     <value>Shake mouse</value>
@@ -4364,7 +4364,7 @@ Activate by holding the key for the character you want to add an accent to, then
   </data>
   <data name="MouseUtils_FindMyMouse_ActivationDoubleRightControlPress.Content" xml:space="preserve">
     <value>Press Right Control twice</value>
-    <comment>Right control is the physical key on the keyboard. In Traditional Chinese, keep the key label as "Ctrl" instead of translating it as "控制鍵".</comment>
+    <comment>Right control is the physical key on the keyboard. In Chinese, keep the key label as "Ctrl" instead of translating it as "控制键" (Simplified) or "控制鍵" (Traditional).</comment>
   </data>
   <data name="MouseUtils_FindMyMouse_ActivationShortcut.Description" xml:space="preserve">
     <value>Customize the shortcut used to turn this mode on or off</value>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -2719,7 +2719,7 @@ Right-click to remove the key combination, thereby deactivating the shortcut.</v
   </data>
   <data name="MouseUtils_FindMyMouse_ActivationDoubleControlPress.Content" xml:space="preserve">
     <value>Press Left Control twice</value>
-    <comment>Left control is the physical key on the keyboard.</comment>
+    <comment>Left control is the physical key on the keyboard. In Traditional Chinese, keep the key label as "Ctrl" instead of translating it as "控制鍵".</comment>
   </data>
   <data name="MouseUtils_FindMyMouse_ActivationShakeMouse.Content" xml:space="preserve">
     <value>Shake mouse</value>
@@ -4364,7 +4364,7 @@ Activate by holding the key for the character you want to add an accent to, then
   </data>
   <data name="MouseUtils_FindMyMouse_ActivationDoubleRightControlPress.Content" xml:space="preserve">
     <value>Press Right Control twice</value>
-    <comment>Right control is the physical key on the keyboard.</comment>
+    <comment>Right control is the physical key on the keyboard. In Traditional Chinese, keep the key label as "Ctrl" instead of translating it as "控制鍵".</comment>
   </data>
   <data name="MouseUtils_FindMyMouse_ActivationShortcut.Description" xml:space="preserve">
     <value>Customize the shortcut used to turn this mode on or off</value>


### PR DESCRIPTION
## Summary of the Pull Request

Adds Simplified and Traditional Chinese translator guidance for both Find My Mouse double-Control activation options so the localized UI keeps the familiar `Ctrl` key label instead of using `控制键` or `控制鍵`.

## PR Checklist

- [x] Closes: #46223
- [x] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [x] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments

As discussed in [#46223](https://github.com/microsoft/PowerToys/issues/46223#issuecomment-5189066402), Chinese users commonly identify this physical keyboard key by its `Ctrl` label. Translating it as `控制键` in Simplified Chinese or `控制鍵` in Traditional Chinese makes the Find My Mouse activation options harder to understand.

PowerToys localized resources are generated through the CDPX localization pipeline, so this PR expands the translator comments for both the left and right Control activation strings. The English values, resource keys, settings schema, UI tests, and runtime behavior remain unchanged.

## Validation Steps Performed

- Parsed the modified `Resources.resw` successfully as XML.
- Verified both affected Find My Mouse entries contain Simplified and Traditional Chinese guidance.
- Confirmed the diff changes translator comments only and passes `git diff --check`.
- No build or automated tests were run because this is a comment-only localization guidance change with no runtime impact.
