### PR TITLE
fix(mousewithoutborders): harden impersonation cleanup

### DIFF
--- a/src/modules/MouseWithoutBorders/App/Core/ImpersonationHelper.cs
+++ b/src/modules/MouseWithoutBorders/App/Core/ImpersonationHelper.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace MouseWithoutBorders.Core;
+
+internal sealed class FatalImpersonationException : Exception
+{
+    internal FatalImpersonationException(string message)
+        : base(message)
+    {
+    }
+}
+
+internal static class ImpersonationHelper
+{
+    internal const int RevertToSelfAttempts = 3;
+    internal const int RevertToSelfRetryDelayMilliseconds = 10;
+
+    internal static bool TryRevertToSelf(Func<bool> revertToSelf, Action<int> delay)
+    {
+        ArgumentNullException.ThrowIfNull(revertToSelf);
+        ArgumentNullException.ThrowIfNull(delay);
+
+        for (int attempt = 0; attempt < RevertToSelfAttempts; attempt++)
+        {
+            if (revertToSelf())
+            {
+                return true;
+            }
+
+            if (attempt + 1 < RevertToSelfAttempts)
+            {
+                delay(RevertToSelfRetryDelayMilliseconds);
+            }
+        }
+
+        return false;
+    }
+
+    internal static void RevertToSelfOrFailFast(
+        Func<bool> revertToSelf,
+        Action<int> delay,
+        Action<string> failFast,
+        Func<string> failureMessageFactory)
+    {
+        ArgumentNullException.ThrowIfNull(failFast);
+        ArgumentNullException.ThrowIfNull(failureMessageFactory);
+
+        if (TryRevertToSelf(revertToSelf, delay))
+        {
+            return;
+        }
+
+        string failureMessage = failureMessageFactory();
+        failFast(failureMessage);
+
+        // Environment.FailFast never returns. This throw protects test hooks and
+        // any future failure handler from allowing the impersonated thread to continue.
+        throw new FatalImpersonationException(failureMessage);
+    }
+}

--- a/src/modules/MouseWithoutBorders/App/Core/Launch.cs
+++ b/src/modules/MouseWithoutBorders/App/Core/Launch.cs
@@ -28,6 +28,27 @@ internal static class Launch
         return WindowsIdentity.GetCurrent().Owner.IsWellKnown(WellKnownSidType.BuiltinAdministratorsSid);
     }
 
+    private static void RevertToSelfOrFailFast()
+    {
+        int lastError = 0;
+        ImpersonationHelper.RevertToSelfOrFailFast(
+            () =>
+            {
+                bool result = NativeMethods.RevertToSelf();
+                if (!result)
+                {
+                    lastError = Marshal.GetLastWin32Error();
+                }
+
+                return result;
+            },
+            milliseconds => System.Threading.Thread.Sleep(milliseconds),
+            message => Environment.FailFast(message),
+            () => string.Concat(
+                $"{nameof(NativeMethods.RevertToSelf)} did not succeed after " +
+                $"{ImpersonationHelper.RevertToSelfAttempts} attempts. Last error: {lastError}."));
+    }
+
     internal static bool ImpersonateLoggedOnUserAndDoSomething(Action targetFunc)
     {
         if (Common.RunWithNoAdminRight)
@@ -47,6 +68,8 @@ internal static class Launch
             IntPtr hUserToken = IntPtr.Zero, hUserTokenDup = IntPtr.Zero;
             try
             {
+                RevertToSelfOrFailFast();
+
                 dwSessionId = (uint)Process.GetCurrentProcess().SessionId;
                 uint rv = NativeMethods.WTSQueryUserToken(dwSessionId, ref hUserToken);
                 var lastError = rv == 0 ? Marshal.GetLastWin32Error() : 0;
@@ -62,31 +85,47 @@ internal static class Launch
                 if (!NativeMethods.DuplicateToken(hUserToken, (int)NativeMethods.SECURITY_IMPERSONATION_LEVEL.SecurityImpersonation, ref hUserTokenDup))
                 {
                     Logger.TelemetryLogTrace($"{nameof(NativeMethods.DuplicateToken)} Failed! {Logger.GetStackTrace(new StackTrace())}", SeverityLevel.Warning);
-                    _ = NativeMethods.CloseHandle(hUserToken);
-                    _ = NativeMethods.CloseHandle(hUserTokenDup);
                     return false;
                 }
 
                 if (NativeMethods.ImpersonateLoggedOnUser(hUserTokenDup))
                 {
-                    targetFunc();
-                    _ = NativeMethods.RevertToSelf();
-                    _ = NativeMethods.CloseHandle(hUserToken);
-                    _ = NativeMethods.CloseHandle(hUserTokenDup);
-                    return true;
+                    try
+                    {
+                        targetFunc();
+                        return true;
+                    }
+                    finally
+                    {
+                        RevertToSelfOrFailFast();
+                    }
                 }
                 else
                 {
                     Logger.Log("ImpersonateLoggedOnUser Failed!");
-                    _ = NativeMethods.CloseHandle(hUserToken);
-                    _ = NativeMethods.CloseHandle(hUserTokenDup);
                     return false;
                 }
+            }
+            catch (FatalImpersonationException)
+            {
+                throw;
             }
             catch (Exception e)
             {
                 Logger.Log(e);
                 return false;
+            }
+            finally
+            {
+                if (hUserToken != IntPtr.Zero)
+                {
+                    _ = NativeMethods.CloseHandle(hUserToken);
+                }
+
+                if (hUserTokenDup != IntPtr.Zero)
+                {
+                    _ = NativeMethods.CloseHandle(hUserTokenDup);
+                }
             }
         }
     }

--- a/src/modules/MouseWithoutBorders/MouseWithoutBorders.UnitTests/Core/ImpersonationHelperTests.cs
+++ b/src/modules/MouseWithoutBorders/MouseWithoutBorders.UnitTests/Core/ImpersonationHelperTests.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MouseWithoutBorders.Core;
+
+namespace MouseWithoutBorders.UnitTests.Core;
+
+[TestClass]
+public sealed class ImpersonationHelperTests
+{
+    [TestMethod]
+    public void TryRevertToSelf_RetriesUntilItSucceeds()
+    {
+        int calls = 0;
+        List<int> delays = [];
+
+        bool result = ImpersonationHelper.TryRevertToSelf(
+            () => ++calls == 2,
+            milliseconds => delays.Add(milliseconds));
+
+        Assert.IsTrue(result);
+        Assert.AreEqual(2, calls);
+        CollectionAssert.AreEqual(
+            new[] { ImpersonationHelper.RevertToSelfRetryDelayMilliseconds },
+            delays);
+    }
+
+    [TestMethod]
+    public void TryRevertToSelf_FailsAfterBoundedRetries()
+    {
+        int calls = 0;
+        int delays = 0;
+
+        bool result = ImpersonationHelper.TryRevertToSelf(
+            () =>
+            {
+                calls++;
+                return false;
+            },
+            _ => delays++);
+
+        Assert.IsFalse(result);
+        Assert.AreEqual(ImpersonationHelper.RevertToSelfAttempts, calls);
+        Assert.AreEqual(ImpersonationHelper.RevertToSelfAttempts - 1, delays);
+    }
+
+    [TestMethod]
+    public void RevertToSelfOrFailFast_PreventsContinuationAfterFinalFailure()
+    {
+        bool failFastCalled = false;
+        bool continued = false;
+
+        _ = Assert.ThrowsException<FatalImpersonationException>(() =>
+        {
+            ImpersonationHelper.RevertToSelfOrFailFast(
+                () => false,
+                _ => { },
+                _ => failFastCalled = true,
+                () => "Unable to restore the process identity.");
+            continued = true;
+        });
+
+        Assert.IsTrue(failFastCalled);
+        Assert.IsFalse(continued);
+    }
+}


### PR DESCRIPTION
## Summary of the Pull Request

Hardens Mouse Without Borders impersonation cleanup so execution cannot continue under the wrong identity when `RevertToSelf` fails.

- Centralizes bounded `RevertToSelf` retries in `ImpersonationHelper`.
- Runs impersonation cleanup from `finally` and terminates on unrecoverable identity restoration failure.
- Reliably closes duplicated token handles on every path.
- Adds focused unit coverage for retry, bounded failure, and no-continuation behavior.

## PR Checklist

- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** N/A; no end-user-facing strings
- [x] **Dev docs:** N/A; no developer-facing contract change
- [x] **New binaries:** N/A

## Detailed Description of the Pull Request / Additional comments

This extracts the impersonation cleanup lifecycle into a focused prerequisite change. `Launch.ImpersonateLoggedOnUserAndDoSomething` now restores the original identity from a `finally` block, retries transient failures, and fails fast if restoration remains impossible. This prevents later work from continuing with an unintended thread token.

Touched paths:
- `src/modules/MouseWithoutBorders/App/Core/Launch.cs`
- `src/modules/MouseWithoutBorders/App/Core/ImpersonationHelper.cs`
- `src/modules/MouseWithoutBorders/MouseWithoutBorders.UnitTests/Core/ImpersonationHelperTests.cs`

## Validation Steps Performed

- Built Mouse Without Borders App in Release x64.
- Built Mouse Without Borders UnitTests in Release x64.
- Ran focused impersonation tests with `vstest.console.exe`: 3/3 passed.
- Completed independent correctness and security reviews with no findings.