### PR TITLE
chore(common): remove unused shared UI dependencies

### DIFF
--- a/src/common/Common.UI.Controls/Common.UI.Controls.csproj
+++ b/src/common/Common.UI.Controls/Common.UI.Controls.csproj
@@ -19,9 +19,7 @@
     <PackageReference Include="Microsoft.WindowsAppSDK" />
     <PackageReference Include="WinUIEx" />
     <PackageReference Include="CommunityToolkit.WinUI.Animations" />
-    <PackageReference Include="CommunityToolkit.WinUI.Controls.Primitives" />
     <PackageReference Include="CommunityToolkit.WinUI.Extensions" />
-    <PackageReference Include="CommunityToolkit.WinUI.Converters" />
     <PackageReference Include="CommunityToolkit.Labs.WinUI.Controls.MarkdownTextBlock" />
   </ItemGroup>
 

--- a/src/common/Common.UI.Controls/Window/FlyoutWindowHelper.cs
+++ b/src/common/Common.UI.Controls/Window/FlyoutWindowHelper.cs
@@ -41,15 +41,6 @@ public static partial class FlyoutWindowHelper
     private static partial int GetDpiForMonitor(nint hMonitor, uint dpiType, out uint dpiX, out uint dpiY);
 
     /// <summary>
-    /// Get the DPI scale factor (1.0 = 100%, 1.25 = 125%, 1.5 = 150%, 2.0 = 200%) for a window.
-    /// </summary>
-    public static double GetDpiScale(WindowEx window)
-    {
-        ArgumentNullException.ThrowIfNull(window);
-        return (double)window.GetDpiForWindow() / DefaultDpi;
-    }
-
-    /// <summary>
     /// Get the DPI scale factor for a given <see cref="DisplayArea"/>.
     /// Resolves DPI from the underlying monitor handle so the value reflects the
     /// target display, regardless of which monitor the window is currently on.

--- a/src/common/Common.UI/SettingsDeepLink.cs
+++ b/src/common/Common.UI/SettingsDeepLink.cs
@@ -22,7 +22,6 @@ namespace Common.UI
             LightSwitch,
             FancyZones,
             FileLocksmith,
-            Run,
             ImageResizer,
             KBM,
             MouseUtils,
@@ -30,7 +29,6 @@ namespace Common.UI
             Peek,
             PowerAccent,
             PowerLauncher,
-            PowerPreview,
             PowerRename,
             FileExplorer,
             ShortcutGuide,
@@ -69,8 +67,6 @@ namespace Common.UI
                     return "FancyZones";
                 case SettingsWindow.FileLocksmith:
                     return "FileLocksmith";
-                case SettingsWindow.Run:
-                    return "Run";
                 case SettingsWindow.ImageResizer:
                     return "ImageResizer";
                 case SettingsWindow.KBM:
@@ -85,8 +81,6 @@ namespace Common.UI
                     return "PowerAccent";
                 case SettingsWindow.PowerLauncher:
                     return "PowerLauncher";
-                case SettingsWindow.PowerPreview:
-                    return "PowerPreview";
                 case SettingsWindow.PowerRename:
                     return "PowerRename";
                 case SettingsWindow.FileExplorer:

--- a/src/common/Common.UI/SettingsDeepLink.cs
+++ b/src/common/Common.UI/SettingsDeepLink.cs
@@ -45,7 +45,6 @@ namespace Common.UI
             NewPlus,
             CmdPal,
             ZoomIt,
-            PowerDisplay,
         }
 
         private static string SettingsWindowNameToString(SettingsWindow value)
@@ -116,8 +115,6 @@ namespace Common.UI
                     return "CmdPal";
                 case SettingsWindow.ZoomIt:
                     return "ZoomIt";
-                case SettingsWindow.PowerDisplay:
-                    return "PowerDisplay";
                 default:
                     {
                         return string.Empty;

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PowerToys/Helpers/ModuleEnablementService.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PowerToys/Helpers/ModuleEnablementService.cs
@@ -112,7 +112,6 @@ internal static class ModuleEnablementService
         SettingsWindow.Peek => "Peek",
         SettingsWindow.PowerAccent => "QuickAccent",
         SettingsWindow.PowerLauncher => "PowerToys Run",
-        SettingsWindow.Run => "PowerToys Run",
         SettingsWindow.PowerRename => "PowerRename",
         SettingsWindow.PowerOCR => "TextExtractor",
         SettingsWindow.RegistryPreview => "RegistryPreview",

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PowerToys/Helpers/PowerToysResourcesHelper.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PowerToys/Helpers/PowerToysResourcesHelper.cs
@@ -35,7 +35,6 @@ internal static class PowerToysResourcesHelper
             SettingsWindow.EnvironmentVariables => "EnvironmentVariables.png",
             SettingsWindow.Awake => "Awake.png",
             SettingsWindow.PowerRename => "PowerRename.png",
-            SettingsWindow.Run => "PowerToysRun.png",
             SettingsWindow.ImageResizer => "ImageResizer.png",
             SettingsWindow.KBM => "KeyboardManager.png",
             SettingsWindow.MouseUtils => "MouseUtils.png",
@@ -53,7 +52,6 @@ internal static class PowerToysResourcesHelper
             SettingsWindow.MouseWithoutBorders => "MouseWithoutBorders.png",
             SettingsWindow.PowerAccent => "QuickAccent.png",
             SettingsWindow.PowerLauncher => "PowerToysRun.png",
-            SettingsWindow.PowerPreview => "FileExplorerPreview.png",
             SettingsWindow.Overview => "PowerToys.png",
             SettingsWindow.Dashboard => "PowerToys.png",
             _ => "PowerToys.png",
@@ -77,7 +75,6 @@ internal static class PowerToysResourcesHelper
             SettingsWindow.EnvironmentVariables => "Environment Variables",
             SettingsWindow.Awake => "Awake",
             SettingsWindow.PowerRename => "PowerRename",
-            SettingsWindow.Run => "PowerToys Run",
             SettingsWindow.ImageResizer => "Image Resizer",
             SettingsWindow.KBM => "Keyboard Manager",
             SettingsWindow.MouseUtils => "Mouse Utilities",
@@ -97,7 +94,6 @@ internal static class PowerToysResourcesHelper
             SettingsWindow.Overview => "General",
             SettingsWindow.Dashboard => "Dashboard",
             SettingsWindow.PowerLauncher => "PowerToys Run",
-            SettingsWindow.PowerPreview => "File Explorer Add-ons",
             _ => module.ToString(),
         };
     }


### PR DESCRIPTION
## Summary of the Pull Request

Removes unused dependencies, stale API surface, and unreachable managed settings deep-link aliases from the shared UI libraries.

## PR Checklist

- [x] **Communication:** Cleanup scope was reviewed before implementation
- [x] **Tests:** No automated tests were needed for unused dependency/API removal; affected projects build successfully
- [x] **Localization:** No end-user-facing strings are changed
- [x] **New binaries:** No new binaries are introduced

## Detailed Description of the Pull Request / Additional comments

- Removes unused `CommunityToolkit.WinUI.Controls.Primitives` and `CommunityToolkit.WinUI.Converters` package references from `src/common/Common.UI.Controls/Common.UI.Controls.csproj`.
- Removes the unused `FlyoutWindowHelper.GetDpiScale(WindowEx)` overload from `src/common/Common.UI.Controls/Window/FlyoutWindowHelper.cs`.
- Removes the unused `SettingsDeepLink.SettingsWindow.PowerDisplay` value; PowerDisplay uses its module-local settings deep-link helper.
- Removes unreachable `Run` and `PowerPreview` managed aliases, superseded by `PowerLauncher` and `FileExplorer`, plus their dead CmdPal lookup cases.
- Preserves the runner's raw `--open-settings=Run` and `--open-settings=PowerPreview` routes for backward compatibility.
- Intentionally leaves the existing WinForms configuration and compatibility project references unchanged.

## Validation Steps Performed

- Built `src/common/Common.UI/Common.UI.csproj` for x64 Debug.
- Built `src/common/Common.UI.Controls/Common.UI.Controls.csproj` for x64 Debug.
- Built `src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.PowerToys/Microsoft.CmdPal.Ext.PowerToys.csproj` for x64 Debug.
- Ran `git diff --check`.