### PR TITLE
[Mouse Jump] Sign new WinUI3 binaries

### DIFF
--- a/.pipelines/ESRPSigning_core.json
+++ b/.pipelines/ESRPSigning_core.json
@@ -195,9 +195,11 @@
             "PowerToys.MouseHighlighter.dll",
             "PowerToys.MouseJump.dll",
             "PowerToys.MouseJump.Common.dll",
+            "PowerToys.MouseJump.HotKeys.dll",
+            "PowerToys.MouseJump.Models.dll",
+            "PowerToys.MouseJump.WinUI3.dll",
+            "PowerToys.MouseJump.WinUI3.exe",
             "PowerToys.MousePointerCrosshairs.dll",
-            "PowerToys.MouseJumpUI.dll",
-            "PowerToys.MouseJumpUI.exe",
             "PowerToys.CursorWrap.dll",
 
             "PowerToys.MouseWithoutBorders.dll",

--- a/.pipelines/ESRPSigning_core.json
+++ b/.pipelines/ESRPSigning_core.json
@@ -195,10 +195,10 @@
             "PowerToys.MouseHighlighter.dll",
             "PowerToys.MouseJump.dll",
             "PowerToys.MouseJump.Common.dll",
-            "PowerToys.MouseJump.HotKeys.dll",
+            "WinUI3Apps\\PowerToys.MouseJump.HotKeys.dll",
             "PowerToys.MouseJump.Models.dll",
-            "PowerToys.MouseJump.WinUI3.dll",
-            "PowerToys.MouseJump.WinUI3.exe",
+            "WinUI3Apps\\PowerToys.MouseJump.WinUI3.dll",
+            "WinUI3Apps\\PowerToys.MouseJump.WinUI3.exe",
             "PowerToys.MousePointerCrosshairs.dll",
             "PowerToys.CursorWrap.dll",
 


### PR DESCRIPTION
## Summary
- add the new Mouse Jump HotKeys, Models, and WinUI3 binaries to the core ESRP signing policy
- remove the retired MouseJumpUI signing entries

## Context
The signed main build [154175666](https://microsoft.visualstudio.com/Dart/_build/results?buildId=154175666) failed for both x64 and ARM64 because the binaries introduced by #48393 were not selected for signing.

## Validation
- parsed `.pipelines/ESRPSigning_core.json` successfully
- confirmed all four new binary names are present and the two obsolete names are removed