### PR TITLE
Fix PowerToys Run settings text: searchbox -> search box

### DIFF
--- a/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
+++ b/src/settings-ui/Settings.UI/Strings/en-us/Resources.resw
@@ -3463,7 +3463,7 @@ Right-click to remove the key combination, thereby deactivating the shortcut.</v
     <value>Plugin hints</value>
   </data>
   <data name="PowerLauncher_ShowPluginKeywords.Description" xml:space="preserve">
-    <value>Choose which plugin keywords to be shown when the searchbox is empty</value>
+    <value>Choose which plugin keywords to be shown when the search box is empty</value>
   </data>
   <data name="PowerLauncher_PluginWeightBoost.Description" xml:space="preserve">
     <value>Use a higher number to have this plugin's result show higher in the global results. Default is 0.</value>


### PR DESCRIPTION
## Summary

Fixes #49717.

On the PowerToys Run settings page, the plugin keywords description said "searchbox". Updated the English string to "search box".

## Validation Steps / Documentation

1. Open PowerToys Settings
2. Go to PowerToys Run
3. Confirm the plugin keywords description uses "search box"

## PR Checklist

- [x] Closes: #49717
- [x] Communication: I've discussed this with a PowerToys maintainer or discussed this in a GitHub issue / discussion
- [ ] Tests: Added or updated tests for this change / N/A for string-only change
- [ ] Docs: Documentation has been updated or N/A
- [x] Binary assets: N/A