### PR TITLE
Mouse Without Borders: Validate settings sync peers

### DIFF
--- a/src/modules/MouseWithoutBorders/App/Class/IClipboardHelper.cs
+++ b/src/modules/MouseWithoutBorders/App/Class/IClipboardHelper.cs
@@ -180,7 +180,7 @@ WellKnownSidType.AuthenticatedUserSid, null);
                 PipeAccessRights.ReadWrite | PipeAccessRights.CreateNewInstance,
                 AccessControlType.Allow));
 
-            _ = Task.Factory.StartNew(
+            _ = Task.Run(
                 async () =>
                 {
                     try
@@ -207,9 +207,7 @@ WellKnownSidType.AuthenticatedUserSid, null);
 #endif
                     }
                 },
-                cancellationToken,
-                TaskCreationOptions.None,
-                TaskScheduler.Default);
+                cancellationToken);
 
             return default(T);
         }
@@ -220,10 +218,20 @@ WellKnownSidType.AuthenticatedUserSid, null);
             NamedPipePeerPolicy clientPolicy,
             CancellationToken cancellationToken)
         {
+            return StartAuthenticatedIpcServer(pipeName, allowedUser, clientPolicy, null, cancellationToken);
+        }
+
+        internal static T StartAuthenticatedIpcServer(
+            string pipeName,
+            SecurityIdentifier allowedUser,
+            NamedPipePeerPolicy clientPolicy,
+            Action<Exception> serverErrorObserver,
+            CancellationToken cancellationToken)
+        {
             var authenticator = new NamedPipePeerAuthenticator(
                 new WindowsNamedPipePeerIdentityProvider(new MicrosoftMachineRootSignatureVerifier()));
 
-            _ = Task.Factory.StartNew(
+            _ = Task.Run(
                 async () =>
                 {
                     while (!cancellationToken.IsCancellationRequested)
@@ -255,6 +263,7 @@ WellKnownSidType.AuthenticatedUserSid, null);
                         }
                         catch (Exception e)
                         {
+                            serverErrorObserver?.Invoke(e);
 #if MM_HELPER
                             _ = e;
 #else
@@ -267,9 +276,7 @@ WellKnownSidType.AuthenticatedUserSid, null);
                         }
                     }
                 },
-                cancellationToken,
-                TaskCreationOptions.None,
-                TaskScheduler.Default);
+                cancellationToken);
 
             return default(T);
         }

--- a/src/modules/MouseWithoutBorders/App/Class/IClipboardHelper.cs
+++ b/src/modules/MouseWithoutBorders/App/Class/IClipboardHelper.cs
@@ -17,6 +17,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 
+using Microsoft.PowerToys.Settings.UI.Library.Utilities;
 using Microsoft.VisualStudio.Threading;
 using MouseWithoutBorders.Core;
 using Newtonsoft.Json;
@@ -204,6 +205,62 @@ WellKnownSidType.AuthenticatedUserSid, null);
 #else
                         Logger.Log(e);
 #endif
+                    }
+                },
+                cancellationToken,
+                TaskCreationOptions.None,
+                TaskScheduler.Default);
+
+            return default(T);
+        }
+
+        public static T StartAuthenticatedIpcServer(
+            string pipeName,
+            SecurityIdentifier allowedUser,
+            NamedPipePeerPolicy clientPolicy,
+            CancellationToken cancellationToken)
+        {
+            var authenticator = new NamedPipePeerAuthenticator(
+                new WindowsNamedPipePeerIdentityProvider(new MicrosoftMachineRootSignatureVerifier()));
+
+            _ = Task.Factory.StartNew(
+                async () =>
+                {
+                    while (!cancellationToken.IsCancellationRequested)
+                    {
+                        try
+                        {
+                            using var serverChannel = RestrictedNamedPipeServer.Create(pipeName, allowedUser);
+                            await serverChannel.WaitForConnectionAsync(cancellationToken);
+
+                            JsonRpc taskRpc = null;
+                            var authentication = authenticator.AuthenticateClientAndExecute(
+                                serverChannel,
+                                clientPolicy,
+                                () => taskRpc = JsonRpc.Attach(serverChannel, new T()));
+                            if (!authentication.Accepted)
+                            {
+#if !MM_HELPER
+                                Logger.Log($"Rejected Settings IPC client: {authentication.ReasonCode}");
+#endif
+                                serverChannel.Disconnect();
+                                continue;
+                            }
+
+                            await taskRpc.Completion;
+                        }
+                        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                        {
+                            break;
+                        }
+                        catch (Exception e)
+                        {
+#if MM_HELPER
+                            _ = e;
+#else
+                            Logger.Log(e);
+#endif
+                        }
                     }
                 },
                 cancellationToken,

--- a/src/modules/MouseWithoutBorders/App/Class/IClipboardHelper.cs
+++ b/src/modules/MouseWithoutBorders/App/Class/IClipboardHelper.cs
@@ -260,6 +260,10 @@ WellKnownSidType.AuthenticatedUserSid, null);
 #else
                             Logger.Log(e);
 #endif
+                            if (!cancellationToken.IsCancellationRequested)
+                            {
+                                await Task.Delay(250);
+                            }
                         }
                     }
                 },

--- a/src/modules/MouseWithoutBorders/App/Class/Program.cs
+++ b/src/modules/MouseWithoutBorders/App/Class/Program.cs
@@ -12,6 +12,7 @@
 // </history>
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Drawing.Printing;
@@ -19,6 +20,7 @@ using System.Globalization;
 using System.IO;
 using System.IO.Pipes;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Security.Authentication.ExtendedProtection;
 using System.Security.Principal;
 using System.ServiceProcess;
@@ -378,8 +380,69 @@ namespace MouseWithoutBorders.Class
         {
             var serverTaskCancellationSource = new CancellationTokenSource();
             CancellationToken cancellationToken = serverTaskCancellationSource.Token;
+            using var currentIdentity = WindowsIdentity.GetCurrent();
+            var processUserSid = currentIdentity.User;
+            if (processUserSid == null)
+            {
+                Logger.Log("Settings IPC v2 cannot determine the process user SID.");
+                return;
+            }
 
-            IpcChannel<SettingsSyncHelper>.StartIpcServer("MouseWithoutBorders/SettingsSync", cancellationToken);
+            var sessionId = Process.GetCurrentProcess().SessionId;
+            SecurityIdentifier currentUserSid;
+            try
+            {
+                currentUserSid = ResolveSettingsIpcUserSid(processUserSid, sessionId, GetInteractiveSessionUserSid);
+            }
+            catch (Exception e)
+            {
+                Logger.Log($"Settings IPC v2 cannot determine the interactive user SID: {e.Message}");
+                return;
+            }
+
+            var settingsPath = Path.Combine(AppContext.BaseDirectory, "WinUI3Apps", "PowerToys.Settings.exe");
+            var clientPolicy = MouseWithoutBordersIpcPolicy.CreateSettingsClientPolicy(settingsPath, sessionId, currentUserSid.Value);
+
+            IpcChannel<SettingsSyncHelper>.StartAuthenticatedIpcServer(
+                MouseWithoutBordersIpc.GetSettingsSyncPipeName(sessionId),
+                currentUserSid,
+                clientPolicy,
+                cancellationToken);
+        }
+
+        internal static SecurityIdentifier ResolveSettingsIpcUserSid(
+            SecurityIdentifier processUserSid,
+            int sessionId,
+            Func<int, SecurityIdentifier> interactiveUserSidResolver)
+        {
+            ArgumentNullException.ThrowIfNull(processUserSid);
+            ArgumentNullException.ThrowIfNull(interactiveUserSidResolver);
+
+            return processUserSid.IsWellKnown(WellKnownSidType.LocalSystemSid)
+                ? interactiveUserSidResolver(sessionId) ?? throw new InvalidOperationException("The interactive session has no user SID.")
+                : processUserSid;
+        }
+
+        private static SecurityIdentifier GetInteractiveSessionUserSid(int sessionId)
+        {
+            IntPtr userToken = IntPtr.Zero;
+            try
+            {
+                if (NativeMethods.WTSQueryUserToken(unchecked((uint)sessionId), ref userToken) == 0)
+                {
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+                }
+
+                using var interactiveIdentity = new WindowsIdentity(userToken);
+                return interactiveIdentity.User ?? throw new InvalidOperationException("The interactive session token has no user SID.");
+            }
+            finally
+            {
+                if (userToken != IntPtr.Zero)
+                {
+                    _ = NativeMethods.CloseHandle(userToken);
+                }
+            }
         }
 
         internal static void StartInputCallbackThread()

--- a/src/modules/MouseWithoutBorders/App/Class/Program.cs
+++ b/src/modules/MouseWithoutBorders/App/Class/Program.cs
@@ -400,7 +400,7 @@ namespace MouseWithoutBorders.Class
                 return;
             }
 
-            var settingsPath = Path.Combine(AppContext.BaseDirectory, "WinUI3Apps", "PowerToys.Settings.exe");
+            var settingsPath = MouseWithoutBordersIpc.GetSettingsExecutablePath(AppContext.BaseDirectory);
             var clientPolicy = MouseWithoutBordersIpcPolicy.CreateSettingsClientPolicy(settingsPath, sessionId, currentUserSid.Value);
 
             IpcChannel<SettingsSyncHelper>.StartAuthenticatedIpcServer(

--- a/src/modules/MouseWithoutBorders/App/Class/Program.cs
+++ b/src/modules/MouseWithoutBorders/App/Class/Program.cs
@@ -400,6 +400,19 @@ namespace MouseWithoutBorders.Class
                 return;
             }
 
+            try
+            {
+                GrantSettingsIpcProcessQueryAccessIfNeeded(
+                    processUserSid,
+                    currentUserSid,
+                    MouseWithoutBordersIpc.GrantCurrentProcessQueryAccess);
+            }
+            catch (Exception e)
+            {
+                Logger.Log($"Settings IPC v2 cannot grant process query access to the interactive user: {e.Message}");
+                return;
+            }
+
             var settingsPath = MouseWithoutBordersIpc.GetSettingsExecutablePath(AppContext.BaseDirectory);
             var clientPolicy = MouseWithoutBordersIpcPolicy.CreateSettingsClientPolicy(settingsPath, sessionId, currentUserSid.Value);
 
@@ -421,6 +434,21 @@ namespace MouseWithoutBorders.Class
             return processUserSid.IsWellKnown(WellKnownSidType.LocalSystemSid)
                 ? interactiveUserSidResolver(sessionId) ?? throw new InvalidOperationException("The interactive session has no user SID.")
                 : processUserSid;
+        }
+
+        internal static void GrantSettingsIpcProcessQueryAccessIfNeeded(
+            SecurityIdentifier processUserSid,
+            SecurityIdentifier interactiveUserSid,
+            Action<SecurityIdentifier> grantAccess)
+        {
+            ArgumentNullException.ThrowIfNull(processUserSid);
+            ArgumentNullException.ThrowIfNull(interactiveUserSid);
+            ArgumentNullException.ThrowIfNull(grantAccess);
+
+            if (processUserSid.IsWellKnown(WellKnownSidType.LocalSystemSid))
+            {
+                grantAccess(interactiveUserSid);
+            }
         }
 
         private static SecurityIdentifier GetInteractiveSessionUserSid(int sessionId)

--- a/src/modules/MouseWithoutBorders/MouseWithoutBorders.UnitTests/IpcSerializationCompatibilityTests.cs
+++ b/src/modules/MouseWithoutBorders/MouseWithoutBorders.UnitTests/IpcSerializationCompatibilityTests.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MouseWithoutBorders.Class;
+using Newtonsoft.Json;
+
+namespace MouseWithoutBorders.UnitTests;
+
+[TestClass]
+public sealed class IpcSerializationCompatibilityTests
+{
+    [TestMethod]
+    public void SettingsSyncPayloadKeepsExistingJsonShape()
+    {
+        var contract = typeof(Program).GetNestedType("ISettingsSyncHelper", BindingFlags.NonPublic);
+        var stateType = contract!.GetNestedType("MachineSocketState");
+        var state = Activator.CreateInstance(stateType!);
+        stateType!.GetField("Name")!.SetValue(state, "PC");
+        stateType.GetField("Status")!.SetValue(state, Enum.ToObject(stateType.GetField("Status")!.FieldType, 9));
+
+        Assert.AreEqual("""{"Name":"PC","Status":9}""", JsonConvert.SerializeObject(state));
+    }
+}

--- a/src/modules/MouseWithoutBorders/MouseWithoutBorders.UnitTests/SettingsIpcIdentityTests.cs
+++ b/src/modules/MouseWithoutBorders/MouseWithoutBorders.UnitTests/SettingsIpcIdentityTests.cs
@@ -1,0 +1,103 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Security.Principal;
+
+using Microsoft.PowerToys.Settings.UI.Library.Utilities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MouseWithoutBorders.Class;
+
+namespace MouseWithoutBorders.UnitTests;
+
+[TestClass]
+public sealed class SettingsIpcIdentityTests
+{
+    [TestMethod]
+    public void CurrentUserProcessUsesItsOwnSid()
+    {
+        using var identity = WindowsIdentity.GetCurrent();
+        var processSid = identity.User!;
+        var resolverCalled = false;
+
+        var result = Program.ResolveSettingsIpcUserSid(
+            processSid,
+            42,
+            _ =>
+            {
+                resolverCalled = true;
+                return processSid;
+            });
+
+        Assert.AreEqual(processSid, result);
+        Assert.IsFalse(resolverCalled);
+    }
+
+    [TestMethod]
+    public void SystemProcessUsesInteractiveSessionSid()
+    {
+        var systemSid = new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null);
+        var interactiveSid = new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null);
+        var resolvedSessionId = -1;
+
+        var result = Program.ResolveSettingsIpcUserSid(
+            systemSid,
+            42,
+            sessionId =>
+            {
+                resolvedSessionId = sessionId;
+                return interactiveSid;
+            });
+
+        Assert.AreEqual(interactiveSid, result);
+        Assert.AreEqual(42, resolvedSessionId);
+    }
+
+    [TestMethod]
+    public async Task ProductionAuthenticatedServerAcceptsReconnect()
+    {
+        var pipeName = $"PowerToys.MWB.v2.UnitTest.{Environment.ProcessId}.{Guid.NewGuid():N}";
+        using var identity = WindowsIdentity.GetCurrent();
+        var peerIdentity = new WindowsNamedPipePeerIdentityProvider(new AcceptSignatureVerifier()).GetIdentity(Environment.ProcessId);
+        var policy = new NamedPipePeerPolicy
+        {
+            ExpectedSessionId = Process.GetCurrentProcess().SessionId,
+            ExpectedUserSid = identity.User!.Value,
+            ExpectedImagePath = peerIdentity.ImagePath,
+            ExpectedFileVersion = peerIdentity.FileVersion,
+            RequireMicrosoftSignature = false,
+        };
+        using var cancellation = new CancellationTokenSource();
+
+        IpcChannel<TestRpcTarget>.StartAuthenticatedIpcServer(pipeName, identity.User, policy, cancellation.Token);
+
+        for (var attempt = 0; attempt < 2; attempt++)
+        {
+            await using var client = await AuthenticatedNamedPipeClient.ConnectAsync(
+                pipeName,
+                policy,
+                new NamedPipePeerAuthenticator(new WindowsNamedPipePeerIdentityProvider(new AcceptSignatureVerifier())),
+                5000);
+            Assert.IsTrue(client.IsConnected);
+        }
+
+        cancellation.Cancel();
+    }
+
+    private sealed class AcceptSignatureVerifier : IProcessSignatureVerifier
+    {
+        public bool HasTrustedMicrosoftSignature(string imagePath) => true;
+    }
+
+    private sealed class TestRpcTarget
+    {
+        public TestRpcTarget()
+        {
+        }
+
+        public void Ping()
+        {
+        }
+    }
+}

--- a/src/modules/MouseWithoutBorders/MouseWithoutBorders.UnitTests/SettingsIpcIdentityTests.cs
+++ b/src/modules/MouseWithoutBorders/MouseWithoutBorders.UnitTests/SettingsIpcIdentityTests.cs
@@ -108,6 +108,44 @@ public sealed class SettingsIpcIdentityTests
         cancellation.Cancel();
     }
 
+    [TestMethod]
+    public async Task ProductionServerRecoversAfterPipeNameBecomesAvailable()
+    {
+        var pipeName = $"PowerToys.MWB.v2.UnitTest.{Environment.ProcessId}.{Guid.NewGuid():N}";
+        using var identity = WindowsIdentity.GetCurrent();
+        var peerIdentity = new WindowsNamedPipePeerIdentityProvider(new AcceptSignatureVerifier()).GetIdentity(Environment.ProcessId);
+        var policy = new NamedPipePeerPolicy
+        {
+            ExpectedSessionId = peerIdentity.SessionId,
+            ExpectedUserSid = peerIdentity.UserSid,
+            ExpectedImagePath = peerIdentity.ImagePath,
+            ExpectedFileVersion = peerIdentity.FileVersion,
+            RequireMicrosoftSignature = false,
+        };
+        using var cancellation = new CancellationTokenSource();
+        var initialCreationFailure = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await using (var occupyingServer = RestrictedNamedPipeServer.Create(pipeName, identity.User!))
+        {
+            IpcChannel<TestRpcTarget>.StartAuthenticatedIpcServer(
+                pipeName,
+                identity.User,
+                policy,
+                _ => initialCreationFailure.TrySetResult(),
+                cancellation.Token);
+            await initialCreationFailure.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+
+        await using var client = await AuthenticatedNamedPipeClient.ConnectAsync(
+            pipeName,
+            policy,
+            new NamedPipePeerAuthenticator(new WindowsNamedPipePeerIdentityProvider(new AcceptSignatureVerifier())),
+            5000);
+
+        Assert.IsTrue(client.IsConnected);
+        cancellation.Cancel();
+    }
+
     private sealed class AcceptSignatureVerifier : IProcessSignatureVerifier
     {
         public bool HasTrustedMicrosoftSignature(string imagePath) => true;

--- a/src/modules/MouseWithoutBorders/MouseWithoutBorders.UnitTests/SettingsIpcIdentityTests.cs
+++ b/src/modules/MouseWithoutBorders/MouseWithoutBorders.UnitTests/SettingsIpcIdentityTests.cs
@@ -55,6 +55,29 @@ public sealed class SettingsIpcIdentityTests
     }
 
     [TestMethod]
+    public void SystemProcessGrantsInteractiveUserQueryAccess()
+    {
+        var systemSid = new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null);
+        var interactiveSid = new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null);
+        SecurityIdentifier? grantedSid = null;
+
+        Program.GrantSettingsIpcProcessQueryAccessIfNeeded(systemSid, interactiveSid, sid => grantedSid = sid);
+
+        Assert.AreEqual(interactiveSid, grantedSid);
+    }
+
+    [TestMethod]
+    public void UserProcessKeepsItsExistingProcessDacl()
+    {
+        var userSid = new SecurityIdentifier(WellKnownSidType.BuiltinUsersSid, null);
+        var grantCount = 0;
+
+        Program.GrantSettingsIpcProcessQueryAccessIfNeeded(userSid, userSid, _ => grantCount++);
+
+        Assert.AreEqual(0, grantCount);
+    }
+
+    [TestMethod]
     public async Task ProductionAuthenticatedServerAcceptsReconnect()
     {
         var pipeName = $"PowerToys.MWB.v2.UnitTest.{Environment.ProcessId}.{Guid.NewGuid():N}";

--- a/src/settings-ui/Settings.UI.Library/Utilities/MouseWithoutBordersIpc.cs
+++ b/src/settings-ui/Settings.UI.Library/Utilities/MouseWithoutBordersIpc.cs
@@ -58,6 +58,59 @@ namespace Microsoft.PowerToys.Settings.UI.Library.Utilities
                 ?? throw new ArgumentException("The Settings directory must have a parent directory.", nameof(settingsDirectory));
             return Path.Combine(installDirectory, "PowerToys.MouseWithoutBorders.exe");
         }
+
+        public static void GrantCurrentProcessQueryAccess(SecurityIdentifier allowedUser)
+        {
+            ArgumentNullException.ThrowIfNull(allowedUser);
+
+            using var processToken = OpenCurrentProcessTokenForDaclUpdate();
+            SetKernelObjectDacl(
+                processToken.DangerousGetHandle(),
+                $"D:P(A;;0x{MwbIpcNativeMethods.TokenQuery:X};;;{allowedUser.Value})(A;;GA;;;SY)(A;;GA;;;BA)");
+            SetKernelObjectDacl(
+                MwbIpcNativeMethods.GetCurrentProcess(),
+                $"D:P(A;;0x{MwbIpcNativeMethods.ProcessQueryLimitedInformation:X};;;{allowedUser.Value})(A;;GA;;;SY)(A;;GA;;;BA)");
+        }
+
+        private static SafeAccessTokenHandle OpenCurrentProcessTokenForDaclUpdate()
+        {
+            if (!MwbIpcNativeMethods.OpenCurrentProcessToken(
+                    MwbIpcNativeMethods.GetCurrentProcess(),
+                    MwbIpcNativeMethods.TokenQuery | MwbIpcNativeMethods.ReadControl | MwbIpcNativeMethods.WriteDac,
+                    out var processToken))
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+
+            return processToken;
+        }
+
+        private static void SetKernelObjectDacl(IntPtr handle, string sddl)
+        {
+            if (!MwbIpcNativeMethods.ConvertStringSecurityDescriptorToSecurityDescriptor(
+                    sddl,
+                    MwbIpcNativeMethods.SddlRevision1,
+                    out var securityDescriptor,
+                    out _))
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+
+            try
+            {
+                if (!MwbIpcNativeMethods.SetKernelObjectSecurity(
+                        handle,
+                        MwbIpcNativeMethods.DaclSecurityInformation,
+                        securityDescriptor))
+                {
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+                }
+            }
+            finally
+            {
+                MwbIpcNativeMethods.LocalFree(securityDescriptor);
+            }
+        }
     }
 
     public sealed class NamedPipePeerIdentity
@@ -508,6 +561,8 @@ namespace Microsoft.PowerToys.Settings.UI.Library.Utilities
     {
         internal const uint ProcessQueryLimitedInformation = 0x1000;
         internal const uint TokenQuery = 0x0008;
+        internal const uint ReadControl = 0x00020000;
+        internal const uint WriteDac = 0x00040000;
         internal const uint PipeAccessDuplex = 0x00000003;
         internal const uint FileFlagFirstPipeInstance = 0x00080000;
         internal const uint FileFlagOverlapped = 0x40000000;
@@ -516,6 +571,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.Utilities
         internal const uint PipeWait = 0x00000000;
         internal const uint PipeRejectRemoteClients = 0x00000008;
         internal const uint SddlRevision1 = 1;
+        internal const uint DaclSecurityInformation = 0x00000004;
         private const uint WtdUiNone = 2;
         private const uint WtdRevokeNone = 0;
         private const uint WtdChoiceFile = 1;
@@ -595,6 +651,16 @@ namespace Microsoft.PowerToys.Settings.UI.Library.Utilities
         [DllImport("kernel32.dll")]
         internal static extern IntPtr LocalFree(IntPtr memory);
 
+        [DllImport("kernel32.dll")]
+        internal static extern IntPtr GetCurrentProcess();
+
+        [DllImport("advapi32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool SetKernelObjectSecurity(
+            IntPtr handle,
+            uint securityInformation,
+            IntPtr securityDescriptor);
+
         [DllImport("kernel32.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool GetNamedPipeClientProcessId(SafePipeHandle pipe, out uint clientProcessId);
@@ -622,6 +688,10 @@ namespace Microsoft.PowerToys.Settings.UI.Library.Utilities
         [DllImport("advapi32.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool OpenProcessToken(SafeProcessHandle processHandle, uint desiredAccess, out SafeAccessTokenHandle tokenHandle);
+
+        [DllImport("advapi32.dll", EntryPoint = "OpenProcessToken", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool OpenCurrentProcessToken(IntPtr processHandle, uint desiredAccess, out SafeAccessTokenHandle tokenHandle);
 
         [DllImport("kernel32.dll", EntryPoint = "QueryFullProcessImageNameW", CharSet = CharSet.Unicode, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]

--- a/src/settings-ui/Settings.UI.Library/Utilities/MouseWithoutBordersIpc.cs
+++ b/src/settings-ui/Settings.UI.Library/Utilities/MouseWithoutBordersIpc.cs
@@ -35,6 +35,29 @@ namespace Microsoft.PowerToys.Settings.UI.Library.Utilities
         {
             return GetSettingsSyncPipeName(Process.GetCurrentProcess().SessionId);
         }
+
+        public static string GetSettingsExecutablePath(string installDirectory)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(installDirectory);
+
+            return Path.Combine(Path.GetFullPath(installDirectory), "WinUI3Apps", "PowerToys.Settings.exe");
+        }
+
+        public static string GetMouseWithoutBordersExecutablePath(string settingsDirectory)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(settingsDirectory);
+
+            var fullSettingsDirectory = Path.GetFullPath(settingsDirectory)
+                .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            if (!string.Equals(Path.GetFileName(fullSettingsDirectory), "WinUI3Apps", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new ArgumentException("The Settings directory must be the WinUI3Apps directory.", nameof(settingsDirectory));
+            }
+
+            var installDirectory = Directory.GetParent(fullSettingsDirectory)?.FullName
+                ?? throw new ArgumentException("The Settings directory must have a parent directory.", nameof(settingsDirectory));
+            return Path.Combine(installDirectory, "PowerToys.MouseWithoutBorders.exe");
+        }
     }
 
     public sealed class NamedPipePeerIdentity

--- a/src/settings-ui/Settings.UI.Library/Utilities/MouseWithoutBordersIpc.cs
+++ b/src/settings-ui/Settings.UI.Library/Utilities/MouseWithoutBordersIpc.cs
@@ -87,6 +87,11 @@ namespace Microsoft.PowerToys.Settings.UI.Library.Utilities
         bool HasTrustedMicrosoftSignature(string imagePath);
     }
 
+    public interface IDeferredProcessSignatureVerifier
+    {
+        bool HasTrustedMicrosoftSignature(NamedPipePeerIdentity identity);
+    }
+
     public sealed class NamedPipePeerPolicy
     {
         public int ExpectedSessionId { get; init; }
@@ -219,7 +224,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.Utilities
             return result;
         }
 
-        private static NamedPipePeerAuthenticationResult Evaluate(NamedPipePeerIdentity identity, NamedPipePeerPolicy policy)
+        private NamedPipePeerAuthenticationResult Evaluate(NamedPipePeerIdentity identity, NamedPipePeerPolicy policy)
         {
             if (identity.SessionId != policy.ExpectedSessionId)
             {
@@ -247,7 +252,10 @@ namespace Microsoft.PowerToys.Settings.UI.Library.Utilities
                 return NamedPipePeerAuthenticationResult.Reject("wrong-version", identity);
             }
 
-            if (policy.RequireMicrosoftSignature && !identity.HasTrustedMicrosoftSignature)
+            if (policy.RequireMicrosoftSignature &&
+                !(identityProvider is IDeferredProcessSignatureVerifier deferredSignatureVerifier
+                    ? deferredSignatureVerifier.HasTrustedMicrosoftSignature(identity)
+                    : identity.HasTrustedMicrosoftSignature))
             {
                 return NamedPipePeerAuthenticationResult.Reject("untrusted-signature", identity);
             }
@@ -270,7 +278,7 @@ namespace Microsoft.PowerToys.Settings.UI.Library.Utilities
         private readonly record struct CacheKey(int ProcessId, long CreationTimeUtcTicks, string PolicyFingerprint);
     }
 
-    public sealed class WindowsNamedPipePeerIdentityProvider : INamedPipePeerIdentityProvider
+    public sealed class WindowsNamedPipePeerIdentityProvider : INamedPipePeerIdentityProvider, IDeferredProcessSignatureVerifier
     {
         private readonly IProcessSignatureVerifier signatureVerifier;
 
@@ -320,8 +328,14 @@ namespace Microsoft.PowerToys.Settings.UI.Library.Utilities
                 UserSid = userSid,
                 ImagePath = imagePath,
                 FileVersion = fileVersion,
-                HasTrustedMicrosoftSignature = signatureVerifier.HasTrustedMicrosoftSignature(imagePath),
             };
+        }
+
+        public bool HasTrustedMicrosoftSignature(NamedPipePeerIdentity identity)
+        {
+            ArgumentNullException.ThrowIfNull(identity);
+
+            return signatureVerifier.HasTrustedMicrosoftSignature(identity.ImagePath);
         }
     }
 

--- a/src/settings-ui/Settings.UI.Library/Utilities/MouseWithoutBordersIpc.cs
+++ b/src/settings-ui/Settings.UI.Library/Utilities/MouseWithoutBordersIpc.cs
@@ -1,0 +1,643 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Pipes;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Security.Principal;
+using System.Threading.Tasks;
+
+using Microsoft.Win32.SafeHandles;
+
+#pragma warning disable SA1402 // The IPC security types form one intentionally cohesive implementation unit.
+
+namespace Microsoft.PowerToys.Settings.UI.Library.Utilities
+{
+    public static class MouseWithoutBordersIpc
+    {
+        public const string SettingsSyncProtocol = "PowerToys.MouseWithoutBorders.v2.SettingsSync";
+
+        public static string GetSettingsSyncPipeName(int sessionId)
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(sessionId);
+
+            return $"{SettingsSyncProtocol}.Session.{sessionId}";
+        }
+
+        public static string GetCurrentSettingsSyncPipeName()
+        {
+            return GetSettingsSyncPipeName(Process.GetCurrentProcess().SessionId);
+        }
+    }
+
+    public sealed class NamedPipePeerIdentity
+    {
+        public int ProcessId { get; init; }
+
+        public long CreationTimeUtcTicks { get; init; }
+
+        public int SessionId { get; init; }
+
+        public string UserSid { get; init; }
+
+        public string ImagePath { get; init; }
+
+        public string FileVersion { get; init; }
+
+        public bool HasTrustedMicrosoftSignature { get; init; }
+    }
+
+    public interface INamedPipePeerIdentityProvider
+    {
+        NamedPipePeerIdentity GetIdentity(int processId);
+    }
+
+    public interface IProcessSignatureVerifier
+    {
+        bool HasTrustedMicrosoftSignature(string imagePath);
+    }
+
+    public sealed class NamedPipePeerPolicy
+    {
+        public int ExpectedSessionId { get; init; }
+
+        public string ExpectedUserSid { get; init; }
+
+        public string ExpectedImagePath { get; init; }
+
+        public string ExpectedFileVersion { get; init; }
+
+        public bool AllowLocalSystem { get; init; }
+
+        public bool RequireMicrosoftSignature { get; init; } = true;
+    }
+
+    public sealed class NamedPipePeerAuthenticationResult
+    {
+        private NamedPipePeerAuthenticationResult(bool accepted, string reasonCode, NamedPipePeerIdentity identity)
+        {
+            Accepted = accepted;
+            ReasonCode = reasonCode;
+            Identity = identity;
+        }
+
+        public bool Accepted { get; }
+
+        public string ReasonCode { get; }
+
+        public NamedPipePeerIdentity Identity { get; }
+
+        public static NamedPipePeerAuthenticationResult Accept(NamedPipePeerIdentity identity)
+        {
+            return new NamedPipePeerAuthenticationResult(true, string.Empty, identity);
+        }
+
+        public static NamedPipePeerAuthenticationResult Reject(string reasonCode, NamedPipePeerIdentity identity = null)
+        {
+            return new NamedPipePeerAuthenticationResult(false, reasonCode, identity);
+        }
+    }
+
+    public sealed class NamedPipePeerAuthenticator
+    {
+        private readonly INamedPipePeerIdentityProvider identityProvider;
+        private readonly Dictionary<CacheKey, NamedPipePeerAuthenticationResult> cache = new();
+        private readonly object cacheLock = new();
+
+        public NamedPipePeerAuthenticator(INamedPipePeerIdentityProvider identityProvider)
+        {
+            this.identityProvider = identityProvider ?? throw new ArgumentNullException(nameof(identityProvider));
+        }
+
+        public NamedPipePeerAuthenticationResult AuthenticateClient(NamedPipeServerStream stream, NamedPipePeerPolicy policy)
+        {
+            ArgumentNullException.ThrowIfNull(stream);
+            if (!MwbIpcNativeMethods.GetNamedPipeClientProcessId(stream.SafePipeHandle, out var processId))
+            {
+                return NamedPipePeerAuthenticationResult.Reject("client-pid-unavailable");
+            }
+
+            return Authenticate(unchecked((int)processId), policy);
+        }
+
+        public NamedPipePeerAuthenticationResult AuthenticateClientAndExecute(
+            NamedPipeServerStream stream,
+            NamedPipePeerPolicy policy,
+            Action authenticatedAction)
+        {
+            ArgumentNullException.ThrowIfNull(authenticatedAction);
+
+            var result = AuthenticateClient(stream, policy);
+            if (result.Accepted)
+            {
+                authenticatedAction();
+            }
+
+            return result;
+        }
+
+        public NamedPipePeerAuthenticationResult AuthenticateServer(NamedPipeClientStream stream, NamedPipePeerPolicy policy)
+        {
+            ArgumentNullException.ThrowIfNull(stream);
+            if (!MwbIpcNativeMethods.GetNamedPipeServerProcessId(stream.SafePipeHandle, out var processId))
+            {
+                return NamedPipePeerAuthenticationResult.Reject("server-pid-unavailable");
+            }
+
+            return Authenticate(unchecked((int)processId), policy);
+        }
+
+        public NamedPipePeerAuthenticationResult Authenticate(int processId, NamedPipePeerPolicy policy)
+        {
+            ArgumentNullException.ThrowIfNull(policy);
+
+            NamedPipePeerIdentity identity;
+            try
+            {
+                identity = identityProvider.GetIdentity(processId);
+            }
+            catch
+            {
+                return NamedPipePeerAuthenticationResult.Reject("identity-unavailable");
+            }
+
+            if (identity == null || identity.ProcessId != processId || identity.CreationTimeUtcTicks == 0)
+            {
+                return NamedPipePeerAuthenticationResult.Reject("invalid-process-instance", identity);
+            }
+
+            var key = new CacheKey(identity.ProcessId, identity.CreationTimeUtcTicks, PolicyFingerprint(policy));
+            lock (cacheLock)
+            {
+                if (cache.TryGetValue(key, out var cached))
+                {
+                    return cached;
+                }
+            }
+
+            var result = Evaluate(identity, policy);
+            lock (cacheLock)
+            {
+                if (cache.Count >= 64)
+                {
+                    cache.Clear();
+                }
+
+                cache[key] = result;
+            }
+
+            return result;
+        }
+
+        private static NamedPipePeerAuthenticationResult Evaluate(NamedPipePeerIdentity identity, NamedPipePeerPolicy policy)
+        {
+            if (identity.SessionId != policy.ExpectedSessionId)
+            {
+                return NamedPipePeerAuthenticationResult.Reject("wrong-session", identity);
+            }
+
+            var isSystem = string.Equals(identity.UserSid, WellKnownSidType.LocalSystemSid.GetSid(), StringComparison.OrdinalIgnoreCase);
+            if (!string.Equals(identity.UserSid, policy.ExpectedUserSid, StringComparison.OrdinalIgnoreCase) &&
+                !(policy.AllowLocalSystem && isSystem))
+            {
+                return NamedPipePeerAuthenticationResult.Reject("wrong-user", identity);
+            }
+
+            if (!string.Equals(
+                    Path.GetFullPath(identity.ImagePath),
+                    Path.GetFullPath(policy.ExpectedImagePath),
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                return NamedPipePeerAuthenticationResult.Reject("wrong-image", identity);
+            }
+
+            if (!string.IsNullOrEmpty(policy.ExpectedFileVersion) &&
+                !string.Equals(identity.FileVersion, policy.ExpectedFileVersion, StringComparison.Ordinal))
+            {
+                return NamedPipePeerAuthenticationResult.Reject("wrong-version", identity);
+            }
+
+            if (policy.RequireMicrosoftSignature && !identity.HasTrustedMicrosoftSignature)
+            {
+                return NamedPipePeerAuthenticationResult.Reject("untrusted-signature", identity);
+            }
+
+            return NamedPipePeerAuthenticationResult.Accept(identity);
+        }
+
+        private static string PolicyFingerprint(NamedPipePeerPolicy policy)
+        {
+            return string.Join(
+                "|",
+                policy.ExpectedSessionId,
+                policy.ExpectedUserSid,
+                policy.ExpectedImagePath,
+                policy.ExpectedFileVersion,
+                policy.AllowLocalSystem,
+                policy.RequireMicrosoftSignature);
+        }
+
+        private readonly record struct CacheKey(int ProcessId, long CreationTimeUtcTicks, string PolicyFingerprint);
+    }
+
+    public sealed class WindowsNamedPipePeerIdentityProvider : INamedPipePeerIdentityProvider
+    {
+        private readonly IProcessSignatureVerifier signatureVerifier;
+
+        public WindowsNamedPipePeerIdentityProvider(IProcessSignatureVerifier signatureVerifier)
+        {
+            this.signatureVerifier = signatureVerifier ?? throw new ArgumentNullException(nameof(signatureVerifier));
+        }
+
+        public NamedPipePeerIdentity GetIdentity(int processId)
+        {
+            using var processHandle = MwbIpcNativeMethods.OpenProcess(MwbIpcNativeMethods.ProcessQueryLimitedInformation, false, unchecked((uint)processId));
+            if (processHandle.IsInvalid)
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+
+            if (!MwbIpcNativeMethods.GetProcessTimes(processHandle, out var creationTime, out _, out _, out _))
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+
+            if (!MwbIpcNativeMethods.ProcessIdToSessionId(unchecked((uint)processId), out var sessionId))
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+
+            var imagePath = MwbIpcNativeMethods.GetProcessImagePath(processHandle);
+            var fileVersion = FileVersionInfo.GetVersionInfo(imagePath).FileVersion ?? string.Empty;
+
+            if (!MwbIpcNativeMethods.OpenProcessToken(processHandle, MwbIpcNativeMethods.TokenQuery, out var tokenHandle))
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+
+            string userSid;
+            using (tokenHandle)
+            using (var identity = new WindowsIdentity(tokenHandle.DangerousGetHandle()))
+            {
+                userSid = identity.User?.Value ?? throw new InvalidOperationException("The process token has no user SID.");
+            }
+
+            return new NamedPipePeerIdentity
+            {
+                ProcessId = processId,
+                CreationTimeUtcTicks = creationTime.ToLong(),
+                SessionId = unchecked((int)sessionId),
+                UserSid = userSid,
+                ImagePath = imagePath,
+                FileVersion = fileVersion,
+                HasTrustedMicrosoftSignature = signatureVerifier.HasTrustedMicrosoftSignature(imagePath),
+            };
+        }
+    }
+
+    public sealed class MicrosoftMachineRootSignatureVerifier : IProcessSignatureVerifier
+    {
+        public bool HasTrustedMicrosoftSignature(string imagePath)
+        {
+            try
+            {
+                if (!MwbIpcNativeMethods.HasIntactAuthenticodeSignature(imagePath))
+                {
+                    return false;
+                }
+
+#pragma warning disable SYSLIB0057 // Embedded Authenticode signer extraction has no X509CertificateLoader equivalent.
+                using var signer = new X509Certificate2(X509Certificate.CreateFromSignedFile(imagePath));
+#pragma warning restore SYSLIB0057
+                if (!signer.Subject.Contains("Microsoft Corporation", StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+
+                using var roots = new X509Store(StoreName.Root, StoreLocation.LocalMachine);
+                roots.Open(OpenFlags.ReadOnly);
+
+                using var chain = new X509Chain();
+                chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+                chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+                chain.ChainPolicy.CustomTrustStore.AddRange(roots.Certificates);
+                chain.ChainPolicy.ApplicationPolicy.Add(new Oid("1.3.6.1.5.5.7.3.3"));
+                return chain.Build(signer);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+
+    public static class MouseWithoutBordersIpcPolicy
+    {
+        public static NamedPipePeerPolicy CreateSettingsClientPolicy(string expectedSettingsPath, int sessionId, string userSid)
+        {
+            return CreatePolicy(expectedSettingsPath, sessionId, userSid, false);
+        }
+
+        public static NamedPipePeerPolicy CreateMwbServerPolicy(string expectedMwbPath, int sessionId, string userSid, bool allowLocalSystem)
+        {
+            return CreatePolicy(expectedMwbPath, sessionId, userSid, allowLocalSystem);
+        }
+
+        private static NamedPipePeerPolicy CreatePolicy(string expectedPath, int sessionId, string userSid, bool allowLocalSystem)
+        {
+            var fullPath = Path.GetFullPath(expectedPath);
+            return new NamedPipePeerPolicy
+            {
+                ExpectedSessionId = sessionId,
+                ExpectedUserSid = userSid,
+                ExpectedImagePath = fullPath,
+                ExpectedFileVersion = File.Exists(fullPath) ? FileVersionInfo.GetVersionInfo(fullPath).FileVersion : string.Empty,
+                AllowLocalSystem = allowLocalSystem,
+#if DEBUG
+                RequireMicrosoftSignature = false,
+#else
+                RequireMicrosoftSignature = true,
+#endif
+            };
+        }
+    }
+
+    public static class RestrictedNamedPipeServer
+    {
+        public static NamedPipeServerStream Create(string pipeName, SecurityIdentifier allowedUser)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(pipeName);
+            ArgumentNullException.ThrowIfNull(allowedUser);
+
+            var systemSid = new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null);
+            var sddl = $"D:P(A;;GA;;;{allowedUser.Value})";
+            if (!allowedUser.Equals(systemSid))
+            {
+                sddl += $"(A;;GA;;;{systemSid.Value})";
+            }
+
+            if (!MwbIpcNativeMethods.ConvertStringSecurityDescriptorToSecurityDescriptor(
+                    sddl,
+                    MwbIpcNativeMethods.SddlRevision1,
+                    out var securityDescriptor,
+                    out _))
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+
+            try
+            {
+                var securityAttributes = new MwbIpcNativeMethods.SecurityAttributes
+                {
+                    Length = Marshal.SizeOf<MwbIpcNativeMethods.SecurityAttributes>(),
+                    SecurityDescriptor = securityDescriptor,
+                    InheritHandle = false,
+                };
+
+                var handle = MwbIpcNativeMethods.CreateNamedPipe(
+                    $@"\\.\pipe\{pipeName}",
+                    MwbIpcNativeMethods.PipeAccessDuplex | MwbIpcNativeMethods.FileFlagOverlapped | MwbIpcNativeMethods.FileFlagFirstPipeInstance,
+                    MwbIpcNativeMethods.PipeTypeByte | MwbIpcNativeMethods.PipeReadModeByte | MwbIpcNativeMethods.PipeWait | MwbIpcNativeMethods.PipeRejectRemoteClients,
+                    1,
+                    4096,
+                    4096,
+                    0,
+                    ref securityAttributes);
+
+                if (handle.IsInvalid)
+                {
+                    var error = Marshal.GetLastWin32Error();
+                    handle.Dispose();
+                    throw new Win32Exception(error);
+                }
+
+                return new NamedPipeServerStream(PipeDirection.InOut, true, false, handle);
+            }
+            finally
+            {
+                MwbIpcNativeMethods.LocalFree(securityDescriptor);
+            }
+        }
+    }
+
+    public static class AuthenticatedNamedPipeClient
+    {
+        public static async Task<NamedPipeClientStream> ConnectAsync(
+            string pipeName,
+            NamedPipePeerPolicy serverPolicy,
+            NamedPipePeerAuthenticator authenticator,
+            int timeoutMilliseconds)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(pipeName);
+            ArgumentNullException.ThrowIfNull(serverPolicy);
+            ArgumentNullException.ThrowIfNull(authenticator);
+
+            var stream = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
+            try
+            {
+                await stream.ConnectAsync(timeoutMilliseconds);
+                var authentication = authenticator.AuthenticateServer(stream, serverPolicy);
+                if (!authentication.Accepted)
+                {
+                    throw new UnauthorizedAccessException($"Rejected named pipe server: {authentication.ReasonCode}");
+                }
+
+                return stream;
+            }
+            catch
+            {
+                await stream.DisposeAsync();
+                throw;
+            }
+        }
+    }
+
+    internal static class WellKnownSidTypeExtensions
+    {
+        public static string GetSid(this WellKnownSidType sidType)
+        {
+            return new SecurityIdentifier(sidType, null).Value;
+        }
+    }
+
+    internal static class MwbIpcNativeMethods
+    {
+        internal const uint ProcessQueryLimitedInformation = 0x1000;
+        internal const uint TokenQuery = 0x0008;
+        internal const uint PipeAccessDuplex = 0x00000003;
+        internal const uint FileFlagFirstPipeInstance = 0x00080000;
+        internal const uint FileFlagOverlapped = 0x40000000;
+        internal const uint PipeTypeByte = 0x00000000;
+        internal const uint PipeReadModeByte = 0x00000000;
+        internal const uint PipeWait = 0x00000000;
+        internal const uint PipeRejectRemoteClients = 0x00000008;
+        internal const uint SddlRevision1 = 1;
+        private const uint WtdUiNone = 2;
+        private const uint WtdRevokeNone = 0;
+        private const uint WtdChoiceFile = 1;
+        private const uint WtdStateActionVerify = 1;
+        private const uint WtdStateActionClose = 2;
+        private const uint WtdSaferFlag = 0x100;
+        private const uint WtdCacheOnlyUrlRetrieval = 0x1000;
+        private static readonly Guid WinTrustActionGenericVerifyV2 = new("00AAC56B-CD44-11d0-8CC2-00C04FC295EE");
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct SecurityAttributes
+        {
+            internal int Length;
+            internal IntPtr SecurityDescriptor;
+
+            [MarshalAs(UnmanagedType.Bool)]
+            internal bool InheritHandle;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct FileTime
+        {
+            internal uint LowDateTime;
+            internal uint HighDateTime;
+
+            internal long ToLong()
+            {
+                return unchecked((long)(((ulong)HighDateTime << 32) | LowDateTime));
+            }
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        private struct WinTrustFileInfo
+        {
+            internal uint StructSize;
+            internal string FilePath;
+            internal IntPtr FileHandle;
+            internal IntPtr KnownSubject;
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        private struct WinTrustData
+        {
+            internal uint StructSize;
+            internal IntPtr PolicyCallbackData;
+            internal IntPtr SipClientData;
+            internal uint UiChoice;
+            internal uint RevocationChecks;
+            internal uint UnionChoice;
+            internal IntPtr FileInfo;
+            internal uint StateAction;
+            internal IntPtr StateData;
+            internal string UrlReference;
+            internal uint ProviderFlags;
+            internal uint UiContext;
+        }
+
+        [DllImport("kernel32.dll", EntryPoint = "CreateNamedPipeW", CharSet = CharSet.Unicode, SetLastError = true)]
+        internal static extern SafePipeHandle CreateNamedPipe(
+            string name,
+            uint openMode,
+            uint pipeMode,
+            uint maxInstances,
+            uint outBufferSize,
+            uint inBufferSize,
+            uint defaultTimeout,
+            ref SecurityAttributes securityAttributes);
+
+        [DllImport("advapi32.dll", EntryPoint = "ConvertStringSecurityDescriptorToSecurityDescriptorW", CharSet = CharSet.Unicode, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool ConvertStringSecurityDescriptorToSecurityDescriptor(
+            string stringSecurityDescriptor,
+            uint stringSdRevision,
+            out IntPtr securityDescriptor,
+            out uint securityDescriptorSize);
+
+        [DllImport("kernel32.dll")]
+        internal static extern IntPtr LocalFree(IntPtr memory);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool GetNamedPipeClientProcessId(SafePipeHandle pipe, out uint clientProcessId);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool GetNamedPipeServerProcessId(SafePipeHandle pipe, out uint serverProcessId);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        internal static extern SafeProcessHandle OpenProcess(uint processAccess, [MarshalAs(UnmanagedType.Bool)] bool inheritHandle, uint processId);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool GetProcessTimes(
+            SafeProcessHandle process,
+            out FileTime creationTime,
+            out FileTime exitTime,
+            out FileTime kernelTime,
+            out FileTime userTime);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool ProcessIdToSessionId(uint processId, out uint sessionId);
+
+        [DllImport("advapi32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool OpenProcessToken(SafeProcessHandle processHandle, uint desiredAccess, out SafeAccessTokenHandle tokenHandle);
+
+        [DllImport("kernel32.dll", EntryPoint = "QueryFullProcessImageNameW", CharSet = CharSet.Unicode, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool QueryFullProcessImageName(SafeProcessHandle process, uint flags, char[] exeName, ref uint size);
+
+        [DllImport("wintrust.dll", ExactSpelling = true, SetLastError = true)]
+        private static extern int WinVerifyTrust(IntPtr windowHandle, [In] ref Guid actionId, ref WinTrustData trustData);
+
+        internal static string GetProcessImagePath(SafeProcessHandle process)
+        {
+            var buffer = new char[32768];
+            var length = unchecked((uint)buffer.Length);
+            if (!QueryFullProcessImageName(process, 0, buffer, ref length))
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+
+            return new string(buffer, 0, unchecked((int)length));
+        }
+
+        internal static bool HasIntactAuthenticodeSignature(string imagePath)
+        {
+            var fileInfo = new WinTrustFileInfo
+            {
+                StructSize = unchecked((uint)Marshal.SizeOf<WinTrustFileInfo>()),
+                FilePath = imagePath,
+            };
+            var fileInfoPointer = Marshal.AllocHGlobal(Marshal.SizeOf<WinTrustFileInfo>());
+            try
+            {
+                Marshal.StructureToPtr(fileInfo, fileInfoPointer, false);
+                var trustData = new WinTrustData
+                {
+                    StructSize = unchecked((uint)Marshal.SizeOf<WinTrustData>()),
+                    UiChoice = WtdUiNone,
+                    RevocationChecks = WtdRevokeNone,
+                    UnionChoice = WtdChoiceFile,
+                    FileInfo = fileInfoPointer,
+                    StateAction = WtdStateActionVerify,
+                    ProviderFlags = WtdSaferFlag | WtdCacheOnlyUrlRetrieval,
+                };
+
+                var action = WinTrustActionGenericVerifyV2;
+                var status = WinVerifyTrust(new IntPtr(-1), ref action, ref trustData);
+                trustData.StateAction = WtdStateActionClose;
+                _ = WinVerifyTrust(new IntPtr(-1), ref action, ref trustData);
+                return status == 0;
+            }
+            finally
+            {
+                Marshal.DestroyStructure<WinTrustFileInfo>(fileInfoPointer);
+                Marshal.FreeHGlobal(fileInfoPointer);
+            }
+        }
+    }
+}

--- a/src/settings-ui/Settings.UI.UnitTests/MouseWithoutBordersIpcSecurityTests.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/MouseWithoutBordersIpcSecurityTests.cs
@@ -97,16 +97,28 @@ namespace Microsoft.PowerToys.Settings.UI.UnitTests
         {
             var pipeName = UniquePipeName();
             using var currentIdentity = WindowsIdentity.GetCurrent();
-            await using var fakeServer = RestrictedNamedPipeServer.Create(pipeName, currentIdentity.User!);
-
-            Assert.ThrowsException<Win32Exception>(() => RestrictedNamedPipeServer.Create(pipeName, currentIdentity.User!));
-
-            var waitTask = fakeServer.WaitForConnectionAsync();
             var identity = GetCurrentIdentity();
-            var policy = CopyPolicy(CreatePolicy(identity), expectedImagePath: Path.Combine(Path.GetDirectoryName(identity.ImagePath)!, "PowerToys.MouseWithoutBorders.exe"));
-            await Assert.ThrowsExceptionAsync<UnauthorizedAccessException>(
-                () => AuthenticatedNamedPipeClient.ConnectAsync(pipeName, policy, CreateRealAuthenticator(), 5000));
-            await waitTask;
+
+            await using (var fakeServer = RestrictedNamedPipeServer.Create(pipeName, currentIdentity.User!))
+            {
+                Assert.ThrowsException<Win32Exception>(() => RestrictedNamedPipeServer.Create(pipeName, currentIdentity.User!));
+
+                var waitTask = fakeServer.WaitForConnectionAsync();
+                var policy = CopyPolicy(CreatePolicy(identity), expectedImagePath: Path.Combine(Path.GetDirectoryName(identity.ImagePath)!, "PowerToys.MouseWithoutBorders.exe"));
+                await Assert.ThrowsExceptionAsync<UnauthorizedAccessException>(
+                    () => AuthenticatedNamedPipeClient.ConnectAsync(pipeName, policy, CreateRealAuthenticator(), 5000));
+                await waitTask;
+            }
+
+            await using var legitimateServer = RestrictedNamedPipeServer.Create(pipeName, currentIdentity.User!);
+            var legitimateWaitTask = legitimateServer.WaitForConnectionAsync();
+            await using var legitimateClient = await AuthenticatedNamedPipeClient.ConnectAsync(
+                pipeName,
+                CreatePolicy(identity),
+                CreateRealAuthenticator(),
+                5000);
+            await legitimateWaitTask;
+            Assert.IsTrue(legitimateClient.IsConnected);
         }
 
         [TestMethod]
@@ -229,19 +241,34 @@ namespace Microsoft.PowerToys.Settings.UI.UnitTests
         {
             var identity = GetCurrentIdentity();
             var policy = CreatePolicy(identity);
-            var authenticator = new NamedPipePeerAuthenticator(new FakeIdentityProvider
+            var provider = new DeferredSignatureIdentityProvider
             {
                 Identity = CopyIdentity(
                     identity,
                     sessionId: identity.SessionId + 1,
                     userSid: new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null).Value,
                     hasTrustedMicrosoftSignature: false),
-            });
+            };
+            var authenticator = new NamedPipePeerAuthenticator(provider);
 
             var result = authenticator.Authenticate(identity.ProcessId, CopyPolicy(policy, requireMicrosoftSignature: true));
 
             Assert.IsFalse(result.Accepted);
             Assert.AreEqual("wrong-session", result.ReasonCode);
+            Assert.AreEqual(0, provider.SignatureVerificationCount);
+        }
+
+        [TestMethod]
+        public void AcceptedProcessInstanceCachesDeferredSignatureResult()
+        {
+            var identity = CopyIdentity(GetCurrentIdentity(), hasTrustedMicrosoftSignature: true);
+            var provider = new DeferredSignatureIdentityProvider { Identity = identity };
+            var authenticator = new NamedPipePeerAuthenticator(provider);
+            var policy = CopyPolicy(CreatePolicy(identity), requireMicrosoftSignature: true);
+
+            Assert.IsTrue(authenticator.Authenticate(identity.ProcessId, policy).Accepted);
+            Assert.IsTrue(authenticator.Authenticate(identity.ProcessId, policy).Accepted);
+            Assert.AreEqual(1, provider.SignatureVerificationCount);
         }
 
         [TestMethod]
@@ -342,6 +369,21 @@ namespace Microsoft.PowerToys.Settings.UI.UnitTests
             public NamedPipePeerIdentity Identity { get; set; }
 
             public NamedPipePeerIdentity GetIdentity(int processId) => Identity;
+        }
+
+        private sealed class DeferredSignatureIdentityProvider : INamedPipePeerIdentityProvider, IDeferredProcessSignatureVerifier
+        {
+            public NamedPipePeerIdentity Identity { get; set; }
+
+            public int SignatureVerificationCount { get; private set; }
+
+            public NamedPipePeerIdentity GetIdentity(int processId) => Identity;
+
+            public bool HasTrustedMicrosoftSignature(NamedPipePeerIdentity identity)
+            {
+                SignatureVerificationCount++;
+                return identity.HasTrustedMicrosoftSignature;
+            }
         }
     }
 }

--- a/src/settings-ui/Settings.UI.UnitTests/MouseWithoutBordersIpcSecurityTests.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/MouseWithoutBordersIpcSecurityTests.cs
@@ -93,6 +93,26 @@ namespace Microsoft.PowerToys.Settings.UI.UnitTests
         }
 
         [TestMethod]
+        public async Task RealProcessTokenWithUnexpectedSidIsRejectedBeforeDispatch()
+        {
+            var pair = await CreateConnectedPairAsync();
+            await using var server = pair.Server;
+            await using var client = pair.Client;
+
+            var identity = GetCurrentIdentity();
+            var policy = CopyPolicy(
+                CreatePolicy(identity),
+                expectedUserSid: new SecurityIdentifier(WellKnownSidType.AnonymousSid, null).Value);
+            var dispatchCount = 0;
+
+            var result = CreateRealAuthenticator().AuthenticateClientAndExecute(server, policy, () => dispatchCount++);
+
+            Assert.IsFalse(result.Accepted);
+            Assert.AreEqual("wrong-user", result.ReasonCode);
+            Assert.AreEqual(0, dispatchCount);
+        }
+
+        [TestMethod]
         public async Task FakeServerAndPipeSquattingAreRejected()
         {
             var pipeName = UniquePipeName();
@@ -303,6 +323,7 @@ namespace Microsoft.PowerToys.Settings.UI.UnitTests
         private static NamedPipePeerPolicy CopyPolicy(
             NamedPipePeerPolicy policy,
             int? expectedSessionId = null,
+            string expectedUserSid = null,
             string expectedImagePath = null,
             bool? allowLocalSystem = null,
             bool? requireMicrosoftSignature = null)
@@ -310,7 +331,7 @@ namespace Microsoft.PowerToys.Settings.UI.UnitTests
             return new NamedPipePeerPolicy
             {
                 ExpectedSessionId = expectedSessionId ?? policy.ExpectedSessionId,
-                ExpectedUserSid = policy.ExpectedUserSid,
+                ExpectedUserSid = expectedUserSid ?? policy.ExpectedUserSid,
                 ExpectedImagePath = expectedImagePath ?? policy.ExpectedImagePath,
                 ExpectedFileVersion = policy.ExpectedFileVersion,
                 AllowLocalSystem = allowLocalSystem ?? policy.AllowLocalSystem,

--- a/src/settings-ui/Settings.UI.UnitTests/MouseWithoutBordersIpcSecurityTests.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/MouseWithoutBordersIpcSecurityTests.cs
@@ -32,6 +32,37 @@ namespace Microsoft.PowerToys.Settings.UI.UnitTests
         }
 
         [TestMethod]
+        public void PackagedExecutablePathsMatchInstallerLayout()
+        {
+            var installDirectory = Path.GetFullPath(Path.Combine("TestInstall", $"PowerToys-{Guid.NewGuid():N}"));
+            var settingsDirectory = Path.Combine(installDirectory, "WinUI3Apps");
+
+            Assert.AreEqual(
+                Path.Combine(settingsDirectory, "PowerToys.Settings.exe"),
+                MouseWithoutBordersIpc.GetSettingsExecutablePath(installDirectory));
+            Assert.AreEqual(
+                Path.Combine(installDirectory, "PowerToys.MouseWithoutBorders.exe"),
+                MouseWithoutBordersIpc.GetMouseWithoutBordersExecutablePath(settingsDirectory + Path.DirectorySeparatorChar));
+            Assert.ThrowsException<ArgumentException>(
+                () => MouseWithoutBordersIpc.GetMouseWithoutBordersExecutablePath(installDirectory));
+        }
+
+        [TestMethod]
+        public void PolicyCapturesExpectedExecutablePathAndVersion()
+        {
+            var identity = GetCurrentIdentity();
+
+            var policy = MouseWithoutBordersIpcPolicy.CreateMwbServerPolicy(
+                identity.ImagePath,
+                identity.SessionId,
+                identity.UserSid,
+                allowLocalSystem: false);
+
+            Assert.AreEqual(Path.GetFullPath(identity.ImagePath), policy.ExpectedImagePath);
+            Assert.AreEqual(identity.FileVersion, policy.ExpectedFileVersion);
+        }
+
+        [TestMethod]
         public async Task LegitimateSameSessionConnectionIsAccepted()
         {
             var pair = await CreateConnectedPairAsync();

--- a/src/settings-ui/Settings.UI.UnitTests/MouseWithoutBordersIpcSecurityTests.cs
+++ b/src/settings-ui/Settings.UI.UnitTests/MouseWithoutBordersIpcSecurityTests.cs
@@ -1,0 +1,316 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Pipes;
+using System.Reflection;
+using System.Security.AccessControl;
+using System.Security.Principal;
+using System.Threading.Tasks;
+
+using Microsoft.PowerToys.Settings.UI.Library.Utilities;
+using Microsoft.PowerToys.Settings.UI.ViewModels;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+
+namespace Microsoft.PowerToys.Settings.UI.UnitTests
+{
+    [TestClass]
+    public sealed class MouseWithoutBordersIpcSecurityTests
+    {
+        [TestMethod]
+        public void PipeNameIsStableAndSessionQualified()
+        {
+            Assert.AreEqual(
+                "PowerToys.MouseWithoutBorders.v2.SettingsSync.Session.42",
+                MouseWithoutBordersIpc.GetSettingsSyncPipeName(42));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => MouseWithoutBordersIpc.GetSettingsSyncPipeName(-1));
+        }
+
+        [TestMethod]
+        public async Task LegitimateSameSessionConnectionIsAccepted()
+        {
+            var pair = await CreateConnectedPairAsync();
+            await using var server = pair.Server;
+            await using var client = pair.Client;
+
+            var identity = GetCurrentIdentity();
+            var result = CreateRealAuthenticator().AuthenticateClient(server, CreatePolicy(identity));
+
+            Assert.IsTrue(result.Accepted, result.ReasonCode);
+        }
+
+        [TestMethod]
+        public async Task UnauthorizedLocalClientIsRejectedBeforeDispatch()
+        {
+            var pair = await CreateConnectedPairAsync();
+            await using var server = pair.Server;
+            await using var client = pair.Client;
+
+            var identity = GetCurrentIdentity();
+            var policy = CreatePolicy(identity);
+            policy = CopyPolicy(policy, expectedImagePath: Path.Combine(Path.GetDirectoryName(identity.ImagePath)!, "not-settings.exe"));
+
+            var result = CreateRealAuthenticator().AuthenticateClient(server, policy);
+
+            Assert.IsFalse(result.Accepted);
+            Assert.AreEqual("wrong-image", result.ReasonCode);
+        }
+
+        [TestMethod]
+        public async Task FakeServerAndPipeSquattingAreRejected()
+        {
+            var pipeName = UniquePipeName();
+            using var currentIdentity = WindowsIdentity.GetCurrent();
+            await using var fakeServer = RestrictedNamedPipeServer.Create(pipeName, currentIdentity.User!);
+
+            Assert.ThrowsException<Win32Exception>(() => RestrictedNamedPipeServer.Create(pipeName, currentIdentity.User!));
+
+            var waitTask = fakeServer.WaitForConnectionAsync();
+            var identity = GetCurrentIdentity();
+            var policy = CopyPolicy(CreatePolicy(identity), expectedImagePath: Path.Combine(Path.GetDirectoryName(identity.ImagePath)!, "PowerToys.MouseWithoutBorders.exe"));
+            await Assert.ThrowsExceptionAsync<UnauthorizedAccessException>(
+                () => AuthenticatedNamedPipeClient.ConnectAsync(pipeName, policy, CreateRealAuthenticator(), 5000));
+            await waitTask;
+        }
+
+        [TestMethod]
+        public void PipeDaclAllowsOnlyExpectedUserAndLocalSystem()
+        {
+            using var currentIdentity = WindowsIdentity.GetCurrent();
+            using var server = RestrictedNamedPipeServer.Create(UniquePipeName(), currentIdentity.User!);
+            var expectedSids = new[]
+            {
+                currentIdentity.User!,
+                new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null),
+            };
+            var accessRules = server.GetAccessControl().GetAccessRules(true, false, typeof(SecurityIdentifier));
+
+            Assert.AreEqual(expectedSids.Length, accessRules.Count);
+            foreach (AuthorizationRule rule in accessRules)
+            {
+                var pipeRule = (PipeAccessRule)rule;
+                Assert.AreEqual(AccessControlType.Allow, pipeRule.AccessControlType);
+                Assert.AreEqual(
+                    PipeAccessRights.FullControl,
+                    pipeRule.PipeAccessRights & PipeAccessRights.FullControl);
+                Assert.IsTrue(Array.Exists(expectedSids, sid => sid.Equals(pipeRule.IdentityReference)));
+            }
+        }
+
+        [TestMethod]
+        public void DifferentRdpSessionIdentityIsRejected()
+        {
+            var identity = GetCurrentIdentity();
+            var provider = new FakeIdentityProvider { Identity = identity };
+            var policy = CopyPolicy(CreatePolicy(identity), expectedSessionId: identity.SessionId + 1);
+
+            var result = new NamedPipePeerAuthenticator(provider).Authenticate(identity.ProcessId, policy);
+
+            Assert.IsFalse(result.Accepted);
+            Assert.AreEqual("wrong-session", result.ReasonCode);
+        }
+
+        [TestMethod]
+        public void ProcessCreationTimeSeparatesCacheEntries()
+        {
+            var identity = GetCurrentIdentity();
+            var provider = new FakeIdentityProvider { Identity = identity };
+            var authenticator = new NamedPipePeerAuthenticator(provider);
+            var policy = CreatePolicy(identity);
+
+            Assert.IsTrue(authenticator.Authenticate(identity.ProcessId, policy).Accepted);
+
+            provider.Identity = CopyIdentity(
+                identity,
+                creationTimeUtcTicks: identity.CreationTimeUtcTicks + 1,
+                sessionId: identity.SessionId + 1);
+            var restartedProcessResult = authenticator.Authenticate(identity.ProcessId, policy);
+
+            Assert.IsFalse(restartedProcessResult.Accepted);
+            Assert.AreEqual("wrong-session", restartedProcessResult.ReasonCode);
+        }
+
+        [TestMethod]
+        public async Task ServerRestartAllowsAuthenticatedReconnect()
+        {
+            var pipeName = UniquePipeName();
+            var identity = GetCurrentIdentity();
+            for (var attempt = 0; attempt < 2; attempt++)
+            {
+                await using var server = RestrictedNamedPipeServer.Create(pipeName, new SecurityIdentifier(identity.UserSid));
+                var waitTask = server.WaitForConnectionAsync();
+                await using var client = await AuthenticatedNamedPipeClient.ConnectAsync(
+                    pipeName,
+                    CreatePolicy(identity),
+                    CreateRealAuthenticator(),
+                    5000);
+                await waitTask;
+                Assert.IsTrue(client.IsConnected);
+            }
+        }
+
+        [TestMethod]
+        public async Task RejectedConnectionDoesNotReplayMutation()
+        {
+            var identity = GetCurrentIdentity();
+            var provider = new FakeIdentityProvider { Identity = identity };
+            var authenticator = new NamedPipePeerAuthenticator(provider);
+            var mutationCount = 0;
+
+            var rejectedPolicy = CopyPolicy(CreatePolicy(identity), expectedSessionId: identity.SessionId + 1);
+            var pair = await CreateConnectedPairAsync();
+            await using var server = pair.Server;
+            await using var client = pair.Client;
+
+            authenticator.AuthenticateClientAndExecute(server, rejectedPolicy, () => mutationCount++);
+            authenticator.AuthenticateClientAndExecute(server, CreatePolicy(identity), () => mutationCount++);
+
+            Assert.AreEqual(1, mutationCount);
+        }
+
+        [TestMethod]
+        public void SystemAndSignatureCasesArePolicyControlled()
+        {
+            var identity = GetCurrentIdentity();
+            var systemIdentity = CopyIdentity(
+                identity,
+                userSid: new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null).Value,
+                hasTrustedMicrosoftSignature: false);
+            var provider = new FakeIdentityProvider { Identity = systemIdentity };
+            var authenticator = new NamedPipePeerAuthenticator(provider);
+
+            var labPolicy = CopyPolicy(CreatePolicy(identity), allowLocalSystem: true, requireMicrosoftSignature: false);
+            Assert.IsTrue(authenticator.Authenticate(identity.ProcessId, labPolicy).Accepted);
+
+            var releasePolicy = CopyPolicy(labPolicy, requireMicrosoftSignature: true);
+            var releaseResult = authenticator.Authenticate(identity.ProcessId, releasePolicy);
+            Assert.IsFalse(releaseResult.Accepted);
+            Assert.AreEqual("untrusted-signature", releaseResult.ReasonCode);
+        }
+
+        [TestMethod]
+        public void IdentityChecksRejectInCheapToExpensiveOrder()
+        {
+            var identity = GetCurrentIdentity();
+            var policy = CreatePolicy(identity);
+            var authenticator = new NamedPipePeerAuthenticator(new FakeIdentityProvider
+            {
+                Identity = CopyIdentity(
+                    identity,
+                    sessionId: identity.SessionId + 1,
+                    userSid: new SecurityIdentifier(WellKnownSidType.LocalSystemSid, null).Value,
+                    hasTrustedMicrosoftSignature: false),
+            });
+
+            var result = authenticator.Authenticate(identity.ProcessId, CopyPolicy(policy, requireMicrosoftSignature: true));
+
+            Assert.IsFalse(result.Accepted);
+            Assert.AreEqual("wrong-session", result.ReasonCode);
+        }
+
+        [TestMethod]
+        public void SettingsSyncPayloadKeepsExistingJsonShape()
+        {
+            var contract = typeof(MouseWithoutBordersViewModel).GetNestedType("ISettingsSyncHelper", BindingFlags.NonPublic);
+            var stateType = contract!.GetNestedType("MachineSocketState");
+            var state = Activator.CreateInstance(stateType!);
+            stateType!.GetField("Name")!.SetValue(state, "PC");
+            stateType.GetField("Status")!.SetValue(state, Enum.ToObject(stateType.GetField("Status")!.FieldType, 9));
+
+            Assert.AreEqual("""{"Name":"PC","Status":9}""", JsonConvert.SerializeObject(state));
+        }
+
+        private static NamedPipePeerAuthenticator CreateRealAuthenticator()
+        {
+            return new NamedPipePeerAuthenticator(new WindowsNamedPipePeerIdentityProvider(new AcceptSignatureVerifier()));
+        }
+
+        private static NamedPipePeerPolicy CreatePolicy(NamedPipePeerIdentity identity)
+        {
+            return new NamedPipePeerPolicy
+            {
+                ExpectedSessionId = identity.SessionId,
+                ExpectedUserSid = identity.UserSid,
+                ExpectedImagePath = identity.ImagePath,
+                ExpectedFileVersion = identity.FileVersion,
+                RequireMicrosoftSignature = false,
+            };
+        }
+
+        private static NamedPipePeerPolicy CopyPolicy(
+            NamedPipePeerPolicy policy,
+            int? expectedSessionId = null,
+            string expectedImagePath = null,
+            bool? allowLocalSystem = null,
+            bool? requireMicrosoftSignature = null)
+        {
+            return new NamedPipePeerPolicy
+            {
+                ExpectedSessionId = expectedSessionId ?? policy.ExpectedSessionId,
+                ExpectedUserSid = policy.ExpectedUserSid,
+                ExpectedImagePath = expectedImagePath ?? policy.ExpectedImagePath,
+                ExpectedFileVersion = policy.ExpectedFileVersion,
+                AllowLocalSystem = allowLocalSystem ?? policy.AllowLocalSystem,
+                RequireMicrosoftSignature = requireMicrosoftSignature ?? policy.RequireMicrosoftSignature,
+            };
+        }
+
+        private static NamedPipePeerIdentity CopyIdentity(
+            NamedPipePeerIdentity identity,
+            long? creationTimeUtcTicks = null,
+            int? sessionId = null,
+            string userSid = null,
+            bool? hasTrustedMicrosoftSignature = null)
+        {
+            return new NamedPipePeerIdentity
+            {
+                ProcessId = identity.ProcessId,
+                CreationTimeUtcTicks = creationTimeUtcTicks ?? identity.CreationTimeUtcTicks,
+                SessionId = sessionId ?? identity.SessionId,
+                UserSid = userSid ?? identity.UserSid,
+                ImagePath = identity.ImagePath,
+                FileVersion = identity.FileVersion,
+                HasTrustedMicrosoftSignature = hasTrustedMicrosoftSignature ?? identity.HasTrustedMicrosoftSignature,
+            };
+        }
+
+        private static NamedPipePeerIdentity GetCurrentIdentity()
+        {
+            return new WindowsNamedPipePeerIdentityProvider(new AcceptSignatureVerifier()).GetIdentity(Environment.ProcessId);
+        }
+
+        private static async Task<(NamedPipeServerStream Server, NamedPipeClientStream Client)> CreateConnectedPairAsync(string pipeName = null)
+        {
+            pipeName ??= UniquePipeName();
+            using var currentIdentity = WindowsIdentity.GetCurrent();
+            var server = RestrictedNamedPipeServer.Create(pipeName, currentIdentity.User!);
+            var client = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
+            var waitTask = server.WaitForConnectionAsync();
+            await client.ConnectAsync(5000);
+            await waitTask;
+            return (server, client);
+        }
+
+        private static string UniquePipeName()
+        {
+            return $"PowerToys.MWB.v2.UnitTest.{Environment.ProcessId}.{Guid.NewGuid():N}";
+        }
+
+        private sealed class AcceptSignatureVerifier : IProcessSignatureVerifier
+        {
+            public bool HasTrustedMicrosoftSignature(string imagePath) => true;
+        }
+
+        private sealed class FakeIdentityProvider : INamedPipePeerIdentityProvider
+        {
+            public NamedPipePeerIdentity Identity { get; set; }
+
+            public NamedPipePeerIdentity GetIdentity(int processId) => Identity;
+        }
+    }
+}

--- a/src/settings-ui/Settings.UI/ViewModels/MouseWithoutBordersViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/MouseWithoutBordersViewModel.cs
@@ -4,12 +4,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.IO.Pipes;
 using System.Linq;
 using System.Net;
 using System.Runtime.CompilerServices;
+using System.Security.Principal;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -19,6 +21,7 @@ using Microsoft.PowerToys.Settings.UI.Helpers;
 using Microsoft.PowerToys.Settings.UI.Library;
 using Microsoft.PowerToys.Settings.UI.Library.Helpers;
 using Microsoft.PowerToys.Settings.UI.Library.Interfaces;
+using Microsoft.PowerToys.Settings.UI.Library.Utilities;
 using Microsoft.PowerToys.Settings.UI.Library.ViewModels.Commands;
 using Microsoft.PowerToys.Settings.UI.SerializationContext;
 using Microsoft.UI;
@@ -321,8 +324,24 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
 
                 if (recreateStream)
                 {
-                    syncHelperStream = new NamedPipeClientStream(".", "MouseWithoutBorders/SettingsSync", PipeDirection.InOut, PipeOptions.Asynchronous);
-                    await syncHelperStream.ConnectAsync(10000);
+                    var sessionId = Process.GetCurrentProcess().SessionId;
+                    using var currentIdentity = WindowsIdentity.GetCurrent();
+                    var currentUserSid = currentIdentity.User?.Value ?? throw new InvalidOperationException("Settings process has no user SID.");
+                    var settingsDirectory = AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar);
+                    var installDirectory = Directory.GetParent(settingsDirectory)?.FullName ?? settingsDirectory;
+                    var mwbPath = Path.Combine(installDirectory, "PowerToys.MouseWithoutBorders.exe");
+                    var serverPolicy = MouseWithoutBordersIpcPolicy.CreateMwbServerPolicy(
+                        mwbPath,
+                        sessionId,
+                        currentUserSid,
+                        allowLocalSystem: true);
+                    var authenticator = new NamedPipePeerAuthenticator(
+                        new WindowsNamedPipePeerIdentityProvider(new MicrosoftMachineRootSignatureVerifier()));
+                    syncHelperStream = await AuthenticatedNamedPipeClient.ConnectAsync(
+                        MouseWithoutBordersIpc.GetSettingsSyncPipeName(sessionId),
+                        serverPolicy,
+                        authenticator,
+                        10000);
                 }
 
                 return new SyncHelper(syncHelperStream);

--- a/src/settings-ui/Settings.UI/ViewModels/MouseWithoutBordersViewModel.cs
+++ b/src/settings-ui/Settings.UI/ViewModels/MouseWithoutBordersViewModel.cs
@@ -327,9 +327,7 @@ namespace Microsoft.PowerToys.Settings.UI.ViewModels
                     var sessionId = Process.GetCurrentProcess().SessionId;
                     using var currentIdentity = WindowsIdentity.GetCurrent();
                     var currentUserSid = currentIdentity.User?.Value ?? throw new InvalidOperationException("Settings process has no user SID.");
-                    var settingsDirectory = AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar);
-                    var installDirectory = Directory.GetParent(settingsDirectory)?.FullName ?? settingsDirectory;
-                    var mwbPath = Path.Combine(installDirectory, "PowerToys.MouseWithoutBorders.exe");
+                    var mwbPath = MouseWithoutBordersIpc.GetMouseWithoutBordersExecutablePath(AppContext.BaseDirectory);
                     var serverPolicy = MouseWithoutBordersIpcPolicy.CreateMwbServerPolicy(
                         mwbPath,
                         sessionId,


### PR DESCRIPTION
## Summary

- use a session-scoped pipe for Mouse Without Borders settings synchronization
- validate each endpoint before starting JSON-RPC communication
- limit pipe access to the interactive user and LocalSystem
- preserve the existing settings-sync payload format and reconnect behavior
- defer executable signature checks until cheaper peer checks pass and cache the accepted process instance
- allow the interactive Settings process to inspect the service-hosted peer with query-only access
- keep the asynchronous accept loop observable and retry after transient pipe creation failures

## Validation

- Settings UI Debug builds: x64 and ARM64
- Mouse Without Borders Debug builds: x64 and ARM64
- Settings IPC tests: 16 passed, including native process-token SID mismatch rejection before dispatch
- Mouse Without Borders IPC identity and serialization tests: 7 passed, including deterministic accept-loop recovery after pipe-name contention
- final x64 and ARM64 CI build with tests passed against the PR merge ref
- a signed Release build was queued against the final merge ref with public symbol publishing disabled; release artifact generation failed before product signing because an expected build-log directory was unavailable
- an earlier signed Release validation passed for x64 and ARM64 peer-validation and packaged-path changes
- packaged Settings and Mouse Without Borders executable locations were verified by release-build logs

## Additional validation

Service-mode, elevated Settings, RDP-session, installed update/restart, final packaged-signature, and two-machine scenarios require environment-specific validation.