### PR TITLE
ci: pin .NET 10 SDK to runtime package version

### DIFF
--- a/.pipelines/v2/templates/job-build-project.yml
+++ b/.pipelines/v2/templates/job-build-project.yml
@@ -213,6 +213,8 @@ jobs:
     parameters:
       sdk: true
       version: '10.0'
+      # Keep this SDK version aligned with the .NET servicing package versions in Directory.Packages.props.
+      exactVersion: '10.0.302'
 
   - ${{ if eq(parameters.runTests, true) }}:
     - task: VisualStudioTestPlatformInstaller@1

--- a/.pipelines/v2/templates/job-build-project.yml
+++ b/.pipelines/v2/templates/job-build-project.yml
@@ -213,7 +213,7 @@ jobs:
     parameters:
       sdk: true
       version: '10.0'
-      # Keep this SDK version aligned with the .NET servicing package versions in Directory.Packages.props.
+      # SDK 10.0.302 contains runtime 10.0.10. Keep this aligned with DotNetRuntimePackageVersion in Directory.Packages.props.
       exactVersion: '10.0.302'
 
   - ${{ if eq(parameters.runTests, true) }}:

--- a/.pipelines/v2/templates/steps-ensure-dotnet-version.yml
+++ b/.pipelines/v2/templates/steps-ensure-dotnet-version.yml
@@ -2,6 +2,9 @@ parameters:
 - name: version
   type: string
   default: "10.0"
+- name: exactVersion
+  type: string
+  default: ""
 - name: sdk
   type: boolean
   default: false
@@ -21,7 +24,12 @@ steps:
       exit 1
     }
     $NEW_DOTNET_ROOT = "$(Agent.ToolsDirectory)\dotnet"
-    & ./dotnet-install.ps1 -Channel "${{parameters.version}}" -InstallDir $NEW_DOTNET_ROOT
+    $EXACT_VERSION = "${{parameters.exactVersion}}"
+    if ([string]::IsNullOrWhiteSpace($EXACT_VERSION)) {
+      & ./dotnet-install.ps1 -Channel "${{parameters.version}}" -InstallDir $NEW_DOTNET_ROOT
+    } else {
+      & ./dotnet-install.ps1 -Version $EXACT_VERSION -InstallDir $NEW_DOTNET_ROOT
+    }
     Write-Host "##vso[task.setvariable variable=DOTNET_ROOT]${NEW_DOTNET_ROOT}"
     Write-Host "##vso[task.prependpath]${NEW_DOTNET_ROOT}"
     Remove-Item dotnet-install.ps1 -ErrorAction:Ignore

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,9 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <MSTestVersion>3.8.3</MSTestVersion>
+    <!-- .NET SDK 10.0.302 contains runtime 10.0.10. Keep this aligned with exactVersion in .pipelines/v2/templates/job-build-project.yml. -->
+    <DotNetRuntimePackageVersion>10.0.10</DotNetRuntimePackageVersion>
   </PropertyGroup>
-  <!-- Keep .NET servicing package versions aligned with exactVersion for .NET 10 in .pipelines/v2/templates/job-build-project.yml. -->
   <ItemGroup>
     <PackageVersion Include="AdaptiveCards.ObjectModel.WinUI3" Version="2.0.2-beta" />
     <PackageVersion Include="AdaptiveCards.Rendering.WinUI3" Version="2.2.4-beta" />
@@ -42,21 +43,21 @@
     <PackageVersion Include="MessagePack" Version="3.1.7" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.102" />
     <PackageVersion Include="Microsoft.CommandPalette.Extensions" Version="0.9.260303001" />
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="$(DotNetRuntimePackageVersion)" />
     <!-- Including Microsoft.Bcl.AsyncInterfaces to force version, since it's used by Microsoft.SemanticKernel. -->
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="$(DotNetRuntimePackageVersion)" />
     <PackageVersion Include="Microsoft.Graphics.Win2D" Version="1.3.2" />
     <PackageVersion Include="Microsoft.Windows.CppWinRT" Version="2.0.250303.1" />
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.16" />
     <PackageVersion Include="Microsoft.Extensions.AI" Version="10.2.0" />
     <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="10.0.1-preview.1.25571.5" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="$(DotNetRuntimePackageVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="$(DotNetRuntimePackageVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="$(DotNetRuntimePackageVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="$(DotNetRuntimePackageVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(DotNetRuntimePackageVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(DotNetRuntimePackageVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="$(DotNetRuntimePackageVersion)" />
     <PackageVersion Include="Microsoft.AI.Foundry.Local" Version="0.3.0" />
     <PackageVersion Include="Microsoft.SemanticKernel" Version="1.71.0" />
     <PackageVersion Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.71.0" />
@@ -67,9 +68,9 @@
     <PackageVersion Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.2" />
     <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.4022.49" />
     <!-- Package Microsoft.Win32.SystemEvents added as a hack for being able to exclude the runtime assets so they don't conflict with 8.0.1. This is a dependency of System.Drawing.Common but the 8.0.1 version wasn't published to nuget. -->
-    <PackageVersion Include="Microsoft.Win32.SystemEvents" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Win32.SystemEvents" Version="$(DotNetRuntimePackageVersion)" />
     <PackageVersion Include="Microsoft.WindowsPackageManager.ComInterop" Version="1.10.340" />
-    <PackageVersion Include="Microsoft.Windows.Compatibility" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Windows.Compatibility" Version="$(DotNetRuntimePackageVersion)" />
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.269" />
     <!-- CsWinRT version needs to be set to have a WinRT.Runtime.dll at the same version contained inside the NET SDK we're currently building on CI. -->
     <!-- 
@@ -108,28 +109,28 @@
     <PackageVersion Include="StreamJsonRpc" Version="2.21.69" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <!-- Package System.CodeDom added as a hack for being able to exclude the runtime assets so they don't conflict with 8.0.1. This is a dependency of System.Management but the 8.0.1 version wasn't published to nuget. -->
-    <PackageVersion Include="System.CodeDom" Version="10.0.10" />
+    <PackageVersion Include="System.CodeDom" Version="$(DotNetRuntimePackageVersion)" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
-    <PackageVersion Include="System.ComponentModel.Composition" Version="10.0.10" />
-    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="10.0.10" />
-    <PackageVersion Include="System.Data.OleDb" Version="10.0.10" />
+    <PackageVersion Include="System.ComponentModel.Composition" Version="$(DotNetRuntimePackageVersion)" />
+    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="$(DotNetRuntimePackageVersion)" />
+    <PackageVersion Include="System.Data.OleDb" Version="$(DotNetRuntimePackageVersion)" />
     <!-- Package System.Diagnostics.EventLog added as a hack for being able to exclude the runtime assets so they don't conflict with 8.0.1. This is a dependency of System.Data.OleDb but the 8.0.1 version wasn't published to nuget. -->
-    <PackageVersion Include="System.Diagnostics.EventLog" Version="10.0.10" />
+    <PackageVersion Include="System.Diagnostics.EventLog" Version="$(DotNetRuntimePackageVersion)" />
     <!-- Package System.Diagnostics.PerformanceCounter added as a hack for being able to exclude the runtime assets so they don't conflict with 8.0.11. -->
-    <PackageVersion Include="System.Diagnostics.PerformanceCounter" Version="10.0.10" />
+    <PackageVersion Include="System.Diagnostics.PerformanceCounter" Version="$(DotNetRuntimePackageVersion)" />
     <PackageVersion Include="System.ClientModel" Version="1.8.1" />
-    <PackageVersion Include="System.Drawing.Common" Version="10.0.10" />
+    <PackageVersion Include="System.Drawing.Common" Version="$(DotNetRuntimePackageVersion)" />
     <PackageVersion Include="System.IO.Abstractions" Version="22.0.13" />
     <PackageVersion Include="System.IO.Abstractions.TestingHelpers" Version="22.0.13" />
-    <PackageVersion Include="System.Management" Version="10.0.10" />
+    <PackageVersion Include="System.Management" Version="$(DotNetRuntimePackageVersion)" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Numerics.Tensors" Version="10.0.2" />
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
     <PackageVersion Include="System.Reactive" Version="6.0.1" />
-    <PackageVersion Include="System.Runtime.Caching" Version="10.0.10" />
-    <PackageVersion Include="System.ServiceProcess.ServiceController" Version="10.0.10" />
-    <PackageVersion Include="System.Text.Encoding.CodePages" Version="10.0.10" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.10" />
+    <PackageVersion Include="System.Runtime.Caching" Version="$(DotNetRuntimePackageVersion)" />
+    <PackageVersion Include="System.ServiceProcess.ServiceController" Version="$(DotNetRuntimePackageVersion)" />
+    <PackageVersion Include="System.Text.Encoding.CodePages" Version="$(DotNetRuntimePackageVersion)" />
+    <PackageVersion Include="System.Text.Json" Version="$(DotNetRuntimePackageVersion)" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageVersion Include="ToolGood.Words.Pinyin" Version="3.1.0.3" />
     <PackageVersion Include="UnicodeInformation" Version="2.6.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,7 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <MSTestVersion>3.8.3</MSTestVersion>
   </PropertyGroup>
+  <!-- Keep .NET servicing package versions aligned with exactVersion for .NET 10 in .pipelines/v2/templates/job-build-project.yml. -->
   <ItemGroup>
     <PackageVersion Include="AdaptiveCards.ObjectModel.WinUI3" Version="2.0.2-beta" />
     <PackageVersion Include="AdaptiveCards.Rendering.WinUI3" Version="2.2.4-beta" />


### PR DESCRIPTION
## Summary of the Pull Request

Pins the .NET 10 SDK used by CI to `10.0.302`, whose `10.0.10` runtime matches the .NET servicing packages declared in `Directory.Packages.props`. This prevents dependency-audit failures caused by the floating `10.0` SDK channel advancing independently of the repository's package versions.

## PR Checklist

- [x] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [x] **Tests:** N/A for this pipeline-only configuration change; validation is documented below

## Detailed Description of the Pull Request / Additional comments

The CI template previously passed `10.0` to `dotnet-install.ps1 -Channel`. After .NET 10.0.11 became the latest release, CI combined SDK-provided 10.0.11 runtime assets with NuGet runtime assets pinned to 10.0.10. `.pipelines/verifyDepsJsonLibraryVersions.ps1` consequently detected different `System.Private.Windows.GdiPlus.dll` file versions across generated `.deps.json` files.

This PR:

- Adds the optional `exactVersion` parameter to `.pipelines/v2/templates/steps-ensure-dotnet-version.yml`. Existing callers continue using channel-based installation when the parameter is omitted.
- Sets `exactVersion` to `10.0.302` in `.pipelines/v2/templates/job-build-project.yml`; that SDK contains the 10.0.10 runtime.
- Defines `DotNetRuntimePackageVersion` once in `Directory.Packages.props` and references it from all 23 .NET servicing packages.
- Adds cross-referenced comments so future SDK and runtime package servicing updates remain aligned.

## Validation Steps Performed

- Confirmed the centralization assertion failed before the change with 23 literal `10.0.10` package versions and passed afterward with 23 `$(DotNetRuntimePackageVersion)` references and no remaining literals.
- Restored `PowerToys.slnx` successfully using `tools/build/build.ps1 -RestoreOnly`.
- Ran `dotnet-install.ps1 -Version 10.0.302 -DryRun` and confirmed that it resolves the exact `10.0.302` SDK payload.
- Parsed `Directory.Packages.props` successfully as XML.
- Ran `git diff --check` successfully.
- Azure Pipelines validation remains pending while this PR is in Draft.