### PR TITLE
CmdPal: Shelf (5/n) - Add Alt+Shift+# shortcuts that select the shelf item

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/QuickAccessShelfResolver.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/QuickAccessShelfResolver.cs
@@ -12,7 +12,7 @@ internal static class QuickAccessShelfResolver
     {
         return index switch
         {
-            >= 0 and <= 8 => (index + 1).ToString(System.Globalization.CultureInfo.InvariantCulture),
+            >= 0 and < QuickAccessShelfShortcuts.NumberedShortcutCount => (index + 1).ToString(System.Globalization.CultureInfo.InvariantCulture),
             _ => string.Empty,
         };
     }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/QuickAccessShelfShortcuts.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/QuickAccessShelfShortcuts.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Windows.System;
+
+namespace Microsoft.CmdPal.UI.ViewModels;
+
+public static class QuickAccessShelfShortcuts
+{
+    public const int NumberedShortcutCount = 9;
+
+    public enum SelectionShortcutTarget
+    {
+        None,
+        Visible,
+        Unavailable,
+    }
+
+    public static int GetTopRowShortcutIndex(VirtualKey key)
+    {
+        var index = (int)key - (int)VirtualKey.Number1;
+        return index is >= 0 and < NumberedShortcutCount ? index : -1;
+    }
+
+    public static bool IsSelectionAccessKey(bool ctrl, bool shift, bool win) =>
+        shift &&
+        !ctrl &&
+        !win;
+
+    public static bool IsSelectionShortcut(VirtualKey key, bool ctrl, bool alt, bool shift, bool win) =>
+        alt &&
+        IsSelectionAccessKey(ctrl, shift, win) &&
+        GetTopRowShortcutIndex(key) >= 0;
+
+    public static SelectionShortcutTarget ResolveSelectionShortcut(
+        VirtualKey key,
+        bool ctrl,
+        bool alt,
+        bool shift,
+        bool win,
+        int visibleItemCount)
+    {
+        if (!IsSelectionShortcut(key, ctrl, alt, shift, win))
+        {
+            return SelectionShortcutTarget.None;
+        }
+
+        return GetTopRowShortcutIndex(key) < visibleItemCount
+            ? SelectionShortcutTarget.Visible
+            : SelectionShortcutTarget.Unavailable;
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml
@@ -492,6 +492,7 @@
 
             <Grid
                 x:Name="QuickAccessShelfItemsHost"
+                KeyTipPlacementMode="Bottom"
                 SizeChanged="QuickAccessShelfItemsHost_SizeChanged">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
@@ -517,6 +518,8 @@
                                     Height="40"
                                     Padding="8"
                                     AccessKey="{x:Bind ShortcutDigit, Mode=OneTime}"
+                                    AccessKeyInvoked="QuickAccessShelfItem_AccessKeyInvoked"
+                                    AutomationProperties.HelpText="{x:Bind ShortcutDigit, Mode=OneTime, Converter={StaticResource QuickAccessShortcutTextConverter}}"
                                     AutomationProperties.Name="{x:Bind Title, Mode=OneTime}"
                                     Click="QuickAccessShelfItem_Click"
                                     ContextCanceled="QuickAccessShelfItem_ContextCanceled"

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
@@ -1059,6 +1059,24 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
         }
     }
 
+    private void QuickAccessShelfItem_AccessKeyInvoked(UIElement sender, AccessKeyInvokedEventArgs args)
+    {
+        var modifiers = KeyModifiers.GetCurrent();
+        if (!QuickAccessShelfShortcuts.IsSelectionAccessKey(modifiers.Ctrl, modifiers.Shift, modifiers.Win))
+        {
+            // Leave plain Alt+# unhandled so the Button performs its normal access-key action.
+            return;
+        }
+
+        // WinUI resolves Alt+Shift+# through this same native access key as Alt+#. Handle the
+        // shifted form at the target so it only moves focus and cannot activate the Button.
+        args.Handled = true;
+        if (sender is Button button)
+        {
+            _ = button.Focus(FocusState.Keyboard);
+        }
+    }
+
     private async void QuickAccessShelfItem_ContextRequested(UIElement sender, ContextRequestedEventArgs e)
     {
         if (sender is not Button { Tag: QuickAccessShelfItem item } button)
@@ -1663,6 +1681,24 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
             FindQuickAccessShelfButton(e.OriginalSource as DependencyObject) is not Button { Tag: QuickAccessShelfItem item } anchor)
         {
             return false;
+        }
+
+        switch (QuickAccessShelfShortcuts.ResolveSelectionShortcut(
+            e.Key,
+            modifiers.Ctrl,
+            modifiers.Alt,
+            modifiers.Shift,
+            modifiers.Win,
+            QuickAccessShelf.VisibleItemCount))
+        {
+            case QuickAccessShelfShortcuts.SelectionShortcutTarget.Visible:
+                // Let the matching native access key move focus to the requested shelf item.
+                return false;
+            case QuickAccessShelfShortcuts.SelectionShortcutTarget.Unavailable:
+                // Reserve shelf selection chords even when their targets are in overflow so
+                // they cannot invoke a context shortcut on the currently focused shelf item.
+                e.Handled = true;
+                return true;
         }
 
         if (e.Key == VirtualKey.Enter && modifiers.OnlyCtrl)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Strings/en-us/Resources.resw
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Strings/en-us/Resources.resw
@@ -413,7 +413,7 @@ Right-click to remove the key combination, thereby deactivating the shortcut.</v
     <value>Quick access shelf</value>
   </data>
   <data name="Settings_GeneralPage_QuickAccessShelf_SettingsCard.Description" xml:space="preserve">
-    <value>Shows quick access commands below the search box while compact mode is collapsed. Use Alt+1 through Alt+9 for visible items, starting from the left, and Alt+0 for overflow.</value>
+    <value>Shows quick access commands below the search box while compact mode is collapsed. Use Alt+1 through Alt+9 to run visible items, Alt+Shift+1 through Alt+Shift+9 to select them, and Alt+0 for overflow.</value>
   </data>
   <data name="Settings_GeneralPage_QuickAccessShelfPinnedCommandLimit_SettingsCard.Header" xml:space="preserve">
     <value>Maximum pinned commands</value>
@@ -464,8 +464,8 @@ Right-click to remove the key combination, thereby deactivating the shortcut.</v
     <value>Quick access</value>
   </data>
   <data name="QuickAccessShelfShortcutTextFormat" xml:space="preserve">
-    <value>Alt+{0}</value>
-    <comment>Tooltip shortcut text for a quick access item. {0} is a digit from 1 through 9.</comment>
+    <value>Alt+{0} to run; Alt+Shift+{0} to select</value>
+    <comment>Tooltip shortcut text for running or selecting a quick access item. {0} is a digit from 1 through 9.</comment>
   </data>
   <data name="QuickAccessShelfChangeOrderDragCaption" xml:space="preserve">
     <value>Change order</value>

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/QuickAccessShelfResolverTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/QuickAccessShelfResolverTests.cs
@@ -9,6 +9,7 @@ using Microsoft.CmdPal.UI.ViewModels.Commands;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Windows.ApplicationModel.DataTransfer;
+using Windows.System;
 
 namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
 
@@ -16,6 +17,7 @@ namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
 public partial class QuickAccessShelfResolverTests
 {
     [DataTestMethod]
+    [DataRow(-1, "")]
     [DataRow(0, "1")]
     [DataRow(8, "9")]
     [DataRow(9, "")]
@@ -23,6 +25,63 @@ public partial class QuickAccessShelfResolverTests
     public void IndexToShortcutDigit_MapsFirstNineItems(int index, string expectedDigit)
     {
         Assert.AreEqual(expectedDigit, QuickAccessShelfResolver.IndexToShortcutDigit(index));
+    }
+
+    [DataTestMethod]
+    [DataRow((int)VirtualKey.Number1, 0)]
+    [DataRow((int)VirtualKey.Number5, 4)]
+    [DataRow((int)VirtualKey.Number9, 8)]
+    [DataRow((int)VirtualKey.Number0, -1)]
+    [DataRow((int)VirtualKey.NumberPad1, -1)]
+    public void GetTopRowShortcutIndex_MapsOnlyOneThroughNine(int key, int expectedIndex)
+    {
+        Assert.AreEqual(expectedIndex, QuickAccessShelfShortcuts.GetTopRowShortcutIndex((VirtualKey)key));
+    }
+
+    [TestMethod]
+    public void IsSelectionShortcut_RequiresOnlyAltShiftAndNumberedKey()
+    {
+        Assert.IsTrue(QuickAccessShelfShortcuts.IsSelectionShortcut(VirtualKey.Number4, ctrl: false, alt: true, shift: true, win: false));
+        Assert.IsFalse(QuickAccessShelfShortcuts.IsSelectionShortcut(VirtualKey.Number4, ctrl: true, alt: true, shift: true, win: false));
+        Assert.IsFalse(QuickAccessShelfShortcuts.IsSelectionShortcut(VirtualKey.Number4, ctrl: false, alt: false, shift: true, win: false));
+        Assert.IsFalse(QuickAccessShelfShortcuts.IsSelectionShortcut(VirtualKey.Number4, ctrl: false, alt: true, shift: false, win: false));
+        Assert.IsFalse(QuickAccessShelfShortcuts.IsSelectionShortcut(VirtualKey.Number4, ctrl: false, alt: true, shift: true, win: true));
+        Assert.IsFalse(QuickAccessShelfShortcuts.IsSelectionShortcut(VirtualKey.Number0, ctrl: false, alt: true, shift: true, win: false));
+    }
+
+    [DataTestMethod]
+    [DataRow((int)VirtualKey.Number4, false, true, true, false, 4, (int)QuickAccessShelfShortcuts.SelectionShortcutTarget.Visible)]
+    [DataRow((int)VirtualKey.Number4, false, true, true, false, 3, (int)QuickAccessShelfShortcuts.SelectionShortcutTarget.Unavailable)]
+    [DataRow((int)VirtualKey.Number9, false, true, true, false, 0, (int)QuickAccessShelfShortcuts.SelectionShortcutTarget.Unavailable)]
+    [DataRow((int)VirtualKey.Number4, true, true, true, false, 3, (int)QuickAccessShelfShortcuts.SelectionShortcutTarget.None)]
+    [DataRow((int)VirtualKey.Number0, false, true, true, false, 0, (int)QuickAccessShelfShortcuts.SelectionShortcutTarget.None)]
+    public void ResolveSelectionShortcut_ReservesUnavailableTargets(
+        int key,
+        bool ctrl,
+        bool alt,
+        bool shift,
+        bool win,
+        int visibleItemCount,
+        int expectedTarget)
+    {
+        var target = QuickAccessShelfShortcuts.ResolveSelectionShortcut(
+            (VirtualKey)key,
+            ctrl,
+            alt,
+            shift,
+            win,
+            visibleItemCount);
+
+        Assert.AreEqual((QuickAccessShelfShortcuts.SelectionShortcutTarget)expectedTarget, target);
+    }
+
+    [TestMethod]
+    public void IsSelectionAccessKey_RequiresShiftWithoutCtrlOrWin()
+    {
+        Assert.IsTrue(QuickAccessShelfShortcuts.IsSelectionAccessKey(ctrl: false, shift: true, win: false));
+        Assert.IsFalse(QuickAccessShelfShortcuts.IsSelectionAccessKey(ctrl: false, shift: false, win: false));
+        Assert.IsFalse(QuickAccessShelfShortcuts.IsSelectionAccessKey(ctrl: true, shift: true, win: false));
+        Assert.IsFalse(QuickAccessShelfShortcuts.IsSelectionAccessKey(ctrl: false, shift: true, win: true));
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary of the Pull Request

This PR adds support for Alt+Shift+# shortcuts that select the shelf item. User then can use Ctrl+Enter or Ctrl+K to activate secondary / extra commands.


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #49930 
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

