### PR TITLE
[Settings] Fix first-build search index embedding

### DIFF
--- a/src/settings-ui/Settings.UI.XamlIndexBuilder/Settings.UI.XamlIndexBuilder.csproj
+++ b/src/settings-ui/Settings.UI.XamlIndexBuilder/Settings.UI.XamlIndexBuilder.csproj
@@ -32,13 +32,11 @@
 		<XamlRootDir Condition="'$(XamlRootDir)' == ''">$(MSBuildProjectDirectory)\..\Settings.UI\SettingsXAML</XamlRootDir>
 		<XamlRootDir Condition="'$(XamlViewsDir)' != ''">$([System.IO.Path]::GetDirectoryName('$(XamlViewsDir)'))</XamlRootDir>
 		<GeneratedJsonFile Condition="'$(GeneratedJsonFile)' == ''">$(MSBuildProjectDirectory)\..\Settings.UI\Assets\Settings\search.index.json</GeneratedJsonFile>
-		<!-- Generate Settings search index in Release and Custom builds. Debug builds skip index generation for faster builds. 
-		     To enable index generation in Debug, uncomment the line below: -->
-		<!-- <GenerateSettingsSearchIndex>true</GenerateSettingsSearchIndex> -->
+		<!-- Defaults for standalone builds. PowerToys.Settings.csproj passes this property explicitly. -->
 		<GenerateSettingsSearchIndex Condition="'$(GenerateSettingsSearchIndex)' == '' and '$(Configuration)' != 'Debug'">true</GenerateSettingsSearchIndex>
 		<GenerateSettingsSearchIndex Condition="'$(GenerateSettingsSearchIndex)' == ''">false</GenerateSettingsSearchIndex>
 	</PropertyGroup>
-	<Target Name="GenerateSearchIndexSelf" AfterTargets="Build" Condition="'$(GenerateSettingsSearchIndex)' == 'true'">
+	<Target Name="GenerateSearchIndexSelf" AfterTargets="Build" Condition="'$(DesignTimeBuild)' != 'true' and '$(GenerateSettingsSearchIndex)' == 'true'">
 		<RemoveDir Directories="$(MSBuildProjectDirectory)\obj\ARM64;$(MSBuildProjectDirectory)\obj\x64;$(MSBuildProjectDirectory)\bin" />
 		<MakeDir Directories="$([System.IO.Path]::GetDirectoryName('$(GeneratedJsonFile)'))" />
 		<Message Importance="high" Text="[XamlIndexBuilder] Generating search index. Root='$(XamlRootDir)'; Out='$(GeneratedJsonFile)'; Tool='$(TargetPath)'; DotNet='$(DotNetExe)'." />

--- a/src/settings-ui/Settings.UI/PowerToys.Settings.csproj
+++ b/src/settings-ui/Settings.UI/PowerToys.Settings.csproj
@@ -129,8 +129,8 @@
 	<!-- XamlIndexBuilder now outputs directly to Assets\Settings -->
 	<PropertyGroup>
 		<GeneratedJsonFile>$(MSBuildProjectDirectory)\Assets\Settings\search.index.json</GeneratedJsonFile>
-		<!-- Generate Settings search index in Release and Custom builds. Debug builds skip index generation for faster builds. 
-		     To enable index generation in Debug, uncomment the line below: -->
+		<!-- Generate Settings search index in Release and Custom builds. Debug builds skip index generation for faster builds.
+		     To enable index generation in Debug, pass /p:GenerateSettingsSearchIndex=true or uncomment the line below: -->
 		<!-- <GenerateSettingsSearchIndex>true</GenerateSettingsSearchIndex> -->
 		<GenerateSettingsSearchIndex Condition="'$(GenerateSettingsSearchIndex)' == '' and '$(Configuration)' != 'Debug'">true</GenerateSettingsSearchIndex>
 		<GenerateSettingsSearchIndex Condition="'$(GenerateSettingsSearchIndex)' == ''">false</GenerateSettingsSearchIndex>
@@ -145,15 +145,13 @@
 		<NoWarn>VSTHRD002;VSTHRD110;VSTHRD100;VSTHRD200;VSTHRD101</NoWarn>
 	</PropertyGroup>
 
-	<!-- Include the search index only if generation is enabled and the file exists (prevents accidentally embedding stale indices) -->
-
-	<ItemGroup>
-		<!-- Ensure the generated search index is present in the project; only if it exists to prevent CS1566 in clean CI -->
-		<Content Include="$(GeneratedJsonFile)" Condition="'$(GenerateSettingsSearchIndex)' == 'true' and Exists('$(GeneratedJsonFile)')">
+	<!-- Register the generated file during project evaluation. Do not use Exists() here: the file is generated later, before CoreCompile. -->
+	<ItemGroup Condition="'$(DesignTimeBuild)' != 'true' and '$(GenerateSettingsSearchIndex)' == 'true'">
+		<Content Include="$(GeneratedJsonFile)">
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</Content>
 		<!-- Embed the generated search index; logical name must match PrebuiltIndexResourceName -->
-		<EmbeddedResource Include="$(GeneratedJsonFile)" Condition="'$(GenerateSettingsSearchIndex)' == 'true' and Exists('$(GeneratedJsonFile)')">
+		<EmbeddedResource Include="$(GeneratedJsonFile)">
 			<LogicalName>Microsoft.PowerToys.Settings.UI.Assets.search.index.json</LogicalName>
 		</EmbeddedResource>
 	</ItemGroup>
@@ -215,5 +213,6 @@
 	<Target Name="BuildXamlIndexBeforeSettings" BeforeTargets="CoreCompile" Condition="'$(DesignTimeBuild)' != 'true' and '$(GenerateSettingsSearchIndex)' == 'true'">
 		<Message Importance="high" Text="[Settings] Building XamlIndexBuilder prior to compile. Views='$(MSBuildProjectDirectory)\SettingsXAML\Views' Out='$(GeneratedJsonFile)'" />
 		<MSBuild Projects="..\Settings.UI.XamlIndexBuilder\Settings.UI.XamlIndexBuilder.csproj" Targets="Build" Properties="Configuration=$(Configuration);Platform=Any CPU;TargetFramework=$(CoreTargetFramework);XamlViewsDir=$(MSBuildProjectDirectory)\SettingsXAML\Views;GeneratedJsonFile=$(GeneratedJsonFile);GenerateSettingsSearchIndex=$(GenerateSettingsSearchIndex)" />
+		<Error Condition="!Exists('$(GeneratedJsonFile)')" Text="Settings search index generation did not produce '$(GeneratedJsonFile)'." />
 	</Target>
 </Project>


### PR DESCRIPTION
## Summary

Stacked follow-up to #49709. The base is intentionally set to the source branch of that PR so this draft shows only the first-build embedding fix.

MSBuild evaluates the top-level item conditions before `BuildXamlIndexBeforeSettings` generates `search.index.json`. On a clean checkout, `Exists(...)` therefore removes the `Content` and `EmbeddedResource` items for the entire first build. The JSON is generated later, but it is not embedded until a second build.

## Changes

- Register the generated index during project evaluation whenever index generation is enabled.
- Keep generation disabled for design-time builds and default Debug builds.
- Validate after the nested builder finishes that the expected JSON was produced.
- Keep the Debug opt-in guidance only in the Settings project and clarify the command-line override.
- Add a defensive design-time guard to the standalone builder target.

## Validation

Validated from an isolated worktree at the head of #49709 using the repository build scripts:

- Reproduced before the fix: clean Release and first Debug opt-in builds generated JSON but omitted the manifest resource; the second build embedded it.
- `Release|x64` first build with no generated JSON: build succeeded; JSON was generated, copied, and embedded in the same build.
- `Debug|x64` first build with `GenerateSettingsSearchIndex=true`: build succeeded and embedded the resource in the same build.
- `Debug|x64` default build with a stale generated JSON: DLL was rebuilt and did not embed the resource.
- Settings solution-filter `Release|x64` build succeeded.
- Verified the exact manifest resource name with `System.Reflection.Metadata.PEReader`.
- `git diff --check` passes.