### PR TITLE
[Grab and Move] Prevent Start from opening after a Win-modified drag

### DIFF
--- a/src/modules/GrabAndMove/GrabAndMove/main.cpp
+++ b/src/modules/GrabAndMove/GrabAndMove/main.cpp
@@ -817,6 +817,17 @@ static void ReplayAbsorbedModifier(bool alsoKeyUp)
     SendInput(alsoKeyUp ? 2 : 1, inputs, sizeof(INPUT));
 }
 
+static void SendDummyKeyEvent()
+{
+    constexpr WORD dummyKey = 0xFF;
+    INPUT inputs[2] = {};
+    inputs[0].type = INPUT_KEYBOARD;
+    inputs[0].ki.wVk = dummyKey;
+    inputs[1] = inputs[0];
+    inputs[1].ki.dwFlags = KEYEVENTF_KEYUP;
+    SendInput(ARRAYSIZE(inputs), inputs, sizeof(INPUT));
+}
+
 // ---------------------------------------------------------------------------
 // Deferred activation helpers.
 // A modifier+button press does not start an interaction immediately; it is held
@@ -826,6 +837,11 @@ static void ReplayAbsorbedModifier(bool alsoKeyUp)
 // ---------------------------------------------------------------------------
 static void BeginDrag(HWND hwnd, POINT pt)
 {
+    if (g_modifierKey == GrabAndMoveModifier::Win && !g_activatedDuringHold)
+    {
+        // Mark Win as part of a chord before it is released so Windows doesn't open Start.
+        SendDummyKeyEvent();
+    }
     g_dragging = true;
     g_dragFirstMove = true;
     g_dragConsumedAlt = true;
@@ -840,6 +856,11 @@ static void BeginDrag(HWND hwnd, POINT pt)
 
 static void BeginResize(HWND hwnd, POINT pt)
 {
+    if (g_modifierKey == GrabAndMoveModifier::Win && !g_activatedDuringHold)
+    {
+        // Mark Win as part of a chord before it is released so Windows doesn't open Start.
+        SendDummyKeyEvent();
+    }
     g_resizing = true;
     g_resizeFirstMove = true;
     g_dragConsumedAlt = true;


### PR DESCRIPTION
## Summary of the Pull Request

Prevents the Start menu from opening after a Grab and Move interaction that uses Win as the activation modifier.

When a drag or resize actually begins, Grab and Move sends a single dummy key event so Windows treats Win as part of a chord. The event is sent once per modifier hold and does not affect Alt-based activation or clicks that never become a drag.

## PR Checklist

- [x] Closes: #49704
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [x] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

## Detailed Description of the Pull Request / Additional comments

A mouse-only Grab and Move interaction does not register as a keyboard chord. Windows can therefore interpret the later Win key-up as a standalone Win press and open Start.

This change emits a `0xFF` key down/up pair when a Win-modified drag or resize is promoted from a pending mouse action to an active interaction. The existing activation state prevents repeated events during the same modifier hold. No settings, user-facing strings, dependencies, or IPC contracts are changed.

## Validation Steps Performed

- Built Grab and Move for Debug x64 and Release x64 successfully. `SpectreMitigation=false` was used because the local Visual Studio installation does not include the optional Spectre-mitigated libraries.
- With a physical Win key, dragged a normal window, released the mouse first, then released Win. The window moved and Start remained closed.
- Repeated the test with Win released before the mouse. Start remained closed.
- Confirmed that tapping Win still opens Start and `Win+E` still opens File Explorer.
- Ran changed-line `clang-format --dry-run --Werror` and `git diff --check` successfully.
- Grab and Move does not currently have a dedicated unit test project; the regression was validated through focused runtime testing.
