### PR TITLE
CmdPal: Clean up replaced command view models

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandItemViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/CommandItemViewModel.cs
@@ -67,7 +67,21 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel, ICommandBa
 
     public IconInfoViewModel Icon => _icon.IsSet ? _icon : Command.Icon;
 
-    public CommandViewModel Command { get; private set; }
+    /// <summary>
+    /// The command and whether we own it, held as a single immutable pair.
+    /// </summary>
+    private CommandOwnership _commandState;
+
+    /// <summary>
+    /// Gets the command backing this item.
+    /// </summary>
+    /// <remarks>
+    /// Read-only on purpose. Assigning it directly would silently drop the  previous view-model without unsubscribing it,
+    /// which strands it and its extension command across the process boundary for good.
+    /// Mutate it through <see cref="ReplaceCommand"/> when this item owns the command,
+    /// or <see cref="BorrowCommand"/> when it is holding one owned elsewhere.
+    /// </remarks>
+    public CommandViewModel Command => _commandState.Command;
 
     // Reuse a cached read-only snapshot so repeated reads don't allocate.
     public IReadOnlyList<IContextItemViewModel> MoreCommands => _moreCommandsSnapshot;
@@ -123,7 +137,7 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel, ICommandBa
     {
         _commandItemModel = item;
         _contextMenuFactory = contextMenuFactory;
-        Command = new(null, errorContext);
+        _commandState = new(new CommandViewModel(null, errorContext), Owned: true);
     }
 
     public void FastInitializeProperties()
@@ -140,7 +154,7 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel, ICommandBa
         }
 
         var command = model.Command;
-        Command = new(command, PageContext);
+        ReplaceCommand(command);
         Command.FastInitializeProperties();
 
         _itemTitle = model.Title;
@@ -249,7 +263,7 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel, ICommandBa
         catch (Exception ex)
         {
             CoreLogger.LogError("error fast initializing CommandItemViewModel", ex);
-            Command = new(null, PageContext);
+            ReplaceCommand(null);
             _itemTitle = "Error";
             Subtitle = "Item failed to load";
             ClearMoreCommands();
@@ -288,7 +302,7 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel, ICommandBa
         catch (Exception ex)
         {
             CoreLogger.LogError("error initializing CommandItemViewModel", ex);
-            Command = new(null, PageContext);
+            ReplaceCommand(null);
             _itemTitle = "Error";
             Subtitle = "Item failed to load";
             ClearMoreCommands();
@@ -324,9 +338,12 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel, ICommandBa
         switch (propertyName)
         {
             case nameof(Command):
-                Command.PropertyChanged -= Command_PropertyChanged;
                 var command = model.Command;
-                Command = new(command, PageContext);
+
+                // ReplaceCommand detaches this item's handler from the command it
+                // displaces, so there is no manual unsubscribe to remember here.
+                ReplaceCommand(command);
+
                 Command.InitializeProperties();
                 Command.PropertyChanged += Command_PropertyChanged;
 
@@ -336,7 +353,7 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel, ICommandBa
 
                 if (_defaultCommandContextItemViewModel is not null)
                 {
-                    _defaultCommandContextItemViewModel.Command = Command;
+                    _defaultCommandContextItemViewModel.BorrowCommand(Command);
                     _defaultCommandContextItemViewModel.UpdateTitle(_itemTitle);
                     UpdateDefaultContextItemIcon();
                 }
@@ -452,15 +469,21 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel, ICommandBa
             return;
         }
 
-        _defaultCommandContextItemViewModel = new CommandContextItemViewModel(new CommandContextItem(commandModel), PageContext)
+        var defaultContextItem = new CommandContextItemViewModel(new CommandContextItem(commandModel), PageContext)
         {
             _itemTitle = Name,
             Subtitle = Subtitle,
-            Command = Command,
 
             // TODO this probably should just be a CommandContextItemViewModel(CommandItemViewModel) ctor, or a copy ctor or whatever
             // Anything we set manually here must stay in sync with the corresponding properties on CommandItemViewModel.
         };
+
+        // The synthesized entry stands in for this item's own command, so it
+        // shares the view-model rather than building a second one for the same
+        // extension object.
+        defaultContextItem.BorrowCommand(Command);
+
+        _defaultCommandContextItemViewModel = defaultContextItem;
 
         UpdateDefaultContextItemIcon();
 
@@ -506,6 +529,54 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel, ICommandBa
 
     public FuzzyTarget GetSubtitleTarget(IPrecomputedFuzzyMatcher matcher)
         => _subtitleCache.GetOrUpdate(matcher, Subtitle);
+
+    /// <summary>
+    /// Replaces <see cref="Command"/> with a newly built view-model this item owns, cleaning up the one being dropped.
+    /// </summary>
+    /// <remarks>
+    /// Takes the extension command instead of a view-model - the view-model is built here so that we can guarantee ownership..
+    /// </remarks>
+    private void ReplaceCommand(ICommand? model)
+    {
+        var command = new CommandViewModel(model, PageContext);
+        var replaced = Interlocked.Exchange(ref _commandState, new CommandOwnership(command, Owned: true));
+
+        ReleaseReplaced(replaced, command);
+    }
+
+    /// <summary>
+    /// Points <see cref="Command"/> at a view-model owned by someone else.
+    /// </summary>
+    /// <remarks>
+    /// The borrowed instance is never cleaned up here - that is its owner's job.
+    /// </remarks>
+    private void BorrowCommand(CommandViewModel command)
+    {
+        var replaced = Interlocked.Exchange(ref _commandState, new CommandOwnership(command, Owned: false));
+
+        ReleaseReplaced(replaced, command);
+    }
+
+    /// <summary>
+    /// Cleans up a displaced command, if we owned it and it is not the one that just took its place.
+    /// </summary>
+    private void ReleaseReplaced(CommandOwnership replaced, CommandViewModel current)
+    {
+        if (ReferenceEquals(replaced.Command, current))
+        {
+            return;
+        }
+
+        // Detach regardless of ownership: this item attaches its own handler to
+        // whichever command it is showing, borrowed or not, so the handler has to
+        // come off whenever that command is swapped out.
+        replaced.Command.PropertyChanged -= Command_PropertyChanged;
+
+        if (replaced.Owned)
+        {
+            replaced.Command.SafeCleanup();
+        }
+    }
 
     /// <remarks>
     /// * Does call SlowInitializeProperties on the created items.
@@ -588,8 +659,18 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel, ICommandBa
         // _listItemIcon.SafeCleanup();
         _icon = new(null); // necessary?
 
-        Command.PropertyChanged -= Command_PropertyChanged;
-        Command.SafeCleanup();
+        // One read of the pair, so a replacement racing this teardown cannot
+        // leave us cleaning up a command against the wrong ownership flag.
+        var commandState = _commandState;
+        commandState.Command.PropertyChanged -= Command_PropertyChanged;
+
+        // Only tear down a command this item built. The synthesized default
+        // context item borrows its parent's, and cleaning that up from here
+        // would pull it out from under an item that is still using it.
+        if (commandState.Owned)
+        {
+            commandState.Command.SafeCleanup();
+        }
 
         var model = _commandItemModel.Unsafe;
         if (model is not null)
@@ -637,6 +718,16 @@ public partial class CommandItemViewModel : ExtensionObjectViewModel, ICommandBa
                   .ToList()
                   .ForEach(c => c.SafeCleanup());
     }
+
+    /// <summary>
+    /// A command together with whether this item is responsible for cleaning it up.
+    /// </summary>
+    /// <param name="Command">The command view-model.</param>
+    /// <param name="Owned">
+    /// <see langword="true"/> when this item constructed <paramref name="Command"/>,
+    /// <see langword="false"/> when it is borrowing one owned elsewhere.
+    /// </param>
+    private sealed record CommandOwnership(CommandViewModel Command, bool Owned);
 }
 
 [Flags]

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ParametersViewModels.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ParametersViewModels.cs
@@ -547,7 +547,17 @@ public partial class ParametersPageViewModel : PageViewModel, IDisposable
 
     public List<ParameterRunViewModel> Items { get; set; } = [];
 
-    public CommandItemViewModel Command { get; private set; }
+    /// <summary>
+    /// Gets the command shown once every parameter has a value.
+    /// </summary>
+    /// <remarks>
+    /// Mutate through <see cref="ReplaceCommand"/>. Assigning directly drops the
+    /// outgoing item without revoking its subscriptions, which strands it and its
+    /// extension command across the process boundary for good.
+    /// </remarks>
+    public CommandItemViewModel Command => _command;
+
+    private CommandItemViewModel _command;
 
     public bool ShowCommand =>
         IsInitialized &&
@@ -591,10 +601,22 @@ public partial class ParametersPageViewModel : PageViewModel, IDisposable
     {
         _model = new(model);
         _contextMenuFactory = contextMenuFactory;
-        Command = new(new(null), PageContext, _contextMenuFactory);
+        _command = new(new(null), PageContext, _contextMenuFactory);
     }
 
-    private void Model_ItemsChanged(object sender, IItemsChangedEventArgs args) => FetchItems();
+    /// <summary>
+    /// Replaces <see cref="Command"/> with a newly built view-model, cleaning up the one being dropped.
+    /// </summary>
+    private void ReplaceCommand(ICommandItem? model)
+    {
+        var command = new CommandItemViewModel(new(model), PageContext, _contextMenuFactory);
+        var replaced = Interlocked.Exchange(ref _command, command);
+
+        if (!ReferenceEquals(replaced, command))
+        {
+            replaced.SafeCleanup();
+        }
+    }
 
     //// Run on background thread, from InitializeAsync
     public override void InitializeProperties()
@@ -607,7 +629,7 @@ public partial class ParametersPageViewModel : PageViewModel, IDisposable
             return; // throw?
         }
 
-        Command = new(new(model.Command), PageContext, _contextMenuFactory);
+        ReplaceCommand(model.Command);
         Command.SlowInitializeProperties();
 
         FetchItems();
@@ -618,6 +640,8 @@ public partial class ParametersPageViewModel : PageViewModel, IDisposable
     {
         // Collect all the items into new viewmodels
         Collection<ParameterRunViewModel> newViewModels = [];
+        var transferred = false;
+
         try
         {
             var newItems = _model.Unsafe!.Parameters;
@@ -635,8 +659,10 @@ public partial class ParametersPageViewModel : PageViewModel, IDisposable
                 CoreLogger.LogDebug($"Parameter item was a {t}");
                 if (itemVm != null)
                 {
-                    itemVm.InitializeProperties();
+                    // Track before initializing, so we can cleanup in finally
                     newViewModels.Add(itemVm);
+
+                    itemVm.InitializeProperties();
                     itemVm.PropertyChanged += ItemPropertyChanged;
 
                     if (itemVm is CommandParameterRunViewModel cmdParamVm)
@@ -663,29 +689,30 @@ public partial class ParametersPageViewModel : PageViewModel, IDisposable
                 // .Items
             }
 
+            transferred = true;
+
             // If we removed items, we need to clean them up, to remove our event handlers
             foreach (var removedItem in removedItems)
             {
-                removedItem.PropertyChanged -= ItemPropertyChanged;
-                if (removedItem is CommandParameterRunViewModel removedCmdParam)
-                {
-                    removedCmdParam.ValueChanged -= ListParamValueChanged;
-
-                    // If the active list param is being removed, clear the
-                    // active references so we don't hold on to a disposed
-                    // ListViewModel.
-                    if (removedCmdParam == _activeListParam)
-                    {
-                        SetActiveListParameter(null);
-                    }
-                }
-
-                removedItem.SafeCleanup();
+                ReleaseItem(removedItem);
             }
         }
         catch (Exception ex)
         {
             CoreLogger.LogError($"Error fetching parameter items: {ex.Message}");
+        }
+        finally
+        {
+            // Reading the extension's parameters can throw part-way through.
+            // Anything built so far already subscribed, so it has to be torn
+            // down rather than dropped.
+            if (!transferred)
+            {
+                foreach (var itemVm in newViewModels)
+                {
+                    ReleaseItem(itemVm);
+                }
+            }
         }
 
         DoOnUiThread(
@@ -697,6 +724,28 @@ public partial class ParametersPageViewModel : PageViewModel, IDisposable
 
                 WeakReferenceMessenger.Default.Send(new FocusSearchBoxMessage());
             });
+    }
+
+    /// <summary>
+    /// Detaches this page's handlers from an item it is giving up, and cleans it up.
+    /// </summary>
+    private void ReleaseItem(ParameterRunViewModel item)
+    {
+        item.PropertyChanged -= ItemPropertyChanged;
+
+        if (item is CommandParameterRunViewModel cmdParam)
+        {
+            cmdParam.ValueChanged -= ListParamValueChanged;
+
+            // If the active list param is going away, clear the active
+            // references so we don't hold on to a disposed ListViewModel.
+            if (cmdParam == _activeListParam)
+            {
+                SetActiveListParameter(null);
+            }
+        }
+
+        item.SafeCleanup();
     }
 
     private void UpdateCommand()
@@ -861,6 +910,8 @@ public partial class ParametersPageViewModel : PageViewModel, IDisposable
 
             Items.Clear();
         }
+
+        _command.SafeCleanup();
     }
 }
 

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/ParametersPageViewModelTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/ParametersPageViewModelTests.cs
@@ -1,0 +1,159 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.Foundation;
+
+namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
+
+[TestClass]
+public partial class ParametersPageViewModelTests
+{
+    private sealed partial class TestAppExtensionHost : AppExtensionHost
+    {
+        public override string? GetExtensionDisplayName() => "Test Host";
+    }
+
+    /// <summary>
+    /// A parameters page with no parameter runs - these tests are about the
+    /// page's own Command, not its parameters.
+    /// </summary>
+    private sealed partial class TestParametersPage : Page, IParametersPage
+    {
+        public IParameterRun[] Parameters { get; set; } = [];
+
+        public IListItem Command { get; set => SetProperty(ref field, value); } = null!;
+    }
+
+    /// <summary>
+    /// A label run that reports whether anything is still subscribed, and can
+    /// fail the way a dying extension would once a view-model has attached.
+    /// </summary>
+    private sealed partial class CountingLabelRun : ILabelRun
+    {
+        private TypedEventHandler<object, IPropChangedEventArgs>? _propChanged;
+
+        public event TypedEventHandler<object, IPropChangedEventArgs> PropChanged
+        {
+            add => _propChanged += value;
+            remove => _propChanged -= value;
+        }
+
+        public int HandlerCount => _propChanged?.GetInvocationList().Length ?? 0;
+
+        public bool ThrowOnText { get; init; }
+
+        public string Text => ThrowOnText
+            ? throw new InvalidOperationException("Extension went away")
+            : "label";
+    }
+
+    [TestMethod]
+    public void FetchItems_ThatThrows_ReleasesPartiallyBuiltItems()
+    {
+        // LabelRunViewModel subscribes in base.InitializeProperties and only
+        // then reads Text, so the failing run has already attached by the time
+        // it throws - both it and the run before it have to come off.
+        var host = new TestAppExtensionHost();
+        var good = new CountingLabelRun();
+        var bad = new CountingLabelRun { ThrowOnText = true };
+        var page = new TestParametersPage
+        {
+            Command = new ListItem(new NoOpCommand { Name = "Run it" }) { Title = "Go" },
+            Parameters = [good, bad],
+        };
+
+        var vm = CreateViewModel(page, host);
+        vm.InitializeProperties();
+
+        Assert.AreEqual(0, good.HandlerCount, "an item built before the failure was left subscribed");
+        Assert.AreEqual(0, bad.HandlerCount, "the item that failed was left subscribed");
+    }
+
+    [TestMethod]
+    public void Cleanup_ReleasesCommandItemViewModel()
+    {
+        // The extension-side list item is the root: CommandItemViewModel
+        // subscribes to its PropChanged when it initializes.
+        var host = new TestAppExtensionHost();
+        var item = new ListItem(new NoOpCommand { Name = "Run it" }) { Title = "Go" };
+        var page = new TestParametersPage { Command = item };
+
+        var weakCommandVm = InitializeAndCleanup(page, host);
+
+        AssertCollected(weakCommandVm, "CommandItemViewModel from the parameters page");
+
+        GC.KeepAlive(item);
+        GC.KeepAlive(page);
+        GC.KeepAlive(host);
+    }
+
+    [TestMethod]
+    public void ReplaceCommand_ReleasesDisplacedCommandItemViewModel()
+    {
+        var host = new TestAppExtensionHost();
+        var item = new ListItem(new NoOpCommand { Name = "Run it" }) { Title = "Go" };
+        var page = new TestParametersPage { Command = item };
+
+        var weakDisplacedVm = InitializeTwice(page, host);
+
+        AssertCollected(weakDisplacedVm, "CommandItemViewModel displaced by a rebuild");
+
+        GC.KeepAlive(item);
+        GC.KeepAlive(page);
+        GC.KeepAlive(host);
+    }
+
+    // Separate frames so the view-models are unreachable on return - a Debug
+    // build keeps locals alive to the end of their scope.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference<CommandItemViewModel> InitializeAndCleanup(IParametersPage page, AppExtensionHost host)
+    {
+        var vm = CreateViewModel(page, host);
+        vm.InitializeProperties();
+
+        var weak = new WeakReference<CommandItemViewModel>(vm.Command);
+
+        vm.SafeCleanup();
+        vm.Dispose();
+        return weak;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference<CommandItemViewModel> InitializeTwice(IParametersPage page, AppExtensionHost host)
+    {
+        var vm = CreateViewModel(page, host);
+        vm.InitializeProperties();
+
+        var weak = new WeakReference<CommandItemViewModel>(vm.Command);
+
+        // Rebuilds Command, which must release the instance it displaces.
+        vm.InitializeProperties();
+
+        vm.SafeCleanup();
+        vm.Dispose();
+        return weak;
+    }
+
+    private static void AssertCollected<T>(WeakReference<T> reference, string what)
+        where T : class
+    {
+        // BatchUpdateManager holds queued targets until its timer drains.
+        Thread.Sleep(200);
+        GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true);
+        GC.WaitForPendingFinalizers();
+        GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true);
+
+        Assert.IsFalse(reference.TryGetTarget(out _), $"{what} is still reachable after cleanup.");
+    }
+
+    private static ParametersPageViewModel CreateViewModel(IParametersPage page, AppExtensionHost host) =>
+        new(page, TaskScheduler.Default, host, CommandProviderContext.Empty, DefaultContextMenuFactory.Instance);
+}


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This PR formalizes ownership of command view models so replacing a command releases the outgoing owned instance without cleaning up commands borrowed by synthetic context items. It applies the same cleanup discipline to parameter commands and partially built parameter lists.

This is one of the places that let Command Palette hold COM proxies much longer than it's desirable.

- Track whether a `CommandViewModel` is owned or borrowed.
- Add replacement logic that cleans up outgoing owned commands.
- Add a borrowing path for shared command instances.
- Clean up commands replaced in parameter view models.
- Roll back partially initialized parameter-list updates.
- Add regression tests for replacement and failure paths.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] Closes: #xxx
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
