### PR TITLE
Fix #49725: Block mapping any chords involving Win+L

### DIFF
--- a/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/EditorHelpers.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorLibrary/EditorHelpers.cpp
@@ -137,10 +137,10 @@ namespace EditorHelpers
     // Function to check if the shortcut is illegal (i.e. Win+L or Ctrl+Alt+Del)
     ShortcutErrorType IsShortcutIllegal(Shortcut shortcut)
     {
-        // Win+L
-        if (shortcut.winKey != ModifierKey::Disabled && shortcut.ctrlKey == ModifierKey::Disabled && shortcut.altKey == ModifierKey::Disabled && shortcut.shiftKey == ModifierKey::Disabled && shortcut.actionKey == 0x4C)
+        // Win+L (and any chords involving it like Win+Ctrl+L)
+        if (shortcut.winKey != ModifierKey::Disabled && shortcut.actionKey == 0x4C)
         {
-            Logger::info(L"Illegal shortcut detected: Win+L");
+            Logger::info(L"Illegal shortcut detected: Win+L or a chord involving Win+L");
             return ShortcutErrorType::WinL;
         }
 

--- a/src/modules/keyboardmanager/KeyboardManagerEditorTest/BufferValidationTests.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorTest/BufferValidationTests.cpp
@@ -940,6 +940,36 @@ namespace RemappingUITests
                 });
             }
 
+            // Test if the ValidateShortcutBufferElement method returns WinL error on setting a drop down resulting in a chord involving Win+L (e.g. Win+Ctrl+L)
+            TEST_METHOD (ValidateShortcutBufferElement_ShouldReturnWinLError_OnSettingDropDownResultingInChordInvolvingWinL)
+            {
+                std::vector<ValidateShortcutBufferElementArgs> testCases;
+                // Case 1: Validate the element when selecting L (0x4C) on third dropdown of first column of LWin + Ctrl + Empty shortcut
+                testCases.push_back({ 0, 0, 2, std::vector<int32_t>{ VK_LWIN, VK_CONTROL, 0x4C }, std::wstring(), false, RemapBufferRow{ RemapBufferItem{ std::vector<int32_t>{ VK_LWIN, VK_CONTROL }, Shortcut() }, std::wstring() } });
+                // Case 2: Validate the element when selecting L (0x4C) on third dropdown of second column of LWin + Ctrl + Empty shortcut
+                testCases.push_back({ 0, 1, 2, std::vector<int32_t>{ VK_LWIN, VK_CONTROL, 0x4C }, std::wstring(), false, RemapBufferRow{ RemapBufferItem{ Shortcut(), std::vector<int32_t>{ VK_LWIN, VK_CONTROL } }, std::wstring() } });
+                // Case 3: Validate the element when selecting L (0x4C) on third dropdown of second column of hybrid LWin + Ctrl + Empty shortcut
+                testCases.push_back({ 0, 1, 2, std::vector<int32_t>{ VK_LWIN, VK_CONTROL, 0x4C }, std::wstring(), true, RemapBufferRow{ RemapBufferItem{ Shortcut(), std::vector<int32_t>{ VK_LWIN, VK_CONTROL } }, std::wstring() } });
+                // Case 4: Validate the element when selecting L (0x4C) on third dropdown of first column of Win + Shift + Empty shortcut
+                testCases.push_back({ 0, 0, 2, std::vector<int32_t>{ CommonSharedConstants::VK_WIN_BOTH, VK_SHIFT, 0x4C }, std::wstring(), false, RemapBufferRow{ RemapBufferItem{ std::vector<int32_t>{ CommonSharedConstants::VK_WIN_BOTH, VK_SHIFT }, Shortcut() }, std::wstring() } });
+                // Case 5: Validate the element when selecting L (0x4C) on third dropdown of second column of Win + Shift + Empty shortcut
+                testCases.push_back({ 0, 1, 2, std::vector<int32_t>{ CommonSharedConstants::VK_WIN_BOTH, VK_SHIFT, 0x4C }, std::wstring(), false, RemapBufferRow{ RemapBufferItem{ Shortcut(), std::vector<int32_t>{ CommonSharedConstants::VK_WIN_BOTH, VK_SHIFT } }, std::wstring() } });
+                // Case 6: Validate the element when selecting L (0x4C) on third dropdown of second column of hybrid Win + Shift + Empty shortcut
+                testCases.push_back({ 0, 1, 2, std::vector<int32_t>{ CommonSharedConstants::VK_WIN_BOTH, VK_SHIFT, 0x4C }, std::wstring(), true, RemapBufferRow{ RemapBufferItem{ Shortcut(), std::vector<int32_t>{ CommonSharedConstants::VK_WIN_BOTH, VK_SHIFT } }, std::wstring() } });
+
+                RunTestCases(testCases, [this](const ValidateShortcutBufferElementArgs& testCase) {
+                    // Arrange
+                    RemapBuffer remapBuffer;
+                    remapBuffer.push_back(testCase.bufferRow);
+
+                    // Act
+                    std::pair<ShortcutErrorType, BufferValidationHelpers::DropDownAction> result = BufferValidationHelpers::ValidateShortcutBufferElement(testCase.elementRowIndex, testCase.elementColIndex, testCase.indexOfDropDownLastModified, testCase.selectedCodesOnDropDowns, testCase.targetAppNameInTextBox, testCase.isHybridColumn, remapBuffer, true);
+
+                    // Assert that the element is invalid
+                    Assert::AreEqual(true, result.first == ShortcutErrorType::WinL);
+                });
+            }
+
             // Test if the ValidateShortcutBufferElement method returns CtrlAltDel error on setting a drop down to Ctrl, Alt or Del on a column resulting in Ctrl+Alt+Del
             TEST_METHOD (ValidateShortcutBufferElement_ShouldReturnCtrlAltDelError_OnSettingDropDownToCtrlAltOrDelOnColumnResultingInCtrlAltDel)
             {

--- a/src/modules/keyboardmanager/KeyboardManagerEditorTest/EditorHelpersTests.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorTest/EditorHelpersTests.cpp
@@ -9,6 +9,7 @@
 #include <keyboardmanager/KeyboardManagerEditorLibrary/ShortcutErrorType.h>
 #include <keyboardmanager/common/Helpers.h>
 #include <common/interop/keyboard_layout.h>
+#include <common/interop/shared_constants.h>
 #include <keyboardmanager/KeyboardManagerEditorLibrary/EditorHelpers.h>
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;

--- a/src/modules/keyboardmanager/KeyboardManagerEditorTest/EditorHelpersTests.cpp
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorTest/EditorHelpersTests.cpp
@@ -297,5 +297,23 @@ namespace EditorHelpersTests
             // Assert
             Assert::IsTrue(result == ShortcutErrorType::NoError);
         }
+
+        // Test if the IsShortcutIllegal method returns WinL on Win+L and any chords involving Win+L
+        TEST_METHOD (IsShortcutIllegal_ShouldReturnWinL_OnWinLAndChordsInvolvingWinL)
+        {
+            // Win+L
+            Assert::IsTrue(EditorHelpers::IsShortcutIllegal(Shortcut(std::vector<int32_t>{ VK_LWIN, 0x4C })) == ShortcutErrorType::WinL);
+            Assert::IsTrue(EditorHelpers::IsShortcutIllegal(Shortcut(std::vector<int32_t>{ CommonSharedConstants::VK_WIN_BOTH, 0x4C })) == ShortcutErrorType::WinL);
+
+            // Chords with Win+L
+            Assert::IsTrue(EditorHelpers::IsShortcutIllegal(Shortcut(std::vector<int32_t>{ VK_LWIN, VK_CONTROL, 0x4C })) == ShortcutErrorType::WinL);
+            Assert::IsTrue(EditorHelpers::IsShortcutIllegal(Shortcut(std::vector<int32_t>{ VK_LWIN, VK_SHIFT, 0x4C })) == ShortcutErrorType::WinL);
+            Assert::IsTrue(EditorHelpers::IsShortcutIllegal(Shortcut(std::vector<int32_t>{ VK_LWIN, VK_MENU, 0x4C })) == ShortcutErrorType::WinL);
+            Assert::IsTrue(EditorHelpers::IsShortcutIllegal(Shortcut(std::vector<int32_t>{ VK_LWIN, VK_CONTROL, VK_SHIFT, 0x4C })) == ShortcutErrorType::WinL);
+
+            // Valid combinations (not Win+L)
+            Assert::IsTrue(EditorHelpers::IsShortcutIllegal(Shortcut(std::vector<int32_t>{ VK_CONTROL, 0x4C })) == ShortcutErrorType::NoError);
+            Assert::IsTrue(EditorHelpers::IsShortcutIllegal(Shortcut(std::vector<int32_t>{ VK_LWIN, VK_CONTROL, 0x41 })) == ShortcutErrorType::NoError);
+        }
     };
 }

--- a/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/ValidationHelper.cs
+++ b/src/modules/keyboardmanager/KeyboardManagerEditorUI/Helpers/ValidationHelper.cs
@@ -60,7 +60,8 @@ namespace KeyboardManagerEditorUI.Helpers
                 return ValidationErrorType.EmptyAppName;
             }
 
-            if (originalKeys.Count > 1 && IsIllegalShortcut(originalKeys, mappingService))
+            if ((originalKeys.Count > 1 && IsIllegalShortcut(originalKeys, mappingService)) ||
+                (remappedKeys.Count > 1 && IsIllegalShortcut(remappedKeys, mappingService)))
             {
                 return ValidationErrorType.IllegalShortcut;
             }


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
This PR fixes an issue where mapping a chord involving `Win + L` (such as `Win + Ctrl + L`) breaks silently because Windows natively intercepts the sequence to lock the PC. 

The Keyboard Manager previously only blocked mapping to strictly `Win + L` without any other modifiers. This PR updates `IsShortcutIllegal` to block any shortcut containing both the `Win` modifier and the `L` action key. 

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #49725
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
In `src\modules\keyboardmanager\KeyboardManagerEditorLibrary\EditorHelpers.cpp`, the validation for illegal shortcuts checked if `shortcut.ctrlKey`, `shortcut.altKey`, and `shortcut.shiftKey` were all disabled. By removing those checks, `Win+Ctrl+L`, `Win+Shift+L`, and other combinations are now correctly captured by the existing `ShortcutErrorType::WinL` validation and will surface the appropriate error banner to the user instead of breaking silently.

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed
- Validated that `Win+L` continues to be flagged as an illegal shortcut.
- Validated that `Win+Ctrl+L` and other chords containing `Win` + `L` are now properly flagged as illegal.
- Ensured existing unit tests covering buffer validation pass with the updated logic.
