### PR TITLE
fix(screen-ruler): migrate legacy measurement unit values

### DIFF
--- a/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/MeasureTool.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/ViewModelTests/MeasureTool.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO.Abstractions;
+using Microsoft.PowerToys.Settings.UI.Library;
+using Microsoft.PowerToys.Settings.UI.Library.Interfaces;
+using Microsoft.PowerToys.Settings.UI.ViewModels;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace ViewModelTests
+{
+    [TestClass]
+    public class MeasureTool
+    {
+        [TestMethod]
+        [DataRow(-1, 0)]
+        [DataRow(0, 0)]
+        [DataRow(3, 3)]
+        [DataRow(4, 2)]
+        [DataRow(8, 3)]
+        public void NormalizeUnitsOfMeasureIndexReturnsValidComboBoxIndex(int value, int expected)
+        {
+            Assert.AreEqual(expected, MeasureToolViewModel.NormalizeUnitsOfMeasureIndex(value));
+        }
+
+        [TestMethod]
+        public void ConstructorRepairsInvalidPersistedUnitsOfMeasureIndex()
+        {
+            var settingsUtils = new Mock<SettingsUtils>(new FileSystem(), null);
+            var generalSettingsRepository = new Mock<ISettingsRepository<GeneralSettings>>();
+            generalSettingsRepository.SetupGet(repository => repository.SettingsConfig).Returns(new GeneralSettings());
+
+            var measureToolSettings = new MeasureToolSettings();
+            measureToolSettings.Properties.UnitsOfMeasure.Value = 4;
+
+            var measureToolSettingsRepository = new Mock<ISettingsRepository<MeasureToolSettings>>();
+            measureToolSettingsRepository.SetupGet(repository => repository.SettingsConfig).Returns(measureToolSettings);
+
+            var viewModel = new MeasureToolViewModel(
+                settingsUtils.Object,
+                generalSettingsRepository.Object,
+                measureToolSettingsRepository.Object,
+                _ => 0);
+
+            Assert.AreEqual(2, viewModel.UnitsOfMeasure);
+            Assert.AreEqual(2, measureToolSettings.Properties.UnitsOfMeasure.Value);
+            settingsUtils.Verify(
+                utils => utils.SaveSettings(It.IsAny<string>(), MeasureToolSettings.ModuleName, SettingsUtils.DefaultFileName),
+                Times.Once);
+        }
+    }
+}

--- a/src/settings-ui/Settings.UI/ViewModels/MeasureToolViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/MeasureToolViewModel.cs
@@ -18,6 +18,9 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
 {
     public partial class MeasureToolViewModel : PageViewModelBase
     {
+        private const int DefaultUnitsOfMeasureIndex = 0;
+        private const int MaximumUnitsOfMeasureIndex = 3;
+
         protected override string ModuleName => MeasureToolSettings.ModuleName;
 
         private SettingsUtils SettingsUtils { get; set; }
@@ -43,6 +46,12 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
             ArgumentNullException.ThrowIfNull(measureToolSettingsRepository);
 
             Settings = measureToolSettingsRepository.SettingsConfig;
+            int normalizedUnitsOfMeasure = NormalizeUnitsOfMeasureIndex(Settings.Properties.UnitsOfMeasure.Value);
+            if (normalizedUnitsOfMeasure != Settings.Properties.UnitsOfMeasure.Value)
+            {
+                Settings.Properties.UnitsOfMeasure.Value = normalizedUnitsOfMeasure;
+                SettingsUtils.SaveSettings(Settings.ToJsonString(), MeasureToolSettings.ModuleName);
+            }
 
             SendConfigMSG = ipcMSGCallBackFunc;
         }
@@ -177,11 +186,12 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         {
             get
             {
-                return Settings.Properties.UnitsOfMeasure.Value;
+                return NormalizeUnitsOfMeasureIndex(Settings.Properties.UnitsOfMeasure.Value);
             }
 
             set
             {
+                value = NormalizeUnitsOfMeasureIndex(value);
                 if (Settings.Properties.UnitsOfMeasure.Value != value)
                 {
                     Settings.Properties.UnitsOfMeasure.Value = value;
@@ -271,6 +281,19 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
         public bool ShowContinuousCaptureWarning
         {
             get => IsEnabled && ContinuousCapture;
+        }
+
+        internal static int NormalizeUnitsOfMeasureIndex(int value)
+        {
+            return value switch
+            {
+                // Before the units selector was added, this setting stored Measurement::Unit
+                // enum values. Preserve the user's centimetre/millimetre choice during migration.
+                4 => 2,
+                8 => 3,
+                >= DefaultUnitsOfMeasureIndex and <= MaximumUnitsOfMeasureIndex => value,
+                _ => DefaultUnitsOfMeasureIndex,
+            };
         }
 
         private Func<string, int> SendConfigMSG { get; }


### PR DESCRIPTION
## Summary of the Pull Request

Closes #49899

Fixes a PowerToys Settings crash when navigating away from the Screen Ruler page with legacy measurement-unit settings.

Older Screen Ruler builds persisted `Measurement::Unit` enum values (`Pixel = 1`, `Inch = 2`, `Centimetre = 4`, `Millimetre = 8`). The current Settings page binds the persisted value directly to a four-item `ComboBox.SelectedIndex`, which only accepts `0-3`. A persisted value such as `4` therefore produces a WinUI `E_INVALIDARG` stowed exception when the page is unloaded.

`MeasureToolViewModel` now migrates legacy values to the current indices, validates all values before exposing them to XAML, and persists the repaired setting:

- `4` (legacy centimetres) → `2`
- `8` (legacy millimetres) → `3`
- other out-of-range values → `0` (pixels)

## PR Checklist

- [x] Closes: #49899
- [x] **Tests:** Added/updated and all pass
- [x] **Localization:** N/A - no user-facing strings changed

## Detailed Description of the Pull Request / Additional comments

The failure was reproduced on `main` with `%LOCALAPPDATA%\Microsoft\PowerToys\Measure Tool\settings.json` containing:

```json
"UnitsOfMeasure": { "value": 4 }
```

Screen Ruler opened successfully, but navigating to Shortcut Guide terminated `PowerToys.Settings.exe` in `Microsoft.UI.Xaml.dll` with exception `0xc000027b` and `E_INVALIDARG` (`0x80070057`). Changing the persisted value to `0` eliminated the crash, confirming the invalid `SelectedIndex` as the cause.

The migration preserves the intended legacy centimetre/millimetre selection rather than resetting it unnecessarily.

## Validation Steps Performed

- Built `PowerToys.Settings.csproj` in ARM64 Release.
- Added six Measure Tool ViewModel regression cases covering valid, invalid, and legacy values.
- Ran the full Settings unit suite: **222 passed, 0 failed**.
- Reproduced the original UI flow with `UnitsOfMeasure = 4`:
  - opened Screen Ruler;
  - verified the setting migrated to `2`;
  - navigated to Shortcut Guide;
  - repeated Screen Ruler → Shortcut Guide navigation;
  - verified the Settings process remained alive after both transitions.



