### PR TITLE
[Shortcut Guide] Fix "Open Shortcut guide" behaviour for the windows key

### DIFF
--- a/src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuideXAML/App.xaml.cs
+++ b/src/modules/ShortcutGuide/ShortcutGuide.Ui/ShortcutGuideXAML/App.xaml.cs
@@ -91,6 +91,7 @@ namespace ShortcutGuide
                 catch (Exception ex)
                 {
                     Logger.LogError($"Failed to open existing event '{Constants.ShortcutGuideTriggerEvent()}': {ex.Message}");
+                    _launchedEvent = new EventWaitHandle(false, EventResetMode.AutoReset, Constants.ShortcutGuideTriggerEvent());
                 }
 
                 _listenForLaunchedEventThread = new Thread(ListenForLaunchedEvents)
@@ -222,6 +223,22 @@ namespace ShortcutGuide
                                 OverlayWindow.ShowOverlay();
                                 OverlayWindow.UpdateTaskbarPaneLayout();
                                 OverlayWindow.TaskbarPaneControl.Visibility = Visibility.Visible;
+                                return;
+                            }
+
+                            if (winKeyDown && ShortcutGuideProperties.WindowsKeyAction.Value == (int)ShortcutGuideWindowsKeyAction.OpenShortcutGuide)
+                            {
+                                if (OverlayWindow.AppWindow.IsVisible)
+                                {
+                                    return;
+                                }
+
+                                OverlayWindow.MainPaneControl.Visibility = Visibility.Collapsed;
+                                OverlayWindow.ShowOverlay();
+                                await OverlayWindow.MainPaneControl.Open();
+                                OverlayWindow.UpdateTaskbarPaneLayout();
+                                OverlayWindow.MainPaneControl.Visibility = Visibility.Visible;
+                                OverlayWindow.MainPaneControl.FocusSearch();
                                 return;
                             }
 

--- a/src/modules/ShortcutGuide/ShortcutGuideModuleInterface/dllmain.cpp
+++ b/src/modules/ShortcutGuide/ShortcutGuideModuleInterface/dllmain.cpp
@@ -91,7 +91,7 @@ public:
         if (!_enabled)
         {
             _enabled = true;
-            StartProcess();
+            EnsureProcessRuns();
         }
         else
         {
@@ -150,10 +150,7 @@ public:
             return;
         }
 
-        if (!IsProcessActive())
-        {
-            StartProcess();
-        }
+        EnsureProcessRuns();
 
         SetEvent(triggerEvent);
     }
@@ -161,13 +158,13 @@ public:
     virtual void send_settings_telemetry() override
     {
         Logger::trace("Send settings telemetry");
-        if (!StartProcess(L"telemetry"))
+        if (!EnsureProcessRuns(L"telemetry"))
         {
             Logger::error("Failed to create a process to send settings telemetry");
         }
     }
     virtual bool keep_track_of_pressed_win_key() override { return true; }
-    virtual UINT milliseconds_win_key_must_be_pressed() override { return m_millisecondsWinKeyPressTimeForGlobalWindowsShortcuts; }
+    virtual UINT milliseconds_win_key_must_be_pressed() override { return 900; }
 
 private:
     std::wstring app_name;
@@ -188,8 +185,14 @@ private:
     HANDLE triggerEvent;
     HANDLE exitEvent;
 
-    bool StartProcess(std::wstring args = L"")
+    bool EnsureProcessRuns(std::wstring args = L"")
     {
+        if (IsProcessActive())
+        {
+            Logger::trace(L"SG process is already running with pid={}", GetProcessId(m_hProcess));
+            return true;
+        }
+
         if (exitEvent)
         {
             ResetEvent(exitEvent);
@@ -301,30 +304,6 @@ private:
             {
                 Logger::warn("Failed to initialize Shortcut Guide start shortcut");
             }
-
-try
-            {
-                auto propertiesObject = settingsObject.GetNamedObject(L"properties");
-                if (propertiesObject.HasKey(L"press_time"))
-                {
-                    auto jsonDurationObject = propertiesObject.GetNamedObject(L"press_time");
-                    if (jsonDurationObject.HasKey(L"value"))
-                    {
-                        auto pressTime = static_cast<UINT>(jsonDurationObject.GetNamedNumber(L"value"));
-                        if (pressTime < 100)
-                        {
-                            pressTime = 100;
-                        }
-                        else if (pressTime > 5000)
-                        {
-                            pressTime = 5000;
-                        }
-
-                        m_millisecondsWinKeyPressTimeForGlobalWindowsShortcuts = pressTime;
-                    }
-                }
-            }
-            catch (...) { /* Keep defaults */ }
         }
         else
         {
@@ -336,14 +315,6 @@ try
             Logger::info("Shortcut Guide is going to use default shortcut");
             m_hotkey.modifiersMask = MOD_SHIFT | MOD_WIN;
             m_hotkey.vkCode = VK_OEM_2;
-        }
-    }
-
-    void WindowsKeyPressBehavior()
-    {
-        if (IsProcessActive())
-        {
-            TerminateProcess(m_hProcess, 0);
         }
     }
 };


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Fixes a bug that appeared when the following setting was set at startup of PowerToys that prevented Shortcut Guide from opening:

<img width="1022" height="77" alt="image" src="https://github.com/user-attachments/assets/dc831391-f9be-440a-aa47-71b5a962ea18" />



<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [ ] Closes: #xxx
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

