### PR TITLE
Add PoetSearch to third-party Run plugins list

### DIFF
--- a/doc/thirdPartyRunPlugins.md
+++ b/doc/thirdPartyRunPlugins.md
@@ -57,6 +57,7 @@ Contact the developers of a plugin directly for assistance with a specific plugi
 | [QuickAI](https://github.com/ruslanlap/PowerToysRun-QuickAi) | [ruslanlap](https://github.com/ruslanlap) | AI-powered assistance with instant, smart responses from multiple providers (Groq, Together, Fireworks, OpenRouter, Cohere) |
 | [Launchy](https://github.com/PsychodelEKS/PowerToysRun-Launchy) | [PsychodelEKS](https://github.com/PsychodelEKS) | Index and launch files from configured folders |
 | [DevDocs](https://github.com/jan-jaros/PowerToys-Run-DevDocs) | [jan-jaros](https://github.com/jan-jaros) | Search programming documentation from DevDocs.io |
+| [PoetSearch](https://github.com/Greyaircraft/PowerToysRun-PoetSearch) | [Greyaircraft](https://github.com/Greyaircraft) | Search 78,581 classical Chinese poems (全唐诗 + 全宋词) |
 
 ## Extending software plugins
 


### PR DESCRIPTION
## Add PoetSearch 📜

Add [PoetSearch](https://github.com/Greyaircraft/PowerToysRun-PoetSearch) to the third-party PowerToys Run plugins list.

### Features
- Search **78,581 classical Chinese poems** (全唐诗 + 全宋词) directly from PowerToys Run
- Search by title, author, or content: `poet 静夜思`, `poet 李白`, `poet 床前明月光`
- `poet 随机` / `poet random` — random poem
- **Enter** copies the full poem to the clipboard
- Dark/light theme aware icons

### Install
Extract the release ZIP to `%LOCALAPPDATA%\Microsoft\PowerToys\PowerToys Run\Plugins\PoetSearch`.

### Note
This is a docs-only change to `doc/thirdPartyRunPlugins.md`.