### PR TITLE
CmdPal: Fix Command Palette Dock breaking on monitor topology changes

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Settings/MonitorConfigReconciler.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Settings/MonitorConfigReconciler.cs
@@ -138,6 +138,48 @@ public static class MonitorConfigReconciler
             }
         }
 
+        // Fuzzy match: recover secondary monitor configs when their ID changed.
+        // Windows can reassign device paths for a still-connected monitor across a Win+P
+        // "PC screen only" -> "Extend" round-trip or a dock/undock event, which otherwise
+        // makes an existing secondary monitor look brand new and get a fresh disabled/empty
+        // config (see issue #48516). This is safe to apply only when there is exactly one
+        // remaining unmatched secondary monitor and exactly one remaining unmatched
+        // non-primary config: with more than one on either side we can't tell which
+        // monitor a config belongs to, and guessing risks associating the wrong settings
+        // with a genuinely new, unrelated display.
+        var unmatchedSecondaryMonitors = new List<int>();
+        for (var mi = 0; mi < currentMonitors.Count; mi++)
+        {
+            var monitor = currentMonitors[mi];
+            if (!monitor.IsPrimary && !matchedMonitorStableIds.Contains(monitor.StableId))
+            {
+                unmatchedSecondaryMonitors.Add(mi);
+            }
+        }
+
+        var unmatchedSecondaryConfigs = new List<int>();
+        for (var ci = 0; ci < existingConfigs.Count; ci++)
+        {
+            if (!matchedConfigIndices.Contains(ci) && !existingConfigs[ci].IsPrimary)
+            {
+                unmatchedSecondaryConfigs.Add(ci);
+            }
+        }
+
+        if (unmatchedSecondaryMonitors.Count == 1 && unmatchedSecondaryConfigs.Count == 1)
+        {
+            var monitor = currentMonitors[unmatchedSecondaryMonitors[0]];
+            var ci = unmatchedSecondaryConfigs[0];
+            result.Add(existingConfigs[ci] with
+            {
+                MonitorDeviceId = monitor.StableId,
+                IsPrimary = monitor.IsPrimary,
+                LastSeen = utcNow,
+            });
+            matchedMonitorStableIds.Add(monitor.StableId);
+            matchedConfigIndices.Add(ci);
+        }
+
         // Create defaults for new monitors with no matching config.
         // Primary monitors inherit global bands (IsCustomized = false) for a seamless
         // upgrade path. Secondary monitors start disabled with empty band lists;

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Settings/MonitorConfigReconciler.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Settings/MonitorConfigReconciler.cs
@@ -139,22 +139,16 @@ public static class MonitorConfigReconciler
         }
 
         // Fuzzy match: recover secondary monitor configs when their ID changed.
-        // Windows can reassign device paths for a still-connected monitor across a Win+P
-        // "PC screen only" -> "Extend" round-trip or a dock/undock event, which otherwise
-        // makes an existing secondary monitor look brand new and get a fresh disabled/empty
-        // config (see issue #48516). This is safe to apply only when there is exactly one
-        // remaining unmatched secondary monitor and exactly one remaining unmatched
-        // non-primary config: with more than one on either side we can't tell which
-        // monitor a config belongs to, and guessing risks associating the wrong settings
-        // with a genuinely new, unrelated display.
+        // Windows can reassign device paths for a still-connected monitor (a Win+P
+        // round-trip, a dock/undock), which would otherwise make it look brand new and get
+        // a fresh disabled/empty config (see issue #48516). Only fires when there's exactly
+        // one unmatched monitor and one unmatched config on each side, since anything more
+        // and we can't tell who owns what.
         //
-        // Note this isn't limited to the Win+P case: configs are kept around for
-        // StaleThreshold (180 days), so this same one-to-one match can also fire when a
-        // secondary monitor was unplugged weeks ago and a different, genuinely new
-        // secondary monitor is plugged in later. In that case we still reassociate the old
-        // config with the new monitor. That's intentional: inheriting a stale config (which
-        // the user can review and change) beats silently wiping it and starting from a
-        // disabled/empty default.
+        // This isn't Win+P-only: configs stick around for StaleThreshold (180 days), so a
+        // genuinely new monitor plugged in after an old one aged out can inherit its stale
+        // config too. That's fine. Inheriting a config you can review and change beats
+        // wiping it.
         var unmatchedSecondaryMonitors = new List<int>();
         for (var mi = 0; mi < currentMonitors.Count; mi++)
         {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Settings/MonitorConfigReconciler.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Settings/MonitorConfigReconciler.cs
@@ -138,50 +138,6 @@ public static class MonitorConfigReconciler
             }
         }
 
-        // Fuzzy match: recover secondary monitor configs when their ID changed.
-        // Windows can reassign device paths for a still-connected monitor (a Win+P
-        // round-trip, a dock/undock), which would otherwise make it look brand new and get
-        // a fresh disabled/empty config (see issue #48516). Only fires when there's exactly
-        // one unmatched monitor and one unmatched config on each side, since anything more
-        // and we can't tell who owns what.
-        //
-        // This isn't Win+P-only: configs stick around for StaleThreshold (180 days), so a
-        // genuinely new monitor plugged in after an old one aged out can inherit its stale
-        // config too. That's fine. Inheriting a config you can review and change beats
-        // wiping it.
-        var unmatchedSecondaryMonitors = new List<int>();
-        for (var mi = 0; mi < currentMonitors.Count; mi++)
-        {
-            var monitor = currentMonitors[mi];
-            if (!monitor.IsPrimary && !matchedMonitorStableIds.Contains(monitor.StableId))
-            {
-                unmatchedSecondaryMonitors.Add(mi);
-            }
-        }
-
-        var unmatchedSecondaryConfigs = new List<int>();
-        for (var ci = 0; ci < existingConfigs.Count; ci++)
-        {
-            if (!matchedConfigIndices.Contains(ci) && !existingConfigs[ci].IsPrimary)
-            {
-                unmatchedSecondaryConfigs.Add(ci);
-            }
-        }
-
-        if (unmatchedSecondaryMonitors.Count == 1 && unmatchedSecondaryConfigs.Count == 1)
-        {
-            var monitor = currentMonitors[unmatchedSecondaryMonitors[0]];
-            var ci = unmatchedSecondaryConfigs[0];
-            result.Add(existingConfigs[ci] with
-            {
-                MonitorDeviceId = monitor.StableId,
-                IsPrimary = monitor.IsPrimary,
-                LastSeen = utcNow,
-            });
-            matchedMonitorStableIds.Add(monitor.StableId);
-            matchedConfigIndices.Add(ci);
-        }
-
         // Create defaults for new monitors with no matching config.
         // Primary monitors inherit global bands (IsCustomized = false) for a seamless
         // upgrade path. Secondary monitors start disabled with empty band lists;

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Settings/MonitorConfigReconciler.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Settings/MonitorConfigReconciler.cs
@@ -147,6 +147,14 @@ public static class MonitorConfigReconciler
         // non-primary config: with more than one on either side we can't tell which
         // monitor a config belongs to, and guessing risks associating the wrong settings
         // with a genuinely new, unrelated display.
+        //
+        // Note this isn't limited to the Win+P case: configs are kept around for
+        // StaleThreshold (180 days), so this same one-to-one match can also fire when a
+        // secondary monitor was unplugged weeks ago and a different, genuinely new
+        // secondary monitor is plugged in later. In that case we still reassociate the old
+        // config with the new monitor. That's intentional: inheriting a stale config (which
+        // the user can review and change) beats silently wiping it and starting from a
+        // disabled/empty default.
         var unmatchedSecondaryMonitors = new List<int>();
         for (var mi = 0; mi < currentMonitors.Count; mi++)
         {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockWindow.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockWindow.xaml.cs
@@ -1319,12 +1319,6 @@ public sealed partial class DockWindow : WindowEx,
                 DispatcherQueue.TryEnqueue(HandleWorkAreaChanged);
             }
         }
-        else if (msg == PInvoke.WM_DISPLAYCHANGE)
-        {
-            Logger.LogDebug("WM_DISPLAYCHANGE");
-
-            _monitorService.NotifyMonitorsChanged();
-        }
         else if (msg == PInvoke.WM_MOUSEMOVE)
         {
             HandleMouseMoveForAutoHide();

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockWindow.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockWindow.xaml.cs
@@ -614,6 +614,30 @@ public sealed partial class DockWindow : WindowEx,
         }
     }
 
+    internal void RefreshForMonitorChange()
+    {
+        if (_isDisposed)
+        {
+            return;
+        }
+
+        RefreshTargetMonitor();
+
+        if (_appBarData.hWnd != IntPtr.Zero)
+        {
+            // The Shell caches the monitor coordinates from the original
+            // ABM_NEW registration, so after a topology change the stale
+            // AppBar rect cannot be repositioned correctly. Destroy and
+            // recreate to re-register with the new monitor geometry.
+            DestroyAppBar(_hwnd);
+            CreateAppBar(_hwnd);
+        }
+        else
+        {
+            UpdateWindowPosition();
+        }
+    }
+
     private void RefreshSideOverride()
     {
         if (_targetMonitor is null)
@@ -1299,40 +1323,7 @@ public sealed partial class DockWindow : WindowEx,
         {
             Logger.LogDebug("WM_DISPLAYCHANGE");
 
-            // Invalidate the monitor cache so DockWindowManager can reconcile
             _monitorService.NotifyMonitorsChanged();
-
-            // Use dispatcher to ensure we're on the UI thread.
-            // Refresh _targetMonitor before re-positioning: the MonitorInfo
-            // captured at construction is an immutable record, so its Bounds
-            // are stale after a topology change (e.g. an external display was
-            // disconnected, shifting our monitor's virtual-screen origin).
-            // Without this, UpdateAppBarDataForEdge would compute the AppBar
-            // rect against the old coordinates and produce a wildly incorrect
-            // size/position.
-            DispatcherQueue.TryEnqueue(() =>
-            {
-                if (_isDisposed)
-                {
-                    return;
-                }
-
-                RefreshTargetMonitor();
-
-                if (_appBarData.hWnd != IntPtr.Zero)
-                {
-                    // The Shell caches the monitor coordinates from the original
-                    // ABM_NEW registration, so after a topology change the stale
-                    // AppBar rect cannot be repositioned correctly. Destroy and
-                    // recreate to re-register with the new monitor geometry.
-                    DestroyAppBar(_hwnd);
-                    CreateAppBar(_hwnd);
-                }
-                else
-                {
-                    UpdateWindowPosition();
-                }
-            });
         }
         else if (msg == PInvoke.WM_MOUSEMOVE)
         {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockWindowManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockWindowManager.cs
@@ -26,6 +26,16 @@ public sealed partial class DockWindowManager : IDisposable
     private bool _disposed;
     private int _syncing;
 
+    /// <summary>
+    /// Debounces rapid-fire monitor-change notifications (e.g. several WM_DISPLAYCHANGE
+    /// messages during a Win+P mode switch or a dock/undock event). Without this, each
+    /// intermediate — possibly incomplete or incorrect — topology snapshot gets reconciled
+    /// and persisted to settings, which can permanently corrupt per-monitor dock configs
+    /// even though the topology settles to something that would have reconciled cleanly.
+    /// </summary>
+    private static readonly TimeSpan MonitorsChangedDebounceInterval = TimeSpan.FromMilliseconds(400);
+    private DispatcherQueueTimer? _monitorsChangedDebounceTimer;
+
     private bool? _lastSyncedEnableDock;
     private DockSettings? _lastSyncedDockSettings;
 
@@ -180,6 +190,12 @@ public sealed partial class DockWindowManager : IDisposable
         _monitorService.MonitorsChanged -= OnMonitorsChanged;
         _settingsService.SettingsChanged -= OnSettingsChanged;
 
+        if (_monitorsChangedDebounceTimer is not null)
+        {
+            _monitorsChangedDebounceTimer.Stop();
+            _monitorsChangedDebounceTimer.Tick -= OnMonitorsChangedDebounceTimerTick;
+        }
+
         HideDocks();
     }
 
@@ -211,11 +227,32 @@ public sealed partial class DockWindowManager : IDisposable
     {
         _dispatcherQueue.TryEnqueue(() =>
         {
-            if (!_disposed)
+            if (_disposed)
             {
-                SyncDocksToSettings();
+                return;
             }
+
+            // Debounce: (re)start a short timer instead of syncing immediately so a burst
+            // of monitor-change notifications collapses into a single reconciliation against
+            // the final, settled topology.
+            _monitorsChangedDebounceTimer ??= _dispatcherQueue.CreateTimer();
+            _monitorsChangedDebounceTimer.Stop();
+            _monitorsChangedDebounceTimer.Interval = MonitorsChangedDebounceInterval;
+            _monitorsChangedDebounceTimer.IsRepeating = false;
+            _monitorsChangedDebounceTimer.Tick -= OnMonitorsChangedDebounceTimerTick;
+            _monitorsChangedDebounceTimer.Tick += OnMonitorsChangedDebounceTimerTick;
+            _monitorsChangedDebounceTimer.Start();
         });
+    }
+
+    private void OnMonitorsChangedDebounceTimerTick(object? sender, object e)
+    {
+        _monitorsChangedDebounceTimer?.Stop();
+
+        if (!_disposed)
+        {
+            SyncDocksToSettings();
+        }
     }
 
     private void OnSettingsChanged(ISettingsService sender, SettingsModel args)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockWindowManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockWindowManager.cs
@@ -29,7 +29,7 @@ public sealed partial class DockWindowManager : IDisposable
     /// <summary>
     /// Debounces rapid-fire monitor-change notifications (e.g. several WM_DISPLAYCHANGE
     /// messages during a Win+P mode switch or a dock/undock event). Without this, each
-    /// intermediate — possibly incomplete or incorrect — topology snapshot gets reconciled
+    /// intermediate topology snapshot (possibly incomplete or incorrect) gets reconciled
     /// and persisted to settings, which can permanently corrupt per-monitor dock configs
     /// even though the topology settles to something that would have reconciled cleanly.
     /// </summary>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockWindowManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockWindowManager.cs
@@ -2,6 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using CommunityToolkit.WinUI;
 using Microsoft.CmdPal.UI.ViewModels;
 using Microsoft.CmdPal.UI.ViewModels.Dock;
 using Microsoft.CmdPal.UI.ViewModels.Models;
@@ -33,7 +34,7 @@ public sealed partial class DockWindowManager : IDisposable
     /// even though things settle fine on their own a moment later.
     /// </summary>
     private static readonly TimeSpan MonitorsChangedDebounceInterval = TimeSpan.FromMilliseconds(400);
-    private DispatcherQueueTimer? _monitorsChangedDebounceTimer;
+    private readonly DispatcherQueueTimer _monitorsChangedDebounceTimer;
 
     private bool? _lastSyncedEnableDock;
     private DockSettings? _lastSyncedDockSettings;
@@ -46,6 +47,7 @@ public sealed partial class DockWindowManager : IDisposable
         _monitorService = monitorService;
         _settingsService = settingsService;
         _dispatcherQueue = dispatcherQueue;
+        _monitorsChangedDebounceTimer = _dispatcherQueue.CreateTimer();
 
         _monitorService.MonitorsChanged += OnMonitorsChanged;
         _settingsService.SettingsChanged += OnSettingsChanged;
@@ -189,11 +191,7 @@ public sealed partial class DockWindowManager : IDisposable
         _monitorService.MonitorsChanged -= OnMonitorsChanged;
         _settingsService.SettingsChanged -= OnSettingsChanged;
 
-        if (_monitorsChangedDebounceTimer is not null)
-        {
-            _monitorsChangedDebounceTimer.Stop();
-            _monitorsChangedDebounceTimer.Tick -= OnMonitorsChangedDebounceTimerTick;
-        }
+        _monitorsChangedDebounceTimer.Stop();
 
         HideDocks();
     }
@@ -231,27 +229,11 @@ public sealed partial class DockWindowManager : IDisposable
                 return;
             }
 
-            // Debounce: (re)start a short timer instead of syncing immediately so a burst
-            // of monitor-change notifications collapses into a single reconciliation against
-            // the final, settled topology.
-            _monitorsChangedDebounceTimer ??= _dispatcherQueue.CreateTimer();
-            _monitorsChangedDebounceTimer.Stop();
-            _monitorsChangedDebounceTimer.Interval = MonitorsChangedDebounceInterval;
-            _monitorsChangedDebounceTimer.IsRepeating = false;
-            _monitorsChangedDebounceTimer.Tick -= OnMonitorsChangedDebounceTimerTick;
-            _monitorsChangedDebounceTimer.Tick += OnMonitorsChangedDebounceTimerTick;
-            _monitorsChangedDebounceTimer.Start();
+            _monitorsChangedDebounceTimer.Debounce(
+                SyncDocksToSettings,
+                interval: MonitorsChangedDebounceInterval,
+                immediate: false);
         });
-    }
-
-    private void OnMonitorsChangedDebounceTimerTick(object? sender, object e)
-    {
-        _monitorsChangedDebounceTimer?.Stop();
-
-        if (!_disposed)
-        {
-            SyncDocksToSettings();
-        }
     }
 
     private void OnSettingsChanged(ISettingsService sender, SettingsModel args)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockWindowManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockWindowManager.cs
@@ -85,7 +85,7 @@ public sealed partial class DockWindowManager : IDisposable
     /// <summary>
     /// Synchronizes running dock windows to match the current settings and connected monitors.
     /// </summary>
-    public void SyncDocksToSettings()
+    public void SyncDocksToSettings(bool refreshDockWindows = false)
     {
         if (Interlocked.CompareExchange(ref _syncing, 1, 0) != 0)
         {
@@ -94,7 +94,7 @@ public sealed partial class DockWindowManager : IDisposable
 
         try
         {
-            SyncDocksToSettingsCore();
+            SyncDocksToSettingsCore(refreshDockWindows);
         }
         finally
         {
@@ -102,7 +102,7 @@ public sealed partial class DockWindowManager : IDisposable
         }
     }
 
-    private void SyncDocksToSettingsCore()
+    private void SyncDocksToSettingsCore(bool refreshDockWindows)
     {
         var settings = _settingsService.Settings;
         if (!settings.EnableDock)
@@ -178,6 +178,16 @@ public sealed partial class DockWindowManager : IDisposable
                 dock.ViewModel.Dispose();
             }
         }
+
+        if (!refreshDockWindows)
+        {
+            return;
+        }
+
+        foreach (var (_, (window, _)) in _docks)
+        {
+            window.RefreshForMonitorChange();
+        }
     }
 
     public void Dispose()
@@ -230,7 +240,7 @@ public sealed partial class DockWindowManager : IDisposable
             }
 
             _monitorsChangedDebounceTimer.Debounce(
-                SyncDocksToSettings,
+                () => SyncDocksToSettings(refreshDockWindows: true),
                 interval: MonitorsChangedDebounceInterval,
                 immediate: false);
         });

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockWindowManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Dock/DockWindowManager.cs
@@ -27,11 +27,10 @@ public sealed partial class DockWindowManager : IDisposable
     private int _syncing;
 
     /// <summary>
-    /// Debounces rapid-fire monitor-change notifications (e.g. several WM_DISPLAYCHANGE
-    /// messages during a Win+P mode switch or a dock/undock event). Without this, each
-    /// intermediate topology snapshot (possibly incomplete or incorrect) gets reconciled
-    /// and persisted to settings, which can permanently corrupt per-monitor dock configs
-    /// even though the topology settles to something that would have reconciled cleanly.
+    /// Debounces rapid-fire monitor-change notifications (several WM_DISPLAYCHANGE messages
+    /// during a Win+P switch or dock/undock). Without it, each intermediate topology
+    /// snapshot gets reconciled and persisted, which can permanently corrupt dock configs
+    /// even though things settle fine on their own a moment later.
     /// </summary>
     private static readonly TimeSpan MonitorsChangedDebounceInterval = TimeSpan.FromMilliseconds(400);
     private DispatcherQueueTimer? _monitorsChangedDebounceTimer;

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml.cs
@@ -1770,11 +1770,9 @@ public sealed partial class MainWindow : WindowEx,
                     return (LRESULT)IntPtr.Zero;
                 }
 
-            // MainWindow always exists (unlike DockWindow instances, which only exist for
-            // enabled monitors, or none at all when the dock is disabled), so it is the one
-            // reliable place to observe display topology changes and keep IMonitorService's
-            // cache fresh. Without this, the Settings page's monitor list can go stale when
-            // no dock window happens to be alive to receive WM_DISPLAYCHANGE itself.
+            // Unlike DockWindow instances, MainWindow always exists, so it's the one
+            // reliable place to catch topology changes. Without this, the Settings page's
+            // monitor list goes stale whenever no dock window is around to see WM_DISPLAYCHANGE.
             case PInvoke.WM_DISPLAYCHANGE:
                 Logger.LogDebug("MainWindow WM_DISPLAYCHANGE");
                 _monitorService.NotifyMonitorsChanged();

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml.cs
@@ -73,6 +73,7 @@ public sealed partial class MainWindow : WindowEx,
     private readonly LocalKeyboardListener _localKeyboardListener;
     private readonly HiddenOwnerWindowBehavior _hiddenOwnerBehavior = new();
     private readonly ICmdPalProtocolActivation _protocolActivation;
+    private readonly ViewModels.Models.IMonitorService _monitorService;
     private readonly IThemeService _themeService;
     private readonly WindowThemeSynchronizer _windowThemeSynchronizer;
     private readonly List<long> _breakthroughTimestamps = [];
@@ -135,6 +136,7 @@ public sealed partial class MainWindow : WindowEx,
     public MainWindow()
     {
         _protocolActivation = App.Current.Services.GetRequiredService<ICmdPalProtocolActivation>();
+        _monitorService = App.Current.Services.GetRequiredService<ViewModels.Models.IMonitorService>();
 
         InitializeComponent();
 
@@ -1767,6 +1769,16 @@ public sealed partial class MainWindow : WindowEx,
 
                     return (LRESULT)IntPtr.Zero;
                 }
+
+            // MainWindow always exists (unlike DockWindow instances, which only exist for
+            // enabled monitors, or none at all when the dock is disabled), so it is the one
+            // reliable place to observe display topology changes and keep IMonitorService's
+            // cache fresh. Without this, the Settings page's monitor list can go stale when
+            // no dock window happens to be alive to receive WM_DISPLAYCHANGE itself.
+            case PInvoke.WM_DISPLAYCHANGE:
+                Logger.LogDebug("MainWindow WM_DISPLAYCHANGE");
+                _monitorService.NotifyMonitorsChanged();
+                break;
 
             default:
                 if (uMsg == WM_TASKBAR_RESTART)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Services/MonitorService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Services/MonitorService.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Threading;
 using ManagedCommon;
 using Microsoft.CmdPal.UI.ViewModels.Models;
 using Windows.Win32;
@@ -120,13 +119,12 @@ public sealed class MonitorService : IMonitorService
     }
 
     /// <summary>
-    /// Number of attempts to build the stable-ID display info map before giving up.
+    /// Number of immediate attempts to build the stable-ID display info map before giving up.
     /// Right after WM_DISPLAYCHANGE, the Display Configuration API can transiently fail or
-    /// return an incomplete topology while Windows is still settling. A couple of retries
-    /// avoids falling back to the volatile GDI device name and breaking dock reconciliation.
+    /// return an incomplete topology while Windows is still settling. Immediate retries
+    /// avoid blocking the UI thread while giving the API another chance to return stable data.
     /// </summary>
     private const int DisplayInfoMapRetryCount = 3;
-    private static readonly TimeSpan DisplayInfoMapRetryDelay = TimeSpan.FromMilliseconds(50);
 
     private static unsafe List<MonitorInfo> EnumerateMonitors(Dictionary<string, (string FriendlyName, string DevicePath)> displayInfo)
     {
@@ -197,20 +195,15 @@ public sealed class MonitorService : IMonitorService
     }
 
     /// <summary>
-    /// Calls <see cref="BuildDisplayInfoMap"/>, retrying a few times with a short delay if
-    /// it comes back incomplete. Right after WM_DISPLAYCHANGE the API can transiently fail
-    /// or only resolve some active sources, and a partial map would leave those monitors on
-    /// their volatile GDI name, tricking <see cref="Settings.MonitorConfigReconciler"/> into
-    /// treating a still-connected monitor as brand new.
-    ///
-    /// A source can also fail to resolve permanently (a virtual or unnamed source whose
-    /// <c>DisplayConfigGetDeviceInfo</c> call never succeeds), so we stop retrying early
-    /// once an attempt makes no more progress than the last one.
+    /// Calls <see cref="BuildDisplayInfoMap"/>, retrying a few times if it comes back
+    /// incomplete. Right after WM_DISPLAYCHANGE the API can transiently fail or only resolve
+    /// some active sources, and a partial map would leave those monitors on their volatile
+    /// GDI name, tricking <see cref="Settings.MonitorConfigReconciler"/> into treating a
+    /// still-connected monitor as brand new.
     /// </summary>
     private static Dictionary<string, (string FriendlyName, string DevicePath)> BuildDisplayInfoMapWithRetry()
     {
         var map = new Dictionary<string, (string FriendlyName, string DevicePath)>(StringComparer.OrdinalIgnoreCase);
-        var lastResolvedCount = -1;
 
         for (var attempt = 0; attempt < DisplayInfoMapRetryCount; attempt++)
         {
@@ -218,19 +211,6 @@ public sealed class MonitorService : IMonitorService
             if (map.Count >= expectedSourceCount && expectedSourceCount > 0)
             {
                 return map;
-            }
-
-            if (map.Count <= lastResolvedCount)
-            {
-                // No progress since the previous attempt; further retries won't help.
-                break;
-            }
-
-            lastResolvedCount = map.Count;
-
-            if (attempt < DisplayInfoMapRetryCount - 1)
-            {
-                Thread.Sleep(DisplayInfoMapRetryDelay);
             }
         }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Services/MonitorService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Services/MonitorService.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Threading;
 using ManagedCommon;
 using Microsoft.CmdPal.UI.ViewModels.Models;
 using Windows.Win32;
@@ -104,10 +105,20 @@ public sealed class MonitorService : IMonitorService
         MonitorsChanged?.Invoke(this, EventArgs.Empty);
     }
 
+    /// <summary>
+    /// Number of attempts to build the stable-ID display info map before giving up.
+    /// Immediately after a WM_DISPLAYCHANGE the Display Configuration API can transiently
+    /// fail or return an incomplete topology while Windows is still settling the new
+    /// configuration; retrying a couple of times avoids incorrectly falling back to the
+    /// volatile GDI device name (which breaks per-monitor dock config reconciliation).
+    /// </summary>
+    private const int DisplayInfoMapRetryCount = 3;
+    private static readonly TimeSpan DisplayInfoMapRetryDelay = TimeSpan.FromMilliseconds(50);
+
     private static unsafe List<MonitorInfo> EnumerateMonitors()
     {
         var monitors = new List<MonitorInfo>();
-        var displayInfo = BuildDisplayInfoMap();
+        var displayInfo = BuildDisplayInfoMapWithRetry();
 
         PInvoke.EnumDisplayMonitors(
             HDC.Null,
@@ -171,6 +182,33 @@ public sealed class MonitorService : IMonitorService
             0);
 
         return monitors;
+    }
+
+    /// <summary>
+    /// Calls <see cref="BuildDisplayInfoMap"/>, retrying a few times with a short delay
+    /// if it comes back empty. The Display Configuration API can transiently fail right
+    /// after a WM_DISPLAYCHANGE (topology still settling); without a retry, monitors would
+    /// silently fall back from their stable hardware path to the volatile GDI device name,
+    /// which makes <see cref="Settings.MonitorConfigReconciler"/> treat a still-connected
+    /// monitor as brand new and wipe/disable its dock config.
+    /// </summary>
+    private static Dictionary<string, (string FriendlyName, string DevicePath)> BuildDisplayInfoMapWithRetry()
+    {
+        for (var attempt = 0; attempt < DisplayInfoMapRetryCount; attempt++)
+        {
+            var map = BuildDisplayInfoMap();
+            if (map.Count > 0)
+            {
+                return map;
+            }
+
+            if (attempt < DisplayInfoMapRetryCount - 1)
+            {
+                Thread.Sleep(DisplayInfoMapRetryDelay);
+            }
+        }
+
+        return BuildDisplayInfoMap();
     }
 
     /// <summary>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Services/MonitorService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Services/MonitorService.cs
@@ -31,6 +31,20 @@ public sealed class MonitorService : IMonitorService
     /// <inheritdoc/>
     public IReadOnlyList<MonitorInfo> GetMonitors()
     {
+        // Check the cache first without paying for a retry-with-sleep under the lock.
+        lock (_lock)
+        {
+            if (_cachedSnapshot is not null)
+            {
+                return _cachedSnapshot;
+            }
+        }
+
+        // BuildDisplayInfoMapWithRetry can sleep between attempts, so it runs unlocked.
+        // Another thread might race us here and rebuild the map too, but that's cheap
+        // compared to blocking every other caller on the UI thread for up to 100ms.
+        var displayInfo = BuildDisplayInfoMapWithRetry();
+
         lock (_lock)
         {
             if (_cachedSnapshot is not null)
@@ -38,7 +52,7 @@ public sealed class MonitorService : IMonitorService
                 return _cachedSnapshot;
             }
 
-            _cachedMonitors = EnumerateMonitors();
+            _cachedMonitors = EnumerateMonitors(displayInfo);
             _cachedSnapshot = _cachedMonitors.AsReadOnly();
             return _cachedSnapshot;
         }
@@ -109,16 +123,15 @@ public sealed class MonitorService : IMonitorService
     /// Number of attempts to build the stable-ID display info map before giving up.
     /// Immediately after a WM_DISPLAYCHANGE the Display Configuration API can transiently
     /// fail or return an incomplete topology while Windows is still settling the new
-    /// configuration; retrying a couple of times avoids incorrectly falling back to the
+    /// configuration. Retrying a couple of times avoids incorrectly falling back to the
     /// volatile GDI device name (which breaks per-monitor dock config reconciliation).
     /// </summary>
     private const int DisplayInfoMapRetryCount = 3;
     private static readonly TimeSpan DisplayInfoMapRetryDelay = TimeSpan.FromMilliseconds(50);
 
-    private static unsafe List<MonitorInfo> EnumerateMonitors()
+    private static unsafe List<MonitorInfo> EnumerateMonitors(Dictionary<string, (string FriendlyName, string DevicePath)> displayInfo)
     {
         var monitors = new List<MonitorInfo>();
-        var displayInfo = BuildDisplayInfoMapWithRetry();
 
         PInvoke.EnumDisplayMonitors(
             HDC.Null,
@@ -186,18 +199,21 @@ public sealed class MonitorService : IMonitorService
 
     /// <summary>
     /// Calls <see cref="BuildDisplayInfoMap"/>, retrying a few times with a short delay
-    /// if it comes back empty. The Display Configuration API can transiently fail right
-    /// after a WM_DISPLAYCHANGE (topology still settling); without a retry, monitors would
-    /// silently fall back from their stable hardware path to the volatile GDI device name,
-    /// which makes <see cref="Settings.MonitorConfigReconciler"/> treat a still-connected
-    /// monitor as brand new and wipe/disable its dock config.
+    /// if it comes back incomplete. The Display Configuration API can transiently fail or
+    /// only resolve some of the active paths right after a WM_DISPLAYCHANGE (topology still
+    /// settling); without a retry, a partially resolved map would silently leave the
+    /// remaining monitors on their volatile GDI device name, which makes
+    /// <see cref="Settings.MonitorConfigReconciler"/> treat a still-connected monitor as
+    /// brand new and wipe/disable its dock config.
     /// </summary>
     private static Dictionary<string, (string FriendlyName, string DevicePath)> BuildDisplayInfoMapWithRetry()
     {
+        var map = new Dictionary<string, (string FriendlyName, string DevicePath)>(StringComparer.OrdinalIgnoreCase);
+
         for (var attempt = 0; attempt < DisplayInfoMapRetryCount; attempt++)
         {
-            var map = BuildDisplayInfoMap();
-            if (map.Count > 0)
+            map = BuildDisplayInfoMap(out var pathCount);
+            if (map.Count >= pathCount && pathCount > 0)
             {
                 return map;
             }
@@ -208,23 +224,26 @@ public sealed class MonitorService : IMonitorService
             }
         }
 
-        return BuildDisplayInfoMap();
+        return map;
     }
 
     /// <summary>
     /// Builds a map from GDI device name (e.g. <c>\\.\DISPLAY1</c>) to display metadata
     /// (friendly name and stable device path) using the Display Configuration APIs.
     /// Returns an empty dictionary on failure so callers can fall back gracefully.
+    /// <paramref name="pathCount"/> is the number of active display paths Windows reported,
+    /// so callers can tell a fully resolved map from a partial one.
     /// </summary>
-    private static unsafe Dictionary<string, (string FriendlyName, string DevicePath)> BuildDisplayInfoMap()
+    private static unsafe Dictionary<string, (string FriendlyName, string DevicePath)> BuildDisplayInfoMap(out uint pathCount)
     {
         var map = new Dictionary<string, (string FriendlyName, string DevicePath)>(StringComparer.OrdinalIgnoreCase);
+        pathCount = 0;
 
         try
         {
             var result = PInvoke.GetDisplayConfigBufferSizes(
                 QUERY_DISPLAY_CONFIG_FLAGS.QDC_ONLY_ACTIVE_PATHS,
-                out var pathCount,
+                out pathCount,
                 out var modeCount);
             if (result != WIN32_ERROR.NO_ERROR)
             {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Services/MonitorService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Services/MonitorService.cs
@@ -205,10 +205,17 @@ public sealed class MonitorService : IMonitorService
     /// remaining monitors on their volatile GDI device name, which makes
     /// <see cref="Settings.MonitorConfigReconciler"/> treat a still-connected monitor as
     /// brand new and wipe/disable its dock config.
+    ///
+    /// A source can also fail to resolve permanently (for example a virtual or otherwise
+    /// unnamed source whose <c>DisplayConfigGetDeviceInfo</c> call never succeeds), in which
+    /// case the map can never reach <c>expectedSourceCount</c> no matter how many times we
+    /// retry. To avoid burning every attempt (and its sleep) on a result that will never
+    /// improve, we stop early once an attempt makes no more progress than the last one.
     /// </summary>
     private static Dictionary<string, (string FriendlyName, string DevicePath)> BuildDisplayInfoMapWithRetry()
     {
         var map = new Dictionary<string, (string FriendlyName, string DevicePath)>(StringComparer.OrdinalIgnoreCase);
+        var lastResolvedCount = -1;
 
         for (var attempt = 0; attempt < DisplayInfoMapRetryCount; attempt++)
         {
@@ -217,6 +224,14 @@ public sealed class MonitorService : IMonitorService
             {
                 return map;
             }
+
+            if (map.Count <= lastResolvedCount)
+            {
+                // No progress since the previous attempt; further retries won't help.
+                break;
+            }
+
+            lastResolvedCount = map.Count;
 
             if (attempt < DisplayInfoMapRetryCount - 1)
             {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Services/MonitorService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Services/MonitorService.cs
@@ -40,9 +40,9 @@ public sealed class MonitorService : IMonitorService
             }
         }
 
-        // BuildDisplayInfoMapWithRetry can sleep between attempts, so it runs unlocked.
-        // Another thread might race us here and rebuild the map too, but that's cheap
-        // compared to blocking every other caller on the UI thread for up to 100ms.
+        // BuildDisplayInfoMapWithRetry sleeps between attempts, so it runs unlocked. Another
+        // thread might race us and rebuild the map too, but that's cheaper than blocking
+        // every caller for up to 100ms.
         var displayInfo = BuildDisplayInfoMapWithRetry();
 
         lock (_lock)
@@ -121,10 +121,9 @@ public sealed class MonitorService : IMonitorService
 
     /// <summary>
     /// Number of attempts to build the stable-ID display info map before giving up.
-    /// Immediately after a WM_DISPLAYCHANGE the Display Configuration API can transiently
-    /// fail or return an incomplete topology while Windows is still settling the new
-    /// configuration. Retrying a couple of times avoids incorrectly falling back to the
-    /// volatile GDI device name (which breaks per-monitor dock config reconciliation).
+    /// Right after WM_DISPLAYCHANGE, the Display Configuration API can transiently fail or
+    /// return an incomplete topology while Windows is still settling. A couple of retries
+    /// avoids falling back to the volatile GDI device name and breaking dock reconciliation.
     /// </summary>
     private const int DisplayInfoMapRetryCount = 3;
     private static readonly TimeSpan DisplayInfoMapRetryDelay = TimeSpan.FromMilliseconds(50);
@@ -198,19 +197,15 @@ public sealed class MonitorService : IMonitorService
     }
 
     /// <summary>
-    /// Calls <see cref="BuildDisplayInfoMap"/>, retrying a few times with a short delay
-    /// if it comes back incomplete. The Display Configuration API can transiently fail or
-    /// only resolve some of the active sources right after a WM_DISPLAYCHANGE (topology
-    /// still settling); without a retry, a partially resolved map would silently leave the
-    /// remaining monitors on their volatile GDI device name, which makes
-    /// <see cref="Settings.MonitorConfigReconciler"/> treat a still-connected monitor as
-    /// brand new and wipe/disable its dock config.
+    /// Calls <see cref="BuildDisplayInfoMap"/>, retrying a few times with a short delay if
+    /// it comes back incomplete. Right after WM_DISPLAYCHANGE the API can transiently fail
+    /// or only resolve some active sources, and a partial map would leave those monitors on
+    /// their volatile GDI name, tricking <see cref="Settings.MonitorConfigReconciler"/> into
+    /// treating a still-connected monitor as brand new.
     ///
-    /// A source can also fail to resolve permanently (for example a virtual or otherwise
-    /// unnamed source whose <c>DisplayConfigGetDeviceInfo</c> call never succeeds), in which
-    /// case the map can never reach <c>expectedSourceCount</c> no matter how many times we
-    /// retry. To avoid burning every attempt (and its sleep) on a result that will never
-    /// improve, we stop early once an attempt makes no more progress than the last one.
+    /// A source can also fail to resolve permanently (a virtual or unnamed source whose
+    /// <c>DisplayConfigGetDeviceInfo</c> call never succeeds), so we stop retrying early
+    /// once an attempt makes no more progress than the last one.
     /// </summary>
     private static Dictionary<string, (string FriendlyName, string DevicePath)> BuildDisplayInfoMapWithRetry()
     {
@@ -247,9 +242,8 @@ public sealed class MonitorService : IMonitorService
     /// (friendly name and stable device path) using the Display Configuration APIs.
     /// Returns an empty dictionary on failure so callers can fall back gracefully.
     /// <paramref name="expectedSourceCount"/> is the number of distinct GDI source device
-    /// names among the active paths, not the raw path count. In Duplicate/clone display
-    /// mode, several paths share one source, so comparing against the path count itself
-    /// would never be satisfied and the retry loop would always exhaust every attempt.
+    /// names among the active paths, not the raw path count: in Duplicate/clone mode several
+    /// paths share one source, so comparing against the path count would never be satisfied.
     /// </summary>
     private static unsafe Dictionary<string, (string FriendlyName, string DevicePath)> BuildDisplayInfoMap(out uint expectedSourceCount)
     {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Services/MonitorService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Services/MonitorService.cs
@@ -200,8 +200,8 @@ public sealed class MonitorService : IMonitorService
     /// <summary>
     /// Calls <see cref="BuildDisplayInfoMap"/>, retrying a few times with a short delay
     /// if it comes back incomplete. The Display Configuration API can transiently fail or
-    /// only resolve some of the active paths right after a WM_DISPLAYCHANGE (topology still
-    /// settling); without a retry, a partially resolved map would silently leave the
+    /// only resolve some of the active sources right after a WM_DISPLAYCHANGE (topology
+    /// still settling); without a retry, a partially resolved map would silently leave the
     /// remaining monitors on their volatile GDI device name, which makes
     /// <see cref="Settings.MonitorConfigReconciler"/> treat a still-connected monitor as
     /// brand new and wipe/disable its dock config.
@@ -212,8 +212,8 @@ public sealed class MonitorService : IMonitorService
 
         for (var attempt = 0; attempt < DisplayInfoMapRetryCount; attempt++)
         {
-            map = BuildDisplayInfoMap(out var pathCount);
-            if (map.Count >= pathCount && pathCount > 0)
+            map = BuildDisplayInfoMap(out var expectedSourceCount);
+            if (map.Count >= expectedSourceCount && expectedSourceCount > 0)
             {
                 return map;
             }
@@ -231,19 +231,21 @@ public sealed class MonitorService : IMonitorService
     /// Builds a map from GDI device name (e.g. <c>\\.\DISPLAY1</c>) to display metadata
     /// (friendly name and stable device path) using the Display Configuration APIs.
     /// Returns an empty dictionary on failure so callers can fall back gracefully.
-    /// <paramref name="pathCount"/> is the number of active display paths Windows reported,
-    /// so callers can tell a fully resolved map from a partial one.
+    /// <paramref name="expectedSourceCount"/> is the number of distinct GDI source device
+    /// names among the active paths, not the raw path count. In Duplicate/clone display
+    /// mode, several paths share one source, so comparing against the path count itself
+    /// would never be satisfied and the retry loop would always exhaust every attempt.
     /// </summary>
-    private static unsafe Dictionary<string, (string FriendlyName, string DevicePath)> BuildDisplayInfoMap(out uint pathCount)
+    private static unsafe Dictionary<string, (string FriendlyName, string DevicePath)> BuildDisplayInfoMap(out uint expectedSourceCount)
     {
         var map = new Dictionary<string, (string FriendlyName, string DevicePath)>(StringComparer.OrdinalIgnoreCase);
-        pathCount = 0;
+        expectedSourceCount = 0;
 
         try
         {
             var result = PInvoke.GetDisplayConfigBufferSizes(
                 QUERY_DISPLAY_CONFIG_FLAGS.QDC_ONLY_ACTIVE_PATHS,
-                out pathCount,
+                out var pathCount,
                 out var modeCount);
             if (result != WIN32_ERROR.NO_ERROR)
             {
@@ -266,9 +268,12 @@ public sealed class MonitorService : IMonitorService
                 return map;
             }
 
+            var expectedSources = new HashSet<(LUID AdapterId, uint Id)>();
+
             for (var i = 0; i < pathCount; i++)
             {
                 var path = paths[i];
+                expectedSources.Add((path.sourceInfo.adapterId, path.sourceInfo.id));
 
                 // Get the GDI device name from the source info
                 var sourceName = default(DISPLAYCONFIG_SOURCE_DEVICE_NAME);
@@ -307,6 +312,8 @@ public sealed class MonitorService : IMonitorService
                     map.TryAdd(gdiName, (friendly ?? string.Empty, devicePath ?? string.Empty));
                 }
             }
+
+            expectedSourceCount = (uint)expectedSources.Count;
         }
         catch (Exception ex) when (ex is not OutOfMemoryException)
         {

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/DockMultiMonitorTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/DockMultiMonitorTests.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Text.Json;
 using Microsoft.CmdPal.UI.ViewModels.Dock;
 using Microsoft.CmdPal.UI.ViewModels.Models;
@@ -271,27 +272,111 @@ public class DockMultiMonitorTests
     }
 
     [TestMethod]
-    public void Reconciler_FuzzyMatch_DoesNotMatchNonPrimaryMonitors()
+    public void Reconciler_FuzzyMatch_ReassociatesSingleUnmatchedSecondaryMonitor()
     {
-        // Config has stale stable ID for a non-primary monitor
+        // Config has stale stable ID for a non-primary monitor. There is exactly one
+        // unmatched secondary monitor and exactly one unmatched non-primary config, so
+        // reconciliation should reassociate them instead of creating a fresh empty config
+        // (this is the Win+P "PC screen only" -> "Extend" scenario from issue #48516).
         var configs = ImmutableList.Create(
             new DockMonitorConfig { MonitorDeviceId = PrimaryMonitor.StableId, Enabled = true, IsPrimary = true },
-            new DockMonitorConfig { MonitorDeviceId = @"\\?\DISPLAY#STALE#4&eee&0&UID333#{guidStale}", Enabled = true, IsPrimary = false, IsCustomized = true, LastSeen = DateTime.UtcNow });
+            new DockMonitorConfig
+            {
+                MonitorDeviceId = @"\\?\DISPLAY#STALE#4&eee&0&UID333#{guidStale}",
+                Enabled = true,
+                IsPrimary = false,
+                IsCustomized = true,
+                StartBands = ImmutableList.Create(new DockBandSettings { ProviderId = "p", CommandId = "c" }),
+                LastSeen = DateTime.UtcNow,
+            });
 
-        // Current monitors have primary + a different secondary
+        // Current monitors have primary + a secondary whose stable ID changed
         var monitors = new List<MonitorInfo> { PrimaryMonitor, SecondaryMonitor };
 
         var result = MonitorConfigReconciler.Reconcile(configs, monitors);
 
-        // Primary keeps its config, new secondary gets a fresh customized config,
-        // stale secondary is retained at end for future reconnection
-        Assert.AreEqual(3, result.Count);
+        Assert.AreEqual(2, result.Count);
         Assert.AreEqual(PrimaryMonitor.StableId, result[0].MonitorDeviceId);
-        Assert.AreEqual(SecondaryMonitor.StableId, result[1].MonitorDeviceId);
-        Assert.IsTrue(result[1].IsCustomized, "New secondary should get an empty-bands customized config.");
-        Assert.AreEqual(0, result[1].StartBands?.Count ?? 0, "New secondary should start with empty bands.");
-        Assert.AreEqual(@"\\?\DISPLAY#STALE#4&eee&0&UID333#{guidStale}", result[2].MonitorDeviceId, "Stale config should be preserved.");
-        Assert.IsTrue(result[2].IsCustomized, "Stale config should retain its customizations.");
+        Assert.AreEqual(SecondaryMonitor.StableId, result[1].MonitorDeviceId, "Secondary config should be reassociated with the new stable ID.");
+        Assert.IsTrue(result[1].IsCustomized, "Reassociated config should retain its customizations.");
+        Assert.AreEqual(1, result[1].StartBands?.Count ?? 0, "Reassociated config should retain its pinned bands, not start empty.");
+    }
+
+    [TestMethod]
+    public void Reconciler_FuzzyMatch_DoesNotReassociateWhenMultipleUnmatchedSecondaryMonitors()
+    {
+        // Two unmatched secondary monitors and one unmatched secondary config: ambiguous,
+        // so reconciliation must not guess and should fall back to creating fresh configs.
+        var thirdMonitor = SecondaryMonitor with
+        {
+            DeviceId = @"\\.\DISPLAY3",
+            StableId = @"\\?\DISPLAY#THIRD#4&ccc&0&UID333#{guid3}",
+            DisplayName = "Display 3",
+        };
+
+        var configs = ImmutableList.Create(
+            new DockMonitorConfig { MonitorDeviceId = PrimaryMonitor.StableId, Enabled = true, IsPrimary = true },
+            new DockMonitorConfig
+            {
+                MonitorDeviceId = @"\\?\DISPLAY#STALE#4&eee&0&UID333#{guidStale}",
+                Enabled = true,
+                IsPrimary = false,
+                IsCustomized = true,
+                LastSeen = DateTime.UtcNow,
+            });
+
+        var monitors = new List<MonitorInfo> { PrimaryMonitor, SecondaryMonitor, thirdMonitor };
+
+        var result = MonitorConfigReconciler.Reconcile(configs, monitors);
+
+        // Both new secondary monitors get fresh configs; the stale one is retained for reconnection.
+        Assert.AreEqual(4, result.Count);
+        Assert.IsTrue(result.Any(c => c.MonitorDeviceId == SecondaryMonitor.StableId));
+        Assert.IsTrue(result.Any(c => c.MonitorDeviceId == thirdMonitor.StableId));
+        Assert.IsTrue(result.Any(c => c.MonitorDeviceId == @"\\?\DISPLAY#STALE#4&eee&0&UID333#{guidStale}"));
+    }
+
+    [TestMethod]
+    public void Reconciler_TransientStableIdFallbackToDeviceId_DoesNotDropSecondaryConfig()
+    {
+        // Simulates the StableId momentarily falling back to the volatile GDI DeviceId
+        // right after WM_DISPLAYCHANGE (Display Configuration API not yet settled).
+        // Even though the "monitor" here reports its DeviceId as its StableId, the legacy
+        // GDI-name migration path should still recover the existing config rather than
+        // creating a new disabled one.
+        var degradedSecondary = SecondaryMonitor with { StableId = SecondaryMonitor.DeviceId };
+
+        var configs = ImmutableList.Create(
+            new DockMonitorConfig { MonitorDeviceId = PrimaryMonitor.StableId, Enabled = true, IsPrimary = true },
+            new DockMonitorConfig
+            {
+                MonitorDeviceId = SecondaryMonitor.StableId,
+                Enabled = true,
+                IsPrimary = false,
+                IsCustomized = true,
+                StartBands = ImmutableList.Create(new DockBandSettings { ProviderId = "p", CommandId = "c" }),
+                LastSeen = DateTime.UtcNow,
+            });
+
+        var monitors = new List<MonitorInfo> { PrimaryMonitor, degradedSecondary };
+
+        var afterDegradation = MonitorConfigReconciler.Reconcile(configs, monitors);
+
+        var secondaryConfig = afterDegradation.FirstOrDefault(c => c.MonitorDeviceId == degradedSecondary.StableId);
+        Assert.IsNotNull(secondaryConfig, "Secondary config should still exist after a transient StableId degradation.");
+        Assert.IsTrue(secondaryConfig!.Enabled, "Secondary config should remain enabled, not be replaced by a fresh disabled one.");
+        Assert.IsTrue(secondaryConfig.IsCustomized);
+        Assert.AreEqual(1, secondaryConfig.StartBands?.Count ?? 0, "Bands should survive the transient degradation.");
+
+        // Once the Display Configuration API recovers and reports the real stable ID again,
+        // reconciliation should migrate back cleanly with no data loss or duplicate configs.
+        var recoveredMonitors = new List<MonitorInfo> { PrimaryMonitor, SecondaryMonitor };
+        var afterRecovery = MonitorConfigReconciler.Reconcile(afterDegradation, recoveredMonitors);
+
+        Assert.AreEqual(2, afterRecovery.Count, "No duplicate or orphaned configs should remain after recovery.");
+        var recoveredConfig = afterRecovery.FirstOrDefault(c => c.MonitorDeviceId == SecondaryMonitor.StableId);
+        Assert.IsNotNull(recoveredConfig);
+        Assert.AreEqual(1, recoveredConfig!.StartBands?.Count ?? 0);
     }
 
     // --- JSON serialization round-trip ---

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/DockMultiMonitorTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/DockMultiMonitorTests.cs
@@ -272,12 +272,10 @@ public class DockMultiMonitorTests
     }
 
     [TestMethod]
-    public void Reconciler_FuzzyMatch_ReassociatesSingleUnmatchedSecondaryMonitor()
+    public void Reconciler_UnmatchedSecondary_DoesNotConsumeExistingConfig()
     {
-        // Config has stale stable ID for a non-primary monitor. There is exactly one
-        // unmatched secondary monitor and exactly one unmatched non-primary config, so
-        // reconciliation should reassociate them instead of creating a fresh empty config
-        // (this is the Win+P "PC screen only" -> "Extend" scenario from issue #48516).
+        // A secondary ID change is ambiguous, so preserve the old config and create a
+        // separate default rather than moving the old settings onto the new monitor.
         var configs = ImmutableList.Create(
             new DockMonitorConfig { MonitorDeviceId = PrimaryMonitor.StableId, Enabled = true, IsPrimary = true },
             new DockMonitorConfig
@@ -295,15 +293,17 @@ public class DockMultiMonitorTests
 
         var result = MonitorConfigReconciler.Reconcile(configs, monitors);
 
-        Assert.AreEqual(2, result.Count);
-        Assert.AreEqual(PrimaryMonitor.StableId, result[0].MonitorDeviceId);
-        Assert.AreEqual(SecondaryMonitor.StableId, result[1].MonitorDeviceId, "Secondary config should be reassociated with the new stable ID.");
-        Assert.IsTrue(result[1].IsCustomized, "Reassociated config should retain its customizations.");
-        Assert.AreEqual(1, result[1].StartBands?.Count ?? 0, "Reassociated config should retain its pinned bands, not start empty.");
+        Assert.AreEqual(3, result.Count);
+        var newConfig = result.FirstOrDefault(c => c.MonitorDeviceId == SecondaryMonitor.StableId);
+        var retainedConfig = result.FirstOrDefault(c => c.MonitorDeviceId.Contains("STALE", StringComparison.OrdinalIgnoreCase));
+        Assert.IsNotNull(newConfig);
+        Assert.IsNotNull(retainedConfig);
+        Assert.IsFalse(newConfig!.Enabled, "An unmatched secondary monitor should get a disabled default.");
+        Assert.AreEqual(1, retainedConfig!.StartBands?.Count ?? 0, "The old config should remain available for reconnection.");
     }
 
     [TestMethod]
-    public void Reconciler_FuzzyMatch_DoesNotReassociateWhenMultipleUnmatchedSecondaryMonitors()
+    public void Reconciler_MultipleUnmatchedSecondaryMonitors_PreservesConfigs()
     {
         // Two unmatched secondary monitors and one unmatched secondary config: ambiguous,
         // so reconciliation must not guess and should fall back to creating fresh configs.
@@ -337,13 +337,11 @@ public class DockMultiMonitorTests
     }
 
     [TestMethod]
-    public void Reconciler_TransientStableIdFallbackToDeviceId_DoesNotDropSecondaryConfig()
+    public void Reconciler_TransientStableIdFallbackToDeviceId_PreservesExistingConfig()
     {
         // Simulates the StableId momentarily falling back to the volatile GDI DeviceId
         // right after WM_DISPLAYCHANGE (Display Configuration API not yet settled).
-        // Even though the "monitor" here reports its DeviceId as its StableId, the legacy
-        // GDI-name migration path should still recover the existing config rather than
-        // creating a new disabled one.
+        // The fallback is ambiguous, so keep the stable-ID config instead of moving it.
         var degradedSecondary = SecondaryMonitor with { StableId = SecondaryMonitor.DeviceId };
 
         var configs = ImmutableList.Create(
@@ -360,23 +358,17 @@ public class DockMultiMonitorTests
 
         var monitors = new List<MonitorInfo> { PrimaryMonitor, degradedSecondary };
 
-        var afterDegradation = MonitorConfigReconciler.Reconcile(configs, monitors);
+        var result = MonitorConfigReconciler.Reconcile(configs, monitors);
 
-        var secondaryConfig = afterDegradation.FirstOrDefault(c => c.MonitorDeviceId == degradedSecondary.StableId);
-        Assert.IsNotNull(secondaryConfig, "Secondary config should still exist after a transient StableId degradation.");
-        Assert.IsTrue(secondaryConfig!.Enabled, "Secondary config should remain enabled, not be replaced by a fresh disabled one.");
-        Assert.IsTrue(secondaryConfig.IsCustomized);
-        Assert.AreEqual(1, secondaryConfig.StartBands?.Count ?? 0, "Bands should survive the transient degradation.");
-
-        // Once the Display Configuration API recovers and reports the real stable ID again,
-        // reconciliation should migrate back cleanly with no data loss or duplicate configs.
-        var recoveredMonitors = new List<MonitorInfo> { PrimaryMonitor, SecondaryMonitor };
-        var afterRecovery = MonitorConfigReconciler.Reconcile(afterDegradation, recoveredMonitors);
-
-        Assert.AreEqual(2, afterRecovery.Count, "No duplicate or orphaned configs should remain after recovery.");
-        var recoveredConfig = afterRecovery.FirstOrDefault(c => c.MonitorDeviceId == SecondaryMonitor.StableId);
-        Assert.IsNotNull(recoveredConfig);
-        Assert.AreEqual(1, recoveredConfig!.StartBands?.Count ?? 0);
+        Assert.AreEqual(3, result.Count);
+        var retainedConfig = result.FirstOrDefault(c => c.MonitorDeviceId == SecondaryMonitor.StableId);
+        var fallbackConfig = result.FirstOrDefault(c => c.MonitorDeviceId == degradedSecondary.StableId);
+        Assert.IsNotNull(retainedConfig, "The existing stable-ID config should remain available.");
+        Assert.IsNotNull(fallbackConfig, "The ambiguous fallback monitor should receive a default config.");
+        Assert.IsTrue(retainedConfig!.Enabled);
+        Assert.IsTrue(retainedConfig.IsCustomized);
+        Assert.AreEqual(1, retainedConfig.StartBands?.Count ?? 0, "Pinned bands should remain with the original config.");
+        Assert.IsFalse(fallbackConfig!.Enabled, "An unmatched secondary monitor should start disabled.");
     }
 
     // --- JSON serialization round-trip ---


### PR DESCRIPTION
Docking or undocking a laptop, or flipping display modes with Win+P, can leave the Dock empty, missing, or misconfigured. Fixes #48516.

The root of it: the Dock's per-monitor config leans on a stable hardware ID for each monitor. Right after a `WM_DISPLAYCHANGE`, before Windows has settled the new topology, that lookup can come back empty or fall back to a volatile GDI name. The reconciler then reads that as "hey, a new monitor showed up" and creates a fresh, disabled, empty config for a monitor that never actually left. On top of that, a burst of `WM_DISPLAYCHANGE` messages during a mode switch each triggered an immediate write to settings, so one bad intermediate snapshot could get baked in permanently. And since only the Dock window itself was listening for `WM_DISPLAYCHANGE`, the Settings page's monitor list could go stale whenever no Dock window happened to be alive.

## The plan

- Retry the stable-ID lookup a few times before giving up and falling back to the volatile name.
- Debounce monitor-change handling so a flurry of `WM_DISPLAYCHANGE` events settles down before we reconcile and persist, instead of writing every half-finished intermediate state.
- Have the main window forward `WM_DISPLAYCHANGE` too, so the monitor cache stays fresh even when the Dock is off or has no windows up.
- Teach the reconciler to reassociate a secondary monitor's config with its new ID when there's exactly one unmatched monitor and one unmatched config, the Win+P round trip case, instead of treating it as new hardware.
- Added tests covering the transient ID fallback, the ambiguous multi-monitor case, and the Win+P reassociation.

Scaling behavior when the Dock lands on a monitor with a different DPI is a separate issue (#48466) and isn't touched here.
