### PR TITLE
Fix uninstall with mixed PowerToys install scopes

### DIFF
--- a/installer/PowerToysSetupVNext/PowerToys.wxs
+++ b/installer/PowerToysSetupVNext/PowerToys.wxs
@@ -42,10 +42,10 @@
       <util:ProductSearch Id="SearchInstalledPowerToysUserVersion" Variable="DetectedPowerToysUserVersion" UpgradeCode="D8B559DB-4C98-487A-A33F-50A8EEE42726" Result="version" />
 
       <?if $(var.PerUser) = "true" ?>
-        <bal:Condition Message="PowerToys is already installed on this system for all users. We recommend first uninstalling that version before installing this one." Condition="MinimumVersion &gt;= DetectedPowerToysVersion" />
+        <bal:Condition Message="PowerToys is already installed on this system for all users. We recommend first uninstalling that version before installing this one." Condition="MinimumVersion &gt;= DetectedPowerToysVersion OR WixBundleInstalled" />
         <bal:Condition Message="The same or later version of PowerToys is already installed." Condition="TargetPowerToysVersion &gt;= DetectedPowerToysUserVersion OR WixBundleInstalled" />
       <?else?>
-        <bal:Condition Message="PowerToys is already installed on this system for current user. We recommend first uninstalling that version before installing this one." Condition="MinimumVersion &gt;= DetectedPowerToysUserVersion" />
+        <bal:Condition Message="PowerToys is already installed on this system for current user. We recommend first uninstalling that version before installing this one." Condition="MinimumVersion &gt;= DetectedPowerToysUserVersion OR WixBundleInstalled" />
         <bal:Condition Message="A later version of PowerToys is already installed." Condition="TargetPowerToysVersion &gt;= DetectedPowerToysVersion OR WixBundleInstalled" />
       <?endif?>
 


### PR DESCRIPTION
## Summary of the Pull Request

Allow an already-installed PowerToys bootstrapper to enter maintenance or uninstall when an installation of the opposite scope is also present. The per-user and per-machine opposite-scope `bal:Condition` checks now include the existing `WixBundleInstalled` maintenance-mode exception.

Fixes #43774. #49800 was the duplicate report.

## PR Checklist

- [x] Closes: #43774
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [x] **Tests:** No automated test changes; both WiX preprocessor branches compile successfully
- [x] **Localization:** No end-user-facing strings changed
- [x] **Dev docs:** Not applicable
- [x] **New binaries:** None
- [x] **Documentation updated:** Not applicable

## Detailed Description of the Pull Request / Additional comments

When per-user and per-machine PowerToys installations coexist, an older cached bootstrapper can reject maintenance before uninstall starts because its opposite-scope condition only compares detected versions. This creates a deadlock where each scope blocks removal of the other.

During maintenance or uninstall, Burn sets `WixBundleInstalled=1`. Adding that exception lets the already-installed bundle proceed. A fresh opposite-scope installation still has `WixBundleInstalled=0`, so new mixed-scope installs remain blocked.

## Validation Steps Performed

- Compiled `PowerToys.wxs` with WiX Toolset 5.0.2 to a temporary `.wixlib` with `PerUser=true`
- Compiled `PowerToys.wxs` with WiX Toolset 5.0.2 to a temporary `.wixlib` with `PerUser=false`
- Ran `git diff --check`
- Removed all temporary WiX outputs