### PR TITLE
build(release): advance release train to 0.101

### DIFF
--- a/src/Version.props
+++ b/src/Version.props
@@ -4,7 +4,7 @@
     <Version>0.0.1</Version>
     <VersionChannel>private</VersionChannel>
     <!-- Update once when main moves to the next stable release train. -->
-    <ReleaseTrainVersion>0.100</ReleaseTrainVersion>
+    <ReleaseTrainVersion>0.101</ReleaseTrainVersion>
     <!-- Y in YDDDB counts calendar years from this January 1. Reset it on the first release-train minor change of a new year. -->
     <ReleaseTrainEpoch>2026-01-01</ReleaseTrainEpoch>
     <SourceCommit></SourceCommit>


### PR DESCRIPTION
## Summary of the Pull Request

Updates `ReleaseTrainVersion` in `src/Version.props` from `0.100` to `0.101` so automatic builds from `main` use the 0.101 release train.

## PR Checklist

- [x] **Communication:** This release-train transition was requested and discussed with a core contributor
- [x] **Tests:** Existing version resolution was exercised with the updated checked-in value

## Detailed Description of the Pull Request / Additional comments

The release pipeline defaults `versionNumber` to `auto`, which reads the checked-in release train from `src/Version.props`. This change advances that source of truth to `0.101` while retaining `ReleaseTrainEpoch` as `2026-01-01` because the train transition occurs in the same calendar year.

Automatic builds now generate versions in the form `0.101.<YDDDB>.0`.

## Validation Steps Performed

- Ran `.pipelines/resolveBuildMetadata.ps1` for a `main` build with `versionNumber=auto`, build date `20260810`, and daily sequence `1`.
- Confirmed the resolved version is `0.101.2221.0` with the `preview` channel.