### PR TITLE
CmdPal: Avoid redundant performance widget refreshes

### DIFF
--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceWidgetsPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PerformanceMonitor/PerformanceWidgetsPage.cs
@@ -190,7 +190,6 @@ internal sealed partial class PerformanceWidgetsPage : OnLoadStaticListPage, IDi
                 _diskWriteSpeed = _diskPage.GetWriteSpeed();
                 _diskReadItem?.Title = $"{_diskReadSpeed}";
                 _diskWriteItem?.Title = $"{_diskWriteSpeed}";
-                RaiseItemsChanged();
             };
         }
 


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

This PR removes a redundant collection refresh from Performance Monitor's periodically invoked disk metrics callback. The callback already updates the existing list item titles in place, so raising `ItemsChanged` on every sample needlessly asks Command Palette to refresh an unchanged collection.

- Stop raising `ItemsChanged` from the disk page's `Updated` handler.
- Continue updating disk usage and read/write speed titles in place.
- Avoid repeated collection refresh work during periodic performance sampling.
