### PR TITLE
fix(ci): support automatic versions and counter-exhaustion recovery

### DIFF
--- a/.pipelines/resolveBuildMetadata.ps1
+++ b/.pipelines/resolveBuildMetadata.ps1
@@ -20,6 +20,11 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+$VersionOverride = $VersionOverride.Trim()
+if ($VersionOverride.Equals("auto", [StringComparison]::OrdinalIgnoreCase)) {
+    $VersionOverride = ""
+}
+
 function Get-BuildStamp {
     param([string]$PipelineBuildNumber)
 
@@ -186,11 +191,27 @@ function Get-ReleaseDailySequence {
     return [int]::Parse($Sequence)
 }
 
-function Get-PreviewVersion {
+function Get-AutomaticReleaseVersion {
     param(
         [Parameter(Mandatory)][string]$ReleaseTrain,
-        [AllowEmptyString()][string]$Override,
-        [Parameter(Mandatory)][string]$GeneratedVersion
+        [Parameter(Mandatory)][datetime]$Epoch,
+        [Parameter(Mandatory)]$BuildStamp,
+        [Parameter(Mandatory)][AllowEmptyString()][string]$DateOverride,
+        [Parameter(Mandatory)][AllowEmptyString()][string]$DailySequence
+    )
+
+    $releaseBuildStamp = [pscustomobject]@{
+        Date = Get-VersionDate -DateOverride $DateOverride -BuildStamp $BuildStamp
+        Revision = $BuildStamp.Revision
+    }
+    $releaseDailySequence = Get-ReleaseDailySequence -Sequence $DailySequence
+    return Get-ReleaseVersion -ReleaseTrain $ReleaseTrain -Epoch $Epoch -BuildStamp $releaseBuildStamp -DailySequence $releaseDailySequence
+}
+
+function Get-PreviewVersionOverride {
+    param(
+        [Parameter(Mandatory)][string]$ReleaseTrain,
+        [AllowEmptyString()][string]$Override
     )
 
     $inputVersion = $Override.Trim()
@@ -199,7 +220,7 @@ function Get-PreviewVersion {
     }
 
     if ([string]::IsNullOrWhiteSpace($inputVersion)) {
-        return $GeneratedVersion
+        return $null
     }
 
     if ($inputVersion -match "^(?<major>\d+)\.(?<minor>\d+)$") {
@@ -207,7 +228,7 @@ function Get-PreviewVersion {
             throw "Preview version base '$inputVersion' does not match ReleaseTrainVersion '$ReleaseTrain'"
         }
 
-        return $GeneratedVersion
+        return $null
     }
 
     if ($inputVersion -notmatch "^(?<major>\d+)\.(?<minor>\d+)\.(?<revision>\d+)\.(?<build>\d+)$") {
@@ -258,14 +279,13 @@ function Get-MsiSafeVersionOverride {
     return ($parts | ForEach-Object { [int]::Parse($_) }) -join "."
 }
 
-function Get-StableVersion {
+function Get-StableVersionOverride {
     param(
-        [Parameter(Mandatory)][AllowEmptyString()][string]$Override,
-        [Parameter(Mandatory)][string]$GeneratedVersion
+        [Parameter(Mandatory)][AllowEmptyString()][string]$Override
     )
 
     if ([string]::IsNullOrWhiteSpace($Override)) {
-        return $GeneratedVersion
+        return $null
     }
 
     return Get-MsiSafeVersionOverride -Override $Override -VersionKind "Stable"
@@ -290,10 +310,15 @@ if ($isMain) {
 
     $intent = if ($isScheduled) { "preview-release" } else { "preview-validation" }
     $channel = "preview"
-    $buildStamp.Date = Get-VersionDate -DateOverride $BuildDate -BuildStamp $buildStamp
-    $releaseDailySequence = Get-ReleaseDailySequence -Sequence $DailyVersionSequence
-    $generatedVersion = Get-ReleaseVersion -ReleaseTrain $releaseTrain -Epoch $releaseMetadata.Epoch -BuildStamp $buildStamp -DailySequence $releaseDailySequence
-    $version = Get-PreviewVersion -ReleaseTrain $releaseTrain -Override $VersionOverride -GeneratedVersion $generatedVersion
+    $version = Get-PreviewVersionOverride -ReleaseTrain $releaseTrain -Override $VersionOverride
+    if ($null -eq $version) {
+        $version = Get-AutomaticReleaseVersion `
+            -ReleaseTrain $releaseTrain `
+            -Epoch $releaseMetadata.Epoch `
+            -BuildStamp $buildStamp `
+            -DateOverride $BuildDate `
+            -DailySequence $DailyVersionSequence
+    }
     $allowPublicSymbols = $false
     $shouldPublishPreview = $isScheduled
 }
@@ -304,10 +329,15 @@ elseif ($isStable) {
 
     $intent = "stable-release"
     $channel = "stable"
-    $buildStamp.Date = Get-VersionDate -DateOverride $BuildDate -BuildStamp $buildStamp
-    $releaseDailySequence = Get-ReleaseDailySequence -Sequence $DailyVersionSequence
-    $generatedVersion = Get-ReleaseVersion -ReleaseTrain $releaseTrain -Epoch $releaseMetadata.Epoch -BuildStamp $buildStamp -DailySequence $releaseDailySequence
-    $version = Get-StableVersion -Override $VersionOverride -GeneratedVersion $generatedVersion
+    $version = Get-StableVersionOverride -Override $VersionOverride
+    if ($null -eq $version) {
+        $version = Get-AutomaticReleaseVersion `
+            -ReleaseTrain $releaseTrain `
+            -Epoch $releaseMetadata.Epoch `
+            -BuildStamp $buildStamp `
+            -DateOverride $BuildDate `
+            -DailySequence $DailyVersionSequence
+    }
     $allowPublicSymbols = $true
     $shouldPublishPreview = $false
 }

--- a/.pipelines/tests/resolveBuildMetadata.Tests.ps1
+++ b/.pipelines/tests/resolveBuildMetadata.Tests.ps1
@@ -36,8 +36,9 @@ function Assert-Throws {
 }
 
 Describe "resolveBuildMetadata" {
-    It "generates the canonical preview version for main" {
+    It "generates the canonical preview version for scheduled main with the auto default" {
         $result = & $scriptPath `
+            -VersionOverride "auto" `
             -SourceBranch "refs/heads/main" `
             -BuildReason "Schedule" `
             -BuildNumber "PowerToys Signed YAML Release Build_2607.30099-main" `
@@ -59,6 +60,18 @@ Describe "resolveBuildMetadata" {
 
         $result.Intent | Should Be "stable-release"
         $result.Channel | Should Be "stable"
+        $result.Version | Should Be "0.100.2112.0"
+    }
+
+    It "treats the pipeline auto sentinel as an automatic version" {
+        $result = & $scriptPath `
+            -VersionOverride "auto" `
+            -SourceBranch "refs/heads/stable" `
+            -BuildReason "Manual" `
+            -BuildNumber "PowerToys Signed YAML Release Build_2607.30099-stable" `
+            -DailyVersionSequence "2" `
+            -VersionPropsPath (New-VersionProps)
+
         $result.Version | Should Be "0.100.2112.0"
     }
 
@@ -151,6 +164,18 @@ Describe "resolveBuildMetadata" {
         $result.Version | Should Be "0.100.2.0"
     }
 
+    It "allows an explicit stable override after the automatic sequence is exhausted" {
+        $result = & $scriptPath `
+            -VersionOverride "0.101.0" `
+            -SourceBranch "refs/heads/stable" `
+            -BuildReason "Manual" `
+            -BuildNumber "PowerToys Signed YAML Release Build_2607.30001-stable" `
+            -DailyVersionSequence "10" `
+            -VersionPropsPath (New-VersionProps)
+
+        $result.Version | Should Be "0.101.0.0"
+    }
+
     It "rejects a stable override with a nonzero fourth component" {
         Assert-Throws {
             & $scriptPath `
@@ -182,6 +207,18 @@ Describe "resolveBuildMetadata" {
             -BuildReason "Manual" `
             -BuildNumber "PowerToys Signed YAML Release Build_2607.30001-main" `
             -DailyVersionSequence "1" `
+            -VersionPropsPath (New-VersionProps)
+
+        $result.Version | Should Be "0.100.2111.0"
+    }
+
+    It "allows a full preview override after the automatic sequence is exhausted" {
+        $result = & $scriptPath `
+            -VersionOverride "0.100.2111.0" `
+            -SourceBranch "refs/heads/main" `
+            -BuildReason "Manual" `
+            -BuildNumber "PowerToys Signed YAML Release Build_2607.30001-main" `
+            -DailyVersionSequence "10" `
             -VersionPropsPath (New-VersionProps)
 
         $result.Version | Should Be "0.100.2111.0"

--- a/.pipelines/v2/release.yml
+++ b/.pipelines/v2/release.yml
@@ -16,9 +16,9 @@ parameters:
     default: false
 
   - name: versionNumber
-    displayName: "Version Override (optional; main and stable default to the release-train version)"
+    displayName: "Version Override ('auto' generates a release-train version)"
     type: string
-    default: ''
+    default: 'auto'
 
   - name: buildConfigurations
     displayName: "Build Configurations"


### PR DESCRIPTION
## Summary of the Pull Request

Follow-up to #49414 that fixes two release-pipeline recovery issues:

- Azure DevOps treats an empty runtime string parameter as required, so `.pipelines/v2/release.yml` now uses `auto` as the default version override.
- Explicit `main` and `stable` version overrides are resolved before automatic `YDDDB` generation, allowing a manually versioned build to proceed after the daily sequence exceeds 9.

## PR Checklist

- [x] **Communication:** This is a follow-up to the reviewed preview-release versioning design in #49414
- [x] **Tests:** Added/updated and all pass

## Detailed Description of the Pull Request / Additional comments

`auto` is normalized to an empty override in `.pipelines/resolveBuildMetadata.ps1`, preserving automatic release-train version generation without requiring input in the Run Pipeline dialog.

Override parsing is now separated from automatic version generation. Full explicit versions bypass daily-sequence and generated-date validation, while automatic versions continue to require a sequence from 1 through 9 and fail closed outside that range.

`.pipelines/tests/resolveBuildMetadata.Tests.ps1` covers scheduled `main` with the `auto` default, automatic `stable` generation, and explicit preview/stable recovery when the daily counter has reached 10.

## Validation Steps Performed

- `Invoke-Pester .pipelines\tests\resolveBuildMetadata.Tests.ps1 -EnableExit` — 22 passed
- Confirmed `auto` resolves a first August 7 stable build to `0.100.2191.0`
- Confirmed explicit `0.101.0` resolves to `0.101.0.0` with daily sequence 10