### PR TITLE
Protect ZoomIt audio initialization from race on failure

### DIFF
--- a/src/modules/ZoomIt/ZoomIt/AudioSampleGenerator.cpp
+++ b/src/modules/ZoomIt/ZoomIt/AudioSampleGenerator.cpp
@@ -217,6 +217,40 @@ winrt::AudioEncodingProperties AudioSampleGenerator::GetEncodingProperties()
     return m_audioOutputNode.EncodingProperties();
 }
 
+winrt::fire_and_forget AudioSampleGenerator::DisposeAsync(
+    std::unique_ptr<AudioSampleGenerator> generator,
+    winrt::IAsyncAction initAction )
+{
+    if (!generator)
+    {
+        co_return;
+    }
+
+    // InitializeAsync signals m_asyncInitialized from its own continuation.
+    // While it is still suspended at a co_await, that continuation is queued
+    // back to the apartment that started it - normally the UI STA.  Destroying
+    // the generator there runs Stop(), which waits on m_asyncInitialized and so
+    // stops the thread from pumping, meaning the continuation can never be
+    // delivered: a self-deadlock.  Awaiting yields the thread instead of
+    // blocking it, so the pending initialization can complete (or fail).
+    if (initAction)
+    {
+        try
+        {
+            co_await initAction;
+        }
+        catch (...)
+        {
+            // Initialization failed; the object still has to be torn down.
+        }
+    }
+
+    // Keep the teardown (graph stop, device node close, buffer flush) off the
+    // calling thread.
+    co_await winrt::resume_background();
+    generator.reset();
+}
+
 std::optional<winrt::MediaStreamSample> AudioSampleGenerator::TryGetNextSample()
 {
     CheckInitialized();

--- a/src/modules/ZoomIt/ZoomIt/AudioSampleGenerator.h
+++ b/src/modules/ZoomIt/ZoomIt/AudioSampleGenerator.h
@@ -16,6 +16,12 @@ public:
     winrt::Windows::Foundation::IAsyncAction InitializeAsync();
     winrt::Windows::Media::MediaProperties::AudioEncodingProperties GetEncodingProperties();
 
+    // Takes ownership of a generator whose InitializeAsync may still be in
+    // flight and disposes of it without blocking the calling thread.
+    static winrt::fire_and_forget DisposeAsync(
+        std::unique_ptr<AudioSampleGenerator> generator,
+        winrt::Windows::Foundation::IAsyncAction initAction );
+
     std::optional<winrt::Windows::Media::Core::MediaStreamSample> TryGetNextSample();
     void Start(int64_t videoStartTimestamp = 0);
     void Stop();

--- a/src/modules/ZoomIt/ZoomIt/VideoRecordingSession.cpp
+++ b/src/modules/ZoomIt/ZoomIt/VideoRecordingSession.cpp
@@ -1021,6 +1021,21 @@ VideoRecordingSession::VideoRecordingSession(
     RecDiag( L"Constructor: audio generator received (init %s)\n",
              m_audioInitAction ? L"pending" : L"none" );
 
+    // If the rest of construction throws, member destruction would run
+    // ~AudioSampleGenerator -> Stop(), which waits on m_asyncInitialized.  That
+    // event is only signalled by the still-pending InitializeAsync
+    // continuation, and on an STA that continuation is queued back to this very
+    // thread - so the wait would never be satisfied.  Hand the generator to the
+    // async disposer instead; the guard runs before any member destructor.
+    auto disposeAudioGenerator = wil::scope_exit( [this]
+    {
+        if( m_audioGenerator )
+        {
+            AudioSampleGenerator::DisposeAsync( std::move( m_audioGenerator ), m_audioInitAction );
+            m_audioInitAction = nullptr;
+        }
+    } );
+
     m_device = device;
     m_d3dDevice = GetDXGIInterfaceFromObject<ID3D11Device>(m_device);
     m_d3dDevice->GetImmediateContext(m_d3dContext.put());
@@ -1227,6 +1242,8 @@ VideoRecordingSession::VideoRecordingSession(
         }
     }
     RecDiag( L"Constructor: exit\n" );
+
+    disposeAudioGenerator.release();
 }
 
 
@@ -1336,6 +1353,18 @@ void VideoRecordingSession::Close()
 {
     RecDiag( L"Close: totalVideoFrames=%d totalAudioSamples=%d\n",
              s_diagVideoCount, s_diagAudioCount );
+
+    // If audio initialization never completed, dispose of the generator
+    // asynchronously.  Stop() - called below from CloseInternal, or later from
+    // the member destructor - would otherwise block on m_asyncInitialized,
+    // which only the still-pending InitializeAsync continuation can signal.
+    // Nothing can be consuming samples in this state: StartAsync creates the
+    // MediaStreamSource only after that initialization has completed.
+    if( m_audioGenerator && m_audioInitAction )
+    {
+        AudioSampleGenerator::DisposeAsync( std::move( m_audioGenerator ), m_audioInitAction );
+        m_audioInitAction = nullptr;
+    }
 
     // Stop webcam capture before closing the main session.
     if( m_webcamCapture )

--- a/src/modules/ZoomIt/ZoomIt/Zoomit.cpp
+++ b/src/modules/ZoomIt/ZoomIt/Zoomit.cpp
@@ -7069,6 +7069,21 @@ winrt::fire_and_forget StartRecordingAsync( HWND hWnd, LPRECT rcCrop, HWND hWndR
         audioInitAction = audioGenerator->InitializeAsync();
     }
 
+    // audioGenerator must never be destroyed by stack unwinding while
+    // InitializeAsync is still pending: ~AudioSampleGenerator -> Stop() would
+    // block this (STA) thread on the event that only the pending continuation
+    // can set, and that continuation needs this thread to pump.  Hand ownership
+    // to the async disposer instead.  On the success path the generator has
+    // already been moved into the recording session, so this is a no-op.
+    auto disposeAudioGenerator = wil::scope_exit( [&]
+    {
+        if( audioGenerator )
+        {
+            AudioSampleGenerator::DisposeAsync( std::move( audioGenerator ), audioInitAction );
+            audioInitAction = nullptr;
+        }
+    } );
+
     auto tempFolderPath = std::filesystem::temp_directory_path().wstring();
     auto tempFolder = co_await winrt::StorageFolder::GetFolderFromPathAsync( tempFolderPath );
     auto appFolder = co_await tempFolder.CreateFolderAsync( L"ZoomIt", winrt::CreationCollisionOption::OpenIfExists );


### PR DESCRIPTION
This could end up in a deadlock upon trying to record while the previous recording was still initializing but in an error state.

<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] Closes: #xxx
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

