### PR TITLE
CmdPal: Shelf (2/n) - Add recent commands to Home and quick access shelf

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
@@ -57,13 +57,17 @@ public sealed partial class MainListPage : DynamicListPage,
     // Stable separator instances so that the VM cache and InPlaceUpdateList
     // recognise them across successive GetItems() calls
     private readonly Separator _pinnedSeparator = new(Resources.home_sections_pinned_title);
+    private readonly Separator _recentSeparator = new(Resources.home_sections_recent_title);
     private readonly Separator _resultsSeparator = new(Resources.results);
     private readonly Separator _fallbacksSeparator = new(Resources.fallbacks);
     private readonly Separator _commandsSeparator = new(Resources.home_sections_commands_title);
 
-    private TopLevelViewModel[]? _cachedPinnedViewModels;
-    private TopLevelViewModel[]? _cachedRegularViewModels;
+    private IListItem[]? _cachedPinnedViewModels;
+    private IListItem[]? _cachedRecentViewModels;
+    private IListItem[]? _cachedRegularViewModels;
     private bool _defaultViewDirty = true;
+    private volatile RecentCommandsManager _recentCommands;
+    private HomeRecentCommandsPlacement _recentCommandsOnHome;
 
     private RoScored<IListItem>[]? _filteredItems;
     private RoScored<IListItem>[]? _filteredApps;
@@ -121,6 +125,7 @@ public sealed partial class MainListPage : DynamicListPage,
         _settingsService = settingsService;
         _aliasManager = aliasManager;
         _appStateService = appStateService;
+        _recentCommands = _appStateService.State.RecentCommands;
         _tlcManager = topLevelCommandManager;
         _fuzzyMatcherProvider = fuzzyMatcherProvider;
         _scoringFunction = (in query, item) => ScoreTopLevelItem(in query, item, _appStateService.State.RecentCommands, _fuzzyMatcherProvider.Current, ResolveProviderSearchWeight);
@@ -165,6 +170,7 @@ public sealed partial class MainListPage : DynamicListPage,
             RaiseItemsChangedThrottle);
 
         _fallbackUpdateManager = new FallbackUpdateManager(() => RequestRefresh(fullRefresh: false));
+        _appStateService.StateChanged += AppStateService_StateChanged;
 
         // The all apps page will kick off a BG thread to start loading apps.
         // We just want to know when it is done.
@@ -194,6 +200,11 @@ public sealed partial class MainListPage : DynamicListPage,
         if (e.PropertyName == nameof(AllAppsCommandProvider.Page.IsLoading))
         {
             IsLoading = ActuallyLoading();
+            if (!AllAppsCommandProvider.Page.IsLoading && _recentCommandsOnHome != HomeRecentCommandsPlacement.Hidden)
+            {
+                _defaultViewDirty = true;
+                RequestRefresh(fullRefresh: false);
+            }
         }
     }
 
@@ -213,6 +224,21 @@ public sealed partial class MainListPage : DynamicListPage,
         }
         else
         {
+            RequestRefresh(fullRefresh: false);
+        }
+    }
+
+    private void AppStateService_StateChanged(IAppStateService sender, AppStateModel args)
+    {
+        if (ReferenceEquals(_recentCommands, args.RecentCommands))
+        {
+            return;
+        }
+
+        _recentCommands = args.RecentCommands;
+        if (_recentCommandsOnHome != HomeRecentCommandsPlacement.Hidden)
+        {
+            _defaultViewDirty = true;
             RequestRefresh(fullRefresh: false);
         }
     }
@@ -274,9 +300,14 @@ public sealed partial class MainListPage : DynamicListPage,
 
     public override IListItem[] GetItems()
     {
+        if (string.IsNullOrWhiteSpace(SearchText))
+        {
+            return GetDefaultViewItems();
+        }
+
         lock (_tlcManager.TopLevelCommands)
         {
-            return string.IsNullOrWhiteSpace(SearchText) ? GetDefaultViewItems() : GetSearchViewItems();
+            return GetSearchViewItems();
         }
     }
 
@@ -411,70 +442,78 @@ public sealed partial class MainListPage : DynamicListPage,
         }
 
         var pinned = _cachedPinnedViewModels!;
+        var recent = _cachedRecentViewModels!;
         var regular = _cachedRegularViewModels!;
         var pinnedCount = pinned.Length;
+        var recentCount = recent.Length;
         var regularCount = regular.Length;
 
-        var sectionCount = (pinnedCount > 0 ? 1 : 0) + (regularCount > 0 ? 1 : 0);
+        var sectionCount =
+            (pinnedCount > 0 ? 1 : 0) +
+            (recentCount > 0 ? 1 : 0) +
+            (regularCount > 0 ? 1 : 0);
         if (sectionCount == 0)
         {
             return [];
         }
 
-        var result = new IListItem[pinnedCount + regularCount + sectionCount];
+        var result = new IListItem[pinnedCount + recentCount + regularCount + sectionCount];
         var writeIndex = 0;
-        if (pinnedCount > 0)
+
+        void AppendSection(Separator separator, IListItem[] items)
         {
-            result[writeIndex++] = _pinnedSeparator;
-            Array.Copy(pinned, 0, result, writeIndex, pinnedCount);
-            writeIndex += pinnedCount;
+            if (items.Length == 0)
+            {
+                return;
+            }
+
+            result[writeIndex++] = separator;
+            Array.Copy(items, 0, result, writeIndex, items.Length);
+            writeIndex += items.Length;
         }
 
-        if (regularCount > 0)
+        if (_recentCommandsOnHome == HomeRecentCommandsPlacement.BeforePinned)
         {
-            result[writeIndex++] = _commandsSeparator;
-            Array.Copy(regular, 0, result, writeIndex, regularCount);
+            AppendSection(_recentSeparator, recent);
+            AppendSection(_pinnedSeparator, pinned);
         }
+        else
+        {
+            AppendSection(_pinnedSeparator, pinned);
+            AppendSection(_recentSeparator, recent);
+        }
+
+        AppendSection(_commandsSeparator, regular);
 
         return result;
     }
 
     private void RebuildDefaultViewCache()
     {
-        var allCommands = _tlcManager.TopLevelCommands;
-        var pinnedSettings = _tlcManager.PinnedCommands;
-
-        // Resolve pinned VMs in settings order
-        var pinned = new List<TopLevelViewModel>(pinnedSettings.Count);
-        for (var i = 0; i < pinnedSettings.Count; i++)
+        PinnedCommandSettings[] pinnedSettings;
+        lock (_tlcManager.PinnedCommands)
         {
-            var s = pinnedSettings[i];
-            for (var j = 0; j < allCommands.Count; j++)
-            {
-                var cmd = allCommands[j];
-                if (TopLevelCommandEligibility.IsEligibleForHome(cmd) &&
-                    cmd.CommandProviderId == s.ProviderId &&
-                    cmd.Id == s.CommandId)
-                {
-                    pinned.Add(cmd);
-                    break;
-                }
-            }
+            pinnedSettings = [.. _tlcManager.PinnedCommands];
         }
 
-        // Single pass for regular items
-        var regular = new List<TopLevelViewModel>(allCommands.Count);
-        for (var i = 0; i < allCommands.Count; i++)
+        TopLevelViewModel[] allCommands;
+        lock (_tlcManager.TopLevelCommands)
         {
-            var candidate = allCommands[i];
-            if (TopLevelCommandEligibility.IsEligibleForHome(candidate) && !_tlcManager.IsPinned(candidate.CommandProviderId, candidate.Id))
-            {
-                regular.Add(candidate);
-            }
+            allCommands = [.. _tlcManager.TopLevelCommands];
         }
 
-        _cachedPinnedViewModels = [.. pinned];
-        _cachedRegularViewModels = [.. regular];
+        IEnumerable<string> recentCommandIds = _recentCommandsOnHome == HomeRecentCommandsPlacement.Hidden
+            ? []
+            : _recentCommands.EnumerateRecentCommandIds();
+        var sections = TopLevelCommandResolver.Resolve(
+            pinnedSettings,
+            recentCommandIds,
+            allCommands,
+            includeApps: _includeApps);
+
+        _cachedPinnedViewModels = [.. sections.Pinned];
+        _cachedRecentViewModels = [.. sections.Recent];
+        _cachedRegularViewModels = [.. sections.Regular];
         _defaultViewDirty = false;
     }
 
@@ -1017,6 +1056,13 @@ public sealed partial class MainListPage : DynamicListPage,
     {
         ShowDetails = settings.ShowAppDetails;
 
+        if (_recentCommandsOnHome != settings.RecentCommandsOnHome)
+        {
+            _recentCommandsOnHome = settings.RecentCommandsOnHome;
+            _defaultViewDirty = true;
+            RequestRefresh(fullRefresh: false);
+        }
+
         // A per-provider search-weight change has to reorder the query that is already on screen.
         // Scoring reads the weight live, but scored results are cached, so without an explicit
         // re-score the active query keeps its old order until the next keystroke. Detect a weight
@@ -1083,6 +1129,7 @@ public sealed partial class MainListPage : DynamicListPage,
         _tlcManager.PropertyChanged -= TlcManager_PropertyChanged;
         _tlcManager.TopLevelCommands.CollectionChanged -= Commands_CollectionChanged;
         _tlcManager.PinnedCommands.CollectionChanged -= PinnedCommands_CollectionChanged;
+        _appStateService.StateChanged -= AppStateService_StateChanged;
 
         AllAppsCommandProvider.Page.PropChanged -= AllApps_PropChanged;
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
@@ -537,6 +537,7 @@ public sealed partial class MainListPage : DynamicListPage,
             pinnedSettings,
             recentCommandIds,
             allCommands,
+            _allAppsPage,
             includeApps: _includeApps,
             recentCommandLimit: _recentCommandsDisplayLimit,
             recentCommandsFirst: _recentCommandsOnHome == RecentCommandsPlacement.BeforePinned);

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
@@ -62,11 +62,9 @@ public sealed partial class MainListPage : DynamicListPage,
     private readonly Separator _fallbacksSeparator = new(Resources.fallbacks);
     private readonly Separator _commandsSeparator = new(Resources.home_sections_commands_title);
 
-    private IListItem[]? _cachedPinnedViewModels;
-    private IListItem[]? _cachedRecentViewModels;
-    private IListItem[]? _cachedRegularViewModels;
-    private bool _defaultViewDirty = true;
+    private DefaultViewCache? _defaultViewCache;
     private volatile RecentCommandsManager _recentCommands;
+    private int _defaultViewGeneration;
     private RecentCommandsPlacement _recentCommandsOnHome;
     private int _recentCommandsDisplayLimit = SettingsModel.DefaultRecentCommandsDisplayLimit;
 
@@ -134,7 +132,7 @@ public sealed partial class MainListPage : DynamicListPage,
 
         _tlcManager.PropertyChanged += TlcManager_PropertyChanged;
         _tlcManager.TopLevelCommands.CollectionChanged += Commands_CollectionChanged;
-        _tlcManager.PinnedCommands.CollectionChanged += PinnedCommands_CollectionChanged;
+        _tlcManager.PinnedCommandsChanged += PinnedCommands_Changed;
 
         _refreshThrottledDebouncedAction = new ThrottledDebouncedAction(
             () =>
@@ -203,21 +201,21 @@ public sealed partial class MainListPage : DynamicListPage,
             IsLoading = ActuallyLoading();
             if (!AllAppsCommandProvider.Page.IsLoading && _recentCommandsOnHome != RecentCommandsPlacement.Hidden)
             {
-                _defaultViewDirty = true;
+                InvalidateDefaultView();
                 RequestRefresh(fullRefresh: false);
             }
         }
     }
 
-    private void PinnedCommands_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    private void PinnedCommands_Changed(object? sender, EventArgs e)
     {
-        _defaultViewDirty = true;
+        InvalidateDefaultView();
         RaiseItemsChanged();
     }
 
     private void Commands_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
-        _defaultViewDirty = true;
+        InvalidateDefaultView();
         _includeApps = _tlcManager.IsProviderActive(AllAppsCommandProvider.WellKnownId);
         if (_includeApps != _filteredItemsIncludesApps)
         {
@@ -239,7 +237,7 @@ public sealed partial class MainListPage : DynamicListPage,
         _recentCommands = args.RecentCommands;
         if (_recentCommandsOnHome != RecentCommandsPlacement.Hidden)
         {
-            _defaultViewDirty = true;
+            InvalidateDefaultView();
             RequestRefresh(fullRefresh: false);
         }
     }
@@ -437,14 +435,8 @@ public sealed partial class MainListPage : DynamicListPage,
 
     private IListItem[] GetDefaultViewItems()
     {
-        if (_defaultViewDirty)
-        {
-            RebuildDefaultViewCache();
-        }
+        var (_, pinned, recent, regular) = GetDefaultViewCache();
 
-        var pinned = _cachedPinnedViewModels!;
-        var recent = _cachedRecentViewModels!;
-        var regular = _cachedRegularViewModels!;
         var pinnedCount = pinned.Length;
         var recentCount = recent.Length;
         var regularCount = regular.Length;
@@ -489,13 +481,28 @@ public sealed partial class MainListPage : DynamicListPage,
         return result;
     }
 
-    private void RebuildDefaultViewCache()
+    private DefaultViewCache GetDefaultViewCache()
     {
-        PinnedCommandSettings[] pinnedSettings;
-        lock (_tlcManager.PinnedCommands)
+        var existing = Volatile.Read(ref _defaultViewCache);
+        var generation = Volatile.Read(ref _defaultViewGeneration);
+        if (existing?.Generation == generation)
         {
-            pinnedSettings = [.. _tlcManager.PinnedCommands];
+            return existing;
         }
+
+        var rebuilt = BuildDefaultViewCache(existing, generation);
+        if (generation == Volatile.Read(ref _defaultViewGeneration))
+        {
+            Interlocked.CompareExchange(ref _defaultViewCache, rebuilt, existing);
+        }
+
+        var current = Volatile.Read(ref _defaultViewCache);
+        return current?.Generation == Volatile.Read(ref _defaultViewGeneration) ? current : rebuilt;
+    }
+
+    private DefaultViewCache BuildDefaultViewCache(DefaultViewCache? existing, int generation)
+    {
+        var pinnedSettings = _tlcManager.GetPinnedCommandsSnapshot();
 
         TopLevelViewModel[] allCommands;
         lock (_tlcManager.TopLevelCommands)
@@ -514,16 +521,18 @@ public sealed partial class MainListPage : DynamicListPage,
             recentCommandLimit: _recentCommandsDisplayLimit,
             recentCommandsFirst: _recentCommandsOnHome == RecentCommandsPlacement.BeforePinned);
 
-        var previousRecentViewModels = _cachedRecentViewModels;
-        _cachedPinnedViewModels = [.. sections.Pinned];
-        _cachedRecentViewModels = sections.Recent
+        var recent = sections.Recent
             .Select(item => (IListItem)RecentCommandListItem.CreateOrReuse(
-                previousRecentViewModels,
+                existing?.Recent,
                 item,
                 IdForTopLevelOrAppItem(item)))
             .ToArray();
-        _cachedRegularViewModels = [.. sections.Regular];
-        _defaultViewDirty = false;
+        return new(generation, [.. sections.Pinned], recent, [.. sections.Regular]);
+    }
+
+    private void InvalidateDefaultView()
+    {
+        Interlocked.Increment(ref _defaultViewGeneration);
     }
 
     private void ClearResults()
@@ -1059,7 +1068,7 @@ public sealed partial class MainListPage : DynamicListPage,
     public void Receive(UpdateFallbackItemsMessage message)
     {
         _tlcManager.RebuildPinnedCache();
-        _defaultViewDirty = true;
+        InvalidateDefaultView();
         RequestRefresh(fullRefresh: false);
     }
 
@@ -1074,7 +1083,7 @@ public sealed partial class MainListPage : DynamicListPage,
         {
             _recentCommandsOnHome = settings.RecentCommandsOnHome;
             _recentCommandsDisplayLimit = settings.RecentCommandsDisplayLimit;
-            _defaultViewDirty = true;
+            InvalidateDefaultView();
             RequestRefresh(fullRefresh: false);
         }
 
@@ -1143,7 +1152,7 @@ public sealed partial class MainListPage : DynamicListPage,
 
         _tlcManager.PropertyChanged -= TlcManager_PropertyChanged;
         _tlcManager.TopLevelCommands.CollectionChanged -= Commands_CollectionChanged;
-        _tlcManager.PinnedCommands.CollectionChanged -= PinnedCommands_CollectionChanged;
+        _tlcManager.PinnedCommandsChanged -= PinnedCommands_Changed;
         _appStateService.StateChanged -= AppStateService_StateChanged;
 
         AllAppsCommandProvider.Page.PropChanged -= AllApps_PropChanged;
@@ -1156,4 +1165,10 @@ public sealed partial class MainListPage : DynamicListPage,
         WeakReferenceMessenger.Default.UnregisterAll(this);
         GC.SuppressFinalize(this);
     }
+
+    private sealed record DefaultViewCache(
+        int Generation,
+        IListItem[] Pinned,
+        IListItem[] Recent,
+        IListItem[] Regular);
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
@@ -235,8 +235,8 @@ public sealed partial class MainListPage : DynamicListPage,
 
     private void Commands_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
-        InvalidateDefaultView();
         _includeApps = _tlcManager.IsProviderActive(AllAppsCommandProvider.WellKnownId);
+        InvalidateDefaultView();
         if (_includeApps != _filteredItemsIncludesApps)
         {
             ReapplySearchInBackground();

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
@@ -46,6 +46,7 @@ public sealed partial class MainListPage : DynamicListPage,
     private readonly AliasManager _aliasManager;
     private readonly ISettingsService _settingsService;
     private readonly IAppStateService _appStateService;
+    private readonly IListPage _allAppsPage;
     private readonly ScoringFunction<IListItem> _scoringFunction;
     private readonly ScoringFunction<IListItem> _fallbackScoringFunction;
     private readonly IFuzzyMatcherProvider _fuzzyMatcherProvider;
@@ -115,6 +116,25 @@ public sealed partial class MainListPage : DynamicListPage,
         IFuzzyMatcherProvider fuzzyMatcherProvider,
         ISettingsService settingsService,
         IAppStateService appStateService)
+        : this(
+            topLevelCommandManager,
+            aliasManager,
+            fuzzyMatcherProvider,
+            settingsService,
+            appStateService,
+            AllAppsCommandProvider.Page)
+    {
+    }
+
+    // Temp constructor for unit tests so they can avoid AllAppsCommandProvider.Page dependency
+    // TODO: Replace with a proper abstraction during AllApps refactor.
+    internal MainListPage(
+        TopLevelCommandManager topLevelCommandManager,
+        AliasManager aliasManager,
+        IFuzzyMatcherProvider fuzzyMatcherProvider,
+        ISettingsService settingsService,
+        IAppStateService appStateService,
+        IListPage allAppsPage)
     {
         Id = "com.microsoft.cmdpal.home";
         Title = Resources.builtin_home_name;
@@ -124,6 +144,7 @@ public sealed partial class MainListPage : DynamicListPage,
         _settingsService = settingsService;
         _aliasManager = aliasManager;
         _appStateService = appStateService;
+        _allAppsPage = allAppsPage;
         _recentCommands = _appStateService.State.RecentCommands;
         _tlcManager = topLevelCommandManager;
         _fuzzyMatcherProvider = fuzzyMatcherProvider;
@@ -173,8 +194,7 @@ public sealed partial class MainListPage : DynamicListPage,
 
         // The all apps page will kick off a BG thread to start loading apps.
         // We just want to know when it is done.
-        var allApps = AllAppsCommandProvider.Page;
-        allApps.PropChanged += AllApps_PropChanged;
+        _allAppsPage.PropChanged += AllApps_PropChanged;
 
         WeakReferenceMessenger.Default.Register<ClearSearchMessage>(this);
         WeakReferenceMessenger.Default.Register<UpdateFallbackItemsMessage>(this);
@@ -196,10 +216,10 @@ public sealed partial class MainListPage : DynamicListPage,
 
     private void AllApps_PropChanged(object? sender, IPropChangedEventArgs e)
     {
-        if (e.PropertyName == nameof(AllAppsCommandProvider.Page.IsLoading))
+        if (e.PropertyName == nameof(IListPage.IsLoading))
         {
             IsLoading = ActuallyLoading();
-            if (!AllAppsCommandProvider.Page.IsLoading && _recentCommandsOnHome != RecentCommandsPlacement.Hidden)
+            if (!_allAppsPage.IsLoading && _recentCommandsOnHome != RecentCommandsPlacement.Hidden)
             {
                 InvalidateDefaultView();
                 RequestRefresh(fullRefresh: false);
@@ -716,7 +736,7 @@ public sealed partial class MainListPage : DynamicListPage,
 
                 if (includeAppsSnapshot)
                 {
-                    var allNewApps = AllAppsCommandProvider.Page.GetItems().Cast<AppListItem>().ToList();
+                    var allNewApps = _allAppsPage.GetItems().Cast<AppListItem>().ToList();
 
                     // We need to remove pinned apps from allNewApps so they don't show twice.
                     var pinnedCommandIds = _settingsService.Settings.GetPinnedCommandIds(AllAppsCommandProvider.WellKnownId);
@@ -884,8 +904,7 @@ public sealed partial class MainListPage : DynamicListPage,
 
     private bool ActuallyLoading()
     {
-        var allApps = AllAppsCommandProvider.Page;
-        return allApps.IsLoading || _tlcManager.IsLoading;
+        return _allAppsPage.IsLoading || _tlcManager.IsLoading;
     }
 
     // Almost verbatim ListHelpers.ScoreListItem. Fallbacks tier by the same title match as any
@@ -1155,7 +1174,7 @@ public sealed partial class MainListPage : DynamicListPage,
         _tlcManager.PinnedCommandsChanged -= PinnedCommands_Changed;
         _appStateService.StateChanged -= AppStateService_StateChanged;
 
-        AllAppsCommandProvider.Page.PropChanged -= AllApps_PropChanged;
+        _allAppsPage.PropChanged -= AllApps_PropChanged;
 
         if (_settingsService is not null)
         {

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
@@ -67,7 +67,8 @@ public sealed partial class MainListPage : DynamicListPage,
     private IListItem[]? _cachedRegularViewModels;
     private bool _defaultViewDirty = true;
     private volatile RecentCommandsManager _recentCommands;
-    private HomeRecentCommandsPlacement _recentCommandsOnHome;
+    private RecentCommandsPlacement _recentCommandsOnHome;
+    private int _recentCommandsDisplayLimit = SettingsModel.DefaultRecentCommandsDisplayLimit;
 
     private RoScored<IListItem>[]? _filteredItems;
     private RoScored<IListItem>[]? _filteredApps;
@@ -200,7 +201,7 @@ public sealed partial class MainListPage : DynamicListPage,
         if (e.PropertyName == nameof(AllAppsCommandProvider.Page.IsLoading))
         {
             IsLoading = ActuallyLoading();
-            if (!AllAppsCommandProvider.Page.IsLoading && _recentCommandsOnHome != HomeRecentCommandsPlacement.Hidden)
+            if (!AllAppsCommandProvider.Page.IsLoading && _recentCommandsOnHome != RecentCommandsPlacement.Hidden)
             {
                 _defaultViewDirty = true;
                 RequestRefresh(fullRefresh: false);
@@ -236,7 +237,7 @@ public sealed partial class MainListPage : DynamicListPage,
         }
 
         _recentCommands = args.RecentCommands;
-        if (_recentCommandsOnHome != HomeRecentCommandsPlacement.Hidden)
+        if (_recentCommandsOnHome != RecentCommandsPlacement.Hidden)
         {
             _defaultViewDirty = true;
             RequestRefresh(fullRefresh: false);
@@ -472,7 +473,7 @@ public sealed partial class MainListPage : DynamicListPage,
             writeIndex += items.Length;
         }
 
-        if (_recentCommandsOnHome == HomeRecentCommandsPlacement.BeforePinned)
+        if (_recentCommandsOnHome == RecentCommandsPlacement.BeforePinned)
         {
             AppendSection(_recentSeparator, recent);
             AppendSection(_pinnedSeparator, pinned);
@@ -502,17 +503,25 @@ public sealed partial class MainListPage : DynamicListPage,
             allCommands = [.. _tlcManager.TopLevelCommands];
         }
 
-        IEnumerable<string> recentCommandIds = _recentCommandsOnHome == HomeRecentCommandsPlacement.Hidden
+        IEnumerable<string> recentCommandIds = _recentCommandsOnHome == RecentCommandsPlacement.Hidden
             ? []
             : _recentCommands.EnumerateRecentCommandIds();
         var sections = TopLevelCommandResolver.Resolve(
             pinnedSettings,
             recentCommandIds,
             allCommands,
-            includeApps: _includeApps);
+            includeApps: _includeApps,
+            recentCommandLimit: _recentCommandsDisplayLimit,
+            recentCommandsFirst: _recentCommandsOnHome == RecentCommandsPlacement.BeforePinned);
 
+        var previousRecentViewModels = _cachedRecentViewModels;
         _cachedPinnedViewModels = [.. sections.Pinned];
-        _cachedRecentViewModels = [.. sections.Recent];
+        _cachedRecentViewModels = sections.Recent
+            .Select(item => (IListItem)RecentCommandListItem.CreateOrReuse(
+                previousRecentViewModels,
+                item,
+                IdForTopLevelOrAppItem(item)))
+            .ToArray();
         _cachedRegularViewModels = [.. sections.Regular];
         _defaultViewDirty = false;
     }
@@ -1000,9 +1009,13 @@ public sealed partial class MainListPage : DynamicListPage,
         _searchTelemetry.ReportSelection(topLevelOrAppItem, _resultsSeparator, _fallbacksSeparator);
     }
 
-    private static string IdForTopLevelOrAppItem(IListItem topLevelOrAppItem)
+    internal static string IdForTopLevelOrAppItem(IListItem topLevelOrAppItem)
     {
-        if (topLevelOrAppItem is TopLevelViewModel topLevel)
+        if (topLevelOrAppItem is RecentCommandListItem recentItem)
+        {
+            return recentItem.CommandId;
+        }
+        else if (topLevelOrAppItem is TopLevelViewModel topLevel)
         {
             return topLevel.Id;
         }
@@ -1056,9 +1069,11 @@ public sealed partial class MainListPage : DynamicListPage,
     {
         ShowDetails = settings.ShowAppDetails;
 
-        if (_recentCommandsOnHome != settings.RecentCommandsOnHome)
+        if (_recentCommandsOnHome != settings.RecentCommandsOnHome ||
+            _recentCommandsDisplayLimit != settings.RecentCommandsDisplayLimit)
         {
             _recentCommandsOnHome = settings.RecentCommandsOnHome;
+            _recentCommandsDisplayLimit = settings.RecentCommandsDisplayLimit;
             _defaultViewDirty = true;
             RequestRefresh(fullRefresh: false);
         }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/RecentCommandListItem.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/RecentCommandListItem.cs
@@ -14,11 +14,21 @@ namespace Microsoft.CmdPal.UI.ViewModels.Commands;
 /// context commands without changing the item everywhere else it is displayed.
 /// </summary>
 [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
-public sealed partial class RecentCommandListItem : IListItem, IExtendedAttributesProvider
+public sealed partial class RecentCommandListItem : IListItem, IExtendedAttributesProvider, ICommandContextSource
 {
+    public event TypedEventHandler<object, IPropChangedEventArgs>? PropChanged
+    {
+        add => Source.PropChanged += value;
+        remove => Source.PropChanged -= value;
+    }
+
     public IListItem Source { get; }
 
     public string CommandId { get; }
+
+    AppExtensionHost? ICommandContextSource.ExtensionHost => (Source as ICommandContextSource)?.ExtensionHost;
+
+    ICommandProviderContext? ICommandContextSource.ProviderContext => (Source as ICommandContextSource)?.ProviderContext;
 
     public ICommand? Command => Source.Command;
 
@@ -65,14 +75,10 @@ public sealed partial class RecentCommandListItem : IListItem, IExtendedAttribut
         return new RecentCommandListItem(source, commandId);
     }
 
-    public event TypedEventHandler<object, IPropChangedEventArgs>? PropChanged
+    public IDictionary<string, object?> GetProperties()
     {
-        add => Source.PropChanged += value;
-        remove => Source.PropChanged -= value;
-    }
-
-    public IDictionary<string, object?> GetProperties() =>
-        Source is IExtendedAttributesProvider attributes
+        return Source is IExtendedAttributesProvider attributes
             ? attributes.GetProperties()
             : new Dictionary<string, object?>();
+    }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/RecentCommandListItem.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/RecentCommandListItem.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CommandPalette.Extensions;
+using Windows.Foundation;
+
+namespace Microsoft.CmdPal.UI.ViewModels.Commands;
+
+/// <summary>
+/// Marks an item as the recent-section presentation of another list item while preserving the
+/// extension-owned item and its live properties. The host uses this marker to add recent-only
+/// context commands without changing the item everywhere else it is displayed.
+/// </summary>
+[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+public sealed partial class RecentCommandListItem : IListItem, IExtendedAttributesProvider
+{
+    public IListItem Source { get; }
+
+    public string CommandId { get; }
+
+    public ICommand? Command => Source.Command;
+
+    public IContextItem?[] MoreCommands => Source.MoreCommands;
+
+    public IIconInfo? Icon => Source.Icon;
+
+    public string Title => Source.Title;
+
+    public string Subtitle => Source.Subtitle;
+
+    public ITag[] Tags => Source.Tags;
+
+    public IDetails? Details => Source.Details;
+
+    public string Section => Source.Section;
+
+    public string TextToSuggest => Source.TextToSuggest;
+
+    public RecentCommandListItem(IListItem source, string commandId)
+    {
+        Source = source;
+        CommandId = commandId;
+    }
+
+    internal static RecentCommandListItem CreateOrReuse(
+        IReadOnlyList<IListItem>? existingItems,
+        IListItem source,
+        string commandId)
+    {
+        if (existingItems is not null)
+        {
+            foreach (var existingItem in existingItems)
+            {
+                if (existingItem is RecentCommandListItem recentItem &&
+                    ReferenceEquals(recentItem.Source, source) &&
+                    string.Equals(recentItem.CommandId, commandId, StringComparison.Ordinal))
+                {
+                    return recentItem;
+                }
+            }
+        }
+
+        return new RecentCommandListItem(source, commandId);
+    }
+
+    public event TypedEventHandler<object, IPropChangedEventArgs>? PropChanged
+    {
+        add => Source.PropChanged += value;
+        remove => Source.PropChanged -= value;
+    }
+
+    public IDictionary<string, object?> GetProperties() =>
+        Source is IExtendedAttributesProvider attributes
+            ? attributes.GetProperties()
+            : new Dictionary<string, object?>();
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ICommandContextSource.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/ICommandContextSource.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace Microsoft.CmdPal.UI.ViewModels;
+
+/// <summary>
+/// Supplies invocation ownership for host-owned items. Presentation wrappers forward
+/// these values from their source, or return null to inherit the current page's context.
+/// </summary>
+public interface ICommandContextSource
+{
+    AppExtensionHost? ExtensionHost { get; }
+
+    ICommandProviderContext? ProviderContext { get; }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Icons.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Icons.cs
@@ -21,4 +21,6 @@ public static class Icons
     public static IconInfo SettingsIcon => new("\uE713"); // Settings icon
 
     public static IconInfo EditIcon => new("\uE70F"); // Edit icon
+
+    public static IconInfo DeleteIcon => new("\uE74D"); // Delete icon
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Properties/Resources.Designer.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Properties/Resources.Designer.cs
@@ -1184,6 +1184,15 @@ namespace Microsoft.CmdPal.UI.ViewModels.Properties {
                 return ResourceManager.GetString("home_sections_pinned_title", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Recent.
+        /// </summary>
+        public static string home_sections_recent_title {
+            get {
+                return ResourceManager.GetString("home_sections_recent_title", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Pinned.

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Properties/Resources.resx
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Properties/Resources.resx
@@ -322,6 +322,9 @@
   <data name="home_sections_pinned_title" xml:space="preserve">
     <value>Pinned</value>
   </data>
+  <data name="home_sections_recent_title" xml:space="preserve">
+    <value>Recent</value>
+  </data>
   <data name="home_sections_commands_title" xml:space="preserve">
     <value>Commands</value>
   </data>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/QuickAccessShelfItem.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/QuickAccessShelfItem.cs
@@ -2,22 +2,75 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.CmdPal.UI.ViewModels.Messages;
+using Microsoft.CmdPal.UI.ViewModels.Models;
+using Microsoft.CommandPalette.Extensions;
+
 namespace Microsoft.CmdPal.UI.ViewModels;
 
-public sealed class QuickAccessShelfItem(TopLevelViewModel command, int index) : IEquatable<QuickAccessShelfItem>
+public sealed class QuickAccessShelfItem : IEquatable<QuickAccessShelfItem>
 {
-    public TopLevelViewModel Command { get; } = command;
+    private readonly IListItem _item;
+    private readonly object? _sourceIcon;
+    private readonly int _shortcutIndex;
 
-    public int Index { get; } = index;
+    public string Title { get; }
 
-    public string ShortcutDigit => QuickAccessShelfResolver.IndexToShortcutDigit(Index);
+    public IconInfoViewModel Icon { get; }
+
+    public string ProviderId { get; }
+
+    public string CommandId { get; }
+
+    public bool StartsRecentSection { get; }
+
+    public string ShortcutDigit => QuickAccessShelfResolver.IndexToShortcutDigit(_shortcutIndex);
+
+    public QuickAccessShelfItem(IListItem item, int shortcutIndex, bool startsRecentSection)
+    {
+        _item = item;
+        Title = item.Title;
+        _shortcutIndex = shortcutIndex;
+        StartsRecentSection = startsRecentSection;
+        ProviderId = TopLevelCommandResolver.GetProviderId(item);
+        CommandId = TopLevelCommandResolver.GetCommandId(item);
+
+        if (item is TopLevelViewModel topLevel)
+        {
+            Icon = topLevel.IconViewModel;
+            _sourceIcon = Icon;
+        }
+        else
+        {
+            var sourceIcon = item.Icon;
+            _sourceIcon = sourceIcon;
+            Icon = new IconInfoViewModel(sourceIcon);
+            Icon.InitializeProperties();
+        }
+    }
+
+    public PerformCommandMessage GetPerformCommandMessage()
+    {
+        if (_item is TopLevelViewModel topLevel)
+        {
+            return topLevel.GetPerformCommandMessage();
+        }
+
+        var command = _item.Command ?? throw new InvalidOperationException("Quick-access items must have a command");
+        return new PerformCommandMessage(
+            new ExtensionObject<ICommand>(command),
+            new ExtensionObject<IListItem>(_item));
+    }
 
     public bool Equals(QuickAccessShelfItem? other) =>
         other is not null &&
-        ReferenceEquals(Command, other.Command) &&
-        Index == other.Index;
+        ReferenceEquals(_item, other._item) &&
+        ReferenceEquals(_sourceIcon, other._sourceIcon) &&
+        string.Equals(Title, other.Title, StringComparison.Ordinal) &&
+        _shortcutIndex == other._shortcutIndex &&
+        StartsRecentSection == other.StartsRecentSection;
 
     public override bool Equals(object? obj) => Equals(obj as QuickAccessShelfItem);
 
-    public override int GetHashCode() => HashCode.Combine(Command, Index);
+    public override int GetHashCode() => HashCode.Combine(_item, _sourceIcon, Title, _shortcutIndex, StartsRecentSection);
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/QuickAccessShelfItem.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/QuickAccessShelfItem.cs
@@ -22,31 +22,63 @@ public sealed class QuickAccessShelfItem : IEquatable<QuickAccessShelfItem>
 
     public string CommandId { get; }
 
-    public bool StartsRecentSection { get; }
+    public bool StartsNewSection { get; }
 
     public string ShortcutDigit => QuickAccessShelfResolver.IndexToShortcutDigit(_shortcutIndex);
 
-    public QuickAccessShelfItem(IListItem item, int shortcutIndex, bool startsRecentSection)
+    private QuickAccessShelfItem(
+        IListItem item,
+        string title,
+        object? sourceIcon,
+        IconInfoViewModel icon,
+        int shortcutIndex,
+        bool startsNewSection)
     {
         _item = item;
-        Title = item.Title;
+        Title = title;
+        _sourceIcon = sourceIcon;
+        Icon = icon;
         _shortcutIndex = shortcutIndex;
-        StartsRecentSection = startsRecentSection;
+        StartsNewSection = startsNewSection;
         ProviderId = TopLevelCommandResolver.GetProviderId(item);
         CommandId = TopLevelCommandResolver.GetCommandId(item);
+    }
 
+    // Accessing extension properties and initializing IconInfoViewModel must stay off the UI thread.
+    internal static QuickAccessShelfItem CreateOrReuse(
+        IReadOnlyList<QuickAccessShelfItem> existingItems,
+        IListItem item,
+        int shortcutIndex,
+        bool startsNewSection)
+    {
+        var title = item.Title;
+        object? sourceIcon;
+        IconInfoViewModel? icon = null;
         if (item is TopLevelViewModel topLevel)
         {
-            Icon = topLevel.IconViewModel;
-            _sourceIcon = Icon;
+            sourceIcon = topLevel.IconViewModel;
+            icon = topLevel.IconViewModel;
         }
         else
         {
-            var sourceIcon = item.Icon;
-            _sourceIcon = sourceIcon;
-            Icon = new IconInfoViewModel(sourceIcon);
-            Icon.InitializeProperties();
+            sourceIcon = item.Icon;
         }
+
+        foreach (var existingItem in existingItems)
+        {
+            if (existingItem.Matches(item, title, sourceIcon, shortcutIndex, startsNewSection))
+            {
+                return existingItem;
+            }
+        }
+
+        if (icon is null)
+        {
+            icon = new IconInfoViewModel((IIconInfo?)sourceIcon);
+            icon.InitializeProperties();
+        }
+
+        return new QuickAccessShelfItem(item, title, sourceIcon, icon, shortcutIndex, startsNewSection);
     }
 
     public PerformCommandMessage GetPerformCommandMessage()
@@ -68,9 +100,21 @@ public sealed class QuickAccessShelfItem : IEquatable<QuickAccessShelfItem>
         ReferenceEquals(_sourceIcon, other._sourceIcon) &&
         string.Equals(Title, other.Title, StringComparison.Ordinal) &&
         _shortcutIndex == other._shortcutIndex &&
-        StartsRecentSection == other.StartsRecentSection;
+        StartsNewSection == other.StartsNewSection;
 
     public override bool Equals(object? obj) => Equals(obj as QuickAccessShelfItem);
 
-    public override int GetHashCode() => HashCode.Combine(_item, _sourceIcon, Title, _shortcutIndex, StartsRecentSection);
+    public override int GetHashCode() => HashCode.Combine(_item, _sourceIcon, Title, _shortcutIndex, StartsNewSection);
+
+    private bool Matches(
+        IListItem item,
+        string title,
+        object? sourceIcon,
+        int shortcutIndex,
+        bool startsNewSection) =>
+        ReferenceEquals(_item, item) &&
+        ReferenceEquals(_sourceIcon, sourceIcon) &&
+        string.Equals(Title, title, StringComparison.Ordinal) &&
+        _shortcutIndex == shortcutIndex &&
+        StartsNewSection == startsNewSection;
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/QuickAccessShelfResolver.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/QuickAccessShelfResolver.cs
@@ -6,35 +6,6 @@ namespace Microsoft.CmdPal.UI.ViewModels;
 
 internal static class QuickAccessShelfResolver
 {
-    internal static IReadOnlyList<TCommand> Resolve<TCommand>(
-        IEnumerable<PinnedCommandSettings> pinnedCommands,
-        IEnumerable<TCommand> availableCommands,
-        Func<TCommand, string> providerIdSelector,
-        Func<TCommand, string> commandIdSelector,
-        Func<TCommand, bool> isEligible)
-        where TCommand : class
-    {
-        var commandsById = new Dictionary<(string ProviderId, string CommandId), TCommand>();
-        foreach (var command in availableCommands)
-        {
-            if (isEligible(command))
-            {
-                commandsById.TryAdd((providerIdSelector(command), commandIdSelector(command)), command);
-            }
-        }
-
-        var resolvedCommands = new List<TCommand>();
-        foreach (var pinnedCommand in pinnedCommands)
-        {
-            if (commandsById.TryGetValue((pinnedCommand.ProviderId, pinnedCommand.CommandId), out var command))
-            {
-                resolvedCommands.Add(command);
-            }
-        }
-
-        return resolvedCommands;
-    }
-
     internal static string IndexToShortcutDigit(int index)
     {
         return index switch

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/QuickAccessShelfResolver.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/QuickAccessShelfResolver.cs
@@ -6,6 +6,8 @@ namespace Microsoft.CmdPal.UI.ViewModels;
 
 internal static class QuickAccessShelfResolver
 {
+    internal sealed record ResolvedItem<T>(T Item, bool IsPinned, int ShortcutIndex, bool StartsNewSection);
+
     internal static string IndexToShortcutDigit(int index)
     {
         return index switch
@@ -38,5 +40,46 @@ internal static class QuickAccessShelfResolver
         // Reserve one item-width slot for the overflow button plus the gap before it.
         var widthBeforeOverflow = Math.Max(0, availableWidth - itemWidth - spacing);
         return Math.Min(itemCount, CountThatFits(widthBeforeOverflow, itemWidth, spacing));
+    }
+
+    internal static IReadOnlyList<ResolvedItem<T>> ComposeSections<T>(
+        IReadOnlyList<T> pinnedItems,
+        IReadOnlyList<T> recentItems,
+        RecentCommandsPlacement recentCommandsPlacement)
+    {
+        var pinnedCount = pinnedItems.Count;
+        var includeRecentCommands = recentCommandsPlacement is
+            RecentCommandsPlacement.BeforePinned or RecentCommandsPlacement.AfterPinned;
+        var recentCount = includeRecentCommands ? recentItems.Count : 0;
+        var result = new List<ResolvedItem<T>>(pinnedCount + recentCount);
+
+        void AppendPinned(bool startsNewSection)
+        {
+            for (var i = 0; i < pinnedCount; i++)
+            {
+                result.Add(new ResolvedItem<T>(pinnedItems[i], true, result.Count, startsNewSection && i == 0));
+            }
+        }
+
+        void AppendRecent(bool startsNewSection)
+        {
+            for (var i = 0; i < recentCount; i++)
+            {
+                result.Add(new ResolvedItem<T>(recentItems[i], false, result.Count, startsNewSection && i == 0));
+            }
+        }
+
+        if (recentCommandsPlacement == RecentCommandsPlacement.BeforePinned)
+        {
+            AppendRecent(startsNewSection: false);
+            AppendPinned(startsNewSection: recentCount > 0);
+        }
+        else
+        {
+            AppendPinned(startsNewSection: false);
+            AppendRecent(startsNewSection: pinnedCount > 0);
+        }
+
+        return result;
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/QuickAccessShelfViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/QuickAccessShelfViewModel.cs
@@ -5,6 +5,9 @@
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using CommunityToolkit.Mvvm.ComponentModel;
+using Microsoft.CmdPal.Ext.Apps;
+using Microsoft.CmdPal.UI.ViewModels.Services;
+using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 
 namespace Microsoft.CmdPal.UI.ViewModels;
@@ -12,17 +15,30 @@ namespace Microsoft.CmdPal.UI.ViewModels;
 public sealed partial class QuickAccessShelfViewModel : ObservableObject, IDisposable
 {
     private readonly TopLevelCommandManager _topLevelCommandManager;
+    private readonly IAppStateService _appStateService;
     private readonly TaskScheduler _scheduler;
+    private readonly List<INotifyPropChanged> _observedItems = [];
+    private volatile RecentCommandsManager _recentCommands;
+    private volatile bool _includeRecentCommands;
     private volatile bool _isDisposed;
     private int _rebuildQueued;
     private int _visibleCapacity = int.MaxValue;
 
-    public QuickAccessShelfViewModel(TopLevelCommandManager topLevelCommandManager, TaskScheduler scheduler)
+    public QuickAccessShelfViewModel(
+        TopLevelCommandManager topLevelCommandManager,
+        IAppStateService appStateService,
+        bool includeRecentCommands,
+        TaskScheduler scheduler)
     {
         _topLevelCommandManager = topLevelCommandManager;
+        _appStateService = appStateService;
+        _recentCommands = _appStateService.State.RecentCommands;
+        _includeRecentCommands = includeRecentCommands;
         _scheduler = scheduler;
         _topLevelCommandManager.PinnedCommands.CollectionChanged += Commands_CollectionChanged;
         _topLevelCommandManager.TopLevelCommands.CollectionChanged += Commands_CollectionChanged;
+        _appStateService.StateChanged += AppStateService_StateChanged;
+        AllAppsCommandProvider.Page.PropChanged += AllApps_PropChanged;
         RebuildItems();
     }
 
@@ -39,6 +55,17 @@ public sealed partial class QuickAccessShelfViewModel : ObservableObject, IDispo
     public int ItemCount => Items.Count;
 
     public int VisibleItemCount => VisibleItems.Count;
+
+    public void SetIncludeRecentCommands(bool includeRecentCommands)
+    {
+        if (_includeRecentCommands == includeRecentCommands)
+        {
+            return;
+        }
+
+        _includeRecentCommands = includeRecentCommands;
+        QueueRebuild();
+    }
 
     public void SetVisibleCapacity(int capacity)
     {
@@ -60,6 +87,38 @@ public sealed partial class QuickAccessShelfViewModel : ObservableObject, IDispo
     private void Commands_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
         QueueRebuild();
+    }
+
+    private void AppStateService_StateChanged(IAppStateService sender, AppStateModel args)
+    {
+        if (ReferenceEquals(_recentCommands, args.RecentCommands))
+        {
+            return;
+        }
+
+        _recentCommands = args.RecentCommands;
+        if (_includeRecentCommands)
+        {
+            QueueRebuild();
+        }
+    }
+
+    private void AllApps_PropChanged(object? sender, IPropChangedEventArgs args)
+    {
+        if (_includeRecentCommands &&
+            args.PropertyName == nameof(AllAppsCommandProvider.Page.IsLoading) &&
+            !AllAppsCommandProvider.Page.IsLoading)
+        {
+            QueueRebuild();
+        }
+    }
+
+    private void ObservedItem_PropChanged(object? sender, IPropChangedEventArgs args)
+    {
+        if (args.PropertyName is nameof(IListItem.Title) or nameof(IListItem.Icon))
+        {
+            QueueRebuild();
+        }
     }
 
     private void QueueRebuild()
@@ -100,14 +159,25 @@ public sealed partial class QuickAccessShelfViewModel : ObservableObject, IDispo
             availableCommands = [.. _topLevelCommandManager.TopLevelCommands];
         }
 
-        var resolvedCommands = QuickAccessShelfResolver.Resolve(
+        IEnumerable<string> recentCommandIds = _includeRecentCommands
+            ? _recentCommands.EnumerateRecentCommandIds()
+            : [];
+        var sections = TopLevelCommandResolver.Resolve(
             pinnedCommands,
+            recentCommandIds,
             availableCommands,
-            static command => command.CommandProviderId,
-            static command => command.Id,
-            TopLevelCommandEligibility.IsEligibleForHome);
+            includeApps: _includeRecentCommands && _topLevelCommandManager.IsProviderActive(AllAppsCommandProvider.WellKnownId),
+            includeRegular: false);
 
-        var shelfItems = resolvedCommands.Select((command, index) => new QuickAccessShelfItem(command, index));
+        UpdateObservedItems(sections.Pinned.Concat(sections.Recent));
+
+        var shelfItems = sections.Pinned.Select(
+            (command, index) => new QuickAccessShelfItem(command, index, startsRecentSection: false))
+            .Concat(sections.Recent.Select(
+                (command, index) => new QuickAccessShelfItem(
+                    command,
+                    shortcutIndex: -1,
+                    startsRecentSection: index == 0 && sections.Pinned.Count > 0)));
         ListHelpers.InPlaceUpdateList(Items, shelfItems);
         RepartitionItems();
 
@@ -119,6 +189,24 @@ public sealed partial class QuickAccessShelfViewModel : ObservableObject, IDispo
         if (previousItemCount != ItemCount)
         {
             OnPropertyChanged(nameof(ItemCount));
+        }
+    }
+
+    private void UpdateObservedItems(IEnumerable<IListItem> items)
+    {
+        foreach (var item in _observedItems)
+        {
+            item.PropChanged -= ObservedItem_PropChanged;
+        }
+
+        _observedItems.Clear();
+        foreach (var item in items)
+        {
+            if (item is INotifyPropChanged observable)
+            {
+                observable.PropChanged += ObservedItem_PropChanged;
+                _observedItems.Add(observable);
+            }
         }
     }
 
@@ -152,6 +240,9 @@ public sealed partial class QuickAccessShelfViewModel : ObservableObject, IDispo
         _isDisposed = true;
         _topLevelCommandManager.PinnedCommands.CollectionChanged -= Commands_CollectionChanged;
         _topLevelCommandManager.TopLevelCommands.CollectionChanged -= Commands_CollectionChanged;
+        _appStateService.StateChanged -= AppStateService_StateChanged;
+        AllAppsCommandProvider.Page.PropChanged -= AllApps_PropChanged;
+        UpdateObservedItems([]);
         GC.SuppressFinalize(this);
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/QuickAccessShelfViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/QuickAccessShelfViewModel.cs
@@ -5,6 +5,7 @@
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using CommunityToolkit.Mvvm.ComponentModel;
+using Microsoft.CmdPal.Common;
 using Microsoft.CmdPal.Ext.Apps;
 using Microsoft.CmdPal.UI.ViewModels.Services;
 using Microsoft.CommandPalette.Extensions;
@@ -17,29 +18,39 @@ public sealed partial class QuickAccessShelfViewModel : ObservableObject, IDispo
     private readonly TopLevelCommandManager _topLevelCommandManager;
     private readonly IAppStateService _appStateService;
     private readonly TaskScheduler _scheduler;
+    private readonly Lock _observedItemsLock = new();
     private readonly List<INotifyPropChanged> _observedItems = [];
     private volatile RecentCommandsManager _recentCommands;
-    private volatile bool _includeRecentCommands;
+    private volatile ShelfConfiguration _configuration;
+    private volatile QuickAccessShelfItem[] _itemSnapshot = [];
     private volatile bool _isDisposed;
-    private int _rebuildQueued;
+    private int _rebuildVersion;
+    private int _rebuildRunning;
     private int _visibleCapacity = int.MaxValue;
+
+    private sealed record ShelfConfiguration(
+        RecentCommandsPlacement RecentCommandsPlacement,
+        int PinnedCommandLimit,
+        int RecentCommandLimit);
 
     public QuickAccessShelfViewModel(
         TopLevelCommandManager topLevelCommandManager,
         IAppStateService appStateService,
-        bool includeRecentCommands,
+        RecentCommandsPlacement recentCommandsPlacement,
+        int pinnedCommandLimit,
+        int recentCommandLimit,
         TaskScheduler scheduler)
     {
         _topLevelCommandManager = topLevelCommandManager;
         _appStateService = appStateService;
         _recentCommands = _appStateService.State.RecentCommands;
-        _includeRecentCommands = includeRecentCommands;
+        _configuration = CreateConfiguration(recentCommandsPlacement, pinnedCommandLimit, recentCommandLimit);
         _scheduler = scheduler;
         _topLevelCommandManager.PinnedCommands.CollectionChanged += Commands_CollectionChanged;
         _topLevelCommandManager.TopLevelCommands.CollectionChanged += Commands_CollectionChanged;
         _appStateService.StateChanged += AppStateService_StateChanged;
         AllAppsCommandProvider.Page.PropChanged += AllApps_PropChanged;
-        RebuildItems();
+        QueueRebuild();
     }
 
     public ObservableCollection<QuickAccessShelfItem> Items { get; } = [];
@@ -56,14 +67,18 @@ public sealed partial class QuickAccessShelfViewModel : ObservableObject, IDispo
 
     public int VisibleItemCount => VisibleItems.Count;
 
-    public void SetIncludeRecentCommands(bool includeRecentCommands)
+    public void SetItemConfiguration(
+        RecentCommandsPlacement recentCommandsPlacement,
+        int pinnedCommandLimit,
+        int recentCommandLimit)
     {
-        if (_includeRecentCommands == includeRecentCommands)
+        var configuration = CreateConfiguration(recentCommandsPlacement, pinnedCommandLimit, recentCommandLimit);
+        if (_configuration == configuration)
         {
             return;
         }
 
-        _includeRecentCommands = includeRecentCommands;
+        _configuration = configuration;
         QueueRebuild();
     }
 
@@ -97,7 +112,7 @@ public sealed partial class QuickAccessShelfViewModel : ObservableObject, IDispo
         }
 
         _recentCommands = args.RecentCommands;
-        if (_includeRecentCommands)
+        if (IncludesRecentCommands(_configuration.RecentCommandsPlacement))
         {
             QueueRebuild();
         }
@@ -105,7 +120,7 @@ public sealed partial class QuickAccessShelfViewModel : ObservableObject, IDispo
 
     private void AllApps_PropChanged(object? sender, IPropChangedEventArgs args)
     {
-        if (_includeRecentCommands &&
+        if (IncludesRecentCommands(_configuration.RecentCommandsPlacement) &&
             args.PropertyName == nameof(AllAppsCommandProvider.Page.IsLoading) &&
             !AllAppsCommandProvider.Page.IsLoading)
         {
@@ -123,29 +138,35 @@ public sealed partial class QuickAccessShelfViewModel : ObservableObject, IDispo
 
     private void QueueRebuild()
     {
-        if (_isDisposed || Interlocked.Exchange(ref _rebuildQueued, 1) != 0)
+        if (_isDisposed)
         {
             return;
         }
 
-        _ = Task.Factory.StartNew(
-            () =>
-            {
-                Interlocked.Exchange(ref _rebuildQueued, 0);
-                if (!_isDisposed)
-                {
-                    RebuildItems();
-                }
-            },
+        Interlocked.Increment(ref _rebuildVersion);
+        TryStartRebuild();
+    }
+
+    private void TryStartRebuild()
+    {
+        if (_isDisposed || Interlocked.CompareExchange(ref _rebuildRunning, 1, 0) != 0)
+        {
+            return;
+        }
+
+        var rebuildVersion = Volatile.Read(ref _rebuildVersion);
+        var existingItems = _itemSnapshot;
+        _ = Task.Run(() => BuildItems(existingItems)).ContinueWith(
+            task => CompleteRebuild(rebuildVersion, task),
             CancellationToken.None,
-            TaskCreationOptions.None,
+            TaskContinuationOptions.None,
             _scheduler);
     }
 
-    private void RebuildItems()
+    private QuickAccessShelfItem[] BuildItems(IReadOnlyList<QuickAccessShelfItem> existingItems)
     {
-        var hadItems = HasItems;
-        var previousItemCount = ItemCount;
+        var configuration = _configuration;
+        var includeRecentCommands = IncludesRecentCommands(configuration.RecentCommandsPlacement);
 
         PinnedCommandSettings[] pinnedCommands;
         lock (_topLevelCommandManager.PinnedCommands)
@@ -159,26 +180,66 @@ public sealed partial class QuickAccessShelfViewModel : ObservableObject, IDispo
             availableCommands = [.. _topLevelCommandManager.TopLevelCommands];
         }
 
-        IEnumerable<string> recentCommandIds = _includeRecentCommands
+        IEnumerable<string> recentCommandIds = includeRecentCommands
             ? _recentCommands.EnumerateRecentCommandIds()
             : [];
         var sections = TopLevelCommandResolver.Resolve(
             pinnedCommands,
             recentCommandIds,
             availableCommands,
-            includeApps: _includeRecentCommands && _topLevelCommandManager.IsProviderActive(AllAppsCommandProvider.WellKnownId),
-            includeRegular: false);
+            includeApps: includeRecentCommands && _topLevelCommandManager.IsProviderActive(AllAppsCommandProvider.WellKnownId),
+            pinnedCommandLimit: configuration.PinnedCommandLimit,
+            recentCommandLimit: configuration.RecentCommandLimit,
+            includeRegular: false,
+            recentCommandsFirst: configuration.RecentCommandsPlacement == RecentCommandsPlacement.BeforePinned);
 
-        UpdateObservedItems(sections.Pinned.Concat(sections.Recent));
+        var resolvedItems = QuickAccessShelfResolver.ComposeSections(
+            sections.Pinned,
+            sections.Recent,
+            configuration.RecentCommandsPlacement);
+        var observedItems = resolvedItems.Select(item => item.Item).ToArray();
 
-        var shelfItems = sections.Pinned.Select(
-            (command, index) => new QuickAccessShelfItem(command, index, startsRecentSection: false))
-            .Concat(sections.Recent.Select(
-                (command, index) => new QuickAccessShelfItem(
-                    command,
-                    shortcutIndex: -1,
-                    startsRecentSection: index == 0 && sections.Pinned.Count > 0)));
+        // AppListItem.Icon can publish an async update immediately after it is read below.
+        // Observe first so a fast load cannot leave the shelf showing the placeholder icon.
+        UpdateObservedItems(observedItems);
+        return resolvedItems.Select(
+            item => QuickAccessShelfItem.CreateOrReuse(
+                existingItems,
+                item.Item,
+                item.ShortcutIndex,
+                item.StartsNewSection)).ToArray();
+    }
+
+    private void CompleteRebuild(int rebuildVersion, Task<QuickAccessShelfItem[]> task)
+    {
+        try
+        {
+            if (task.IsFaulted)
+            {
+                CoreLogger.LogError("Failed to rebuild quick access shelf", task.Exception.GetBaseException());
+            }
+            else if (!_isDisposed && rebuildVersion == Volatile.Read(ref _rebuildVersion))
+            {
+                ApplyRebuild(task.Result);
+            }
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _rebuildRunning, 0);
+            if (!_isDisposed && rebuildVersion != Volatile.Read(ref _rebuildVersion))
+            {
+                TryStartRebuild();
+            }
+        }
+    }
+
+    private void ApplyRebuild(IReadOnlyList<QuickAccessShelfItem> shelfItems)
+    {
+        var hadItems = HasItems;
+        var previousItemCount = ItemCount;
+
         ListHelpers.InPlaceUpdateList(Items, shelfItems);
+        _itemSnapshot = [.. Items];
         RepartitionItems();
 
         if (hadItems != HasItems)
@@ -192,20 +253,54 @@ public sealed partial class QuickAccessShelfViewModel : ObservableObject, IDispo
         }
     }
 
-    private void UpdateObservedItems(IEnumerable<IListItem> items)
+    private static ShelfConfiguration CreateConfiguration(
+        RecentCommandsPlacement recentCommandsPlacement,
+        int pinnedCommandLimit,
+        int recentCommandLimit)
     {
-        foreach (var item in _observedItems)
+        if (recentCommandsPlacement is not
+            (RecentCommandsPlacement.BeforePinned or RecentCommandsPlacement.AfterPinned))
         {
-            item.PropChanged -= ObservedItem_PropChanged;
+            recentCommandsPlacement = RecentCommandsPlacement.Hidden;
         }
 
-        _observedItems.Clear();
-        foreach (var item in items)
+        return new ShelfConfiguration(
+            recentCommandsPlacement,
+            Math.Clamp(
+                pinnedCommandLimit,
+                SettingsModel.MinQuickAccessShelfPinnedCommandLimit,
+                SettingsModel.MaxQuickAccessShelfPinnedCommandLimit),
+            Math.Clamp(
+                recentCommandLimit,
+                SettingsModel.MinRecentCommandsDisplayLimit,
+                SettingsModel.MaxRecentCommandsDisplayLimit));
+    }
+
+    private static bool IncludesRecentCommands(RecentCommandsPlacement recentCommandsPlacement) =>
+        recentCommandsPlacement is RecentCommandsPlacement.BeforePinned or RecentCommandsPlacement.AfterPinned;
+
+    private void UpdateObservedItems(IEnumerable<IListItem> items)
+    {
+        lock (_observedItemsLock)
         {
-            if (item is INotifyPropChanged observable)
+            foreach (var item in _observedItems)
             {
-                observable.PropChanged += ObservedItem_PropChanged;
-                _observedItems.Add(observable);
+                item.PropChanged -= ObservedItem_PropChanged;
+            }
+
+            _observedItems.Clear();
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            foreach (var item in items)
+            {
+                if (item is INotifyPropChanged observable)
+                {
+                    observable.PropChanged += ObservedItem_PropChanged;
+                    _observedItems.Add(observable);
+                }
             }
         }
     }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/QuickAccessShelfViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/QuickAccessShelfViewModel.cs
@@ -188,6 +188,7 @@ public sealed partial class QuickAccessShelfViewModel : ObservableObject, IDispo
             pinnedCommands,
             recentCommandIds,
             availableCommands,
+            AllAppsCommandProvider.Page,
             includeApps: includeRecentCommands && _topLevelCommandManager.IsProviderActive(AllAppsCommandProvider.WellKnownId),
             pinnedCommandLimit: configuration.PinnedCommandLimit,
             recentCommandLimit: configuration.RecentCommandLimit,

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/QuickAccessShelfViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/QuickAccessShelfViewModel.cs
@@ -46,7 +46,7 @@ public sealed partial class QuickAccessShelfViewModel : ObservableObject, IDispo
         _recentCommands = _appStateService.State.RecentCommands;
         _configuration = CreateConfiguration(recentCommandsPlacement, pinnedCommandLimit, recentCommandLimit);
         _scheduler = scheduler;
-        _topLevelCommandManager.PinnedCommands.CollectionChanged += Commands_CollectionChanged;
+        _topLevelCommandManager.PinnedCommandsChanged += PinnedCommands_Changed;
         _topLevelCommandManager.TopLevelCommands.CollectionChanged += Commands_CollectionChanged;
         _appStateService.StateChanged += AppStateService_StateChanged;
         AllAppsCommandProvider.Page.PropChanged += AllApps_PropChanged;
@@ -100,6 +100,11 @@ public sealed partial class QuickAccessShelfViewModel : ObservableObject, IDispo
     }
 
     private void Commands_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        QueueRebuild();
+    }
+
+    private void PinnedCommands_Changed(object? sender, EventArgs e)
     {
         QueueRebuild();
     }
@@ -168,11 +173,7 @@ public sealed partial class QuickAccessShelfViewModel : ObservableObject, IDispo
         var configuration = _configuration;
         var includeRecentCommands = IncludesRecentCommands(configuration.RecentCommandsPlacement);
 
-        PinnedCommandSettings[] pinnedCommands;
-        lock (_topLevelCommandManager.PinnedCommands)
-        {
-            pinnedCommands = [.. _topLevelCommandManager.PinnedCommands];
-        }
+        var pinnedCommands = _topLevelCommandManager.GetPinnedCommandsSnapshot();
 
         TopLevelViewModel[] availableCommands;
         lock (_topLevelCommandManager.TopLevelCommands)
@@ -333,7 +334,7 @@ public sealed partial class QuickAccessShelfViewModel : ObservableObject, IDispo
         }
 
         _isDisposed = true;
-        _topLevelCommandManager.PinnedCommands.CollectionChanged -= Commands_CollectionChanged;
+        _topLevelCommandManager.PinnedCommandsChanged -= PinnedCommands_Changed;
         _topLevelCommandManager.TopLevelCommands.CollectionChanged -= Commands_CollectionChanged;
         _appStateService.StateChanged -= AppStateService_StateChanged;
         AllAppsCommandProvider.Page.PropChanged -= AllApps_PropChanged;

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/RecentCommandsManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/RecentCommandsManager.cs
@@ -106,6 +106,18 @@ public record RecentCommandsManager : IRecentCommandsManager
     /// </summary>
     public void PrewarmIndex() => _ = Index;
 
+    /// <summary>
+    /// Enumerates command ids from most recently used to least recently used without copying the
+    /// persisted history. Consumers can stop as soon as they have resolved enough visible items.
+    /// </summary>
+    public IEnumerable<string> EnumerateRecentCommandIds()
+    {
+        foreach (var item in History)
+        {
+            yield return item.CommandId;
+        }
+    }
+
     public int GetCommandHistoryWeight(string commandId)
         => GetCommandHistoryWeight(commandId, DateTimeOffset.UtcNow);
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/RecentCommandsManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/RecentCommandsManager.cs
@@ -160,6 +160,29 @@ public record RecentCommandsManager : IRecentCommandsManager
         => WithHistoryItem(commandId, DateTimeOffset.UtcNow);
 
     /// <summary>
+    /// Returns a new RecentCommandsManager without the given command, or this instance when the
+    /// command is not present. Pure function - does not mutate this instance.
+    /// </summary>
+    public RecentCommandsManager WithoutHistoryItem(string commandId)
+    {
+        var existing = History.FirstOrDefault(item => item.CommandId == commandId);
+        return existing is null
+            ? this
+            : this with { History = History.Remove(existing) };
+    }
+
+    /// <summary>
+    /// Returns an empty recent-command history, or this instance when it is already empty.
+    /// Pure function - does not mutate this instance.
+    /// </summary>
+    public RecentCommandsManager ClearHistory() =>
+        History.Count == 0
+            ? this
+            : this with { History = ImmutableList<HistoryItem>.Empty };
+
+    public bool IsEmpty => History.Count == 0;
+
+    /// <summary>
     /// Records a use of <paramref name="commandId"/> at the explicit time <paramref name="now"/>.
     /// The public overload uses the current time; this overload lets tests inject
     /// strictly-increasing timestamps so time-decay behavior is deterministic.
@@ -201,6 +224,10 @@ public interface IRecentCommandsManager
     int GetCommandHistoryWeight(string commandId, DateTimeOffset now);
 
     RecentCommandsManager WithHistoryItem(string commandId);
+
+    RecentCommandsManager WithoutHistoryItem(string commandId);
+
+    RecentCommandsManager ClearHistory();
 
     /// <summary>
     /// Builds any lazy internal state on the calling thread. Call it once before scoring items in

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/RecentCommandsManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/RecentCommandsManager.cs
@@ -180,6 +180,7 @@ public record RecentCommandsManager : IRecentCommandsManager
             ? this
             : this with { History = ImmutableList<HistoryItem>.Empty };
 
+    [JsonIgnore]
     public bool IsEmpty => History.Count == 0;
 
     /// <summary>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsModel.cs
@@ -52,6 +52,10 @@ public record SettingsModel
 
     public bool ShowQuickAccessShelf { get; init; }
 
+    public bool ShowRecentCommandsInQuickAccessShelf { get; init; }
+
+    public HomeRecentCommandsPlacement RecentCommandsOnHome { get; init; }
+
     // When compact mode is on and the palette is centered on launch, this is the relative
     // height from the bottom of the screen (as a percentage) at which the collapsed search
     // box is vertically centered. 75 places it in the upper portion of the display. Ignored
@@ -478,4 +482,11 @@ public enum EscapeKeyBehavior
     AlwaysGoBack = 1,
     AlwaysDismiss = 2,
     AlwaysHide = 3,
+}
+
+public enum HomeRecentCommandsPlacement
+{
+    Hidden = 0,
+    BeforePinned = 1,
+    AfterPinned = 2,
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsModel.cs
@@ -17,6 +17,13 @@ public record SettingsModel
 
     ///////////////////////////////////////////////////////////////////////////
     // SETTINGS HERE
+    internal const int MinQuickAccessShelfPinnedCommandLimit = 0;
+    internal const int MaxQuickAccessShelfPinnedCommandLimit = 9;
+    internal const int DefaultQuickAccessShelfPinnedCommandLimit = 9;
+    internal const int MinRecentCommandsDisplayLimit = 1;
+    internal const int MaxRecentCommandsDisplayLimit = 10;
+    internal const int DefaultRecentCommandsDisplayLimit = 5;
+
     public static HotkeySettings DefaultActivationShortcut { get; } = new HotkeySettings(true, false, true, false, 0x20); // win+alt+space
 
     public HotkeySettings? Hotkey { get; init; } = DefaultActivationShortcut;
@@ -52,9 +59,31 @@ public record SettingsModel
 
     public bool ShowQuickAccessShelf { get; init; }
 
-    public bool ShowRecentCommandsInQuickAccessShelf { get; init; }
+    public RecentCommandsPlacement RecentCommandsOnQuickAccessShelf { get; init; }
 
-    public HomeRecentCommandsPlacement RecentCommandsOnHome { get; init; }
+    public RecentCommandsPlacement RecentCommandsOnHome { get; init; }
+
+    private int _quickAccessShelfPinnedCommandLimit = DefaultQuickAccessShelfPinnedCommandLimit;
+
+    public int QuickAccessShelfPinnedCommandLimit
+    {
+        get => _quickAccessShelfPinnedCommandLimit;
+        init => _quickAccessShelfPinnedCommandLimit = Math.Clamp(
+            value,
+            MinQuickAccessShelfPinnedCommandLimit,
+            MaxQuickAccessShelfPinnedCommandLimit);
+    }
+
+    private int _recentCommandsDisplayLimit = DefaultRecentCommandsDisplayLimit;
+
+    public int RecentCommandsDisplayLimit
+    {
+        get => _recentCommandsDisplayLimit;
+        init => _recentCommandsDisplayLimit = Math.Clamp(
+            value,
+            MinRecentCommandsDisplayLimit,
+            MaxRecentCommandsDisplayLimit);
+    }
 
     // When compact mode is on and the palette is centered on launch, this is the relative
     // height from the bottom of the screen (as a percentage) at which the collapsed search
@@ -180,13 +209,17 @@ public record SettingsModel
           ImmutableDictionary<string, ProviderSettings>? providerSettings = null,
           string[]? fallbackRanks = null,
           ImmutableDictionary<string, CommandAlias>? aliases = null,
-          ImmutableList<TopLevelHotkey>? commandHotkeys = null)
+          ImmutableList<TopLevelHotkey>? commandHotkeys = null,
+          int quickAccessShelfPinnedCommandLimit = DefaultQuickAccessShelfPinnedCommandLimit,
+          int recentCommandsDisplayLimit = DefaultRecentCommandsDisplayLimit)
     {
         PinnedCommands = pinnedCommands ?? ImmutableList<PinnedCommandSettings>.Empty;
         ProviderSettings = providerSettings ?? ImmutableDictionary<string, ProviderSettings>.Empty;
         FallbackRanks = fallbackRanks ?? [];
         Aliases = aliases ?? ImmutableDictionary<string, CommandAlias>.Empty;
         CommandHotkeys = commandHotkeys ?? ImmutableList<TopLevelHotkey>.Empty;
+        QuickAccessShelfPinnedCommandLimit = quickAccessShelfPinnedCommandLimit;
+        RecentCommandsDisplayLimit = recentCommandsDisplayLimit;
     }
 
     public SettingsModel()
@@ -484,7 +517,7 @@ public enum EscapeKeyBehavior
     AlwaysHide = 3,
 }
 
-public enum HomeRecentCommandsPlacement
+public enum RecentCommandsPlacement
 {
     Hidden = 0,
     BeforePinned = 1,

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsViewModel.cs
@@ -160,6 +160,7 @@ public partial class SettingsViewModel : INotifyPropertyChanged,
         {
             _settingsService.UpdateSettings(s => s with { CompactMode = value });
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CompactMode)));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CanConfigureQuickAccessShelf)));
         }
     }
 
@@ -169,6 +170,27 @@ public partial class SettingsViewModel : INotifyPropertyChanged,
         set
         {
             _settingsService.UpdateSettings(s => s with { ShowQuickAccessShelf = value });
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CanConfigureQuickAccessShelf)));
+        }
+    }
+
+    public bool CanConfigureQuickAccessShelf => CompactMode && ShowQuickAccessShelf;
+
+    public bool ShowRecentCommandsInQuickAccessShelf
+    {
+        get => _settingsService.Settings.ShowRecentCommandsInQuickAccessShelf;
+        set
+        {
+            _settingsService.UpdateSettings(s => s with { ShowRecentCommandsInQuickAccessShelf = value });
+        }
+    }
+
+    public int RecentCommandsOnHomeIndex
+    {
+        get => (int)_settingsService.Settings.RecentCommandsOnHome;
+        set
+        {
+            _settingsService.UpdateSettings(s => s with { RecentCommandsOnHome = (HomeRecentCommandsPlacement)value });
         }
     }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsViewModel.cs
@@ -176,12 +176,27 @@ public partial class SettingsViewModel : INotifyPropertyChanged,
 
     public bool CanConfigureQuickAccessShelf => CompactMode && ShowQuickAccessShelf;
 
-    public bool ShowRecentCommandsInQuickAccessShelf
+    public double QuickAccessShelfPinnedCommandLimit
     {
-        get => _settingsService.Settings.ShowRecentCommandsInQuickAccessShelf;
+        get => _settingsService.Settings.QuickAccessShelfPinnedCommandLimit;
         set
         {
-            _settingsService.UpdateSettings(s => s with { ShowRecentCommandsInQuickAccessShelf = value });
+            if (double.IsNaN(value))
+            {
+                return;
+            }
+
+            var limit = (int)Math.Round(value, MidpointRounding.AwayFromZero);
+            _settingsService.UpdateSettings(s => s with { QuickAccessShelfPinnedCommandLimit = limit });
+        }
+    }
+
+    public int RecentCommandsOnQuickAccessShelfIndex
+    {
+        get => (int)_settingsService.Settings.RecentCommandsOnQuickAccessShelf;
+        set
+        {
+            _settingsService.UpdateSettings(s => s with { RecentCommandsOnQuickAccessShelf = (RecentCommandsPlacement)value });
         }
     }
 
@@ -190,7 +205,22 @@ public partial class SettingsViewModel : INotifyPropertyChanged,
         get => (int)_settingsService.Settings.RecentCommandsOnHome;
         set
         {
-            _settingsService.UpdateSettings(s => s with { RecentCommandsOnHome = (HomeRecentCommandsPlacement)value });
+            _settingsService.UpdateSettings(s => s with { RecentCommandsOnHome = (RecentCommandsPlacement)value });
+        }
+    }
+
+    public double RecentCommandsDisplayLimit
+    {
+        get => _settingsService.Settings.RecentCommandsDisplayLimit;
+        set
+        {
+            if (double.IsNaN(value))
+            {
+                return;
+            }
+
+            var limit = (int)Math.Round(value, MidpointRounding.AwayFromZero);
+            _settingsService.UpdateSettings(s => s with { RecentCommandsDisplayLimit = limit });
         }
     }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandManager.cs
@@ -35,6 +35,7 @@ public sealed partial class TopLevelCommandManager : ObservableObject,
 
     private readonly List<CommandProviderWrapper> _commandProviders = [];
     private readonly Lock _commandProvidersLock = new();
+    private readonly Lock _pinnedCommandsUpdateLock = new();
 
     // watch out: if you add code that locks CommandProviders, be sure to always
     // lock CommandProviders before locking DockBands, or you will cause a
@@ -43,8 +44,9 @@ public sealed partial class TopLevelCommandManager : ObservableObject,
     private readonly SupersedingAsyncGate _reloadCommandsGate;
     private CancellationTokenSource _extensionLoadCts = new();
     private CancellationToken _currentExtensionLoadCancellationToken;
+    private IReadOnlyList<PinnedCommandSettings> _pinnedCommands = [];
 
-    private HashSet<(string ProviderId, string CommandId)> _pinnedCommandSet = [];
+    internal event EventHandler? PinnedCommandsChanged;
 
     public TopLevelCommandManager(IServiceProvider serviceProvider, IEnumerable<IExtensionService> extensionServices)
     {
@@ -66,8 +68,6 @@ public sealed partial class TopLevelCommandManager : ObservableObject,
             service.OnProviderRemoved += ExtensionService_OnProviderRemoved;
         }
     }
-
-    public ObservableCollection<PinnedCommandSettings> PinnedCommands { get; } = [];
 
     public ObservableCollection<TopLevelViewModel> TopLevelCommands { get; set; } = [];
 
@@ -92,16 +92,24 @@ public sealed partial class TopLevelCommandManager : ObservableObject,
         }
     }
 
-    internal bool IsPinned(string providerId, string commandId)
-    {
-        return _pinnedCommandSet.Contains((providerId, commandId));
-    }
+    internal IReadOnlyList<PinnedCommandSettings> GetPinnedCommandsSnapshot() => Volatile.Read(ref _pinnedCommands);
 
     internal void RebuildPinnedCache()
     {
-        var settings = _serviceProvider.GetRequiredService<ISettingsService>().Settings;
-        _pinnedCommandSet = new(settings.PinnedCommands.Select(p => (p.ProviderId, p.CommandId)));
-        ListHelpers.InPlaceUpdateList(PinnedCommands, settings.PinnedCommands);
+        bool changed;
+        var settingsService = _serviceProvider.GetRequiredService<ISettingsService>();
+
+        lock (_pinnedCommandsUpdateLock)
+        {
+            var pinnedCommands = settingsService.Settings.PinnedCommands;
+            changed = !_pinnedCommands.SequenceEqual(pinnedCommands);
+            Volatile.Write(ref _pinnedCommands, pinnedCommands);
+        }
+
+        if (changed)
+        {
+            PinnedCommandsChanged?.Invoke(this, EventArgs.Empty);
+        }
     }
 
     // May be called from a background thread
@@ -387,15 +395,6 @@ public sealed partial class TopLevelCommandManager : ObservableObject,
                     foreach (var band in dockBandsToRemove)
                     {
                         DockBands.Remove(band);
-                    }
-                }
-
-                lock (PinnedCommands)
-                {
-                    var pinnedToRemove = PinnedCommands.Where(p => p.ProviderId == providerId).ToList();
-                    foreach (var command in pinnedToRemove)
-                    {
-                        PinnedCommands.Remove(command);
                     }
                 }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandResolver.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandResolver.cs
@@ -1,0 +1,158 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CmdPal.Ext.Apps;
+using Microsoft.CommandPalette.Extensions;
+
+namespace Microsoft.CmdPal.UI.ViewModels;
+
+internal static class TopLevelCommandResolver
+{
+    internal const int RecentCommandLimit = 5;
+
+    internal sealed record Sections<TCommand>(
+        IReadOnlyList<TCommand> Pinned,
+        IReadOnlyList<TCommand> Recent,
+        IReadOnlyList<TCommand> Regular);
+
+    internal static Sections<IListItem> Resolve(
+        IEnumerable<PinnedCommandSettings> pinnedCommands,
+        IEnumerable<string> recentCommandIds,
+        IEnumerable<TopLevelViewModel> availableCommands,
+        bool includeApps,
+        int recentCommandLimit = RecentCommandLimit,
+        bool includeRegular = true)
+    {
+        static IListItem? ResolveRecentApp(string commandId) =>
+            AllAppsCommandProvider.Page.TryGetCurrentItem(commandId, out var item) ? item : null;
+
+        Func<string, IListItem?>? additionalRecentResolver = includeApps ? ResolveRecentApp : null;
+        return Resolve<IListItem>(
+            pinnedCommands,
+            recentCommandIds,
+            availableCommands,
+            GetProviderId,
+            GetCommandId,
+            IsEligibleForHome,
+            additionalRecentResolver,
+            recentCommandLimit,
+            includeRegular);
+    }
+
+    internal static string GetProviderId(IListItem command) =>
+        command is TopLevelViewModel topLevel ? topLevel.CommandProviderId : AllAppsCommandProvider.WellKnownId;
+
+    internal static string GetCommandId(IListItem command) =>
+        command is TopLevelViewModel topLevel ? topLevel.Id : command.Command?.Id ?? string.Empty;
+
+    internal static bool IsEligibleForHome(IListItem command) =>
+        command is TopLevelViewModel topLevel
+            ? TopLevelCommandEligibility.IsEligibleForHome(topLevel)
+            : command.Command is not null && !string.IsNullOrEmpty(command.Title);
+
+    internal static Sections<TCommand> Resolve<TCommand>(
+        IEnumerable<PinnedCommandSettings> pinnedCommands,
+        IEnumerable<string> recentCommandIds,
+        IEnumerable<TCommand> availableCommands,
+        Func<TCommand, string> providerIdSelector,
+        Func<TCommand, string> commandIdSelector,
+        Func<TCommand, bool> isEligible,
+        Func<string, TCommand?>? resolveAdditionalRecentCommand = null,
+        int recentCommandLimit = RecentCommandLimit,
+        bool includeRegular = true)
+        where TCommand : class
+    {
+        var eligibleCommands = new List<TCommand>();
+        var commandsByProviderAndId = new Dictionary<(string ProviderId, string CommandId), TCommand>();
+        var commandsById = new Dictionary<string, TCommand>(StringComparer.Ordinal);
+
+        foreach (var command in availableCommands)
+        {
+            if (!isEligible(command))
+            {
+                continue;
+            }
+
+            if (includeRegular)
+            {
+                eligibleCommands.Add(command);
+            }
+
+            var providerId = providerIdSelector(command);
+            var commandId = commandIdSelector(command);
+            commandsByProviderAndId.TryAdd((providerId, commandId), command);
+            if (!string.IsNullOrEmpty(commandId))
+            {
+                commandsById.TryAdd(commandId, command);
+            }
+        }
+
+        var featuredCommandKeys = new HashSet<(string ProviderId, string CommandId)>();
+        var featuredCommandIds = new HashSet<string>(StringComparer.Ordinal);
+        var pinned = new List<TCommand>();
+        foreach (var pinnedCommand in pinnedCommands)
+        {
+            var key = (pinnedCommand.ProviderId, pinnedCommand.CommandId);
+            if (commandsByProviderAndId.TryGetValue(key, out var command) && featuredCommandKeys.Add(key))
+            {
+                pinned.Add(command);
+                if (!string.IsNullOrEmpty(pinnedCommand.CommandId))
+                {
+                    featuredCommandIds.Add(pinnedCommand.CommandId);
+                }
+            }
+        }
+
+        var recent = new List<TCommand>();
+        if (recentCommandLimit > 0)
+        {
+            foreach (var commandId in recentCommandIds)
+            {
+                if (recent.Count == recentCommandLimit)
+                {
+                    break;
+                }
+
+                if (string.IsNullOrEmpty(commandId) || featuredCommandIds.Contains(commandId))
+                {
+                    continue;
+                }
+
+                if (!commandsById.TryGetValue(commandId, out var command))
+                {
+                    command = resolveAdditionalRecentCommand?.Invoke(commandId);
+                    if (command is null || !isEligible(command))
+                    {
+                        continue;
+                    }
+                }
+
+                var key = (providerIdSelector(command), commandIdSelector(command));
+                if (featuredCommandKeys.Add(key))
+                {
+                    recent.Add(command);
+                    featuredCommandIds.Add(commandId);
+                }
+            }
+        }
+
+        IReadOnlyList<TCommand> regular = [];
+        if (includeRegular)
+        {
+            var regularCommands = new List<TCommand>(eligibleCommands.Count);
+            foreach (var command in eligibleCommands)
+            {
+                var key = (providerIdSelector(command), commandIdSelector(command));
+                if (!featuredCommandKeys.Contains(key))
+                {
+                    regularCommands.Add(command);
+                }
+            }
+
+            regular = regularCommands;
+        }
+
+        return new Sections<TCommand>(pinned, recent, regular);
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandResolver.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandResolver.cs
@@ -67,7 +67,7 @@ internal static class TopLevelCommandResolver
         bool recentCommandsFirst = false)
         where TCommand : class
     {
-        var eligibleCommands = new List<TCommand>();
+        var eligibleCommands = new List<(TCommand Command, (string ProviderId, string CommandId) Key)>();
         var commandsByProviderAndId = new Dictionary<(string ProviderId, string CommandId), TCommand>();
         var commandsById = new Dictionary<string, TCommand>(StringComparer.Ordinal);
 
@@ -78,14 +78,15 @@ internal static class TopLevelCommandResolver
                 continue;
             }
 
-            if (includeRegular)
-            {
-                eligibleCommands.Add(command);
-            }
-
             var providerId = providerIdSelector(command);
             var commandId = commandIdSelector(command);
-            commandsByProviderAndId.TryAdd((providerId, commandId), command);
+            var key = (providerId, commandId);
+            if (includeRegular)
+            {
+                eligibleCommands.Add((command, key));
+            }
+
+            commandsByProviderAndId.TryAdd(key, command);
             if (!string.IsNullOrEmpty(commandId))
             {
                 commandsById.TryAdd(commandId, command);
@@ -173,9 +174,8 @@ internal static class TopLevelCommandResolver
         if (includeRegular)
         {
             var regularCommands = new List<TCommand>(eligibleCommands.Count);
-            foreach (var command in eligibleCommands)
+            foreach (var (command, key) in eligibleCommands)
             {
-                var key = (providerIdSelector(command), commandIdSelector(command));
                 if (!featuredCommandKeys.Contains(key))
                 {
                     regularCommands.Add(command);

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandResolver.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandResolver.cs
@@ -18,15 +18,13 @@ internal static class TopLevelCommandResolver
         IEnumerable<PinnedCommandSettings> pinnedCommands,
         IEnumerable<string> recentCommandIds,
         IEnumerable<TopLevelViewModel> availableCommands,
+        IListPage allAppsPage,
         bool includeApps,
         int pinnedCommandLimit = int.MaxValue,
         int recentCommandLimit = SettingsModel.DefaultRecentCommandsDisplayLimit,
         bool includeRegular = true,
         bool recentCommandsFirst = false)
     {
-        static IListItem? ResolveRecentApp(string commandId) =>
-            AllAppsCommandProvider.Page.TryGetCurrentItem(commandId, out var item) ? item : null;
-
         Func<string, IListItem?>? additionalRecentResolver = includeApps ? ResolveRecentApp : null;
         return Resolve<IListItem>(
             pinnedCommands,
@@ -40,6 +38,16 @@ internal static class TopLevelCommandResolver
             recentCommandLimit,
             includeRegular,
             recentCommandsFirst);
+
+        IListItem? ResolveRecentApp(string commandId)
+        {
+            if (allAppsPage is AllAppsPage appsPage)
+            {
+                return appsPage.TryGetCurrentItem(commandId, out var item) ? item : null;
+            }
+
+            return allAppsPage.GetItems().FirstOrDefault(item => item.Command?.Id == commandId);
+        }
     }
 
     internal static string GetProviderId(IListItem command) =>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandResolver.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandResolver.cs
@@ -9,8 +9,6 @@ namespace Microsoft.CmdPal.UI.ViewModels;
 
 internal static class TopLevelCommandResolver
 {
-    internal const int RecentCommandLimit = 5;
-
     internal sealed record Sections<TCommand>(
         IReadOnlyList<TCommand> Pinned,
         IReadOnlyList<TCommand> Recent,
@@ -21,8 +19,10 @@ internal static class TopLevelCommandResolver
         IEnumerable<string> recentCommandIds,
         IEnumerable<TopLevelViewModel> availableCommands,
         bool includeApps,
-        int recentCommandLimit = RecentCommandLimit,
-        bool includeRegular = true)
+        int pinnedCommandLimit = int.MaxValue,
+        int recentCommandLimit = SettingsModel.DefaultRecentCommandsDisplayLimit,
+        bool includeRegular = true,
+        bool recentCommandsFirst = false)
     {
         static IListItem? ResolveRecentApp(string commandId) =>
             AllAppsCommandProvider.Page.TryGetCurrentItem(commandId, out var item) ? item : null;
@@ -36,8 +36,10 @@ internal static class TopLevelCommandResolver
             GetCommandId,
             IsEligibleForHome,
             additionalRecentResolver,
+            pinnedCommandLimit,
             recentCommandLimit,
-            includeRegular);
+            includeRegular,
+            recentCommandsFirst);
     }
 
     internal static string GetProviderId(IListItem command) =>
@@ -59,8 +61,10 @@ internal static class TopLevelCommandResolver
         Func<TCommand, string> commandIdSelector,
         Func<TCommand, bool> isEligible,
         Func<string, TCommand?>? resolveAdditionalRecentCommand = null,
-        int recentCommandLimit = RecentCommandLimit,
-        bool includeRegular = true)
+        int pinnedCommandLimit = int.MaxValue,
+        int recentCommandLimit = SettingsModel.DefaultRecentCommandsDisplayLimit,
+        bool includeRegular = true,
+        bool recentCommandsFirst = false)
         where TCommand : class
     {
         var eligibleCommands = new List<TCommand>();
@@ -91,22 +95,37 @@ internal static class TopLevelCommandResolver
         var featuredCommandKeys = new HashSet<(string ProviderId, string CommandId)>();
         var featuredCommandIds = new HashSet<string>(StringComparer.Ordinal);
         var pinned = new List<TCommand>();
-        foreach (var pinnedCommand in pinnedCommands)
+        var recent = new List<TCommand>();
+
+        void ResolvePinnedCommands()
         {
-            var key = (pinnedCommand.ProviderId, pinnedCommand.CommandId);
-            if (commandsByProviderAndId.TryGetValue(key, out var command) && featuredCommandKeys.Add(key))
+            var effectivePinnedCommandLimit = Math.Max(0, pinnedCommandLimit);
+            foreach (var pinnedCommand in pinnedCommands)
             {
-                pinned.Add(command);
-                if (!string.IsNullOrEmpty(pinnedCommand.CommandId))
+                if (pinned.Count >= effectivePinnedCommandLimit)
                 {
-                    featuredCommandIds.Add(pinnedCommand.CommandId);
+                    break;
+                }
+
+                var key = (pinnedCommand.ProviderId, pinnedCommand.CommandId);
+                if (commandsByProviderAndId.TryGetValue(key, out var command) && featuredCommandKeys.Add(key))
+                {
+                    pinned.Add(command);
+                    if (!string.IsNullOrEmpty(pinnedCommand.CommandId))
+                    {
+                        featuredCommandIds.Add(pinnedCommand.CommandId);
+                    }
                 }
             }
         }
 
-        var recent = new List<TCommand>();
-        if (recentCommandLimit > 0)
+        void ResolveRecentCommands()
         {
+            if (recentCommandLimit <= 0)
+            {
+                return;
+            }
+
             foreach (var commandId in recentCommandIds)
             {
                 if (recent.Count == recentCommandLimit)
@@ -135,6 +154,19 @@ internal static class TopLevelCommandResolver
                     featuredCommandIds.Add(commandId);
                 }
             }
+        }
+
+        // Resolve in presentation order so the first section owns duplicates and the second
+        // section can continue scanning to fill its configured limit with distinct items.
+        if (recentCommandsFirst)
+        {
+            ResolveRecentCommands();
+            ResolvePinnedCommands();
+        }
+        else
+        {
+            ResolvePinnedCommands();
+            ResolveRecentCommands();
         }
 
         IReadOnlyList<TCommand> regular = [];

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelViewModel.cs
@@ -20,7 +20,7 @@ using WyHash;
 namespace Microsoft.CmdPal.UI.ViewModels;
 
 [DebuggerDisplay($"{{{nameof(GetDebuggerDisplay)}(),nq}}")]
-public sealed partial class TopLevelViewModel : ObservableObject, IListItem, IExtendedAttributesProvider, IPrecomputedListItem
+public sealed partial class TopLevelViewModel : ObservableObject, IListItem, IExtendedAttributesProvider, IPrecomputedListItem, ICommandContextSource
 {
     private readonly ISettingsService _settingsService;
     private readonly ProviderSettings _providerSettings;
@@ -53,6 +53,8 @@ public sealed partial class TopLevelViewModel : ObservableObject, IListItem, IEx
     public string Id => string.IsNullOrWhiteSpace(IdFromModel) ? _generatedId : IdFromModel;
 
     public CommandPaletteHost ExtensionHost { get; private set; }
+
+    AppExtensionHost? ICommandContextSource.ExtensionHost => ExtensionHost;
 
     public string ExtensionName => ExtensionHost.GetExtensionDisplayName() ?? string.Empty;
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/CommandPaletteContextMenuFactory.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/CommandPaletteContextMenuFactory.cs
@@ -9,6 +9,7 @@ using ManagedCommon;
 using Microsoft.CmdPal.Ext.Apps;
 using Microsoft.CmdPal.Ext.Apps.Programs;
 using Microsoft.CmdPal.UI.ViewModels;
+using Microsoft.CmdPal.UI.ViewModels.Commands;
 using Microsoft.CmdPal.UI.ViewModels.Dock;
 using Microsoft.CmdPal.UI.ViewModels.Messages;
 using Microsoft.CmdPal.UI.ViewModels.Models;
@@ -24,12 +25,18 @@ internal sealed partial class CommandPaletteContextMenuFactory : IContextMenuFac
 {
     private readonly ISettingsService _settingsService;
     private readonly TopLevelCommandManager _topLevelCommandManager;
+    private readonly IAppStateService _appStateService;
     private readonly IMonitorService? _monitorService;
 
-    public CommandPaletteContextMenuFactory(ISettingsService settingsService, TopLevelCommandManager topLevelCommandManager, IMonitorService? monitorService = null)
+    public CommandPaletteContextMenuFactory(
+        ISettingsService settingsService,
+        TopLevelCommandManager topLevelCommandManager,
+        IAppStateService appStateService,
+        IMonitorService? monitorService = null)
     {
         _settingsService = settingsService;
         _topLevelCommandManager = topLevelCommandManager;
+        _appStateService = appStateService;
         _monitorService = monitorService;
     }
 
@@ -64,33 +71,28 @@ internal sealed partial class CommandPaletteContextMenuFactory : IContextMenuFac
         List<IContextItem> moreCommands = [];
         var itemId = commandItem.Command.Id;
         var providerContext = page.ProviderContext;
+        var model = commandItem.Model.Unsafe;
+        var sourceModel = model is RecentCommandListItem recentItem ? recentItem.Source : model;
 
         // AppListItems can be surfaced on the main page even though they still
         // belong to the All Apps provider.
         // MainListPage only returns our in-proc wrappers/items.
         if (providerContext.ProviderId != AllAppsCommandProvider.WellKnownId &&
             page is ListViewModel { IsMainPage: true } &&
-            commandItem.Model.Unsafe is AppListItem)
+            sourceModel is AppListItem)
         {
             providerContext = _topLevelCommandManager.LookupProvider(AllAppsCommandProvider.WellKnownId)?.GetProviderContext() ?? providerContext;
         }
 
         var supportsPinning = providerContext.SupportsPinning;
 
-        // Also bail early for ListItemViewModels that wrap a TopLevelViewModel.
-        // For those items, TopLevelViewModel.BuildContextMenu() already includes
-        // the correct pin commands by calling AddMoreCommandsToTopLevel with the
-        // item's own provider context. Adding them again here (using the page's
-        // potentially incorrect provider context) would produce duplicate pin
-        // entries such as two "Pin to Dock" buttons.
-        // Check SupportsPinning first to avoid the .Unsafe type-check in the
-        // common non-pinning case.
-        if (supportsPinning && commandItem.Model.Unsafe is TopLevelViewModel)
-        {
-            return results;
-        }
+        // TopLevelViewModel.BuildContextMenu() already includes the correct pin commands using the
+        // item's own provider context. Adding them again here would produce duplicate entries,
+        // including when a recent-section marker wraps the TopLevelViewModel.
+        var pinCommandsAlreadyAdded = sourceModel is TopLevelViewModel;
 
-        if (supportsPinning &&
+        if (!pinCommandsAlreadyAdded &&
+            supportsPinning &&
             !string.IsNullOrEmpty(itemId))
         {
             // Add pin/unpin commands for pinning items to the top-level or to
@@ -122,6 +124,19 @@ internal sealed partial class CommandPaletteContextMenuFactory : IContextMenuFac
 
                 TryAddPinToDockCommand(itemId, providerId, moreCommands, commandItem);
             }
+        }
+
+        if (model is RecentCommandListItem recentCommandItem)
+        {
+            if (moreCommands.Count > 0)
+            {
+                moreCommands.Add(new Separator());
+            }
+
+            moreCommands.Add(new CommandContextItem(new RemoveFromRecentCommand(recentCommandItem.CommandId, _appStateService))
+            {
+                IsCritical = true,
+            });
         }
 
         if (moreCommands.Count > 0)
@@ -333,6 +348,37 @@ internal sealed partial class CommandPaletteContextMenuFactory : IContextMenuFac
         ~MovePinnedContextItem()
         {
             _command.MoveStateChanged -= this.OnMoveStateChanged;
+        }
+    }
+
+    private sealed partial class RemoveFromRecentCommand : InvokableCommand
+    {
+        private readonly string _commandId;
+        private readonly IAppStateService _appStateService;
+
+        public override IconInfo Icon => Icons.DeleteIcon;
+
+        public override string Name => RS_.GetString("recent_commands_remove_name");
+
+        public RemoveFromRecentCommand(string commandId, IAppStateService appStateService)
+        {
+            _commandId = commandId;
+            _appStateService = appStateService;
+        }
+
+        public override CommandResult Invoke()
+        {
+            var current = _appStateService.State.RecentCommands;
+            if (ReferenceEquals(current, current.WithoutHistoryItem(_commandId)))
+            {
+                return CommandResult.KeepOpen();
+            }
+
+            _appStateService.UpdateState(state => state with
+            {
+                RecentCommands = state.RecentCommands.WithoutHistoryItem(_commandId),
+            });
+            return CommandResult.KeepOpen();
         }
     }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml
@@ -479,36 +479,48 @@
                     </ItemsRepeater.Layout>
                     <ItemsRepeater.ItemTemplate>
                         <DataTemplate x:DataType="viewModels:QuickAccessShelfItem">
-                            <Button
+                            <Grid
                                 Width="44"
-                                Height="40"
-                                Padding="8"
-                                AccessKey="{x:Bind ShortcutDigit, Mode=OneTime}"
-                                AutomationProperties.Name="{x:Bind Command.Title, Mode=OneWay}"
-                                Click="QuickAccessShelfItem_Click"
-                                Style="{StaticResource SubtleButtonStyle}"
-                                Tag="{x:Bind}"
-                                UseSystemFocusVisuals="{StaticResource UseSystemFocusVisuals}">
-                                <ToolTipService.ToolTip>
-                                    <ToolTip>
-                                        <StackPanel Spacing="2">
-                                            <TextBlock Text="{x:Bind Command.Title, Mode=OneWay}" />
-                                            <TextBlock
-                                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                                Style="{StaticResource CaptionTextBlockStyle}"
-                                                Text="{x:Bind ShortcutDigit, Mode=OneTime, Converter={StaticResource QuickAccessShortcutTextConverter}}"
-                                                Visibility="{x:Bind ShortcutDigit, Mode=OneTime, Converter={StaticResource StringNotEmptyToVisibilityConverter}}" />
-                                        </StackPanel>
-                                    </ToolTip>
-                                </ToolTipService.ToolTip>
-                                <cpcontrols:IconBox
-                                    Width="20"
-                                    Height="20"
-                                    AutomationProperties.AccessibilityView="Raw"
-                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                    SourceKey="{x:Bind Command.IconViewModel, Mode=OneWay}"
-                                    SourceRequested="{x:Bind help:IconProvider.SourceRequested20}" />
-                            </Button>
+                                Height="40">
+                                <Button
+                                    Width="44"
+                                    Height="40"
+                                    Padding="8"
+                                    AccessKey="{x:Bind ShortcutDigit, Mode=OneTime}"
+                                    AutomationProperties.Name="{x:Bind Title, Mode=OneTime}"
+                                    Click="QuickAccessShelfItem_Click"
+                                    Style="{StaticResource SubtleButtonStyle}"
+                                    Tag="{x:Bind}"
+                                    UseSystemFocusVisuals="{StaticResource UseSystemFocusVisuals}">
+                                    <ToolTipService.ToolTip>
+                                        <ToolTip>
+                                            <StackPanel Spacing="2">
+                                                <TextBlock Text="{x:Bind Title, Mode=OneTime}" />
+                                                <TextBlock
+                                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                    Style="{StaticResource CaptionTextBlockStyle}"
+                                                    Text="{x:Bind ShortcutDigit, Mode=OneTime, Converter={StaticResource QuickAccessShortcutTextConverter}}"
+                                                    Visibility="{x:Bind ShortcutDigit, Mode=OneTime, Converter={StaticResource StringNotEmptyToVisibilityConverter}}" />
+                                            </StackPanel>
+                                        </ToolTip>
+                                    </ToolTipService.ToolTip>
+                                    <cpcontrols:IconBox
+                                        Width="20"
+                                        Height="20"
+                                        AutomationProperties.AccessibilityView="Raw"
+                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                        SourceKey="{x:Bind Icon, Mode=OneTime}"
+                                        SourceRequested="{x:Bind help:IconProvider.SourceRequested20}" />
+                                </Button>
+                                <Border
+                                    Width="1"
+                                    Height="24"
+                                    Margin="-2,0,0,0"
+                                    HorizontalAlignment="Left"
+                                    Background="{ThemeResource CmdPal.DividerStrokeColorDefaultBrush}"
+                                    IsHitTestVisible="False"
+                                    Visibility="{x:Bind help:BindTransformers.BoolToVisibility(StartsRecentSection), Mode=OneTime}" />
+                            </Grid>
                         </DataTemplate>
                     </ItemsRepeater.ItemTemplate>
                 </ItemsRepeater>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <Page
     x:Class="Microsoft.CmdPal.UI.Pages.ShellPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
@@ -438,7 +438,7 @@
             x:Uid="QuickAccessShelfSurface"
             Grid.Row="1"
             MinHeight="48"
-            Padding="12,4"
+            Padding="10,4"
             AutomationProperties.LandmarkType="Custom"
             Background="{ThemeResource LayerOnAcrylicSecondaryBackgroundBrush}"
             BorderBrush="{ThemeResource CmdPal.DividerStrokeColorDefaultBrush}"
@@ -480,10 +480,10 @@
                     <ItemsRepeater.ItemTemplate>
                         <DataTemplate x:DataType="viewModels:QuickAccessShelfItem">
                             <Grid
-                                Width="44"
+                                Width="40"
                                 Height="40">
                                 <Button
-                                    Width="44"
+                                    Width="40"
                                     Height="40"
                                     Padding="8"
                                     AccessKey="{x:Bind ShortcutDigit, Mode=OneTime}"
@@ -519,7 +519,7 @@
                                     HorizontalAlignment="Left"
                                     Background="{ThemeResource CmdPal.DividerStrokeColorDefaultBrush}"
                                     IsHitTestVisible="False"
-                                    Visibility="{x:Bind help:BindTransformers.BoolToVisibility(StartsRecentSection), Mode=OneTime}" />
+                                    Visibility="{x:Bind help:BindTransformers.BoolToVisibility(StartsNewSection), Mode=OneTime}" />
                             </Grid>
                         </DataTemplate>
                     </ItemsRepeater.ItemTemplate>
@@ -529,7 +529,7 @@
                     x:Name="QuickAccessOverflowButton"
                     x:Uid="QuickAccessOverflowButton"
                     Grid.Column="1"
-                    Width="44"
+                    Width="40"
                     Height="40"
                     Padding="8"
                     AccessKey="0"

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
@@ -148,7 +148,11 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
         _quickAccessShelfEnabled = settings.ShowQuickAccessShelf;
         this.ExpandedMode = !_compactMode;
 
-        QuickAccessShelf = new(App.Current.Services.GetRequiredService<TopLevelCommandManager>(), _mainTaskScheduler);
+        QuickAccessShelf = new(
+            App.Current.Services.GetRequiredService<TopLevelCommandManager>(),
+            App.Current.Services.GetRequiredService<IAppStateService>(),
+            settings.ShowQuickAccessShelf && settings.ShowRecentCommandsInQuickAccessShelf,
+            _mainTaskScheduler);
         QuickAccessShelf.PropertyChanged += QuickAccessShelf_PropertyChanged;
 
         this.InitializeComponent();
@@ -1003,7 +1007,7 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
 
     private static void InvokeQuickAccessShelfItem(QuickAccessShelfItem item)
     {
-        WeakReferenceMessenger.Default.Send(item.Command.GetPerformCommandMessage());
+        WeakReferenceMessenger.Default.Send(item.GetPerformCommandMessage());
     }
 
     private void QuickAccessShelfItemsHost_SizeChanged(object sender, SizeChangedEventArgs e)
@@ -1027,17 +1031,22 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
 
         foreach (var item in QuickAccessShelf.OverflowItems)
         {
+            if (item.StartsRecentSection && QuickAccessOverflowFlyout.Items.Count > 0)
+            {
+                QuickAccessOverflowFlyout.Items.Add(new MenuFlyoutSeparator());
+            }
+
             var iconBox = new IconBox
             {
                 Width = 16,
                 Height = 16,
-                SourceKey = item.Command.IconViewModel,
+                SourceKey = item.Icon,
             };
             iconBox.SourceRequested += IconProvider.SourceRequested16;
 
             var menuItem = new MenuFlyoutItem
             {
-                Text = item.Command.Title,
+                Text = item.Title,
                 Tag = item,
                 Icon = new ContentIcon { Content = iconBox },
             };
@@ -1064,8 +1073,8 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
         // invoke the current view model for the same command rather than the stale snapshot.
         foreach (var currentItem in QuickAccessShelf.Items)
         {
-            if (currentItem.Command.CommandProviderId == snapshotItem.Command.CommandProviderId &&
-                currentItem.Command.Id == snapshotItem.Command.Id)
+            if (currentItem.ProviderId == snapshotItem.ProviderId &&
+                currentItem.CommandId == snapshotItem.CommandId)
             {
                 InvokeQuickAccessShelfItem(currentItem);
                 return;
@@ -1227,8 +1236,11 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
         // state single-threaded regardless of which thread raises the event.
         var compactMode = args.CompactMode;
         var quickAccessShelfEnabled = args.ShowQuickAccessShelf;
+        var includeRecentCommands = args.ShowQuickAccessShelf && args.ShowRecentCommandsInQuickAccessShelf;
         this.DispatcherQueue.TryEnqueue(() =>
         {
+            QuickAccessShelf.SetIncludeRecentCommands(includeRecentCommands);
+
             var compactModeChanged = compactMode != _compactMode;
             var quickAccessShelfChanged = quickAccessShelfEnabled != _quickAccessShelfEnabled;
             if (!compactModeChanged && !quickAccessShelfChanged)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
@@ -58,7 +58,7 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
     INotifyPropertyChanged,
     IDisposable
 {
-    private const double QuickAccessShelfButtonWidth = 44;
+    private const double QuickAccessShelfButtonWidth = 40;
     private const double QuickAccessShelfSpacing = 4;
 
     private readonly DispatcherQueue _queue = DispatcherQueue.GetForCurrentThread();
@@ -147,11 +147,16 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
         _compactMode = settings.CompactMode;
         _quickAccessShelfEnabled = settings.ShowQuickAccessShelf;
         this.ExpandedMode = !_compactMode;
+        var recentCommandsOnQuickAccessShelf = settings.ShowQuickAccessShelf
+            ? settings.RecentCommandsOnQuickAccessShelf
+            : RecentCommandsPlacement.Hidden;
 
         QuickAccessShelf = new(
             App.Current.Services.GetRequiredService<TopLevelCommandManager>(),
             App.Current.Services.GetRequiredService<IAppStateService>(),
-            settings.ShowQuickAccessShelf && settings.ShowRecentCommandsInQuickAccessShelf,
+            recentCommandsOnQuickAccessShelf,
+            settings.QuickAccessShelfPinnedCommandLimit,
+            settings.RecentCommandsDisplayLimit,
             _mainTaskScheduler);
         QuickAccessShelf.PropertyChanged += QuickAccessShelf_PropertyChanged;
 
@@ -1031,7 +1036,7 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
 
         foreach (var item in QuickAccessShelf.OverflowItems)
         {
-            if (item.StartsRecentSection && QuickAccessOverflowFlyout.Items.Count > 0)
+            if (item.StartsNewSection && QuickAccessOverflowFlyout.Items.Count > 0)
             {
                 QuickAccessOverflowFlyout.Items.Add(new MenuFlyoutSeparator());
             }
@@ -1236,10 +1241,17 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
         // state single-threaded regardless of which thread raises the event.
         var compactMode = args.CompactMode;
         var quickAccessShelfEnabled = args.ShowQuickAccessShelf;
-        var includeRecentCommands = args.ShowQuickAccessShelf && args.ShowRecentCommandsInQuickAccessShelf;
+        var recentCommandsPlacement = args.ShowQuickAccessShelf
+            ? args.RecentCommandsOnQuickAccessShelf
+            : RecentCommandsPlacement.Hidden;
+        var pinnedCommandLimit = args.QuickAccessShelfPinnedCommandLimit;
+        var recentCommandLimit = args.RecentCommandsDisplayLimit;
         this.DispatcherQueue.TryEnqueue(() =>
         {
-            QuickAccessShelf.SetIncludeRecentCommands(includeRecentCommands);
+            QuickAccessShelf.SetItemConfiguration(
+                recentCommandsPlacement,
+                pinnedCommandLimit,
+                recentCommandLimit);
 
             var compactModeChanged = compactMode != _compactMode;
             var quickAccessShelfChanged = quickAccessShelfEnabled != _quickAccessShelfEnabled;

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/PowerToysAppHostService.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/PowerToysAppHostService.cs
@@ -17,23 +17,19 @@ internal sealed class PowerToysAppHostService : IAppHostService
 
     public AppExtensionHost GetHostForCommand(object? context, AppExtensionHost? currentHost)
     {
-        AppExtensionHost? topLevelHost = null;
-        if (context is TopLevelViewModel topLevelViewModel)
-        {
-            topLevelHost = topLevelViewModel.ExtensionHost;
-        }
+        var contextProvidedHost = (context as ICommandContextSource)?.ExtensionHost;
 
-        return topLevelHost ?? currentHost ?? CommandPaletteHost.Instance;
+        return contextProvidedHost
+               ?? currentHost
+               ?? CommandPaletteHost.Instance;
     }
 
     public ICommandProviderContext GetProviderContextForCommand(object? command, ICommandProviderContext? currentContext)
     {
-        ICommandProviderContext? topLevelId = null;
-        if (command is TopLevelViewModel topLevelViewModel)
-        {
-            topLevelId = topLevelViewModel.ProviderContext;
-        }
+        var contextProvidedProviderContext = (command as ICommandContextSource)?.ProviderContext;
 
-        return topLevelId ?? currentContext ?? throw new InvalidOperationException("No command provider context could be found for the given command, and no current context was provided.");
+        return contextProvidedProviderContext
+               ?? currentContext
+               ?? throw new InvalidOperationException("No command provider context could be found for the given command, and no current context was provided.");
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/AppearancePage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/AppearancePage.xaml
@@ -299,6 +299,13 @@
                                     AutomationProperties.AutomationId="CmdPal_GeneralPage_QuickAccessShelf"
                                     IsOn="{x:Bind ViewModel.ShowQuickAccessShelf, Mode=TwoWay}" />
                             </controls:SettingsCard>
+                            <controls:SettingsCard
+                                x:Uid="Settings_GeneralPage_QuickAccessShelfRecentCommands_SettingsCard"
+                                IsEnabled="{x:Bind ViewModel.CanConfigureQuickAccessShelf, Mode=OneWay}">
+                                <ToggleSwitch
+                                    AutomationProperties.AutomationId="CmdPal_GeneralPage_QuickAccessShelfRecentCommands"
+                                    IsOn="{x:Bind ViewModel.ShowRecentCommandsInQuickAccessShelf, Mode=TwoWay}" />
+                            </controls:SettingsCard>
                             <controls:SettingsCard x:Uid="Settings_GeneralPage_CompactCenterHeight_SettingsCard" IsEnabled="{x:Bind ViewModel.CompactMode, Mode=OneWay}">
                                 <Slider
                                     MinWidth="{StaticResource SettingActionControlMinWidth}"
@@ -313,6 +320,19 @@
                             </controls:SettingsCard>
                         </controls:SettingsExpander.Items>
                     </controls:SettingsExpander>
+
+                    <controls:SettingsCard
+                        x:Uid="Settings_GeneralPage_HomeRecentCommands_SettingsCard"
+                        HeaderIcon="{ui:FontIcon Glyph=&#xE81C;}">
+                        <ComboBox
+                            MinWidth="{StaticResource SettingActionControlMinWidth}"
+                            AutomationProperties.AutomationId="CmdPal_GeneralPage_HomeRecentCommands"
+                            SelectedIndex="{x:Bind ViewModel.RecentCommandsOnHomeIndex, Mode=TwoWay}">
+                            <ComboBoxItem x:Uid="Settings_GeneralPage_HomeRecentCommands_Hidden" />
+                            <ComboBoxItem x:Uid="Settings_GeneralPage_HomeRecentCommands_BeforePinned" />
+                            <ComboBoxItem x:Uid="Settings_GeneralPage_HomeRecentCommands_AfterPinned" />
+                        </ComboBox>
+                    </controls:SettingsCard>
 
                     <controls:SettingsCard x:Uid="Run_PositionHeader" HeaderIcon="{ui:FontIcon Glyph=&#xe78b;}">
                         <ComboBox

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/AppearancePage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/AppearancePage.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <Page
     x:Class="Microsoft.CmdPal.UI.Settings.AppearancePage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
@@ -300,11 +300,28 @@
                                     IsOn="{x:Bind ViewModel.ShowQuickAccessShelf, Mode=TwoWay}" />
                             </controls:SettingsCard>
                             <controls:SettingsCard
+                                x:Uid="Settings_GeneralPage_QuickAccessShelfPinnedCommandLimit_SettingsCard"
+                                IsEnabled="{x:Bind ViewModel.CanConfigureQuickAccessShelf, Mode=OneWay}">
+                                <NumberBox
+                                    MinWidth="{StaticResource SettingActionControlMinWidth}"
+                                    AutomationProperties.AutomationId="CmdPal_GeneralPage_QuickAccessShelfPinnedCommandLimit"
+                                    Maximum="9"
+                                    Minimum="0"
+                                    SmallChange="1"
+                                    SpinButtonPlacementMode="Compact"
+                                    Value="{x:Bind ViewModel.QuickAccessShelfPinnedCommandLimit, Mode=TwoWay}" />
+                            </controls:SettingsCard>
+                            <controls:SettingsCard
                                 x:Uid="Settings_GeneralPage_QuickAccessShelfRecentCommands_SettingsCard"
                                 IsEnabled="{x:Bind ViewModel.CanConfigureQuickAccessShelf, Mode=OneWay}">
-                                <ToggleSwitch
+                                <ComboBox
+                                    MinWidth="{StaticResource SettingActionControlMinWidth}"
                                     AutomationProperties.AutomationId="CmdPal_GeneralPage_QuickAccessShelfRecentCommands"
-                                    IsOn="{x:Bind ViewModel.ShowRecentCommandsInQuickAccessShelf, Mode=TwoWay}" />
+                                    SelectedIndex="{x:Bind ViewModel.RecentCommandsOnQuickAccessShelfIndex, Mode=TwoWay}">
+                                    <ComboBoxItem x:Uid="Settings_GeneralPage_RecentCommands_Hidden" />
+                                    <ComboBoxItem x:Uid="Settings_GeneralPage_RecentCommands_BeforePinned" />
+                                    <ComboBoxItem x:Uid="Settings_GeneralPage_RecentCommands_AfterPinned" />
+                                </ComboBox>
                             </controls:SettingsCard>
                             <controls:SettingsCard x:Uid="Settings_GeneralPage_CompactCenterHeight_SettingsCard" IsEnabled="{x:Bind ViewModel.CompactMode, Mode=OneWay}">
                                 <Slider
@@ -328,10 +345,32 @@
                             MinWidth="{StaticResource SettingActionControlMinWidth}"
                             AutomationProperties.AutomationId="CmdPal_GeneralPage_HomeRecentCommands"
                             SelectedIndex="{x:Bind ViewModel.RecentCommandsOnHomeIndex, Mode=TwoWay}">
-                            <ComboBoxItem x:Uid="Settings_GeneralPage_HomeRecentCommands_Hidden" />
-                            <ComboBoxItem x:Uid="Settings_GeneralPage_HomeRecentCommands_BeforePinned" />
-                            <ComboBoxItem x:Uid="Settings_GeneralPage_HomeRecentCommands_AfterPinned" />
+                            <ComboBoxItem x:Uid="Settings_GeneralPage_RecentCommands_Hidden" />
+                            <ComboBoxItem x:Uid="Settings_GeneralPage_RecentCommands_BeforePinned" />
+                            <ComboBoxItem x:Uid="Settings_GeneralPage_RecentCommands_AfterPinned" />
                         </ComboBox>
+                    </controls:SettingsCard>
+
+                    <controls:SettingsCard
+                        x:Uid="Settings_GeneralPage_RecentCommandsDisplayLimit_SettingsCard"
+                        HeaderIcon="{ui:FontIcon Glyph=&#xE81C;}">
+                        <NumberBox
+                            MinWidth="{StaticResource SettingActionControlMinWidth}"
+                            AutomationProperties.AutomationId="CmdPal_GeneralPage_RecentCommandsDisplayLimit"
+                            Maximum="10"
+                            Minimum="1"
+                            SmallChange="1"
+                            SpinButtonPlacementMode="Compact"
+                            Value="{x:Bind ViewModel.RecentCommandsDisplayLimit, Mode=TwoWay}" />
+                    </controls:SettingsCard>
+
+                    <controls:SettingsCard
+                        x:Uid="Settings_GeneralPage_ClearRecentCommands_SettingsCard"
+                        HeaderIcon="{ui:FontIcon Glyph=&#xE74D;}">
+                        <Button
+                            x:Uid="Settings_GeneralPage_ClearRecentCommandsButton"
+                            AutomationProperties.AutomationId="CmdPal_GeneralPage_ClearRecentCommands"
+                            Click="ClearRecentCommands_Click" />
                     </controls:SettingsCard>
 
                     <controls:SettingsCard x:Uid="Run_PositionHeader" HeaderIcon="{ui:FontIcon Glyph=&#xe78b;}">

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/AppearancePage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/AppearancePage.xaml.cs
@@ -24,6 +24,7 @@ namespace Microsoft.CmdPal.UI.Settings;
 public sealed partial class AppearancePage : Page
 {
     private readonly TaskScheduler _mainTaskScheduler = TaskScheduler.FromCurrentSynchronizationContext();
+    private readonly IAppStateService _appStateService;
 
     internal SettingsViewModel ViewModel { get; }
 
@@ -34,7 +35,22 @@ public sealed partial class AppearancePage : Page
         var themeService = App.Current.Services.GetRequiredService<IThemeService>();
         var topLevelCommandManager = App.Current.Services.GetService<TopLevelCommandManager>()!;
         var settingsService = App.Current.Services.GetRequiredService<ISettingsService>();
+        _appStateService = App.Current.Services.GetRequiredService<IAppStateService>();
         ViewModel = new SettingsViewModel(topLevelCommandManager, _mainTaskScheduler, themeService, settingsService);
+    }
+
+    private void ClearRecentCommands_Click(object sender, RoutedEventArgs e)
+    {
+        var current = _appStateService.State.RecentCommands;
+        if (current.IsEmpty)
+        {
+            return;
+        }
+
+        _appStateService.UpdateState(state => state with
+        {
+            RecentCommands = state.RecentCommands.ClearHistory(),
+        });
     }
 
     private async void PickBackgroundImage_Click(object sender, RoutedEventArgs e)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Strings/en-us/Resources.resw
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Strings/en-us/Resources.resw
@@ -413,7 +413,28 @@ Right-click to remove the key combination, thereby deactivating the shortcut.</v
     <value>Quick access shelf</value>
   </data>
   <data name="Settings_GeneralPage_QuickAccessShelf_SettingsCard.Description" xml:space="preserve">
-    <value>Shows pinned home commands below the search box while compact mode is collapsed. Use Alt+1 through Alt+9 for the first nine visible commands and Alt+0 for overflow.</value>
+    <value>Shows pinned home commands below the search box while compact mode is collapsed. Use Alt+1 through Alt+9 for the first nine visible pinned commands and Alt+0 for overflow.</value>
+  </data>
+  <data name="Settings_GeneralPage_QuickAccessShelfRecentCommands_SettingsCard.Header" xml:space="preserve">
+    <value>Include recent commands</value>
+  </data>
+  <data name="Settings_GeneralPage_QuickAccessShelfRecentCommands_SettingsCard.Description" xml:space="preserve">
+    <value>Adds up to five recently used home commands after pinned commands on the quick access shelf.</value>
+  </data>
+  <data name="Settings_GeneralPage_HomeRecentCommands_SettingsCard.Header" xml:space="preserve">
+    <value>Recent commands on Home</value>
+  </data>
+  <data name="Settings_GeneralPage_HomeRecentCommands_SettingsCard.Description" xml:space="preserve">
+    <value>Show up to five recently used commands before or after the Pinned section.</value>
+  </data>
+  <data name="Settings_GeneralPage_HomeRecentCommands_Hidden.Content" xml:space="preserve">
+    <value>Don't show</value>
+  </data>
+  <data name="Settings_GeneralPage_HomeRecentCommands_BeforePinned.Content" xml:space="preserve">
+    <value>Before pinned</value>
+  </data>
+  <data name="Settings_GeneralPage_HomeRecentCommands_AfterPinned.Content" xml:space="preserve">
+    <value>After pinned</value>
   </data>
   <data name="QuickAccessShelfSurface.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Quick access</value>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Strings/en-us/Resources.resw
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Strings/en-us/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
     Microsoft ResX Schema
@@ -413,28 +413,52 @@ Right-click to remove the key combination, thereby deactivating the shortcut.</v
     <value>Quick access shelf</value>
   </data>
   <data name="Settings_GeneralPage_QuickAccessShelf_SettingsCard.Description" xml:space="preserve">
-    <value>Shows pinned home commands below the search box while compact mode is collapsed. Use Alt+1 through Alt+9 for the first nine visible pinned commands and Alt+0 for overflow.</value>
+    <value>Shows quick access commands below the search box while compact mode is collapsed. Use Alt+1 through Alt+9 for visible items, starting from the left, and Alt+0 for overflow.</value>
+  </data>
+  <data name="Settings_GeneralPage_QuickAccessShelfPinnedCommandLimit_SettingsCard.Header" xml:space="preserve">
+    <value>Maximum pinned commands</value>
+  </data>
+  <data name="Settings_GeneralPage_QuickAccessShelfPinnedCommandLimit_SettingsCard.Description" xml:space="preserve">
+    <value>Choose how many pinned commands appear on the shelf. Set this to 0 to omit pinned commands.</value>
   </data>
   <data name="Settings_GeneralPage_QuickAccessShelfRecentCommands_SettingsCard.Header" xml:space="preserve">
-    <value>Include recent commands</value>
+    <value>Recent items</value>
   </data>
   <data name="Settings_GeneralPage_QuickAccessShelfRecentCommands_SettingsCard.Description" xml:space="preserve">
-    <value>Adds up to five recently used home commands after pinned commands on the quick access shelf.</value>
+    <value>Choose whether recently used commands and launched apps appear before or after pinned commands on the shelf.</value>
   </data>
   <data name="Settings_GeneralPage_HomeRecentCommands_SettingsCard.Header" xml:space="preserve">
-    <value>Recent commands on Home</value>
+    <value>Recent items on Home</value>
   </data>
   <data name="Settings_GeneralPage_HomeRecentCommands_SettingsCard.Description" xml:space="preserve">
-    <value>Show up to five recently used commands before or after the Pinned section.</value>
+    <value>Choose whether recently used commands and launched apps appear before or after the Pinned section.</value>
   </data>
-  <data name="Settings_GeneralPage_HomeRecentCommands_Hidden.Content" xml:space="preserve">
+  <data name="Settings_GeneralPage_RecentCommands_Hidden.Content" xml:space="preserve">
     <value>Don't show</value>
   </data>
-  <data name="Settings_GeneralPage_HomeRecentCommands_BeforePinned.Content" xml:space="preserve">
+  <data name="Settings_GeneralPage_RecentCommands_BeforePinned.Content" xml:space="preserve">
     <value>Before pinned</value>
   </data>
-  <data name="Settings_GeneralPage_HomeRecentCommands_AfterPinned.Content" xml:space="preserve">
+  <data name="Settings_GeneralPage_RecentCommands_AfterPinned.Content" xml:space="preserve">
     <value>After pinned</value>
+  </data>
+  <data name="Settings_GeneralPage_RecentCommandsDisplayLimit_SettingsCard.Header" xml:space="preserve">
+    <value>Maximum recent items</value>
+  </data>
+  <data name="Settings_GeneralPage_RecentCommandsDisplayLimit_SettingsCard.Description" xml:space="preserve">
+    <value>Choose how many recently used commands and launched apps, from 1 through 10, can appear on Home and the quick access shelf.</value>
+  </data>
+  <data name="Settings_GeneralPage_ClearRecentCommands_SettingsCard.Header" xml:space="preserve">
+    <value>Recent history</value>
+  </data>
+  <data name="Settings_GeneralPage_ClearRecentCommands_SettingsCard.Description" xml:space="preserve">
+    <value>Remove all recently used commands and launched apps from Command Palette history.</value>
+  </data>
+  <data name="Settings_GeneralPage_ClearRecentCommandsButton.Content" xml:space="preserve">
+    <value>Clear recent history</value>
+  </data>
+  <data name="recent_commands_remove_name" xml:space="preserve">
+    <value>Remove from recent</value>
   </data>
   <data name="QuickAccessShelfSurface.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Quick access</value>

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Apps.UnitTests/AllAppsPageTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Apps.UnitTests/AllAppsPageTests.cs
@@ -76,6 +76,22 @@ public class AllAppsPageTests : AppsTestBase
     }
 
     [TestMethod]
+    public async Task AllAppsPage_TryGetCurrentItemUsesPublishedCatalogWithoutReloading()
+    {
+        var mockCache = new MockAppCache();
+        mockCache.AddWin32Program(TestDataHelper.CreateTestWin32Program("Notepad", "C:\\Windows\\System32\\notepad.exe"));
+        var page = new AllAppsPage(mockCache);
+        await Task.Delay(100);
+
+        var expected = page.GetItems().OfType<AppListItem>().Single();
+
+        Assert.IsTrue(page.TryGetCurrentItem(expected.Command.Id, out var actual));
+        Assert.AreSame(expected, actual);
+        Assert.IsFalse(page.TryGetCurrentItem("missing", out var missing));
+        Assert.IsNull(missing);
+    }
+
+    [TestMethod]
     public async Task AllAppsPage_GetItems_HidesSubtitlesWhenSettingEnabled()
     {
         // Arrange

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/CommandContextSourceTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/CommandContextSourceTests.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.CmdPal.Common.Services;
+using Microsoft.CmdPal.UI.ViewModels.Commands;
+using Microsoft.CmdPal.UI.ViewModels.Messages;
+using Microsoft.CmdPal.UI.ViewModels.Models;
+using Microsoft.CmdPal.UI.ViewModels.Services;
+using Microsoft.CommandPalette.Extensions;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
+
+[TestClass]
+public sealed class CommandContextSourceTests
+{
+    private sealed class TestPageContext : IPageContext
+    {
+        public TaskScheduler Scheduler => TaskScheduler.Default;
+
+        public ICommandProviderContext ProviderContext => CommandProviderContext.Empty;
+
+        public void ShowException(Exception ex, string? extensionHint = null) =>
+            throw new AssertFailedException($"Unexpected exception from view model: {ex}");
+    }
+
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(1)]
+    [DataRow(2)]
+    public void TopLevelAndRecentItems_PreserveHostAndProviderContext(int wrapperCount)
+    {
+        var host = new CommandPaletteHost(Mock.Of<IExtensionWrapper>());
+        var provider = Mock.Of<ICommandProviderContext>(context => context.ProviderId == "test.provider" && context.SupportsPinning);
+        var services = Mock.Of<IServiceProvider>(service => service.GetService(typeof(ISettingsService)) == Mock.Of<ISettingsService>());
+        var pageContext = new TestPageContext();
+        var page = new ListPage { Id = "test.page", Name = "Test page" };
+        var model = new CommandItem(page);
+        var itemViewModel = new CommandItemViewModel(new(model), new(pageContext), DefaultContextMenuFactory.Instance);
+        itemViewModel.SlowInitializeProperties();
+        var topLevel = new TopLevelViewModel(itemViewModel, TopLevelType.Normal, host, provider, new ProviderSettings(), services, model, DefaultContextMenuFactory.Instance);
+
+        try
+        {
+            IListItem item = topLevel;
+            for (var i = 0; i < wrapperCount; i++)
+            {
+                item = new RecentCommandListItem(item, "recorded-history-id");
+            }
+
+            var message = new PerformCommandMessage(new(item.Command), new ExtensionObject<IListItem>(item));
+            var contextSource = message.Context as ICommandContextSource;
+
+            Assert.IsNotNull(contextSource);
+            Assert.AreSame(host, contextSource.ExtensionHost);
+            Assert.AreSame(provider, contextSource.ProviderContext);
+            Assert.AreSame(page, message.Command.Unsafe);
+            Assert.AreSame(item, message.Context);
+        }
+        finally
+        {
+            topLevel.Cleanup();
+        }
+    }
+
+    [TestMethod]
+    public void RecentItem_ForwardsAnyContextSource()
+    {
+        var host = new CommandPaletteHost(Mock.Of<IExtensionWrapper>());
+        var provider = Mock.Of<ICommandProviderContext>();
+        var source = new Mock<IListItem>();
+        source.As<ICommandContextSource>().SetupGet(context => context.ExtensionHost).Returns(host);
+        source.As<ICommandContextSource>().SetupGet(context => context.ProviderContext).Returns(provider);
+        ICommandContextSource recent = new RecentCommandListItem(source.Object, "recorded-history-id");
+
+        Assert.AreSame(host, recent.ExtensionHost);
+        Assert.AreSame(provider, recent.ProviderContext);
+    }
+
+    [TestMethod]
+    public void RecentItem_WithoutContextSource_ProvidesNoContext()
+    {
+        var app = new ListItem(new NoOpCommand());
+        ICommandContextSource recent = new RecentCommandListItem(app, "app.id");
+
+        Assert.IsNull(recent.ExtensionHost);
+        Assert.IsNull(recent.ProviderContext);
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/MainListPageCacheTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/MainListPageCacheTests.cs
@@ -1,0 +1,222 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CmdPal.Common.Text;
+using Microsoft.CmdPal.UI.ViewModels.MainPage;
+using Microsoft.CmdPal.UI.ViewModels.Services;
+using Microsoft.CommandPalette.Extensions.Toolkit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
+
+[TestClass]
+public sealed class MainListPageCacheTests
+{
+    private const string ProviderId = "test.provider";
+
+    private sealed class TestPageContext : IPageContext
+    {
+        public TaskScheduler Scheduler => TaskScheduler.Default;
+
+        public ICommandProviderContext ProviderContext => CommandProviderContext.Empty;
+
+        public void ShowException(Exception ex, string? extensionHint = null) =>
+            throw new AssertFailedException($"Unexpected exception from view model: {ex}");
+    }
+
+    private sealed class BlockingCommandProviderContext : ICommandProviderContext, IDisposable
+    {
+        private readonly ManualResetEventSlim _readStarted = new();
+        private readonly ManualResetEventSlim _continueRead = new();
+        private Action? _nextReadAction;
+        private int _blockNextRead;
+        private int _readCount;
+
+        public string ProviderId
+        {
+            get
+            {
+                Interlocked.Increment(ref _readCount);
+                Interlocked.Exchange(ref _nextReadAction, null)?.Invoke();
+                if (Interlocked.Exchange(ref _blockNextRead, 0) != 0)
+                {
+                    _readStarted.Set();
+                    if (!_continueRead.Wait(TimeSpan.FromSeconds(5)))
+                    {
+                        throw new TimeoutException("Timed out waiting to continue reading the provider ID.");
+                    }
+                }
+
+                return MainListPageCacheTests.ProviderId;
+            }
+        }
+
+        public bool SupportsPinning => true;
+
+        public int ReadCount => Volatile.Read(ref _readCount);
+
+        public void BlockNextRead()
+        {
+            _readStarted.Reset();
+            _continueRead.Reset();
+            Volatile.Write(ref _blockNextRead, 1);
+        }
+
+        public void RunOnNextRead(Action action) => Interlocked.Exchange(ref _nextReadAction, action);
+
+        public bool WaitForBlockedRead(TimeSpan timeout) => _readStarted.Wait(timeout);
+
+        public void ContinueRead() => _continueRead.Set();
+
+        public void Dispose()
+        {
+            _readStarted.Dispose();
+            _continueRead.Dispose();
+        }
+    }
+
+    [TestMethod]
+    public async Task ConcurrentDefaultViewRebuilds_CannotOverwriteNewerSnapshot()
+    {
+        var settings = new SettingsModel();
+        var settingsService = new Mock<ISettingsService>();
+        settingsService.SetupGet(service => service.Settings).Returns(() => settings);
+
+        var services = new Mock<IServiceProvider>();
+        services.Setup(service => service.GetService(typeof(TaskScheduler))).Returns(TaskScheduler.Default);
+        services.Setup(service => service.GetService(typeof(ISettingsService))).Returns(settingsService.Object);
+
+        var appStateService = new Mock<IAppStateService>();
+        appStateService.SetupGet(service => service.State).Returns(new AppStateModel());
+
+        var fuzzyMatcherProvider = new Mock<IFuzzyMatcherProvider>();
+        using var providerContext = new BlockingCommandProviderContext();
+        using var commandManager = new TopLevelCommandManager(services.Object, []);
+        var pageContext = new TestPageContext();
+        var first = CreateTopLevelCommand("first", "First", services.Object, pageContext, providerContext);
+        var second = CreateTopLevelCommand("second", "Second", services.Object, pageContext, providerContext);
+        commandManager.TopLevelCommands.Add(first);
+        commandManager.TopLevelCommands.Add(second);
+
+        using var page = new MainListPage(
+            commandManager,
+            null!,
+            fuzzyMatcherProvider.Object,
+            settingsService.Object,
+            appStateService.Object,
+            new ListPage());
+
+        try
+        {
+            _ = page.GetItems();
+            settings = settings.TryPinCommand(ProviderId, first.Id);
+            commandManager.RebuildPinnedCache();
+
+            providerContext.BlockNextRead();
+            var rebuild = Task.Run(page.GetItems);
+            Assert.IsTrue(providerContext.WaitForBlockedRead(TimeSpan.FromSeconds(5)));
+
+            settings = settings.TryPinCommand(ProviderId, second.Id);
+            commandManager.RebuildPinnedCache();
+            var newerRebuild = await Task.Run(page.GetItems).WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.AreEqual(3, newerRebuild.Length);
+            Assert.AreSame(first, newerRebuild[1]);
+            Assert.AreSame(second, newerRebuild[2]);
+
+            providerContext.ContinueRead();
+            var olderRebuild = await rebuild.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.AreEqual(3, olderRebuild.Length);
+            Assert.AreSame(first, olderRebuild[1]);
+            Assert.AreSame(second, olderRebuild[2]);
+        }
+        finally
+        {
+            providerContext.ContinueRead();
+            first.Cleanup();
+            second.Cleanup();
+        }
+    }
+
+    [TestMethod]
+    public void InvalidatedDefaultViewRebuild_IsRetriedByNextGetItemsCall()
+    {
+        var settings = new SettingsModel();
+        var settingsService = new Mock<ISettingsService>();
+        settingsService.SetupGet(service => service.Settings).Returns(() => settings);
+
+        var services = new Mock<IServiceProvider>();
+        services.Setup(service => service.GetService(typeof(TaskScheduler))).Returns(TaskScheduler.Default);
+        services.Setup(service => service.GetService(typeof(ISettingsService))).Returns(settingsService.Object);
+
+        var appStateService = new Mock<IAppStateService>();
+        appStateService.SetupGet(service => service.State).Returns(new AppStateModel());
+
+        var fuzzyMatcherProvider = new Mock<IFuzzyMatcherProvider>();
+        using var providerContext = new BlockingCommandProviderContext();
+        using var commandManager = new TopLevelCommandManager(services.Object, []);
+        var pageContext = new TestPageContext();
+        var command = CreateTopLevelCommand("command", "Command", services.Object, pageContext, providerContext);
+        commandManager.TopLevelCommands.Add(command);
+
+        using var page = new MainListPage(
+            commandManager,
+            null!,
+            fuzzyMatcherProvider.Object,
+            settingsService.Object,
+            appStateService.Object,
+            new ListPage());
+
+        try
+        {
+            _ = page.GetItems();
+            settings = settings.TryPinCommand("missing.provider", "missing.command");
+            commandManager.RebuildPinnedCache();
+
+            var readsBeforeRebuild = providerContext.ReadCount;
+            providerContext.RunOnNextRead(() =>
+            {
+                settings = settings.TryPinCommand(ProviderId, command.Id);
+                commandManager.RebuildPinnedCache();
+            });
+
+            _ = page.GetItems();
+            Assert.AreEqual(readsBeforeRebuild + 1, providerContext.ReadCount);
+
+            _ = page.GetItems();
+            Assert.AreEqual(readsBeforeRebuild + 2, providerContext.ReadCount);
+        }
+        finally
+        {
+            command.Cleanup();
+        }
+    }
+
+    private static TopLevelViewModel CreateTopLevelCommand(
+        string id,
+        string title,
+        IServiceProvider services,
+        IPageContext pageContext,
+        ICommandProviderContext providerContext)
+    {
+        var model = new CommandItem(new NoOpCommand { Id = id, Name = title }) { Title = title };
+        var item = new CommandItemViewModel(new(model), new(pageContext), DefaultContextMenuFactory.Instance);
+        var topLevel = new TopLevelViewModel(
+            item,
+            TopLevelType.Normal,
+            CommandPaletteHost.Instance,
+            providerContext,
+            new ProviderSettings(),
+            services,
+            model,
+            DefaultContextMenuFactory.Instance);
+        topLevel.InitializeProperties();
+        return topLevel;
+    }
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/QuickAccessShelfResolverTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/QuickAccessShelfResolverTests.cs
@@ -2,7 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Linq;
+using Microsoft.CommandPalette.Extensions.Toolkit;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
@@ -10,43 +10,6 @@ namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
 [TestClass]
 public class QuickAccessShelfResolverTests
 {
-    [TestMethod]
-    public void Resolve_UsesPinOrderAndSkipsUnavailableOrIneligibleCommands()
-    {
-        var pins = new[]
-        {
-            new PinnedCommandSettings("provider-b", "second"),
-            new PinnedCommandSettings("missing", "command"),
-            new PinnedCommandSettings("provider-a", "first"),
-            new PinnedCommandSettings("provider-a", "hidden"),
-        };
-        var commands = new[]
-        {
-            new TestCommand("provider-a", "first", IsEligible: true),
-            new TestCommand("provider-a", "hidden", IsEligible: false),
-            new TestCommand("provider-b", "second", IsEligible: true),
-        };
-
-        var resolved = QuickAccessShelfResolver.Resolve(
-            pins,
-            commands,
-            static command => command.ProviderId,
-            static command => command.CommandId,
-            static command => command.IsEligible);
-
-        CollectionAssert.AreEqual(new[] { commands[2], commands[0] }, resolved.ToArray());
-    }
-
-    [DataTestMethod]
-    [DataRow(false, "Command", true)]
-    [DataRow(true, "Command", false)]
-    [DataRow(false, "", false)]
-    [DataRow(false, null, false)]
-    public void IsEligibleForHome_ExcludesFallbacksAndUntitledCommands(bool isFallback, string? title, bool expected)
-    {
-        Assert.AreEqual(expected, TopLevelCommandEligibility.IsEligibleForHome(isFallback, title));
-    }
-
     [DataTestMethod]
     [DataRow(0, "1")]
     [DataRow(8, "9")]
@@ -55,6 +18,18 @@ public class QuickAccessShelfResolverTests
     public void IndexToShortcutDigit_MapsFirstNineItems(int index, string expectedDigit)
     {
         Assert.AreEqual(expectedDigit, QuickAccessShelfResolver.IndexToShortcutDigit(index));
+    }
+
+    [TestMethod]
+    public void RecentItemsDoNotReceiveMruDependentAccessKeys()
+    {
+        var item = new ListItem { Title = "Recent" };
+
+        var pinned = new QuickAccessShelfItem(item, shortcutIndex: 2, startsRecentSection: false);
+        var recent = new QuickAccessShelfItem(item, shortcutIndex: -1, startsRecentSection: true);
+
+        Assert.AreEqual("3", pinned.ShortcutDigit);
+        Assert.AreEqual(string.Empty, recent.ShortcutDigit);
     }
 
     [DataTestMethod]
@@ -74,6 +49,4 @@ public class QuickAccessShelfResolverTests
             expectedCapacity,
             QuickAccessShelfResolver.CalculateVisibleCapacity(itemCount, availableWidth, itemWidth: 44, spacing: 4));
     }
-
-    private sealed record TestCommand(string ProviderId, string CommandId, bool IsEligible);
 }

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/QuickAccessShelfResolverTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/QuickAccessShelfResolverTests.cs
@@ -2,13 +2,14 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Linq;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
 
 [TestClass]
-public class QuickAccessShelfResolverTests
+public partial class QuickAccessShelfResolverTests
 {
     [DataTestMethod]
     [DataRow(0, "1")]
@@ -21,25 +22,107 @@ public class QuickAccessShelfResolverTests
     }
 
     [TestMethod]
-    public void RecentItemsDoNotReceiveMruDependentAccessKeys()
+    public void ShelfItemsUseAssignedRowPositionForAccessKeys()
     {
         var item = new ListItem { Title = "Recent" };
 
-        var pinned = new QuickAccessShelfItem(item, shortcutIndex: 2, startsRecentSection: false);
-        var recent = new QuickAccessShelfItem(item, shortcutIndex: -1, startsRecentSection: true);
+        var first = QuickAccessShelfItem.CreateOrReuse([], item, shortcutIndex: 0, startsNewSection: true);
+        var third = QuickAccessShelfItem.CreateOrReuse([], item, shortcutIndex: 2, startsNewSection: false);
 
-        Assert.AreEqual("3", pinned.ShortcutDigit);
-        Assert.AreEqual(string.Empty, recent.ShortcutDigit);
+        Assert.AreEqual("1", first.ShortcutDigit);
+        Assert.AreEqual("3", third.ShortcutDigit);
+    }
+
+    [TestMethod]
+    public void CreateOrReuse_UnchangedItemReusesInitializedIcon()
+    {
+        var icon = new CountingIconInfo();
+        var item = new ListItem { Title = "Recent", Icon = icon };
+
+        var original = QuickAccessShelfItem.CreateOrReuse([], item, shortcutIndex: -1, startsNewSection: false);
+        var iconReadCount = icon.ReadCount;
+        var reused = QuickAccessShelfItem.CreateOrReuse([original], item, shortcutIndex: -1, startsNewSection: false);
+
+        Assert.IsTrue(iconReadCount > 0);
+        Assert.AreSame(original, reused);
+        Assert.AreEqual(iconReadCount, icon.ReadCount);
+    }
+
+    [TestMethod]
+    public void ComposeSections_PinnedFirstAssignsRowShortcuts()
+    {
+        var result = QuickAccessShelfResolver.ComposeSections(
+            ["pinned-1", "pinned-2"],
+            ["recent-1", "recent-2"],
+            RecentCommandsPlacement.AfterPinned);
+
+        string[] expectedItems = ["pinned-1", "pinned-2", "recent-1", "recent-2"];
+        int[] expectedShortcutIndexes = [0, 1, 2, 3];
+        bool[] expectedSectionStarts = [false, false, true, false];
+        bool[] expectedPinnedState = [true, true, false, false];
+        CollectionAssert.AreEqual(expectedItems, result.Select(item => item.Item).ToArray());
+        CollectionAssert.AreEqual(expectedShortcutIndexes, result.Select(item => item.ShortcutIndex).ToArray());
+        CollectionAssert.AreEqual(expectedSectionStarts, result.Select(item => item.StartsNewSection).ToArray());
+        CollectionAssert.AreEqual(expectedPinnedState, result.Select(item => item.IsPinned).ToArray());
+    }
+
+    [TestMethod]
+    public void ComposeSections_RecentFirstAssignsRowShortcuts()
+    {
+        var result = QuickAccessShelfResolver.ComposeSections(
+            ["pinned-1", "pinned-2"],
+            ["recent-1", "recent-2"],
+            RecentCommandsPlacement.BeforePinned);
+
+        string[] expectedItems = ["recent-1", "recent-2", "pinned-1", "pinned-2"];
+        int[] expectedShortcutIndexes = [0, 1, 2, 3];
+        bool[] expectedSectionStarts = [false, false, true, false];
+        bool[] expectedPinnedState = [false, false, true, true];
+        CollectionAssert.AreEqual(expectedItems, result.Select(item => item.Item).ToArray());
+        CollectionAssert.AreEqual(expectedShortcutIndexes, result.Select(item => item.ShortcutIndex).ToArray());
+        CollectionAssert.AreEqual(expectedSectionStarts, result.Select(item => item.StartsNewSection).ToArray());
+        CollectionAssert.AreEqual(expectedPinnedState, result.Select(item => item.IsPinned).ToArray());
+    }
+
+    [TestMethod]
+    public void ComposeSections_HiddenRecentCommandsAreExcluded()
+    {
+        var result = QuickAccessShelfResolver.ComposeSections(
+            ["pinned-1"],
+            ["recent-1"],
+            RecentCommandsPlacement.Hidden);
+
+        Assert.AreEqual(1, result.Count);
+        Assert.AreEqual("pinned-1", result[0].Item);
+        Assert.IsTrue(result[0].IsPinned);
+        Assert.AreEqual(0, result[0].ShortcutIndex);
+        Assert.IsFalse(result[0].StartsNewSection);
+    }
+
+    [TestMethod]
+    public void ComposeSections_EmptyPinnedSupportsRecentOnlyShelf()
+    {
+        var result = QuickAccessShelfResolver.ComposeSections(
+            [],
+            ["recent-1", "recent-2"],
+            RecentCommandsPlacement.AfterPinned);
+
+        string[] expectedItems = ["recent-1", "recent-2"];
+        int[] expectedShortcutIndexes = [0, 1];
+        CollectionAssert.AreEqual(expectedItems, result.Select(item => item.Item).ToArray());
+        CollectionAssert.AreEqual(expectedShortcutIndexes, result.Select(item => item.ShortcutIndex).ToArray());
+        Assert.IsTrue(result.All(item => !item.IsPinned));
+        Assert.IsTrue(result.All(item => !item.StartsNewSection));
     }
 
     [DataTestMethod]
     [DataRow(0, 300, 0)]
-    [DataRow(1, 44, 1)]
-    [DataRow(3, 140, 3)]
-    [DataRow(4, 140, 2)]
-    [DataRow(4, 188, 4)]
-    [DataRow(3, 92, 1)]
-    [DataRow(3, 44, 0)]
+    [DataRow(1, 40, 1)]
+    [DataRow(3, 128, 3)]
+    [DataRow(4, 128, 2)]
+    [DataRow(4, 172, 4)]
+    [DataRow(3, 84, 1)]
+    [DataRow(3, 40, 0)]
     public void CalculateVisibleCapacity_ReservesOverflowOnlyWhenNeeded(
         int itemCount,
         double availableWidth,
@@ -47,6 +130,38 @@ public class QuickAccessShelfResolverTests
     {
         Assert.AreEqual(
             expectedCapacity,
-            QuickAccessShelfResolver.CalculateVisibleCapacity(itemCount, availableWidth, itemWidth: 44, spacing: 4));
+            QuickAccessShelfResolver.CalculateVisibleCapacity(itemCount, availableWidth, itemWidth: 40, spacing: 4));
+    }
+
+    private sealed partial class CountingIconInfo : IconInfo
+    {
+        public int ReadCount { get; private set; }
+
+        public CountingIconInfo()
+            : base("icon")
+        {
+        }
+
+        public override IconData Light
+        {
+            get
+            {
+                ReadCount++;
+                return base.Light;
+            }
+
+            set => base.Light = value;
+        }
+
+        public override IconData Dark
+        {
+            get
+            {
+                ReadCount++;
+                return base.Dark;
+            }
+
+            set => base.Dark = value;
+        }
     }
 }

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/RecentCommandsTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/RecentCommandsTests.cs
@@ -49,6 +49,18 @@ public partial class RecentCommandsTests : CommandPaletteUnitTestBase
     }
 
     [TestMethod]
+    public void RecentCommandIdsAreMostRecentFirstAndCanBeBoundedByConsumer()
+    {
+        var history = CreateHistory(["oldest", "middle", "newest"]);
+        string[] expected = ["newest", "middle"];
+
+        CollectionAssert.AreEqual(
+            expected,
+            history.EnumerateRecentCommandIds().Take(2).ToArray());
+        Assert.AreEqual(3, history.EnumerateRecentCommandIds().Count());
+    }
+
+    [TestMethod]
     public void ValidateHistoryWeighting()
     {
         // Build history with explicit, strictly-increasing timestamps so time-decay is

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/RecentCommandsTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/RecentCommandsTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Text.Json;
 using Microsoft.CmdPal.Common.Text;
 using Microsoft.CmdPal.Ext.UnitTestBase;
+using Microsoft.CmdPal.UI.ViewModels.Commands;
 using Microsoft.CmdPal.UI.ViewModels.MainPage;
 using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
@@ -244,6 +245,61 @@ public partial class RecentCommandsTests : CommandPaletteUnitTestBase
 
         // The original instance is unchanged - its index never gained beta.
         Assert.AreEqual(0, first.GetCommandHistoryWeight("beta", now), "the original instance must not see beta");
+    }
+
+    [TestMethod]
+    public void WithoutHistoryItem_RemovesOnlyRequestedCommand()
+    {
+        var original = CreateHistory(["alpha", "beta", "gamma"]);
+
+        var updated = original.WithoutHistoryItem("beta");
+
+        string[] expectedUpdated = ["gamma", "alpha"];
+        string[] expectedOriginal = ["gamma", "beta", "alpha"];
+        CollectionAssert.AreEqual(expectedUpdated, updated.EnumerateRecentCommandIds().ToArray());
+        CollectionAssert.AreEqual(expectedOriginal, original.EnumerateRecentCommandIds().ToArray());
+        Assert.AreSame(updated, updated.WithoutHistoryItem("missing"));
+    }
+
+    [TestMethod]
+    public void ClearHistory_RemovesEverythingAndPreservesEmptyInstance()
+    {
+        var original = CreateHistory(["alpha", "beta"]);
+
+        var cleared = original.ClearHistory();
+
+        Assert.IsTrue(cleared.IsEmpty);
+        Assert.AreEqual(0, cleared.EnumerateRecentCommandIds().Count());
+        Assert.AreSame(cleared, cleared.ClearHistory());
+        Assert.AreEqual(2, original.EnumerateRecentCommandIds().Count());
+    }
+
+    [TestMethod]
+    public void RecentCommandListItem_PreservesRecordedHistoryId()
+    {
+        var source = new ListItemMock("A command", GivenId: "source-command-id");
+        var recentItem = new RecentCommandListItem(source, "recorded-history-id");
+
+        Assert.AreSame(source, recentItem.Source);
+        Assert.AreEqual("recorded-history-id", MainListPage.IdForTopLevelOrAppItem(recentItem));
+    }
+
+    [TestMethod]
+    public void RecentCommandListItem_CreateOrReuse_ReusesOnlyMatchingPresentation()
+    {
+        var source = new ListItemMock("A command", GivenId: "source-command-id");
+        var first = RecentCommandListItem.CreateOrReuse(null, source, "recorded-history-id");
+
+        var reused = RecentCommandListItem.CreateOrReuse([first], source, "recorded-history-id");
+        var differentCommand = RecentCommandListItem.CreateOrReuse([first], source, "other-history-id");
+        var differentSource = RecentCommandListItem.CreateOrReuse(
+            [first],
+            new ListItemMock("A command", GivenId: "source-command-id"),
+            "recorded-history-id");
+
+        Assert.AreSame(first, reused);
+        Assert.AreNotSame(first, differentCommand);
+        Assert.AreNotSame(first, differentSource);
     }
 
     [TestMethod]

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/SettingsServiceTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/SettingsServiceTests.cs
@@ -100,18 +100,27 @@ public class SettingsServiceTests
 
         Assert.IsNotNull(settings);
         Assert.IsFalse(settings.ShowQuickAccessShelf);
+        Assert.IsFalse(settings.ShowRecentCommandsInQuickAccessShelf);
+        Assert.AreEqual(HomeRecentCommandsPlacement.Hidden, settings.RecentCommandsOnHome);
     }
 
     [TestMethod]
     public void QuickAccessShelf_ExplicitValueRoundTrips()
     {
-        var source = CreateMinimalSettingsModel() with { ShowQuickAccessShelf = true };
+        var source = CreateMinimalSettingsModel() with
+        {
+            ShowQuickAccessShelf = true,
+            ShowRecentCommandsInQuickAccessShelf = true,
+            RecentCommandsOnHome = HomeRecentCommandsPlacement.BeforePinned,
+        };
 
         var json = System.Text.Json.JsonSerializer.Serialize(source, JsonSerializationContext.Default.SettingsModel);
         var settings = System.Text.Json.JsonSerializer.Deserialize(json, JsonSerializationContext.Default.SettingsModel);
 
         Assert.IsNotNull(settings);
         Assert.IsTrue(settings.ShowQuickAccessShelf);
+        Assert.IsTrue(settings.ShowRecentCommandsInQuickAccessShelf);
+        Assert.AreEqual(HomeRecentCommandsPlacement.BeforePinned, settings.RecentCommandsOnHome);
     }
 
     [TestMethod]

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/SettingsServiceTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/SettingsServiceTests.cs
@@ -100,8 +100,10 @@ public class SettingsServiceTests
 
         Assert.IsNotNull(settings);
         Assert.IsFalse(settings.ShowQuickAccessShelf);
-        Assert.IsFalse(settings.ShowRecentCommandsInQuickAccessShelf);
-        Assert.AreEqual(HomeRecentCommandsPlacement.Hidden, settings.RecentCommandsOnHome);
+        Assert.AreEqual(RecentCommandsPlacement.Hidden, settings.RecentCommandsOnQuickAccessShelf);
+        Assert.AreEqual(RecentCommandsPlacement.Hidden, settings.RecentCommandsOnHome);
+        Assert.AreEqual(SettingsModel.DefaultQuickAccessShelfPinnedCommandLimit, settings.QuickAccessShelfPinnedCommandLimit);
+        Assert.AreEqual(SettingsModel.DefaultRecentCommandsDisplayLimit, settings.RecentCommandsDisplayLimit);
     }
 
     [TestMethod]
@@ -110,8 +112,10 @@ public class SettingsServiceTests
         var source = CreateMinimalSettingsModel() with
         {
             ShowQuickAccessShelf = true,
-            ShowRecentCommandsInQuickAccessShelf = true,
-            RecentCommandsOnHome = HomeRecentCommandsPlacement.BeforePinned,
+            RecentCommandsOnQuickAccessShelf = RecentCommandsPlacement.AfterPinned,
+            RecentCommandsOnHome = RecentCommandsPlacement.BeforePinned,
+            QuickAccessShelfPinnedCommandLimit = 4,
+            RecentCommandsDisplayLimit = 7,
         };
 
         var json = System.Text.Json.JsonSerializer.Serialize(source, JsonSerializationContext.Default.SettingsModel);
@@ -119,8 +123,28 @@ public class SettingsServiceTests
 
         Assert.IsNotNull(settings);
         Assert.IsTrue(settings.ShowQuickAccessShelf);
-        Assert.IsTrue(settings.ShowRecentCommandsInQuickAccessShelf);
-        Assert.AreEqual(HomeRecentCommandsPlacement.BeforePinned, settings.RecentCommandsOnHome);
+        Assert.AreEqual(RecentCommandsPlacement.AfterPinned, settings.RecentCommandsOnQuickAccessShelf);
+        Assert.AreEqual(RecentCommandsPlacement.BeforePinned, settings.RecentCommandsOnHome);
+        Assert.AreEqual(4, settings.QuickAccessShelfPinnedCommandLimit);
+        Assert.AreEqual(7, settings.RecentCommandsDisplayLimit);
+    }
+
+    [DataTestMethod]
+    [DataRow(-1, 0, 0, 1)]
+    [DataRow(100, 100, 9, 10)]
+    public void QuickAccessLimits_OutOfRangePersistedValuesAreClamped(
+        int pinnedCommandLimit,
+        int recentCommandLimit,
+        int expectedPinnedCommandLimit,
+        int expectedRecentCommandLimit)
+    {
+        var json = $"{{ \"QuickAccessShelfPinnedCommandLimit\": {pinnedCommandLimit}, " +
+            $"\"RecentCommandsDisplayLimit\": {recentCommandLimit} }}";
+        var settings = System.Text.Json.JsonSerializer.Deserialize(json, JsonSerializationContext.Default.SettingsModel);
+
+        Assert.IsNotNull(settings);
+        Assert.AreEqual(expectedPinnedCommandLimit, settings.QuickAccessShelfPinnedCommandLimit);
+        Assert.AreEqual(expectedRecentCommandLimit, settings.RecentCommandsDisplayLimit);
     }
 
     [TestMethod]

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/TopLevelCommandResolverTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/TopLevelCommandResolverTests.cs
@@ -1,0 +1,99 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
+
+[TestClass]
+public class TopLevelCommandResolverTests
+{
+    [TestMethod]
+    public void Resolve_UsesPinOrderAndSkipsUnavailableOrIneligibleCommands()
+    {
+        var pins = new[]
+        {
+            new PinnedCommandSettings("provider-b", "second"),
+            new PinnedCommandSettings("missing", "command"),
+            new PinnedCommandSettings("provider-a", "first"),
+            new PinnedCommandSettings("provider-a", "hidden"),
+        };
+        var commands = new[]
+        {
+            new TestCommand("provider-a", "first", IsEligible: true),
+            new TestCommand("provider-a", "hidden", IsEligible: false),
+            new TestCommand("provider-b", "second", IsEligible: true),
+        };
+
+        var sections = TopLevelCommandResolver.Resolve(
+            pins,
+            [],
+            commands,
+            static command => command.ProviderId,
+            static command => command.CommandId,
+            static command => command.IsEligible);
+
+        CollectionAssert.AreEqual(new[] { commands[2], commands[0] }, sections.Pinned.ToArray());
+        Assert.AreEqual(0, sections.Recent.Count);
+        Assert.AreEqual(0, sections.Regular.Count);
+    }
+
+    [TestMethod]
+    public void Resolve_RecentCommandsFollowHistoryAndExcludePinsAndMissingCommands()
+    {
+        var commands = new[]
+        {
+            new TestCommand("provider-e", "pinned", IsEligible: true),
+            new TestCommand("provider-a", "pinned", IsEligible: true),
+            new TestCommand("provider-b", "older", IsEligible: true),
+            new TestCommand("provider-c", "newer", IsEligible: true),
+            new TestCommand("provider-d", "regular", IsEligible: true),
+        };
+
+        var sections = TopLevelCommandResolver.Resolve(
+            [new PinnedCommandSettings("provider-a", "pinned")],
+            ["pinned", "missing", "newer", "older", "regular"],
+            commands,
+            static command => command.ProviderId,
+            static command => command.CommandId,
+            static command => command.IsEligible,
+            recentCommandLimit: 2);
+
+        CollectionAssert.AreEqual(new[] { commands[1] }, sections.Pinned.ToArray());
+        CollectionAssert.AreEqual(new[] { commands[3], commands[2] }, sections.Recent.ToArray());
+        CollectionAssert.AreEqual(new[] { commands[0], commands[4] }, sections.Regular.ToArray());
+    }
+
+    [TestMethod]
+    public void Resolve_UsesAdditionalResolverForRecentItemsWithoutAddingThemToRegularCommands()
+    {
+        var regular = new TestCommand("provider-a", "regular", IsEligible: true);
+        var recentApp = new TestCommand("AllApps", "recent-app", IsEligible: true);
+
+        var sections = TopLevelCommandResolver.Resolve(
+            [],
+            ["missing", "recent-app"],
+            [regular],
+            static command => command.ProviderId,
+            static command => command.CommandId,
+            static command => command.IsEligible,
+            commandId => commandId == recentApp.CommandId ? recentApp : null);
+
+        CollectionAssert.AreEqual(new[] { recentApp }, sections.Recent.ToArray());
+        CollectionAssert.AreEqual(new[] { regular }, sections.Regular.ToArray());
+    }
+
+    [DataTestMethod]
+    [DataRow(false, "Command", true)]
+    [DataRow(true, "Command", false)]
+    [DataRow(false, "", false)]
+    [DataRow(false, null, false)]
+    public void IsEligibleForHome_ExcludesFallbacksAndUntitledCommands(bool isFallback, string? title, bool expected)
+    {
+        Assert.AreEqual(expected, TopLevelCommandEligibility.IsEligibleForHome(isFallback, title));
+    }
+
+    private sealed record TestCommand(string ProviderId, string CommandId, bool IsEligible);
+}

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/TopLevelCommandResolverTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/TopLevelCommandResolverTests.cs
@@ -41,6 +41,69 @@ public class TopLevelCommandResolverTests
     }
 
     [TestMethod]
+    public void Resolve_PinnedLimitCountsResolvedPinsAndLetsDroppedPinsAppearInRecent()
+    {
+        var pins = new[]
+        {
+            new PinnedCommandSettings("missing", "missing"),
+            new PinnedCommandSettings("provider-a", "first"),
+            new PinnedCommandSettings("provider-b", "second"),
+        };
+        var commands = new[]
+        {
+            new TestCommand("provider-a", "first", IsEligible: true),
+            new TestCommand("provider-b", "second", IsEligible: true),
+        };
+
+        var sections = TopLevelCommandResolver.Resolve(
+            pins,
+            ["second", "first"],
+            commands,
+            static command => command.ProviderId,
+            static command => command.CommandId,
+            static command => command.IsEligible,
+            pinnedCommandLimit: 1,
+            recentCommandLimit: 2);
+
+        CollectionAssert.AreEqual(new[] { commands[0] }, sections.Pinned.ToArray());
+        CollectionAssert.AreEqual(new[] { commands[1] }, sections.Recent.ToArray());
+        Assert.AreEqual(0, sections.Regular.Count);
+    }
+
+    [TestMethod]
+    public void Resolve_RecentFirstExcludesRecentItemsFromPinsAndBackfillsPinnedLimit()
+    {
+        var pins = new[]
+        {
+            new PinnedCommandSettings("provider-a", "recent-pin"),
+            new PinnedCommandSettings("provider-b", "second"),
+            new PinnedCommandSettings("provider-c", "third"),
+        };
+        var commands = new[]
+        {
+            new TestCommand("provider-a", "recent-pin", IsEligible: true),
+            new TestCommand("provider-b", "second", IsEligible: true),
+            new TestCommand("provider-c", "third", IsEligible: true),
+            new TestCommand("provider-d", "recent-only", IsEligible: true),
+        };
+
+        var sections = TopLevelCommandResolver.Resolve(
+            pins,
+            ["recent-pin", "recent-only"],
+            commands,
+            static command => command.ProviderId,
+            static command => command.CommandId,
+            static command => command.IsEligible,
+            pinnedCommandLimit: 2,
+            recentCommandLimit: 2,
+            recentCommandsFirst: true);
+
+        CollectionAssert.AreEqual(new[] { commands[0], commands[3] }, sections.Recent.ToArray());
+        CollectionAssert.AreEqual(new[] { commands[1], commands[2] }, sections.Pinned.ToArray());
+        Assert.AreEqual(0, sections.Regular.Count);
+    }
+
+    [TestMethod]
     public void Resolve_RecentCommandsFollowHistoryAndExcludePinsAndMissingCommands()
     {
         var commands = new[]

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/TopLevelCommandResolverTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/TopLevelCommandResolverTests.cs
@@ -148,6 +148,25 @@ public class TopLevelCommandResolverTests
         CollectionAssert.AreEqual(new[] { regular }, sections.Regular.ToArray());
     }
 
+    [TestMethod]
+    public void Resolve_UsesFirstPassKeyForRegularCommands()
+    {
+        var command = new TestCommand("provider-a", "command", IsEligible: true);
+        var providerIdReads = 0;
+
+        var sections = TopLevelCommandResolver.Resolve(
+            [new PinnedCommandSettings("provider-a", "command")],
+            [],
+            [command],
+            _ => ++providerIdReads == 1 ? "provider-a" : "provider-b",
+            static command => command.CommandId,
+            static command => command.IsEligible);
+
+        Assert.AreEqual(1, providerIdReads);
+        CollectionAssert.AreEqual(new[] { command }, sections.Pinned.ToArray());
+        Assert.AreEqual(0, sections.Regular.Count);
+    }
+
     [DataTestMethod]
     [DataRow(false, "Command", true)]
     [DataRow(true, "Command", false)]

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/AllAppsPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/AllAppsPage.cs
@@ -20,7 +20,7 @@ public sealed partial class AllAppsPage : ListPage
     private readonly Lock _listLock = new();
     private readonly IAppCache _appCache;
 
-    private AppListItem[] allAppListItems = [];
+    private volatile AppListSnapshot _snapshot = AppListSnapshot.Empty;
 
     public AllAppsPage()
         : this(AppCache.Instance.Value)
@@ -50,12 +50,26 @@ public sealed partial class AllAppsPage : ListPage
         // Build or update the list if needed
         BuildListItems();
 
-        return allAppListItems;
+        return _snapshot.Items;
+    }
+
+    /// <summary>
+    /// Looks up an item in the most recently published app catalog without waiting for a reload.
+    /// </summary>
+    public bool TryGetCurrentItem(string commandId, out AppListItem? item)
+    {
+        if (string.IsNullOrEmpty(commandId))
+        {
+            item = null;
+            return false;
+        }
+
+        return _snapshot.ItemsByCommandId.TryGetValue(commandId, out item);
     }
 
     private void BuildListItems()
     {
-        if (allAppListItems.Length == 0 || _appCache.ShouldReload())
+        if (_snapshot.Items.Length == 0 || _appCache.ShouldReload())
         {
             lock (_listLock)
             {
@@ -64,7 +78,18 @@ public sealed partial class AllAppsPage : ListPage
                 Stopwatch stopwatch = new();
                 stopwatch.Start();
 
-                this.allAppListItems = GetPrograms();
+                var items = GetPrograms();
+                var itemsByCommandId = new Dictionary<string, AppListItem>(items.Length, StringComparer.Ordinal);
+                foreach (var item in items)
+                {
+                    var commandId = item.Command?.Id;
+                    if (!string.IsNullOrEmpty(commandId))
+                    {
+                        itemsByCommandId.TryAdd(commandId, item);
+                    }
+                }
+
+                _snapshot = new AppListSnapshot(items, itemsByCommandId);
 
                 this.IsLoading = false;
 
@@ -107,5 +132,12 @@ public sealed partial class AllAppsPage : ListPage
         }
 
         return [.. items];
+    }
+
+    private sealed record AppListSnapshot(
+        AppListItem[] Items,
+        IReadOnlyDictionary<string, AppListItem> ItemsByCommandId)
+    {
+        public static AppListSnapshot Empty { get; } = new([], new Dictionary<string, AppListItem>(StringComparer.Ordinal));
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request

This PR adds support for recent commands on the home page and in the quick access shelf.

- Adds a configurable Recent section before or after Pinned on Home.
- Optionally appends up to five unpinned recent commands and apps to the compact shelf.
- Keeps Alt access keys stable for pinned items and separate recent shelf items visually.
- Shares command resolution and use non-blocking app catalog snapshots.
- Adds localized settings and coverage for history, resolution, persistence, and app lookup.

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #49910
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

