### PR TITLE
[FancyZones] Re-seed Shift state at drag start

### DIFF
--- a/src/modules/fancyzones/FancyZonesLib/DraggingState.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/DraggingState.cpp
@@ -21,6 +21,14 @@ void DraggingState::Enable()
     }
 
     m_ctrlKeyState.enable();
+
+    // m_shift is fed by raw input (FancyZones::OnKeyboardInput), which cannot
+    // observe Shift transitions delivered while the secure desktop, a detached
+    // session leg (RDP attach/detach), or an elevated foreground window owns
+    // input, so the latched value can go stale between drags. Re-seed it from
+    // the live key state at drag start, the same way KeyState::enable()
+    // re-seeds Ctrl above. Raw input still drives mid-drag transitions.
+    m_shift = (GetAsyncKeyState(VK_SHIFT) & 0x8000) != 0;
 }
 
 void DraggingState::Disable()


### PR DESCRIPTION
## Summary of the Pull Request

FancyZones activates zones on the first window drag after an RDP session, a wake, or an unlock, as if Shift were held, with the second and later drags behaving normally. `DraggingState::m_shift` is a latched copy of the Shift key fed only by the raw input sink, and it is never reconciled against real key state at drag start the way Ctrl already is. This re-seeds it in `DraggingState::Enable()`, one line, mirroring the existing Ctrl path.

## PR Checklist

- [x] Closes: #33375
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
  - Not yet agreed. I posted the full diagnosis on #33375 and offered to open this; submitting the patch so the analysis is concrete and reviewable. Happy to close or rework it if the team prefers a different approach.
- [ ] **Tests:** Added/updated and all pass
  - No test was added: nothing under `FancyZonesTests` currently exercises `DraggingState`, and `GetAsyncKeyState` has no injection seam here, so a unit test would require introducing an indirection. Glad to add one if you want that seam. See the validation section for what was run.
- [x] **Localization:** All end-user-facing strings can be localized (no new strings)
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
- [ ] **Documentation updated**

## Detailed Description of the Pull Request / Additional comments

`m_shift` (`DraggingState.h`) has exactly two writers: `SetShiftState`, driven by the raw input sink registered with `RIDEV_INPUTSINK` (`KeyboardInput.cpp`, dispatched from `FancyZones::OnKeyboardInput`), and `Disable()`, which zeroes it at drag end.

A raw input sink window on the default desktop does not observe key transitions delivered while the secure desktop, a detached session leg during an RDP attach/detach, or (when PowerToys runs unelevated) an elevated foreground window owns input. Any Shift make whose matching break lands in one of those gaps leaves the latch stale, and nothing re-syncs it: `DraggingState::Enable()` re-seeds Ctrl from `GetAsyncKeyState` through `KeyState::enable()` (`KeyState.h`) but leaves Shift alone. The next drag reads the stale value, and `MoveSizeEnd`'s unconditional `Disable()` clears it afterwards, which is why exactly one drag misbehaves per transition.

This is a regression from #32116 (v0.80). Moving Shift from the low-level hook to raw input, to fix the physical Shift-key breakage in #29257, also removed the drag-start `GetAsyncKeyState` re-seed that #6039 introduced in 2020 ("Update key state on window drag start in case if it was pressed before dragging was started"). Ctrl kept both the hook and the re-seed and has no reports of this class; Shift lost the re-seed and the reports start immediately after that release (#33375 on v0.81.1, #33691 on v0.82.0, #36369, #39625, #43332, #44354, plus the RDP reports on #30090).

The fix deliberately does **not** reinstate a keyboard hook for Shift. `GetAsyncKeyState` is a passive poll that installs nothing and swallows nothing, so the #29257 hazard cannot recur, and raw input remains the only mid-drag update path. The poll is confined to `Enable()` on purpose: during a drag the app-level hook swallows bare Shift makes, so the async key state is not a reliable source mid-drag, whereas at drag start it reflects every transition that happened while no drag was in progress.

Expected side benefits, not separately verified here: #39104 (Shift break delivered to an elevated Task Manager latches phantom Shift) and #48167 (consecutive Shift-drags need a Shift re-press, the stale-false direction of the same latch).

Known limitation, stated for the record: if the OS async key state is itself stuck Shift-down (rare, system-wide visible, cleared by one real Shift press), the re-seed reads that stuck state at every drag start rather than only once. This matches the behavior that shipped from 2020 through v0.80.

Related, deliberately not bundled: `m_monitorRotationKeyState` (`FancyZones.h`) is a second latch fed by the always-on low-level hook with no re-sync, reset only on a settings change. Its blast radius is the monitor-rotation chord and it self-heals on the next real key-up, so I left it alone.

## Validation Steps Performed

Built x64 Release with the v143 toolset, 0 warnings and 0 errors, and validated against a 100% reproducible real-world case.

1. **The reported bug, before and after.** With the stock build, RDP into the machine, return to the physical console, and the first window drag activates zones and snaps. With the patched build running, the same round trip leaves the first drag completely normal: no overlay, no snap. Settings were the default repro configuration (`fancyzones_shiftDrag: true`, `fancyzones_mouseSwitch: false`).
2. **Normal Shift-drag still works.** Holding Shift while dragging activates zones and snaps as expected, so the seed reads a genuinely held key correctly.
3. **The diagnostic that identifies the latch.** On the stock build, tapping Shift once before the first post-RDP drag prevents the phantom activation, because that tap's break event reaches the raw input sink. This matches the reporter's observation on #39625 and confirms the stale-latch mechanism rather than an OS-level stuck key.

Unit tests: the FancyZones suite builds clean and 282 of 283 tests pass. `WindowKeyboardSnap_MoveAcrossMonitors_ByPosition::Snap_Down` failed and the test host then exited with an access violation. I have **not** attributed that failure, because I did not complete a baseline run on unpatched `main` to compare. It is very unlikely to be related: `WindowKeyboardSnap.cpp`, its header, and its spec contain no reference to `DraggingState`, and no test source in the suite touches `DraggingState`, so the failing test cannot reach the changed function. Flagging it rather than claiming a clean run. If a maintainer can confirm whether that test is already flaky on multi-monitor or single-monitor setups, I'm happy to dig further.
