### PR TITLE
fix(settings-ui): restore General page navigation

### DIFF
--- a/src/settings-ui/Settings.UI/SettingsXAML/Views/GeneralPage.xaml
+++ b/src/settings-ui/Settings.UI/SettingsXAML/Views/GeneralPage.xaml
@@ -108,7 +108,7 @@
                             IsEnabled="{x:Bind ViewModel.IsIncludePrereleaseUpdatesCardEnabled, Mode=OneWay}">
                             <tkcontrols:SettingsExpander.Description>
                                 <StackPanel Orientation="Vertical">
-                                    <ptcontrols:IsEnabledTextBlock x:Uid="GeneralPage_UpdateChannelDescription" Style="{StaticResource SecondaryTextStyle}" />
+                                    <ptcontrols:IsEnabledTextBlock x:Uid="GeneralPage_UpdateChannelDescription" Style="{StaticResource SecondaryIsEnabledTextBlockStyle}" />
                                     <HyperlinkButton
                                         x:Uid="GeneralPage_UpdateChannelLearnMore"
                                         Margin="0,2,0,0"


### PR DESCRIPTION
## Summary of the Pull Request

Fixes Settings navigation to the General page by applying the correctly typed `SecondaryIsEnabledTextBlockStyle` to `GeneralPage_UpdateChannelDescription` in `src/settings-ui/Settings.UI/SettingsXAML/Views/GeneralPage.xaml`.

The previous `SecondaryTextStyle` targets `TextBlock`, so WinUI threw a `XamlParseException` when applying it to the custom `IsEnabledTextBlock` control. This prevented `GeneralPage.InitializeComponent()` from completing.

## PR Checklist

- [x] **Communication:** Regression identified while validating the v0.101 preview candidate
- [x] **Tests:** Existing Settings tests pass and the runtime regression was verified
- [x] **Localization:** No end-user-facing strings changed

## Detailed Description of the Pull Request / Additional comments

PR #49722 introduced the incompatible style assignment. This change reuses the existing `SecondaryIsEnabledTextBlockStyle`, which targets `controls:IsEnabledTextBlock` and preserves the intended secondary foreground and 12px font size.

The same regression is present on `stable`; this fix should be included in the v0.101 release branch after merge.

## Validation Steps Performed

- Built `src/settings-ui/PowerToys.Settings.slnf` in Release x64.
- Ran `Settings.UI.UnitTests.dll`: 185 passed, 0 failed, 0 skipped.
- Launched the fixed Release Settings binary directly on `Overview`; the General header and Update channel controls rendered.
- Confirmed no new `NavigationService` or `XamlParseException` log entries and no relevant Event Viewer crash.