### PR TITLE
[Peek] Add CLI support for previewing multiple files/folders. Fix multiple CLI issues

### DIFF
--- a/src/modules/peek/Peek.Common.UnitTests/LaunchArgumentsClassifierTests.cs
+++ b/src/modules/peek/Peek.Common.UnitTests/LaunchArgumentsClassifierTests.cs
@@ -1,0 +1,124 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Peek.Common.Helpers;
+
+using ClassificationMode = Peek.Common.Helpers.LaunchArgumentsClassifier.ClassificationMode;
+
+namespace Peek.Common.UnitTests
+{
+    [TestClass]
+    public class LaunchArgumentsClassifierTests
+    {
+        [TestMethod]
+        public void Classify_NullArguments_ReturnsNone()
+        {
+            var result = LaunchArgumentsClassifier.Classify(null);
+
+            Assert.AreEqual(ClassificationMode.None, result.Mode);
+        }
+
+        [TestMethod]
+        public void Classify_EmptyArguments_ReturnsNone()
+        {
+            var result = LaunchArgumentsClassifier.Classify([]);
+
+            Assert.AreEqual(ClassificationMode.None, result.Mode);
+        }
+
+        [TestMethod]
+        public void Classify_ValidRunnerArguments_ReturnsRunnerWithPid()
+        {
+            var result = LaunchArgumentsClassifier.Classify(["--runner-pid", "1234"]);
+
+            Assert.AreEqual(ClassificationMode.Runner, result.Mode);
+            Assert.AreEqual(1234, result.RunnerPid);
+        }
+
+        [TestMethod]
+        public void Classify_ValidRunnerArgumentsCaseInsensitive_ReturnsRunnerWithPid()
+        {
+            var result = LaunchArgumentsClassifier.Classify(["--RUNNER-PID", "5678"]);
+
+            Assert.AreEqual(ClassificationMode.Runner, result.Mode);
+            Assert.AreEqual(5678, result.RunnerPid);
+        }
+
+        [TestMethod]
+        public void Classify_RunnerArgumentsMissingPid_ReturnsInvalidRunnerArguments()
+        {
+            var result = LaunchArgumentsClassifier.Classify(["--runner-pid"]);
+
+            Assert.AreEqual(ClassificationMode.InvalidRunnerArguments, result.Mode);
+        }
+
+        [TestMethod]
+        public void Classify_RunnerArgumentsWithNonIntegerPid_ReturnsInvalidRunnerArguments()
+        {
+            var result = LaunchArgumentsClassifier.Classify(["--runner-pid", "abc"]);
+
+            Assert.AreEqual(ClassificationMode.InvalidRunnerArguments, result.Mode);
+        }
+
+        [TestMethod]
+        public void Classify_RunnerArgumentsWithExtraValues_ReturnsInvalidRunnerArguments()
+        {
+            var result = LaunchArgumentsClassifier.Classify(["--runner-pid", "123", "extra"]);
+
+            Assert.AreEqual(ClassificationMode.InvalidRunnerArguments, result.Mode);
+        }
+
+        [TestMethod]
+        public void Classify_CliSingleArgument_ReturnsCli()
+        {
+            var result = LaunchArgumentsClassifier.Classify(["C:\\temp\\file.png"]);
+
+            Assert.AreEqual(ClassificationMode.Cli, result.Mode);
+            Assert.AreEqual(1, result.CliArguments.Count);
+            Assert.AreEqual("C:\\temp\\file.png", result.CliArguments[0]);
+        }
+
+        [TestMethod]
+        public void Classify_CliMultipleArguments_ReturnsCliWithAllArguments()
+        {
+            var result = LaunchArgumentsClassifier.Classify(["one.png", "two.png", "three.png"]);
+
+            Assert.AreEqual(ClassificationMode.Cli, result.Mode);
+            Assert.AreEqual(3, result.CliArguments.Count);
+            Assert.AreEqual("one.png", result.CliArguments[0]);
+            Assert.AreEqual("two.png", result.CliArguments[1]);
+            Assert.AreEqual("three.png", result.CliArguments[2]);
+        }
+
+        [TestMethod]
+        public void Classify_NumericCliArgumentWithoutRunnerFlag_RemainsCli()
+        {
+            var result = LaunchArgumentsClassifier.Classify(["1234"]);
+
+            Assert.AreEqual(ClassificationMode.Cli, result.Mode);
+            Assert.AreEqual(1, result.CliArguments.Count);
+            Assert.AreEqual("1234", result.CliArguments[0]);
+        }
+
+        [TestMethod]
+        public void Classify_FileNameThenNumericArgument_RemainsCliWithBothArguments()
+        {
+            var result = LaunchArgumentsClassifier.Classify(["image.png", "1234"]);
+
+            Assert.AreEqual(ClassificationMode.Cli, result.Mode);
+            Assert.AreEqual(2, result.CliArguments.Count);
+            Assert.AreEqual("image.png", result.CliArguments[0]);
+            Assert.AreEqual("1234", result.CliArguments[1]);
+        }
+
+        [TestMethod]
+        public void Classify_RunnerPidFollowedByPath_ReturnsInvalidRunnerArguments()
+        {
+            var result = LaunchArgumentsClassifier.Classify(["--runner-pid", "1234", "image.png"]);
+
+            Assert.AreEqual(ClassificationMode.InvalidRunnerArguments, result.Mode);
+        }
+    }
+}

--- a/src/modules/peek/Peek.Common/Helpers/LaunchArgumentsClassifier.cs
+++ b/src/modules/peek/Peek.Common/Helpers/LaunchArgumentsClassifier.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Peek.Common.Helpers
+{
+    public static class LaunchArgumentsClassifier
+    {
+        public const string RunnerPidArgumentName = "--runner-pid";
+
+        private static readonly IReadOnlyList<string> EmptyCliArguments = [];
+
+        public enum ClassificationMode
+        {
+            None,
+            Runner,
+            Cli,
+            InvalidRunnerArguments,
+        }
+
+        public readonly record struct Classification(ClassificationMode Mode, int RunnerPid, IReadOnlyList<string> CliArguments)
+        {
+            public static Classification None { get; } =
+                new(ClassificationMode.None, 0, EmptyCliArguments);
+
+            public static Classification InvalidRunnerArguments { get; } =
+                new(ClassificationMode.InvalidRunnerArguments, 0, EmptyCliArguments);
+
+            public static Classification CreateRunner(int runnerPid) =>
+                new(ClassificationMode.Runner, runnerPid, EmptyCliArguments);
+
+            public static Classification CreateCli(IReadOnlyList<string> cliArguments) =>
+                new(ClassificationMode.Cli, 0, cliArguments);
+        }
+
+        public static Classification Classify(IReadOnlyList<string>? launchArgs)
+        {
+            if (launchArgs is null || launchArgs.Count == 0)
+            {
+                return Classification.None;
+            }
+
+            // Keep Runner and CLI activation unambiguous: only "--runner-pid <pid>" is treated
+            // as Runner input, and all other argument shapes are interpreted as CLI paths.
+            if (string.Equals(launchArgs[0], RunnerPidArgumentName, StringComparison.OrdinalIgnoreCase))
+            {
+                return launchArgs.Count == 2 && int.TryParse(launchArgs[1], out int runnerPid)
+                    ? Classification.CreateRunner(runnerPid)
+                    : Classification.InvalidRunnerArguments;
+            }
+
+            return Classification.CreateCli(launchArgs);
+        }
+    }
+}

--- a/src/modules/peek/Peek.UI/MainWindowViewModel.cs
+++ b/src/modules/peek/Peek.UI/MainWindowViewModel.cs
@@ -62,12 +62,6 @@ namespace Peek.UI
         [ObservableProperty]
         private IFileSystemItem? _currentItem;
 
-        /// <summary>
-        /// Work around missing navigation when peeking from CLI.
-        /// TODO: Implement navigation when peeking from CLI.
-        /// </summary>
-        private bool _isFromCli;
-
         partial void OnCurrentItemChanged(IFileSystemItem? value)
         {
             WindowTitle = value != null
@@ -80,7 +74,8 @@ namespace Peek.UI
 
         [ObservableProperty]
         [NotifyPropertyChangedFor(nameof(DisplayItemCount))]
-        private NeighboringItems? _items;
+        [NotifyPropertyChangedFor(nameof(HasMultipleItems))]
+        private IReadOnlyList<IFileSystemItem>? _items;
 
         /// <summary>
         /// The number of items selected and available to preview. Decreases as the user deletes
@@ -100,6 +95,13 @@ namespace Peek.UI
                 }
             }
         }
+
+        /// <summary>
+        /// Gets a value indicating whether more than one item is available for
+        /// navigation, from either Explorer or CLI.
+        /// Controls the visibility of the index/total counter in the title bar.
+        /// </summary>
+        public bool HasMultipleItems => (Items?.Count ?? 0) > 1;
 
         [ObservableProperty]
         private double _scalingFactor = 1.0;
@@ -139,6 +141,10 @@ namespace Peek.UI
         {
             switch (selectedItem)
             {
+                case SelectedItemsByPaths selectedItemsByPaths:
+                    InitializeFromCliPaths(selectedItemsByPaths.Paths);
+                    break;
+
                 case SelectedItemByPath selectedItemByPath:
                     InitializeFromCli(selectedItemByPath.Path);
                     break;
@@ -164,18 +170,30 @@ namespace Peek.UI
             }
 
             _currentIndex = DisplayIndex = 0;
-            _isFromCli = false;
 
             CurrentItem = (Items != null && Items.Count > 0) ? Items[0] : null;
         }
 
         private void InitializeFromCli(string path)
         {
-            // TODO: implement navigation
-            _isFromCli = true;
-            Items = null;
+            InitializeFromCliPaths([path]);
+        }
+
+        private void InitializeFromCliPaths(IReadOnlyList<string> paths)
+        {
             _currentIndex = DisplayIndex = 0;
-            CurrentItem = new FileItem(path, Path.GetFileName(path));
+
+            var items = new List<IFileSystemItem>(paths.Count);
+            foreach (var path in paths)
+            {
+                string name = Path.GetFileName(path);
+                items.Add(Directory.Exists(path)
+                    ? new FolderItem(path, name, path)
+                    : new FileItem(path, name));
+            }
+
+            Items = items;
+            CurrentItem = items.Count > 0 ? items[0] : null;
         }
 
         public void Uninitialize()
@@ -186,7 +204,6 @@ namespace Peek.UI
             Items = null;
             _navigationDirection = NavigationDirection.Forwards;
             IsErrorVisible = false;
-            _isFromCli = false;
         }
 
         public void AttemptPreviousNavigation() => Navigate(NavigationDirection.Backwards);
@@ -196,12 +213,6 @@ namespace Peek.UI
         private void Navigate(NavigationDirection direction, bool isAfterDelete = false)
         {
             if (NavigationThrottleTimer.IsEnabled)
-            {
-                return;
-            }
-
-            // TODO: implement navigation.
-            if (_isFromCli)
             {
                 return;
             }

--- a/src/modules/peek/Peek.UI/Models/SelectedItemsByPaths.cs
+++ b/src/modules/peek/Peek.UI/Models/SelectedItemsByPaths.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace Peek.UI.Models
+{
+    /// <summary>
+    /// A CLI activation where the user supplied two or more file/folder paths. All paths are
+    /// shown and navigation between them is enabled.
+    /// </summary>
+    public class SelectedItemsByPaths : SelectedItem
+    {
+        public IReadOnlyList<string> Paths { get; }
+
+        public SelectedItemsByPaths(IReadOnlyList<string> paths)
+        {
+            Paths = paths;
+        }
+
+        public override bool Matches(string? path)
+        {
+            foreach (string p in Paths)
+            {
+                if (string.Equals(p, path, System.StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/modules/peek/Peek.UI/NativeMethods.txt
+++ b/src/modules/peek/Peek.UI/NativeMethods.txt
@@ -21,6 +21,3 @@ SetWindowPos
 GetWindowPlacement
 SetWindowPlacement
 GetGUIThreadInfo
-AttachConsole
-CreateFile
-SetStdHandle

--- a/src/modules/peek/Peek.UI/NativeMethods.txt
+++ b/src/modules/peek/Peek.UI/NativeMethods.txt
@@ -21,3 +21,6 @@ SetWindowPos
 GetWindowPlacement
 SetWindowPlacement
 GetGUIThreadInfo
+AttachConsole
+CreateFile
+SetStdHandle

--- a/src/modules/peek/Peek.UI/PeekXAML/App.xaml.cs
+++ b/src/modules/peek/Peek.UI/PeekXAML/App.xaml.cs
@@ -3,15 +3,16 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
-using System.Threading;
 using ManagedCommon;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.PowerToys.Telemetry;
 using Microsoft.UI.Xaml;
-using Microsoft.UI.Xaml.Controls.Primitives;
 using Peek.Common;
+using Peek.Common.Helpers;
 using Peek.FilePreviewer;
 using Peek.FilePreviewer.Models;
 using Peek.FilePreviewer.Previewers;
@@ -20,6 +21,8 @@ using Peek.UI.Native;
 using Peek.UI.Telemetry.Events;
 using Peek.UI.Views;
 using PowerToys.Interop;
+
+using ClassificationMode = Peek.Common.Helpers.LaunchArgumentsClassifier.ClassificationMode;
 
 namespace Peek.UI
 {
@@ -38,6 +41,9 @@ namespace Peek.UI
         }
 
         private MainWindow? Window { get; set; }
+
+        private const string RunnerProcessName = "PowerToys";
+        private const int CliInvalidArgumentsExitCode = 2;
 
         private bool _disposed;
         private SelectedItem? _selectedItem;
@@ -106,30 +112,27 @@ namespace Peek.UI
             var cmdArgs = Environment.GetCommandLineArgs();
             if (cmdArgs?.Length > 1)
             {
-                // Check if the last argument is a PowerToys Runner PID
-                if (int.TryParse(cmdArgs[^1], out int powerToysRunnerPid))
+                string[] launchArgs = cmdArgs[1..];
+                var classification = LaunchArgumentsClassifier.Classify(launchArgs);
+
+                switch (classification.Mode)
                 {
-                    RunnerHelper.WaitForPowerToysRunner(powerToysRunnerPid, () =>
-                    {
-                        EtwTrace?.Dispose();
-                        Environment.Exit(0);
-                    });
-                }
-                else
-                {
-                    // Command line argument is a file path - activate Peek with that file
-                    string filePath = cmdArgs[^1];
-                    if (File.Exists(filePath) || Directory.Exists(filePath))
-                    {
-                        _selectedItem = new SelectedItemByPath(filePath);
-                        _launchedFromCli = true;
-                        OnShowPeek();
+                    case ClassificationMode.Runner:
+                        TryHandleRunnerLaunch(classification.RunnerPid);
+                        break;
+
+                    case ClassificationMode.Cli:
+                        TryHandleCliLaunch(classification.CliArguments!);
                         return;
-                    }
-                    else
-                    {
-                        Logger.LogError($"Command line argument is not a valid file or directory: {filePath}");
-                    }
+
+                    case ClassificationMode.InvalidRunnerArguments:
+                        Logger.LogError("Peek: invalid runner arguments. Expected '--runner-pid <pid>'.");
+                        Environment.Exit(CliInvalidArgumentsExitCode);
+                        return;
+
+                    case ClassificationMode.None:
+                    default:
+                        break;
                 }
             }
 
@@ -140,6 +143,88 @@ namespace Peek.UI
                 EtwTrace?.Dispose();
                 Environment.Exit(0);
             });
+        }
+
+        private void TryHandleRunnerLaunch(int powerToysRunnerPid)
+        {
+            if (!IsRunnerProcessAlive(powerToysRunnerPid))
+            {
+                Logger.LogError($"Runner launch provided a PID that is not active or is not PowerToys.exe: {powerToysRunnerPid}");
+                Environment.Exit(CliInvalidArgumentsExitCode);
+                return;
+            }
+
+            RunnerHelper.WaitForPowerToysRunner(powerToysRunnerPid, () =>
+            {
+                EtwTrace?.Dispose();
+                Environment.Exit(0);
+            });
+        }
+
+        private void TryHandleCliLaunch(IReadOnlyList<string> launchArgs)
+        {
+            var validPaths = new List<string>(launchArgs.Count);
+            var invalidPaths = new List<string>();
+
+            foreach (string arg in launchArgs)
+            {
+                if (TryResolveExistingPath(arg, out string? resolvedPath))
+                {
+                    validPaths.Add(resolvedPath!);
+                }
+                else
+                {
+                    invalidPaths.Add(arg);
+                    Logger.LogError($"Command line argument is not a valid file or directory: {arg}");
+                }
+            }
+
+            if (validPaths.Count == 0)
+            {
+                Logger.LogError("No valid file or directory paths were provided");
+                Environment.Exit(CliInvalidArgumentsExitCode);
+                return;
+            }
+
+            _selectedItem = validPaths.Count == 1
+                ? new SelectedItemByPath(validPaths[0])
+                : new SelectedItemsByPaths(validPaths);
+            _launchedFromCli = true;
+            OnShowPeek();
+        }
+
+        private static bool TryResolveExistingPath(string path, out string? resolvedPath)
+        {
+            resolvedPath = null;
+
+            try
+            {
+                string fullPath = Path.GetFullPath(path);
+                if (File.Exists(fullPath) || Directory.Exists(fullPath))
+                {
+                    resolvedPath = fullPath;
+                    return true;
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError($"Could not resolve command line path argument '{path}'.", ex);
+            }
+
+            return false;
+        }
+
+        private static bool IsRunnerProcessAlive(int pid)
+        {
+            try
+            {
+                using Process process = Process.GetProcessById(pid);
+                return !process.HasExited && string.Equals(process.ProcessName, RunnerProcessName, StringComparison.OrdinalIgnoreCase);
+            }
+            catch
+            {
+                return false;
+            }
         }
 
         private void App_UnhandledException(object sender, Microsoft.UI.Xaml.UnhandledExceptionEventArgs e)

--- a/src/modules/peek/Peek.UI/PeekXAML/MainWindow.xaml
+++ b/src/modules/peek/Peek.UI/PeekXAML/MainWindow.xaml
@@ -41,7 +41,7 @@
             x:Name="TitleBarControl"
             Grid.Row="0"
             FileIndex="{x:Bind ViewModel.DisplayIndex, Mode=OneWay}"
-            IsMultiSelection="{x:Bind ViewModel.NeighboringItemsQuery.IsMultipleFilesActivation, Mode=OneWay}"
+            IsMultiSelection="{x:Bind ViewModel.HasMultipleItems, Mode=OneWay}"
             Item="{x:Bind ViewModel.CurrentItem, Mode=OneWay}"
             NumberOfFiles="{x:Bind ViewModel.DisplayItemCount, Mode=OneWay}" />
 

--- a/src/modules/peek/peek/dllmain.cpp
+++ b/src/modules/peek/peek/dllmain.cpp
@@ -438,7 +438,7 @@ private:
 
         unsigned long powertoys_pid = GetCurrentProcessId();
 
-        std::wstring executable_args = L"";
+        std::wstring executable_args = L"--runner-pid ";
         executable_args.append(std::to_wstring(powertoys_pid));
 
         if (m_alwaysRunNotElevated && is_process_elevated(false))


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
Previously, only one file could be previewed via the CLI. This adds support for multiple files, adds the ability to preview folders, and fixes a number of related issues with the CLI parameter parsing and validation code.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #49667
- [x] Closes: #49666
- [x] Closes: #49665
- [x] Closes: #49664
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

### 1. Relative paths were not expanded into full paths
Submitting relative paths via the CLI passed file validation (the file was recognised as existing), but when passed to Shell APIs for opening, a full path is required, resulting in Peek showing an error message. This is fixed in the new `InitializeFromCliPaths()` method which validates the path arguments and expands out the valid ones into full paths.

### 2. Only a single file was supported
The previous CLI code

```csharp
_selectedItem = new SelectedItemByPath(filePath);
```

meant that only 1 file was ever supported. Multiple files and/or folders were not. 

To support multiple files via the command line this PR:
1. Introduces a `SelectedItemsByPaths` class (notice the plurals), which inherits from `SelectedItem` and returns `true` from `Matches()` if the passed in path matches any of the paths passed in via the command line.
2. Updates the `Items` field in the `MainWindowViewModel` from `NeighboringItems` to a more generic `IReadOnlyList<IFileSystemItem>`. `NeighboringItems` is closely tied to the Explorer Shell API query path and should not have been exposed directly to the model and front-end.
3. Adds a `HasMultipleItems` property, replacing the `NeighboringItemsQuery.IsMultipleFilesActivation`, which controls whether the title bar shows the number of items and the current item number. This is similar to 2., where `NeighboringItems` and related types should not be part of the front-end. 

Screenshot showing current item number and total items in title bar:

<img width="671" height="731" alt="image" src="https://github.com/user-attachments/assets/d4d724fc-728e-40d4-92cc-3a70f40f10f9" />

Folders are supported by this code in the new `InitializeFromCliPaths()`, which creates `FileItem` or `FolderItem` instances:

```csharp
        foreach (var path in paths)
        {
            string name = Path.GetFileName(path);
            items.Add(Directory.Exists(path)
                ? new FolderItem(path, name, path)
                : new FileItem(path, name));
        }
```

Folder view from running `PowerToys.Peek.UI.exe .` (i.e. current folder):

<img width="756" height="575" alt="image" src="https://github.com/user-attachments/assets/d834c12d-1e3e-423f-ad5b-0d2f93e55510" />

### 3. Startup and validation fixes and increased robustness

1. **Added `--runner-pid` as a required parameter when supplying the Runner's process ID**
This fixes the issue where the last argument would always be interpreted as the Runner's process ID if it was numeric. With the addition of folder previews via the CLI, this was necessary, otherwise folders with numeric names could not be previewed if they were listed as the last argument.

2. **Validated Runner PID**
The numeric PID argument was always assumed to be correct previously. Providing an incorrect value manually would result in Peek opening, but it would not be linked to the Runner and could only be closed via a Task Manager kill. This PR validates that the PID is a running process and the linked exe is called "PowerToys.exe".

3. **Refactored startup code**
A new `LaunchArgumentsClassifier` class determines whether Peek is being opened via the Runner or the CLI, with new `TryHandleRunnerLaunch()` and `TryHandleCliLaunch()` methods validating and preparing the items for navigation.

### 4. Other changes
The more generic navigation of `IFileSystemItem`s means that the CLI does not have to be treated as a special case in the MainWindowViewModel, so `_isFromCli` has been removed.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
1. New unit tests for the `LaunchArgumentsClassifier` code
2. All new and existing unit tests pass:

<img width="391" height="137" alt="image" src="https://github.com/user-attachments/assets/3b6a3148-9043-42b5-a2d8-69feaa6aed32" />

3. Manual tests:
- Open Peek via Explorer selection of 1 file, 1 folder, and multiple files and folder(s) mix
- Open Peek via CLI with 1 file, 1 folder, and multiple files and folder(s) mix
- Test navigation for all above combinations
- Confirm Peek process closes on CLI validation error
- Confirm Peek process closes when opened via the CLI when user exits the application normally
- Confirm file delete still works, independent of how Peek was opened