### PR TITLE
[Image Resizer] Clarify preset size descriptions

### DIFF
--- a/src/modules/imageresizer/ui/ImageResizerXAML/Views/InputPage.xaml
+++ b/src/modules/imageresizer/ui/ImageResizerXAML/Views/InputPage.xaml
@@ -22,7 +22,11 @@
                 </Grid.RowDefinitions>
                 <TextBlock Style="{StaticResource BodyStrongTextBlockStyle}" Text="{x:Bind Name}" />
                 <StackPanel Grid.Row="1" Orientation="Horizontal">
-                    <TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="{x:Bind Fit, Converter={StaticResource EnumValueConverter}, ConverterParameter=ThirdPersonSingular}" />
+                    <TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="{x:Bind Fit, Converter={StaticResource EnumValueConverter}}" />
+                    <TextBlock
+                        Margin="4,0,0,0"
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        Text="-" />
                     <TextBlock
                         Margin="4,0,0,0"
                         Style="{StaticResource BodyStrongTextBlockStyle}"

--- a/src/modules/imageresizer/ui/Strings/en-us/Resources.resw
+++ b/src/modules/imageresizer/ui/Strings/en-us/Resources.resw
@@ -257,20 +257,11 @@
   <data name="ResizeFit_Fill" xml:space="preserve">
     <value>Fill</value>
   </data>
-  <data name="ResizeFit_Fill_ThirdPersonSingular" xml:space="preserve">
-    <value>fills</value>
-  </data>
   <data name="ResizeFit_Fit" xml:space="preserve">
     <value>Fit</value>
   </data>
-  <data name="ResizeFit_Fit_ThirdPersonSingular" xml:space="preserve">
-    <value>fits within</value>
-  </data>
   <data name="ResizeFit_Stretch" xml:space="preserve">
     <value>Stretch</value>
-  </data>
-  <data name="ResizeFit_Stretch_ThirdPersonSingular" xml:space="preserve">
-    <value>stretches to</value>
   </data>
   <data name="ResizeUnit_Centimeter" xml:space="preserve">
     <value>Centimeters</value>

--- a/src/settings-ui/Settings.UI/Converters/ImageResizerFitToStringConverter.cs
+++ b/src/settings-ui/Settings.UI/Converters/ImageResizerFitToStringConverter.cs
@@ -16,9 +16,9 @@ public sealed partial class ImageResizerFitToStringConverter : IValueConverter
     // Maps each ResizeFit to its localized string.
     private static readonly Dictionary<ResizeFit, string> FitToText = new()
     {
-        { ResizeFit.Fill,    Helpers.ResourceLoaderInstance.ResourceLoader.GetString("ImageResizer_Fit_Fill_ThirdPersonSingular") },
-        { ResizeFit.Fit,     Helpers.ResourceLoaderInstance.ResourceLoader.GetString("ImageResizer_Fit_Fit_ThirdPersonSingular") },
-        { ResizeFit.Stretch, Helpers.ResourceLoaderInstance.ResourceLoader.GetString("ImageResizer_Fit_Stretch_ThirdPersonSingular") },
+        { ResizeFit.Fill,    Helpers.ResourceLoaderInstance.ResourceLoader.GetString("ImageResizer_Sizes_Fit_Fill/Content") },
+        { ResizeFit.Fit,     Helpers.ResourceLoaderInstance.ResourceLoader.GetString("ImageResizer_Sizes_Fit_Fit/Content") },
+        { ResizeFit.Stretch, Helpers.ResourceLoaderInstance.ResourceLoader.GetString("ImageResizer_Sizes_Fit_Stretch/Content") },
     };
 
     public object Convert(object value, Type targetType, object parameter, string language)

--- a/src/settings-ui/Settings.UI/Converters/ImageResizerSizeToAccessibleTextConverter.cs
+++ b/src/settings-ui/Settings.UI/Converters/ImageResizerSizeToAccessibleTextConverter.cs
@@ -15,7 +15,7 @@ namespace Microsoft.PowerToys.Settings.UI.Converters;
 /// Creates accessibility text for controls related to <see cref="ImageSize"/> properties.
 /// </summary>
 /// <example>(Name) "Edit the Small preset"</example>
-/// <example>(FullDescription) "Large - Fits within 1920 × 1080 pixels"</example>"
+/// <example>(FullDescription) "Large - Fit - 1920 × 1080 pixels"</example>
 public sealed partial class ImageResizerSizeToAccessibleTextConverter : IValueConverter
 {
     private const char TimesGlyph = '\u00D7';   // Unicode "MULTIPLICATION SIGN"
@@ -59,8 +59,8 @@ public sealed partial class ImageResizerSizeToAccessibleTextConverter : IValueCo
         string unitText = _unitConverter.Convert(preset.Unit, typeof(string), null, null) as string;
 
         return preset.IsHeightUsed ?
-            $"{preset.Name} - {fitText} {preset.Width} {TimesGlyph} {preset.Height} {unitText}" :
-            $"{preset.Name} - {fitText} {preset.Width} {unitText}";
+            $"{preset.Name} - {fitText} - {preset.Width} {TimesGlyph} {preset.Height} {unitText}" :
+            $"{preset.Name} - {fitText} - {preset.Width} {unitText}";
     }
 
     public object ConvertBack(object value, Type targetType, object parameter, string language)

--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/ImageResizerPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/ImageResizerPage.xaml
@@ -82,6 +82,11 @@
                                                 Text="{x:Bind Fit, Mode=OneWay, Converter={StaticResource ImageResizerFitToStringConverter}}" />
                                             <TextBlock
                                                 Margin="0,0,4,0"
+                                                AutomationProperties.AccessibilityView="Raw"
+                                                Style="{ThemeResource SecondaryTextStyle}"
+                                                Text="-" />
+                                            <TextBlock
+                                                Margin="0,0,4,0"
                                                 FontWeight="SemiBold"
                                                 Style="{ThemeResource SecondaryTextStyle}"
                                                 Text="{x:Bind Width, Mode=OneWay, Converter={StaticResource ImageResizerDoubleToAutoConverter}, ConverterParameter=Auto}" />

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -2378,15 +2378,6 @@ From there, simply click on one of the supported files in the File Explorer and 
   <data name="General_DownloadAndInstall.Content" xml:space="preserve">
     <value>Download &amp; install</value>
   </data>
-  <data name="ImageResizer_Fit_Fill_ThirdPersonSingular" xml:space="preserve">
-    <value>Fills</value>
-  </data>
-  <data name="ImageResizer_Fit_Fit_ThirdPersonSingular" xml:space="preserve">
-    <value>Fits within</value>
-  </data>
-  <data name="ImageResizer_Fit_Stretch_ThirdPersonSingular" xml:space="preserve">
-    <value>Stretches to</value>
-  </data>
   <data name="ImageResizer_Unit_Centimeter" xml:space="preserve">
     <value>Centimeters</value>
   </data>


### PR DESCRIPTION
## Summary of the Pull Request

Updates Image Resizer preset descriptions in both the resize dialog and the Settings page from sentence fragments such as `Fits within 1920 × 1080 pixels` to CRUTKAS's proposed `Fit - 1920 × 1080 pixels` format. The UI reuses existing localized mode labels and removes the obsolete third-person resources.

## Screenshots

### Resize dialog

![Image Resizer dialog showing the new Fit - Width × Height unit format](https://raw.githubusercontent.com/niels9001/PowerToys/pr-assets/screenshots/49694/image-resizer-preset-format.png)

### Settings page

![Image Resizer Settings page showing the new Fit - Width × Height unit format](https://raw.githubusercontent.com/niels9001/PowerToys/pr-assets/screenshots/49694/image-resizer-settings-preset-format.png)

## PR Checklist

- [x] Closes: #16790
- [x] **Communication:** Implements the pattern proposed and accepted by core contributors in #16790
- [x] **Tests:** Existing Image Resizer tests pass; the Image Resizer and Settings UI projects build successfully
- [x] **Localization:** Reuses existing localized mode and unit strings; no new translatable text
- [x] **Dev docs:** Not applicable
- [x] **New binaries:** Not applicable
- [x] **Documentation updated:** Not applicable

## Detailed Description of the Pull Request / Additional comments

Preset details now use the infinitive resize mode followed by a neutral dash and the dimensions on both Image Resizer surfaces. This avoids requiring translators to make a sentence fragment agree grammatically with the dimensions.

Accessible Settings descriptions use the same wording, and the obsolete third-person mode resources are removed from both resource sets.

## Validation Steps Performed

- Built `ImageResizerUI.csproj` for x64 Debug
- Built `ImageResizer.UnitTests.csproj` for x64 Debug
- Ran all 149 Image Resizer unit tests successfully
- Built `Settings.UI.csproj` for x64 Debug
- Ran the PR-built resize dialog and Settings page and verified the new text in both surfaces