### PR TITLE
Dock: update the displays list when navigating to dock settings

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/DockSettingsPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/DockSettingsPage.xaml.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Documents;
+using Microsoft.UI.Xaml.Navigation;
 using Microsoft.Windows.Storage.Pickers;
 
 namespace Microsoft.CmdPal.UI.Settings;
@@ -38,6 +39,12 @@ public sealed partial class DockSettingsPage : Page
 
         // Initialize UI state
         InitializeSettings();
+    }
+
+    protected override void OnNavigatedTo(NavigationEventArgs e)
+    {
+        base.OnNavigatedTo(e);
+        ViewModel.PopulateMonitorConfigs();
     }
 
     private void InitializeSettings()


### PR DESCRIPTION
I opened the settings when my laptop was portable.

I docked my laptop to my displays.

I navigated to the dock settings.

I **expected**: to see all my displays

I _actually_: saw only the laptop display

------

the fix: make sure to update the displays when we navigate to the dock settings page, so that we properly show all of them

Closes: nope didn't file this
