### PR TITLE
feat(settings-ui): add update channel selector

### DIFF
--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/GeneralPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/GeneralPage.xaml
@@ -92,9 +92,6 @@
                                 Visibility="{x:Bind ViewModel.IsAdmin, Converter={StaticResource BoolToVisibilityConverter}, Mode=OneWay}">
                                 <ptcontrols:CheckBoxWithDescriptionControl x:Uid="GeneralPage_AutoDownloadAndInstallUpdates" IsChecked="{Binding Mode=TwoWay, Path=AutoDownloadUpdates}" />
                             </tkcontrols:SettingsCard>
-                            <tkcontrols:SettingsCard ContentAlignment="Left" IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsIncludePrereleaseUpdatesCardEnabled}">
-                                <ptcontrols:CheckBoxWithDescriptionControl x:Uid="GeneralPage_IncludePrereleaseUpdates" IsChecked="{Binding Mode=TwoWay, Path=IncludePrereleaseUpdates}" />
-                            </tkcontrols:SettingsCard>
                             <tkcontrols:SettingsCard ContentAlignment="Left" IsEnabled="{x:Bind Mode=OneWay, Path=ViewModel.IsShowNewUpdatesToastNotificationCardEnabled}">
                                 <ptcontrols:CheckBoxWithDescriptionControl x:Uid="GeneralPage_ShowNewUpdatesToast" IsChecked="{Binding Mode=TwoWay, Path=ShowNewUpdatesToastNotification}" />
                             </tkcontrols:SettingsCard>
@@ -103,6 +100,62 @@
                             </tkcontrols:SettingsCard>
                         </tkcontrols:SettingsExpander.Items>
                     </tkcontrols:SettingsExpander>
+
+                    <controls:GPOInfoControl ShowWarning="{x:Bind ViewModel.IsIncludePrereleaseUpdatesGpoManaged, Mode=OneWay}">
+                        <tkcontrols:SettingsExpander
+                            x:Uid="GeneralPage_UpdateChannel"
+                            HeaderIcon="{ui:FontIcon Glyph=&#xF1AD;}"
+                            IsEnabled="{x:Bind ViewModel.IsIncludePrereleaseUpdatesCardEnabled, Mode=OneWay}">
+                            <tkcontrols:SettingsExpander.Description>
+                                <StackPanel Orientation="Vertical">
+                                    <ptcontrols:IsEnabledTextBlock x:Uid="GeneralPage_UpdateChannelDescription" Style="{StaticResource SecondaryTextStyle}" />
+                                    <HyperlinkButton
+                                        x:Uid="GeneralPage_UpdateChannelLearnMore"
+                                        Margin="0,2,0,0"
+                                        FontWeight="SemiBold"
+                                        NavigateUri="https://aka.ms/powertoys-insiders" />
+                                </StackPanel>
+                            </tkcontrols:SettingsExpander.Description>
+                            <tkcontrols:SwitchPresenter TargetType="x:Boolean" Value="{x:Bind ViewModel.IncludePrereleaseUpdates, Mode=OneWay}">
+                                <tkcontrols:Case Value="True">
+                                    <ptcontrols:IsEnabledTextBlock x:Uid="GeneralPage_UpdateChannelInsiderStatus" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                                </tkcontrols:Case>
+                                <tkcontrols:Case Value="False">
+                                    <ptcontrols:IsEnabledTextBlock x:Uid="GeneralPage_UpdateChannelStableStatus" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                                </tkcontrols:Case>
+                            </tkcontrols:SwitchPresenter>
+                            <tkcontrols:SettingsExpander.Items>
+                                <tkcontrols:SettingsCard ContentAlignment="Left">
+                                    <StackPanel Orientation="Vertical" Spacing="12">
+                                        <RadioButton
+                                            AutomationProperties.AutomationId="StableUpdateChannelRadioButton"
+                                            GroupName="PowerToysUpdateChannel"
+                                            IsChecked="{x:Bind ViewModel.IncludePrereleaseUpdates, Mode=TwoWay, Converter={StaticResource BoolNegationConverter}}">
+                                            <StackPanel Orientation="Vertical" Spacing="4">
+                                                <TextBlock x:Uid="GeneralPage_UpdateChannelStableTitle" Style="{StaticResource BodyStrongTextBlockStyle}" />
+                                                <TextBlock
+                                                    x:Uid="GeneralPage_UpdateChannelStableDescription"
+                                                    Style="{StaticResource SecondaryTextStyle}"
+                                                    TextWrapping="Wrap" />
+                                            </StackPanel>
+                                        </RadioButton>
+                                        <RadioButton
+                                            AutomationProperties.AutomationId="InsiderUpdateChannelRadioButton"
+                                            GroupName="PowerToysUpdateChannel"
+                                            IsChecked="{x:Bind ViewModel.IncludePrereleaseUpdates, Mode=TwoWay}">
+                                            <StackPanel Orientation="Vertical" Spacing="4">
+                                                <TextBlock x:Uid="GeneralPage_UpdateChannelInsiderTitle" Style="{StaticResource BodyStrongTextBlockStyle}" />
+                                                <TextBlock
+                                                    x:Uid="GeneralPage_UpdateChannelInsiderDescription"
+                                                    Style="{StaticResource SecondaryTextStyle}"
+                                                    TextWrapping="Wrap" />
+                                            </StackPanel>
+                                        </RadioButton>
+                                    </StackPanel>
+                                </tkcontrols:SettingsCard>
+                            </tkcontrols:SettingsExpander.Items>
+                        </tkcontrols:SettingsExpander>
+                    </controls:GPOInfoControl>
 
                     <StackPanel Orientation="Vertical">
                         <InfoBar

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -1425,11 +1425,32 @@ opera.exe</value>
   <data name="GeneralPage_AutoDownloadAndInstallUpdates.Description" xml:space="preserve">
     <value>Except on metered connections</value>
   </data>
-  <data name="GeneralPage_IncludePrereleaseUpdates.Header" xml:space="preserve">
-    <value>Include prerelease updates</value>
+  <data name="GeneralPage_UpdateChannel.Header" xml:space="preserve">
+    <value>Update channel</value>
   </data>
-  <data name="GeneralPage_IncludePrereleaseUpdates.Description" xml:space="preserve">
-    <value>Allow update checks to include preview builds. You may stay ahead of stable until a later stable release is available.</value>
+  <data name="GeneralPage_UpdateChannelDescription.Text" xml:space="preserve">
+    <value>Choose which PowerToys releases you receive.</value>
+  </data>
+  <data name="GeneralPage_UpdateChannelLearnMore.Content" xml:space="preserve">
+    <value>Learn more</value>
+  </data>
+  <data name="GeneralPage_UpdateChannelStableStatus.Text" xml:space="preserve">
+    <value>Stable</value>
+  </data>
+  <data name="GeneralPage_UpdateChannelInsiderStatus.Text" xml:space="preserve">
+    <value>Insider</value>
+  </data>
+  <data name="GeneralPage_UpdateChannelStableTitle.Text" xml:space="preserve">
+    <value>Stable (Recommended)</value>
+  </data>
+  <data name="GeneralPage_UpdateChannelStableDescription.Text" xml:space="preserve">
+    <value>Receive tested, generally available releases.</value>
+  </data>
+  <data name="GeneralPage_UpdateChannelInsiderTitle.Text" xml:space="preserve">
+    <value>Insider</value>
+  </data>
+  <data name="GeneralPage_UpdateChannelInsiderDescription.Text" xml:space="preserve">
+    <value>Get nightly builds with the latest features and fixes. These builds may be unstable.</value>
   </data>
   <data name="GeneralSettings_AlwaysRunAsAdminText.Header" xml:space="preserve">
     <value>Always run as administrator</value>

--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -1429,7 +1429,7 @@ opera.exe</value>
     <value>Update channel</value>
   </data>
   <data name="GeneralPage_UpdateChannelDescription.Text" xml:space="preserve">
-    <value>Choose which PowerToys releases you receive.</value>
+    <value>Choose which PowerToys releases you receive</value>
   </data>
   <data name="GeneralPage_UpdateChannelLearnMore.Content" xml:space="preserve">
     <value>Learn more</value>

--- a/src/settings-ui/Settings.UI/ViewModels/GeneralViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/GeneralViewModel.cs
@@ -598,7 +598,6 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             {
                 return _newUpdatesToastIsGpoDisabled ||
                     (_isAdmin && _autoDownloadUpdatesIsGpoDisabled) ||
-                    _includePrereleaseUpdatesIsGpoDisabled ||
                     _showWhatsNewAfterUpdatesIsGpoDisabled;
             }
         }
@@ -668,6 +667,11 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         public bool IsIncludePrereleaseUpdatesCardEnabled
         {
             get => !_isDevBuild && !_includePrereleaseUpdatesIsGpoDisabled;
+        }
+
+        public bool IsIncludePrereleaseUpdatesGpoManaged
+        {
+            get => _includePrereleaseUpdatesIsGpoDisabled;
         }
 
         public bool ShowWhatsNewAfterUpdates


### PR DESCRIPTION
Supersedes #49719, which could not be reopened after its original base branch was deleted when #49414 merged.

## Summary of the Pull Request

Improves the update settings introduced by #49414 by replacing the prerelease checkbox with a dedicated **Update channel** expander. Users can choose between Stable and Insider channels, see the current selection while the expander is collapsed, and access the PowerToys Insider documentation.

The new expander preserves the existing `IncludePrereleaseUpdates` setting and displays its own managed-by-organization state when the preview update policy is configured.

<img width="1576" height="526" alt="Update channel expander" src="https://github.com/user-attachments/assets/35863d4b-5ca1-4662-9d84-f184c98dbbc6" />

## PR Checklist

- [x] **Communication:** This builds on the update channel work merged in #49414
- [ ] **Tests:** No automated tests added; this is a Settings UI presentation change over the existing setting
- [x] **Localization:** All end-user-facing strings can be localized
- [ ] **Documentation updated:** Documentation changes are maintained separately

## Detailed Description of the Pull Request / Additional comments

- Moves `IncludePrereleaseUpdates` out of the general update settings list into a dedicated SettingsExpander in `src/settings-ui/Settings.UI/SettingsXAML/Views/GeneralPage.xaml`.
- Adds Stable and Insider radio-button choices, descriptions, collapsed status text, and an Insider learn-more link.
- Adds localized strings in `src/settings-ui/Settings.UI/Strings/en-us/Resources.resw`.
- Separates the preview update policy warning from the other update settings warnings in `src/settings-ui/Settings.UI/ViewModels/GeneralViewModel.cs`.

## Validation Steps Performed

- Built `src/settings-ui/Settings.UI/PowerToys.Settings.csproj` for Debug ARM64 with the repository build script.
- Applied the repository XAML Styler configuration to `GeneralPage.xaml`.
