### PR TITLE
Add regression test for issue #49838

### DIFF
--- a/src/modules/AdvancedPaste/AdvancedPaste.UnitTests/ServicesTests/SemanticKernelPasteProviderTests.cs
+++ b/src/modules/AdvancedPaste/AdvancedPaste.UnitTests/ServicesTests/SemanticKernelPasteProviderTests.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection;
+using AdvancedPaste.Models;
+using AdvancedPaste.Services.CustomActions;
+using Microsoft.PowerToys.Settings.UI.Library;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Connectors.OpenAI;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AdvancedPaste.UnitTests.ServicesTests;
+
+[TestClass]
+public sealed class SemanticKernelPasteProviderTests
+{
+    // Guards against regression of #49838
+    [TestMethod]
+    public void CreateExecutionSettings_ForOpenAI_DoesNotSetReasoningEffort()
+    {
+        // Arrange
+        var config = new PasteAIConfig
+        {
+            ProviderType = AIServiceType.OpenAI,
+            Model = "gpt-4o",
+            ApiKey = "fake-key",
+        };
+        var provider = new SemanticKernelPasteProvider(config);
+
+        // Act
+        // CreateExecutionSettings is private, so we use reflection to invoke it.
+        var methodInfo = typeof(SemanticKernelPasteProvider).GetMethod(
+            "CreateExecutionSettings",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+
+        Assert.IsNotNull(methodInfo, "CreateExecutionSettings method not found");
+
+        var settings = (PromptExecutionSettings)methodInfo.Invoke(provider, null);
+
+        // Assert
+        Assert.IsNotNull(settings, "Expected non-null execution settings.");
+        Assert.IsInstanceOfType(settings, typeof(OpenAIPromptExecutionSettings), "Expected OpenAIPromptExecutionSettings for OpenAI provider.");
+
+        var openAISettings = (OpenAIPromptExecutionSettings)settings;
+
+        // Assert that ReasoningEffort is not set (is null) to prevent HTTP 400 on models that don't support it
+        Assert.IsNull(openAISettings.ReasoningEffort, "ReasoningEffort should not be set (see #49838)");
+    }
+}


### PR DESCRIPTION
## Summary of the Pull Request

Adds a regression test guarding against re-introduction of a hardcoded `ReasoningEffort` value in `SemanticKernelPasteProvider.CreateExecutionSettings()`. This value previously broke every OpenAI/Azure OpenAI custom paste action for models that don't support `reasoning_effort: minimal`, causing HTTP 400 errors (see #49838).

The underlying fix already exists on `main` — `CreateExecutionSettings()` no longer sets `ReasoningEffort`, and the Phi Silica on-device provider has since been split into its own `PhiSilicaPasteProvider` class. This PR does not modify provider logic; it adds test coverage to prevent this specific regression from being reintroduced.

## PR Checklist

- [x] Closes: #xxx
  _(Not applicable — this PR does not close #49838, since the underlying fix already landed separately. Filed to add regression coverage only.)_
- [x] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
  _(Not yet discussed with core contributors — flagging that this is a test-only addition in response to already-observed regression risk, and happy to adjust scope/approach based on maintainer feedback.)_
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** All end-user-facing strings can be localized
  _(N/A — no user-facing strings changed.)_
- [x] **Dev docs:** Added/updated
  _(N/A — internal test-only change, no dev docs affected.)_
- [x] **New binaries:** Added on the required places
  _(N/A — no new binaries introduced.)_
- [x] **Documentation updated:** If checked, please file a pull request on our docs repo and link it here: #xxx
  _(N/A — no user-facing documentation changes.)_

## Detailed Description of the Pull Request / Additional comments

Issue #49838 reported that Advanced Paste custom actions fail with HTTP 400 for OpenAI/Azure OpenAI models that don't support `reasoning_effort: minimal`, a value that was hardcoded in `SemanticKernelPasteProvider.CreateExecutionSettings()` (originally introduced in #46727 alongside the Phi Silica on-device provider).

By the time this was investigated, the hardcoded value had already been removed from `main`, and the code now includes an explicit comment warning against reintroducing model-specific tuning properties in this shared method. However, there was no test enforcing that guarantee — meaning a future change could silently reintroduce the same class of bug (this is the second time this exact pattern has caused a regression; see #43766 for the first).

This PR adds a unit test in `AdvancedPaste.UnitTests` that constructs an OpenAI-configured `SemanticKernelPasteProvider` and asserts that `CreateExecutionSettings()` returns an `OpenAIPromptExecutionSettings` object with `ReasoningEffort` left unset. No production code is modified.

## Validation Steps Performed

- Added the new unit test to `AdvancedPaste.UnitTests`.
- Ran the test locally against the current `main` branch and confirmed it passes.
- Confirmed no other tests in the `AdvancedPaste.UnitTests` project were affected by this change.