### PR TITLE
[Quick Accent] Isolate press-and-hold activation

### DIFF
--- a/src/modules/poweraccent/PowerAccent.Core.UnitTests/DelayedDisplayStateTests.cs
+++ b/src/modules/poweraccent/PowerAccent.Core.UnitTests/DelayedDisplayStateTests.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PowerAccent.Core;
+
+namespace PowerAccent.Core.UnitTests;
+
+[TestClass]
+public sealed class DelayedDisplayStateTests
+{
+    [TestMethod]
+    public void Cancel_InvalidatesPendingDisplay()
+    {
+        var state = new DelayedDisplayState();
+        int generation = state.Begin();
+
+        state.Cancel();
+
+        Assert.IsFalse(state.ShouldShow(generation));
+        Assert.IsFalse(state.IsVisible);
+    }
+
+    [TestMethod]
+    public void Begin_AfterCancellation_RearmsDisplay()
+    {
+        var state = new DelayedDisplayState();
+        int cancelledGeneration = state.Begin();
+        state.Cancel();
+
+        int rearmedGeneration = state.Begin();
+
+        Assert.IsFalse(state.ShouldShow(cancelledGeneration));
+        Assert.IsTrue(state.ShouldShow(rearmedGeneration));
+        Assert.IsTrue(state.IsVisible);
+    }
+}

--- a/src/modules/poweraccent/PowerAccent.Core.UnitTests/DelayedDisplayStateTests.cs
+++ b/src/modules/poweraccent/PowerAccent.Core.UnitTests/DelayedDisplayStateTests.cs
@@ -14,11 +14,11 @@ public sealed class DelayedDisplayStateTests
     public void Cancel_InvalidatesPendingDisplay()
     {
         var state = new DelayedDisplayState();
-        int generation = state.Begin();
+        var pendingDisplay = state.Begin(displayDelay: 500);
 
         state.Cancel();
 
-        Assert.IsFalse(state.ShouldShow(generation));
+        Assert.IsFalse(state.ShouldShow(pendingDisplay));
         Assert.IsFalse(state.IsVisible);
     }
 
@@ -26,13 +26,23 @@ public sealed class DelayedDisplayStateTests
     public void Begin_AfterCancellation_RearmsDisplay()
     {
         var state = new DelayedDisplayState();
-        int cancelledGeneration = state.Begin();
+        var cancelledDisplay = state.Begin(displayDelay: 500);
         state.Cancel();
 
-        int rearmedGeneration = state.Begin();
+        var rearmedDisplay = state.Begin(displayDelay: 1000);
 
-        Assert.IsFalse(state.ShouldShow(cancelledGeneration));
-        Assert.IsTrue(state.ShouldShow(rearmedGeneration));
+        Assert.IsFalse(state.ShouldShow(cancelledDisplay));
+        Assert.IsTrue(state.ShouldShow(rearmedDisplay));
         Assert.IsTrue(state.IsVisible);
+    }
+
+    [TestMethod]
+    public void Begin_SnapshotsDisplayDelay()
+    {
+        var state = new DelayedDisplayState();
+
+        var pendingDisplay = state.Begin(displayDelay: 500);
+
+        Assert.AreEqual(500, pendingDisplay.Delay);
     }
 }

--- a/src/modules/poweraccent/PowerAccent.Core/DelayedDisplayState.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/DelayedDisplayState.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace PowerAccent.Core;
+
+internal sealed class DelayedDisplayState
+{
+    private int _generation;
+
+    public bool IsVisible { get; private set; }
+
+    public int Begin()
+    {
+        IsVisible = true;
+        return ++_generation;
+    }
+
+    public bool ShouldShow(int generation)
+    {
+        return IsVisible && generation == _generation;
+    }
+
+    public void Cancel()
+    {
+        IsVisible = false;
+        _generation++;
+    }
+}

--- a/src/modules/poweraccent/PowerAccent.Core/DelayedDisplayState.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/DelayedDisplayState.cs
@@ -6,19 +6,21 @@ namespace PowerAccent.Core;
 
 internal sealed class DelayedDisplayState
 {
+    public readonly record struct PendingDisplay(int Generation, int Delay);
+
     private int _generation;
 
     public bool IsVisible { get; private set; }
 
-    public int Begin()
+    public PendingDisplay Begin(int displayDelay)
     {
         IsVisible = true;
-        return ++_generation;
+        return new PendingDisplay(++_generation, displayDelay);
     }
 
-    public bool ShouldShow(int generation)
+    public bool ShouldShow(PendingDisplay pendingDisplay)
     {
-        return IsVisible && generation == _generation;
+        return IsVisible && pendingDisplay.Generation == _generation;
     }
 
     public void Cancel()

--- a/src/modules/poweraccent/PowerAccent.Core/PowerAccent.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/PowerAccent.cs
@@ -23,8 +23,7 @@ public partial class PowerAccent : IDisposable
     private readonly LetterKey[] _letterKeysShowingDescription = new LetterKey[] { LetterKey.VK_O };
     private const double ScreenMinPadding = 150;
 
-    private bool _visible;
-    private int _showGeneration;
+    private readonly DelayedDisplayState _displayState = new();
     private string[] _characters = Array.Empty<string>();
     private string[] _characterDescriptions = Array.Empty<string>();
     private int _selectedIndex = -1;
@@ -78,6 +77,11 @@ public partial class PowerAccent : IDisposable
             });
         }));
 
+        _keyboardListener.SetCancelToolbarEvent(new PowerToys.PowerAccentKeyboardService.CancelToolbar(() =>
+        {
+            _runOnUiThread(CancelToolbar);
+        }));
+
         _keyboardListener.SetHideToolbarEvent(new PowerToys.PowerAccentKeyboardService.HideToolbar((InputType inputType) =>
         {
             _runOnUiThread(() =>
@@ -102,13 +106,11 @@ public partial class PowerAccent : IDisposable
 
     private void ShowToolbar(LetterKey letterKey)
     {
-        _visible = true;
-
         bool isPressAndHold = _settingService.ActivationKey == PowerAccentActivationKey.PressAndHold;
 
         // Each summon gets a generation id so a delayed render queued by an earlier
         // press can't fire for a newer one (or after the toolbar was hidden).
-        int generation = ++_showGeneration;
+        int generation = _displayState.Begin();
 
         // Trigger modes navigate the instant the toolbar is summoned, so the character data must
         // be ready synchronously. Press-and-hold can't navigate until the popup is actually shown,
@@ -124,7 +126,7 @@ public partial class PowerAccent : IDisposable
         Task.Delay(displayDelay).ContinueWith(
         t =>
         {
-            if (_visible && generation == _showGeneration)
+            if (_displayState.ShouldShow(generation))
             {
                 if (isPressAndHold)
                 {
@@ -135,6 +137,14 @@ public partial class PowerAccent : IDisposable
             }
         },
         TaskScheduler.FromCurrentSynchronizationContext());
+    }
+
+    private void CancelToolbar()
+    {
+        _displayState.Cancel();
+        _characters = Array.Empty<string>();
+        _selectedIndex = -1;
+        OnChangeDisplay?.Invoke(false, null);
     }
 
     private void PrepareCharacters(LetterKey letterKey)
@@ -269,8 +279,7 @@ public partial class PowerAccent : IDisposable
         _keyboardListener.ForceReset();
         OnChangeDisplay?.Invoke(false, null);
         _selectedIndex = -1;
-        _visible = false;
-        _showGeneration++;
+        _displayState.Cancel();
     }
 
     private void ProcessNextChar(TriggerKey triggerKey, bool shiftPressed)
@@ -289,7 +298,7 @@ public partial class PowerAccent : IDisposable
         bool isHardwareShiftPressed = WindowsFunctions.IsShiftState() && !_initialShiftState;
         shiftPressed = shiftPressed || isHardwareShiftPressed;
 
-        if (_visible && _selectedIndex == -1)
+        if (_displayState.IsVisible && _selectedIndex == -1)
         {
             if (triggerKey == TriggerKey.Space)
             {

--- a/src/modules/poweraccent/PowerAccent.Core/PowerAccent.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/PowerAccent.cs
@@ -112,14 +112,9 @@ public partial class PowerAccent : IDisposable
         // press can't fire for a newer one (or after the toolbar was hidden).
         int generation = _displayState.Begin();
 
-        // Trigger modes navigate the instant the toolbar is summoned, so the character data must
-        // be ready synchronously. Press-and-hold can't navigate until the popup is actually shown,
-        // so defer the (relatively expensive) character/description build to the delayed render and
-        // keep quick taps off the keystroke hot path.
-        if (!isPressAndHold)
-        {
-            PrepareCharacters(letterKey);
-        }
+        // Character data must be ready before the native listener accepts navigation. This also
+        // keeps an in-progress gesture coherent if the configured hold duration changes.
+        PrepareCharacters(letterKey);
 
         int displayDelay = isPressAndHold ? _settingService.HoldDuration : _settingService.InputTime;
 
@@ -128,11 +123,6 @@ public partial class PowerAccent : IDisposable
         {
             if (_displayState.ShouldShow(generation))
             {
-                if (isPressAndHold)
-                {
-                    PrepareCharacters(letterKey);
-                }
-
                 OnChangeDisplay?.Invoke(true, _characters);
             }
         },
@@ -284,8 +274,7 @@ public partial class PowerAccent : IDisposable
 
     private void ProcessNextChar(TriggerKey triggerKey, bool shiftPressed)
     {
-        // Press-and-hold builds its character set lazily when the popup renders; ignore any
-        // navigation that races ahead of it (there is nothing to select yet).
+        // Ignore navigation after cancellation or reset, when there is nothing to select.
         if (_characters.Length == 0)
         {
             return;

--- a/src/modules/poweraccent/PowerAccent.Core/PowerAccent.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/PowerAccent.cs
@@ -11,8 +11,6 @@ using PowerAccent.Core.Services;
 using PowerAccent.Core.Tools;
 using PowerToys.PowerAccentKeyboardService;
 
-using PowerAccentActivationKey = Microsoft.PowerToys.Settings.UI.Library.Enumerations.PowerAccentActivationKey;
-
 namespace PowerAccent.Core;
 
 public partial class PowerAccent : IDisposable
@@ -69,11 +67,11 @@ public partial class PowerAccent : IDisposable
 
     private void SetEvents()
     {
-        _keyboardListener.SetShowToolbarEvent(new PowerToys.PowerAccentKeyboardService.ShowToolbar((LetterKey letterKey) =>
+        _keyboardListener.SetShowToolbarEvent(new PowerToys.PowerAccentKeyboardService.ShowToolbar((LetterKey letterKey, int displayDelay) =>
         {
             _runOnUiThread(() =>
             {
-                ShowToolbar(letterKey);
+                ShowToolbar(letterKey, displayDelay);
             });
         }));
 
@@ -104,24 +102,20 @@ public partial class PowerAccent : IDisposable
         }));
     }
 
-    private void ShowToolbar(LetterKey letterKey)
+    private void ShowToolbar(LetterKey letterKey, int displayDelay)
     {
-        bool isPressAndHold = _settingService.ActivationKey == PowerAccentActivationKey.PressAndHold;
-
         // Each summon gets a generation id so a delayed render queued by an earlier
         // press can't fire for a newer one (or after the toolbar was hidden).
-        int generation = _displayState.Begin();
+        var pendingDisplay = _displayState.Begin(displayDelay);
 
         // Character data must be ready before the native listener accepts navigation. This also
         // keeps an in-progress gesture coherent if the configured hold duration changes.
         PrepareCharacters(letterKey);
 
-        int displayDelay = isPressAndHold ? _settingService.HoldDuration : _settingService.InputTime;
-
-        Task.Delay(displayDelay).ContinueWith(
+        Task.Delay(pendingDisplay.Delay).ContinueWith(
         t =>
         {
-            if (_displayState.ShouldShow(generation))
+            if (_displayState.ShouldShow(pendingDisplay))
             {
                 OnChangeDisplay?.Invoke(true, _characters);
             }

--- a/src/modules/poweraccent/PowerAccent.Core/Services/SettingsService.cs
+++ b/src/modules/poweraccent/PowerAccent.Core/Services/SettingsService.cs
@@ -51,16 +51,12 @@ public class SettingsService
                     if (settings != null)
                     {
                         ActivationKey = settings.Properties.ActivationKey;
-                        _keyboardListener.UpdateActivationKey((int)ActivationKey);
+                        InputTime = settings.Properties.InputTime.Value;
+                        HoldDuration = settings.Properties.HoldDuration.Value;
+                        _keyboardListener.UpdateActivationSettings((int)ActivationKey, InputTime, HoldDuration);
 
                         DoNotActivateOnGameMode = settings.Properties.DoNotActivateOnGameMode;
                         _keyboardListener.UpdateDoNotActivateOnGameMode(DoNotActivateOnGameMode);
-
-                        InputTime = settings.Properties.InputTime.Value;
-                        _keyboardListener.UpdateInputTime(InputTime);
-
-                        HoldDuration = settings.Properties.HoldDuration.Value;
-                        _keyboardListener.UpdateHoldDuration(HoldDuration);
 
                         ExcludedApps = settings.Properties.ExcludedApps.Value;
                         _keyboardListener.UpdateExcludedApps(ExcludedApps);

--- a/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.cpp
+++ b/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.cpp
@@ -213,30 +213,33 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
             m_rightShiftPressed = true;
         }
 
-        if (std::find(letters.begin(), letters.end(), letterKey) != cend(letters) && m_isLanguageLetterCb(letterKey))
+        const bool isLetterKey = std::find(letters.begin(), letters.end(), letterKey) != cend(letters);
+        if (isLetterKey &&
+            m_toolbarVisible &&
+            m_gestureActivationKey == PowerAccentActivationKey::PressAndHold)
         {
-            if (m_toolbarVisible && m_gestureActivationKey == PowerAccentActivationKey::PressAndHold)
+            if (letterPressed == letterKey)
             {
-                if (letterPressed == letterKey)
-                {
-                    // On-screen keyboard continuously sends WM_KEYDOWN when a key is held down.
-                    // If Quick Accent is active, prevent the owner letter from being processed.
-                    // https://github.com/microsoft/PowerToys/issues/36853
-                    return true;
-                }
-
-                // In press-and-hold, a different typed letter must not be replaced when the
-                // original owner is released. Cancel the owner gesture and pass this key through.
-                if (!m_pressAndHoldCancelled)
-                {
-                    m_pressAndHoldCancelled = true;
-                    m_cancelToolbarCb();
-                }
-
-                // A different letter must not steal or re-arm the active owner-letter gesture.
-                return false;
+                // On-screen keyboard continuously sends WM_KEYDOWN when a key is held down.
+                // If Quick Accent is active, prevent the owner letter from being processed.
+                // https://github.com/microsoft/PowerToys/issues/36853
+                return true;
             }
 
+            // Any different physical letter must not be replaced when the original owner is
+            // released, even if that letter has no mapping in the selected language.
+            if (!m_pressAndHoldCancelled)
+            {
+                m_pressAndHoldCancelled = true;
+                m_cancelToolbarCb();
+            }
+
+            return false;
+        }
+
+        // Language eligibility gates starting a new owner gesture, not canceling an active one.
+        if (isLetterKey && m_isLanguageLetterCb(letterKey))
+        {
             if (m_toolbarVisible && letterPressed == letterKey)
             {
                 // Preserve repeat suppression for trigger-key activation modes.
@@ -365,7 +368,12 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
         }
 
         const auto releasedLetter = static_cast<LetterKey>(info.vkCode);
-        if (std::find(std::begin(letters), end(letters), releasedLetter) != end(letters) && m_isLanguageLetterCb(releasedLetter))
+        const bool isLetterKey = std::find(std::begin(letters), end(letters), releasedLetter) != end(letters);
+        const bool isActivePressAndHoldOwner =
+            m_toolbarVisible &&
+            m_gestureActivationKey == PowerAccentActivationKey::PressAndHold &&
+            letterPressed == releasedLetter;
+        if (isLetterKey && (isActivePressAndHoldOwner || m_isLanguageLetterCb(releasedLetter)))
         {
             // Only react to the key-up of the letter that owns the toolbar, so releasing a
             // different held letter can't cancel or commit the active picker.

--- a/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.cpp
+++ b/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.cpp
@@ -214,6 +214,15 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
                     return true;
                 }
 
+                // In press-and-hold, a different typed letter must not be replaced when the
+                // original owner is released. Cancel the owner gesture and pass this key through.
+                if (m_settings.activationKey == PowerAccentActivationKey::PressAndHold &&
+                    !m_pressAndHoldCancelled)
+                {
+                    m_pressAndHoldCancelled = true;
+                    m_cancelToolbarCb();
+                }
+
                 // A different letter must not steal or re-arm the active owner-letter gesture.
                 return false;
             }

--- a/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.cpp
+++ b/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.cpp
@@ -369,11 +369,8 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
 
         const auto releasedLetter = static_cast<LetterKey>(info.vkCode);
         const bool isLetterKey = std::find(std::begin(letters), end(letters), releasedLetter) != end(letters);
-        const bool isActivePressAndHoldOwner =
-            m_toolbarVisible &&
-            m_gestureActivationKey == PowerAccentActivationKey::PressAndHold &&
-            letterPressed == releasedLetter;
-        if (isLetterKey && (isActivePressAndHoldOwner || m_isLanguageLetterCb(releasedLetter)))
+        const bool isActiveOwner = letterPressed == releasedLetter;
+        if (isLetterKey && (isActiveOwner || m_isLanguageLetterCb(releasedLetter)))
         {
             // Only react to the key-up of the letter that owns the toolbar, so releasing a
             // different held letter can't cancel or commit the active picker.

--- a/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.cpp
+++ b/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.cpp
@@ -13,7 +13,7 @@
 namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
 {
     KeyboardListener::KeyboardListener() :
-        m_toolbarVisible(false), m_triggeredWithSpace(false), m_leftShiftPressed(false), m_rightShiftPressed(false), m_triggeredWithLeftArrow(false), m_triggeredWithRightArrow(false)
+        m_toolbarVisible(false), m_triggeredWithSpace(false), m_triggeredWithLeftArrow(false), m_triggeredWithRightArrow(false), m_leftShiftPressed(false), m_rightShiftPressed(false), m_pressAndHoldCancelled(false)
     {
         s_instance = this;
         LoggerHelpers::init_logger(L"PowerAccent", L"PowerAccentKeyboardService", "PowerAccent");
@@ -60,12 +60,20 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
         m_triggeredWithRightArrow = false;
         m_leftShiftPressed = false;
         m_rightShiftPressed = false;
+        m_pressAndHoldCancelled = false;
     }
 
     void KeyboardListener::SetShowToolbarEvent(ShowToolbar showToolbarEvent)
     {
         m_showToolbarCb = [trigger = std::move(showToolbarEvent)](LetterKey key) {
             trigger(key);
+        };
+    }
+
+    void KeyboardListener::SetCancelToolbarEvent(CancelToolbar cancelToolbarEvent)
+    {
+        m_cancelToolbarCb = [trigger = std::move(cancelToolbarEvent)]() {
+            trigger();
         };
     }
 
@@ -196,16 +204,23 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
 
         if (std::find(letters.begin(), letters.end(), letterKey) != cend(letters) && m_isLanguageLetterCb(letterKey))
         {
-            if (m_toolbarVisible && letterPressed == letterKey)
+            if (m_toolbarVisible)
             {
-                // On-screen keyboard continuously sends WM_KEYDOWN when a key is held down
-                // If Quick Accent is visible, prevent the letter key from being processed
-                // https://github.com/microsoft/PowerToys/issues/36853
-                return true;
+                if (letterPressed == letterKey)
+                {
+                    // On-screen keyboard continuously sends WM_KEYDOWN when a key is held down.
+                    // If Quick Accent is active, prevent the owner letter from being processed.
+                    // https://github.com/microsoft/PowerToys/issues/36853
+                    return true;
+                }
+
+                // A different letter must not steal or re-arm the active owner-letter gesture.
+                return false;
             }
 
             m_stopwatch.reset();
             letterPressed = letterKey;
+            m_pressAndHoldCancelled = false;
         }
 
         // Press-and-hold activation: the held letter itself opens the toolbar after the hold
@@ -259,10 +274,24 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
             m_showToolbarCb(letterPressed);
         }
 
+        // A legacy trigger pressed while a hold is still pending cancels this owner-letter
+        // gesture. Let the trigger pass through and require a fresh letter press to re-arm.
+        if (m_settings.activationKey == PowerAccentActivationKey::PressAndHold &&
+            m_toolbarVisible &&
+            !m_pressAndHoldCancelled &&
+            triggerPressed &&
+            m_stopwatch.elapsed() < m_settings.holdDuration)
+        {
+            m_pressAndHoldCancelled = true;
+            m_cancelToolbarCb();
+            return false;
+        }
+
         // In press-and-hold the popup only appears once the hold duration elapses, so Space/arrow
         // must pass through until then; treat the picker as interactive only once it is shown.
         const bool pickerInteractive =
             m_toolbarVisible &&
+            !m_pressAndHoldCancelled &&
             (m_settings.activationKey != PowerAccentActivationKey::PressAndHold ||
              m_stopwatch.elapsed() >= m_settings.holdDuration);
 
@@ -313,6 +342,13 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
             }
 
             letterPressed = LetterKey::None;
+
+            if (m_pressAndHoldCancelled)
+            {
+                m_toolbarVisible = false;
+                m_pressAndHoldCancelled = false;
+                return false;
+            }
 
             if (m_toolbarVisible)
             {

--- a/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.cpp
+++ b/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.cpp
@@ -65,8 +65,8 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
 
     void KeyboardListener::SetShowToolbarEvent(ShowToolbar showToolbarEvent)
     {
-        m_showToolbarCb = [trigger = std::move(showToolbarEvent)](LetterKey key) {
-            trigger(key);
+        m_showToolbarCb = [trigger = std::move(showToolbarEvent)](LetterKey key, int32_t displayDelay) {
+            trigger(key, displayDelay);
         };
     }
 
@@ -102,7 +102,16 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
 
     void KeyboardListener::UpdateActivationKey(int32_t activationKey)
     {
+        std::lock_guard<std::mutex> lock(m_mutex_activation_settings);
         m_settings.activationKey = static_cast<PowerAccentActivationKey>(activationKey);
+    }
+
+    void KeyboardListener::UpdateActivationSettings(int32_t activationKey, int32_t inputTime, int32_t holdDuration)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex_activation_settings);
+        m_settings.activationKey = static_cast<PowerAccentActivationKey>(activationKey);
+        m_settings.inputTime = std::chrono::milliseconds(inputTime);
+        m_settings.holdDuration = std::chrono::milliseconds(holdDuration);
     }
 
     void KeyboardListener::UpdateDoNotActivateOnGameMode(bool doNotActivateOnGameMode)
@@ -112,11 +121,13 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
 
     void KeyboardListener::UpdateInputTime(int32_t inputTime)
     {
+        std::lock_guard<std::mutex> lock(m_mutex_activation_settings);
         m_settings.inputTime = std::chrono::milliseconds(inputTime);
     }
 
     void KeyboardListener::UpdateHoldDuration(int32_t holdDuration)
     {
+        std::lock_guard<std::mutex> lock(m_mutex_activation_settings);
         m_settings.holdDuration = std::chrono::milliseconds(holdDuration);
     }
 
@@ -204,7 +215,7 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
 
         if (std::find(letters.begin(), letters.end(), letterKey) != cend(letters) && m_isLanguageLetterCb(letterKey))
         {
-            if (m_toolbarVisible)
+            if (m_toolbarVisible && m_gestureActivationKey == PowerAccentActivationKey::PressAndHold)
             {
                 if (letterPressed == letterKey)
                 {
@@ -216,8 +227,7 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
 
                 // In press-and-hold, a different typed letter must not be replaced when the
                 // original owner is released. Cancel the owner gesture and pass this key through.
-                if (m_settings.activationKey == PowerAccentActivationKey::PressAndHold &&
-                    !m_pressAndHoldCancelled)
+                if (!m_pressAndHoldCancelled)
                 {
                     m_pressAndHoldCancelled = true;
                     m_cancelToolbarCb();
@@ -227,14 +237,28 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
                 return false;
             }
 
+            if (m_toolbarVisible && letterPressed == letterKey)
+            {
+                // Preserve repeat suppression for trigger-key activation modes.
+                return true;
+            }
+
+            const bool isNewOwnerGesture = letterPressed != letterKey;
             m_stopwatch.reset();
             letterPressed = letterKey;
             m_pressAndHoldCancelled = false;
+            if (isNewOwnerGesture && !m_toolbarVisible)
+            {
+                std::lock_guard<std::mutex> lock(m_mutex_activation_settings);
+                m_gestureActivationKey = m_settings.activationKey;
+                m_gestureInputTime = m_settings.inputTime;
+                m_gestureHoldDuration = m_settings.holdDuration;
+            }
         }
 
         // Press-and-hold activation: the held letter itself opens the toolbar after the hold
         // duration. The base letter still types on first press; auto-repeats are swallowed above.
-        if (m_settings.activationKey == PowerAccentActivationKey::PressAndHold &&
+        if (m_gestureActivationKey == PowerAccentActivationKey::PressAndHold &&
             !m_toolbarVisible &&
             letterPressed != LetterKey::None &&
             letterKey == letterPressed &&
@@ -247,7 +271,7 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
             m_triggeredWithLeftArrow = false;
             m_triggeredWithRightArrow = false;
             m_toolbarVisible = true;
-            m_showToolbarCb(letterPressed);
+            m_showToolbarCb(letterPressed, static_cast<int32_t>(m_gestureHoldDuration.count()));
             return false;
         }
 
@@ -260,8 +284,8 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
                 const bool isLetterReleased = (GetAsyncKeyState((int)letterPressed) & 0x8000) == 0;
 
                 if (isLetterReleased ||
-                    (triggerPressed == VK_SPACE && m_settings.activationKey == PowerAccentActivationKey::LeftRightArrow) ||
-                    ((triggerPressed == VK_LEFT || triggerPressed == VK_RIGHT) && m_settings.activationKey == PowerAccentActivationKey::Space))
+                    (triggerPressed == VK_SPACE && m_gestureActivationKey == PowerAccentActivationKey::LeftRightArrow) ||
+                    ((triggerPressed == VK_LEFT || triggerPressed == VK_RIGHT) && m_gestureActivationKey == PowerAccentActivationKey::Space))
                 {
                     Logger::debug(L"Reset trigger key");
                     return false;
@@ -270,7 +294,7 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
         }
 
         // Trigger-key activation (letter + Space/arrow) is exclusive to the non-hold modes.
-        if (m_settings.activationKey != PowerAccentActivationKey::PressAndHold &&
+        if (m_gestureActivationKey != PowerAccentActivationKey::PressAndHold &&
             !m_toolbarVisible && letterPressed != LetterKey::None && triggerPressed && !IsSuppressedByGameMode() && !IsForegroundAppExcluded())
         {
             Logger::debug(L"Show toolbar. Letter: {}, Trigger: {}", letterPressed, triggerPressed);
@@ -280,16 +304,16 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
             m_triggeredWithLeftArrow = triggerPressed == VK_LEFT;
             m_triggeredWithRightArrow = triggerPressed == VK_RIGHT;
             m_toolbarVisible = true;
-            m_showToolbarCb(letterPressed);
+            m_showToolbarCb(letterPressed, static_cast<int32_t>(m_gestureInputTime.count()));
         }
 
         // A legacy trigger pressed while a hold is still pending cancels this owner-letter
         // gesture. Let the trigger pass through and require a fresh letter press to re-arm.
-        if (m_settings.activationKey == PowerAccentActivationKey::PressAndHold &&
+        if (m_gestureActivationKey == PowerAccentActivationKey::PressAndHold &&
             m_toolbarVisible &&
             !m_pressAndHoldCancelled &&
             triggerPressed &&
-            m_stopwatch.elapsed() < m_settings.holdDuration)
+            m_stopwatch.elapsed() < m_gestureHoldDuration)
         {
             m_pressAndHoldCancelled = true;
             m_cancelToolbarCb();
@@ -301,8 +325,8 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
         const bool pickerInteractive =
             m_toolbarVisible &&
             !m_pressAndHoldCancelled &&
-            (m_settings.activationKey != PowerAccentActivationKey::PressAndHold ||
-             m_stopwatch.elapsed() >= m_settings.holdDuration);
+            (m_gestureActivationKey != PowerAccentActivationKey::PressAndHold ||
+             m_stopwatch.elapsed() >= m_gestureHoldDuration);
 
         if (pickerInteractive && triggerPressed)
         {
@@ -364,9 +388,9 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
                 // Press-and-hold uses its own (typically longer) hold duration as the
                 // minimum-hold threshold; the trigger-key modes use inputTime.
                 const auto activationThreshold =
-                    m_settings.activationKey == PowerAccentActivationKey::PressAndHold
-                        ? m_settings.holdDuration
-                        : m_settings.inputTime;
+                    m_gestureActivationKey == PowerAccentActivationKey::PressAndHold
+                        ? m_gestureHoldDuration
+                        : m_gestureInputTime;
                 if (m_stopwatch.elapsed() < activationThreshold)
                 {
                     Logger::debug(L"Activation too fast. Do nothing.");

--- a/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.h
+++ b/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.h
@@ -34,6 +34,7 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
         void KeyboardListener::InitHook();
         void KeyboardListener::UnInitHook();
         void SetShowToolbarEvent(ShowToolbar showToolbarEvent);
+        void SetCancelToolbarEvent(CancelToolbar cancelToolbarEvent);
         void SetHideToolbarEvent(HideToolbar hideToolbarEvent);
         void SetNextCharEvent(NextChar NextCharEvent);
         void SetIsLanguageLetterDelegate(IsLanguageLetter IsLanguageLetterDelegate);
@@ -60,6 +61,7 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
         bool m_toolbarVisible;
         PowerAccentSettings m_settings;
         std::function<void(LetterKey)> m_showToolbarCb;
+        std::function<void()> m_cancelToolbarCb;
         std::function<void(InputType)> m_hideToolbarCb;
         std::function<void(TriggerKey, bool)> m_nextCharCb;
         std::function<bool(LetterKey)> m_isLanguageLetterCb;
@@ -69,6 +71,7 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
         spdlog::stopwatch m_stopwatch;
         bool m_leftShiftPressed;
         bool m_rightShiftPressed;
+        bool m_pressAndHoldCancelled;
 
         std::mutex m_mutex_excluded_apps;
         std::pair<HWND, bool> m_prevForegroundAppExcl{ NULL, false };

--- a/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.h
+++ b/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.h
@@ -39,6 +39,7 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
         void SetNextCharEvent(NextChar NextCharEvent);
         void SetIsLanguageLetterDelegate(IsLanguageLetter IsLanguageLetterDelegate);
 
+        void UpdateActivationSettings(int32_t activationKey, int32_t inputTime, int32_t holdDuration);
         void UpdateActivationKey(int32_t activationKey);
         void UpdateDoNotActivateOnGameMode(bool doNotActivateOnGameMode);
         void UpdateInputTime(int32_t inputTime);
@@ -60,7 +61,7 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
         HHOOK s_llKeyboardHook = nullptr;
         bool m_toolbarVisible;
         PowerAccentSettings m_settings;
-        std::function<void(LetterKey)> m_showToolbarCb;
+        std::function<void(LetterKey, int32_t)> m_showToolbarCb;
         std::function<void()> m_cancelToolbarCb;
         std::function<void(InputType)> m_hideToolbarCb;
         std::function<void(TriggerKey, bool)> m_nextCharCb;
@@ -72,8 +73,12 @@ namespace winrt::PowerToys::PowerAccentKeyboardService::implementation
         bool m_leftShiftPressed;
         bool m_rightShiftPressed;
         bool m_pressAndHoldCancelled;
+        PowerAccentActivationKey m_gestureActivationKey{ PowerAccentActivationKey::Both };
+        std::chrono::milliseconds m_gestureInputTime{ 300 };
+        std::chrono::milliseconds m_gestureHoldDuration{ 500 };
 
         std::mutex m_mutex_excluded_apps;
+        std::mutex m_mutex_activation_settings;
         std::pair<HWND, bool> m_prevForegroundAppExcl{ NULL, false };
 
         static inline const std::vector<LetterKey> letters = { LetterKey::VK_0,

--- a/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.idl
+++ b/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.idl
@@ -67,7 +67,7 @@ namespace PowerToys
             Char
         };
 
-        [version(1.0), uuid(37197089-5438-4479-af57-30ab3f3c8be4)] delegate void ShowToolbar(LetterKey key);
+        [version(1.0), uuid(37197089-5438-4479-af57-30ab3f3c8be4)] delegate void ShowToolbar(LetterKey key, Int32 displayDelay);
         [version(1.0), uuid(18a02453-5317-45f5-849a-fc500f7cf42e)] delegate void CancelToolbar();
         [version(1.0), uuid(8eb79d6b-1826-424f-9fbc-af21ae19725e)] delegate void HideToolbar(InputType inputType);
         [version(1.0), uuid(db72d45c-a5a2-446f-bdc1-506e9121764a)] delegate void NextChar(TriggerKey inputSpace, boolean shiftPressed);
@@ -82,6 +82,7 @@ namespace PowerToys
             void SetHideToolbarEvent(event HideToolbar hideToolbarEvent);
             void SetNextCharEvent(event NextChar nextCharEvent);
             void SetIsLanguageLetterDelegate(IsLanguageLetter isLanguageLetterDelegate);
+            void UpdateActivationSettings(Int32 activationKey, Int32 inputTime, Int32 holdDuration);
             void UpdateActivationKey(Int32 activationKey);
             void UpdateDoNotActivateOnGameMode(Boolean doNotActivateOnGameMode);
             void UpdateInputTime(Int32 inputTime);

--- a/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.idl
+++ b/src/modules/poweraccent/PowerAccentKeyboardService/KeyboardListener.idl
@@ -68,6 +68,7 @@ namespace PowerToys
         };
 
         [version(1.0), uuid(37197089-5438-4479-af57-30ab3f3c8be4)] delegate void ShowToolbar(LetterKey key);
+        [version(1.0), uuid(18a02453-5317-45f5-849a-fc500f7cf42e)] delegate void CancelToolbar();
         [version(1.0), uuid(8eb79d6b-1826-424f-9fbc-af21ae19725e)] delegate void HideToolbar(InputType inputType);
         [version(1.0), uuid(db72d45c-a5a2-446f-bdc1-506e9121764a)] delegate void NextChar(TriggerKey inputSpace, boolean shiftPressed);
         [version(1.0), uuid(20be2919-2b91-4313-b6e0-4c3484fe91ef)] delegate void IsLanguageLetter(LetterKey key, [out] boolean* result);
@@ -77,6 +78,7 @@ namespace PowerToys
             void InitHook();
             void UnInitHook();
             void SetShowToolbarEvent(event ShowToolbar showToolbarEvent);
+            void SetCancelToolbarEvent(event CancelToolbar cancelToolbarEvent);
             void SetHideToolbarEvent(event HideToolbar hideToolbarEvent);
             void SetNextCharEvent(event NextChar nextCharEvent);
             void SetIsLanguageLetterDelegate(IsLanguageLetter isLanguageLetterDelegate);


### PR DESCRIPTION
## Summary of the Pull Request

Makes the **Press and hold the letter** activation method exclusive. Pressing a legacy trigger key (Space or either arrow) before the hold threshold now cancels that owner-letter gesture and passes the trigger through normally, instead of allowing the already-scheduled picker to appear later. Typing any different supported physical letter during the gesture also cancels it, preventing that intervening character from being replaced when the owner letter is released.

Space and arrow navigation remains available after a genuine hold activation reaches its threshold.

## PR Checklist

- [ ] Closes: N/A
- [x] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: N/A

## Detailed Description of the Pull Request / Additional comments

The native keyboard listener previously armed press-and-hold on owner-letter key-down and immediately queued a delayed managed render. Although pre-threshold Space/arrows were excluded from native trigger-key activation, they did not invalidate that pending render. Holding the owner letter after pressing Space therefore still displayed the picker and made both invocation systems feel enabled.

This change adds an explicit native-to-managed cancellation event and a generation-based managed display state:

- In `PressAndHold`, Space or either arrow before the snapshotted hold threshold cancels the current gesture and passes through without input injection.
- Space/arrows at or after the threshold retain their intended picker navigation behavior.
- Any different physical letter in Quick Accent's supported key set cancels the owner gesture before passing through, even when that letter has no mapping in the selected language.
- Owner repeats and owner key-up are handled from active physical ownership rather than current language eligibility, so live language changes cannot leave stale state.
- Activation mode, input time, and hold duration are atomically published and snapshotted once per owner gesture. The native listener passes the same delay snapshot to managed scheduling, so live settings changes apply to the next gesture instead of desynchronizing native interaction from picker visibility.
- Character data is prepared before native navigation can become interactive, preventing accepted navigation from being dropped.
- Legacy Space/arrow/Both acquisition behavior is preserved.

The low-level hook has no clean deterministic native unit-test seam because its private handlers depend on Win32 keyboard state. Managed regression coverage exercises delayed-display cancellation, re-arming, generation invalidation, and delay snapshot preservation.

## Validation Steps Performed

- Built `src/modules/poweraccent/PowerAccent.UI/PowerAccent.UI.csproj` in `Debug|x64`, covering the native WinRT projection and managed Core/UI.
- Built `src/modules/poweraccent/PowerAccentKeyboardService/PowerAccentKeyboardService.vcxproj` in `Debug|x64`.
- Built and ran all `PowerAccent.Core.UnitTests`: **35 passed, 0 failed**.
- Ran `git diff --check`.
- Performed focused code reviews of pre-threshold trigger cancellation, intervening mapped/unmapped letters, live mode/duration snapshots, language changes, owner key-up balance, and post-threshold navigation.
