### PR TITLE
CmdPal: Release extension objects after navigation

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/ExtViews/ListPage.xaml.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using ManagedCommon;
+using Microsoft.CmdPal.UI.Helpers;
 using Microsoft.CmdPal.UI.ViewModels;
 using Microsoft.CmdPal.UI.ViewModels.Commands;
 using Microsoft.UI.Xaml;
@@ -74,7 +75,7 @@ public sealed partial class ListPage : Page
         // Clean-up event listeners
         ViewModel = null;
 
-        GC.Collect();
+        ExtensionObjectReleaser.AfterNavigation();
     }
 
     private static void OnViewModelChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/ExtensionObjectReleaser.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Helpers/ExtensionObjectReleaser.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CmdPal.Common.Helpers;
+using Microsoft.CmdPal.Core.Common.Helpers;
+
+namespace Microsoft.CmdPal.UI.Helpers;
+
+/// <summary>
+/// Releases the extension objects behind pages the user has left.
+/// </summary>
+internal static class ExtensionObjectReleaser
+{
+    // Long enough that the page the user just navigated to renders first, and
+    // that a burst of navigations collapses into a single cycle.
+    private static readonly ThrottledDebouncedAction ReleaseAction = new(Release, TimeSpan.FromSeconds(5));
+
+    private static InterlockedBoolean _releaseInProgress;
+
+    /// <summary>
+    /// Schedules a release after navigating away from a page.
+    /// </summary>
+    public static void AfterNavigation() => ReleaseAction.Invoke();
+
+    private static void Release()
+    {
+        // Collect, drain, collect:
+        // a bare collect only queues the finalizers, and it is the finalizers that release the cross-process proxies.
+        // Don't run on the UI thread - apartment-bound proxies marshal their release back to it.
+        // A slow cycle may still be draining; come back later rather than dropping this request.
+        if (!_releaseInProgress.Set())
+        {
+            ReleaseAction.Invoke();
+            return;
+        }
+
+        try
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+        }
+        finally
+        {
+            _releaseInProgress.Clear();
+        }
+    }
+}


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This PR replaces the bare collection performed after leaving a list page with a complete collection and finalization cycle. WinRT and COM proxies are released by their finalizers, so a single `GC.Collect()` can leave extension-owned objects retained on the finalizer queue.

Correctly offloaded onto background thread shouldn't pose UX issue, and finalizers are only way to release COM garbage.

For now, I left the call only in the original place:
- Content and Parameter pages shouldn't generate too much garbage, so we don't have to push for release explicitly.
- I considered cleanup when the CmdPal cloaks, but that would be redundant to the cleanup after navigation.

Changes:
- Adds a reusable `ExtensionObjectReleaser` class that can push hard enough on GC to trash COM garbage.
- Schedules cleanup after navigation instead of collecting immediately.
- Runs a collect, finalizer drain, and second collect off the UI thread.
- Debounces navigation bursts into a single cleanup cycle.
- Reschedules requests when another release cycle is already running.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] Closes: #xxx
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
