### PR TITLE
CmdPal SDK: Fix weak command property subscriptions

### DIFF
--- a/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/CommandItem.cs
+++ b/src/modules/cmdpal/extensionsdk/Microsoft.CommandPalette.Extensions.Toolkit/CommandItem.cs
@@ -55,8 +55,12 @@ public partial class CommandItem : BaseObservable, ICommandItem
 
             var oldTitle = Title;
 
+            // Unsubscribe the outgoing command explicitly. OnDetachAction only
+            // runs once this CommandItem has been collected, so it can't cover
+            // the case where the command is simply replaced.
             if (_commandListener is not null)
             {
+                _command?.PropChanged -= _commandListener.OnEvent;
                 _commandListener.Detach();
                 _commandListener = null;
             }
@@ -65,6 +69,16 @@ public partial class CommandItem : BaseObservable, ICommandItem
 
             if (value is not null)
             {
+                // OnCommandPropertyChanged must be static so the delegate's Target is null.
+                // An instance method group would bind `this` into OnEventAction,
+                // giving the listener a strong ref back to this CommandItem and
+                // defeating the weak reference. That was the actual leak.
+                //
+                // OnDetachAction does capture `value`, but that is not a leak: the
+                // only thing keeping the listener alive is `value`'s own PropChanged
+                // list, so the two form a cycle the GC reclaims together. Without it
+                // the listener could never unsubscribe itself, and every collected
+                // CommandItem would leave a dead handler on a long-lived command.
                 _commandListener = new(this, OnCommandPropertyChanged, listener => value.PropChanged -= listener.OnEvent);
                 value.PropChanged += _commandListener.OnEvent;
             }
@@ -77,10 +91,10 @@ public partial class CommandItem : BaseObservable, ICommandItem
         }
     }
 
-    private void OnCommandPropertyChanged(CommandItem instance, object source, IPropChangedEventArgs args)
+    private static void OnCommandPropertyChanged(CommandItem instance, object source, IPropChangedEventArgs args)
     {
         // command's name affects Title only if Title wasn't explicitly set
-        if (args.PropertyName == nameof(ICommand.Name) && string.IsNullOrEmpty(_title))
+        if (args.PropertyName == nameof(ICommand.Name) && string.IsNullOrEmpty(instance._title))
         {
             instance.OnPropertyChanged(nameof(Title));
         }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This PR fixes a weak-event subscription in the CmdPal toolkit that still captured its owning `CommandItem` through an instance callback. That strong reference defeated the weak listener, while command replacement could also leave a stale handler attached to the outgoing command.

- Make the command property-change callback static.
- Resolve the owning `CommandItem` through the listener's weak reference.
- Explicitly unsubscribe from the outgoing command during replacement.
- Retain the detach callback that removes dead listeners from long-lived commands.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] Closes: #xxx
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
