### PR TITLE
[Mouse Highlighter] Update default click colors

### DIFF
--- a/doc/dsc/modules/MouseHighlighter.md
+++ b/doc/dsc/modules/MouseHighlighter.md
@@ -45,7 +45,7 @@ Sets the color for left mouse button clicks.
 
 **Type:** string (hex color)  
 **Format:** `"#RRGGBB"`  
-**Default:** `"#FFFF00"` (yellow)
+**Default:** `"#BFFF00"` (green)
 
 ### RightButtonClickColor
 
@@ -53,7 +53,7 @@ Sets the color for right mouse button clicks.
 
 **Type:** string (hex color)  
 **Format:** `"#RRGGBB"`  
-**Default:** `"#0000FF"` (blue)
+**Default:** `"#00BFFF"` (blue)
 
 ### HighlightOpacity
 

--- a/src/modules/MouseUtils/MouseHighlighter/MouseHighlighter.h
+++ b/src/modules/MouseUtils/MouseHighlighter/MouseHighlighter.h
@@ -1,8 +1,8 @@
 #pragma once
 #include "pch.h"
 
-const winrt::Windows::UI::Color MOUSE_HIGHLIGHTER_DEFAULT_LEFT_BUTTON_COLOR = winrt::Windows::UI::ColorHelper::FromArgb(166, 255, 255, 0);
-const winrt::Windows::UI::Color MOUSE_HIGHLIGHTER_DEFAULT_RIGHT_BUTTON_COLOR = winrt::Windows::UI::ColorHelper::FromArgb(166, 0, 0, 255);
+const winrt::Windows::UI::Color MOUSE_HIGHLIGHTER_DEFAULT_LEFT_BUTTON_COLOR = winrt::Windows::UI::ColorHelper::FromArgb(166, 191, 255, 0);
+const winrt::Windows::UI::Color MOUSE_HIGHLIGHTER_DEFAULT_RIGHT_BUTTON_COLOR = winrt::Windows::UI::ColorHelper::FromArgb(166, 0, 191, 255);
 const winrt::Windows::UI::Color MOUSE_HIGHLIGHTER_DEFAULT_ALWAYS_COLOR = winrt::Windows::UI::ColorHelper::FromArgb(0, 255, 0, 0);
 constexpr int MOUSE_HIGHLIGHTER_DEFAULT_RADIUS = 30;
 constexpr int MOUSE_HIGHLIGHTER_DEFAULT_DELAY_MS = 400;

--- a/src/settings-ui/Settings.UI.Library/MouseHighlighterProperties.cs
+++ b/src/settings-ui/Settings.UI.Library/MouseHighlighterProperties.cs
@@ -10,6 +10,9 @@ namespace Microsoft.PowerToys.Settings.UI.Library
 {
     public class MouseHighlighterProperties
     {
+        public const string DefaultLeftButtonClickColor = "#a6BFFF00";
+        public const string DefaultRightButtonClickColor = "#a600BFFF";
+
         [CmdConfigureIgnore]
         public HotkeySettings DefaultActivationShortcut => new HotkeySettings(true, false, false, true, 0x48);
 
@@ -65,8 +68,8 @@ namespace Microsoft.PowerToys.Settings.UI.Library
         public MouseHighlighterProperties()
         {
             ActivationShortcut = DefaultActivationShortcut;
-            LeftButtonClickColor = new StringProperty("#a6FFFF00");
-            RightButtonClickColor = new StringProperty("#a60000FF");
+            LeftButtonClickColor = new StringProperty(DefaultLeftButtonClickColor);
+            RightButtonClickColor = new StringProperty(DefaultRightButtonClickColor);
             AlwaysColor = new StringProperty("#00FF0000");
             HighlightOpacity = new IntProperty(166); // for migration from <=1.1 to 1.2
             HighlightRadius = new IntProperty(30);

--- a/src/settings-ui/Settings.UI.UnitTests/ModelsTests/MouseHighlighterSettingsTests.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ModelsTests/MouseHighlighterSettingsTests.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.PowerToys.Settings.UI.Library;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CommonLibTest
+{
+    [TestClass]
+    public class MouseHighlighterSettingsTests
+    {
+        [TestMethod]
+        public void Defaults_ShouldUseRecommendedClickColors()
+        {
+            var settings = new MouseHighlighterSettings();
+
+            Assert.AreEqual("#a6BFFF00", settings.Properties.LeftButtonClickColor.Value);
+            Assert.AreEqual("#a600BFFF", settings.Properties.RightButtonClickColor.Value);
+        }
+    }
+}

--- a/src/settings-ui/Settings.UI/ViewModels/MouseUtilsViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/MouseUtilsViewModel.cs
@@ -69,10 +69,10 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
 
             MouseHighlighterSettingsConfig = mouseHighlighterSettingsRepository.SettingsConfig;
             string leftClickColor = MouseHighlighterSettingsConfig.Properties.LeftButtonClickColor.Value;
-            _highlighterLeftButtonClickColor = !string.IsNullOrEmpty(leftClickColor) ? leftClickColor : "#a6FFFF00";
+            _highlighterLeftButtonClickColor = !string.IsNullOrEmpty(leftClickColor) ? leftClickColor : MouseHighlighterProperties.DefaultLeftButtonClickColor;
 
             string rightClickColor = MouseHighlighterSettingsConfig.Properties.RightButtonClickColor.Value;
-            _highlighterRightButtonClickColor = !string.IsNullOrEmpty(rightClickColor) ? rightClickColor : "#a60000FF";
+            _highlighterRightButtonClickColor = !string.IsNullOrEmpty(rightClickColor) ? rightClickColor : MouseHighlighterProperties.DefaultRightButtonClickColor;
 
             string alwaysColor = MouseHighlighterSettingsConfig.Properties.AlwaysColor.Value;
             _highlighterAlwaysColor = !string.IsNullOrEmpty(alwaysColor) ? alwaysColor : "#00FF0000";


### PR DESCRIPTION
## Summary of the Pull Request

Updates Mouse Highlighter's default click colors to the recommended palette colors:

- Left click: green (`#BFFF00`)
- Right click: blue (`#00BFFF`)

Keeps the Settings UI, native module fallback, and DSC reference aligned while preserving the existing 65% opacity. Existing saved preferences are unchanged.

## PR Checklist

- [ ] Closes: N/A
- [x] **Communication:** Requested by a core contributor
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** No end-user-facing strings changed
- [x] **Dev docs:** Updated the Mouse Highlighter DSC reference
- [ ] **New binaries:** No new binaries
   - [ ] JSON for signing
   - [ ] WXS for installer
   - [ ] YML for CI pipeline
   - [ ] YML for signed pipeline
- [ ] **Documentation updated:** No external documentation update required

## Detailed Description of the Pull Request / Additional comments

Adds shared managed constants for the two click-color defaults so serialized settings and Settings UI fallback behavior cannot drift. The native Mouse Highlighter fallback uses the same RGB values, and a focused unit test locks down the defaults.

## Validation Steps Performed

- Built `MouseHighlighter.vcxproj` for x64 Debug
- Built `Settings.UI.UnitTests.csproj` for x64 Debug
- Passed `MouseHighlighterSettingsTests.Defaults_ShouldUseRecommendedClickColors`