### PR TITLE
Add release channel to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -80,6 +80,7 @@ body:
       - Shortcut Guide
       - System tray interaction
       - TextExtractor
+      - Window Hopper
       - Workspaces
       - Welcome / PowerToys Tour window
       - ZoomIt

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -17,9 +17,9 @@ body:
 - id: version
   type: input
   attributes:
-    label: Microsoft PowerToys version
-    placeholder: X.XX.X
-    description: Hover over the system tray icon or look at Settings
+    label: Microsoft PowerToys version and release channel
+    placeholder: 0.100.2 (Stable) or 0.101.2211.0 (Preview (Insider))
+    description: Find the version and update channel in PowerToys Settings > General.
   validations:
     required: true
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -18,7 +18,7 @@ body:
   type: input
   attributes:
     label: Microsoft PowerToys version and release channel
-    placeholder: 0.100.2 (Stable) or 0.101.2211.0 (Preview (Insider))
+    placeholder: 0.100.2 - Stable or 0.101.2211.0 - Preview (Insider)
     description: Find the version and update channel in PowerToys Settings > General.
   validations:
     required: true

--- a/.github/ISSUE_TEMPLATE/translation_issue.yml
+++ b/.github/ISSUE_TEMPLATE/translation_issue.yml
@@ -12,9 +12,9 @@ body:
     value: Please make sure to [search for existing issues](https://github.com/microsoft/PowerToys/issues) before filing a new one!
 - type: input
   attributes:
-    label: Microsoft PowerToys version
-    placeholder: 0.70.0
-    description: Hover over the system tray icon or look at Settings
+    label: Microsoft PowerToys version and release channel
+    placeholder: 0.100.2 (Stable) or 0.101.2211.0 (Preview (Insider))
+    description: Find the version and update channel in PowerToys Settings > General.
   validations:
     required: true
 - type: dropdown

--- a/.github/ISSUE_TEMPLATE/translation_issue.yml
+++ b/.github/ISSUE_TEMPLATE/translation_issue.yml
@@ -13,7 +13,7 @@ body:
 - type: input
   attributes:
     label: Microsoft PowerToys version and release channel
-    placeholder: 0.100.2 (Stable) or 0.101.2211.0 (Preview (Insider))
+    placeholder: 0.100.2 - Stable or 0.101.2211.0 - Preview (Insider)
     description: Find the version and update channel in PowerToys Settings > General.
   validations:
     required: true

--- a/.github/workflows/auto-labeler.yml
+++ b/.github/workflows/auto-labeler.yml
@@ -131,6 +131,7 @@ jobs:
                 'Product-Settings',
                 'Product-Shortcut Guide',
                 'Product-Text Extractor',
+                'Product-Window Hopper',
                 'Product-Workspaces',
                 'Product-ZoomIt',
                 'Area-Setup/Install',


### PR DESCRIPTION
## Summary of the Pull Request

Updates the bug report and localization issue forms to collect the PowerToys version and release channel in one required field. The placeholder shows both supported formats: `0.100.2 - Stable` and `0.101.2211.0 - Preview (Insider)`.

## PR Checklist

- [ ] Closes: N/A
- [x] **Communication:** This change was requested and reviewed before submission
- [x] **Tests:** Both issue form YAML files parse successfully and the required combined field was validated
- [x] **Localization:** N/A; this changes GitHub issue form metadata
- [x] **Dev docs:** N/A
- [x] **New binaries:** N/A
- [x] **Documentation updated:** N/A

## Detailed Description of the Pull Request / Additional comments

Combining the values makes the generated issue easier to scan. Submitted issues now contain one section such as:

```markdown
### Microsoft PowerToys version and release channel

0.101.2211.0 - Preview (Insider)
```

The field description directs reporters to PowerToys Settings > General to find both values.

The bug report **Area(s) with issue?** dropdown now includes **Window Hopper**, and the automatic triager recognizes its `Product-Window Hopper` label.

## Validation Steps Performed

- Parsed both modified issue forms as YAML.
- Asserted that each form contains one required `Microsoft PowerToys version and release channel` input.
- Ran `git diff --check`.
