### PR TITLE
[Always On Top] Render a solid border frame

### DIFF
--- a/src/modules/alwaysontop/AlwaysOnTop/FrameDrawer.cpp
+++ b/src/modules/alwaysontop/AlwaysOnTop/FrameDrawer.cpp
@@ -14,6 +14,21 @@ namespace
         std::hash<pod_repr_t> hasher{};
         return hasher(*reinterpret_cast<const pod_repr_t*>(&rect));
     }
+
+    bool AreEqual(const D2D1_RECT_F& left, const D2D1_RECT_F& right)
+    {
+        return left.left == right.left &&
+               left.top == right.top &&
+               left.right == right.right &&
+               left.bottom == right.bottom;
+    }
+
+    bool AreEqual(const D2D1_ROUNDED_RECT& left, const D2D1_ROUNDED_RECT& right)
+    {
+        return AreEqual(left.rect, right.rect) &&
+               left.radiusX == right.radiusX &&
+               left.radiusY == right.radiusY;
+    }
 }
 
 std::unique_ptr<FrameDrawer> FrameDrawer::Create(HWND window)
@@ -52,6 +67,7 @@ bool FrameDrawer::CreateRenderTargets(const RECT& clientRect)
     }
 
     m_renderTarget = nullptr;
+    m_borderBrush = nullptr;
 
     const auto hwndRenderTargetProperties = D2D1::HwndRenderTargetProperties(m_window, renderTargetSize, D2D1_PRESENT_OPTIONS_NONE);
 
@@ -63,6 +79,14 @@ bool FrameDrawer::CreateRenderTargets(const RECT& clientRect)
     }
 
     m_renderTarget->SetAntialiasMode(D2D1_ANTIALIAS_MODE_PER_PRIMITIVE);
+
+    hr = m_renderTarget->CreateSolidColorBrush(m_sceneRect.borderColor, m_borderBrush.put());
+    if (FAILED(hr))
+    {
+        m_renderTarget = nullptr;
+        return false;
+    }
+
     m_renderTargetSizeHash = rectHash;
 
     return true;
@@ -108,8 +132,11 @@ void FrameDrawer::SetBorderRect(RECT windowRect, COLORREF rgb, float alpha, int 
     
     const bool colorUpdated = std::memcmp(&m_sceneRect.borderColor, &newSceneRect.borderColor, sizeof(newSceneRect.borderColor));
     const bool thicknessUpdated = m_sceneRect.thickness != newSceneRect.thickness;
-    const bool cornersUpdated = m_sceneRect.rect.has_value() != newSceneRect.rect.has_value() || m_sceneRect.roundedRect.has_value() != newSceneRect.roundedRect.has_value();
-    const bool needsRedraw = colorUpdated || thicknessUpdated || cornersUpdated;
+    const bool rectangleUpdated = m_sceneRect.rect.has_value() != newSceneRect.rect.has_value() ||
+                                  (m_sceneRect.rect && !AreEqual(m_sceneRect.rect.value(), newSceneRect.rect.value()));
+    const bool roundedRectangleUpdated = m_sceneRect.roundedRect.has_value() != newSceneRect.roundedRect.has_value() ||
+                                         (m_sceneRect.roundedRect && !AreEqual(m_sceneRect.roundedRect.value(), newSceneRect.roundedRect.value()));
+    const bool needsRedraw = colorUpdated || thicknessUpdated || rectangleUpdated || roundedRectangleUpdated;
 
     RECT clientRect;
     if (!SUCCEEDED(DwmGetWindowAttribute(m_window, DWMWA_EXTENDED_FRAME_BOUNDS, &clientRect, sizeof(clientRect))))
@@ -142,10 +169,9 @@ void FrameDrawer::SetBorderRect(RECT windowRect, COLORREF rgb, float alpha, int 
 
     if (colorUpdated)
     {
-        m_borderBrush = nullptr;
-        if (m_renderTarget)
+        if (m_borderBrush)
         {
-            m_renderTarget->CreateSolidColorBrush(m_sceneRect.borderColor, m_borderBrush.put());
+            m_borderBrush->SetColor(m_sceneRect.borderColor);
         }
     }
 
@@ -206,6 +232,104 @@ D2D1_RECT_F FrameDrawer::ConvertRect(RECT rect, int thickness)
         static_cast<float>(rect.bottom) - halfThickness - 1);
 }
 
+winrt::com_ptr<ID2D1Geometry> FrameDrawer::CreateBorderGeometry(const DrawableRect& drawableRect)
+{
+    const float halfThickness = drawableRect.thickness / 2.0f;
+    winrt::com_ptr<ID2D1Geometry> outerGeometry;
+    winrt::com_ptr<ID2D1Geometry> innerGeometry;
+
+    if (drawableRect.roundedRect)
+    {
+        const auto& borderRect = drawableRect.roundedRect.value();
+        const auto outerRect = D2D1::RoundedRect(
+            D2D1::RectF(
+                borderRect.rect.left - halfThickness,
+                borderRect.rect.top - halfThickness,
+                borderRect.rect.right + halfThickness,
+                borderRect.rect.bottom + halfThickness),
+            borderRect.radiusX + halfThickness,
+            borderRect.radiusY + halfThickness);
+        const auto innerRect = D2D1::RoundedRect(
+            D2D1::RectF(
+                borderRect.rect.left + halfThickness,
+                borderRect.rect.top + halfThickness,
+                borderRect.rect.right - halfThickness,
+                borderRect.rect.bottom - halfThickness),
+            (std::max)(borderRect.radiusX - halfThickness, 0.0f),
+            (std::max)(borderRect.radiusY - halfThickness, 0.0f));
+
+        winrt::com_ptr<ID2D1RoundedRectangleGeometry> outerRoundedGeometry;
+        if (FAILED(GetD2DFactory()->CreateRoundedRectangleGeometry(outerRect, outerRoundedGeometry.put())))
+        {
+            return nullptr;
+        }
+
+        outerGeometry = outerRoundedGeometry.as<ID2D1Geometry>();
+
+        if (innerRect.rect.left >= innerRect.rect.right || innerRect.rect.top >= innerRect.rect.bottom)
+        {
+            return outerGeometry;
+        }
+
+        winrt::com_ptr<ID2D1RoundedRectangleGeometry> innerRoundedGeometry;
+        if (FAILED(GetD2DFactory()->CreateRoundedRectangleGeometry(innerRect, innerRoundedGeometry.put())))
+        {
+            return nullptr;
+        }
+
+        innerGeometry = innerRoundedGeometry.as<ID2D1Geometry>();
+    }
+    else if (drawableRect.rect)
+    {
+        const auto& borderRect = drawableRect.rect.value();
+        const auto outerRect = D2D1::RectF(
+            borderRect.left - halfThickness,
+            borderRect.top - halfThickness,
+            borderRect.right + halfThickness,
+            borderRect.bottom + halfThickness);
+        const auto innerRect = D2D1::RectF(
+            borderRect.left + halfThickness,
+            borderRect.top + halfThickness,
+            borderRect.right - halfThickness,
+            borderRect.bottom - halfThickness);
+
+        winrt::com_ptr<ID2D1RectangleGeometry> outerRectangleGeometry;
+        if (FAILED(GetD2DFactory()->CreateRectangleGeometry(outerRect, outerRectangleGeometry.put())))
+        {
+            return nullptr;
+        }
+
+        outerGeometry = outerRectangleGeometry.as<ID2D1Geometry>();
+
+        if (innerRect.left >= innerRect.right || innerRect.top >= innerRect.bottom)
+        {
+            return outerGeometry;
+        }
+
+        winrt::com_ptr<ID2D1RectangleGeometry> innerRectangleGeometry;
+        if (FAILED(GetD2DFactory()->CreateRectangleGeometry(innerRect, innerRectangleGeometry.put())))
+        {
+            return nullptr;
+        }
+
+        innerGeometry = innerRectangleGeometry.as<ID2D1Geometry>();
+    }
+
+    if (!outerGeometry || !innerGeometry)
+    {
+        return nullptr;
+    }
+
+    ID2D1Geometry* geometries[] = { outerGeometry.get(), innerGeometry.get() };
+    winrt::com_ptr<ID2D1GeometryGroup> borderGeometry;
+    if (FAILED(GetD2DFactory()->CreateGeometryGroup(D2D1_FILL_MODE_ALTERNATE, geometries, ARRAYSIZE(geometries), borderGeometry.put())))
+    {
+        return nullptr;
+    }
+
+    return borderGeometry.as<ID2D1Geometry>();
+}
+
 void FrameDrawer::Render()
 {
     if (!m_renderTarget || !m_borderBrush)
@@ -217,16 +341,20 @@ void FrameDrawer::Render()
 
     m_renderTarget->Clear(D2D1::ColorF(0.f, 0.f, 0.f, 0.f));
 
-    // The border stroke is centered on the line.
+    if (const auto borderGeometry = CreateBorderGeometry(m_sceneRect))
+    {
+        m_renderTarget->FillGeometry(borderGeometry.get(), m_borderBrush.get());
+    }
 
-    if (m_sceneRect.roundedRect)
+    const HRESULT hr = m_renderTarget->EndDraw();
+    if (hr == D2DERR_RECREATE_TARGET)
     {
-        m_renderTarget->DrawRoundedRectangle(m_sceneRect.roundedRect.value(), m_borderBrush.get(), static_cast<float>(m_sceneRect.thickness));
+        m_borderBrush = nullptr;
+        m_renderTarget = nullptr;
+        m_renderTargetSizeHash = {};
     }
-    else if (m_sceneRect.rect)
+    else if (FAILED(hr))
     {
-        m_renderTarget->DrawRectangle(m_sceneRect.rect.value(), m_borderBrush.get(), static_cast<float>(m_sceneRect.thickness));
+        Logger::error(L"Failed to render the border. HRESULT: 0x{:08X}", static_cast<unsigned long>(hr));
     }
-    
-    m_renderTarget->EndDraw();
 }

--- a/src/modules/alwaysontop/AlwaysOnTop/FrameDrawer.h
+++ b/src/modules/alwaysontop/AlwaysOnTop/FrameDrawer.h
@@ -36,6 +36,7 @@ private:
     static D2D1_COLOR_F ConvertColor(COLORREF color, float alpha);
     static D2D1_ROUNDED_RECT ConvertRect(RECT rect, int thickness, float radius);
     static D2D1_RECT_F ConvertRect(RECT rect, int thickness);
+    static winrt::com_ptr<ID2D1Geometry> CreateBorderGeometry(const DrawableRect& drawableRect);
     void Render();
 
     HWND m_window = nullptr;


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Fixes the Always On Top frame appearing mottled or translucent even when frame opacity is set to 100%.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] Closes: #xxx
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [x] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [x] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

The frame helper window is intentionally placed behind the tracked window. The previous Direct2D rendering used a centered stroke, so the tracked window occluded the stroke's inner half. With per-primitive antialiasing enabled, partial-coverage pixels became disproportionately visible in the remaining thin outer half, making a fully opaque frame look mottled.

This change replaces the centered stroke with a filled, even-odd outer/inner geometry ring. It preserves configured opacity, the transparent interior, DPI-scaled frame thickness and corner radius, smooth rounded corners, and target-window occlusion while limiting antialiasing to the ring's actual contours.

It also recreates render-target-bound brush resources when the HWND render target is recreated, clears stale resources on `D2DERR_RECREATE_TARGET`, and redraws when rectangle or corner geometry changes.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

- Built `src\modules\alwaysontop\AlwaysOnTop\AlwaysOnTop.vcxproj` for Debug x64 successfully.
- Ran the freshly built `PowerToys.AlwaysOnTop.exe` with frame opacity 100%, thickness 4, and rounded corners enabled.
- Pinned a controlled Win32 window and confirmed it received `WS_EX_TOPMOST`.
- Confirmed the module created an `AlwaysOnTop_Border` HWND sized 946x627 behind the 960x630 target window.
- Restored the temporary setting change and stopped the test processes.

Residual limitation: the RDP input desktop was detached, so composed-screen pixel capture was unavailable. `winapp` could capture the layered border HWND only by flattening transparency to black, which is not trustworthy visual pixel evidence. An interactive-desktop visual check is still recommended.
