### PR TITLE
CmdPal: Refresh adaptive cards when the theme changes

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContentFormControl.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Controls/ContentFormControl.xaml.cs
@@ -25,6 +25,7 @@ public sealed partial class ContentFormControl : UserControl
     // form will do seemingly nothing.
     private RenderedAdaptiveCard? _renderedCard;
     private AdaptiveCard? _adaptiveCard;
+    private bool _isThemeRefreshPending;
 
     public ContentFormViewModel? ViewModel { get => _viewModel; set => AttachViewModel(value); }
 
@@ -42,8 +43,7 @@ public sealed partial class ContentFormControl : UserControl
     public ContentFormControl()
     {
         this.InitializeComponent();
-        var lightTheme = ActualTheme == Microsoft.UI.Xaml.ElementTheme.Light;
-        _renderer.HostConfig = lightTheme ? AdaptiveCardsConfig.Light : AdaptiveCardsConfig.Dark;
+        UpdateRendererTheme();
 
         // 5% BODGY: if we set this multiple times over the lifetime of the app,
         // then the second call will explode, because "CardOverrideStyles is already the child of another element".
@@ -53,8 +53,43 @@ public sealed partial class ContentFormControl : UserControl
             _renderer.OverrideStyles = CardOverrideStyles;
         }
 
-        // TODO in the future, we should handle ActualThemeChanged and replace
-        // our rendered card with one for that theme. But today is not that day
+        ActualThemeChanged += ContentFormControl_ActualThemeChanged;
+    }
+
+    private void ContentFormControl_ActualThemeChanged(FrameworkElement sender, object args)
+    {
+        // Theme changes can raise this event multiple times while WinUI refreshes
+        // its resources. Re-render once the final theme has been applied.
+        if (_isThemeRefreshPending)
+        {
+            return;
+        }
+
+        _isThemeRefreshPending = true;
+        if (!DispatcherQueue.TryEnqueue(() =>
+        {
+            try
+            {
+                UpdateRendererTheme();
+                if (_adaptiveCard is not null)
+                {
+                    DisplayCard(_adaptiveCard);
+                }
+            }
+            finally
+            {
+                _isThemeRefreshPending = false;
+            }
+        }))
+        {
+            _isThemeRefreshPending = false;
+        }
+    }
+
+    private void UpdateRendererTheme()
+    {
+        var lightTheme = ActualTheme == ElementTheme.Light;
+        _renderer.HostConfig = lightTheme ? AdaptiveCardsConfig.Light : AdaptiveCardsConfig.Dark;
     }
 
     private void AttachViewModel(ContentFormViewModel? vm)
@@ -97,8 +132,13 @@ public sealed partial class ContentFormControl : UserControl
 
     private void DisplayCard(AdaptiveCardParseResult result)
     {
-        _renderedCard = _renderer.RenderAdaptiveCard(result.AdaptiveCard);
-        _adaptiveCard = result.AdaptiveCard;
+        DisplayCard(result.AdaptiveCard);
+    }
+
+    private void DisplayCard(AdaptiveCard adaptiveCard)
+    {
+        _renderedCard = _renderer.RenderAdaptiveCard(adaptiveCard);
+        _adaptiveCard = adaptiveCard;
         ContentGrid.Children.Clear();
         if (_renderedCard.FrameworkElement is not null)
         {


### PR DESCRIPTION
## Summary of the Pull Request

Updates Command Palette extension settings so Adaptive Card text refreshes when the active Windows theme changes. This addresses the behavior reported in #49435.

## PR Checklist

- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
  - I reproduced the issue and posted the root cause and planned fix in #49435.
- [ ] **Tests:** Added/updated and all pass
  - No automated test was added because this behavior depends on WinUI `ActualThemeChanged` notifications and the Adaptive Cards WinUI renderer. The focused project was built successfully and the behavior was verified in the running application.
- [x] **Localization:** All end-user-facing strings can be localized
  - No end-user-facing strings changed.
- [x] **Dev docs:** Added/updated
  - No developer documentation changes are needed for this focused UI correction.
- [x] **New binaries:** Added on the required places
  - No binaries or projects were added.
  - [x] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries ? not applicable
  - [x] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder ? not applicable
  - [x] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects ? not applicable
  - [x] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml) ? not applicable
- [ ] **Documentation updated:** Not applicable; this does not change user-facing functionality or configuration.

## Detailed Description of the Pull Request / Additional comments

`ContentFormControl` previously selected the light or dark Adaptive Cards host configuration only when the control was constructed. The surrounding WinUI settings interface could respond to a system theme change, but an already-rendered card continued using its original colors.

The control now listens for `ActualThemeChanged`, updates the renderer's host configuration, and re-renders the current card. Theme notifications are queued and coalesced because WinUI may raise the event multiple times while refreshing its resources.

The change is made in the shared `ContentFormControl`, so it applies to Adaptive Card settings supplied by all Command Palette extensions rather than being specific to Window Walker.

## Validation Steps Performed

- `git diff --check` passes.
- Built `Microsoft.CmdPal.UI` locally in `Debug|x64` using `tools/build/build.ps1`; the build completed successfully with exit code 0.
- Reproduced the original issue using Window Walker's extension settings on the current `main` branch.
- Verified the patched build refreshes the card text and preserves readable contrast after the Windows theme changes.
- Verified the reverse theme transition restores the appropriate card colors.

### Before

![Before: Adaptive Card text remains dark and unreadable after the system changes to dark mode](https://raw.githubusercontent.com/0utsights/PowerToys/pr-assets-49817/pr-assets/49817/before.png)

### After

![After: Adaptive Card text refreshes with readable light text in dark mode](https://raw.githubusercontent.com/0utsights/PowerToys/pr-assets-49817/pr-assets/49817/after.png)

