### PR TITLE
ci: remove redundant Azure module installation

### DIFF
--- a/.pipelines/v2/templates/job-publish-symbols-using-symbolrequestprod-api.yml
+++ b/.pipelines/v2/templates/job-publish-symbols-using-symbolrequestprod-api.yml
@@ -83,11 +83,6 @@ jobs:
       itemPattern: '**/*.pdb'
       targetPath: '$(Build.SourcesDirectory)/symbolStaging'
 
-  - powershell: |-
-      Get-PackageProvider -Name NuGet -ForceBootstrap
-      Install-Module -Verbose -AllowClobber -Force Az.Accounts, Az.Storage, Az.Network, Az.Resources, Az.Compute
-    displayName: Install Azure Module Dependencies
-
   # Transit the Azure token from the Service Connection into a secret variable for the rest of the pipeline to use.
   - task: AzurePowerShell@5
     displayName: Generate an Azure Token


### PR DESCRIPTION
## Summary of the Pull Request

Removes a redundant Azure module-install step from the release symbol-publishing job.

The following `AzurePowerShell@5` task already provides the only required command, `Get-AzAccessToken`.

## PR Checklist

- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [x] **Tests:** Added/updated and all pass

## Detailed Description of the Pull Request / Additional comments

The removed step bootstrapped a package provider and installed several Azure modules.

Only `Get-AzAccessToken` is used by the job, inside the retained `AzurePowerShell@5` task. The other installed modules are unused.

This change does not alter feeds, dependency versions, service connections, token resources, symbol destinations, or artifacts.

## Validation Steps Performed

- Parsed `.pipelines/v2/templates/job-publish-symbols-using-symbolrequestprod-api.yml` successfully with PyYAML.
- Ran `git diff --check`.
- Confirmed the redundant package-provider and module-install commands are removed.
- Signed x64/ARM64 release pipeline completed successfully.
- Required PR CI checks passed for x64 and ARM64 Release.
